### PR TITLE
Do not tell DUNE build systems that dune-common is a dependency.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,3 @@ Label: 2018.10-pre
 Maintainer: opm@opm-project.org
 MaintainerName: OPM community
 Url: http://opm-project.org
-Depends: dune-common


### PR DESCRIPTION
We simply do not use it in this module. I guess this was introduced
by accident or not correctly removed when we reverted some changes.