### PR TITLE
Fixes for warnings from static code analysis

### DIFF
--- a/opm/common/OpmLog/CounterLog.hpp
+++ b/opm/common/OpmLog/CounterLog.hpp
@@ -33,7 +33,7 @@ namespace Opm {
     class CounterLog : public LogBackend
     {
     public:
-        CounterLog(int64_t messageMask);
+        explicit CounterLog(int64_t messageMask);
         CounterLog();
 
         size_t numMessages(int64_t messageType) const;

--- a/opm/common/OpmLog/MessageFormatter.hpp
+++ b/opm/common/OpmLog/MessageFormatter.hpp
@@ -64,7 +64,7 @@ namespace Opm
         }
 
 
-        SimpleMessageFormatter(const bool use_color_coding)
+        explicit SimpleMessageFormatter(const bool use_color_coding)
             : use_color_coding_(use_color_coding)
         {
             prefix_flag_ = Log::MessageType::Warning + Log::MessageType::Error 

--- a/opm/common/OpmLog/MessageLimiter.hpp
+++ b/opm/common/OpmLog/MessageLimiter.hpp
@@ -62,7 +62,7 @@ namespace Opm
         {
         }
 
-        MessageLimiter(const int tag_limit, const std::map<int64_t, int> category_limits)
+        MessageLimiter(const int tag_limit, const std::map<int64_t, int>& category_limits)
             : tag_limit_(tag_limit < 0 ? NoLimit : tag_limit),
               category_limits_(category_limits)
         {

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -83,7 +83,7 @@ public:
 
     template <class BackendType>
     static std::shared_ptr<BackendType> popBackend(const std::string& name) {
-        auto logger = OpmLog::getLogger();
+        auto logger = getLogger();
         return logger->popBackend<BackendType>(name);
     }
 

--- a/opm/common/OpmLog/TimerLog.cpp
+++ b/opm/common/OpmLog/TimerLog.cpp
@@ -32,11 +32,13 @@ namespace Opm {
 TimerLog::TimerLog(const std::string& logFile) : StreamLog( logFile , StopTimer | StartTimer )
 {
     m_work.precision(8);
+    m_start = 0;
 }
 
 TimerLog::TimerLog(std::ostream& os) : StreamLog( os , StopTimer | StartTimer )
 {
     m_work.precision(8);
+    m_start = 0;
 }
 
 

--- a/opm/common/OpmLog/TimerLog.hpp
+++ b/opm/common/OpmLog/TimerLog.hpp
@@ -39,8 +39,8 @@ public:
     static const int64_t StartTimer = 4096;
     static const int64_t StopTimer  = 8192;
 
-    TimerLog(const std::string& logFile);
-    TimerLog(std::ostream& os);
+    explicit TimerLog(const std::string& logFile);
+    explicit TimerLog(std::ostream& os);
 
     void clear();
     ~TimerLog() {};


### PR DESCRIPTION
This quells all errors in this module.

- mark single-param constructors as explicit to avoid unexpected implicit casts
- initialize members (even though it does not point out a bug)
- pass by reference
- remove extra qualifications