### PR TITLE
Improve the UseVersion module.

### DIFF
--- a/cmake/Modules/UseVersion.cmake
+++ b/cmake/Modules/UseVersion.cmake
@@ -13,10 +13,17 @@
 # information as it gets tiresome to rebuild the project everytime one
 # makes changes to any of the unit tests.
 
+message("-- Writing version information to local header project-version.h")
+
 string (TOUPPER "${CMAKE_BUILD_TYPE}" cmake_build_type_upper_)
 if (cmake_build_type_upper_ MATCHES DEBUG)
   file (WRITE "${PROJECT_BINARY_DIR}/project-version.h"
-	"#define PROJECT_VERSION \"${${project}_LABEL} (debug)\"\n"
+        "#ifndef OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+        "#define OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+        "#define PROJECT_VERSION_NAME \"${${project}_LABEL}\"\n"
+        "#define PROJECT_VERSION_HASH \"debug\"\n"
+        "#define PROJECT_VERSION \"${${project}_LABEL} (debug)\"\n"
+        "#endif // OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
 	)
 else ()
   if (NOT GIT_FOUND)
@@ -29,8 +36,13 @@ else ()
   # above.
   if (NOT GIT_FOUND)
 	file (WRITE "${PROJECT_BINARY_DIR}/project-version.h"
-	  "#define PROJECT_VERSION \"${${project}_LABEL}\"\n"
-	  )
+              "#ifndef OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+              "#define OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+              "#define PROJECT_VERSION_NAME \"${${project}_LABEL}\"\n"
+              "#define PROJECT_VERSION_HASH \"unknown git version\"\n"
+              "#define PROJECT_VERSION \"${${project}_LABEL} (unknown git version)\"\n"
+              "#endif // OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+              )
   else ()
 	add_custom_target (update-version ALL
 	  COMMAND ${CMAKE_COMMAND}

--- a/cmake/Scripts/WriteVerSHA.cmake
+++ b/cmake/Scripts/WriteVerSHA.cmake
@@ -45,15 +45,17 @@ if (sha1)
   if (dirty OR staged)
 	set (sha1 "${sha1}*")
   endif ()
-
-  # make a formatted version that can be appended to the label
-  set (sha1 " (${sha1})")
 endif ()
 
 # write the content to a temporary file in a C compatible format
 file (WRITE "${PROJECT_BINARY_DIR}/project-version.tmp"
-  "#define PROJECT_VERSION \"${PROJECT_LABEL}${sha1}\"\n"
-  )
+      "#ifndef OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+      "#define OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+      "#define PROJECT_VERSION_NAME \"${PROJECT_LABEL}\"\n"
+      "#define PROJECT_VERSION_HASH \"${sha1}\"\n"
+      "#define PROJECT_VERSION \"${PROJECT_LABEL} (${sha1})\"\n"
+      "#endif // OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+      )
 
 # only commit this to source code if it actually changed. here
 # we use execute_process instead of exec_program to avoid having


### PR DESCRIPTION
The changes are (in the produced project-version.h headers):
 - Add new macros PROJECT_VERSION_NAME and PROJECT_VERSION_HASH in addition to the existing PROJECT_VERSION.
 - Add header include guards.

This will be included in the release (for rc2).