### PR TITLE
Mark opm-common as required.

### DIFF
--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -17,7 +17,7 @@ set (opm-material_DEPS
 	"CXX11Features REQUIRED"
 	# prerequisite OPM modules
 	"opm-parser"
-	"opm-common"
+	"opm-common REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED"
 	)


### PR DESCRIPTION
This PR will mark the `opm-common` module as required in the `opm-materiaø-prereqs.cmake` file. The ordering of `opm-common`  and `opm-parser` seems weird - but this seems to be what it takes!?

See: https://github.com/OPM/opm-common/pull/90