### PR TITLE
Simplify dune/opm module search by relying on cmake package config files

### DIFF
--- a/cmake/Modules/Findopm-output.cmake
+++ b/cmake/Modules/Findopm-output.cmake
@@ -42,14 +42,3 @@ include (UseDynamicBoost)
 #debug_find_vars ("opm-output")
 
 
-if(OPM_OUTPUT_FOUND)
-  get_filename_component(opm-output_PREFIX_DIR ${opm-output_LIBRARY} PATH)
-  find_program(COMPARE_SUMMARY_COMMAND compareSummary
-               PATHS ${opm-output_PREFIX_DIR}/../bin
-                     ${opm-output_PREFIX_DIR}/../../bin)
-  find_program(COMPARE_ECL_COMMAND compareECL
-               PATHS ${opm-output_PREFIX_DIR}/../bin
-                     ${opm-output_PREFIX_DIR}/../../bin)
-
-endif()
-

--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -173,6 +173,10 @@ macro (find_and_append_package_to prefix name)
 	if (NOT DEFINED ${NAME}_FOUND)
 	  set (${NAME}_FOUND "${${name}_FOUND}")
 	endif ()
+
+       if(name STREQUAL "opm-common")
+         set(_opm_common_deps_processed ON)
+       endif()
   endif ()
 
   # the variable "NAME" may be replaced during find_package (as this is

--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -144,7 +144,10 @@ macro (find_and_append_package_to prefix name)
 		message (STATUS "Finding package ${name} using config mode")
 		find_package (${name} ${ARGN} NO_MODULE PATHS ${${name}_DIR} NO_DEFAULT_PATH)
 	  else ()
-		message (STATUS "Finding package ${name} using module mode")
+		# print message if this neither an opm module nor ecl
+		if (NOT _${name}_exempted EQUAL -1)
+		  message (STATUS "Finding package ${name} using module mode")
+		endif()
 		if(${name} STREQUAL "ecl")
 			# Give us a chance to find ecl installed to CMAKE_INSTALL_PREFIX.
 			# We need to deactivate the package registry for this.

--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -33,6 +33,7 @@
 #	)
 
 include (Duplicates)
+include (OpmSiblingSearch)
 
 # list of suffixes for all the project variables
 set (_opm_proj_vars
@@ -144,6 +145,15 @@ macro (find_and_append_package_to prefix name)
 		find_package (${name} ${ARGN} NO_MODULE PATHS ${${name}_DIR} NO_DEFAULT_PATH)
 	  else ()
 		message (STATUS "Finding package ${name} using module mode")
+		if(${name} STREQUAL "ecl")
+			# Give us a chance to find ecl installed to CMAKE_INSTALL_PREFIX.
+			# We need to deactivate the package registry for this.
+			create_module_dir_var(ecl)
+			set(ARGN_NO_REQUIRED ${ARGN})
+			list(REMOVE_ITEM ARGN_NO_REQUIRED "REQUIRED")
+ 			find_package (${name} ${ARGN_NO_REQUIRED} NO_CMAKE_SYSTEM_PACKAGE_REGISTRY NO_CMAKE_PACKAGE_REGISTRY)
+			# If everything else failed fall back to the registry
+		endif()	
 		find_package (${name} ${ARGN})
 	  endif ()
 	endif ()

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -145,16 +145,14 @@ macro (find_opm_package module deps header lib defs prog conf)
   # tidy the lists before returning them
   remove_dup_deps (${module})
 
-  if( NOT ${module}_CONFIG_VARS)
-    # these defines are used in dune/${module} headers, and should be put
-    # in config.h when we include those
-    foreach (_var IN ITEMS ${conf})
-      # massage the name to remove source code formatting
-      string (REGEX REPLACE "^[\n\t\ ]+" "" _var "${_var}")
-      string (REGEX REPLACE "[\n\t\ ]+$" "" _var "${_var}")
-      list (APPEND ${module}_CONFIG_VARS ${_var})
-    endforeach (_var)
-  endif()
+  # these defines are used in dune/${module} headers, and should be put
+  # in config.h when we include those
+  foreach (_var IN ITEMS ${conf})
+    # massage the name to remove source code formatting
+    string (REGEX REPLACE "^[\n\t\ ]+" "" _var "${_var}")
+    string (REGEX REPLACE "[\n\t\ ]+$" "" _var "${_var}")
+    list (APPEND ${module}_CONFIG_VARS ${_var})
+  endforeach (_var)
 
   # these are the defines that should be set when compiling
   # without config.h

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -37,9 +37,7 @@
 # <http://www.vtk.org/Wiki/CMake:How_To_Find_Libraries>
 
 include (OpmFind)
-
-option (SIBLING_SEARCH "Search sibling directories before system paths" ON)
-mark_as_advanced (SIBLING_SEARCH)
+include (OpmSiblingSearch)
 
 # append all items from src into dst; both must be *names* of lists
 macro (append_found src dst)
@@ -73,31 +71,7 @@ macro (find_opm_package module deps header lib defs prog conf)
 	set (_${module}_required "")
   endif (${module}_FIND_REQUIRED)
 
-  if(SIBLING_SEARCH AND NOT ${module}_DIR)
-    # guess the sibling dir
-    get_filename_component(_leaf_dir_name ${PROJECT_BINARY_DIR} NAME)
-    get_filename_component(_parent_full_dir ${PROJECT_BINARY_DIR} DIRECTORY)
-    get_filename_component(_parent_dir_name ${_parent_full_dir} NAME)
-    #Try if <module-name>/<build-dir> is used
-    get_filename_component(_modules_dir ${_parent_full_dir} DIRECTORY)
-    if(IS_DIRECTORY ${_modules_dir}/${module}/${_leaf_dir_name})
-      set(${module}_DIR ${_modules_dir}/${module}/${_leaf_dir_name})
-    else()
-      string(REPLACE ${PROJECT_NAME} ${module} _module_leaf ${_leaf_dir_name})
-      if(NOT _leaf_dir_name STREQUAL _module_leaf
-          AND IS_DIRECTORY ${_parent_full_dir}/${_module_leaf})
-        # We are using build directories named <prefix><module-name><postfix>
-        set(${module}_DIR ${_parent_full_dir}/${_module_leaf})
-      elseif(IS_DIRECTORY ${_parent_full_dir}/${module})
-        # All modules are in a common build dir
-        set(${module}_DIR "${_parent_full_dir}/${module}}")
-      endif()
-    endif()
-  endif()
-  if(${module}_DIR AND NOT IS_DIRECTORY ${${module}_DIR})
-    message(WARNING "Value ${${module}_DIR} passed to variable"
-      " ${module}_DIR is not a directory")
-  endif()
+  create_module_dir_var(${module})
 
   # This will also set all the needed variables with the exception of
   # ${module}_CONFIG_VARS for dune modules.

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -55,8 +55,15 @@ macro (find_opm_package module deps header lib defs prog conf)
   string (REPLACE "-" "_" MODULE "${MODULE_UPPER}")
 
   # if someone else has included this test, don't do it again
+  # one exception is opm-common which is already found in the
+  # top most CMakeLists.txt but we still need to search for its
+  # dependencies
   if (${MODULE}_FOUND OR ${module}_FOUND)
-	return ()
+    if (${module} STREQUAL "opm-common" AND NOT _opm_common_deps_processed)
+      set(_opm_common_deps_processed ON)
+    else()
+      return ()
+    endif()
   endif ()
 
   # variables to pass on to other packages

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -73,198 +73,37 @@ macro (find_opm_package module deps header lib defs prog conf)
 	set (_${module}_required "")
   endif (${module}_FIND_REQUIRED)
 
-  # see if there is a pkg-config entry for this package, and use those
-  # settings as a starting point
-  find_package (PkgConfig)
-  pkg_check_modules (PkgConf_${module} QUIET ${module})
-
-  # these variables have non-standard names in FindPkgConfig (sic)
-  set (${module}_DEFINITIONS ${PkgConf_${module}_CFLAGS_OTHER})
-  set (${module}_LINKER_FLAG ${PkgConf_${module}_LDFLAGS_OTHER})
-
-  # try to figure out whether we are in a subdir build tree, and attempt
-  # to put the same name as the appropriate build tree for the module
-  get_filename_component (_build_dir "${CMAKE_CURRENT_BINARY_DIR}" NAME)
-
-  # don't bother if we are in a project specific directory already
-  # (assuming no-one wants to name the build dir after another module!)
-  if ("${_build_dir}" STREQUAL "${PROJECT_NAME}")
-	set (_build_dir "")
-  endif ("${_build_dir}" STREQUAL "${PROJECT_NAME}")
-
-  # if the user hasn't specified any location, and it isn't found
-  # in standard system locations either, then start to wander
-  # about and look for it in proximity to ourself. Qt Creator likes
-  # to put the build-directories as siblings to the source trees,
-  # but with a -build suffix, DUNE likes to have the the build tree
-  # in a "build-cmake" sub-directory of each module
-  set(workaround_cmake_bug 0)
-  if(${module}_DIR})
-    set(workaround_cmake_bug 1)
+  if(SIBLING_SEARCH AND NOT ${module}_DIR)
+    # guess the sibling dir
+    get_filename_component(_leaf_dir_name ${PROJECT_BINARY_DIR} NAME)
+    get_filename_component(_parent_full_dir ${PROJECT_BINARY_DIR} DIRECTORY)
+    get_filename_component(_parent_dir_name ${_parent_full_dir} NAME)
+    #Try if <module-name>/<build-dir> is used
+    get_filename_component(_modules_dir ${_parent_full_dir} DIRECTORY)
+    if(IS_DIRECTORY ${_modules_dir}/${module}/${_leaf_dir_name})
+      set(${module}_DIR ${_modules_dir}/${module}/${_leaf_dir_name})
+    else()
+      string(REPLACE ${PROJECT_NAME} ${module} _module_leaf ${_leaf_dir_name})
+      if(NOT _leaf_dir_name STREQUAL _module_leaf
+          AND IS_DIRECTORY ${_parent_full_dir}/${_module_leaf})
+        # We are using build directories named <prefix><module-name><postfix>
+        set(${module}_DIR ${_parent_full_dir}/${_module_leaf})
+      elseif(IS_DIRECTORY ${_parent_full_dir}/${module})
+        # All modules are in a common build dir
+        set(${module}_DIR "${_parent_full_dir}/${module}}")
+      endif()
+    endif()
   endif()
-  if(${module}_ROOT})
-    set(workaround_cmake_bug 1)
+  if(${module}_DIR AND NOT IS_DIRECTORY ${${module}_DIR})
+    message(WARNING "Value ${${module}_DIR} passed to variable"
+      " ${module}_DIR is not a directory")
   endif()
-  if(${MODULE}_ROOT})
-    set(workaround_cmake_bug 1)
-  endif()
-  if (NOT workaround_cmake_bug)
-	string (TOLOWER "${module}" _module_lower)
-	set (_guess
-	  "../${module}"
-	  "../${_module_lower}"
-	  )
-	set (_guess_bin_only
-	  "../${module}-build"
-	  "../${_module_lower}-build"
-	  )
 
-	# look in similar dirs for the other module
-	if (_build_dir)
-	  list (APPEND _guess_bin_only
-		"../../${module}/${_build_dir}"
-		"../../${_module_lower}/${_build_dir}"
-		)
-	endif (_build_dir)
+  # This will also set all the needed variables with the exception of
+  # ${module}_CONFIG_VARS for dune modules.
+  find_package(${module} ${_${module}_quiet} ${_${module}_required} CONFIG)
 
-	# generate items that are in the build, not source dir
-	set (_guess_bin)
-	foreach (_item IN ITEMS ${_guess} ${_guess_bin_only})
-	  list (APPEND _guess_bin "${PROJECT_BINARY_DIR}/${_item}")
-	endforeach (_item)
-	set (_no_system "")
-  else ()
-	# start looking at the paths in this order
-	set (_guess_bin
-	  ${${module}_DIR}
-	  ${${module}_ROOT}
-	  ${${MODULE}_ROOT}
-	  )
-	# if every package is installed directly in the "suite" directory
-	# (e.g. /usr) then allow us to back-track one directory from the
-	# module sub-dir that was added by OpmFind (this happens incidently
-	# already for the source do to the out-of-source support)
-	if ("${${MODULE}_ROOT}" MATCHES "/${module}$")
-	  get_filename_component (_suite_parent ${${MODULE}_ROOT} PATH)
-	  list (APPEND _guess_bin
-		${_suite_parent}
-		${_suite_parent}/${module}
-		${_suite_parent}/${module}/${_build_dir}
-		)
-	endif ("${${MODULE}_ROOT}" MATCHES "/${module}$")
-	# when we look for the source, it may be that we have been specified
-	# a build directory which is a sub-dir of the source, so we look in
-	# the parent also
-	set (_guess
-	  ${${module}_DIR}
-	  ${${module}_ROOT}
-	  ${${MODULE}_ROOT}
-	  )
-	# only add parent directories for those variants that are actually set
-	# (otherwise, we'll inadvertedly add the root directory (=all))
-	if (${module}_DIR)
-	  list (APPEND _guess ${${module}_DIR}/..)
-	endif (${module}_DIR)
-	if (${module}_ROOT)
-	  list (APPEND _guess ${${module}_ROOT}/..)
-	endif (${module}_ROOT)
-	if (${MODULE}_ROOT)
-	  list (APPEND _guess ${${MODULE}_ROOT}/..)
-	endif (${MODULE}_ROOT)
-	# don't search the system paths! that would be dangerous; if there
-	# is a problem in our own specified directory, we don't necessarily
-	# want an old version that is left in one of the system paths!
-	set (_no_system "NO_DEFAULT_PATH")
-  endif ()
 
-  # by specifying _guess in the HINTS section, it gets searched before
-  # the system locations as well. the CMake documentation has a cloudy
-  # recommendation, but it ends up like this: if NO_DEFAULT_PATH is
-  # specified, then PATHS is used. Otherwise, it looks in HINTS, then in
-  # system paths, and the finally in PATHS (!)
-  if (SIBLING_SEARCH)
-	set (_guess_hints ${_guess})
-	set (_guess_hints_bin ${_guess_bin})
-  else (SIBLING_SEARCH)
-	set (_guess_hints)
-	set (_guess_hints_bin)
-  endif (SIBLING_SEARCH)
-
-  # if an include directory is specified directly (e.g. OPM_CORE_INCLUDE_DIR=
-  # /usr/include/opm-2013.03) then this overrides everything else. Notice that
-  # this variable uses the fully capitalized version of the name.
-  if (${MODULE}_INCLUDE_DIR)
-	set (_guess "${${MODULE}_INCLUDE_DIR}")
-	set (_no_system_incl "NO_DEFAULT_PATH")
-  else ()
-	set (_no_system_incl "${_no_system}")
-  endif ()
-
-  # search for this include and library file to get the installation
-  # directory of the package; hints are searched before the system locations,
-  # paths are searched afterwards
-  find_path (${module}_INCLUDE_DIR
-	NAMES "${header}"
-	PATHS ${_guess}
-	HINTS ${PkgConf_${module}_INCLUDE_DIRS} ${_guess_hints}
-	PATH_SUFFIXES "include"
-	${_no_system_incl}
-	)
-
-  # some modules are all in headers
-  if (NOT "${lib}" STREQUAL "")
-	if (CMAKE_SIZEOF_VOID_P)
-	  math (EXPR _BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
-	endif (CMAKE_SIZEOF_VOID_P)
-
-	# again, we may directly override the location of the library alone by
-	# specifying e.g. OPM_CORE_LIB_DIR. notice that this is a *directory*
-	# and not the name of the library
-	if (${MODULE}_LIB_DIR)
-	  set (_guess_bin "${${MODULE}_LIB_DIR}")
-	  set (_no_system_lib "NO_DEFAULT_PATH")
-	else ()
-	  set (_no_system_lib "${_no_system}")
-	endif ()
-
-	# if there is more than one library, then look for all of them, putting
-	# them in variables with the name of the library appended. however, the
-	# first entry is assumed to be the "primary" library and will be named
-	# like the module. thus, with a lib entry of "foo;bar", the first library
-	# is called ${module}_LIBRARY and the second ${module}_LIBRARY_bar
-	foreach (_lib IN ITEMS ${lib})
-	  # don't include any suffix if it is the first one
-	  if ("${lib}" MATCHES "^${_lib}")
-		set (_which)
-	  else ()
-		set (_which "_${_lib}")
-	  endif ()
-	  find_library (${module}_LIBRARY${_which}
-		NAMES "${_lib}"
-		PATHS ${_guess_bin}
-		HINTS ${PkgConf_${module}_LIBRARY_DIRS} ${_guess_hints_bin}
-		PATH_SUFFIXES "lib" "lib/Debug" "lib/Release" "lib/.libs" ".libs" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "build-cmake/lib"
-		${_no_system_lib}		
-		)
-	  # debug info if we didn't find the desired library
-	  if (NOT ${module}_LIBRARY${_which})
-		message (STATUS "Failed to find library \"${_lib}\" for module ${module}")
-	  endif ()
-	endforeach (_lib)
-  else (NOT "${lib}" STREQUAL "")
-	set (${module}_LIBRARY "")
-  endif (NOT "${lib}" STREQUAL "")
-
-  # add dependencies so that our result variables are complete
-  # list of necessities to build with the software
-  set (${module}_INCLUDE_DIRS "${${module}_INCLUDE_DIR}")
-  foreach (_lib IN ITEMS ${lib})
-	if ("${lib}" MATCHES "^${_lib}")
-	  set (${module}_LIBRARIES "${${module}_LIBRARY}")
-	else ()
-	  list (APPEND ${module}_LIBRARIES "${${module}_LIBRARY_${_lib}}")
-	endif ()
-  endforeach (_lib)
   # period because it should be something that evaluates to true
   # in find_package_handle_standard_args
   set (${module}_ALL_PREREQS ".")
@@ -306,14 +145,16 @@ macro (find_opm_package module deps header lib defs prog conf)
   # tidy the lists before returning them
   remove_dup_deps (${module})
 
-  # these defines are used in dune/${module} headers, and should be put
-  # in config.h when we include those
-  foreach (_var IN ITEMS ${conf})
-	# massage the name to remove source code formatting
-	string (REGEX REPLACE "^[\n\t\ ]+" "" _var "${_var}")
-	string (REGEX REPLACE "[\n\t\ ]+$" "" _var "${_var}")
-	list (APPEND ${module}_CONFIG_VARS ${_var})
-  endforeach (_var)
+  if( NOT ${module}_CONFIG_VARS)
+    # these defines are used in dune/${module} headers, and should be put
+    # in config.h when we include those
+    foreach (_var IN ITEMS ${conf})
+      # massage the name to remove source code formatting
+      string (REGEX REPLACE "^[\n\t\ ]+" "" _var "${_var}")
+      string (REGEX REPLACE "[\n\t\ ]+$" "" _var "${_var}")
+      list (APPEND ${module}_CONFIG_VARS ${_var})
+    endforeach (_var)
+  endif()
 
   # these are the defines that should be set when compiling
   # without config.h
@@ -335,51 +176,19 @@ macro (find_opm_package module deps header lib defs prog conf)
 
   # write status message in the same manner as everyone else
   include (FindPackageHandleStandardArgs)
-  if ("${lib}" STREQUAL "")
-	set (_lib_var "")
-	set (_and_lib_var)
-  else ("${lib}" STREQUAL "")
-	foreach (_lib IN ITEMS ${lib})
-	  if ("${lib}" MATCHES "^${_lib}")
-		set (_lib_var "${module}_LIBRARY")
-		set (_and_lib_var AND ${_lib_var})
-	  else ()
-		list (APPEND _lib_var "${module}_LIBRARY_${_lib}")
-		set (_and_lib_var ${_and_lib_var} AND "${module}_LIBRARY_${_lib}")
-	  endif ()
-	endforeach (_lib)
-  endif ("${lib}" STREQUAL "")
-  # if the search is going to fail, then write these variables to
-  # the console as well as a diagnostics
-  if ((NOT (${module}_INCLUDE_DIR ${_and_lib_var} AND HAVE_${MODULE}))
-	  AND (_${module}_required OR NOT _${module}_quiet))
-	if (DEFINED ${module}_DIR)
-	  message (STATUS "${module}_DIR = ${${module}_DIR}")
-	elseif (DEFINED ${module}_ROOT)
-	  message (STATUS "${module}_ROOT = ${${module}_ROOT}")
-	elseif (DEFINED ${MODULE}_ROOT)
-	  message (STATUS "${MODULE}_ROOT = ${${MODULE}_ROOT}")
-	endif (DEFINED ${module}_DIR)
-  endif ((NOT (${module}_INCLUDE_DIR ${_and_lib_var} AND HAVE_${MODULE}))
-	AND (_${module}_required OR NOT _${module}_quiet))
-  if ("${${module}_ALL_PREREQS}" MATCHES "-NOTFOUND")
-	message (STATUS "${module} prereqs: ${${module}_ALL_PREREQS}")
-  endif ()
   find_package_handle_standard_args (
-	${module}
-	DEFAULT_MSG
-	${module}_INCLUDE_DIR ${_lib_var} HAVE_${MODULE} ${module}_ALL_PREREQS
-	)
-
-  # allow the user to override these from user interface
-  mark_as_advanced (${module}_INCLUDE_DIR)
-  mark_as_advanced (${module}_LIBRARY)
+        ${module}
+        DEFAULT_MSG
+        ${module}_INCLUDE_DIRS ${module}_LIBRARIES ${module}_FOUND ${module}_ALL_PREREQS
+        )
 
   # some genius that coded the FindPackageHandleStandardArgs figured out
   # that the module name should be in uppercase (?!)
   set (${module}_FOUND "${${MODULE_UPPER}_FOUND}")
   set (${MODULE}_FOUND "${${MODULE_UPPER}_FOUND}")
 
+  # This variable is used by UseDuneVer
+  list(GET ${module}_INCLUDE_DIRS 0 ${module}_INCLUDE_DIR)
   # print everything out if we're asked to
   if (${module}_DEBUG)
 	debug_find_vars (${module})

--- a/cmake/Modules/OpmSiblingSearch.cmake
+++ b/cmake/Modules/OpmSiblingSearch.cmake
@@ -9,17 +9,23 @@ macro(create_module_dir_var module)
     get_filename_component(_parent_dir_name ${_parent_full_dir} NAME)
     #Try if <module-name>/<build-dir> is used
     get_filename_component(_modules_dir ${_parent_full_dir} DIRECTORY)
-    if(IS_DIRECTORY ${_modules_dir}/${module}/${_leaf_dir_name})
-      set(${module}_DIR ${_modules_dir}/${module}/${_leaf_dir_name})
+    if (module STREQUAL "ecl")
+      #use clone directory libecl
+      set(_clone_dir "libecl")
     else()
-      string(REPLACE ${PROJECT_NAME} ${module} _module_leaf ${_leaf_dir_name})
+      set(_clone_dir "${module}")
+    endif()
+    if(IS_DIRECTORY ${_modules_dir}/${_clone_dir}/${_leaf_dir_name})
+      set(${module}_DIR ${_modules_dir}/${_clone_dir}/${_leaf_dir_name})
+    else()
+      string(REPLACE ${PROJECT_NAME} ${_clone_dir} _module_leaf ${_leaf_dir_name})
       if(NOT _leaf_dir_name STREQUAL _module_leaf
           AND IS_DIRECTORY ${_parent_full_dir}/${_module_leaf})
         # We are using build directories named <prefix><module-name><postfix>
         set(${module}_DIR ${_parent_full_dir}/${_module_leaf})
-      elseif(IS_DIRECTORY ${_parent_full_dir}/${module})
+      elseif(IS_DIRECTORY ${_parent_full_dir}/${_clone_dir})
         # All modules are in a common build dir
-        set(${module}_DIR "${_parent_full_dir}/${module}}")
+        set(${module}_DIR "${_parent_full_dir}/${_clone_dir}}")
       endif()
     endif()
   endif()

--- a/cmake/Modules/OpmSiblingSearch.cmake
+++ b/cmake/Modules/OpmSiblingSearch.cmake
@@ -1,0 +1,30 @@
+option (SIBLING_SEARCH "Search sibling directories before system paths" ON)
+mark_as_advanced (SIBLING_SEARCH)
+
+macro(create_module_dir_var module)
+  if(SIBLING_SEARCH AND NOT ${module}_DIR)
+    # guess the sibling dir
+    get_filename_component(_leaf_dir_name ${PROJECT_BINARY_DIR} NAME)
+    get_filename_component(_parent_full_dir ${PROJECT_BINARY_DIR} DIRECTORY)
+    get_filename_component(_parent_dir_name ${_parent_full_dir} NAME)
+    #Try if <module-name>/<build-dir> is used
+    get_filename_component(_modules_dir ${_parent_full_dir} DIRECTORY)
+    if(IS_DIRECTORY ${_modules_dir}/${module}/${_leaf_dir_name})
+      set(${module}_DIR ${_modules_dir}/${module}/${_leaf_dir_name})
+    else()
+      string(REPLACE ${PROJECT_NAME} ${module} _module_leaf ${_leaf_dir_name})
+      if(NOT _leaf_dir_name STREQUAL _module_leaf
+          AND IS_DIRECTORY ${_parent_full_dir}/${_module_leaf})
+        # We are using build directories named <prefix><module-name><postfix>
+        set(${module}_DIR ${_parent_full_dir}/${_module_leaf})
+      elseif(IS_DIRECTORY ${_parent_full_dir}/${module})
+        # All modules are in a common build dir
+        set(${module}_DIR "${_parent_full_dir}/${module}}")
+      endif()
+    endif()
+  endif()
+  if(${module}_DIR AND NOT IS_DIRECTORY ${${module}_DIR})
+    message(WARNING "Value ${${module}_DIR} passed to variable"
+      " ${module}_DIR is not a directory")
+  endif()
+endmacro()

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -19,51 +19,55 @@
 
 # <http://www.vtk.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file>
 
-# propagate these properties from one build system to the other
-set (@opm-project_NAME@_VERSION "@opm-project_VERSION@")
-set (@opm-project_NAME@_DEFINITIONS "@opm-project_DEFINITIONS@")
-set (@opm-project_NAME@_INCLUDE_DIRS "@opm-project_INCLUDE_DIRS@")
-set (@opm-project_NAME@_LIBRARY_DIRS "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
-set (@opm-project_NAME@_LINKER_FLAGS "@opm-project_LINKER_FLAGS@")
-set (@opm-project_NAME@_CONFIG_VARS "@opm-project_CONFIG_VARS@")
+# Prevent multiple inclusions
+if(NOT @opm-project_NAME@_FOUND)
 
-# libraries come from the build tree where this file was generated
-set (@opm-project_NAME@_LIBRARY "@opm-project_LIBRARY@")
-set (@opm-project_NAME@_LIBRARIES ${@opm-project_NAME@_LIBRARY} "@opm-project_LIBRARIES@")
-mark_as_advanced (@opm-project_NAME@_LIBRARY)
+  # propagate these properties from one build system to the other
+  set (@opm-project_NAME@_VERSION "@opm-project_VERSION@")
+  set (@opm-project_NAME@_DEFINITIONS "@opm-project_DEFINITIONS@")
+  set (@opm-project_NAME@_INCLUDE_DIRS "@opm-project_INCLUDE_DIRS@")
+  set (@opm-project_NAME@_LIBRARY_DIRS "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
+  set (@opm-project_NAME@_LINKER_FLAGS "@opm-project_LINKER_FLAGS@")
+  set (@opm-project_NAME@_CONFIG_VARS "@opm-project_CONFIG_VARS@")
 
-# not all projects have targets; conditionally add this part
-if (NOT "@opm-project_TARGET@" STREQUAL "")
-  # add the library as a target, so that other things in the project including
-  # this file may depend on it and get rebuild if this library changes.
-  add_library (@opm-project_TARGET@ UNKNOWN IMPORTED)
-  set_property (TARGET @opm-project_TARGET@ PROPERTY IMPORTED_LOCATION "${@opm-project_NAME@_LIBRARY}")
-endif (NOT "@opm-project_TARGET@" STREQUAL "")
+  # libraries come from the build tree where this file was generated
+  set (@opm-project_NAME@_LIBRARY "@opm-project_LIBRARY@")
+  set (@opm-project_NAME@_LIBRARIES ${@opm-project_NAME@_LIBRARY} "@opm-project_LIBRARIES@")
+  mark_as_advanced (@opm-project_NAME@_LIBRARY)
 
-# ensure that we build with support for C++11 to preserve ABI
-string (REPLACE "@CXX_STD0X_FLAGS@" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-string (REPLACE "@CXX_STDLIB_FLAGS@" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-string (STRIP "${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS)
-set (CMAKE_CXX_FLAGS "@CXX_STD0X_FLAGS@@CXX_SPACE@@CXX_STDLIB_FLAGS@ ${CMAKE_CXX_FLAGS}")
+  # not all projects have targets; conditionally add this part
+  if (NOT "@opm-project_TARGET@" STREQUAL "")
+    # add the library as a target, so that other things in the project including
+    # this file may depend on it and get rebuild if this library changes.
+    add_library (@opm-project_TARGET@ UNKNOWN IMPORTED)
+    set_property (TARGET @opm-project_TARGET@ PROPERTY IMPORTED_LOCATION "${@opm-project_NAME@_LIBRARY}")
+  endif (NOT "@opm-project_TARGET@" STREQUAL "")
 
-# same as above, but for C99
-string (REPLACE "@C_STD99_FLAGS@" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-string (STRIP "${CMAKE_C_FLAGS}" CMAKE_C_FLAGS)
-set (CMAKE_C_FLAG "@C_STD99_FLAGS@ ${CMAKE_C_FLAGS}")
-
-# build with OpenMP if that was found
-if (NOT "@OpenMP_C_FLAGS@" STREQUAL "")
-  string (REPLACE "@OpenMP_C_FLAGS@" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-  string (STRIP "${CMAKE_C_FLAGS}" CMAKE_C_FLAGS)
-  set (CMAKE_C_FLAG "@OpenMP_C_FLAGS@ ${CMAKE_C_FLAGS}")
-endif (NOT "@OpenMP_C_FLAGS@" STREQUAL "")
-if (NOT "@OpenMP_CXX_FLAGS@" STREQUAL "")
-  string (REPLACE "@OpenMP_CXX_FLAGS@" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  # ensure that we build with support for C++11 to preserve ABI
+  string (REPLACE "@CXX_STD0X_FLAGS@" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  string (REPLACE "@CXX_STDLIB_FLAGS@" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   string (STRIP "${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS)
-  set (CMAKE_C_FLAG "@OpenMP_CXX_FLAGS@ ${CMAKE_CXX_FLAGS}")
-endif (NOT "@OpenMP_CXX_FLAGS@" STREQUAL "")
+  set (CMAKE_CXX_FLAGS "@CXX_STD0X_FLAGS@@CXX_SPACE@@CXX_STDLIB_FLAGS@ ${CMAKE_CXX_FLAGS}")
 
-# this is the contents of config.h as far as our probes can tell:
+  # same as above, but for C99
+  string (REPLACE "@C_STD99_FLAGS@" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  string (STRIP "${CMAKE_C_FLAGS}" CMAKE_C_FLAGS)
+  set (CMAKE_C_FLAG "@C_STD99_FLAGS@ ${CMAKE_C_FLAGS}")
 
-# extra code
-@OPM_PROJECT_EXTRA_CODE@
+  # build with OpenMP if that was found
+  if (NOT "@OpenMP_C_FLAGS@" STREQUAL "")
+    string (REPLACE "@OpenMP_C_FLAGS@" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    string (STRIP "${CMAKE_C_FLAGS}" CMAKE_C_FLAGS)
+    set (CMAKE_C_FLAG "@OpenMP_C_FLAGS@ ${CMAKE_C_FLAGS}")
+  endif (NOT "@OpenMP_C_FLAGS@" STREQUAL "")
+  if (NOT "@OpenMP_CXX_FLAGS@" STREQUAL "")
+    string (REPLACE "@OpenMP_CXX_FLAGS@" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    string (STRIP "${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS)
+    set (CMAKE_C_FLAG "@OpenMP_CXX_FLAGS@ ${CMAKE_CXX_FLAGS}")
+  endif (NOT "@OpenMP_CXX_FLAGS@" STREQUAL "")
+
+  # this is the contents of config.h as far as our probes can tell:
+
+  # extra code
+  @OPM_PROJECT_EXTRA_CODE@
+endif()


### PR DESCRIPTION
We use ${module}_DIR to set the correct path when sibling search is activated. The package configuration files set all the necessary variables and we save us a lot of CMake magic.

Note that we previously used PkgConfig to find system installed DUNE and OPM packages. The paths found ended up as first hints in the find_* calls. Therefore the semantics might have been changed here. Previously system installed stuffed might have had higher priority than package found via sibling search.

We use the sibling search logic here as in the other modules.

This is at least a first step in simplifying our CMake scripts.