### PR TITLE
Jenkins reboot

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,11 @@
+# opm-common jenkins build scripts:
+
+**build-opm-module.sh**:
+This is a helper script which contains functions for building,
+testing and cloning modules.
+
+**build.sh**:
+This expects to run on a jenkins instance with opm-common as the 'origin' remote.
+
+It will build and test opm-common. It can be used both for post-merge builds
+of the master branch and for a github pull request builder job.

--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# $1 = Additional cmake parameters
+# $2 = 0 to build and install module, 1 to build and test module
+# $3 = Source root of module to build
+function build_module {
+  cmake $3 -DCMAKE_BUILD_TYPE=Release $1
+  test $? -eq 0 || exit 1
+  if test $2 -eq 1
+  then
+    make test-suite
+    test $? -eq 0 || exit 2
+    ctest -T Test --no-compress-output
+    $WORKSPACE/deps/opm-common/jenkins/convert.py -x $WORKSPACE/deps/opm-common/jenkins/conv.xsl -t . > testoutput.xml
+  else
+    make install
+  fi
+}
+
+# $1 = Name of module
+# $2 = git-rev to use for module
+function clone_module {
+  pushd .
+  mkdir -p $WORKSPACE/deps/$1
+  cd $WORKSPACE/deps/$1
+  git init .
+  git remote add origin https://github.com/OPM/$1
+  git fetch origin $2:branch_to_build
+  git checkout branch_to_build
+  test $? - eq 0 || exit 1
+  popd
+}
+
+# $1 = Module to clone
+# $2 = Additional cmake parameters
+# $3 = git-rev to use for module
+# $4 = Build root
+function clone_and_build_module {
+  clone_module $1 $3
+  pushd .
+  mkdir $4/build-$1
+  cd $4/build-$1
+  build_module $2 0 $WORKSPACE/deps/$1
+  test $? -eq 0 || exit 1
+  popd
+}

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source `dirname $0`/build-opm-module.sh
+
+# Create symlink so build_module can find the test result converter
+mkdir deps
+ln -sf $WORKSPACE deps/opm-common
+
+# Build without MPI
+pushd .
+mkdir -p serial/build-opm-common
+cd serial/build-opm-common
+build_module "-DUSE_MPI=0" 1 $WORKSPACE
+test $? -eq 0 || exit 1
+popd
+
+cp serial/build-opm-common/testoutput.xml .

--- a/jenkins/conv.xsl
+++ b/jenkins/conv.xsl
@@ -1,0 +1,116 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:output method="xml" indent="yes"/>
+
+<xsl:template match="/Site">
+		<testsuite>
+			<xsl:variable name="BuildName"><xsl:value-of select="@BuildName"/></xsl:variable>
+			<xsl:variable name="BuildStamp"><xsl:value-of select="@BuildStamp"/></xsl:variable>
+			<xsl:variable name="Name"><xsl:value-of select="@Name"/></xsl:variable>
+			<xsl:variable name="Generator"><xsl:value-of select="@Generator"/></xsl:variable>
+			<xsl:variable name="CompilerName"><xsl:value-of select="@CompilerName"/></xsl:variable>
+			<xsl:variable name="OSName"><xsl:value-of select="@OSName"/></xsl:variable>
+			<xsl:variable name="Hostname"><xsl:value-of select="@Hostname"/></xsl:variable>
+			<xsl:variable name="OSRelease"><xsl:value-of select="@OSRelease"/></xsl:variable>
+			<xsl:variable name="OSVersion"><xsl:value-of select="@OSVersion"/></xsl:variable>
+			<xsl:variable name="OSPlatform"><xsl:value-of select="@OSPlatform"/></xsl:variable>
+			<xsl:variable name="Is64Bits"><xsl:value-of select="@Is64Bits"/></xsl:variable>
+			<xsl:variable name="VendorString"><xsl:value-of select="@VendorString"/></xsl:variable>
+			<xsl:variable name="VendorID"><xsl:value-of select="@VendorID"/></xsl:variable>
+			<xsl:variable name="FamilyID"><xsl:value-of select="@FamilyID"/></xsl:variable>
+			<xsl:variable name="ModelID"><xsl:value-of select="@ModelID"/></xsl:variable>
+			<xsl:variable name="ProcessorCacheSize"><xsl:value-of select="@ProcessorCacheSize"/></xsl:variable>
+			<xsl:variable name="NumberOfLogicalCPU"><xsl:value-of select="@NumberOfLogicalCPU"/></xsl:variable>
+			<xsl:variable name="NumberOfPhysicalCPU"><xsl:value-of select="@NumberOfPhysicalCPU"/></xsl:variable>
+			<xsl:variable name="TotalVirtualMemory"><xsl:value-of select="@TotalVirtualMemory"/></xsl:variable>
+			<xsl:variable name="TotalPhysicalMemory"><xsl:value-of select="@TotalPhysicalMemory"/></xsl:variable>
+			<xsl:variable name="LogicalProcessorsPerPhysical"><xsl:value-of select="@LogicalProcessorsPerPhysical"/></xsl:variable>
+			<xsl:variable name="ProcessorClockFrequency"><xsl:value-of select="@ProcessorClockFrequency"/></xsl:variable>
+			<properties>
+				<property name="BuildName" value="{$BuildName}" />
+				<property name="BuildStamp" value="{$BuildStamp}" />
+				<property name="Name" value="{$Name}" />
+				<property name="Generator" value="{$Generator}" />
+				<property name="CompilerName" value="{$CompilerName}" />
+				<property name="OSName" value="{$OSName}" />
+				<property name="Hostname" value="{$Hostname}" />
+				<property name="OSRelease" value="{$OSRelease}" />
+				<property name="OSVersion" value="{$OSVersion}" />
+				<property name="OSPlatform" value="{$OSPlatform}" />
+				<property name="Is64Bits" value="{$Is64Bits}" />
+				<property name="VendorString" value="{$VendorString}" />
+				<property name="VendorID" value="{$VendorID}" />
+				<property name="FamilyID" value="{$FamilyID}" />
+				<property name="ModelID" value="{$ModelID}" />
+				<property name="ProcessorCacheSize" value="{$ProcessorCacheSize}" />
+				<property name="NumberOfLogicalCPU" value="{$NumberOfLogicalCPU}" />
+				<property name="NumberOfPhysicalCPU" value="{$NumberOfPhysicalCPU}" />
+				<property name="TotalVirtualMemory" value="{$TotalVirtualMemory}" />
+				<property name="TotalPhysicalMemory" value="{$TotalPhysicalMemory}" />
+				<property name="LogicalProcessorsPerPhysical" value="{$LogicalProcessorsPerPhysical}" />
+				<property name="ProcessorClockFrequency" value="{$ProcessorClockFrequency}" />
+			</properties>
+			<xsl:apply-templates select="Testing/Test"/>
+			
+			<system-out>
+				BuildName: <xsl:value-of select="$BuildName" />
+				BuildStamp: <xsl:value-of select="$BuildStamp" />
+				Name: <xsl:value-of select="$Name" />
+				Generator: <xsl:value-of select="$Generator" />
+				CompilerName: <xsl:value-of select="$CompilerName" />
+				OSName: <xsl:value-of select="$OSName" />
+				Hostname: <xsl:value-of select="$Hostname" />
+				OSRelease: <xsl:value-of select="$OSRelease" />
+				OSVersion: <xsl:value-of select="$OSVersion" />
+				OSPlatform: <xsl:value-of select="$OSPlatform" />
+				Is64Bits: <xsl:value-of select="$Is64Bits" />
+				VendorString: <xsl:value-of select="$VendorString" />
+				VendorID: <xsl:value-of select="$VendorID" />
+				FamilyID: <xsl:value-of select="$FamilyID" />
+				ModelID: <xsl:value-of select="$ModelID" />
+				ProcessorCacheSize: <xsl:value-of select="$ProcessorCacheSize" />
+				NumberOfLogicalCPU: <xsl:value-of select="$NumberOfLogicalCPU" />
+				NumberOfPhysicalCPU: <xsl:value-of select="$NumberOfPhysicalCPU" />
+				TotalVirtualMemory: <xsl:value-of select="$TotalVirtualMemory" />
+				TotalPhysicalMemory: <xsl:value-of select="$TotalPhysicalMemory" />
+				LogicalProcessorsPerPhysical: <xsl:value-of select="$LogicalProcessorsPerPhysical" />
+				ProcessorClockFrequency: <xsl:value-of select="$ProcessorClockFrequency" />
+			</system-out>
+		</testsuite>
+	</xsl:template>
+
+    <xsl:template match="Testing/Test">
+        <xsl:variable name="testcasename"><xsl:value-of select= "Name"/></xsl:variable>
+		<xsl:variable name="exectime">
+			<xsl:for-each select="Results/NamedMeasurement">
+				<xsl:if test="@name = 'Execution Time'">
+					<xsl:value-of select="."/>
+				</xsl:if>
+			</xsl:for-each>
+		</xsl:variable>
+		
+			<testcase name="{$testcasename}" classname="TestSuite" time="{$exectime}">
+            <xsl:if test="@Status = 'passed'">
+            </xsl:if>
+            <xsl:if test="@Status = 'failed'">
+				<xsl:variable name="failtype">
+					<xsl:for-each select="Results/NamedMeasurement">
+						<xsl:if test="@name = 'Exit Code'">
+							<xsl:value-of select="."/>
+						</xsl:if>
+					</xsl:for-each>
+				</xsl:variable>
+				<xsl:variable name="failcode">
+					<xsl:for-each select="Results/NamedMeasurement">
+						<xsl:if test="@name = 'Exit Value'">
+							<xsl:value-of select="."/>
+						</xsl:if>
+					</xsl:for-each>
+				</xsl:variable>
+                <error message="{$failtype} ({$failcode})"><xsl:value-of select="Results/Measurement/Value/text()" /></error>
+            </xsl:if>
+            <xsl:if test="@Status = 'notrun'">
+                <skipped><xsl:value-of select="Results/Measurement/Value/text()" /></skipped>
+            </xsl:if>
+        </testcase>
+      </xsl:template>
+</xsl:stylesheet>

--- a/jenkins/convert.py
+++ b/jenkins/convert.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# coding: utf-8
+# originally from:
+#  http://www.warp1337.com/content/how-use-ctest-jenkins-xunit-or-junit-plugin
+# improved by:
+#  Jorge Araya Navarro <elcorreo@deshackra.com>
+
+#                         Veni, Sancte Spiritus.
+
+from lxml import etree
+import argparse
+from os.path import expanduser
+from os.path import join
+import logging
+
+# configure logging
+logging.basicConfig(format="%(levelname)s: %(message)s",
+                    level=logging.ERROR)
+
+desc = ("Converts ctest XML file to xUnit/JUnit XML "
+        "compatible file to use with Jenkins-CI. "
+        "Did you found any bug? please report it on: "
+        "https://bitbucket.org/shackra/ctest-jenkins/issues")
+
+# configure argument parser.
+parser = argparse.ArgumentParser(description=desc)
+parser.add_argument("-x", "--xslt", help="the XSLT file to use", required=True)
+parser.add_argument("-t", "--tag", help=("the directory where 'Testing/TAG'"
+                                         "file is. Remember to call ctest with"
+                                         " '-T test' option to generate it"),
+                    required=True)
+
+parsed = parser.parse_args()
+# expanding user symbol "~"
+parsed.xsl = expanduser(parsed.xslt)
+parsed.tag = expanduser(parsed.tag)
+
+# opening the TAG file
+directory = None
+try:
+    with open(join(parsed.tag, "Testing", "TAG")) as tagfile:
+        directory = tagfile.readline().strip()
+
+except NotADirectoryError:
+    logging.error(
+        "'Testing/TAG' wasn't found on directory '{}'.".format(parsed.tag))
+    exit(1)
+except FileNotFoundError:
+    logging.error(
+        "File '{}' not found.".format(join(parsed.tag, "Testing", "TAG")))
+    exit(1)
+
+xmldoc = None
+transform = None
+try:
+    with open(join(parsed.tag, "Testing", directory, "Test.xml"))\
+            as testxmlfile:
+        xmldoc = etree.parse(testxmlfile)
+
+except FileNotFoundError:
+    logging.error("File {} not found. Was it deleted or moved?".format(
+        join(parsed.tag, "Testing", directory, "Test.xml")))
+    exit(1)
+
+try:
+    with open(parsed.xslt) as xsltfile:
+        xslt_root = etree.XML(xsltfile.read())
+        transform = etree.XSLT(xslt_root)
+except FileNotFoundError:
+    logging.error("File {} not found.".format(parsed.xslt))
+    exit(1)
+
+result_tree = transform(xmldoc)
+print(result_tree)


### PR DESCRIPTION
Hi,

I have been tasked with getting opm-output integrated in the Jenkins builds. The current Jenkins system has been annoying me to bits for a long time. Since I was going to work on it anyways, I decided to do a complete reboot.

The current Jenkins builds are fundamentally broken because they rely on global installations of the different modules. This by itself would not be a problem as such, however there is no upstream dependency tracking for build jobs, and jobs are spawned in parallel. This leads to all kinds of race conditions when multiple modules are updated in tandem. Which results in SPAM for whomever obtains the emails on build failures.

The only proper way to do it, is to build dedicated copies of dependencies as part of the build jobs, instead of using shared copies between the jobs. This way, the only requirement with companion PRs is that they are merged in dependency order.

A second problem I wanted to address is that post-merge builds are all nice and dandy, but they do not help stop build breakage in the first place. While Travis does serve to alleviate this somewhat, there's still a fundamental problem; it does not help when a pull request have companion PRs in upstream modules.

I have also addressed this through the use of the github pull request builder, in combination with my own scripting. This part is not visible here (I will open a downstream PR in opm-parser to show this off).

The third issue was that the current Jenkins build jobs do no actually upload test results to Jenkins.

A fourth issue I have prepared for adressing, but not currently implemented, is the ability to run both serial and parallel (MPI) tests on the jenkins jobs.

A fifth issue I have not adressed is that API changes in an upstream can break downstream modules. It's not fundamentally hard to solve as such, but I chose to omit this to limit the scope of the work a little. 

The files include in the PR serve the following tasks:
- README.md - simple instructions for how to use/setup Jenkins.
- build-opm-module.sh - Contains helper functions used for achieving the things described above. The way this is factored might not make sense in this context, but it is necessary to implement functionality in the downstreams with minimal code duplication (sadly, some duplication is unavoidable).
- convert.py, conv.xsl - This is a helper script to convert from ctest format to jUnit format. jUnit is the only format supported for test result uploads on Jenkins.