### PR TITLE
Run Python / ERT based integration tests.

### DIFF
--- a/cmake/Modules/OpmPythonTest.cmake
+++ b/cmake/Modules/OpmPythonTest.cmake
@@ -1,0 +1,7 @@
+function (opm_add_python_test TEST_NAME TEST_SCRIPT)
+    add_test(NAME ${TEST_NAME} 
+             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+             COMMAND ${TEST_SCRIPT} ${ARGN})
+
+    set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "PYTHONPATH=${ERT_PYTHON_PATH}:${PYTHONPATH}")
+endfunction(opm_add_python_test)

--- a/cmake/Modules/opm-simulators-prereqs.cmake
+++ b/cmake/Modules/opm-simulators-prereqs.cmake
@@ -19,7 +19,8 @@ set (opm-simulators_DEPS
 	# DUNE prerequisites
 	"dune-common REQUIRED;
 	dune-istl REQUIRED"
-	# OPM dependency
+	"ERTPython"
+        # OPM dependency
 	"opm-common REQUIRED;
         opm-parser REQUIRED;
 	opm-core REQUIRED;


### PR DESCRIPTION
When working with output module comparison of the output files generated by flow with reference files is a quite common task. Schematically this involves the two steps:

1. Run `<TARGET_FILE:flow> input_file.data`.
2. Compare generated files with reference solution

Further requirements:

1. The comparison will typically involve floating point comparison of selected parts of Eclipse formatted output files - i.e. `diff` or similar shell utilities is to simple minded.
2. As seen from `cmake` the two steps must be coupled together as *one test*.

In this PR I suggest a python based solution, the solution consists of three parts:

1. `ERTPython` is added as an optional  requirement to `opm-simulator`. The Python distribution is built by default by ERT, and has been integrated in the travis build system from more-or-less day one, so I suspect no surprises here.

2. The small cmake function `opm_add_python_test()`

3. The actual script running `flow` and then doing whatever comparisons we are interested in, an example comparing the `TRANX, TRANY` and `TRANZ` keywords from the `INIT`file are in the last commit of: https://github.com/OPM/opm-simulators/pull/738  