### PR TITLE
Disable ewoms tests

### DIFF
--- a/travis/build-and-test.sh
+++ b/travis/build-and-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-build_order=(opm-common opm-parser opm-material opm-output opm-core opm-grid ewoms opm-simulators opm-upscaling)
+build_order=(opm-common opm-parser opm-material opm-output opm-core opm-grid ewoms opm-simulators)
 
 # This shell script should be started with the name of a module as
 # only only command line argument. It will start by building all
@@ -44,9 +44,14 @@ function downstream_build_and_test {
     # The build commands cmake, make and ctest must be given as
     # separate commands and not chained with &&. If chaining with &&
     # is used the 'set -e' does not exit on first error.
-    cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=ON -DSILENCE_EXTERNAL_WARNINGS=ON -DUSE_QUADMATH=OFF -DADD_DISABLED_CTESTS=OFF
-    make
-    ctest --output-on-failure
+    if [ "$project" == "ewoms" ]; then
+       cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=OFF -DSILENCE_EXTERNAL_WARNINGS=ON -DUSE_QUADMATH=OFF -DADD_DISABLED_CTESTS=OFF
+       make
+    else
+       cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=ON -DSILENCE_EXTERNAL_WARNINGS=ON -DUSE_QUADMATH=OFF -DADD_DISABLED_CTESTS=OFF
+       make
+       ctest --output-on-failure
+    fi
     popd > /dev/null
 }
 

--- a/travis/build-and-test.sh
+++ b/travis/build-and-test.sh
@@ -30,7 +30,7 @@ function upstream_build {
     echo "Building: ${project}"
     mkdir -p ${project}/build
     pushd ${project}/build > /dev/null
-    cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=OFF -DSILENCE_EXTERNAL_WARNINGS=True -DUSE_QUADMATH=OFF -DADD_DISABLED_CTESTS=OFF
+    cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=OFF -DSILENCE_EXTERNAL_WARNINGS=ON -DUSE_QUADMATH=OFF -DADD_DISABLED_CTESTS=OFF
     make 
     popd > /dev/null
 }
@@ -44,7 +44,7 @@ function downstream_build_and_test {
     # The build commands cmake, make and ctest must be given as
     # separate commands and not chained with &&. If chaining with &&
     # is used the 'set -e' does not exit on first error.
-    cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=ON -DSILENCE_EXTERNAL_WARNINGS=True -DUSE_QUADMATH=OFF -DADD_DISABLED_CTESTS=OFF
+    cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=ON -DSILENCE_EXTERNAL_WARNINGS=ON -DUSE_QUADMATH=OFF -DADD_DISABLED_CTESTS=OFF
     make
     ctest --output-on-failure
     popd > /dev/null


### PR DESCRIPTION
1. Disable ewoms testing.
2. Disable opm-upscaling completely

This should be temporary measures to get the Travis build testing to complete before it times out.