### PR TITLE
Revise Infrastructure for Well Arrays in Restart Files

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -138,6 +138,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/test_util/summaryRegressionTest.cpp
           src/opm/test_util/summaryComparator.cpp
           src/opm/test_util/EclFilesComparator.cpp
+          src/opm/output/eclipse/AggregateWellData.cpp
           src/opm/output/eclipse/CreateDoubHead.cpp
           src/opm/output/eclipse/CreateInteHead.cpp
           src/opm/output/eclipse/CreateLogiHead.cpp
@@ -232,6 +233,7 @@ if(ENABLE_ECL_INPUT)
 endif()
 if(ENABLE_ECL_OUTPUT)
   list (APPEND TEST_SOURCE_FILES
+          tests/test_AggregateWellData.cpp
           tests/test_CharArrayNullTerm.cpp
           tests/test_compareSummary.cpp
           tests/test_EclFilesComparator.cpp
@@ -490,6 +492,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/data/Cells.hpp
         opm/output/data/Solution.hpp
         opm/output/data/Wells.hpp
+        opm/output/eclipse/AggregateWellData.hpp
         opm/output/eclipse/CharArrayNullTerm.hpp
         opm/output/eclipse/DoubHEAD.hpp
         opm/output/eclipse/EclipseGridInspector.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -492,6 +492,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/data/Cells.hpp
         opm/output/data/Solution.hpp
         opm/output/data/Wells.hpp
+        opm/output/eclipse/VectorItems/intehead.hpp
         opm/output/eclipse/AggregateWellData.hpp
         opm/output/eclipse/CharArrayNullTerm.hpp
         opm/output/eclipse/DoubHEAD.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -232,6 +232,7 @@ if(ENABLE_ECL_INPUT)
 endif()
 if(ENABLE_ECL_OUTPUT)
   list (APPEND TEST_SOURCE_FILES
+          tests/test_CharArrayNullTerm.cpp
           tests/test_compareSummary.cpp
           tests/test_EclFilesComparator.cpp
           tests/test_EclipseIO.cpp
@@ -246,6 +247,7 @@ if(ENABLE_ECL_OUTPUT)
           tests/test_Summary.cpp
           tests/test_Tables.cpp
           tests/test_Wells.cpp
+          tests/test_WindowedArray.cpp
           tests/test_writenumwells.cpp
           tests/test_serialize_ICON.cpp
           tests/test_serialize_SCON.cpp
@@ -488,6 +490,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/data/Cells.hpp
         opm/output/data/Solution.hpp
         opm/output/data/Wells.hpp
+        opm/output/eclipse/CharArrayNullTerm.hpp
         opm/output/eclipse/DoubHEAD.hpp
         opm/output/eclipse/EclipseGridInspector.hpp
         opm/output/eclipse/EclipseIO.hpp
@@ -501,6 +504,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/Summary.hpp
         opm/output/eclipse/SummaryState.hpp
         opm/output/eclipse/Tables.hpp
+        opm/output/eclipse/WindowedArray.hpp
         opm/output/eclipse/WriteRestartHelpers.hpp
         opm/output/OutputWriter.hpp
         opm/test_util/EclFilesComparator.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -493,6 +493,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/data/Solution.hpp
         opm/output/data/Wells.hpp
         opm/output/eclipse/VectorItems/intehead.hpp
+        opm/output/eclipse/VectorItems/well.hpp
         opm/output/eclipse/AggregateWellData.hpp
         opm/output/eclipse/CharArrayNullTerm.hpp
         opm/output/eclipse/DoubHEAD.hpp

--- a/opm/output/eclipse/AggregateWellData.hpp
+++ b/opm/output/eclipse/AggregateWellData.hpp
@@ -1,0 +1,99 @@
+/*
+  Copyright (c) 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_AGGREGATE_WELL_DATA_HPP
+#define OPM_AGGREGATE_WELL_DATA_HPP
+
+#include <opm/output/eclipse/CharArrayNullTerm.hpp>
+#include <opm/output/eclipse/WindowedArray.hpp>
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace Opm {
+    class Schedule;
+    class SummaryState;
+    class UnitSystem;
+} // Opm
+
+namespace Opm { namespace data {
+    class WellRates;
+}} // Opm::data
+
+namespace Opm { namespace RestartIO { namespace Helpers {
+
+    class AggregateWellData
+    {
+    public:
+        explicit AggregateWellData(const std::vector<int>& inteHead);
+
+        void captureDeclaredWellData(const Opm::Schedule&   sched,
+                                     const Opm::UnitSystem& units,
+                                     const std::size_t      sim_step);
+
+        void captureDynamicWellData(const Opm::Schedule&        sched,
+                                    const std::size_t           sim_step,
+                                    const Opm::data::WellRates& xw,
+                                    const Opm::SummaryState&    smry);
+
+        /// Retrieve Integer Well Data Array.
+        const std::vector<int>& getIWell() const
+        {
+            return this->iWell_.data();
+        }
+
+        /// Retrieve Floating-Point (Real) Well Data Array.
+        const std::vector<float>& getSWell() const
+        {
+            return this->sWell_.data();
+        }
+
+        /// Retrieve Floating-Point (Double Precision) Well Data Array.
+        const std::vector<double>& getXWell() const
+        {
+            return this->xWell_.data();
+        }
+
+        /// Retrieve Character Well Data Array.
+        const std::vector<CharArrayNullTerm<8>>& getZWell() const
+        {
+            return this->zWell_.data();
+        }
+
+    private:
+        /// Aggregate 'IWEL' array (Integer) for all wells.
+        WindowedArray<int> iWell_;
+
+        /// Aggregate 'SWEL' array (Real) for all wells.
+        WindowedArray<float> sWell_;
+
+        /// Aggregate 'XWEL' array (Double Precision) for all wells.
+        WindowedArray<double> xWell_;
+
+        /// Aggregate 'ZWEL' array (Character) for all wells.
+        WindowedArray<CharArrayNullTerm<8>> zWell_;
+
+        /// Maximum number of groups in model.
+        int nWGMax_;
+    };
+
+}}} // Opm::RestartIO::Helpers
+
+#endif // OPM_AGGREGATE_WELL_DATA_HPP

--- a/opm/output/eclipse/CharArrayNullTerm.hpp
+++ b/opm/output/eclipse/CharArrayNullTerm.hpp
@@ -1,0 +1,103 @@
+/*
+  Copyright (c) 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_CHARARRAY_HEADER_HPP
+#define OPM_CHARARRAY_HEADER_HPP
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <cstddef>
+#include <string>
+
+namespace Opm { namespace RestartIO { namespace Helpers {
+
+    /// Null-terminated, left adjusted, space padded array of N characters.
+    ///
+    /// Simple container of character data.  Exists solely for purpose of
+    /// outputting std::string (or types convertible to std::string) as
+    /// Fortran-style \code character (len=N) \endcode values.
+    ///
+    /// \tparam N Number of characters.
+    template <std::size_t N>
+    class CharArrayNullTerm
+    {
+    public:
+        CharArrayNullTerm()
+        {
+            this->clear();
+        }
+
+        explicit CharArrayNullTerm(const std::string& s)
+            : CharArrayNullTerm()
+        {
+            this->copy_in(s.c_str(), s.size());
+        }
+
+        ~CharArrayNullTerm() = default;
+
+        CharArrayNullTerm(const CharArrayNullTerm& rhs) = default;
+        CharArrayNullTerm(CharArrayNullTerm&& rhs) = default;
+
+        CharArrayNullTerm& operator=(const CharArrayNullTerm& rhs) = default;
+        CharArrayNullTerm& operator=(CharArrayNullTerm&& rhs) = default;
+
+        /// Assign from \code std::string \endcode.
+        CharArrayNullTerm& operator=(const std::string& s)
+        {
+            this->clear();
+            this->copy_in(s.data(), s.size());
+
+            return *this;
+        }
+
+        const char* c_str() const
+        {
+            return this->s_.data();
+        }
+
+    private:
+        enum : typename std::array<char, N + 1>::size_type { NChar = N };
+
+        std::array<char, NChar + 1> s_;
+
+        /// Clear contents of internal array (fill with ' ').
+        void clear()
+        {
+            this->s_.fill(' ');
+            this->s_[NChar] = '\0';
+        }
+
+        /// Assign new value to internal array (left adjusted, space padded
+        /// and null-terminated).
+        void copy_in(const char*                                           s,
+                     const typename std::array<char, NChar + 1>::size_type len)
+        {
+            const auto ncpy = std::min(len, static_cast<decltype(len)>(NChar));
+
+            // Note: Not strcpy() or strncpy() here.  The former has no bounds
+            // checking, the latter writes a null-terminator at position 'ncpy'
+            // (s_[ncpy]) which violates the post condition if ncpy < NChar.
+            std::memcpy(this->s_.data(), s,
+                        ncpy * sizeof *this->s_.data());
+        }
+    };
+
+}}} // Opm::RestartIO::Helpers
+#endif // CHARARRAY_HEADER

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -23,6 +23,9 @@
 #include <vector>
 
 namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+
+    // This is a subset of the items in src/opm/output/eclipse/InteHEAD.cpp .
+    // Promote items from that list to this in order to make them public.
     enum intehead : std::vector<int>::size_type {
         ISNUM   =   0,      //  An encoded integer corresponding to the
                             //  time the file was created.  For files not

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -1,0 +1,87 @@
+/*
+  Copyright (c) 2018 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_ECLIPSE_VECTOR_INTEHEAD_HPP
+#define OPM_OUTPUT_ECLIPSE_VECTOR_INTEHEAD_HPP
+
+#include <vector>
+
+namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+    enum intehead : std::vector<int>::size_type {
+        ISNUM   =   0,      //  An encoded integer corresponding to the
+                            //  time the file was created.  For files not
+                            //  originating from ECLIPSE, this value may
+                            //  be set to zero.
+
+        VERSION =   1,      //  Simulator version
+        UNIT    =   2,      //  Units convention
+                            //     1: METRIC, 2: FIELD, 3: LAB, 4: PVT-M
+
+        NX      =   8,      //  #cells in X direction (Cartesian)
+        NY      =   9,      //  #cells in Y direction (Cartesian)
+        NZ      =  10,      //  #cells in Z direction (Cartesian)
+        NACTIV  =  11,      //  Number of active cells
+
+        PHASE   =  14,      //  Phase indicator:
+                            //     1: oil, 2: water, 3: O/W, 4: gas,
+                            //     5: G/O, 6: G/W, 7: O/G/W
+
+        NWELLS  =  16,      //  Number of wells
+        NCWMAX  =  17,      //  Maximum number of completions per well
+        NWGMAX  =  19,      //  Maximum number of wells in any well group
+        NGMAXZ  =  20,      //  Maximum number of groups in field
+
+        NIWELZ  =  24,      //  Number of data elements per well in IWEL array
+                            //  (default 97 for ECLIPSE, 94 for ECLIPSE 300).
+        NSWELZ  =  25,      //  Number of data elements per well in SWEL array
+        NXWELZ  =  26,      //  Number of delements per well in XWEL array
+        NZWELZ  =  27,      //  Number of 8-character words per well in ZWEL array
+
+        NICONZ  =  32,      //  Number of data elements per completion
+                            //  in ICON array (default 19)
+        NSCONZ  =  33,      //  Number of data elements per completion in SCON array
+        NXCONZ  =  34,      //  Number of data elements per completion in XCON array
+
+        NIGRPZ  =  36,      //  Number of data elements per group in IGRP array
+        NSGRPZ  =  37,      //  Number of data elements per group in SGRP array
+        NXGRPZ  =  38,      //  Number of data elements per group in XGRP array
+        NZGRPZ  =  39,      //  Number of data elements per group in ZGRP array
+
+        NCAMAX  =  41,      //  Maximum number of analytic aquifer connections
+
+        NIAAQZ  =  42,      //  Number of data elements per aquifer in IAAQ array
+        NSAAQZ  =  43,      //  Number of data elements per aquifer in SAAQ array
+        NXAAQZ  =  44,      //  Number of data elements per aquifer in XAAQ array
+
+        NICAQZ  =  45,      //  Number of data elements per aquifer connection in ICAQ array
+        NSCAQZ  =  46,      //  Number of data elements per aquifer connection in SCAQ array
+        NACAQZ  =  47,      //  Number of data elements per aquifer connection in ACAQ array
+
+        NSEGWL  = 174,      //  Number of multisegment wells defined with WELSEG
+        NSWLMX  = 175,      //  Maximum number of segmented wells (item 1 ofWSEGDIMS)
+        NSEGMX  = 176,      //  Maximum number of segments per well (item 2 of WSEGDIMS)
+        NLBRMX  = 177,      //  Maximum number of lateral branches (item 3 of WSEGDIMS)
+
+        NISEGZ  = 178,      //  Number of entries per segment in ISEG array
+        NRSEGZ  = 179,      //  Number of entries per segment in RSEG array
+        NILBRZ  = 180,      //  Number of entries per segment in ILBR array
+    };
+}}}} // Opm::RestartIO::Helpers::VectorItems
+
+#endif // OPM_OUTPUT_ECLIPSE_VECTOR_INTEHEAD_HPP

--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -1,0 +1,164 @@
+/*
+  Copyright (c) 2018 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_ECLIPSE_VECTOR_WELL_HPP
+#define OPM_OUTPUT_ECLIPSE_VECTOR_WELL_HPP
+
+#include <vector>
+
+namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+
+    namespace IWell {
+        enum index : std::vector<int>::size_type {
+            IHead  =  0, // I-location (one-based) of well head
+            JHead  =  1, // J-location (one-based) of well head
+            FirstK =  2, // Layer ID (one-based) of top/first connection
+            LastK  =  3, // Layer ID (one-based) of bottom/last connection
+            NConn  =  4, // Number of active cells connected to well
+            Group  =  5, // Index (one-based) of well's current group
+            WType  =  6, // Well type
+            WCtrl  =  7, // Well control
+
+            item9  =  8,
+            item11 = 10,
+
+            VFPTab = 11, // ID (one-based) of well's current VFP table
+
+            item18 = 17, // Unknown
+            item25 = 24, // Unknown
+            item32 = 31, // Unknown
+            item48 = 47, // Unknown
+            item50 = 49, // Unknown
+
+            MsWID  = 70, // Multisegment well ID
+                         //   Value 0 for regular wells
+                         //   Value 1..#MS wells for MS wells
+            NWseg  = 71, // Number of well segments
+                         //   Value 0 for regular wells
+                         //   Value #segments for MS wells
+
+            CompOrd = 98,
+        };
+
+        namespace Value {
+            enum WellType : int {
+                WTUnk    = 0,  // Unknown well type (OPM only)
+                Producer = 1,  // Well is producer
+                OilInj   = 2,  // Well is oil injector
+                WatInj   = 3,  // Well is water injector
+                GasInj   = 4,  // Well is gas injector
+            };
+
+            enum WellCtrlMode : int {
+                WMCtlUnk = -10,  // Unknown well control mode (OPM only)
+                Group    = - 1,  // Well under group control
+                Shut     =   0,  // Well is shut
+                OilRate  =   1,  // Well controlled by oil rate
+                WatRate  =   2,  // Well controlled by water rate
+                GasRate  =   3,  // Well controlled by gas rate
+                LiqRate  =   4,  // Well controlled by liquid rate
+
+                ResVRate =   5,  // Well controlled by
+                                 // reservoir voidage rate
+
+                THP      =   6,  // Well controlled by
+                                 // tubing head pressure target
+
+                BHP      =   7,  // Well controlled by
+                                 // bottom-hole pressure target
+
+                CombRate =   9,  // Well controlled by linearly
+                                 // combined rate target
+            };
+
+            enum CompOrder : int {
+                Track = 0, // Connections ordered along
+                           // well track (increasing MD)
+
+                Depth = 1, // Connections ordered by inceasing
+                           // true vertical depth.  Not really
+                           // supported in OPM Flow.
+
+                Input = 2, // Connections listed in order of
+                           // appearance in simulation model's
+                           // COMPDAT keyword.
+            };
+        } // Value
+    } // IWell
+
+    namespace SWell {
+        enum index : std::vector<float>::size_type {
+            OilRateTarget  = 0, // Well's current oil rate production target
+            WatRateTarget  = 1, // Well's current water rate production target
+            GasRateTarget  = 2, // Well's current gas rate production target
+            LiqRateTarget  = 3, // Well's current liquid rate production target
+            ResVRateTarget = 4, // Well's current reservoir voidate rate
+                                // production target
+
+            THPTarget      = 5, // Well's tubing head pressure target
+            BHPTarget      = 6, // Well's bottom hole pressure target
+
+            DatumDepth     = 9, // Well's reference depth for BHP
+        };
+    } // SWell
+
+    namespace XWell {
+        enum index : std::vector<double>::size_type {
+            OilPrRate  =  0, // Well's oil production rate
+            WatPrRate  =  1, // Well's water production rate
+            GasPrRate  =  2, // Well's gas production rate
+            LiqPrRate  =  3, // Well's liquid production rate
+            VoidPrRate =  4, // Well's reservoir voidage production rate
+
+            FlowBHP    =  6, // Well's flowing/producing bottom hole pressure
+            WatCut     =  7, // Well's producing water cut
+            GORatio    =  8, // Well's producing gas/oil ratio
+
+            OilPrTotal   = 18, // Well's total cumulative oil production
+            WatPrTotal   = 19, // Well's total cumulative water production
+            GasPrTotal   = 20, // Well's total cumulative gas production
+            VoidPrTotal  = 21, // Well's total cumulative reservoir
+                               // voidage production
+
+            WatInjTotal = 23,  // Well's total cumulative water injection
+            GasInjTotal = 24,  // Well's total cumulative gas injection
+
+            GasFVF      = 34,  // Well's producing gas formation volume factor.
+
+            item37     = 36,
+            item38     = 37,
+
+            BHPTarget  = 41, // Well's current BHP Target/Limit
+
+            item82     = 81,
+            item83     = 82,
+
+            WatVoidPrRate = 122, // Well's voidage production rate
+            GasVoidPrRate = 123, // Well's voidage production rate
+        };
+    } // XWell
+
+    namespace ZWell {
+        enum index : std::vector<const char*>::size_type {
+            WellName = 0, // Well name
+        };
+    } // ZWell
+}}}} // Opm::RestartIO::Helpers::VectorItems
+
+#endif // OPM_OUTPUT_ECLIPSE_VECTOR_WELL_HPP

--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -35,8 +35,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             WType  =  6, // Well type
             WCtrl  =  7, // Well control
 
-            item9  =  8,
-            item11 = 10,
+            item9  =  8, // Unknown
+            item11 = 10, // Unknown
 
             VFPTab = 11, // ID (one-based) of well's current VFP table
 
@@ -53,7 +53,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
                          //   Value 0 for regular wells
                          //   Value #segments for MS wells
 
-            CompOrd = 98,
+            CompOrd = 98, // Well's completion ordering scheme.
         };
 
         namespace Value {
@@ -141,13 +141,13 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
             GasFVF      = 34,  // Well's producing gas formation volume factor.
 
-            item37     = 36,
-            item38     = 37,
+            item37     = 36,   // Unknown
+            item38     = 37,   // Unknown
 
             BHPTarget  = 41, // Well's current BHP Target/Limit
 
-            item82     = 81,
-            item83     = 82,
+            item82     = 81,   // Unknown
+            item83     = 82,   // Unknown
 
             WatVoidPrRate = 122, // Well's voidage production rate
             GasVoidPrRate = 123, // Well's voidage production rate

--- a/opm/output/eclipse/WindowedArray.hpp
+++ b/opm/output/eclipse/WindowedArray.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OPM_WINDOWED_VECTOR_HPP
-#define OPM_WINDOWED_VECTOR_HPP
+#ifndef OPM_WINDOWED_ARRAY_HPP
+#define OPM_WINDOWED_ARRAY_HPP
 
 #include <cassert>
 #include <iterator>
@@ -174,4 +174,4 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 
 }}} // Opm::RestartIO::Helpers
 
-#endif // OPM_WINDOW_VECTOR_HPP
+#endif // OPM_WINDOW_ARRAY_HPP

--- a/opm/output/eclipse/WindowedArray.hpp
+++ b/opm/output/eclipse/WindowedArray.hpp
@@ -1,0 +1,177 @@
+/*
+  Copyright (c) 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WINDOWED_VECTOR_HPP
+#define OPM_WINDOWED_VECTOR_HPP
+
+#include <cassert>
+#include <iterator>
+#include <type_traits>
+#include <vector>
+
+#include <boost/range/iterator_range.hpp>
+
+namespace Opm { namespace RestartIO { namespace Helpers {
+
+    template <typename T>
+    class WindowedArray
+    {
+    private:
+        using Vector = std::vector<T>;
+
+    public:
+        using WriteWindow = boost::iterator_range<
+            typename Vector::iterator>;
+
+        using ReadWindow = boost::iterator_range<
+            typename Vector::const_iterator>;
+
+        using Idx = typename Vector::size_type;
+
+        struct NumWindows { Idx value; };
+        struct WindowSize { Idx value; };
+
+        explicit WindowedArray(const NumWindows n, const WindowSize sz)
+            : x_         (n.value * sz.value)
+            , windowSize_(sz.value)
+        {}
+
+        Idx numWindows() const
+        {
+            return this->x_.size() / this->windowSize_;
+        }
+
+        Idx windowSize() const
+        {
+            return this->windowSize_;
+        }
+
+        WriteWindow operator[](const Idx window)
+        {
+            assert ((window < this->numWindows()) &&
+                    "Window ID Out of Bounds");
+
+            auto b = std::begin(this->x_) + window*this->windowSize_;
+            auto e = b + this->windowSize_;
+
+            return { b, e };
+        }
+
+        ReadWindow operator[](const Idx window) const
+        {
+            assert ((window < this->numWindows()) &&
+                    "Window ID Out of Bounds");
+
+            auto b = std::begin(this->x_) + window*this->windowSize_;
+            auto e = b + this->windowSize_;
+
+            return { b, e };
+        }
+
+        const Vector& data() const
+        {
+            return this->x_;
+        }
+
+        Vector getDataDestructively()
+        {
+            return std::move(this->x_);
+        }
+
+    private:
+        std::vector<T> x_;
+
+        Idx windowSize_;
+    };
+
+    template <typename T>
+    class WindowedMatrix
+    {
+    private:
+        using NumWindows  = typename WindowedArray<T>::NumWindows;
+
+    public:
+        using WriteWindow = typename WindowedArray<T>::WriteWindow;
+        using ReadWindow  = typename WindowedArray<T>::ReadWindow;
+        using WindowSize  = typename WindowedArray<T>::WindowSize;
+        using Idx         = typename WindowedArray<T>::Idx;
+
+        struct NumRows { Idx value; };
+        struct NumCols { Idx value; };
+
+        explicit WindowedMatrix(const NumRows& nRows,
+                                const NumCols& nCols,
+                                const WindowSize& sz)
+            : data_   (NumWindows{ nRows.value * nCols.value }, sz)
+            , numCols_(nCols.value)
+        {}
+
+        Idx numCols() const
+        {
+            return this->numCols_;
+        }
+
+        Idx numRows() const
+        {
+            return this->data_.numWindows() / this->numCols();
+        }
+
+        Idx windowSize() const
+        {
+            return this->data_.windowSize();
+        }
+
+        WriteWindow operator()(const Idx row, const Idx col)
+        {
+            return this->data_[ this->i(row, col) ];
+        }
+
+        ReadWindow operator()(const Idx row, const Idx col) const
+        {
+            return this->data_[ this->i(row, col) ];
+        }
+
+        auto data() const
+            -> decltype(std::declval<const WindowedArray<T>>().data())
+        {
+            return this->data_.data();
+        }
+
+        auto getDataDestructively()
+            -> decltype(std::declval<WindowedArray<T>>()
+                        .getDataDestructively())
+        {
+            return this->data_.getDataDestructively();
+        }
+
+    private:
+        WindowedArray<T> data_;
+
+        Idx numCols_;
+
+        /// Row major (C) order.
+        Idx i(const Idx row, const Idx col) const
+        {
+            return row*this->numCols() + col;
+        }
+    };
+
+}}} // Opm::RestartIO::Helpers
+
+#endif // OPM_WINDOW_VECTOR_HPP

--- a/opm/output/eclipse/WindowedArray.hpp
+++ b/opm/output/eclipse/WindowedArray.hpp
@@ -32,17 +32,14 @@ namespace Opm { namespace RestartIO { namespace Helpers {
     template <typename T>
     class WindowedArray
     {
-    private:
-        using Vector = std::vector<T>;
-
     public:
         using WriteWindow = boost::iterator_range<
-            typename Vector::iterator>;
+            typename std::vector<T>::iterator>;
 
         using ReadWindow = boost::iterator_range<
-            typename Vector::const_iterator>;
+            typename std::vector<T>::const_iterator>;
 
-        using Idx = typename Vector::size_type;
+        using Idx = typename std::vector<T>::size_type;
 
         struct NumWindows { Idx value; };
         struct WindowSize { Idx value; };
@@ -84,12 +81,12 @@ namespace Opm { namespace RestartIO { namespace Helpers {
             return { b, e };
         }
 
-        const Vector& data() const
+        const std::vector<T>& data() const
         {
             return this->x_;
         }
 
-        Vector getDataDestructively()
+        std::vector<T> getDataDestructively()
         {
             return std::move(this->x_);
         }

--- a/opm/output/eclipse/WindowedArray.hpp
+++ b/opm/output/eclipse/WindowedArray.hpp
@@ -27,38 +27,69 @@
 
 #include <boost/range/iterator_range.hpp>
 
+/// \file
+///
+/// Provide facilities to simplify constructing restart vectors
+/// such as IWEL or RSEG.
+
 namespace Opm { namespace RestartIO { namespace Helpers {
 
+    /// Provide read-only and read/write access to constantly sized
+    /// portions/windows of a linearised buffer with an implied
+    /// 1D array structure.
+    ///
+    /// Intended as backing store for vectors that have a constant
+    /// number of items per entity (e.g., N integer data items for
+    /// each active group at a report step).
+    ///
+    /// \tparam T Element type for underlying data items.
     template <typename T>
     class WindowedArray
     {
     public:
+        /// Read/write access.
         using WriteWindow = boost::iterator_range<
             typename std::vector<T>::iterator>;
 
+        /// Read-only access.
         using ReadWindow = boost::iterator_range<
             typename std::vector<T>::const_iterator>;
 
         using Idx = typename std::vector<T>::size_type;
 
+        /// Distinct compile-time type for number of windows in
+        /// underlying storage.
         struct NumWindows { Idx value; };
+
+        /// Distinct compile-time type for size of windows
+        /// (number of data items per window.)
         struct WindowSize { Idx value; };
 
+        /// Constructor.
+        ///
+        /// \param[in] n Number of windows.
+        /// \param[in] sz Number of data items per window.
         explicit WindowedArray(const NumWindows n, const WindowSize sz)
             : x_         (n.value * sz.value)
             , windowSize_(sz.value)
         {}
 
+        /// Retrieve number of windows allocated for this array.
         Idx numWindows() const
         {
             return this->x_.size() / this->windowSize_;
         }
 
+        /// Retrieve number of data items per windows.
         Idx windowSize() const
         {
             return this->windowSize_;
         }
 
+        /// Request read/write access to individual window.
+        ///
+        /// \param[in] window Numeric ID of particular read/write window.
+        ///   Must be in range \code [0 .. numWindows()-1] \endcode.
         WriteWindow operator[](const Idx window)
         {
             assert ((window < this->numWindows()) &&
@@ -70,6 +101,10 @@ namespace Opm { namespace RestartIO { namespace Helpers {
             return { b, e };
         }
 
+        /// Request read-only access to individual window.
+        ///
+        /// \param[in] window Numeric ID of particular read-only window.
+        ///   Must be in range \code [0 .. numWindows()-1] \endcode.
         ReadWindow operator[](const Idx window) const
         {
             assert ((window < this->numWindows()) &&
@@ -81,11 +116,16 @@ namespace Opm { namespace RestartIO { namespace Helpers {
             return { b, e };
         }
 
+        /// Get read-only access to full, linearised data items for
+        /// all windows.
         const std::vector<T>& data() const
         {
             return this->x_;
         }
 
+        /// Extract full, linearised data items for all windows.
+        ///
+        /// Destroys the internal state of the \c WindowedArray.
         std::vector<T> getDataDestructively()
         {
             return std::move(this->x_);
@@ -97,6 +137,18 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         Idx windowSize_;
     };
 
+
+    /// Provide read-only and read/write access to constantly sized
+    /// portions/windows of a linearised buffer with an implied
+    /// row/column matrix (2D array) structure.
+    ///
+    /// Intended as backing store for vectors that have a constant
+    /// number of items per sub-entity of a fixed number of containing
+    /// entities (e.g., K double precision data items for each of N
+    /// maximum well connections for each of M maximum active wells at
+    /// a particular report step).
+    ///
+    /// \tparam T Element type for underlying data items.
     template <typename T>
     class WindowedMatrix
     {
@@ -109,9 +161,19 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         using WindowSize  = typename WindowedArray<T>::WindowSize;
         using Idx         = typename WindowedArray<T>::Idx;
 
+        /// Distinct compile-time type for number of matrix rows
+        /// in underlying storage.
         struct NumRows { Idx value; };
+
+        /// Distinct compile-time type for number of matrix columns
+        /// in underlying storage.
         struct NumCols { Idx value; };
 
+        /// Constructor.
+        ///
+        /// \param[in] nRows Number of rows.
+        /// \param[in] nCols Number of columns.
+        /// \param[in] sz Number of data items per (row,column) window.
         explicit WindowedMatrix(const NumRows& nRows,
                                 const NumCols& nCols,
                                 const WindowSize& sz)
@@ -119,37 +181,63 @@ namespace Opm { namespace RestartIO { namespace Helpers {
             , numCols_(nCols.value)
         {}
 
+        /// Retrieve number of columns allocated for this matrix.
         Idx numCols() const
         {
             return this->numCols_;
         }
 
+        /// Retrieve number of rows allocated for this matrix.
         Idx numRows() const
         {
             return this->data_.numWindows() / this->numCols();
         }
 
+        /// Retrieve number of data items per windows.
         Idx windowSize() const
         {
             return this->data_.windowSize();
         }
 
+        /// Request read/write access to individual window.
+        ///
+        /// \param[in] row Numeric ID of particular row in matrix.
+        ///   Must be in range \code [0 .. numRows()-1] \endcode.
+        ///
+        /// \param[in] col Numeric ID of particular column in matrix.
+        ///   Must be in range \code [0 .. numCols()-1] \endcode.
+        ///
+        /// \return Read/write window at position \code (row,col) \endcode.
         WriteWindow operator()(const Idx row, const Idx col)
         {
             return this->data_[ this->i(row, col) ];
         }
 
+        /// Request read-only access to individual window.
+        ///
+        /// \param[in] row Numeric ID of particular row in matrix.
+        ///   Must be in range \code [0 .. numRows()-1] \endcode.
+        ///
+        /// \param[in] col Numeric ID of particular column in matrix.
+        ///   Must be in range \code [0 .. numCols()-1] \endcode.
+        ///
+        /// \return Read-only window at position \code (row,col) \endcode.
         ReadWindow operator()(const Idx row, const Idx col) const
         {
             return this->data_[ this->i(row, col) ];
         }
 
+        /// Get read-only access to full, linearised data items for
+        /// all windows.
         auto data() const
             -> decltype(std::declval<const WindowedArray<T>>().data())
         {
             return this->data_.data();
         }
 
+        /// Extract full, linearised data items for all windows.
+        ///
+        /// Destroys the internal state of the \c WindowedMatrix.
         auto getDataDestructively()
             -> decltype(std::declval<WindowedArray<T>>()
                         .getDataDestructively())

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -469,6 +469,12 @@ namespace {
                     sWell[Ix::LiqRateTarget] =
                         swprop(M::liquid_surface_rate, pp.LiquidRate);
                 }
+                else if (pp.hasProductionControl(PP::ORAT) &&
+                         pp.hasProductionControl(PP::WRAT))
+                {
+                    sWell[Ix::LiqRateTarget] =
+                        swprop(M::liquid_surface_rate, pp.OilRate + pp.WaterRate);
+                }
 
                 if (pp.hasProductionControl(PP::RESV)) {
                     sWell[Ix::ResVRateTarget] =

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -1,0 +1,773 @@
+/*
+  Copyright 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/AggregateWellData.hpp>
+
+#include <opm/output/data/Wells.hpp>
+
+#include <opm/output/eclipse/SummaryState.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
+
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <iterator>
+#include <string>
+
+// #####################################################################
+// Class Opm::RestartIO::Helpers::AggregateWellData
+// ---------------------------------------------------------------------
+
+namespace {
+    std::size_t numWells(const std::vector<int>& inteHead)
+    {
+        // INTEHEAD(17) = NWELLS
+        return inteHead[17 - 1];
+    }
+
+    int maxNumGroups(const std::vector<int>& inteHead)
+    {
+        // INTEHEAD(21) = NWGMAX
+        return inteHead[21 - 1];
+    }
+
+    std::string trim(const std::string& s)
+    {
+        const auto b = s.find_first_not_of(" \t");
+        if (b == std::string::npos) {
+            // No blanks.  Return unchanged.
+            return s;
+        }
+
+        auto e = s.find_last_not_of(" \t");
+        if (e == std::string::npos) {
+            // No trailing blanks.  Return [b, end)
+            return s.substr(b, std::string::npos);
+        }
+
+        // Remove leading/trailing blanks.
+        return s.substr(b, e - b + 1);
+    }
+
+    std::vector<std::string>
+    groupNames(const std::vector<const Opm::Group*>& groups)
+    {
+        auto gnms = std::vector<std::string>{};
+        gnms.reserve(groups.size());
+
+        for (const auto* group : groups) {
+            gnms.push_back(trim(group->name()));
+        }
+
+        return gnms;
+    }
+
+    template <typename WellOp>
+    void wellLoop(const std::vector<const Opm::Well*>& wells,
+                  WellOp&&                             wellOp)
+    {
+        auto wellID = std::size_t{0};
+        for (const auto* well : wells) {
+            wellID += 1;
+
+            if (well == nullptr) { continue; }
+
+            wellOp(*well, wellID - 1);
+        }
+    }
+
+    namespace IWell {
+        std::size_t entriesPerWell(const std::vector<int>& inteHead)
+        {
+            // INTEHEAD(25) = NIWELZ
+            return inteHead[25 - 1];
+        }
+
+        Opm::RestartIO::Helpers::WindowedArray<int>
+        allocate(const std::vector<int>& inteHead)
+        {
+            using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
+
+            return WV {
+                WV::NumWindows{ numWells(inteHead) },
+                WV::WindowSize{ entriesPerWell(inteHead) }
+            };
+        }
+
+        int groupIndex(const std::string&              grpName,
+                       const std::vector<std::string>& groupNames,
+                       const int                       maxGroups)
+        {
+            if (grpName == "FIELD") {
+                // Not really supposed to happen since wells are
+                // not supposed to be parented dirctly to FIELD.
+                return maxGroups + 1;
+            }
+
+            auto b = std::begin(groupNames);
+            auto e = std::end  (groupNames);
+            auto i = std::find(b, e, grpName);
+
+            if (i == e) {
+                // Not really supposed to happen since wells are
+                // not supposed to be parented dirctly to FIELD.
+                return maxGroups + 1;
+            }
+
+            // One-based indexing.
+            return std::distance(b, i) + 1;
+        }
+
+        int wellType(const Opm::Well&  well,
+                     const std::size_t sim_step)
+        {
+            if (well.isProducer(sim_step)) {
+                return 1;      // Producer flag
+            }
+
+            using IType = ::Opm::WellInjector::TypeEnum;
+
+            const auto itype = well
+                .getInjectionProperties(sim_step).injectorType;
+
+            switch (itype) {
+            case IType::OIL:   return 2; // Oil Injector
+            case IType::WATER: return 3; // Water Injector
+            case IType::GAS:   return 4; // Gas Injector
+            default:           return 0; // Undefined
+            }
+        }
+
+        int wellVFPTab(const Opm::Well&  well,
+                       const std::size_t sim_step)
+        {
+            if (well.isInjector(sim_step)) {
+                return well.getInjectionProperties(sim_step).VFPTableNumber;
+            }
+
+            return well.getProductionProperties(sim_step).VFPTableNumber;
+        }
+
+        int ctrlMode(const Opm::Well&  well,
+                     const std::size_t sim_step)
+        {
+            {
+                const auto stat = well.getStatus(sim_step);
+
+                using WStat = ::Opm::WellCommon::StatusEnum;
+
+                if ((stat == WStat::SHUT) || (stat == WStat::STOP)) {
+                    return 0;
+                }
+            }
+
+            if (well.isInjector(sim_step)) {
+                const auto& prop = well
+                    .getInjectionProperties(sim_step);
+
+                const auto wmctl = prop.controlMode;
+                const auto wtype = prop.injectorType;
+
+                using CMode = ::Opm::WellInjector::ControlModeEnum;
+                using WType = ::Opm::WellInjector::TypeEnum;
+
+                switch (wmctl) {
+                case CMode::RATE: {
+                    switch (wtype) {
+                    case WType::OIL:   return 1; // ORAT
+                    case WType::WATER: return 2; // WRAT
+                    case WType::GAS:   return 3; // GRAT
+                    case WType::MULTI: return 0; // MULTI (value not known)
+                    }
+                }
+                    break;
+
+                case CMode::RESV: return 5; // RESV
+                case CMode::THP:  return 6;
+                case CMode::BHP:  return 7;
+                case CMode::GRUP: return -1;
+
+                default:
+                    return 0;
+                }
+            }
+            else if (well.isProducer(sim_step)) {
+                const auto& prop = well
+                    .getProductionProperties(sim_step);
+
+                using CMode = ::Opm::WellProducer::ControlModeEnum;
+
+                switch (prop.controlMode) {
+                case CMode::ORAT: return 1;
+                case CMode::WRAT: return 2;
+                case CMode::GRAT: return 3;
+                case CMode::LRAT: return 4;
+                case CMode::RESV: return 5;
+                case CMode::THP:  return 6;
+                case CMode::BHP:  return 7;
+                case CMode::CRAT: return 9;
+                case CMode::GRUP: return -1;
+
+                default: return 0;
+                }
+            }
+
+            return 0;
+        }
+
+        int compOrder(const Opm::Well& well)
+        {
+            using WCO = ::Opm::WellCompletion::CompletionOrderEnum;
+
+            switch (well.getWellConnectionOrdering()) {
+            case WCO::TRACK: return 0;
+            case WCO::DEPTH: return 1; // Not really supported in Flow
+            case WCO::INPUT: return 2;
+            }
+
+            return 0;
+        }
+
+        template <class IWellArray>
+        void staticContrib(const Opm::Well&                well,
+                           const std::size_t               msWellID,
+                           const std::vector<std::string>& groupNames,
+                           const int                       maxGroups,
+                           const std::size_t               sim_step,
+                           IWellArray&                     iWell)
+        {
+            iWell[1 - 1] = well.getHeadI(sim_step) + 1;
+            iWell[2 - 1] = well.getHeadJ(sim_step) + 1;
+
+            // Connections
+            {
+                const auto& conn = well.getConnections(sim_step);
+
+                // IWEL(5) = Number of active cells connected to well.
+                iWell[5 - 1] = static_cast<int>(conn.size());
+
+                // IWEL(3) = Layer ID of top connection.
+                iWell[3 - 1] = (iWell[5 - 1] == 0)
+                    ? 0 : conn.get(0).getK() + 1;
+
+                // IWEL(4) = Layer ID of last connection.
+                iWell[4 - 1] = (iWell[5 - 1] == 0)
+                    ? 0 : conn.get(conn.size() - 1).getK() + 1;
+            }
+
+            iWell[ 6 - 1] =
+                groupIndex(trim(well.getGroupName(sim_step)),
+                           groupNames, maxGroups);
+
+            iWell[ 7 - 1] = wellType  (well, sim_step);
+            iWell[ 8 - 1] = ctrlMode  (well, sim_step);
+            iWell[12 - 1] = wellVFPTab(well, sim_step);
+
+            // The following items aren't fully characterised yet, but
+            // needed for restart of M2.  Will need further refinement.
+            iWell[18 - 1] = -100;
+            iWell[25 - 1] = -  1;
+            iWell[32 - 1] =    7;
+            iWell[48 - 1] = -  1;
+
+            iWell[50 - 1] = iWell[8 - 1];  // Copy of ctrl mode.
+
+            // Multi-segmented well information
+            iWell[71 - 1] = 0;  // MS Well ID (0 or 1..#MS wells)
+            iWell[72 - 1] = 0;  // Number of well segments
+            if (well.isMultiSegment(sim_step)) {
+                iWell[71 - 1] = static_cast<int>(msWellID);
+                iWell[72 - 1] =
+                    well.getWellSegments(sim_step).size();
+            }
+
+            iWell[99 - 1] = compOrder(well);
+        }
+
+        template <class IWellArray>
+        void dynamicContribShut(IWellArray& iWell)
+        {
+            iWell[ 9 - 1] = -1000;
+            iWell[11 - 1] = -1000;
+        }
+
+        template <class IWellArray>
+        void dynamicContribOpen(const Opm::data::Well& xw,
+                                IWellArray&            iWell)
+        {
+            const auto any_flowing_conn =
+                std::any_of(std::begin(xw.connections),
+                            std::end  (xw.connections),
+                    [](const Opm::data::Connection& c)
+                {
+                    return c.rates.any();
+                });
+
+            iWell[ 9 - 1] = any_flowing_conn ? iWell[8 - 1] : -1;
+            iWell[11 - 1] = 1;
+        }
+    } // IWell
+
+    namespace SWell {
+        std::size_t entriesPerWell(const std::vector<int>& inteHead)
+        {
+            // INTEHEAD(26) = NSWELZ
+            assert ((inteHead[26 - 1] > 121) &&
+                    "SWEL must allocate at least 122 elements per well");
+
+            return inteHead[26 - 1];
+        }
+
+        float datumDepth(const Opm::Well&  well,
+                         const std::size_t sim_step)
+        {
+            if (well.isMultiSegment(sim_step)) {
+                // Datum depth for multi-segment wells is
+                // depth of top-most segment.
+                return well.getWellSegments(sim_step)
+                    .depthTopSegment();
+            }
+
+            // Not a multi-segment well--i.e., this is a regular
+            // well.  Use well's reference depth.
+            return well.getRefDepth(sim_step);
+        }
+
+        Opm::RestartIO::Helpers::WindowedArray<float>
+        allocate(const std::vector<int>& inteHead)
+        {
+            using WV = Opm::RestartIO::Helpers::WindowedArray<float>;
+
+            return WV {
+                WV::NumWindows{ numWells(inteHead) },
+                WV::WindowSize{ entriesPerWell(inteHead) }
+            };
+        }
+
+        std::vector<float> defaultSWell()
+        {
+            const auto dflt  = -1.0e+20f;
+            const auto infty =  1.0e+20f;
+            const auto zero  =  0.0f;
+            const auto one   =  1.0f;
+            const auto half  =  0.5f;
+
+            // Initial data by Statoil ASA.
+            return { // 122 Items (0..121)
+                // 0     1      2      3      4      5
+                infty, infty, infty, infty, infty, infty,    //   0..  5  ( 0)
+                one  , zero , zero , zero , zero , 1.0e-05f, //   6.. 11  ( 1)
+                zero , zero , infty, infty, zero , dflt ,    //  12.. 17  ( 2)
+                infty, infty, infty, infty, infty, zero ,    //  18.. 23  ( 3)
+                one  , zero , zero , zero , zero , zero ,    //  24.. 29  ( 4)
+                zero , one  , zero , infty, zero , zero ,    //  30.. 35  ( 5)
+                zero , zero , zero , zero , zero , zero ,    //  36.. 41  ( 6)
+                zero , zero , zero , zero , zero , zero ,    //  42.. 47  ( 7)
+                zero , zero , zero , zero , zero , zero ,    //  48.. 53  ( 8)
+                infty, zero , zero , zero , zero , zero ,    //  54.. 59  ( 9)
+                zero , zero , zero , zero , zero , zero ,    //  60.. 65  (10)
+                zero , zero , zero , zero , zero , zero ,    //  66.. 71  (11)
+                zero , zero , zero , zero , zero , zero ,    //  72.. 77  (12)
+                zero , infty, infty, zero , zero , one  ,    //  78.. 83  (13)
+                one  , one  , zero , infty, zero , infty,    //  84.. 89  (14)
+                one  , dflt , one  , zero , zero , zero ,    //  90.. 95  (15)
+                zero , zero , zero , zero , zero , zero ,    //  96..101  (16)
+                zero , zero , zero , zero , zero , zero ,    // 102..107  (17)
+                zero , zero , half , one  , zero , zero ,    // 108..113  (18)
+                zero , zero , zero , zero , zero , infty,    // 114..119  (19)
+                zero , one  ,                                // 120..121  (20)
+            };
+        }
+
+        template <class SWellArray>
+        void assignDefaultSWell(SWellArray& sWell)
+        {
+            const auto& init = defaultSWell();
+
+            const auto sz = static_cast<
+                decltype(init.size())>(sWell.size());
+
+            auto b = std::begin(init);
+            auto e = b + std::min(init.size(), sz);
+
+            std::copy(b, e, std::begin(sWell));
+        }
+
+        template <class SWellArray>
+        void staticContrib(const Opm::Well&       well,
+                           const Opm::UnitSystem& units,
+                           const std::size_t      sim_step,
+                           SWellArray&            sWell)
+        {
+            using M = ::Opm::UnitSystem::measure;
+
+            auto swprop = [&units](const M u, const double x) -> float
+            {
+                return static_cast<float>(units.from_si(u, x));
+            };
+
+            assignDefaultSWell(sWell);
+
+            if (well.isProducer(sim_step)) {
+                const auto& pp = well.getProductionProperties(sim_step);
+
+                using PP = ::Opm::WellProducer::ControlModeEnum;
+
+                if (pp.hasProductionControl(PP::ORAT)) {
+                    sWell[1 - 1] = swprop(M::liquid_surface_rate, pp.OilRate);
+                }
+
+                if (pp.hasProductionControl(PP::WRAT)) {
+                    sWell[2 - 1] = swprop(M::liquid_surface_rate, pp.WaterRate);
+                }
+
+                if (pp.hasProductionControl(PP::GRAT)) {
+                    sWell[3 - 1] = swprop(M::gas_surface_rate, pp.GasRate);
+                }
+
+                if (pp.hasProductionControl(PP::LRAT)) {
+                    sWell[4 - 1] = swprop(M::liquid_surface_rate, pp.LiquidRate);
+                }
+
+                if (pp.hasProductionControl(PP::RESV)) {
+                    sWell[5 - 1] = swprop(M::rate, pp.ResVRate);
+                }
+
+                if (pp.hasProductionControl(PP::THP)) {
+                    sWell[6 - 1] = swprop(M::pressure, pp.THPLimit);
+                }
+
+                if (pp.hasProductionControl(PP::BHP)) {
+                    sWell[7 - 1] = swprop(M::pressure, pp.BHPLimit);
+                }
+            }
+            else if (well.isInjector(sim_step)) {
+                const auto& ip = well.getInjectionProperties(sim_step);
+
+                using IP = ::Opm::WellInjector::ControlModeEnum;
+
+                if (ip.hasInjectionControl(IP::THP)) {
+                    sWell[6 - 1] = swprop(M::pressure, ip.THPLimit);
+                }
+
+                if (ip.hasInjectionControl(IP::BHP)) {
+                    sWell[7 - 1] = swprop(M::pressure, ip.BHPLimit);
+                }
+            }
+
+            sWell[10 - 1] = swprop(M::length, datumDepth(well, sim_step));
+        }
+    } // SWell
+
+    namespace XWell {
+        std::size_t entriesPerWell(const std::vector<int>& inteHead)
+        {
+            // INTEHEAD(27) = NXWELZ
+            assert ((inteHead[27 - 1] > 123) &&
+                    "XWEL must allocate at least 124 elements per well");
+
+            return inteHead[27 - 1];
+        }
+
+        Opm::RestartIO::Helpers::WindowedArray<double>
+        allocate(const std::vector<int>& inteHead)
+        {
+            using WV = Opm::RestartIO::Helpers::WindowedArray<double>;
+
+            return WV {
+                WV::NumWindows{ numWells(inteHead) },
+                WV::WindowSize{ entriesPerWell(inteHead) }
+            };
+        }
+
+        template <class XWellArray>
+        void staticContrib(const ::Opm::Well&     well,
+                           const Opm::UnitSystem& units,
+                           const std::size_t      sim_step,
+                           XWellArray&            xWell)
+        {
+            using M = ::Opm::UnitSystem::measure;
+
+            // xWell[41] = BHP target.
+
+            xWell[41] = well.isInjector(sim_step)
+                ? well.getInjectionProperties (sim_step).BHPLimit
+                : well.getProductionProperties(sim_step).BHPLimit;
+
+            xWell[41] = units.from_si(M::pressure, xWell[41]);
+        }
+
+        template <class XWellArray>
+        void assignProducer(const std::string&         well,
+                            const ::Opm::SummaryState& smry,
+                            XWellArray&                xWell)
+        {
+            auto get = [&smry, &well](const std::string& vector)
+            {
+                return smry.get(vector + ':' + well);
+            };
+
+            xWell[0] = get("WOPR");
+            xWell[1] = get("WWPR");
+            xWell[2] = get("WGPR");
+            xWell[3] = xWell[0] + xWell[1]; // LPR
+            xWell[4] = get("WVPR");
+
+            xWell[6] = get("WBHP");
+            xWell[7] = get("WWCT");
+            xWell[8] = get("WGOR");
+
+            xWell[18] = get("WOPT");
+            xWell[19] = get("WWPT");
+            xWell[20] = get("WGPT");
+            xWell[21] = get("WVPT");
+
+            xWell[36] = xWell[1]; // Copy of WWPR
+            xWell[37] = xWell[2]; // Copy of WGPR
+        }
+
+        template <class XWellArray>
+        void assignWaterInjector(const std::string&         well,
+                                 const ::Opm::SummaryState& smry,
+                                 XWellArray&                xWell)
+        {
+            auto get = [&smry, &well](const std::string& vector)
+            {
+                return smry.get(vector + ':' + well);
+            };
+
+            // Rates reported as negative, cumulative totals as positive.
+            xWell[1] = -get("WWIR");
+            xWell[3] = xWell[1];  // Copy of WWIR
+
+            xWell[6] = get("WBHP");
+
+            xWell[23] = get("WWIT");
+
+            xWell[36] = xWell[1];  // Copy of WWIR
+            xWell[81] = xWell[23]; // Copy of WWIT
+
+            xWell[122] = -get("WWVIR");
+        }
+
+        template <class XWellArray>
+        void assignGasInjector(const std::string&         well,
+                               const ::Opm::SummaryState& smry,
+                               XWellArray&                xWell)
+        {
+            auto get = [&smry, &well](const std::string& vector)
+            {
+                return smry.get(vector + ':' + well);
+            };
+
+            // Rates reported as negative, cumulative totals as positive.
+            xWell[2] = -get("WGIR");
+            xWell[4] = -get("WGVIR");
+
+            xWell[6] = get("WBHP");
+
+            xWell[24] = get("WGIT");
+
+            xWell[34] = xWell[4] / xWell[2]; // Bg
+
+            xWell[37] = xWell[2]; // Copy of WGIR
+
+            xWell[82] = xWell[24]; // Copy of WGIT
+
+            xWell[123] = xWell[4]; // Copy of WGVIR
+        }
+
+        template <class XWellArray>
+        void dynamicContrib(const ::Opm::Well&         well,
+                            const ::Opm::SummaryState& smry,
+                            const std::size_t          sim_step,
+                            XWellArray&                xWell)
+        {
+            if (well.isProducer(sim_step)) {
+                assignProducer(well.name(), smry, xWell);
+            }
+            else if (well.isInjector(sim_step)) {
+                using IType = ::Opm::WellInjector::TypeEnum;
+
+                const auto itype = well
+                    .getInjectionProperties(sim_step).injectorType;
+
+                switch (itype) {
+                case IType::OIL:
+                    // Do nothing.
+                    break;
+
+                case IType::WATER:
+                    assignWaterInjector(well.name(), smry, xWell);
+                    break;
+
+                case IType::GAS:
+                    assignGasInjector(well.name(), smry, xWell);
+                    break;
+
+                case IType::MULTI:
+                    assignWaterInjector(well.name(), smry, xWell);
+                    assignGasInjector  (well.name(), smry, xWell);
+                    break;
+                }
+            }
+        }
+    } // XWell
+
+    namespace ZWell {
+        std::size_t entriesPerWell(const std::vector<int>& inteHead)
+        {
+            // INTEHEAD(28) = NZWELZ
+            assert ((inteHead[28 - 1] > 1) &&
+                    "ZWEL must allocate at least 1 element per well");
+
+            return inteHead[28 - 1];
+        }
+
+        Opm::RestartIO::Helpers::WindowedArray<
+            Opm::RestartIO::Helpers::CharArrayNullTerm<8>
+        >
+        allocate(const std::vector<int>& inteHead)
+        {
+            using WV = Opm::RestartIO::Helpers::WindowedArray<
+                Opm::RestartIO::Helpers::CharArrayNullTerm<8>
+            >;
+
+            return WV {
+                WV::NumWindows{ numWells(inteHead) },
+                WV::WindowSize{ entriesPerWell(inteHead) }
+            };
+        }
+
+        template <class ZWellArray>
+        void staticContrib(const Opm::Well& well, ZWellArray& zWell)
+        {
+            zWell[1 - 1] = well.name();
+        }
+    } // ZWell
+} // Anonymous
+
+// =====================================================================
+
+Opm::RestartIO::Helpers::AggregateWellData::
+AggregateWellData(const std::vector<int>& inteHead)
+    : iWell_ (IWell::allocate(inteHead))
+    , sWell_ (SWell::allocate(inteHead))
+    , xWell_ (XWell::allocate(inteHead))
+    , zWell_ (ZWell::allocate(inteHead))
+    , nWGMax_(maxNumGroups(inteHead))
+{}
+
+// ---------------------------------------------------------------------
+
+void
+Opm::RestartIO::Helpers::AggregateWellData::
+captureDeclaredWellData(const Schedule&   sched,
+                        const UnitSystem& units,
+                        const std::size_t sim_step)
+{
+    const auto& wells = sched.getWells(sim_step);
+
+    // Static contributions to IWEL array.
+    {
+        const auto grpNames = groupNames(sched.getGroups());
+        auto msWellID       = std::size_t{0};
+
+        wellLoop(wells, [&grpNames, &msWellID, sim_step, this]
+            (const Well& well, const std::size_t wellID) -> void
+        {
+            msWellID += well.isMultiSegment(sim_step);  // 1-based index.
+            auto iw   = this->iWell_[wellID];
+
+            IWell::staticContrib(well, msWellID, grpNames,
+                                 this->nWGMax_, sim_step, iw);
+        });
+    }
+
+    // Static contributions to SWEL array.
+    wellLoop(wells, [&units, sim_step, this]
+        (const Well& well, const std::size_t wellID) -> void
+    {
+        auto sw = this->sWell_[wellID];
+
+        SWell::staticContrib(well, units, sim_step, sw);
+    });
+
+    // Static contributions to XWEL array.
+    wellLoop(wells, [&units, sim_step, this]
+        (const Well& well, const std::size_t wellID) -> void
+    {
+        auto xw = this->xWell_[wellID];
+
+        XWell::staticContrib(well, units, sim_step, xw);
+    });
+
+    // Static contributions to ZWEL array.
+    wellLoop(wells,
+        [this](const Well& well, const std::size_t wellID) -> void
+    {
+        auto zw = this->zWell_[wellID];
+
+        ZWell::staticContrib(well, zw);
+    });
+}
+
+// ---------------------------------------------------------------------
+
+void
+Opm::RestartIO::Helpers::AggregateWellData::
+captureDynamicWellData(const Schedule&             sched,
+                       const std::size_t           sim_step,
+                       const Opm::data::WellRates& xw,
+                       const ::Opm::SummaryState&  smry)
+{
+    const auto& wells = sched.getWells(sim_step);
+
+    // Dynamic contributions to IWEL array.
+    wellLoop(wells, [this, &xw]
+        (const Well& well, const std::size_t wellID) -> void
+    {
+        auto iWell = this->iWell_[wellID];
+
+        auto i = xw.find(well.name());
+        if ((i == std::end(xw)) || !i->second.flowing()) {
+            IWell::dynamicContribShut(iWell);
+        }
+        else {
+            IWell::dynamicContribOpen(i->second, iWell);
+        }
+    });
+
+    // Dynamic contributions to XWEL array.
+    wellLoop(wells, [this, sim_step, &smry]
+        (const Well& well, const std::size_t wellID) -> void
+    {
+        auto xw = this->xWell_[wellID];
+
+        XWell::dynamicContrib(well, smry, sim_step, xw);
+    });
+}

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -61,15 +61,12 @@ namespace {
     {
         const auto b = s.find_first_not_of(" \t");
         if (b == std::string::npos) {
-            // No blanks.  Return unchanged.
-            return s;
+            // All blanks.  Return empty.
+            return "";
         }
 
-        auto e = s.find_last_not_of(" \t");
-        if (e == std::string::npos) {
-            // No trailing blanks.  Return [b, end)
-            return s.substr(b, std::string::npos);
-        }
+        const auto e = s.find_last_not_of(" \t");
+        assert ((e != std::string::npos) && "Logic Error");
 
         // Remove leading/trailing blanks.
         return s.substr(b, e - b + 1);

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/output/eclipse/AggregateWellData.hpp>
 
+#include <opm/output/eclipse/VectorItems/intehead.hpp>
+
 #include <opm/output/data/Wells.hpp>
 
 #include <opm/output/eclipse/SummaryState.hpp>
@@ -38,6 +40,8 @@
 #include <iterator>
 #include <string>
 
+namespace VI = Opm::RestartIO::Helpers::VectorItems;
+
 // #####################################################################
 // Class Opm::RestartIO::Helpers::AggregateWellData
 // ---------------------------------------------------------------------
@@ -45,14 +49,12 @@
 namespace {
     std::size_t numWells(const std::vector<int>& inteHead)
     {
-        // INTEHEAD(17) = NWELLS
-        return inteHead[17 - 1];
+        return inteHead[VI::intehead::NWELLS];
     }
 
     int maxNumGroups(const std::vector<int>& inteHead)
     {
-        // INTEHEAD(21) = NWGMAX
-        return inteHead[21 - 1];
+        return inteHead[VI::intehead::NWGMAX];
     }
 
     std::string trim(const std::string& s)
@@ -103,8 +105,7 @@ namespace {
     namespace IWell {
         std::size_t entriesPerWell(const std::vector<int>& inteHead)
         {
-            // INTEHEAD(25) = NIWELZ
-            return inteHead[25 - 1];
+            return inteHead[VI::intehead::NIWELZ];
         }
 
         Opm::RestartIO::Helpers::WindowedArray<int>
@@ -335,11 +336,10 @@ namespace {
     namespace SWell {
         std::size_t entriesPerWell(const std::vector<int>& inteHead)
         {
-            // INTEHEAD(26) = NSWELZ
-            assert ((inteHead[26 - 1] > 121) &&
+            assert ((inteHead[VI::intehead::NSWELZ] > 121) &&
                     "SWEL must allocate at least 122 elements per well");
 
-            return inteHead[26 - 1];
+            return inteHead[VI::intehead::NSWELZ];
         }
 
         float datumDepth(const Opm::Well&  well,
@@ -486,11 +486,10 @@ namespace {
     namespace XWell {
         std::size_t entriesPerWell(const std::vector<int>& inteHead)
         {
-            // INTEHEAD(27) = NXWELZ
-            assert ((inteHead[27 - 1] > 123) &&
+            assert ((inteHead[VI::intehead::NXWELZ] > 123) &&
                     "XWEL must allocate at least 124 elements per well");
 
-            return inteHead[27 - 1];
+            return inteHead[VI::intehead::NXWELZ];
         }
 
         Opm::RestartIO::Helpers::WindowedArray<double>
@@ -641,11 +640,10 @@ namespace {
     namespace ZWell {
         std::size_t entriesPerWell(const std::vector<int>& inteHead)
         {
-            // INTEHEAD(28) = NZWELZ
-            assert ((inteHead[28 - 1] > 1) &&
+            assert ((inteHead[VI::intehead::NZWELZ] > 1) &&
                     "ZWEL must allocate at least 1 element per well");
 
-            return inteHead[28 - 1];
+            return inteHead[VI::intehead::NZWELZ];
         }
 
         Opm::RestartIO::Helpers::WindowedArray<

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -33,6 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -479,10 +480,9 @@ namespace {
                         swprop(M::pressure, pp.THPLimit);
                 }
 
-                if (pp.hasProductionControl(PP::BHP)) {
-                    sWell[Ix::BHPTarget] =
-                        swprop(M::pressure, pp.BHPLimit);
-                }
+                sWell[Ix::BHPTarget] = pp.hasProductionControl(PP::BHP)
+                    ? swprop(M::pressure, pp.BHPLimit)
+                    : swprop(M::pressure, 100.0e3*::Opm::unit::psia);
             }
             else if (well.isInjector(sim_step)) {
                 const auto& ip = well.getInjectionProperties(sim_step);
@@ -493,9 +493,9 @@ namespace {
                     sWell[Ix::THPTarget] = swprop(M::pressure, ip.THPLimit);
                 }
 
-                if (ip.hasInjectionControl(IP::BHP)) {
-                    sWell[Ix::BHPTarget] = swprop(M::pressure, ip.BHPLimit);
-                }
+                sWell[Ix::BHPTarget] = ip.hasInjectionControl(IP::BHP)
+                    ? swprop(M::pressure, ip.BHPLimit)
+                    : swprop(M::pressure, 1.0*::Opm::unit::atm);
             }
 
             sWell[Ix::DatumDepth] =

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -92,13 +92,14 @@ namespace {
     void wellLoop(const std::vector<const Opm::Well*>& wells,
                   WellOp&&                             wellOp)
     {
-        auto wellID = std::size_t{0};
-        for (const auto* well : wells) {
-            wellID += 1;
+        for (auto nWell = wells.size(), wellID = 0*nWell;
+             wellID < nWell; ++wellID)
+        {
+            const auto* well = wells[wellID];
 
             if (well == nullptr) { continue; }
 
-            wellOp(*well, wellID - 1);
+            wellOp(*well, wellID);
         }
     }
 

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -1,5 +1,7 @@
 #include <opm/output/eclipse/InteHEAD.hpp>
 
+#include <opm/output/eclipse/VectorItems/intehead.hpp>
+
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -8,55 +10,57 @@
 #include <utility>
 #include <vector>
 
+namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
+
 enum index : std::vector<int>::size_type {
-  ISNUM		=	0	,		//	0	0		An encoded integer corresponding to the time the file was created. For files not originating from ECLIPSE, this value may be set to zero.
-  VERSION	=	1	,		//	0	0
-  UNIT		=	2	,		//	(1,2,3)	1		units type: 1 - METRIC, 2 - FIELD, 3 - LAB
+  ISNUM		=	VI::intehead::ISNUM	,		//	0	0		An encoded integer corresponding to the time the file was created. For files not originating from ECLIPSE, this value may be set to zero.
+  VERSION	=	VI::intehead::VERSION	,		//	0	0
+  UNIT		=	VI::intehead::UNIT	,		//	(1,2,3)	1		units type: 1 - METRIC, 2 - FIELD, 3 - LAB
   ih_003	=	3	,		//	0	0
   ih_004	=	4	,		//	0	0
   ih_005	=	5	,		//	0	0
   ih_006	=	6	,		//	0	0
   ih_007	=	7	,		//	0	0
-  NX		=	8	,		//	NX	137		Grid x-direction dimension, NX
-  NY		=	9	,		//	NY	236		Grid x-direction dimension, NY
-  NZ		=	10	,		//	NZ	58		Grid x-direction dimension, NZ
-  NACTIV	=	11	,		//	NACTIV?	89022		NACTIV = number of active cells
+  NX		=	VI::intehead::NX	,		//	NX	137		Grid x-direction dimension, NX
+  NY		=	VI::intehead::NY	,		//	NY	236		Grid x-direction dimension, NY
+  NZ		=	VI::intehead::NZ	,		//	NZ	58		Grid x-direction dimension, NZ
+  NACTIV	=	VI::intehead::NACTIV	,		//	NACTIV?	89022		NACTIV = number of active cells
   ih_012	=	12	,		//	0	0
   ih_013	=	13	,		//	0	0
-  PHASE		=	14	,		//	IPHS	7		IPHS = phase indicator: 1 - oil, 2 - water, 3 - oil/water, 4 - gas, 5 – oil/gas, 6 - gas/water, 7 - oil/water/gas (ECLIPSE output only)
+  PHASE		=	VI::intehead::PHASE	,		//	IPHS	7		IPHS = phase indicator: 1 - oil, 2 - water, 3 - oil/water, 4 - gas, 5 – oil/gas, 6 - gas/water, 7 - oil/water/gas (ECLIPSE output only)
   ih_015	=	15	,		//	0	0
-  NWELLS	=	16	,		//	NWELLS	39		NWELL = number of wells
-  NCWMAX	=	17	,		//	NCWMAX	108	Weldims item2	NCWMAX = maximum number of completions per well
+  NWELLS	=	VI::intehead::NWELLS	,		//	NWELLS	39		NWELL = number of wells
+  NCWMAX	=	VI::intehead::NCWMAX	,		//	NCWMAX	108	Weldims item2	NCWMAX = maximum number of completions per well
   ih_018	=	18	,		//	NGRP?	0	Number of actual groups
-  NWGMAX	=	19	,		//	NWGMAX	0	maximum of weldims item3 or item4	NWGMAX = maximum number of wells in any well group
-  NGMAXZ	=	20	,		//	NGMAXZ	0	weldims item3 + 1	NGMAXZ = maximum number of groups in field
+  NWGMAX	=	VI::intehead::NWGMAX	,		//	NWGMAX	0	maximum of weldims item3 or item4	NWGMAX = maximum number of wells in any well group
+  NGMAXZ	=	VI::intehead::NGMAXZ	,		//	NGMAXZ	0	weldims item3 + 1	NGMAXZ = maximum number of groups in field
   ih_021	=	21	,		//	0	0
   ih_022	=	22	,		//	0	0
   ih_023	=	23	,		//	0	0
-  NIWELZ	=	24	,		//	NIWELZ	155	155	NIWELZ = no of data elements per well in IWEL array (default 97 for ECLIPSE, 94 for ECLIPSE 300)
-  NSWELZ	=	25	,		//	NSWELZ	122	122	NSWELZ = number of daelements per well in SWEL array
-  NXWELZ	=	26	,		//	NXWELZ	130	130	NXWELZ = number of delements per well in XWEL array
-  NZWELZ	=	27	,		//	NZWEL	3	3	NZWEL = no of 8-character words per well in ZWEL array (= 3)
+  NIWELZ	=	VI::intehead::NIWELZ	,		//	NIWELZ	155	155	NIWELZ = no of data elements per well in IWEL array (default 97 for ECLIPSE, 94 for ECLIPSE 300)
+  NSWELZ	=	VI::intehead::NSWELZ	,		//	NSWELZ	122	122	NSWELZ = number of daelements per well in SWEL array
+  NXWELZ	=	VI::intehead::NXWELZ	,		//	NXWELZ	130	130	NXWELZ = number of delements per well in XWEL array
+  NZWELZ	=	VI::intehead::NZWELZ	,		//	NZWEL	3	3	NZWEL = no of 8-character words per well in ZWEL array (= 3)
   ih_028	=	28	,		//	0	0
   ih_029	=	29	,		//	0	0
   ih_030	=	30	,		//	0	0
   ih_031	=	31	,		//	0	0
-  NICONZ	=	32	,		//	25	15	25	NICON = no of data elements per completion in ICON array (default 19)
-  NSCONZ	=	33	,		//	40	0		NSCONZ = number of data elements per completion in SCON array
-  NXCONZ	=	34	,		//	58	0	58	NXCONZ = number of data elements per completion in XCON array
+  NICONZ	=	VI::intehead::NICONZ	,		//	25	15	25	NICON = no of data elements per completion in ICON array (default 19)
+  NSCONZ	=	VI::intehead::NSCONZ	,		//	40	0		NSCONZ = number of data elements per completion in SCON array
+  NXCONZ	=	VI::intehead::NXCONZ	,		//	58	0	58	NXCONZ = number of data elements per completion in XCON array
   ih_035	=	35	,		//	0	0
-  NIGRPZ	=	36	,		//	97+intehead_array[19]	0	97 + intehead[19]	NIGRPZ = no of data elements per group in IGRP array
-  NSGRPZ	=	37	,		//	112	0	112	NSGRPZ = number of data elements per group in SGRP array
-  NXGRPZ	=	38	,		//	180	0	180	NXGRPZ = number of data elements per group in XGRP array
-  NZGRPZ	=	39	,		//	5	0		NZGRPZ = number of data elements per group in ZGRP array
+  NIGRPZ	=	VI::intehead::NIGRPZ	,		//	97+intehead_array[19]	0	97 + intehead[19]	NIGRPZ = no of data elements per group in IGRP array
+  NSGRPZ	=	VI::intehead::NSGRPZ	,		//	112	0	112	NSGRPZ = number of data elements per group in SGRP array
+  NXGRPZ	=	VI::intehead::NXGRPZ	,		//	180	0	180	NXGRPZ = number of data elements per group in XGRP array
+  NZGRPZ	=	VI::intehead::NZGRPZ	,		//	5	0		NZGRPZ = number of data elements per group in ZGRP array
   ih_040	=	40	,		//	0	0
-  NCAMAX	=	41	,		//	1	0		NCAMAX = maximum number of analytic aquifer connections
-  NIAAQZ	=	42	,		//	18	0		NIAAQZ = number of data elements per aquifer in IAAQ array
-  NSAAQZ	=	43	,		//	24	0		NSAAQZ = number of data elements per aquifer in SAAQ array
-  NXAAQZ	=	44	,		//	10	0		NXAAQZ = number of data elements per aquifer in XAAQ array
-  NICAQZ	=	45	,		//	7	0		NSCAQZ= number of data elements per aquifer connection in SCAQ array
-  NSCAQZ	=	46	,		//	2	0
-  NACAQZ	=	47	,		//	4	0
+  NCAMAX	=	VI::intehead::NCAMAX	,		//	1	0		NCAMAX = maximum number of analytic aquifer connections
+  NIAAQZ	=	VI::intehead::NIAAQZ	,		//	18	0		NIAAQZ = number of data elements per aquifer in IAAQ array
+  NSAAQZ	=	VI::intehead::NSAAQZ	,		//	24	0		NSAAQZ = number of data elements per aquifer in SAAQ array
+  NXAAQZ	=	VI::intehead::NXAAQZ	,		//	10	0		NXAAQZ = number of data elements per aquifer in XAAQ array
+  NICAQZ	=	VI::intehead::NICAQZ	,		//	7	0		NSCAQZ= number of data elements per aquifer connection in SCAQ array
+  NSCAQZ	=	VI::intehead::NSCAQZ	,		//	2	0
+  NACAQZ	=	VI::intehead::NACAQZ	,		//	4	0
   ih_048	=	48	,		//	0	0
   ih_049	=	49	,		//	0	0
   ih_050	=	50	,		//	0	0
@@ -183,13 +187,13 @@ enum index : std::vector<int>::size_type {
   ih_171	=	171	,		//	0	0
   ih_172	=	172	,		//	0	0
   ih_173	=	173	,		//	0	0
-  NSEGWL	=	174	,		//	0	0	number of mswm wells defined with WELSEG
-  NSWLMX	=	175	,		//	NSWLMX	0	Item 1 in WSEGDIMS keyword (runspec section)	NSWLMX = maximum number of segmented wells
-  NSEGMX	=	176	,		//	NSEGMX	0	Item 2 in WSEGDIMS keyword (runspec section)	NSEGMX = maximum number of segments per well
-  NLBRMX	=	177	,		//	NLBRMX	0	Item 3 in WSEGDIMS keyword (runspec section)	NLBRMX = maximum number of lateral branches per well
-  NISEGZ	=	178	,		//	22	0	22	NISEGZ = number of entries per segment in ISEG array
-  NRSEGZ	=	179	,		//	140	0	140	NRSEGZ = number of entries per segment in RSEG array
-  NILBRZ	=	180	,		//	10		10	NILBRZ = number of entries per segment in ILBR array
+  NSEGWL	=	VI::intehead::NSEGWL	,		//	0	0	number of mswm wells defined with WELSEG
+  NSWLMX	=	VI::intehead::NSWLMX	,		//	NSWLMX	0	Item 1 in WSEGDIMS keyword (runspec section)	NSWLMX = maximum number of segmented wells
+  NSEGMX	=	VI::intehead::NSEGMX	,		//	NSEGMX	0	Item 2 in WSEGDIMS keyword (runspec section)	NSEGMX = maximum number of segments per well
+  NLBRMX	=	VI::intehead::NLBRMX	,		//	NLBRMX	0	Item 3 in WSEGDIMS keyword (runspec section)	NLBRMX = maximum number of lateral branches per well
+  NISEGZ	=	VI::intehead::NISEGZ	,		//	22	0	22	NISEGZ = number of entries per segment in ISEG array
+  NRSEGZ	=	VI::intehead::NRSEGZ	,		//	140	0	140	NRSEGZ = number of entries per segment in RSEG array
+  NILBRZ	=	VI::intehead::NILBRZ	,		//	10		10	NILBRZ = number of entries per segment in ILBR array
   RSTSIZE	=	181	,		//	0
   ih_182	=	182	,		//	0
   ih_183	=	183	,		//	0

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -10,6 +10,12 @@
 #include <utility>
 #include <vector>
 
+// Public INTEHEAD items are recorded in the common header file
+//
+//     opm/output/eclipse/VectorItems/intehead.hpp
+//
+// Promote items from 'index' to that list to make them public.
+// The 'index' list always uses public items where available.
 namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 
 enum index : std::vector<int>::size_type {

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -505,9 +505,6 @@ Opm::RestartIO::InteHEAD::calendarDate(const TimePoint& timePoint)
     this->data_[IHOURZ] = timePoint.hour;
     this->data_[IMINTS] = timePoint.minute;
 
-    this->data_[IHOURZ] = timePoint.hour;
-    this->data_[IMINTS] = timePoint.minute;
-
     // Microseonds...
     this->data_[ISECND] =
         ((timePoint.second * 1000) * 1000) + timePoint.microseconds;

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -76,7 +76,9 @@ namespace {
 
             makeEntities('W', well_name);
 
-            entities.emplace_back("WBHP", well_name);
+            entities.emplace_back("WBHP" , well_name);
+            entities.emplace_back("WGVIR", well_name);
+            entities.emplace_back("WWVIR", well_name);
         }
 
         for (const auto* grp : sched.getGroups()) {

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -1,0 +1,676 @@
+/*
+  Copyright 2018 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Aggregate_Well_Data
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/AggregateWellData.hpp>
+
+#include <opm/output/eclipse/SummaryState.hpp>
+
+#include <opm/output/data/Wells.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+
+#include <exception>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+struct MockIH
+{
+    MockIH(const int numWells,
+           const int iwelPerWell = 155,  // E100
+           const int swelPerWell = 122,  // E100
+           const int xwelPerWell = 130,  // E100
+           const int zwelPerWell =   3); // E100
+
+    std::vector<int> value;
+
+    using Sz = std::vector<int>::size_type;
+
+    Sz nwells;
+    Sz niwelz;
+    Sz nswelz;
+    Sz nxwelz;
+    Sz nzwelz;
+};
+
+MockIH::MockIH(const int numWells,
+               const int iwelPerWell,
+               const int swelPerWell,
+               const int xwelPerWell,
+               const int zwelPerWell)
+    : value(411, 0)
+{
+    this->nwells = this->value[17 - 1] = numWells;
+    this->niwelz = this->value[25 - 1] = iwelPerWell;
+    this->nswelz = this->value[26 - 1] = swelPerWell;
+    this->nxwelz = this->value[27 - 1] = xwelPerWell;
+    this->nzwelz = this->value[28 - 1] = zwelPerWell;
+}
+
+namespace {
+    Opm::Deck first_sim()
+    {
+        // Mostly copy of tests/FIRST_SIM.DATA
+        const auto input = std::string {
+            R"~(
+RUNSPEC
+OIL
+GAS
+WATER
+DISGAS
+VAPOIL
+UNIFOUT
+UNIFIN
+DIMENS
+ 10 10 10 /
+
+GRID
+DXV
+10*0.25 /
+DYV
+10*0.25 /
+DZV
+10*0.25 /
+TOPS
+100*0.25 /
+
+PORO
+1000*0.2 /
+
+SOLUTION
+RESTART
+FIRST_SIM 1/
+
+
+START             -- 0
+1 NOV 1979 /
+
+SCHEDULE
+SKIPREST
+RPTRST
+BASIC=1
+/
+DATES             -- 1
+ 10  OKT 2008 /
+/
+WELSPECS
+      'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+      'OP_2'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+/
+COMPDAT
+      'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+      'OP_2'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 /
+      'OP_1'  9  9   3   3 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+WCONPROD
+      'OP_1' 'OPEN' 'ORAT' 20000  4* 1000 /
+/
+WCONINJE
+      'OP_2' 'GAS' 'OPEN' 'RATE' 100 200 400 /
+/
+
+DATES             -- 2
+ 20  JAN 2011 /
+/
+WELSPECS
+      'OP_3'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+/
+COMPDAT
+      'OP_3'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+WCONPROD
+      'OP_3' 'OPEN' 'ORAT' 20000  4* 1000 /
+/
+WCONINJE
+      'OP_2' 'WATER' 'OPEN' 'RATE' 100 200 400 /
+/
+
+DATES             -- 3
+ 15  JUN 2013 /
+/
+COMPDAT
+      'OP_2'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+      'OP_1'  9  9   7  7 'SHUT' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+
+DATES             -- 4
+ 22  APR 2014 /
+/
+WELSPECS
+      'OP_4'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+/
+COMPDAT
+      'OP_4'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+      'OP_3'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+WCONPROD
+      'OP_4' 'OPEN' 'ORAT' 20000  4* 1000 /
+/
+
+DATES             -- 5
+ 30  AUG 2014 /
+/
+WELSPECS
+      'OP_5'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+/
+COMPDAT
+      'OP_5'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+WCONPROD
+      'OP_5' 'OPEN' 'ORAT' 20000  4* 1000 /
+/
+
+DATES             -- 6
+ 15  SEP 2014 /
+/
+WCONPROD
+      'OP_3' 'SHUT' 'ORAT' 20000  4* 1000 /
+/
+
+DATES             -- 7
+ 9  OCT 2014 /
+/
+WELSPECS
+      'OP_6'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+/
+COMPDAT
+      'OP_6'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+WCONPROD
+      'OP_6' 'OPEN' 'ORAT' 20000  4* 1000 /
+/
+TSTEP            -- 8
+10 /
+)~" };
+
+        return Opm::Parser{}.parseString(input);
+    }
+
+    Opm::SummaryState sim_state()
+    {
+        auto state = Opm::SummaryState{};
+
+        state.add("WOPR:OP_1" ,    1.0);
+        state.add("WWPR:OP_1" ,    2.0);
+        state.add("WGPR:OP_1" ,    3.0);
+        state.add("WVPR:OP_1" ,    4.0);
+        state.add("WOPT:OP_1" ,   10.0);
+        state.add("WWPT:OP_1" ,   20.0);
+        state.add("WGPT:OP_1" ,   30.0);
+        state.add("WVPT:OP_1" ,   40.0);
+        state.add("WWIR:OP_1" ,    0.0);
+        state.add("WGIR:OP_1" ,    0.0);
+        state.add("WWIT:OP_1" ,    0.0);
+        state.add("WGIT:OP_1" ,    0.0);
+        state.add("WWCT:OP_1" ,    0.625);
+        state.add("WGOR:OP_1" ,  234.5);
+        state.add("WBHP:OP_1" ,  314.15);
+        state.add("WGVIR:OP_1",    0.0);
+        state.add("WWVIR:OP_1",    0.0);
+
+        state.add("WOPR:OP_2" ,    0.0);
+        state.add("WWPR:OP_2" ,    0.0);
+        state.add("WGPR:OP_2" ,    0.0);
+        state.add("WVPR:OP_2" ,    0.0);
+        state.add("WOPT:OP_2" ,    0.0);
+        state.add("WWPT:OP_2" ,    0.0);
+        state.add("WGPT:OP_2" ,    0.0);
+        state.add("WVPT:OP_2" ,    0.0);
+        state.add("WWIR:OP_2" ,  100.0);
+        state.add("WGIR:OP_2" ,  200.0);
+        state.add("WWIT:OP_2" , 1000.0);
+        state.add("WGIT:OP_2" , 2000.0);
+        state.add("WWCT:OP_2" ,    0.0);
+        state.add("WGOR:OP_2" ,    0.0);
+        state.add("WBHP:OP_2" ,  400.6);
+        state.add("WGVIR:OP_2", 1234.0);
+        state.add("WWVIR:OP_2", 4321.0);
+
+        state.add("WOPR:OP_3" ,   11.0);
+        state.add("WWPR:OP_3" ,   12.0);
+        state.add("WGPR:OP_3" ,   13.0);
+        state.add("WVPR:OP_3" ,   14.0);
+        state.add("WOPT:OP_3" ,  110.0);
+        state.add("WWPT:OP_3" ,  120.0);
+        state.add("WGPT:OP_3" ,  130.0);
+        state.add("WVPT:OP_3" ,  140.0);
+        state.add("WWIR:OP_3" ,    0.0);
+        state.add("WGIR:OP_3" ,    0.0);
+        state.add("WWIT:OP_3" ,    0.0);
+        state.add("WGIT:OP_3" ,    0.0);
+        state.add("WWCT:OP_3" ,    0.0625);
+        state.add("WGOR:OP_3" , 1234.5);
+        state.add("WBHP:OP_3" ,  314.15);
+        state.add("WGVIR:OP_3",    0.0);
+        state.add("WWVIR:OP_3",   43.21);
+
+        return state;
+    }
+
+    Opm::data::WellRates well_rates_1()
+    {
+        using o = ::Opm::data::Rates::opt;
+
+        auto xw = ::Opm::data::WellRates{};
+
+        {
+            xw["OP_1"].rates
+                .set(o::wat, 1.0)
+                .set(o::oil, 2.0)
+                .set(o::gas, 3.0);
+
+            xw["OP_1"].connections.emplace_back();
+            auto& c = xw["OP_1"].connections.back();
+
+            c.rates.set(o::wat, 1.0)
+                   .set(o::oil, 2.0)
+                   .set(o::gas, 3.0);
+        }
+
+        {
+            xw["OP_2"].bhp = 234.0;
+
+            xw["OP_2"].rates.set(o::gas, 5.0);
+            xw["OP_2"].connections.emplace_back();
+        }
+
+        return xw;
+    }
+
+    Opm::data::WellRates well_rates_2()
+    {
+        using o = ::Opm::data::Rates::opt;
+
+        auto xw = ::Opm::data::WellRates{};
+
+        {
+            xw["OP_1"].bhp = 150.0;  // Closed
+        }
+
+        {
+            xw["OP_2"].bhp = 234.0;
+
+            xw["OP_2"].rates.set(o::wat, 5.0);
+            xw["OP_2"].connections.emplace_back();
+
+            auto& c = xw["OP_2"].connections.back();
+            c.rates.set(o::wat, 5.0);
+        }
+
+        return xw;
+    }
+}
+
+struct SimulationCase
+{
+    explicit SimulationCase(const Opm::Deck& deck)
+        : es   { deck }
+        , sched{ deck, es }
+    {}
+
+    // Order requirement: 'es' must be declared/initialised before 'sched'.
+    Opm::EclipseState es;
+    Opm::Schedule     sched;
+};
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE(Aggregate_WD)
+
+BOOST_AUTO_TEST_CASE (Constructor)
+{
+    const auto ih = MockIH{ 5 };
+
+    const auto awd = Opm::RestartIO::Helpers::AggregateWellData{ ih.value };
+
+    BOOST_CHECK_EQUAL(awd.getIWell().size(), ih.nwells * ih.niwelz);
+    BOOST_CHECK_EQUAL(awd.getSWell().size(), ih.nwells * ih.nswelz);
+    BOOST_CHECK_EQUAL(awd.getXWell().size(), ih.nwells * ih.nxwelz);
+    BOOST_CHECK_EQUAL(awd.getZWell().size(), ih.nwells * ih.nzwelz);
+}
+
+BOOST_AUTO_TEST_CASE (Declared_Well_Data)
+{
+    const auto simCase = SimulationCase{first_sim()};
+
+    // Report Step 1: 2008-10-10 --> 2011-01-20
+    const auto rptStep = std::size_t{1};
+
+    const auto ih = MockIH {
+        static_cast<int>(simCase.sched.getWells(rptStep).size())
+    };
+
+    BOOST_CHECK_EQUAL(ih.nwells, MockIH::Sz{2});
+
+    auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
+    awd.captureDeclaredWellData(simCase.sched,
+                                simCase.es.getUnits(), rptStep);
+
+    // IWEL (OP_1)
+    {
+        const auto start = 0*ih.niwelz;
+
+        const auto& iwell = awd.getIWell();
+        BOOST_CHECK_EQUAL(iwell[start +  0], 9); // OP_1 -> I
+        BOOST_CHECK_EQUAL(iwell[start +  1], 9); // OP_1 -> J
+        BOOST_CHECK_EQUAL(iwell[start +  2], 1); // OP_1/Head -> K
+        BOOST_CHECK_EQUAL(iwell[start +  4], 2); // OP_1 #Compl
+        BOOST_CHECK_EQUAL(iwell[start +  6], 1); // OP_1 -> Producer
+        BOOST_CHECK_EQUAL(iwell[start + 11], 0); // VFP defaulted -> 0
+
+        // Completion order
+        BOOST_CHECK_EQUAL(iwell[start + 98], 0); // Track ordering (default)
+
+        BOOST_CHECK_EQUAL(iwell[start + 17], -100); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + 24], -  1); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + 47], -  1); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + 31],    7); // M2 Magic
+    }
+
+    // IWEL (OP_2)
+    {
+        const auto start = 1*ih.niwelz;
+
+        const auto& iwell = awd.getIWell();
+        BOOST_CHECK_EQUAL(iwell[start +  0], 9); // OP_2 -> I
+        BOOST_CHECK_EQUAL(iwell[start +  1], 9); // OP_2 -> J
+        BOOST_CHECK_EQUAL(iwell[start +  2], 2); // OP_2/Head -> K
+        BOOST_CHECK_EQUAL(iwell[start +  4], 1); // OP_2 #Compl
+        BOOST_CHECK_EQUAL(iwell[start +  6], 4); // OP_2 -> Gas Inj.
+        BOOST_CHECK_EQUAL(iwell[start + 11], 0); // VFP defaulted -> 0
+
+        // Completion order
+        BOOST_CHECK_EQUAL(iwell[start + 98], 0); // Track ordering (default)
+
+        BOOST_CHECK_EQUAL(iwell[start + 17], -100); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + 24], -  1); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + 47], -  1); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + 31],    7); // M2 Magic
+    }
+
+    // SWEL (OP_1)
+    {
+        const auto start = 0*ih.nswelz;
+
+        const auto& swell = awd.getSWell();
+        BOOST_CHECK_CLOSE(swell[start + 0], 20.0e3f, 1.0e-7f); // ORAT Target
+        BOOST_CHECK_CLOSE(swell[start + 1], 1.0e20f, 1.0e-7f); // WRAT Limit
+        BOOST_CHECK_CLOSE(swell[start + 2], 1.0e20f, 1.0e-7f); // GRAT Limit
+        BOOST_CHECK_CLOSE(swell[start + 3], 1.0e20f, 1.0e-7f); // LRAT Limit
+        BOOST_CHECK_CLOSE(swell[start + 4], 1.0e20f, 1.0e-7f); // RESV Limit
+        BOOST_CHECK_CLOSE(swell[start + 5], 1.0e20f, 1.0e-7f); // THP Limit
+        BOOST_CHECK_CLOSE(swell[start + 6], 1000.0f, 1.0e-7f); // BHP Limit
+
+        BOOST_CHECK_CLOSE(swell[start + 9], 0.375f, 1.0e-7f); // Datum depth
+    }
+
+    // SWEL (OP_2)
+    {
+        const auto start = 1*ih.nswelz;
+
+        const auto& swell = awd.getSWell();
+        BOOST_CHECK_CLOSE(swell[start + 5], 1.0e20f, 1.0e-7f); // THP Limit
+        BOOST_CHECK_CLOSE(swell[start + 6],  400.0f, 1.0e-7f); // BHP Limit
+
+        BOOST_CHECK_CLOSE(swell[start + 9], 0.625f, 1.0e-7f); // Datum depth
+    }
+
+    // XWEL (OP_1)
+    {
+        const auto start = 0*ih.nxwelz;
+
+        const auto& xwell = awd.getXWell();
+
+        BOOST_CHECK_CLOSE(xwell[start + 41], 1000.0, 1.0e-10); // BHP Limit
+    }
+
+    // XWEL (OP_2)
+    {
+        const auto start = 1*ih.nxwelz;
+
+        const auto& xwell = awd.getXWell();
+
+        BOOST_CHECK_CLOSE(xwell[start + 41], 400.0, 1.0e-10); // BHP Limit
+    }
+
+    // ZWEL (OP_1)
+    {
+        const auto start = 0*ih.nzwelz;
+
+        const auto& zwell = awd.getZWell();
+
+        BOOST_CHECK_EQUAL(zwell[start + 0].c_str(), "OP_1    ");
+    }
+
+    // ZWEL (OP_2)
+    {
+        const auto start = 1*ih.nzwelz;
+
+        const auto& zwell = awd.getZWell();
+
+        BOOST_CHECK_EQUAL(zwell[start + 0].c_str(), "OP_2    ");
+    }
+}
+
+// --------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE (Dynamic_Well_Data_Step1)
+{
+    const auto simCase = SimulationCase{first_sim()};
+
+    // Report Step 1: 2008-10-10 --> 2011-01-20
+    const auto rptStep = std::size_t{1};
+
+    const auto ih = MockIH {
+        static_cast<int>(simCase.sched.getWells(rptStep).size())
+    };
+
+    const auto xw   = well_rates_1();
+    const auto smry = sim_state();
+    auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
+
+    awd.captureDynamicWellData(simCase.sched, rptStep, xw, smry);
+
+    // IWEL (OP_1)
+    {
+        const auto start = 0*ih.niwelz;
+
+        const auto& iwell = awd.getIWell();
+
+        BOOST_CHECK_EQUAL(iwell[start +  8], iwell[start + 7]); // Control mode
+        BOOST_CHECK_EQUAL(iwell[start + 10], 1); // Well open/shut flag
+    }
+
+    // IWEL (OP_2)
+    {
+        const auto start = 1*ih.niwelz;
+
+        const auto& iwell = awd.getIWell();
+
+        BOOST_CHECK_EQUAL(iwell[start +  8], -1); // No flowing conns.
+        BOOST_CHECK_EQUAL(iwell[start + 10],  1); // Well open/shut flag
+    }
+
+    // XWEL (OP_1)
+    {
+        const auto  start = 0*ih.nxwelz;
+        const auto& xwell = awd.getXWell();
+
+        BOOST_CHECK_CLOSE(xwell[start + 0], 1.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 1], 2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 2], 3.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 3], 1.0 + 2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 4], 4.0, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 6], 314.15, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 7], 0.625, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 8], 234.5, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 18], 10.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 19], 20.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 20], 30.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 21], 40.0, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 36], xwell[start + 1], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 37], xwell[start + 2], 1.0e-10);
+    }
+
+    // XWEL (OP_2)
+    {
+        const auto  start = 1*ih.nxwelz;
+        const auto& xwell = awd.getXWell();
+
+        BOOST_CHECK_CLOSE(xwell[start + 2], -200.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 4], -1234.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 6], 400.6, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 24], 2000.0, 1.0e-10);
+
+        // Bg = VGIR / GIR = 1234.0 / 200.0
+        BOOST_CHECK_CLOSE(xwell[start + 34], 6.17, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 37], xwell[start + 2], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 82], xwell[start + 24], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 123], xwell[start + 4], 1.0e-10);
+    }
+}
+
+// --------------------------------------------------------------------
+
+BOOST_AUTO_TEST_CASE (Dynamic_Well_Data_Step2)
+{
+    const auto simCase = SimulationCase{first_sim()};
+
+    // Report Step 2: 2011-01-20 --> 2013-06-15
+    const auto rptStep = std::size_t{2};
+
+    const auto ih = MockIH {
+        static_cast<int>(simCase.sched.getWells(rptStep).size())
+    };
+
+    const auto xw   = well_rates_2();
+    const auto smry = sim_state();
+    auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
+
+    awd.captureDynamicWellData(simCase.sched, rptStep, xw, smry);
+
+    // IWEL (OP_1) -- closed producer
+    {
+        const auto start = 0*ih.niwelz;
+
+        const auto& iwell = awd.getIWell();
+
+        BOOST_CHECK_EQUAL(iwell[start +  8], -1000); // Control mode
+        BOOST_CHECK_EQUAL(iwell[start + 10], -1000); // Well open/shut flag
+    }
+
+    // IWEL (OP_2) -- water injector
+    {
+        const auto start = 1*ih.niwelz;
+
+        const auto& iwell = awd.getIWell();
+
+        BOOST_CHECK_EQUAL(iwell[start +  8], iwell[start + 7]); // Control mode
+        BOOST_CHECK_EQUAL(iwell[start + 10],  1); // Well open/shut flag
+    }
+
+    // XWEL (OP_1) -- closed producer
+    {
+        const auto  start = 0*ih.nxwelz;
+        const auto& xwell = awd.getXWell();
+
+        BOOST_CHECK_CLOSE(xwell[start + 0], 1.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 1], 2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 2], 3.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 3], 1.0 + 2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 4], 4.0, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 6], 314.15, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 7], 0.625, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 8], 234.5, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 18], 10.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 19], 20.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 20], 30.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 21], 40.0, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 36], xwell[start + 1], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 37], xwell[start + 2], 1.0e-10);
+    }
+
+    // XWEL (OP_2) -- water injector
+    {
+        const auto  start = 1*ih.nxwelz;
+        const auto& xwell = awd.getXWell();
+
+        BOOST_CHECK_CLOSE(xwell[start + 1], -100.0, 1.0e-10);
+
+        // Copy of WWIR
+        BOOST_CHECK_CLOSE(xwell[start + 3], xwell[start + 1], 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 6], 400.6, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 23], 1000.0, 1.0e-10);
+
+        // Copy of WWIR
+        BOOST_CHECK_CLOSE(xwell[start + 36], xwell[start + 1], 1.0e-10);
+
+        // Copy of WWIT
+        BOOST_CHECK_CLOSE(xwell[start + 81], xwell[start + 23], 1.0e-10);
+
+        // WWVIR
+        BOOST_CHECK_CLOSE(xwell[start + 122], -4321.0, 1.0e-10);
+    }
+
+    // XWEL (OP_3) -- producer
+    {
+        const auto  start = 2*ih.nxwelz;
+        const auto& xwell = awd.getXWell();
+
+        BOOST_CHECK_CLOSE(xwell[start + 0], 11.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 1], 12.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 2], 13.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 3], 11.0 + 12.0, 1.0e-10); // LPR
+        BOOST_CHECK_CLOSE(xwell[start + 4], 14.0, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 6], 314.15, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 7], 0.0625, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 8], 1234.5, 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[start + 18], 110.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 19], 120.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 20], 130.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[start + 21], 140.0, 1.0e-10);
+
+        // Copy of WWPR
+        BOOST_CHECK_CLOSE(xwell[start + 36], xwell[start + 1], 1.0e-10);
+
+        // Copy of WGPR
+        BOOST_CHECK_CLOSE(xwell[start + 37], xwell[start + 2], 1.0e-10);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -25,6 +25,9 @@
 
 #include <opm/output/eclipse/SummaryState.hpp>
 
+#include <opm/output/eclipse/VectorItems/intehead.hpp>
+#include <opm/output/eclipse/VectorItems/well.hpp>
+
 #include <opm/output/data/Wells.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -63,11 +66,13 @@ MockIH::MockIH(const int numWells,
                const int zwelPerWell)
     : value(411, 0)
 {
-    this->nwells = this->value[17 - 1] = numWells;
-    this->niwelz = this->value[25 - 1] = iwelPerWell;
-    this->nswelz = this->value[26 - 1] = swelPerWell;
-    this->nxwelz = this->value[27 - 1] = xwelPerWell;
-    this->nzwelz = this->value[28 - 1] = zwelPerWell;
+    using Ix = ::Opm::RestartIO::Helpers::VectorItems::intehead;
+
+    this->nwells = this->value[Ix::NWELLS] = numWells;
+    this->niwelz = this->value[Ix::NIWELZ] = iwelPerWell;
+    this->nswelz = this->value[Ix::NSWELZ] = swelPerWell;
+    this->nxwelz = this->value[Ix::NXWELZ] = xwelPerWell;
+    this->nzwelz = this->value[Ix::NZWELZ] = zwelPerWell;
 }
 
 namespace {
@@ -371,107 +376,123 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data)
 
     // IWEL (OP_1)
     {
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+
         const auto start = 0*ih.niwelz;
 
         const auto& iwell = awd.getIWell();
-        BOOST_CHECK_EQUAL(iwell[start +  0], 9); // OP_1 -> I
-        BOOST_CHECK_EQUAL(iwell[start +  1], 9); // OP_1 -> J
-        BOOST_CHECK_EQUAL(iwell[start +  2], 1); // OP_1/Head -> K
-        BOOST_CHECK_EQUAL(iwell[start +  4], 2); // OP_1 #Compl
-        BOOST_CHECK_EQUAL(iwell[start +  6], 1); // OP_1 -> Producer
-        BOOST_CHECK_EQUAL(iwell[start + 11], 0); // VFP defaulted -> 0
+        BOOST_CHECK_EQUAL(iwell[start + Ix::IHead] , 9); // OP_1 -> I
+        BOOST_CHECK_EQUAL(iwell[start + Ix::JHead] , 9); // OP_1 -> J
+        BOOST_CHECK_EQUAL(iwell[start + Ix::FirstK], 1); // OP_1/Head -> K
+        BOOST_CHECK_EQUAL(iwell[start + Ix::NConn] , 2); // OP_1 #Compl
+        BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 1); // OP_1 -> Producer
+        BOOST_CHECK_EQUAL(iwell[start + Ix::VFPTab], 0); // VFP defaulted -> 0
 
         // Completion order
-        BOOST_CHECK_EQUAL(iwell[start + 98], 0); // Track ordering (default)
+        BOOST_CHECK_EQUAL(iwell[start + Ix::CompOrd], 0); // Track ordering (default)
 
-        BOOST_CHECK_EQUAL(iwell[start + 17], -100); // M2 Magic
-        BOOST_CHECK_EQUAL(iwell[start + 24], -  1); // M2 Magic
-        BOOST_CHECK_EQUAL(iwell[start + 47], -  1); // M2 Magic
-        BOOST_CHECK_EQUAL(iwell[start + 31],    7); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + Ix::item18], -100); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + Ix::item25], -  1); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + Ix::item48], -  1); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + Ix::item32],    7); // M2 Magic
     }
 
     // IWEL (OP_2)
     {
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+
         const auto start = 1*ih.niwelz;
 
         const auto& iwell = awd.getIWell();
-        BOOST_CHECK_EQUAL(iwell[start +  0], 9); // OP_2 -> I
-        BOOST_CHECK_EQUAL(iwell[start +  1], 9); // OP_2 -> J
-        BOOST_CHECK_EQUAL(iwell[start +  2], 2); // OP_2/Head -> K
-        BOOST_CHECK_EQUAL(iwell[start +  4], 1); // OP_2 #Compl
-        BOOST_CHECK_EQUAL(iwell[start +  6], 4); // OP_2 -> Gas Inj.
-        BOOST_CHECK_EQUAL(iwell[start + 11], 0); // VFP defaulted -> 0
+        BOOST_CHECK_EQUAL(iwell[start + Ix::IHead] , 9); // OP_2 -> I
+        BOOST_CHECK_EQUAL(iwell[start + Ix::JHead] , 9); // OP_2 -> J
+        BOOST_CHECK_EQUAL(iwell[start + Ix::FirstK], 2); // OP_2/Head -> K
+        BOOST_CHECK_EQUAL(iwell[start + Ix::NConn] , 1); // OP_2 #Compl
+        BOOST_CHECK_EQUAL(iwell[start + Ix::WType] , 4); // OP_2 -> Gas Inj.
+        BOOST_CHECK_EQUAL(iwell[start + Ix::VFPTab], 0); // VFP defaulted -> 0
 
         // Completion order
-        BOOST_CHECK_EQUAL(iwell[start + 98], 0); // Track ordering (default)
+        BOOST_CHECK_EQUAL(iwell[start + Ix::CompOrd], 0); // Track ordering (default)
 
-        BOOST_CHECK_EQUAL(iwell[start + 17], -100); // M2 Magic
-        BOOST_CHECK_EQUAL(iwell[start + 24], -  1); // M2 Magic
-        BOOST_CHECK_EQUAL(iwell[start + 47], -  1); // M2 Magic
-        BOOST_CHECK_EQUAL(iwell[start + 31],    7); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + Ix::item18], -100); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + Ix::item25], -  1); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + Ix::item48], -  1); // M2 Magic
+        BOOST_CHECK_EQUAL(iwell[start + Ix::item32],    7); // M2 Magic
     }
 
     // SWEL (OP_1)
     {
-        const auto start = 0*ih.nswelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::SWell::index;
+
+        const auto i0 = 0*ih.nswelz;
 
         const auto& swell = awd.getSWell();
-        BOOST_CHECK_CLOSE(swell[start + 0], 20.0e3f, 1.0e-7f); // ORAT Target
-        BOOST_CHECK_CLOSE(swell[start + 1], 1.0e20f, 1.0e-7f); // WRAT Limit
-        BOOST_CHECK_CLOSE(swell[start + 2], 1.0e20f, 1.0e-7f); // GRAT Limit
-        BOOST_CHECK_CLOSE(swell[start + 3], 1.0e20f, 1.0e-7f); // LRAT Limit
-        BOOST_CHECK_CLOSE(swell[start + 4], 1.0e20f, 1.0e-7f); // RESV Limit
-        BOOST_CHECK_CLOSE(swell[start + 5], 1.0e20f, 1.0e-7f); // THP Limit
-        BOOST_CHECK_CLOSE(swell[start + 6], 1000.0f, 1.0e-7f); // BHP Limit
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::OilRateTarget] , 20.0e3f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::WatRateTarget] , 1.0e20f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::GasRateTarget] , 1.0e20f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::LiqRateTarget] , 1.0e20f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::ResVRateTarget], 1.0e20f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::THPTarget]     , 1.0e20f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::BHPTarget]     , 1000.0f, 1.0e-7f);
 
-        BOOST_CHECK_CLOSE(swell[start + 9], 0.375f, 1.0e-7f); // Datum depth
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::DatumDepth]    , 0.375f, 1.0e-7f);
     }
 
     // SWEL (OP_2)
     {
-        const auto start = 1*ih.nswelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::SWell::index;
+
+        const auto i1 = 1*ih.nswelz;
 
         const auto& swell = awd.getSWell();
-        BOOST_CHECK_CLOSE(swell[start + 5], 1.0e20f, 1.0e-7f); // THP Limit
-        BOOST_CHECK_CLOSE(swell[start + 6],  400.0f, 1.0e-7f); // BHP Limit
+        BOOST_CHECK_CLOSE(swell[i1 + Ix::THPTarget], 1.0e20f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i1 + Ix::BHPTarget],  400.0f, 1.0e-7f);
 
-        BOOST_CHECK_CLOSE(swell[start + 9], 0.625f, 1.0e-7f); // Datum depth
+        BOOST_CHECK_CLOSE(swell[i1 + Ix::DatumDepth], 0.625f, 1.0e-7f);
     }
 
     // XWEL (OP_1)
     {
-        const auto start = 0*ih.nxwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XWell::index;
+
+        const auto i0 = 0*ih.nxwelz;
 
         const auto& xwell = awd.getXWell();
 
-        BOOST_CHECK_CLOSE(xwell[start + 41], 1000.0, 1.0e-10); // BHP Limit
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::BHPTarget], 1000.0, 1.0e-10);
     }
 
     // XWEL (OP_2)
     {
-        const auto start = 1*ih.nxwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XWell::index;
+
+        const auto i1 = 1*ih.nxwelz;
 
         const auto& xwell = awd.getXWell();
 
-        BOOST_CHECK_CLOSE(xwell[start + 41], 400.0, 1.0e-10); // BHP Limit
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::BHPTarget], 400.0, 1.0e-10);
     }
 
     // ZWEL (OP_1)
     {
-        const auto start = 0*ih.nzwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::ZWell::index;
+
+        const auto i0 = 0*ih.nzwelz;
 
         const auto& zwell = awd.getZWell();
 
-        BOOST_CHECK_EQUAL(zwell[start + 0].c_str(), "OP_1    ");
+        BOOST_CHECK_EQUAL(zwell[i0 + Ix::WellName].c_str(), "OP_1    ");
     }
 
     // ZWEL (OP_2)
     {
-        const auto start = 1*ih.nzwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::ZWell::index;
+
+        const auto i1 = 1*ih.nzwelz;
 
         const auto& zwell = awd.getZWell();
 
-        BOOST_CHECK_EQUAL(zwell[start + 0].c_str(), "OP_2    ");
+        BOOST_CHECK_EQUAL(zwell[i1 + Ix::WellName].c_str(), "OP_2    ");
     }
 }
 
@@ -496,65 +517,78 @@ BOOST_AUTO_TEST_CASE (Dynamic_Well_Data_Step1)
 
     // IWEL (OP_1)
     {
-        const auto start = 0*ih.niwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+
+        const auto i0 = 0*ih.niwelz;
 
         const auto& iwell = awd.getIWell();
 
-        BOOST_CHECK_EQUAL(iwell[start +  8], iwell[start + 7]); // Control mode
-        BOOST_CHECK_EQUAL(iwell[start + 10], 1); // Well open/shut flag
+        BOOST_CHECK_EQUAL(iwell[i0 + Ix::item9 ], iwell[i0 + Ix::WCtrl]);
+        BOOST_CHECK_EQUAL(iwell[i0 + Ix::item11], 1);
     }
 
     // IWEL (OP_2)
     {
-        const auto start = 1*ih.niwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+
+        const auto i1 = 1*ih.niwelz;
 
         const auto& iwell = awd.getIWell();
 
-        BOOST_CHECK_EQUAL(iwell[start +  8], -1); // No flowing conns.
-        BOOST_CHECK_EQUAL(iwell[start + 10],  1); // Well open/shut flag
+        BOOST_CHECK_EQUAL(iwell[i1 + Ix::item9 ], -1); // No flowing conns.
+        BOOST_CHECK_EQUAL(iwell[i1 + Ix::item11],  1); // Well open/shut flag
     }
 
     // XWEL (OP_1)
     {
-        const auto  start = 0*ih.nxwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XWell::index;
+
+        const auto  i0 = 0*ih.nxwelz;
         const auto& xwell = awd.getXWell();
 
-        BOOST_CHECK_CLOSE(xwell[start + 0], 1.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 1], 2.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 2], 3.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 3], 1.0 + 2.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 4], 4.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::OilPrRate], 1.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::WatPrRate], 2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::GasPrRate], 3.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::LiqPrRate], 1.0 + 2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::VoidPrRate], 4.0, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 6], 314.15, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 7], 0.625, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 8], 234.5, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::FlowBHP], 314.15, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::WatCut] , 0.625, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::GORatio], 234.5, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 18], 10.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 19], 20.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 20], 30.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 21], 40.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::OilPrTotal], 10.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::WatPrTotal], 20.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::GasPrTotal], 30.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::VoidPrTotal], 40.0, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 36], xwell[start + 1], 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 37], xwell[start + 2], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::item37], xwell[i0 + Ix::WatPrRate], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::item38], xwell[i0 + Ix::GasPrRate], 1.0e-10);
     }
 
     // XWEL (OP_2)
     {
-        const auto  start = 1*ih.nxwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XWell::index;
+
+        const auto  i1 = 1*ih.nxwelz;
         const auto& xwell = awd.getXWell();
 
-        BOOST_CHECK_CLOSE(xwell[start + 2], -200.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 4], -1234.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 6], 400.6, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::GasPrRate], -200.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::VoidPrRate], -1234.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::FlowBHP], 400.6, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 24], 2000.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::GasInjTotal], 2000.0, 1.0e-10);
 
         // Bg = VGIR / GIR = 1234.0 / 200.0
-        BOOST_CHECK_CLOSE(xwell[start + 34], 6.17, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::GasFVF], 6.17, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 37], xwell[start + 2], 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 82], xwell[start + 24], 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 123], xwell[start + 4], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::item38],
+                          xwell[i1 + Ix::GasPrRate], 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::item83],
+                          xwell[i1 + Ix::GasInjTotal], 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::GasVoidPrRate],
+                          xwell[i1 + Ix::VoidPrRate], 1.0e-10);
     }
 }
 
@@ -579,97 +613,117 @@ BOOST_AUTO_TEST_CASE (Dynamic_Well_Data_Step2)
 
     // IWEL (OP_1) -- closed producer
     {
-        const auto start = 0*ih.niwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+
+        const auto i0 = 0*ih.niwelz;
 
         const auto& iwell = awd.getIWell();
 
-        BOOST_CHECK_EQUAL(iwell[start +  8], -1000); // Control mode
-        BOOST_CHECK_EQUAL(iwell[start + 10], -1000); // Well open/shut flag
+        BOOST_CHECK_EQUAL(iwell[i0 + Ix::item9] , -1000);
+        BOOST_CHECK_EQUAL(iwell[i0 + Ix::item11], -1000);
     }
 
     // IWEL (OP_2) -- water injector
     {
-        const auto start = 1*ih.niwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+
+        const auto i1 = 1*ih.niwelz;
 
         const auto& iwell = awd.getIWell();
 
-        BOOST_CHECK_EQUAL(iwell[start +  8], iwell[start + 7]); // Control mode
-        BOOST_CHECK_EQUAL(iwell[start + 10],  1); // Well open/shut flag
+        BOOST_CHECK_EQUAL(iwell[i1 + Ix::item9],
+                          iwell[i1 + Ix::WCtrl]);
+        BOOST_CHECK_EQUAL(iwell[i1 + Ix::item11], 1);
     }
 
     // XWEL (OP_1) -- closed producer
     {
-        const auto  start = 0*ih.nxwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XWell::index;
+
+        const auto  i0 = 0*ih.nxwelz;
         const auto& xwell = awd.getXWell();
 
-        BOOST_CHECK_CLOSE(xwell[start + 0], 1.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 1], 2.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 2], 3.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 3], 1.0 + 2.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 4], 4.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::OilPrRate], 1.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::WatPrRate], 2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::GasPrRate], 3.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::LiqPrRate], 1.0 + 2.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::VoidPrRate], 4.0, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 6], 314.15, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 7], 0.625, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 8], 234.5, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::FlowBHP], 314.15, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::WatCut] , 0.625, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::GORatio], 234.5, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 18], 10.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 19], 20.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 20], 30.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 21], 40.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::OilPrTotal], 10.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::WatPrTotal], 20.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::GasPrTotal], 30.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::VoidPrTotal], 40.0, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 36], xwell[start + 1], 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 37], xwell[start + 2], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::item37],
+                          xwell[i0 + Ix::WatPrRate], 1.0e-10);
+
+        BOOST_CHECK_CLOSE(xwell[i0 + Ix::item38],
+                          xwell[i0 + Ix::GasPrRate], 1.0e-10);
     }
 
     // XWEL (OP_2) -- water injector
     {
-        const auto  start = 1*ih.nxwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XWell::index;
+
+        const auto  i1 = 1*ih.nxwelz;
         const auto& xwell = awd.getXWell();
 
-        BOOST_CHECK_CLOSE(xwell[start + 1], -100.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::WatPrRate], -100.0, 1.0e-10);
 
         // Copy of WWIR
-        BOOST_CHECK_CLOSE(xwell[start + 3], xwell[start + 1], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::LiqPrRate],
+                          xwell[i1 + Ix::WatPrRate], 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 6], 400.6, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::FlowBHP], 400.6, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 23], 1000.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::WatInjTotal], 1000.0, 1.0e-10);
 
         // Copy of WWIR
-        BOOST_CHECK_CLOSE(xwell[start + 36], xwell[start + 1], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::item37],
+                          xwell[i1 + Ix::WatPrRate], 1.0e-10);
 
         // Copy of WWIT
-        BOOST_CHECK_CLOSE(xwell[start + 81], xwell[start + 23], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::item82],
+                          xwell[i1 + Ix::WatInjTotal], 1.0e-10);
 
         // WWVIR
-        BOOST_CHECK_CLOSE(xwell[start + 122], -4321.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i1 + Ix::WatVoidPrRate],
+                          -4321.0, 1.0e-10);
     }
 
     // XWEL (OP_3) -- producer
     {
-        const auto  start = 2*ih.nxwelz;
+        using Ix = ::Opm::RestartIO::Helpers::VectorItems::XWell::index;
+
+        const auto  i2 = 2*ih.nxwelz;
         const auto& xwell = awd.getXWell();
 
-        BOOST_CHECK_CLOSE(xwell[start + 0], 11.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 1], 12.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 2], 13.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 3], 11.0 + 12.0, 1.0e-10); // LPR
-        BOOST_CHECK_CLOSE(xwell[start + 4], 14.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::OilPrRate], 11.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::WatPrRate], 12.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::GasPrRate], 13.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::LiqPrRate], 11.0 + 12.0, 1.0e-10); // LPR
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::VoidPrRate], 14.0, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 6], 314.15, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 7], 0.0625, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 8], 1234.5, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::FlowBHP], 314.15, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::WatCut] , 0.0625, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::GORatio], 1234.5, 1.0e-10);
 
-        BOOST_CHECK_CLOSE(xwell[start + 18], 110.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 19], 120.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 20], 130.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(xwell[start + 21], 140.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::OilPrTotal], 110.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::WatPrTotal], 120.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::GasPrTotal], 130.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::VoidPrTotal], 140.0, 1.0e-10);
 
         // Copy of WWPR
-        BOOST_CHECK_CLOSE(xwell[start + 36], xwell[start + 1], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::item37],
+                          xwell[i2 + Ix::WatPrRate], 1.0e-10);
 
         // Copy of WGPR
-        BOOST_CHECK_CLOSE(xwell[start + 37], xwell[start + 2], 1.0e-10);
+        BOOST_CHECK_CLOSE(xwell[i2 + Ix::item38],
+                          xwell[i2 + Ix::GasPrRate], 1.0e-10);
     }
 }
 

--- a/tests/test_CharArrayNullTerm.cpp
+++ b/tests/test_CharArrayNullTerm.cpp
@@ -1,0 +1,99 @@
+#define BOOST_TEST_MODULE Aggregate_Well_Data
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/CharArrayNullTerm.hpp>
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE(AChar8)
+
+BOOST_AUTO_TEST_CASE (Basic_Operations)
+{
+    // Default Constructor
+    {
+        const auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{};
+
+        BOOST_CHECK_EQUAL(s.c_str(), std::string(8, ' '));
+    }
+
+    // Construct from Constant String
+    {
+        const auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+
+        BOOST_CHECK_EQUAL(s.c_str(), std::string{"Inj-1   "});
+    }
+
+    // Copy Construction
+    {
+        const auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+        const auto s2 = s1;
+
+        BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
+    }
+
+    // Move Construction
+    {
+        const auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+        const auto s2 = s1;
+
+        BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
+    }
+
+    // Move Construction
+    {
+        auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+        const auto s2 = std::move(s1);
+
+        BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
+    }
+
+    // Assignment Operator
+    {
+        const auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+        auto s2 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Prod-2"};
+
+        s2 = s1;
+        BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
+    }
+
+    // Move Assignment Operator
+    {
+        auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+        auto s2 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Prod-2"};
+
+        s2 = std::move(s1);
+        BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
+    }
+
+    // Assign std::string
+    {
+        auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"@Hi Hoo@"};
+
+        s = "Prod-2";
+        BOOST_CHECK_EQUAL(s.c_str(), std::string{"Prod-2  "});
+    }
+}
+
+BOOST_AUTO_TEST_CASE (String_Shortening)
+{
+    // Construct from string of more than N characters
+    {
+        const auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<10>{
+            "String too long"
+        };
+
+        BOOST_CHECK_EQUAL(s.c_str(), std::string{"String too"});
+    }
+
+    // Assign string of more than N characters
+    {
+        auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<11>{};
+
+        s = "This string has too many characters";
+
+        BOOST_CHECK_EQUAL(s.c_str(), std::string{"This string"});
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_CharArrayNullTerm.cpp
+++ b/tests/test_CharArrayNullTerm.cpp
@@ -4,6 +4,10 @@
 
 #include <opm/output/eclipse/CharArrayNullTerm.hpp>
 
+// Convenience alias.
+template <std::size_t N>
+using AChar = ::Opm::RestartIO::Helpers::CharArrayNullTerm<N>;
+
 // =====================================================================
 
 BOOST_AUTO_TEST_SUITE(AChar8)
@@ -12,21 +16,21 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 {
     // Default Constructor
     {
-        const auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{};
+        const auto s = AChar<8>{};
 
         BOOST_CHECK_EQUAL(s.c_str(), std::string(8, ' '));
     }
 
     // Construct from Constant String
     {
-        const auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+        const auto s = AChar<8>{"Inj-1"};
 
         BOOST_CHECK_EQUAL(s.c_str(), std::string{"Inj-1   "});
     }
 
     // Copy Construction
     {
-        const auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+        const auto s1 = AChar<8>{"Inj-1"};
         const auto s2 = s1;
 
         BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
@@ -34,7 +38,7 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Move Construction
     {
-        auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
+        auto s1 = AChar<8>{"Inj-1"};
         const auto s2 = std::move(s1);
 
         BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
@@ -42,8 +46,8 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Assignment Operator
     {
-        const auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
-        auto s2 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Prod-2"};
+        const auto s1 = AChar<8>{"Inj-1"};
+        auto s2 = AChar<8>{"Prod-2"};
 
         s2 = s1;
         BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
@@ -51,8 +55,8 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Move Assignment Operator
     {
-        auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
-        auto s2 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Prod-2"};
+        auto s1 = AChar<8>{"Inj-1"};
+        auto s2 = AChar<8>{"Prod-2"};
 
         s2 = std::move(s1);
         BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
@@ -60,7 +64,7 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Assign std::string
     {
-        auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"@Hi Hoo@"};
+        auto s = AChar<8>{"@Hi Hoo@"};
 
         s = "Prod-2";
         BOOST_CHECK_EQUAL(s.c_str(), std::string{"Prod-2  "});
@@ -71,7 +75,7 @@ BOOST_AUTO_TEST_CASE (String_Shortening)
 {
     // Construct from string of more than N characters
     {
-        const auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<10>{
+        const auto s = AChar<10>{
             "String too long"
         };
 
@@ -80,7 +84,7 @@ BOOST_AUTO_TEST_CASE (String_Shortening)
 
     // Assign string of more than N characters
     {
-        auto s = Opm::RestartIO::Helpers::CharArrayNullTerm<11>{};
+        auto s = AChar<11>{};
 
         s = "This string has too many characters";
 

--- a/tests/test_CharArrayNullTerm.cpp
+++ b/tests/test_CharArrayNullTerm.cpp
@@ -34,14 +34,6 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Move Construction
     {
-        const auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
-        const auto s2 = s1;
-
-        BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
-    }
-
-    // Move Construction
-    {
         auto s1 = Opm::RestartIO::Helpers::CharArrayNullTerm<8>{"Inj-1"};
         const auto s2 = std::move(s1);
 

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -23,6 +23,8 @@
 
 #include <opm/output/eclipse/InteHEAD.hpp>
 
+#include <opm/output/eclipse/VectorItems/intehead.hpp>
+
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -35,6 +37,8 @@
 #include <numeric>              // partial_sum()
 #include <string>
 #include <vector>
+
+namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 
 namespace {
     std::vector<double> elapsedTime(const Opm::TimeMap& tmap)
@@ -79,21 +83,21 @@ BOOST_AUTO_TEST_CASE(Dimensions_Individual)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[ 9 - 1], 100); // Nx
-    BOOST_CHECK_EQUAL(v[10 - 1],  60); // Ny
-    BOOST_CHECK_EQUAL(v[11 - 1],  15); // Nz
+    BOOST_CHECK_EQUAL(v[VI::intehead::NX], 100);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NY],  60);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NZ],  15);
 }
 
 BOOST_AUTO_TEST_CASE(Dimensions_Array)
 {
     const auto ih = Opm::RestartIO::InteHEAD{}
-        .dimensions({100, 60, 15});
+        .dimensions({ {100, 60, 15} });
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[ 9 - 1], 100); // Nx
-    BOOST_CHECK_EQUAL(v[10 - 1],  60); // Ny
-    BOOST_CHECK_EQUAL(v[11 - 1],  15); // Nz
+    BOOST_CHECK_EQUAL(v[VI::intehead::NX], 100);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NY],  60);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NZ],  15);
 }
 
 BOOST_AUTO_TEST_CASE(NumActive)
@@ -103,7 +107,7 @@ BOOST_AUTO_TEST_CASE(NumActive)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[12 - 1], 72390); // NACTIVE
+    BOOST_CHECK_EQUAL(v[VI::intehead::NACTIV], 72390);
 }
 
 BOOST_AUTO_TEST_CASE(UnitConventions)
@@ -118,7 +122,7 @@ BOOST_AUTO_TEST_CASE(UnitConventions)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[3 - 1], 1); // Unit
+        BOOST_CHECK_EQUAL(v[VI::intehead::UNIT], 1);
     }
 
     // Field
@@ -127,7 +131,7 @@ BOOST_AUTO_TEST_CASE(UnitConventions)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[3 - 1], 2); // Unit
+        BOOST_CHECK_EQUAL(v[VI::intehead::UNIT], 2);
     }
 
     // Lab
@@ -136,7 +140,7 @@ BOOST_AUTO_TEST_CASE(UnitConventions)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[3 - 1], 3); // Unit
+        BOOST_CHECK_EQUAL(v[VI::intehead::UNIT], 3);
     }
 
     // PVT-M
@@ -145,7 +149,7 @@ BOOST_AUTO_TEST_CASE(UnitConventions)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[3 - 1], 4); // Unit
+        BOOST_CHECK_EQUAL(v[VI::intehead::UNIT], 4);
     }
 }
 
@@ -164,10 +168,10 @@ BOOST_AUTO_TEST_CASE(WellTableDimensions)
     const auto& v = ih.data();
     const auto nwgmax = std::max(maxWellInGroup, maxGroupInField);
 
-    BOOST_CHECK_EQUAL(v[17 - 1], numWells);            // NWELLS
-    BOOST_CHECK_EQUAL(v[18 - 1], maxPerf);             // NCWMAX
-    BOOST_CHECK_EQUAL(v[20 - 1], nwgmax);              // NWGMAX
-    BOOST_CHECK_EQUAL(v[21 - 1], maxGroupInField + 1); // NGMAXZ
+    BOOST_CHECK_EQUAL(v[VI::intehead::NWELLS], numWells);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NCWMAX], maxPerf);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NWGMAX], nwgmax);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NGMAXZ], maxGroupInField + 1);
 }
 
 BOOST_AUTO_TEST_CASE(CalendarDate)
@@ -201,7 +205,7 @@ BOOST_AUTO_TEST_CASE(ActivePhases)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[15 - 1], 1);
+        BOOST_CHECK_EQUAL(v[VI::intehead::PHASE], 1);
     }
 
     // Water
@@ -210,7 +214,7 @@ BOOST_AUTO_TEST_CASE(ActivePhases)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[15 - 1], 2);
+        BOOST_CHECK_EQUAL(v[VI::intehead::PHASE], 2);
     }
 
     // Gas
@@ -219,7 +223,7 @@ BOOST_AUTO_TEST_CASE(ActivePhases)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[15 - 1], 4);
+        BOOST_CHECK_EQUAL(v[VI::intehead::PHASE], 4);
     }
 
     // Oil/Water
@@ -228,7 +232,7 @@ BOOST_AUTO_TEST_CASE(ActivePhases)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[15 - 1], 3);
+        BOOST_CHECK_EQUAL(v[VI::intehead::PHASE], 3);
     }
 
     // Oil/Gas
@@ -237,7 +241,7 @@ BOOST_AUTO_TEST_CASE(ActivePhases)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[15 - 1], 5);
+        BOOST_CHECK_EQUAL(v[VI::intehead::PHASE], 5);
     }
 
     // Water/Gas
@@ -246,7 +250,7 @@ BOOST_AUTO_TEST_CASE(ActivePhases)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[15 - 1], 6);
+        BOOST_CHECK_EQUAL(v[VI::intehead::PHASE], 6);
     }
 
     // Oil/Water/Gas
@@ -255,7 +259,7 @@ BOOST_AUTO_TEST_CASE(ActivePhases)
 
         const auto& v = ih.data();
 
-        BOOST_CHECK_EQUAL(v[15 - 1], 7);
+        BOOST_CHECK_EQUAL(v[VI::intehead::PHASE], 7);
     }
 }
 
@@ -266,10 +270,10 @@ BOOST_AUTO_TEST_CASE(NWell_Parameters)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[25 - 1], 27); // NIWELZ
-    BOOST_CHECK_EQUAL(v[26 - 1], 18); // NSWELZ
-    BOOST_CHECK_EQUAL(v[27 - 1], 28); // NXWELZ
-    BOOST_CHECK_EQUAL(v[28 - 1],  1); // NZWELZ
+    BOOST_CHECK_EQUAL(v[VI::intehead::NIWELZ], 27);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSWELZ], 18);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NXWELZ], 28);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NZWELZ],  1);
 }
 
 BOOST_AUTO_TEST_CASE(NConn_Parameters)
@@ -279,22 +283,25 @@ BOOST_AUTO_TEST_CASE(NConn_Parameters)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[33 - 1], 31); // NICONZ
-    BOOST_CHECK_EQUAL(v[34 - 1], 41); // NSCONZ
-    BOOST_CHECK_EQUAL(v[35 - 1], 59); // NXCONZ
+    BOOST_CHECK_EQUAL(v[VI::intehead::NICONZ], 31);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSCONZ], 41);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NXCONZ], 59);
 }
 
 BOOST_AUTO_TEST_CASE(GroupSize_Parameters)
 {
+    // https://oeis.org/A001620
     const auto ih = Opm::RestartIO::InteHEAD{}
-        .params_GRPZ({ 577, 215, 664, 901 }); // https://oeis.org/A001620
+        .params_GRPZ({
+            { 577, 215, 664, 901 }
+        });
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[37 - 1], 577); // NIGRPZ
-    BOOST_CHECK_EQUAL(v[38 - 1], 215); // NSGRPZ
-    BOOST_CHECK_EQUAL(v[39 - 1], 664); // NXGRPZ
-    BOOST_CHECK_EQUAL(v[40 - 1], 901); // NZGRPZ
+    BOOST_CHECK_EQUAL(v[VI::intehead::NIGRPZ], 577);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSGRPZ], 215);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NXGRPZ], 664);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NZGRPZ], 901);
 }
 
 BOOST_AUTO_TEST_CASE(Analytic_Aquifer_Parameters)
@@ -305,13 +312,13 @@ BOOST_AUTO_TEST_CASE(Analytic_Aquifer_Parameters)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[42 - 1], 1);       // NCAMAX
-    BOOST_CHECK_EQUAL(v[43 - 1], 61);      // NIAAQZ
-    BOOST_CHECK_EQUAL(v[44 - 1], 803);     // NSAAQZ
-    BOOST_CHECK_EQUAL(v[45 - 1], 3988);    // NXAAQZ
-    BOOST_CHECK_EQUAL(v[46 - 1], 74989);   // NICAQZ
-    BOOST_CHECK_EQUAL(v[47 - 1], 484820);  // NSCAQZ
-    BOOST_CHECK_EQUAL(v[48 - 1], 4586834); // NACAQZ
+    BOOST_CHECK_EQUAL(v[VI::intehead::NCAMAX], 1);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NIAAQZ], 61);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSAAQZ], 803);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NXAAQZ], 3988);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NICAQZ], 74989);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSCAQZ], 484820);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NACAQZ], 4586834);
 }
 
 BOOST_AUTO_TEST_CASE(Time_and_report_step)
@@ -380,13 +387,13 @@ BOOST_AUTO_TEST_CASE(wellSegDimensions)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[174], nsegwl);
-    BOOST_CHECK_EQUAL(v[175], nswlmx);
-    BOOST_CHECK_EQUAL(v[176], nsegmx);
-    BOOST_CHECK_EQUAL(v[177], nlbrmx);
-    BOOST_CHECK_EQUAL(v[178], nisegz);
-    BOOST_CHECK_EQUAL(v[179], nrsegz);
-    BOOST_CHECK_EQUAL(v[180], nilbrz);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSEGWL], nsegwl);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSWLMX], nswlmx);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSEGMX], nsegmx);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NLBRMX], nlbrmx);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NISEGZ], nisegz);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NRSEGZ], nrsegz);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NILBRZ], nilbrz);
 }
 
 BOOST_AUTO_TEST_CASE(regionDimensions)

--- a/tests/test_WindowedArray.cpp
+++ b/tests/test_WindowedArray.cpp
@@ -1,0 +1,145 @@
+/*
+  Copyright 2018 Statoil IT
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Windowed_Array
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/WindowedArray.hpp>
+
+#include <exception>
+#include <iterator>
+#include <stdexcept>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(WriteOperations)
+
+BOOST_AUTO_TEST_CASE(Array)
+{
+    using Wa = Opm::RestartIO::Helpers::WindowedArray<int>;
+
+    auto wa = Wa{ Wa::NumWindows{ 5 }, Wa::WindowSize{ 7 } };
+
+    for (auto m = wa.numWindows(), i = 0*m; i < m; ++i) {
+        auto w = wa[i];
+
+        std::fill(std::begin(w), std::end(w), 10*i);
+    }
+
+    BOOST_CHECK_EQUAL(wa.numWindows(), Wa::Idx{5});
+    BOOST_CHECK_EQUAL(wa.windowSize(), Wa::Idx{7});
+
+    {
+        const auto expect = std::vector<int>{
+          // 0   1   2   3   4   5   6
+             0,  0,  0,  0,  0,  0,  0, // 0
+            10, 10, 10, 10, 10, 10, 10, // 1
+            20, 20, 20, 20, 20, 20, 20, // 2
+            30, 30, 30, 30, 30, 30, 30, // 3
+            40, 40, 40, 40, 40, 40, 40, // 4
+        };
+
+        const auto& actual = wa.data();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(actual), std::end(actual),
+                                      std::begin(expect), std::end(expect));
+    }
+
+    for (auto m = wa.numWindows(), i = 0*m; i < m; ++i) {
+        auto w = wa[i];
+
+        for (auto n = w.size(), j = 0*n; j < n; ++j) {
+            w[j] = 10*i - 3*j;
+        }
+    }
+
+    {
+        const auto expect = std::vector<int>{
+          // 0    1    2    3    4    5    6
+             0, - 3, - 6, - 9, -12, -15, -18, // 0
+            10,   7,   4,   1, - 2, - 5, - 8, // 1
+            20,  17,  14,  11,   8,   5,   2, // 2
+            30,  27,  24,  21,  18,  15,  12, // 3
+            40,  37,  34,  31,  28,  25,  22, // 4
+        };
+
+        const auto& actual = wa.data();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(actual), std::end(actual),
+                                      std::begin(expect), std::end(expect));
+    }
+}
+
+// ====================================================================
+
+BOOST_AUTO_TEST_CASE(Matrix)
+{
+    using Wm = Opm::RestartIO::Helpers::WindowedMatrix<int>;
+
+    auto wm = Wm{ Wm::NumRows{ 3 }, Wm::NumCols{ 2 }, Wm::WindowSize{ 4 } };
+
+    BOOST_CHECK_EQUAL(wm.numCols(), Wm::Idx{2});
+    BOOST_CHECK_EQUAL(wm.numRows(), Wm::Idx{3});
+
+    for (auto m = wm.numRows(), i = 0*m; i < m; ++i) {
+        for (auto n = wm.numCols(), j = 0*n; j < n; ++j) {
+            auto w = wm(i, j);
+
+            std::fill(std::begin(w), std::end(w), 100*i + 10*j);
+        }
+    }
+
+    {
+        const auto expect = std::vector<int> {
+              0,   0,   0,   0,    10,  10,  10,  10,
+            100, 100, 100, 100,   110, 110, 110, 110,
+            200, 200, 200, 200,   210, 210, 210, 210,
+        };
+
+        const auto& actual = wm.data();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(actual), std::end(actual),
+                                      std::begin(expect), std::end(expect));
+    }
+
+    for (auto m = wm.numRows(), i = 0*m; i < m; ++i) {
+        for (auto n = wm.numCols(), j = 0*n; j < n; ++j) {
+            auto w = wm(i, j);
+
+            for (auto sz = w.size(), k = 0*sz; k < sz; ++k) {
+                w[k] = 100*i + 10*j - 13*k;
+            }
+        }
+    }
+
+    {
+        const auto expect = std::vector<int> {
+              0, - 13, - 26, - 39,       10, -  3, - 16, - 29,
+            100,   87,   74,   61,      110,   97,   84,   71,
+            200,  187,  174,  161,      210,  197,  184,  171,
+        };
+
+        const auto& actual = wm.data();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(actual), std::end(actual),
+                                      std::begin(expect), std::end(expect));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
This change-set, a follow-up to #382 which was merged as #397, adds a new class that aggregates the `*WEL` vectors for restart purposes.  Using the data sources

  * Simulation run's `Schedule` object
  * Simulation run's `UnitSystem` object
  * Current simulation step (`sim_step`)
  * `WellRates` object from simulator at the end of `sim_step`
  * `SummaryState` object from Summary class at the end of sim_step

this class will fill in the (presently) known elements of the `IWEL` (integers), `SWEL` (Real/float), `XWEL` (double precision), and `ZWEL` arrays for output to a restart file.  We distinguish contributions of data sources extracted directly from the simulation deck from those computed dynamically by the simulator--mostly to separate concerns and to enable independent testing.  If this introduces too much computational overhead in actual simulation runs we can fuse the member functions
```
AggregateWellData::captureDeclaredWellData()
AggregateWellData::captureDynamicWellData()
```
to reduce the number of loops over active wells.

The overall structure of this facility is that we have a single templated function, [`wellLoop()`](https://github.com/OPM/opm-common/blob/19c0033122008ba5b6032fd528472735daba6a1a/src/opm/output/eclipse/AggregateWellData.cpp#L89-L101), that calls user-defined "operations" on each active well.  Each of these operations in turn define a subset of one of the `{I,S,X,Z}WEL` arrays pertaining to the particular well.  We furthermore put implementation functions into namespaces according to the pertinent arrays.

Many thanks to my Equinor collaborators&mdash;especially @jalvestad and @tskille.

---

Note that this code is not yet activated in `RestartIO::save()` and therefore does not affect the contents of the existing restart files.  We exercise the interfaces through unit tests only.