### PR TITLE
Support dune-uggrid (successor of UG).

### DIFF
--- a/cmake/Modules/Finddune-grid.cmake
+++ b/cmake/Modules/Finddune-grid.cmake
@@ -25,6 +25,7 @@ find_opm_package (
   "CXX11Features REQUIRED;
   dune-common REQUIRED;
   dune-geometry REQUIRED;
+  dune-uggrid;
   MPI;
   UG
   "

--- a/cmake/Modules/Finddune-uggrid.cmake
+++ b/cmake/Modules/Finddune-uggrid.cmake
@@ -1,0 +1,34 @@
+include (OpmPackage)
+
+find_opm_package (
+  # module name
+  "dune-uggrid"
+
+  # dependencies
+  # TODO: we should probe for all the HAVE_* values listed below;
+  # however, we don't actually use them in our implementation, so
+  "CXX11Features REQUIRED;
+  dune-common REQUIRED
+  "
+  # header to search for
+  ""
+
+  # library to search for
+  "duneuggrid"
+
+  # defines to be added to compilations
+  ""
+
+  # test program
+  ""
+  # config variable
+  "")
+
+#debug_find_vars ("dune-uggrid")
+
+# make version number available in config.h
+include (UseDuneVer)
+find_dune_version ("dune" "uggrid")
+
+# deactivate search for UH
+set(UG_FOUND ${dune-uggrid_FOUND})

--- a/cmake/Modules/Finddune-uggrid.cmake
+++ b/cmake/Modules/Finddune-uggrid.cmake
@@ -30,5 +30,5 @@ find_opm_package (
 include (UseDuneVer)
 find_dune_version ("dune" "uggrid")
 
-# deactivate search for UH
+# deactivate search for UG
 set(UG_FOUND ${dune-uggrid_FOUND})

--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -60,6 +60,7 @@ set (_opm_proj_exemptions
   dune-istl
   dune-grid
   dune-geometry
+  dune-uggrid
   dune-alugrid
   dune-localfunctions
   dune-fem


### PR DESCRIPTION
UG will not work for newer DUNE versions any more.

This makes opm-grid compile with DUNE 2.6. Note sure whether this PR is all that is needed.