### PR TITLE
Restart cwd

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -141,7 +141,8 @@ namespace Opm {
             UnitSystem& getActiveUnitSystem();
             UnitSystem& getDefaultUnitSystem();
 
-            const std::string getDataFile() const;
+            const std::string& getInputPath() const;
+            const std::string& getDataFile() const;
             void setDataFile(const std::string& dataFile);
 
             iterator begin();
@@ -156,6 +157,7 @@ namespace Opm {
             UnitSystem activeUnits;
 
             std::string m_dataFile;
+            std::string input_path;
     };
 }
 #endif  /* DECK_HPP */

--- a/src/opm/parser/eclipse/Deck/Deck.cpp
+++ b/src/opm/parser/eclipse/Deck/Deck.cpp
@@ -13,7 +13,6 @@
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
@@ -139,7 +138,8 @@ namespace Opm {
         keywordList( std::move( x ) ),
         defaultUnits( UnitSystem::newMETRIC() ),
         activeUnits( UnitSystem::newMETRIC() ),
-        m_dataFile("")
+        m_dataFile(""),
+        input_path("")
     {
         /*
          * If multiple unit systems are requested, metric is preferred over
@@ -169,8 +169,8 @@ namespace Opm {
         keywordList( d.keywordList ),
         defaultUnits( d.defaultUnits ),
         activeUnits( d.activeUnits ),
-        m_dataFile( d.m_dataFile ) {
-
+        m_dataFile( d.m_dataFile ),
+        input_path( d.input_path ) {
         this->reinit(this->keywordList.begin(), this->keywordList.end());
     }
 
@@ -209,12 +209,22 @@ namespace Opm {
         return this->activeUnits;
     }
 
-    const std::string Deck::getDataFile() const {
+    const std::string& Deck::getDataFile() const {
         return m_dataFile;
     }
 
+    const std::string& Deck::getInputPath() const {
+        return this->input_path;
+    }
+
     void Deck::setDataFile(const std::string& dataFile) {
-        m_dataFile = dataFile;
+        this->m_dataFile = dataFile;
+
+        auto slash_pos = dataFile.find_last_of("/\\");
+        if (slash_pos == std::string::npos)
+            this->input_path = "";
+        else
+            this->input_path = dataFile.substr(0, slash_pos);
     }
 
     Deck::iterator Deck::begin() {

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -56,10 +56,14 @@ namespace Opm {
                     "only from RESTART files");
         }
 
-        const std::string& root = record.getItem( 0 ).get< std::string >( 0 );
         int step = record.getItem( 1 ).get< int >(0);
+        const std::string& root = record.getItem( 0 ).get< std::string >( 0 );
+        const std::string& input_path = deck.getInputPath();
 
-        this->setRestart( root, step );
+        if (root[0] == '/' || input_path.empty())
+            this->setRestart(root, step);
+        else
+            this->setRestart( input_path + "/" + root, step );
     }
 
     void InitConfig::setRestart( const std::string& root, int step) {

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -166,9 +166,15 @@ BOOST_AUTO_TEST_CASE(keywordList_getbyindex_correctkeywordreturned) {
 BOOST_AUTO_TEST_CASE(set_and_get_data_file) {
     Deck deck;
     BOOST_CHECK_EQUAL("", deck.getDataFile());
+    BOOST_CHECK_EQUAL("", deck.getInputPath());
     std::string file("/path/to/file.DATA");
     deck.setDataFile( file );
     BOOST_CHECK_EQUAL(file, deck.getDataFile());
+    BOOST_CHECK_EQUAL("/path/to", deck.getInputPath());
+
+    deck.setDataFile("FILE");
+    BOOST_CHECK_EQUAL("FILE", deck.getDataFile());
+    BOOST_CHECK_EQUAL("", deck.getInputPath());
 }
 
 BOOST_AUTO_TEST_CASE(DummyDefaultsString) {

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -474,11 +474,6 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData_double) {
 }
 
 BOOST_AUTO_TEST_CASE(WriteWrongSOlutionSize) {
-    // This test leads to a segmentation violation on travis, disable until
-    // the cause has been found and fixed.
-    if (std::getenv("TRAVIS_CI"))
-        return;
-
     Setup setup("FIRST_SIM.DATA");
     {
         ERT::TestArea testArea("test_Restart");


### PR DESCRIPTION
Internalize the directory path of the datafile, to ensure that the path to restartfile is interpreted correctly. Should fix: https://github.com/OPM/opm-simulators/issues/1537

Test failure is due to line 31 here: https://github.com/OPM/opm-simulators/blob/master/tests/run-restart-regressionTest.sh

OK: The restart testi setup is based on searching for restart files from CWD and not from the location of the data file. Personally I think the semantics implemented by this PR is "correct", but of course that can be discussed. If we go for this semantcs we need to to make the following additional changes:

1. We can add a non-Eclipse commandline argument `--restart-path=` which means flow should search for restart files in this location instead of what is in the deck.
2. The setup must be updated by copying the input deck - with all includes ... into the folder where the restarted simulation is run.

I'll let it linger for now.