### PR TITLE
Also search for Alberta (Fixes ebos compile issue with g++-8.2)

### DIFF
--- a/cmake/Modules/FindAlberta.cmake
+++ b/cmake/Modules/FindAlberta.cmake
@@ -1,0 +1,46 @@
+find_library(ALBERTA_LTDL_LIB
+  NAMES ltdl
+  PATH_SUFFIXES lib lib32 lib64
+)
+find_path(ALBERTA_INCLUDE_DIR
+  NAMES alberta/alberta.h
+  PATHS ${ALBERTA_ROOT}
+  PATH_SUFFIXES alberta include NO_DEFAULT_PATH
+  DOC "Include path of Alberta")
+find_path(ALBERTA_INCLUDE_DIR
+  NAMES
+  alberta/alberta.h
+  PATHS /usr/local /opt
+  PATH_SUFFIXES alberta)
+#look for libraries
+find_library(ALBERTA_UTIL_LIB
+  NAMES alberta_util alberta_utilities
+  PATHS ${ALBERTA_ROOT}
+  PATH_SUFFIXES lib lib32 lib64
+  NO_DEFAULT_PATH)
+find_library(ALBERTA_UTIL_LIB
+  NAMES alberta_util alberta_utilities
+  PATH_SUFFIXES lib lib32 lib64)
+
+foreach(dim RANGE 1 9)
+  find_library(ALBERTA_${dim}D_LIB alberta_${dim}d
+    PATHS ${ALBERTA_ROOT}
+    PATH_SUFFIXES lib lib32 lib64
+    Cache FILEPATH DOC "Alberta lib for ${dim}D" NO_DEFAULT_PATH)
+  find_library(ALBERTA_${dim}D_LIB alberta_${dim}d  PATH_SUFFIXES lib lib32 lib64)
+  if(ALBERTA_${dim}D_LIB)
+    set(ALBERTA_LIBRARIES ${ALBERTA_LIBRARIES} ${ALBERTA_${dim}D_LIB})
+  endif()
+endforeach(dim RANGE 1 9)
+
+if(ALBERTA_LIBRARIES AND ALBERTA_INCLUDE_DIR)
+  set(ALBERTA_INCLUDE_DIRS ${ALBERTA_INCLUDE_DIR})
+  set(ALBERTA_LIBRARIES ${ALBERTA_LIBRARIES} ${ALBERTA_UTIL_LIB} ${ALBERTA_LTDL_LIB})
+  set(ALBERTA_FOUND ON)
+  set(Alberta_FOUND ON)
+  set(HAVE_ALBERTA 1)
+  set(DUNE_ALBERTA_VERSION 0x300)
+else()
+  set(ALBERTA_FOUND ON)
+  set(Alberta_FOUND ON)
+endif()

--- a/cmake/Modules/Finddune-grid.cmake
+++ b/cmake/Modules/Finddune-grid.cmake
@@ -27,7 +27,8 @@ find_opm_package (
   dune-geometry REQUIRED;
   dune-uggrid;
   MPI;
-  UG
+  UG;
+  Alberta
   "
   # header to search for
   "dune/grid/onedgrid.hh"
@@ -55,7 +56,8 @@ int main (void) {
    HAVE_AMIRAMESH;
    HAVE_ALBERTA;
    HAVE_STDINT_H;
-   DUNE_GRID_EXPERIMENTAL_GRID_EXTENSIONS
+   DUNE_GRID_EXPERIMENTAL_GRID_EXTENSIONS;
+   DUNE_ALBERTA_VERSION
   ")
 
 #debug_find_vars ("dune-grid")


### PR DESCRIPTION
We do not use it in OPM, but for whatever reason I was experiencing
linker errors (unresolved symbol) when compiling ebos with DUNE 2.6
and g++-8.2. dune-grid exports its alberta wrapper libraries in dune-grid_LIBRARIES. Previously this did not pose a problem. Somehow it does now. If
I strip the libraries from the linker line everything is fine but this
is not a good solution.

Therefore I have added a test for Alberta that is triggered by the test of
dune-grid.