### PR TITLE
Expose Additional Maximum Dimension Values to EclipseState Clients

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -82,6 +82,7 @@ private:
 
 class WellSegmentDims {
 public:
+    WellSegmentDims();
     explicit WellSegmentDims(const Deck& deck);
 
     int maxSegmentedWells() const
@@ -100,9 +101,9 @@ public:
     }
 
 private:
-    int nSegWellMax   { 0 };
-    int nSegmentMax   { 1 };
-    int nLatBranchMax { 1 };
+    int nSegWellMax;
+    int nSegmentMax;
+    int nLatBranchMax;
 };
 
 class Runspec {

--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -80,6 +80,31 @@ private:
     int nGMax  { 0 };
 };
 
+class WellSegmentDims {
+public:
+    explicit WellSegmentDims(const Deck& deck);
+
+    int maxSegmentedWells() const
+    {
+        return this->nSegWellMax;
+    }
+
+    int maxSegmentsPerWell() const
+    {
+        return this->nSegmentMax;
+    }
+
+    int maxLateralBranchesPerWell() const
+    {
+        return this->nLatBranchMax;
+    }
+
+private:
+    int nSegWellMax   { 0 };
+    int nSegmentMax   { 1 };
+    int nLatBranchMax { 1 };
+};
+
 class Runspec {
    public:
         explicit Runspec( const Deck& );
@@ -88,6 +113,7 @@ class Runspec {
         const Tabdims&  tabdims() const noexcept;
         const EndpointScaling& endpointScaling() const noexcept;
         const Welldims& wellDimensions() const noexcept;
+        const WellSegmentDims& wellSegmentDimensions() const noexcept;
         int eclPhaseMask( ) const noexcept;
 
    private:
@@ -95,6 +121,7 @@ class Runspec {
         Tabdims m_tabdims;
         EndpointScaling endscale;
         Welldims welldims;
+        WellSegmentDims wsegdims;
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -64,6 +64,7 @@ namespace Opm {
         const Tabdims& getTabdims() const;
         const Eqldims& getEqldims() const;
         const Aqudims& getAqudims() const;
+        const Regdims& getRegdims() const;
 
         /*
           WIll return max{ Tabdims::NTFIP , Regdims::NTFIP }.

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -22,6 +22,7 @@
 #include <ert/ecl/ecl_util.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 namespace Opm {
@@ -92,10 +93,13 @@ Welldims::Welldims(const Deck& deck)
     }
 }
 
-WellSegmentDims::WellSegmentDims(const Deck& deck) :
-    nSegWellMax( 0 ),
-    nSegmentMax( 1 ),
-    nLatBranchMax( 1 )
+WellSegmentDims::WellSegmentDims() :
+    nSegWellMax( ParserKeywords::WSEGDIMS::NSWLMX::defaultValue ),
+    nSegmentMax( ParserKeywords::WSEGDIMS::NSEGMX::defaultValue ),
+    nLatBranchMax( ParserKeywords::WSEGDIMS::NLBRMX::defaultValue )
+{}
+
+WellSegmentDims::WellSegmentDims(const Deck& deck) : WellSegmentDims()
 {
     if (deck.hasKeyword("WSEGDIMS")) {
         const auto& wsd = deck.getKeyword("WSEGDIMS", 0).getRecord(0);

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -92,6 +92,20 @@ Welldims::Welldims(const Deck& deck)
     }
 }
 
+WellSegmentDims::WellSegmentDims(const Deck& deck) :
+    nSegWellMax( 0 ),
+    nSegmentMax( 1 ),
+    nLatBranchMax( 1 )
+{
+    if (deck.hasKeyword("WSEGDIMS")) {
+        const auto& wsd = deck.getKeyword("WSEGDIMS", 0).getRecord(0);
+
+        this->nSegWellMax   = wsd.getItem("NSWLMX").get<int>(0);
+        this->nSegmentMax   = wsd.getItem("NSEGMX").get<int>(0);
+        this->nLatBranchMax = wsd.getItem("NLBRMX").get<int>(0);
+    }
+}
+
 Runspec::Runspec( const Deck& deck ) :
     active_phases( Phases( deck.hasKeyword( "OIL" ),
                            deck.hasKeyword( "GAS" ),
@@ -102,7 +116,8 @@ Runspec::Runspec( const Deck& deck ) :
                            deck.hasKeyword( "POLYMW"  ) ) ),
     m_tabdims( deck ),
     endscale( deck ),
-    welldims( deck )
+    welldims( deck ),
+    wsegdims( deck )
 {}
 
 const Phases& Runspec::phases() const noexcept {
@@ -120,6 +135,11 @@ const EndpointScaling& Runspec::endpointScaling() const noexcept {
 const Welldims& Runspec::wellDimensions() const noexcept
 {
     return this->welldims;
+}
+
+const WellSegmentDims& Runspec::wellSegmentDimensions() const noexcept
+{
+    return this->wsegdims;
 }
 
 /*

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -566,6 +566,10 @@ namespace Opm {
         return m_aqudims;
     }
 
+    const Regdims& TableManager::getRegdims() const {
+        return *this->m_regdims;
+    }
+
     /*
       const std::vector<SwofTable>& TableManager::getSwofTables() const {
         return m_swofTables;

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -367,6 +367,101 @@ WELLDIMS
     BOOST_CHECK_EQUAL(wd.maxGroupsInField(), 0);  // WELLDIMS(3), defaulted
 }
 
+BOOST_AUTO_TEST_CASE(WSEGDIMS_NotSpecified)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+)" };
+
+    const auto wsd = WellSegmentDims {
+        Parser{}.parseString(input, ParseContext{})
+    };
+
+    BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 0);         // WSEGDIMS1), defaulted
+    BOOST_CHECK_EQUAL(wsd.maxSegmentsPerWell(), 1);        // WSEGDIMS(2), defaulted
+    BOOST_CHECK_EQUAL(wsd.maxLateralBranchesPerWell(), 1); // WSEGDIMS(3), defaulted
+}
+
+BOOST_AUTO_TEST_CASE(WSEGDIMS_AllDefaulted)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+
+WSEGDIMS
+/
+)" };
+
+    const auto wsd = WellSegmentDims {
+        Parser{}.parseString(input, ParseContext{})
+    };
+
+    BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 0);         // WSEGDIMS1), defaulted
+    BOOST_CHECK_EQUAL(wsd.maxSegmentsPerWell(), 1);        // WSEGDIMS(2), defaulted
+    BOOST_CHECK_EQUAL(wsd.maxLateralBranchesPerWell(), 1); // WSEGDIMS(3), defaulted
+}
+
+BOOST_AUTO_TEST_CASE(WSEGDIMS_MaxSegmentedWells)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+
+WSEGDIMS
+  11
+/
+)" };
+
+    const auto wsd = WellSegmentDims {
+        Parser{}.parseString(input, ParseContext{})
+    };
+
+    BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 11);        // WSEGDIMS(1)
+    BOOST_CHECK_EQUAL(wsd.maxSegmentsPerWell(), 1);        // WSEGDIMS(2), defaulted
+    BOOST_CHECK_EQUAL(wsd.maxLateralBranchesPerWell(), 1); // WSEGDIMS(3), defaulted
+}
+
+BOOST_AUTO_TEST_CASE(WSEGDIMS_MaxSegmentsPerWell)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+
+WSEGDIMS
+  1* 22
+/
+)" };
+
+    const auto wsd = WellSegmentDims {
+        Parser{}.parseString(input, ParseContext{})
+    };
+
+    BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 0);         // WSEGDIMS(1), defaulted
+    BOOST_CHECK_EQUAL(wsd.maxSegmentsPerWell(), 22);       // WSEGDIMS(2)
+    BOOST_CHECK_EQUAL(wsd.maxLateralBranchesPerWell(), 1); // WSEGDIMS(3), defaulted
+}
+
+BOOST_AUTO_TEST_CASE(WSEGDIMS_MaxLatBrPerWell)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+
+WSEGDIMS
+  2* 33
+/
+)" };
+
+    const auto wsd = WellSegmentDims {
+        Parser{}.parseString(input, ParseContext{})
+    };
+
+    BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 0);          // WSEGDIMS(1), defaulted
+    BOOST_CHECK_EQUAL(wsd.maxSegmentsPerWell(), 1);         // WSEGDIMS(2), defaulted
+    BOOST_CHECK_EQUAL(wsd.maxLateralBranchesPerWell(), 33); // WSEGDIMS(3)
+}
+
 BOOST_AUTO_TEST_CASE( SWATINIT ) {
     const std::string input = R"(
     SWATINIT

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -31,6 +31,7 @@
 
 // keyword specific table classes
 #include <opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Regdims.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgwfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
@@ -1356,4 +1357,48 @@ BOOST_AUTO_TEST_CASE( TestParseTABDIMS ) {
       "  1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 /\n";
     Opm::Parser parser;
     BOOST_CHECK_NO_THROW( parser.parseString(data, Opm::ParseContext()));
+}
+
+BOOST_AUTO_TEST_CASE (Regdims_Entries) {
+
+    // All defaulted
+    {
+        const auto input = std::string {
+            R"~(
+REGDIMS
+/
+)~"     };
+
+        const auto tabMgr = ::Opm::TableManager {
+            ::Opm::Parser{}.parseString(input)
+        };
+
+        const auto& rd = tabMgr.getRegdims();
+
+        BOOST_CHECK_EQUAL(rd.getNTFIP() , std::size_t{1});
+        BOOST_CHECK_EQUAL(rd.getNMFIPR(), std::size_t{1});
+        BOOST_CHECK_EQUAL(rd.getNRFREG(), std::size_t{0});
+        BOOST_CHECK_EQUAL(rd.getNTFREG(), std::size_t{0});
+    }
+
+    // All user-specified
+    {
+        const auto input = std::string {
+            R"~(
+REGDIMS
+  11 22 33 44 55 66 77 88 99 110
+/
+)~"     };
+
+        const auto tabMgr = ::Opm::TableManager {
+            ::Opm::Parser{}.parseString(input)
+        };
+
+        const auto& rd = tabMgr.getRegdims();
+
+        BOOST_CHECK_EQUAL(rd.getNTFIP() , std::size_t{11});
+        BOOST_CHECK_EQUAL(rd.getNMFIPR(), std::size_t{22});
+        BOOST_CHECK_EQUAL(rd.getNRFREG(), std::size_t{33});
+        BOOST_CHECK_EQUAL(rd.getNTFREG(), std::size_t{44});
+    }
 }


### PR DESCRIPTION
These values&mdash;region dimensions (REGDIMS) and well segment dimensions (WSEGDIMS)&mdash; are needed to correctly define portions of `INTEHEAD` in a restart step.