### PR TITLE
remove the dependency on boost::iostreams if it is not used

### DIFF
--- a/cmake/Modules/dune-cornerpoint-prereqs.cmake
+++ b/cmake/Modules/dune-cornerpoint-prereqs.cmake
@@ -20,7 +20,7 @@ set (dune-cornerpoint_DEPS
 	"CXX11Features"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
+		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED;
 	dune-grid REQUIRED;

--- a/cmake/Modules/opm-autodiff-prereqs.cmake
+++ b/cmake/Modules/opm-autodiff-prereqs.cmake
@@ -14,7 +14,7 @@ set (opm-autodiff_DEPS
 	"CXX11Features"
 	# Various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
+		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# DUNE prerequisites
 	"dune-common REQUIRED;
 	dune-istl REQUIRED;

--- a/cmake/Modules/opm-benchmarks-prereqs.cmake
+++ b/cmake/Modules/opm-benchmarks-prereqs.cmake
@@ -11,7 +11,7 @@ set (opm-benchmarks_DEPS
 	"CXX11Features REQUIRED"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
+		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# OPM dependency
 	"opm-common"
 	"opm-core REQUIRED"

--- a/cmake/Modules/opm-core-prereqs.cmake
+++ b/cmake/Modules/opm-core-prereqs.cmake
@@ -18,7 +18,7 @@ set (opm-core_DEPS
 	"CXX11Features REQUIRED"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
+		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# matrix library
 	"BLAS REQUIRED"
 	"LAPACK REQUIRED"

--- a/cmake/Modules/opm-polymer-prereqs.cmake
+++ b/cmake/Modules/opm-polymer-prereqs.cmake
@@ -13,7 +13,7 @@ set (opm-polymer_DEPS
 	"CXX11Features"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
+		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# Ensembles-based Reservoir Tools
 	"ERT"
 	# OPM dependency

--- a/cmake/Modules/opm-porsol-prereqs.cmake
+++ b/cmake/Modules/opm-porsol-prereqs.cmake
@@ -13,7 +13,7 @@ set (opm-porsol_DEPS
 	"CXX11Features"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
+		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED;
 	dune-istl REQUIRED;

--- a/cmake/Modules/opm-verteq-prereqs.cmake
+++ b/cmake/Modules/opm-verteq-prereqs.cmake
@@ -13,7 +13,7 @@ set (opm-verteq_DEPS
 	"CXX11Features"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
+		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# OPM dependency
 	"opm-common;
 	opm-core REQUIRED"


### PR DESCRIPTION
as far as I can see, it is not used in any module except opm-upscaling
and it caused the configure stage to fail if I tried to use with a
self-compiled boost 1.60 (which I have to do in order to use clang on
any modern linux distribution.)