### PR TITLE
Allow disabling output in EclipsePRTLog.

### DIFF
--- a/opm/common/OpmLog/EclipsePRTLog.cpp
+++ b/opm/common/OpmLog/EclipsePRTLog.cpp
@@ -45,6 +45,11 @@ namespace Opm {
 
     EclipsePRTLog::~EclipsePRTLog()
     {
+        if( ! print_summary_ )
+        {
+            return;
+        }
+
         //output summary.
         const std::string summary_msg = "\n\nError summary:" + 
             std::string("\nWarnings          " + std::to_string(numMessages(Log::MessageType::Warning))) +
@@ -56,4 +61,14 @@ namespace Opm {
         StreamLog::addTaggedMessage(Log::MessageType::Info, "", summary_msg);
     }
 
+    EclipsePRTLog::EclipsePRTLog(const std::string& logFile , int64_t messageMask,
+                  bool append, bool print_summary)
+        : StreamLog(logFile, messageMask, append),
+          print_summary_(print_summary)
+    {}
+
+    EclipsePRTLog::EclipsePRTLog(std::ostream& os , int64_t messageMask,
+                                 bool print_summary)
+        : StreamLog(os, messageMask), print_summary_(print_summary)
+    {}
 }

--- a/opm/common/OpmLog/EclipsePRTLog.cpp
+++ b/opm/common/OpmLog/EclipsePRTLog.cpp
@@ -61,13 +61,16 @@ namespace Opm {
         StreamLog::addTaggedMessage(Log::MessageType::Info, "", summary_msg);
     }
 
-    EclipsePRTLog::EclipsePRTLog(const std::string& logFile , int64_t messageMask,
-                  bool append, bool print_summary)
+    EclipsePRTLog::EclipsePRTLog(const std::string& logFile,
+                                 int64_t messageMask,
+                                 bool append,
+                                 bool print_summary)
         : StreamLog(logFile, messageMask, append),
           print_summary_(print_summary)
     {}
 
-    EclipsePRTLog::EclipsePRTLog(std::ostream& os , int64_t messageMask,
+    EclipsePRTLog::EclipsePRTLog(std::ostream& os,
+                                 int64_t messageMask,
                                  bool print_summary)
         : StreamLog(os, messageMask), print_summary_(print_summary)
     {}

--- a/opm/common/OpmLog/EclipsePRTLog.hpp
+++ b/opm/common/OpmLog/EclipsePRTLog.hpp
@@ -57,7 +57,7 @@ public:
 private:
     std::map<int64_t, size_t> m_count;
     /// \brief Whether to print a summary to the log file.
-    bool print_summary_;
+    bool print_summary_ = true;
 };
 }
 #endif // ECLIPSEPRTLOG_H

--- a/opm/common/OpmLog/EclipsePRTLog.hpp
+++ b/opm/common/OpmLog/EclipsePRTLog.hpp
@@ -29,6 +29,7 @@ namespace Opm {
 class EclipsePRTLog : public StreamLog {
 
 public:
+    using StreamLog::StreamLog;
 
     void addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& message);
 
@@ -37,10 +38,10 @@ public:
     ~EclipsePRTLog();
 
     EclipsePRTLog(const std::string& logFile , int64_t messageMask,
-                  bool append, bool print_summary=true);
+                  bool append, bool print_summary);
 
     EclipsePRTLog(std::ostream& os , int64_t messageMask,
-                  bool print_summary=true);
+                  bool print_summary);
 private:
     std::map<int64_t, size_t> m_count;
     bool print_summary_;

--- a/opm/common/OpmLog/EclipsePRTLog.hpp
+++ b/opm/common/OpmLog/EclipsePRTLog.hpp
@@ -29,7 +29,6 @@ namespace Opm {
 class EclipsePRTLog : public StreamLog {
 
 public:
-    using StreamLog::StreamLog;
 
     void addTaggedMessage(int64_t messageType, const std::string& messageTag, const std::string& message);
 
@@ -37,8 +36,14 @@ public:
 
     ~EclipsePRTLog();
 
+    EclipsePRTLog(const std::string& logFile , int64_t messageMask,
+                  bool append, bool print_summary=true);
+
+    EclipsePRTLog(std::ostream& os , int64_t messageMask,
+                  bool print_summary=true);
 private:
     std::map<int64_t, size_t> m_count;
+    bool print_summary_;
 };
 }
 #endif // ECLIPSEPRTLOG_H

--- a/opm/common/OpmLog/EclipsePRTLog.hpp
+++ b/opm/common/OpmLog/EclipsePRTLog.hpp
@@ -37,13 +37,26 @@ public:
 
     ~EclipsePRTLog();
 
+    /// \brief Construct a logger to the <MODLE>.PRT file
+    /// \param logFile The name of the logfile to use.
+    /// \param messageMask ????
+    /// \param append If true then we append messages to the file.
+    ///               Otherwise a new file is created.
+    /// \param print_summary If true print a summary to the PRT file.
     EclipsePRTLog(const std::string& logFile , int64_t messageMask,
                   bool append, bool print_summary);
 
+    /// \brief Construct a logger to the <MODLE>.PRT file
+    /// \param logFile The name of the logfile to use.
+    /// \param messageMask ????
+    /// \param append If true then we append messages to the file.
+    ///               Otherwise a new file is created.
+    /// \param print_summary If true print a summary to the PRT file.
     EclipsePRTLog(std::ostream& os , int64_t messageMask,
                   bool print_summary);
 private:
     std::map<int64_t, size_t> m_count;
+    /// \brief Whether to print a summary to the log file.
     bool print_summary_;
 };
 }


### PR DESCRIPTION
In a parallel run we need to be able to disable output in EclipsePRTLog
as only one process is allowed to output messages. This commit adds a
new defaulted constructor parameter to allow this.