### PR TITLE
not converting the unit of ALQ value in VFPPROD

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp
@@ -182,9 +182,6 @@ private:
     static void convertGFRToSI(const GFR_TYPE& type,
                                std::vector<double>& values,
                                const UnitSystem& unit_system);
-    static void convertALQToSI(const ALQ_TYPE& type,
-                               std::vector<double>& values,
-                               const UnitSystem& unit_system);
 };
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
@@ -258,7 +258,6 @@ VFPProdTable::VFPProdTable( const DeckKeyword& table, const UnitSystem& deck_uni
 
     //Get actual gas fraction values
     m_alq_data = table.getRecord(5).getItem<VFPPROD::ALQ_VALUES>().getData< double >();
-    convertALQToSI(m_alq_type, m_alq_data, deck_unit_system);
 
     //Finally, read the actual table itself.
     size_t nt = m_thp_data.size();
@@ -514,35 +513,5 @@ void VFPProdTable::convertGFRToSI(const GFR_TYPE& type,
     }
     scaleValues(values, scaling_factor);
 }
-
-
-
-
-
-
-
-void VFPProdTable::convertALQToSI(const ALQ_TYPE& type,
-                                  std::vector<double>& values,
-                                  const UnitSystem& unit_system) {
-    double scaling_factor = 1.0;
-    switch (type) {
-        case ALQ_GRAT:
-            scaling_factor = unit_system.parse("GasSurfaceVolume/Time").getSIScaling();
-            break;
-        case ALQ_IGLR:
-        case ALQ_TGLR:
-            scaling_factor = unit_system.parse("GasSurfaceVolume/LiquidSurfaceVolume").getSIScaling();
-            break;
-        case ALQ_PUMP:
-        case ALQ_COMP:
-        case ALQ_BEAN:
-        case ALQ_UNDEF:
-            break;
-        default:
-            throw std::logic_error("Invalid FLO type");
-    }
-    scaleValues(values, scaling_factor);
-}
-
 
 } //Namespace opm


### PR DESCRIPTION
Since the ALQ value in WCON* keywords are not converted based on the unit of ALQ in the VFPPROD keyword, the interpolation can be wrong when ALQ value is there. 

This is a problem revealed during the debugging related to VFP/THP. The ALQ values in the WCON* keyword should have the same unit of the ALQ values in the VFPPROD keyword. We convert the unit of the ALQ values in the VFPPROD tables, while we do not convert the one in  the WCON* keywords. 

For some types of ALQ, like GRAT, it will cause the interpolation of the VFP tables crazy. 

This is the easiest "fix" I can imagine. I will use this for my debugging. Everyone is welcome to suggest some more correct fix for this problem. I will not be able to spend time on this very soon. 

There might be some testing failure. 