### PR TITLE
Request Boost.Regex to Support FD-Application Acceptance Tests

### DIFF
--- a/cmake/Modules/opm-flowdiagnostics-applications-prereqs.cmake
+++ b/cmake/Modules/opm-flowdiagnostics-applications-prereqs.cmake
@@ -12,7 +12,7 @@ set (opm-flowdiagnostics-applications_DEPS
 	# compile with C++0x/11 support if available
 	"CXX11Features REQUIRED"
 	"Boost 1.44.0
-		COMPONENTS filesystem system unit_test_framework REQUIRED"
+		COMPONENTS filesystem regex system unit_test_framework REQUIRED"
 	"ERT REQUIRED"
 	# prerequisite OPM modules
 	"opm-common REQUIRED;


### PR DESCRIPTION
Incoming support for running solution acceptance tests in module [opm-flowdiagnostics-applications](https://github.com/OPM/opm-flowdiagnostics-applications) requires ability to work with regular expressions in C++.  OPM's minimum requirement of GCC 4.8 means we cannot rely on standard facilities in this respect.