### PR TITLE
Use full path to auto-detected sources

### DIFF
--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -210,12 +210,13 @@ macro(opm_add_test TestName)
   # explicitly specified.
   if (NOT CURTEST_SOURCES)
     set(CURTEST_SOURCES "")
+    set(_SDir "${CMAKE_PROJECT_SOURCE_DIR}")
     foreach(CURTEST_CANDIDATE "${CURTEST_EXE_NAME}.cpp"
                               "${CURTEST_EXE_NAME}.cc"
                               "tests/${CURTEST_EXE_NAME}.cpp"
                               "tests/${CURTEST_EXE_NAME}.cc")
-      if (EXISTS "${CURTEST_CANDIDATE}")
-        set(CURTEST_SOURCES "${CURTEST_CANDIDATE}")
+      if (EXISTS "${_SDir}/${CURTEST_CANDIDATE}")
+        set(CURTEST_SOURCES "${_SDir}/${CURTEST_CANDIDATE}")
       endif()
     endforeach()
   endif()


### PR DESCRIPTION
This is a work-around for an issue that presented when switching module opm-material's test framework to using the `opm_add_test` macro with automatically detected sources.  The macro would not find any
source files and subsequently end up effectively calling
```cmake
add_executable("${CURTEST_EXE_NAME}")
```
which promts CMake to respond with `incorrect number of parameters`.

There may be other, more fundamental, problems here, but this does at least restore the build of module opm-material on the Jenkins CI system.