### PR TITLE
Fix typo in FindERT compile check

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -243,7 +243,7 @@ if (NOT (ERT_INCLUDE_DIR MATCHES "-NOTFOUND" OR ERT_LIBRARIES MATCHES "-NOTFOUND
   check_cxx_source_compiles (
 "#include <ert/ecl/EclKW.hpp>
 int main ( ) {
-    ERT::EclKW< int >( ecl_kw_alloc( "SATNUM", 0, ECL_INT_TYPE ) );
+    ERT::EclKW< int > kw( ecl_kw_alloc( \"SATNUM\", 0, ECL_INT_TYPE ) );
     return 0;
 }" HAVE_ERT)
   cmake_pop_check_state ()


### PR DESCRIPTION
The test program compiled fine, except that strings need to be escaped in CMake.

Mea culpa, signori.