### PR TITLE
Make setupSimpleDefaultLogging() more flexible.

### DIFF
--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -176,12 +176,14 @@ namespace Opm {
 
 
 
-    void OpmLog::setupSimpleDefaultLogging(const bool use_prefix)
+    void OpmLog::setupSimpleDefaultLogging(const bool use_prefix,
+                                           const bool use_color_coding,
+                                           const int message_limit)
     {
          std::shared_ptr<StreamLog> streamLog = std::make_shared<StreamLog>(std::cout, Log::DefaultMessageTypes);
          OpmLog::addBackend( "SimpleDefaultLog", streamLog);
-         streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(10));
-         streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(use_prefix, true));
+         streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(message_limit));
+         streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(use_prefix, use_color_coding));
     }
 /******************************************************************/
 

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -21,8 +21,16 @@
 #include <opm/common/OpmLog/Logger.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
 #include <iostream>
+#include <unistd.h> // For isatty() etc.
 
 namespace Opm {
+
+    namespace {
+        bool stdoutIsTerminal()
+        {
+            return isatty(fileno(stdout));
+        }
+    }
 
 
     std::shared_ptr<Logger> OpmLog::getLogger() {
@@ -183,7 +191,7 @@ namespace Opm {
          std::shared_ptr<StreamLog> streamLog = std::make_shared<StreamLog>(std::cout, Log::DefaultMessageTypes);
          OpmLog::addBackend( "SimpleDefaultLog", streamLog);
          streamLog->setMessageLimiter(std::make_shared<MessageLimiter>(message_limit));
-         streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(use_prefix, use_color_coding));
+         streamLog->setMessageFormatter(std::make_shared<SimpleMessageFormatter>(use_prefix, use_color_coding && stdoutIsTerminal()));
     }
 /******************************************************************/
 

--- a/opm/common/OpmLog/OpmLog.cpp
+++ b/opm/common/OpmLog/OpmLog.cpp
@@ -21,14 +21,24 @@
 #include <opm/common/OpmLog/Logger.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
 #include <iostream>
-#include <unistd.h> // For isatty() etc.
+#include <errno.h>  // For errno
+#include <stdio.h>  // For fileno() and stdout
+#include <unistd.h> // For isatty()
 
 namespace Opm {
 
     namespace {
         bool stdoutIsTerminal()
         {
-            return isatty(fileno(stdout));
+            const int errno_save = errno; // For playing nice with C error handling.
+            const int file_descriptor = fileno(stdout);
+            if (file_descriptor == -1) {
+                // stdout is an invalid stream
+                errno = errno_save;
+                return false;
+            } else {
+                return isatty(file_descriptor);
+            }
         }
     }
 

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -64,7 +64,16 @@ public:
     static void removeAllBackends();
     static bool enabledMessageType( int64_t messageType );
     static void addMessageType( int64_t messageType , const std::string& prefix);
-    static void setupSimpleDefaultLogging(const bool use_prefix);
+
+    /// Create a basic logging setup that will send all log messages to standard output.
+    ///
+    /// By default category prefixes will be printed (i.e. Error: or
+    /// Warning:), color coding will be used, and a maximum of 10
+    /// messages with the same tag will be printed. These settings can
+    /// be controlled by the function parameters.
+    static void setupSimpleDefaultLogging(const bool use_prefix = true,
+                                          const bool use_color_coding = true,
+                                          const int message_limit = 10);
 
     template <class BackendType>
     static std::shared_ptr<BackendType> getBackend(const std::string& name) {


### PR DESCRIPTION
With this, it is now possible (at the call site) to turn off message colorization and change message tag limits when using the `setupSimpleDefaultLogging()` feature. Existing behaviour has been preserved with default arguments, so this PR requires no downstream changes (although it will trigger plenty of recompiles). Also added documentation for the function.

This should make it easier to start using logging functionality in programs such as the upscaling codes, as discussed in OPM/opm-grid#267.

Assigning @joakim-hove to review/merge as he has been involved with logging, but if any other maintainers feel like taking this please do.