### PR TITLE
Summary: Ensure that we don't step backwards during simulation

### DIFF
--- a/tests/FIRST_SIM.DATA
+++ b/tests/FIRST_SIM.DATA
@@ -9,6 +9,9 @@ UNIFIN
 DIMENS
  10 10 10 /
 
+START             -- 0
+1 NOV 1979 /
+
 WELLDIMS
 -- Item 1: NWMAX  (Maximum number of wells in model)
 -- Item 2: NCWMAX (Maximum number of connections per well)
@@ -35,9 +38,6 @@ SOLUTION
 RESTART
 FIRST_SIM 1/
 
-
-START             -- 0 
-1 NOV 1979 / 
 
 SCHEDULE
 SKIPREST

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -209,11 +209,11 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
 
         Schedule schedule(deck, grid, eclipseState.get3DProperties(), eclipseState.runspec().phases(), parse_context);
         SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ), parse_context);
-        EclipseIO eclipseWriter( eclipseState, grid, schedule, summary_config );
         time_t start_time = schedule.posixStartTime();
         const auto& time_map = schedule.getTimeMap( );
 
         for (int counter = 0; counter < 2; counter++) {
+            EclipseIO eclipseWriter( eclipseState, grid, schedule, summary_config );
             for (size_t step = 0; step < time_map.size(); step++) {
                 time_t step_time = time_map[step];
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -412,7 +412,7 @@ RestartValue first_sim(const EclipseState& es, EclipseIO& eclWriter, bool write_
     auto num_cells = grid.getNumActive( );
 
     auto start_time = ecl_util_make_date( 1, 11, 1979 );
-    auto first_step = ecl_util_make_date( 10, 10, 2008 );
+    auto first_step = ecl_util_make_date( 1,  2, 2011 ); // Must be after 2011-01-20
 
     auto sol = mkSolution( num_cells );
     auto wells = mkWells();


### PR DESCRIPTION
This commit, a preparation for restoring cumulative quantities from a restart file, reinitialises Summary::prev_time_elapsed in the case of simulation restart and adds a check to
```
Summary::write_timestep()
```
which throws if the input argument `secs_elapsed` is prior to the previously recorded elapsed time.  The latter is a change in the behaviour of `write_timestep()`, but ensures that we don't integrate rate quantities across a very large timestep in the case of simulation restart and also prevents double accumulation.

Update impacted unit tests accordingly, and move FIRST_SIM's START date into the RUNSPEC section where it belongs.  Note, in particular, that we alter the setup of `test_RFT.cpp:test_RFT2` here.  Previously that test would use a single `EclipseIO` object for both iterations of the `counter` variable.  Now we create a new `EclipseIO` object on each iteration of `counter`.  This means that we no longer check that the `RFT` class supports merging multiple specifications of the same dates to one.