### PR TITLE
Only set the library directories if module builds a library.

### DIFF
--- a/cmake/Modules/OpmFiles.cmake
+++ b/cmake/Modules/OpmFiles.cmake
@@ -2,8 +2,10 @@
 
 macro (opm_out_dirs)
   # put libraries in lib/ (no multi-arch support in build tree)
-  set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
-  set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+  if(MAIN_SOURCE_FILES)
+    set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+    set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
+  endif()
   set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
   set (CMAKE_Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/CMakeFiles")
 endmacro (opm_out_dirs)

--- a/cmake/Modules/OpmProject.cmake
+++ b/cmake/Modules/OpmProject.cmake
@@ -87,7 +87,7 @@ function (opm_cmake_config name)
 	${template_dir}/opm-project.pc.in
 	${PROJECT_BINARY_DIR}/${${name}_NAME}.pc
 	${PROJECT_BINARY_DIR}
-	${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+	"${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
 	${PROJECT_SOURCE_DIR}
 	)
 


### PR DESCRIPTION
With this commit @opm-project_NAME@_LIBRARY_DIRS will only be set if the module actually builds a library.

This should prevent linker warnings like 
```
ld: warning: directory not found for option '-L/path/opm-build-debug/opm-material/lib'
ld: warning: directory not found for option '-L/path/opm-build-debug/ewoms/lib'
```