### PR TITLE
Add catch-all else clause to satisfy compiler

### DIFF
--- a/src/opm/common/utility/numeric/calculateCellVol.cpp
+++ b/src/opm/common/utility/numeric/calculateCellVol.cpp
@@ -17,6 +17,7 @@
 
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <opm/common/utility/numeric/calculateCellVol.hpp>
 
@@ -126,6 +127,12 @@ double calculateCellVol(const std::vector<double>& X, const std::vector<double>&
 	   vect[j] = Y.data();
 	} else if (permutation[j] == 3){
 	   vect[j] = Z.data();
+	} else {
+	     // this condition can never happen, since all values in 'permutation'
+	     // is covered, but compiler analysis may not be deep enough to not give
+	     // warnings about 'vect' being uninitialized further down.
+	     assert(false);
+	     vect[j] = 0;
         } 
      }
     


### PR DESCRIPTION
Some compilers (notably GCC 5.4.0; default in Ubuntu 16.04) does not
do sufficient static analysis to determine that 'vect' is actually
exhaustively defined due to all indices being enumerated, and issue
a (spurious) warning that an unassigned value may be used.

This patch provides a default branch for the if-statements so that
'vect' is always assigned to, even in the eyes of the compiler. Since
entering this branch is unequivocally a bug, an assert is added so that
the null value is not mistakenly used.