### PR TITLE
Added non const cellData() access.

### DIFF
--- a/opm/common/data/SimulationDataContainer.cpp
+++ b/opm/common/data/SimulationDataContainer.cpp
@@ -184,6 +184,10 @@ namespace Opm {
         return m_cell_data;
     }
 
+    std::unordered_map<std::string, std::vector<double>>& SimulationDataContainer::cellData() {
+        return m_cell_data;
+    }
+
 
     /* This is very deprecated. */
     void SimulationDataContainer::addDefaultFields() {

--- a/opm/common/data/SimulationDataContainer.hpp
+++ b/opm/common/data/SimulationDataContainer.hpp
@@ -95,6 +95,7 @@ namespace Opm {
         const std::vector<double>& faceflux    () const;
 
         const std::unordered_map<std::string, std::vector<double>>& cellData() const;
+        std::unordered_map<std::string, std::vector<double>>& cellData();
     private:
         void  addDefaultFields();
 


### PR DESCRIPTION
Required - at least for now - for the `ParallellDebugOutput` implementation in opm-autodiff.