### PR TITLE
hack around CMake policy CMP00054

### DIFF
--- a/cmake/Modules/ConfigVars.cmake
+++ b/cmake/Modules/ConfigVars.cmake
@@ -27,11 +27,10 @@
 
 function (configure_vars obj syntax filename verb)
   # this is just to make the syntax look like the build-in commands
-  if (NOT ("${obj}" STREQUAL "FILE" AND
+  if (NOT ("X Y Z ${obj}" STREQUAL "X Y Z FILE" AND
 		(("${verb}" STREQUAL "WRITE") OR ("${verb}" STREQUAL "APPEND"))))
 	message (FATAL_ERROR "Syntax error in argument list")
-  endif (NOT ("${obj}" STREQUAL "FILE" AND
-	  (("${verb}" STREQUAL "WRITE") OR ("${verb}" STREQUAL "APPEND"))))
+  endif ()
   if (NOT (("${syntax}" STREQUAL "CXX") OR ("${syntax}" STREQUAL "CMAKE")))
 	message (FATAL_ERROR "Invalid target syntax \"${syntax}\"")
   endif (NOT (("${syntax}" STREQUAL "CXX") OR ("${syntax}" STREQUAL "CMAKE")))
@@ -67,14 +66,14 @@ function (configure_vars obj syntax filename verb)
 	
 	# if the name of a variable has the syntax of a comments, write it
 	# verbatim to the file; this can be used to create headings
-	if ("${_var}" MATCHES "^/[/*]")
+	if ("X Y Z ${_var}" MATCHES "^X Y Z /[/*]")
 	  if (NOT _prev_verbatim)
 		file (APPEND "${filename}" "\n")
 	  endif (NOT _prev_verbatim)
 	  file (APPEND "${filename}" "${_var}\n")
 	  set (_prev_verbatim TRUE)
 	  
-	else ("${_var}" MATCHES "^/[/*]")
+	else ()
 
 	  # write a CMake statements that warns if the value has changed
 	  if ("${syntax}" STREQUAL "CMAKE")
@@ -106,6 +105,6 @@ function (configure_vars obj syntax filename verb)
 		
 	  endif ((NOT DEFINED ${_var}) OR ("${${_var}}" STREQUAL ""))
 	  set (_prev_verbatim FALSE)
-	endif ("${_var}" MATCHES "^/[/*]")
+	endif ()
   endforeach(_var)
 endfunction (configure_vars obj syntax filename verb)


### PR DESCRIPTION
newer versions of cmake (mine is 3.2.2) complain about policy CMP00054:

```
CMake Warning (dev) at /home/and/src/opm-common/cmake/Modules/ConfigVars.cmake:30 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "FILE" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  /home/and/src/opm-common/cmake/Modules/OpmLibMain.cmake:173 (configure_vars)
  CMakeLists.txt:109 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

since I'm pretty sure that the old behaviour was not intended here,
fix this for older versions of cmake as well (by adding a prefix so that
CMake does not interpret "FILE" as a variable.)