### PR TITLE
update jenkins build scripts

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -32,10 +32,10 @@ source $WORKSPACE/deps/opm-common/jenkins/setup-opm-data.sh
 # Downstream revisions
 declare -a downstreams
 downstreams=(opm-parser
+             opm-output
              opm-material
              opm-core
              opm-grid
-             opm-output
              opm-simulators
              opm-upscaling
              ewoms)


### PR DESCRIPTION
update build order, opm-output moved in the dependency tree