### PR TITLE
fixed: pass by const ref

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/WellTestState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellTestState.hpp
@@ -96,7 +96,7 @@ public:
     */
     void dropCompletion(const std::string& well_name, size_t completionIdx);
 
-    bool hasWell(const std::string well_name, WellTestConfig::Reason reason) const;
+    bool hasWell(const std::string& well_name, WellTestConfig::Reason reason) const;
     void openWell(const std::string& well_name);
 
     bool hasCompletion(const std::string well_name, const size_t completionIdx) const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellTestState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellTestState.cpp
@@ -48,7 +48,7 @@ namespace Opm {
     }
 
 
-    bool WellTestState::hasWell(const std::string well_name, WellTestConfig::Reason reason) const {
+    bool WellTestState::hasWell(const std::string& well_name, WellTestConfig::Reason reason) const {
         const auto well_iter = std::find_if(wells.begin(),
                                             wells.end(),
                                             [&well_name, &reason](const ClosedWell& well)


### PR DESCRIPTION
quells a (recently introduced) static analyzer warning.