### PR TITLE
Revert "[bugfix] since HAVE_DUNE_ISTL is used in opm-grid it should b…

### DIFF
--- a/cmake/Modules/opm-grid-prereqs.cmake
+++ b/cmake/Modules/opm-grid-prereqs.cmake
@@ -9,9 +9,6 @@ set (opm-grid_CONFIG_VAR
 	DUNE_COMMON_VERSION_MAJOR
 	DUNE_COMMON_VERSION_MINOR
 	DUNE_COMMON_VERSION_REVISION
-	DUNE_ISTL_VERSION_MAJOR
-	DUNE_ISTL_VERSION_MINOR
-	DUNE_ISTL_VERSION_REVISION
 	HAVE_ZOLTAN
 	)
 
@@ -26,11 +23,10 @@ set (opm-grid_DEPS
 		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED;
-   dune-grid REQUIRED;
-   dune-geometry REQUIRED
-	 dune-istl"
+	dune-grid REQUIRED;
+	dune-geometry REQUIRED"
 	# OPM dependency
-  "opm-common REQUIRED;
-   opm-core REQUIRED"
+        "opm-common REQUIRED;
+        opm-core REQUIRED"
 	"ZOLTAN"
 	)


### PR DESCRIPTION
…e tested for. It's"

This exposed problems in the build system design resulting in
scary warnings building downstreams of opm-grid with dune-control.

Hotfix the release by reverting the commit. 

This reverts commit b9af87abc227145673280f9713efe69f2516505e.