### PR TITLE
opm_add_test: make it possible to hide disabled tests

### DIFF
--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -1,4 +1,8 @@
 # - Build satellites that are dependent of main library
+
+set(ADD_DISABLED_CTESTS YES CACHE BOOL "Add the tests which are disabled due to failed preconditions to the ctest output (this makes ctest return an error if such a test is present)")
+mark_as_advanced(ADD_DISABLED_CTESTS)
+
 #
 # Enumerate all source code in a "satellite" directory such as tests/,
 # compile each of them and optionally set them as a test for CTest to
@@ -337,7 +341,7 @@ macro(opm_add_test TestName)
     # the following causes the test to appear as 'skipped' in the
     # CDash dashboard. it this is removed, the test is just silently
     # ignored.
-    if (NOT CURTEST_ONLY_COMPILE)
+    if (NOT CURTEST_ONLY_COMPILE AND ADD_DISABLED_CTESTS)
       add_test(${TestName} skip_test_dummy)
     endif()
   endif()


### PR DESCRIPTION
the purpose is to make CI systems like travis happy because ctest counts tests with status "(Not Run)" as failed and returns a non-zero exit code.

this feature can be enabled using the -DADD_DISABLED_CTESTS=ON cmake parameter.

(note that, strictly speaking, eWoms is not the only module which suffers from this problem. To my knowledge it is just the only OPM module which uses conditional tests-)