### PR TITLE
Include vendor-specific header for isatty function

### DIFF
--- a/src/opm/common/OpmLog/OpmLog.cpp
+++ b/src/opm/common/OpmLog/OpmLog.cpp
@@ -23,7 +23,20 @@
 #include <iostream>
 #include <errno.h>  // For errno
 #include <stdio.h>  // For fileno() and stdout
+
+#if defined(_MSC_VER)
+// MS put some POSIX-like functions in io.h, but prefix them with underscore
+// since they are considered "vendor" and not standard functions.
+#define _CRT_NONSTDC_NO_DEPRECATE
+#include <io.h>
+#define isatty _isatty
+#elif defined(__MINGW32__)
+// MinGW also has the isatty function in io.h instead of unistd.h, but without
+// the underscore.
+#include <io.h>
+#else
 #include <unistd.h> // For isatty()
+#endif
 
 namespace Opm {
 


### PR DESCRIPTION
MS gutted several of the POSIX functions a while ago under the pretense that these were in conflict with the C++ standard, since they contained non-underscored "vendor" functions. They have been moved to io.h 