### PR TITLE
travis: switch from dune 2.3.1 to dune 2.4.1

### DIFF
--- a/travis/build-prereqs.sh
+++ b/travis/build-prereqs.sh
@@ -25,7 +25,7 @@ function build_dune {
    pushd . > /dev/null
    git clone ${url}
    cd ${project}
-   git checkout tags/v2.3.1
+   git checkout tags/v2.4.1
    mkdir build
    cd build
    cmake ../


### PR DESCRIPTION
It seems like OPM support for Dune 2.3 is going to be removed sooner rather than later. Also, all relevant distributions which I'm aware of seem to ship at least Dune-2.4 packages.

note that this patch switches to Dune 2.4.1 instead of the latest Dune
2.4 release (i.e., 2.4.2) because travis seems to block downloads from
sites it does not know -- in this case dune-project.org -- and the
Dune github mirrors seem to have been abandoned a few months ago and
thus do not feature dune 2.4.2.