### PR TITLE
opm-autodiff requires opm-output

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -23,8 +23,8 @@ find_opm_package (
   # header to search for
   "opm/output/Output.hpp"
 
-  # library to search for
-  # "opmoutput"
+  # library to search for  
+  ""
 
   # defines to be added to compilations
   ""

--- a/cmake/Modules/opm-autodiff-prereqs.cmake
+++ b/cmake/Modules/opm-autodiff-prereqs.cmake
@@ -21,6 +21,7 @@ set (opm-autodiff_DEPS
 	# OPM dependency
 	"opm-common REQUIRED;
 	opm-core REQUIRED;
+	opm-output REQUIRED;
 	dune-cornerpoint"
 	# Eigen
 	"Eigen3 3.2.0"


### PR DESCRIPTION
[ Hold on merging ]

With this PR opm-autodiff will depend on opm-output.