### PR TITLE
Add precision property to DeckOutput class - default = 10

### DIFF
--- a/opm/parser/eclipse/Deck/DeckOutput.hpp
+++ b/opm/parser/eclipse/Deck/DeckOutput.hpp
@@ -28,7 +28,8 @@ namespace Opm {
 
     class DeckOutput {
     public:
-        explicit DeckOutput(std::ostream& s);
+        explicit DeckOutput(std::ostream& s, int precision = 10);
+        ~DeckOutput();
         void stash_default( );
 
         void start_record( );
@@ -51,9 +52,11 @@ namespace Opm {
         size_t default_count;
         size_t row_count;
         bool record_on;
+        int org_precision;
 
         template <typename T> void write_value(const T& value);
         void write_sep( );
+        void set_precision(int precision);
     };
 }
 

--- a/src/opm/parser/eclipse/Deck/Deck.cpp
+++ b/src/opm/parser/eclipse/Deck/Deck.cpp
@@ -237,7 +237,7 @@ namespace Opm {
     }
 
     std::ostream& operator<<(std::ostream& os, const Deck& deck) {
-        DeckOutput out( os );
+        DeckOutput out( os, 10 );
         deck.write( out );
         return os;
     }

--- a/src/opm/parser/eclipse/Deck/DeckOutput.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckOutput.cpp
@@ -24,12 +24,24 @@
 
 namespace Opm {
 
-    DeckOutput::DeckOutput( std::ostream& s) :
+    DeckOutput::DeckOutput( std::ostream& s, int precision) :
         os( s ),
         default_count( 0 ),
         row_count( 0 ),
-        record_on( false )
+        record_on( false ),
+        org_precision( os.precision(precision) )
     {}
+
+
+    DeckOutput::~DeckOutput() {
+        this->set_precision(this->org_precision);
+    }
+
+
+    void DeckOutput::set_precision(int precision) {
+        this->os.precision(precision);
+    }
+
 
     void DeckOutput::endl() {
         this->os << std::endl;


### PR DESCRIPTION
Followup to https://github.com/OPM/opm-simulators/pull/1544

Increase output precision when writing deck streams.