### PR TITLE
add a jenkins script for setting up opm-data

### DIFF
--- a/jenkins/setup-opm-data.sh
+++ b/jenkins/setup-opm-data.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Predefined by environment
+if test -z "$OPM_DATA_ROOT"
+then
+  OPM_DATA_REVISION="master"
+  if grep -q "opm-data=" <<< $ghprbCommentBody
+  then
+    OPM_DATA_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-data=([0-9]+).*/\1/g'`/merge
+  fi
+  # Not specified in trigger, use shared copy
+  if [[ "$OPM_DATA_REVISION" = "master" ]] && [[ ! "$OPM_DATA_ROOT_PREDEFINED" = "" ]]
+  then
+    if ! test -d $WORKSPACE/deps/opm-data
+    then
+      cp $OPM_DATA_ROOT_PREDEFINED $WORKSPACE/deps/opm-data -R
+    fi
+  else
+    # Specified in trigger, download it
+    source $WORKSPACE/deps/opm-common/jenkins/build-opm-module.sh
+    clone_module opm-data $OPM_DATA_REVISION
+  fi
+else
+  if ! test -d $WORKSPACE/deps/opm-data
+  then
+    cp $OPM_DATA_ROOT $WORKSPACE/deps/opm-data -R
+  fi
+fi
+OPM_DATA_ROOT=$WORKSPACE/deps/opm-data


### PR DESCRIPTION
there are two modes:
- user supplies OPM_DATA_ROOT directly. in this case, the supplied
  directory is copied into the workspace and used.
- user supplies OPM_DATA_ROOT_PREDEFINED. in this case, the
  supplied path copied into the workspace unless a specific
  PR is defined in the trigger comment.

is the commit message up to your standards now @bska ?