### PR TITLE
Provide Effective Kh Product as an Extra Connection Property

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -112,6 +112,7 @@ namespace Opm {
         double cell_pressure;
         double cell_saturation_water;
         double cell_saturation_gas;
+        double effective_Kh;
 
         template <class MessageBufferType>
         void write(MessageBufferType& buffer) const;
@@ -296,6 +297,7 @@ namespace Opm {
             buffer.write(this->cell_pressure);
             buffer.write(this->cell_saturation_water);
             buffer.write(this->cell_saturation_gas);
+            buffer.write(this->effective_Kh);
     }
 
     template <class MessageBufferType>
@@ -336,6 +338,7 @@ namespace Opm {
             buffer.read(this->cell_pressure);
             buffer.read(this->cell_saturation_water);
             buffer.read(this->cell_saturation_gas);
+            buffer.read(this->effective_Kh);
    }
 
     template <class MessageBufferType>

--- a/opm/parser/eclipse/EclipseState/Schedule/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Connection.hpp
@@ -45,6 +45,7 @@ namespace Opm {
                    const Value<double>& connectionTransmissibilityFactor,
                    const Value<double>& diameter,
                    const Value<double>& skinFactor,
+                   const Value<double>& Kh,
                    const int satTableId,
                    const WellCompletion::DirectionEnum direction);
 
@@ -58,6 +59,7 @@ namespace Opm {
         double getSkinFactor() const;
         bool attachedToSegment() const;
         const Value<double>& getConnectionTransmissibilityFactorAsValueObject() const;
+        const Value<double>& getEffectiveKhAsValueObject() const;
 
         bool operator==( const Connection& ) const;
         bool operator!=( const Connection& ) const;
@@ -73,6 +75,7 @@ namespace Opm {
         Value<double> m_diameter;
         Value<double> m_connectionTransmissibilityFactor;
         Value<double> m_skinFactor;
+        Value<double> m_Kh;
 
     public:
         // related segment number

--- a/opm/parser/eclipse/EclipseState/Schedule/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellConnections.hpp
@@ -38,6 +38,7 @@ namespace Opm {
                            const Value<double>& connectionTransmissibilityFactor,
                            const Value<double>& diameter,
                            const Value<double>& skinFactor,
+                           const Value<double>& Kh,
                            const int satTableId,
                            const WellCompletion::DirectionEnum direction = WellCompletion::DirectionEnum::Z);
         void loadCOMPDAT(const DeckRecord& record, const EclipseGrid& grid, const Eclipse3DProperties& eclipseProperties);
@@ -79,6 +80,7 @@ namespace Opm {
                            const Value<double>& connectionTransmissibilityFactor,
                            const Value<double>& diameter,
                            const Value<double>& skinFactor,
+                           const Value<double>& Kh,
                            const int satTableId,
                            const WellCompletion::DirectionEnum direction = WellCompletion::DirectionEnum::Z);
 

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -58,6 +58,7 @@ namespace Opm {
             gas_surface_rate,
             rate,
             transmissibility,
+            effective_Kh,
             mass,
             mass_rate,
             gas_oil_ratio,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Connection.cpp
@@ -43,6 +43,7 @@ namespace Opm {
                            const Value<double>& connectionTransmissibilityFactor,
                            const Value<double>& diameter,
                            const Value<double>& skinFactor,
+                           const Value<double>& Kh,
                            const int satTableId,
                            const WellCompletion::DirectionEnum direction)
         : dir(direction),
@@ -53,7 +54,8 @@ namespace Opm {
           ijk({i,j,k}),
           m_diameter(diameter),
           m_connectionTransmissibilityFactor(connectionTransmissibilityFactor),
-          m_skinFactor(skinFactor)
+          m_skinFactor(skinFactor),
+          m_Kh(Kh)
     {}
 
     bool Connection::sameCoordinate(const int i, const int j, const int k) const {
@@ -95,6 +97,11 @@ namespace Opm {
     const Value<double>& Connection::getConnectionTransmissibilityFactorAsValueObject() const {
         return m_connectionTransmissibilityFactor;
     }
+
+    const Value<double>& Connection::getEffectiveKhAsValueObject() const {
+        return m_Kh;
+    }
+
     bool Connection::attachedToSegment() const {
         return (segment_number > 0);
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellConnections.cpp
@@ -51,12 +51,13 @@ namespace Opm {
                                         const Value<double>& connectionTransmissibilityFactor,
                                         const Value<double>& diameter,
                                         const Value<double>& skinFactor,
+                                        const Value<double>& Kh,
                                         const int satTableId,
                                         const WellCompletion::DirectionEnum direction)
     {
         int conn_i = (i < 0) ? this->headI : i;
         int conn_j = (j < 0) ? this->headJ : j;
-        Connection conn(conn_i, conn_j, k, complnum, depth, state, connectionTransmissibilityFactor, diameter, skinFactor, satTableId, direction);
+        Connection conn(conn_i, conn_j, k, complnum, depth, state, connectionTransmissibilityFactor, diameter, skinFactor, Kh, satTableId, direction);
         this->add(conn);
     }
 
@@ -68,6 +69,7 @@ namespace Opm {
                                         const Value<double>& connectionTransmissibilityFactor,
                                         const Value<double>& diameter,
                                         const Value<double>& skinFactor,
+                                        const Value<double>& Kh,
                                         const int satTableId,
                                         const WellCompletion::DirectionEnum direction)
     {
@@ -81,6 +83,7 @@ namespace Opm {
                             connectionTransmissibilityFactor,
                             diameter,
                             skinFactor,
+                            Kh,
                             satTableId,
                             direction);
     }
@@ -100,6 +103,7 @@ namespace Opm {
         Value<double> connectionTransmissibilityFactor("CompletionTransmissibilityFactor");
         Value<double> diameter("Diameter");
         Value<double> skinFactor("SkinFactor");
+        Value<double> Kh("Kh");
         const auto& satnum = eclipseProperties.getIntGridProperty("SATNUM");
         int satTableId = -1;
         bool defaultSatTable = true;
@@ -107,6 +111,7 @@ namespace Opm {
             const auto& connectionTransmissibilityFactorItem = record.getItem("CONNECTION_TRANSMISSIBILITY_FACTOR");
             const auto& diameterItem = record.getItem("DIAMETER");
             const auto& skinFactorItem = record.getItem("SKIN");
+            const auto& KhItem = record.getItem("Kh");
             const auto& satTableIdItem = record.getItem("SAT_TABLE");
 
             if (connectionTransmissibilityFactorItem.hasValue(0) && connectionTransmissibilityFactorItem.getSIDouble(0) > 0)
@@ -117,6 +122,9 @@ namespace Opm {
 
             if (skinFactorItem.hasValue(0))
                 skinFactor.setValue( skinFactorItem.get< double >(0));
+
+            if (KhItem.hasValue(0) && (KhItem.get< double >(0) > 0.0))
+                Kh.setValue( KhItem.getSIDouble(0));
 
             if (satTableIdItem.hasValue(0) && satTableIdItem.get < int > (0) > 0)
             {
@@ -146,6 +154,7 @@ namespace Opm {
                                     connectionTransmissibilityFactor,
                                     diameter,
                                     skinFactor,
+                                    Kh,
                                     satTableId,
                                     direction );
             } else {
@@ -159,6 +168,7 @@ namespace Opm {
                                    connectionTransmissibilityFactor,
                                    diameter,
                                    skinFactor,
+                                   Kh,
                                    satTableId,
                                    direction );
             }

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -594,10 +594,12 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
         0.0
     };
 
     static const double to_input[] = {
+        1,
         1,
         1,
         1,
@@ -656,6 +658,7 @@ namespace {
         1,
         1,
         1,
+        1,
         1
     };
 
@@ -676,6 +679,7 @@ namespace {
         "SM3/DAY",
         "RM3/DAY",
         "CPR3/DAY/BARS",
+        "MDM",
         "KG",
         "KG/DAY",
         "SM3/SM3",

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -38,6 +38,10 @@ namespace {
      * metric and field arrays. C++ does not support designated initializers, so
      * this cannot be done in a declaration-order independent matter.
      */
+
+    // =================================================================
+    // METRIC Unit Conventions
+
     static const double from_metric_offset[] = {
         0.0,
         0.0,
@@ -46,6 +50,7 @@ namespace {
         0.0,
         0.0,
         Metric::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -86,6 +91,7 @@ namespace {
         1 / ( Metric::GasSurfaceVolume / Metric::Time ),
         1 / ( Metric::ReservoirVolume / Metric::Time ),
         1 / Metric::Transmissibility,
+        1 / (Metric::Permeability * Metric::Length),
         1 / Metric::Mass,
         1 / ( Metric::Mass / Metric::Time ),
         1, /* gas-oil ratio */
@@ -117,6 +123,7 @@ namespace {
         Metric::GasSurfaceVolume / Metric::Time,
         Metric::ReservoirVolume / Metric::Time,
         Metric::Transmissibility,
+        Metric::Permeability * Metric::Length,
         Metric::Mass,
         Metric::Mass / Metric::Time,
         1, /* gas-oil ratio */
@@ -148,6 +155,7 @@ namespace {
         "SM3/DAY",
         "RM3/DAY",
         "CPR3/DAY/BARS",
+        "MDM",
         "KG",
         "KG/DAY",
         "SM3/SM3",
@@ -162,6 +170,9 @@ namespace {
         "KJ", /* energy */
     };
 
+    // =================================================================
+    // FIELD Unit Conventions
+
     static const double from_field_offset[] = {
         0.0,
         0.0,
@@ -170,6 +181,7 @@ namespace {
         0.0,
         0.0,
         Field::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -210,6 +222,7 @@ namespace {
         1 / ( Field::GasSurfaceVolume / Field::Time ),
         1 / ( Field::ReservoirVolume / Field::Time ),
         1 / Field::Transmissibility,
+        1 / (Field::Permeability * Field::Length),
         1 / Field::Mass,
         1 / ( Field::Mass / Field::Time ),
         1 / ( Field::GasSurfaceVolume / Field::LiquidSurfaceVolume ), /* gas-oil ratio */
@@ -241,6 +254,7 @@ namespace {
          Field::GasSurfaceVolume / Field::Time,
          Field::ReservoirVolume / Field::Time,
          Field::Transmissibility,
+         Field::Permeability * Field::Length,
          Field::Mass,
          Field::Mass / Field::Time,
          Field::GasSurfaceVolume / Field::LiquidSurfaceVolume, /* gas-oil ratio */
@@ -272,6 +286,7 @@ namespace {
         "MSCF/DAY",
         "RB/DAY",
         "CPRB/DAY/PSI",
+        "MDFT",
         "LB",
         "LB/DAY"
         "MSCF/STB",
@@ -286,6 +301,9 @@ namespace {
         "BTU", /* energy */
     };
 
+    // =================================================================
+    // LAB Unit Conventions
+
     static const double from_lab_offset[] = {
         0.0,
         0.0,
@@ -294,6 +312,7 @@ namespace {
         0.0,
         0.0,
         Lab::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -334,6 +353,7 @@ namespace {
         1 / ( Lab::GasSurfaceVolume / Lab::Time ),
         1 / ( Lab::ReservoirVolume / Lab::Time ),
         1 / Lab::Transmissibility,
+        1 / (Lab::Permeability * Lab::Length),
         1 / Lab::Mass,
         1 / ( Lab::Mass / Lab::Time ),
         1 / Lab::GasDissolutionFactor, /* gas-oil ratio */
@@ -365,6 +385,7 @@ namespace {
         Lab::GasSurfaceVolume / Lab::Time,
         Lab::ReservoirVolume / Lab::Time,
         Lab::Transmissibility,
+        Lab::Permeability * Lab::Length,
         Lab::Mass,
         Lab::Mass / Lab::Time,
         Lab::GasDissolutionFactor,  /* gas-oil ratio */
@@ -396,6 +417,7 @@ namespace {
         "SCC/HR",
         "RCC/HR",
         "CPRCC/HR/ATM",
+        "MDCC",
         "G",
         "G/HR",
         "SCC/SCC",
@@ -410,6 +432,9 @@ namespace {
         "J", /* energy */
     };
 
+    // =================================================================
+    // PVT-M Unit Conventions
+
     static const double from_pvt_m_offset[] = {
         0.0,
         0.0,
@@ -418,6 +443,7 @@ namespace {
         0.0,
         0.0,
         PVT_M::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -458,6 +484,7 @@ namespace {
         1 / ( PVT_M::GasSurfaceVolume / PVT_M::Time ),
         1 / ( PVT_M::ReservoirVolume / PVT_M::Time ),
         1 / PVT_M::Transmissibility,
+        1 / (PVT_M::Permeability * PVT_M::Length),
         1 / PVT_M::Mass,
         1 / ( PVT_M::Mass / PVT_M::Time ),
         1 / (PVT_M::GasSurfaceVolume / PVT_M::LiquidSurfaceVolume), // Rs
@@ -489,6 +516,7 @@ namespace {
         PVT_M::GasSurfaceVolume / PVT_M::Time,
         PVT_M::ReservoirVolume / PVT_M::Time,
         PVT_M::Transmissibility,
+        PVT_M::Permeability * PVT_M::Length,
         PVT_M::Mass,
         PVT_M::Mass / PVT_M::Time,
         PVT_M::GasSurfaceVolume / PVT_M::LiquidSurfaceVolume, // Rs
@@ -520,6 +548,7 @@ namespace {
         "SM3/DAY",
         "RM3/DAY",
         "CPR3/DAY/ATM",
+        "MDM",
         "KG",
         "KG/DAY",
         "SM3/SM3",
@@ -534,6 +563,8 @@ namespace {
         "KJ" /* energy */
     };
 
+    // =================================================================
+    // INPUT Unit Conventions
 
     static const double from_input_offset[] = {
         0.0,
@@ -659,8 +690,7 @@ namespace {
         "KJ", /* energy */
     };
 
-
-}
+} // namespace Anonymous
 
     UnitSystem::UnitSystem(const UnitType unit) :
         m_unittype( unit )

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -56,7 +56,7 @@ inline std::ostream& operator<<( std::ostream& stream, const WellConnections& cs
 
 BOOST_AUTO_TEST_CASE(testGetFunctions) {
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
-    Opm::Connection completion(10,11,12, 1, 0.0, Opm::WellCompletion::OPEN,Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
+    Opm::Connection completion(10,11,12, 1, 0.0, Opm::WellCompletion::OPEN,Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",17.29), 0, dir);
     BOOST_CHECK_EQUAL( 10 , completion.getI() );
     BOOST_CHECK_EQUAL( 11 , completion.getJ() );
     BOOST_CHECK_EQUAL( 12 , completion.getK() );
@@ -65,6 +65,7 @@ BOOST_AUTO_TEST_CASE(testGetFunctions) {
     BOOST_CHECK_EQUAL( 99.88 , completion.getConnectionTransmissibilityFactor());
     BOOST_CHECK_EQUAL( 22.33 , completion.getDiameter());
     BOOST_CHECK_EQUAL( 33.22 , completion.getSkinFactor());
+    BOOST_CHECK_CLOSE( 17.29 , completion.getEffectiveKhAsValueObject().getValue() , 1.0e-10);
     BOOST_CHECK_EQUAL( 0 , completion.sat_tableId);
 }
 
@@ -80,8 +81,8 @@ BOOST_AUTO_TEST_CASE(CreateWellConnectionsOK) {
 BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
     Opm::WellConnections completionSet;
-    Opm::Connection completion1( 10,10,10, 1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
-    Opm::Connection completion2( 11,10,10, 1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
+    Opm::Connection completion1( 10,10,10, 1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",2.718), 0, dir);
+    Opm::Connection completion2( 11,10,10, 1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",3.141), 0, dir);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -95,8 +96,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
 BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
     Opm::WellConnections completionSet;
-    Opm::Connection completion1( 10,10,10,1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
-    Opm::Connection completion2( 11,10,10,1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
+    Opm::Connection completion1( 10,10,10,1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",17.29), 0, dir);
+    Opm::Connection completion2( 11,10,10,1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",355.113), 0, dir);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -114,9 +115,9 @@ BOOST_AUTO_TEST_CASE(AddCompletionCopy) {
     Opm::WellConnections completionSet;
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
 
-    Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
-    Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
-    Opm::Connection completion3( 10,10,12, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
+    Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",355.113), 0, dir);
+    Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",355.113), 0, dir);
+    Opm::Connection completion3( 10,10,12, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",355.113), 0, dir);
 
     completionSet.add( completion1 );
     completionSet.add( completion2 );
@@ -136,9 +137,9 @@ BOOST_AUTO_TEST_CASE(ActiveCompletions) {
     Opm::EclipseGrid grid(10,10,10);
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
     Opm::WellConnections completions;
-    Opm::Connection completion1( 0,0,0, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
-    Opm::Connection completion2( 0,0,1, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
-    Opm::Connection completion3( 0,0,2, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), 0, dir);
+    Opm::Connection completion1( 0,0,0, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",355.113), 0, dir);
+    Opm::Connection completion2( 0,0,1, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",355.113), 0, dir);
+    Opm::Connection completion3( 0,0,2, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22), Opm::Value<double>("Kh",355.113), 0, dir);
 
     completions.add( completion1 );
     completions.add( completion2 );
@@ -153,4 +154,3 @@ BOOST_AUTO_TEST_CASE(ActiveCompletions) {
     BOOST_CHECK_EQUAL( completion2, active_completions.get(0));
     BOOST_CHECK_EQUAL( completion3, active_completions.get(1));
 }
-

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -44,14 +44,14 @@
 BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
 Opm::WellConnections connection_set;
- connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.5), Opm::Value<double>("SKIN", 0.), 0, dir) );
- connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.5), Opm::Value<double>("SKIN", 0.), 0, dir) );
- connection_set.add(Opm::Connection( 19, 0, 2, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), 0, dir) );
+ connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.5), Opm::Value<double>("SKIN", 0.), Opm::Value<double>("Kh", 17.29), 0, dir) );
+ connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.5), Opm::Value<double>("SKIN", 0.), Opm::Value<double>("Kh", 17.29), 0, dir) );
+ connection_set.add(Opm::Connection( 19, 0, 2, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), Opm::Value<double>("Kh", 17.29), 0, dir) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), 0,  Opm::WellCompletion::DirectionEnum::X) );
-    connection_set.add(Opm::Connection( 17, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), 0,  Opm::WellCompletion::DirectionEnum::X) );
-    connection_set.add(Opm::Connection( 16, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), 0,  Opm::WellCompletion::DirectionEnum::X) );
-    connection_set.add(Opm::Connection( 15, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), 0,  Opm::WellCompletion::DirectionEnum::X) );
+    connection_set.add(Opm::Connection( 18, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), Opm::Value<double>("Kh", 17.29), 0,  Opm::WellCompletion::DirectionEnum::X) );
+    connection_set.add(Opm::Connection( 17, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), Opm::Value<double>("Kh", 17.29), 0,  Opm::WellCompletion::DirectionEnum::X) );
+    connection_set.add(Opm::Connection( 16, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), Opm::Value<double>("Kh", 17.29), 0,  Opm::WellCompletion::DirectionEnum::X) );
+    connection_set.add(Opm::Connection( 15, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor", 200.), Opm::Value<double>("D", 0.4), Opm::Value<double>("SKIN", 0.), Opm::Value<double>("Kh", 17.29), 0,  Opm::WellCompletion::DirectionEnum::X) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -122,4 +122,3 @@ Opm::WellConnections connection_set;
     BOOST_CHECK_EQUAL(segment_number_connection7, 7);
     BOOST_CHECK_EQUAL(center_depth_connection7, 2534.5);
 }
-

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -300,6 +300,215 @@ BOOST_AUTO_TEST_CASE ( UnitConstants ) {
     BOOST_REQUIRE_CLOSE (flux_m3py, 1e4, 0.01);
 }
 
+BOOST_AUTO_TEST_CASE(METRIC_UNITS)
+{
+    using Meas = UnitSystem::measure;
+
+    auto metric = UnitSystem::newMETRIC();
+
+    BOOST_CHECK( metric.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC );
+    BOOST_CHECK( metric.getEclType() == ECL_METRIC_UNITS );
+
+    // ----------------------------------------------------------------
+    // METRIC -> SI
+
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::length , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::time , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::density , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::pressure , 1.0 ) , 100.0e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::temperature_absolute , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::temperature , 1.0 ) , 274.15 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::viscosity , 1.0 ) , 1.0e-3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::permeability , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::liquid_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::liquid_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::transmissibility , 1.0 ) , 1.157407407407407e-13 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::water_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::oil_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+
+    // ----------------------------------------------------------------
+    // SI -> METRIC
+
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::length , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::time , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::density , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::pressure , 1.0 ) , 1.0e-5 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::temperature_absolute , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::temperature , 274.15 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::viscosity , 1.0 ) , 1.0e+3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::permeability , 1.0 ) , 1.01325e+15 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::liquid_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::liquid_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::rate , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::transmissibility , 1.0 ) , 8.64e+12 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+15 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::water_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::oil_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+}
+
+BOOST_AUTO_TEST_CASE(FIELD_UNITS)
+{
+    using Meas = UnitSystem::measure;
+
+    auto field = UnitSystem::newFIELD();
+
+    BOOST_CHECK( field.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD );
+    BOOST_CHECK( field.getEclType() == ECL_FIELD_UNITS );
+
+    // ----------------------------------------------------------------
+    // FIELD -> SI
+
+    BOOST_CHECK_CLOSE( field.to_si( Meas::length , 1.0 ) , 0.3048 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::time , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::density , 1.0 ) , 1.601846337396014e+01, 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::pressure , 1.0 ) , 6.894757293168360e+03 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::temperature_absolute , 1.0 ) , 5.0/9.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::temperature , 1.0 ) , 255.9277777777778 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::viscosity , 1.0 ) , 1.0e-3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::permeability , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::liquid_surface_volume , 1.0 ) , 0.1589872949280001 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::gas_surface_volume , 1.0 ) , 28.31684659200000 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::volume , 1.0 ) , 0.1589872949280001 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::liquid_surface_rate , 1.0 ) , 1.840130728333334e-06 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::gas_surface_rate , 1.0 ) , 3.277412800000001e-04 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::rate , 1.0 ) , 1.840130728333334e-06 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::transmissibility , 1.0 ) , 2.668883979653090e-13 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::effective_Kh , 1.0 ) , 3.008142116950407e-16 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::mass , 1.0 ) , 0.45359237 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::gas_oil_ratio , 1.0 ) , 178.1076066790352 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::oil_gas_ratio , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::gas_formation_volume_factor , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::water_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::gas_inverse_formation_volume_factor , 1.0 ) , 178.1076066790352 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::oil_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+
+    // ----------------------------------------------------------------
+    // SI -> FIELD
+
+    BOOST_CHECK_CLOSE( field.from_si( Meas::length , 1.0 ) , 3.280839895013123e+00 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::time , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::density , 1.0 ) , 6.242796057614462e-02 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::pressure , 1.0 ) , 1.450377377302092e-04 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::temperature_absolute , 1.0 ) , 1.8 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::temperature , 255.9277777777778 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::viscosity , 1.0 ) , 1.0e+3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::permeability , 1.0 ) , 1.01325e+15 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::liquid_surface_volume , 1.0 ) , 6.289810770432102e+00 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::gas_surface_volume , 1.0 ) , 3.531466672148859e-02 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::volume , 1.0 ) , 6.289810770432102e+00 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::liquid_surface_rate , 1.0 ) , 5.434396505653337e+05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::gas_surface_rate , 1.0 ) , 3.051187204736614e+03 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::rate , 1.0 ) , 5.434396505653337e+05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::transmissibility , 1.0 ) , 3.746884494132199e+12 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::effective_Kh , 1.0 ) , 3.324311023622047e+15 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::mass , 1.0 ) , 2.204622621848776e+00 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::gas_oil_ratio , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::oil_gas_ratio , 1.0 ) , 178.1076066790352 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::gas_formation_volume_factor , 1.0 ) , 178.1076066790352 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::water_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::gas_inverse_formation_volume_factor , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::oil_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+}
+
+BOOST_AUTO_TEST_CASE(LAB_UNITS)
+{
+    using Meas = UnitSystem::measure;
+
+    auto lab = UnitSystem::newLAB();
+
+    BOOST_CHECK( lab.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_LAB );
+    BOOST_CHECK( lab.getEclType() == ECL_LAB_UNITS );
+
+    // ----------------------------------------------------------------
+    // LAB -> SI
+
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::length , 1.0 ) , 0.01 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::time , 1.0 ) , 3600.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::density , 1.0 ) , 1.0e3, 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::pressure , 1.0 ) , 101325.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::temperature_absolute , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::temperature , 1.0 ) , 274.15 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::viscosity , 1.0 ) , 1.0e-3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::permeability , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::liquid_surface_volume , 1.0 ) , 1.0e-6 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_surface_volume , 1.0 ) , 1.0e-6 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::volume , 1.0 ) , 1.0e-6 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::liquid_surface_rate , 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_surface_rate , 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::rate , 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::transmissibility , 1.0 ) , 2.741453518655592e-18 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160130e-18 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::mass , 1.0 ) , 1.0e-3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::water_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::oil_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+
+    // ----------------------------------------------------------------
+    // SI -> LAB
+
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::length , 1.0 ) , 100.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::time , 1.0 ) , 2.777777777777778e-04 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::density , 1.0 ) , 1.0e-3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::pressure , 1.0 ) , 9.869232667160129e-06 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::temperature_absolute , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::temperature , 274.15 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::viscosity , 1.0 ) , 1.0e+3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::permeability , 1.0 ) , 1.01325e+15 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::liquid_surface_volume , 1.0 ) , 1.0e6 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_surface_volume , 1.0 ) , 1.0e6 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::volume , 1.0 ) , 1.0e6 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::liquid_surface_rate , 1.0 ) , 3.6e9 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_surface_rate , 1.0 ) , 3.6e9 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::rate , 1.0 ) , 3.6e9 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::transmissibility , 1.0 ) , 3.647699999999999e+17 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+17 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::mass , 1.0 ) , 1.0e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::oil_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::water_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::oil_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+}
 
 BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
 {
@@ -328,6 +537,7 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::transmissibility , 1.0 ) , 1.142272299439830e-13 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
@@ -357,6 +567,7 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::transmissibility , 1.0 ) , 8.75448e+12 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -346,6 +346,7 @@ inline Opm::Connection connection( int i, int j, int k, int complnum = 1 ) {
                             Opm::Value<double>("ConnectionTransmissibilityFactor",99.88),
                             Opm::Value<double>("D",22.33),
                             Opm::Value<double>("SKIN",33.22),
+                            Opm::Value<double>("Kh",17.29),
                             0,
                             Opm::WellCompletion::DirectionEnum::Z };
 }

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -135,12 +135,12 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
 
         std::vector<Opm::data::Connection> well1_comps(9);
         for (size_t i = 0; i < 9; ++i) {
-            Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i};
+            Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 1.2e3};
             well1_comps[i] = well_comp;
         }
         std::vector<Opm::data::Connection> well2_comps(6);
         for (size_t i = 0; i < 6; ++i) {
-            Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2};
+            Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 0.15};
             well2_comps[i] = well_comp;
         }
 
@@ -227,12 +227,12 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
 
                 std::vector<Opm::data::Connection> well1_comps(9);
                 for (size_t i = 0; i < 9; ++i) {
-                    Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i};
+                    Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 3.14e5};
                     well1_comps[i] = well_comp;
                 }
                 std::vector<Opm::data::Connection> well2_comps(6);
                 for (size_t i = 0; i < 6; ++i) {
-                    Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2};
+                    Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 355.113};
                     well2_comps[i] = well_comp;
                 }
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -300,14 +300,14 @@ data::Wells mkWells() {
      *  the completion keys (active indices) and well names correspond to the
      *  input deck. All other entries in the well structures are arbitrary.
      */
-    w1.connections.push_back( { 88, rc1, 30.45, 123.4 } );
-    w1.connections.push_back( { 288, rc2, 33.19, 123.4 } );
+    w1.connections.push_back( { 88, rc1, 30.45, 123.4, 543.21, 0.62, 0.15, 1.0e3 } );
+    w1.connections.push_back( { 288, rc2, 33.19, 123.4, 432.1, 0.26, 0.45, 2.56 } );
 
     w2.rates = r2;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
     w2.control = 2;
-    w2.connections.push_back( { 188, rc3, 36.22, 123.4 } );
+    w2.connections.push_back( { 188, rc3, 36.22, 123.4, 256.1, 0.55, 0.0125, 314.15 } );
 
     {
         data::Wells wellRates;

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -146,10 +146,10 @@ static data::Wells result_wells() {
       syncronized with the global index in the COMPDAT keyword in the
       input deck.
     */
-    data::Connection well1_comp1 { 0  , crates1, 1.9 , 123.4};
-    data::Connection well2_comp1 { 1  , crates2, 1.10 , 123.4};
-    data::Connection well2_comp2 { 101, crates3, 1.11 , 123.4};
-    data::Connection well3_comp1 { 2  , crates3, 1.11 , 123.4};
+    data::Connection well1_comp1 { 0  , crates1, 1.9 , 123.4, 314.15, 0.35, 0.25, 2.718e2};
+    data::Connection well2_comp1 { 1  , crates2, 1.10 , 123.4, 212.1, 0.78, 0.0, 12.34};
+    data::Connection well2_comp2 { 101, crates3, 1.11 , 123.4, 150.6, 0.001, 0.89, 100.0};
+    data::Connection well3_comp1 { 2  , crates3, 1.11 , 123.4, 456.78, 0.0, 0.15, 432.1};
 
     /*
       The completions

--- a/tests/test_Wells.cpp
+++ b/tests/test_Wells.cpp
@@ -103,14 +103,14 @@ BOOST_AUTO_TEST_CASE(get_completions) {
      *  the completion keys (active indices) and well names correspond to the
      *  input deck. All other entries in the well structures are arbitrary.
      */
-    w1.connections.push_back( { 88, rc1, 30.45, 123.45 } );
-    w1.connections.push_back( { 288, rc2, 33.19, 67.89 } );
+    w1.connections.push_back( { 88, rc1, 30.45, 123.45, 543.21, 0.123, 0.5, 17.29 } );
+    w1.connections.push_back( { 288, rc2, 33.19, 67.89, 98.76, 0.5, 0.125, 355.113 } );
 
     w2.rates = r2;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
     w2.control = 2;
-    w2.connections.push_back( { 188, rc3, 36.22, 19.28 } );
+    w2.connections.push_back( { 188, rc3, 36.22, 19.28, 28.91, 0.125, 0.125, 3.141 } );
 
     data::Wells wellRates;
 


### PR DESCRIPTION
Needed for restart output (especially, SCON), and also useful for computing the connection transmissibility factor (WI) in some cases if not supplied in COMPDAT.

For complete coverage, we also add a unit conversion type (`effective_Kh`) in order to produce SCON restart values that honour the run's unit conventions.  Finally, add simple checks for the unit conversion constants in the METRIC, FIELD, and LAB unit conventions to mirror the checks that were already there for PVT-M.