### PR TITLE
opm-material-prereqs.cmake: fix the ordering of the dependencies

### DIFF
--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -11,13 +11,11 @@ set (opm-material_CONFIG_VAR
 
 # dependencies
 set (opm-material_DEPS
-	# compile with C99 support if available
-	"C99"
-	# compile with C++0x/11 support if available
+	# compile with C++-2011 support
 	"CXX11Features REQUIRED"
-	# prerequisite OPM modules
-	"opm-parser"
-	"opm-common REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED"
+	# prerequisite OPM modules
+	"opm-common REQUIRED"
+	"opm-parser"
 	)


### PR DESCRIPTION
packages marked REQUIRED must currently preceed optional ones. Also
C99 is not required by opm-material because that module only consists
of c++ code.

this is basically a follow-up of #92.