### PR TITLE
Revert dependencies of opm-core and opm-grid. opm-core is not depende…

### DIFF
--- a/cmake/Modules/ewoms-prereqs.cmake
+++ b/cmake/Modules/ewoms-prereqs.cmake
@@ -35,6 +35,7 @@ set (ewoms_DEPS
 	"dune-fem"
 	"opm-parser"
 	"opm-grid"
+	"opm-core"
 	# librt (on some systems necessary for clock_gettime())
 	"librt REQUIRED"
 	# valgrind client requests

--- a/cmake/Modules/opm-core-prereqs.cmake
+++ b/cmake/Modules/opm-core-prereqs.cmake
@@ -42,5 +42,8 @@ set (opm-core_DEPS
 	"opm-parser REQUIRED"
 	# the code which implements the material laws
 	"opm-material REQUIRED"
+	# the code which implements the output routines
 	"opm-output REQUIRED"
+	# the code which implements grids
+	"opm-grid REQUIRED"
 	)

--- a/cmake/Modules/opm-grid-prereqs.cmake
+++ b/cmake/Modules/opm-grid-prereqs.cmake
@@ -9,9 +9,6 @@ set (opm-grid_CONFIG_VAR
 	DUNE_COMMON_VERSION_MAJOR
 	DUNE_COMMON_VERSION_MINOR
 	DUNE_COMMON_VERSION_REVISION
-	DUNE_ISTL_VERSION_MAJOR
-	DUNE_ISTL_VERSION_MINOR
-	DUNE_ISTL_VERSION_REVISION
 	HAVE_ZOLTAN
 	)
 
@@ -27,10 +24,8 @@ set (opm-grid_DEPS
 	# DUNE dependency
 	"dune-common REQUIRED;
    dune-grid REQUIRED;
-   dune-geometry REQUIRED
-	 dune-istl"
-	# OPM dependency
-  "opm-common REQUIRED;
-   opm-core REQUIRED"
+	 dune-geometry REQUIRED;
+   opm-common REQUIRED;
+	 opm-parser REQUIRED"
 	"ZOLTAN"
 	)

--- a/cmake/Modules/opm-simulators-prereqs.cmake
+++ b/cmake/Modules/opm-simulators-prereqs.cmake
@@ -20,12 +20,13 @@ set (opm-simulators_DEPS
 	"dune-common REQUIRED;
 	dune-istl REQUIRED"
 	"ERTPython"
-        # OPM dependency
+  # OPM dependency
 	"opm-common REQUIRED;
-        opm-parser REQUIRED;
-	opm-core REQUIRED;
-	opm-output REQUIRED;
-	opm-grid"
+   opm-parser REQUIRED;
+	 opm-grid REQUIRED;
+	 opm-core REQUIRED;
+	 opm-output REQUIRED;
+	 ewoms REQUIRED"
 	# Eigen
 	"Eigen3 3.2.0"
 	)

--- a/cmake/Modules/opm-upscaling-prereqs.cmake
+++ b/cmake/Modules/opm-upscaling-prereqs.cmake
@@ -26,7 +26,7 @@ set (opm-upscaling_DEPS
 	dune-geometry REQUIRED;
 	dune-grid REQUIRED;
 	opm-common REQUIRED;
+  opm-grid REQUIRED;
 	opm-core REQUIRED;
-        opm-grid REQUIRED;
 	opm-output REQUIRED"
 	)


### PR DESCRIPTION
opm-core is not dependent on opm-grid. All headers in opm/core/grid redirect to the corresponding headers in opm-grid/opm/grid with a deprecation warning. This needs PR #254 in opm-grid