### PR TITLE
Embed restart_step in restarted summary writer.

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -846,23 +846,26 @@ Summary::Summary( const EclipseState& st,
 
     const auto& init_config = st.getInitConfig();
     const char * restart_case = nullptr;
+    int restart_step = -1;
 
     if (init_config.restartRequested( )) {
-        if (init_config.getRestartRootName().size() <= ECL_STRING8_LENGTH * SUMMARY_RESTART_SIZE)
+        if (init_config.getRestartRootName().size() <= ECL_STRING8_LENGTH * SUMMARY_RESTART_SIZE) {
             restart_case = init_config.getRestartRootName().c_str();
-        else
+            restart_step = init_config.getRestartStep();
+        } else
             OpmLog::warning("Restart case too long - not embedded in SMSPEC file");
     }
-    ecl_sum.reset( ecl_sum_alloc_restart_writer(basename,
-                                                restart_case,
-                                                st.getIOConfig().getFMTOUT(),
-                                                st.getIOConfig().getUNIFOUT(),
-                                                ":",
-                                                schedule.posixStartTime(),
-                                                true,
-                                                st.getInputGrid().getNX(),
-                                                st.getInputGrid().getNY(),
-                                                st.getInputGrid().getNZ()));
+    ecl_sum.reset( ecl_sum_alloc_restart_writer2(basename,
+                                                 restart_case,
+                                                 restart_step,
+                                                 st.getIOConfig().getFMTOUT(),
+                                                 st.getIOConfig().getUNIFOUT(),
+                                                 ":",
+                                                 schedule.posixStartTime(),
+                                                 true,
+                                                 st.getInputGrid().getNX(),
+                                                 st.getInputGrid().getNY(),
+                                                 st.getInputGrid().getNZ()));
 
     /* register all keywords handlers and pair with the newly-registered ert
      * entry.


### PR DESCRIPTION
In the case of restarted simulations this will embed the report step it has been restarted from in the generated SMSPEC file.

When this is merged you must update libecl to include: https://github.com/Statoil/libecl/pull/353