### PR TITLE
Make calling prereq function possible without fuss

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,12 @@ endmacro (dir_hook)
 
 # We need to define this variable in the installed cmake config file.
 set(OPM_PROJECT_EXTRA_CODE_INSTALLED  "set(OPM_MACROS_ROOT ${CMAKE_INSTALL_PREFIX}/share/opm)
-                                       list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
+                                       list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)
+                                       include(OpmPackage) #Make macros availabe after find_package(opm-common)")
 
-set(OPM_PROJECT_EXTRA_CODE_INTREE  "set(OPM_MACROS_ROOT ${OPM_MACROS_ROOT})
-                                    list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)")
+set(OPM_PROJECT_EXTRA_CODE_INTREE "set(OPM_MACROS_ROOT ${OPM_MACROS_ROOT})
+                                   list(APPEND CMAKE_MODULE_PATH \${OPM_MACROS_ROOT}/cmake/Modules)
+                                   include(OpmPackage) #Make macros availabe after find_package(opm-common)")
 if(ENABLE_ECL_OUTPUT)
   set(OPM_PROJECT_EXTRA_CODE_INSTALLED "${OPM_PROJECT_EXTRA_CODE_INSTALLED}
                                         set(COMPARE_SUMMARY_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareSummary)

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -73,6 +73,8 @@ if(NOT @opm-project_NAME@_FOUND)
 
   # this is the contents of config.h as far as our probes can tell:
 
-  # extra code
+  # extra code from variable OPM_PROJECT_EXTRA_CODE
   @OPM_PROJECT_EXTRA_CODE@
+  # end extra code
+
 endif()


### PR DESCRIPTION
While using dumux as a test case for using OPM from dune I stumbled over the error rerported in OPM/opm-grid#327:

```
CMake Error at /home/mblatt/src/dune/opm-2.6/opm-grid/opm-grid-prereqs.cmake:37 (find_package_deps):
  Unknown CMake command "find_package_deps".
Call Stack (most recent call first):
  /home/mblatt/src/dune/opm-2.6/opm-grid/opm-parallel/opm-grid-config.cmake:25 (include)
  /home/mblatt/src/dune/opm-2.6/dune-common/cmake/modules/DuneMacros.cmake:178 (find_package)
  /home/mblatt/src/dune/opm-2.6/dune-common/cmake/modules/DuneMacros.cmake:426 (find_dune_package)
  /home/mblatt/src/dune/opm-2.6/dune-common/cmake/modules/DuneMacros.cmake:473 (dune_process_dependency_leafs)
  /home/mblatt/src/dune/opm-2.6/dune-common/cmake/modules/DuneMacros.cmake:493 (dune_create_dependency_leafs)
  /home/mblatt/src/dune/opm-2.6/dune-common/cmake/modules/DuneMacros.cmake:643 (dune_create_dependency_tree)
  CMakeLists.txt:34 (dune_project)
```

Seems like we did not test well enough and the macros are still not known. With this PR we now include the OpmPackage Macro from opm-common-config.cmake which fixed the problem for every module. Of course users have to issue a `find_package(opm-common)` call early in their CMakeLists.txt.