### PR TITLE
Using plain C api for smspec_nodes

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
@@ -42,6 +42,7 @@ namespace Opm {
 
         size_t getNY() const;
         size_t getNZ() const;
+        size_t operator[](int dim) const;
 
         const std::array<int, 3> getNXYZ() const;
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
@@ -62,6 +62,22 @@ namespace Opm {
         return m_nz;
     }
 
+    size_t GridDims::operator[](int dim) const {
+        switch (dim) {
+        case 0:
+            return this->m_nx;
+            break;
+        case 1:
+            return this->m_ny;
+            break;
+        case 2:
+            return this->m_nz;
+            break;
+        default:
+            throw std::invalid_argument("Invalid argument dim:" + std::to_string(dim));
+        }
+    }
+
     const std::array<int, 3> GridDims::getNXYZ() const {
         return std::array<int, 3> {{int( m_nx ), int( m_ny ), int( m_nz )}};
     }
@@ -116,4 +132,5 @@ namespace Opm {
         m_ny = dims[1];
         m_nz = dims[2];
     }
+
 }

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -127,6 +127,11 @@ BOOST_AUTO_TEST_CASE(CreateGridNoCells) {
     BOOST_CHECK_EQUAL( 10 , grid.getNX());
     BOOST_CHECK_EQUAL( 10 , grid.getNY());
     BOOST_CHECK_EQUAL( 10 , grid.getNZ());
+
+    BOOST_CHECK_EQUAL(10, grid[0]);
+    BOOST_CHECK_EQUAL(10, grid[2]);
+    BOOST_CHECK_THROW( grid[10], std::invalid_argument);
+
     BOOST_CHECK_EQUAL( 1000 , grid.getCartesianSize());
 }
 

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -98,9 +98,9 @@ static Deck createDeck( const std::string& summary ) {
 static std::vector< std::string > sorted_names( const SummaryConfig& summary ) {
     std::vector< std::string > ret;
     for( const auto& x : summary ) {
-        auto wgname = x.wgname();
+        auto wgname = smspec_node_get_wgname(x.get());
         if(wgname)
-            ret.push_back( x.wgname() );
+            ret.push_back( smspec_node_get_wgname(x.get()));
     }
 
     std::sort( ret.begin(), ret.end() );
@@ -110,7 +110,7 @@ static std::vector< std::string > sorted_names( const SummaryConfig& summary ) {
 static std::vector< std::string > sorted_keywords( const SummaryConfig& summary ) {
     std::vector< std::string > ret;
     for( const auto& x : summary )
-        ret.push_back( x.keyword() );
+        ret.push_back( smspec_node_get_keyword(x.get()));
 
     std::sort( ret.begin(), ret.end() );
     return ret;
@@ -119,7 +119,7 @@ static std::vector< std::string > sorted_keywords( const SummaryConfig& summary 
 static std::vector< std::string > sorted_key_names( const SummaryConfig& summary ) {
     std::vector< std::string > ret;
     for( const auto& x : summary ) {
-        ret.push_back( x.key1() );
+        ret.push_back( smspec_node_get_gen_key1(x.get()));
     }
 
     std::sort( ret.begin(), ret.end() );


### PR DESCRIPTION
Use plain C api for smspec node - instead of not-so-succesfull C++ wrapper. Later change to "proper" C++ implementation.