### PR TITLE
Add prtinfo type

### DIFF
--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -52,6 +52,7 @@ namespace Log {
             prefix = "debug";
             break;
         case MessageType::Info:
+	case MessageType::Prtinfo:
             prefix = "info";
             break;
         case MessageType::Warning:

--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -51,8 +51,10 @@ namespace Log {
         case MessageType::Debug:
             prefix = "debug";
             break;
-        case MessageType::Info:
         case MessageType::Note:
+            prefix = "note";
+            break;
+        case MessageType::Info:
             prefix = "info";
             break;
         case MessageType::Warning:

--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -52,7 +52,7 @@ namespace Log {
             prefix = "debug";
             break;
         case MessageType::Info:
-	case MessageType::Prtinfo:
+        case MessageType::Prtinfo:
             prefix = "info";
             break;
         case MessageType::Warning:

--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -52,7 +52,7 @@ namespace Log {
             prefix = "debug";
             break;
         case MessageType::Info:
-        case MessageType::Prtinfo:
+        case MessageType::Note:
             prefix = "info";
             break;
         case MessageType::Warning:
@@ -79,6 +79,7 @@ namespace Log {
         switch (messageType) {
         case MessageType::Debug:
         case MessageType::Info:
+        case MessageType::Note:
             return message; // No color coding, not even the code for default color.
         case MessageType::Warning:
             return AnsiTerminalColors::blue_strong + message + AnsiTerminalColors::none;

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -32,10 +32,12 @@ namespace Log {
         const int64_t Error     =  8;   /* Error in the input data - should probably exit. */
         const int64_t Problem   = 16;   /* Calculation problems - e.g. convergence failure. */
         const int64_t Bug       = 32;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
+        const int64_t Prtinfo   = 64;  /* Information that should only go into print file.*/
     }
 
-    const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
-    const int64_t NoDebugMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
+    const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Prtinfo;
+    const int64_t NoDebugMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Prtinfo;
+    const int64_t StdoutMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
 
     /// Terminal codes for ANSI/vt100 compatible terminals.
     /// See for example http://ascii-table.com/ansi-escape-sequences.php

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -26,17 +26,17 @@
 namespace Opm {
 namespace Log {
     namespace MessageType {
-        const int64_t Debug     =  1;   /* Excessive information */
-        const int64_t Info      =  2;   /* Normal status information */
-        const int64_t Warning   =  4;   /* Input anomaly - possible error */
-        const int64_t Error     =  8;   /* Error in the input data - should probably exit. */
-        const int64_t Problem   = 16;   /* Calculation problems - e.g. convergence failure. */
-        const int64_t Bug       = 32;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
-        const int64_t Prtinfo   = 64;  /* Information that should only go into print file.*/
+        const int64_t Debug    =  1;   /* Excessive information */
+        const int64_t Info     =  2;   /* Normal status information */
+        const int64_t Warning  =  4;   /* Input anomaly - possible error */
+        const int64_t Error    =  8;   /* Error in the input data - should probably exit. */
+        const int64_t Problem  = 16;   /* Calculation problems - e.g. convergence failure. */
+        const int64_t Bug      = 32;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
+        const int64_t Note     = 64;  /* Information that should only go into print file.*/
     }
 
-    const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Prtinfo;
-    const int64_t NoDebugMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Prtinfo;
+    const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Note;
+    const int64_t NoDebugMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Note;
     const int64_t StdoutMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
 
     /// Terminal codes for ANSI/vt100 compatible terminals.

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -27,12 +27,12 @@ namespace Opm {
 namespace Log {
     namespace MessageType {
         const int64_t Debug    =  1;   /* Excessive information */
-        const int64_t Info     =  2;   /* Normal status information */
-        const int64_t Warning  =  4;   /* Input anomaly - possible error */
-        const int64_t Error    =  8;   /* Error in the input data - should probably exit. */
-        const int64_t Problem  = 16;   /* Calculation problems - e.g. convergence failure. */
-        const int64_t Bug      = 32;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
-        const int64_t Note     = 64;  /* Information that should only go into print file.*/
+        const int64_t Note     =  2;  /* Information that should only go into print file.*/
+        const int64_t Info     =  4;   /* Normal status information */
+        const int64_t Warning  =  8;   /* Input anomaly - possible error */
+        const int64_t Error    = 16;   /* Error in the input data - should probably exit. */
+        const int64_t Problem  = 32;   /* Calculation problems - e.g. convergence failure. */
+        const int64_t Bug      = 64;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
     }
 
     const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Note;

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -26,17 +26,17 @@
 namespace Opm {
 namespace Log {
     namespace MessageType {
-        const int64_t Debug    =  1;   /* Excessive information */
-        const int64_t Note     =  2;  /* Information that should only go into print file.*/
-        const int64_t Info     =  4;   /* Normal status information */
-        const int64_t Warning  =  8;   /* Input anomaly - possible error */
-        const int64_t Error    = 16;   /* Error in the input data - should probably exit. */
-        const int64_t Problem  = 32;   /* Calculation problems - e.g. convergence failure. */
-        const int64_t Bug      = 64;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
+        const int64_t Debug     =  1;   /* Excessive information */
+        const int64_t Note      =  2;  /* Information that should only go into print file.*/
+        const int64_t Info      =  4;   /* Normal status information */
+        const int64_t Warning   =  8;   /* Input anomaly - possible error */
+        const int64_t Error     = 16;   /* Error in the input data - should probably exit. */
+        const int64_t Problem   = 32;   /* Calculation problems - e.g. convergence failure. */
+        const int64_t Bug       = 64;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
     }
 
-    const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Note;
-    const int64_t NoDebugMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug + MessageType::Note;
+    const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Note + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
+    const int64_t NoDebugMessageTypes = MessageType::Info + MessageType::Note + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
     const int64_t StdoutMessageTypes = MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;
 
     /// Terminal codes for ANSI/vt100 compatible terminals.

--- a/opm/common/OpmLog/Logger.cpp
+++ b/opm/common/OpmLog/Logger.cpp
@@ -36,7 +36,7 @@ namespace Opm {
         addMessageType( Log::MessageType::Error , "error");
         addMessageType( Log::MessageType::Problem , "problem");
         addMessageType( Log::MessageType::Bug , "bug");
-        addMessageType( Log::MessageType::Prtinfo , "prtinfo");
+        addMessageType( Log::MessageType::Note , "note");
     }
 
     void Logger::addTaggedMessage(int64_t messageType, const std::string& tag, const std::string& message) const {

--- a/opm/common/OpmLog/Logger.cpp
+++ b/opm/common/OpmLog/Logger.cpp
@@ -36,6 +36,7 @@ namespace Opm {
         addMessageType( Log::MessageType::Error , "error");
         addMessageType( Log::MessageType::Problem , "problem");
         addMessageType( Log::MessageType::Bug , "bug");
+        addMessageType( Log::MessageType::Prtinfo , "prtinfo");
     }
 
     void Logger::addTaggedMessage(int64_t messageType, const std::string& tag, const std::string& message) const {

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -81,9 +81,9 @@ namespace Opm {
     }
 
 
-    void OpmLog::prtinfo(const std::string& message)
+    void OpmLog::note(const std::string& message)
     {
-        addMessage(Log::MessageType::Prtinfo, message);
+        addMessage(Log::MessageType::Note, message);
     }
 
 
@@ -125,9 +125,9 @@ namespace Opm {
 
 
 
-    void OpmLog::prtinfo(const std::string& tag, const std::string& message)
+    void OpmLog::note(const std::string& tag, const std::string& message)
     {
-        addTaggedMessage(Log::MessageType::Prtinfo, tag, message);
+        addTaggedMessage(Log::MessageType::Note, tag, message);
     }
 
 

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -81,6 +81,12 @@ namespace Opm {
     }
 
 
+    void OpmLog::prtinfo(const std::string& message)
+    {
+        addMessage(Log::MessageType::Prtinfo, message);
+    }
+
+
 
     void OpmLog::info(const std::string& tag, const std::string& message)
     {
@@ -115,6 +121,13 @@ namespace Opm {
     void OpmLog::debug(const std::string& tag, const std::string& message)
     {
         addTaggedMessage(Log::MessageType::Debug, tag, message);
+    }
+
+
+
+    void OpmLog::prtinfo(const std::string& tag, const std::string& message)
+    {
+        addTaggedMessage(Log::MessageType::Prtinfo, tag, message);
     }
 
 

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -48,6 +48,7 @@ public:
     static void problem(const std::string& message);
     static void bug(const std::string& message);
     static void debug(const std::string& message);
+    static void prtinfo(const std::string& message);
 
     static void info(const std::string& tag, const std::string& message);
     static void warning(const std::string& tag, const std::string& message);
@@ -55,6 +56,7 @@ public:
     static void problem(const std::string& tag, const std::string& message);
     static void bug(const std::string& tag, const std::string& message);
     static void debug(const std::string& tag, const std::string& message);
+    static void prtinfo(const std::string& tag, const std::string& message);
 
     static bool hasBackend( const std::string& backendName );
     static void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -48,7 +48,7 @@ public:
     static void problem(const std::string& message);
     static void bug(const std::string& message);
     static void debug(const std::string& message);
-    static void prtinfo(const std::string& message);
+    static void note(const std::string& message);
 
     static void info(const std::string& tag, const std::string& message);
     static void warning(const std::string& tag, const std::string& message);
@@ -56,7 +56,7 @@ public:
     static void problem(const std::string& tag, const std::string& message);
     static void bug(const std::string& tag, const std::string& message);
     static void debug(const std::string& tag, const std::string& message);
-    static void prtinfo(const std::string& tag, const std::string& message);
+    static void note(const std::string& tag, const std::string& message);
 
     static bool hasBackend( const std::string& backendName );
     static void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -169,10 +169,12 @@ BOOST_AUTO_TEST_CASE( CounterLogTesting) {
 
     counter.addMessage( Log::MessageType::Error , "This is an error ...");
     counter.addMessage( Log::MessageType::Warning , "This is a warning");
+    counter.addMessage( Log::MessageType::Prtinfo , "This is a info(prtinfo)");
 
     BOOST_CHECK_EQUAL(1U , counter.numMessages( Log::MessageType::Error ));
     BOOST_CHECK_EQUAL(1U , counter.numMessages( Log::MessageType::Warning ));
     BOOST_CHECK_EQUAL(0  , counter.numMessages( Log::MessageType::Info ));
+    BOOST_CHECK_EQUAL(1U  , counter.numMessages( Log::MessageType::Prtinfo ));
 
     {
         int64_t not_enabled = 4096;
@@ -252,6 +254,7 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     // prefixMessage
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "error: message");
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "info: message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Prtinfo, "message"), "info: message");
 
     // colorCode Message
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), "message");

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -169,12 +169,12 @@ BOOST_AUTO_TEST_CASE( CounterLogTesting) {
 
     counter.addMessage( Log::MessageType::Error , "This is an error ...");
     counter.addMessage( Log::MessageType::Warning , "This is a warning");
-    counter.addMessage( Log::MessageType::Prtinfo , "This is a info(prtinfo)");
+    counter.addMessage( Log::MessageType::Note , "This is a info(note)");
 
     BOOST_CHECK_EQUAL(1U , counter.numMessages( Log::MessageType::Error ));
     BOOST_CHECK_EQUAL(1U , counter.numMessages( Log::MessageType::Warning ));
     BOOST_CHECK_EQUAL(0  , counter.numMessages( Log::MessageType::Info ));
-    BOOST_CHECK_EQUAL(1U  , counter.numMessages( Log::MessageType::Prtinfo ));
+    BOOST_CHECK_EQUAL(1U  , counter.numMessages( Log::MessageType::Note ));
 
     {
         int64_t not_enabled = 4096;
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     // prefixMessage
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "error: message");
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "info: message");
-    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Prtinfo, "message"), "info: message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Note, "message"), "info: message");
 
     // colorCode Message
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), "message");

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE( CounterLogTesting) {
 
     counter.addMessage( Log::MessageType::Error , "This is an error ...");
     counter.addMessage( Log::MessageType::Warning , "This is a warning");
-    counter.addMessage( Log::MessageType::Note , "This is a info(note)");
+    counter.addMessage( Log::MessageType::Note , "This is a note");
 
     BOOST_CHECK_EQUAL(1U , counter.numMessages( Log::MessageType::Error ));
     BOOST_CHECK_EQUAL(1U , counter.numMessages( Log::MessageType::Warning ));
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     // prefixMessage
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "error: message");
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "info: message");
-    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Note, "message"), "info: message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Note, "message"), "note: message");
 
     // colorCode Message
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), "message");


### PR DESCRIPTION
For some reasons, see https://github.com/OPM/opm-parser/pull/828. Lots of information that we don't want send them to stdout but  print file. This obviously can be done by the **tagged** functionality, but opm-parser does not support that, add a new message type could be the easiest way to achieve the target.