### PR TITLE
Add more flexibility to compareECL.

### DIFF
--- a/examples/test_util/compareECL.cpp
+++ b/examples/test_util/compareECL.cpp
@@ -114,11 +114,12 @@ int main(int argc, char** argv) {
     bool specificKeyword         = false;
     bool specificFileType        = false;
     bool throwOnError            = true;
+    bool volumecheck             = true;
     char* keyword                = nullptr;
     char* fileTypeCstr           = nullptr;
     int c                        = 0;
 
-    while ((c = getopt(argc, argv, "hiIk:lnpPt:")) != -1) {
+    while ((c = getopt(argc, argv, "hiIk:lnpPt:V")) != -1) {
         switch (c) {
             case 'h':
                 printHelp();
@@ -149,6 +150,9 @@ int main(int argc, char** argv) {
             case 't':
                 specificFileType = true;
                 fileTypeCstr = optarg;
+                break;
+            case 'V':
+                volumecheck = false;
                 break;
             case '?':
                 if (optopt == 'k') {
@@ -254,11 +258,11 @@ int main(int argc, char** argv) {
                 comparator.setOnlyLastOccurrence(true);
             }
             if (specificKeyword) {
-                comparator.gridCompare();
+                comparator.gridCompare(volumecheck);
                 comparator.resultsForKeyword(keyword);
             }
             else {
-                comparator.gridCompare();
+                comparator.gridCompare(volumecheck);
                 comparator.results();
             }
             if (comparator.getNoErrors() > 0)

--- a/opm/test_util/EclFilesComparator.hpp
+++ b/opm/test_util/EclFilesComparator.hpp
@@ -175,8 +175,8 @@ class RegressionTest: public ECLFilesComparator {
         void setOnlyLastOccurrence(bool onlyLastOccurrenceArg) {this->onlyLastOccurrence = onlyLastOccurrenceArg;}
 
         //! \brief Compares grid properties of the two cases.
-        // gridCompare() checks if both the number of active and global cells in the two cases are the same. If they are, all cells are looped over to calculate the cell volume deviation for the two cases. If the both the relative and absolute deviation exceeds the tolerances, an exception is thrown.
-        void gridCompare() const;
+        // gridCompare() checks if both the number of active and global cells in the two cases are the same. If they are, and volumecheck is true, all cells are looped over to calculate the cell volume deviation for the two cases. If the both the relative and absolute deviation exceeds the tolerances, an exception is thrown.
+        void gridCompare(const bool volumecheck) const;
         //! \brief Calculates deviations for all keywords.
         // This function checks if the number of keywords of the two cases are equal, and if it is, resultsForKeyword() is called for every keyword. If not, an exception is thrown.
         void results();


### PR DESCRIPTION
In particular:
 - Grid comparison will now also check that the active cells are the same,
   not just that the number of active cells is identical.
 - In the grid comparison, checking volumes is now optional, from compareECL
   this feature is used by passing the '-V' option on the command line.

This replaces #439.