### PR TITLE
Komodo: cmake config changes

### DIFF
--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -71,12 +71,12 @@ if(NOT @opm-project_NAME@_FOUND)
 
   # this is the contents of config.h as far as our probes can tell:
 
+  # This is required to include OpmPackage
+  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" @PREREQ_LOCATION@)
+
   # extra code from variable OPM_PROJECT_EXTRA_CODE
   @OPM_PROJECT_EXTRA_CODE@
   # end extra code
 
-  # This call is at the bottom as we need to include
-  # the OpmPackage Macros.
-  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" @PREREQ_LOCATION@)
   include(@opm-project_NAME@-prereqs)
 endif()

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -29,11 +29,34 @@ if(NOT @opm-project_NAME@_FOUND)
   set (@opm-project_NAME@_LIBRARY_DIRS "@opm-project_LIBRARY_DIRS@" "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@")
   set (@opm-project_NAME@_LINKER_FLAGS "@opm-project_LINKER_FLAGS@")
   set (@opm-project_NAME@_CONFIG_VARS "@opm-project_CONFIG_VARS@")
-  set (HAVE_@opm-project_NAME_UC@ 1)
 
   # libraries come from the build tree where this file was generated
   set (@opm-project_NAME@_LIBRARY "@opm-project_LIBRARY@")
   set (@opm-project_NAME@_LIBRARIES ${@opm-project_NAME@_LIBRARY} "@opm-project_LIBRARIES@")
+
+  # The purpose of this string replacement operation is to enable use of the
+  # generated opm-project-config.cmake file also in the situation where 'make
+  # install' has been invoked with the DESTDIR option:
+  #
+  # opm-common/build> cmake .. -DCMAKE_INSTALL_PREFIX=/real/prefix
+  # opm-common/budil> make install DESTDIR=/tmp/prefix
+  #
+  # downstream/build> cmake .. -DDEST_PREFIX=/tmp/prefix -DCMAKE_PREFIX_PATH=/tmp/prefix
+  # downstream/build> make install
+  #
+  # That way the downstream dependency can still use find_package( opm-common )
+  # even though the opm-common-config.cmake file is not internally consistent
+  # with it's own location in the filesystem.
+
+  if(DEST_PREFIX)
+    set(DEST_PREFIX "${DEST_PREFIX}${@opm-project_NAME@_PREFIX}")
+    string(REPLACE ${@opm-project_NAME@_PREFIX} ${DEST_PREFIX} @opm-project_NAME@_INCLUDE_DIRS ${@opm-project_NAME@_INCLUDE_DIRS})
+    string(REPLACE ${@opm-project_NAME@_PREFIX} ${DEST_PREFIX} @opm-project_NAME@_LIBRARY_DIRS ${@opm-project_NAME@_LIBRARY_DIRS})
+    string(REPLACE ${@opm-project_NAME@_PREFIX} ${DEST_PREFIX} @opm-project_NAME@_LIBRARY      ${@opm-project_NAME@_LIBRARY})
+  endif()
+
+
+  set (HAVE_@opm-project_NAME_UC@ 1)
   mark_as_advanced (@opm-project_NAME@_LIBRARY)
 
   # not all projects have targets; conditionally add this part
@@ -71,12 +94,17 @@ if(NOT @opm-project_NAME@_FOUND)
 
   # this is the contents of config.h as far as our probes can tell:
 
-  # This is required to include OpmPackage
-  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" @PREREQ_LOCATION@)
 
-  # extra code from variable OPM_PROJECT_EXTRA_CODE
-  @OPM_PROJECT_EXTRA_CODE@
-  # end extra code
+  # The settings in this block do not mix well with the DEST_PREFIX
+  # setting.
+  if (NOT DEST_PREFIX)
+    # This is required to include OpmPackage
+    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" @PREREQ_LOCATION@)
 
-  include(@opm-project_NAME@-prereqs)
+    # extra code from variable OPM_PROJECT_EXTRA_CODE
+    @OPM_PROJECT_EXTRA_CODE@
+    # end extra code
+
+    include(@opm-project_NAME@-prereqs)
+  endif()
 endif()


### PR DESCRIPTION
Internally in equinor we have a system for installing inhouse developed software called Komodo[1]. That system stresses the cmake features of both the packages and the operators to the limit.

Currently I am struggling to build [sunbeam](https://github.com/Statoil/sunbeam/blob/master/CMakeLists.txt) which depends on opm-common through:
```
find_package(opm-common REQUIRED)
```

My installed version of `opm-common-config.cmake` ends like this:
```cmake

  # extra code from variable OPM_PROJECT_EXTRA_CODE
  #ENABLE_ECL_INPUT is needed by opm-common-prereq.cmake
                                       set(ENABLE_ECL_INPUT ON)
                                       set(OPM_MACROS_ROOT /project/res/komodo/opm-common/root/share/opm)
                                       list(APPEND CMAKE_MODULE_PATH ${OPM_MACROS_ROOT}/cmake/Modules)
                                       include(OpmPackage) #Make macros availabe after find_package(opm-common)
                                        set(COMPARE_SUMMARY_COMMAND /project/res/komodo/opm-common/root/bin/compareSummary)
                                        set(COMPARE_ECL_COMMAND /project/res/komodo/opm-common/root/bin/compareECL)
                                            set(HAVE_ECL_INPUT 1)
                                            set(HAVE_ECL_OUTPUT 1)
  # end extra code

  # This call is at the bottom as we need to include
  # the OpmPackage Macros.
  set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" /var/jenkins/jenkins-be/workspace/komodo-advanced/opm-common/project/res/komodo/opm-common/root/share/opm/cmake/Modules)
  include(opm-common-prereqs)
```

and when invoked from my the sunbeam build system this fails on the `include(OpmPackage)` with `"No such file or directory"`. Moving the explicit manipulation of the `CMAKE_MODULE_PATH` up seems to fix it?!


[1]: NB: `flow` is **not** distributed using komodo, so this not relevant for the `flow` hot-path.