### PR TITLE
added: option to not define NDEBUG for release builds

### DIFF
--- a/cmake/Modules/UseOptimization.cmake
+++ b/cmake/Modules/UseOptimization.cmake
@@ -44,7 +44,11 @@ if (CXX_COMPAT_GCC)
   add_options (ALL_LANGUAGES "${_prof_DEBUG}" ${_opt_dbg} "-DDEBUG")
 
   # use these options for release builds - full optimization
-  add_options (ALL_LANGUAGES "${_prof_RELEASE}" ${_opt_rel} "-DNDEBUG" ${_opt_flags})
+  add_options (ALL_LANGUAGES "${_prof_RELEASE}" ${_opt_rel} ${_opt_flags})
+  option(WITH_NDEBUG "Disable asserts in release mode" ON)
+  if(WITH_NDEBUG)
+    add_options (ALL_LANGUAGES "${_prof_RELEASE}" -DNDEBUG)
+  endif()
 
 else ()
   # default information from system


### PR DESCRIPTION
It is useful for the CI system to have asserts enabled. While I could fiddle with CXX flags I think this is cleaner. ref https://github.com/OPM/opm-simulators/pull/1327