### PR TITLE
Include WPIMULT for CTFAC output

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -442,8 +442,8 @@ inline quantity srate( const fn_args& args ) {
     const auto& name = well->name();
     if( args.wells.count( name ) == 0 ) return zero;
 
-    const auto& well_data = args.wells.at( name );    
-    
+    const auto& well_data = args.wells.at( name );
+
     const auto& segment = well_data.segments.find(segNumber);
 
     if( segment == well_data.segments.end() ) return zero;
@@ -485,7 +485,7 @@ inline quantity trans_factors ( const fn_args& args ) {
 
     if( connection == connections.end() ) return zero;
 
-    const auto& v = connection->CF();
+    const auto& v = connection->CF() * connection->wellPi();
     return { v, measure::transmissibility };
 }
 

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -675,5 +675,16 @@ COMPDAT
     W_4 1 1 3 3 /
 /
 
+WPIMULT
+W_1 0.5 /
+/
+
 TSTEP
-10 10 /
+10 /
+
+WPIMULT
+W_1 0.5 /
+/
+
+TSTEP
+10 /

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1052,6 +1052,8 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES) {
     writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
     writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
     writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
+    writer.add_timestep( 3, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
+    writer.add_timestep( 4, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -1073,6 +1075,9 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES) {
     BOOST_CHECK_CLOSE( 2.1430730819702148 , ecl_sum_get_well_completion_var( resp, 1, "W_2", "CTFAC", 2)   , 1e-5);
     BOOST_CHECK_CLOSE( 2.6788413524627686 , ecl_sum_get_well_completion_var( resp, 1, "W_2", "CTFAC", 102) , 1e-5);
     BOOST_CHECK_CLOSE( 2.7855057716369629 , ecl_sum_get_well_completion_var( resp, 1, "W_3", "CTFAC", 3)   , 1e-5);
+
+    BOOST_CHECK_CLOSE( 50                 , ecl_sum_get_well_completion_var( resp, 3, "W_1", "CTFAC", 1)   , 1e-5);
+    BOOST_CHECK_CLOSE( 25                 , ecl_sum_get_well_completion_var( resp, 4, "W_1", "CTFAC", 1)   , 1e-5);
 
     // Cell is not active
     BOOST_CHECK( !ecl_sum_has_general_var( resp , "BPR:2,1,10"));


### PR DESCRIPTION
The PR applies the PI multiplier just as opm-simulator does. 