### PR TITLE
Improve status message when libtool is not present

### DIFF
--- a/cmake/Modules/LibtoolArchives.cmake
+++ b/cmake/Modules/LibtoolArchives.cmake
@@ -123,7 +123,7 @@ function (configure_la name target)
 	mark_as_advanced (libtool_MAIN)
 	# notify the user if it not found after we explicitly searched
 	if (NOT libtool_MAIN)
-	  message (STATUS "Libtool not found!")	  
+	  message (STATUS "Not generating libtool archive (.la) since libtool was not found")
 	endif (NOT libtool_MAIN)
   endif (NOT libtool_MAIN)
   if (libtool_MAIN)


### PR DESCRIPTION
Libtool uses libtool archive files (.la) to determine how to do a
platform-specific link. To generate these files, it is necessary to have
libtool installed on the system, since it will only accept files with
its own particular version number embedded. If libtool is not installed,
you probably don't need the libtool archive files either, so no .la is
generated. However, the status message sounded like libtool was probed
but not found, and that this was something that you should install.

This patch modifies the status message to make it more clear way libtool
was probed, and what the consequence of a missing libtool is (i.e. no
.la file for you).