### PR TITLE
Add option to bring in external cmake build system for experimental extensions. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,25 @@
+# -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t
+# vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
+
+# specify the option that allows to select the build system. if
+# dunecontrol is used, we default to the opm build system.
+set(USE_OPM_BUILDSYSTEM_DEFAULT ON)
+
+# if dunecontrol is used switch to DUNE build system
+if (DEFINED ENV{DUNE_CONTROL_PATH})
+	set(USE_OPM_BUILDSYSTEM_DEFAULT OFF)
+endif()
+
+option(USE_OPM_BUILDSYSTEM "Use the OPM build system?" ${USE_OPM_BUILDSYSTEM_DEFAULT})
+
+if (USE_OPM_BUILDSYSTEM)
+#########################################
+# use the traditional OPM build system
+#########################################
+
+# set up project
+project("opm-common" CXX)
+
 cmake_minimum_required (VERSION 2.8)
 
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
@@ -52,3 +74,10 @@ include (OpmLibMain)
 
 # Install build system files
 install(DIRECTORY cmake DESTINATION share/opm)
+
+else()
+###############################################
+# use other build system provided outside OPM
+###############################################
+include(ExternalBuild)
+endif()

--- a/dune.module
+++ b/dune.module
@@ -10,3 +10,4 @@ Label: 2018.04-pre
 Maintainer: opm@opm-project.org
 MaintainerName: OPM community
 Url: http://opm-project.org
+Suggests: dune-common (>= 2.4)


### PR DESCRIPTION
This is a minimal set of requirements to allow OPM being build with a build system not contained inside the OPM modules. This is not restricted to the DUNE build system. 