### PR TITLE
 Ability to ignore named keywords in ParseContext

### DIFF
--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <map>
+#include <set>
 #include <vector>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
@@ -84,12 +85,14 @@ namespace Opm {
         explicit ParseContext(const std::vector<std::pair<std::string , InputError::Action>>& initial);
 
         void handleError( const std::string& errorKey, const std::string& msg ) const;
+        void handleUnknownKeyword(const std::string& keyword) const;
         bool hasKey(const std::string& key) const;
         ParseContext  withKey(const std::string& key, InputError::Action action = InputError::WARN) const;
         ParseContext& withKey(const std::string& key, InputError::Action action = InputError::WARN);
         void updateKey(const std::string& key , InputError::Action action);
         void update(InputError::Action action);
         void update(const std::string& keyString , InputError::Action action);
+        void ignoreKeyword(const std::string& keyword);
         InputError::Action get(const std::string& key) const;
         std::map<std::string,InputError::Action>::const_iterator begin() const;
         std::map<std::string,InputError::Action>::const_iterator end() const;
@@ -256,6 +259,7 @@ namespace Opm {
         void envUpdate( const std::string& envVariable , InputError::Action action );
         void patternUpdate( const std::string& pattern , InputError::Action action);
         std::map<std::string , InputError::Action> m_errorContexts;
+        std::set<std::string> ignore_keywords;
 }; }
 
 

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -95,6 +95,11 @@ namespace Opm {
     }
 
 
+    void ParseContext::ignoreKeyword(const std::string& keyword) {
+        this->ignore_keywords.insert(keyword);
+    }
+
+
     void ParseContext::handleError(
             const std::string& errorKey,
             const std::string& msg ) const {
@@ -109,6 +114,13 @@ namespace Opm {
         else if (action == InputError::THROW_EXCEPTION) {
             OpmLog::error(msg);
             throw std::invalid_argument(errorKey + ": " + msg);
+        }
+    }
+
+    void ParseContext::handleUnknownKeyword(const std::string& keyword) const {
+        if (this->ignore_keywords.find(keyword) == this->ignore_keywords.end()) {
+            std::string msg = "Unknown keyword: " + keyword;
+            this->handleError(ParseContext::PARSE_UNKNOWN_KEYWORD, msg);
         }
     }
 

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -417,7 +417,7 @@ std::shared_ptr< RawKeyword > createRawKeyword( const string_view& kw, ParserSta
     if( !parser.isRecognizedKeyword( keywordString ) ) {
         if( ParserKeyword::validDeckName( keywordString ) ) {
             std::string msg = "Keyword " + keywordString + " not recognized.";
-            parserState.parseContext.handleError( ParseContext::PARSE_UNKNOWN_KEYWORD, msg );
+            parserState.parseContext.handleUnknownKeyword( keywordString.string() );
             parserState.unknown_keyword = true;
             return {};
         }

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -86,6 +86,26 @@ BOOST_AUTO_TEST_CASE(TestUnkownKeyword) {
 }
 
 
+BOOST_AUTO_TEST_CASE(TestUnkownKeywordII) {
+    const char * deck1 =
+        "RUNSPEC\n"
+        "DIMENS\n"
+        "  10 10 10 /n"
+        "\n";
+
+
+    ParseContext parseContext;
+    Parser parser(false);
+
+
+    parser.addKeyword<ParserKeywords::DIMENS>();
+    parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::THROW_EXCEPTION );
+    BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext ) , std::invalid_argument);
+    parseContext.ignoreKeyword("RUNSPEC");
+    BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext ) );
+}
+
+
 BOOST_AUTO_TEST_CASE(Handle_extra_records) {
     const char * deck_string = 
          "EQLDIMS\n"


### PR DESCRIPTION
With this it is possible to add keywords to the `ParseContext` which should be ignored.