### PR TITLE
Move OutputWriter to opm-output

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -21,16 +21,16 @@ find_opm_package (
   "${opm-output_DEPS}"
   
   # header to search for
-  "opm/output/Output.hpp"
+  "opm/output/OutputWriter.hpp"
 
   # library to search for
-  # "opmoutput"
+  "opmoutput"
 
   # defines to be added to compilations
   ""
 
   # test program
-"#include <opm/output/Output.hpp>
+"#include <opm/output/OutputWriter.hpp>
 int main (void) {
   return 0;  
 }

--- a/cmake/Modules/opm-output-prereqs.cmake
+++ b/cmake/Modules/opm-output-prereqs.cmake
@@ -21,4 +21,6 @@ set (opm-output_DEPS
 	"opm-common REQUIRED"
 	# Parser library for ECL-type simulation models
 	"opm-parser REQUIRED"
+	# TODO remove this dependancy
+	"opm-core REQUIRED";
 	)


### PR DESCRIPTION
Currently opm-output will depend on opm-core when pushed out. This dependancy may be removed later. Should it?

The changes here will only be relevant for opm-output so it should be a safe PR