### PR TITLE
add opm-parser to the required prerequisites of opm-upscaling

### DIFF
--- a/cmake/Modules/opm-upscaling-prereqs.cmake
+++ b/cmake/Modules/opm-upscaling-prereqs.cmake
@@ -26,6 +26,7 @@ set (opm-upscaling_DEPS
 	dune-geometry REQUIRED;
 	dune-grid REQUIRED;
 	opm-common REQUIRED;
+	opm-parser REQUIRED;
   opm-grid REQUIRED;
 	opm-core REQUIRED;
 	opm-output REQUIRED"


### PR DESCRIPTION
I don't really understand why, but this fixed my opm-upscaling build.