### PR TITLE
Swap opm-core/opm-output dependencies

### DIFF
--- a/cmake/Modules/opm-core-prereqs.cmake
+++ b/cmake/Modules/opm-core-prereqs.cmake
@@ -42,4 +42,5 @@ set (opm-core_DEPS
 	"opm-parser REQUIRED"
 	# the code which implements the material laws
 	"opm-material REQUIRED"
+	"opm-output REQUIRED"
 	)

--- a/cmake/Modules/opm-output-prereqs.cmake
+++ b/cmake/Modules/opm-output-prereqs.cmake
@@ -14,13 +14,11 @@ set (opm-output_DEPS
 	"CXX11Features REQUIRED"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
+		COMPONENTS filesystem system unit_test_framework REQUIRED"
 	# Ensembles-based Reservoir Tools (ERT)
 	"ERT REQUIRED"
 	# Look for MPI support
 	"opm-common REQUIRED"
 	# Parser library for ECL-type simulation models
 	"opm-parser REQUIRED"
-	# TODO remove this dependancy
-	"opm-core REQUIRED"
 	)

--- a/travis/build-and-test.sh
+++ b/travis/build-and-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-build_order=(opm-common opm-parser opm-material opm-core opm-output opm-grid opm-simulators opm-upscaling)
+build_order=(opm-common opm-parser opm-material opm-output opm-core opm-grid opm-simulators opm-upscaling)
 
 # This shell script should be started with the name of a module as
 # only only command line argument. It will start by building all


### PR DESCRIPTION
Core depends on output, not the other way around.

See https://github.com/OPM/opm-output/pull/30