### PR TITLE
Added travis/build-opm-common-shared.sh

### DIFF
--- a/travis/build-opm-common-shared.sh
+++ b/travis/build-opm-common-shared.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+pushd . > /dev/null
+cd opm-common
+mkdir build
+cd build
+cmake ../ -DBUILD_SHARED_LIBS=ON
+make
+popd > /dev/null


### PR DESCRIPTION
Added a travis build script to build a shared libopmcommon.

The underlying purpose of this is the same as for: #93. 