### PR TITLE
Adding rftRegressionTest command

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -55,6 +55,9 @@ if(OPM_OUTPUT_FOUND)
   find_program(INIT_REGRESSION_TEST_COMMAND initRegressionTest
                PATHS ${opm-output_PREFIX_DIR}/../bin
                      ${opm-output_PREFIX_DIR}/../../bin)
+  find_program(RFT_REGRESSION_TEST_COMMAND rftRegressionTest
+               PATHS ${opm-output_PREFIX_DIR}/../bin
+                     ${opm-output_PREFIX_DIR}/../../bin)
 
 endif()
 


### PR DESCRIPTION
CMake variable created, to be used (for instance) in opm-simulators to run the RFT application in OPM/opm-output#55.