### PR TITLE
Simulation Config: Add Predicate for Thermal Simulations

### DIFF
--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -40,12 +40,14 @@ namespace Opm {
         bool useCPR() const;
         bool hasDISGAS() const;
         bool hasVAPOIL() const;
+        bool isThermal() const;
 
     private:
         ThresholdPressure m_ThresholdPressure;
         bool m_useCPR;
         bool m_DISGAS;
         bool m_VAPOIL;
+        bool m_isThermal;
     };
 
 } //namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -26,6 +26,7 @@
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/D.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/V.hpp>
 
 
@@ -52,7 +53,8 @@ namespace Opm {
         m_ThresholdPressure( restart, deck, eclipseProperties ),
         m_useCPR(false),
         m_DISGAS(false),
-        m_VAPOIL(false)
+        m_VAPOIL(false),
+        m_isThermal(false)
     {
         if (Section::hasRUNSPEC(deck)) {
             const RUNSPECSection runspec(deck);
@@ -69,6 +71,9 @@ namespace Opm {
             if (runspec.hasKeyword<ParserKeywords::VAPOIL>()) {
                 m_VAPOIL = true;
             }
+
+            this->m_isThermal = runspec.hasKeyword<ParserKeywords::THERMAL>()
+                || runspec.hasKeyword<ParserKeywords::TEMP>();
         }
     }
 
@@ -90,6 +95,10 @@ namespace Opm {
 
     bool SimulationConfig::hasVAPOIL() const {
         return m_VAPOIL;
+    }
+
+    bool SimulationConfig::isThermal() const {
+        return this->m_isThermal;
     }
 
 } //namespace Opm

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/T/THERMAL
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/T/THERMAL
@@ -1,0 +1,1 @@
+{"name" : "THERMAL", "sections" : ["RUNSPEC"]}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -326,6 +326,7 @@ set( keywords
      000_Eclipse100/T/TABDIMS
      000_Eclipse100/T/TEMP
      000_Eclipse100/T/THCONR
+     000_Eclipse100/T/THERMAL
      000_Eclipse100/T/THPRES
      000_Eclipse100/T/TITLE
      000_Eclipse100/T/TLMIXPAR

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -104,6 +104,32 @@ const std::string& inputStr_vap_dis = "RUNSPEC\n"
                                       "REGIONS\n"
                                       "\n";
 
+namespace {
+    std::string simDeckStringTEMP()
+    {
+        return R"(
+RUNSPEC
+
+TEMP
+
+DIMENS
+  10 3 4 /
+)";
+    }
+
+    std::string simDeckStringTHERMAL()
+    {
+        return R"(
+RUNSPEC
+
+THERMAL
+
+DIMENS
+  10 3 4 /
+)";
+    }
+}
+
 static Deck createDeck(const ParseContext& parseContext , const std::string& input) {
     Opm::Parser parser;
     return parser.parseString(input, parseContext);
@@ -210,4 +236,40 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     SimulationConfig simulationConfig_vd(false, deck_vd, ep_vd);
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasDISGAS());
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasVAPOIL());
+}
+
+
+BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
+{
+    const auto parseContext = Opm::ParseContext {};
+
+    {
+        const auto deck = createDeck(parseContext, inputStr);
+        const auto tm = Opm::TableManager(deck);
+        const auto eg = Opm::EclipseGrid(10, 3, 4);
+        const auto ep = Opm::Eclipse3DProperties(deck, tm, eg);
+        const auto simulationConfig = Opm::SimulationConfig(false, deck, ep);
+
+        BOOST_CHECK(! simulationConfig.isThermal());
+    }
+
+    {
+        const auto deck = createDeck(parseContext, simDeckStringTEMP());
+        const auto tm = Opm::TableManager(deck);
+        const auto eg = Opm::EclipseGrid(10, 3, 4);
+        const auto ep = Opm::Eclipse3DProperties(deck, tm, eg);
+        const auto simulationConfig = Opm::SimulationConfig(false, deck, ep);
+
+        BOOST_CHECK(simulationConfig.isThermal());
+    }
+
+    {
+        const auto deck = createDeck(parseContext, simDeckStringTHERMAL());
+        const auto tm = Opm::TableManager(deck);
+        const auto eg = Opm::EclipseGrid(10, 3, 4);
+        const auto ep = Opm::Eclipse3DProperties(deck, tm, eg);
+        const auto simulationConfig = Opm::SimulationConfig(false, deck, ep);
+
+        BOOST_CHECK(simulationConfig.isThermal());
+    }
 }


### PR DESCRIPTION
This commit introduces a new predicate,
```C++
bool SimulationConfig::isThermal() const
```
that determines whether or not either of the keywords

    TEMP or THERMAL

are specified in the RUNSPEC section of a simulation run.