### PR TITLE
make the COPY keyword work as ECLIPSE if the source and the destination fields exhibit different dimensions

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -36,6 +36,7 @@ namespace Opm {
     class DeckKeyword;
     class EclipseGrid;
     class TableManager;
+    class UnitSystem;
     template< typename > class GridProperties;
 
 template< typename T >
@@ -134,7 +135,7 @@ public:
     void loadFromDeckKeyword( const DeckKeyword& );
     void loadFromDeckKeyword( const Box&, const DeckKeyword& );
 
-    void copyFrom( const GridProperty< T >&, const Box& );
+    void copyFrom( const GridProperty< T >&, const Box&, const UnitSystem* unitSystem = nullptr );
     void scale( T scaleFactor, const Box& );
     void maxvalue( T value, const Box& );
     void minvalue( T value, const Box& );

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperties.cpp
@@ -230,7 +230,7 @@ namespace Opm {
         const auto& src = this->getKeyword( srcField );
         auto& target    = this->getOrCreateProperty( targetField );
 
-        target.copyFrom( src , inputBox );
+        target.copyFrom( src , inputBox, m_deckUnitSystem );
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -283,7 +283,7 @@ namespace Opm {
 
     template< typename T >
     void GridProperty< T >::copyFrom( const GridProperty< T >& src, const Box& inputBox, const UnitSystem* unitSystem ) {
-        if (unitSystem) {
+        if (unitSystem && src.getDimensionString() != getDimensionString()) {
             // this deals with assignments of fields that exhibit different units. after the
             // COPY operation the grid property ought to exhibit the same values in terms of
             // the unit system used by the deck, which do not necessarily correspond to


### PR DESCRIPTION
this issue was discovered during #462. Even though it is a corner case which does not seem to exhibit too much practical significance, I decided to give it a go, and voila: it was a quite simple fix. Note the we checked that E100 can do this and that the COPY operation in E100 is done in terms of deck units, so without any fix, this will probably fall on our feet sooner or later.