### PR TITLE
Add WellTestState object to keep track of automatically closed wells

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -94,6 +94,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/WellTestState.cpp
     src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
     src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
     src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -459,6 +460,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/MSW/updatingCompletionsWithSegments.hpp
        opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
        opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp
+       opm/parser/eclipse/EclipseState/Schedule/WellTestState.hpp
        opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/WellTestState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellTestState.hpp
@@ -1,0 +1,82 @@
+/*
+  Copyright 2018 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef WELLTEST_STATE_H
+#define WELLTEST_STATE_H
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp>
+
+namespace Opm {
+
+class WellTestState {
+public:
+    /*
+      This class implements a small mutable state object which keeps track of
+      which wells have been automatically closed by the simulator, and by
+      checking with the WTEST configuration object the class can return a list
+      (well_name,reason) pairs for wells which should be checked as candiates
+      for opening.
+    */
+
+
+
+    struct ClosedWell {
+        std::string name;
+        WellTestConfig::Reason reason;
+        double last_test;
+        int num_attempt;
+    };
+
+    /*
+      The simulator has decided to close a particular well; we then add it here
+      as a closed well with a particualar reason.
+    */
+    void addClosedWell(const std::string& well_name, WellTestConfig::Reason reason, double sim_time);
+
+    /*
+      The update will consult the WellTestConfig object and return a list of
+      wells which should be checked for possible reopening; observe that the
+      update method will update the internal state of the object by counting up
+      the openiing attempts, and also set the time for the last attempt to open.
+    */
+    std::vector<std::pair<std::string, WellTestConfig::Reason>> update(const WellTestConfig& config, double sim_time);
+
+    /*
+      If the simulator decides that a constraint is no longer met the drop()
+      method should be called to indicate that this reason for keeping the well
+      closed is no longer active.
+    */
+    void drop(const std::string& well_name, WellTestConfig::Reason reason);
+
+
+    bool has(const std::string well_name, WellTestConfig::Reason reason) const;
+    void openWell(const std::string& well_name);
+    size_t size() const;
+private:
+    std::vector<ClosedWell> wells;
+};
+
+
+}
+
+#endif
+

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellTestState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellTestState.cpp
@@ -1,0 +1,86 @@
+/*
+  Copyright 2018 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <stdexcept>
+#include <algorithm>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WellTestConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/WellTestState.hpp>
+
+namespace Opm {
+
+    void WellTestState::addClosedWell(const std::string& well_name, WellTestConfig::Reason reason, double sim_time) {
+        if (this->has(well_name, reason))
+            return;
+
+        this->wells.push_back({well_name, reason, sim_time, 0});
+    }
+
+
+    void WellTestState::openWell(const std::string& well_name) {
+        wells.erase(std::remove_if(wells.begin(),
+                                   wells.end(),
+                                   [&well_name](const ClosedWell& well) { return (well.name == well_name); }),
+                    wells.end());
+    }
+
+
+    void WellTestState::drop(const std::string& well_name, WellTestConfig::Reason reason) {
+        wells.erase(std::remove_if(wells.begin(),
+                                   wells.end(),
+                                   [&well_name, reason](const ClosedWell& well) { return (well.name == well_name && well.reason == reason); }),
+                    wells.end());
+    }
+
+
+    bool WellTestState::has(const std::string well_name, WellTestConfig::Reason reason) const {
+        const auto well_iter = std::find_if(wells.begin(),
+                                            wells.end(),
+                                            [&well_name, &reason](const ClosedWell& well)
+                                             {
+                                                return (reason == well.reason && well.name == well_name);
+                                            });
+        return (well_iter != wells.end());
+    }
+
+    size_t WellTestState::size() const {
+        return this->wells.size();
+    }
+
+
+    std::vector<std::pair<std::string, WellTestConfig::Reason>> WellTestState::update(const WellTestConfig& config, double sim_time) {
+        std::vector<std::pair<std::string, WellTestConfig::Reason>> output;
+        for (auto& closed_well : this->wells) {
+            if (config.has(closed_well.name, closed_well.reason)) {
+                const auto& well_config = config.get(closed_well.name, closed_well.reason);
+                double elapsed = sim_time - closed_well.last_test;
+
+                if (elapsed >= well_config.test_interval)
+                    if (well_config.num_test == 0 || (closed_well.num_attempt < well_config.num_test)) {
+                        closed_well.last_test = sim_time;
+                        closed_well.num_attempt += 1;
+                        output.push_back(std::make_pair(closed_well.name, closed_well.reason));
+                    }
+
+            }
+        }
+        return output;
+    }
+}
+
+


### PR DESCRIPTION
This object should be instantiated and managed from the simulator; dangling here.

@totto82 : I hope this seems usable; please suggest changes.