### PR TITLE
Installing numpy using conda before building ert.

### DIFF
--- a/travis/build-and-test.sh
+++ b/travis/build-and-test.sh
@@ -25,7 +25,6 @@ build_order=(opm-common opm-parser opm-material opm-output opm-core opm-grid opm
 # This can typically be achived by using the 'clone-opm.sh' script.
 
 
-
 function upstream_build {
     project=${1}
     echo "Building: ${project}"
@@ -50,6 +49,11 @@ function downstream_build_and_test {
     ctest --output-on-failure
     popd > /dev/null
 }
+
+#-----------------------------------------------------------------
+
+export CONDA_HOME="$HOME/miniconda"
+export PATH="$CONDA_HOME/bin:$PATH"
 
 
 for i in "${!build_order[@]}"; do

--- a/travis/build-prereqs.sh
+++ b/travis/build-prereqs.sh
@@ -47,8 +47,23 @@ function build_superlu {
 }
 
 
+function install_python_deps {
+    export TRAVIS_PYTHON_VERSION="2.7"
+    wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+
+    bash miniconda.sh -b -p $HOME/miniconda
+    export CONDA_HOME="$HOME/miniconda"
+    export PATH="$CONDA_HOME/bin:$PATH"
+    hash -r
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+
+    conda install numpy
+}
+
 
 function build_ert {
+    install_python_deps
     git clone https://github.com/Ensembles/ert.git
     mkdir -p ert/build
     pushd ert/build > /dev/null


### PR DESCRIPTION
The python class: `ert.ecl.ecl_sum.EclSum` requires the `numpy` package; with this PR that is installed on the Travis build node before building. The `numpy` package is already installed on the Jenkins build server, that was why this was not discovered earlier - sorry about this last minute glitch.

Status Python based integration testing:

1. The dependencies are: python, `numpy` and the Python bindings for ert. If you are missing any of these the tests will be skipped silently.
2. Examples of tests are [here](https://github.com/OPM/opm-simulators/blob/master/CMakeLists.txt#L155) where some of the keywords from the INIT file in the SPE1 and Norne are compared with reference data - the script doing the comparison is [here](https://github.com/OPM/opm-simulators/blob/master/tests/compare_INIT.py).[1]

I sincerely hope this will be a positive contribution to OPM; if that turns out be false we will remove it again.

[1]: The conclusion from these tests are: https://github.com/OPM/opm-simulators/issues/746 can closed, and we now have *basic* support for `TRAN?` output. 