### PR TITLE
Change Find-output test source code

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -30,8 +30,9 @@ find_opm_package (
   ""
 
   # test program
-"#include <opm/output/OutputWriter.hpp>
+  "#include <opm/output/Wells.hpp>
 int main (void) {
+  data::Rates r;
   return 0;  
 }
 "

--- a/cmake/Modules/opm-output-prereqs.cmake
+++ b/cmake/Modules/opm-output-prereqs.cmake
@@ -14,7 +14,7 @@ set (opm-output_DEPS
 	"CXX11Features REQUIRED"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS filesystem system unit_test_framework REQUIRED"
+		COMPONENTS unit_test_framework REQUIRED"
 	# Ensembles-based Reservoir Tools (ERT)
 	"ERT REQUIRED"
 	# Look for MPI support


### PR DESCRIPTION
opm-output is about to remove the OutputWriter.hpp header, which means
this test program will break. Wells.hpp and default-constructed
data::Rates is a better fit for the future.