### PR TITLE
Add WTEST configuration

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -93,6 +93,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.cpp
     src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
     src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
     src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -223,7 +224,8 @@ if(ENABLE_ECL_INPUT)
     tests/parser/UnitTests.cpp
     tests/parser/ValueTests.cpp
     tests/parser/WellSolventTests.cpp
-    tests/parser/WellTests.cpp)
+    tests/parser/WellTests.cpp
+    tests/parser/WTEST.cpp)
 endif()
 if(ENABLE_ECL_OUTPUT)
   list (APPEND TEST_SOURCE_FILES
@@ -453,6 +455,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/MSW/SegmentSet.hpp
        opm/parser/eclipse/EclipseState/Schedule/MSW/updatingCompletionsWithSegments.hpp
        opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+       opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -39,6 +39,7 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp>
 
 namespace Opm
 {
@@ -64,7 +65,7 @@ namespace Opm
         Schedule(const Deck& deck,
                  const EclipseState& es,
                  const ParseContext& parseContext = ParseContext());
- 
+
         /*
          * If the input deck does not specify a start time, Eclipse's 1. Jan
          * 1983 is defaulted
@@ -97,6 +98,8 @@ namespace Opm
         std::vector< const Well* > getWells(const std::string& group, size_t timeStep) const;
         std::vector< const Well* > getWellsMatching( const std::string& ) const;
         const OilVaporizationProperties& getOilVaporizationProperties(size_t timestep) const;
+
+        const WellTestConfig& wtestConfig(size_t timestep) const;
 
         const GroupTree& getGroupTree(size_t t) const;
         size_t numGroups() const;
@@ -133,6 +136,7 @@ namespace Opm
         Phases m_phases;
         std::map<int, DynamicState<std::shared_ptr<VFPProdTable>>> vfpprod_tables;
         std::map<int, DynamicState<std::shared_ptr<VFPInjTable>>> vfpinj_tables;
+        DynamicState<std::shared_ptr<WellTestConfig>> wtest_config;
 
         WellProducer::ControlModeEnum m_controlModeWHISTCTL;
 
@@ -172,6 +176,7 @@ namespace Opm
         void handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep);
         void handleGRUPNET( const DeckKeyword& keyword, size_t currentStep);
         void handleWRFT( const DeckKeyword& keyword, size_t currentStep);
+        void handleWTEST( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
         void handleWRFTPLT( const DeckKeyword& keyword, size_t currentStep);
         void handleWPIMULT( const DeckKeyword& keyword, size_t currentStep);
         void handleDRSDT( const DeckKeyword& keyword, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp
@@ -1,0 +1,64 @@
+/*
+  Copyright 2018 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef WELLTEST_CONFIG_H
+#define WELLTEST_CONFIG_H
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+
+namespace Opm {
+
+class WellTestConfig {
+public:
+    enum Reason {
+        PHYSICAL = 1,
+        ECONOMIC = 2,
+        GROUP = 4,
+        THP_DESIGN=8,
+        COMPLETION=16,
+    };
+
+    struct WTESTWell {
+        std::string name;
+        Reason shut_reason;
+        double test_interval;
+        int num_test;
+        double startup_time;
+    };
+
+    WellTestConfig();
+    void add_well(const std::string& well, Reason reason, double test_interval, int num_test, double startup_time);
+    void add_well(const std::string& well, const std::string& reasons, double test_interval, int num_test, double startup_time);
+    void drop_well(const std::string& well);
+    bool has(const std::string& well) const;
+    bool has(const std::string& well, Reason reason) const;
+    const WTESTWell& get(const std::string& well, Reason reason) const;
+    size_t size() const;
+
+private:
+    std::vector<WTESTWell> wells;
+};
+
+
+}
+
+#endif
+

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.cpp
@@ -1,0 +1,113 @@
+/*
+  Copyright 2018 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <stdexcept>
+#include <algorithm>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp>
+
+namespace Opm {
+
+
+WellTestConfig::WellTestConfig() {
+
+}
+
+void WellTestConfig::add_well(const std::string& well, Reason shut_reason, double test_interval, int num_retries, double startup_time) {
+    wells.push_back({well, shut_reason, test_interval, num_retries, startup_time});
+}
+
+
+void WellTestConfig::add_well(const std::string& well, const std::string& reasons, double test_interval, int num_retries, double startup_time) {
+    if (reasons.size() == 0)
+        throw std::invalid_argument("Can not pass empty string to stop testing to add_well() method.");
+
+    for (auto c : reasons) {
+        switch(c) {
+        case 'P' :
+            add_well(well, Reason::PHYSICAL, test_interval, num_retries, startup_time);
+            break;
+         case 'E' :
+            add_well(well, Reason::ECONOMIC, test_interval, num_retries, startup_time);
+            break;
+        case 'G':
+            add_well(well, Reason::GROUP, test_interval, num_retries, startup_time);
+            break;
+        case 'D':
+            add_well(well, Reason::THP_DESIGN, test_interval, num_retries, startup_time);
+            break;
+        case 'C':
+            add_well(well, Reason::COMPLETION, test_interval, num_retries, startup_time);
+            break;
+        default:
+            throw std::invalid_argument("Invalid character in WTEST configuration");
+        }
+    }
+}
+
+
+void WellTestConfig::drop_well(const std::string& well) {
+    wells.erase(std::remove_if(wells.begin(),
+                               wells.end(),
+                               [&well](const WTESTWell& wtest_well) { return (wtest_well.name == well); }),
+                wells.end());
+}
+
+bool WellTestConfig::has(const std::string& well) const {
+    const auto well_iter = std::find_if(wells.begin(),
+                                        wells.end(),
+                                        [&well](const WTESTWell& wtest_well) { return (wtest_well.name == well); });
+    return (well_iter != wells.end());
+}
+
+
+bool WellTestConfig::has(const std::string& well, Reason reason) const {
+    const auto well_iter = std::find_if(wells.begin(),
+                                        wells.end(),
+                                        [&well, &reason](const WTESTWell& wtest_well)
+                                        {
+                                            return (reason == wtest_well.shut_reason && wtest_well.name == well);
+                                        });
+    return (well_iter != wells.end());
+}
+
+
+const WellTestConfig::WTESTWell& WellTestConfig::get(const std::string& well, Reason reason) const {
+    const auto well_iter = std::find_if(wells.begin(),
+                                        wells.end(),
+                                        [&well, &reason](const WTESTWell& wtest_well)
+                                        {
+                                            return (reason == wtest_well.shut_reason && wtest_well.name == well);
+                                        });
+    if (well_iter == wells.end())
+        throw std::invalid_argument("No such WTEST object");
+
+    return *well_iter;
+}
+
+
+
+
+
+size_t WellTestConfig::size() const {
+    return wells.size();
+}
+
+}
+
+

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WTEST
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WTEST
@@ -1,7 +1,7 @@
 {"name" : "WTEST" , "sections" : ["SCHEDULE"], "items" : [
-        {"name" : "well" , "value_type" : "STRING"},
-        {"name" : "interval" , "value_type" : "DOUBLE" },
-        {"name" : "reason" , "value_type" : "STRING"},
+        {"name" : "WELL" , "value_type" : "STRING"},
+        {"name" : "INTERVAL" , "value_type" : "DOUBLE", "dimension" : "Time"  },
+        {"name" : "REASON" , "value_type" : "STRING"},
         {"name" : "TEST_NUM" , "value_type" : "INT" , "default" : 0},
-        {"name" : "START_TIME" , "value_type" : "DOUBLE" , "default" : 0}]}
+        {"name" : "START_TIME" , "value_type" : "DOUBLE" , "dimension" : "Time",  "default" : 0}]}
 

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -1,0 +1,70 @@
+/*
+  Copyright 2018 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdexcept>
+#include <iostream>
+#include <boost/filesystem.hpp>
+
+#define BOOST_TEST_MODULE WTEST
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+using namespace Opm;
+
+
+BOOST_AUTO_TEST_CASE(CreateWellTestConfig) {
+    WellTestConfig wc;
+
+    BOOST_CHECK_EQUAL(wc.size() , 0);
+
+
+    wc.add_well("NAME", WellTestConfig::Reason::PHYSICAL, 10, 10, 10);
+    BOOST_CHECK_EQUAL(wc.size(), 1);
+    BOOST_CHECK_THROW(wc.add_well("NAME2", "", 10.0,10,10.0), std::invalid_argument);
+    BOOST_CHECK_THROW(wc.add_well("NAME3", "X", 1,2,3), std::invalid_argument);
+
+    wc.add_well("NAME", "PEGDC", 10, 10, 10);
+    BOOST_CHECK_EQUAL(wc.size(), 6);
+    wc.add_well("NAMEX", "PGDC", 10, 10, 10);
+    BOOST_CHECK_EQUAL(wc.size(), 10);
+    wc.drop_well("NAME");
+    BOOST_CHECK_EQUAL(wc.size(), 4);
+    BOOST_CHECK(wc.has("NAMEX"));
+    BOOST_CHECK(wc.has("NAMEX", WellTestConfig::Reason::PHYSICAL));
+    BOOST_CHECK(!wc.has("NAMEX", WellTestConfig::Reason::ECONOMIC));
+    BOOST_CHECK(!wc.has("NAME"));
+
+
+    BOOST_CHECK_THROW(wc.get("NAMEX", WellTestConfig::Reason::ECONOMIC), std::invalid_argument);
+    BOOST_CHECK_THROW(wc.get("NO_NAME", WellTestConfig::Reason::ECONOMIC), std::invalid_argument);
+    const auto& wt = wc.get("NAMEX", WellTestConfig::Reason::PHYSICAL);
+    BOOST_CHECK_EQUAL(wt.name, "NAMEX");
+}
+

--- a/tests/parser/data/integration_tests/IOConfig/RPT_TEST2.DATA
+++ b/tests/parser/data/integration_tests/IOConfig/RPT_TEST2.DATA
@@ -39,6 +39,9 @@ RPTRST
 --ALLPROPS --> fluid densities, viscosities , reciprocal formation volume factors and phase relative permeabilities
 --NORST=1  --> output for visualization only 
 
+WELSPECS
+     'F-14A'    'FIELD'   12   85  1*       'OIL'  7* /
+/
 
 DATES
  3 'JAN' 2000  /


### PR DESCRIPTION
When a well is automatically closed by the simulator the WTEST keyword can be used to configure how the well should be tested as a candidate eligible for reopening.

With this PR a WellTestConfig object is added to the Schedule object. This PR configures *how* wells should be tested for reopening, it does not actually implement the reopening itself.