### PR TITLE
Ert repo reorg

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -34,7 +34,7 @@ find_path (ERT_ECL_INCLUDE_DIR
   NAMES "ert/ecl/ecl_util.h"
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_SOURCE_DIR}/../ert"
-  PATH_SUFFIXES "devel/libecl/include/" "include"
+  PATH_SUFFIXES "libecl/include/" "include"
   DOC "Path to ERT Eclipse library header files"
   ${_no_default_path}
   )
@@ -42,7 +42,7 @@ find_path (ERT_ECL_WELL_INCLUDE_DIR
   NAMES "ert/ecl_well/well_const.h"
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_SOURCE_DIR}/../ert"
-  PATH_SUFFIXES "devel/libecl_well/include/" "include"
+  PATH_SUFFIXES "libecl_well/include/" "include"
   DOC "Path to ERT Eclipse library header files"
   ${_no_default_path}
   )
@@ -50,7 +50,7 @@ find_path (ERT_ECLXX_INCLUDE_DIR
   NAMES "ert/ecl/EclKW.hpp"
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_SOURCE_DIR}/../ert"
-  PATH_SUFFIXES "devel/libeclxx/include/" "include"
+  PATH_SUFFIXES "libeclxx/include/" "include"
   DOC "Path to ERT Eclipse C++ library header files"
   ${_no_default_path}
   )
@@ -58,7 +58,7 @@ find_path (ERT_UTIL_INCLUDE_DIR
   NAMES "ert/util/stringlist.h"
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_SOURCE_DIR}/../ert"
-  PATH_SUFFIXES "devel/libert_util/include/" "include"
+  PATH_SUFFIXES "libert_util/include/" "include"
   DOC "Path to ERT Eclipse library header files"
   ${_no_default_path}
   )
@@ -66,7 +66,7 @@ find_path (ERT_UTILXX_INCLUDE_DIR
   NAMES "ert/util/ert_unique_ptr.hpp"
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_SOURCE_DIR}/../ert"
-  PATH_SUFFIXES "devel/libert_utilxx/include/" "include"
+  PATH_SUFFIXES "libert_utilxx/include/" "include"
   DOC "Path to ERT Eclipse C++ library header files"
   ${_no_default_path}
   )  
@@ -74,8 +74,8 @@ find_path (ERT_GEN_INCLUDE_DIR
   NAMES "ert/util/int_vector.h"
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_SOURCE_DIR}/../ert"
-  PATH_SUFFIXES "devel/libert_util/include"
-                "include" "build/libert_util/include" "devel/build/libert_util/include"
+  PATH_SUFFIXES "libert_util/include"
+                "include" "build/libert_util/include" "build/libert_util/include"
   DOC "Path to ERT generated library header files"
   ${_no_default_path}
   )
@@ -90,9 +90,7 @@ find_library (ERT_LIBRARY_ECL
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert"
         "${PROJECT_SOURCE_DIR}/../ert/build"
-        "${PROJECT_SOURCE_DIR}/../ert/devel/build"
         "${PROJECT_BINARY_DIR}/../ert-build"
-        "${PROJECT_BINARY_DIR}/../ert/devel"
   PATH_SUFFIXES "lib" "lib/Release" "lib/Debug" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Eclipse library archive/shared object files"
   ${_no_default_path}
@@ -102,9 +100,7 @@ find_library (ERT_LIBRARY_ECLXX
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert"
         "${PROJECT_SOURCE_DIR}/../ert/build"
-        "${PROJECT_SOURCE_DIR}/../ert/devel/build"
         "${PROJECT_BINARY_DIR}/../ert-build"
-        "${PROJECT_BINARY_DIR}/../ert/devel"
   PATH_SUFFIXES "lib" "lib/Release" "lib/Debug" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Eclipse C++ library archive/shared object files"
   ${_no_default_path}
@@ -114,9 +110,7 @@ find_library (ERT_LIBRARY_ECL_WELL
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert"
         "${PROJECT_SOURCE_DIR}/../ert/build"
-        "${PROJECT_SOURCE_DIR}/../ert/devel/build"
         "${PROJECT_BINARY_DIR}/../ert-build"
-        "${PROJECT_BINARY_DIR}/../ert/devel"
   PATH_SUFFIXES "lib" "lib/Release" "lib/Debug" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Eclipse library archive/shared object files"
   ${_no_default_path}
@@ -126,9 +120,7 @@ find_library (ERT_LIBRARY_GEOMETRY
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert"
         "${PROJECT_SOURCE_DIR}/../ert/build"
-        "${PROJECT_SOURCE_DIR}/../ert/devel/build"
         "${PROJECT_BINARY_DIR}/../ert-build"
-        "${PROJECT_BINARY_DIR}/../ert/devel"
   PATH_SUFFIXES "lib" "lib/Release" "lib/Debug" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Geometry library archive/shared object files"
   ${_no_default_path}
@@ -138,9 +130,7 @@ find_library (ERT_LIBRARY_UTIL
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert"
         "${PROJECT_SOURCE_DIR}/../ert/build"
-        "${PROJECT_SOURCE_DIR}/../ert/devel/build"
         "${PROJECT_BINARY_DIR}/../ert-build"
-        "${PROJECT_BINARY_DIR}/../ert/devel"
   PATH_SUFFIXES "lib" "lib/Release" "lib/Debug" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Utilities library archive/shared object files"
   ${_no_default_path}
@@ -150,9 +140,7 @@ find_library (ERT_LIBRARY_UTILXX
   HINTS "${ERT_ROOT}"
   PATHS "${PROJECT_BINARY_DIR}/../ert"
         "${PROJECT_SOURCE_DIR}/../ert/build"
-        "${PROJECT_SOURCE_DIR}/../ert/devel/build"
         "${PROJECT_BINARY_DIR}/../ert-build"
-        "${PROJECT_BINARY_DIR}/../ert/devel"
   PATH_SUFFIXES "lib" "lib/Release" "lib/Debug" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   DOC "Path to ERT Utilities library archive/shared object files"
   ${_no_default_path}

--- a/cmake/Modules/FindERTPython.cmake
+++ b/cmake/Modules/FindERTPython.cmake
@@ -31,9 +31,7 @@ if(PYTHONINTERP_FOUND)
 
   # Add various popular sibling alternatives.
   list(APPEND PATH_LIST "${PROJECT_SOURCE_DIR}/../ert/build"
-    			"${PROJECT_SOURCE_DIR}/../ert/devel/build"
-    			"${PROJECT_BINARY_DIR}/../ert-build"
-    			"${PROJECT_BINARY_DIR}/../ert/devel")
+    			"${PROJECT_BINARY_DIR}/../ert-build")
 
   foreach( PATH ${PATH_LIST})
       set( python_code "import sys; sys.path.insert(0 , '${PATH}/${PYTHON_INSTALL_PREFIX}'); import os.path; import inspect; import ert; print os.path.dirname(os.path.dirname(inspect.getfile(ert))); from ert.ecl import EclSum")

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -65,7 +65,7 @@ popd
 pushd .
 mkdir -p serial/build-ert
 cd serial/build-ert
-cmake $WORKSPACE/deps/ert/devel -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install
+cmake $WORKSPACE/deps/ert -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install
 cmake --build . --target install
 popd
 

--- a/travis/build-prereqs.sh
+++ b/travis/build-prereqs.sh
@@ -67,7 +67,7 @@ function build_ert {
     git clone https://github.com/Ensembles/ert.git
     mkdir -p ert/build
     pushd ert/build > /dev/null
-    cmake ../devel && make
+    cmake .. && make
     popd > /dev/null
 }
 


### PR DESCRIPTION
In this https://github.com/Ensembles/ert/pull/1196 the ERT repository layout is changed to be more standard compliant. This PR updates jenkins/ and travis/ build configurations accordingly.

I will self-merge this when https://github.com/Ensembles/ert/pull/1196 has been merged - and this PR is green again; probably on monday. 