### PR TITLE
simplify jenkins scripts after ert reorganization

### DIFF
--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -24,7 +24,12 @@ function clone_module {
   mkdir -p $WORKSPACE/deps/$1
   cd $WORKSPACE/deps/$1
   git init .
-  git remote add origin https://github.com/OPM/$1
+  if [ "$1" == "ert" ]
+  then
+    git remote add origin https://github.com/Ensembles/$1
+  else
+    git remote add origin https://github.com/OPM/$1
+  fi
   git fetch --depth 1 origin $2:branch_to_build
   git checkout branch_to_build
   test $? -eq 0 || exit 1

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -31,7 +31,8 @@ source $WORKSPACE/deps/opm-common/jenkins/setup-opm-data.sh
 
 # Downstream revisions
 declare -a downstreams
-downstreams=(opm-parser
+downstreams=(ert
+             opm-parser
              opm-output
              opm-material
              opm-core
@@ -41,6 +42,7 @@ downstreams=(opm-parser
              ewoms)
 
 declare -A downstreamRev
+downstreamRev[ert]=master
 downstreamRev[opm-parser]=master
 downstreamRev[opm-material]=master
 downstreamRev[opm-core]=master
@@ -49,25 +51,6 @@ downstreamRev[opm-output]=master
 downstreamRev[opm-simulators]=master
 downstreamRev[opm-upscaling]=master
 downstreamRev[ewoms]=master
-
-# Build ERT
-echo "Building downstream ert=$ERT_REVISION"
-pushd .
-mkdir -p $WORKSPACE/deps/ert
-cd $WORKSPACE/deps/ert
-git init .
-git remote add origin https://github.com/Ensembles/ert
-git fetch --depth 1 origin $ERT:branch_to_build
-test $? -eq 0 || exit 1
-git checkout branch_to_build
-popd
-
-pushd .
-mkdir -p serial/build-ert
-cd serial/build-ert
-cmake $WORKSPACE/deps/ert -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install
-cmake --build . --target install
-popd
 
 build_downstreams opm-common
 


### PR DESCRIPTION
The reorganization allows handling ert as any other upstream except the necessary github url exception.