### PR TITLE
fixed: set the boost dynamic test define if we build shared libs

### DIFF
--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -65,6 +65,11 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
 	set_target_properties (${_sat_NAME} PROPERTIES
 	  LINK_FLAGS "${${opm}_LINKER_FLAGS_STR}"
 	  )
+        if(HAVE_DYNAMIC_BOOST_TEST AND NOT (${opm} STREQUAL "opm-parser" AND NOT BUILD_SHARED_LIBS))
+	  set_target_properties (${_sat_NAME} PROPERTIES
+		  COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK
+	  )
+	endif()
 	# are we building a test? luckily, the testing framework doesn't
 	# require anything else, so we don't have to figure out where it
 	# should go in the library list

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -17,7 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE LogTests
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>

--- a/tests/test_SimulationDataContainer.cpp
+++ b/tests/test_SimulationDataContainer.cpp
@@ -18,7 +18,6 @@
  */
 
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE SIMULATION_DATA_CONTAINER_TESTS
 #include <boost/test/unit_test.hpp>
 

--- a/tests/test_cmp.cpp
+++ b/tests/test_cmp.cpp
@@ -18,7 +18,6 @@
  */
 
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE FLOAT_CMP_TESTS
 #include <boost/test/unit_test.hpp>
 

--- a/tests/test_cubic.cpp
+++ b/tests/test_cubic.cpp
@@ -36,11 +36,6 @@
 
 #include "config.h"
 
-/* --- Boost.Test boilerplate --- */
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-
 #define NVERBOSE  // Suppress own messages when throw()ing
 
 #define BOOST_TEST_MODULE CubicTest

--- a/tests/test_messagelimiter.cpp
+++ b/tests/test_messagelimiter.cpp
@@ -17,7 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE MESSAGELIMITER_TESTS
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>

--- a/tests/test_nonuniformtablelinear.cpp
+++ b/tests/test_nonuniformtablelinear.cpp
@@ -19,9 +19,6 @@
 */
 #include <config.h>
 
-#if defined(HAVE_DYNAMIC_BOOST_TEST)
-#define BOOST_TEST_DYN_LINK
-#endif
 #define NVERBOSE // to suppress our messages when throwing
 
 

--- a/tests/test_param.cpp
+++ b/tests/test_param.cpp
@@ -36,9 +36,6 @@
 
 #include <config.h>
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
 #define NVERBOSE // to suppress our messages when throwing
 
 #define BOOST_TEST_MODULE ParameterTest

--- a/tests/test_sparsevector.cpp
+++ b/tests/test_sparsevector.cpp
@@ -35,9 +35,6 @@
 
 #include <config.h>
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
 #define NVERBOSE // to suppress our messages when throwing
 
 #define BOOST_TEST_MODULE SparseVectorTest

--- a/tests/test_uniformtablelinear.cpp
+++ b/tests/test_uniformtablelinear.cpp
@@ -18,9 +18,6 @@
 */
 #include <config.h>
 
-#if defined(HAVE_DYNAMIC_BOOST_TEST)
-#define BOOST_TEST_DYN_LINK
-#endif
 #define NVERBOSE // to suppress our messages when throwing
 
 


### PR DESCRIPTION
Downstreams: 
- https://github.com/OPM/opm-grid/pull/310
- https://github.com/OPM/opm-output/pull/254
- https://github.com/OPM/opm-simulators/pull/1406
- https://github.com/OPM/opm-upscaling/pull/250

Sidestream: 
- https://github.com/OPM/opm-parser/pull/1214