### PR TITLE
Recognise Requests for Stone's Second Model of 3-Phase Oil Relperm

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/STONE
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/STONE
@@ -1,0 +1,4 @@
+{
+  "name"     : "STONE",
+  "sections" : ["PROPS"]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/STONE2
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/STONE2
@@ -1,0 +1,4 @@
+{
+  "name"     : "STONE2",
+  "sections" : ["PROPS"]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -314,8 +314,10 @@ set( keywords
      000_Eclipse100/S/SSFN
      000_Eclipse100/S/SSOL
      000_Eclipse100/S/START
+     000_Eclipse100/S/STONE
      000_Eclipse100/S/STONE1
      000_Eclipse100/S/STONE1EX
+     000_Eclipse100/S/STONE2
      000_Eclipse100/S/SUMMARY
      000_Eclipse100/S/SUMTHIN
      000_Eclipse100/S/SWAT

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1856,3 +1856,31 @@ UDQ
     BOOST_CHECK_EQUAL_COLLECTIONS( data0.begin(), data0.end(), expected0.begin(), expected0.end());
     BOOST_CHECK_EQUAL_COLLECTIONS( data1.begin(), data1.end(), expected1.begin(), expected1.end());
  }
+
+
+BOOST_AUTO_TEST_CASE(ParseThreePhaseRelpermModels) {
+    {
+        const auto deck_string = std::string{ R"(
+STONE1
+STONE2
+)" };
+
+        const auto deck = Parser{}.parseString( deck_string, ParseContext() );
+
+        BOOST_CHECK( !deck.hasKeyword( "STONE" ) );
+        BOOST_CHECK(  deck.hasKeyword( "STONE1" ) );
+        BOOST_CHECK(  deck.hasKeyword( "STONE2" ) );
+    }
+
+    {
+        const auto deck_string = std::string{ R"(
+STONE
+)" };
+
+        const auto deck = Parser{}.parseString( deck_string, ParseContext() );
+
+        BOOST_CHECK(  deck.hasKeyword( "STONE" ) );
+        BOOST_CHECK( !deck.hasKeyword( "STONE1" ) );
+        BOOST_CHECK( !deck.hasKeyword( "STONE2" ) );
+    }
+}


### PR DESCRIPTION
This commit makes the parser aware of the keywords `STONE` and `STONE2` which both request that the simulation run use Stone's second model for three-phase relative permeability for oil.

The [material law manager](https://github.com/OPM/opm-material/blob/7cac10640e596047a03d86e8dc06f2aa9dbb2936/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp#L465-L466) knows about these models and treats the former as an alias for the latter.

Note that we do not implement mutual exclusion between the Stone models in this PR.  If an input deck specifies (e.g.,) **both** `STONE` and `STONE1`, then this will silently imply `STONE2`.

Is there a way of recognising that mutually exclusive keywords have been supplied in the input deck?