### PR TITLE
Disable package registry when finding opm-parser.

### DIFF
--- a/cmake/Modules/Findopm-parser.cmake
+++ b/cmake/Modules/Findopm-parser.cmake
@@ -18,7 +18,8 @@ else ()
   set (OPM_PARSER_QUIET "")
 endif ()
 
-find_package(opm-parser CONFIG)
+find_package(opm-parser CONFIG
+                        NO_CMAKE_PACKAGE_REGISTRY)
 if (opm-parser_FOUND)
     find_package(ecl REQUIRED)
     set(HAVE_OPM_PARSER 1)


### PR DESCRIPTION
This is probably not the right way to do it - but hopefully this can trigger a discussion which eventually ends with a good solution on the problem with cmake picking up wrong versions from the package registry.