### PR TITLE
Move warning suppression header

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -44,3 +44,8 @@ list (APPEND EXAMPLE_SOURCE_FILES
 # installation
 list (APPEND PROGRAM_SOURCE_FILES
 	)
+
+
+list( APPEND PUBLIC_HEADER_FILES
+      opm/common/utility/platform_dependent/disable_warnings.h
+      opm/common/utility/platform_dependent/reenable_warnings.h )

--- a/cmake/Modules/Findopm-common.cmake
+++ b/cmake/Modules/Findopm-common.cmake
@@ -21,7 +21,7 @@ find_opm_package (
   "${opm-common_DEPS}"
 
   # header to search for
-  ""
+  "opm/common/utility/platform_dependent/disable_warnings.h"
 
   # library to search for
   ""
@@ -30,7 +30,11 @@ find_opm_package (
   ""
 
   # test program
-  ""
+  "#include <opm/common/utility/platform_dependent/disable_warnings.h>
+int main (void) {
+  return 0;  
+}
+"
 
   # config variables
   "${opm-common_CONFIG_VAR}"

--- a/opm/common/utility/platform_dependent/disable_warnings.h
+++ b/opm/common/utility/platform_dependent/disable_warnings.h
@@ -1,0 +1,78 @@
+/*
+  Copyright 2014 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Note: this file shall not have include guards or #pragma once.
+
+#ifdef SILENCE_EXTERNAL_WARNINGS
+
+// To use this feature, we must have sufficiently new compiler.
+
+// Using gcc is ok if version 4.6 or newer.
+#if defined(__GNUC__)
+#  define __GNUC_VERSION__ (__GNUC__ * 100 \
+                            + __GNUC_MINOR__ * 1)
+#  if (__GNUC_VERSION__ >= 406)
+#    define GNU_COMPILER_OK 1
+#  else
+#    define GNU_COMPILER_OK 0
+#  endif
+#else
+#  define GNU_COMPILER_OK 0
+#endif
+
+// Uncertain what version of clang to require,
+// assume all versions are fine.
+#if defined(__clang__)
+#  define CLANG_COMPILER_OK 1
+#else
+#  define CLANG_COMPILER_OK 0
+#endif
+
+// More compilers can be added here if necessary.
+#define COMPATIBLE_COMPILER (GNU_COMPILER_OK || CLANG_COMPILER_OK)
+
+// If compiler is compatible, push current warning level
+// and ignore warnings that are usually generated from
+// third-party libraries that are not warning-clean.
+// Note that both clang and (newer) gcc accept the
+// "#pragma GCC diagnostic" syntax.
+#if COMPATIBLE_COMPILER
+#pragma GCC diagnostic push
+// Suppress warnings: "unknown option after ‘#pragma GCC diagnostic’ kind [-Wpragmas]".
+// This is necessary because not all the compilers have the same warning options.
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wdeprecated-register"
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+#pragma GCC diagnostic ignored "-Wmismatched-tags"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunneeded-internal-declaration"
+#pragma GCC diagnostic ignored "-Wunused-private-field"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#pragma GCC diagnostic ignored "-Wcast-align"
+#endif // COMPATIBLE_COMPILER
+
+#endif // SILENCE_EXTERNAL_WARNINGS

--- a/opm/common/utility/platform_dependent/reenable_warnings.h
+++ b/opm/common/utility/platform_dependent/reenable_warnings.h
@@ -1,0 +1,57 @@
+/*
+  Copyright 2014 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Note: this file shall not have include guards or #pragma once.
+
+#ifdef SILENCE_EXTERNAL_WARNINGS
+
+// To use this feature, we must have sufficiently new compiler.
+
+// Using gcc is ok if version 4.6 or newer.
+#if defined(__GNUC__)
+#  define __GNUC_VERSION__ (__GNUC__ * 100 \
+                            + __GNUC_MINOR__ * 1)
+#  if (__GNUC_VERSION__ >= 406)
+#    define GNU_COMPILER_OK 1
+#  else
+#    define GNU_COMPILER_OK 0
+#  endif
+#else
+#  define GNU_COMPILER_OK 0
+#endif
+
+// Uncertain what version of clang to require,
+// assume all versions are fine.
+#if defined(__clang__)
+#  define CLANG_COMPILER_OK 1
+#else
+#  define CLANG_COMPILER_OK 0
+#endif
+
+// More compilers can be added here if necessary.
+#define COMPATIBLE_COMPILER (GNU_COMPILER_OK || CLANG_COMPILER_OK)
+
+// If compiler is compatible, pop current warning level.
+// Note that both clang and (newer) gcc accept the
+// "#pragma GCC diagnostic" syntax.
+#if COMPATIBLE_COMPILER
+#pragma GCC diagnostic pop
+#endif // COMPATIBLE_COMPILER
+
+#endif // SILENCE_EXTERNAL_WARNINGS


### PR DESCRIPTION
This PR will:

1. Add the warning disable/enable headers from opm-parser.
2. Updated the Findopm-common to actually search for the warning suppression header, so that Findopm-common can succeed. I guess `Findopm-common` will be updated again when a more interesting header is installed.

Currently the headers are also in opm-parser, but when/if this is merged I will create followup PR's in the other modules.
