### PR TITLE
Make ecl compatible restart files default

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -201,7 +201,7 @@ namespace Opm {
         std::string     m_output_dir;
         std::string     m_base_name;
         bool            m_nosim;
-        bool            ecl_compatible_rst = false;
+        bool            ecl_compatible_rst = true;
 
         IOConfig( const GRIDSection&,
                   const RUNSPECSection&,


### PR DESCRIPTION
See description here: https://github.com/OPM/opm-common/pull/488

This PR changes the default to Eclipse compatible restart files. This is a *policy* decision which I urge others to chime in on.

Downstream:
https://github.com/OPM/ewoms/pull/384
https://github.com/OPM/opm-simulators/pull/1569

**NB: For `flow` usage the more relevant default is the one used when registering the property tag - see: https://github.com/OPM/ewoms/pull/384**