### PR TITLE
Do not use REALPATH for OPM_DATA_ROOT.

### DIFF
--- a/cmake/Modules/Findopm-data.cmake
+++ b/cmake/Modules/Findopm-data.cmake
@@ -16,7 +16,7 @@ endif()
 
 if (EXISTS "${_opm_data_root}/norne/NORNE_ATW2013.DATA")
    set( HAVE_OPM_DATA True )
-   get_filename_component( OPM_DATA_ROOT ${_opm_data_root} REALPATH )
+   set( OPM_DATA_ROOT ${_opm_data_root} )
    message( "-- Setting OPM_DATA_ROOT: ${OPM_DATA_ROOT}")
 else()
    set( HAVE_OPM_DATA False )


### PR DESCRIPTION
This caused trouble when the PROJECT_SOURCE_DIR is a symlink. When 'b' is a symlink, 'a/b/../' is not the same as 'a', but that is exactly what REALPATH does. In this case, it means that the opm-data is found (at ../ relative to the symlink), but the path that is set does not point to it.

This resulted in opm-data-dependent tests being run that then failed since the path was wrong.

This is the first time I have successfully debugged a cmake problem (message() is my new friend), so bear with me if the solution is rough... In order to get a release out soon, I'd appreciate a quick review (and merge if ok) by @andlaus, @bska, @joakim-hove, @blattms, @akva2 or @dr-robertk.