### PR TITLE
changed: remove REQUIRED from opm-common

### DIFF
--- a/cmake/Modules/opm-benchmarks-prereqs.cmake
+++ b/cmake/Modules/opm-benchmarks-prereqs.cmake
@@ -13,7 +13,7 @@ set (opm-benchmarks_DEPS
 	"Boost 1.44.0
 		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
 	# OPM dependency
-	"opm-common REQUIRED"
+	"opm-common"
 	"opm-core REQUIRED"
 	"opm-upscaling REQUIRED"
 	)

--- a/cmake/Modules/opm-polymer-prereqs.cmake
+++ b/cmake/Modules/opm-polymer-prereqs.cmake
@@ -18,7 +18,7 @@ set (opm-polymer_DEPS
 	"ERT"
 	# OPM dependency
 	"opm-autodiff REQUIRED;
-	opm-common REQUIRED;
+	opm-common;
 	opm-core REQUIRED"
 	# Eigen
 	"Eigen3 3.1 REQUIRED"

--- a/cmake/Modules/opm-upscaling-prereqs.cmake
+++ b/cmake/Modules/opm-upscaling-prereqs.cmake
@@ -25,7 +25,7 @@ set (opm-upscaling_DEPS
 	dune-istl REQUIRED;
 	dune-geometry REQUIRED;
 	dune-grid REQUIRED;
-	opm-common REQUIRED;
+	opm-common;
 	opm-core REQUIRED;
 	dune-cornerpoint REQUIRED;
 	opm-porsol REQUIRED"

--- a/cmake/Modules/opm-verteq-prereqs.cmake
+++ b/cmake/Modules/opm-verteq-prereqs.cmake
@@ -15,6 +15,6 @@ set (opm-verteq_DEPS
 	"Boost 1.44.0
 		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
 	# OPM dependency
-	"opm-common REQUIRED;
+	"opm-common;
 	opm-core REQUIRED"
 	)


### PR DESCRIPTION
a module requires at least headers to be marked as found by the macros