### PR TITLE
Update find output

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -30,9 +30,8 @@ find_opm_package (
   ""
 
   # test program
-"#include <opm/output/Wells.hpp>
+"#include <opm/output/eclipse/Summary.hpp>
 int main (void) {
-    Opm::data::Rates r;
     return 0;
 }
 "


### PR DESCRIPTION
Due to upcoming changes in the opm-output: https://github.com/OPM/opm-output/pull/101 the Findopm-output module is updated. Due to the same ongoing updates we currently do not have any easily constructable symbols in opm-output, so the test does currently not involve linking.

Will update at a later stage when changes in opm-output have settled down.

This PR can be merged without any downstream changes, but it must be merged *before* https://github.com/OPM/opm-output/pull/101