### PR TITLE
Add Initial Implementation of Correctly Sized Header Vectors for Restart

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -136,8 +136,10 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/test_util/summaryRegressionTest.cpp
           src/opm/test_util/summaryComparator.cpp
           src/opm/test_util/EclFilesComparator.cpp
+          src/opm/output/eclipse/CreateInteHead.cpp
           src/opm/output/eclipse/EclipseGridInspector.cpp
           src/opm/output/eclipse/EclipseIO.cpp
+          src/opm/output/eclipse/InteHEAD.cpp
           src/opm/output/eclipse/LinearisedOutputTable.cpp
           src/opm/output/eclipse/RestartIO.cpp
           src/opm/output/eclipse/Summary.cpp
@@ -223,15 +225,16 @@ if(ENABLE_ECL_OUTPUT)
           tests/test_compareSummary.cpp
           tests/test_EclFilesComparator.cpp
           tests/test_EclipseIO.cpp
+          tests/test_InteHEAD.cpp
           tests/test_LinearisedOutputTable.cpp
           tests/test_Restart.cpp
+          tests/test_regionCache.cpp
           tests/test_RFT.cpp
+          tests/test_Solution.cpp
           tests/test_Summary.cpp
           tests/test_Tables.cpp
           tests/test_Wells.cpp
           tests/test_writenumwells.cpp
-          tests/test_Solution.cpp
-          tests/test_regionCache.cpp
       )
 endif()
 
@@ -468,20 +471,21 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/OutputWriter.hpp
         opm/output/data/Wells.hpp
         opm/output/data/Cells.hpp
-        opm/test_util/summaryRegressionTest.hpp
-        opm/test_util/summaryIntegrationTest.hpp
-        opm/test_util/summaryComparator.hpp
         opm/output/eclipse/EclipseGridInspector.hpp
-        opm/output/eclipse/EclipseIOUtil.hpp
         opm/output/eclipse/EclipseIO.hpp
+        opm/output/eclipse/EclipseIOUtil.hpp
+        opm/output/eclipse/InteHEAD.hpp
         opm/output/eclipse/LinearisedOutputTable.hpp
+        opm/output/eclipse/RegionCache.hpp
         opm/output/eclipse/RestartIO.hpp
         opm/output/eclipse/RestartValue.hpp
         opm/output/eclipse/Summary.hpp
         opm/output/eclipse/Tables.hpp
-        opm/output/eclipse/RegionCache.hpp
+        opm/output/eclipse/WriteRestartHelpers.hpp
         opm/output/data/Solution.hpp
         opm/test_util/EclFilesComparator.hpp
+        opm/test_util/summaryComparator.hpp
+        opm/test_util/summaryIntegrationTest.hpp
         opm/test_util/summaryRegressionTest.hpp
-        opm/test_util/summaryComparator.hpp)
+        )
 endif()

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -136,8 +136,10 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/test_util/summaryRegressionTest.cpp
           src/opm/test_util/summaryComparator.cpp
           src/opm/test_util/EclFilesComparator.cpp
+          src/opm/output/eclipse/CreateDoubHead.cpp
           src/opm/output/eclipse/CreateInteHead.cpp
           src/opm/output/eclipse/CreateLogiHead.cpp
+          src/opm/output/eclipse/DoubHEAD.cpp
           src/opm/output/eclipse/EclipseGridInspector.cpp
           src/opm/output/eclipse/EclipseIO.cpp
           src/opm/output/eclipse/InteHEAD.cpp
@@ -227,6 +229,7 @@ if(ENABLE_ECL_OUTPUT)
           tests/test_compareSummary.cpp
           tests/test_EclFilesComparator.cpp
           tests/test_EclipseIO.cpp
+          tests/test_DoubHEAD.cpp
           tests/test_InteHEAD.cpp
           tests/test_LinearisedOutputTable.cpp
           tests/test_LogiHEAD.cpp
@@ -474,6 +477,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/OutputWriter.hpp
         opm/output/data/Wells.hpp
         opm/output/data/Cells.hpp
+        opm/output/eclipse/DoubHEAD.hpp
         opm/output/eclipse/EclipseGridInspector.hpp
         opm/output/eclipse/EclipseIO.hpp
         opm/output/eclipse/EclipseIOUtil.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -137,10 +137,12 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/test_util/summaryComparator.cpp
           src/opm/test_util/EclFilesComparator.cpp
           src/opm/output/eclipse/CreateInteHead.cpp
+          src/opm/output/eclipse/CreateLogiHead.cpp
           src/opm/output/eclipse/EclipseGridInspector.cpp
           src/opm/output/eclipse/EclipseIO.cpp
           src/opm/output/eclipse/InteHEAD.cpp
           src/opm/output/eclipse/LinearisedOutputTable.cpp
+          src/opm/output/eclipse/LogiHEAD.cpp
           src/opm/output/eclipse/RestartIO.cpp
           src/opm/output/eclipse/Summary.cpp
           src/opm/output/eclipse/Tables.cpp
@@ -227,8 +229,9 @@ if(ENABLE_ECL_OUTPUT)
           tests/test_EclipseIO.cpp
           tests/test_InteHEAD.cpp
           tests/test_LinearisedOutputTable.cpp
-          tests/test_Restart.cpp
+          tests/test_LogiHEAD.cpp
           tests/test_regionCache.cpp
+          tests/test_Restart.cpp
           tests/test_RFT.cpp
           tests/test_Solution.cpp
           tests/test_Summary.cpp
@@ -475,6 +478,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/EclipseIO.hpp
         opm/output/eclipse/EclipseIOUtil.hpp
         opm/output/eclipse/InteHEAD.hpp
+        opm/output/eclipse/LogiHEAD.hpp
         opm/output/eclipse/LinearisedOutputTable.hpp
         opm/output/eclipse/RegionCache.hpp
         opm/output/eclipse/RestartIO.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -474,9 +474,9 @@ if(ENABLE_ECL_INPUT)
 endif()
 if(ENABLE_ECL_OUTPUT)
   list(APPEND PUBLIC_HEADER_FILES
-        opm/output/OutputWriter.hpp
-        opm/output/data/Wells.hpp
         opm/output/data/Cells.hpp
+        opm/output/data/Solution.hpp
+        opm/output/data/Wells.hpp
         opm/output/eclipse/DoubHEAD.hpp
         opm/output/eclipse/EclipseGridInspector.hpp
         opm/output/eclipse/EclipseIO.hpp
@@ -490,7 +490,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/Summary.hpp
         opm/output/eclipse/Tables.hpp
         opm/output/eclipse/WriteRestartHelpers.hpp
-        opm/output/data/Solution.hpp
+        opm/output/OutputWriter.hpp
         opm/test_util/EclFilesComparator.hpp
         opm/test_util/summaryComparator.hpp
         opm/test_util/summaryIntegrationTest.hpp

--- a/opm/output/eclipse/DoubHEAD.hpp
+++ b/opm/output/eclipse/DoubHEAD.hpp
@@ -1,0 +1,71 @@
+/*
+  Copyright 2018 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_DOUBHEAD_HEADER_INCLUDED
+#define OPM_DOUBHEAD_HEADER_INCLUDED
+
+#include <chrono>
+#include <cstddef>
+#include <vector>
+
+namespace Opm {
+    class Tuning;
+    class Schedule;
+}
+
+namespace Opm { namespace RestartIO {
+
+    class DoubHEAD
+    {
+    public:
+        struct TimeStamp {
+            std::chrono::time_point<std::chrono::system_clock>          start;
+            std::chrono::duration<double, std::chrono::seconds::period> elapsed;
+        };
+
+        DoubHEAD();
+
+        ~DoubHEAD() = default;
+        DoubHEAD(const DoubHEAD& rhs) = default;
+        DoubHEAD(DoubHEAD&& rhs) = default;
+
+        DoubHEAD& operator=(const DoubHEAD& rhs) = default;
+        DoubHEAD& operator=(DoubHEAD&& rhs) = default;
+
+        DoubHEAD& tuningParameters(const Tuning&     tuning,
+                                   const std::size_t rptStep,
+                                   const double      cnvT);
+
+        DoubHEAD& timeStamp(const TimeStamp& ts);
+
+        DoubHEAD& drsdt(const Schedule&   sched,
+                        const std::size_t rptStep);
+
+        const std::vector<double>& data() const
+        {
+            return this->data_;
+        }
+
+    private:
+        std::vector<double> data_;
+    };
+
+}} // Opm::RestartIO
+
+#endif  // OPM_DOUBHEAD_HEADER_INCLUDED

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2016, 2017 Statoil ASA.
+  Copyright 2016, 2017, 2018 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
 
@@ -39,26 +39,25 @@ namespace Opm { namespace RestartIO {
             int maxWellInGroup;
             int maxGroupInField;
         };
-	
-	struct WellSegDims {
-	    int nsegwl;	
-	    int nswlmx;	
-	    int nsegmx;	
-	    int nlbrmx;	
-	    int nisegz; 	
-	    int nrsegz;
-	    int nilbrz; 	
 
+        struct WellSegDims {
+            int nsegwl;
+            int nswlmx;
+            int nsegmx;
+            int nlbrmx;
+            int nisegz;
+            int nrsegz;
+            int nilbrz;
         };
 
-	struct RegDims {
-	    int ntfip;	
-	    int nmfipr;
-	    int nrfreg;
-	    int ntfreg;
-	    int nplmix;
+        struct RegDims {
+            int ntfip;
+            int nmfipr;
+            int nrfreg;
+            int ntfreg;
+            int nplmix;
+        };
 
-        };	
 	
         struct Date {
             int year;
@@ -81,10 +80,10 @@ namespace Opm { namespace RestartIO {
             int newtmn;
             int litmax;
             int litmin;
-	    int mxwsit;	
-	    int mxwpit;
+            int mxwsit;
+            int mxwpit;
         };
-	
+
         InteHEAD();
         ~InteHEAD() = default;
 
@@ -102,23 +101,23 @@ namespace Opm { namespace RestartIO {
         InteHEAD& wellTableDimensions(const WellTableDim& wtdim);
         InteHEAD& calenderDate(const Date& date);
         InteHEAD& activePhases(const Phases& phases);
-	InteHEAD& params_NWELZ(const int niwelz, const int nswelz, const int nxwelz, const int nzwelz);
-	InteHEAD& params_NCON(const int niconz, const int nsconz, const int nxconz);
-	InteHEAD& params_GRPZ(const std::array<int, 4>& grpz);
-	InteHEAD& params_NAAQZ(const int ncamax, const int niaaqz, const int nsaaqz, const int nxaaqz, const int nicaqz, const int nscaqz, const int nacaqz);
-	InteHEAD& stepParam(const int tstep, const int repstep);
-	InteHEAD& tuningParam(const TuningPar& tunpar);
-	InteHEAD& variousParam(const int iprog, const int ih101, const int ih103);
-	InteHEAD& wellSegDimensions(const WellSegDims& wsdim);
-	InteHEAD& regionDimensions(const RegDims& rdim);
-	
+        InteHEAD& params_NWELZ(const int niwelz, const int nswelz, const int nxwelz, const int nzwelz);
+        InteHEAD& params_NCON(const int niconz, const int nsconz, const int nxconz);
+        InteHEAD& params_GRPZ(const std::array<int, 4>& grpz);
+        InteHEAD& params_NAAQZ(const int ncamax, const int niaaqz, const int nsaaqz, const int nxaaqz, const int nicaqz, const int nscaqz, const int nacaqz);
+        InteHEAD& stepParam(const int tstep, const int repstep);
+        InteHEAD& tuningParam(const TuningPar& tunpar);
+        InteHEAD& variousParam(const int version, const int iprog);
+        InteHEAD& wellSegDimensions(const WellSegDims& wsdim);
+        InteHEAD& regionDimensions(const RegDims& rdim);
+
         const std::vector<int>& data() const
-	{
-	    return this->data_;
-	}
+        {
+            return this->data_;
+        }
 
     private:
-	std::vector<int> data_;
+        std::vector<int> data_;
     };
 
 }} // Opm::RestartIO

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -21,6 +21,7 @@
 #define OPM_INTEHEAD_HEADER_INCLUDED
 
 #include <array>
+#include <ctime>
 #include <memory>
 #include <vector>
 
@@ -58,15 +59,16 @@ namespace Opm { namespace RestartIO {
             int nplmix;
         };
 
-	
-        struct Date {
+        struct TimePoint {
             int year;
-            int month;		// 1..12
-            int day;		// 1..31
+            int month;          // 1..12
+            int day;            // 1..31
 
-            int hour;		// 0..23
-            int minute;		// 0..59
-            int second;		// 0..59
+            int hour;           // 0..23
+            int minute;         // 0..59
+            int second;         // 0..59
+
+            int microseconds;   // 0..999999
         };
 
         struct Phases {
@@ -99,7 +101,7 @@ namespace Opm { namespace RestartIO {
 
         InteHEAD& unitConventions(const UnitSystem& usys);
         InteHEAD& wellTableDimensions(const WellTableDim& wtdim);
-        InteHEAD& calenderDate(const Date& date);
+        InteHEAD& calenderDate(const TimePoint& date);
         InteHEAD& activePhases(const Phases& phases);
         InteHEAD& params_NWELZ(const int niwelz, const int nswelz, const int nxwelz, const int nzwelz);
         InteHEAD& params_NCON(const int niconz, const int nsconz, const int nxconz);
@@ -120,6 +122,11 @@ namespace Opm { namespace RestartIO {
         std::vector<int> data_;
     };
 
+    std::time_t makeUTCTime(const std::tm& timePoint);
+
+    InteHEAD::TimePoint
+    getSimulationTimePoint(const std::time_t start,
+                           const double      elapsed);
 }} // Opm::RestartIO
 
 #endif // OPM_INTEHEAD_HEADER_INCLUDED

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -1,0 +1,126 @@
+/*
+  Copyright 2016, 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_INTEHEAD_HEADER_INCLUDED
+#define OPM_INTEHEAD_HEADER_INCLUDED
+
+#include <array>
+#include <memory>
+#include <vector>
+
+namespace Opm { namespace RestartIO {
+
+    class InteHEAD
+    {
+    public:
+        enum class UnitSystem {
+            Metric, Field, Lab, PVT_M
+        };
+
+        struct WellTableDim {
+            int numWells;
+            int maxPerf;
+            int maxWellInGroup;
+            int maxGroupInField;
+        };
+	
+	struct WellSegDims {
+	    int nsegwl;	
+	    int nswlmx;	
+	    int nsegmx;	
+	    int nlbrmx;	
+	    int nisegz; 	
+	    int nrsegz;
+	    int nilbrz; 	
+
+        };
+
+	struct RegDims {
+	    int ntfip;	
+	    int nmfipr;
+	    int nrfreg;
+	    int ntfreg;
+	    int nplmix;
+
+        };	
+	
+        struct Date {
+            int year;
+            int month;		// 1..12
+            int day;		// 1..31
+
+            int hour;		// 0..23
+            int minute;		// 0..59
+            int second;		// 0..59
+        };
+
+        struct Phases {
+            int oil;
+            int water;
+            int gas;
+        };
+
+        struct TuningPar {
+            int newtmx;
+            int newtmn;
+            int litmax;
+            int litmin;
+	    int mxwsit;	
+	    int mxwpit;
+        };
+	
+        InteHEAD();
+        ~InteHEAD() = default;
+
+        InteHEAD(const InteHEAD& rhs) = default;
+        InteHEAD(InteHEAD&& rhs) = default;
+
+        InteHEAD& operator=(const InteHEAD& rhs) = default;
+        InteHEAD& operator=(InteHEAD&& rhs) = default;
+
+        InteHEAD& dimensions(const int nx, const int ny, const int nz);
+        InteHEAD& dimensions(const std::array<int,3>& cartDims);
+        InteHEAD& numActive(const int nactive);
+
+        InteHEAD& unitConventions(const UnitSystem& usys);
+        InteHEAD& wellTableDimensions(const WellTableDim& wtdim);
+        InteHEAD& calenderDate(const Date& date);
+        InteHEAD& activePhases(const Phases& phases);
+	InteHEAD& params_NWELZ(const int niwelz, const int nswelz, const int nxwelz, const int nzwelz);
+	InteHEAD& params_NCON(const int niconz, const int nsconz, const int nxconz);
+	InteHEAD& params_GRPZ(const std::array<int, 4>& grpz);
+	InteHEAD& params_NAAQZ(const int ncamax, const int niaaqz, const int nsaaqz, const int nxaaqz, const int nicaqz, const int nscaqz, const int nacaqz);
+	InteHEAD& stepParam(const int tstep, const int repstep);
+	InteHEAD& tuningParam(const TuningPar& tunpar);
+	InteHEAD& variousParam(const int iprog, const int ih101, const int ih103);
+	InteHEAD& wellSegDimensions(const WellSegDims& wsdim);
+	InteHEAD& regionDimensions(const RegDims& rdim);
+	
+        const std::vector<int>& data() const
+	{
+	    return this->data_;
+	}
+
+    private:
+	std::vector<int> data_;
+    };
+
+}} // Opm::RestartIO
+
+#endif // OPM_INTEHEAD_HEADER_INCLUDED

--- a/opm/output/eclipse/LogiHEAD.hpp
+++ b/opm/output/eclipse/LogiHEAD.hpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2016, 2017 Statoil ASA.
+
+  This file is part of the Open Porous Media Project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_LOGIHEAD_HEADER_INCLUDED
+#define OPM_LOGIHEAD_HEADER_INCLUDED
+
+#include <vector>
+
+namespace Opm { namespace RestartIO {
+
+    class LogiHEAD
+    {
+    public:
+        LogiHEAD();
+        ~LogiHEAD() = default;
+
+        LogiHEAD(const LogiHEAD& rhs) = default;
+        LogiHEAD(LogiHEAD&& rhs) = default;
+
+        LogiHEAD& operator=(const LogiHEAD& rhs) = default;
+        LogiHEAD& operator=(LogiHEAD&& rhs) = default;
+
+        LogiHEAD& variousParam(const bool e300_radial,
+                               const bool e100_radial,
+                               const int  nswlmx);
+
+        const std::vector<bool>& data() const
+        {
+            return this->data_;
+        }
+
+    private:
+        std::vector<bool> data_;
+    };
+
+}} // Opm::RestartIO
+
+#endif // OPM_LOGIHEAD_HEADER_INCLUDED

--- a/opm/output/eclipse/WriteRestartHelpers.hpp
+++ b/opm/output/eclipse/WriteRestartHelpers.hpp
@@ -42,6 +42,9 @@ namespace Opm { namespace RestartIO { namespace Helpers {
                    const double        simTime,
                    const int           report_step);
 
+    std::vector<bool>
+    createLogiHead(const EclipseState& es);
+
 }}} // Opm::RestartIO::Helpers
 
 #endif  // OPM_WRITE_RESTART_HELPERS_HPP

--- a/opm/output/eclipse/WriteRestartHelpers.hpp
+++ b/opm/output/eclipse/WriteRestartHelpers.hpp
@@ -1,0 +1,47 @@
+/*
+  Copyright (c) 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WRITE_RESTART_HELPERS_HPP
+#define OPM_WRITE_RESTART_HELPERS_HPP
+
+#include <vector>
+
+// Forward declarations
+
+namespace Opm {
+
+    class EclipseGrid;
+    class EclipseState;
+    class Schedule;
+    class Tuning;
+
+} // Opm
+
+namespace Opm { namespace RestartIO { namespace Helpers {
+
+    std::vector<int>
+    createInteHead(const EclipseState& es,
+                   const EclipseGrid&  grid,
+                   const Schedule&     sched,
+                   const double        simTime,
+                   const int           report_step);
+
+}}} // Opm::RestartIO::Helpers
+
+#endif  // OPM_WRITE_RESTART_HELPERS_HPP

--- a/opm/output/eclipse/WriteRestartHelpers.hpp
+++ b/opm/output/eclipse/WriteRestartHelpers.hpp
@@ -29,11 +29,16 @@ namespace Opm {
     class EclipseGrid;
     class EclipseState;
     class Schedule;
-    class Tuning;
 
 } // Opm
 
 namespace Opm { namespace RestartIO { namespace Helpers {
+
+    std::vector<double>
+    createDoubHead(const EclipseState& es,
+                   const Schedule&     sched,
+                   const std::size_t   rptStep,
+                   const double        simTime);
 
     std::vector<int>
     createInteHead(const EclipseState& es,

--- a/src/opm/output/eclipse/CreateDoubHead.cpp
+++ b/src/opm/output/eclipse/CreateDoubHead.cpp
@@ -1,0 +1,89 @@
+/*
+  Copyright (c) 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
+
+#include <opm/output/eclipse/DoubHEAD.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <vector>
+
+namespace {
+    Opm::RestartIO::DoubHEAD::TimeStamp
+    computeTimeStamp(const ::Opm::Schedule& sched,
+                     const double           elapsed)
+    {
+        return {
+            std::chrono::system_clock::from_time_t(sched.getStartTime()),
+            std::chrono::duration<
+                double, std::chrono::seconds::period>{ elapsed },
+        };
+    }
+
+    double getTimeConv(const ::Opm::UnitSystem& us)
+    {
+        switch (us.getType()) {
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC:
+            return static_cast<double>(Opm::Metric::Time);
+
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD:
+            return static_cast<double>(Opm::Field::Time);
+
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_LAB:
+            return static_cast<double>(Opm::Lab::Time);
+
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_PVT_M:
+            return static_cast<double>(Opm::PVT_M::Time);
+
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_INPUT:
+            throw std::invalid_argument {
+                "Cannot Run Simulation With Non-Standard Units"
+            };
+        }
+
+        return static_cast<double>(Opm::Metric::Time);
+    }
+} // Anonymous
+
+// #####################################################################
+// Public Interface (createDoubHead()) Below Separator
+// ---------------------------------------------------------------------
+
+std::vector<double>
+Opm::RestartIO::Helpers::
+createDoubHead(const EclipseState& es,
+               const Schedule&     sched,
+               const std::size_t   rptStep,
+               const double        simTime)
+{
+    const auto dh = DoubHEAD{}
+        .tuningParameters(sched.getTuning(), rptStep,
+                          getTimeConv(es.getDeckUnitSystem()))
+        .timeStamp       (computeTimeStamp(sched, simTime))
+        .drsdt           (sched, rptStep)
+        ;
+
+    return dh.data();
+}

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -1,0 +1,273 @@
+/*
+  Copyright (c) 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
+
+#include <opm/output/eclipse/InteHEAD.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Regdims.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+    Opm::RestartIO::InteHEAD::WellTableDim
+    getWellTableDims(const ::Opm::Runspec&  rspec,
+                     const ::Opm::Schedule& sched)
+    {
+        const auto& td = rspec.tabdims();
+        const auto& wd = rspec.wellDimensions();
+
+        const auto numWells = static_cast<int>(sched.numWells());
+
+        const auto maxPerf         = wd.maxConnPerWell();
+        const auto maxWellInGroup  = wd.maxWellsPerGroup();
+        const auto maxGroupInField = wd.maxGroupsInField();
+
+        return {
+            numWells,
+            maxPerf,
+            maxWellInGroup,
+            maxGroupInField,
+        };
+    }
+
+    std::array<int, 4> getNGRPZ(const ::Opm::Runspec& rspec)
+    {
+        const auto& wd = rspec.wellDimensions();
+        const auto maxWellInGroup  = wd.maxWellsPerGroup();
+        const int nigrpz = 97 + maxWellInGroup;
+        const int nsgrpz = 112;
+        const int nxgrpz = 180;
+        const int nzgrpz = 5;
+
+        return {
+            nigrpz,
+            nsgrpz,
+            nxgrpz,
+            nzgrpz
+        };
+    }
+
+    Opm::RestartIO::InteHEAD::UnitSystem
+    getUnitConvention(const ::Opm::UnitSystem& us)
+    {
+        using US = ::Opm::RestartIO::InteHEAD::UnitSystem;
+
+        switch (us.getType()) {
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC:
+            return US::Metric;
+
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD:
+            return US::Field;
+
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_LAB:
+            return US::Lab;
+
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_PVT_M:
+            return US::PVT_M;
+
+        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_INPUT:
+            throw std::invalid_argument {
+                "Cannot Run Simulation With Non-Standard Units"
+            };
+        }
+
+        return US::Metric;
+    }
+
+    Opm::RestartIO::InteHEAD::Date
+    getSimulationDate(const ::Opm::Schedule& sched,
+                      const double           simTime)
+    {
+        // Would have liked to use H.Hinnant's "date" library here
+        // (https://github.com/HowardHinnant/date), especially to avoid
+        // dealing with std::time_t and the threading issues of calendar
+        // function std::gmtime().  Library proposed (LEWG) for C++20.
+        //
+        // Pray that we're on a system for which std::time_t is 64 bits (or
+        // more) so that we at least don't run into 2k38 with the typical
+        // definition of time_point::time_since_epoch(system_clock::now())
+
+        using namespace std::chrono;
+
+        const auto start = system_clock::
+            from_time_t(sched.posixStartTime());
+
+        // Discard sub-second resolution.
+        const auto now = start + duration_cast<seconds>(
+            duration<double, seconds::period>(simTime));
+
+        const auto t = system_clock::to_time_t(now);
+
+        // Not thread-safe (returns pointer to internal, static storage).
+        // May wish to add some locking here...
+        const auto timepoint = *std::localtime(&t);
+
+        return {
+            timepoint.tm_year + 1900,
+            timepoint.tm_mon  + 1,
+            timepoint.tm_mday ,
+            timepoint.tm_hour ,
+            timepoint.tm_min  ,
+            std::min(timepoint.tm_sec, 59), // Ignore leap seconds...
+        };
+    }
+
+    Opm::RestartIO::InteHEAD::Phases
+    getActivePhases(const ::Opm::Runspec& rspec)
+    {
+        auto phases = ::Opm::RestartIO::InteHEAD::Phases{};
+
+        const auto& phasePred = rspec.phases();
+
+        phases.oil   = phasePred.active(Opm::Phase::OIL);
+        phases.water = phasePred.active(Opm::Phase::WATER);
+        phases.gas   = phasePred.active(Opm::Phase::GAS);
+
+        return phases;
+    }
+
+    Opm::RestartIO::InteHEAD::TuningPar
+    getTuningPars(const ::Opm::Tuning&  tuning, const size_t step)
+    {
+        const auto& newtmx = tuning.getNEWTMX(step);
+	const auto& newtmn = tuning.getNEWTMN(step);
+	const auto& litmax = tuning.getLITMAX(step);
+	const auto& litmin = tuning.getLITMIN(step);
+	const auto& mxwsit = tuning.getMXWSIT(step);
+	const auto& mxwpit = tuning.getMXWPIT(step);
+
+        return {
+            newtmx,
+            newtmn,
+	    litmax,
+	    litmin,
+            mxwsit,
+            mxwpit,
+        };
+    }
+    
+    Opm::RestartIO::InteHEAD::WellSegDims
+    getWellSegDims(const ::Opm::Runspec&  rspec,
+		   const ::Opm::Schedule sched,
+		   const size_t step)
+    {
+        const auto& wsd = rspec.wellSegmentDimensions();
+	const auto& sched_wells = sched.getWells( step );
+	int n_act_seg_wels = 0; 
+	for (const auto& wl : sched_wells)  {
+	  /*if (wl->isMultiSegment(step)) {
+	    std::cout << "sched_well wl: " << wl->name() << std::endl;
+	    n_act_seg_wels += 1;
+	  }
+	  else {
+	    std::cout << "non_sched_well wl: " << wl->name() << std::endl;
+	  }*/
+	    n_act_seg_wels = (wl->isMultiSegment(step))
+	      ? n_act_seg_wels +1 : n_act_seg_wels;
+	}
+
+	const auto nsegwl	= n_act_seg_wels;
+        const auto nswlmx	= wsd.maxSegmentedWells();
+        const auto nsegmx	= wsd.maxSegmentsPerWell();
+        const auto nlbrmx 	= wsd.maxLateralBranchesPerWell();
+	const auto nisegz 	= 22;
+	const auto nrsegz	= 140;
+	const auto nilbrz 	= 10;
+
+        return {
+            nsegwl,
+            nswlmx,
+            nsegmx,
+            nlbrmx,
+	    nisegz,
+	    nrsegz,
+	    nilbrz
+        };
+    }
+    
+    Opm::RestartIO::InteHEAD::RegDims
+    getRegDims(const ::Opm::TableManager tdims,  const ::Opm::Regdims&  rdims)
+    {
+        const auto& ntfip  = tdims.numFIPRegions();
+	const auto& nmfipr = rdims.getNMFIPR();
+	const auto& nrfreg = rdims.getNRFREG();
+	const auto& ntfreg = rdims.getNTFREG();
+	const auto& nplmix = rdims.getNPLMIX();
+
+
+        return {
+            ntfip,
+            nmfipr,
+            nrfreg,
+            ntfreg,
+	    nplmix
+        };
+    }
+} 
+// Anonymous
+
+// #####################################################################
+// Public Interface (createInteHead()) Below Separator
+// ---------------------------------------------------------------------
+
+std::vector<int>
+Opm::RestartIO::Helpers::
+createInteHead(const EclipseState& es,
+               const EclipseGrid&  grid,
+               const Schedule&     sched,
+               const double        simTime,
+               const int           report_step)
+{
+    const auto& rspec = es.runspec();
+    const auto& tdim = es.getTableManager();
+    const auto& rdim = tdim.getRegdims();
+
+    const auto ih = InteHEAD{}
+        .dimensions         (grid.getNXYZ())
+        .numActive          (static_cast<int>(grid.getNumActive()))
+        .unitConventions    (getUnitConvention(es.getDeckUnitSystem()))
+        .wellTableDimensions(getWellTableDims(rspec, sched))
+        .calenderDate       (getSimulationDate(sched, simTime))
+        .activePhases       (getActivePhases(rspec))
+        .params_NWELZ       (155, 122, 130, 3)
+        .params_NCON        (25, 40, 58)
+        .params_GRPZ        (getNGRPZ(rspec))
+        .params_NAAQZ       (1, 18, 24, 10, 7, 2, 4)
+	.stepParam(report_step, report_step)
+	.tuningParam(getTuningPars(sched.getTuning(), report_step))
+	.wellSegDimensions(getWellSegDims(rspec, sched, report_step))
+	.regionDimensions(getRegDims(tdim, rdim))
+	.variousParam(100, 1, 1)
+	;
+
+    return ih.data();
+}

--- a/src/opm/output/eclipse/CreateLogiHead.cpp
+++ b/src/opm/output/eclipse/CreateLogiHead.cpp
@@ -1,0 +1,45 @@
+/*
+  Copyright (c) 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
+
+#include <opm/output/eclipse/LogiHEAD.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+
+#include <vector>
+
+// #####################################################################
+// Public Interface (createLogiHead()) Below Separator
+// ---------------------------------------------------------------------
+
+std::vector<bool>
+Opm::RestartIO::Helpers::
+createLogiHead(const EclipseState& es)
+{
+    const auto& rspec = es.runspec();
+    const auto& wsd   = rspec.wellSegmentDimensions();
+
+    const auto lh = LogiHEAD{}
+        .variousParam(false, false, wsd.maxSegmentedWells())
+        ;
+
+    return lh.data();
+}

--- a/src/opm/output/eclipse/DoubHEAD.cpp
+++ b/src/opm/output/eclipse/DoubHEAD.cpp
@@ -1,0 +1,603 @@
+/*
+  Copyright (c) 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/DoubHEAD.hpp>
+
+// Note: DynamicState.hpp and <map> are prerequisites of Tuning.hpp
+#include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <opm/output/eclipse/InteHEAD.hpp> // Opm::RestartIO::makeUTCTime()
+
+#include <chrono>
+#include <cmath>
+#include <ctime>
+#include <iterator>
+#include <map>
+#include <numeric>
+#include <ratio>
+#include <utility>
+#include <vector>
+
+enum Index : std::vector<double>::size_type {
+    // 0..9
+    SimTime =   0,
+    TsInit  =   1,
+    TsMaxz  =   2,
+    TsMinz  =   3,
+    TsMchp  =   4,
+    TsFMax  =   5,
+    TsFMin  =   6,
+    TsFcnv  =   7,
+    TrgTTE  =   8,
+    TrgCNV  =   9,
+
+    // 10..19
+    TrgMBE  =  10,
+    TrgLCV  =  11,
+    dh_012  =  12,
+    dh_013  =  13,
+    dh_014  =  14,
+    dh_015  =  15,
+    XxxTTE  =  16,
+    XxxCNV  =  17,
+    XxxMBE  =  18,
+    XxxLCV  =  19,
+
+    // 20..29
+    XxxWFL  =  20,
+    dh_021  =  21,
+    dh_022  =  22,
+    dh_023  =  23,
+    dh_024  =  24,
+    dRsdt   =  25,
+    dh_026  =  26,
+    dh_027  =  27,
+    dh_028  =  28,
+    dh_029  =  29,
+
+    // 30..39
+    dh_030  =  30,
+    dh_031  =  31,
+    dh_032  =  32,
+    dh_033  =  33,
+    dh_034  =  34,
+    dh_035  =  35,
+    dh_036  =  36,
+    dh_037  =  37,
+    dh_038  =  38,
+    dh_039  =  39,
+
+    // 40..49
+    dh_040  =  40,
+    dh_041  =  41,
+    dh_042  =  42,
+    dh_043  =  43,
+    dh_044  =  44,
+    dh_045  =  45,
+    dh_046  =  46,
+    dh_047  =  47,
+    dh_048  =  48,
+    dh_049  =  49,
+
+    // 50..59
+    dh_050  =  50,
+    dh_051  =  51,
+    dh_052  =  52,
+    dh_053  =  53,
+    dh_054  =  54,
+    dh_055  =  55,
+    dh_056  =  56,
+    dh_057  =  57,
+    dh_058  =  58,
+    dh_059  =  59,
+
+    // 60..69
+    dh_060  =  60,
+    dh_061  =  61,
+    dh_062  =  62,
+    dh_063  =  63,
+    dh_064  =  64,
+    dh_065  =  65,
+    dh_066  =  66,
+    dh_067  =  67,
+    dh_068  =  68,
+    dh_069  =  69,
+
+    // 70..79
+    dh_070  =  70,
+    dh_071  =  71,
+    dh_072  =  72,
+    dh_073  =  73,
+    dh_074  =  74,
+    dh_075  =  75,
+    dh_076  =  76,
+    dh_077  =  77,
+    dh_078  =  78,
+    dh_079  =  79,
+
+    // 80..89
+    dh_080  =  80,
+    dh_081  =  81,
+    TrgDPR  =  82,
+    TfDIFF  =  83,
+    DdpLim  =  84,
+    DdsLim  =  85,
+    dh_086  =  86,
+    dh_087  =  87,
+    dh_088  =  88,
+    dh_089  =  89,
+
+    // 90..99
+    dh_090  =  90,
+    dh_091  =  91,
+    dh_092  =  92,
+    dh_093  =  93,
+    dh_094  =  94,
+    dh_095  =  95,
+    dh_096  =  96,
+    dh_097  =  97,
+    dh_098  =  98,
+    ThrUPT  =  99,
+
+    // 100..109
+    XxxDPR  = 100,
+    TrgFIP  = 101,
+    TrgSFT  = 102,
+    dh_103  = 103,
+    dh_104  = 104,
+    dh_105  = 105,
+    dh_106  = 106,
+    dh_107  = 107,
+    dh_108  = 108,
+    dh_109  = 109,
+
+    // 110..119
+    dh_110  = 110,
+    dh_111  = 111,
+    dh_112  = 112,
+    dh_113  = 113,
+    dh_114  = 114,
+    dh_115  = 115,
+    dh_116  = 116,
+    dh_117  = 117,
+    dh_118  = 118,
+    dh_119  = 119,
+
+    // 120..129
+    dh_120  = 120,
+    dh_121  = 121,
+    dh_122  = 122,
+    dh_123  = 123,
+    dh_124  = 124,
+    dh_125  = 125,
+    dh_126  = 126,
+    dh_127  = 127,
+    dh_128  = 128,
+    dh_129  = 129,
+
+    // 130..139
+    dh_130  = 130,
+    dh_131  = 131,
+    dh_132  = 132,
+    dh_133  = 133,
+    dh_134  = 134,
+    dh_135  = 135,
+    dh_136  = 136,
+    dh_137  = 137,
+    dh_138  = 138,
+    dh_139  = 139,
+
+    // 140..149
+    dh_140  = 140,
+    dh_141  = 141,
+    dh_142  = 142,
+    dh_143  = 143,
+    dh_144  = 144,
+    dh_145  = 145,
+    dh_146  = 146,
+    dh_147  = 147,
+    dh_148  = 148,
+    dh_149  = 149,
+
+    // 150..159
+    dh_150  = 150,
+    dh_151  = 151,
+    dh_152  = 152,
+    dh_153  = 153,
+    dh_154  = 154,
+    dh_155  = 155,
+    dh_156  = 156,
+    dh_157  = 157,
+    dh_158  = 158,
+    dh_159  = 159,
+
+    // 160..169
+    Start   = 160,
+    Time    = 161,
+    dh_162  = 162,
+    dh_163  = 163,
+    dh_164  = 164,
+    dh_165  = 165,
+    dh_166  = 166,
+    dh_167  = 167,
+    dh_168  = 168,
+    dh_169  = 169,
+
+    // 170..179
+    dh_170  = 170,
+    dh_171  = 171,
+    dh_172  = 172,
+    dh_173  = 173,
+    dh_174  = 174,
+    dh_175  = 175,
+    dh_176  = 176,
+    dh_177  = 177,
+    dh_178  = 178,
+    dh_179  = 179,
+
+    // 180..189
+    dh_180  = 180,
+    dh_181  = 181,
+    dh_182  = 182,
+    dh_183  = 183,
+    dh_184  = 184,
+    dh_185  = 185,
+    dh_186  = 186,
+    dh_187  = 187,
+    dh_188  = 188,
+    dh_189  = 189,
+
+    // 190..199
+    dh_190  = 190,
+    dh_191  = 191,
+    dh_192  = 192,
+    dh_193  = 193,
+    dh_194  = 194,
+    dh_195  = 195,
+    dh_196  = 196,
+    dh_197  = 197,
+    dh_198  = 198,
+    dh_199  = 199,
+
+    // 200..209
+    dh_200  = 200,
+    dh_201  = 201,
+    dh_202  = 202,
+    dh_203  = 203,
+    dh_204  = 204,
+    dh_205  = 205,
+    dh_206  = 206,
+    dh_207  = 207,
+    dh_208  = 208,
+    dh_209  = 209,
+
+    // 210..219
+    dh_210  = 210,
+    dh_211  = 211,
+    dh_212  = 212,
+    dh_213  = 213,
+    dh_214  = 214,
+    dh_215  = 215,
+    dh_216  = 216,
+    dh_217  = 217,
+    dh_218  = 218,
+    dh_219  = 219,
+
+    // 220..227
+    dh_220  = 220,
+    dh_221  = 221,
+    dh_222  = 222,
+    dh_223  = 223,
+    dh_224  = 224,
+    dh_225  = 225,
+    dh_226  = 226,
+    dh_227  = 227,
+    dh_228  = 228,
+
+// ---------------------------------------------------------------------
+// ---------------------------------------------------------------------
+
+    NUMBER_OF_ITEMS        // MUST be last element of enum.
+};
+
+namespace {
+    /// Convert std::tm{} to Date-Number.
+    ///
+    /// ECL Restrictions:
+    ///   - Calendar start: 1st January 0000
+    ///   - Year length: 365.25 days
+    ///   - No special leap year handling
+    ///
+    /// \param[in] year tm::tm_year of date (years since 1900).
+    ///
+    /// \param[in] yday tm::tm_yday of date (days since 1st January).
+    ///
+    /// \return Date-number corresponding to specified day-of-year in
+    ///    specified year, subject to restrictions outlined above.
+    double toDateNum(const int year, const int yday)
+    {
+        return std::floor(365.25 * (year + 1900))
+            + (yday + 1); // Day of year [1 .. 365]
+    }
+
+    double toDateNum(const std::chrono::time_point<std::chrono::system_clock> tp)
+    {
+        const auto t0  =  std::chrono::system_clock::to_time_t(tp);
+        const auto tm0 = *std::gmtime(&t0);
+
+        // Set clock to 01:00:00+0000 on 1901-<month>-<day> to get
+        // "accurate" day-of-year calculation (no leap year, no DST offset,
+        // not previous day reported).
+        auto tm1 = std::tm{};
+        tm1.tm_year = 1;        // 1901
+        tm1.tm_mon  = tm0.tm_mon;
+        tm1.tm_mday = tm0.tm_mday;
+
+        tm1.tm_hour  = 1;
+        tm1.tm_min   = 0;
+        tm1.tm_sec   = 0;
+        tm1.tm_isdst = 0;
+
+        const auto t1 = ::Opm::RestartIO::makeUTCTime(tm1);
+
+        if (t1 != static_cast<std::time_t>(-1)) {
+            tm1 = *std::gmtime(&t1); // Get new tm_yday.
+            return toDateNum(tm0.tm_year, tm1.tm_yday);
+        }
+
+        // Failed to convert tm1 to time_t (unexpected).  Use initial value.
+        return toDateNum(tm0.tm_year, tm0.tm_yday);
+    }
+}
+
+// =====================================================================
+// Public Interface (DoubHEAD member functions) Below Separator
+// ---------------------------------------------------------------------
+
+Opm::RestartIO::DoubHEAD::DoubHEAD()
+    : data_(Index::NUMBER_OF_ITEMS, -1.0e20)
+{
+    this->data_[Index::dh_024] = 1.0e+20;
+    this->data_[Index::dh_026] = 0.0;
+    this->data_[Index::dh_027] = 0.0;
+    this->data_[Index::dh_028] = 0.0;
+    this->data_[Index::dh_050] = 0.01;
+    this->data_[Index::dh_054] = 1.0e+20;
+    this->data_[Index::dh_055] = 1.0e+20;
+    this->data_[Index::dh_063] = 1.0e+20;
+    this->data_[Index::dh_064] = 1.0e+20;
+    this->data_[Index::dh_065] = 0.0;
+    this->data_[Index::dh_066] = 0.0;
+    this->data_[Index::dh_069] = -1.0;
+    this->data_[Index::dh_080] = 1.0e+20;
+    this->data_[Index::dh_081] = 1.0e+20;
+    this->data_[Index::dh_091] = 0.0;
+    this->data_[Index::dh_092] = 0.0;
+    this->data_[Index::dh_093] = 0.0;
+    this->data_[Index::dh_096] = 0.0;
+    this->data_[Index::dh_105] = 1.0;
+    this->data_[Index::dh_108] = 0.0;
+    this->data_[Index::dh_109] = 0.0;
+    this->data_[Index::dh_110] = 0.0;
+
+    this->data_[Index::dh_123] = 365.0;
+    this->data_[Index::dh_124] = 0.1;
+    this->data_[Index::dh_125] = 0.15;
+    this->data_[Index::dh_126] = 3.0;
+    this->data_[Index::dh_127] = 0.3;
+    this->data_[Index::dh_128] = 0.1;
+    this->data_[Index::dh_129] = 0.1;
+
+    this->data_[Index::dh_130] = 0.001;
+    this->data_[Index::dh_131] = 1.0e-7;
+    this->data_[Index::dh_132] = 1.0e-4;
+    this->data_[Index::dh_133] = 10.0;
+    this->data_[Index::dh_134] = 0.01;
+    this->data_[Index::dh_135] = 1.0e-6;
+    this->data_[Index::dh_136] = 0.001;
+    this->data_[Index::dh_137] = 0.001;
+
+    this->data_[Index::dh_140] = 1.0e-20;   // check this value
+    this->data_[Index::dh_141] = 1.013;
+    this->data_[Index::dh_142] = 0.0;
+    this->data_[Index::dh_143] = 1.0;
+    this->data_[Index::dh_145] = 0.3;
+    this->data_[Index::dh_146] = 2.0;
+    this->data_[Index::dh_147] = 0.0;
+    this->data_[Index::dh_148] = 0.0;
+    this->data_[Index::dh_149] = 0.0;
+
+    this->data_[Index::dh_150] = 0.0;
+    this->data_[Index::dh_151] = 0.0;
+    this->data_[Index::dh_152] = 0.0;
+    this->data_[Index::dh_153] = 0.0;
+    this->data_[Index::dh_154] = 0.0;
+
+    this->data_[Index::dh_162] = 1.0;
+    this->data_[Index::dh_163] = 0.2;
+    this->data_[Index::dh_164] = 0.4;
+    this->data_[Index::dh_165] = 1.2;
+    this->data_[Index::dh_166] = 0.3;
+    this->data_[Index::dh_167] = 1.0;
+
+    this->data_[Index::dh_170] = 0.4;
+    this->data_[Index::dh_171] = 0.7;
+    this->data_[Index::dh_172] = 2.0;
+    this->data_[Index::dh_178] = 1.0;
+    this->data_[Index::dh_179] = 1.0;
+
+    this->data_[Index::dh_180] = 1.0;
+    this->data_[Index::dh_181] = 0.0;
+    this->data_[Index::dh_182] = 0.0;
+    this->data_[Index::dh_183] = 1.0;
+    this->data_[Index::dh_184] = 1.0e-4;
+    this->data_[Index::dh_185] = 0.0;
+    this->data_[Index::dh_186] = 0.0;
+    this->data_[Index::dh_187] = 1.0e+20;
+    this->data_[Index::dh_188] = 1.0e+20;
+    this->data_[Index::dh_189] = 1.0e+20;
+
+    this->data_[Index::dh_190] = 1.0e+20;
+    this->data_[Index::dh_191] = 1.0e+20;
+    this->data_[Index::dh_192] = 1.0e+20;
+    this->data_[Index::dh_193] = 1.0e+20;
+    this->data_[Index::dh_194] = 1.0e+20;
+    this->data_[Index::dh_195] = 1.0e+20;
+    this->data_[Index::dh_196] = 1.0e+20;
+    this->data_[Index::dh_197] = 1.0e+20;
+    this->data_[Index::dh_198] = 1.0e+20;
+    this->data_[Index::dh_199] = 1.0;
+
+    this->data_[Index::dh_200] = 0.0;
+    this->data_[Index::dh_201] = 0.0;
+    this->data_[Index::dh_202] = 0.0;
+    this->data_[Index::dh_203] = 0.0;
+    this->data_[Index::dh_204] = 0.0;
+    this->data_[Index::dh_205] = 0.0;
+    this->data_[Index::dh_206] = 0.0;
+    this->data_[Index::dh_207] = 0.0;
+    this->data_[Index::dh_208] = 0.0;
+    this->data_[Index::dh_209] = 0.0;
+
+    this->data_[Index::dh_210] = 0.0;
+    this->data_[Index::dh_211] = 0.0;
+    this->data_[Index::dh_214] = 1.0e-4;
+    this->data_[Index::dh_215] = -2.0e+20;
+    this->data_[Index::dh_217] = 0.0;
+    this->data_[Index::dh_218] = 0.0;
+    this->data_[Index::dh_219] = 0.0;
+
+    this->data_[Index::dh_220] = 0.01;
+    this->data_[Index::dh_221] = 1.0;
+    this->data_[Index::dh_222] = 0.0;
+    this->data_[Index::dh_223] = 1.0e+20;
+    this->data_[Index::dh_225] = 0.0;
+    this->data_[Index::dh_226] = 0.0;
+    this->data_[Index::dh_227] = 0.0;
+
+    this->data_[Index::TsInit]  = 1.0;
+    this->data_[Index::TsMaxz]  = 365.0;
+    this->data_[Index::TsMinz]  = 0.1;
+    this->data_[Index::TsMchp]  = 0.15;
+    this->data_[Index::TsFMax]  = 3.0;
+    this->data_[Index::TsFMin]  = 0.3;
+    this->data_[Index::TsFcnv]  = 0.1;
+    this->data_[Index::TrgTTE]  = 0.1;
+    this->data_[Index::TrgCNV]  = 0.001;
+    this->data_[Index::TrgMBE]  = 1.0E-7;
+    this->data_[Index::TrgLCV]  = 0.0001;
+
+    this->data_[Index::XxxTTE] = 10.0;
+    this->data_[Index::XxxCNV] = 0.01;
+    this->data_[Index::XxxMBE] = 1.0e-6;
+    this->data_[Index::XxxLCV] = 0.001;
+    this->data_[Index::XxxWFL] = 0.001;
+
+    this->data_[Index::dRsdt]  = 1.0e+20; // "Infinity"
+
+    this->data_[Index::TrgDPR] = 1.0e+6;
+    this->data_[Index::TfDIFF] = 1.25;
+    this->data_[Index::DdpLim] = 1.0e+6;
+    this->data_[Index::DdsLim] = 1.0e+6;
+
+
+    this->data_[Index::ThrUPT] = 1.0e+20;
+    this->data_[Index::XxxDPR] = 1.0e+20;
+    this->data_[Index::TrgFIP] = 0.025;
+    this->data_[Index::TrgSFT] = 1.0e+20;
+}
+
+Opm::RestartIO::DoubHEAD&
+Opm::RestartIO::DoubHEAD::tuningParameters(const Tuning&     tuning,
+                                           const std::size_t rptStep,
+                                           const double      cnvT)
+{
+    const std::size_t rptStep_m = (rptStep == 0) ? 0 : rptStep - 1;
+
+    // Record 1
+    this->data_[Index::TsInit] = tuning.getTSINIT(rptStep_m) / cnvT;
+    this->data_[Index::TsMaxz] = tuning.getTSMAXZ(rptStep_m) / cnvT;
+    this->data_[Index::TsMinz] = tuning.getTSMINZ(rptStep_m) / cnvT;
+    this->data_[Index::TsMchp] = tuning.getTSMCHP(rptStep_m) / cnvT;
+    this->data_[Index::TsFMax] = tuning.getTSFMAX(rptStep_m);
+    this->data_[Index::TsFMin] = tuning.getTSFMIN(rptStep_m);
+    this->data_[Index::TsFcnv] = tuning.getTSFCNV(rptStep_m);
+    this->data_[Index::ThrUPT] = tuning.getTHRUPT(rptStep_m);
+    this->data_[Index::TfDIFF] = tuning.getTFDIFF(rptStep_m);
+
+    // Record 2
+    this->data_[Index::TrgTTE] = tuning.getTRGTTE(rptStep_m);
+    this->data_[Index::TrgCNV] = tuning.getTRGCNV(rptStep_m);
+    this->data_[Index::TrgMBE] = tuning.getTRGMBE(rptStep_m);
+    this->data_[Index::TrgLCV] = tuning.getTRGLCV(rptStep_m);
+    this->data_[Index::XxxTTE] = tuning.getXXXTTE(rptStep_m);
+    this->data_[Index::XxxCNV] = tuning.getXXXCNV(rptStep_m);
+    this->data_[Index::XxxMBE] = tuning.getXXXMBE(rptStep_m);
+    this->data_[Index::XxxLCV] = tuning.getXXXLCV(rptStep_m);
+    this->data_[Index::XxxWFL] = tuning.getXXXWFL(rptStep_m);
+    this->data_[Index::TrgFIP] = tuning.getTRGFIP(rptStep_m);
+    this->data_[Index::TrgSFT] = tuning.getTRGSFT(rptStep_m);
+
+    // Record 3
+    this->data_[Index::TrgDPR] = tuning.getTRGDPR(rptStep_m);
+    this->data_[Index::XxxDPR] = tuning.getXXXDPR(rptStep_m);
+    this->data_[Index::DdpLim] = tuning.getDDPLIM(rptStep_m);
+    this->data_[Index::DdsLim] = tuning.getDDSLIM(rptStep_m);
+
+    return *this;
+}
+
+Opm::RestartIO::DoubHEAD&
+Opm::RestartIO::DoubHEAD::timeStamp(const TimeStamp& ts)
+{
+    using day = std::chrono::duration<double,
+        std::ratio_multiply<std::chrono::hours::period, std::ratio<24>>
+    >;
+
+    // Elapsed time in days
+    this->data_[Index::SimTime] = day{ ts.elapsed }.count();
+
+    // Start time in date-numbers
+    this->data_[Index::Start] = toDateNum(ts.start);
+
+    // Simulation time-stamp in date-numbers
+    this->data_[Index::Time] = this->data_[Index::Start]
+        + this->data_[Index::SimTime];
+
+    return *this;
+}
+
+Opm::RestartIO::DoubHEAD&
+Opm::RestartIO::DoubHEAD::drsdt(const Schedule&   sched,
+                                const std::size_t rptStep)
+{
+    const auto& vappar =
+        sched.getOilVaporizationProperties(rptStep);
+
+    this->data_[dRsdt] =
+        (vappar.getType() == Opm::OilVaporizationEnum::DRSDT)
+        ? vappar.getMaxDRSDT()
+        : 1.0e+20;
+
+    return *this;
+}

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -4,137 +4,137 @@
 #include <vector>
 
 enum index : std::vector<int>::size_type {
-  ISNUM	=	0	,		//	0	0		An encoded integer corresponding to the time the file was created. For files not originating from ECLIPSE, this value may be set to zero.
-  METRIC	=	1	,		//	0	0		
-  UNIT	=	2	,		//	(1,2,3)	1		units type: 1 - METRIC, 2 - FIELD, 3 - LAB
-  ih_003	=	3	,		//	0	0		
-  ih_004	=	4	,		//	0	0		
-  ih_005	=	5	,		//	0	0		
-  ih_006	=	6	,		//	0	0		
-  ih_007	=	7	,		//	0	0		
-  NX	=	8	,		//	NX	137		Grid x-direction dimension, NX
-  NY	=	9	,		//	NY	236		Grid x-direction dimension, NY
-  NZ	=	10	,		//	NZ	58		Grid x-direction dimension, NZ
+  ISNUM		=	0	,		//	0	0		An encoded integer corresponding to the time the file was created. For files not originating from ECLIPSE, this value may be set to zero.
+  VERSION	=	1	,		//	0	0
+  UNIT		=	2	,		//	(1,2,3)	1		units type: 1 - METRIC, 2 - FIELD, 3 - LAB
+  ih_003	=	3	,		//	0	0
+  ih_004	=	4	,		//	0	0
+  ih_005	=	5	,		//	0	0
+  ih_006	=	6	,		//	0	0
+  ih_007	=	7	,		//	0	0
+  NX		=	8	,		//	NX	137		Grid x-direction dimension, NX
+  NY		=	9	,		//	NY	236		Grid x-direction dimension, NY
+  NZ		=	10	,		//	NZ	58		Grid x-direction dimension, NZ
   NACTIV	=	11	,		//	NACTIV?	89022		NACTIV = number of active cells
-  ih_012	=	12	,		//	0	0		
-  ih_013	=	13	,		//	0	0		
-  PHASE	=	14	,		//	IPHS	7		IPHS = phase indicator: 1 - oil, 2 - water, 3 - oil/water, 4 - gas, 5 – oil/gas, 6 - gas/water, 7 - oil/water/gas (ECLIPSE output only)
-  ih_015	=	15	,		//	0	0		
+  ih_012	=	12	,		//	0	0
+  ih_013	=	13	,		//	0	0
+  PHASE		=	14	,		//	IPHS	7		IPHS = phase indicator: 1 - oil, 2 - water, 3 - oil/water, 4 - gas, 5 – oil/gas, 6 - gas/water, 7 - oil/water/gas (ECLIPSE output only)
+  ih_015	=	15	,		//	0	0
   NWELLS	=	16	,		//	NWELLS	39		NWELL = number of wells
   NCWMAX	=	17	,		//	NCWMAX	108	Weldims item2	NCWMAX = maximum number of completions per well
-  ih_018	=	18	,		//	NGRP?	0	Number of actual groups	
+  ih_018	=	18	,		//	NGRP?	0	Number of actual groups
   NWGMAX	=	19	,		//	NWGMAX	0	maximum of weldims item3 or item4	NWGMAX = maximum number of wells in any well group
   NGMAXZ	=	20	,		//	NGMAXZ	0	weldims item3 + 1	NGMAXZ = maximum number of groups in field
-  ih_021	=	21	,		//	0	0		
-  ih_022	=	22	,		//	0	0		
-  ih_023	=	23	,		//	0	0		
+  ih_021	=	21	,		//	0	0
+  ih_022	=	22	,		//	0	0
+  ih_023	=	23	,		//	0	0
   NIWELZ	=	24	,		//	NIWELZ	155	155	NIWELZ = no of data elements per well in IWEL array (default 97 for ECLIPSE, 94 for ECLIPSE 300)
   NSWELZ	=	25	,		//	NSWELZ	122	122	NSWELZ = number of daelements per well in SWEL array
   NXWELZ	=	26	,		//	NXWELZ	130	130	NXWELZ = number of delements per well in XWEL array
   NZWELZ	=	27	,		//	NZWEL	3	3	NZWEL = no of 8-character words per well in ZWEL array (= 3)
-  ih_028	=	28	,		//	0	0		
-  ih_029	=	29	,		//	0	0		
-  ih_030	=	30	,		//	0	0		
-  ih_031	=	31	,		//	0	0		
+  ih_028	=	28	,		//	0	0
+  ih_029	=	29	,		//	0	0
+  ih_030	=	30	,		//	0	0
+  ih_031	=	31	,		//	0	0
   NICONZ	=	32	,		//	25	15	25	NICON = no of data elements per completion in ICON array (default 19)
   NSCONZ	=	33	,		//	40	0		NSCONZ = number of data elements per completion in SCON array
   NXCONZ	=	34	,		//	58	0	58	NXCONZ = number of data elements per completion in XCON array
-  ih_035	=	35	,		//	0	0		
+  ih_035	=	35	,		//	0	0
   NIGRPZ	=	36	,		//	97+intehead_array[19]	0	97 + intehead[19]	NIGRPZ = no of data elements per group in IGRP array
   NSGRPZ	=	37	,		//	112	0	112	NSGRPZ = number of data elements per group in SGRP array
   NXGRPZ	=	38	,		//	180	0	180	NXGRPZ = number of data elements per group in XGRP array
   NZGRPZ	=	39	,		//	5	0		NZGRPZ = number of data elements per group in ZGRP array
-  ih_040	=	40	,		//	0	0		
+  ih_040	=	40	,		//	0	0
   NCAMAX	=	41	,		//	1	0		NCAMAX = maximum number of analytic aquifer connections
   NIAAQZ	=	42	,		//	18	0		NIAAQZ = number of data elements per aquifer in IAAQ array
   NSAAQZ	=	43	,		//	24	0		NSAAQZ = number of data elements per aquifer in SAAQ array
   NXAAQZ	=	44	,		//	10	0		NXAAQZ = number of data elements per aquifer in XAAQ array
   NICAQZ	=	45	,		//	7	0		NSCAQZ= number of data elements per aquifer connection in SCAQ array
-  NSCAQZ	=	46	,		//	2	0		
-  NACAQZ	=	47	,		//	4	0		
-  ih_048	=	48	,		//	0	0		
-  ih_049	=	49	,		//	0	0		
-  ih_050	=	50	,		//	0	0		
-  ih_051	=	51	,		//	0	0		
-  ih_052	=	52	,		//	0	0		
-  ih_053	=	53	,		//	0	0		
-  ih_054	=	54	,		//	0	0		
-  ih_055	=	55	,		//	0	0		
-  ih_056	=	56	,		//	0	0		
-  ih_057	=	57	,		//	0	0		
-  ih_058	=	58	,		//	0	0		
-  ih_059	=	59	,		//	0	0		
-  ih_060	=	60	,		//	0	0		
-  ih_061	=	61	,		//	0	0		
-  ih_062	=	62	,		//	0	0		
-  ih_063	=	63	,		//	0	0		
+  NSCAQZ	=	46	,		//	2	0
+  NACAQZ	=	47	,		//	4	0
+  ih_048	=	48	,		//	0	0
+  ih_049	=	49	,		//	0	0
+  ih_050	=	50	,		//	0	0
+  ih_051	=	51	,		//	0	0
+  ih_052	=	52	,		//	0	0
+  ih_053	=	53	,		//	0	0
+  ih_054	=	54	,		//	0	0
+  ih_055	=	55	,		//	0	0
+  ih_056	=	56	,		//	0	0
+  ih_057	=	57	,		//	0	0
+  ih_058	=	58	,		//	0	0
+  ih_059	=	59	,		//	0	0
+  ih_060	=	60	,		//	0	0
+  ih_061	=	61	,		//	0	0
+  ih_062	=	62	,		//	0	0
+  ih_063	=	63	,		//	0	0
   DAY	=	64	,		//	IDAY	2		IDAY = calendar day at this report time
   MONTH	=	65	,		//	IMON	6		IMON = calendar month at this report time
   YEAR	=	66	,		//	IYEAR	2016		IYEAR = calendar year at this report time
-  TSTEP	=	67	,		//	CurrentTimestep	0		
-  REPSTEP	=	68	,		//	CurrentReportStep	0		
-  ih_069	=	69	,		//	0	0		
-  ih_070	=	70	,		//	0	0		
-  ih_071	=	71	,		//	0	0		
-  ih_072	=	72	,		//	0	0		
-  ih_073	=	73	,		//	0	0		
-  ih_074	=	74	,		//	0	0		
-  ih_075	=	75	,		//	0	0		
-  ih_076	=	76	,		//	0	0	2	
-  ih_077	=	77	,		//	0	0		
-  ih_078	=	78	,		//	0	0		
-  ih_079	=	79	,		//	0	0		
-  NEWTMX	=	80	,		//	0	0	Tuning,Record3,Item1	
-  NEWTMN	=	81	,		//	0	0	Tuning,Record3,Item2	
-  LITMAX	=	82	,		//	0	0	Tuning,Record3,Item3	
-  LITMIN	=	83	,		//	0	0	Tuning,Record3,Item4	
-  MXWSIT	=	84	,		//	0	0		
-  MXWPIT	=	85	,		//	0	0		
-  ih_086	=	86	,		//	0	0	Tuning,Record3,Item5	
-  ih_087	=	87	,		//	0	0	Tuning,Record3,Item6	
-  NTFIP 	=	88	,		//	0	0	REGDIMS item1, or TABDIMS item 5	
-  ih_089	=	89	,		//	0	0		
-  ih_090	=	90	,		//	0	0		
-  ih_091	=	91	,		//	0	0		
-  ih_092	=	92	,		//	0	0		
-  ih_093	=	93	,		//	0	0		
+  TSTEP	=	67	,		//	CurrentTimestep	0
+  REPSTEP	=	68	,		//	CurrentReportStep	0
+  ih_069	=	69	,		//	0	0
+  ih_070	=	70	,		//	0	0
+  ih_071	=	71	,		//	0	0
+  ih_072	=	72	,		//	0	0
+  ih_073	=	73	,		//	0	0
+  ih_074	=	74	,		//	0	0
+  ih_075	=	75	,		//	0	0
+  ih_076	=	76	,		//	0	0	2
+  ih_077	=	77	,		//	0	0
+  ih_078	=	78	,		//	0	0
+  ih_079	=	79	,		//	0	0
+  NEWTMX	=	80	,		//	0	0	Tuning,Record3,Item1
+  NEWTMN	=	81	,		//	0	0	Tuning,Record3,Item2
+  LITMAX	=	82	,		//	0	0	Tuning,Record3,Item3
+  LITMIN	=	83	,		//	0	0	Tuning,Record3,Item4
+  ih_084	=	84	,		//	0	0	Tuning,Record3,Item5
+  ih_085	=	85	,		//	0	0	Tuning,Record3,Item6
+  MXWSIT	=	86	,		//	0	0
+  MXWPIT	=	87	,		//	0	0
+  ih_088	=	88	,		//	0	0
+  NTFIP	=	89	,		//	0	0	REGDIMS item1, or TABDIMS item 5
+  ih_090	=	90	,		//	0	0
+  ih_091	=	91	,		//	0	0
+  ih_092	=	92	,		//	0	0
+  ih_093	=	93	,		//	0	0
   IPROG		=	94	,		//	0	100		IPROG = simulation program identifier:  100 - ECLIPSE 100, 300 - ECLIPSE 300, 500 - ECLIPSE 300 (thermal option), negative - Other simulator
-  INITSIZE	=	95	,		//	0	0		
-  ih_096	=	96	,		//	0	0		
-  ih_097	=	97	,		//	0	0		
-  ih_098	=	98	,		//	0	0		
-  NMFIPR	=	99	,		//	0	0	 REGDIMS item2	
-  ih_100	=	100	,		//	0	0		
-  ih_101	=	101	,		//	0	0	1	
-  ih_102	=	102	,		//	0	0		
-  ih_103	=	103	,		//	0	0	1	
-  ih_104	=	104	,		//	0	0		
-  ih_105	=	105	,		//	0	0		
-  ih_106	=	106	,		//	0	0		
-  ih_107	=	107	,		//	0	0		
-  ih_108	=	108	,		//	0	0		
-  ih_109	=	109	,		//	0	0		
-  ih_110	=	110	,		//	0	0		
-  ih_111	=	111	,		//	0	0		
-  ih_112	=	112	,		//	0	0		
-  ih_113	=	113	,		//	0	0		
-  ih_114	=	114	,		//	0	0		
-  ih_115	=	115	,		//	0	0		
-  ih_116	=	116	,		//	0	0		
-  ih_117	=	117	,		//	0	0		
-  ih_118	=	118	,		//	0	0		
-  ih_119	=	119	,		//	0	0		
-  ih_120	=	120	,		//	0	0		
-  ih_121	=	121	,		//	0	0		
-  ih_122	=	122	,		//	0	0		
-  ih_123	=	123	,		//	0	0		
-  ih_124	=	124	,		//	0	0		
-  ih_125	=	125	,		//	0	0		
-  ih_126	=	126	,		//	0	0		
-  ih_127	=	127	,		//	0	0		
-  ih_128	=	128	,		//	0	0		
-  ih_129	=	129	,		//	0	0		
-  ih_130	=	130	,		//	0	0		
+  INITSIZE	=	95	,		//	0	0
+  ih_096	=	96	,		//	0	0
+  ih_097	=	97	,		//	0	0
+  ih_098	=	98	,		//	0	0
+  NMFIPR	=	99	,		//	0	0	REGDIMS item2
+  ih_100	=	100	,		//	0	0
+  ih_101	=	101	,		//	0	0	1
+  ih_102	=	102	,		//	0	0
+  ih_103	=	103	,		//	0	0	1
+  ih_104	=	104	,		//	0	0
+  ih_105	=	105	,		//	0	0
+  ih_106	=	106	,		//	0	0
+  ih_107	=	107	,		//	0	0
+  ih_108	=	108	,		//	0	0
+  ih_109	=	109	,		//	0	0
+  ih_110	=	110	,		//	0	0
+  ih_111	=	111	,		//	0	0
+  ih_112	=	112	,		//	0	0
+  ih_113	=	113	,		//	0	0
+  ih_114	=	114	,		//	0	0
+  ih_115	=	115	,		//	0	0
+  ih_116	=	116	,		//	0	0
+  ih_117	=	117	,		//	0	0
+  ih_118	=	118	,		//	0	0
+  ih_119	=	119	,		//	0	0
+  ih_120	=	120	,		//	0	0
+  ih_121	=	121	,		//	0	0
+  ih_122	=	122	,		//	0	0
+  ih_123	=	123	,		//	0	0
+  ih_124	=	124	,		//	0	0
+  ih_125	=	125	,		//	0	0
+  ih_126	=	126	,		//	0	0
+  ih_127	=	127	,		//	0	0
+  ih_128	=	128	,		//	0	0
+  ih_129	=	129	,		//	0	0
+  ih_130	=	130	,		//	0	0
   NODMAX	=	131	,		//	0	0		NODMAX = maximum number of nodes in extended network option
   NBRMAX	=	132	,		//	0	0		NBRMAX = maximum number of branches in extended network option
   NIBRAN	=	133	,		//	0	0		NIBRAN = number of entries per branch in the IBRAN array
@@ -143,101 +143,101 @@ enum index : std::vector<int>::size_type {
   NRNODE	=	136	,		//	0	0		NRNODE = number of entries per node in the RNODE array
   NZNODE	=	137	,		//	0	0		NZNODE = number of entries per node in the ZNODE array
   NINOBR	=	138	,		//	0	0		NINOBR = size of the INOBR array
-  ih_139	=	139	,		//	0	0		
-  ih_140	=	140	,		//	0	0		
-  ih_141	=	141	,		//	0	0		
-  ih_142	=	142	,		//	0	0		
-  ih_143	=	143	,		//	0	0		
-  ih_144	=	144	,		//	0	0		
-  ih_145	=	145	,		//	0	0		
-  ih_146	=	146	,		//	0	0		
-  ih_147	=	147	,		//	0	0		
-  ih_148	=	148	,		//	0	0		
-  ih_149	=	149	,		//	0	0		
-  ih_150	=	150	,		//	0	0		
-  ih_151	=	151	,		//	0	0		
-  ih_152	=	152	,		//	0	0		
-  ih_153	=	153	,		//	0	0		
-  ih_154	=	154	,		//	0	0		
-  ih_155	=	155	,		//	0	0		
-  ih_156	=	156	,		//	0	0		
-  ih_157	=	157	,		//	0	0		
-  ih_158	=	158	,		//	0	0		
-  ih_159	=	159	,		//	0	0		
-  ih_160	=	160	,		//	0	0		
-  ih_161	=	161	,		//	0	0		
+  ih_139	=	139	,		//	0	0
+  ih_140	=	140	,		//	0	0
+  ih_141	=	141	,		//	0	0
+  ih_142	=	142	,		//	0	0
+  ih_143	=	143	,		//	0	0
+  ih_144	=	144	,		//	0	0
+  ih_145	=	145	,		//	0	0
+  ih_146	=	146	,		//	0	0
+  ih_147	=	147	,		//	0	0
+  ih_148	=	148	,		//	0	0
+  ih_149	=	149	,		//	0	0
+  ih_150	=	150	,		//	0	0
+  ih_151	=	151	,		//	0	0
+  ih_152	=	152	,		//	0	0
+  ih_153	=	153	,		//	0	0
+  ih_154	=	154	,		//	0	0
+  ih_155	=	155	,		//	0	0
+  ih_156	=	156	,		//	0	0
+  ih_157	=	157	,		//	0	0
+  ih_158	=	158	,		//	0	0
+  ih_159	=	159	,		//	0	0
+  ih_160	=	160	,		//	0	0
+  ih_161	=	161	,		//	0	0
   NGCAUS	=	162	,		//	0	0		NGCAUS = maximum number of aquifer connections actually used.
-  ih_163	=	163	,		//	0	0		
-  ih_164	=	164	,		//	0	0		
-  ih_165	=	165	,		//	0	0		
-  ih_166	=	166	,		//	0	0		
-  ih_167	=	167	,		//	0	0		
-  ih_168	=	168	,		//	0	0		
-  ih_169	=	169	,		//	0	0		
-  ih_170	=	170	,		//	0	0		
-  ih_171	=	171	,		//	0	0		
-  ih_172	=	172	,		//	0	0		
-  ih_173	=	173	,		//	0	0		
-  NSEGWL	=	174	,		//	0	0	number of mswm wells defined with WELSEG	
+  ih_163	=	163	,		//	0	0
+  ih_164	=	164	,		//	0	0
+  ih_165	=	165	,		//	0	0
+  ih_166	=	166	,		//	0	0
+  ih_167	=	167	,		//	0	0
+  ih_168	=	168	,		//	0	0
+  ih_169	=	169	,		//	0	0
+  ih_170	=	170	,		//	0	0
+  ih_171	=	171	,		//	0	0
+  ih_172	=	172	,		//	0	0
+  ih_173	=	173	,		//	0	0
+  NSEGWL	=	174	,		//	0	0	number of mswm wells defined with WELSEG
   NSWLMX	=	175	,		//	NSWLMX	0	Item 1 in WSEGDIMS keyword (runspec section)	NSWLMX = maximum number of segmented wells
   NSEGMX	=	176	,		//	NSEGMX	0	Item 2 in WSEGDIMS keyword (runspec section)	NSEGMX = maximum number of segments per well
   NLBRMX	=	177	,		//	NLBRMX	0	Item 3 in WSEGDIMS keyword (runspec section)	NLBRMX = maximum number of lateral branches per well
   NISEGZ	=	178	,		//	22	0	22	NISEGZ = number of entries per segment in ISEG array
   NRSEGZ	=	179	,		//	140	0	140	NRSEGZ = number of entries per segment in RSEG array
   NILBRZ	=	180	,		//	10		10	NILBRZ = number of entries per segment in ILBR array
-  RSTSIZE	=	181	,		//	0			
-  ih_182	=	182	,		//	0			
-  ih_183	=	183	,		//	0			
-  ih_184	=	184	,		//	0			
-  ih_185	=	185	,		//	0			
-  ih_186	=	186	,		//	0			
-  ih_187	=	187	,		//	0			
-  ih_188	=	188	,		//	0			
-  ih_189	=	189	,		//	0			
-  ih_190	=	190	,		//	0			
-  ih_191	=	191	,		//	0			
-  ih_192	=	192	,		//	0			
-  ih_193	=	193	,		//	0			
-  ih_194	=	194	,		//	0			
-  ih_195	=	195	,		//	0			
-  ih_196	=	196	,		//	0			
-  ih_197	=	197	,		//	0			
-  ih_198	=	198	,		//	0			
-  ih_199	=	199	,		//	0			
-  ih_200	=	200	,		//	0			
-  ih_201	=	201	,		//	0			
-  ih_202	=	202	,		//	0			
-  ih_203	=	203	,		//	0			
-  ih_204	=	204	,		//	0			
-  ih_205	=	205	,		//	0			
+  RSTSIZE	=	181	,		//	0
+  ih_182	=	182	,		//	0
+  ih_183	=	183	,		//	0
+  ih_184	=	184	,		//	0
+  ih_185	=	185	,		//	0
+  ih_186	=	186	,		//	0
+  ih_187	=	187	,		//	0
+  ih_188	=	188	,		//	0
+  ih_189	=	189	,		//	0
+  ih_190	=	190	,		//	0
+  ih_191	=	191	,		//	0
+  ih_192	=	192	,		//	0
+  ih_193	=	193	,		//	0
+  ih_194	=	194	,		//	0
+  ih_195	=	195	,		//	0
+  ih_196	=	196	,		//	0
+  ih_197	=	197	,		//	0
+  ih_198	=	198	,		//	0
+  ih_199	=	199	,		//	0
+  ih_200	=	200	,		//	0
+  ih_201	=	201	,		//	0
+  ih_202	=	202	,		//	0
+  ih_203	=	203	,		//	0
+  ih_204	=	204	,		//	0
+  ih_205	=	205	,		//	0
   IHOURZ	=	206	,		//	IHOURZ			IHOURZ = current simulation time HH:MM:SS – number of hours (HH) (0-23).
   IMINTS	=	207	,		//	IMINTS			IMINTS = current simulation time HH:MM:SS - number of minutes (MM) (0-59).
-  ih_208	=	208	,		//	0			
-  ih_209	=	209	,		//	0			
-  ih_210	=	210	,		//	0			
-  ih_211	=	211	,		//	0			
-  ih_212	=	212	,		//	0			
-  ih_213	=	213	,		//	0			
-  ih_214	=	214	,		//	0			
-  ih_215	=	215	,		//	0			
-  ih_216	=	216	,		//	0			
-  ih_217	=	217	,		//	0			
-  ih_218	=	218	,		//	0			
-  ih_219	=	219	,		//	0			
-  ih_220	=	220	,		//	0			
-  ih_221	=	221	,		//	0			
-  ih_222	=	222	,		//	0			
+  ih_208	=	208	,		//	0
+  ih_209	=	209	,		//	0
+  ih_210	=	210	,		//	0
+  ih_211	=	211	,		//	0
+  ih_212	=	212	,		//	0
+  ih_213	=	213	,		//	0
+  ih_214	=	214	,		//	0
+  ih_215	=	215	,		//	0
+  ih_216	=	216	,		//	0
+  ih_217	=	217	,		//	0
+  ih_218	=	218	,		//	0
+  ih_219	=	219	,		//	0
+  ih_220	=	220	,		//	0
+  ih_221	=	221	,		//	0
+  ih_222	=	222	,		//	0
   NIIAQN	=	223	,		//	0			NIIAQN = number of lines of integer AQUNUM data.
   NIRAQN	=	224	,		//	0			NIRAQN = number of lines of real AQUNUM data.
-  ih_225	=	225	,		//	0			
+  ih_225	=	225	,		//	0
   NUMAQN	=	226	,		//	0			NUMAQN = number of lines of AQUNUM data entered.
-  ih_227	=	227	,		//	0			
-  ih_228	=	228	,		//	0			
-  ih_229	=	229	,		//	0			
-  ih_230	=	230	,		//	0			
-  ih_231	=	231	,		//	0			
-  ih_232	=	232	,		//	0			
-  ih_233	=	233	,		//	0			
+  ih_227	=	227	,		//	0
+  ih_228	=	228	,		//	0
+  ih_229	=	229	,		//	0
+  ih_230	=	230	,		//	0
+  ih_231	=	231	,		//	0
+  ih_232	=	232	,		//	0
+  ih_233	=	233	,		//	0
   NICOTZ	=	234	,		//	0			NICOTZ = number of entries in the ICOT array
   NXCOTZ	=	235	,		//	0			NXCOTZ = number of entries in the XCOT array
   NIWETZ	=	236	,		//	0			NIWETZ = number of entries in the IWET array
@@ -245,175 +245,175 @@ enum index : std::vector<int>::size_type {
   NIGRTZ	=	238	,		//	0			NIGRTZ = number of entries in the IGRT array
   NXGRTZ	=	239	,		//	0			NXGRTZ = number of entries in the XGRT array
   NSTRA2	=	240	,		//	0			NSTRA2 = number of tracers + 2
-  ih_241	=	241	,		//	0			
-  ih_242	=	242	,		//	0			
-  ih_243	=	243	,		//	0			
-  ih_244	=	244	,		//	0			
-  ih_245	=	245	,		//	0			
-  ih_246	=	246	,		//	0			
-  ih_247	=	247	,		//	0			
-  ih_248	=	248	,		//	0			
-  ih_249	=	249	,		//	0			
-  ih_250	=	250	,		//	0			
-  ih_251	=	251	,		//	0			
+  ih_241	=	241	,		//	0
+  ih_242	=	242	,		//	0
+  ih_243	=	243	,		//	0
+  ih_244	=	244	,		//	0
+  ih_245	=	245	,		//	0
+  ih_246	=	246	,		//	0
+  ih_247	=	247	,		//	0
+  ih_248	=	248	,		//	0
+  ih_249	=	249	,		//	0
+  ih_250	=	250	,		//	0
+  ih_251	=	251	,		//	0
   MAAQID	=	252	,		//	0			MAAQID = maximum number of analytic aquifers
-  ih_253	=	253	,		//	0			
-  ih_254	=	254	,		//	0			
-  ih_255	=	255	,		//	0			
-  ih_256	=	256	,		//	0			
-  ih_257	=	257	,		//	0			
-  ih_258	=	258	,		//	0			
-  ih_259	=	259	,		//	0			
-  ih_260	=	260	,		//	0			
-  ih_261	=	261	,		//	0			
-  ih_262	=	262	,		//	0			
-  ih_263	=	263	,		//	0			
-  ih_264	=	264	,		//	0			
-  ih_265	=	265	,		//	0			
-  ih_266	=	266	,		//	0			
-  ih_267	=	267	,		//	0			
-  ih_268	=	268	,		//	0			
-  ih_269	=	269	,		//	0			
-  ih_270	=	270	,		//	0			
+  ih_253	=	253	,		//	0
+  ih_254	=	254	,		//	0
+  ih_255	=	255	,		//	0
+  ih_256	=	256	,		//	0
+  ih_257	=	257	,		//	0
+  ih_258	=	258	,		//	0
+  ih_259	=	259	,		//	0
+  ih_260	=	260	,		//	0
+  ih_261	=	261	,		//	0
+  ih_262	=	262	,		//	0
+  ih_263	=	263	,		//	0
+  ih_264	=	264	,		//	0
+  ih_265	=	265	,		//	0
+  ih_266	=	266	,		//	0
+  ih_267	=	267	,		//	0
+  ih_268	=	268	,		//	0
+  ih_269	=	269	,		//	0
+  ih_270	=	270	,		//	0
   NCRDMX	=	271	,		//	0			NCRDMX = maximum number of chord segment links per well
-  ih_272	=	272	,		//	0			
-  ih_273	=	273	,		//	0			
-  ih_274	=	274	,		//	0			
-  ih_275	=	275	,		//	0			
-  ih_276	=	276	,		//	0			
-  ih_277	=	277	,		//	0			
-  ih_278	=	278	,		//	0			
-  ih_279	=	279	,		//	0			
-  ih_280	=	280	,		//	0			
-  ih_281	=	281	,		//	0			
-  ih_282	=	282	,		//	0			
-  ih_283	=	283	,		//	0			
-  ih_284	=	284	,		//	0			
-  ih_285	=	285	,		//	0			
-  ih_286	=	286	,		//	0			
-  ih_287	=	287	,		//	0			
-  ih_288	=	288	,		//	0			
-  ih_289	=	289	,		//	0			
-  ih_290	=	290	,		//	0			
-  ih_291	=	291	,		//	0			
-  ih_292	=	292	,		//	0			
-  ih_293	=	293	,		//	0			
-  ih_294	=	294	,		//	0			
-  ih_295	=	295	,		//	0			
-  ih_296	=	296	,		//	0			
-  ih_297	=	297	,		//	0			
-  ih_298	=	298	,		//	0			
-  ih_299	=	299	,		//	0			
-  ih_300	=	300	,		//	0			
-  ih_301	=	301	,		//	0			
-  ih_302	=	302	,		//	0			
-  ih_303	=	303	,		//	0			
-  ih_304	=	304	,		//	0			
-  ih_305	=	305	,		//	0			
-  ih_306	=	306	,		//	0			
-  ih_307	=	307	,		//	0			
-  ih_308	=	308	,		//	0			
-  ih_309	=	309	,		//	0			
-  ih_310	=	310	,		//	0			
-  ih_311	=	311	,		//	0			
-  ih_312	=	312	,		//	0			
-  ih_313	=	313	,		//	0			
-  ih_314	=	314	,		//	0			
-  ih_315	=	315	,		//	0			
-  ih_316	=	316	,		//	0			
-  ih_317	=	317	,		//	0			
-  ih_318	=	318	,		//	0			
-  ih_319	=	319	,		//	0			
-  ih_320	=	320	,		//	0			
-  ih_321	=	321	,		//	0			
-  ih_322	=	322	,		//	0			
-  ih_323	=	323	,		//	0			
-  ih_324	=	324	,		//	0			
-  ih_325	=	325	,		//	0			
-  ih_326	=	326	,		//	0			
-  ih_327	=	327	,		//	0			
-  ih_328	=	328	,		//	0			
-  ih_329	=	329	,		//	0			
-  ih_330	=	330	,		//	0			
-  ih_331	=	331	,		//	0			
-  ih_332	=	332	,		//	0			
-  ih_333	=	333	,		//	0			
-  ih_334	=	334	,		//	0			
-  ih_335	=	335	,		//	0			
-  ih_336	=	336	,		//	0			
-  ih_337	=	337	,		//	0			
-  ih_338	=	338	,		//	0			
-  ih_339	=	339	,		//	0			
-  ih_340	=	340	,		//	0			
-  ih_341	=	341	,		//	0			
-  ih_342	=	342	,		//	0			
-  ih_343	=	343	,		//	0			
-  ih_344	=	344	,		//	0			
-  ih_345	=	345	,		//	0			
-  ih_346	=	346	,		//	0			
-  ih_347	=	347	,		//	0			
-  ih_348	=	348	,		//	0			
-  ih_349	=	349	,		//	0			
-  ih_350	=	350	,		//	0			
-  ih_351	=	351	,		//	0			
-  ih_352	=	352	,		//	0			
-  ih_353	=	353	,		//	0			
-  ih_354	=	354	,		//	0			
-  ih_355	=	355	,		//	0			
-  ih_356	=	356	,		//	0			
-  ih_357	=	357	,		//	0			
-  ih_358	=	358	,		//	0			
-  ih_359	=	359	,		//	0			
-  ih_360	=	360	,		//	0			
-  ih_361	=	361	,		//	0			
-  ih_362	=	362	,		//	0			
-  ih_363	=	363	,		//	0			
-  ih_364	=	364	,		//	0			
-  ih_365	=	365	,		//	0			
-  ih_366	=	366	,		//	0			
-  ih_367	=	367	,		//	0			
-  ih_368	=	368	,		//	0			
-  ih_369	=	369	,		//	0			
-  ih_370	=	370	,		//	0			
-  ih_371	=	371	,		//	0			
-  ih_372	=	372	,		//	0			
-  ih_373	=	373	,		//	0			
-  ih_374	=	374	,		//	0			
-  ih_375	=	375	,		//	0			
-  ih_376	=	376	,		//	0			
-  ih_377	=	377	,		//	0			
-  ih_378	=	378	,		//	0			
-  ih_379	=	379	,		//	0			
-  ih_380	=	380	,		//	0			
-  ih_381	=	381	,		//	0			
-  ih_382	=	382	,		//	0			
-  ih_383	=	383	,		//	0			
-  ih_384	=	384	,		//	0			
-  ih_385	=	385	,		//	0			
-  ih_386	=	386	,		//	0			
-  ih_387	=	387	,		//	0			
-  ih_388	=	388	,		//	0			
-  ih_389	=	389	,		//	0			
-  ih_390	=	390	,		//	0			
-  ih_391	=	391	,		//	0			
-  ih_392	=	392	,		//	0			
-  ih_393	=	393	,		//	0			
-  ih_394	=	394	,		//	0			
-  ih_395	=	395	,		//	0			
-  ih_396	=	396	,		//	0			
-  ih_397	=	397	,		//	0			
-  ih_398	=	398	,		//	0			
-  ih_399	=	399	,		//	0			
-  ih_400	=	400	,		//	0			
-  ih_401	=	401	,		//	0			
-  ih_402	=	402	,		//	0			
-  ih_403	=	403	,		//	0			
-  ih_404	=	404	,		//	0			
-  ih_405	=	405	,		//	0			
-  ih_406	=	406	,		//	0			
-  ih_407	=	407	,		//	0			
-  ih_408	=	408	,		//	0			
-  ih_409	=	409	,		//	0		
+  ih_272	=	272	,		//	0
+  ih_273	=	273	,		//	0
+  ih_274	=	274	,		//	0
+  ih_275	=	275	,		//	0
+  ih_276	=	276	,		//	0
+  ih_277	=	277	,		//	0
+  ih_278	=	278	,		//	0
+  ih_279	=	279	,		//	0
+  ih_280	=	280	,		//	0
+  ih_281	=	281	,		//	0
+  ih_282	=	282	,		//	0
+  ih_283	=	283	,		//	0
+  ih_284	=	284	,		//	0
+  ih_285	=	285	,		//	0
+  ih_286	=	286	,		//	0
+  ih_287	=	287	,		//	0
+  ih_288	=	288	,		//	0
+  ih_289	=	289	,		//	0
+  ih_290	=	290	,		//	0
+  ih_291	=	291	,		//	0
+  ih_292	=	292	,		//	0
+  ih_293	=	293	,		//	0
+  ih_294	=	294	,		//	0
+  ih_295	=	295	,		//	0
+  ih_296	=	296	,		//	0
+  ih_297	=	297	,		//	0
+  ih_298	=	298	,		//	0
+  ih_299	=	299	,		//	0
+  ih_300	=	300	,		//	0
+  ih_301	=	301	,		//	0
+  ih_302	=	302	,		//	0
+  ih_303	=	303	,		//	0
+  ih_304	=	304	,		//	0
+  ih_305	=	305	,		//	0
+  ih_306	=	306	,		//	0
+  ih_307	=	307	,		//	0
+  ih_308	=	308	,		//	0
+  ih_309	=	309	,		//	0
+  ih_310	=	310	,		//	0
+  ih_311	=	311	,		//	0
+  ih_312	=	312	,		//	0
+  ih_313	=	313	,		//	0
+  ih_314	=	314	,		//	0
+  ih_315	=	315	,		//	0
+  ih_316	=	316	,		//	0
+  ih_317	=	317	,		//	0
+  ih_318	=	318	,		//	0
+  ih_319	=	319	,		//	0
+  ih_320	=	320	,		//	0
+  ih_321	=	321	,		//	0
+  ih_322	=	322	,		//	0
+  ih_323	=	323	,		//	0
+  ih_324	=	324	,		//	0
+  ih_325	=	325	,		//	0
+  ih_326	=	326	,		//	0
+  ih_327	=	327	,		//	0
+  ih_328	=	328	,		//	0
+  ih_329	=	329	,		//	0
+  ih_330	=	330	,		//	0
+  ih_331	=	331	,		//	0
+  ih_332	=	332	,		//	0
+  ih_333	=	333	,		//	0
+  ih_334	=	334	,		//	0
+  ih_335	=	335	,		//	0
+  ih_336	=	336	,		//	0
+  ih_337	=	337	,		//	0
+  ih_338	=	338	,		//	0
+  ih_339	=	339	,		//	0
+  ih_340	=	340	,		//	0
+  ih_341	=	341	,		//	0
+  ih_342	=	342	,		//	0
+  ih_343	=	343	,		//	0
+  ih_344	=	344	,		//	0
+  ih_345	=	345	,		//	0
+  ih_346	=	346	,		//	0
+  ih_347	=	347	,		//	0
+  ih_348	=	348	,		//	0
+  ih_349	=	349	,		//	0
+  ih_350	=	350	,		//	0
+  ih_351	=	351	,		//	0
+  ih_352	=	352	,		//	0
+  ih_353	=	353	,		//	0
+  ih_354	=	354	,		//	0
+  ih_355	=	355	,		//	0
+  ih_356	=	356	,		//	0
+  ih_357	=	357	,		//	0
+  ih_358	=	358	,		//	0
+  ih_359	=	359	,		//	0
+  ih_360	=	360	,		//	0
+  ih_361	=	361	,		//	0
+  ih_362	=	362	,		//	0
+  ih_363	=	363	,		//	0
+  ih_364	=	364	,		//	0
+  ih_365	=	365	,		//	0
+  ih_366	=	366	,		//	0
+  ih_367	=	367	,		//	0
+  ih_368	=	368	,		//	0
+  ih_369	=	369	,		//	0
+  ih_370	=	370	,		//	0
+  ih_371	=	371	,		//	0
+  ih_372	=	372	,		//	0
+  ih_373	=	373	,		//	0
+  ih_374	=	374	,		//	0
+  ih_375	=	375	,		//	0
+  ih_376	=	376	,		//	0
+  ih_377	=	377	,		//	0
+  ih_378	=	378	,		//	0
+  ih_379	=	379	,		//	0
+  ih_380	=	380	,		//	0
+  ih_381	=	381	,		//	0
+  ih_382	=	382	,		//	0
+  ih_383	=	383	,		//	0
+  ih_384	=	384	,		//	0
+  ih_385	=	385	,		//	0
+  ih_386	=	386	,		//	0
+  ih_387	=	387	,		//	0
+  ih_388	=	388	,		//	0
+  ih_389	=	389	,		//	0
+  ih_390	=	390	,		//	0
+  ih_391	=	391	,		//	0
+  ih_392	=	392	,		//	0
+  ih_393	=	393	,		//	0
+  ih_394	=	394	,		//	0
+  ih_395	=	395	,		//	0
+  ih_396	=	396	,		//	0
+  ih_397	=	397	,		//	0
+  ih_398	=	398	,		//	0
+  ih_399	=	399	,		//	0
+  ih_400	=	400	,		//	0
+  ih_401	=	401	,		//	0
+  ih_402	=	402	,		//	0
+  ih_403	=	403	,		//	0
+  ih_404	=	404	,		//	0
+  ih_405	=	405	,		//	0
+  ih_406	=	406	,		//	0
+  ih_407	=	407	,		//	0
+  ih_408	=	408	,		//	0
+  ih_409	=	409	,		//	0
   ISECND	=	410	,		//	0			ISECND = current simulation time HH:MM:SS - number of seconds (SS), reported in microseconds (0-59,999,999)
 
   // ---------------------------------------------------------------------
@@ -481,8 +481,11 @@ Opm::RestartIO::InteHEAD::wellTableDimensions(const WellTableDim& wtdim)
 {
     this->data_[NWELLS] = wtdim.numWells;
     this->data_[NCWMAX] = wtdim.maxPerf;
-    this->data_[NWGMAX] = wtdim.maxWellInGroup;
-    this->data_[NGMAXZ] = wtdim.maxGroupInField;
+
+    this->data_[NWGMAX] = std::max(wtdim.maxWellInGroup,
+                                   wtdim.maxGroupInField);
+
+    this->data_[NGMAXZ] = wtdim.maxGroupInField + 1;
 
     return *this;
 }
@@ -539,7 +542,6 @@ params_NCON(const int niconz, const int nsconz, const int nxconz)
     return *this;
 }
 
-
 Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::
 params_GRPZ(const std::array<int, 4>& grpz)
@@ -551,7 +553,6 @@ params_GRPZ(const std::array<int, 4>& grpz)
 
     return *this;
 }
-
 
 Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::
@@ -584,7 +585,6 @@ stepParam(const int tstep, const int repstep)
     return *this;
 }
 
-
 Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::tuningParam(const TuningPar& tunpar)
 {
@@ -598,13 +598,16 @@ Opm::RestartIO::InteHEAD::tuningParam(const TuningPar& tunpar)
     return *this;
 }
 
-
 Opm::RestartIO::InteHEAD&
-Opm::RestartIO::InteHEAD::variousParam(const int iprog, const int ih101, const int ih103)
+Opm::RestartIO::InteHEAD::variousParam(const int version,
+                                       const int iprog)
 {
-    this->data_[IPROG]  = iprog;
-    this->data_[ih_101] = ih101;
-    this->data_[ih_103] = ih103;
+    this->data_[VERSION] = version;
+    this->data_[IPROG]   = iprog;
+    this->data_[ih_076]  = 2;
+    this->data_[ih_101]  = 1;
+    this->data_[ih_103]  = 1;
+    this->data_[ih_200]  = 1;
 
     return *this;
 }

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -1,0 +1,633 @@
+#include <opm/output/eclipse/InteHEAD.hpp>
+
+#include <utility>
+#include <vector>
+
+enum index : std::vector<int>::size_type {
+  ISNUM	=	0	,		//	0	0		An encoded integer corresponding to the time the file was created. For files not originating from ECLIPSE, this value may be set to zero.
+  METRIC	=	1	,		//	0	0		
+  UNIT	=	2	,		//	(1,2,3)	1		units type: 1 - METRIC, 2 - FIELD, 3 - LAB
+  ih_003	=	3	,		//	0	0		
+  ih_004	=	4	,		//	0	0		
+  ih_005	=	5	,		//	0	0		
+  ih_006	=	6	,		//	0	0		
+  ih_007	=	7	,		//	0	0		
+  NX	=	8	,		//	NX	137		Grid x-direction dimension, NX
+  NY	=	9	,		//	NY	236		Grid x-direction dimension, NY
+  NZ	=	10	,		//	NZ	58		Grid x-direction dimension, NZ
+  NACTIV	=	11	,		//	NACTIV?	89022		NACTIV = number of active cells
+  ih_012	=	12	,		//	0	0		
+  ih_013	=	13	,		//	0	0		
+  PHASE	=	14	,		//	IPHS	7		IPHS = phase indicator: 1 - oil, 2 - water, 3 - oil/water, 4 - gas, 5 – oil/gas, 6 - gas/water, 7 - oil/water/gas (ECLIPSE output only)
+  ih_015	=	15	,		//	0	0		
+  NWELLS	=	16	,		//	NWELLS	39		NWELL = number of wells
+  NCWMAX	=	17	,		//	NCWMAX	108	Weldims item2	NCWMAX = maximum number of completions per well
+  ih_018	=	18	,		//	NGRP?	0	Number of actual groups	
+  NWGMAX	=	19	,		//	NWGMAX	0	maximum of weldims item3 or item4	NWGMAX = maximum number of wells in any well group
+  NGMAXZ	=	20	,		//	NGMAXZ	0	weldims item3 + 1	NGMAXZ = maximum number of groups in field
+  ih_021	=	21	,		//	0	0		
+  ih_022	=	22	,		//	0	0		
+  ih_023	=	23	,		//	0	0		
+  NIWELZ	=	24	,		//	NIWELZ	155	155	NIWELZ = no of data elements per well in IWEL array (default 97 for ECLIPSE, 94 for ECLIPSE 300)
+  NSWELZ	=	25	,		//	NSWELZ	122	122	NSWELZ = number of daelements per well in SWEL array
+  NXWELZ	=	26	,		//	NXWELZ	130	130	NXWELZ = number of delements per well in XWEL array
+  NZWELZ	=	27	,		//	NZWEL	3	3	NZWEL = no of 8-character words per well in ZWEL array (= 3)
+  ih_028	=	28	,		//	0	0		
+  ih_029	=	29	,		//	0	0		
+  ih_030	=	30	,		//	0	0		
+  ih_031	=	31	,		//	0	0		
+  NICONZ	=	32	,		//	25	15	25	NICON = no of data elements per completion in ICON array (default 19)
+  NSCONZ	=	33	,		//	40	0		NSCONZ = number of data elements per completion in SCON array
+  NXCONZ	=	34	,		//	58	0	58	NXCONZ = number of data elements per completion in XCON array
+  ih_035	=	35	,		//	0	0		
+  NIGRPZ	=	36	,		//	97+intehead_array[19]	0	97 + intehead[19]	NIGRPZ = no of data elements per group in IGRP array
+  NSGRPZ	=	37	,		//	112	0	112	NSGRPZ = number of data elements per group in SGRP array
+  NXGRPZ	=	38	,		//	180	0	180	NXGRPZ = number of data elements per group in XGRP array
+  NZGRPZ	=	39	,		//	5	0		NZGRPZ = number of data elements per group in ZGRP array
+  ih_040	=	40	,		//	0	0		
+  NCAMAX	=	41	,		//	1	0		NCAMAX = maximum number of analytic aquifer connections
+  NIAAQZ	=	42	,		//	18	0		NIAAQZ = number of data elements per aquifer in IAAQ array
+  NSAAQZ	=	43	,		//	24	0		NSAAQZ = number of data elements per aquifer in SAAQ array
+  NXAAQZ	=	44	,		//	10	0		NXAAQZ = number of data elements per aquifer in XAAQ array
+  NICAQZ	=	45	,		//	7	0		NSCAQZ= number of data elements per aquifer connection in SCAQ array
+  NSCAQZ	=	46	,		//	2	0		
+  NACAQZ	=	47	,		//	4	0		
+  ih_048	=	48	,		//	0	0		
+  ih_049	=	49	,		//	0	0		
+  ih_050	=	50	,		//	0	0		
+  ih_051	=	51	,		//	0	0		
+  ih_052	=	52	,		//	0	0		
+  ih_053	=	53	,		//	0	0		
+  ih_054	=	54	,		//	0	0		
+  ih_055	=	55	,		//	0	0		
+  ih_056	=	56	,		//	0	0		
+  ih_057	=	57	,		//	0	0		
+  ih_058	=	58	,		//	0	0		
+  ih_059	=	59	,		//	0	0		
+  ih_060	=	60	,		//	0	0		
+  ih_061	=	61	,		//	0	0		
+  ih_062	=	62	,		//	0	0		
+  ih_063	=	63	,		//	0	0		
+  DAY	=	64	,		//	IDAY	2		IDAY = calendar day at this report time
+  MONTH	=	65	,		//	IMON	6		IMON = calendar month at this report time
+  YEAR	=	66	,		//	IYEAR	2016		IYEAR = calendar year at this report time
+  TSTEP	=	67	,		//	CurrentTimestep	0		
+  REPSTEP	=	68	,		//	CurrentReportStep	0		
+  ih_069	=	69	,		//	0	0		
+  ih_070	=	70	,		//	0	0		
+  ih_071	=	71	,		//	0	0		
+  ih_072	=	72	,		//	0	0		
+  ih_073	=	73	,		//	0	0		
+  ih_074	=	74	,		//	0	0		
+  ih_075	=	75	,		//	0	0		
+  ih_076	=	76	,		//	0	0	2	
+  ih_077	=	77	,		//	0	0		
+  ih_078	=	78	,		//	0	0		
+  ih_079	=	79	,		//	0	0		
+  NEWTMX	=	80	,		//	0	0	Tuning,Record3,Item1	
+  NEWTMN	=	81	,		//	0	0	Tuning,Record3,Item2	
+  LITMAX	=	82	,		//	0	0	Tuning,Record3,Item3	
+  LITMIN	=	83	,		//	0	0	Tuning,Record3,Item4	
+  MXWSIT	=	84	,		//	0	0		
+  MXWPIT	=	85	,		//	0	0		
+  ih_086	=	86	,		//	0	0	Tuning,Record3,Item5	
+  ih_087	=	87	,		//	0	0	Tuning,Record3,Item6	
+  NTFIP 	=	88	,		//	0	0	REGDIMS item1, or TABDIMS item 5	
+  ih_089	=	89	,		//	0	0		
+  ih_090	=	90	,		//	0	0		
+  ih_091	=	91	,		//	0	0		
+  ih_092	=	92	,		//	0	0		
+  ih_093	=	93	,		//	0	0		
+  IPROG		=	94	,		//	0	100		IPROG = simulation program identifier:  100 - ECLIPSE 100, 300 - ECLIPSE 300, 500 - ECLIPSE 300 (thermal option), negative - Other simulator
+  INITSIZE	=	95	,		//	0	0		
+  ih_096	=	96	,		//	0	0		
+  ih_097	=	97	,		//	0	0		
+  ih_098	=	98	,		//	0	0		
+  NMFIPR	=	99	,		//	0	0	 REGDIMS item2	
+  ih_100	=	100	,		//	0	0		
+  ih_101	=	101	,		//	0	0	1	
+  ih_102	=	102	,		//	0	0		
+  ih_103	=	103	,		//	0	0	1	
+  ih_104	=	104	,		//	0	0		
+  ih_105	=	105	,		//	0	0		
+  ih_106	=	106	,		//	0	0		
+  ih_107	=	107	,		//	0	0		
+  ih_108	=	108	,		//	0	0		
+  ih_109	=	109	,		//	0	0		
+  ih_110	=	110	,		//	0	0		
+  ih_111	=	111	,		//	0	0		
+  ih_112	=	112	,		//	0	0		
+  ih_113	=	113	,		//	0	0		
+  ih_114	=	114	,		//	0	0		
+  ih_115	=	115	,		//	0	0		
+  ih_116	=	116	,		//	0	0		
+  ih_117	=	117	,		//	0	0		
+  ih_118	=	118	,		//	0	0		
+  ih_119	=	119	,		//	0	0		
+  ih_120	=	120	,		//	0	0		
+  ih_121	=	121	,		//	0	0		
+  ih_122	=	122	,		//	0	0		
+  ih_123	=	123	,		//	0	0		
+  ih_124	=	124	,		//	0	0		
+  ih_125	=	125	,		//	0	0		
+  ih_126	=	126	,		//	0	0		
+  ih_127	=	127	,		//	0	0		
+  ih_128	=	128	,		//	0	0		
+  ih_129	=	129	,		//	0	0		
+  ih_130	=	130	,		//	0	0		
+  NODMAX	=	131	,		//	0	0		NODMAX = maximum number of nodes in extended network option
+  NBRMAX	=	132	,		//	0	0		NBRMAX = maximum number of branches in extended network option
+  NIBRAN	=	133	,		//	0	0		NIBRAN = number of entries per branch in the IBRAN array
+  NRBRAN	=	134	,		//	0	0		NRBRAN = number of tries per branch in the RBRAN array
+  NINODE	=	135	,		//	0	0		NINODE = number of entries per node in the INODE array
+  NRNODE	=	136	,		//	0	0		NRNODE = number of entries per node in the RNODE array
+  NZNODE	=	137	,		//	0	0		NZNODE = number of entries per node in the ZNODE array
+  NINOBR	=	138	,		//	0	0		NINOBR = size of the INOBR array
+  ih_139	=	139	,		//	0	0		
+  ih_140	=	140	,		//	0	0		
+  ih_141	=	141	,		//	0	0		
+  ih_142	=	142	,		//	0	0		
+  ih_143	=	143	,		//	0	0		
+  ih_144	=	144	,		//	0	0		
+  ih_145	=	145	,		//	0	0		
+  ih_146	=	146	,		//	0	0		
+  ih_147	=	147	,		//	0	0		
+  ih_148	=	148	,		//	0	0		
+  ih_149	=	149	,		//	0	0		
+  ih_150	=	150	,		//	0	0		
+  ih_151	=	151	,		//	0	0		
+  ih_152	=	152	,		//	0	0		
+  ih_153	=	153	,		//	0	0		
+  ih_154	=	154	,		//	0	0		
+  ih_155	=	155	,		//	0	0		
+  ih_156	=	156	,		//	0	0		
+  ih_157	=	157	,		//	0	0		
+  ih_158	=	158	,		//	0	0		
+  ih_159	=	159	,		//	0	0		
+  ih_160	=	160	,		//	0	0		
+  ih_161	=	161	,		//	0	0		
+  NGCAUS	=	162	,		//	0	0		NGCAUS = maximum number of aquifer connections actually used.
+  ih_163	=	163	,		//	0	0		
+  ih_164	=	164	,		//	0	0		
+  ih_165	=	165	,		//	0	0		
+  ih_166	=	166	,		//	0	0		
+  ih_167	=	167	,		//	0	0		
+  ih_168	=	168	,		//	0	0		
+  ih_169	=	169	,		//	0	0		
+  ih_170	=	170	,		//	0	0		
+  ih_171	=	171	,		//	0	0		
+  ih_172	=	172	,		//	0	0		
+  ih_173	=	173	,		//	0	0		
+  NSEGWL	=	174	,		//	0	0	number of mswm wells defined with WELSEG	
+  NSWLMX	=	175	,		//	NSWLMX	0	Item 1 in WSEGDIMS keyword (runspec section)	NSWLMX = maximum number of segmented wells
+  NSEGMX	=	176	,		//	NSEGMX	0	Item 2 in WSEGDIMS keyword (runspec section)	NSEGMX = maximum number of segments per well
+  NLBRMX	=	177	,		//	NLBRMX	0	Item 3 in WSEGDIMS keyword (runspec section)	NLBRMX = maximum number of lateral branches per well
+  NISEGZ	=	178	,		//	22	0	22	NISEGZ = number of entries per segment in ISEG array
+  NRSEGZ	=	179	,		//	140	0	140	NRSEGZ = number of entries per segment in RSEG array
+  NILBRZ	=	180	,		//	10		10	NILBRZ = number of entries per segment in ILBR array
+  RSTSIZE	=	181	,		//	0			
+  ih_182	=	182	,		//	0			
+  ih_183	=	183	,		//	0			
+  ih_184	=	184	,		//	0			
+  ih_185	=	185	,		//	0			
+  ih_186	=	186	,		//	0			
+  ih_187	=	187	,		//	0			
+  ih_188	=	188	,		//	0			
+  ih_189	=	189	,		//	0			
+  ih_190	=	190	,		//	0			
+  ih_191	=	191	,		//	0			
+  ih_192	=	192	,		//	0			
+  ih_193	=	193	,		//	0			
+  ih_194	=	194	,		//	0			
+  ih_195	=	195	,		//	0			
+  ih_196	=	196	,		//	0			
+  ih_197	=	197	,		//	0			
+  ih_198	=	198	,		//	0			
+  ih_199	=	199	,		//	0			
+  ih_200	=	200	,		//	0			
+  ih_201	=	201	,		//	0			
+  ih_202	=	202	,		//	0			
+  ih_203	=	203	,		//	0			
+  ih_204	=	204	,		//	0			
+  ih_205	=	205	,		//	0			
+  IHOURZ	=	206	,		//	IHOURZ			IHOURZ = current simulation time HH:MM:SS – number of hours (HH) (0-23).
+  IMINTS	=	207	,		//	IMINTS			IMINTS = current simulation time HH:MM:SS - number of minutes (MM) (0-59).
+  ih_208	=	208	,		//	0			
+  ih_209	=	209	,		//	0			
+  ih_210	=	210	,		//	0			
+  ih_211	=	211	,		//	0			
+  ih_212	=	212	,		//	0			
+  ih_213	=	213	,		//	0			
+  ih_214	=	214	,		//	0			
+  ih_215	=	215	,		//	0			
+  ih_216	=	216	,		//	0			
+  ih_217	=	217	,		//	0			
+  ih_218	=	218	,		//	0			
+  ih_219	=	219	,		//	0			
+  ih_220	=	220	,		//	0			
+  ih_221	=	221	,		//	0			
+  ih_222	=	222	,		//	0			
+  NIIAQN	=	223	,		//	0			NIIAQN = number of lines of integer AQUNUM data.
+  NIRAQN	=	224	,		//	0			NIRAQN = number of lines of real AQUNUM data.
+  ih_225	=	225	,		//	0			
+  NUMAQN	=	226	,		//	0			NUMAQN = number of lines of AQUNUM data entered.
+  ih_227	=	227	,		//	0			
+  ih_228	=	228	,		//	0			
+  ih_229	=	229	,		//	0			
+  ih_230	=	230	,		//	0			
+  ih_231	=	231	,		//	0			
+  ih_232	=	232	,		//	0			
+  ih_233	=	233	,		//	0			
+  NICOTZ	=	234	,		//	0			NICOTZ = number of entries in the ICOT array
+  NXCOTZ	=	235	,		//	0			NXCOTZ = number of entries in the XCOT array
+  NIWETZ	=	236	,		//	0			NIWETZ = number of entries in the IWET array
+  NXWETZ	=	237	,		//	0			NXWETZ = number of entries in the XWET array
+  NIGRTZ	=	238	,		//	0			NIGRTZ = number of entries in the IGRT array
+  NXGRTZ	=	239	,		//	0			NXGRTZ = number of entries in the XGRT array
+  NSTRA2	=	240	,		//	0			NSTRA2 = number of tracers + 2
+  ih_241	=	241	,		//	0			
+  ih_242	=	242	,		//	0			
+  ih_243	=	243	,		//	0			
+  ih_244	=	244	,		//	0			
+  ih_245	=	245	,		//	0			
+  ih_246	=	246	,		//	0			
+  ih_247	=	247	,		//	0			
+  ih_248	=	248	,		//	0			
+  ih_249	=	249	,		//	0			
+  ih_250	=	250	,		//	0			
+  ih_251	=	251	,		//	0			
+  MAAQID	=	252	,		//	0			MAAQID = maximum number of analytic aquifers
+  ih_253	=	253	,		//	0			
+  ih_254	=	254	,		//	0			
+  ih_255	=	255	,		//	0			
+  ih_256	=	256	,		//	0			
+  ih_257	=	257	,		//	0			
+  ih_258	=	258	,		//	0			
+  ih_259	=	259	,		//	0			
+  ih_260	=	260	,		//	0			
+  ih_261	=	261	,		//	0			
+  ih_262	=	262	,		//	0			
+  ih_263	=	263	,		//	0			
+  ih_264	=	264	,		//	0			
+  ih_265	=	265	,		//	0			
+  ih_266	=	266	,		//	0			
+  ih_267	=	267	,		//	0			
+  ih_268	=	268	,		//	0			
+  ih_269	=	269	,		//	0			
+  ih_270	=	270	,		//	0			
+  NCRDMX	=	271	,		//	0			NCRDMX = maximum number of chord segment links per well
+  ih_272	=	272	,		//	0			
+  ih_273	=	273	,		//	0			
+  ih_274	=	274	,		//	0			
+  ih_275	=	275	,		//	0			
+  ih_276	=	276	,		//	0			
+  ih_277	=	277	,		//	0			
+  ih_278	=	278	,		//	0			
+  ih_279	=	279	,		//	0			
+  ih_280	=	280	,		//	0			
+  ih_281	=	281	,		//	0			
+  ih_282	=	282	,		//	0			
+  ih_283	=	283	,		//	0			
+  ih_284	=	284	,		//	0			
+  ih_285	=	285	,		//	0			
+  ih_286	=	286	,		//	0			
+  ih_287	=	287	,		//	0			
+  ih_288	=	288	,		//	0			
+  ih_289	=	289	,		//	0			
+  ih_290	=	290	,		//	0			
+  ih_291	=	291	,		//	0			
+  ih_292	=	292	,		//	0			
+  ih_293	=	293	,		//	0			
+  ih_294	=	294	,		//	0			
+  ih_295	=	295	,		//	0			
+  ih_296	=	296	,		//	0			
+  ih_297	=	297	,		//	0			
+  ih_298	=	298	,		//	0			
+  ih_299	=	299	,		//	0			
+  ih_300	=	300	,		//	0			
+  ih_301	=	301	,		//	0			
+  ih_302	=	302	,		//	0			
+  ih_303	=	303	,		//	0			
+  ih_304	=	304	,		//	0			
+  ih_305	=	305	,		//	0			
+  ih_306	=	306	,		//	0			
+  ih_307	=	307	,		//	0			
+  ih_308	=	308	,		//	0			
+  ih_309	=	309	,		//	0			
+  ih_310	=	310	,		//	0			
+  ih_311	=	311	,		//	0			
+  ih_312	=	312	,		//	0			
+  ih_313	=	313	,		//	0			
+  ih_314	=	314	,		//	0			
+  ih_315	=	315	,		//	0			
+  ih_316	=	316	,		//	0			
+  ih_317	=	317	,		//	0			
+  ih_318	=	318	,		//	0			
+  ih_319	=	319	,		//	0			
+  ih_320	=	320	,		//	0			
+  ih_321	=	321	,		//	0			
+  ih_322	=	322	,		//	0			
+  ih_323	=	323	,		//	0			
+  ih_324	=	324	,		//	0			
+  ih_325	=	325	,		//	0			
+  ih_326	=	326	,		//	0			
+  ih_327	=	327	,		//	0			
+  ih_328	=	328	,		//	0			
+  ih_329	=	329	,		//	0			
+  ih_330	=	330	,		//	0			
+  ih_331	=	331	,		//	0			
+  ih_332	=	332	,		//	0			
+  ih_333	=	333	,		//	0			
+  ih_334	=	334	,		//	0			
+  ih_335	=	335	,		//	0			
+  ih_336	=	336	,		//	0			
+  ih_337	=	337	,		//	0			
+  ih_338	=	338	,		//	0			
+  ih_339	=	339	,		//	0			
+  ih_340	=	340	,		//	0			
+  ih_341	=	341	,		//	0			
+  ih_342	=	342	,		//	0			
+  ih_343	=	343	,		//	0			
+  ih_344	=	344	,		//	0			
+  ih_345	=	345	,		//	0			
+  ih_346	=	346	,		//	0			
+  ih_347	=	347	,		//	0			
+  ih_348	=	348	,		//	0			
+  ih_349	=	349	,		//	0			
+  ih_350	=	350	,		//	0			
+  ih_351	=	351	,		//	0			
+  ih_352	=	352	,		//	0			
+  ih_353	=	353	,		//	0			
+  ih_354	=	354	,		//	0			
+  ih_355	=	355	,		//	0			
+  ih_356	=	356	,		//	0			
+  ih_357	=	357	,		//	0			
+  ih_358	=	358	,		//	0			
+  ih_359	=	359	,		//	0			
+  ih_360	=	360	,		//	0			
+  ih_361	=	361	,		//	0			
+  ih_362	=	362	,		//	0			
+  ih_363	=	363	,		//	0			
+  ih_364	=	364	,		//	0			
+  ih_365	=	365	,		//	0			
+  ih_366	=	366	,		//	0			
+  ih_367	=	367	,		//	0			
+  ih_368	=	368	,		//	0			
+  ih_369	=	369	,		//	0			
+  ih_370	=	370	,		//	0			
+  ih_371	=	371	,		//	0			
+  ih_372	=	372	,		//	0			
+  ih_373	=	373	,		//	0			
+  ih_374	=	374	,		//	0			
+  ih_375	=	375	,		//	0			
+  ih_376	=	376	,		//	0			
+  ih_377	=	377	,		//	0			
+  ih_378	=	378	,		//	0			
+  ih_379	=	379	,		//	0			
+  ih_380	=	380	,		//	0			
+  ih_381	=	381	,		//	0			
+  ih_382	=	382	,		//	0			
+  ih_383	=	383	,		//	0			
+  ih_384	=	384	,		//	0			
+  ih_385	=	385	,		//	0			
+  ih_386	=	386	,		//	0			
+  ih_387	=	387	,		//	0			
+  ih_388	=	388	,		//	0			
+  ih_389	=	389	,		//	0			
+  ih_390	=	390	,		//	0			
+  ih_391	=	391	,		//	0			
+  ih_392	=	392	,		//	0			
+  ih_393	=	393	,		//	0			
+  ih_394	=	394	,		//	0			
+  ih_395	=	395	,		//	0			
+  ih_396	=	396	,		//	0			
+  ih_397	=	397	,		//	0			
+  ih_398	=	398	,		//	0			
+  ih_399	=	399	,		//	0			
+  ih_400	=	400	,		//	0			
+  ih_401	=	401	,		//	0			
+  ih_402	=	402	,		//	0			
+  ih_403	=	403	,		//	0			
+  ih_404	=	404	,		//	0			
+  ih_405	=	405	,		//	0			
+  ih_406	=	406	,		//	0			
+  ih_407	=	407	,		//	0			
+  ih_408	=	408	,		//	0			
+  ih_409	=	409	,		//	0		
+  ISECND	=	410	,		//	0			ISECND = current simulation time HH:MM:SS - number of seconds (SS), reported in microseconds (0-59,999,999)
+
+  // ---------------------------------------------------------------------
+  // ---------------------------------------------------------------------
+
+  INTEHEAD_NUMBER_OF_ITEMS        // MUST be last element of enum.
+};
+
+// =====================================================================
+// Public Interface Below Separator
+// =====================================================================
+
+Opm::RestartIO::InteHEAD::InteHEAD()
+    : data_(INTEHEAD_NUMBER_OF_ITEMS, 0)
+{}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::
+dimensions(const int nx, const int ny, const int nz)
+{
+    this -> data_[NX] = nx;
+    this -> data_[NY] = ny;
+    this -> data_[NZ] = nz;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::
+dimensions(const std::array<int,3>& cartDims)
+{
+    return this->dimensions(cartDims[0], cartDims[1], cartDims[2]);
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::numActive(const int nactive)
+{
+    this->data_[NACTIV] = nactive;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::unitConventions(const UnitSystem& usys)
+{
+    const auto unit = [&usys]()
+    {
+        switch (usys) {
+        case UnitSystem::Metric: return 1;
+        case UnitSystem::Field:  return 2;
+        case UnitSystem::Lab:    return 3;
+        case UnitSystem::PVT_M:  return 4;
+        }
+
+        return 1;
+    }();
+
+    this->data_[UNIT] = unit;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::wellTableDimensions(const WellTableDim& wtdim)
+{
+    this->data_[NWELLS] = wtdim.numWells;
+    this->data_[NCWMAX] = wtdim.maxPerf;
+    this->data_[NWGMAX] = wtdim.maxWellInGroup;
+    this->data_[NGMAXZ] = wtdim.maxGroupInField;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::calenderDate(const Date& date)
+{
+    this->data_[DAY]   = date.day;
+    this->data_[MONTH] = date.month;
+    this->data_[YEAR]  = date.year;
+
+    this->data_[IHOURZ] = date.hour;
+    this->data_[IMINTS] = date.minute;
+
+    // Microseonds...
+    this->data_[ISECND] = (date.second * 1000) * 1000;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::activePhases(const Phases& phases)
+{
+    const auto iphs =
+        (static_cast<unsigned int>  (phases.oil)   << 0u)
+        | (static_cast<unsigned int>(phases.water) << 1u)
+        | (static_cast<unsigned int>(phases.gas)   << 2u);
+
+    this->data_[PHASE] = static_cast<int>(iphs);
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::
+params_NWELZ(const int niwelz, const int nswelz, const int nxwelz, const int nzwelz)
+{
+    this -> data_[NIWELZ] = niwelz;
+    this -> data_[NSWELZ] = nswelz;
+    this -> data_[NXWELZ] = nxwelz;
+    this -> data_[NZWELZ] = nzwelz;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::
+params_NCON(const int niconz, const int nsconz, const int nxconz)
+{
+    this -> data_[NICONZ] = niconz;
+    this -> data_[NSCONZ] = nsconz;
+    this -> data_[NXCONZ] = nxconz;
+
+    return *this;
+}
+
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::
+params_GRPZ(const std::array<int, 4>& grpz)
+{
+    this -> data_[NIGRPZ] = grpz[0];
+    this -> data_[NSGRPZ] = grpz[1];
+    this -> data_[NXGRPZ] = grpz[2];
+    this -> data_[NZGRPZ] = grpz[3];
+
+    return *this;
+}
+
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::
+params_NAAQZ(const int ncamax,
+             const int niaaqz,
+             const int nsaaqz,
+             const int nxaaqz,
+             const int nicaqz,
+             const int nscaqz,
+             const int nacaqz)
+{
+    this -> data_[NCAMAX] = ncamax;
+    this -> data_[NIAAQZ] = niaaqz;
+    this -> data_[NSAAQZ] = nsaaqz;
+    this -> data_[NXAAQZ] = nxaaqz;
+    this -> data_[NICAQZ] = nicaqz;
+    this -> data_[NSCAQZ] = nscaqz;
+    this -> data_[NACAQZ] = nacaqz;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::
+stepParam(const int tstep, const int repstep)
+{
+    this -> data_[TSTEP] = tstep;
+    this -> data_[REPSTEP] = repstep;
+
+    return *this;
+}
+
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::tuningParam(const TuningPar& tunpar)
+{
+    this->data_[NEWTMX] = tunpar.newtmx;
+    this->data_[NEWTMN] = tunpar.newtmn;
+    this->data_[LITMAX] = tunpar.litmax;
+    this->data_[LITMIN] = tunpar.litmin;
+    this->data_[MXWSIT] = tunpar.mxwsit;
+    this->data_[MXWPIT] = tunpar.mxwpit;
+
+    return *this;
+}
+
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::variousParam(const int iprog, const int ih101, const int ih103)
+{
+    this->data_[IPROG]  = iprog;
+    this->data_[ih_101] = ih101;
+    this->data_[ih_103] = ih103;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::wellSegDimensions(const WellSegDims& wsdim)
+{
+    this->data_[NSEGWL] = wsdim.nsegwl;
+    this->data_[NSWLMX] = wsdim.nswlmx;
+    this->data_[NSEGMX] = wsdim.nsegmx;
+    this->data_[NLBRMX] = wsdim.nlbrmx;
+    this->data_[NISEGZ] = wsdim.nisegz;
+    this->data_[NRSEGZ] = wsdim.nrsegz;
+    this->data_[NILBRZ] = wsdim.nilbrz;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::regionDimensions(const RegDims& rdim)
+{
+    this->data_[NTFIP]  = rdim.ntfip;
+    this->data_[NMFIPR] = rdim.nmfipr;
+
+    return *this;
+}

--- a/src/opm/output/eclipse/LogiHEAD.cpp
+++ b/src/opm/output/eclipse/LogiHEAD.cpp
@@ -1,0 +1,165 @@
+#include <opm/output/eclipse/LogiHEAD.hpp>
+
+#include <utility>
+#include <vector>
+
+enum index : std::vector<int>::size_type {
+lh_000	=	0	,		//	TRUE
+lh_001	=	1	,		//	TRUE
+lh_002	=	2	,		//	FALSE
+lh_003	=	3	,		//	FALSE		Flag set to FALSE for a non-radial model, TRUE for a radial model (ECLIPSE 300 and other simulators)
+lh_004	=	4	,		//	FALSE		Flag set to FALSE for a non-radial model, TRUE for a radial model (ECLIPSE 100)
+lh_005	=	5	,		//	FALSE
+lh_006	=	6	,		//	FALSE
+lh_007	=	7	,		//	FALSE
+lh_008	=	8	,		//	FALSE
+lh_009	=	9	,		//	FALSE
+lh_010	=	10	,		//	FALSE
+lh_011	=	11	,		//	FALSE
+lh_012	=	12	,		//	FALSE
+lh_013	=	13	,		//	FALSE
+lh_014	=	14	,		//	FALSE		Flag for dual porosity model
+lh_015	=	15	,		//	FALSE
+lh_016	=	16	,		//	TRUE
+lh_017	=	17	,		//	FALSE
+lh_018	=	18	,		//	TRUE
+lh_019	=	19	,		//
+lh_020	=	20	,		//	FALSE
+lh_021	=	21	,		//	FALSE
+lh_022	=	22	,		//	FALSE
+lh_023	=	23	,		//	FALSE
+lh_024	=	24	,		//	FALSE
+lh_025	=	25	,		//	FALSE
+lh_026	=	26	,		//	FALSE
+lh_027	=	27	,		//	FALSE
+lh_028	=	28	,		//	FALSE
+lh_029	=	29	,		//	FALSE
+lh_030	=	30	,		//	FALSE		Flag for coalbed methane (ECLIPSE 100)
+lh_031	=	31	,		//	TRUE
+lh_032	=	32	,		//	FALSE
+lh_033	=	33	,		//	FALSE
+lh_034	=	34	,		//	FALSE
+lh_035	=	35	,		//	FALSE
+lh_036	=	36	,		//	FALSE
+lh_037	=	37	,		//
+lh_038	=	38	,		//	FALSE
+lh_039	=	39	,		//	FALSE
+lh_040	=	40	,		//	FALSE
+lh_041	=	41	,		//	FALSE
+lh_042	=	42	,		//	FALSE
+lh_043	=	43	,		//
+lh_044	=	44	,		//	TRUE
+lh_045	=	45	,		//	FALSE
+lh_046	=	46	,		//	FALSE
+lh_047	=	47	,		//	FALSE
+lh_048	=	48	,		//
+lh_049	=	49	,		//	FALSE
+lh_050	=	50	,		//	FALSE
+lh_051	=	51	,		//	FALSE
+lh_052	=	52	,		//	FALSE
+lh_053	=	53	,		//	FALSE
+lh_054	=	54	,		//	FALSE
+lh_055	=	55	,		//	FALSE
+lh_056	=	56	,		//	FALSE
+lh_057	=	57	,		//	FALSE
+lh_058	=	58	,		//	FALSE
+lh_059	=	59	,		//	FALSE
+lh_060	=	60	,		//	FALSE
+lh_061	=	61	,		//	FALSE
+lh_062	=	62	,		//	FALSE
+lh_063	=	63	,		//	FALSE
+lh_064	=	64	,		//	FALSE
+lh_065	=	65	,		//	FALSE
+lh_066	=	66	,		//	FALSE
+lh_067	=	67	,		//	FALSE
+lh_068	=	68	,		//	FALSE
+lh_069	=	69	,		//	FALSE
+lh_070	=	70	,		//	FALSE
+lh_071	=	71	,		//	FALSE
+lh_072	=	72	,		//	FALSE
+lh_073	=	73	,		//	FALSE
+lh_074	=	74	,		//	FALSE
+lh_075	=	75	,		//	TRUE	If segmented well model is used
+lh_076	=	76	,		//	TRUE
+lh_077	=	77	,		//	FALSE
+lh_078	=	78	,		//	FALSE
+lh_079	=	79	,		//	FALSE
+lh_080	=	80	,		//	FALSE
+lh_081	=	81	,		//	FALSE
+lh_082	=	82	,		//	FALSE
+lh_083	=	83	,		//	FALSE
+lh_084	=	84	,		//	FALSE
+lh_085	=	85	,		//	FALSE
+lh_086	=	86	,		//
+lh_087	=	87	,		//	TRUE
+lh_088	=	88	,		//	FALSE
+lh_089	=	89	,		//	FALSE
+lh_090	=	90	,		//	FALSE
+lh_091	=	91	,		//	FALSE
+lh_092	=	92	,		//	FALSE
+lh_093	=	93	,		//
+lh_094	=	94	,		//	FALSE
+lh_095	=	95	,		//	FALSE
+lh_096	=	96	,		//
+lh_097	=	97	,		//	FALSE
+lh_098	=	98	,		//	FALSE
+lh_099	=	99	,		//	TRUE
+lh_100	=	100	,		//	FALSE
+lh_101	=	101	,		//	FALSE
+lh_102	=	102	,		//	FALSE
+lh_103	=	103	,		//	FALSE
+lh_104	=	104	,		//	FALSE
+lh_105	=	105	,		//	FALSE
+lh_106	=	106	,		//	FALSE
+lh_107	=	107	,		//	FALSE
+lh_108	=	108	,		//	FALSE
+lh_109	=	109	,		//	FALSE
+lh_110	=	110	,		//	FALSE
+lh_111	=	111	,		//	FALSE
+lh_112	=	112	,		//	FALSE
+lh_113	=	113	,		//	TRUE
+lh_114	=	114	,		//	TRUE
+lh_115	=	115	,		//	TRUE
+lh_116	=	116	,		//	FALSE
+lh_117	=	117	,		//	TRUE
+lh_118	=	118	,		//	FALSE
+lh_119	=	119	,		//	FALSE
+lh_120	=	120	,		//	FALSE
+
+  // ---------------------------------------------------------------------
+  // ---------------------------------------------------------------------
+
+  LOGIHEAD_NUMBER_OF_ITEMS        // MUST be last element of enum.
+};
+
+// =====================================================================
+// Public Interface Below Separator
+// =====================================================================
+
+Opm::RestartIO::LogiHEAD::LogiHEAD()
+    : data_(LOGIHEAD_NUMBER_OF_ITEMS, false)
+{}
+
+Opm::RestartIO::LogiHEAD&
+Opm::RestartIO::LogiHEAD::
+variousParam(const bool e300_radial, const bool e100_radial, const int nswlmx)
+{
+    this -> data_[lh_000] = true;
+    this -> data_[lh_001] = true;
+    this -> data_[lh_003] = e300_radial;
+    this -> data_[lh_004] = e100_radial;
+    this -> data_[lh_016] = true;
+    this -> data_[lh_018] = true;
+    this -> data_[lh_031] = true;
+    this -> data_[lh_044] = true;
+    this -> data_[lh_075] = nswlmx >= 1; // True if MS Wells exist.
+    this -> data_[lh_076] = true;
+    this -> data_[lh_087] = true;
+    this -> data_[lh_099] = true;
+    this -> data_[lh_113] = true;
+    this -> data_[lh_114] = true;
+    this -> data_[lh_115] = true;
+    this -> data_[lh_117] = true;
+
+    return *this;
+}

--- a/tests/test_DoubHEAD.cpp
+++ b/tests/test_DoubHEAD.cpp
@@ -1,0 +1,91 @@
+/*
+  Copyright 2018 Statoil IT
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE DoubHEAD_Vector
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/DoubHEAD.hpp>
+
+#include <opm/output/eclipse/InteHEAD.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+
+#include <chrono>
+#include <ctime>
+#include <initializer_list>
+#include <numeric>              // partial_sum()
+#include <ratio>
+#include <vector>
+
+namespace {
+    using Day = std::chrono::duration<double,
+        std::ratio_multiply<std::chrono::hours::period, std::ratio<24>>
+    >;
+
+    std::chrono::time_point<std::chrono::system_clock> startSimulation()
+    {
+        // 2015-04-09T00:00:00+0000
+        auto timePoint = std::tm{};
+
+        timePoint.tm_year = 115;     // 2015
+        timePoint.tm_mon  =   4 - 1; // April
+        timePoint.tm_mday =   9;     // 9th
+
+        return std::chrono::system_clock::from_time_t(
+            ::Opm::RestartIO::makeUTCTime(timePoint));
+    }
+
+    std::chrono::duration<double, std::chrono::seconds::period> tstep_123()
+    {
+        return Day{ 123 };
+    }
+
+    Opm::RestartIO::DoubHEAD::TimeStamp
+    makeTStamp(std::chrono::time_point<std::chrono::system_clock>          start,
+               std::chrono::duration<double, std::chrono::seconds::period> elapsed)
+    {
+        return { start, elapsed };
+    }
+} // Anonymous
+
+BOOST_AUTO_TEST_SUITE(Member_Functions)
+
+BOOST_AUTO_TEST_CASE(Time_Stamp)
+{
+    const auto dh = Opm::RestartIO::DoubHEAD{}
+        .timeStamp(makeTStamp(startSimulation(), tstep_123()));
+
+    const auto& v = dh.data();
+
+    // Elapsed time in days.
+    BOOST_CHECK_CLOSE(v[1 - 1], 123.0, 1.0e-10);
+
+    // DateNum(startSimulation()) ==
+    //     floor(365.25 * 2015) + day_of_year(=99)
+    BOOST_CHECK_CLOSE(v[161 - 1], 736077.0, 1.0e-10);
+
+    // Start + elapsed (days)
+    BOOST_CHECK_CLOSE(v[162 - 1], 736200.0, 1.0e-10);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -1,0 +1,369 @@
+/*
+  Copyright 2018 Statoil IT
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE InteHEAD_Vector
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/InteHEAD.hpp>
+
+#include <array>
+#include <initializer_list>
+
+BOOST_AUTO_TEST_SUITE(Member_Functions)
+
+BOOST_AUTO_TEST_CASE(Dimensions_Individual)
+{
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .dimensions(100, 60, 15);
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[ 9 - 1], 100); // Nx
+    BOOST_CHECK_EQUAL(v[10 - 1],  60); // Ny
+    BOOST_CHECK_EQUAL(v[11 - 1],  15); // Nz
+}
+
+BOOST_AUTO_TEST_CASE(Dimensions_Array)
+{
+    const auto ih = Opm::RestartIO::InteHEAD{}
+    .dimensions({100, 60, 15});
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[ 9 - 1], 100); // Nx
+    BOOST_CHECK_EQUAL(v[10 - 1],  60); // Ny
+    BOOST_CHECK_EQUAL(v[11 - 1],  15); // Nz
+}
+
+BOOST_AUTO_TEST_CASE(NumActive)
+{
+    const auto ih = Opm::RestartIO::InteHEAD{}
+    .numActive(72390);
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[12 - 1], 72390); // NACTIVE
+}
+
+BOOST_AUTO_TEST_CASE(UnitConventions)
+{
+    using USys = Opm::RestartIO::InteHEAD::UnitSystem;
+
+    auto ih = Opm::RestartIO::InteHEAD{};
+
+    // Metric
+    {
+        ih.unitConventions(USys::Metric);
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[3 - 1], 1); // Unit
+    }
+
+    // Field
+    {
+        ih.unitConventions(USys::Field);
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[3 - 1], 2); // Unit
+    }
+
+    // Lab
+    {
+        ih.unitConventions(USys::Lab);
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[3 - 1], 3); // Unit
+    }
+
+    // PVT-M
+    {
+        ih.unitConventions(USys::PVT_M);
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[3 - 1], 4); // Unit
+    }
+}
+
+BOOST_AUTO_TEST_CASE(WellTableDimensions)
+{
+    const auto numWells        = 17;
+    const auto maxPerf         = 29;
+    const auto maxWellInGroup  =  3;
+    const auto maxGroupInField = 14;
+
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .wellTableDimensions({
+            numWells, maxPerf, maxWellInGroup, maxGroupInField
+        });
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[17 - 1], numWells);        // NWELLS
+    BOOST_CHECK_EQUAL(v[18 - 1], maxPerf);         // NCWMAX
+    BOOST_CHECK_EQUAL(v[20 - 1], maxWellInGroup);  // NWGMAX
+    BOOST_CHECK_EQUAL(v[21 - 1], maxGroupInField); // NGMAXZ
+}
+
+BOOST_AUTO_TEST_CASE(CalendarDate)
+{
+    // 2015-04-09T11:22:33+0000
+
+    const auto ih = Opm::RestartIO::InteHEAD{}
+    . calenderDate({
+            2015, 4, 9, 11, 22, 33
+        });
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[67 - 1], 2015); // Year
+    BOOST_CHECK_EQUAL(v[66 - 1],    4); // Month
+    BOOST_CHECK_EQUAL(v[65 - 1],    9); // Day
+
+    BOOST_CHECK_EQUAL(v[207 - 1], 11); // Hour
+    BOOST_CHECK_EQUAL(v[208 - 1], 22); // Minute
+    BOOST_CHECK_EQUAL(v[411 - 1], 33000000); // Second (in microseconds)
+}
+
+BOOST_AUTO_TEST_CASE(ActivePhases)
+{
+    using Ph = Opm::RestartIO::InteHEAD::Phases;
+    auto  ih = Opm::RestartIO::InteHEAD{};
+
+    // Oil
+    {
+        ih.activePhases(Ph{ 1, 0, 0 });
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[15 - 1], 1);
+    }
+
+    // Water
+    {
+        ih.activePhases(Ph{ 0, 1, 0 });
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[15 - 1], 2);
+    }
+
+    // Gas
+    {
+        ih.activePhases(Ph{ 0, 0, 1 });
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[15 - 1], 4);
+    }
+
+    // Oil/Water
+    {
+        ih.activePhases(Ph{ 1, 1, 0 });
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[15 - 1], 3);
+    }
+
+    // Oil/Gas
+    {
+        ih.activePhases(Ph{ 1, 0, 1 });
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[15 - 1], 5);
+    }
+
+    // Water/Gas
+    {
+        ih.activePhases(Ph{ 0, 1, 1 });
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[15 - 1], 6);
+    }
+
+    // Oil/Water/Gas
+    {
+        ih.activePhases(Ph{ 1, 1, 1 });
+
+        const auto& v = ih.data();
+
+        BOOST_CHECK_EQUAL(v[15 - 1], 7);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(NWell_Parameters)
+{
+    const auto ih = Opm::RestartIO::InteHEAD{}
+      .params_NWELZ(27, 18, 28, 1);
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[25 - 1], 27); // NIWELZ
+    BOOST_CHECK_EQUAL(v[26 - 1], 18); // NSWELZ
+    BOOST_CHECK_EQUAL(v[27 - 1], 28); // NXWELZ
+    BOOST_CHECK_EQUAL(v[28 - 1],  1); // NZWELZ
+}
+
+BOOST_AUTO_TEST_CASE(NConn_Parameters)
+{
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .params_NCON(31, 41, 59);
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[33 - 1], 31); // NICONZ
+    BOOST_CHECK_EQUAL(v[34 - 1], 41); // NSCONZ
+    BOOST_CHECK_EQUAL(v[35 - 1], 59); // NXCONZ
+}
+
+BOOST_AUTO_TEST_CASE(GroupSize_Parameters)
+{
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .params_GRPZ({ 577, 215, 664, 901 }); // https://oeis.org/A001620
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[37 - 1], 577); // NIGRPZ
+    BOOST_CHECK_EQUAL(v[38 - 1], 215); // NSGRPZ
+    BOOST_CHECK_EQUAL(v[39 - 1], 664); // NXGRPZ
+    BOOST_CHECK_EQUAL(v[40 - 1], 901); // NZGRPZ
+}
+
+BOOST_AUTO_TEST_CASE(Analytic_Aquifer_Parameters)
+{
+    // https://oeis.org/A001622
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .params_NAAQZ(1, 61, 803, 3988, 74989, 484820, 4586834);
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[42 - 1], 1);       // NCAMAX
+    BOOST_CHECK_EQUAL(v[43 - 1], 61);      // NIAAQZ
+    BOOST_CHECK_EQUAL(v[44 - 1], 803);     // NSAAQZ
+    BOOST_CHECK_EQUAL(v[45 - 1], 3988);    // NXAAQZ
+    BOOST_CHECK_EQUAL(v[46 - 1], 74989);   // NICAQZ
+    BOOST_CHECK_EQUAL(v[47 - 1], 484820);  // NSCAQZ
+    BOOST_CHECK_EQUAL(v[48 - 1], 4586834); // NACAQZ
+}
+
+BOOST_AUTO_TEST_CASE(Time_and_report_step)
+{
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .stepParam(12, 2);
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[67], 12);       // TSTEP
+    BOOST_CHECK_EQUAL(v[68],  2);      // REP_STEP
+
+}
+
+BOOST_AUTO_TEST_CASE(Tuning_param)
+{
+    const auto newtmx	= 17;
+    const auto newtmn	=  5;
+    const auto litmax	= 102;
+    const auto litmin	= 20;
+    const auto mxwsit	= 8;
+    const auto mxwpit	= 6;
+
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .tuningParam({
+            newtmx, newtmn, litmax, litmin, mxwsit, mxwpit
+        });
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[80], newtmx);        // NEWTMX
+    BOOST_CHECK_EQUAL(v[81], newtmn);        // NEWTMN
+    BOOST_CHECK_EQUAL(v[82], litmax);        // LITMAX
+    BOOST_CHECK_EQUAL(v[83], litmin);        // LITMIN
+    BOOST_CHECK_EQUAL(v[84], mxwsit);        // MXWSIT
+    BOOST_CHECK_EQUAL(v[85], mxwpit);        // MXWPIT
+}
+
+BOOST_AUTO_TEST_CASE(Various_Parameters)
+{
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .variousParam(100, 2, 3);
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[ 94], 100); // IPROG
+    BOOST_CHECK_EQUAL(v[101],   2); // IH_101
+    BOOST_CHECK_EQUAL(v[103],   3); // IH_103
+}
+
+BOOST_AUTO_TEST_CASE(wellSegDimensions)
+{
+    const auto nsegwl = 3;
+    const auto nswlmx = 4;
+    const auto nsegmx = 5;
+    const auto nlbrmx = 6;
+    const auto nisegz = 7;
+    const auto nrsegz = 8;
+    const auto nilbrz = 9;
+
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .wellSegDimensions({
+            nsegwl, nswlmx, nsegmx, nlbrmx, nisegz, nrsegz, nilbrz
+        });
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[174], nsegwl);
+    BOOST_CHECK_EQUAL(v[175], nswlmx);
+    BOOST_CHECK_EQUAL(v[176], nsegmx);
+    BOOST_CHECK_EQUAL(v[177], nlbrmx);
+    BOOST_CHECK_EQUAL(v[178], nisegz);
+    BOOST_CHECK_EQUAL(v[179], nrsegz);
+    BOOST_CHECK_EQUAL(v[180], nilbrz);
+}
+
+BOOST_AUTO_TEST_CASE(regionDimensions)
+{
+
+    const auto ntfip  = 12;
+    const auto nmfipr = 22;
+    const auto nrfreg = 5;
+    const auto ntfreg = 6;
+    const auto nplmix = 7;
+
+  const auto ih = Opm::RestartIO::InteHEAD{}
+        .regionDimensions({
+          ntfip, nmfipr, nrfreg, ntfreg, nplmix
+
+        });
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[88], ntfip);       // NTFIP
+    BOOST_CHECK_EQUAL(v[99], nmfipr);       // NMFIPR
+
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(Dimensions_Individual)
 BOOST_AUTO_TEST_CASE(Dimensions_Array)
 {
     const auto ih = Opm::RestartIO::InteHEAD{}
-    .dimensions({100, 60, 15});
+        .dimensions({100, 60, 15});
 
     const auto& v = ih.data();
 
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(Dimensions_Array)
 BOOST_AUTO_TEST_CASE(NumActive)
 {
     const auto ih = Opm::RestartIO::InteHEAD{}
-    .numActive(72390);
+        .numActive(72390);
 
     const auto& v = ih.data();
 
@@ -118,11 +118,12 @@ BOOST_AUTO_TEST_CASE(WellTableDimensions)
         });
 
     const auto& v = ih.data();
+    const auto nwgmax = std::max(maxWellInGroup, maxGroupInField);
 
-    BOOST_CHECK_EQUAL(v[17 - 1], numWells);        // NWELLS
-    BOOST_CHECK_EQUAL(v[18 - 1], maxPerf);         // NCWMAX
-    BOOST_CHECK_EQUAL(v[20 - 1], maxWellInGroup);  // NWGMAX
-    BOOST_CHECK_EQUAL(v[21 - 1], maxGroupInField); // NGMAXZ
+    BOOST_CHECK_EQUAL(v[17 - 1], numWells);            // NWELLS
+    BOOST_CHECK_EQUAL(v[18 - 1], maxPerf);             // NCWMAX
+    BOOST_CHECK_EQUAL(v[20 - 1], nwgmax);              // NWGMAX
+    BOOST_CHECK_EQUAL(v[21 - 1], maxGroupInField + 1); // NGMAXZ
 }
 
 BOOST_AUTO_TEST_CASE(CalendarDate)
@@ -130,7 +131,7 @@ BOOST_AUTO_TEST_CASE(CalendarDate)
     // 2015-04-09T11:22:33+0000
 
     const auto ih = Opm::RestartIO::InteHEAD{}
-    . calenderDate({
+        .calenderDate({
             2015, 4, 9, 11, 22, 33
         });
 
@@ -276,9 +277,8 @@ BOOST_AUTO_TEST_CASE(Time_and_report_step)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[67], 12);       // TSTEP
-    BOOST_CHECK_EQUAL(v[68],  2);      // REP_STEP
-
+    BOOST_CHECK_EQUAL(v[67], 12); // TSTEP
+    BOOST_CHECK_EQUAL(v[68],  2); // REP_STEP
 }
 
 BOOST_AUTO_TEST_CASE(Tuning_param)
@@ -301,20 +301,22 @@ BOOST_AUTO_TEST_CASE(Tuning_param)
     BOOST_CHECK_EQUAL(v[81], newtmn);        // NEWTMN
     BOOST_CHECK_EQUAL(v[82], litmax);        // LITMAX
     BOOST_CHECK_EQUAL(v[83], litmin);        // LITMIN
-    BOOST_CHECK_EQUAL(v[84], mxwsit);        // MXWSIT
-    BOOST_CHECK_EQUAL(v[85], mxwpit);        // MXWPIT
+    BOOST_CHECK_EQUAL(v[86], mxwsit);        // MXWSIT
+    BOOST_CHECK_EQUAL(v[87], mxwpit);        // MXWPIT
 }
 
 BOOST_AUTO_TEST_CASE(Various_Parameters)
 {
     const auto ih = Opm::RestartIO::InteHEAD{}
-        .variousParam(100, 2, 3);
+        .variousParam(2015, 100);
 
     const auto& v = ih.data();
 
+    BOOST_CHECK_EQUAL(v[  1], 2015); // VERSION
     BOOST_CHECK_EQUAL(v[ 94], 100); // IPROG
-    BOOST_CHECK_EQUAL(v[101],   2); // IH_101
-    BOOST_CHECK_EQUAL(v[103],   3); // IH_103
+    BOOST_CHECK_EQUAL(v[ 76],   2); // IH_076
+    BOOST_CHECK_EQUAL(v[101],   1); // IH_101
+    BOOST_CHECK_EQUAL(v[103],   1); // IH_103
 }
 
 BOOST_AUTO_TEST_CASE(wellSegDimensions)
@@ -345,24 +347,21 @@ BOOST_AUTO_TEST_CASE(wellSegDimensions)
 
 BOOST_AUTO_TEST_CASE(regionDimensions)
 {
-
     const auto ntfip  = 12;
     const auto nmfipr = 22;
     const auto nrfreg = 5;
     const auto ntfreg = 6;
     const auto nplmix = 7;
 
-  const auto ih = Opm::RestartIO::InteHEAD{}
+    const auto ih = Opm::RestartIO::InteHEAD{}
         .regionDimensions({
-          ntfip, nmfipr, nrfreg, ntfreg, nplmix
-
+            ntfip, nmfipr, nrfreg, ntfreg, nplmix
         });
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[88], ntfip);       // NTFIP
-    BOOST_CHECK_EQUAL(v[99], nmfipr);       // NMFIPR
-
+    BOOST_CHECK_EQUAL(v[89], ntfip);  // NTFIP
+    BOOST_CHECK_EQUAL(v[99], nmfipr); // NMFIPR
 }
 
 

--- a/tests/test_LogiHEAD.cpp
+++ b/tests/test_LogiHEAD.cpp
@@ -1,0 +1,56 @@
+/*
+  Copyright 2018 Statoil IT
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE LogiHEAD_Vector
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/LogiHEAD.hpp>
+
+BOOST_AUTO_TEST_SUITE(Member_Functions)
+
+BOOST_AUTO_TEST_CASE(Radial_Settings_and_Init)
+{
+    const auto e300_radial = false;
+    const auto e100_radial = true;
+
+    const auto lh = Opm::RestartIO::LogiHEAD{}
+        .variousParam(e300_radial, e100_radial, 4);
+
+    const auto& v = lh.data();
+
+    BOOST_CHECK_EQUAL(v[  0], true);  //
+    BOOST_CHECK_EQUAL(v[  1], true);  //
+    BOOST_CHECK_EQUAL(v[  3], false); // E300 Radial
+    BOOST_CHECK_EQUAL(v[  4], true);  // E100 Radial
+    BOOST_CHECK_EQUAL(v[ 16], true); //
+    BOOST_CHECK_EQUAL(v[ 18], true); //
+    BOOST_CHECK_EQUAL(v[ 31], true); //
+    BOOST_CHECK_EQUAL(v[ 44], true); //
+    BOOST_CHECK_EQUAL(v[ 75], true); // MS Well Simulation Case
+    BOOST_CHECK_EQUAL(v[ 76], true); //
+    BOOST_CHECK_EQUAL(v[ 87], true); //
+    BOOST_CHECK_EQUAL(v[ 99], true); //
+    BOOST_CHECK_EQUAL(v[113], true); //
+    BOOST_CHECK_EQUAL(v[114], true); //
+    BOOST_CHECK_EQUAL(v[115], true); //
+    BOOST_CHECK_EQUAL(v[117], true); //
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is https://github.com/OPM/opm-common/pull/382 where I have:

1. Rebased to current master.
2. Added one extra commit with the [review comments about `report_step`](https://github.com/OPM/opm-common/pull/382#issuecomment-382109788).

