### PR TITLE
Change name of cmake variables and fix jenkins

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -45,14 +45,10 @@ include (UseDynamicBoost)
 
 if(OPM_OUTPUT_FOUND)
   get_filename_component(opm-output_PREFIX_DIR ${opm-output_LIBRARY} PATH)
-  find_program(SUMMARY_REGRESSION_TEST_COMMAND summaryRegressionTest
+  find_program(COMPARE_SUMMARY_COMMAND compareSummary
                PATHS ${opm-output_PREFIX_DIR}/../bin
                      ${opm-output_PREFIX_DIR}/../../bin)
-  find_program(RESTART_REGRESSION_TEST_COMMAND restartRegressionTest
-               PATHS ${opm-output_PREFIX_DIR}/../bin
-                     ${opm-output_PREFIX_DIR}/../../bin)
-
-  find_program(INIT_REGRESSION_TEST_COMMAND initRegressionTest
+  find_program(COMPARE_ECL_COMMAND compareECL
                PATHS ${opm-output_PREFIX_DIR}/../bin
                      ${opm-output_PREFIX_DIR}/../../bin)
 

--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -198,7 +198,7 @@ function build_module_full {
     mkdir -p $configuration/build-$1
     cd $configuration/build-$1
     echo "Building main module $1=$sha1 configuration=$configuration"
-    build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install" 1 $WORKSPACE
+    build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install -DOPM_DATA_ROOT=$OPM_DATA_ROOT" 1 $WORKSPACE
     test $? -eq 0 || exit 1
     popd
 


### PR DESCRIPTION
This

- changes the name of cmake variables for locating regression test applications
- fixes a bug in the jenkins scripts, in particular, passing of opm-data root to the main module build.

Unrelated, but to aid testing I need a PR with both commits.

Replaces #161 