### PR TITLE
Revert "opm-material-prereqs.cmake: fix the ordering of the dependencies"

### DIFF
--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -11,11 +11,13 @@ set (opm-material_CONFIG_VAR
 
 # dependencies
 set (opm-material_DEPS
-	# compile with C++-2011 support
+	# compile with C99 support if available
+	"C99"
+	# compile with C++0x/11 support if available
 	"CXX11Features REQUIRED"
+	# prerequisite OPM modules
+	"opm-parser"
+	"opm-common REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED"
-	# prerequisite OPM modules
-	"opm-common REQUIRED"
-	"opm-parser"
 	)


### PR DESCRIPTION
Reverts OPM/opm-common#98

@andlaus this was necessary because of OPM/opm-core#985. Please resubmit if problem can be fixed.