### PR TITLE
opm-material: actually check for valgrind

### DIFF
--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -20,4 +20,6 @@ set (opm-material_DEPS
 	"opm-common REQUIRED"
 	# DUNE dependency
 	"dune-common REQUIRED"
+	# valgrind client requests
+	"Valgrind"
 	)


### PR DESCRIPTION
a config.h variable was already set but the actual test was not run
for opm-material.