### PR TITLE
Add support for minpvv

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -107,7 +107,7 @@ namespace Opm {
         PinchMode::ModeEnum getMultzOption( ) const;
 
         MinpvMode::ModeEnum getMinpvMode() const;
-        double getMinpvValue( ) const;
+        const std::vector<double>& getMinpvVector( ) const;
 
 
         /*
@@ -176,7 +176,7 @@ namespace Opm {
         const ecl_grid_type * c_ptr() const;
 
     private:
-        double m_minpvValue;
+        std::vector<double> m_minpvVector;
         MinpvMode::ModeEnum m_minpvMode;
         Value<double> m_pinch;
         PinchMode::ModeEnum m_pinchoutMode;

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -397,6 +397,9 @@ namespace Opm {
         // pore volume multipliers
         supportedDoubleKeywords.emplace_back( "MULTPV", 1.0, "1", true );
 
+        // cell mininum pore volume
+        supportedDoubleKeywords.emplace_back( "MINPVV", 0.000001 , "ReservoirVolume", true );
+
         /* rock heat capacity, E300 only */
         supportedDoubleKeywords.emplace_back("HEATCR", nan, distributeTopLayer, "Energy/AbsoluteTemperature*Length*Length*Length" );
         supportedDoubleKeywords.emplace_back("HEATCRT", 0.0, distributeTopLayer, "Energy/AbsoluteTemperature*AbsoluteTemperature*Length*Length*Length", true );

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MINPVV
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MINPVV
@@ -1,0 +1,1 @@
+{"name" : "MINPVV" , "sections" : ["GRID"], "data" : {"value_type" : "DOUBLE" , "default" : 0.000001, "dimension" : "ReservoirVolume"}}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -152,6 +152,7 @@ set( keywords
      000_Eclipse100/M/MESSAGES
      000_Eclipse100/M/METRIC
      000_Eclipse100/M/MINPV
+     000_Eclipse100/M/MINPVV
      000_Eclipse100/M/MINVALUE
      000_Eclipse100/M/MISC
      000_Eclipse100/M/MISCIBLE

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -842,9 +842,9 @@ BOOST_AUTO_TEST_CASE(ConstructorMINPV) {
     BOOST_CHECK(!grid1.equal( grid3 ));
     BOOST_CHECK_EQUAL(grid1.getMinpvMode(), Opm::MinpvMode::ModeEnum::Inactive);
     BOOST_CHECK_EQUAL(grid3.getMinpvMode(), Opm::MinpvMode::ModeEnum::EclSTD);
-    BOOST_CHECK_EQUAL(grid3.getMinpvValue(), 10.0);
+    BOOST_CHECK_EQUAL(grid3.getMinpvVector()[0], 10.0);
     BOOST_CHECK_EQUAL(grid4.getMinpvMode(), Opm::MinpvMode::ModeEnum::OpmFIL);
-    BOOST_CHECK_EQUAL(grid4.getMinpvValue(), 20.0);
+    BOOST_CHECK_EQUAL(grid4.getMinpvVector()[0], 20.0);
 }
 
 


### PR DESCRIPTION
Currently the code does not work with BOX and modifier keywords. A naive implementation would lead to circular dependency between EclipseGrid and EclipseState. @joakim-hove Any suggestions? 