### PR TITLE
VFP related needs to be processed even without THP target/limit

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -55,7 +55,7 @@ namespace Opm {
         bool operator!=(const WellProductionProperties& other) const;
         WellProductionProperties();
 
-        static WellProductionProperties history(double BHPLimit, const DeckRecord& record);
+        static WellProductionProperties history(const WellProductionProperties& prev_properties, const DeckRecord& record);
         static WellProductionProperties prediction( const DeckRecord& record, bool addGroupProductionControl );
 
         bool hasProductionControl(WellProducer::ControlModeEnum controlModeArg) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -650,10 +650,11 @@ namespace Opm {
 
                 if (!record.getItem("THP").defaultApplied(0)) {
                     properties.THPLimit       = record.getItem("THP").getSIDouble(0);
-                    properties.VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
                     properties.addInjectionControl(WellInjector::THP);
                 } else
                     properties.dropInjectionControl(WellInjector::THP);
+
+                properties.VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
 
                 /*
                   There is a sensible default BHP limit defined, so the BHPLimit can be

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -500,8 +500,6 @@ namespace Opm {
                     properties = WellProductionProperties::prediction( record, addGrupProductionControl );
                 } else {
                     const WellProductionProperties& prev_properties = well->getProductionProperties(currentStep);
-                    const double BHPLimit = prev_properties.BHPLimit;
-                    const int VFPTableNumber = prev_properties.VFPTableNumber;
                     properties = WellProductionProperties::history(prev_properties, record);
                 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -501,7 +501,8 @@ namespace Opm {
                 } else {
                     const WellProductionProperties& prev_properties = well->getProductionProperties(currentStep);
                     const double BHPLimit = prev_properties.BHPLimit;
-                    properties = WellProductionProperties::history( BHPLimit , record);
+                    const int VFPTableNumber = prev_properties.VFPTableNumber;
+                    properties = WellProductionProperties::history(prev_properties, record);
                 }
 
                 if (status != WellCommon::SHUT) {
@@ -892,6 +893,11 @@ namespace Opm {
                     properties.BHPH = record.getItem("BHP").getSIDouble(0);
                 if ( record.getItem( "THP" ).hasValue(0) )
                     properties.THPH = record.getItem("THP").getSIDouble(0);
+
+                const int VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
+                if (VFPTableNumber > 0) {
+                    properties.VFPTableNumber = VFPTableNumber;
+                }
 
                 if (well->setInjectionProperties(currentStep, properties))
                     m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , currentStep );

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -41,7 +41,7 @@ namespace Opm {
     {}
 
 
-    WellProductionProperties WellProductionProperties::history(const double BHPLimit, const DeckRecord& record)
+    WellProductionProperties WellProductionProperties::history(const WellProductionProperties& prev_properties, const DeckRecord& record)
     {
         WellProductionProperties p(record);
         p.predictionMode = false;
@@ -70,13 +70,23 @@ namespace Opm {
             if (cmode == wp::BHP)
                 p.BHPLimit = record.getItem( "BHP" ).getSIDouble( 0 );
             else
-                p.BHPLimit = BHPLimit;
+                p.BHPLimit = prev_properties.BHPLimit;
         }
 
         if ( record.getItem( "BHP" ).hasValue(0) )
             p.BHPH = record.getItem("BHP").getSIDouble(0);
         if ( record.getItem( "THP" ).hasValue(0) )
             p.THPH = record.getItem("THP").getSIDouble(0);
+
+        p.VFPTableNumber = record.getItem("VFPTable").get< int >(0);
+
+        if (p.VFPTableNumber == 0)
+            p.VFPTableNumber = prev_properties.VFPTableNumber;
+
+        p.ALQValue       = record.getItem("Lift").get< double >(0); //NOTE: Unit of ALQ is never touched
+
+        if (p.ALQValue == 0.)
+            p.ALQValue = prev_properties.ALQValue;
 
         return p;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -96,15 +96,21 @@ namespace Opm {
         p.VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
 
         namespace wp = WellProducer;
-        using mode = std::pair< const char*, wp::ControlModeEnum >;
+        using mode = std::pair< const std::string, wp::ControlModeEnum >;
         static const mode modes[] = {
             { "ORAT", wp::ORAT }, { "WRAT", wp::WRAT }, { "GRAT", wp::GRAT },
             { "LRAT", wp::LRAT }, { "RESV", wp::RESV }, { "THP", wp::THP }
         };
 
         for( const auto& cmode : modes ) {
-            if( !record.getItem( cmode.first ).defaultApplied( 0 ) )
-                 p.addProductionControl( cmode.second );
+            if( !record.getItem( cmode.first ).defaultApplied( 0 ) ) {
+
+                // a zero value THP limit will not be handled as a THP limit
+                if (cmode.first == "THP" && p.THPLimit == 0.)
+                    continue;
+
+                p.addProductionControl( cmode.second );
+            }
         }
 
         // There is always a BHP constraint, when not specified, will use the default value

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WCONHIST
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WCONHIST
@@ -5,7 +5,7 @@
        {"name" : "ORAT"         , "value_type" : "DOUBLE",  "default" : 0.0, "dimension" : "LiquidSurfaceVolume/Time"},
        {"name" : "WRAT"         , "value_type" : "DOUBLE" , "default" : 0.0, "dimension" : "LiquidSurfaceVolume/Time"},
        {"name" : "GRAT"         , "value_type" : "DOUBLE" , "default" : 0.0, "dimension" : "GasSurfaceVolume/Time"},
-       {"name" : "VFPTable"     , "value_type" : "INT"   , "default" : 0.0 , "comment":"The default is a state variable"},
+       {"name" : "VFPTable"     , "value_type" : "INT"   , "default" : 0, "comment":"The default is a state variable"},
        {"name" : "Lift"         , "value_type" : "DOUBLE" , "default" : 0.0 , "comment":"The default is a state variable"},
        {"name" : "THP"          , "value_type" : "DOUBLE" , "default" : 0.0 , "dimension" : "Pressure"},
        {"name" : "BHP"          , "value_type" : "DOUBLE" , "default" : 0.0 ,"dimension" : "Pressure"},

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -864,7 +864,9 @@ namespace {
 
             auto deck = parser.parseString(input, Opm::ParseContext());
             const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
-            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history( 100 , record);;
+            Opm::WellProductionProperties prev_p;
+            prev_p.BHPLimit = 100.;
+            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(prev_p, record);;
 
             return hist;
         }

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -859,6 +859,24 @@ namespace {
             return input;
         }
 
+        std::string bhp_defaulted() {
+            const std::string input =
+                "WCONHIST\n"
+                "-- 1    2     3    4-9 10\n"
+                "  'P' 'OPEN' 'BHP' 6*  500/\n/\n";
+
+            return input;
+        }
+
+        std::string all_defaulted_with_bhp_vfp_table() {
+            const std::string input =
+                "WCONHIST\n"
+                "-- 1    2     3    4-6  7  8  9  10\n"
+                "  'P' 'OPEN' 'RESV' 3*  3 10. 1* 500/\n/\n";
+
+            return input;
+        }
+
         Opm::WellProductionProperties properties(const std::string& input) {
             Opm::Parser parser;
 
@@ -866,6 +884,8 @@ namespace {
             const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
             Opm::WellProductionProperties prev_p;
             prev_p.BHPLimit = 100.;
+            prev_p.VFPTableNumber = 12;
+            prev_p.ALQValue = 18.;
             Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(prev_p, record);;
 
             return hist;
@@ -877,8 +897,35 @@ namespace {
         all_specified_CMODE_BHP()
         {
             const std::string input =
-                "WCONPROD\n"
+                "WCONHIST\n"
                 "'P' 'OPEN' 'BHP' 1 2 3/\n/\n";
+
+            return input;
+        }
+
+        std::string orat_CMODE_other_defaulted()
+        {
+            const std::string input =
+                "WCONPROD\n"
+                "'P' 'OPEN' 'ORAT' 1 2 3/\n/\n";
+
+            return input;
+        }
+
+        std::string thp_CMODE()
+        {
+            const std::string input =
+                "WCONPROD\n"
+                "'P' 'OPEN' 'THP' 1 2 3 3* 10. 8 13./\n/\n";
+
+            return input;
+        }
+
+        std::string bhp_CMODE()
+        {
+            const std::string input =
+                "WCONPROD\n"
+                "'P' 'OPEN' 'BHP' 1 2 3 2* 20. 10. 8 13./\n/\n";
 
             return input;
         }
@@ -890,7 +937,7 @@ namespace {
             Opm::Parser parser;
 
             auto deck = parser.parseString(input, Opm::ParseContext());
-            const auto& kwd     = deck.getKeyword("WCONHIST");
+            const auto& kwd     = deck.getKeyword("WCONPROD");
             const auto&  record = kwd.getRecord(0);
             Opm::WellProductionProperties pred = Opm::WellProductionProperties::prediction( record, false );
 
@@ -914,6 +961,9 @@ BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::ORAT);
 
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
+    BOOST_CHECK_EQUAL(p.ALQValue, 18.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
@@ -929,6 +979,9 @@ BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::WRAT);
 
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
+    BOOST_CHECK_EQUAL(p.ALQValue, 18.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
@@ -944,6 +997,9 @@ BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::GRAT);
 
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
+    BOOST_CHECK_EQUAL(p.ALQValue, 18.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
@@ -959,6 +1015,9 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::LRAT);
 
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
+    BOOST_CHECK_EQUAL(p.ALQValue, 18.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
@@ -975,6 +1034,112 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::RESV);
 
     BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
+    BOOST_CHECK_EQUAL(p.ALQValue, 18.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+}
+
+BOOST_AUTO_TEST_CASE(WCH_Rates_NON_Defaulted_VFP)
+{
+    const Opm::WellProductionProperties& p =
+        WCONHIST::properties(WCONHIST::all_defaulted_with_bhp_vfp_table());
+
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+
+    BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::RESV);
+
+    BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 3);
+    BOOST_CHECK_EQUAL(p.ALQValue, 10.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+}
+
+BOOST_AUTO_TEST_CASE(WCH_BHP_Specified)
+{
+    const Opm::WellProductionProperties& p =
+        WCONHIST::properties(WCONHIST::bhp_defaulted());
+
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
+
+    BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::BHP);
+
+    BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
+
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
+    BOOST_CHECK_EQUAL(p.ALQValue, 18.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 5.e7); // 500 barsa
+}
+
+BOOST_AUTO_TEST_CASE(WCONPROD_ORAT_CMode)
+{
+    const Opm::WellProductionProperties& p =
+        WCONPROD::properties(WCONPROD::orat_CMODE_other_defaulted());
+
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::THP));
+
+    BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::ORAT);
+
+    BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
+
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 0);
+    BOOST_CHECK_EQUAL(p.ALQValue, 0.);
+}
+
+BOOST_AUTO_TEST_CASE(WCONPROD_THP_CMode)
+{
+    const Opm::WellProductionProperties& p =
+        WCONPROD::properties(WCONPROD::thp_CMODE());
+
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::THP));
+
+    BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::THP);
+
+    BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
+
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 8);
+    BOOST_CHECK_EQUAL(p.ALQValue, 13.);
+    BOOST_CHECK_EQUAL(p.THPLimit, 1000000.); // 10 barsa
+    BOOST_CHECK_EQUAL(p.BHPLimit, 101325.); // 1 atm.
+}
+
+BOOST_AUTO_TEST_CASE(WCONPROD_BHP_CMode)
+{
+    const Opm::WellProductionProperties& p =
+        WCONPROD::properties(WCONPROD::bhp_CMODE());
+
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( p.hasProductionControl(Opm::WellProducer::THP));
+
+    BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::BHP);
+
+    BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
+
+    BOOST_CHECK_EQUAL(p.VFPTableNumber, 8);
+    BOOST_CHECK_EQUAL(p.ALQValue, 13.);
+    BOOST_CHECK_EQUAL(p.THPLimit, 1000000.); // 10 barsa
+    BOOST_CHECK_EQUAL(p.BHPLimit, 2000000.); // 20 barsa
 }
 
 


### PR DESCRIPTION
and a zero-value THP limit for WCONPROD will not be treated as a THP limit.

The history matching part is slightly more tricky, was not handled by this PR yet.