### PR TITLE
Add OPM_THROW_NOLOG macro.

### DIFF
--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -57,6 +57,16 @@
         throw Exception(oss__.str());                                   \
     } while (false)
 
+// Same as OPM_THROW, except for not making an OpmLog::error() call.
+//
+// Usage: OPM_THROW_NOLOG(ExceptionClass, "Error message " << value);
+#define OPM_THROW_NOLOG(Exception, message)                             \
+    do {                                                                \
+        std::ostringstream oss__;                                       \
+        oss__ << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
+        throw Exception(oss__.str());                                   \
+    } while (false)
+
 // throw an exception if a condition is true
 #define OPM_ERROR_IF(condition, message) do {if(condition){ OPM_THROW(std::logic_error, message);}} while(false)
 


### PR DESCRIPTION
The macro added is intended to solve a problem of noisy threads (in parallel) and also that exceptions due to linear solver trouble should be labeled "problem" and not "error" (i.e. it is quite common, and not something we can't handle). So this is intended as a replacement for #179.

Followup PRs are coming that will depend on this, but this can be merged independently.

@joakim-hove, @akva2: can one of you review this?