### PR TITLE
Change name of cmake variable

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -45,14 +45,10 @@ include (UseDynamicBoost)
 
 if(OPM_OUTPUT_FOUND)
   get_filename_component(opm-output_PREFIX_DIR ${opm-output_LIBRARY} PATH)
-  find_program(SUMMARY_REGRESSION_TEST_COMMAND summaryRegressionTest
+  find_program(COMPARE_SUMMARY_COMMAND compareSummary
                PATHS ${opm-output_PREFIX_DIR}/../bin
                      ${opm-output_PREFIX_DIR}/../../bin)
-  find_program(RESTART_REGRESSION_TEST_COMMAND restartRegressionTest
-               PATHS ${opm-output_PREFIX_DIR}/../bin
-                     ${opm-output_PREFIX_DIR}/../../bin)
-
-  find_program(INIT_REGRESSION_TEST_COMMAND initRegressionTest
+  find_program(COMPARE_ECL_COMMAND compareECL
                PATHS ${opm-output_PREFIX_DIR}/../bin
                      ${opm-output_PREFIX_DIR}/../../bin)
 


### PR DESCRIPTION
Due to change of name of binary in opm-output([PR](https://github.com/OPM/opm-output/pull/71)), the cmake variable should change name. 