### PR TITLE
Add PETOPTS

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PETOPTS
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PETOPTS
@@ -1,0 +1,8 @@
+{
+  "name": "PETOPTS",
+  "sections" : ["RUNSPEC"],
+  "size": 1,
+  "items": [
+    { "name": "OPTIONS", "size_type": "ALL", "value_type": "STRING" }
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RSCONSTT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RSCONSTT
@@ -1,4 +1,5 @@
 {"name" : "RSCONSTT" , "sections" : ["PROPS"],
+ "size": {"keyword": "TABDIMS", "item": "NTPVT"},
  "items" : [
  {"name" : "RS_CONSTT" , "value_type" : "DOUBLE"},
  {"name" : "PB_CONSTT" , "value_type" : "DOUBLE", "dimension" : "Pressure"}]}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -204,6 +204,7 @@ set( keywords
      000_Eclipse100/P/PERMYZ
      000_Eclipse100/P/PERMZ
      000_Eclipse100/P/PERMZX
+     000_Eclipse100/P/PETOPTS
      000_Eclipse100/P/PIMTDIMS
      000_Eclipse100/P/PIMULTAB
      000_Eclipse100/P/PINCH


### PR DESCRIPTION
this adds the PETOPTS keyword and fixes the definition of RSCONSTT.