### PR TITLE
Add option to ignore extra keywords in the regresstion testing

### DIFF
--- a/examples/test_util/EclRegressionTest.cpp
+++ b/examples/test_util/EclRegressionTest.cpp
@@ -231,20 +231,23 @@ void ECLRegressionTest::gridCompare(const bool volumecheck) const {
 
 
 void ECLRegressionTest::results() {
-    if (keywords1.size() != keywords2.size()) {
-        std::set<std::string> keys(keywords1.begin() , keywords1.end());
-        for (const auto& key2: keywords2)
-            keys.insert( key2 );
+    if (!this->acceptExtraKeywords) {
+        if (keywords1.size() != keywords2.size()) {
+            std::set<std::string> keys(keywords1.begin() , keywords1.end());
+            for (const auto& key2: keywords2)
+                keys.insert( key2 );
 
-        for (const auto& key : keys)
-            fprintf(stderr," %8s:%3d     %8s:%3d \n",key.c_str() , ecl_file_get_num_named_kw( ecl_file1 , key.c_str()),
-                                                     key.c_str() , ecl_file_get_num_named_kw( ecl_file2 , key.c_str()));
+            for (const auto& key : keys)
+                fprintf(stderr," %8s:%3d     %8s:%3d \n",key.c_str() , ecl_file_get_num_named_kw( ecl_file1 , key.c_str()),
+                                                         key.c_str() , ecl_file_get_num_named_kw( ecl_file2 , key.c_str()));
 
 
-        OPM_THROW(std::runtime_error, "\nKeywords in first file: " << keywords1.size()
-                << "\nKeywords in second file: " << keywords2.size()
-                << "\nThe number of keywords differ.");
+            OPM_THROW(std::runtime_error, "\nKeywords in first file: " << keywords1.size()
+                      << "\nKeywords in second file: " << keywords2.size()
+                      << "\nThe number of keywords differ.");
+        }
     }
+
     for (const auto& it : keywords1)
         resultsForKeyword(it);
 

--- a/examples/test_util/EclRegressionTest.hpp
+++ b/examples/test_util/EclRegressionTest.hpp
@@ -40,6 +40,10 @@ class ECLRegressionTest: public ECLFilesComparator {
         // Only compare last occurrence
         bool onlyLastOccurrence = false;
 
+        // Accept extra keywords in the restart file of the 'new' simulation.
+        bool acceptExtraKeywords = false;
+
+
         // Prints results stored in absDeviation and relDeviation.
         void printResultsForKeyword(const std::string& keyword) const;
 
@@ -68,6 +72,11 @@ class ECLRegressionTest: public ECLFilesComparator {
 
         //! \brief Option to only compare last occurrence
         void setOnlyLastOccurrence(bool onlyLastOccurrenceArg) {this->onlyLastOccurrence = onlyLastOccurrenceArg;}
+
+        // Accept extra keywords: If this switch is set to true the comparison
+        // of restart files will ignore extra keywords which are only present
+        // in the new simulation.
+        void setAcceptExtraKeywords(bool acceptExtraKeywords) { this->acceptExtraKeywords = acceptExtraKeywords; }
 
         //! \brief Compares grid properties of the two cases.
         // gridCompare() checks if both the number of active and global cells in the two cases are the same. If they are, and volumecheck is true, all cells are looped over to calculate the cell volume deviation for the two cases. If the both the relative and absolute deviation exceeds the tolerances, an exception is thrown.

--- a/examples/test_util/compareECL.cpp
+++ b/examples/test_util/compareECL.cpp
@@ -132,6 +132,7 @@ int main(int argc, char** argv) {
     bool allowSpikes             = false;
     bool throwOnError            = true;
     bool throwTooGreatErrorRatio = true;
+    bool acceptExtraKeywords     = false;
     bool analysis                = false;
     bool volumecheck             = true;
     char* keyword                = nullptr;
@@ -140,7 +141,7 @@ int main(int argc, char** argv) {
     int c                        = 0;
     int spikeLimit               = -1;
 
-    while ((c = getopt(argc, argv, "hiIk:alnpPt:VRgs:m:vK")) != -1) {
+    while ((c = getopt(argc, argv, "hiIk:alnpPt:VRgs:m:vKx")) != -1) {
         switch (c) {
             case 'a':
               analysis = true;
@@ -197,6 +198,9 @@ int main(int argc, char** argv) {
                 break;
             case 'V':
                 volumecheck = false;
+                break;
+            case 'x':
+                acceptExtraKeywords = true;
                 break;
             case '?':
                 if (optopt == 'k' || optopt == 'm' || optopt == 's') {
@@ -344,6 +348,7 @@ int main(int argc, char** argv) {
             ECLRegressionTest comparator(file_type, basename1, basename2, absTolerance, relTolerance);
             comparator.throwOnErrors(throwOnError);
             comparator.doAnalysis(analysis);
+            comparator.setAcceptExtraKeywords(acceptExtraKeywords);
             if (printKeywords) {
                 comparator.printKeywords();
                 return 0;


### PR DESCRIPTION
The compareECL program now has a new switch "-x" - if that switch is passed the program will not check that the number of keywords in two restart files is equal. Instead it will loop through all the keywords in the reference simulation and compare with the keywords from the new simulation.

The new switch is not used by jenkins in any way yet.