### PR TITLE
Add deckAssigned() method to GridProperty + default construct TRAN

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -416,7 +416,7 @@ namespace Opm {
          * these keywords don't seem to require a post-processor
          */
         for( const auto& kw : { "TRANX", "TRANY", "TRANZ" } )
-            supportedDoubleKeywords.emplace_back( kw, nan, "Transmissibility" );
+            supportedDoubleKeywords.emplace_back( kw, 1.0 , "Transmissibility", true );
 
         /* gross-to-net thickness (acts as a multiplier for PORO and the
          * permeabilities in the X-Y plane as well as for the well rates.)

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -153,6 +153,11 @@ namespace Opm {
     }
 
     template< typename T >
+    bool GridProperty<T>::deckAssigned() const {
+        return this->assigned;
+    }
+
+    template< typename T >
     T GridProperty< T >::iget( size_t index ) const {
         return this->m_data.at( index );
     }
@@ -207,6 +212,7 @@ namespace Opm {
             if (mask[g])
                 m_data[g] = value;
         }
+        this->assigned = true;
     }
 
     template< typename T >
@@ -232,6 +238,7 @@ namespace Opm {
             if (mask[g])
                 m_data[g] = other.m_data[g];
         }
+        this->assigned = other.deckAssigned();
     }
 
     template< typename T >
@@ -253,6 +260,8 @@ namespace Opm {
             if (!deckItem.defaultApplied(dataPointIdx))
                 setDataPoint(dataPointIdx, dataPointIdx, deckItem);
         }
+
+        this->assigned = true;
     }
 
     template< typename T >
@@ -292,6 +301,7 @@ namespace Opm {
                 m_data[targetIndex] = src.m_data[targetIndex];
             }
         }
+        this->assigned = src.deckAssigned();
     }
 
     template< typename T >
@@ -361,6 +371,7 @@ namespace Opm {
                 m_data[targetIndex] = value;
             }
         }
+        this->assigned = true;
     }
 
     template< typename T >

--- a/tests/parser/Eclipse3DPropertiesTests.cpp
+++ b/tests/parser/Eclipse3DPropertiesTests.cpp
@@ -537,10 +537,22 @@ COPY
   'PERMX' 'PERMY' /
 /
 
+EDIT
+
 MULTIPLY
   'PERMZ' 0.1D0 /
-  'PERMX' 0.1D0 *  *  1  21  *  1 / -- This is a weird way to specify the top layer! 
+  'PERMX' 0.1D0 *  *  1  21  *  1 / -- This is a weird way to specify the top layer!
+  'TRANX' 0.10  /
 /
+
+COPY
+  'TRANX' 'TRANY' /
+/
+
+EQUALS
+  'TRANZ' 0.25 /
+/
+
 )";
 
     Opm::Parser parser;
@@ -555,10 +567,20 @@ BOOST_AUTO_TEST_CASE(DefaultedBox) {
 
   const auto& permx   = s.props.getDoubleGridProperty("PERMX");
   const auto& permz   = s.props.getDoubleGridProperty("PERMZ");
+  const auto& tranx   = s.props.getDoubleGridProperty("TRANX");
+  const auto& trany   = s.props.getDoubleGridProperty("TRANY");
+  const auto& tranz   = s.props.getDoubleGridProperty("TRANZ");
 
   BOOST_CHECK_EQUAL( permx.iget(0,0,0)        , permz.iget(0,0,0));
   BOOST_CHECK_EQUAL( permx.iget(0,0,1) * 0.10 , permz.iget(0,0,1));
+
+  BOOST_CHECK( permx.deckAssigned() );
+  BOOST_CHECK( permz.deckAssigned() );
+  BOOST_CHECK( !tranx.deckAssigned());
+  BOOST_CHECK( !trany.deckAssigned());
+  BOOST_CHECK( tranz.deckAssigned() );
 }
+
 
 static Opm::Deck createMultiplyPorvDeck() {
     const auto* input = R"(

--- a/tests/parser/Eclipse3DPropertiesTests.cpp
+++ b/tests/parser/Eclipse3DPropertiesTests.cpp
@@ -581,6 +581,74 @@ BOOST_AUTO_TEST_CASE(DefaultedBox) {
   BOOST_CHECK( tranz.deckAssigned() );
 }
 
+static Opm::Deck createAddDeck() {
+  const auto* input = R"(
+RUNSPEC
+
+TITLE
+ 'TITTEL'
+
+DIMENS
+  100 21 20 /
+
+METRIC
+
+OIL
+WATER
+
+TABDIMS
+/
+
+START
+  19 JUN 2017
+/
+
+WELLDIMS
+  3 20 1
+/
+
+EQLDIMS
+    2* 100 2* /
+
+GRID
+
+
+DXV
+  5.0D0 10.0D0 2*20.0D0 45.0D0 95*50.0D0
+/
+
+DYV
+  21*4.285714D0
+/
+
+DZV
+  20*0.5D0
+/
+
+TOPS
+  2100*1000.0D0
+/
+
+EDIT
+
+ADD
+  'TRANX' 0.10  /
+/
+
+)";
+
+  Opm::Parser parser;
+  return parser.parseString(input, Opm::ParseContext() );
+}
+
+BOOST_AUTO_TEST_CASE(TRANXADD) {
+  Opm::Deck deck = createAddDeck();
+  Opm::TableManager tables(deck);
+  Opm::EclipseGrid grid(deck);
+
+  BOOST_CHECK_THROW(Opm::Eclipse3DProperties(deck, tables, grid), std::invalid_argument);
+}
+
 
 static Opm::Deck createMultiplyPorvDeck() {
     const auto* input = R"(


### PR DESCRIPTION
The deckAssigned() query method is added to the GridProperty class to enable the
simulator to check whether a property has been explicitly assigned in the deck
or autocreated through the use of some EDIT operators like MULTIPLY.

The current opm parser functionality is quite weak on the *section* concept; i.e. we implement section awareness in the parsing process in a very limited degree. The fundamental ugliness in this problem - that the simulator should interpret the `TRANX` kyeword either as an absolute value, or alternatively as a multiplier, remains the same, but one can envision an alternative implementation based on a more section aware parsing process.

It was my intention to propose a downstream patch according to this [pseudo code](https://github.com/joakim-hove/opm-common/blob/147be696bb36fadaec40dae75cd896b5f372433b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp#L249) but my mojo kind of left me while I was scanning [ebos/ecltransmissibility.hh](https://github.com/OPM/ewoms/blob/032974c3273cc7ebe91f7028c815a74d146ef73c/ebos/ecltransmissibility.hh) so I will leave that for someone else.

This PR can in principle be merged independently, but I will let it linger until someone has worked downstream; and verified that the approach makes sense.