### PR TITLE
Ignore THPRES input for restart runs

### DIFF
--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -31,11 +31,12 @@ namespace Opm {
 
     public:
 
-        SimulationConfig(const Deck& deck,
+        SimulationConfig(bool restart,
+                         const Deck& deck,
                          const Eclipse3DProperties& gridProperties);
 
         const ThresholdPressure& getThresholdPressure() const;
-        bool hasThresholdPressure() const;
+        bool useThresholdPressure() const;
         bool useCPR() const;
         bool hasDISGAS() const;
         bool hasVAPOIL() const;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -32,8 +32,8 @@ namespace Opm {
     class ThresholdPressure {
 
     public:
-
-        ThresholdPressure(const Deck& deck,
+        ThresholdPressure(bool restart,
+                          const Deck& deck,
                           const Eclipse3DProperties& eclipseProperties);
 
 
@@ -63,8 +63,11 @@ namespace Opm {
         */
         double getThresholdPressure(int r1 , int r2) const;
         size_t size() const;
-
+        bool active() const;
+        bool restart() const;
     private:
+        bool m_active;
+        bool m_restart;
         static std::pair<int,int> makeIndex(int r1 , int r2);
         void addPair(int r1 , int r2 , const std::pair<bool , double>& valuePair);
         void addBarrier(int r1 , int r2);

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -58,7 +58,7 @@ namespace Opm {
         m_inputNnc(          deck ),
         m_inputGrid(         deck, nullptr ),
         m_eclipseProperties( deck, m_tables, m_inputGrid ),
-        m_simulationConfig(  deck, m_eclipseProperties ),
+        m_simulationConfig(  m_eclipseConfig.getInitConfig().restartRequested(), deck, m_eclipseProperties ),
         m_transMult(         GridDims(deck), deck, m_eclipseProperties )
     {
         m_inputGrid.resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -46,9 +46,10 @@
 
 namespace Opm {
 
-    SimulationConfig::SimulationConfig(const Deck& deck,
+    SimulationConfig::SimulationConfig(bool restart,
+                                       const Deck& deck,
                                        const Eclipse3DProperties& eclipseProperties) :
-        m_ThresholdPressure( deck, eclipseProperties ),
+        m_ThresholdPressure( restart, deck, eclipseProperties ),
         m_useCPR(false),
         m_DISGAS(false),
         m_VAPOIL(false)
@@ -75,8 +76,8 @@ namespace Opm {
         return m_ThresholdPressure;
     }
 
-    bool SimulationConfig::hasThresholdPressure() const {
-        return m_ThresholdPressure.size() > 0;
+    bool SimulationConfig::useThresholdPressure() const {
+        return m_ThresholdPressure.active();
     }
 
     bool SimulationConfig::useCPR() const {

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
     EclipseState state(deck, ParseContext());
     const auto& simConf = state.getSimulationConfig();
 
-    BOOST_CHECK(simConf.hasThresholdPressure());
+    BOOST_CHECK(simConf.useThresholdPressure());
     BOOST_CHECK_EQUAL(simConf.getThresholdPressure().size(), 3);
 }
 

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -55,6 +55,7 @@ const std::string& inputStr = "RUNSPEC\n"
                               "/\n"
                               "\n";
 
+
 const std::string& inputStr_noTHPRES = "RUNSPEC\n"
                                        "EQLOPTS\n"
                                        "DIMENS\n"
@@ -115,7 +116,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
-    BOOST_CHECK_NO_THROW( SimulationConfig( deck, ep ) );
+    BOOST_CHECK_NO_THROW( SimulationConfig(false, deck, ep ) );
 }
 
 
@@ -125,8 +126,8 @@ BOOST_AUTO_TEST_CASE(SimulationConfigNOTHPRES) {
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
-    SimulationConfig simulationConfig(deck, ep);
-    BOOST_CHECK( !simulationConfig.hasThresholdPressure() );
+    SimulationConfig simulationConfig(false, deck, ep);
+    BOOST_CHECK( !simulationConfig.useThresholdPressure() );
 }
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
@@ -135,7 +136,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
-    SimulationConfig simulationConfig(deck, ep);
+    SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK( ! simulationConfig.useCPR());
 }
 
@@ -146,7 +147,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
     SUMMARYSection summary(deck);
-    SimulationConfig simulationConfig(deck, ep);
+    SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK(     simulationConfig.useCPR() );
     BOOST_CHECK(  !  summary.hasKeyword("CPR") );
 }
@@ -159,7 +160,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRInSUMMARYSection) {
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
     SUMMARYSection summary(deck);
-    SimulationConfig simulationConfig(deck, ep);
+    SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK( ! simulationConfig.useCPR());
     BOOST_CHECK(   summary.hasKeyword("CPR"));
 }
@@ -172,7 +173,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
     SUMMARYSection summary(deck);
-    SimulationConfig simulationConfig(deck, ep);
+    SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK(  simulationConfig.useCPR());
     BOOST_CHECK(  summary.hasKeyword("CPR"));
 
@@ -198,7 +199,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
-    SimulationConfig simulationConfig(deck, ep);
+    SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK_EQUAL( false , simulationConfig.hasDISGAS());
     BOOST_CHECK_EQUAL( false , simulationConfig.hasVAPOIL());
 
@@ -206,7 +207,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     TableManager tm_vd(deck_vd);
     EclipseGrid eg_vd(10, 3, 4);
     Eclipse3DProperties ep_vd(deck_vd, tm, eg);
-    SimulationConfig simulationConfig_vd(deck_vd, ep_vd);
+    SimulationConfig simulationConfig_vd(false, deck_vd, ep_vd);
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasDISGAS());
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasVAPOIL());
 }

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -53,6 +53,32 @@ const std::string& inputStr = "RUNSPEC\n"
                               "2 3 7.0/\n"
                               "/\n"
                               "\n";
+const std::string& inputStr_RESTART = "RUNSPEC\n"
+  "EQLOPTS\n"
+  "THPRES /\n "
+  "\n"
+  "SOLUTION\n"
+  "RESTART\n"
+  " CASE 100 /\n"
+  "\n";
+
+const std::string& inputStr_RESTART2 = "RUNSPEC\n"
+  "EQLOPTS\n"
+  "THPRES /\n "
+  "\n"
+  "REGIONS\n"
+  "EQLNUM\n"
+  "   27*4 /\n"
+  "SOLUTION\n"
+  "RESTART\n"
+  "  CASE 100/\n"
+  "THPRES\n"
+  "1 3 5.0/\n"
+  "2 3 33.0 /\n"
+  "2 4 7.0/\n"
+  "/\n"
+  "\n";
+
 
 const std::string& inputStrWithEqlNum =
                               "RUNSPEC\n"
@@ -108,6 +134,7 @@ const std::string& inputStrTHPRESinRUNSPECnotSoultion = "RUNSPEC\n"
                                                         "\n"
                                                         "SOLUTION\n"
                                                         "\n";
+
 
 
 const std::string& inputStrIrrevers = "RUNSPEC\n"
@@ -184,6 +211,7 @@ struct Setup
     TableManager tablemanager;
     EclipseGrid grid;
     Eclipse3DProperties props;
+    InitConfig initConfig;
     ThresholdPressure threshPres;
 
     explicit Setup(const std::string& input) :
@@ -192,7 +220,8 @@ struct Setup
             tablemanager(deck),
             grid(10, 3, 4),
             props(deck, tablemanager, grid),
-            threshPres(deck, props)
+            initConfig(deck),
+            threshPres(initConfig.restartRequested(), deck, props)
     {
     }
     explicit Setup(const std::string& input, ParseContext& parseContextArg) :
@@ -201,7 +230,8 @@ struct Setup
             tablemanager(deck),
             grid(10, 3, 4),
             props(deck, tablemanager, grid),
-            threshPres(deck, props)
+            initConfig(deck),
+            threshPres(initConfig.restartRequested(), deck, props)
     {
     }
 
@@ -258,6 +288,24 @@ BOOST_AUTO_TEST_CASE(ThresholdPressureThrowTest) {
     pc.update(ParseContext::INTERNAL_ERROR_UNINITIALIZED_THPRES, InputError::THROW_EXCEPTION);
     BOOST_CHECK_THROW(s.threshPres.getThresholdPressure(2, 3), std::invalid_argument);
 }
+
+
+BOOST_AUTO_TEST_CASE(Restart) {
+    Setup sx(inputStr_RESTART);
+    BOOST_CHECK(sx.threshPres.active());
+    BOOST_CHECK_EQUAL(sx.threshPres.size(), 0);
+    BOOST_CHECK(sx.threshPres.restart());
+}
+
+BOOST_AUTO_TEST_CASE(Restart2) {
+  Setup sx(inputStr_RESTART2);
+  BOOST_CHECK(sx.threshPres.active());
+  BOOST_CHECK_EQUAL(sx.threshPres.size(), 3);
+  BOOST_CHECK(sx.threshPres.restart());
+}
+
+
+
 
 BOOST_AUTO_TEST_CASE(HasPair) {
     Setup s(inputStrWithEqlNum);


### PR DESCRIPTION
OK - in #391 we added support for writing THPRES data to restart file; now we are ready to read it. 