### PR TITLE
dune 2.5 support

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -33,20 +33,34 @@ include(CheckIncludeFileCXX)
 # macro to only add option once
 include(AddOptions)
 
-if(CMAKE_VERSION VERSION_LESS 3.1)
+# Force CXX Standard cross platfrom for CMakeVersion >=3.1
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+
+
   if(NOT MSVC)
-    foreach(_flag "c++14" "c++11" "c++0x")
-      string(REPLACE "c++" "CXX_FLAG_CXX" _FLAG ${_flag})
-      # try to use compiler flag -std=${_flag}
-      CHECK_CXX_ACCEPTS_FLAG("-std=${_flag}" ${_FLAG})
+    foreach(_flag "14" "11")
+      set(_FLAG "CXX_FLAG_CXX${_flag}")
+      string(TOUPPER ${_FLAG} _FLAG)
+      # try to use compiler flag -std=c++${_flag}
+      CHECK_CXX_ACCEPTS_FLAG("-std=c++${_flag}" ${_FLAG})
+
       if(${_FLAG})
-	add_options (CXX ALL_BUILDS "-std=${_flag}")
-	set(CXX_STD0X_FLAGS "-std=${_flag}")
-	break()
+        if(CMAKE_VERSION VERSION_LESS 3.1)
+          add_options (CXX ALL_BUILDS "-std=${_flag}")
+        endif()
+        set(CXX_STD0X_FLAGS "-std=${_flag}")
+        #Use vriables for CMake > 3.1 set the standard with no extensions
+        set(CMAKE_CXX_STANDARD ${_flag})
+        break()
       endif()
     endforeach()
   endif(NOT MSVC)
+endif()
 
+if(CMAKE_VERSION VERSION_LESS 3.1)
   # if we are building with an Apple toolchain in MacOS X,
   # we cannot use the old GCC 4.2 fork, but must use the
   # new runtime library
@@ -55,8 +69,8 @@ if(CMAKE_VERSION VERSION_LESS 3.1)
   if (APPLE AND (_comp_id MATCHES "CLANG"))
     CHECK_CXX_ACCEPTS_FLAG ("-stdlib=libc++" CXX_FLAG_STDLIB_LIBCXX)
     if (CXX_FLAG_STDLIB_LIBCXX)
-          add_options (CXX ALL_BUILDS "-stdlib=libc++")
-          set (CXX_STDLIB_FLAGS "-stdlib=libc++")
+      add_options (CXX ALL_BUILDS "-stdlib=libc++")
+      set (CXX_STDLIB_FLAGS "-stdlib=libc++")
     endif (CXX_FLAG_STDLIB_LIBCXX)
   endif (APPLE AND (_comp_id MATCHES "CLANG"))
 
@@ -66,19 +80,15 @@ if(CMAKE_VERSION VERSION_LESS 3.1)
   else (CXX_STD0X_FLAGS AND CXX_STDLIB_FLAGS)
     set (CXX_SPACE)
   endif (CXX_STD0X_FLAGS AND CXX_STDLIB_FLAGS)
-else()
-  if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-  endif()
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
 
-  # Workaround bug in cmake:
-  # cxx standard flags are not applied in CheckCXXSourceCompiles
-  if (CMAKE_CXX_STANDARD EQUAL 14)
-    add_options(CXX ALL_BUILDS ${CMAKE_CXX14_STANDARD_COMPILE_OPTION})
-  else()
-    add_options(CXX ALL_BUILDS ${CMAKE_CXX11_STANDARD_COMPILE_OPTION})
+  if(NOT CMAKE_VERSION VERSION_LESS 3.1)
+    # Workaround bug in cmake:
+    # cxx standard flags are not applied in CheckCXXSourceCompiles
+    if (CMAKE_CXX_STANDARD EQUAL 14)
+      add_options(CXX ALL_BUILDS ${CMAKE_CXX14_STANDARD_COMPILE_OPTION})
+    else()
+      add_options(CXX ALL_BUILDS ${CMAKE_CXX11_STANDARD_COMPILE_OPTION})
+    endif()
   endif()
 endif()
 
@@ -330,7 +340,6 @@ CHECK_CXX_SOURCE_COMPILES("
      return 0;
    }
 " HAVE_VARIADIC_TEMPLATES
-)
 
 # SFINAE on variadic template constructors within template classes
 CHECK_CXX_SOURCE_COMPILES("

--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -340,6 +340,7 @@ CHECK_CXX_SOURCE_COMPILES("
      return 0;
    }
 " HAVE_VARIADIC_TEMPLATES
+)
 
 # SFINAE on variadic template constructors within template classes
 CHECK_CXX_SOURCE_COMPILES("

--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -35,19 +35,16 @@ include(AddOptions)
 
 if(CMAKE_VERSION VERSION_LESS 3.1)
   if(NOT MSVC)
-    # try to use compiler flag -std=c++11
-    CHECK_CXX_ACCEPTS_FLAG("-std=c++11" CXX_FLAG_CXX11)
-    if(CXX_FLAG_CXX11)
-      add_options (CXX ALL_BUILDS "-std=c++11")
-      set(CXX_STD0X_FLAGS "-std=c++11")
-    else()
-      # try to use compiler flag -std=c++0x for older compilers
-      CHECK_CXX_ACCEPTS_FLAG("-std=c++0x" CXX_FLAG_CXX0X)
-      if(CXX_FLAG_CXX0X)
-        add_options (CXX ALL_BUILDS "-std=c++0x")
-        set(CXX_STD0X_FLAGS "-std=c++0x")
-      endif(CXX_FLAG_CXX0X)
-    endif(CXX_FLAG_CXX11)
+    foreach(_flag "c++14" "c++11" "c++0x")
+      string(REPLACE "c++" "CXX_FLAG_CXX" _FLAG ${_flag})
+      # try to use compiler flag -std=${_flag}
+      CHECK_CXX_ACCEPTS_FLAG("-std=${_flag}" ${_FLAG})
+      if(${_FLAG})
+	add_options (CXX ALL_BUILDS "-std=${_flag}")
+	set(CXX_STD0X_FLAGS "-std=${_flag}")
+	break()
+      endif()
+    endforeach()
   endif(NOT MSVC)
 
   # if we are building with an Apple toolchain in MacOS X,

--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -80,17 +80,18 @@ if(CMAKE_VERSION VERSION_LESS 3.1)
   else (CXX_STD0X_FLAGS AND CXX_STDLIB_FLAGS)
     set (CXX_SPACE)
   endif (CXX_STD0X_FLAGS AND CXX_STDLIB_FLAGS)
+endif()
 
-  if(NOT CMAKE_VERSION VERSION_LESS 3.1)
-    # Workaround bug in cmake:
-    # cxx standard flags are not applied in CheckCXXSourceCompiles
-    if (CMAKE_CXX_STANDARD EQUAL 14)
-      add_options(CXX ALL_BUILDS ${CMAKE_CXX14_STANDARD_COMPILE_OPTION})
-    else()
-      add_options(CXX ALL_BUILDS ${CMAKE_CXX11_STANDARD_COMPILE_OPTION})
-    endif()
+if(NOT CMAKE_VERSION VERSION_LESS 3.1)
+  # Workaround bug in cmake:
+  # cxx standard flags are not applied in CheckCXXSourceCompiles
+  if (CMAKE_CXX_STANDARD EQUAL 14)
+    add_options(CXX ALL_BUILDS ${CMAKE_CXX14_STANDARD_COMPILE_OPTION})
+  else()
+    add_options(CXX ALL_BUILDS ${CMAKE_CXX11_STANDARD_COMPILE_OPTION})
   endif()
 endif()
+
 
 # perform tests
 include(CheckCXXSourceCompiles)

--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -49,9 +49,9 @@ if(NOT CMAKE_CXX_STANDARD)
 
       if(${_FLAG})
         if(CMAKE_VERSION VERSION_LESS 3.1)
-          add_options (CXX ALL_BUILDS "-std=${_flag}")
+          add_options (CXX ALL_BUILDS "-std=c++${_flag}")
         endif()
-        set(CXX_STD0X_FLAGS "-std=${_flag}")
+        set(CXX_STD0X_FLAGS "-std=c++${_flag}")
         #Use vriables for CMake > 3.1 set the standard with no extensions
         set(CMAKE_CXX_STANDARD ${_flag})
         break()

--- a/cmake/Modules/Finddune-grid.cmake
+++ b/cmake/Modules/Finddune-grid.cmake
@@ -41,7 +41,7 @@ find_opm_package (
 "#include <dune/grid/onedgrid.hh>
 int main (void) {
   Dune::OneDGrid grid(1, 0., 1.);
-  return grid.lbegin<0>(0) == grid.lend<0>(0);
+  return grid.leafGridView().begin<0>() == grid.leafGridView().end<0>();
 }
 "
   # config variables

--- a/cmake/Modules/Finddune-grid.cmake
+++ b/cmake/Modules/Finddune-grid.cmake
@@ -41,7 +41,7 @@ find_opm_package (
 "#include <dune/grid/onedgrid.hh>
 int main (void) {
   Dune::OneDGrid grid(1, 0., 1.);
-  return grid.leafGridView().begin<0>() == grid.leafGridView().end<0>();
+  return grid.size(0);
 }
 "
   # config variables


### PR DESCRIPTION
This is needed to make OPM compile with 2.5. Otherwise dune-common
is not found because of missing std::decay_t support.
