### PR TITLE
Include <module>-prereqs.cmake in <module>-config.cmake to process all dependencies

### DIFF
--- a/cmake/Modules/OpmInstall.cmake
+++ b/cmake/Modules/OpmInstall.cmake
@@ -61,4 +61,8 @@ macro (opm_install opm)
 	FILES ${PROJECT_SOURCE_DIR}/dune.module
 	DESTINATION lib/${${opm}_VER_DIR}/dunecontrol/${${opm}_NAME}
 	)
+  install (
+        FILES ${PROJECT_SOURCE_DIR}/${CMAKE_PROJECT_NAME}-prereqs.cmake
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/opm/cmake/Modules
+        )
 endmacro (opm_install opm)

--- a/cmake/Modules/OpmProject.cmake
+++ b/cmake/Modules/OpmProject.cmake
@@ -77,6 +77,7 @@ function (opm_cmake_config name)
 
   # write configuration file to locate library
   set(OPM_PROJECT_EXTRA_CODE ${OPM_PROJECT_EXTRA_CODE_INTREE})
+  set(PREREQ_LOCATION "${PROJECT_SOURCE_DIR}")
   configure_cmake_file (${name} "config" "")
   configure_cmake_file (${name} "config" "-version")
   configure_vars (
@@ -114,6 +115,7 @@ function (opm_cmake_config name)
   # create a config mode file which targets the install directory instead
   # of the build directory (using the same input template)
   set(OPM_PROJECT_EXTRA_CODE ${OPM_PROJECT_EXTRA_CODE_INSTALLED})
+  set(PREREQ_LOCATION "${CMAKE_INSTALL_PREFIX}/share/opm/cmake/Modules")
   configure_cmake_file (${name} "install" "")
   configure_vars (
 	FILE CMAKE "${PROJECT_BINARY_DIR}/${${name}_NAME}-install.cmake"

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -21,7 +21,8 @@
 
 # Prevent multiple inclusions
 if(NOT @opm-project_NAME@_FOUND)
-
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" @PREREQ_LOCATION@)
+  include(@opm-project_NAME@-prereqs)
   # propagate these properties from one build system to the other
   set (@opm-project_NAME@_VERSION "@opm-project_VERSION@")
   set (@opm-project_NAME@_DEFINITIONS "@opm-project_DEFINITIONS@")


### PR DESCRIPTION
Otherwise implicit dependencies are search for. That was the case
 for dune-geometry and dune-grid when configuring opm-core.
We also install the file now as wee need it for installed modules, too.

Fixes fallout of #304.
Closes #305.
