### PR TITLE
Aquct default

### DIFF
--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -61,7 +61,7 @@ namespace Opm {
                             p0, //Initial aquifer pressure at datum depth, d0
                             theta , //angle subtended by the aquifer boundary
                             c2 ; //6.283 (METRIC, PVT-M); 1.1191 (FIELD); 6.283 (LAB).
-                    
+
                     std::vector<double> td, pi;
             };
 
@@ -70,23 +70,23 @@ namespace Opm {
             const std::vector<AquiferCT::AQUCT_data>& getAquifers() const;
             int getAqInflTabID(size_t aquiferIndex);
             int getAqPvtTabID(size_t aquiferIndex);
-    
+
         private:
-  
+
             std::vector<AquiferCT::AQUCT_data> m_aquct;
-            
-            //Set the default Pd v/s Td tables (constant terminal rate case for an infinite aquifer) as described in 
-            //Van Everdingen, A. & Hurst, W., December, 1949.The Application of the Laplace Transformation to Flow Problems in Reservoirs. 
+
+            //Set the default Pd v/s Td tables (constant terminal rate case for an infinite aquifer) as described in
+            //Van Everdingen, A. & Hurst, W., December, 1949.The Application of the Laplace Transformation to Flow Problems in Reservoirs.
             //Petroleum Transactions, AIME.
             inline void set_default_tables(std::vector<double>& td, std::vector<double>& pi)
-            {   
-                std::vector<double> default_pressure_ = { 0.112, 0.229, 0.315, 0.376, 0.424, 0.469, 0.503, 0.564, 0.616, 0.659, 0.702, 0.735, 
-                                                          0.772, 0.802, 0.927, 1.02, 1.101, 1.169, 1.275, 1.362, 1.436, 1.5, 1.556, 1.604, 
-                                                          1.651, 1.829, 1.96, 2.067, 2.147, 2.282, 2.388, 2.476, 2.55, 2.615, 2.672, 2.723, 
+            {
+                std::vector<double> default_pressure_ = { 0.112, 0.229, 0.315, 0.376, 0.424, 0.469, 0.503, 0.564, 0.616, 0.659, 0.702, 0.735,
+                                                          0.772, 0.802, 0.927, 1.02, 1.101, 1.169, 1.275, 1.362, 1.436, 1.5, 1.556, 1.604,
+                                                          1.651, 1.829, 1.96, 2.067, 2.147, 2.282, 2.388, 2.476, 2.55, 2.615, 2.672, 2.723,
                                                           2.921, 3.064, 3.173, 3.263, 3.406, 3.516, 3.608, 3.684, 3.75, 3.809, 3.86 };
 
-                std::vector<double> default_time_ = { 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 
-                                                        1.5, 2, 2.5, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60, 70, 
+                std::vector<double> default_time_ = { 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1,
+                                                        1.5, 2, 2.5, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60, 70,
                                                         80, 90, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000 };
 
                 td = default_time_;

--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -58,10 +58,10 @@ namespace Opm {
                             k_a , //aquifer permeability
                             c1, // 0.008527 (METRIC, PVT-M); 0.006328 (FIELD); 3.6 (LAB)
                             h , //aquifer thickness
-                            p0, //Initial aquifer pressure at datum depth, d0
                             theta , //angle subtended by the aquifer boundary
                             c2 ; //6.283 (METRIC, PVT-M); 1.1191 (FIELD); 6.283 (LAB).
 
+                    std::shared_ptr<double> p0; // Initial aquifer pressure at datum detpt d0 - nullptr if the pressure has been defaulted.
                     std::vector<double> td, pi;
             };
 

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -22,18 +22,18 @@
 namespace Opm {
 
     AquiferCT::AquiferCT(const EclipseState& eclState, const Deck& deck)
-    { 
+    {
         if (!deck.hasKeyword("AQUCT"))
             return;
 
         const auto& aquctKeyword = deck.getKeyword("AQUCT");
 
         for (auto& aquctRecord : aquctKeyword){
-  
+
             AquiferCT::AQUCT_data data;
 
             data.c1 = 1.0;
-            data.c2 = 6.283;        // Value of C2 used by E100 (for METRIC, PVT-M and LAB unit systems)        
+            data.c2 = 6.283;        // Value of C2 used by E100 (for METRIC, PVT-M and LAB unit systems)
             data.aquiferID = aquctRecord.getItem("AQUIFER_ID").template get<int>(0);
             data.h = aquctRecord.getItem("THICKNESS_AQ").getSIDouble(0);
             data.p0 = aquctRecord.getItem("P_INI").getSIDouble(0);
@@ -42,7 +42,7 @@ namespace Opm {
             data.C_t = aquctRecord.getItem("C_T").getSIDouble(0);
             data.r_o = aquctRecord.getItem("RAD").getSIDouble(0);
             data.k_a = aquctRecord.getItem("PERM_AQ").getSIDouble(0);
-            data.theta = aquctRecord.getItem("INFLUENCE_ANGLE").getSIDouble(0)/360.0; 
+            data.theta = aquctRecord.getItem("INFLUENCE_ANGLE").getSIDouble(0)/360.0;
             data.inftableID = aquctRecord.getItem("TABLE_NUM_INFLUENCE_FN").template get<int>(0);
             data.pvttableID = aquctRecord.getItem("TABLE_NUM_WATER_PRESS").template get<int>(0);
 
@@ -59,7 +59,7 @@ namespace Opm {
                     set_default_tables(data.td,data.pi);
                 }
                 m_aquct.push_back( std::move(data) );
-            }     
+            }
     }
 
     const std::vector<AquiferCT::AQUCT_data>& AquiferCT::getAquifers() const

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -36,7 +36,6 @@ namespace Opm {
             data.c2 = 6.283;        // Value of C2 used by E100 (for METRIC, PVT-M and LAB unit systems)
             data.aquiferID = aquctRecord.getItem("AQUIFER_ID").template get<int>(0);
             data.h = aquctRecord.getItem("THICKNESS_AQ").getSIDouble(0);
-            data.p0 = aquctRecord.getItem("P_INI").getSIDouble(0);
             data.phi_aq = aquctRecord.getItem("PORO_AQ").getSIDouble(0);
             data.d0 = aquctRecord.getItem("DAT_DEPTH").getSIDouble(0);
             data.C_t = aquctRecord.getItem("C_T").getSIDouble(0);
@@ -45,6 +44,13 @@ namespace Opm {
             data.theta = aquctRecord.getItem("INFLUENCE_ANGLE").getSIDouble(0)/360.0;
             data.inftableID = aquctRecord.getItem("TABLE_NUM_INFLUENCE_FN").template get<int>(0);
             data.pvttableID = aquctRecord.getItem("TABLE_NUM_WATER_PRESS").template get<int>(0);
+
+
+            if (aquctRecord.getItem("P_INI").hasValue(0)) {
+                double * raw_ptr = new double[1];
+                raw_ptr[0] = aquctRecord.getItem("P_INI").getSIDouble(0);
+                data.p0.reset( raw_ptr );
+            }
 
             // Get the correct influence table values
             if (data.inftableID > 1){

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUCT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUCT
@@ -2,7 +2,7 @@
  "items" : [
  {"name" : "AQUIFER_ID" , "value_type" : "INT"},
  {"name" : "DAT_DEPTH"  , "value_type" : "DOUBLE", "dimension" : "Length"},
- {"name" : "P_INI"      , "value_type" : "DOUBLE", "dimension" : "Pressure", "default" : 0.0},
+ {"name" : "P_INI"      , "value_type" : "DOUBLE", "dimension" : "Pressure"},
  {"name" : "PERM_AQ"    , "value_type" : "DOUBLE", "dimension" : "Permeability"},
  {"name" : "PORO_AQ"    , "value_type" : "DOUBLE", "dimension" : "1" , "default" : 1.0},
  {"name" : "C_T"        , "value_type" : "DOUBLE", "dimension" : "1/Pressure"},

--- a/tests/parser/AquiferCTTests.cpp
+++ b/tests/parser/AquiferCTTests.cpp
@@ -46,8 +46,8 @@ inline Deck createAquiferCTDeck() {
         "\n"
         "PROPS\n"
         "AQUTAB\n"
-        " 0.01 0.112 \n" 
-        " 0.05 0.229 /\n" 
+        " 0.01 0.112 \n"
+        " 0.05 0.229 /\n"
         "SOLUTION\n"
         "\n"
         "AQUCT\n"
@@ -73,6 +73,6 @@ BOOST_AUTO_TEST_CASE(AquiferCTTest){
         BOOST_CHECK_EQUAL(it.aquiferID , 1);
         BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
         BOOST_CHECK_EQUAL(it.inftableID , 2);
-        
-    }    
-}    
+
+    }
+}


### PR DESCRIPTION
Use pointer semantics to access to aquifer P0 value; to enable defaulted without the use special values like `-1` - use of boolean flag is an alternative solution.