### PR TITLE
handling the over-writing control part of WHISTCTL

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -55,7 +55,10 @@ namespace Opm {
         bool operator!=(const WellProductionProperties& other) const;
         WellProductionProperties();
 
-        static WellProductionProperties history(const WellProductionProperties& prev_properties, const DeckRecord& record);
+        static WellProductionProperties history(const WellProductionProperties& prevProperties,
+                                                const DeckRecord& record,
+                                                const WellProducer::ControlModeEnum controlModeWHISTCL);
+
         static WellProductionProperties prediction( const DeckRecord& record, bool addGroupProductionControl );
 
         bool hasProductionControl(WellProducer::ControlModeEnum controlModeArg) const {
@@ -71,6 +74,9 @@ namespace Opm {
             if (! hasProductionControl(controlModeArg))
                 m_productionControls += controlModeArg;
         }
+
+        // this is used to check whether the specified control mode is an effective history matching production mode
+        static bool effectiveHistoryProductionControl(const WellProducer::ControlModeEnum cmode);
 
     private:
         int m_productionControls = 0;


### PR DESCRIPTION
for producers. The termination flag part is not handled yet.

The major difference is that, when we have `WHISTCTL` keyword, we overwrite the control mode (specified by the WCONHIST) instead of adding one. 

// TODO in the future
1. its effect on injectors, I guess only BHP control can be used or things can be more messy.
2. WHISTCTL is a schedule keyword. Its usage need to be verified by running.