### PR TITLE
adding -Wcast-qual to disable_warnings.h

### DIFF
--- a/opm/common/utility/platform_dependent/disable_warnings.h
+++ b/opm/common/utility/platform_dependent/disable_warnings.h
@@ -73,6 +73,7 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wcast-align"
+#pragma GCC diagnostic ignored "-Wcast-qual"
 #endif // COMPATIBLE_COMPILER
 
 #endif // SILENCE_EXTERNAL_WARNINGS


### PR DESCRIPTION
To avoid a lot of warnings from `mpi.h` when building in parallel. 
