### PR TITLE
Use non-const string type in map.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp
@@ -34,8 +34,8 @@ class GroupTree {
         bool exists( const std::string& group ) const;
         const std::string& parent( const std::string& name ) const;
         std::vector< std::string > children( const std::string& parent ) const;
-	const std::map<const std::string , size_t>& nameSeqIndMap() const;
-	const std::map<size_t, const std::string >& seqIndNameMap() const;
+	const std::map<std::string , size_t>& nameSeqIndMap() const;
+	const std::map<size_t, std::string >& seqIndNameMap() const;
 	size_t groupTreeSize();
         bool operator==( const GroupTree& ) const;
         bool operator!=( const GroupTree& ) const;
@@ -57,8 +57,8 @@ class GroupTree {
         std::vector< group > groups = { group { "FIELD", "" } };
         friend bool operator<( const std::string&, const group& );
         std::vector< group >::iterator find( const std::string& );
-	std::map<const std::string , size_t> m_nameSeqIndMap;
-	std::map<size_t, const std::string > m_seqIndNameMap;
+	std::map<std::string , size_t> m_nameSeqIndMap;
+	std::map<size_t, std::string > m_seqIndNameMap;
 };
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/GroupTree.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/GroupTree.cpp
@@ -37,11 +37,11 @@ void GroupTree::update( const std::string& name) {
  * and represented elsewhere)
  */
  
-const std::map<const std::string , size_t>& GroupTree::nameSeqIndMap() const {
+const std::map<std::string , size_t>& GroupTree::nameSeqIndMap() const {
   return m_nameSeqIndMap;
 }
 
-const std::map<size_t, const std::string >& GroupTree::seqIndNameMap() const {
+const std::map<size_t, std::string >& GroupTree::seqIndNameMap() const {
   return m_seqIndNameMap;
 }
 


### PR DESCRIPTION
Using const string as key type instead of plain string fails with libc++, the standard library implementation used by clang. The libc++ implementation assumes that map keys can be copied, and the standard requires map keys to be copyable.

Using `const string` as a value also fails with clang, I am not 100% sure why. It does severely restrict how you can interact with the container, and seems to make it noncopyable. The error is reported from `DynamicState<GroupTree>::update()`, the `std::fill()` call. Below is the horribly long compile message trail I get, it is somewhat hard to understand what is going on.

@joakim-hove I think this should be picked into the release branch due to severity (compilation failure).
```
In file included from /Users/atgeirr/release-opm/src/opm-common/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp:20:
In file included from /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:439:
In file included from /Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/algorithm:627:
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/utility:348:16: error: no viable overloaded
      '='
        second = _VSTD::forward<second_type>(__p.second);
        ~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/map:650:15: note: in instantiation of
      member function 'std::__1::pair<unsigned long, const std::__1::basic_string<char> >::operator='
      requested here
        {__nc = __v.__cc; return *this;}
              ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/__tree:1200:35: note: in instantiation of
      member function 'std::__1::__value_type<unsigned long, const std::__1::basic_string<char>
      >::operator=' requested here
                __cache->__value_ = *__first;
                                  ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/__tree:1141:9: note: in instantiation of
      function template specialization 'std::__1::__tree<std::__1::__value_type<unsigned long, const
      std::__1::basic_string<char> >, std::__1::__map_value_compare<unsigned long,
      std::__1::__value_type<unsigned long, const std::__1::basic_string<char> >, std::__1::less<unsigned
      long>, true>, std::__1::allocator<std::__1::__value_type<unsigned long, const
      std::__1::basic_string<char> > >
      >::__assign_multi<std::__1::__tree_const_iterator<std::__1::__value_type<unsigned long, const
      std::__1::basic_string<char> >, std::__1::__tree_node<std::__1::__value_type<unsigned long, const
      std::__1::basic_string<char> >, void *> *, long> >' requested here
        __assign_multi(__t.begin(), __t.end());
        ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/map:928:21: note: in instantiation of
      member function 'std::__1::__tree<std::__1::__value_type<unsigned long, const
      std::__1::basic_string<char> >, std::__1::__map_value_compare<unsigned long,
      std::__1::__value_type<unsigned long, const std::__1::basic_string<char> >, std::__1::less<unsigned
      long>, true>, std::__1::allocator<std::__1::__value_type<unsigned long, const
      std::__1::basic_string<char> > > >::operator=' requested here
            __tree_ = __m.__tree_;
                    ^
/Users/atgeirr/release-opm/src/opm-common/opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp:29:7: note: 
      in instantiation of member function 'std::__1::map<unsigned long, const
      std::__1::basic_string<char>, std::__1::less<unsigned long>,
      std::__1::allocator<std::__1::pair<const unsigned long, const std::__1::basic_string<char> > >
      >::operator=' requested here
class GroupTree {
      ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/algorithm:2072:18: note: in instantiation
      of function template specialization 'std::__1::__fill_n<std::__1::__wrap_iter<Opm::GroupTree *>,
      long, Opm::GroupTree>' requested here
   return _VSTD::__fill_n(__first, __convert_to_integral(__n), __value_);
                 ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/algorithm:2091:12: note: in instantiation
      of function template specialization 'std::__1::fill_n<std::__1::__wrap_iter<Opm::GroupTree *>,
      long, Opm::GroupTree>' requested here
    _VSTD::fill_n(__first, __last - __first, __value_);
           ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/algorithm:2099:12: note: in instantiation
      of function template specialization 'std::__1::__fill<std::__1::__wrap_iter<Opm::GroupTree *>,
      Opm::GroupTree>' requested here
    _VSTD::__fill(__first, __last, __value_, typename iterator_traits<_ForwardIterator>::iterator...
           ^
/Users/atgeirr/release-opm/src/opm-common/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp:103:18: note: 
      in instantiation of function template specialization
      'std::__1::fill<std::__1::__wrap_iter<Opm::GroupTree *>, Opm::GroupTree>' requested here
            std::fill( this->m_data.begin() + index,
                 ^
/Users/atgeirr/release-opm/src/opm-common/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp:495:29: note: 
      in instantiation of member function 'Opm::DynamicState<Opm::GroupTree>::update' requested here
            m_rootGroupTree.update(currentStep, newTree);
                            ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:1392:19: note: candidate function
      not viable: 'this' argument has type 'const std::__1::basic_string<char>', but method is not marked
      const
    basic_string& operator=(const basic_string& __str);
                  ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:1395:19: note: candidate function
      not viable: 'this' argument has type 'const std::__1::basic_string<char>', but method is not marked
      const
    basic_string& operator=(basic_string&& __str)
                  ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:1399:45: note: candidate function
      not viable: 'this' argument has type 'const std::__1::basic_string<char>', but method is not marked
      const
    _LIBCPP_INLINE_VISIBILITY basic_string& operator=(const value_type* __s) {return assign(__s);}
                                            ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:1400:19: note: candidate function
      not viable: 'this' argument has type 'const std::__1::basic_string<char>', but method is not marked
      const
    basic_string& operator=(value_type __c);
                  ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/string:1403:19: note: candidate function
      not viable: 'this' argument has type 'const std::__1::basic_string<char>', but method is not marked
      const
    basic_string& operator=(initializer_list<value_type> __il) {return assign(__il.begin(), __il....
```