### PR TITLE
Change Find-output test source code

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -30,9 +30,10 @@ find_opm_package (
   ""
 
   # test program
-"#include <opm/output/OutputWriter.hpp>
+"#include <opm/output/Wells.hpp>
 int main (void) {
-  return 0;  
+    Opm::data::Rates r;
+    return 0;
 }
 "
   # config variables


### PR DESCRIPTION
opm-output is about to remove the OutputWriter.hpp header, which means
this test program will break. Wells.hpp and default-constructed
data::Rates is a better fit for the future.