### PR TITLE
Force the use MPI C bindings.

### DIFF
--- a/cmake/Modules/FindPETSc.cmake
+++ b/cmake/Modules/FindPETSc.cmake
@@ -82,11 +82,11 @@ set(PETSC_MPI_LIBRARY "")
 set(PETSC_MPI_INCLUDE_DIRS "")
 
 find_package(MPI)
-if(MPI_FOUND)
-    list(APPEND PETSC_MPI_LIBRARY "${MPI_LIBRARIES}")
-    set(PETSC_MPI_INCLUDE_DIRS ${MPI_INCLUDE_PATH})
+if(MPI_C_FOUND)
+    list(APPEND PETSC_MPI_LIBRARY "${MPI_C_LIBRARIES}")
+    set(PETSC_MPI_INCLUDE_DIRS ${MPI_C_INCLUDE_PATH})
 
-else(MPI_FOUND)
+else(MPI_C_FOUND)
 # if a system MPI wasn't found, look for PETSc's serial implementation. This
 # won't be available if PETSc was compiled with --with-mpi=0, so not finding
 # this won't be an error. This only needs to find the header, as the MPI
@@ -98,7 +98,7 @@ else(MPI_FOUND)
         PATH_SUFFIXES "mpiuni"
         ${_no_default_path}
         )
-endif(MPI_FOUND)
+endif(MPI_C_FOUND)
 
 if(NOT PETSC_MPI_INCLUDE_DIRS)
     message(WARNING "Could not find any MPI implementation. If PETSc is compiled with --with-mpi=0 this is ok. Otherwise you will get linker errors or (possibly subtle) runtime errors. Continuing.")

--- a/cmake/Modules/Finddune-common.cmake
+++ b/cmake/Modules/Finddune-common.cmake
@@ -76,6 +76,8 @@ if(MPI_C_FOUND)
   set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES};${MPI_C_INCLUDES})
   check_function_exists(MPI_Finalized MPI_2)
   cmake_pop_check_state()
+  # actively deactivate CXX bindings
+  add_definitions(-DMPICH_SKIP_MPICXX -DMPIPP_H -DMPI_NO_CPPBIND)
 endif(MPI_C_FOUND)
 
 # make version number available in config.h

--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -183,15 +183,18 @@ macro (find_and_append_package_to prefix name)
   # now a macro, and not a function anymore), so we must reinitialize
   string (TOUPPER "${name}" NAME)
   string (REPLACE "-" "_" NAME "${NAME}")
-
+  # Special treatment for MPI to deactivate CXX bindings 100%
+  string (REGEX REPLACE "^MPI" "MPI_C" NAME "${NAME}")
+  # We cannot overwrite name as it is a macro parameter. Go for name_for_mpi 
+  string (REGEX REPLACE "^MPI" "MPI_C" name_for_mpi "${name}")
   if (${name}_FOUND OR ${NAME}_FOUND)
 	foreach (var IN LISTS _opm_proj_vars)
-	  if (DEFINED ${name}_${var})
-		list (APPEND ${prefix}_${var} ${${name}_${var}})
+	  if (DEFINED ${name_for_mpi}_${var})
+		list (APPEND ${prefix}_${var} ${${name_for_mpi}_${var}})
 	  # some packages define an uppercase version of their own name
 	  elseif (DEFINED ${NAME}_${var})
 		list (APPEND ${prefix}_${var} ${${NAME}_${var}})
-	  endif (DEFINED ${name}_${var})
+	  endif (DEFINED ${name_for_mpi}_${var})
 	  # some packages define _PATH instead of _DIRS (Hi, MPI!)
 	  if ("${var}" STREQUAL "INCLUDE_DIRS")
 		if (DEFINED ${name}_INCLUDE_PATH)


### PR DESCRIPTION
Previously, these slipped in when appending flags, directories,
and libraries for the modules as the default of CMake is to use
CXX bindings of MPI. With commit we always append the corresponding flags
for the C bindings and actively deactivate the CXX bindings of MPI
via compile definitions.