### PR TITLE
Make opm-core and opm-common a hard requirement.

### DIFF
--- a/cmake/Modules/opm-autodiff-prereqs.cmake
+++ b/cmake/Modules/opm-autodiff-prereqs.cmake
@@ -17,10 +17,11 @@ set (opm-autodiff_DEPS
 		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# DUNE prerequisites
 	"dune-common REQUIRED;
-	dune-istl REQUIRED;
-	dune-cornerpoint;
-	opm-common REQUIRED;
-	opm-core REQUIRED"
+	dune-istl REQUIRED"
+	# OPM dependency
+	"opm-common REQUIRED;
+	opm-core REQUIRED;
+	dune-cornerpoint"
 	# Eigen
 	"Eigen3 3.2.0"
 	)


### PR DESCRIPTION
Previously, cmake succeeded even if opm-core or opm-common was not found.
The cause for this was that dune-cornerpoint was searched for first. As
it was not required it seems like opm-common and opm-core were treated as
optional, too.

This commit moves the opm modules to the opm section of the variable and
changes the order of the modules such that modules listed first do not
depend on modules listed afterwards. Now cmake fails if it cannot finy any
of the required modules.