### PR TITLE
VS2015 :  Removed Linux-only cmake directives and added missing include

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -34,19 +34,21 @@ include(CheckIncludeFileCXX)
 # macro to only add option once
 include(AddOptions)
 
-# try to use compiler flag -std=c++11
-CHECK_CXX_ACCEPTS_FLAG("-std=c++11" CXX_FLAG_CXX11)
-if(CXX_FLAG_CXX11)
-  add_options (CXX ALL_BUILDS "-std=c++11")
-  set(CXX_STD0X_FLAGS "-std=c++11")
-else()
-  # try to use compiler flag -std=c++0x for older compilers
-  CHECK_CXX_ACCEPTS_FLAG("-std=c++0x" CXX_FLAG_CXX0X)
-  if(CXX_FLAG_CXX0X)
-  add_options (CXX ALL_BUILDS "-std=c++0x")
-  set(CXX_STD0X_FLAGS "-std=c++0x")
-  endif(CXX_FLAG_CXX0X)
-endif(CXX_FLAG_CXX11)
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  # try to use compiler flag -std=c++11
+  CHECK_CXX_ACCEPTS_FLAG("-std=c++11" CXX_FLAG_CXX11)
+  if(CXX_FLAG_CXX11)
+    add_options (CXX ALL_BUILDS "-std=c++11")
+    set(CXX_STD0X_FLAGS "-std=c++11")
+  else()
+    # try to use compiler flag -std=c++0x for older compilers
+    CHECK_CXX_ACCEPTS_FLAG("-std=c++0x" CXX_FLAG_CXX0X)
+    if(CXX_FLAG_CXX0X)
+    add_options (CXX ALL_BUILDS "-std=c++0x")
+    set(CXX_STD0X_FLAGS "-std=c++0x")
+    endif(CXX_FLAG_CXX0X)
+  endif(CXX_FLAG_CXX11)
+endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
 # if we are building with an Apple toolchain in MacOS X,
 # we cannot use the old GCC 4.2 fork, but must use the

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -218,10 +218,12 @@ endif (COMMAND install_hook)
 opm_install (${project})
 message (STATUS "This build defaults to installing in ${CMAKE_INSTALL_PREFIX}")
 
-# installation of CMake modules to help user programs locate the library
-include (OpmProject)
-opm_cmake_config (${project})
-
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    #installation of CMake modules to help user programs locate the library
+    include (OpmProject)
+    opm_cmake_config (${project})
+endif()
+    
 # routines to build satellites such as tests, tutorials and samples
 include (OpmSatellites)
 

--- a/opm/common/util/numeric/cmp.hpp
+++ b/opm/common/util/numeric/cmp.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <type_traits>
 #include <cmath>
+#include <algorithm>
 
 namespace Opm {
 


### PR DESCRIPTION
Adjustments to be able to compile on VS2015