### PR TITLE
[bugfix] since HAVE_DUNE_ISTL is used in opm-grid it should be tested for.

### DIFF
--- a/cmake/Modules/opm-grid-prereqs.cmake
+++ b/cmake/Modules/opm-grid-prereqs.cmake
@@ -9,6 +9,9 @@ set (opm-grid_CONFIG_VAR
 	DUNE_COMMON_VERSION_MAJOR
 	DUNE_COMMON_VERSION_MINOR
 	DUNE_COMMON_VERSION_REVISION
+	DUNE_ISTL_VERSION_MAJOR
+	DUNE_ISTL_VERSION_MINOR
+	DUNE_ISTL_VERSION_REVISION
 	HAVE_ZOLTAN
 	)
 
@@ -23,10 +26,11 @@ set (opm-grid_DEPS
 		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED;
-	dune-grid REQUIRED;
-	dune-geometry REQUIRED"
+   dune-grid REQUIRED;
+   dune-geometry REQUIRED
+	 dune-istl"
 	# OPM dependency
-        "opm-common REQUIRED;
-        opm-core REQUIRED"
+  "opm-common REQUIRED;
+   opm-core REQUIRED"
 	"ZOLTAN"
 	)


### PR DESCRIPTION
Since HAVE_DUNE_ISTL is used in the opm-grid, dune-istl needs to be tested for. It's as before not a hard dependency.
