### PR TITLE
[discussion] adding UMFpack to prerequisite of opm-simulators

### DIFF
--- a/cmake/Modules/opm-simulators-prereqs.cmake
+++ b/cmake/Modules/opm-simulators-prereqs.cmake
@@ -25,6 +25,8 @@ set (opm-simulators_DEPS
 	"dune-common REQUIRED;
 	dune-istl REQUIRED"
 	"ERTPython"
+	# Tim Davis' SuiteSparse archive
+	"SuiteSparse COMPONENTS umfpack REQUIRED"
   # OPM dependency
 	"opm-common REQUIRED;
    opm-parser REQUIRED;


### PR DESCRIPTION
I am not sure if this is the correct place or correct way to do it. 

The reason for this is because a direct solver is required as part of the multisegment well solution procedure. 

Please suggest. 