### PR TITLE
Refine logging output

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -59,6 +59,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/OpmLog/LogBackend.hpp
       opm/common/OpmLog/Logger.hpp
       opm/common/OpmLog/LogUtil.hpp
+      opm/common/OpmLog/MessageFormatter.hpp
       opm/common/OpmLog/OpmLog.hpp
       opm/common/OpmLog/StreamLog.hpp
       opm/common/OpmLog/TimerLog.hpp

--- a/opm/common/OpmLog/LogBackend.cpp
+++ b/opm/common/OpmLog/LogBackend.cpp
@@ -27,6 +27,9 @@ namespace Opm {
     {
     }
 
+    LogBackend::~LogBackend()
+    {
+    }
 
     bool LogBackend::includeMessage(int64_t messageFlag) {
         if (((messageFlag & m_mask) == messageFlag) &&

--- a/opm/common/OpmLog/LogBackend.cpp
+++ b/opm/common/OpmLog/LogBackend.cpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <cstdint>
 #include <opm/common/OpmLog/LogBackend.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
 
 namespace Opm {
 
@@ -31,16 +31,32 @@ namespace Opm {
     {
     }
 
-    bool LogBackend::includeMessage(int64_t messageFlag) {
-        if (((messageFlag & m_mask) == messageFlag) &&
-            (messageFlag > 0))
-            return true;
-        else
-            return false;
+    void LogBackend::configureDecoration(bool use_prefix, bool use_color_coding)
+    {
+        use_prefix_ = use_prefix;
+        use_color_coding_ = use_color_coding;
     }
 
-    int64_t LogBackend::getMask() const {
+    int64_t LogBackend::getMask() const
+    {
         return m_mask;
+    }
+
+    bool LogBackend::includeMessage(int64_t messageFlag)
+    {
+        return ((messageFlag & m_mask) == messageFlag) && (messageFlag > 0);
+    }
+
+    std::string LogBackend::decorateMessage(int64_t messageFlag, const std::string& message)
+    {
+        std::string msg = message;
+        if (use_prefix_) {
+            msg = Log::prefixMessage(messageFlag, msg);
+        }
+        if (use_color_coding_) {
+            msg = Log::colorCodeMessage(messageFlag, msg);
+        }
+        return msg;
     }
 
 

--- a/opm/common/OpmLog/LogBackend.cpp
+++ b/opm/common/OpmLog/LogBackend.cpp
@@ -31,10 +31,9 @@ namespace Opm {
     {
     }
 
-    void LogBackend::configureDecoration(bool use_prefix, bool use_color_coding)
+    void LogBackend::configureDecoration(std::shared_ptr<MessageFormatterInterface> formatter)
     {
-        use_prefix_ = use_prefix;
-        use_color_coding_ = use_color_coding;
+        formatter_ = formatter;
     }
 
     int64_t LogBackend::getMask() const
@@ -49,14 +48,11 @@ namespace Opm {
 
     std::string LogBackend::decorateMessage(int64_t messageFlag, const std::string& message)
     {
-        std::string msg = message;
-        if (use_prefix_) {
-            msg = Log::prefixMessage(messageFlag, msg);
+        if (formatter_) {
+            return formatter_->format(messageFlag, message);
+        } else {
+            return message;
         }
-        if (use_color_coding_) {
-            msg = Log::colorCodeMessage(messageFlag, msg);
-        }
-        return msg;
     }
 
 

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -37,6 +37,9 @@ namespace Opm
         /// Virtual destructor to enable inheritance.
         virtual ~LogBackend();
 
+        /// Configure how decorateMessage() will modify message strings.
+        void configureDecoration(bool use_prefix, bool use_color_coding);
+
         /// Add a message to the backend.
         ///
         /// Typically a subclass may filter, change, and output
@@ -49,10 +52,15 @@ namespace Opm
 
     protected:
         /// Return true if all bits of messageFlag are also set in our mask.
-        bool    includeMessage(int64_t messageFlag);
+        bool includeMessage(int64_t messageFlag);
+
+        /// Return decorated version of message depending on configureDecoration() arguments.
+        std::string decorateMessage(int64_t messageFlag, const std::string& message);
 
     private:
         int64_t m_mask;
+        bool use_prefix_ = false;
+        bool use_color_coding_ = false;
     };
 
 } // namespace LogBackend

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -21,8 +21,10 @@
 #ifndef OPM_LOGBACKEND_HPP
 #define OPM_LOGBACKEND_HPP
 
+#include <opm/common/OpmLog/MessageFormatter.hpp>
 #include <cstdint>
 #include <string>
+#include <memory>
 
 namespace Opm
 {
@@ -38,7 +40,7 @@ namespace Opm
         virtual ~LogBackend();
 
         /// Configure how decorateMessage() will modify message strings.
-        void configureDecoration(bool use_prefix, bool use_color_coding);
+        void configureDecoration(std::shared_ptr<MessageFormatterInterface> formatter);
 
         /// Add a message to the backend.
         ///
@@ -59,8 +61,7 @@ namespace Opm
 
     private:
         int64_t m_mask;
-        bool use_prefix_ = false;
-        bool use_color_coding_ = false;
+        std::shared_ptr<MessageFormatterInterface> formatter_;
     };
 
 } // namespace LogBackend

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -24,22 +24,38 @@
 #include <cstdint>
 #include <string>
 
-namespace Opm {
+namespace Opm
+{
 
-class LogBackend {
+    /// Abstract interface class for log backends.
+    class LogBackend
+    {
+    public:
+        /// Construct with given message mask.
+        explicit LogBackend(int64_t mask);
 
-public:
-    LogBackend( int64_t mask );
-    virtual ~LogBackend() { };
-    virtual void addMessage(int64_t , const std::string& ) { };
+        /// Virtual destructor to enable inheritance.
+        virtual ~LogBackend();
 
-    int64_t getMask() const;
-    bool    includeMessage(int64_t messageFlag);
+        /// Add a message to the backend.
+        ///
+        /// Typically a subclass may filter, change, and output
+        /// messages based on configuration and the messageFlag.
+        virtual void addMessage(int64_t messageFlag, const std::string& message) = 0;
 
-private:
-    int64_t m_mask;
-};
-}
+        /// The message mask types are specified in the
+        /// Opm::Log::MessageType namespace, in file LogUtils.hpp.
+        int64_t getMask() const;
+
+    protected:
+        /// Return true if all bits of messageFlag are also set in our mask.
+        bool    includeMessage(int64_t messageFlag);
+
+    private:
+        int64_t m_mask;
+    };
+
+} // namespace LogBackend
 
 
 #endif

--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -72,5 +72,29 @@ namespace Log {
 
         return prefix + ": " + message;
     }
+
+
+    std::string colorCodeMessage(int64_t messageType, const std::string& message) {
+        std::string colorcode;
+        switch (messageType) {
+        case MessageType::Debug:
+        case MessageType::Info:
+            colorcode = "\033[39m";
+            break;
+        case MessageType::Warning:
+            colorcode = "\033[33;1m";
+            break;
+        case MessageType::Error:
+        case MessageType::Problem:
+        case MessageType::Bug:
+            colorcode = "\033[31;1m";
+            break;
+        default:
+            throw std::invalid_argument("Unhandled messagetype");
+        }
+
+        return colorcode + message + "\033[0m";
+    }
+
 }
 }

--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -79,21 +79,21 @@ namespace Log {
         switch (messageType) {
         case MessageType::Debug:
         case MessageType::Info:
-            colorcode = "\033[39m";
+            colorcode = AnsiTerminalColors::default_color;
             break;
         case MessageType::Warning:
-            colorcode = "\033[33;1m";
+            colorcode = AnsiTerminalColors::yellow_strong;
             break;
         case MessageType::Error:
         case MessageType::Problem:
         case MessageType::Bug:
-            colorcode = "\033[31;1m";
+            colorcode = AnsiTerminalColors::red_strong;
             break;
         default:
             throw std::invalid_argument("Unhandled messagetype");
         }
 
-        return colorcode + message + "\033[0m";
+        return colorcode + message + AnsiTerminalColors::none;
     }
 
 }

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -36,6 +36,18 @@ namespace Log {
 
     const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
 
+    /// Terminal codes for ANSI/vt100 compatible terminals.
+    /// See for example http://ascii-table.com/ansi-escape-sequences.php
+    namespace AnsiTerminalColors {
+        const std::string none = "\033[0m";
+        const std::string red = "\033[31m";
+        const std::string red_strong = "\033[31;1m";
+        const std::string yellow = "\033[33m";
+        const std::string yellow_strong = "\033[33;1m";
+        const std::string default_color = "\033[39m";
+    }
+
+
     bool isPower2(int64_t x);
     std::string fileMessage(const std::string& path, int line , const std::string& msg);
     std::string fileMessage(int64_t messageType , const std::string& path, int line , const std::string& msg);

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -40,6 +40,7 @@ namespace Log {
     std::string fileMessage(const std::string& path, int line , const std::string& msg);
     std::string fileMessage(int64_t messageType , const std::string& path, int line , const std::string& msg);
     std::string prefixMessage(int64_t messageType , const std::string& msg);
+    std::string colorCodeMessage(int64_t messageType , const std::string& msg);
 
 }
 }

--- a/opm/common/OpmLog/Logger.cpp
+++ b/opm/common/OpmLog/Logger.cpp
@@ -63,7 +63,7 @@ namespace Opm {
             return true;
     }
 
-    void Logger::clearBackends() {
+    void Logger::removeAllBackends() {
         m_backends.clear();
         m_globalMask = 0;
     }

--- a/opm/common/OpmLog/Logger.cpp
+++ b/opm/common/OpmLog/Logger.cpp
@@ -63,6 +63,11 @@ namespace Opm {
             return true;
     }
 
+    void Logger::clearBackends() {
+        m_backends.clear();
+        m_globalMask = 0;
+    }
+
     bool Logger::removeBackend(const std::string& name) {
         size_t eraseCount = m_backends.erase( name );
         if (eraseCount == 1)

--- a/opm/common/OpmLog/Logger.hpp
+++ b/opm/common/OpmLog/Logger.hpp
@@ -44,6 +44,7 @@ public:
     void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);
     bool hasBackend(const std::string& name);
     bool removeBackend(const std::string& name);
+    void clearBackends();
 
     template <class BackendType>
     std::shared_ptr<BackendType> getBackend(const std::string& name) const {

--- a/opm/common/OpmLog/Logger.hpp
+++ b/opm/common/OpmLog/Logger.hpp
@@ -44,7 +44,7 @@ public:
     void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);
     bool hasBackend(const std::string& name);
     bool removeBackend(const std::string& name);
-    void clearBackends();
+    void removeAllBackends();
 
     template <class BackendType>
     std::shared_ptr<BackendType> getBackend(const std::string& name) const {

--- a/opm/common/OpmLog/MessageFormatter.hpp
+++ b/opm/common/OpmLog/MessageFormatter.hpp
@@ -1,0 +1,79 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_MESSAGEFORMATTER_HEADER_INCLUDED
+#define OPM_MESSAGEFORMATTER_HEADER_INCLUDED
+
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <string>
+
+namespace Opm
+{
+
+
+    /// Abstract interface for message formatting classes.
+    class MessageFormatterInterface
+    {
+    public:
+        /// Virtual destructor to enable inheritance.
+        virtual ~MessageFormatterInterface() = default;
+        /// Should return a possibly modified/decorated version of the
+        /// input string, the formatting applied depending on the
+        /// message_flag.
+        virtual std::string format(const int64_t message_flag, const std::string& message) = 0;
+    };
+
+
+
+
+
+    /// A simple formatter capable of adding message prefixes and colors.
+    class SimpleMessageFormatter : public MessageFormatterInterface
+    {
+    public:
+        /// Constructor controlling formatting to be applied.
+        SimpleMessageFormatter(const bool use_prefix, const bool use_color_coding)
+            : use_prefix_(use_prefix),
+              use_color_coding_(use_color_coding)
+        {
+        }
+
+        /// Returns a copy of the input string with a flag-dependant
+        /// prefix (if use_prefix) and the entire message in a
+        /// flag-dependent color (if use_color_coding).
+        virtual std::string format(const int64_t message_flag, const std::string& message) override
+        {
+            std::string msg = message;
+            if (use_prefix_) {
+                msg = Log::prefixMessage(message_flag, msg);
+            }
+            if (use_color_coding_) {
+                msg = Log::colorCodeMessage(message_flag, msg);
+            }
+            return msg;
+        }
+    private:
+        bool use_prefix_ = false;
+        bool use_color_coding_ = false;
+    };
+
+
+} // namespace Opm
+
+#endif // OPM_MESSAGEFORMATTER_HEADER_INCLUDED

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -39,43 +39,37 @@ namespace Opm {
 
     void OpmLog::info(const std::string& message)
     {
-        const std::string msg = Log::prefixMessage(Log::MessageType::Info, message);
-        addMessage(Log::MessageType::Info, msg);
+        addMessage(Log::MessageType::Info, message);
     }
 
 
     void OpmLog::warning(const std::string& message)
     {
-        const std::string msg = Log::prefixMessage(Log::MessageType::Warning, message);
-        addMessage(Log::MessageType::Warning, msg);
+        addMessage(Log::MessageType::Warning, message);
     }
 
 
     void OpmLog::problem(const std::string& message)
     {
-        const std::string msg = Log::prefixMessage(Log::MessageType::Problem, message);
-        addMessage(Log::MessageType::Problem, msg);
+        addMessage(Log::MessageType::Problem, message);
     }
 
 
     void OpmLog::error(const std::string& message)
     {
-        const std::string msg = Log::prefixMessage(Log::MessageType::Error, message);
-        addMessage(Log::MessageType::Error, msg);
+        addMessage(Log::MessageType::Error, message);
     }
 
 
     void OpmLog::bug(const std::string& message)
     {
-        const std::string msg = Log::prefixMessage(Log::MessageType::Bug, message);
-        addMessage(Log::MessageType::Bug, msg);
+        addMessage(Log::MessageType::Bug, message);
     }
 
     
     void OpmLog::debug(const std::string& message)
     {
-        const std::string msg = Log::prefixMessage(Log::MessageType::Debug, message);
-        addMessage(Log::MessageType::Debug, msg);
+        addMessage(Log::MessageType::Debug, message);
     }
 
 

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -96,6 +96,13 @@ namespace Opm {
     }
 
 
+    void OpmLog::clearBackends() {
+        if (m_logger) {
+            m_logger->clearBackends();
+        }
+    }
+
+
     void OpmLog::addMessageType( int64_t messageType , const std::string& prefix) {
         auto logger = OpmLog::getLogger();
         logger->addMessageType( messageType , prefix );

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -96,9 +96,9 @@ namespace Opm {
     }
 
 
-    void OpmLog::clearBackends() {
+    void OpmLog::removeAllBackends() {
         if (m_logger) {
-            m_logger->clearBackends();
+            m_logger->removeAllBackends();
         }
     }
 

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -50,7 +50,7 @@ public:
     static bool hasBackend( const std::string& backendName );
     static void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);
     static bool removeBackend(const std::string& name);
-    static void clearBackends();
+    static void removeAllBackends();
     static bool enabledMessageType( int64_t messageType );
     static void addMessageType( int64_t messageType , const std::string& prefix);
 

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -50,6 +50,7 @@ public:
     static bool hasBackend( const std::string& backendName );
     static void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);
     static bool removeBackend(const std::string& name);
+    static void clearBackends();
     static bool enabledMessageType( int64_t messageType );
     static void addMessageType( int64_t messageType , const std::string& prefix);
 

--- a/opm/common/OpmLog/StreamLog.cpp
+++ b/opm/common/OpmLog/StreamLog.cpp
@@ -46,7 +46,7 @@ void StreamLog::close() {
 
 void StreamLog::addMessage(int64_t messageType , const std::string& message) {
     if (includeMessage( messageType )) {
-        (*m_ostream) << message << std::endl;
+        (*m_ostream) << decorateMessage(messageType, message) << std::endl;
 
         if (m_ofstream.is_open())
             m_ofstream.flush();

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -55,23 +55,6 @@ BOOST_AUTO_TEST_CASE(Test_Format) {
 
 
 
-BOOST_AUTO_TEST_CASE(Test_AbstractBackend) {
-    int64_t mask = 1+4+16;
-    LogBackend backend(mask);
-
-    BOOST_CHECK_EQUAL(false , backend.includeMessage(0 ));
-    BOOST_CHECK_EQUAL(true  , backend.includeMessage(1 ));
-    BOOST_CHECK_EQUAL(false , backend.includeMessage(2 ));
-    BOOST_CHECK_EQUAL(true  , backend.includeMessage(4 ));
-    BOOST_CHECK_EQUAL(false , backend.includeMessage(8 ));
-    BOOST_CHECK_EQUAL(true  , backend.includeMessage(16 ));
-
-    BOOST_CHECK_EQUAL(false, backend.includeMessage(6 ));
-    BOOST_CHECK_EQUAL(true , backend.includeMessage(5 ));
-}
-
-
-
 BOOST_AUTO_TEST_CASE(Test_Logger) {
     Logger logger;
     std::ostringstream log_stream;

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
         BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("COUNTER"));
         BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM"));
 
-        streamLog->configureDecoration(false, true);
+        streamLog->configureDecoration(std::make_shared<SimpleMessageFormatter>(false, true));
     }
 
     OpmLog::warning("Warning");
@@ -299,4 +299,7 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
         BOOST_CHECK_EQUAL( 1 , counter->numMessages(Log::MessageType::Info) );
         BOOST_CHECK_EQUAL( 1 , counter->numMessages(Log::MessageType::Bug) );
     }
+
+
+    std::cout << log_stream.str() << std::endl;
 }

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -235,6 +235,32 @@ BOOST_AUTO_TEST_CASE(TestOpmLog) {
 
 
 
+BOOST_AUTO_TEST_CASE(TestHelperFunctions)
+{
+    using namespace Log;
+
+    // isPower2
+    BOOST_CHECK(!isPower2(0));
+    BOOST_CHECK(isPower2(1));
+    BOOST_CHECK(isPower2(1 << 3));
+    BOOST_CHECK(isPower2(1ul << 62));
+
+    // fileMessage
+    BOOST_CHECK_EQUAL(fileMessage("foo/bar", 1, "message"), "foo/bar:1: message");
+    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "foo/bar:1: error: message");
+
+    // prefixMessage
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "error: message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "info: message");
+
+    // colorCode Message
+    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), "\033[39mmessage\033[0m");
+    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Warning, "message"), "\033[33;1mmessage\033[0m");
+    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Error, "message"), "\033[31;1mmessage\033[0m");
+}
+
+
+
 BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
 {
     OpmLog::clearBackends();

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
 
 BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
 {
-    OpmLog::clearBackends();
+    OpmLog::removeAllBackends();
 
     std::ostringstream log_stream;
 

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -254,9 +254,9 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "info: message");
 
     // colorCode Message
-    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), "\033[39mmessage\033[0m");
-    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Warning, "message"), "\033[33;1mmessage\033[0m");
-    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Error, "message"), "\033[31;1mmessage\033[0m");
+    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), AnsiTerminalColors::default_color + "message" + AnsiTerminalColors::none);
+    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Warning, "message"), AnsiTerminalColors::yellow_strong + "message" + AnsiTerminalColors::none);
+    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Error, "message"), AnsiTerminalColors::red_strong + "message" + AnsiTerminalColors::none);
 }
 
 


### PR DESCRIPTION
This adds the possibility to configure how any back-end should decorate messages. Decoration here means adding a prefix and/or changing color depending on message type. The default is to have no decoration.

Actual decoration is handled by the concrete log backend calling the decorateMessage() protected method from the LogBackend superclass. So far only the StreamLog does this (it is the only log actually doing any output, all others inherit it).

Behavior should be preserved for now, with the exception of disappearing prefixes (like "warning: ") before log messages (unless client code configures the backend to use them).

I did some cleanup and docs for the LogBackend class, in the first commit, which can make reading the diff for that class a little unclear.