### PR TITLE
add dune-common to the list of modules depended on by dune.module

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,3 +10,4 @@ Label: 2018.04-pre
 Maintainer: opm@opm-project.org
 MaintainerName: OPM community
 Url: http://opm-project.org
+Depends: dune-common


### PR DESCRIPTION
since dune.module is primarily required for dunecontrol support and you cannot run dunecontrol without dune-common anyway, nothing changes for dunecontrol users.

for users who stubbornly refuse to use dunecontrol, nothing changes either because the dependencies are specified in opm-common-prereqs.cmake which stays untouched by this commit.