### PR TITLE
Add opm_formatted property to the IOConfig

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -105,6 +105,41 @@ namespace Opm {
       ------ Default ------
       If no keywords for config of writing restart files have been handled; no restart files are written.
 
+
+      ECL compatible restart
+      ======================
+
+      Unfortunately flow & eclipse are not compatible across restarts. The
+      RestartIO implementation can write restart files for flow -> flow restart
+      or alternatively for flow -> eclipse restart. This is regulated by the
+      boolean flag ecl_compatible_restart in the IOConfig class. The difference
+      between the two are as follows:
+
+      ecl_compatible_restart = false:
+
+        1. The 'extra' fields in the RestartValue structure are actually
+           written to disk.
+
+        2. You can optionally ask the RestartIO::save() function to save the
+           solution in double precision.
+
+        3. The RestartIO::save() function will save opm specific vector OPM_IWEL
+           and OPM_XWEL.
+
+      ecl_compatible_restart = true:
+
+        1. The 'extra' fields in the RestartValue are silently ignored.
+
+        2. If request double precision solution data that is silently ignored,
+           it will be float.
+
+        3. The OPM_IWEL and OPM_XWEL vectors will not be written.
+
+      Observe that the solution data in the RestartValue is passed
+      unconditionally to the solution section in the restart file, so if you
+      pass a field in the solution section which Eclipse does not recognize you
+      will end up with a restart file which Eclipse can not read, even if you
+      have set ecl_compatible_restart to true.
     */
 
 
@@ -117,7 +152,8 @@ namespace Opm {
         explicit IOConfig( const Deck& );
         explicit IOConfig( const std::string& input_path );
 
-
+        void setEclCompatibleRST(bool ecl_rst);
+        bool getEclCompatibleRST() const;
         bool getWriteEGRIDFile() const;
         bool getWriteINITFile() const;
         bool getUNIFOUT() const;
@@ -165,6 +201,7 @@ namespace Opm {
         std::string     m_output_dir;
         std::string     m_base_name;
         bool            m_nosim;
+        bool            ecl_compatible_rst = false;
 
         IOConfig( const GRIDSection&,
                   const RUNSPECSection&,

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -122,6 +122,14 @@ namespace Opm {
     }
 
 
+    bool IOConfig::getEclCompatibleRST() const {
+        return this->ecl_compatible_rst;
+    }
+
+
+    void IOConfig::setEclCompatibleRST(bool ecl_rst) {
+        this->ecl_compatible_rst = ecl_rst;
+    }
 
 
     void IOConfig::overrideNOSIM(bool nosim) {


### PR DESCRIPTION
Problem: There is an incompatability between the restart files required for flow -> flow restart and flow -> eclipse restart. This PR is a first step towards facilitating a commandline switch akin to:
```
flow --opm-formatted-rst ....
```
which will write a restart file suitable for `flow -> flow` restart. This PR just adds a flag - and the necessary control logic - to the output code. The current PR does *not* imply any change in behaviour. When this has been merged the next step is to add a commandline option to `flow`. 

The loose plan behind the current PR is that the default behaviour will be to create an Eclipse compatible restart file, and that flow formatted will require an concious decision by the user. But that is a policy decision which must be taken as part of next PR; feel free to voice an opinion already now.

PS1: As the flow -> eclipse restart matures the functionality in this PR can hopefully be removed again; but I think this is a meaningful intermediate step.

PS2: Irrespective of whether the flow formatted or eclipse formatted restart file is chosen it will work nicely in Resinsight (and probably also other third party viewers).