### PR TITLE
Force UPPER_CASE when input deck has MixeDCase basename

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -174,7 +174,7 @@ namespace Opm {
         void setOutputDir(const std::string& outputDir);
 
         const std::string& getBaseName() const;
-        void setBaseName(std::string baseName);
+        void setBaseName(const std::string& baseName);
 
         /// Return a string consisting of outputpath and basename;
         /// i.e. /path/to/sim/CASE
@@ -199,8 +199,8 @@ namespace Opm {
         std::string     m_deck_filename;
         bool            m_output_enabled = true;
         std::string     m_output_dir;
-        std::string     m_base_name;
         bool            m_nosim;
+        std::string     m_base_name;
         bool            ecl_compatible_rst = true;
 
         IOConfig( const GRIDSection&,

--- a/tests/parser/IOConfigTests.cpp
+++ b/tests/parser/IOConfigTests.cpp
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(OutputPaths) {
     IOConfig config2( deck2 );
     std::string output_dir2 =  ".";
     BOOST_CHECK_EQUAL( output_dir2,  config2.getOutputDir() );
-    BOOST_CHECK_EQUAL( "testString", config2.getBaseName() );
+    BOOST_CHECK_EQUAL( "TESTSTRING", config2.getBaseName() );
 
     namespace fs = boost::filesystem;
 
@@ -270,8 +270,8 @@ BOOST_AUTO_TEST_CASE(OutputPaths) {
     IOConfig config3( deck3 );
     std::string output_dir3 =  "/path/to";
     config3.setOutputDir( output_dir3 );
-    auto testpath = fs::path( "/path/to/testString" ).make_preferred().string();
+    auto testpath = fs::path( "/path/to/TESTSTRING" ).make_preferred().string();
     BOOST_CHECK_EQUAL( output_dir3,  config3.getOutputDir() );
-    BOOST_CHECK_EQUAL( "testString", config3.getBaseName() );
+    BOOST_CHECK_EQUAL( "TESTSTRING", config3.getBaseName() );
     BOOST_CHECK_EQUAL( testpath, config3.fullBasePath() );
 }


### PR DESCRIPTION
See: https://github.com/OPM/opm-simulators/issues/1653

The current PR is one approach; personally I do not see any very good and clean solution. Opinions welcome!