### PR TITLE
Fix forgotten <string> include.

### DIFF
--- a/opm/output/eclipse/SummaryState.hpp
+++ b/opm/output/eclipse/SummaryState.hpp
@@ -20,7 +20,7 @@
 #ifndef SUMMARY_STATE_H
 #define SUMMARY_STATE_H
 
-#include <cstddef>
+#include <string>
 #include <unordered_map>
 
 namespace Opm{


### PR DESCRIPTION
Required to compile with clang.