### PR TITLE
Ordered groups

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -120,7 +120,7 @@ namespace Opm
     private:
         TimeMap m_timeMap;
         OrderedMap< Well > m_wells;
-        std::map<std::string, Group > m_groups;
+        OrderedMap< Group > m_groups;
         DynamicState< GroupTree > m_rootGroupTree;
         DynamicState< OilVaporizationProperties > m_oilvaporizationproperties;
         Events m_events;

--- a/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
@@ -91,6 +91,22 @@ public:
         return m_vector[index];
     }
 
+    const T& at(size_t index) const {
+        return this->get(index);
+    }
+
+    const T& at(const std::string &key) const {
+        return this->get(key);
+    }
+
+    T& at(size_t index) {
+        return this->get(index);
+    }
+
+    T& at(const std::string& key) {
+        return this->get(key);
+    }
+
 
     T* getPtr(const std::string& key) const {
         auto iter = m_map.find( key );

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1542,7 +1542,7 @@ namespace Opm {
     }
 
     void Schedule::addGroup(const std::string& groupName, size_t timeStep) {
-        m_groups.emplace( groupName, Group { groupName, m_timeMap, timeStep } );
+        m_groups.insert( groupName, Group { groupName, m_timeMap, timeStep } );
         m_events.addEvent( ScheduleEvents::NEW_GROUP , timeStep );
     }
 
@@ -1551,7 +1551,7 @@ namespace Opm {
     }
 
     bool Schedule::hasGroup(const std::string& groupName) const {
-        return m_groups.find(groupName) != m_groups.end();
+        return m_groups.hasKey(groupName);
     }
 
 
@@ -1565,8 +1565,8 @@ namespace Opm {
     std::vector< const Group* > Schedule::getGroups() const {
         std::vector< const Group* > groups;
 
-        for( const auto& itr : m_groups )
-            groups.push_back( &itr.second );
+        for( const auto& group : m_groups )
+            groups.push_back( &group );
 
         return groups;
     }

--- a/tests/parser/OrderedMapTests.cpp
+++ b/tests/parser/OrderedMapTests.cpp
@@ -34,6 +34,8 @@ BOOST_AUTO_TEST_CASE( check_empty) {
     BOOST_CHECK( !map.hasKey("KEY"));
     BOOST_CHECK_THROW( map.get( 0 ) , std::invalid_argument);
     BOOST_CHECK_THROW( map.get( "KEY" ) , std::invalid_argument);
+    BOOST_CHECK_THROW( map.at("KEY"), std::invalid_argument);
+    BOOST_CHECK_THROW( map.at(0), std::invalid_argument);
 }
 
 
@@ -54,8 +56,8 @@ BOOST_AUTO_TEST_CASE( check_order ) {
     BOOST_CHECK_EQUAL( "Value2" , map.get("BKEY2"));
     BOOST_CHECK_EQUAL( "Value2" , map.get( 1 ));
 
-    BOOST_CHECK_EQUAL( "Value3" , map.get("AKEY3"));
-    BOOST_CHECK_EQUAL( "Value3" , map.get( 2 ));
+    BOOST_CHECK_EQUAL( "Value3" , map.at("AKEY3"));
+    BOOST_CHECK_EQUAL( "Value3" , map.at( 2 ));
 
     map.insert( "CKEY1" , "NewValue1");
     BOOST_CHECK_EQUAL( "NewValue1" , map.get("CKEY1"));

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -153,9 +153,9 @@ static Deck createDeckWithWellsOrdered() {
             "10 MAI 2007 / \n"
             "SCHEDULE\n"
             "WELSPECS\n"
-            "     \'CW_1\'        \'OP\'   30   37  3.33       \'OIL\'  7* /   \n"
-            "     \'BW_2\'        \'OP\'   30   37  3.33       \'OIL\'  7* /   \n"
-            "     \'AW_3\'        \'OP\'   20   51  3.92       \'OIL\'  7* /  \n"
+            "     \'CW_1\'        \'CG\'   30   37  3.33       \'OIL\'  7* /   \n"
+            "     \'BW_2\'        \'BG\'   30   37  3.33       \'OIL\'  7* /   \n"
+            "     \'AW_3\'        \'AG\'   20   51  3.92       \'OIL\'  7* /  \n"
             "/\n";
 
     return parser.parseString(input, ParseContext());
@@ -238,6 +238,12 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     BOOST_CHECK_EQUAL( "CW_1" , wells[0]->name());
     BOOST_CHECK_EQUAL( "BW_2" , wells[1]->name());
     BOOST_CHECK_EQUAL( "AW_3" , wells[2]->name());
+
+    auto groups = schedule.getGroups();
+    // groups[0] is 'FIELD'
+    BOOST_CHECK_EQUAL( "CG", groups[1]->name());
+    BOOST_CHECK_EQUAL( "BG", groups[2]->name());
+    BOOST_CHECK_EQUAL( "AG", groups[3]->name());
 }
 
 bool has_well( const std::vector<const Well*> wells, const std::string& well_name);


### PR DESCRIPTION
Use `OrderedMap<Group>` to handle groups, to ensure that insert-order is retained.