### PR TITLE
Utility to compare keywords: check if grid parameter

### DIFF
--- a/opm/test_util/EclFilesComparator.hpp
+++ b/opm/test_util/EclFilesComparator.hpp
@@ -82,7 +82,7 @@ class ECLFilesComparator {
         //! \param[in] value2 Value for second file, the data type can be bool, int, double or std::string.
         //! \details Templatefunction for printing values when exceptions are thrown. The function is defined for bool, int, double and std::string.
         template <typename T>
-        void printValuesForCell(const std::string& keyword, int occurrence1, int occurrence2, size_t cell, const T& value1, const T& value2) const;
+        void printValuesForCell(const std::string& keyword, int occurrence1, int occurrence2, size_t kw_size, size_t cell, const T& value1, const T& value2) const;
 
     public:
         //! \brief Open ECLIPSE files and set tolerances and keywords.
@@ -159,7 +159,7 @@ class RegressionTest: public ECLFilesComparator {
         // are larger than absTolerance and relTolerance, respectively. In addition,
         // if allowNegativeValues is passed as false, an exception will be thrown when the absolute value
         // of a negative value exceeds absTolerance. If no exceptions are thrown, the absolute and relative deviations are added to absDeviation and relDeviation.
-        void deviationsForCell(double val1, double val2, const std::string& keyword, int occurrence1, int occurrence2, size_t cell, bool allowNegativeValues = true);
+        void deviationsForCell(double val1, double val2, const std::string& keyword, int occurrence1, int occurrence2, size_t kw_size, size_t cell, bool allowNegativeValues = true);
     public:
         //! \brief Sets up the regression test.
         //! \param[in] file_type Specifies which filetype to be compared, possible inputs are UNRSTFILE, INITFILE and RFTFILE.


### PR DESCRIPTION
The functionality to compare eclipse kewords from restart/iniit file would print a grid coordinate anyways if a comparison failed. This does not make much sense when e.g. comparing header keywords like `IWEL`; see for instance the test failure [here](https://ci.opm-project.org/job/opm-common-PR-builder/226/testReport/(root)/mpi/compareECLFiles_flow_SPE5CASE1/).

With this PR some size based heuristsics is used to infer whether a keyword represents of a 3D property - and should have i,j,k printed.