### PR TITLE
adapt Finddune-alugrid.cmake to the "paramerge" branch of dune-alugrid

### DIFF
--- a/cmake/Modules/Finddune-alugrid.cmake
+++ b/cmake/Modules/Finddune-alugrid.cmake
@@ -29,13 +29,13 @@ find_opm_package (
   "dune/alugrid/grid.hh"
 
   # library to search for
-  "dunealugrid;alugrid_2d;alugrid_parallel;alugrid_serial"
+  "dunealugrid;alugrid_parallel;alugrid_serial"
 
   # defines to be added to compilations
   ""
 
   # test program
-"#include <dune/alugrid/2d/indexsets.hh>
+"#include <dune/alugrid/common/interfaces.hh>
 int main (void) {
    return 0;
 }


### PR DESCRIPTION
recently the `paramerge` branch has been made the new `master` version of dune-alugrid. this PR adapts the CMake module of the OPM build system to this change. Note that old versions of ALUGrid do not work with this anymore, but detecting whether a pre-merge or a post-merge version of dune-alugrid is installed would require a complete rewrite of Finddune-alugrid.cmake (as far as I can see). I'd appreciate if someone had a better solution.