### PR TITLE
Added routine for calculating cell volumes based on corner point input.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -34,6 +34,7 @@ list (APPEND MAIN_SOURCE_FILES
       src/opm/common/utility/parameters/Parameter.cpp
       src/opm/common/utility/parameters/ParameterGroup.cpp
       src/opm/common/utility/parameters/ParameterTools.cpp
+      src/opm/common/utility/numeric/calc_cellvol.cpp
 )
 if(ENABLE_ECL_INPUT)
   list(APPEND MAIN_SOURCE_FILES
@@ -228,6 +229,7 @@ if(ENABLE_ECL_OUTPUT)
           tests/test_writenumwells.cpp
           tests/test_Solution.cpp
           tests/test_regionCache.cpp
+          tests/test_calc_cellvol.cpp
       )
 endif()
 
@@ -309,6 +311,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/utility/parameters/ParameterRequirement.hpp
       opm/common/utility/parameters/ParameterStrings.hpp
       opm/common/utility/parameters/ParameterTools.hpp
+      opm/common/utility/numeric/calc_cellvol.hpp
 )
 if(ENABLE_ECL_INPUT)
   list(APPEND PUBLIC_HEADER_FILES

--- a/opm/common/utility/numeric/calc_cellvol.hpp
+++ b/opm/common/utility/numeric/calc_cellvol.hpp
@@ -1,0 +1,8 @@
+#include <vector>
+#include <math.h>  
+
+//using namespace std;
+
+double calc_cell_volume(const std::vector<double>& X,const std::vector<double>& Y,const std::vector<double>& Z);
+
+

--- a/src/opm/common/utility/numeric/calc_cellvol.cpp
+++ b/src/opm/common/utility/numeric/calc_cellvol.cpp
@@ -1,0 +1,191 @@
+#include <opm/common/utility/numeric/calc_cellvol.hpp>
+
+
+using namespace std;
+
+
+
+
+double C(const std::vector<double>& r,int i1,int i2,int i3){
+
+   double temp;
+
+   temp=0.0;
+   
+   if ((i1==0) && (i2==0) && (i3==0)){
+      temp=r[0];
+   }
+
+   if ((i1==1) && (i2==0) && (i3==0)){
+      temp=r[1]-r[0];
+   }
+
+   if ((i1==0) && (i2==1) && (i3==0)){
+      temp=r[2]-r[0];
+   }
+
+   if ((i1==0) && (i2==0) && (i3==1)){
+      temp=r[4]-r[0];
+   }
+
+   if ((i1==1) && (i2==1) && (i3==0)){
+      temp=r[3]+r[0]-r[2]-r[1];
+   }
+
+   if ((i1==0) && (i2==1) && (i3==1)){
+      temp=r[6]+r[0]-r[4]-r[2];
+   }
+
+   if ((i1==1) && (i2==0) && (i3==1)){
+      temp=r[5]+r[0]-r[4]-r[1];
+   }
+
+   if ((i1==1) && (i2==1) && (i3==1)){
+      temp=r[7]+r[4]+r[2]+r[1]-r[6]-r[5]-r[3]-r[0];
+   }
+
+   return temp;
+
+}
+
+double perm123(int i1,int i2,int i3){
+
+   int temp;
+   
+   if ((i1==1) && (i2==2) && (i3==3)){
+      temp=0;
+   }
+   
+   if ((i1==1) && (i2==3) && (i3==2)){
+      temp=1;
+   }
+   
+   if ((i1==2) && (i2==1) && (i3==3)){
+      temp=1;
+   }
+   
+   if ((i1==2) && (i2==3) && (i3==1)){
+      temp=2;
+   }
+   
+   if ((i1==3) && (i2==1) && (i3==2)){
+      temp=2;
+   }
+   
+   if ((i1==3) && (i2==2) && (i3==1)){
+      temp=3;
+   }
+
+   
+   return temp;
+
+}
+
+
+
+double calc_cell_volume(const std::vector<double>& X,const std::vector<double>& Y,const std::vector<double>& Z){
+      
+  int pb,pg,qa,qg,ra,rb;
+
+  double volume=0.0;
+   
+  /* permutasjon (1,2,3)  */
+    
+  for (pb=0;pb<2;pb++){
+    for (pg=0;pg<2;pg++){
+      for (qa=0;qa<2;qa++){
+  	for (qg=0;qg<2;qg++){
+  	  for (ra=0;ra<2;ra++){
+  	    for (rb=0;rb<2;rb++){
+  	        volume=volume+(pow(-1.0,perm123(1,2,3))*(C(X,1,pb,pg)*C(Y,qa,1,qg)*C(Z,ra,rb,1))/((qa+ra+1)*(pb+rb+1)*(pg+qg+1)));
+  	    }
+          }
+        }
+      }
+    }
+  }  
+  
+  /* permutasjon (1,3,2) */
+  
+  for (pb=0;pb<2;pb++){
+    for (pg=0;pg<2;pg++){
+      for (qa=0;qa<2;qa++){
+  	for (qg=0;qg<2;qg++){
+  	  for (ra=0;ra<2;ra++){
+  	    for (rb=0;rb<2;rb++){
+        	 volume=volume+(pow(-1.0,perm123(1,3,2))*(C(X,1,pb,pg)*C(Z,qa,1,qg)*C(Y,ra,rb,1))/((qa+ra+1)*(pb+rb+1)*(pg+qg+1)));
+  	    }
+          }
+        }
+      }
+    }
+  }  
+  
+  /* permutasjon (2,1,3) */  
+  
+  for (pb=0;pb<2;pb++){
+    for (pg=0;pg<2;pg++){
+      for (qa=0;qa<2;qa++){
+  	for (qg=0;qg<2;qg++){
+  	  for (ra=0;ra<2;ra++){
+  	    for (rb=0;rb<2;rb++){
+        	volume=volume+pow(-1.0,perm123(2,1,3))*(C(Y,1,pb,pg)*C(X,qa,1,qg)*C(Z,ra,rb,1))/((qa+ra+1)*(pb+rb+1)*(pg+qg+1));
+  	    }
+          }
+        }
+      }
+    }
+  }  
+
+  /* permutasjon (2,3,1)  */ 
+  
+  for (pb=0;pb<2;pb++){
+    for (pg=0;pg<2;pg++){
+      for (qa=0;qa<2;qa++){
+  	for (qg=0;qg<2;qg++){
+  	  for (ra=0;ra<2;ra++){
+  	    for (rb=0;rb<2;rb++){
+        	volume=volume+pow(-1.0,perm123(2,3,1))*(C(Y,1,pb,pg)*C(Z,qa,1,qg)*C(X,ra,rb,1))/((qa+ra+1)*(pb+rb+1)*(pg+qg+1));
+  	    }
+          }
+        }
+      }
+    }
+  }  
+
+  /* permutasjon (3,1,2) */ 
+  
+  for (pb=0;pb<2;pb++){
+    for (pg=0;pg<2;pg++){
+      for (qa=0;qa<2;qa++){
+  	for (qg=0;qg<2;qg++){
+  	  for (ra=0;ra<2;ra++){
+  	    for (rb=0;rb<2;rb++){
+        	volume=volume+pow(-1.0,perm123(3,1,2))*(C(Z,1,pb,pg)*C(X,qa,1,qg)*C(Y,ra,rb,1))/((qa+ra+1)*(pb+rb+1)*(pg+qg+1));
+  	    }
+          }
+        }
+      }
+    }
+  }  
+  
+  /* permutasjon (3,2,1) */ 
+  
+  for (pb=0;pb<2;pb++){
+    for (pg=0;pg<2;pg++){
+      for (qa=0;qa<2;qa++){
+  	for (qg=0;qg<2;qg++){
+  	  for (ra=0;ra<2;ra++){
+  	    for (rb=0;rb<2;rb++){
+        	volume=volume+pow(-1.0,perm123(3,2,1))*(C(Z,1,pb,pg)*C(Y,qa,1,qg)*C(X,ra,rb,1))/((qa+ra+1)*(pb+rb+1)*(pg+qg+1));
+  	    }
+          }
+        }
+      }
+    }
+  }  
+  
+  return fabs(volume);
+
+}
+

--- a/tests/test_calc_cellvol.cpp
+++ b/tests/test_calc_cellvol.cpp
@@ -1,0 +1,84 @@
+//===========================================================================
+//
+// File: monotcubicinterpolator_test.cpp
+//
+// Created: Tue Dec  8 12:25:30 2009
+//
+// Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
+//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//
+// $Date$
+//
+// $Revision$
+//
+//===========================================================================
+
+/*
+  Copyright 2009, 2010 SINTEF ICT, Applied Mathematics.
+  Copyright 2009, 2010 Statoil ASA.
+  Portions Copyright 2013 Uni Research AS.
+
+  This file is part of The Open Reservoir Simulator Project (OpenRS).
+
+  OpenRS is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OpenRS is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OpenRS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+
+/* --- Boost.Test boilerplate --- */
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
+
+#define NVERBOSE  // Suppress own messages when throw()ing
+
+#define BOOST_TEST_MODULE CubicTest
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+/* --- our own headers --- */
+#include <opm/common/utility/numeric/calc_cellvol.hpp>
+
+
+
+//using namespace Opm;
+
+BOOST_AUTO_TEST_SUITE ()
+
+BOOST_AUTO_TEST_CASE (calc_cellvol)
+{
+    
+    std::vector<double> x1 {488100.140035,488196.664549,488085.584866,488182.365605,488099.065709,488195.880889,488084.559409,488181.633495};
+    std::vector<double> y1 {6692539.945578,6692550.834909,6692638.574346,6692650.086244,6692538.810649,6692550.080826,6692637.628127,6692649.429649};
+    std::vector<double> z1 {2841.856000,2840.138000,2842.042000,2839.816000,2846.142000,2844.252000,2846.244000,2843.868000};
+ 
+    std::vector<double> x2 {489539.050892,489638.562319,489527.025803,489627.914272,489537.173839,489638.562319,489524.119410,489627.914272};
+    std::vector<double> y2 {6695907.426615,6695923.399538,6696003.688945,6696020.073168,6695908.526577,6695923.399538,6696005.533276,6696020.073168};
+    std::vector<double> z2 {2652.859000,2651.765000,2652.381000,2652.608000,2655.276000,2651.765000,2656.381000,2652.608000};
+
+    std::vector<double> x3 {486819.009056,486904.877179,486812.975440,486900.527416,486818.450563,486903.978383,486812.975440,486900.527416};
+    std::vector<double> y3 {6694966.253697,6694998.360834,6695061.104896,6695086.717018,6694967.135567,6695000.197284,6695061.104896,6695086.717018};
+    std::vector<double> z3 {2795.193000,2799.997000,2792.240000,2793.972000,2795.671000,2800.927000,2792.240000,2793.972000};
+
+    std::vector<double> x4 {489194.711544,489259.232449,489206.220219,489294.099099,489194.711544,489254.725623,489201.723535,489289.423088};
+    std::vector<double> y4 {6694510.504054,6694525.862296,6694608.410134,6694621.029382,6694510.504054,6694526.272988,6694608.819829,6694621.467114};
+    std::vector<double> z4 {2740.7340,2754.7810,2730.0150,2726.1080,2740.7340,2758.3530,2733.9490,2730.1080};
+    
+    BOOST_REQUIRE_CLOSE (calc_cell_volume(x1,y1,z1), 40368.7852157, 1e-9);
+    BOOST_REQUIRE_CLOSE (calc_cell_volume(x2,y2,z2), 15766.9187847524, 1e-9);
+    BOOST_REQUIRE_CLOSE (calc_cell_volume(x3,y3,z3), 3268.8819007839, 1e-9);
+    BOOST_REQUIRE_CLOSE (calc_cell_volume(x4,y4,z4), 23391.4917234564, 1e-9);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Cell Volume calculation for corner point grids based on following publication:
  http://www.earthdoc.org/publication/publicationdetails/?publication=49775



