### PR TITLE
Add dune buildsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,36 @@ if (USE_DUNE_BUILDSYSTEM)
 # set up project
 project("opm-common" C CXX)
 
+# Sibling build
+option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
+if(SIBLING_SEARCH)
+  # guess the sibling dir
+  get_filename_component(_leaf_dir_name ${PROJECT_BINARY_DIR} NAME)
+  get_filename_component(_parent_full_dir ${PROJECT_BINARY_DIR} DIRECTORY)
+  get_filename_component(_parent_dir_name ${_parent_full_dir} NAME)
+  get_filename_component(_modules_dir ${_parent_full_dir} DIRECTORY)
+  foreach(MOD dune-common)
+    # do not overwrite the location of a module if it was explicitly
+    # specified by the user
+    if(${MOD}_DIR)
+      continue()
+    endif()
+
+    # Try various possible locations for the build directory of the dependency
+    foreach(BUILD_DIR "${_leaf_dir_name}" "build-cmake" "build" "../${MOD}-build" "../build-${MOD}" "../build" ".")
+      if(EXISTS "${_modules_dir}/${MOD}/${BUILD_DIR}/${MOD}-config.cmake")
+        set(${MOD}_DIR ${_modules_dir}/${MOD}/${BUILD_DIR})
+        break()
+      endif()
+    endforeach()
+  endforeach()
+endif()
+
+if(dune-common_DIR AND NOT IS_DIRECTORY ${dune-common_DIR})
+  message(WARNING "Value ${dune-common_DIR} passed to variable"
+    " dune-common_DIR is not a directory")
+endif()
+
 # Set CMP0053 (how to handle escape sequences in strings) to the new
 # behavior to avoid a pretty annoying cmake warning if a library is
 # defined in the toplevel CMakeLists.txt. This should probably be

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,94 @@
-cmake_minimum_required (VERSION 2.8)
+# -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
+# vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
+
+# specify the minimum cmake version
+cmake_minimum_required(VERSION 3.0)
+
+# specify the option that allows to select the build system. if
+# dunecontrol is used, we default to the dune build system. if not, we
+# use the OPM home-brewn one
+set(USE_DUNE_BUILDSYSTEM_DEFAULT OFF)
+if (DEFINED ENV{DUNE_CONTROL_PATH})
+  set(USE_DUNE_BUILDSYSTEM_DEFAULT ON)
+endif()
+option(USE_DUNE_BUILDSYSTEM "Use the Dune build system?" ${USE_DUNE_BUILDSYSTEM_DEFAULT})
+
+if (USE_DUNE_BUILDSYSTEM)
+
+######
+# use DUNE's build system
+######
+
+# set up project
+project("opm-common" C CXX)
+
+# Set CMP0053 (how to handle escape sequences in strings) to the new
+# behavior to avoid a pretty annoying cmake warning if a library is
+# defined in the toplevel CMakeLists.txt. This should probably be
+# considered to be a bug in the dune build system. Note that the old
+# behaviour will most likely also work fine, but the result of setting
+# this policy to NEW is most likely what's intended.
+if (POLICY CMP0053)
+  cmake_policy(SET CMP0053 NEW)
+endif()
+
+# find the build system (i.e., dune-common) and set cmake's module path
+find_package(dune-common REQUIRED)
+list(APPEND CMAKE_MODULE_PATH ${dune-common_MODULE_PATH}
+  "${PROJECT_SOURCE_DIR}/cmake/modules")
+
+# include the dune macros
+include(DuneMacros)
+
+# include the OPM cmake macros
+include(OpmMacros)
+
+# find the packages needed to compile the module
+find_package(Boost COMPONENTS unit_test_framework  REQUIRED)
+
+# start a dune project with information from dune.module
+dune_project()
+
+# recursively mark all header files beneath the "opm" directory for
+# installation.
+opm_recusive_export_all_headers("opm")
+
+# the cmake modules get a special treatment
+opm_export_cmake_modules()
+
+# we want all features detected by the build system to be enabled,
+# thank you!
+dune_enable_all_packages()
+
+# add libopmcommon.a and specify that it encompasses all source files
+# which are located somewhere beneath the "opm" directory. Note that
+# if the tests and the source files of the library were intermingled,
+# this would be not so easy, i.e. it would require a separate
+# CMakeLists.txt file in each subdirectory and a call to
+# add_subdirectory() for each of them.
+opm_recursive_add_library("opmcommon" "opm")
+
+# add all unit tests
+opm_add_test(test_cmp LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
+opm_add_test(test_ConditionalStorage LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
+opm_add_test(test_messagelimiter LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
+opm_add_test(test_OpmLog LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
+opm_add_test(test_param LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
+opm_add_test(test_SimulationDataContainer LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
+
+opm_recusive_copy_testdata("tests/*.param")
+
+# finalize the dune project, e.g. generating config.h etc.
+finalize_dune_project(GENERATE_CONFIG_H_CMAKE)
+
+else()
+
+######
+# use the traditional OPM build system
+######
+
+# set up project
+project("opm-common" CXX)
 
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
@@ -52,3 +142,5 @@ include (OpmLibMain)
 
 # Install build system files
 install(DIRECTORY cmake DESTINATION share/opm)
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ if (USE_OPM_BUILDSYSTEM)
 # set up project
 project("opm-common" CXX)
 
+cmake_minimum_required (VERSION 2.8)
+
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 set(OPM_MACROS_ROOT ${PROJECT_SOURCE_DIR})
@@ -141,13 +143,6 @@ find_package(Boost COMPONENTS unit_test_framework  REQUIRED)
 
 # start a dune project with information from dune.module
 dune_project()
-
-# the cmake modules get a special treatment
-opm_export_cmake_modules()
-
-# we want all features detected by the build system to be enabled,
-# thank you!
-dune_enable_all_packages()
 
 # add headers, source files from CMakeLists_files.cmake to
 # library libopmgrid.a and create executables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,86 @@
 # -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
+# specify the option that allows to select the build system. if
+# dunecontrol is used, we default to the opm build system.
+set(USE_OPM_BUILDSYSTEM_DEFAULT ON)
+
+# if dunecontrol is used switch to DUNE build system
+if (DEFINED ENV{DUNE_CONTROL_PATH})
+	set(USE_OPM_BUILDSYSTEM_DEFAULT OFF)
+endif()
+
+option(USE_OPM_BUILDSYSTEM "Use the OPM build system?" ${USE_OPM_BUILDSYSTEM_DEFAULT})
+
+if (USE_OPM_BUILDSYSTEM)
+#########################################
+# use the traditional OPM build system
+#########################################
+
+# set up project
+project("opm-common" CXX)
+
+option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
+set(OPM_MACROS_ROOT ${PROJECT_SOURCE_DIR})
+
+# not the same location as most of the other projects; this hook overrides
+macro (dir_hook)
+endmacro (dir_hook)
+
+# We need to define this variable in the installed cmake config file.
+set(OPM_PROJECT_EXTRA_CODE_INSTALLED  "set(OPM_MACROS_ROOT ${CMAKE_INSTALL_PREFIX}/share/opm)
+                                       list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
+
+set(OPM_PROJECT_EXTRA_CODE_INTREE  "set(OPM_MACROS_ROOT ${OPM_MACROS_ROOT})
+                                    list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
+
+# project information is in dune.module. Read this file and set variables.
+# we cannot generate dune.module since it is read by dunecontrol before
+# the build starts, so it makes sense to keep the data there then.
+include (OpmInit)
+
+# list of prerequisites for this particular project; this is in a
+# separate file (in cmake/Modules sub-directory) because it is shared
+# with the find module
+include (${project}-prereqs)
+
+# read the list of components from this file (in the project directory);
+# it should set various lists with the names of the files to include
+include (CMakeLists_files.cmake)
+
+macro (config_hook)
+endmacro (config_hook)
+
+macro (prereqs_hook)
+endmacro (prereqs_hook)
+
+macro (sources_hook)
+endmacro (sources_hook)
+
+macro (fortran_hook)
+endmacro (fortran_hook)
+
+macro (files_hook)
+endmacro (files_hook)
+
+macro (tests_hook)
+endmacro (tests_hook)
+
+# all setup common to the OPM library modules is done here
+include (OpmLibMain)
+
+# Install build system files
+install(DIRECTORY cmake DESTINATION share/opm)
+
+else()
+
+###############################
+# use DUNE's build system
+###############################
+
 # specify the minimum cmake version
 cmake_minimum_required(VERSION 3.0)
-
-# specify the option that allows to select the build system. if
-# dunecontrol is used, we default to the dune build system. if not, we
-# use the OPM home-brewn one
-set(USE_DUNE_BUILDSYSTEM_DEFAULT OFF)
-if (DEFINED ENV{DUNE_CONTROL_PATH})
-  set(USE_DUNE_BUILDSYSTEM_DEFAULT ON)
-endif()
-option(USE_DUNE_BUILDSYSTEM "Use the Dune build system?" ${USE_DUNE_BUILDSYSTEM_DEFAULT})
-
-if (USE_DUNE_BUILDSYSTEM)
-
-######
-# use DUNE's build system
-######
 
 # set up project
 project("opm-common" C CXX)
@@ -79,10 +142,6 @@ find_package(Boost COMPONENTS unit_test_framework  REQUIRED)
 # start a dune project with information from dune.module
 dune_project()
 
-# recursively mark all header files beneath the "opm" directory for
-# installation.
-opm_recusive_export_all_headers("opm")
-
 # the cmake modules get a special treatment
 opm_export_cmake_modules()
 
@@ -90,87 +149,13 @@ opm_export_cmake_modules()
 # thank you!
 dune_enable_all_packages()
 
-# add libopmcommon.a and specify that it encompasses all source files
-# which are located somewhere beneath the "opm" directory. Note that
-# if the tests and the source files of the library were intermingled,
-# this would be not so easy, i.e. it would require a separate
-# CMakeLists.txt file in each subdirectory and a call to
-# add_subdirectory() for each of them.
-opm_recursive_add_library("opmcommon" "opm")
-
-# add all unit tests
-opm_add_test(test_cmp LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
-opm_add_test(test_ConditionalStorage LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
-opm_add_test(test_messagelimiter LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
-opm_add_test(test_OpmLog LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
-opm_add_test(test_param LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
-opm_add_test(test_SimulationDataContainer LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
+# add headers, source files from CMakeLists_files.cmake to
+# library libopmgrid.a and create executables
+opm_add_headers_library_and_executables("opmcommon")
 
 opm_recusive_copy_testdata("tests/*.param")
 
 # finalize the dune project, e.g. generating config.h etc.
 finalize_dune_project(GENERATE_CONFIG_H_CMAKE)
-
-else()
-
-######
-# use the traditional OPM build system
-######
-
-# set up project
-project("opm-common" CXX)
-
-option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
-set(OPM_MACROS_ROOT ${PROJECT_SOURCE_DIR})
-
-# not the same location as most of the other projects; this hook overrides
-macro (dir_hook)
-endmacro (dir_hook)
-
-# We need to define this variable in the installed cmake config file.
-set(OPM_PROJECT_EXTRA_CODE_INSTALLED  "set(OPM_MACROS_ROOT ${CMAKE_INSTALL_PREFIX}/share/opm)
-                                       list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
-
-set(OPM_PROJECT_EXTRA_CODE_INTREE  "set(OPM_MACROS_ROOT ${OPM_MACROS_ROOT})
-                                    list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
-
-# project information is in dune.module. Read this file and set variables.
-# we cannot generate dune.module since it is read by dunecontrol before
-# the build starts, so it makes sense to keep the data there then.
-include (OpmInit)
-
-# list of prerequisites for this particular project; this is in a
-# separate file (in cmake/Modules sub-directory) because it is shared
-# with the find module
-include (${project}-prereqs)
-
-# read the list of components from this file (in the project directory);
-# it should set various lists with the names of the files to include
-include (CMakeLists_files.cmake)
-
-macro (config_hook)
-endmacro (config_hook)
-
-macro (prereqs_hook)
-endmacro (prereqs_hook)
-
-macro (sources_hook)
-endmacro (sources_hook)
-
-macro (fortran_hook)
-endmacro (fortran_hook)
-
-macro (files_hook)
-endmacro (files_hook)
-
-macro (tests_hook)
-endmacro (tests_hook)
-
-# all setup common to the OPM library modules is done here
-include (OpmLibMain)
-
-# Install build system files
-install(DIRECTORY cmake DESTINATION share/opm)
 
 endif()

--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -103,7 +103,7 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
 		add_test (${_sat_FANCY} ${_sat_LOC})
 		# run the test in the directory where the data files are
 		set_tests_properties (${_sat_FANCY} PROPERTIES
-		  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${${satellite}_DIR}
+		  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${${satellite}_DIR/bin}
 		  )
 	  endif (CMAKE_VERSION VERSION_LESS "2.8.4")
           if(NOT TARGET test-suite)
@@ -242,7 +242,7 @@ macro(opm_add_test TestName)
     if (OPM_TEST_DEFAULT_WORKING_DIRECTORY)
       set(CURTEST_WORKING_DIRECTORY ${OPM_TEST_DEFAULT_WORKING_DIRECTORY})
     else()
-      set(CURTEST_WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+      set(CURTEST_WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     endif()
   endif()
 

--- a/cmake/modules/FindValgrind.cmake
+++ b/cmake/modules/FindValgrind.cmake
@@ -1,0 +1,26 @@
+# Find Valgrind.
+#
+# This module defines:
+#  VALGRIND_INCLUDE_DIR, where to find valgrind/memcheck.h, etc.
+#  VALGRIND_PROGRAM, the valgrind executable.
+#  VALGRIND_FOUND, If false, do not try to use valgrind.
+#
+# If you have valgrind installed in a non-standard place, you can define
+# VALGRIND_ROOT to tell cmake where it is.
+if (VALGRIND_FOUND)
+  return()
+endif()
+
+find_path(VALGRIND_INCLUDE_DIR valgrind/memcheck.h
+  HINTS ${VALGRIND_ROOT}/include)
+
+# if VALGRIND_ROOT is empty, we explicitly add /bin to the search
+# path, but this does not hurt...
+find_program(VALGRIND_PROGRAM NAMES valgrind
+  HINTS ${VALGRIND_ROOT}/bin)
+
+find_package_handle_standard_args(VALGRIND DEFAULT_MSG
+  VALGRIND_INCLUDE_DIR
+  VALGRIND_PROGRAM)
+
+mark_as_advanced(VALGRIND_ROOT VALGRIND_INCLUDE_DIR VALGRIND_PROGRAM)

--- a/cmake/modules/OpmCommonMacros.cmake
+++ b/cmake/modules/OpmCommonMacros.cmake
@@ -4,6 +4,17 @@
 # suggests opm-common!
 #
 
+option(ENABLE_OPENMP "Turn OpenMP on if it is available?" OFF)
+if(ENABLE_OPENMP)
+  find_package(OpenMP)
+
+  if(OPENMP_FOUND)
+    set(HAVE_OPENMP 1)
+    dune_register_package_flags(
+      COMPILE_OPTIONS "${OpenMP_CXX_FLAGS}"
+      LIBRARIES "${OpenMP_CXX_FLAGS}")
+  endif()
+endif()
 
 # Check if valgrind library is available or not.
 find_package(Valgrind)

--- a/cmake/modules/OpmCommonMacros.cmake
+++ b/cmake/modules/OpmCommonMacros.cmake
@@ -1,0 +1,16 @@
+# .. cmake_module::
+#
+# This module's content is executed whenever a Dune module requires or
+# suggests opm-common!
+#
+
+
+# Check if valgrind library is available or not.
+find_package(Valgrind)
+
+# export include flags for valgrind
+set(HAVE_VALGRIND "${VALGRIND_FOUND}")
+if(VALGRIND_FOUND)
+  dune_register_package_flags(
+    INCLUDE_DIRS "${VALGRIND_INCLUDE_DIR}")
+endif()

--- a/cmake/modules/OpmMacros.cmake
+++ b/cmake/modules/OpmMacros.cmake
@@ -1,0 +1,291 @@
+# .. cmake_module::
+#
+# This module contains a few convenience macros which are relevant for
+# all OPM modules
+#
+
+# Specify the BUILD_TESTING option and set it to off by default. The
+# reason is that builing the unit tests often takes considerable more
+# time than the actual module and that these tests are not interesting
+# for people who just want to use the module but not develop on
+# it. Before merging changes into master, the continuous integration
+# system makes sure that the unit tests pass, though.
+option(BUILD_TESTING "Build the unit tests" OFF)
+
+option(ADD_DISABLED_CTESTS "Add the tests which are disabled due to failed preconditions to the ctest output (this makes ctest return an error if such a test is present)" ON)
+mark_as_advanced(ADD_DISABLED_CTESTS)
+
+# add a "test-suite" target if it does not already exist
+if(NOT TARGET test-suite)
+  add_custom_target(test-suite)
+endif()
+
+
+# Add a single unit test (can be orchestrated by the 'ctest' command)
+#
+# Synopsis:
+#       opm_add_test(TestName)
+#
+# Parameters:
+#       TestName           Name of test
+#       ONLY_COMPILE       Only build test but do not run it (optional)
+#       ALWAYS_ENABLE      Force enabling test even if -DBUILD_TESTING=OFF was set (optional)
+#       EXE_NAME           Name of test executable (optional, default: ./bin/${TestName})
+#       CONDITION          Condition to enable test (optional, cmake code)
+#       DEPENDS            Targets which the test depends on (optional)
+#       DRIVER             The script which supervises the test (optional, default: ${OPM_TEST_DRIVER})
+#       DRIVER_ARGS        The script which supervises the test (optional, default: ${OPM_TEST_DRIVER_ARGS})
+#       TEST_ARGS          Arguments to pass to test's binary (optional, default: empty)
+#       SOURCES            Source files for the test (optional, default: ${EXE_NAME}.cpp)
+#       PROCESSORS         Number of processors to run test on (optional, default: 1)
+#       TEST_DEPENDS       Other tests which must be run before running this test (optional, default: None)
+#       INCLUDE_DIRS       Additional directories to look for include files (optional)
+#       LIBRARIES          Libraries to link test against (optional)
+#       WORKING_DIRECTORY  Working directory for test (optional, default: ${PROJECT_BINARY_DIR})
+#
+# Example:
+#
+# opm_add_test(funky_test
+#              ALWAYS_ENABLE
+#              CONDITION FUNKY_GRID_FOUND
+#              SOURCES tests/MyFunkyTest.cpp
+#              LIBRARIES -lgmp -lm)
+include(CMakeParseArguments)
+
+set(DUNE_REENABLE_ADD_TEST "YES")
+
+macro(opm_add_test TestName)
+  cmake_parse_arguments(CURTEST
+                        "NO_COMPILE;ONLY_COMPILE;ALWAYS_ENABLE" # flags
+                        "EXE_NAME;PROCESSORS;WORKING_DIRECTORY" # one value args
+                        "CONDITION;TEST_DEPENDS;DRIVER;DRIVER_ARGS;DEPENDS;TEST_ARGS;SOURCES;LIBRARIES;INCLUDE_DIRS" # multi-value args
+                        ${ARGN})
+
+  # set the default values for optional parameters
+  if (NOT CURTEST_EXE_NAME)
+    set(CURTEST_EXE_NAME ${TestName})
+  endif()
+
+  # try to auto-detect the name of the source file if SOURCES are not
+  # explicitly specified.
+  if (NOT CURTEST_SOURCES)
+    set(CURTEST_SOURCES "")
+    set(_SDir "${PROJECT_SOURCE_DIR}")
+    foreach(CURTEST_CANDIDATE "${CURTEST_EXE_NAME}.cpp"
+                              "${CURTEST_EXE_NAME}.cc"
+                              "tests/${CURTEST_EXE_NAME}.cpp"
+                              "tests/${CURTEST_EXE_NAME}.cc")
+      if (EXISTS "${_SDir}/${CURTEST_CANDIDATE}")
+        set(CURTEST_SOURCES "${_SDir}/${CURTEST_CANDIDATE}")
+      endif()
+    endforeach()
+  endif()
+
+  # the default working directory is the content of
+  # OPM_TEST_DEFAULT_WORKING_DIRECTORY or the source directory if this
+  # is unspecified
+  if (NOT CURTEST_WORKING_DIRECTORY)
+    if (OPM_TEST_DEFAULT_WORKING_DIRECTORY)
+      set(CURTEST_WORKING_DIRECTORY ${OPM_TEST_DEFAULT_WORKING_DIRECTORY})
+    else()
+      set(CURTEST_WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    endif()
+  endif()
+
+  # don't build the tests by _default_ if BUILD_TESTING is false,
+  # i.e., when typing 'make' the tests are not build in that
+  # case. They can still be build using 'make test-suite' and they can
+  # be build and run using 'make check'
+  set(CURTEST_EXCLUDE_FROM_ALL "")
+  if (NOT BUILD_TESTING AND NOT CURTEST_ALWAYS_ENABLE)
+    set(CURTEST_EXCLUDE_FROM_ALL "EXCLUDE_FROM_ALL")
+  endif()
+
+  # figure out the test driver script and its arguments. (the variable
+  # for the driver script may be empty. In this case the binary is run
+  # "bare metal".)
+  if (NOT CURTEST_DRIVER)
+    set(CURTEST_DRIVER "${OPM_TEST_DRIVER}")
+  endif()
+  if (NOT CURTEST_DRIVER_ARGS)
+    set(CURTEST_DRIVER_ARGS "${OPM_TEST_DRIVER_ARGS}")
+  endif()
+
+  # the libraries to link against. the libraries produced by the
+  # current module are always linked against
+  get_property(DUNE_MODULE_LIBRARIES GLOBAL PROPERTY DUNE_MODULE_LIBRARIES)
+  if (NOT CURTEST_LIBRARIES)
+    SET(CURTEST_LIBRARIES "${DUNE_MODULE_LIBRARIES}")
+  else()
+    SET(CURTEST_LIBRARIES "${CURTEST_LIBRARIES};${DUNE_MODULE_LIBRARIES}")
+  endif()
+
+  # the additional include directories
+  get_property(DUNE_MODULE_INCLUDE_DIRS GLOBAL PROPERTY DUNE_INCLUDE_DIRS)
+  if (NOT CURTEST_INCLUDE_DIRS)
+    SET(CURTEST_INCLUDE_DIRS "${DUNE_INCLUDE_DIRS}")
+  else()
+    SET(CURTEST_INCLUDE_DIRS "${CURTEST_INCLUDE_DIRS};${DUNE_MODULE_INCLUDE_DIRS}")
+  endif()
+
+  # determine if the test should be completely ignored, i.e., the
+  # CONDITION argument evaluates to false. the "AND OR " is a hack
+  # which is required to prevent CMake from evaluating the condition
+  # in the string. (which might evaluate to an empty string even
+  # though "${CURTEST_CONDITION}" is not empty.)
+  if ("AND OR ${CURTEST_CONDITION}" STREQUAL "AND OR ")
+    set(SKIP_CUR_TEST "0")
+  elseif(${CURTEST_CONDITION})
+    set(SKIP_CUR_TEST "0")
+  else()
+    set(SKIP_CUR_TEST "1")
+  endif()
+
+  if (NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
+  endif()
+
+  if (NOT SKIP_CUR_TEST)
+    if (CURTEST_ONLY_COMPILE)
+      # only compile the binary but do not run it as a test
+      add_executable("${CURTEST_EXE_NAME}" ${CURTEST_EXCLUDE_FROM_ALL} ${CURTEST_SOURCES})
+      target_link_libraries (${CURTEST_EXE_NAME} ${CURTEST_LIBRARIES})
+      target_include_directories(${CURTEST_EXE_NAME} PRIVATE ${CURTEST_INCLUDE_DIRS})
+      
+      if(CURTEST_DEPENDS)
+        add_dependencies("${CURTEST_EXE_NAME}" ${CURTEST_DEPENDS})
+      endif()
+    else()
+      if (NOT CURTEST_NO_COMPILE)
+        # in addition to being run, the test must be compiled. (the
+        # run-only case occurs if the binary is already compiled by an
+        # earlier test.)
+        add_executable("${CURTEST_EXE_NAME}" ${CURTEST_EXCLUDE_FROM_ALL} ${CURTEST_SOURCES})
+        target_link_libraries (${CURTEST_EXE_NAME} ${CURTEST_LIBRARIES})
+        target_include_directories(${CURTEST_EXE_NAME} PRIVATE ${CURTEST_INCLUDE_DIRS})
+
+        if(CURTEST_DEPENDS)
+          add_dependencies("${CURTEST_EXE_NAME}" ${CURTEST_DEPENDS})
+        endif()
+      endif()
+
+      # figure out how the test should be run. if a test driver script
+      # has been specified to supervise the test binary, use it else
+      # run the test binary "naked".
+      if (CURTEST_DRIVER)
+        set(CURTEST_COMMAND ${CURTEST_DRIVER} ${CURTEST_DRIVER_ARGS} ${CURTEST_EXE_NAME} ${CURTEST_TEST_ARGS})
+      else()
+        set(CURTEST_COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CURTEST_EXE_NAME})
+        if (CURTEST_TEST_ARGS)
+          list(APPEND CURTEST_COMMAND ${CURTEST_TEST_ARGS})
+        endif()
+      endif()
+
+      add_test(NAME ${TestName}
+               WORKING_DIRECTORY "${CURTEST_WORKING_DIRECTORY}"
+               COMMAND ${CURTEST_COMMAND})
+
+      # return code 77 should be interpreted as skipped test
+      set_tests_properties(${TestName} PROPERTIES SKIP_RETURN_CODE 77)
+
+      # specify the dependencies between the tests
+      if (CURTEST_TEST_DEPENDS)
+        set_tests_properties(${TestName} PROPERTIES DEPENDS "${CURTEST_TEST_DEPENDS}")
+      endif()
+
+      # tell ctest how many cores it should reserve to run the test
+      if (CURTEST_PROCESSORS)
+        set_tests_properties(${TestName} PROPERTIES PROCESSORS "${CURTEST_PROCESSORS}")
+      endif()
+    endif()
+
+    if (NOT CURTEST_NO_COMPILE)
+      if(NOT TARGET test-suite)
+        add_custom_target(test-suite)
+      endif()
+      add_dependencies(test-suite "${CURTEST_EXE_NAME}")#
+    endif()
+
+  else() # test is skipped
+
+    # the following causes the test to appear as 'skipped' in the
+    # CDash dashboard. it this is removed, the test is just silently
+    # ignored.
+    if (NOT CURTEST_ONLY_COMPILE AND ADD_DISABLED_CTESTS)
+      add_test(${TestName} skip_test_dummy)
+
+      # return code 77 should be interpreted as skipped test
+      set_tests_properties(${TestName} PROPERTIES SKIP_RETURN_CODE 77)
+    endif()
+
+  endif()
+endmacro()
+
+# Add an application. This macro takes the same arguments as
+# opm_add_test() but applications are always compiled if CONDITION
+# evaluates to true and that applications are not added to the test
+# suite.
+#
+# opm_add_application(AppName
+#                     [EXE_NAME AppExecutableName]
+#                     [CONDITION ConditionalExpression]
+#                     [SOURCES SourceFile1 SourceFile2 ...])
+macro(opm_add_application AppName)
+  opm_add_test(${AppName} ${ARGN} ALWAYS_ENABLE ONLY_COMPILE)
+endmacro()
+
+# macro to set the default test driver script and the its default
+# arguments
+macro(opm_set_test_driver DriverBinary DriverDefaultArgs)
+  set(OPM_TEST_DRIVER "${DriverBinary}")
+  set(OPM_TEST_DRIVER_ARGS "${DriverDefaultArgs}")
+endmacro()
+
+# macro to set the default test driver script and the its default
+# arguments
+macro(opm_set_test_default_working_directory Dir)
+  set(OPM_TEST_DEFAULT_WORKING_DIRECTORY "${Dir}")
+endmacro()
+
+macro(opm_recursive_add_library LIBNAME)
+  set(TMP2 "")
+  foreach(DIR ${ARGN})
+    file(GLOB_RECURSE TMP RELATIVE "${CMAKE_SOURCE_DIR}" "${DIR}/*.cpp" "${DIR}/*.cc" "${DIR}/*.c")
+    list(APPEND TMP2 ${TMP})
+  endforeach()
+
+  dune_add_library("${LIBNAME}"
+    SOURCES "${TMP2}"
+    )
+endmacro()
+
+macro(opm_recusive_copy_testdata)
+  foreach(PAT ${ARGN})
+    file(GLOB_RECURSE TMP RELATIVE "${CMAKE_SOURCE_DIR}" "${PAT}")
+
+    foreach(SOURCE_FILE ${TMP})
+      get_filename_component(DIRNAME "${SOURCE_FILE}" DIRECTORY)
+      file(COPY "${SOURCE_FILE}" DESTINATION "${CMAKE_BINARY_DIR}/${DIRNAME}")
+    endforeach()
+  endforeach()
+endmacro()
+
+macro(opm_recusive_export_all_headers)
+  foreach(DIR ${ARGN})
+    file(GLOB_RECURSE TMP RELATIVE "${CMAKE_SOURCE_DIR}" "${DIR}/*.hpp" "${DIR}/*.hh" "${DIR}/*.h")
+
+    foreach(HEADER ${TMP})
+      get_filename_component(DIRNAME "${HEADER}" DIRECTORY)
+      install(FILES "${HEADER}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${DIRNAME}")
+    endforeach()
+  endforeach()
+endmacro()
+
+macro(opm_export_cmake_modules)
+  file(GLOB_RECURSE TMP RELATIVE "${CMAKE_SOURCE_DIR}" "cmake/*.cmake")
+
+  foreach(CM_MOD ${TMP})
+    get_filename_component(DIRNAME "${CM_MOD}" DIRECTORY)
+    install(FILES "${CM_MOD}" DESTINATION "${DUNE_INSTALL_MODULEDIR}")
+  endforeach()
+endmacro()

--- a/cmake/modules/OpmMacros.cmake
+++ b/cmake/modules/OpmMacros.cmake
@@ -50,6 +50,8 @@ endif()
 #              CONDITION FUNKY_GRID_FOUND
 #              SOURCES tests/MyFunkyTest.cpp
 #              LIBRARIES -lgmp -lm)
+include(UseWarnings)
+
 include(CMakeParseArguments)
 
 set(DUNE_REENABLE_ADD_TEST "YES")

--- a/cmake/modules/OpmMacros.cmake
+++ b/cmake/modules/OpmMacros.cmake
@@ -153,7 +153,7 @@ macro(opm_add_test TestName)
       add_executable("${CURTEST_EXE_NAME}" ${CURTEST_EXCLUDE_FROM_ALL} ${CURTEST_SOURCES})
       target_link_libraries (${CURTEST_EXE_NAME} ${CURTEST_LIBRARIES})
       target_include_directories(${CURTEST_EXE_NAME} PRIVATE ${CURTEST_INCLUDE_DIRS})
-      
+
       if(CURTEST_DEPENDS)
         add_dependencies("${CURTEST_EXE_NAME}" ${CURTEST_DEPENDS})
       endif()
@@ -259,6 +259,39 @@ macro(opm_recursive_add_library LIBNAME)
   dune_add_library("${LIBNAME}"
     SOURCES "${TMP2}"
     )
+endmacro()
+
+# add all source files from each modules CMakeLists_files.cmake
+# to the library and executables. Argument is the library name
+macro(opm_add_headers_library_and_executables LIBNAME)
+
+  # include list with source files and executables
+  include(${CMAKE_SOURCE_DIR}/CMakeLists_files.cmake)
+
+  dune_add_library("${LIBNAME}"
+    SOURCES "${MAIN_SOURCE_FILES}"
+    )
+
+  # add header for installation
+  foreach( HEADER ${PUBLIC_HEADER_FILES})
+    # extract header directory for installation
+    get_filename_component(DIRNAME "${HEADER}" DIRECTORY)
+    install(FILES "${HEADER}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${DIRNAME}")
+  endforeach()
+
+  # add executables from list of executables
+  foreach( FILE_NAME ${EXAMPLE_SOURCE_FILES} )
+    # extract executable name
+    get_filename_component(EXEC_NAME ${FILE_NAME} NAME_WE)
+    opm_add_application( ${EXEC_NAME} SOURCES ${FILE_NAME} )
+  endforeach()
+
+  # add tests from list of test files
+  foreach( FILE_NAME ${TEST_SOURCE_FILES} )
+    # extract executable name
+    get_filename_component(EXEC_NAME ${FILE_NAME} NAME_WE)
+    opm_add_test( ${EXEC_NAME} SOURCES "${FILE_NAME}" LIBRARIES "${Boost_LIBRARIES}" INCLUDE_DIRS "${Boost_INCLUDE_DIRS}")
+  endforeach()
 endmacro()
 
 macro(opm_recusive_copy_testdata)

--- a/cmake/modules/OpmMacros.cmake
+++ b/cmake/modules/OpmMacros.cmake
@@ -264,6 +264,12 @@ endmacro()
 # add all source files from each modules CMakeLists_files.cmake
 # to the library and executables. Argument is the library name
 macro(opm_add_headers_library_and_executables LIBNAME)
+  # the cmake modules get a special treatment
+  opm_export_cmake_modules()
+
+  # we want all features detected by the build system to be enabled,
+  # thank you!
+  dune_enable_all_packages()
 
   # include list with source files and executables
   include(${CMAKE_SOURCE_DIR}/CMakeLists_files.cmake)
@@ -271,6 +277,8 @@ macro(opm_add_headers_library_and_executables LIBNAME)
   dune_add_library("${LIBNAME}"
     SOURCES "${MAIN_SOURCE_FILES}"
     )
+
+
 
   # add header for installation
   foreach( HEADER ${PUBLIC_HEADER_FILES})

--- a/cmake/modules/UseWarnings.cmake
+++ b/cmake/modules/UseWarnings.cmake
@@ -1,0 +1,38 @@
+# - Turn on warnings when compiling
+
+# sets CXX_COMPAT_GCC if we have either GCC or Clang
+macro (is_compiler_gcc_compatible)
+  # is the C++ compiler clang++?
+  string (TOUPPER "${CMAKE_CXX_COMPILER_ID}" _comp_id)
+  if (_comp_id MATCHES "CLANG")
+    set (CMAKE_COMPILER_IS_CLANGXX TRUE)
+  else ()
+    set (CMAKE_COMPILER_IS_CLANGXX FALSE)
+  endif ()
+  # is the C++ compiler g++ or clang++?
+  if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
+    set (CXX_COMPAT_GCC TRUE)
+  else ()
+    set (CXX_COMPAT_GCC FALSE)
+  endif ()
+  # is the C compiler clang?
+  string (TOUPPER "${CMAKE_C_COMPILER_ID}" _comp_id)
+  if (_comp_id MATCHES "CLANG")
+    set (CMAKE_COMPILER_IS_CLANG TRUE)
+  else ()
+    set (CMAKE_COMPILER_IS_CLANG FALSE)
+  endif ()
+  # is the C compiler gcc or clang?
+  if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+    set (C_COMPAT_GCC TRUE)
+  else ()
+    set (C_COMPAT_GCC FALSE)
+  endif ()
+endmacro (is_compiler_gcc_compatible)
+
+is_compiler_gcc_compatible ()
+
+option(SILENCE_EXTERNAL_WARNINGS "Disable some warnings from external packages (requires GCC 4.6 or newer)" OFF)
+if(SILENCE_EXTERNAL_WARNINGS AND CXX_COMPAT_GCC)
+  dune_register_package_flags(COMPILE_DEFINITIONS "SILENCE_EXTERNAL_WARNINGS=1")
+endif()

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,0 +1,49 @@
+/* begin opm-common
+   put the definitions for config.h specific to
+   your project here. Everything above will be
+   overwritten
+*/
+/* begin private */
+/* Name of package */
+#define PACKAGE "@DUNE_MOD_NAME@"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "@DUNE_MAINTAINER@"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "@DUNE_MOD_NAME@"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "@DUNE_MOD_NAME@ @DUNE_MOD_VERSION@"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "@DUNE_MOD_NAME@"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@DUNE_MOD_URL@"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@DUNE_MOD_VERSION@"
+
+/* end private */
+
+/* Define to the version of opm-common */
+#define OPM_COMMON_VERSION "${OPM_COMMON_VERSION}"
+
+/* Define to the major version of opm-common */
+#define OPM_COMMON_VERSION_MAJOR ${OPM_COMMON_VERSION_MAJOR}
+
+/* Define to the minor version of opm-common */
+#define OPM_COMMON_VERSION_MINOR ${OPM_COMMON_VERSION_MINOR}
+
+/* Define to the revision of opm-common */
+#define OPM_COMMON_VERSION_REVISION ${OPM_COMMON_VERSION_REVISION}
+
+/* Define whether valgrind is available */
+#cmakedefine HAVE_VALGRIND 1
+
+/* begin bottom */
+
+/* end bottom */
+
+/* end opm-common */

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -39,6 +39,9 @@
 /* Define to the revision of opm-common */
 #define OPM_COMMON_VERSION_REVISION ${OPM_COMMON_VERSION_REVISION}
 
+/* Specify whether OpenMP is available or not */
+#cmakedefine HAVE_OPENMP 1
+
 /* Define whether valgrind is available */
 #cmakedefine HAVE_VALGRIND 1
 

--- a/dune.module
+++ b/dune.module
@@ -7,6 +7,7 @@ Module: opm-common
 Description: Open Porous Media Initiative shared infrastructure
 Version: 2018.04-pre
 Label: 2018.04-pre
+Depends: dune-common (>= 2.4)
 Maintainer: opm@opm-project.org
-MaintainerName: OPM community
+MaintainerName: The Open Porous Media Project
 Url: http://opm-project.org

--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -79,16 +79,7 @@ function printHeader {
 # $2 = 0 to build and install module, 1 to build and test module
 # $3 = Source root of module to build
 function build_module {
-  CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=$2 -DCMAKE_INSTALL_PREFIX=\"$WORKSPACE/$configuration/install\" -DCMAKE_PREFIX_PATH=\"$WORKSPACE/$configuration/install\" -DCMAKE_TOOLCHAIN_FILE=${configurations[$configuration]}"
-  for upstream in ${upstreams[*]}
-  do
-      CMAKE_ARGS="$CMAKE_ARGS -D${upstream}_DIR=\"$WORKSPACE/$configuration/install\""
-  done
-
-  CMAKE_CMD="cmake $3 $CMAKE_ARGS $1"
-  echo "configuring: $CMAKE_CMD"
-  eval $CMAKE_CMD
-
+  cmake $3 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=$2 -DCMAKE_TOOLCHAIN_FILE=${configurations[$configuration]} $1
   test $? -eq 0 || exit 1
   if test $2 -eq 1
   then
@@ -171,7 +162,7 @@ function build_upstreams {
   do
     echo "Building upstream $upstream=${upstreamRev[$upstream]} configuration=$configuration"
     # Build upstream and execute installation
-    clone_and_build_module $upstream "" ${upstreamRev[$upstream]} $WORKSPACE/$configuration
+    clone_and_build_module $upstream "-DCMAKE_PREFIX_PATH=$WORKSPACE/$configuration/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install" ${upstreamRev[$upstream]} $WORKSPACE/$configuration
     test $? -eq 0 || exit 1
   done
   test $? -eq 0 || exit 1
@@ -186,7 +177,7 @@ function build_downstreams {
   do
     echo "Building downstream $downstream=${downstreamRev[$downstream]} configuration=$configuration"
     # Build downstream and execute installation
-    clone_and_build_module $downstream "-DOPM_DATA_ROOT=$OPM_DATA_ROOT" ${downstreamRev[$downstream]} $WORKSPACE/$configuration 1
+    clone_and_build_module $downstream "-DCMAKE_PREFIX_PATH=$WORKSPACE/$configuration/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install -DOPM_DATA_ROOT=$OPM_DATA_ROOT" ${downstreamRev[$downstream]} $WORKSPACE/$configuration 1
     test $? -eq 0 || exit 1
 
     # Installation for downstream
@@ -223,7 +214,7 @@ function build_module_full {
     mkdir -p $configuration/build-$1
     cd $configuration/build-$1
     echo "Building main module $1=$sha1 configuration=$configuration"
-    build_module "-DOPM_DATA_ROOT=$OPM_DATA_ROOT" 1 $WORKSPACE
+    build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install -DOPM_DATA_ROOT=$OPM_DATA_ROOT" 1 $WORKSPACE
     test $? -eq 0 || exit 1
     cmake --build . --target install
     test $? -eq 0 || exit 1

--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -181,11 +181,6 @@ function build_upstreams {
 # Uses pre-filled arrays downstreams, and associativ array downstreamRev
 # which holds the default revisions to use for downstreams
 function build_downstreams {
-  pushd .
-  cd $WORKSPACE/$configuration/build-$1
-  cmake --build . --target install
-  popd
-
   egrep_cmd="xml_grep --wrap testsuites --cond testsuite $WORKSPACE/$configuration/build-$1/testoutput.xml"
   for downstream in ${downstreams[*]}
   do
@@ -229,6 +224,8 @@ function build_module_full {
     cd $configuration/build-$1
     echo "Building main module $1=$sha1 configuration=$configuration"
     build_module "-DOPM_DATA_ROOT=$OPM_DATA_ROOT" 1 $WORKSPACE
+    test $? -eq 0 || exit 1
+    cmake --build . --target install
     test $? -eq 0 || exit 1
     popd
 

--- a/opm-common.pc.in
+++ b/opm-common.pc.in
@@ -1,0 +1,15 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+CXX=@CXX@
+CC=@CC@
+DEPENDENCIES=@REQUIRES@
+
+Name: @PACKAGE_NAME@
+Version: @VERSION@
+Description: The opm-common module
+URL: http://www.opm-project.org/
+Requires: ${DEPENDENCIES}
+Libs: -L${libdir}
+Cflags: -I${includedir}

--- a/tests/test_param.cpp
+++ b/tests/test_param.cpp
@@ -36,9 +36,7 @@
 
 #include <config.h>
 
-#if HAVE_DYNAMIC_BOOST_TEST
 #define BOOST_TEST_DYN_LINK
-#endif
 #define NVERBOSE // to suppress our messages when throwing
 
 #define BOOST_TEST_MODULE ParameterTest
@@ -87,7 +85,7 @@ BOOST_AUTO_TEST_CASE(xml_syntax_init)
 {
     typedef const char* cp;
     std::vector<cp> argv = { "program_command",
-                             "testdata.param",
+                             "tests/testdata.param",
                              "/group/item=overridingstring",
                              "unhandledargument",
                              0};
@@ -115,7 +113,7 @@ BOOST_AUTO_TEST_CASE(failing_strict_xml_syntax_init)
 {
     typedef const char* cp;
     std::vector<cp> argv = { "program_command",
-                             "testdata.param",
+                             "tests/testdata.param",
                              "/group/item=overridingstring",
                              "unhandledargument",
                              0 };


### PR DESCRIPTION
This PR is related to #277, but it does not remove the current build system. Instead, it just adds everything required to use DUNE's build system and the `USE_OPM_BUILD_SYSTEM` option to select which of those two shall be used. The default is to stick with the current system. (except when running under dunecontrol, because in that case you most probably *really* want to use DUNE's system.)

The reasons why the dune system might want to be used are the same as for #277:

- Playing the usual whack-a-mole game for new Dune releases is not necessary anymore
- It makes it significantly easier to play around with less common libraries that are not (yet?) relevant for `flow` but already have support in Dune build system but not by the OPM one. Examples are dune-fem, dune-spgrid, AlbertaGrid, PTScotch, METIS, VC, UG and quite a few more.
- The dune build system is more widely tested, e.g., it should work fine on most supercomputers or with some alternative compilers like `icc`.
