### PR TITLE
remove namespace qualifier

### DIFF
--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -77,7 +77,7 @@ public:
 
     template <class BackendType>
     static std::shared_ptr<BackendType> getBackend(const std::string& name) {
-        auto logger = OpmLog::getLogger();
+        auto logger = getLogger();
         return logger->getBackend<BackendType>(name);
     }
 


### PR DESCRIPTION
code is already in the namespace, some compilers consider this an error.

this PR is mainly to draw attention to the new static analysis jobs.

see https://ci.opm-project.org/job/opm-common-static-analysis/

each module will get such a job. they pull the git on a nightly schedule. this takes care of https://ci.opm-project.org/job/opm-common-static-analysis/1/testReport/junit/(root)/clang/cppcheck_opm_common_data_SimulationDataContainer_cpp/