### PR TITLE
Make opm-output REQUIRED for opm-upscaling.

### DIFF
--- a/cmake/Modules/opm-output-prereqs.cmake
+++ b/cmake/Modules/opm-output-prereqs.cmake
@@ -22,5 +22,5 @@ set (opm-output_DEPS
 	# Parser library for ECL-type simulation models
 	"opm-parser REQUIRED"
 	# TODO remove this dependancy
-	"opm-core REQUIRED";
+	"opm-core REQUIRED"
 	)

--- a/cmake/Modules/opm-upscaling-prereqs.cmake
+++ b/cmake/Modules/opm-upscaling-prereqs.cmake
@@ -27,5 +27,6 @@ set (opm-upscaling_DEPS
 	dune-grid REQUIRED;
 	opm-common REQUIRED;
 	opm-core REQUIRED;
+        opm-output REQUIRED;
 	dune-cornerpoint REQUIRED"
 	)

--- a/cmake/Modules/opm-upscaling-prereqs.cmake
+++ b/cmake/Modules/opm-upscaling-prereqs.cmake
@@ -27,6 +27,6 @@ set (opm-upscaling_DEPS
 	dune-grid REQUIRED;
 	opm-common REQUIRED;
 	opm-core REQUIRED;
-        opm-output REQUIRED;
-	dune-cornerpoint REQUIRED"
+        dune-cornerpoint REQUIRED;
+	opm-output REQUIRED"
 	)


### PR DESCRIPTION
Needed since CornerpointChopper and EclipseGridInspector is now in opm-output.