### PR TITLE
Finddune-alugrid.cmake: add missing libraries

### DIFF
--- a/cmake/Modules/Finddune-alugrid.cmake
+++ b/cmake/Modules/Finddune-alugrid.cmake
@@ -64,7 +64,7 @@ find_opm_package (
   "dune/alugrid/grid.hh"
 
   # library to search for
-  "dunealugrid"
+  "alugrid_serial;alugrid_parallel;dunealugrid"
 
   # defines to be added to compilations
   ""


### PR DESCRIPTION
without this, I get missing symbols for both the releases/2.4 and
master branches of dune-alugrid. Note that I don't know if this fix is
correct or not. (@dr-robertk should probably comment on this.)