### PR TITLE
Add multiconfiguration support to jenkins scripts

### DIFF
--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -1,17 +1,100 @@
 #!/bin/bash
 
+declare -A configurations
+
+# Parse revisions from trigger comment and setup arrays
+# Depends on: 'upstreams', upstreamRev',
+#             'downstreams', 'downstreamRev',
+#             'ghprbCommentBody',
+#             'CONFIGURATIONS', 'TOOLCHAINS'
+function parseRevisions {
+  for upstream in ${upstreams[*]}
+  do
+    if grep -qi "$upstream=" <<< $ghprbCommentBody
+    then
+      upstreamRev[$upstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*${upstream,,}=([0-9]+).*/\1/g"`/merge
+    fi
+  done
+  if grep -q "with downstreams" <<< $ghprbCommentBody
+  then
+    for downstream in ${downstreams[*]}
+    do
+      if grep -qi "$downstream=" <<< $ghprbCommentBody
+      then
+        downstreamRev[$downstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*${downstream,,}=([0-9]+).*/\1/g"`/merge
+      fi
+    done
+  fi
+
+  # Default to a serial build if no types are given
+  if test -z "$BTYPES"
+  then
+    BTYPES="serial"
+  fi
+
+  # Convert to arrays for easy looping
+  declare -a BTYPES_ARRAY
+  for btype in $BTYPES
+  do
+    BTYPES_ARRAY=($BTYPES_ARRAY $btype)
+  done
+  TOOLCHAIN_ARRAY=($CMAKE_TOOLCHAIN_FILES)
+  for index in ${!BTYPES_ARRAY[*]}
+  do
+    key=${BTYPES_ARRAY[$index]}
+    data=${TOOLCHAIN_ARRAY[$index]}
+    configurations[$key]=$data
+  done
+}
+
+# Print revisions and configurations
+# $1 = Name of main module
+# Depends on: 'upstreams', upstreamRev',
+#             'downstreams', 'downstreamRev',
+#             'ghprbCommentBody',
+#             'configurations', 'sha1'
+function printHeader {
+  echo -e "Repository revisions:"
+  for upstream in ${upstreams[*]}
+  do
+    echo -e "\t   [upstream] $upstream=${upstreamRev[$upstream]}"
+  done
+  echo -e "\t[main module] $1=$sha1"
+  if grep -q "with downstreams" <<< $ghprbCommentBody
+  then
+    for downstream in ${downstreams[*]}
+    do
+      echo -e "\t [downstream] $downstream=${downstreamRev[$downstream]}"
+    done
+  fi
+
+  echo "Configurations to process:"
+  for conf in ${!configurations[@]}
+  do
+    echo -e "\t$conf=${configurations[$conf]}"
+  done
+}
+
 # $1 = Additional cmake parameters
 # $2 = 0 to build and install module, 1 to build and test module
 # $3 = Source root of module to build
 function build_module {
-  cmake $3 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=$2 $1
+  cmake $3 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=$2 -DCMAKE_TOOLCHAIN_FILE=${configurations[$configuration]} $1
   test $? -eq 0 || exit 1
   if test $2 -eq 1
   then
     cmake --build .
     test $? -eq 0 || exit 2
     ctest -T Test --no-compress-output
+
+    # Convert to junit format
     $WORKSPACE/deps/opm-common/jenkins/convert.py -x $WORKSPACE/deps/opm-common/jenkins/conv.xsl -t . > testoutput.xml
+
+    if ! grep -q "with downstreams" <<< $ghprbCommentBody
+    then
+      # Add configuration name
+      sed -e "s/classname=\"TestSuite\"/classname=\"${configuration}\"/g" testoutput.xml > $WORKSPACE/$configuration/testoutput.xml
+    fi
   else
     cmake --build . --target install
   fi
@@ -20,6 +103,8 @@ function build_module {
 # $1 = Name of module
 # $2 = git-rev to use for module
 function clone_module {
+  # Already cloned by an earlier configuration
+  test -d $WORKSPACE/deps/$1 && return 0
   pushd .
   mkdir -p $WORKSPACE/deps/$1
   cd $WORKSPACE/deps/$1
@@ -43,7 +128,7 @@ function clone_module {
 function clone_and_build_module {
   clone_module $1 $3
   pushd .
-  mkdir $4/build-$1
+  mkdir -p $4/build-$1
   cd $4/build-$1
   test_build=0
   if test -n "$5"
@@ -60,10 +145,9 @@ function clone_and_build_module {
 function build_upstreams {
   for upstream in ${upstreams[*]}
   do
-    echo "Building upstream $upstream=${upstreamRev[$upstream]}"
+    echo "Building upstream $upstream=${upstreamRev[$upstream]} configuration=$configuration"
     # Build upstream and execute installation
-    # ENABLE_PYTHON - will build the Python wrappers for OpmParser, ignored by the other modules.
-    clone_and_build_module $upstream "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install -DENABLE_PYTHON=ON" ${upstreamRev[$upstream]} $WORKSPACE/serial
+    clone_and_build_module $upstream "-DCMAKE_PREFIX_PATH=$WORKSPACE/$configuration/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install" ${upstreamRev[$upstream]} $WORKSPACE/$configuration
     test $? -eq 0 || exit 1
   done
   test $? -eq 0 || exit 1
@@ -74,35 +158,55 @@ function build_upstreams {
 # which holds the default revisions to use for downstreams
 function build_downstreams {
   pushd .
-  cd $WORKSPACE/serial/build-$1
+  cd $WORKSPACE/$configuration/build-$1
   cmake --build . --target install
   popd
 
-  egrep_cmd="xml_grep --wrap testsuites --cond testsuite $WORKSPACE/serial/build-$1/testoutput.xml"
+  egrep_cmd="xml_grep --wrap testsuites --cond testsuite $WORKSPACE/$configuration/build-$1/testoutput.xml"
   for downstream in ${downstreams[*]}
   do
-    if grep -q "$downstream=" <<< $ghprbCommentBody
-    then
-      downstreamRev[$downstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*$downstream=([0-9]+).*/\1/g"`/merge
-    fi
-    echo "Building downstream $downstream=${downstreamRev[$downstream]}"
+    echo "Building downstream $downstream=${downstreamRev[$downstream]} configuration=$configuration"
     # Build downstream and execute installation
-    # Additional cmake parameters:
-    # OPM_DATA_ROOT - passed for modules having opm-data based integration tests
-    # USE_QUADMATH - used by ewoms to disable quadmath support (makes tests usable)
-    # ENABLE_PYTHON - will build the Python wrappers for OpmParser, ignored by the other modules.
-    # ADD_DISABLED_CTESTS - will not add ctests to the output which are disabled due to missing dependencies.
-    clone_and_build_module $downstream "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install -DOPM_DATA_ROOT=$OPM_DATA_ROOT -DENABLE_PYTHON=ON -DUSE_QUADMATH=0 -DADD_DISABLED_CTESTS=OFF" ${downstreamRev[$downstream]} $WORKSPACE/serial 1
+    clone_and_build_module $downstream "-DCMAKE_PREFIX_PATH=$WORKSPACE/$configuration/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install -DOPM_DATA_ROOT=$OPM_DATA_ROOT" ${downstreamRev[$downstream]} $WORKSPACE/$configuration 1
     test $? -eq 0 || exit 1
 
     # Installation for downstream
     pushd .
-    cd $WORKSPACE/serial/build-$downstream
+    cd $WORKSPACE/$configuration/build-$downstream
     cmake --build . --target install
     popd
-    egrep_cmd="$egrep_cmd $WORKSPACE/serial/build-$downstream/testoutput.xml"
+    egrep_cmd="$egrep_cmd $WORKSPACE/$configuration/build-$downstream/testoutput.xml"
   done
 
-  $egrep_cmd > testoutput.xml
+  $egrep_cmd > $WORKSPACE/$configuration/testoutput.xml
+
+  # Add testsuite name
+  sed -e "s/classname=\"TestSuite\"/classname=\"${configuration}\"/g" -i $WORKSPACE/$configuration/testoutput.xml
+
   test $? -eq 0 || exit 1
+}
+
+# $1 = Name of main module
+function build_module_full {
+  for configuration in ${!configurations[@]}
+  do
+    # Build upstream modules
+    build_upstreams
+
+    # Build main module
+    pushd .
+    mkdir -p $configuration/build-$1
+    cd $configuration/build-$1
+    echo "Building main module $1=$sha1 configuration=$configuration"
+    build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install" 1 $WORKSPACE
+    test $? -eq 0 || exit 1
+    popd
+
+    # If no downstream builds we are done
+    if grep -q "with downstreams" <<< $ghprbCommentBody
+    then
+      build_downstreams $1
+      test $? -eq 0 || exit 1
+    fi
+  done
 }

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -6,30 +6,7 @@ source `dirname $0`/build-opm-module.sh
 mkdir deps
 ln -sf $WORKSPACE deps/opm-common
 
-pushd .
-mkdir -p serial/build-opm-common
-cd serial/build-opm-common
-build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" 1 $WORKSPACE
-test $? -eq 0 || exit 1
-popd
-
-# If no downstream builds we are done
-if ! grep -q "with downstreams" <<< $ghprbCommentBody
-then
-  cp serial/build-opm-common/testoutput.xml .
-  exit 0
-fi
-
-ERT_REVISION=master
-
-if grep -q "ert=" <<< $ghprbCommentBody
-then
-  ERT_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*ert=([0-9]+).*/\1/g'`/merge
-fi
-
-source $WORKSPACE/deps/opm-common/jenkins/setup-opm-data.sh
-
-# Downstream revisions
+# Downstreams and revisions
 declare -a downstreams
 downstreams=(ert
              opm-parser
@@ -52,6 +29,13 @@ downstreamRev[opm-simulators]=master
 downstreamRev[opm-upscaling]=master
 downstreamRev[ewoms]=master
 
-build_downstreams opm-common
+parseRevisions
+printHeader opm-common
 
-test $? -eq 0 || exit 1
+# Setup opm-data if necessary
+if grep -q "with downstreams" <<< $ghprbCommentBody
+then
+  source $WORKSPACE/deps/opm-common/jenkins/setup-opm-data.sh
+fi
+
+build_module_full opm-common


### PR DESCRIPTION
This adds multi-configuration support to the jenkins build scripts. It will be used to do mpi-enabled builds as well on jenkins. The mechanism is pretty simple; you have two environment variables BTYPES and CMAKE_TOOLCHAIN_FILES that is pre-filled by the user. Split and then put into an a-array instead of user supplying the a-array as those are a bugger on the command line. The toolchain files have 'full power', you can set compilers and options etc. (ie we can put -DUSE_MPI=1 in the toolchain file).

WIP, and includes PR #168 since i built on top of that.

@bska does this look acceptable ? should i remove the additional information?
Note that it will look slightly less clean in the output for downstreams (when some downstream is the main module), as i will have to clone opm-common first to obtain the helper scripts. No way around that.