### PR TITLE
Create library in opm-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ install_manifest.txt
 CTestTestfile.cmake
 DartConfiguration.tcl
 Testing/
+
+# Build directory in source.
+build/

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -20,23 +20,17 @@
 #	                      you should only add to this list if the *user* of
 #	                      the library needs it.
 
-# originally generated with the command:
-# find opm -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND MAIN_SOURCE_FILES
+      opm/common/data/DataContainer.cpp
 )
 
-# originally generated with the command:
-# find tests -name '*.cpp' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
 list (APPEND TEST_SOURCE_FILES
-	)
+      tests/test_DataContainer.cpp
+      )
 
-# originally generated with the command:
-# find tests -name '*.xml' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
 list (APPEND TEST_DATA_FILES
 	)
 
-# originally generated with the command:
-# find tutorials examples -name '*.c*' -printf '\t%p\n' | sort
 list (APPEND EXAMPLE_SOURCE_FILES
 	)
 
@@ -47,6 +41,7 @@ list (APPEND PROGRAM_SOURCE_FILES
 
 
 list( APPEND PUBLIC_HEADER_FILES
+      opm/common/data/DataContainer.hpp
       opm/common/ErrorMacros.hpp
       opm/common/Exceptions.hpp
       opm/common/utility/platform_dependent/disable_warnings.h

--- a/cmake/Modules/Findopm-common.cmake
+++ b/cmake/Modules/Findopm-common.cmake
@@ -24,7 +24,7 @@ find_opm_package (
   "opm/common/utility/platform_dependent/disable_warnings.h"
 
   # library to search for
-  ""
+  "opmcommon"
 
   # defines to be added to compilations
   ""

--- a/cmake/Modules/opm-common-prereqs.cmake
+++ b/cmake/Modules/opm-common-prereqs.cmake
@@ -12,5 +12,6 @@ set (opm-common_DEPS
 	# compile with C++0x/11 support if available
 	"CXX11Features REQUIRED"
 	# various runtime library enhancements
-	""
+	"Boost 1.44.0
+		COMPONENTS system unit_test_framework REQUIRED"
 	)

--- a/opm/common/data/DataContainer.cpp
+++ b/opm/common/data/DataContainer.cpp
@@ -1,0 +1,33 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <opm/common/data/DataContainer.hpp>
+
+namespace Opm {
+
+    DataContainer:: DataContainer(size_t num_cells, size_t num_faces , size_t num_phases) :
+        m_num_cells( num_cells),
+        m_num_faces( num_faces),
+        m_num_phases( num_phases )
+    {
+
+    }
+
+}

--- a/opm/common/data/DataContainer.hpp
+++ b/opm/common/data/DataContainer.hpp
@@ -1,0 +1,38 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DATA_CONTAINER_HPP
+#define DATA_CONTAINER_HPP
+
+#include <cstddef>
+
+namespace Opm {
+
+    class DataContainer {
+    public:
+        DataContainer(size_t num_cells, size_t num_faces , size_t num_phases);
+
+    private:
+        size_t m_num_cells;
+        size_t m_num_faces;
+        size_t m_num_phases;
+    };
+}
+
+#endif

--- a/tests/test_DataContainer.cpp
+++ b/tests/test_DataContainer.cpp
@@ -1,0 +1,33 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE DATA_CONTAINER_TESTS
+#include <boost/test/unit_test.hpp>
+
+
+#include <opm/common/data/DataContainer.hpp>
+
+using namespace Opm;
+
+
+BOOST_AUTO_TEST_CASE(TestCreate) {
+    DataContainer container(1000 , 10 , 2);
+}


### PR DESCRIPTION
The main purpose of this PR is to tickle the build system into creating a new library `libopmcommon`, and ensure that the full build chain still works.

The actual content - `class DataContainer` - is meant to be used as a base class for / replacment for the `class ReservoirState` in opm-core - but that is somewhat into the future. 