### PR TITLE
Add pthread support.

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -37,7 +37,7 @@ endif (CMAKE_VERSION VERSION_LESS "2.8.3")
 if (CMAKE_VERSION VERSION_LESS "2.8.5")
 	message (STATUS "Enabling compatibility modules for CMake 2.8.5")
 	list (APPEND CMAKE_MODULE_PATH "${OPM_MACROS_ROOT}/cmake/Modules/compat-2.8.5")
-endif (CMAKE_VERSION VERSION_LESS "2.8.5")	
+endif (CMAKE_VERSION VERSION_LESS "2.8.5")
 
 if (CMAKE_VERSION VERSION_LESS "2.8.7")
 	message (STATUS "Enabling compatibility modules for CMake 2.8.7")
@@ -93,6 +93,8 @@ endif (NOT USE_MPI)
 # parallel programming
 include (UseOpenMP)
 find_openmp (${project})
+include (UseThreads)
+find_threads (${project})
 
 # callback hook to setup additional dependencies
 if (COMMAND prereqs_hook)

--- a/cmake/Modules/UseThreads.cmake
+++ b/cmake/Modules/UseThreads.cmake
@@ -1,0 +1,53 @@
+# - Use PThread features
+#
+# Synopsis:
+#
+#	find_threads (module)
+#
+# where:
+#
+#	module            Name of the module to which Threads support
+#	                  etc. should be added, e.g. "opm-core".
+#
+# Note: Compiler flags are always added globally, to avoid ABI
+# incompatibility problems.
+#
+# It is assumed that the following variables are available
+#
+#	${module}_QUIET      Verbosity level of the parent's find module
+#	${module}_LIBRARIES  List of libraries to which Thread support will be added
+#
+# Example:
+#	find_threads (opm-core)
+
+include (AddOptions)
+include (UseCompVer)
+is_compiler_gcc_compatible ()
+
+macro(find_threads opm)
+# default is that Threads are added
+option(USE_PTHREAD "Use pthreads" ON)
+
+# if USE_PTHREAD is enabled then check and set HAVE_PTHREAD
+if( USE_PTHREAD )
+  # threading library
+  set (CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  find_package (Threads ${${opm}_QUIET})
+  if (CMAKE_USE_PTHREADS_INIT)
+    list (APPEND ${opm}_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+    if (CXX_COMPAT_GCC)
+      check_cxx_accepts_flag ("-pthread" HAVE_PTHREAD)
+      if(HAVE_PTHREAD)
+        add_options (ALL_LANGUAGES ALL_BUILDS "-pthread")
+        set(HAVE_PTHREAD "1")
+      endif(HAVE_PTHREAD)
+    endif (CXX_COMPAT_GCC)
+  else(CMAKE_USE_PTHREADS_INIT)
+    set(USE_PTHREAD OFF)
+  endif (CMAKE_USE_PTHREADS_INIT)
+else( USE_PTHREAD )
+  # reset HAVE_PTHREAD
+  set(HAVE_PTHREAD "")
+endif( USE_PTHREAD )
+
+endmacro(find_threads opm)

--- a/cmake/Modules/opm-simulators-prereqs.cmake
+++ b/cmake/Modules/opm-simulators-prereqs.cmake
@@ -3,7 +3,8 @@
 
 # defines that must be present in config.h for our headers
 set (opm-simulators_CONFIG_VAR
-  HAVE_OPM_GRID
+	HAVE_OPM_GRID
+	HAVE_PTHREAD
 	)
 
 # dependencies


### PR DESCRIPTION
This PR adds the necessary cmake functionality to add -pthread to the compiler flags. 
In addition HAVE_PTHREAD is added to config.h

USE_PTHREAD is ON by default an can be disabled setting it to OFF.
