### PR TITLE
changed: do not open a new PR in repeated update-data calls

### DIFF
--- a/jenkins/update-opm-data.sh
+++ b/jenkins/update-opm-data.sh
@@ -80,4 +80,14 @@ then
   done
 fi
 
-git-open-pull -u jenkins4opm --base-account OPM --base-repo opm-data -r /tmp/cmsg $BRANCH_NAME
+if [ -n "`echo $BRANCHES | tr ' ' '\n' | grep ^jenkins4opm/$BRANCH_NAME$`" ]
+then
+  GH_TOKEN=`git config --get gitOpenPull.Token`
+  REV=${upstreamRev[$MAIN_REPO]}
+  PRNUMBER=${rev//[!0-9]/}
+  DATA_PR=`curl -X GET https://api.github.com/repos/OPM/opm-data/pulls?head=jenkins4opm:$BRANCH_NAME | grep '"number":' | awk -F ':' '{print $2}' | sed -e 's/,//'`
+  git push -u jenkins4opm $BRANCH_NAME -f
+  curl -d '{ "body": "Existing PR opm-data/#$DATA_PR was updated" }' -X POST https://api.github.com/repos/OPM/$MAIN_REPO/issues/$PRNUMBER/comments?access_token=$GH_TOKEN
+else
+  git-open-pull -u jenkins4opm --base-account OPM --base-repo opm-data -r /tmp/cmsg $BRANCH_NAME
+fi


### PR DESCRIPTION
The generation of our devs is special. We have the attention span of the millennials and the memory of our parents ;)

This scripts around our limitations by checking for an existing PR for update-data calls. if it already exists,
the script just push the branch and comments on the PR it was triggered from.