### PR TITLE
FindParMETIS: when USE_MPI is OFF the FindParMETIS check should not called.

### DIFF
--- a/cmake/Modules/FindParMETIS.cmake
+++ b/cmake/Modules/FindParMETIS.cmake
@@ -20,6 +20,8 @@
 # find_package(ParMETIS)
 
 find_package(MPI)
+
+if(MPI_C_FOUND)
 macro(_search_parmetis_lib libvar libname doc)
   find_library(${libvar} ${libname}
     PATHS ${PARMETIS_ROOT} ${PARMETIS_ROOT}/lib PATH_SUFFIXES ${PATH_SUFFIXES}
@@ -89,3 +91,6 @@ if(PARMETIS_FOUND)
 endif(PARMETIS_FOUND)
 
 mark_as_advanced(PARMETIS_INCLUDE_DIRS PARMETIS_LIBRARIES HAVE_PARMETIS)
+else(MPI_C_FOUND)
+  message(WARNING "MPI not found ==> ParMETIS disabled! Plase make sure -DUSE_MPI=ON was set if you need ParMETIS.")
+endif(MPI_C_FOUND)


### PR DESCRIPTION
This PR fixes a problem that occurs (for my tool chain) if I don't explicitly use the -DUSE_MPI=ON. Then opm-core fails to build because of MPI not been included but maybe required by third party packages.