### PR TITLE
wait a little between pushing branch and opening PR in update_data

### DIFF
--- a/jenkins/update-opm-data.sh
+++ b/jenkins/update-opm-data.sh
@@ -52,6 +52,8 @@ export REASON
 export BRANCH_NAME
 $WORKSPACE/deps/opm-simulators/tests/update_reference_data.sh $OPM_DATA_ROOT
 
+sleep 5
+
 # Finally open the pull request
 cd $OPM_DATA_ROOT
 git remote add jenkins4opm git@github.com:jenkins4opm/opm-data


### PR DESCRIPTION
seems the API may not pick up on newly created branches in
all cases. this hopefully is an easy way to make it more reliable.

ref incident in https://github.com/OPM/opm-simulators/pull/1250