### PR TITLE
opm-common is REQUIRED

### DIFF
--- a/cmake/Modules/dune-cornerpoint-prereqs.cmake
+++ b/cmake/Modules/dune-cornerpoint-prereqs.cmake
@@ -26,6 +26,7 @@ set (dune-cornerpoint_DEPS
 	dune-grid REQUIRED;
 	dune-geometry REQUIRED"
 	# OPM dependency
-	"opm-core REQUIRED"
+        "opm-common REQUIRED;
+        opm-core REQUIRED"
 	"ZOLTAN"
 	)

--- a/cmake/Modules/opm-autodiff-prereqs.cmake
+++ b/cmake/Modules/opm-autodiff-prereqs.cmake
@@ -19,7 +19,7 @@ set (opm-autodiff_DEPS
 	"dune-common REQUIRED;
 	dune-istl REQUIRED;
 	dune-cornerpoint;
-	opm-common;
+	opm-common REQUIRED;
 	opm-core REQUIRED"
 	# Eigen
 	"Eigen3 3.2.0"

--- a/cmake/Modules/opm-core-prereqs.cmake
+++ b/cmake/Modules/opm-core-prereqs.cmake
@@ -37,7 +37,7 @@ set (opm-core_DEPS
 	# DUNE dependency
 	"dune-common"
 	"dune-istl"
-	"opm-common"
+	"opm-common REQUIRED"
 	# Parser library for ECL-type simulation models
 	"opm-parser REQUIRED"
 	# the code which implements the material laws


### PR DESCRIPTION
After moving the headers to enable and disable external warnings to
opm-common, opm-common has become a required dependency for
dune-cornerpoint, opm-autodiff and opm-core.