### PR TITLE
Add default simple logging.

### DIFF
--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/Logger.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <iostream>
 
 namespace Opm {
 
@@ -160,6 +162,14 @@ namespace Opm {
     }
 
 
+
+    void OpmLog::setupSimpleDefaultLogging(const bool& use_prefix)
+    {
+         std::shared_ptr<StreamLog> streamLog = std::make_shared<StreamLog>(std::cout, Log::DefaultMessageTypes);
+         OpmLog::addBackend( "STREAMLOG", streamLog);
+         streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));
+         streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(use_prefix, true));
+    }
 /******************************************************************/
 
     std::shared_ptr<Logger> OpmLog::m_logger;

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -163,10 +163,10 @@ namespace Opm {
 
 
 
-    void OpmLog::setupSimpleDefaultLogging(const bool& use_prefix)
+    void OpmLog::setupSimpleDefaultLogging(const bool use_prefix)
     {
          std::shared_ptr<StreamLog> streamLog = std::make_shared<StreamLog>(std::cout, Log::DefaultMessageTypes);
-         OpmLog::addBackend( "STREAMLOG", streamLog);
+         OpmLog::addBackend( "SimpleDefaultLog", streamLog);
          streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));
          streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(use_prefix, true));
     }

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -62,7 +62,7 @@ public:
     static void removeAllBackends();
     static bool enabledMessageType( int64_t messageType );
     static void addMessageType( int64_t messageType , const std::string& prefix);
-    static void setupSimpleDefaultLogging(const bool& use_prefix);
+    static void setupSimpleDefaultLogging(const bool use_prefix);
 
     template <class BackendType>
     static std::shared_ptr<BackendType> getBackend(const std::string& name) {

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -62,7 +62,7 @@ public:
     static void removeAllBackends();
     static bool enabledMessageType( int64_t messageType );
     static void addMessageType( int64_t messageType , const std::string& prefix);
-
+    static void setupSimpleDefaultLogging(const bool& use_prefix);
 
     template <class BackendType>
     static std::shared_ptr<BackendType> getBackend(const std::string& name) {

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -367,5 +367,5 @@ BOOST_AUTO_TEST_CASE(TestsetupSimpleLog)
 {
     bool use_prefix = false;
     OpmLog::setupSimpleDefaultLogging(use_prefix);
-    BOOST_CHECK_EQUAL(true, OpmLog::hasBackend("SimpleDefautLog"));
+    BOOST_CHECK_EQUAL(true, OpmLog::hasBackend("SimpleDefaultLog"));
 }

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -359,3 +359,13 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithLimits)
     std::cout << log_stream1.str() << std::endl;
     std::cout << log_stream2.str() << std::endl;
 }
+
+
+
+
+BOOST_AUTO_TEST_CASE(TestsetupSimpleLog)
+{
+    bool use_prefix = false;
+    OpmLog::setupSimpleDefaultLogging(use_prefix);
+    BOOST_CHECK_EQUAL(true, OpmLog::hasBackend("SimpleDefautLog"));
+}


### PR DESCRIPTION
Add a simple default logging which has std::cout as backend, use colored output. For prefix, user can set ``use_prefix`` to decide.