### PR TITLE
FindQuadmath.cmake: fix the first argument of find_package_handle_standard_args()

### DIFF
--- a/cmake/Modules/FindQuadmath.cmake
+++ b/cmake/Modules/FindQuadmath.cmake
@@ -42,7 +42,7 @@ if (USE_QUADMATH AND NOT QUADMATH_FOUND)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(QuadMath
+find_package_handle_standard_args(Quadmath
   DEFAULT_MSG
   QUADMATH_LIBRARIES
   HAVE_QUAD


### PR DESCRIPTION
It needs to match the filename exacly, i.e. including the case.