### PR TITLE
Add missing <cmath> include for std::fabs().

### DIFF
--- a/src/opm/common/utility/numeric/calculateCellVol.cpp
+++ b/src/opm/common/utility/numeric/calculateCellVol.cpp
@@ -16,7 +16,8 @@
 */
 
 
-#include <algorithm>    
+#include <algorithm>
+#include <cmath>
 #include <opm/common/utility/numeric/calculateCellVol.hpp>
 
 


### PR DESCRIPTION
Necessary for compiling on my clang-based system.