### PR TITLE
Update opm-flowdiagnostics system probe for API change

### DIFF
--- a/cmake/Modules/Findopm-flowdiagnostics.cmake
+++ b/cmake/Modules/Findopm-flowdiagnostics.cmake
@@ -40,7 +40,7 @@ int main()
 {
     using FDT = Opm::FlowDiagnostics::Toolbox;
 
-    const auto pv = FDT::PoreVolume{ std::vector<double>(10, 0.3) };
+    const auto pv = std::vector<double>(10, 0.3);
 }
 "
   # config variables


### PR DESCRIPTION
This commit brings the system probe for module [opm-flowdiagnostics](https://github.com/OPM/opm-flowdiagnostics) up-to-date with recent changes in the public interface of the module's main entry point.  Commit OPM/opm-flowdiagnostics@8456e81 removed the nested type
```C++
Opm::FlowDiagnostics::Toolbox::PoreVolume
```
so we must drop all references to this type.