### PR TITLE
include config.h in all unit tests

### DIFF
--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+
 #define BOOST_TEST_MODULE LogTests
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>

--- a/tests/test_SimulationDataContainer.cpp
+++ b/tests/test_SimulationDataContainer.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 
 #define BOOST_TEST_MODULE SIMULATION_DATA_CONTAINER_TESTS
 #include <boost/test/unit_test.hpp>

--- a/tests/test_cmp.cpp
+++ b/tests/test_cmp.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 
 #define BOOST_TEST_MODULE FLOAT_CMP_TESTS
 #include <boost/test/unit_test.hpp>

--- a/tests/test_cubic.cpp
+++ b/tests/test_cubic.cpp
@@ -34,7 +34,7 @@
   along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
+#include <config.h>
 
 #define NVERBOSE  // Suppress own messages when throw()ing
 

--- a/tests/test_messagelimiter.cpp
+++ b/tests/test_messagelimiter.cpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+
 #define BOOST_TEST_MODULE MESSAGELIMITER_TESTS
 
 #include <opm/common/utility/platform_dependent/disable_warnings.h>


### PR DESCRIPTION
in most tests it already gets included, so let's fix that inconsistency The Right Way (TM).