### PR TITLE
WellConnections: Initialise Head in Copy Constructor

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellConnections.hpp
@@ -94,9 +94,10 @@ namespace Opm {
 			   const double segDistEnd= 0.0,
 			   const bool defaultSatTabId = true);
 
-        std::vector< Connection > m_connections;
         size_t findClosestConnection(int oi, int oj, double oz, size_t start_pos);
+
         int headI, headJ;
+        std::vector< Connection > m_connections;
     };
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellConnections.cpp
@@ -123,7 +123,10 @@ namespace {
 
 
 
-    WellConnections::WellConnections(const WellConnections& src, const EclipseGrid& grid) {
+    WellConnections::WellConnections(const WellConnections& src, const EclipseGrid& grid) :
+        headI(src.headI),
+        headJ(src.headJ)
+    {
         for (const auto& c : src) {
             if (grid.cellActive(c.getI(), c.getJ(), c.getK()))
                 this->add(c);


### PR DESCRIPTION
This commit ensures that the data members 'headI' and 'headJ' are properly initialised in the constructor
```C++
WellConnections(const WellConnections&, const EclipseGrid&)
```
which in turn powers the implementation of
```C++
Well::getActiveConnections()
```