### PR TITLE
Summary: Calculate Independent Set of Vectors for Restart

### DIFF
--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -62,6 +62,8 @@ class Summary {
 
         ~Summary();
 
+        const SummaryState& get_restart_vectors() const;
+
     private:
         class keyword_handlers;
 


### PR DESCRIPTION
This change-set ensures that the following set of vectors are stored/updated in

    Summary::add_timestep()

for all active wells and well groups (including FIELD):

  * Production rates for Oil, Water, Gas, and Reservoir Volume (i.e., (O|W|G|V)PR).

  * Cumulative production totals for Oil, Water, Gas, and Reservoir Volume (i.e., (O|W|G|V)PT).

  * Injection rates for Water and Gas (i.e., (W|G)IR).

  * Cumulative injection totals for Water and Gas ((W|G)IT).

  * Producing Water Cut (WCT).

  * Producing Gas/Oil ratio (GOR).

We additionally capture the well bottom-hole pressure (WBHP) for all wells that are active at the pertinent simulation step (sim_step).

Add an accessor function
```C++
const SummaryState& Summary::get_restart_vectors() const
```
that returns the `prev_state` which contains these summary vectors and add a set of unit tests to exercise the new interface.

---

Note: This is a re-implementation of the previously proposed PR #433.  Thanks to @joakim-hove for suggesting this revised algorithm which leverages the existing summary vector infrastructure to a greater extent.