### PR TITLE
Message limits and tagged messages

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -36,6 +36,7 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_SimulationDataContainer.cpp
       tests/test_cmp.cpp
       tests/test_OpmLog.cpp
+      tests/test_messagelimiter.cpp
       )
 
 list (APPEND TEST_DATA_FILES
@@ -60,6 +61,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/OpmLog/Logger.hpp
       opm/common/OpmLog/LogUtil.hpp
       opm/common/OpmLog/MessageFormatter.hpp
+      opm/common/OpmLog/MessageLimiter.hpp
       opm/common/OpmLog/OpmLog.hpp
       opm/common/OpmLog/StreamLog.hpp
       opm/common/OpmLog/TimerLog.hpp

--- a/opm/common/OpmLog/CounterLog.cpp
+++ b/opm/common/OpmLog/CounterLog.cpp
@@ -48,8 +48,8 @@ size_t CounterLog::numMessages(int64_t messageType) const {
 
 
 
-void CounterLog::addMessage(int64_t messageType , const std::string& ) {
-    if (includeMessage( messageType ))
+void CounterLog::addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& ) {
+    if (includeMessage( messageType, messageTag ))
         m_count[messageType]++;
 }
 

--- a/opm/common/OpmLog/CounterLog.hpp
+++ b/opm/common/OpmLog/CounterLog.hpp
@@ -39,8 +39,9 @@ public:
     size_t numMessages(int64_t messageType) const;
 
 
-    void addMessage(int64_t messageFlag ,
-                    const std::string& message);
+    void addTaggedMessage(int64_t messageFlag,
+                          const std::string& messageTag,
+                          const std::string& message);
 
 
     void clear();

--- a/opm/common/OpmLog/EclipsePRTLog.cpp
+++ b/opm/common/OpmLog/EclipsePRTLog.cpp
@@ -23,9 +23,9 @@
 namespace Opm {
 
 
-    void EclipsePRTLog::addMessage(int64_t messageType, const std::string& message) 
+    void EclipsePRTLog::addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& message)
     {
-        StreamLog::addMessage(messageType, message);
+        StreamLog::addTaggedMessage(messageType, messageTag, message);
         m_count[messageType]++;
     }
 
@@ -53,7 +53,7 @@ namespace Opm {
             std::string("\nBugs              " + std::to_string(numMessages(Log::MessageType::Bug))) + 
             std::string("\nDebug             " + std::to_string(numMessages(Log::MessageType::Debug))) +
             std::string("\nProblems          " + std::to_string(numMessages(Log::MessageType::Problem))) +"\n";
-        addMessage(Log::MessageType::Info, summary_msg);
+        StreamLog::addTaggedMessage(Log::MessageType::Info, "", summary_msg);
     }
 
 }

--- a/opm/common/OpmLog/EclipsePRTLog.hpp
+++ b/opm/common/OpmLog/EclipsePRTLog.hpp
@@ -31,7 +31,7 @@ class EclipsePRTLog : public StreamLog {
 public:
     using StreamLog::StreamLog;
 
-    void addMessage(int64_t messageType, const std::string& message);
+    void addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& message);
 
     size_t numMessages(int64_t messageType) const;
 

--- a/opm/common/OpmLog/LogBackend.cpp
+++ b/opm/common/OpmLog/LogBackend.cpp
@@ -33,7 +33,7 @@ namespace Opm {
 
     void LogBackend::configureDecoration(std::shared_ptr<MessageFormatterInterface> formatter)
     {
-        formatter_ = formatter;
+        m_formatter = formatter;
     }
 
     int64_t LogBackend::getMask() const
@@ -48,8 +48,8 @@ namespace Opm {
 
     std::string LogBackend::decorateMessage(int64_t messageFlag, const std::string& message)
     {
-        if (formatter_) {
-            return formatter_->format(messageFlag, message);
+        if (m_formatter) {
+            return m_formatter->format(messageFlag, message);
         } else {
             return message;
         }

--- a/opm/common/OpmLog/LogBackend.cpp
+++ b/opm/common/OpmLog/LogBackend.cpp
@@ -31,12 +31,12 @@ namespace Opm {
     {
     }
 
-    void LogBackend::configureDecoration(std::shared_ptr<MessageFormatterInterface> formatter)
+    void LogBackend::setMessageFormatter(std::shared_ptr<MessageFormatterInterface> formatter)
     {
         m_formatter = formatter;
     }
 
-    void LogBackend::configureMessageLimiter(std::shared_ptr<MessageLimiter> limiter)
+    void LogBackend::setMessageLimiter(std::shared_ptr<MessageLimiter> limiter)
     {
         m_limiter = limiter;
     }
@@ -62,7 +62,7 @@ namespace Opm {
 
         // Use the message limiter (if any).
         MessageLimiter::Response res = m_limiter
-            ? m_limiter->encounteredMessage(messageTag)
+            ? m_limiter->handleMessageTag(messageTag)
             : MessageLimiter::Response::PrintMessage;
         if (res == MessageLimiter::Response::JustOverLimit) {
             // Special case: add a message to this backend about limit being reached.
@@ -72,7 +72,7 @@ namespace Opm {
         return res == MessageLimiter::Response::PrintMessage;
     }
 
-    std::string LogBackend::decorateMessage(int64_t messageFlag, const std::string& message)
+    std::string LogBackend::formatMessage(int64_t messageFlag, const std::string& message)
     {
         if (m_formatter) {
             return m_formatter->format(messageFlag, message);

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -22,6 +22,7 @@
 #define OPM_LOGBACKEND_HPP
 
 #include <opm/common/OpmLog/MessageFormatter.hpp>
+#include <opm/common/OpmLog/MessageLimiter.hpp>
 #include <cstdint>
 #include <string>
 #include <memory>

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -61,7 +61,7 @@ namespace Opm
 
     private:
         int64_t m_mask;
-        std::shared_ptr<MessageFormatterInterface> formatter_;
+        std::shared_ptr<MessageFormatterInterface> m_formatter;
     };
 
 } // namespace LogBackend

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -43,11 +43,22 @@ namespace Opm
         /// Configure how decorateMessage() will modify message strings.
         void configureDecoration(std::shared_ptr<MessageFormatterInterface> formatter);
 
+        /// Configure how message tags will be used to limit messages.
+        void configureMessageLimiter(std::shared_ptr<MessageLimiter> limiter);
+
         /// Add a message to the backend.
         ///
         /// Typically a subclass may filter, change, and output
         /// messages based on configuration and the messageFlag.
-        virtual void addMessage(int64_t messageFlag, const std::string& message) = 0;
+        void addMessage(int64_t messageFlag, const std::string& message);
+
+        /// Add a tagged message to the backend.
+        ///
+        /// Typically a subclass may filter, change, and output
+        /// messages based on configuration and the messageFlag.
+        virtual void addTaggedMessage(int64_t messageFlag,
+                                      const std::string& messageTag,
+                                      const std::string& message) = 0;
 
         /// The message mask types are specified in the
         /// Opm::Log::MessageType namespace, in file LogUtils.hpp.
@@ -55,7 +66,7 @@ namespace Opm
 
     protected:
         /// Return true if all bits of messageFlag are also set in our mask.
-        bool includeMessage(int64_t messageFlag);
+        bool includeMessage(int64_t messageFlag, const std::string& messageTag);
 
         /// Return decorated version of message depending on configureDecoration() arguments.
         std::string decorateMessage(int64_t messageFlag, const std::string& message);
@@ -63,6 +74,7 @@ namespace Opm
     private:
         int64_t m_mask;
         std::shared_ptr<MessageFormatterInterface> m_formatter;
+        std::shared_ptr<MessageLimiter> m_limiter;
     };
 
 } // namespace LogBackend

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -40,11 +40,11 @@ namespace Opm
         /// Virtual destructor to enable inheritance.
         virtual ~LogBackend();
 
-        /// Configure how decorateMessage() will modify message strings.
-        void configureDecoration(std::shared_ptr<MessageFormatterInterface> formatter);
+        /// Configure how formatMessage() will modify message strings.
+        void setMessageFormatter(std::shared_ptr<MessageFormatterInterface> formatter);
 
         /// Configure how message tags will be used to limit messages.
-        void configureMessageLimiter(std::shared_ptr<MessageLimiter> limiter);
+        void setMessageLimiter(std::shared_ptr<MessageLimiter> limiter);
 
         /// Add a message to the backend.
         ///
@@ -69,7 +69,7 @@ namespace Opm
         bool includeMessage(int64_t messageFlag, const std::string& messageTag);
 
         /// Return decorated version of message depending on configureDecoration() arguments.
-        std::string decorateMessage(int64_t messageFlag, const std::string& message);
+        std::string formatMessage(int64_t messageFlag, const std::string& message);
 
     private:
         int64_t m_mask;

--- a/opm/common/OpmLog/Logger.cpp
+++ b/opm/common/OpmLog/Logger.cpp
@@ -38,6 +38,18 @@ namespace Opm {
         addMessageType( Log::MessageType::Bug , "bug");
     }
 
+    void Logger::addTaggedMessage(int64_t messageType, const std::string& tag, const std::string& message) const {
+        if ((m_enabledTypes & messageType) == 0)
+            throw std::invalid_argument("Tried to issue message with unrecognized message ID");
+
+        if (m_globalMask & messageType) {
+            for (auto iter = m_backends.begin(); iter != m_backends.end(); ++iter) {
+                std::shared_ptr<LogBackend> backend = (*iter).second;
+                backend->addTaggedMessage( messageType, tag, message );
+            }
+        }
+    }
+
     void Logger::addMessage(int64_t messageType , const std::string& message) const {
         if ((m_enabledTypes & messageType) == 0)
             throw std::invalid_argument("Tried to issue message with unrecognized message ID");

--- a/opm/common/OpmLog/Logger.cpp
+++ b/opm/common/OpmLog/Logger.cpp
@@ -43,23 +43,15 @@ namespace Opm {
             throw std::invalid_argument("Tried to issue message with unrecognized message ID");
 
         if (m_globalMask & messageType) {
-            for (auto iter = m_backends.begin(); iter != m_backends.end(); ++iter) {
-                std::shared_ptr<LogBackend> backend = (*iter).second;
-                backend->addTaggedMessage( messageType, tag, message );
+            for (auto iter : m_backends) {
+                LogBackend& backend = *(iter.second);
+                backend.addTaggedMessage( messageType, tag, message );
             }
         }
     }
 
     void Logger::addMessage(int64_t messageType , const std::string& message) const {
-        if ((m_enabledTypes & messageType) == 0)
-            throw std::invalid_argument("Tried to issue message with unrecognized message ID");
-
-        if (m_globalMask & messageType) {
-            for (auto iter = m_backends.begin(); iter != m_backends.end(); ++iter) {
-                std::shared_ptr<LogBackend> backend = (*iter).second;
-                backend->addMessage( messageType , message );
-            }
-        }
+        addTaggedMessage(messageType, "", message);
     }
 
 

--- a/opm/common/OpmLog/Logger.hpp
+++ b/opm/common/OpmLog/Logger.hpp
@@ -35,6 +35,7 @@ class Logger {
 public:
     Logger();
     void addMessage(int64_t messageType , const std::string& message) const;
+    void addTaggedMessage(int64_t messageType, const std::string& tag, const std::string& message) const;
 
     static bool enabledDefaultMessageType( int64_t messageType);
     bool enabledMessageType( int64_t messageType) const;

--- a/opm/common/OpmLog/MessageLimiter.hpp
+++ b/opm/common/OpmLog/MessageLimiter.hpp
@@ -57,7 +57,7 @@ namespace Opm
             return message_limit_;
         }
 
-        /// Used for encounteredMessage() return type (see that
+        /// Used for handleMessageTag() return type (see that
         /// function).
         enum class Response
         {
@@ -68,7 +68,7 @@ namespace Opm
         /// tag (count <= limit), respond PrintMessage.
         /// If (count == limit + 1), respond JustOverLimit.
         /// If (count > limit + 1), respond OverLimit.
-        Response encounteredMessage(const std::string& tag)
+        Response handleMessageTag(const std::string& tag)
         {
             if (tag.empty() || message_limit_ == NoLimit) {
                 return Response::PrintMessage;

--- a/opm/common/OpmLog/MessageLimiter.hpp
+++ b/opm/common/OpmLog/MessageLimiter.hpp
@@ -1,0 +1,111 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_MESSAGELIMITER_HEADER_INCLUDED
+#define OPM_MESSAGELIMITER_HEADER_INCLUDED
+
+#include <string>
+#include <unordered_map>
+
+namespace Opm
+{
+
+
+    /// Handles limiting the number of messages with the same tag.
+    class MessageLimiter
+    {
+    public:
+        /// Used to indicate no message number limit.
+        enum { NoLimit = -1 };
+
+        /// Default constructor, no limit to the number of messages.
+        MessageLimiter()
+            : message_limit_(NoLimit)
+        {
+        }
+
+        /// Construct with given limit to number of messages with the
+        /// same tag.
+        ///
+        /// Negative limits (including NoLimit) are interpreted as
+        /// NoLimit, but the default constructor is the preferred way
+        /// to obtain that behaviour.
+        explicit MessageLimiter(const int message_limit)
+            : message_limit_(message_limit < 0 ? NoLimit : message_limit)
+        {
+        }
+
+        /// The message limit (same for all tags).
+        int messageLimit() const
+        {
+            return message_limit_;
+        }
+
+        /// Used for encounteredMessage() return type (see that
+        /// function).
+        enum class Response
+        {
+            PrintMessage, JustOverLimit, OverLimit
+        };
+
+        /// If a tag is empty, there is no message limit or for that
+        /// tag (count <= limit), respond PrintMessage.
+        /// If (count == limit + 1), respond JustOverLimit.
+        /// If (count > limit + 1), respond OverLimit.
+        Response encounteredMessage(const std::string& tag)
+        {
+            if (tag.empty() || message_limit_ == NoLimit) {
+                return Response::PrintMessage;
+            } else {
+                // See if tag already encountered.
+                auto it = tag_counts_.find(tag);
+                if (it != tag_counts_.end()) {
+                    // Already encountered this tag. Increment its count.
+                    const int count = ++it->second;
+                    return countBasedResponse(count);
+                } else {
+                    // First encounter of this tag. Insert 1.
+                    tag_counts_.insert({tag, 1});
+                    return countBasedResponse(1);
+                }
+            }
+        }
+
+    private:
+        Response countBasedResponse(const int count)
+        {
+            if (count <= message_limit_) {
+                return Response::PrintMessage;
+            } else if (count == message_limit_ + 1) {
+                return Response::JustOverLimit;
+            } else {
+                return Response::OverLimit;
+            }
+        }
+
+
+        int message_limit_;
+        std::unordered_map<std::string, int> tag_counts_;
+    };
+
+
+
+} // namespace Opm
+
+#endif // OPM_MESSAGELIMITER_HEADER_INCLUDED

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -37,6 +37,12 @@ namespace Opm {
     }
 
 
+    void OpmLog::addTaggedMessage(int64_t messageFlag, const std::string& tag, const std::string& message) {
+        if (m_logger)
+            m_logger->addTaggedMessage( messageFlag, tag, message );
+    }
+
+
     void OpmLog::info(const std::string& message)
     {
         addMessage(Log::MessageType::Info, message);
@@ -71,6 +77,45 @@ namespace Opm {
     {
         addMessage(Log::MessageType::Debug, message);
     }
+
+
+
+    void OpmLog::info(const std::string& tag, const std::string& message)
+    {
+        addTaggedMessage(Log::MessageType::Info, tag, message);
+    }
+
+
+    void OpmLog::warning(const std::string& tag, const std::string& message)
+    {
+        addTaggedMessage(Log::MessageType::Warning, tag, message);
+    }
+
+
+    void OpmLog::problem(const std::string& tag, const std::string& message)
+    {
+        addTaggedMessage(Log::MessageType::Problem, tag, message);
+    }
+
+
+    void OpmLog::error(const std::string& tag, const std::string& message)
+    {
+        addTaggedMessage(Log::MessageType::Error, tag, message);
+    }
+
+
+    void OpmLog::bug(const std::string& tag, const std::string& message)
+    {
+        addTaggedMessage(Log::MessageType::Bug, tag, message);
+    }
+
+
+    void OpmLog::debug(const std::string& tag, const std::string& message)
+    {
+        addTaggedMessage(Log::MessageType::Debug, tag, message);
+    }
+
+
 
 
     bool OpmLog::enabledMessageType( int64_t messageType ) {

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -40,6 +40,7 @@ class OpmLog {
 
 public:
     static void addMessage(int64_t messageFlag , const std::string& message);
+    static void addTaggedMessage(int64_t messageFlag, const std::string& tag, const std::string& message);
 
     static void info(const std::string& message);
     static void warning(const std::string& message);
@@ -47,6 +48,14 @@ public:
     static void problem(const std::string& message);
     static void bug(const std::string& message);
     static void debug(const std::string& message);
+
+    static void info(const std::string& tag, const std::string& message);
+    static void warning(const std::string& tag, const std::string& message);
+    static void error(const std::string& tag, const std::string& message);
+    static void problem(const std::string& tag, const std::string& message);
+    static void bug(const std::string& tag, const std::string& message);
+    static void debug(const std::string& tag, const std::string& message);
+
     static bool hasBackend( const std::string& backendName );
     static void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);
     static bool removeBackend(const std::string& name);

--- a/opm/common/OpmLog/StreamLog.cpp
+++ b/opm/common/OpmLog/StreamLog.cpp
@@ -44,12 +44,12 @@ void StreamLog::close() {
     }
 }
 
-void StreamLog::addMessage(int64_t messageType , const std::string& message) {
-    if (includeMessage( messageType )) {
+void StreamLog::addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& message) {
+    if (includeMessage( messageType, messageTag )) {
         (*m_ostream) << decorateMessage(messageType, message) << std::endl;
-
-        if (m_ofstream.is_open())
+        if (m_ofstream.is_open()) {
             m_ofstream.flush();
+        }
     }
 }
 

--- a/opm/common/OpmLog/StreamLog.cpp
+++ b/opm/common/OpmLog/StreamLog.cpp
@@ -46,7 +46,7 @@ void StreamLog::close() {
 
 void StreamLog::addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& message) {
     if (includeMessage( messageType, messageTag )) {
-        (*m_ostream) << decorateMessage(messageType, message) << std::endl;
+        (*m_ostream) << formatMessage(messageType, message) << std::endl;
         if (m_ofstream.is_open()) {
             m_ofstream.flush();
         }

--- a/opm/common/OpmLog/StreamLog.hpp
+++ b/opm/common/OpmLog/StreamLog.hpp
@@ -33,7 +33,7 @@ class StreamLog : public LogBackend {
 public:
     StreamLog(const std::string& logFile , int64_t messageMask);
     StreamLog(std::ostream& os , int64_t messageMask);
-    void addMessage(int64_t messageType , const std::string& message);
+    virtual void addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& message) override;
     ~StreamLog();
 
 private:

--- a/opm/common/OpmLog/TimerLog.cpp
+++ b/opm/common/OpmLog/TimerLog.cpp
@@ -41,14 +41,14 @@ TimerLog::TimerLog(std::ostream& os) : StreamLog( os , StopTimer | StartTimer )
 
 
 
-void TimerLog::addMessage(int64_t messageType , const std::string& msg ) {
+void TimerLog::addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& msg ) {
     if (messageType == StopTimer) {
         clock_t stop = clock();
         double secondsElapsed = 1.0 * (m_start - stop) / CLOCKS_PER_SEC ;
 
         m_work.str("");
         m_work << std::fixed << msg << ": " << secondsElapsed << " seconds ";
-        StreamLog::addMessage( messageType , m_work.str());
+        StreamLog::addTaggedMessage( messageType, messageTag, m_work.str());
     } else {
         if (messageType == StartTimer)
             m_start = clock();

--- a/opm/common/OpmLog/TimerLog.hpp
+++ b/opm/common/OpmLog/TimerLog.hpp
@@ -42,8 +42,9 @@ public:
     TimerLog(const std::string& logFile);
     TimerLog(std::ostream& os);
 
-    void addMessage(int64_t messageFlag ,
-                    const std::string& message);
+    void addTaggedMessage(int64_t messageFlag,
+                          const std::string& messageTag,
+                          const std::string& message) override;
 
     void clear();
     ~TimerLog() {};

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -118,7 +118,7 @@ public:
         m_specialMessages = 0;
     }
 
-    void addMessage(int64_t messageType , const std::string& /* message */) {
+    void addTaggedMessage(int64_t messageType , const std::string& /* messageTag */, const std::string& /* message */) {
         if (messageType & Log::DefaultMessageTypes)
             m_defaultMessages +=1;
         else
@@ -302,4 +302,60 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
 
 
     std::cout << log_stream.str() << std::endl;
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(TestOpmLogWithLimits)
+{
+    OpmLog::removeAllBackends();
+
+    std::ostringstream log_stream1;
+    std::ostringstream log_stream2;
+
+    {
+        std::shared_ptr<StreamLog> streamLog1 = std::make_shared<StreamLog>(log_stream1, Log::DefaultMessageTypes);
+        std::shared_ptr<StreamLog> streamLog2 = std::make_shared<StreamLog>(log_stream2, Log::DefaultMessageTypes);
+        OpmLog::addBackend("STREAM1" , streamLog1);
+        OpmLog::addBackend("STREAM2" , streamLog2);
+        BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM1"));
+        BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM2"));
+
+        streamLog1->configureDecoration(std::make_shared<SimpleMessageFormatter>(false, true));
+        streamLog1->configureMessageLimiter(std::make_shared<MessageLimiter>(2));
+        streamLog2->configureDecoration(std::make_shared<SimpleMessageFormatter>(false, true));
+        streamLog2->configureMessageLimiter(std::make_shared<MessageLimiter>()); // no limit
+    }
+
+    const std::string tag = "ExampleTag";
+    OpmLog::warning(tag, "Warning");
+    OpmLog::error("Error");
+    OpmLog::info("Info");
+    OpmLog::bug("Bug");
+    OpmLog::warning(tag, "Warning");
+    OpmLog::warning(tag, "Warning");
+    OpmLog::warning(tag, "Warning");
+
+    const std::string expected1 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Message limit reached for message tag: " + tag) + "\n";
+
+    BOOST_CHECK_EQUAL(log_stream1.str(), expected1);
+
+    const std::string expected2 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n";
+
+    BOOST_CHECK_EQUAL(log_stream2.str(), expected2);
+
+    std::cout << log_stream1.str() << std::endl;
+    std::cout << log_stream2.str() << std::endl;
 }

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
         BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("COUNTER"));
         BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM"));
 
-        streamLog->configureDecoration(std::make_shared<SimpleMessageFormatter>(false, true));
+        streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false, true));
     }
 
     OpmLog::warning("Warning");
@@ -322,10 +322,10 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithLimits)
         BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM1"));
         BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM2"));
 
-        streamLog1->configureDecoration(std::make_shared<SimpleMessageFormatter>(false, true));
-        streamLog1->configureMessageLimiter(std::make_shared<MessageLimiter>(2));
-        streamLog2->configureDecoration(std::make_shared<SimpleMessageFormatter>(false, true));
-        streamLog2->configureMessageLimiter(std::make_shared<MessageLimiter>()); // no limit
+        streamLog1->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false, true));
+        streamLog1->setMessageLimiter(std::make_shared<MessageLimiter>(2));
+        streamLog2->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false, true));
+        streamLog2->setMessageLimiter(std::make_shared<MessageLimiter>()); // no limit
     }
 
     const std::string tag = "ExampleTag";

--- a/tests/test_messagelimiter.cpp
+++ b/tests/test_messagelimiter.cpp
@@ -1,0 +1,79 @@
+/*
+  Copyright 2016 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE MESSAGELIMITER_TESTS
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/common/OpmLog/MessageLimiter.hpp>
+
+
+using namespace Opm;
+
+
+BOOST_AUTO_TEST_CASE(ConstructionAndLimits)
+{
+    MessageLimiter m1;
+    BOOST_CHECK_EQUAL(m1.messageLimit(), MessageLimiter::NoLimit);
+    MessageLimiter m2(0);
+    BOOST_CHECK_EQUAL(m2.messageLimit(), 0);
+    MessageLimiter m3(1);
+    BOOST_CHECK_EQUAL(m3.messageLimit(), 1);
+    MessageLimiter m4(-4);
+    BOOST_CHECK_EQUAL(m4.messageLimit(), MessageLimiter::NoLimit);
+}
+
+BOOST_AUTO_TEST_CASE(Response)
+{
+    {
+        // No limits.
+        MessageLimiter m;
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::PrintMessage);
+    }
+
+    {
+        // Limit == 0.
+        MessageLimiter m(0);
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::JustOverLimit);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::JustOverLimit);
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::OverLimit);
+    }
+
+    {
+        // Limit == 1.
+        MessageLimiter m(1);
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::JustOverLimit);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::JustOverLimit);
+        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::OverLimit);
+    }
+}

--- a/tests/test_messagelimiter.cpp
+++ b/tests/test_messagelimiter.cpp
@@ -47,33 +47,33 @@ BOOST_AUTO_TEST_CASE(Response)
     {
         // No limits.
         MessageLimiter m;
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::PrintMessage);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::PrintMessage);
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::PrintMessage);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::PrintMessage);
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::PrintMessage);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::PrintMessage);
     }
 
     {
         // Limit == 0.
         MessageLimiter m(0);
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::JustOverLimit);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::JustOverLimit);
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::OverLimit);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::OverLimit);
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::OverLimit);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::JustOverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::JustOverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::OverLimit);
     }
 
     {
         // Limit == 1.
         MessageLimiter m(1);
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::PrintMessage);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::PrintMessage);
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::JustOverLimit);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::JustOverLimit);
-        BOOST_CHECK(m.encounteredMessage("tag1") == MessageLimiter::Response::OverLimit);
-        BOOST_CHECK(m.encounteredMessage("tag2") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::PrintMessage);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::JustOverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::JustOverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag1") == MessageLimiter::Response::OverLimit);
+        BOOST_CHECK(m.handleMessageTag("tag2") == MessageLimiter::Response::OverLimit);
     }
 }


### PR DESCRIPTION
This changes the design of the LogBackend class and its subclasses, now the main virtual method is `addTaggedMessage()`. The former virtual method `addMessage()` is now a regular non-virtual method forwarding to `addTaggedMessage()`.

You can configure message limiting based on tags by passing a `MessageLimiter` to the `configureMessageLimiter()` method, which will then be used by the `includeMessage()` method. That method now takes an additional tag argument.

The most user-visible part of this is that there are new overloads of the static methods `OpmLog::warning()`, `OpmLog::error()` etc, that take message tags. To tie things together the `OpmLog` and `Logger` classes have also gotten new `addTaggedMessage()` methods, but they should mostly be used through the convenience methods such as `OpmLog::warning()`.