### PR TITLE
Error and warning fixes

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Connection.hpp
@@ -21,6 +21,7 @@
 #ifndef COMPLETION_HPP_
 #define COMPLETION_HPP_
 
+#include <array>
 #include <map>
 #include <memory>
 #include <string>

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -58,7 +58,7 @@ namespace Opm {
     private:
         // segment number
         // it should work as a ID.
-        int segment_number;
+        int m_segment_number;
         // branch number
         // for top segment, it should always be 1
         int m_branch;

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -284,7 +284,7 @@ namespace {
 std::vector<int> serialize_ICON( int sim_step,
                                  int ncwmax,
                                  const std::vector<const Well*>& sched_wells,
-                                 const EclipseGrid& grid) {
+                                 const EclipseGrid& /*grid*/) {
 
     size_t well_offset = 0;
     std::vector<int> data( sched_wells.size() * ncwmax * NICONZ , 0 );

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1017,7 +1017,8 @@ Summary::Summary( const EclipseState& st,
                                     node.num(),  // NUMS value for the summary output.
                                     {},          // Well results - data::Wells
                                     {},          // Region <-> cell mappings.
-                                    this->grid};
+                                    this->grid,
+                                    {}};
 
             const auto val = handle( no_args );
 
@@ -1042,7 +1043,7 @@ Summary::Summary( const EclipseState& st,
     // for simulation restart.
     {
         auto& rvec     = this->handlers->rstvec_backing_store;
-        auto& handlers = this->handlers->handlers;
+        auto& hndlrs   = this->handlers->handlers;
 
         for (const auto& vector : requiredRestartVectors(schedule)) {
             const auto& kw     = vector.first;
@@ -1063,7 +1064,7 @@ Summary::Summary( const EclipseState& st,
             }
 
             rvec.push_back(makeRestartVectorSMSPEC(kw, entity));
-            handlers.emplace_back(rvec.back().get(), func->second);
+            hndlrs.emplace_back(rvec.back().get(), func->second);
         }
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Connection.cpp
@@ -39,7 +39,7 @@ namespace Opm {
     Connection::Connection(int i, int j , int k ,
                            int compnum,
                            double depth,
-                           WellCompletion::StateEnum state ,
+                           WellCompletion::StateEnum stateArg ,
                            const Value<double>& connectionTransmissibilityFactor,
                            const Value<double>& diameter,
                            const Value<double>& skinFactor,
@@ -47,7 +47,7 @@ namespace Opm {
                            const WellCompletion::DirectionEnum direction)
         : dir(direction),
           center_depth(depth),
-          state(state),
+          state(stateArg),
           sat_tableId(satTableId),
           complnum( compnum ),
           ijk({i,j,k}),

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
@@ -22,7 +22,7 @@
 namespace Opm {
 
     Segment::Segment()
-    : segment_number(-1),
+    : m_segment_number(-1),
       m_branch(-1),
       m_outlet_segment(-1),
       m_total_length(invalid_value),
@@ -39,7 +39,7 @@ namespace Opm {
     Segment::Segment(int segment_number_in, int branch_in, int outlet_segment_in, double length_in, double depth_in,
                      double internal_diameter_in, double roughness_in, double cross_area_in,
                      double volume_in, bool data_ready_in)
-    : segment_number(segment_number_in),
+    : m_segment_number(segment_number_in),
       m_branch(branch_in),
       m_outlet_segment(outlet_segment_in),
       m_total_length(length_in),
@@ -53,7 +53,7 @@ namespace Opm {
     }
 
     int Segment::segmentNumber() const {
-        return segment_number;
+        return m_segment_number;
     }
 
 
@@ -113,8 +113,8 @@ namespace Opm {
         return m_inlet_segments;
     }
 
-    void Segment::addInletSegment(const int segment_number) {
-        m_inlet_segments.push_back(segment_number);
+    void Segment::addInletSegment(const int segment_number_in) {
+        m_inlet_segments.push_back(segment_number_in);
     }
 
     double Segment::invalidValue() {
@@ -122,7 +122,7 @@ namespace Opm {
     }
 
     bool Segment::operator==( const Segment& rhs ) const {
-        return this->segment_number    == rhs.segment_number
+        return this->m_segment_number    == rhs.m_segment_number
             && this->m_branch            == rhs.m_branch
             && this->m_outlet_segment    == rhs.m_outlet_segment
             && this->m_total_length      == rhs.m_total_length
@@ -135,15 +135,6 @@ namespace Opm {
     }
 
     bool Segment::operator!=( const Segment& rhs ) const {
-        return this->segment_number    == rhs.segment_number
-            && this->m_branch            == rhs.m_branch
-            && this->m_outlet_segment    == rhs.m_outlet_segment
-            && this->m_total_length      == rhs.m_total_length
-            && this->m_depth             == rhs.m_depth
-            && this->m_internal_diameter == rhs.m_internal_diameter
-            && this->m_roughness         == rhs.m_roughness
-            && this->m_cross_area        == rhs.m_cross_area
-            && this->m_volume            == rhs.m_volume
-            && this->m_data_ready        == rhs.m_data_ready;
+        return !this->operator==(rhs);
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -541,17 +541,6 @@ namespace Opm {
         handleWCONProducer( keyword, currentStep, true, parseContext);
     }
 
-    static Opm::Value<int> getValueItem( const DeckItem& item ){
-        Opm::Value<int> data(item.name());
-        if(item.hasValue(0)) {
-            int tempValue = item.get< int >(0);
-            if( tempValue >0){
-                data.setValue(tempValue-1);
-            }
-        }
-        return data;
-    }
-
     void Schedule::handleWPIMULT( const DeckKeyword& keyword, size_t currentStep) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
@@ -859,16 +848,6 @@ namespace Opm {
             }
         }
     }
-
-    namespace {
-
-        bool defaulted( int x ) { return x < 0; }
-        int maybe( const DeckRecord& rec, const std::string& s ) {
-            const auto& item = rec.getItem( s );
-            return item.defaultApplied( 0 ) ? -1 : item.get< int >( 0 ) - 1;
-        }
-    }
-
 
     void Schedule::handleCOMPLUMP( const DeckKeyword& keyword,
                                    size_t timestep ) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ.cpp
@@ -23,7 +23,7 @@
 
 namespace Opm {
 
-    UDQ::UDQ(const UDQConfig& config, const Deck& deck) {
+    UDQ::UDQ(const UDQConfig& /* config */, const Deck& deck) {
         if (deck.hasKeyword("UDQ")) {
             const auto& kw = deck.getKeyword("UDQ");
             for (const auto& record : kw)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQExpression.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQExpression.cpp
@@ -73,11 +73,11 @@ namespace Opm {
       2. For items like '2*(1+WBHP)' the parsing code will expand the 2*
          operator to the repeated tokens : (1+WBHP), (1+WBHP)
     */
-    UDQExpression::UDQExpression(const std::string& action, const std::string& keyword, const std::vector<std::string>& input_data) {
-        assertKeyword(keyword);
+    UDQExpression::UDQExpression(const std::string& action_in, const std::string& keyword_in, const std::vector<std::string>& input_data) {
+        assertKeyword(keyword_in);
 
-        this->action = actionString2Enum(action);
-        this->keyword = keyword;
+        this->action = actionString2Enum(action_in);
+        this->keyword = keyword_in;
 
         for (const std::string& item : input_data) {
             if (RawConsts::is_quote()(item[0])) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellConnections.cpp
@@ -29,9 +29,9 @@
 
 namespace Opm {
 
-    WellConnections::WellConnections(int headI, int headJ) :
-        headI(headI),
-        headJ(headJ)
+    WellConnections::WellConnections(int headIArg, int headJArg) :
+        headI(headIArg),
+        headJ(headJArg)
     {
     }
 

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -674,8 +674,15 @@ namespace {
                 this->measure_table_to_si_offset = from_pvt_m_offset;
                 this->unit_name_table = pvt_m_names;
                 break;
+            case(UnitType::UNIT_TYPE_INPUT):
+                m_name = "Input";
+                this->measure_table_from_si = to_input;
+                this->measure_table_to_si = from_input;
+                this->measure_table_to_si_offset = from_input_offset;
+                this->unit_name_table = input_names;
+                break;
             default:
-                //do nothing
+                throw std::runtime_error("Tried to construct UnitSystem with unknown unit family.");
                 break;
         };
     }
@@ -742,6 +749,7 @@ namespace {
           case UnitType::UNIT_TYPE_FIELD:  return ECL_FIELD_UNITS;
           case UnitType::UNIT_TYPE_LAB:    return ECL_LAB_UNITS;
           case UnitType::UNIT_TYPE_PVT_M:  return ECL_PVT_M_UNITS;
+          case UnitType::UNIT_TYPE_INPUT:  throw std::runtime_error("UNIT_TYPE_INPUT has no counterpart in the ert_ecl_unit_enum type.");
         default:
             throw std::runtime_error("What has happened here?");
         }

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -176,6 +176,23 @@ BOOST_AUTO_TEST_CASE(CreateFieldSystem) {
 
 
 
+BOOST_AUTO_TEST_CASE(CreateInputSystem) {
+    auto system = UnitSystem::newINPUT();
+    checkSystemHasRequiredDimensions( system );
+
+    BOOST_CHECK_EQUAL( 1.0, system.getDimension("Length").getSIScaling() );
+    BOOST_CHECK_EQUAL( 1.0, system.getDimension("Mass").getSIScaling() );
+    BOOST_CHECK_EQUAL( 1.0, system.getDimension("Time").getSIScaling() );
+    BOOST_CHECK_EQUAL( 1.0, system.getDimension("Permeability").getSIScaling() );
+    BOOST_CHECK_EQUAL( 1.0, system.getDimension("Pressure").getSIScaling() );
+
+    BOOST_CHECK_THROW( system.getEclType( ), std::runtime_error );
+    BOOST_CHECK_EQUAL( static_cast<long int>(system.getType( )) , static_cast<long int>(UnitSystem::UnitType::UNIT_TYPE_INPUT) );
+}
+
+
+
+
 BOOST_AUTO_TEST_CASE(DimensionEqual) {
     Dimension d1("Length" , 1);
     Dimension d2("Length" , 1);


### PR DESCRIPTION
This collects various minor fixes that probably have hurt no-one besides myself.

The first commit fixes a missing include (apparently transitively included on gcc).
The second fixes a buggy Segment::operator!=() and also cleans up warnings in that class.
The last just silences warnings in multiple files.