### PR TITLE
do not write the OPM_MACROS_ROOT variable into opm-common-install.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,6 @@ set(OPM_MACROS_ROOT ${PROJECT_SOURCE_DIR})
 macro (dir_hook)
 endmacro (dir_hook)
 
-# We need to define this variable in the installed cmake config file.
-set(OPM_PROJECT_EXTRA_CODE_INSTALLED  "set(OPM_MACROS_ROOT ${CMAKE_INSTALL_PREFIX}/share/opm)
-                                       list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
-
-set(OPM_PROJECT_EXTRA_CODE_INTREE  "set(OPM_MACROS_ROOT ${OPM_COMMON_ROOT})
-                                    list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
-
 # project information is in dune.module. Read this file and set variables.
 # we cannot generate dune.module since it is read by dunecontrol before
 # the build starts, so it makes sense to keep the data there then.


### PR DESCRIPTION
setting it to ${CMAKE_INSTALL_PREFIX}/share/opm breaks things hard if
there's no installed version of opm-common. (and caused me to bang my
head onto the desk for most of today.) On the other hand, setting it to
"${OPM_MACROS_ROOT}" would break things if there was _only_ an
installed version.

but behold, that variable should not be needed in the file, so the
writing excercise seems a bit pointless to me:
opm-common-install.cmake is itself featured by a directory in the
cmake search and if it can be included in the first place, so there's
not much point in redefining the CMAKE_MACROS_ROOT. (note that an
interesting effect of writing the variable can be that the OPM build
system finds opm-common-install.cmake before find_package(opm-common)
but not after it.)