### PR TITLE
Allow to switch of logging during getWriteRestartFile call.

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -324,7 +324,7 @@ namespace Opm {
 
 
         int  getFirstRestartStep() const;
-        bool getWriteRestartFile(size_t timestep) const;
+        bool getWriteRestartFile(size_t timestep, bool log=true) const;
         const std::map< std::string, int >& getRestartKeywords( size_t timestep ) const;
         int getKeyword( const std::string& keyword, size_t timeStep) const;
 

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -498,11 +498,11 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule) {
     }
 
 
-    bool RestartConfig::getWriteRestartFile(size_t timestep) const {
+    bool RestartConfig::getWriteRestartFile(size_t timestep, bool log) const {
         if (0 == timestep)
             return m_write_initial_RST_file;
 
-        if (save_keywords[timestep]) {
+        if (save_keywords[timestep] && log) {
             std::string logstring = "Fast restart using SAVE is not supported. Standard restart file is written instead";
             Opm::OpmLog::warning("Unhandled output keyword", logstring);
             return true;


### PR DESCRIPTION
This needed for parallel runs as otherwise all processes will do logging. There will be a acompanion PR in ewoms