### PR TITLE
Fix for aquifer making connection

### DIFF
--- a/opm/parser/eclipse/EclipseState/Aquancon.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquancon.hpp
@@ -47,6 +47,7 @@ namespace Opm {
                 std::vector<std::shared_ptr<double>> influx_coeff; // Size = size(global_index)
                 std::vector<double> influx_multiplier; // Size = size(global_index)
                 std::vector<int> reservoir_face_dir; // Size = size(global_index)
+                std::vector<int> record_index;
             };
 
             Aquancon(const EclipseGrid& grid, const Deck& deck);
@@ -55,7 +56,7 @@ namespace Opm {
     
         private:
 
-            void logic_application(std::vector<Aquancon::AquanconOutput>& output_vector);
+            std::vector<Aquancon::AquanconOutput> logic_application(const std::vector<Aquancon::AquanconOutput> original_vector);
 
             void collate_function(std::vector<Aquancon::AquanconOutput>& output_vector, 
                                   std::vector<Opm::AquanconRecord>& m_aqurecord, 

--- a/opm/parser/eclipse/EclipseState/Aquancon.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquancon.hpp
@@ -44,7 +44,7 @@ namespace Opm {
             struct AquanconOutput{
                 int aquiferID;
                 std::vector<size_t> global_index;
-                std::vector<double> influx_coeff; // Size = size(global_index)
+                std::vector<std::shared_ptr<double>> influx_coeff; // Size = size(global_index)
                 std::vector<double> influx_multiplier; // Size = size(global_index)
                 std::vector<int> reservoir_face_dir; // Size = size(global_index)
             };

--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -58,10 +58,10 @@ namespace Opm {
                             k_a , //aquifer permeability
                             c1, // 0.008527 (METRIC, PVT-M); 0.006328 (FIELD); 3.6 (LAB)
                             h , //aquifer thickness
-                            p0, //Initial aquifer pressure at datum depth, d0
                             theta , //angle subtended by the aquifer boundary
                             c2 ; //6.283 (METRIC, PVT-M); 1.1191 (FIELD); 6.283 (LAB).
-                    
+
+                    std::shared_ptr<double> p0; //Initial aquifer pressure at datum depth, d0
                     std::vector<double> td, pi;
             };
 

--- a/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
@@ -81,20 +81,22 @@ namespace Opm {
                 for (int j=m_aqurecord.at(aquanconRecordIdx).j1; j <= m_aqurecord.at(aquanconRecordIdx).j2; j++)
                     for (int i=m_aqurecord.at(aquanconRecordIdx).i1; i <= m_aqurecord.at(aquanconRecordIdx).i2; i++)
                         m_aqurecord.at(aquanconRecordIdx).global_index_per_record.push_back
-                                                            (grid.getGlobalIndex(i-1 ,j-1 ,k- 1)
+                                                            (
+                                                                grid.getGlobalIndex(i-1, j-1, k-1)
                                                             );
             }
             size_t global_index_per_record_size = m_aqurecord.at(aquanconRecordIdx).global_index_per_record.size();
 
-            m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.resize(global_index_per_record_size,nullptr);
+            m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.resize(global_index_per_record_size, nullptr);
 
             if (aquanconRecord.getItem("INFLUX_COEFF").hasValue(0))
             {
                 double* influx_coeff = new double( aquanconRecord.getItem("INFLUX_COEFF").getSIDouble(0) );
+
                 std::for_each(
                                 m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.begin(),
                                 m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.end(),
-                                [influx_coeff](std::shared_ptr<double>& i){ i.reset(influx_coeff); }
+                                [influx_coeff](std::shared_ptr<double>& i){ i.reset( new double (*influx_coeff)); }
                              );
             }
 

--- a/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
@@ -91,13 +91,12 @@ namespace Opm {
 
             if (aquanconRecord.getItem("INFLUX_COEFF").hasValue(0))
             {
-                double* influx_coeff = new double( aquanconRecord.getItem("INFLUX_COEFF").getSIDouble(0) );
+                const double influx_coeff = aquanconRecord.getItem("INFLUX_COEFF").getSIDouble(0);
 
-                std::for_each(
-                                m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.begin(),
-                                m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.end(),
-                                [influx_coeff](std::shared_ptr<double>& i){ i.reset( new double (*influx_coeff)); }
-                             );
+                for (auto& influx: m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record)
+                {
+                    influx.reset(new double(influx_coeff));
+                }
             }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
@@ -18,8 +18,10 @@
  */
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquancon.hpp>
+#include <utility>
 #include <algorithm>
 #include <iterator>
+#include <iostream>
 
 namespace Opm {
     namespace{
@@ -33,7 +35,8 @@ namespace Opm {
             std::vector<std::shared_ptr<double>>  influx_coeff_per_record;  //Aquifer influx coefficient
             std::vector<double>  influx_mult_per_record;   //Aquifer influx coefficient Multiplier       
             // Cell face to connect aquifer to        
-            std::vector<int> face_per_record;           
+            std::vector<int> face_per_record;
+            std::vector<int> record_index_per_record;         
         };
     }
 
@@ -53,8 +56,8 @@ namespace Opm {
         m_aquiferID_per_record.resize(aquanconKeyword.size());
 
         // We now do a loop over each record entry in aquancon
-        for (size_t aquanconRecordIdx = 0; aquanconRecordIdx < aquanconKeyword.size(); ++ aquanconRecordIdx) 
-            {
+        for (size_t aquanconRecordIdx = 0; aquanconRecordIdx < aquanconKeyword.size(); ++aquanconRecordIdx) 
+        {
             const auto& aquanconRecord = aquanconKeyword.getRecord(aquanconRecordIdx);
             m_aquiferID_per_record.at(aquanconRecordIdx) = aquanconRecord.getItem("AQUIFER_ID").template get<int>(0);
 
@@ -98,13 +101,14 @@ namespace Opm {
 
             m_aqurecord.at(aquanconRecordIdx).influx_mult_per_record.resize(global_index_per_record_size,influx_mult);
             m_aqurecord.at(aquanconRecordIdx).face_per_record.resize(global_index_per_record_size,faceDir);
+            m_aqurecord.at(aquanconRecordIdx).record_index_per_record.resize(global_index_per_record_size,aquanconRecordIdx);
         }
 
         // Collate_function
         collate_function(m_aquoutput, m_aqurecord, m_aquiferID_per_record, m_maxAquID);
 
         // Logic for grid connection applied here
-        logic_application(m_aquoutput);
+        m_aquoutput = logic_application(m_aquoutput);
     }
                                          
     
@@ -149,22 +153,102 @@ namespace Opm {
                                                                    m_aqurecord.at(record_index_matching_id).face_per_record.begin(),
                                                                    m_aqurecord.at(record_index_matching_id).face_per_record.end()
                                                                  );
+                // This is for the record index in order for us to know which one is updated
+                output_vector.at(i - 1).record_index.insert(
+                                                             output_vector.at(i - 1).record_index.end(),
+                                                             m_aqurecord.at(record_index_matching_id).record_index_per_record.begin(),
+                                                             m_aqurecord.at(record_index_matching_id).record_index_per_record.end()
+                                                           );  
             }
         }
     }
 
-    void Aquancon::logic_application(std::vector<Aquancon::AquanconOutput>& output_vector)
+    std::vector<Aquancon::AquanconOutput> Aquancon::logic_application(const std::vector<Aquancon::AquanconOutput> original_vector)
     {
-        // Find if Global index is repeated for each aquifer, if so, select only the first one
+        std::vector<Aquancon::AquanconOutput> output_vector = original_vector;
+        
+        // Create a local struct to couple each element for easy sorting
+        struct pair_elements
+        {
+          size_t global_index;
+          std::shared_ptr<double> influx_coeff;
+          double influx_multiplier;
+          int reservoir_face_dir;
+          int record_index;
+        };
+
+        // Create a working buffer 
+        std::vector<pair_elements> working_buffer;
+
+        // Iterate through each aquifer IDs (This is because each element in the original vector represents an aquifer ID)
         for (auto aquconvec = output_vector.begin(); aquconvec != output_vector.end(); ++aquconvec)
         {
-            std::sort(aquconvec->global_index.begin(), aquconvec->global_index.end());
-            auto it = std::unique ( aquconvec->global_index.begin(), aquconvec->global_index.end() );
-            aquconvec->global_index.resize( std::distance(aquconvec->global_index.begin(),it) );
-        }
+            //Begin to fill the working buffer
+            working_buffer.clear();
+            working_buffer.resize(aquconvec->global_index.size());
+            for (size_t i = 0; i < aquconvec->global_index.size(); ++i )
+            {
+                working_buffer.at(i).global_index = aquconvec->global_index.at(i);
+                working_buffer.at(i).influx_coeff = aquconvec->influx_coeff.at(i);
+                working_buffer.at(i).influx_multiplier = aquconvec->influx_multiplier.at(i);
+                working_buffer.at(i).reservoir_face_dir = aquconvec->reservoir_face_dir.at(i);
+                working_buffer.at(i).record_index = aquconvec->record_index.at(i);
+            }
 
-        //TODO: Find if face on outside of reservoir or adjoins an inactive cell 
-        //TODO: Total number of grid blocks connected to aquifer must not exceed item 6 of AQUDIMS
+            // Sort by ascending order the working_buffer vector in order of priority:
+            // 1) global_index, then 2) record_index
+
+            std::sort(  working_buffer.begin(),
+                        working_buffer.end(),
+                        [](pair_elements& element1, pair_elements& element2) -> bool
+                        {
+                            if (element1.global_index == element2.global_index)
+                            {
+                                return element1.record_index < element2.record_index;
+                            }
+                            else
+                                return element1.global_index < element2.global_index;
+                        }
+                     );
+
+            // We then proceed to obtain unique elements of the global_index, and we apply the 
+            // following behaviour (as mentioned in the Eclipse 2014.1 Reference Manual p.345):
+            // If a reservoir cell is defined more than once, its previous value for the 
+            // aquifer influx coefficient is added to the present value.
+
+            auto i2 = std::unique(  working_buffer.begin(),
+                                    working_buffer.end(),
+                                    [](pair_elements& element1, pair_elements& element2) -> bool
+                                    {
+                                        if (element1.global_index == element2.global_index)
+                                        {
+                                            *(element1.influx_coeff) += *(element2.influx_coeff);
+                                            return true;
+                                        }
+
+                                        return false;
+                                    }
+                                 );
+            working_buffer.resize( std::distance(working_buffer.begin(),i2) );
+
+            // We now resize and fill the output_vector elements
+            aquconvec->global_index.resize(working_buffer.size());
+            aquconvec->influx_coeff.resize(working_buffer.size());
+            aquconvec->influx_multiplier.resize(working_buffer.size());
+            aquconvec->reservoir_face_dir.resize(working_buffer.size());
+            aquconvec->record_index.resize(working_buffer.size());
+            for (size_t i = 0; i < working_buffer.size(); ++i)
+            {
+                aquconvec->global_index.at(i) = working_buffer.at(i).global_index;
+                aquconvec->influx_coeff.at(i) = working_buffer.at(i).influx_coeff;
+                aquconvec->influx_multiplier.at(i) = working_buffer.at(i).influx_multiplier;
+                aquconvec->reservoir_face_dir.at(i) = working_buffer.at(i).reservoir_face_dir;
+                aquconvec->record_index.at(i) = working_buffer.at(i).record_index;
+            }
+
+        }
+ 
+        return output_vector;
     }
 
     void Aquancon::convert_record_id_to_aquifer_id(std::vector<int>& record_indices_matching_id,

--- a/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
@@ -30,8 +30,8 @@ namespace Opm {
             std::vector<size_t> global_index_per_record;
 
             // Variables constants
-            std::vector<double>  influx_coeff_per_record,  //Aquifer influx coefficient
-                                 influx_mult_per_record;   //Aquifer influx coefficient Multiplier       
+            std::vector<std::shared_ptr<double>>  influx_coeff_per_record;  //Aquifer influx coefficient
+            std::vector<double>  influx_mult_per_record;   //Aquifer influx coefficient Multiplier       
             // Cell face to connect aquifer to        
             std::vector<int> face_per_record;           
         };
@@ -68,8 +68,6 @@ namespace Opm {
             m_aquiferID_per_record.at(aquanconRecordIdx) = aquanconRecord.getItem("AQUIFER_ID").template get<int>(0);
             m_maxAquID = (m_maxAquID < m_aquiferID_per_record.at(aquanconRecordIdx) )?
                             m_aquiferID_per_record.at(aquanconRecordIdx) : m_maxAquID;
-              
-            double influx_coeff = aquanconRecord.getItem("INFLUX_COEFF").getSIDouble(0);
 
             double influx_mult = aquanconRecord.getItem("INFLUX_MULT").getSIDouble(0);
 
@@ -84,7 +82,20 @@ namespace Opm {
                                                             );
             }
             size_t global_index_per_record_size = m_aqurecord.at(aquanconRecordIdx).global_index_per_record.size();
-            m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.resize(global_index_per_record_size,influx_coeff);
+
+            m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.resize(global_index_per_record_size,nullptr);
+
+            if (aquanconRecord.getItem("INFLUX_COEFF").hasValue(0))
+            {
+                double* influx_coeff = new double( aquanconRecord.getItem("INFLUX_COEFF").getSIDouble(0) );
+                std::for_each(
+                                m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.begin(),
+                                m_aqurecord.at(aquanconRecordIdx).influx_coeff_per_record.end(),
+                                [influx_coeff](std::shared_ptr<double>& i){ i.reset(influx_coeff); }
+                             );
+            }
+
+
             m_aqurecord.at(aquanconRecordIdx).influx_mult_per_record.resize(global_index_per_record_size,influx_mult);
             m_aqurecord.at(aquanconRecordIdx).face_per_record.resize(global_index_per_record_size,faceDir);
         }

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -36,7 +36,6 @@ namespace Opm {
             data.c2 = 6.283;        // Value of C2 used by E100 (for METRIC, PVT-M and LAB unit systems)        
             data.aquiferID = aquctRecord.getItem("AQUIFER_ID").template get<int>(0);
             data.h = aquctRecord.getItem("THICKNESS_AQ").getSIDouble(0);
-            data.p0 = aquctRecord.getItem("P_INI").getSIDouble(0);
             data.phi_aq = aquctRecord.getItem("PORO_AQ").getSIDouble(0);
             data.d0 = aquctRecord.getItem("DAT_DEPTH").getSIDouble(0);
             data.C_t = aquctRecord.getItem("C_T").getSIDouble(0);
@@ -45,6 +44,11 @@ namespace Opm {
             data.theta = aquctRecord.getItem("INFLUENCE_ANGLE").getSIDouble(0)/360.0; 
             data.inftableID = aquctRecord.getItem("TABLE_NUM_INFLUENCE_FN").template get<int>(0);
             data.pvttableID = aquctRecord.getItem("TABLE_NUM_WATER_PRESS").template get<int>(0);
+            
+            if (aquctRecord.getItem("P_INI").hasValue(0)) {
+                double * raw_ptr = new double( aquctRecord.getItem("P_INI").getSIDouble(0) );
+                data.p0.reset( raw_ptr );
+            }
 
             // Get the correct influence table values
             if (data.inftableID > 1){

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUCT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUCT
@@ -2,7 +2,7 @@
  "items" : [
  {"name" : "AQUIFER_ID" , "value_type" : "INT"},
  {"name" : "DAT_DEPTH"  , "value_type" : "DOUBLE", "dimension" : "Length"},
- {"name" : "P_INI"      , "value_type" : "DOUBLE", "dimension" : "Pressure", "default" : 0.0},
+ {"name" : "P_INI"      , "value_type" : "DOUBLE", "dimension" : "Pressure"},
  {"name" : "PERM_AQ"    , "value_type" : "DOUBLE", "dimension" : "Permeability"},
  {"name" : "PORO_AQ"    , "value_type" : "DOUBLE", "dimension" : "1" , "default" : 1.0},
  {"name" : "C_T"        , "value_type" : "DOUBLE", "dimension" : "1/Pressure"},

--- a/tests/parser/AquanconTests.cpp
+++ b/tests/parser/AquanconTests.cpp
@@ -50,6 +50,10 @@ inline Deck createAQUANCONDeck() {
         "\n"
         "AQUANCON\n"
         "   1      1  1  1    1   1  1  J-  1.0 1.0 NO /\n"
+        "   1      1  3  1    3   3  3  I+  0.5 1.0 NO /\n"
+        "   1      1  3  1    3   3  3  J+  0.75 1.0 NO /\n"
+        "   1      1  3  1    3   3  3  J-  2.75 1.0 NO /\n"
+        "   1      2  3  2    3   1  1  I+  2.75 1.0 NO /\n"
         "/ \n";
 
     Parser parser;
@@ -65,13 +69,31 @@ inline std::vector<Aquancon::AquanconOutput> init_aquancon(){
     return aquifers;
 }
 
+inline std::vector<Aquancon::AquanconOutput> fill_result(){
+    auto deck = createAQUANCONDeck();
+    EclipseState eclState( deck );
+    Aquancon aqucon( eclState.getInputGrid(), deck);
+    std::vector<Aquancon::AquanconOutput> aquifers = aqucon.getAquOutput();
+
+    return aquifers;
+}
+
 BOOST_AUTO_TEST_CASE(AquanconTest){
     std::vector< Aquancon::AquanconOutput > aquifers = init_aquancon();
-    for (const auto& it : aquifers){
-        for (size_t i = 0; i < it.global_index.size(); ++i){
-            BOOST_CHECK_EQUAL(it.aquiferID , 1);
-            BOOST_CHECK_EQUAL(it.global_index.at(i) , 0);
-            BOOST_CHECK_EQUAL(it.reservoir_face_dir.at(i) , 8);
-        }
-    }    
+    std::vector< Aquancon::AquanconOutput > expected_output = fill_result();
+
+    BOOST_CHECK_EQUAL(aquifers.size(), expected_output.size());
+    for (size_t i = 0; i < aquifers.size(); ++i)
+    {
+        BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).global_index.begin(), aquifers.at(i).global_index.end(),
+                                   expected_output.at(i).global_index.begin(), expected_output.at(i).global_index.end() );
+        BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).influx_coeff.begin(), aquifers.at(i).influx_coeff.end(),
+                                   expected_output.at(i).influx_coeff.begin(), expected_output.at(i).influx_coeff.end() );
+        BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).influx_multiplier.begin(), aquifers.at(i).influx_multiplier.end(),
+                                   expected_output.at(i).influx_multiplier.begin(), expected_output.at(i).influx_multiplier.end() );
+        BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).reservoir_face_dir.begin(), aquifers.at(i).reservoir_face_dir.end(),
+                                   expected_output.at(i).reservoir_face_dir.begin(), expected_output.at(i).reservoir_face_dir.end() );
+        BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).record_index.begin(), aquifers.at(i).record_index.end(),
+                                   expected_output.at(i).record_index.begin(), expected_output.at(i).record_index.end() );
+    }
 }    

--- a/tests/parser/AquanconTests.cpp
+++ b/tests/parser/AquanconTests.cpp
@@ -87,8 +87,6 @@ BOOST_AUTO_TEST_CASE(AquanconTest){
     {
         BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).global_index.begin(), aquifers.at(i).global_index.end(),
                                    expected_output.at(i).global_index.begin(), expected_output.at(i).global_index.end() );
-        BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).influx_coeff.begin(), aquifers.at(i).influx_coeff.end(),
-                                   expected_output.at(i).influx_coeff.begin(), expected_output.at(i).influx_coeff.end() );
         BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).influx_multiplier.begin(), aquifers.at(i).influx_multiplier.end(),
                                    expected_output.at(i).influx_multiplier.begin(), expected_output.at(i).influx_multiplier.end() );
         BOOST_CHECK_EQUAL_COLLECTIONS( aquifers.at(i).reservoir_face_dir.begin(), aquifers.at(i).reservoir_face_dir.end(),

--- a/tests/parser/AquiferCTTests.cpp
+++ b/tests/parser/AquiferCTTests.cpp
@@ -119,6 +119,6 @@ BOOST_AUTO_TEST_CASE(AquiferCTTest){
         BOOST_CHECK_EQUAL(it.aquiferID , 1);
         BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
         BOOST_CHECK_EQUAL(it.inftableID , 2);
-        BOOST_CHECK(it.p0 == false);
+        BOOST_CHECK(it.p0 == nullptr);
     }
 }    

--- a/tests/parser/AquiferCTTests.cpp
+++ b/tests/parser/AquiferCTTests.cpp
@@ -51,15 +51,51 @@ inline Deck createAquiferCTDeck() {
         "SOLUTION\n"
         "\n"
         "AQUCT\n"
-        "   1 2000.0 1000 100 .3 3.0e-5 330 10 360.0 1 2 /\n"
+        "   1 2000.0 1.5 100 .3 3.0e-5 330 10 360.0 1 2 /\n"
         "/ \n";
 
     Parser parser;
     return parser.parseString(deckData, ParseContext());
 }
 
-inline std::vector<AquiferCT::AQUCT_data> init_aquiferct(){
-    auto deck = createAquiferCTDeck();
+inline Deck createAquiferCTDeckDefaultP0() {
+    const char *deckData =
+        "DIMENS\n"
+        "3 3 3 /\n"
+        "\n"
+        "AQUDIMS\n"
+        "1* 1* 2 100 1 1000 /\n"
+        "GRID\n"
+        "\n"
+        "ACTNUM\n"
+        " 0 8*1 0 8*1 0 8*1 /\n"
+        "DXV\n"
+        "1 1 1 /\n"
+        "\n"
+        "DYV\n"
+        "1 1 1 /\n"
+        "\n"
+        "DZV\n"
+        "1 1 1 /\n"
+        "\n"
+        "TOPS\n"
+        "9*100 /\n"
+        "\n"
+        "PROPS\n"
+        "AQUTAB\n"
+        " 0.01 0.112 \n" 
+        " 0.05 0.229 /\n" 
+        "SOLUTION\n"
+        "\n"
+        "AQUCT\n"
+        "   1 2000.0 1* 100 .3 3.0e-5 330 10 360.0 1 2 /\n"
+        "/ \n";
+
+    Parser parser;
+    return parser.parseString(deckData, ParseContext());
+}
+
+inline std::vector<AquiferCT::AQUCT_data> init_aquiferct(Deck& deck){
     EclipseState eclState( deck );
     AquiferCT aquct( eclState, deck);
     std::vector<AquiferCT::AQUCT_data> aquiferct = aquct.getAquifers();
@@ -68,11 +104,21 @@ inline std::vector<AquiferCT::AQUCT_data> init_aquiferct(){
 }
 
 BOOST_AUTO_TEST_CASE(AquiferCTTest){
-    std::vector< AquiferCT::AQUCT_data > aquiferct = init_aquiferct();
+    auto deck = createAquiferCTDeck();
+    std::vector< AquiferCT::AQUCT_data > aquiferct = init_aquiferct(deck);
     for (const auto& it : aquiferct){
         BOOST_CHECK_EQUAL(it.aquiferID , 1);
         BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
         BOOST_CHECK_EQUAL(it.inftableID , 2);
-        
-    }    
+        BOOST_CHECK_CLOSE(*(it.p0), 1.5e5, 1e-6);
+    }
+
+    auto deck_default_p0 = createAquiferCTDeckDefaultP0();
+    aquiferct = init_aquiferct(deck_default_p0);
+    for (const auto& it : aquiferct){
+        BOOST_CHECK_EQUAL(it.aquiferID , 1);
+        BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
+        BOOST_CHECK_EQUAL(it.inftableID , 2);
+        BOOST_CHECK(it.p0 == false);
+    }
 }    


### PR DESCRIPTION
* This will fix the issue where default values of the influx_coeff and aquifer pressure is required. Now it scans for nullptr instead.
* Corrects for the issue where only the global_index vector gets resized but not the other vectors.


Downstream: https://github.com/OPM/opm-simulators/pull/1571