### PR TITLE
Massively improve the startup time for Flow

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -235,19 +235,18 @@ namespace Opm {
 
         for (auto iter = m_searchMap.begin(); iter != m_searchMap.end(); iter++) {
             const Opm::GridProperty<int>& region = m_e3DProps.getIntGridProperty( (*iter).first );
-            MULTREGTSearchMap map = (*iter).second;
+            const MULTREGTSearchMap& map = (*iter).second;
 
             int regionId1 = region.iget(globalIndex1);
             int regionId2 = region.iget(globalIndex2);
 
-
-            std::pair<int,int> pair{regionId1 , regionId2};
+            std::pair<int,int> pair{ regionId1, regionId2 };
             if (map.count(pair) != 1 || !(map.at(pair)->m_directions & faceDir)) {
                 pair = std::pair<int,int>{regionId2 , regionId1};
                 if (map.count(pair) != 1 || !(map.at(pair)->m_directions & faceDir))
                     continue;
             }
-            const MULTREGTRecord * record = map[pair];
+            const MULTREGTRecord* record = map.at(pair);
 
             bool applyMultiplier = true;
             int i1 = globalIndex1 % region.getNX();


### PR DESCRIPTION
...for the Norne case at least, since it uses MULTREGT. For me this was ~3.5s out of ~5.5s total startup time.

Done by using a const reference instead of copying a map. Also use find() instead of operator[], the find() is guaranteed to succeed by the checks of the lines above it.

Found by profiling with Instruments, while looking for ill consequences of changing cell volume calculation (and not finding any).