### PR TITLE
Support external cjson

### DIFF
--- a/cmake/Modules/Findcjson.cmake
+++ b/cmake/Modules/Findcjson.cmake
@@ -20,7 +20,7 @@ endif (CJSON_ROOT)
 find_path (CJSON_INCLUDE_DIR
   NAMES "cjson/cJSON.h"
   HINTS "${CJSON_ROOT}"
-  PATHS "${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/../opm-parser"
+  PATHS "${PROJECT_SOURCE_DIR}"
   PATH_SUFFIXES "include" "external"
   DOC "Path to cjson library header files"
   ${_no_default_path} )

--- a/cmake/Modules/Findcjson.cmake
+++ b/cmake/Modules/Findcjson.cmake
@@ -21,7 +21,7 @@ find_path (CJSON_INCLUDE_DIR
   NAMES "cjson/cJSON.h"
   HINTS "${CJSON_ROOT}"
   PATHS "${PROJECT_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}/../opm-parser"
-  PATH_SUFFIXES "include" "opm/json"
+  PATH_SUFFIXES "include" "external"
   DOC "Path to cjson library header files"
   ${_no_default_path} )
 

--- a/cmake/Modules/Findopm-parser.cmake
+++ b/cmake/Modules/Findopm-parser.cmake
@@ -138,7 +138,12 @@ if (ERT_FOUND AND Boost_FOUND AND
     ${ERT_LIBRARIES})
 
   # We might be using an external cJSON library
+  # but we have to unset the OPM_PARSER_ROOT stuff to find it
+  # (other NO_DEFAULT_PATH will be set).
+  set(_OPM_PARSER_ROOT_bak ${OPM_PARSER_ROOT})
+  set(OPM_PARSER_ROOT "")
   find_package(cjson)
+  set(OPM_PARSER_ROOT ${OPM_PARSER_ROOT_bak})
 
   if (CJSON_FOUND)
     # If we do we need to add it to the libs.

--- a/cmake/Modules/Findopm-parser.cmake
+++ b/cmake/Modules/Findopm-parser.cmake
@@ -137,6 +137,16 @@ if (ERT_FOUND AND Boost_FOUND AND
     ${Boost_LIBRARIES}
     ${ERT_LIBRARIES})
 
+  # We might be using an external cJSON library
+  find_package(cjson)
+
+  if (CJSON_FOUND)
+    # If we do we need to add it to the libs.
+    set (opm-parser_LIBRARIES
+      ${opm-parser_LIBRARIES}
+      ${CJSON_LIBRARY})
+  endif (CJSON_FOUND)
+
   # see if we can compile a minimum example
   # CMake logical test doesn't handle lists (sic)
   include (CMakePushCheckState)


### PR DESCRIPTION
These fixes are needed to support externally installed cJSON libraries.

Please merge together with upcoming PR in opm-parser.