### PR TITLE
Add global target property: POSITION_INDEPENDENT_CODE

### DIFF
--- a/cmake/Modules/OpmCompile.cmake
+++ b/cmake/Modules/OpmCompile.cmake
@@ -27,7 +27,8 @@ macro (opm_compile opm)
 	  SOVERSION ${${opm}_VERSION_MAJOR}
 	  VERSION ${${opm}_VERSION}
 	  LINK_FLAGS "${${opm}_LINKER_FLAGS_STR}"
-	  )
+          POSITION_INDEPENDENT_CODE TRUE 
+          )
 	target_link_libraries (${${opm}_TARGET} ${${opm}_LIBRARIES})
 
         if (STRIP_DEBUGGING_SYMBOLS)


### PR DESCRIPTION
The purpose of this PR is to facilitate mixing of shared and static libraries; in particular this enables a static build of opm-common (the default) and a shared build of opm-parser (required for Python bindings).

This is mainly meant as a "glorified issue" - and not a ready to merge PR. Specifcally:

1. I don't know - maybe it is considered very bad form to mix static and shared libraries in this way?
2. Setting the flag globally from `OpmLibMain.cmake` is obviously not very clean - but I really had no clue of what was the Right&trade; location to set it?