### PR TITLE
don't mark UMFpack as required for opm-simulators

### DIFF
--- a/cmake/Modules/opm-simulators-prereqs.cmake
+++ b/cmake/Modules/opm-simulators-prereqs.cmake
@@ -26,7 +26,7 @@ set (opm-simulators_DEPS
 	dune-istl REQUIRED"
 	"ERTPython"
 	# Tim Davis' SuiteSparse archive
-	"SuiteSparse COMPONENTS umfpack REQUIRED"
+	"SuiteSparse COMPONENTS umfpack"
   # OPM dependency
 	"opm-common REQUIRED;
    opm-parser REQUIRED;


### PR DESCRIPTION
before OPM/opm-simulators#1309 it was required, but this was not enforced by the build system because the SuiteSparse tests are run by the opm-core build system first and UMFpack is optional there.

thanks to [at]akva2 and [at]blattms for the heads-up.