### PR TITLE
ewoms-prereqs.cmake: make the optionaly depency on opm-parser explicit

### DIFF
--- a/cmake/Modules/ewoms-prereqs.cmake
+++ b/cmake/Modules/ewoms-prereqs.cmake
@@ -33,6 +33,7 @@ set (ewoms_DEPS
 	"opm-material REQUIRED"
 	"dune-alugrid"
 	"dune-fem"
+	"opm-parser"
 	"opm-grid"
 	# librt (on some systems necessary for clock_gettime())
 	"librt REQUIRED"


### PR DESCRIPTION
this allows to remove the opm-parser dependency of opm-core without
breaking ewoms/ebos...