### PR TITLE
Check Size Inconsistencies Only for Open Connections

### DIFF
--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -323,7 +323,7 @@ captureDeclaredConnData(const Schedule&        sched,
 		    it->second[connID] = &(xr->second.connections[rCInd]);
 		    rCInd+= 1;
 		}
-		else if (rCInd >= xr->second.connections.size()) {
+		else if ((conns[connID].state() == Opm::WellCompletion::StateEnum::OPEN) && (rCInd >= xr->second.connections.size())) {
 		    throw std::invalid_argument {
 		"Inconsistent number of open connections I in vector<Opm::data::Connection*> (" +
 		std::to_string(xr->second.connections.size()) + ") in Well " + wl->name()


### PR DESCRIPTION
The previous logic was slightly incomplete in that it checked size inconsistencies for all connections, not just open connections. This, in turn would in turn generate diagnostics like
```
Report step 19/247 at day 252/3312, date = 16-Jul-1998

Time step 0, stepsize 16 days.
ERROR: Uncaught std::exception when running tasklet: Inconsistent number of open connections I in vector<Opm::data::Connection*> (3) in Well B-4H. Trying to continue.
```
With this update we look for size inconsistencies between a well's open connections and `data::Wells::connections` only.

This fixes #581