### PR TITLE
internalize the WINJTEMP keyword

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -150,6 +150,7 @@ namespace Opm
         void handleWPOLYMER( const DeckKeyword& keyword, size_t currentStep);
         void handleWSOLVENT( const DeckKeyword& keyword, size_t currentStep);
         void handleWTEMP( const DeckKeyword& keyword, size_t currentStep);
+        void handleWINJTEMP( const DeckKeyword& keyword, size_t currentStep);
         void handleWCONINJH( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep);
         void handleWELOPEN( const DeckKeyword& keyword, size_t currentStep );
         void handleWELTARG( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -182,6 +182,9 @@ namespace Opm {
             else if (keyword.name() == "WTEMP")
                 handleWTEMP(keyword, currentStep);
 
+            else if (keyword.name() == "WINJTEMP")
+                handleWINJTEMP(keyword, currentStep);
+
             else if (keyword.name() == "WCONINJH")
                 handleWCONINJH(section, keyword, currentStep);
 
@@ -722,15 +725,37 @@ namespace Opm {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
 
             for (auto* well : getWells(wellNamePattern)) {
-                // TODO: Can this be done like this? Setting the temperature only has an
-                // effect on injectors, but specifying this for producers won't hurt and
-                // wells can also switch their injector/producer status. Note that
+                // TODO: Is this the right approach? Setting the well temperature only
+                // has an effect on injectors, but specifying it for producers won't hurt
+                // and wells can also switch their injector/producer status. Note that
                 // modifying the injector properties for producer wells currently leads
                 // to a very weird segmentation fault downstream. For now, let's take the
                 // water route.
                 if (well->isInjector(currentStep)) {
                     WellInjectionProperties injectionProperties = well->getInjectionProperties(currentStep);
                     injectionProperties.temperature = record.getItem("TEMP").getSIDouble(0);
+                    well->setInjectionProperties(currentStep, injectionProperties);
+                }
+            }
+        }
+    }
+
+    void Schedule::handleWINJTEMP( const DeckKeyword& keyword, size_t currentStep) {
+        // we do not support the "enthalpy" field yet. how to do this is a more difficult
+        // question.
+        for( const auto& record : keyword ) {
+            const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
+
+            for (auto* well : getWells(wellNamePattern)) {
+                // TODO: Is this the right approach? Setting the well temperature only
+                // has an effect on injectors, but specifying it for producers won't hurt
+                // and wells can also switch their injector/producer status. Note that
+                // modifying the injector properties for producer wells currently leads
+                // to a very weird segmentation fault downstream. For now, let's take the
+                // water route.
+                if (well->isInjector(currentStep)) {
+                    WellInjectionProperties injectionProperties = well->getInjectionProperties(currentStep);
+                    injectionProperties.temperature = record.getItem("TEMPERATURE").getSIDouble(0);
                     well->setInjectionProperties(currentStep, injectionProperties);
                 }
             }


### PR DESCRIPTION
currently the only quantity that us used is the well temperature, i.e., specifying the fluid enthalpy does not have any effect.