### PR TITLE
add a boost dependency to ewoms

### DIFF
--- a/cmake/Modules/ewoms-prereqs.cmake
+++ b/cmake/Modules/ewoms-prereqs.cmake
@@ -23,6 +23,9 @@ set (ewoms_CONFIG_VAR
 set (ewoms_DEPS
 	# compile with C++0x/11 support if available
 	"CXX11Features REQUIRED"
+	# we need boost::alignment (which is header-only, so it does not
+	# need to be specified by the COMPONENTS argument)
+	"Boost 1.44.0 REQUIRED"
 	# DUNE prerequisites
 	"dune-common REQUIRED"
 	"dune-geometry REQUIRED"


### PR DESCRIPTION
this is needed because the alignment requirements of data types also need to be respected on the heap. (otherwise your processor will be _very_ unhappy about AVX/SSE code!)

if anyone knows a better alternative to boost::alignment, please let me know!