### PR TITLE
refine FindQuadmath.cmake

### DIFF
--- a/cmake/Modules/FindQuadmath.cmake
+++ b/cmake/Modules/FindQuadmath.cmake
@@ -11,24 +11,34 @@ include(CheckCXXSourceCompiles)
 include(CMakePushCheckState)
 include(CheckCXXCompilerFlag)
 
-check_cxx_compiler_flag("-Werror -fext-numeric-literals" HAVE_EXTENDED_NUMERIC_LITERALS)
-if (HAVE_EXTENDED_NUMERIC_LITERALS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fext-numeric-literals")
-endif()
+if(NOT DEFINED USE_QUADMATH OR USE_QUADMATH)
+  if(NOT DEFINED HAVE_EXTENDED_NUMERIC_LITERALS)
+    check_cxx_compiler_flag("-Werror -fext-numeric-literals" HAVE_EXTENDED_NUMERIC_LITERALS)
+  endif()
 
-cmake_push_check_state()
-list(APPEND CMAKE_REQUIRED_LIBRARIES "quadmath")
-CHECK_CXX_SOURCE_COMPILES("
+  if (HAVE_EXTENDED_NUMERIC_LITERALS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fext-numeric-literals")
+  endif()
+
+  cmake_push_check_state(RESET)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "quadmath")
+  CHECK_CXX_SOURCE_COMPILES("
 #include <quadmath.h>
 
 int main(void){
     __float128 foo = sqrtq(123.456);
     foo = FLT128_MIN;
-}" HAVE_QUAD)
-cmake_pop_check_state()
+}" QUADMATH_FOUND)
+  cmake_pop_check_state()
 
-if (HAVE_QUAD)
-  set(QUADMATH_LIBRARIES "quadmath")
+  if (QUADMATH_FOUND)
+    set(QUADMATH_LIBRARIES "quadmath")
+    set(HAVE_QUAD "${QUADMATH_FOUND}")
+  endif()
+endif()
+
+if (USE_QUADMATH AND NOT QUADMATH_FOUND)
+  message(FATAL_ERROR "Quadruple precision math support was explicitly requested but is unavailable!")
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
with this, it is now possible to disable quadruple precision math detection without hacks. (by setting USE_QUADMATH to ON or OFF)

(sometimes quadruple precision math is unwanted even though the compiler supports it.)