### PR TITLE
OPM_THROW does not log the error message, new OPM_THROW_LOG does

### DIFF
--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -53,11 +53,30 @@
     do {                                                                \
         std::ostringstream oss__;                                       \
         oss__ << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
-        Opm::OpmLog::error(oss__.str());                                \
+        throw Exception(oss__.str());                                   \
+    } while (false)
+
+// Macro to throw an exception and log the message. NOTE: For this macro
+// to work, the
+// exception class must exhibit a constructor with the signature
+// (const std::string &message). Since this condition is not fulfilled
+// for the std::exception, you should use this macro with some
+// exception class derived from either std::logic_error or
+// std::runtime_error.
+//
+// Usage: OPM_THROW_LOG(ExceptionClass, "Error message " << value);
+#define OPM_THROW_LOG(Exception, message)                                   \
+    do {                                                                \
+        std::ostringstream oss__;                                       \
+        oss__ << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
+        Opm::OpmLog::error(oss__.str())                                 \
         throw Exception(oss__.str());                                   \
     } while (false)
 
 // throw an exception if a condition is true
 #define OPM_ERROR_IF(condition, message) do {if(condition){ OPM_THROW(std::logic_error, message);}} while(false)
+
+// throw an exception and log the message if a condition is true
+#define OPM_ERROR_LOG_IF(condition, message) do {if(condition){ OPM_THROW_LOG(std::logic_error, message);}} while(false)
 
 #endif // OPM_ERRORMACROS_HPP


### PR DESCRIPTION
Logging each exception.message() is suprising for developers as
throwing an exception can often be handled by surrounding code and
does not necessarily present an error of the program. Additionally,
there was no support to suppress any logging at this point.

With this commit OPM_THROW does not log the error message any more.
For people insisting on the logging there are new macros OPM_THROW_LOG
OPM_ERROR_LOG_IF that use the old behaviour.

Still it seems more clean if the calling code does logging if it assumes
that it is needed. This might prevent multipl output in parallel programs
(as was/is the case for non-converging linear solvers.)