### PR TITLE
FindERT uses new EclKW interface.

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -243,9 +243,8 @@ if (NOT (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND
   check_cxx_source_compiles (
 "#include <ert/ecl/EclKW.hpp>
 int main ( ) {
-  ERT::EclKW<int> kw(\"SATNUM\" , 1000);
-  kw[0] = 10;
-  return 0;
+    ERT::EclKW< int >( ecl_kw_alloc( "SATNUM", 0, ECL_INT_TYPE ) );
+    return 0;
 }" HAVE_ERT)
   cmake_pop_check_state ()
 else (NOT (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND"))


### PR DESCRIPTION
Ert has changed, and with it FindERT breaks.