### PR TITLE
use the 'msg + file name + line number' format.

### DIFF
--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -35,7 +35,7 @@ namespace Log {
     std::string fileMessage(const std::string& filename , int line , const std::string& message) {
         std::ostringstream oss;
 
-        oss << message << ", file " << filename << ", line " << line;
+        oss << message << "\n" << "In file " << filename << ", line " << line << "\n";
 
         return oss.str();
     }

--- a/opm/common/OpmLog/LogUtil.cpp
+++ b/opm/common/OpmLog/LogUtil.cpp
@@ -35,7 +35,7 @@ namespace Log {
     std::string fileMessage(const std::string& filename , int line , const std::string& message) {
         std::ostringstream oss;
 
-        oss << filename << ":" << line << ": " << message;
+        oss << message << ", file " << filename << ", line " << line;
 
         return oss.str();
     }

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(DoLogging) {
 
 
 BOOST_AUTO_TEST_CASE(Test_Format) {
-    BOOST_CHECK_EQUAL( "There is a mild fuckup here?, file /path/to/file, line 100" , Log::fileMessage("/path/to/file" , 100 , "There is a mild fuckup here?"));
+    BOOST_CHECK_EQUAL( "There is a mild fuckup here?\nIn file /path/to/file, line 100\n" , Log::fileMessage("/path/to/file" , 100 , "There is a mild fuckup here?"));
 
     BOOST_CHECK_EQUAL( "Error: This is the error" ,     Log::prefixMessage(Log::MessageType::Error , "This is the error"));
     BOOST_CHECK_EQUAL( "Warning: This is the warning" , Log::prefixMessage(Log::MessageType::Warning , "This is the warning"));
@@ -248,8 +248,8 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     BOOST_CHECK(isPower2(1ul << 62));
 
     // fileMessage
-    BOOST_CHECK_EQUAL(fileMessage("foo/bar", 1, "message"), "message, file foo/bar, line 1");
-    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "Error: message, file foo/bar, line 1");
+    BOOST_CHECK_EQUAL(fileMessage("foo/bar", 1, "message"), "message\nIn file foo/bar, line 1\n");
+    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "Error: message\nIn file foo/bar, line 1\n");
 
     // prefixMessage
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "Error: message");

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(DoLogging) {
 
 
 BOOST_AUTO_TEST_CASE(Test_Format) {
-    BOOST_CHECK_EQUAL( "/path/to/file:100: There is a mild fuckup here?" , Log::fileMessage("/path/to/file" , 100 , "There is a mild fuckup here?"));
+    BOOST_CHECK_EQUAL( "There is a mild fuckup here?, file /path/to/file, line 100" , Log::fileMessage("/path/to/file" , 100 , "There is a mild fuckup here?"));
 
     BOOST_CHECK_EQUAL( "Error: This is the error" ,     Log::prefixMessage(Log::MessageType::Error , "This is the error"));
     BOOST_CHECK_EQUAL( "Warning: This is the warning" , Log::prefixMessage(Log::MessageType::Warning , "This is the warning"));
@@ -248,8 +248,8 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     BOOST_CHECK(isPower2(1ul << 62));
 
     // fileMessage
-    BOOST_CHECK_EQUAL(fileMessage("foo/bar", 1, "message"), "foo/bar:1: message");
-    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "foo/bar:1: Error: message");
+    BOOST_CHECK_EQUAL(fileMessage("foo/bar", 1, "message"), "message, file foo/bar, line 1");
+    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "Error: message, file foo/bar, line 1");
 
     // prefixMessage
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "Error: message");


### PR DESCRIPTION
For output, "msg + file name + line number" could be a better order. Just unify the output format as that for VFP checking in opm-parser.