### PR TITLE
Make Error, Problem, Error, Warning with prefix by default.

### DIFF
--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -49,25 +49,25 @@ namespace Log {
         std::string prefix;
         switch (messageType) {
         case MessageType::Debug:
-            prefix = "debug";
+            prefix = "Debug";
             break;
         case MessageType::Note:
-            prefix = "note";
+            prefix = "Note";
             break;
         case MessageType::Info:
-            prefix = "info";
+            prefix = "Info";
             break;
         case MessageType::Warning:
-            prefix = "warning";
+            prefix = "Warning";
             break;
         case MessageType::Error:
-            prefix = "error";
+            prefix = "Error";
             break;
         case MessageType::Problem:
-            prefix = "problem";
+            prefix = "Problem";
             break;
         case MessageType::Bug:
-            prefix = "bug";
+            prefix = "Bug";
             break;
         default:
             throw std::invalid_argument("Unhandled messagetype");
@@ -80,8 +80,8 @@ namespace Log {
     std::string colorCodeMessage(int64_t messageType, const std::string& message) {
         switch (messageType) {
         case MessageType::Debug:
-        case MessageType::Info:
         case MessageType::Note:
+        case MessageType::Info:
             return message; // No color coding, not even the code for default color.
         case MessageType::Warning:
             return AnsiTerminalColors::blue_strong + message + AnsiTerminalColors::none;

--- a/opm/common/OpmLog/MessageFormatter.hpp
+++ b/opm/common/OpmLog/MessageFormatter.hpp
@@ -52,20 +52,30 @@ namespace Opm
             : use_prefix_(use_prefix),
               use_color_coding_(use_color_coding)
         {
+            if (use_prefix_) {
+                prefix_flag_ = Log::DefaultMessageTypes;
+            }
         }
 
+        SimpleMessageFormatter(const int64_t prefix_flag, const bool use_color_coding)
+            : prefix_flag_(prefix_flag),
+              use_color_coding_(use_color_coding)
+        {
+        }
+
+        SimpleMessageFormatter(const bool use_color_coding)
+            : use_color_coding_(use_color_coding)
+        {
+            prefix_flag_ = Log::MessageType::Warning + Log::MessageType::Error 
+                         + Log::MessageType::Problem + Log::MessageType::Bug;
+        }
         /// Returns a copy of the input string with a flag-dependant
         /// prefix (if use_prefix) and the entire message in a
         /// flag-dependent color (if use_color_coding).
         virtual std::string format(const int64_t message_flag, const std::string& message) override
         {
             std::string msg = message;
-            const int64_t prefix_flag = Log::MessageType::Warning + Log::MessageType::Error 
-                                      + Log::MessageType::Problem + Log::MessageType::Bug;
-            if (message_flag & prefix_flag) {
-                msg = Log::prefixMessage(message_flag, msg);
-            }
-            if (use_prefix_ && !(message_flag & prefix_flag)) {
+            if (message_flag & prefix_flag_) {
                 msg = Log::prefixMessage(message_flag, msg);
             }
             if (use_color_coding_) {
@@ -76,6 +86,7 @@ namespace Opm
     private:
         bool use_prefix_ = false;
         bool use_color_coding_ = false;
+        int64_t prefix_flag_ = 0;
     };
 
 

--- a/opm/common/OpmLog/MessageFormatter.hpp
+++ b/opm/common/OpmLog/MessageFormatter.hpp
@@ -60,7 +60,12 @@ namespace Opm
         virtual std::string format(const int64_t message_flag, const std::string& message) override
         {
             std::string msg = message;
-            if (use_prefix_) {
+            const int64_t prefix_flag = Log::MessageType::Warning + Log::MessageType::Error 
+                                      + Log::MessageType::Problem + Log::MessageType::Bug;
+            if (message_flag & prefix_flag) {
+                msg = Log::prefixMessage(message_flag, msg);
+            }
+            if (use_prefix_ && !(message_flag & prefix_flag)) {
                 msg = Log::prefixMessage(message_flag, msg);
             }
             if (use_color_coding_) {

--- a/opm/common/OpmLog/MessageFormatter.hpp
+++ b/opm/common/OpmLog/MessageFormatter.hpp
@@ -49,19 +49,20 @@ namespace Opm
     public:
         /// Constructor controlling formatting to be applied.
         SimpleMessageFormatter(const bool use_prefix, const bool use_color_coding)
-            : use_prefix_(use_prefix),
-              use_color_coding_(use_color_coding)
+            : use_color_coding_(use_color_coding)
         {
-            if (use_prefix_) {
+            if (use_prefix) {
                 prefix_flag_ = Log::DefaultMessageTypes;
             }
         }
 
+
         SimpleMessageFormatter(const int64_t prefix_flag, const bool use_color_coding)
-            : prefix_flag_(prefix_flag),
-              use_color_coding_(use_color_coding)
+            : use_color_coding_(use_color_coding),
+              prefix_flag_(prefix_flag)
         {
         }
+
 
         SimpleMessageFormatter(const bool use_color_coding)
             : use_color_coding_(use_color_coding)
@@ -84,7 +85,6 @@ namespace Opm
             return msg;
         }
     private:
-        bool use_prefix_ = false;
         bool use_color_coding_ = false;
         int64_t prefix_flag_ = 0;
     };

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
 
     // fileMessage
     BOOST_CHECK_EQUAL(fileMessage("foo/bar", 1, "message"), "foo/bar:1: message");
-    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "foo/bar:1: error: message");
+    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "foo/bar:1: Error: message");
 
     // prefixMessage
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "Error: message");
@@ -287,10 +287,10 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
     OpmLog::info("Info");
     OpmLog::bug("Bug");
 
-    const std::string expected = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
+    const std::string expected = Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error: Error") + "\n"
         + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n";
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug: Bug") + "\n";
 
     BOOST_CHECK_EQUAL(log_stream.str(), expected);
 
@@ -340,22 +340,22 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithLimits)
     OpmLog::warning(tag, "Warning");
     OpmLog::warning(tag, "Warning");
 
-    const std::string expected1 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
+    const std::string expected1 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error: Error") + "\n"
         + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Message limit reached for message tag: " + tag) + "\n";
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug: Bug") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Message limit reached for message tag: " + tag) + "\n";
 
     BOOST_CHECK_EQUAL(log_stream1.str(), expected1);
 
-    const std::string expected2 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
+    const std::string expected2 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error: Error") + "\n"
         + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n";
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug: Bug") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n";
 
     BOOST_CHECK_EQUAL(log_stream2.str(), expected2);
 

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -287,10 +287,10 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
     OpmLog::info("Info");
     OpmLog::bug("Bug");
 
-    const std::string expected = Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Error, "Error: Error") + "\n"
+    const std::string expected = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
         + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug: Bug") + "\n";
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n";
 
     BOOST_CHECK_EQUAL(log_stream.str(), expected);
 
@@ -340,22 +340,22 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithLimits)
     OpmLog::warning(tag, "Warning");
     OpmLog::warning(tag, "Warning");
 
-    const std::string expected1 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Error, "Error: Error") + "\n"
+    const std::string expected1 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
         + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug: Bug") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Message limit reached for message tag: " + tag) + "\n";
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Message limit reached for message tag: " + tag) + "\n";
 
     BOOST_CHECK_EQUAL(log_stream1.str(), expected1);
 
-    const std::string expected2 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Error, "Error: Error") + "\n"
+    const std::string expected2 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
         + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug: Bug") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning: Warning") + "\n";
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n";
 
     BOOST_CHECK_EQUAL(log_stream2.str(), expected2);
 
@@ -371,4 +371,52 @@ BOOST_AUTO_TEST_CASE(TestsetupSimpleLog)
     bool use_prefix = false;
     OpmLog::setupSimpleDefaultLogging(use_prefix);
     BOOST_CHECK_EQUAL(true, OpmLog::hasBackend("SimpleDefaultLog"));
+}
+
+
+
+BOOST_AUTO_TEST_CASE(TestFormat)
+{
+    OpmLog::removeAllBackends();
+    std::ostringstream log_stream1;
+    std::ostringstream log_stream2;
+    std::ostringstream log_stream3;
+    {
+        std::shared_ptr<StreamLog> streamLog1 = std::make_shared<StreamLog>(log_stream1, Log::DefaultMessageTypes);
+        std::shared_ptr<StreamLog> streamLog2 = std::make_shared<StreamLog>(log_stream2, Log::DefaultMessageTypes);
+        std::shared_ptr<StreamLog> streamLog3 = std::make_shared<StreamLog>(log_stream3, Log::DefaultMessageTypes);
+        OpmLog::addBackend("STREAM1" , streamLog1);
+        OpmLog::addBackend("STREAM2" , streamLog2);
+        OpmLog::addBackend("STREAM3" , streamLog3);
+        BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM1"));
+        BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM2"));
+        BOOST_CHECK_EQUAL( true , OpmLog::hasBackend("STREAM3"));
+        streamLog1->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false, true));
+        streamLog2->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(Log::MessageType::Info, true));
+        streamLog3->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(false));
+    }
+
+    OpmLog::warning("Warning");
+    OpmLog::error("Error");
+    OpmLog::info("Info");
+    OpmLog::bug("Bug");
+
+    const std::string expected1 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Info, "Info") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n";
+
+    const std::string expected2 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Info, "Info: Info") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n";
+
+    const std::string expected3 = Log::prefixMessage(Log::MessageType::Warning, "Warning") + "\n"
+        + Log::prefixMessage(Log::MessageType::Error, "Error") + "\n"
+        + "Info" + "\n"
+        + Log::prefixMessage(Log::MessageType::Bug, "Bug") + "\n";
+
+    BOOST_CHECK_EQUAL(log_stream1.str(), expected1);
+    BOOST_CHECK_EQUAL(log_stream2.str(), expected2);
+    BOOST_CHECK_EQUAL(log_stream3.str(), expected3);
 }

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -48,9 +48,9 @@ BOOST_AUTO_TEST_CASE(DoLogging) {
 BOOST_AUTO_TEST_CASE(Test_Format) {
     BOOST_CHECK_EQUAL( "/path/to/file:100: There is a mild fuckup here?" , Log::fileMessage("/path/to/file" , 100 , "There is a mild fuckup here?"));
 
-    BOOST_CHECK_EQUAL( "error: This is the error" ,     Log::prefixMessage(Log::MessageType::Error , "This is the error"));
-    BOOST_CHECK_EQUAL( "warning: This is the warning" , Log::prefixMessage(Log::MessageType::Warning , "This is the warning"));
-    BOOST_CHECK_EQUAL( "info: This is the info" ,       Log::prefixMessage(Log::MessageType::Info , "This is the info"));
+    BOOST_CHECK_EQUAL( "Error: This is the error" ,     Log::prefixMessage(Log::MessageType::Error , "This is the error"));
+    BOOST_CHECK_EQUAL( "Warning: This is the warning" , Log::prefixMessage(Log::MessageType::Warning , "This is the warning"));
+    BOOST_CHECK_EQUAL( "Info: This is the info" ,       Log::prefixMessage(Log::MessageType::Info , "This is the info"));
 }
 
 
@@ -252,9 +252,9 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "foo/bar:1: error: message");
 
     // prefixMessage
-    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "error: message");
-    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "info: message");
-    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Note, "message"), "note: message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "Error: message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "Info: message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Note, "message"), "Note: message");
 
     // colorCode Message
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), "message");


### PR DESCRIPTION
I think its better to make these four message types with prefix by default which can be a clear notification.