### PR TITLE
Restore Build on GCC 4.9

### DIFF
--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -146,8 +146,11 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
 
         Opm::data::Solution solution = createBlackoilState(2, numCells);
         Opm::data::Wells wells;
-        wells["OP_1"] = { r1, 1.0, 1.1, 3.1, 1, well1_comps, {} };
-        wells["OP_2"] = { r2, 1.0, 1.1, 3.2, 1, well2_comps, {} };
+
+        using SegRes = decltype(wells["w"].segments);
+
+        wells["OP_1"] = { r1, 1.0, 1.1, 3.1, 1, well1_comps, SegRes{} };
+        wells["OP_2"] = { r2, 1.0, 1.1, 3.2, 1, well2_comps, SegRes{} };
 
 
         RestartValue restart_value(solution, wells);
@@ -239,8 +242,11 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
 
                 Opm::data::Wells wells;
                 Opm::data::Solution solution = createBlackoilState(2, numCells);
-                wells["OP_1"] = { r1, 1.0, 1.1, 3.1, 1, well1_comps, {} };
-                wells["OP_2"] = { r2, 1.0, 1.1, 3.2, 1, well2_comps, {} };
+
+                using SegRes = decltype(wells["w"].segments);
+
+                wells["OP_1"] = { r1, 1.0, 1.1, 3.1, 1, well1_comps, SegRes{} };
+                wells["OP_2"] = { r2, 1.0, 1.1, 3.2, 1, well2_comps, SegRes{} };
 
                 RestartValue restart_value(solution, wells);
                 eclipseWriter.writeTimeStep( step,

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -203,8 +203,11 @@ static data::Wells result_wells() {
         { {well1_comp1} },
         { { segment.segNumber, segment } },
     };
-    data::Well well2 { rates2, 1.1 * ps, 1.2 * ps, 1.3 * ps, 2, { {well2_comp1 , well2_comp2} }, {} };
-    data::Well well3 { rates3, 2.1 * ps, 2.2 * ps, 2.3 * ps, 3, { {well3_comp1} }, {} };
+
+    using SegRes = decltype(well1.segments);
+
+    data::Well well2 { rates2, 1.1 * ps, 1.2 * ps, 1.3 * ps, 2, { {well2_comp1 , well2_comp2} }, SegRes{} };
+    data::Well well3 { rates3, 2.1 * ps, 2.2 * ps, 2.3 * ps, 3, { {well3_comp1} }, SegRes{} };
 
     data::Wells wellrates;
 


### PR DESCRIPTION
Commit 334dbe4e (PR #579) broke GCC 4.9 (invoking explicit constructor with an empty `initializer_list<>`).  Restore build by using the actual type.