### PR TITLE
workaround cmake OpenMP issues

### DIFF
--- a/cmake/Modules/UseOpenMP.cmake
+++ b/cmake/Modules/UseOpenMP.cmake
@@ -43,6 +43,10 @@ macro (find_openmp opm)
   # the appropriate libraries
   find_package (OpenMP ${${opm}_QUIET})
   list (APPEND ${opm}_LIBRARIES ${OpenMP_LIBRARIES})
+  # CMake OpenMP handling is broken and has been broken for 8 years.
+  # See https://gitlab.kitware.com/cmake/cmake/issues/9075
+  # 'Fix' it by adding flag to linker command and pray compiler accepts it.
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_CXX_FLAGS}")
   if (OPENMP_FOUND)
 	add_options (C ALL_BUILDS "${OpenMP_C_FLAGS}")
 	add_options (CXX ALL_BUILDS "${OpenMP_CXX_FLAGS}")


### PR DESCRIPTION
CMake has a 8 year old issue in its OpenMP handling. In particular, the flag is not passed into the linker since it's only given as a compiler flag (which we then append to the list of compile-only flags). Somehow we survive this normally, but this causes havoc when LTO is used, and LTO is used in packaging.

Found it now since I am pondering enabling OpenMP in packaging.

I have tested this with gcc and clang, they both accept the flag in the linker line. I know certain other proprietary compilers are more strict and treats this as an error, so this has the potential to cause problems with these compilers, but since they are not a target..