### PR TITLE
No longer emit default Ansi color code for black.

### DIFF
--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -75,25 +75,19 @@ namespace Log {
 
 
     std::string colorCodeMessage(int64_t messageType, const std::string& message) {
-        std::string colorcode;
         switch (messageType) {
         case MessageType::Debug:
         case MessageType::Info:
-            colorcode = AnsiTerminalColors::default_color;
-            break;
+            return message; // No color coding, not even the code for default color.
         case MessageType::Warning:
-            colorcode = AnsiTerminalColors::yellow_strong;
-            break;
+            return AnsiTerminalColors::yellow_strong + message + AnsiTerminalColors::none;
         case MessageType::Error:
         case MessageType::Problem:
         case MessageType::Bug:
-            colorcode = AnsiTerminalColors::red_strong;
-            break;
+            return AnsiTerminalColors::red_strong + message + AnsiTerminalColors::none;
         default:
             throw std::invalid_argument("Unhandled messagetype");
         }
-
-        return colorcode + message + AnsiTerminalColors::none;
     }
 
 }

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "info: message");
 
     // colorCode Message
-    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), AnsiTerminalColors::default_color + "message" + AnsiTerminalColors::none);
+    BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), "message");
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Warning, "message"), AnsiTerminalColors::yellow_strong + "message" + AnsiTerminalColors::none);
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Error, "message"), AnsiTerminalColors::red_strong + "message" + AnsiTerminalColors::none);
 }


### PR DESCRIPTION
Using no code for black makes it easier to read output with color in editors etc.