### PR TITLE
Make compiling with OpenMP default.

### DIFF
--- a/cmake/Modules/OpmDefaults.cmake
+++ b/cmake/Modules/OpmDefaults.cmake
@@ -47,7 +47,7 @@ macro (opm_defaults opm)
   endif(NOT PRECOMPILE_HEADERS)
 
   # Use of OpenMP is considered experimental
-  set (USE_OPENMP_DEFAULT OFF)
+  set (USE_OPENMP_DEFAULT ON)
 
   # if we are on a system where CMake 2.6 is the default (Hi RHEL 6!),
   # the configuration files for Boost will trip up the library paths


### PR DESCRIPTION
We have conducted quite extensive testing of the OpenMP implementation. In most cases it gives a nice performance improvement. In particular, the feature was turned on at linuxbenchmarking.com on August 5th, http://linuxbenchmarking.com/?open-porous-media-git , providing a good overview of typical performance impact.

In cases where you spawn more threads than there are resources on the hardware, the negative impact is very small. Hence, I suggest turning on OpenMP by default. Please note that a previous PR set the default number of threads to two per process (unless the number of available CPUs are less than twice the number of processes). This can be modified to a user specified number of threads per process at run time. Either through a command line switch, or through the usual OMP_NUM_THREADS environment variable.