### PR TITLE
fix opm-core test

### DIFF
--- a/cmake/Modules/Findopm-core.cmake
+++ b/cmake/Modules/Findopm-core.cmake
@@ -34,7 +34,7 @@ find_opm_package (
 #include <opm/core/utility/parameters/ParameterGroup.hpp>
 int main()
 {
-    Opm::parameter::ParameterGroup parameters;
+    Opm::ParameterGroup parameters;
     parameters.insertParameter(\"number\", \"7\");
     return 0;
 }


### PR DESCRIPTION
namespace has been removed. Upstream of https://github.com/OPM/opm-core/pull/1160