### PR TITLE
Add functionality to capture matching wells when evaluating ACTIONX

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ActionAST.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ActionAST.hpp
@@ -62,6 +62,24 @@ struct ParseNode {
 };
 
 
+class ActionValue {
+public:
+    explicit ActionValue(double value);
+    ActionValue() = default;
+
+    bool eval_cmp(TokenType op, const ActionValue& rhs, std::vector<std::string>& matching_wells) const;
+    void add_well(const std::string& well, double value);
+    double scalar() const;
+
+private:
+    bool eval_cmp_wells(TokenType op, double rhs, std::vector<std::string>& matching_wells) const;
+
+    double scalar_value;
+    double is_scalar = false;
+    std::vector<std::pair<std::string, double>> well_values;
+};
+
+
 class ASTNode {
 public:
 

--- a/opm/parser/eclipse/EclipseState/Schedule/ActionAST.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ActionAST.hpp
@@ -107,8 +107,8 @@ ASTNode(TokenType type_arg, const std::string& func_arg, const std::vector<std::
     arg_list(arg_list_arg)
 {}
 
-    bool eval(const ActionContext& context) const;
-    double value(const ActionContext& context) const;
+    bool eval(const ActionContext& context, std::vector<std::string>& matching_wells) const;
+    ActionValue value(const ActionContext& context) const;
     TokenType type;
     void add_child(const ASTNode& child);
     size_t size() const;
@@ -153,7 +153,7 @@ public:
     ASTNode parse_or(ActionParser& parser);
     ASTNode parse_and(ActionParser& parser);
 
-    bool eval(const ActionContext& context) const;
+    bool eval(const ActionContext& context, std::vector<std::string>& matching_wells) const;
 private:
     ASTNode tree;
 };

--- a/opm/parser/eclipse/EclipseState/Schedule/ActionContext.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ActionContext.hpp
@@ -45,6 +45,8 @@ public:
     double get(const std::string& func) const;
     void   add(const std::string& func, double value);
 
+    std::vector<std::string> wells(const std::string& func) const;
+
 private:
     SummaryState summary_state;
     std::map<std::string, double> values;

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -21,6 +21,7 @@
 #define SUMMARY_STATE_H
 
 #include <string>
+#include <vector>
 #include <unordered_map>
 
 #include <ert/ecl/smspec_node.hpp>
@@ -73,10 +74,13 @@ public:
     bool has_well_var(const std::string& well, const std::string& var) const;
     double get_well_var(const std::string& well, const std::string& var) const;
 
+    std::vector<std::string> wells(const std::string& var) const;
     const_iterator begin() const;
     const_iterator end() const;
 private:
     std::unordered_map<std::string,double> values;
+
+    // The first key is the variable and the second key is the well.
     std::unordered_map<std::string, std::unordered_map<std::string, double>> well_values;
 };
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ActionAST.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ActionAST.cpp
@@ -107,6 +107,95 @@ size_t ActionParser::pos() const {
     return this->current_pos;
 }
 
+
+/*****************************************************************/
+ActionValue::ActionValue(double value) :
+    scalar_value(value),
+    is_scalar(true)
+{ }
+
+
+double ActionValue::scalar() const {
+    if (!this->is_scalar)
+        throw std::invalid_argument("This value node represents a well list and can not be evaluated in scalar context");
+
+    return this->scalar_value;
+}
+
+
+void ActionValue::add_well(const std::string& well, double value) {
+    if (this->is_scalar)
+        throw std::invalid_argument("This value node has been created as a scalar node - can not add well variables");
+
+    this->well_values.emplace_back(well, value);
+}
+
+
+namespace {
+
+    bool eval_cmp_scalar(double lhs, TokenType op, double rhs) {
+        switch (op) {
+
+        case TokenType::op_eq:
+            return lhs == rhs;
+
+        case TokenType::op_ge:
+            return lhs >= rhs;
+
+        case TokenType::op_le:
+            return lhs <= rhs;
+
+        case TokenType::op_ne:
+            return lhs != rhs;
+
+        case TokenType::op_gt:
+            return lhs > rhs;
+
+        case TokenType::op_lt:
+            return lhs < rhs;
+
+        default:
+            throw std::invalid_argument("Incorrect operator type - expected comparison");
+        }
+
+    }
+}
+
+
+bool ActionValue::eval_cmp_wells(TokenType op, double rhs, std::vector<std::string>& matching_wells) const {
+    bool ret_value = false;
+    for (const auto& pair : this->well_values) {
+        const std::string& well = pair.first;
+        const double value = pair.second;
+        if (eval_cmp_scalar(value, op, rhs)) {
+            matching_wells.push_back(well);
+            ret_value = true;
+        }
+    }
+    return ret_value;
+}
+
+
+bool ActionValue::eval_cmp(TokenType op, const ActionValue& rhs, std::vector<std::string>& matching_wells) const {
+    if (op == TokenType::number ||
+        op == TokenType::ecl_expr ||
+        op == TokenType::open_paren ||
+        op == TokenType::close_paren ||
+        op == TokenType::op_and ||
+        op == TokenType::op_or ||
+        op == TokenType::end ||
+        op == TokenType::error)
+        throw std::invalid_argument("Invalid operator");
+
+    if (!rhs.is_scalar)
+        throw std::invalid_argument("The right hand side must be a scalar value");
+
+    if (this->is_scalar)
+        return eval_cmp_scalar(this->scalar(), op, rhs.scalar());
+
+    return this->eval_cmp_wells(op, rhs.scalar(), matching_wells);
+}
+
 /*****************************************************************/
 
 void ASTNode::add_child(const ASTNode& child) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ActionAST.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ActionAST.cpp
@@ -167,6 +167,18 @@ bool ActionValue::eval_cmp_wells(TokenType op, double rhs, std::vector<std::stri
     for (const auto& pair : this->well_values) {
         const std::string& well = pair.first;
         const double value = pair.second;
+        /*
+          It is less than clear how the matching_wells should be treated when
+          multiple conditons are nested; in the current implementation a
+          matching well is quite simply added to the list. This has two
+          consequences which are not-obviously-correct:
+
+          1. The wells might appear multiple times.
+
+          2. If a well matches in *one* conditon, and not in another - it will
+             be in the matching_wells list.
+        */
+
         if (eval_cmp_scalar(value, op, rhs)) {
             matching_wells.push_back(well);
             ret_value = true;
@@ -202,25 +214,32 @@ void ASTNode::add_child(const ASTNode& child) {
     this->children.push_back(child);
 }
 
-double ASTNode::value(const ActionContext& context) const {
+ActionValue ASTNode::value(const ActionContext& context) const {
     if (this->children.size() != 0)
         throw std::invalid_argument("value() method should only reach leafnodes");
 
     if (this->type == TokenType::number)
-        return this->number;
+        return ActionValue(this->number);
 
     if (this->arg_list.size() == 0)
-        return context.get(this->func);
+        return ActionValue(context.get(this->func));
     else {
-        std::string arg_key = this->arg_list[0];
-        for (size_t index = 1; index < this->arg_list.size(); index++)
-            arg_key += ":" + this->arg_list[index];
-        return context.get(this->func, arg_key);
+        if (this->arg_list[0] == "*") {
+            ActionValue well_values;
+            for (const auto& well : context.wells(this->func))
+                well_values.add_well(well, context.get(this->func, well));
+            return well_values;
+        } else {
+            std::string arg_key = this->arg_list[0];
+            for (size_t index = 1; index < this->arg_list.size(); index++)
+                arg_key += ":" + this->arg_list[index];
+            return ActionValue(context.get(this->func, arg_key));
+        }
     }
 }
 
 
-bool ASTNode::eval(const ActionContext& context) const {
+bool ASTNode::eval(const ActionContext& context, std::vector<std::string>& matching_wells) const {
     if (this->children.size() == 0)
         throw std::invalid_argument("bool eval should not reach leafnodes");
 
@@ -228,39 +247,16 @@ bool ASTNode::eval(const ActionContext& context) const {
         bool value = (this->type == TokenType::op_and);
         for (const auto& child : this->children) {
             if (this->type == TokenType::op_or)
-                value = value || child.eval(context);
+                value = value || child.eval(context, matching_wells);
             else
-                value = value && child.eval(context);
+                value = value && child.eval(context, matching_wells);
         }
         return value;
     }
 
-    double v1 = this->children[0].value(context);
-    double v2 = this->children[1].value(context);
-
-    switch (this->type) {
-
-    case TokenType::op_eq:
-        return v1 == v2;
-
-    case TokenType::op_ge:
-        return v1 >= v2;
-
-    case TokenType::op_le:
-        return v1 <= v2;
-
-    case TokenType::op_ne:
-        return v1 != v2;
-
-    case TokenType::op_gt:
-        return v1 > v2;
-
-    case TokenType::op_lt:
-        return v1 < v2;
-
-    default:
-        throw std::invalid_argument("Incorrect operator type - expected comparison");
-    }
+    auto v1 = this->children[0].value(context);
+    auto v2 = this->children[1].value(context);
+    return v1.eval_cmp(this->type, v2, matching_wells);
 }
 
 
@@ -420,8 +416,8 @@ ActionAST::ActionAST(const std::vector<std::string>& tokens) {
         throw std::invalid_argument("Failed to parse");
 }
 
-bool ActionAST::eval(const ActionContext& context) const {
-    return this->tree.eval(context);
+bool ActionAST::eval(const ActionContext& context, std::vector<std::string>& matching_wells) const {
+    return this->tree.eval(context, matching_wells);
 }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ActionContext.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ActionContext.cpp
@@ -50,4 +50,10 @@ namespace Opm {
 
         return this->summary_state.get(key);
     }
+
+
+    std::vector<std::string> ActionContext::wells(const std::string& key) const {
+        return this->summary_state.wells(key);
+    }
+
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -50,23 +50,23 @@ namespace Opm{
 
     void SummaryState::add_well_var(const std::string& well, const std::string& var, double value) {
         this->add(var + ":" + well, value);
-        this->well_values[well][var] = value;
+        this->well_values[var][well] = value;
     }
 
     bool SummaryState::has_well_var(const std::string& well, const std::string& var) const {
-        const auto& well_iter = this->well_values.find(well);
-        if (well_iter == this->well_values.end())
+        const auto& var_iter = this->well_values.find(var);
+        if (var_iter == this->well_values.end())
             return false;
 
-        const auto& var_iter = well_iter->second.find(var);
-        if (var_iter == well_iter->second.end())
+        const auto& well_iter = var_iter->second.find(well);
+        if (well_iter == var_iter->second.end())
             return false;
 
         return true;
     }
 
     double SummaryState::get_well_var(const std::string& well, const std::string& var) const {
-        return this->well_values.at(well).at(var);
+        return this->well_values.at(var).at(well);
     }
 
 
@@ -77,6 +77,18 @@ namespace Opm{
 
     SummaryState::const_iterator SummaryState::end() const {
         return this->values.end();
+    }
+
+
+    std::vector<std::string> SummaryState::wells(const std::string& var) const {
+        const auto& var_iter = this->well_values.find(var);
+        if (var_iter == this->well_values.end())
+            return {};
+
+        std::vector<std::string> wells;
+        for (const auto& pair : var_iter->second)
+            wells.push_back(pair.first);
+        return wells;
     }
 
 }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -196,12 +196,20 @@ BOOST_AUTO_TEST_CASE(TestActions) {
 
 BOOST_AUTO_TEST_CASE(TestContext) {
     Opm::SummaryState st;
+    st.add_well_var("OP1", "WOPR", 100);
     Opm::ActionContext context(st);
 
     BOOST_REQUIRE_THROW(context.get("func", "arg"), std::out_of_range);
 
     context.add("FUNC", "ARG", 100);
     BOOST_CHECK_EQUAL(context.get("FUNC", "ARG"), 100);
+
+    const auto& wopr_wells = context.wells("WOPR");
+    BOOST_CHECK_EQUAL(wopr_wells.size(), 1);
+    BOOST_CHECK_EQUAL(wopr_wells[0], "OP1");
+
+    const auto& wwct_wells = context.wells("WWCT");
+    BOOST_CHECK_EQUAL(wwct_wells.size(), 0);
 }
 
 

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -252,15 +252,16 @@ BOOST_AUTO_TEST_CASE(TestActionAST_BASIC) {
     ActionAST ast3({"WWCT", "OPY", ">", "0.75"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
 
     context.add("WWCT", "OPX", 100);
-    BOOST_CHECK(ast1.eval(context));
+    BOOST_CHECK(ast1.eval(context, matching_wells));
 
     context.add("WWCT", "OPX", -100);
-    BOOST_CHECK(!ast1.eval(context));
+    BOOST_CHECK(!ast1.eval(context, matching_wells));
 
-    BOOST_CHECK(ast2.eval(context));
-    BOOST_REQUIRE_THROW(ast3.eval(context), std::out_of_range);
+    BOOST_CHECK(ast2.eval(context, matching_wells));
+    BOOST_REQUIRE_THROW(ast3.eval(context, matching_wells), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_CASE(TestActionAST_OR_AND) {
@@ -269,50 +270,53 @@ BOOST_AUTO_TEST_CASE(TestActionAST_OR_AND) {
     ActionAST par({"WWCT", "OPX", ">", "0.75", "AND", "(", "WWCT", "OPY", ">", "0.75", "OR", "WWCT", "OPZ", ">", "0.75", ")"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
 
     context.add("WWCT", "OPX", 100);
     context.add("WWCT", "OPY", -100);
     context.add("WWCT", "OPZ", 100);
-    BOOST_CHECK( ast_or.eval(context) );
-    BOOST_CHECK( !ast_and.eval(context) );
-    BOOST_CHECK( par.eval(context));
+    BOOST_CHECK( ast_or.eval(context, matching_wells) );
+    BOOST_CHECK( !ast_and.eval(context, matching_wells) );
+    BOOST_CHECK( par.eval(context, matching_wells));
 
 
     context.add("WWCT", "OPX", -100);
     context.add("WWCT", "OPY", 100);
     context.add("WWCT", "OPZ", 100);
-    BOOST_CHECK( ast_or.eval(context) );
-    BOOST_CHECK( !ast_and.eval(context) );
-    BOOST_CHECK( !par.eval(context));
+    BOOST_CHECK( ast_or.eval(context, matching_wells) );
+    BOOST_CHECK( !ast_and.eval(context, matching_wells) );
+    BOOST_CHECK( !par.eval(context, matching_wells));
 
 
     context.add("WWCT", "OPX", 100);
     context.add("WWCT", "OPY", 100);
     context.add("WWCT", "OPZ", -100);
-    BOOST_CHECK( ast_or.eval(context) );
-    BOOST_CHECK( ast_and.eval(context) );
-    BOOST_CHECK( par.eval(context));
+    BOOST_CHECK( ast_or.eval(context, matching_wells) );
+    BOOST_CHECK( ast_and.eval(context, matching_wells) );
+    BOOST_CHECK( par.eval(context, matching_wells));
 
     context.add("WWCT", "OPX", -100);
     context.add("WWCT", "OPY", -100);
     context.add("WWCT", "OPZ", -100);
-    BOOST_CHECK( !ast_or.eval(context) );
-    BOOST_CHECK( !ast_and.eval(context) );
-    BOOST_CHECK( !par.eval(context));
+    BOOST_CHECK( !ast_or.eval(context, matching_wells) );
+    BOOST_CHECK( !ast_and.eval(context, matching_wells) );
+    BOOST_CHECK( !par.eval(context, matching_wells));
 }
 
 BOOST_AUTO_TEST_CASE(DATE) {
     ActionAST ast({"MNTH", ">=", "JUN"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
+
     context.add("MNTH", 6);
-    BOOST_CHECK( ast.eval(context) );
+    BOOST_CHECK( ast.eval(context, matching_wells) );
 
     context.add("MNTH", 8);
-    BOOST_CHECK( ast.eval(context) );
+    BOOST_CHECK( ast.eval(context, matching_wells) );
 
     context.add("MNTH", 5);
-    BOOST_CHECK( !ast.eval(context) );
+    BOOST_CHECK( !ast.eval(context, matching_wells) );
 }
 
 
@@ -320,79 +324,82 @@ BOOST_AUTO_TEST_CASE(MANUAL1) {
     ActionAST ast({"GGPR", "FIELD", ">", "50000", "AND", "WGOR", "PR", ">" ,"GGOR", "FIELD"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
 
     context.add("GGPR", "FIELD", 60000 );
     context.add("WGOR", "PR" , 300 );
     context.add("GGOR", "FIELD", 200);
-    BOOST_CHECK( ast.eval(context) );
+    BOOST_CHECK( ast.eval(context, matching_wells) );
 
     context.add("GGPR", "FIELD", 0 );
     context.add("WGOR", "PR" , 300 );
     context.add("GGOR", "FIELD", 200);
-    BOOST_CHECK( !ast.eval(context) );
+    BOOST_CHECK( !ast.eval(context, matching_wells) );
 
     context.add("GGPR", "FIELD", 60000 );
     context.add("WGOR", "PR" , 100 );
     context.add("GGOR", "FIELD", 200);
-    BOOST_CHECK( !ast.eval(context) );
+    BOOST_CHECK( !ast.eval(context, matching_wells) );
 }
 
 BOOST_AUTO_TEST_CASE(MANUAL2) {
     ActionAST ast({"GWCT", "LIST1", ">", "0.70", "AND", "(", "GWPR", "LIST1", ">", "GWPR", "LIST2", "OR", "GWPR", "LIST1", ">", "GWPR", "LIST3", ")"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
 
     context.add("GWCT", "LIST1", 1.0);
     context.add("GWPR", "LIST1", 1 );
     context.add("GWPR", "LIST2", 2 );
     context.add("GWPR", "LIST3", 3 );
-    BOOST_CHECK( !ast.eval(context));
+    BOOST_CHECK( !ast.eval(context, matching_wells));
 
     context.add("GWCT", "LIST1", 1.0);
     context.add("GWPR", "LIST1", 1 );
     context.add("GWPR", "LIST2", 2 );
     context.add("GWPR", "LIST3", 0 );
-    BOOST_CHECK( ast.eval(context));
+    BOOST_CHECK( ast.eval(context, matching_wells));
 
     context.add("GWCT", "LIST1", 1.0);
     context.add("GWPR", "LIST1", 1 );
     context.add("GWPR", "LIST2", 0 );
     context.add("GWPR", "LIST3", 3 );
-    BOOST_CHECK( ast.eval(context));
+    BOOST_CHECK( ast.eval(context, matching_wells));
 
     context.add("GWCT", "LIST1", 1.0);
     context.add("GWPR", "LIST1", 1 );
     context.add("GWPR", "LIST2", 0 );
     context.add("GWPR", "LIST3", 0 );
-    BOOST_CHECK( ast.eval(context));
+    BOOST_CHECK( ast.eval(context, matching_wells));
 
     context.add("GWCT", "LIST1", 0.0);
     context.add("GWPR", "LIST1", 1 );
     context.add("GWPR", "LIST2", 0 );
     context.add("GWPR", "LIST3", 3 );
-    BOOST_CHECK( !ast.eval(context));
+    BOOST_CHECK( !ast.eval(context, matching_wells));
 }
 
 BOOST_AUTO_TEST_CASE(MANUAL3) {
     ActionAST ast({"MNTH", ".GE.", "MAR", "AND", "MNTH", ".LE.", "OCT", "AND", "GMWL", "HIGH", ".GE.", "4"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
 
     context.add("MNTH", 4);
     context.add("GMWL", "HIGH", 4);
-    BOOST_CHECK( ast.eval(context));
+    BOOST_CHECK( ast.eval(context, matching_wells));
 
     context.add("MNTH", 3);
     context.add("GMWL", "HIGH", 4);
-    BOOST_CHECK( ast.eval(context));
+    BOOST_CHECK( ast.eval(context, matching_wells));
 
     context.add("MNTH", 11);
     context.add("GMWL", "HIGH", 4);
-    BOOST_CHECK( !ast.eval(context));
+    BOOST_CHECK( !ast.eval(context, matching_wells));
 
     context.add("MNTH", 3);
     context.add("GMWL", "HIGH", 3);
-    BOOST_CHECK( !ast.eval(context));
+    BOOST_CHECK( !ast.eval(context, matching_wells));
 }
 
 
@@ -400,19 +407,20 @@ BOOST_AUTO_TEST_CASE(MANUAL4) {
     ActionAST ast({"GWCT", "FIELD", ">", "0.8", "AND", "DAY", ">", "1", "AND", "MNTH", ">", "JUN", "AND", "YEAR", ">=", "2021"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
 
 
     context.add("MNTH", 7);
     context.add("DAY", 2);
     context.add("YEAR", 2030);
     context.add("GWCT", "FIELD", 1.0);
-    BOOST_CHECK( ast.eval(context) );
+    BOOST_CHECK( ast.eval(context, matching_wells) );
 
     context.add("MNTH", 7);
     context.add("DAY", 2);
     context.add("YEAR", 2019);
     context.add("GWCT", "FIELD", 1.0);
-    BOOST_CHECK( !ast.eval(context) );
+    BOOST_CHECK( !ast.eval(context, matching_wells) );
 }
 
 
@@ -421,6 +429,7 @@ BOOST_AUTO_TEST_CASE(MANUAL5) {
     ActionAST ast({"WCG2", "PROD1", ">", "WCG5", "PROD2", "AND", "GCG3", "G1", ">", "GCG7", "G2", "OR", "FCG1", ">", "FCG7"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
 
     context.add("WCG2", "PROD1", 100);
     context.add("WCG5", "PROD2",  50);
@@ -428,7 +437,7 @@ BOOST_AUTO_TEST_CASE(MANUAL5) {
     context.add("GCG7", "G2", 100);
     context.add("FCG1", 100);
     context.add("FCG7",  50);
-    BOOST_CHECK(ast.eval(context));
+    BOOST_CHECK(ast.eval(context, matching_wells));
 
     context.add("WCG2", "PROD1", 100);
     context.add("WCG5", "PROD2",  50);
@@ -436,7 +445,7 @@ BOOST_AUTO_TEST_CASE(MANUAL5) {
     context.add("GCG7", "G2", 100);
     context.add("FCG1", 100);
     context.add("FCG7", 150);
-    BOOST_CHECK(ast.eval(context));
+    BOOST_CHECK(ast.eval(context, matching_wells));
 
     context.add("WCG2", "PROD1", 100);
     context.add("WCG5", "PROD2",  50);
@@ -444,7 +453,7 @@ BOOST_AUTO_TEST_CASE(MANUAL5) {
     context.add("GCG7", "G2", 100);
     context.add("FCG1", 100);
     context.add("FCG7", 150);
-    BOOST_CHECK(!ast.eval(context));
+    BOOST_CHECK(!ast.eval(context, matching_wells));
 
     context.add("WCG2", "PROD1", 100);
     context.add("WCG5", "PROD2",  50);
@@ -452,7 +461,7 @@ BOOST_AUTO_TEST_CASE(MANUAL5) {
     context.add("GCG7", "G2", 100);
     context.add("FCG1", 200);
     context.add("FCG7", 150);
-    BOOST_CHECK(ast.eval(context));
+    BOOST_CHECK(ast.eval(context, matching_wells));
 }
 
 
@@ -461,12 +470,13 @@ BOOST_AUTO_TEST_CASE(LGR) {
     ActionAST ast({"LWCC" , "OPX", "LOCAL", "1", "2", "3", ">", "100"});
     SummaryState st;
     ActionContext context(st);
+    std::vector<std::string> matching_wells;
 
     context.add("LWCC", "OPX:LOCAL:1:2:3", 200);
-    BOOST_CHECK(ast.eval(context));
+    BOOST_CHECK(ast.eval(context, matching_wells));
 
     context.add("LWCC", "OPX:LOCAL:1:2:3", 20);
-    BOOST_CHECK(!ast.eval(context));
+    BOOST_CHECK(!ast.eval(context, matching_wells));
 }
 
 
@@ -513,3 +523,19 @@ BOOST_AUTO_TEST_CASE(ActionValueTest) {
 }
 
 
+
+BOOST_AUTO_TEST_CASE(TestMatchingWells) {
+    ActionAST ast({"WOPR", "*", ">", "1.0"});
+    SummaryState st;
+    std::vector<std::string> matching_wells;
+
+    st.add_well_var("OPX", "WOPR", 0);
+    st.add_well_var("OPY", "WOPR", 0.50);
+    st.add_well_var("OPZ", "WOPR", 2.0);
+
+    ActionContext context(st);
+    BOOST_CHECK( ast.eval(context, matching_wells) );
+
+    BOOST_CHECK_EQUAL( matching_wells.size(), 1);
+    BOOST_CHECK_EQUAL( matching_wells[0], "OPZ" );
+}

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -483,3 +483,33 @@ BOOST_AUTO_TEST_CASE(ActionContextTest) {
     BOOST_CHECK_EQUAL(context.get("WWCT", "OP1"), 200);
     BOOST_REQUIRE_THROW(context.get("WGOR", "B37"), std::out_of_range);
 }
+
+
+
+BOOST_AUTO_TEST_CASE(ActionValueTest) {
+    ActionValue well_values;
+    ActionValue scalar_value(200);
+    BOOST_REQUIRE_THROW(well_values.scalar(), std::invalid_argument);
+    BOOST_CHECK_EQUAL(scalar_value.scalar(), 200);
+
+    BOOST_REQUIRE_THROW(scalar_value.add_well("A", 100), std::invalid_argument);
+
+    well_values.add_well("A", 100);
+    well_values.add_well("B", 200);
+    well_values.add_well("C", 300);
+
+    std::vector<std::string> matching_wells;
+    // Invalid operator
+    BOOST_REQUIRE_THROW(well_values.eval_cmp(TokenType::number, scalar_value, matching_wells), std::invalid_argument);
+    // Right hand side is not scalar
+    BOOST_REQUIRE_THROW(well_values.eval_cmp(TokenType::op_eq, well_values, matching_wells), std::invalid_argument);
+
+    BOOST_CHECK( !well_values.eval_cmp(TokenType::op_le, ActionValue(-1), matching_wells) );
+    BOOST_CHECK_EQUAL(0, matching_wells.size());
+
+    BOOST_CHECK( well_values.eval_cmp(TokenType::op_eq, scalar_value, matching_wells) );
+    BOOST_CHECK_EQUAL(1, matching_wells.size());
+    BOOST_CHECK_EQUAL("B", matching_wells[0]);
+}
+
+

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1330,9 +1330,18 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
 
 
     st.add_well_var("OP1", "WWCT", 0.75);
+    st.add_well_var("OP2", "WWCT", 0.75);
     BOOST_CHECK( st.has_well_var("OP1", "WWCT"));
     BOOST_CHECK_EQUAL( st.get_well_var("OP1", "WWCT"), 0.75);
     BOOST_CHECK_EQUAL( st.get_well_var("OP1", "WWCT"), st.get("WWCT:OP1"));
+
+
+    const auto& wopr_wells = st.wells("WOPR");
+    BOOST_CHECK_EQUAL( wopr_wells.size() , 0);
+
+    const auto& wwct_wells = st.wells("WWCT");
+    BOOST_CHECK_EQUAL(std::count(wwct_wells.begin(), wwct_wells.end(), "OP1"), 1);
+    BOOST_CHECK_EQUAL(std::count(wwct_wells.begin(), wwct_wells.end(), "OP2"), 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The `ACTIONX` keyword can use wellname `?` which will be replaced with "All matching wells". 

There is some remaining ambiguity when it comes to nested conditons: https://github.com/OPM/opm-common/pull/566/commits/ce70d3a964b398f1a4267ce30ed564e6a6954f6c#diff-edbe5d8d3087796daa51ea7d26a7f8d1R170 - this will require a fine reading of the manual, and maybe some expert input.