### PR TITLE
opm-common: avoid overwriting of OPM_MACROS_ROOT.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,10 @@ macro (dir_hook)
 endmacro (dir_hook)
 
 # We need to define this variable in the cmake config file.
-set(OPM_PROJECT_EXTRA_CODE  "set(OPM_MACROS_ROOT ${CMAKE_INSTALL_PREFIX}/share/opm)
-                             list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
+set(OPM_PROJECT_EXTRA_CODE  "if(NOT OPM_MACROS_ROOT)  
+                               set(OPM_MACROS_ROOT ${CMAKE_INSTALL_PREFIX}/share/opm)
+                               list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)
+                             endif(NOT OPM_MACROS_ROOT)")
 
 # project information is in dune.module. Read this file and set variables.
 # we cannot generate dune.module since it is read by dunecontrol before


### PR DESCRIPTION
This is rather a question then a fix. I cannot build OPM unless I remove the line `set(OPM_MACROS_ROOT ${CMAKE_INSTALL_PREFIX}/share/opm)` from the `CMakeLists.txt` line 12 in opm-common. This falsely sets the path where to search for opm build system macros  to
``` 
/usr/local/share/opm/cmake/Templates
``` 
which does not exist. This makes opm modules fail to build unless I remove the line mentioned. 

This PR fixes the problem for me, but might not be the correct way to do it. So I would appreciate if somebody with more knowledge in the build system could take a look at this.
 
I have to mention that the problem does not occur in opm-parser, but with all other modules.  