### PR TITLE
Reference correct variable in source-file auto-detection

### DIFF
--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -210,7 +210,7 @@ macro(opm_add_test TestName)
   # explicitly specified.
   if (NOT CURTEST_SOURCES)
     set(CURTEST_SOURCES "")
-    set(_SDir "${CMAKE_PROJECT_SOURCE_DIR}")
+    set(_SDir "${PROJECT_SOURCE_DIR}")
     foreach(CURTEST_CANDIDATE "${CURTEST_EXE_NAME}.cpp"
                               "${CURTEST_EXE_NAME}.cc"
                               "tests/${CURTEST_EXE_NAME}.cpp"


### PR DESCRIPTION
Commit f638ee8 contained a last-minute, untested change that caused downstream build failures.  Reference the correct variable,
```cmake
PROJECT_SOURCE_DIR
```
in place of the non-existent `CMAKE_PROJECT_SOURCE_DIR`.

Pointy hat: Bard.Skaflestad@sintef.no