### PR TITLE
Allow DUNE modules to locate the dune.module files during CMake run.

### DIFF
--- a/cmake/Modules/OpmProject.cmake
+++ b/cmake/Modules/OpmProject.cmake
@@ -76,6 +76,7 @@ function (opm_cmake_config name)
   set (template_dir "${OPM_MACROS_ROOT}/cmake/Templates")
 
   # write configuration file to locate library
+  set(DUNE_PREFIX ${PROJECT_SOURCE_DIR})
   set(OPM_PROJECT_EXTRA_CODE ${OPM_PROJECT_EXTRA_CODE_INTREE})
   set(PREREQ_LOCATION "${PROJECT_SOURCE_DIR}")
   configure_cmake_file (${name} "config" "")
@@ -123,6 +124,7 @@ function (opm_cmake_config name)
   # of the build directory (using the same input template)
   set(OPM_PROJECT_EXTRA_CODE ${OPM_PROJECT_EXTRA_CODE_INSTALLED})
   set(PREREQ_LOCATION "${CMAKE_INSTALL_PREFIX}/share/opm/cmake/Modules")
+  set(DUNE_PREFIX ${CMAKE_INSTALL_PREFIX})
   configure_cmake_file (${name} "install" "")
   configure_vars (
 	FILE CMAKE "${PROJECT_BINARY_DIR}/${${name}_NAME}-install.cmake"

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -24,6 +24,7 @@ if(NOT @opm-project_NAME@_FOUND)
   set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" @PREREQ_LOCATION@)
   include(@opm-project_NAME@-prereqs)
   # propagate these properties from one build system to the other
+  set (@opm-project_NAME@_PREFIX "@DUNE_PREFIX@")
   set (@opm-project_NAME@_VERSION "@opm-project_VERSION@")
   set (@opm-project_NAME@_DEFINITIONS "@opm-project_DEFINITIONS@")
   set (@opm-project_NAME@_INCLUDE_DIRS "@opm-project_INCLUDE_DIRS@")


### PR DESCRIPTION
For this we need to set <dune-module>_PREFIX to some ominous value (at least for installed versions). ~I have no idea what I was thinking when implementing and naming it like this in DUNE.~ The name is actually correct, I just did not see it. <dune-module>_PREFIX  either set to where the module is installed to or the source directory for a build with uninstalled modules.


This is an ~untested~ shot to resolve the problem described in #300.