### PR TITLE
Hook FD-Applications up to OPM build system

### DIFF
--- a/cmake/Modules/Findopm-flowdiagnostics.cmake
+++ b/cmake/Modules/Findopm-flowdiagnostics.cmake
@@ -23,7 +23,7 @@ find_opm_package (
   "${opm-flowdiagnostics_DEPS}"
   
   # header to search for
-  "opm/flowdiagnostics/reorder/tarjan.h"
+  "opm/flowdiagnostics/Toolbox.hpp"
 
   # library to search for
   "opmflowdiagnostics"
@@ -32,16 +32,15 @@ find_opm_package (
   ""
 
   # test program
-"#include <opm/flowdiagnostics/reorder/tarjan.h>
-int main() {
-  const int ia[]  = { 0, 0, 1, 2, 4 };
-  const int ja[]  = { 0, 0, 1, 2 };
-  int vert[4]     = { 0 };
-  int comp[4 + 1] = { 0 };
-  int ncomp       =   0  ;
-  int work[3 * 4] = { 0 };
+"#include <opm/flowdiagnostics/Toolbox.hpp>
 
-  tarjan(4, ia, ja, vert, comp, &ncomp, work);
+#include <vector>
+
+int main()
+{
+    using FDT = Opm::FlowDiagnostics::Toolbox;
+
+    const auto pv = FDT::PoreVolume{ std::vector<double>(10, 0.3) };
 }
 "
   # config variables

--- a/cmake/Modules/opm-flowdiagnostics-applications-prereqs.cmake
+++ b/cmake/Modules/opm-flowdiagnostics-applications-prereqs.cmake
@@ -1,0 +1,21 @@
+# -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t; compile-command: "cmake -Wdev" -*-
+# vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
+
+# defines that must be present in config.h for our headers
+set (opm-flowdiagnostics-applications_CONFIG_VAR
+	)
+
+# dependencies
+set (opm-flowdiagnostics-applications_DEPS
+	# compile with C99 support if available
+	"C99"
+	# compile with C++0x/11 support if available
+	"CXX11Features REQUIRED"
+	"Boost 1.44.0
+		COMPONENTS filesystem system unit_test_framework REQUIRED"
+	"ERT REQUIRED"
+	# prerequisite OPM modules
+	"opm-common REQUIRED;
+	opm-flowdiagnostics REQUIRED;
+	opm-core REQUIRED"
+	)


### PR DESCRIPTION
This commit recognizes the [opm-flowdiagnostics-applications](https://github.com/OPM/opm-flowdiagnostics-applications) module in OPM's centralised build system.  We make requisite changes to the FIND support for module opm-flowdiagnostics (header [`tarjan.h`](https://github.com/OPM/opm-flowdiagnostics/blob/master/opm/utility/graph/tarjan.h) is currently not public/installed) and make a first cut at explicit prerequisites for FD-Applications.