### PR TITLE
Add SummaryState class to hold on to summary state.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -149,6 +149,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/output/eclipse/LogiHEAD.cpp
           src/opm/output/eclipse/RestartIO.cpp
           src/opm/output/eclipse/Summary.cpp
+          src/opm/output/eclipse/SummaryState.cpp
           src/opm/output/eclipse/Tables.cpp
           src/opm/output/eclipse/RegionCache.cpp
           src/opm/output/eclipse/RestartValue.cpp
@@ -496,6 +497,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/RestartIO.hpp
         opm/output/eclipse/RestartValue.hpp
         opm/output/eclipse/Summary.hpp
+        opm/output/eclipse/SummaryState.hpp
         opm/output/eclipse/Tables.hpp
         opm/output/eclipse/WriteRestartHelpers.hpp
         opm/output/OutputWriter.hpp

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -29,6 +29,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
+#include <opm/output/eclipse/SummaryState.hpp>
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/RegionCache.hpp>
 
@@ -68,8 +69,8 @@ class Summary {
         out::RegionCache regionCache;
         ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free > ecl_sum;
         std::unique_ptr< keyword_handlers > handlers;
-        const ecl_sum_tstep_type* prev_tstep = nullptr;
         double prev_time_elapsed = 0;
+        SummaryState prev_state;
 };
 
 }

--- a/opm/output/eclipse/SummaryState.hpp
+++ b/opm/output/eclipse/SummaryState.hpp
@@ -1,0 +1,50 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SUMMARY_STATE_H
+#define SUMMARY_STATE_H
+
+#include <cstddef>
+#include <unordered_map>
+
+namespace Opm{
+
+
+/*
+  The purpose of this class is to serve as a small container object for
+  computed, ready to use summary values. The values will typically be used by
+  the UDQ, WTEST and ACTIONX calculations. Observe that all value *have been
+  converted to the correct output units*.
+*/
+class SummaryState {
+public:
+    typedef std::unordered_map<std::string, double>::const_iterator const_iterator;
+
+    void add(const std::string& key, double value);
+    double get(const std::string&) const;
+    bool has(const std::string& key) const;
+
+    const_iterator begin() const;
+    const_iterator end() const;
+private:
+    std::unordered_map<std::string,double> values;
+};
+
+}
+#endif

--- a/src/opm/output/eclipse/SummaryState.cpp
+++ b/src/opm/output/eclipse/SummaryState.cpp
@@ -1,0 +1,52 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <opm/output/eclipse/SummaryState.hpp>
+
+namespace Opm{
+
+    void SummaryState::add(const std::string& key, double value) {
+        this->values[key] = value;
+    }
+
+
+    bool SummaryState::has(const std::string& key) const {
+        return (this->values.find(key) != this->values.end());
+    }
+
+
+    double SummaryState::get(const std::string& key) const {
+        const auto iter = this->values.find(key);
+        if (iter == this->values.end())
+            throw std::invalid_argument("XX No such key: " + key);
+
+        return iter->second;
+    }
+
+    SummaryState::const_iterator SummaryState::begin() const {
+        return this->values.begin();
+    }
+
+
+    SummaryState::const_iterator SummaryState::end() const {
+        return this->values.end();
+    }
+
+}

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -26,11 +26,13 @@
 #include <stdexcept>
 
 #include <ert/ecl/ecl_sum.h>
+#include <ert/ecl/smspec_node.h>
 #include <ert/util/util.h>
 #include <ert/util/TestArea.hpp>
 
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/Summary.hpp>
+#include <opm/output/eclipse/SummaryState.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
@@ -1217,4 +1219,16 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
 
         BOOST_CHECK_CLOSE( 200.1, ecl_sum_get_well_completion_var( resp, 1, "W_2", "COPR", 2 ), 1e-5 );
         BOOST_CHECK_CLOSE( 200.1 * 0.2 * 0.01, ecl_sum_get_well_completion_var( resp, 1, "W_2", "COPT", 2 ), 1e-5 );
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(Test_SummaryState) {
+    Opm::SummaryState st;
+    st.add("WWCT:OP_2", 100);
+    BOOST_CHECK_CLOSE(st.get("WWCT:OP_2"), 100, 1e-5);
+    BOOST_CHECK_THROW(st.get("NO_SUCH_KEY"), std::invalid_argument);
+    BOOST_CHECK(st.has("WWCT:OP_2"));
+    BOOST_CHECK(!st.has("NO_SUCH_KEY"));
 }


### PR DESCRIPTION
Preparation to check/look up summary variables run-time for e.g. UDQ / WTEST / ACTION and other niceties.