### PR TITLE
WIP Make transmissibilities editable from the parser

### DIFF
--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
@@ -50,13 +50,16 @@ namespace Opm {
 
         Eclipse3DProperties() = default;
 
-        Eclipse3DProperties(const Deck& deck,
-                            const TableManager& tableManager,
-                            const EclipseGrid& eclipseGrid);
+        Eclipse3DProperties(const TableManager& tableManager,
+                            const EclipseGrid& eclipseGrid,
+                            const Deck& deck,
+                            const EclipseState &eclipseState);
 
-        Eclipse3DProperties( UnitSystem unit_system,
+        Eclipse3DProperties(UnitSystem unit_system,
                              const TableManager& tableManager,
-                             const EclipseGrid& eclipseGrid);
+                             const EclipseGrid& eclipseGrid,
+                             const Deck& deck,
+                             const EclipseState &eclipseState);
 
         std::vector< int > getRegions( const std::string& keyword ) const;
         std::string getDefaultRegionKeyword() const;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -46,6 +46,7 @@ namespace Opm {
     class DeckKeyword;
     class DeckRecord;
     class EclipseGrid;
+    class EclipseState;
     class InitConfig;
     class IOConfig;
     class ParseContext;
@@ -54,6 +55,17 @@ namespace Opm {
     class SimulationConfig;
     class TableManager;
     class UnitSystem;
+
+    class TransmissibilityInitializer {
+    public:
+        TransmissibilityInitializer() {}
+        virtual ~ TransmissibilityInitializer() {}
+        virtual void setup(const Deck& deck, const EclipseState& eclState) = 0;
+        virtual const std::vector<double>& tranx() = 0;
+        virtual const std::vector<double>& trany() = 0;
+        virtual const std::vector<double>& tranz() = 0;
+        virtual const std::map<std::pair<int,int>, double>& trannnc() = 0;
+    };
 
     class EclipseState {
     public:
@@ -102,13 +114,13 @@ namespace Opm {
 
         const Runspec& runspec() const;
 
-        static void setTransmissibilityInitializer(const TransmissibilityInitializer* transInit)
+        static void setTransmissibilityInitializer(TransmissibilityInitializer* transInit)
         { m_transInit = transInit; }
         static TransmissibilityInitializer* transmissibilityInitializer()
         { return m_transInit; }
 
     private:
-        const TransmissibilityInitializer* m_transInit = nullptr;
+        static TransmissibilityInitializer* m_transInit;
         void initIOConfigPostSchedule(const Deck& deck);
         void initTransMult();
         void initFaults(const Deck& deck);

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -102,7 +102,13 @@ namespace Opm {
 
         const Runspec& runspec() const;
 
+        static void setTransmissibilityInitializer(const TransmissibilityInitializer* transInit)
+        { m_transInit = transInit; }
+        static TransmissibilityInitializer* transmissibilityInitializer()
+        { return m_transInit; }
+
     private:
+        const TransmissibilityInitializer* m_transInit = nullptr;
         void initIOConfigPostSchedule(const Deck& deck);
         void initTransMult();
         void initFaults(const Deck& deck);

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -36,6 +36,8 @@ namespace Opm {
     class DeckKeyword;
     class EclipseGrid;
     class TableManager;
+    class Deck;
+    class EclipseState;
     template< typename > class GridProperties;
 
 template< typename T >
@@ -200,6 +202,21 @@ std::vector< double > temperature_lookup( size_t,
                                           const TableManager*,
                                           const EclipseGrid*,
                                           const GridProperties<int>* );
+
+std::vector< double > transX_lookup(size_t,
+                                    const Deck *deck,
+                                   const EclipseState *state);
+std::vector< double > transY_lookup(size_t,
+                                    const Deck *deck,
+                                    const EclipseState *state);
+std::vector< double > transZ_lookup(size_t,
+                                    const Deck *deck,
+                                   const EclipseState *state);
+//std::vector< double > transNnc_lookup(size_t,
+//                                   const EclipseState *state);
+
 }
+
+
 
 #endif

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -266,6 +266,7 @@ namespace Opm {
         const auto IKRGRLookup  = std::bind( IKRGREndpoint,  _1, tableManager, eclipseGrid, intGridProperties );
 
         const auto tempLookup = std::bind( temperature_lookup, _1, tableManager, eclipseGrid, intGridProperties );
+        const auto transCalculator = std::bind( trans_calculator, _1, tableManager, eclipseGrid, intGridProperties );
 
         const auto distributeTopLayer = std::bind( &distTopLayer, _1, eclipseGrid );
 
@@ -415,8 +416,8 @@ namespace Opm {
         /* the transmissibility keywords for neighboring connections. note that
          * these keywords don't seem to require a post-processor
          */
-        for( const auto& kw : { "TRANX", "TRANY", "TRANZ" } )
-            supportedDoubleKeywords.emplace_back( kw, nan, "Transmissibility" );
+        for( const auto& kw : { "TRANX", "TRANY", "TRANZ", "TRANNNC" } )
+            supportedDoubleKeywords.emplace_back( kw, transCalculator , "Transmissibility", true );
 
         /* gross-to-net thickness (acts as a multiplier for PORO and the
          * permeabilities in the X-Y plane as well as for the well rates.)

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -48,8 +48,9 @@
 
 
 namespace Opm {
+    TransmissibilityInitializer* EclipseState::m_transInit;
 
-    EclipseState::EclipseState(const Deck& deck, ParseContext parseContext) :
+    EclipseState::EclipseState(const Deck& deck, ParseContext parseContext) :        
         m_parseContext(      parseContext ),
         m_tables(            deck ),
         m_runspec(           deck ),
@@ -57,7 +58,7 @@ namespace Opm {
         m_deckUnitSystem(    deck.getActiveUnitSystem() ),
         m_inputNnc(          deck ),
         m_inputGrid(         deck, nullptr ),
-        m_eclipseProperties( deck, m_tables, m_inputGrid ),
+        m_eclipseProperties( m_tables, m_inputGrid, deck, *this ),
         m_simulationConfig(  m_eclipseConfig.getInitConfig().restartRequested(), deck, m_eclipseProperties ),
         m_transMult(         GridDims(deck), deck, m_eclipseProperties )
     {
@@ -167,24 +168,6 @@ namespace Opm {
     void EclipseState::initTransMult() {
         const auto& p = m_eclipseProperties;
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTX"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTX"), FaceDir::XPlus);
-        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTX-"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTX-"), FaceDir::XMinus);
-
-        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTY"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTY"), FaceDir::YPlus);
-        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTY-"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTY-"), FaceDir::YMinus);
-
-        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTZ"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ"), FaceDir::ZPlus);
-        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTZ-"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ-"), FaceDir::ZMinus);
-    }
-
-    void EclipseState::initTrans() {
-        const auto& p = m_eclipseProperties;
-        if (m_eclipseProperties.hasDeckDoubleGridProperty("TRANX"))
             m_transMult.applyMULT(p.getDoubleGridProperty("MULTX"), FaceDir::XPlus);
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTX-"))
             m_transMult.applyMULT(p.getDoubleGridProperty("MULTX-"), FaceDir::XMinus);

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -182,6 +182,24 @@ namespace Opm {
             m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ-"), FaceDir::ZMinus);
     }
 
+    void EclipseState::initTrans() {
+        const auto& p = m_eclipseProperties;
+        if (m_eclipseProperties.hasDeckDoubleGridProperty("TRANX"))
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTX"), FaceDir::XPlus);
+        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTX-"))
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTX-"), FaceDir::XMinus);
+
+        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTY"))
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTY"), FaceDir::YPlus);
+        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTY-"))
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTY-"), FaceDir::YMinus);
+
+        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTZ"))
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ"), FaceDir::ZPlus);
+        if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTZ-"))
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ-"), FaceDir::ZMinus);
+    }
+
     void EclipseState::initFaults(const Deck& deck) {
         const GRIDSection gridSection ( deck );
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -520,6 +520,21 @@ std::vector< double > temperature_lookup( size_t size,
         return std::vector< double >( size, tables->rtemp( ) );
 }
 
+std::vector< double > trans_lookup( size_t size,
+                                    const TableManager* tables,
+                                    const EclipseGrid* grid,
+                                    const GridProperties<int>* ig_props )
+{
+  const TransmissibilityInitialzer* transIni = EclipseState::transmissibilityInitializer();
+  if (transIni)
+    transIni->setup();
+  //extract();
+  else
+   //useNaN;
+
+
+}
+
 }
 
 template class Opm::GridPropertySupportedKeywordInfo< int >;

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -27,6 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
@@ -520,20 +521,53 @@ std::vector< double > temperature_lookup( size_t size,
         return std::vector< double >( size, tables->rtemp( ) );
 }
 
-std::vector< double > trans_lookup( size_t size,
-                                    const TableManager* tables,
-                                    const EclipseGrid* grid,
-                                    const GridProperties<int>* ig_props )
+
+std::vector< double > transX_lookup( size_t size,
+                                     const Deck* deck,
+                                     const EclipseState* state)
 {
-  const TransmissibilityInitialzer* transIni = EclipseState::transmissibilityInitializer();
-  if (transIni)
-    transIni->setup();
-  //extract();
-  else
-   //useNaN;
-
-
+    TransmissibilityInitializer* transIni = EclipseState::transmissibilityInitializer();
+    if (transIni) {
+        transIni->setup(*deck, *state);
+        return transIni->tranx();
+    }
+    std::vector<double> def(size, std::numeric_limits<double>::quiet_NaN());
+    return def;
 }
+std::vector< double > transY_lookup( size_t size,
+                                    const Deck* deck,
+                                     const EclipseState* state)
+{
+    TransmissibilityInitializer* transIni = EclipseState::transmissibilityInitializer();
+    if (transIni) {
+        transIni->setup(*deck, *state);
+        return transIni->trany();
+    }
+    std::vector<double> def(size, std::numeric_limits<double>::quiet_NaN());
+    return def;
+}
+std::vector< double > transZ_lookup( size_t size,
+                                     const Deck* deck,
+                                     const EclipseState* state) {
+    TransmissibilityInitializer* transIni = EclipseState::transmissibilityInitializer();
+    if (transIni) {
+        transIni->setup(*deck, *state);
+        return transIni->tranz();
+    }
+    std::vector<double> def(size, std::numeric_limits<double>::quiet_NaN());
+    return def;
+}
+
+//std::vector< double > transNnc_lookup( size_t size,
+//                                       const EclipseState* state) {
+//    TransmissibilityInitializer* transIni = EclipseState::transmissibilityInitializer();
+//    if (transIni) {
+//        transIni->setup(*state);
+//        return transIni->trannnc();
+//    }
+//    std::vector<double> def(size, std::numeric_limits<double>::quiet_NaN());
+//    return def;
+//}
 
 }
 

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -89,7 +89,8 @@ ENDACTIO
     auto deck2 = parser.parseString(WITH_WELSPECS, Opm::ParseContext());
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck1 );
-    Eclipse3DProperties eclipseProperties ( deck1 , table, grid1);
+    EclipseState state1(deck1, ParseContext());
+    Eclipse3DProperties eclipseProperties(table, grid1, deck1, state1);
 
     // The ACTIONX keyword has no matching 'ENDACTIO' -> exception
     BOOST_CHECK_THROW(Schedule(deck1, grid1, eclipseProperties, Phases(true,true,true), ParseContext()), std::invalid_argument);

--- a/tests/parser/ADDREGTests.cpp
+++ b/tests/parser/ADDREGTests.cpp
@@ -267,8 +267,9 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::Deck deck = createValidIntDeck();
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
-    Opm::Eclipse3DProperties props(deck, tm, eg);
-    const auto& property = props.getIntGridProperty("SATNUM");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, eg, deck, eclipseState);
+    const auto& property = eclipseProperties.getIntGridProperty("SATNUM");
 
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
@@ -285,8 +286,9 @@ BOOST_AUTO_TEST_CASE(UnitAppliedCorrectly) {
     Opm::Deck deck = createValidPERMXDeck();
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
-    Opm::Eclipse3DProperties props(deck, tm, eg);
-    const auto& permx = props.getDoubleGridProperty("PERMX");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, eg, deck, eclipseState);
+    const auto& permx = eclipseProperties.getDoubleGridProperty("PERMX");
 
     for (size_t j=0; j< 5; j++)
         for (size_t i = 0; i < 5; i++) {

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -147,8 +147,10 @@ Opm::WellConnections loadCOMPDAT(const std::string& compdat_keyword) {
     Opm::EclipseGrid grid(10,10,10);
     Opm::TableManager tables;
     Opm::Parser parser;
-    const auto deck = parser.parseString(compdat_keyword, Opm::ParseContext());
-    Opm::Eclipse3DProperties props(deck, tables, grid );
+    const auto deck = parser.parseString(compdat_keyword, Opm::ParseContext());   
+    Opm::EclipseState state(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties props(tables, grid, deck, state);
+
     const auto& keyword = deck.getKeyword("COMPDAT", 0);
     Opm::WellConnections connections;
     std::size_t totnc = 0;

--- a/tests/parser/Eclipse3DPropertiesTests.cpp
+++ b/tests/parser/Eclipse3DPropertiesTests.cpp
@@ -264,13 +264,15 @@ struct Setup
     Opm::Deck deck;
     Opm::TableManager tablemanager;
     Opm::EclipseGrid grid;
+    Opm::EclipseState eclipseState;
     Opm::Eclipse3DProperties props;
 
     explicit Setup(Opm::Deck&& deckArg) :
             deck(std::move( deckArg ) ),
             tablemanager(deck),
             grid(deck),
-            props(deck, tablemanager, grid)
+            eclipseState(deck, Opm::ParseContext()),
+            props(tablemanager, grid, deck, eclipseState)
     {
     }
 };

--- a/tests/parser/GridPropertyTests.cpp
+++ b/tests/parser/GridPropertyTests.cpp
@@ -351,7 +351,8 @@ BOOST_AUTO_TEST_CASE(GridPropertyInitialization) {
     auto deck = parser.parseString(deckString, parseContext);
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
-    Opm::Eclipse3DProperties props(deck, tm, eg);
+    Opm::EclipseState eclState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties props(tm, eg, deck, eclState);
 
     // make sure that Eclipse3DProperties throws if it is bugged about an _unsupported_ keyword
     BOOST_CHECK_THROW(props.hasDeckIntGridProperty("ISWU"), std::logic_error);

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -111,26 +111,27 @@ BOOST_AUTO_TEST_CASE(InvalidInput) {
     Opm::EclipseGrid grid( deck );
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg( deck );
-    Opm::Eclipse3DProperties props(deck, tm, eg);
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, eg, deck, eclipseState);
 
 
     // Invalid direction
     std::vector<const Opm::DeckKeyword*> keywords0;
     const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
     keywords0.push_back( &multregtKeyword0 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords0 ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( eclipseProperties, keywords0 ); , std::invalid_argument );
 
     // Not supported region
     std::vector<const Opm::DeckKeyword*> keywords1;
     const auto& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
     keywords1.push_back( &multregtKeyword1 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords1 ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( eclipseProperties, keywords1 ); , std::invalid_argument );
 
     // The keyword is ok; but it refers to a region which is not in the deck.
     std::vector<const Opm::DeckKeyword*> keywords2;
     const auto& multregtKeyword2 = deck.getKeyword( "MULTREGT", 2 );
     keywords2.push_back( &multregtKeyword2 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords2 ); , std::logic_error );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( eclipseProperties, keywords2 ); , std::logic_error );
 }
 
 
@@ -178,20 +179,21 @@ BOOST_AUTO_TEST_CASE(NotSupported) {
     Opm::EclipseGrid grid( deck );
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg( deck );
-    Opm::Eclipse3DProperties props(deck, tm, eg);
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, eg, deck, eclipseState);
 
 
     // Not support NOAQUNNC behaviour
     std::vector<const Opm::DeckKeyword*> keywords0;
     const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
     keywords0.push_back( &multregtKeyword0 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords0 ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( eclipseProperties, keywords0 ); , std::invalid_argument );
 
     // srcValue == targetValue - not supported
     std::vector<const Opm::DeckKeyword*> keywords1;
     const Opm::DeckKeyword& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
     keywords1.push_back( &multregtKeyword1 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords1 ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( eclipseProperties, keywords1 ); , std::invalid_argument );
 }
 
 static Opm::Deck createDefaultedRegions() {
@@ -237,13 +239,14 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   Opm::EclipseGrid grid( deck );
   Opm::TableManager tm(deck);
   Opm::EclipseGrid eg( deck );
-  Opm::Eclipse3DProperties props(deck, tm, eg);
+  Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+  Opm::Eclipse3DProperties eclipseProperties ( tm, eg, deck, eclipseState);
 
 
   std::vector<const Opm::DeckKeyword*> keywords0;
   const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
   keywords0.push_back( &multregtKeyword0 );
-  Opm::MULTREGTScanner scanner0(props, keywords0);
+  Opm::MULTREGTScanner scanner0(eclipseProperties, keywords0);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(0,0,1), grid.getGlobalIndex(1,0,1), Opm::FaceDir::XPlus ), 1.25);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(2,0,0), Opm::FaceDir::XPlus ), 0.50);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,1), grid.getGlobalIndex(2,0,0), Opm::FaceDir::ZMinus ), 0.50);
@@ -251,7 +254,7 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   std::vector<const Opm::DeckKeyword*> keywords1;
   const Opm::DeckKeyword& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
   keywords1.push_back( &multregtKeyword1 );
-  Opm::MULTREGTScanner scanner1( props, keywords1 );
+  Opm::MULTREGTScanner scanner1( eclipseProperties, keywords1 );
   BOOST_CHECK_EQUAL( scanner1.getRegionMultiplier(grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(1,0,0), Opm::FaceDir::XMinus ), 0.75);
   BOOST_CHECK_EQUAL( scanner1.getRegionMultiplier(grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(2,0,1), Opm::FaceDir::ZPlus), 0.75);
 }
@@ -297,12 +300,13 @@ BOOST_AUTO_TEST_CASE(MULTREGT_COPY_MULTNUM) {
     Opm::Deck deck = createCopyMULTNUMDeck();
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
-    Opm::Eclipse3DProperties props(deck, tm, eg);
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, eg, deck, eclipseState);
 
-    BOOST_CHECK_NO_THROW(props.hasDeckIntGridProperty("FLUXNUM"));
-    BOOST_CHECK_NO_THROW(props.hasDeckIntGridProperty("MULTNUM"));
-    const auto& fdata = props.getIntGridProperty("FLUXNUM").getData();
-    const auto& mdata = props.getIntGridProperty("MULTNUM").getData();
+    BOOST_CHECK_NO_THROW(eclipseProperties.hasDeckIntGridProperty("FLUXNUM"));
+    BOOST_CHECK_NO_THROW(eclipseProperties.hasDeckIntGridProperty("MULTNUM"));
+    const auto& fdata = eclipseProperties.getIntGridProperty("FLUXNUM").getData();
+    const auto& mdata = eclipseProperties.getIntGridProperty("MULTNUM").getData();
     std::vector<int> data = { 1, 2, 1, 2, 3, 4, 3, 4 };
 
     for (auto i = 0; i < 2 * 2 * 2; i++) {

--- a/tests/parser/MessageLimitTests.cpp
+++ b/tests/parser/MessageLimitTests.cpp
@@ -80,7 +80,8 @@ BOOST_AUTO_TEST_CASE(MESSAGES) {
     auto deck = parser.parseString(input, parseContext);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
     Schedule schedule(deck, grid, eclipseProperties, Phases(true, true, true) , parseContext);
     const MessageLimits limits = schedule.getMessageLimits();
 

--- a/tests/parser/MultiRegTests.cpp
+++ b/tests/parser/MultiRegTests.cpp
@@ -216,9 +216,10 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::Deck deck = createValidIntDeck();
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
-    Opm::Eclipse3DProperties props(deck, tm, eg);
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, eg, deck, eclipseState);
 
-    const auto& property = props.getIntGridProperty("SATNUM");
+    const auto& property = eclipseProperties.getIntGridProperty("SATNUM");
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)

--- a/tests/parser/PORVTests.cpp
+++ b/tests/parser/PORVTests.cpp
@@ -256,10 +256,11 @@ BOOST_AUTO_TEST_CASE(PORV_cartesianDeck) {
     Opm::Deck deck = createCARTDeck();
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
-    Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& poro = props.getDoubleGridProperty("PORO");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, grid, deck, eclipseState);
+    const auto& poro = eclipseProperties.getDoubleGridProperty("PORO");
     BOOST_CHECK(poro.containsNaN());
-    BOOST_CHECK_THROW(props.getDoubleGridProperty("PORV"), std::logic_error);
+    BOOST_CHECK_THROW(eclipseProperties.getDoubleGridProperty("PORV"), std::logic_error);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_initFromPoro) {
@@ -267,11 +268,12 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoro) {
     Opm::Deck deck = createDeckWithPORO();
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
-    Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& poro = props.getDoubleGridProperty("PORO");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, grid, deck, eclipseState);
+    const auto& poro = eclipseProperties.getDoubleGridProperty("PORO");
     BOOST_CHECK( !poro.containsNaN() );
 
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv = eclipseProperties.getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
 
     BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv.iget(0,0,0) , 0.001);
@@ -289,8 +291,9 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
     Opm::Deck deck = createDeckWithPORVPORO();
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
-    Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, grid, deck, eclipseState);
+    const auto& porv = eclipseProperties.getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
 
     BOOST_CHECK_CLOSE( 77.0 , porv.iget(0,0,0) , 0.001);
@@ -308,8 +311,9 @@ BOOST_AUTO_TEST_CASE(PORV_multpv) {
     Opm::Deck deck = createDeckWithMULTPV();
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
-    Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, grid, deck, eclipseState);
+    const auto& porv = eclipseProperties.getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
 
     BOOST_CHECK_CLOSE( 770.0 , porv.iget(0,0,0) , 0.001);
@@ -331,8 +335,9 @@ BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
     Opm::Deck deck = createDeckWithBOXPORV();
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
-    Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, grid, deck, eclipseState);
+    const auto& porv = eclipseProperties.getDoubleGridProperty("PORV");
 
     BOOST_CHECK_CLOSE( 1234.56 , porv.iget(0,0,0) , 0.001);
     BOOST_CHECK_CLOSE( 1234.56 , porv.iget(9,9,9) , 0.001);
@@ -347,8 +352,9 @@ BOOST_AUTO_TEST_CASE(PORV_multpvAndNtg) {
     Opm::Deck deck = createDeckWithNTG();
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
-    Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, grid, deck, eclipseState);
+    const auto& porv = eclipseProperties.getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
     double poro = 0.20;
     double multpv = 10;
@@ -363,8 +369,9 @@ BOOST_AUTO_TEST_CASE(PORV_multregp) {
     Opm::Deck deck = createDeckWithMULTREGP();
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
-    Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    Opm::EclipseState eclipseState(deck, Opm::ParseContext());
+    Opm::Eclipse3DProperties eclipseProperties ( tm, grid, deck, eclipseState);
+    const auto& porv = eclipseProperties.getDoubleGridProperty("PORV");
     const auto& porvData = porv.getData();
     double basePorv = 77.0;
 

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -322,7 +322,8 @@ BOOST_AUTO_TEST_CASE( CheckUnsupportedInSCHEDULE ) {
     auto deckUnSupported = parser.parseString( deckStringUnSupported , parseContext );
     EclipseGrid grid( deckSupported );
     TableManager table ( deckSupported );
-    Eclipse3DProperties eclipseProperties ( deckSupported , table, grid);
+    EclipseState eclipseState(deckUnSupported, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deckUnSupported, eclipseState);
 
     parseContext.update( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , InputError::IGNORE );
     BOOST_CHECK_NO_THROW( Schedule( deckSupported  , grid , eclipseProperties, Phases(true, true, true), parseContext  ));
@@ -398,7 +399,8 @@ BOOST_AUTO_TEST_CASE(TestCOMPORD) {
 
     EclipseGrid grid( deck );
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
 
     parseContext.update( ParseContext::UNSUPPORTED_COMPORD_TYPE , InputError::IGNORE);
     BOOST_CHECK_NO_THROW( Schedule( deck , grid , eclipseProperties,  Phases(true, true, true), parseContext ));
@@ -728,7 +730,8 @@ BOOST_AUTO_TEST_CASE( test_invalid_wtemplate_config ) {
 
         EclipseGrid grid( deckUnSupported );
         TableManager table ( deckUnSupported );
-        Eclipse3DProperties eclipseProperties ( deckUnSupported , table, grid);
+        EclipseState eclipseState(deckUnSupported, ParseContext());
+        Eclipse3DProperties eclipseProperties ( table, grid, deckUnSupported, eclipseState);
 
         BOOST_CHECK_THROW( Schedule( deckUnSupported , grid , eclipseProperties, Phases(true, true, true) , parseContext), std::invalid_argument );
     }

--- a/tests/parser/SatfuncPropertyInitializersTests.cpp
+++ b/tests/parser/SatfuncPropertyInitializersTests.cpp
@@ -112,8 +112,8 @@ BOOST_AUTO_TEST_CASE(SaturationFunctionFamilyTests) {
     Deck deck1 = parser.parseString(family1Deck, parseContext) ;
     Opm::TableManager tm1( deck1 );
     Opm::EclipseGrid grid1( deck1 );
-    Opm::Eclipse3DProperties prop1( deck1, tm1, grid1 );
-
+    Opm::EclipseState eclState1(deck1, Opm::ParseContext());
+    Opm::Eclipse3DProperties prop1(tm1, grid1, deck1, eclState1);
 
     char family2Deck[700] = " ";
     strcat(family2Deck , deckdefault);
@@ -121,7 +121,8 @@ BOOST_AUTO_TEST_CASE(SaturationFunctionFamilyTests) {
     Deck deck2 = parser.parseString(family2Deck, parseContext) ;
     Opm::TableManager tm2( deck2 );
     Opm::EclipseGrid grid2( deck2 );
-    Opm::Eclipse3DProperties prop2( deck2, tm2, grid2 );
+    Opm::EclipseState eclState2(deck2, Opm::ParseContext());
+    Opm::Eclipse3DProperties prop2(tm2, grid2, deck2, eclState2);
 
     check_property(prop1, prop2, "SWL");
     check_property(prop1, prop2, "SWU");
@@ -149,6 +150,7 @@ BOOST_AUTO_TEST_CASE(SaturationFunctionFamilyTests) {
     Deck deckMix = parser.parseString(familyMixDeck, parseContext) ;
     Opm::TableManager tmMix( deckMix );
     Opm::EclipseGrid gridMix( deckMix );
-    Opm::Eclipse3DProperties propMix( deckMix, tmMix, gridMix );
+    Opm::EclipseState eclStateMix(deckMix, Opm::ParseContext());
+    Opm::Eclipse3DProperties propMix(tmMix, gridMix, deckMix, eclStateMix);
     BOOST_CHECK_THROW(propMix.getDoubleGridProperty("SGCR") , std::invalid_argument);
 }

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -115,7 +115,8 @@ BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
     auto deck = createDeck(parseContext , inputStr);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    Eclipse3DProperties ep(deck, tm, eg);
+    EclipseState state(deck, ParseContext());
+    Eclipse3DProperties ep(tm, eg, deck, state);
     BOOST_CHECK_NO_THROW( SimulationConfig(false, deck, ep ) );
 }
 
@@ -125,7 +126,8 @@ BOOST_AUTO_TEST_CASE(SimulationConfigNOTHPRES) {
     auto deck = createDeck(parseContext, inputStr_noTHPRES);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    Eclipse3DProperties ep(deck, tm, eg);
+    EclipseState state(deck, ParseContext());
+    Eclipse3DProperties ep(tm, eg, deck, state);
     SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK( !simulationConfig.useThresholdPressure() );
 }
@@ -135,7 +137,8 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
     auto deck = createDeck(parseContext, inputStr_noTHPRES);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    Eclipse3DProperties ep(deck, tm, eg);
+    EclipseState state(deck, ParseContext());
+    Eclipse3DProperties ep(tm, eg, deck, state);
     SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK( ! simulationConfig.useCPR());
 }
@@ -145,7 +148,8 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {
     auto deck = createDeck(parseContext, inputStr_cpr);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    Eclipse3DProperties ep(deck, tm, eg);
+    EclipseState state(deck, ParseContext());
+    Eclipse3DProperties ep(tm, eg, deck, state);
     SUMMARYSection summary(deck);
     SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK(     simulationConfig.useCPR() );
@@ -158,7 +162,8 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRInSUMMARYSection) {
     auto deck = createDeck(parseContext, inputStr_cpr_in_SUMMARY);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    Eclipse3DProperties ep(deck, tm, eg);
+    EclipseState state(deck, ParseContext());
+    Eclipse3DProperties ep(tm, eg, deck, state);
     SUMMARYSection summary(deck);
     SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK( ! simulationConfig.useCPR());
@@ -171,7 +176,8 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
     auto deck = createDeck(parseContext, inputStr_cpr_BOTH);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    Eclipse3DProperties ep(deck, tm, eg);
+    EclipseState state(deck, ParseContext());
+    Eclipse3DProperties ep(tm, eg, deck, state);
     SUMMARYSection summary(deck);
     SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK(  simulationConfig.useCPR());
@@ -198,15 +204,16 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     auto deck = createDeck(parseContext, inputStr);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    Eclipse3DProperties ep(deck, tm, eg);
-    SimulationConfig simulationConfig(false, deck, ep);
+    EclipseState eclipseState(deck, Opm::ParseContext());
+    Eclipse3DProperties ep ( tm, eg, deck, eclipseState);    SimulationConfig simulationConfig(false, deck, ep);
     BOOST_CHECK_EQUAL( false , simulationConfig.hasDISGAS());
     BOOST_CHECK_EQUAL( false , simulationConfig.hasVAPOIL());
 
     auto deck_vd = createDeck(parseContext, inputStr_vap_dis);
     TableManager tm_vd(deck_vd);
     EclipseGrid eg_vd(10, 3, 4);
-    Eclipse3DProperties ep_vd(deck_vd, tm, eg);
+    EclipseState eclipseState_vd(deck_vd, Opm::ParseContext());
+    Eclipse3DProperties ep_vd ( tm, eg, deck_vd, eclipseState_vd);
     SimulationConfig simulationConfig_vd(false, deck_vd, ep_vd);
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasDISGAS());
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasVAPOIL());

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -210,6 +210,7 @@ struct Setup
     Deck deck;
     TableManager tablemanager;
     EclipseGrid grid;
+    EclipseState eclipseState;
     Eclipse3DProperties props;
     InitConfig initConfig;
     ThresholdPressure threshPres;
@@ -219,7 +220,8 @@ struct Setup
             deck(createDeck(parseContext, input)),
             tablemanager(deck),
             grid(10, 3, 4),
-            props(deck, tablemanager, grid),
+            eclipseState(deck, Opm::ParseContext()),
+            props(tablemanager, grid, deck, eclipseState),
             initConfig(deck),
             threshPres(initConfig.restartRequested(), deck, props)
     {
@@ -229,7 +231,8 @@ struct Setup
             deck(createDeck(parseContextArg, input)),
             tablemanager(deck),
             grid(10, 3, 4),
-            props(deck, tablemanager, grid),
+            eclipseState(deck, Opm::ParseContext()),
+            props(tablemanager, grid, deck, eclipseState),
             initConfig(deck),
             threshPres(initConfig.restartRequested(), deck, props)
     {

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -72,7 +72,8 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   auto deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   TableManager table ( deck );
-  Eclipse3DProperties eclipseProperties ( deck , table, grid);
+  EclipseState eclipseState(deck, ParseContext());
+  Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
   Schedule schedule( deck, grid , eclipseProperties, Phases(true, true, true) , ParseContext());
   auto tuning = schedule.getTuning();
   auto event = schedule.getEvents();
@@ -330,7 +331,8 @@ BOOST_AUTO_TEST_CASE(TuningInitTest) {
   auto deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   TableManager table ( deck );
-  Eclipse3DProperties eclipseProperties ( deck , table, grid);
+  EclipseState eclipseState(deck, ParseContext());
+  Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
   Schedule schedule(deck , grid , eclipseProperties, Phases(true, true, true), ParseContext());
   auto tuning = schedule.getTuning();
 
@@ -360,7 +362,8 @@ BOOST_AUTO_TEST_CASE(TuningResetTest) {
   auto deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   TableManager table ( deck );
-  Eclipse3DProperties eclipseProperties ( deck , table, grid);
+  EclipseState eclipseState(deck, ParseContext());
+  Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
   Schedule schedule(deck, grid , eclipseProperties, Phases(true, true, true), ParseContext());
   auto tuning = schedule.getTuning();
 

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -141,7 +141,8 @@ BOOST_AUTO_TEST_CASE(TestNoSolvent) {
     auto deck = createDeckWithOutSolvent();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
     Schedule schedule(deck, grid , eclipseProperties, Phases(true, true, true) , ParseContext());
     BOOST_CHECK(!deck.hasKeyword("WSOLVENT"));
 }
@@ -150,7 +151,8 @@ BOOST_AUTO_TEST_CASE(TestGasInjector) {
     auto deck = createDeckWithGasInjector();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
     Schedule schedule(deck, grid , eclipseProperties, Phases(true, true, true) , ParseContext());
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
 
@@ -160,7 +162,8 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
     auto deck = createDeckWithDynamicWSOLVENT();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
     Schedule schedule(deck, grid , eclipseProperties, Phases(true, true, true) , ParseContext());
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
     const auto& keyword = deck.getKeyword("WSOLVENT");
@@ -179,7 +182,8 @@ BOOST_AUTO_TEST_CASE(TestOilInjector) {
     auto deck = createDeckWithOilInjector();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
     BOOST_CHECK_THROW (Schedule(deck , grid , eclipseProperties, Phases(true, true, true) , ParseContext()), std::invalid_argument);
 }
 
@@ -187,6 +191,6 @@ BOOST_AUTO_TEST_CASE(TestWaterInjector) {
     auto deck = createDeckWithWaterInjector();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
-    BOOST_CHECK_THROW (Schedule(deck, grid , eclipseProperties, Phases(true, true, true) , ParseContext()), std::invalid_argument);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);    BOOST_CHECK_THROW (Schedule(deck, grid , eclipseProperties, Phases(true, true, true) , ParseContext()), std::invalid_argument);
 }

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -227,7 +227,8 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
     auto deck = parser.parseString(input, parseContext);
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
     Opm::Schedule schedule(deck, grid , eclipseProperties, Opm::Phases(true, true, true) , Opm::ParseContext());
     auto* op_1 = schedule.getWell("OP_1");
 
@@ -268,7 +269,8 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestDefaultTRACK) {
     auto deck = parser.parseString(input, parseContext);
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
     Opm::Schedule schedule(deck, grid , eclipseProperties, Opm::Phases(true, true, true) , Opm::ParseContext());
     auto* op_1 = schedule.getWell("OP_1");
 
@@ -311,7 +313,8 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestINPUT) {
     auto deck = parser.parseString(input, parseContext);
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    EclipseState eclipseState(deck, ParseContext());
+    Eclipse3DProperties eclipseProperties ( table, grid, deck, eclipseState);
     Opm::Schedule schedule(deck, grid , eclipseProperties, Opm::Phases(true, true, true) , Opm::ParseContext());
     auto* op_1 = schedule.getWell("OP_1");
 


### PR DESCRIPTION
With this PR modifying TRAN[XYZ] in EDIT works for defaulted transmissibilities. 
This is tested together with upstream PRs for SPE1 with MULTIPLY, ADD and EQUALS. 

The PR is not finished. Many of the tests do not yet compile and the implementation is not yet optimal from the performance points of view. But is should sufficient as a point of discussion. 

