### PR TITLE
Change release build optimization from -O2 to -O3

### DIFF
--- a/cmake/Modules/UseOptimization.cmake
+++ b/cmake/Modules/UseOptimization.cmake
@@ -38,7 +38,7 @@ if (CXX_COMPAT_GCC)
 
   # default optimization flags, if not set by user
   set_default_option (CXX _opt_dbg "-O0" "(^|\ )-O")
-  set_default_option (CXX _opt_rel "-O2" "(^|\ )-O")
+  set_default_option (CXX _opt_rel "-O3" "(^|\ )-O")
 
   # use these options for debug builds - no optimizations
   add_options (ALL_LANGUAGES "${_prof_DEBUG}" ${_opt_dbg} "-DDEBUG")


### PR DESCRIPTION
Changing default optimization from O2 to O3 has a large impact on computational performance, while it should not cause any problems. I have extensively tested the O3 option for weeks with no issues.