### PR TITLE
Silence warnings not from current module.

### DIFF
--- a/cmake/Modules/OpmCompile.cmake
+++ b/cmake/Modules/OpmCompile.cmake
@@ -13,11 +13,13 @@ macro (opm_compile opm)
   # all public header files are together with the source. prepend our own
   # source path to the one of the dependencies so that our version of any
   # ambigious paths are used.
-  set (${opm}_INCLUDE_DIR "${PROJECT_SOURCE_DIR}")
-  set (${opm}_INCLUDE_DIRS ${${opm}_INCLUDE_DIR} ${${opm}_INCLUDE_DIRS})
+  # set (${opm}_INCLUDE_DIR "${PROJECT_SOURCE_DIR}")
+  # set (${opm}_INCLUDE_DIRS ${${opm}_INCLUDE_DIR} ${${opm}_INCLUDE_DIRS})
 
   # create this library, if there are any compilation units
-  include_directories (${${opm}_INCLUDE_DIRS})
+  # include_directories (${${opm}_INCLUDE_DIRS})
+  include_directories("${PROJECT_SOURCE_DIR}")
+  include_directories (SYSTEM ${${opm}_INCLUDE_DIRS})
   link_directories (${${opm}_LIBRARY_DIRS})
   add_definitions (${${opm}_DEFINITIONS})
   set (${opm}_VERSION "${${opm}_VERSION_MAJOR}.${${opm}_VERSION_MINOR}")


### PR DESCRIPTION
Since this summer the situation with respect to warnings from third-party headers has been quite bad, since opm-parser stopped using the header suppression functionality. To avoid such warnings drowning out useful warnings I have been using the contents of this patch, which is something of a hack. One downside is that with this you will not get any warnings from headers in other modules than the one you currently compile, as they are tagged as system includes.

I hope some of the more cmake-skilled can comment on this and propose improvements so that we can get something like this by default.