### PR TITLE
Add output of group and field phase potential injection and production rates to Summary file

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -786,6 +786,13 @@ static const std::unordered_map< std::string, ofun > funs = {
                    duration ) },
     { "GVPT", mul( sum( sum( rate< rt::reservoir_water, producer >, rate< rt::reservoir_oil, producer > ),
                         rate< rt::reservoir_gas, producer > ), duration ) },
+    // Group potential
+    { "GWPP", generic_well_rate< rt::well_potential_water , true, false>},
+    { "GOPP", generic_well_rate< rt::well_potential_oil , true, false>},
+    { "GGPP", generic_well_rate< rt::well_potential_gas , true, false>},
+    { "GWPI", generic_well_rate< rt::well_potential_water , false, true>},
+    { "GOPI", generic_well_rate< rt::well_potential_oil , false, true>},
+    { "GGPI", generic_well_rate< rt::well_potential_gas , false, true>},
 
     { "WWPRH", production_history< Phase::WATER > },
     { "WOPRH", production_history< Phase::OIL > },
@@ -926,6 +933,14 @@ static const std::unordered_map< std::string, ofun > funs = {
                    duration ) },
     { "FVIT", mul( sum( sum( rate< rt::reservoir_water, injector>, rate< rt::reservoir_oil, injector >),
                    rate< rt::reservoir_gas, injector>), duration)},
+    // Field potential
+    { "FWPP", generic_well_rate< rt::well_potential_water , true, false>},
+    { "FOPP", generic_well_rate< rt::well_potential_oil , true, false>},
+    { "FGPP", generic_well_rate< rt::well_potential_gas , true, false>},
+    { "FWPI", generic_well_rate< rt::well_potential_water , false, true>},
+    { "FOPI", generic_well_rate< rt::well_potential_oil , false, true>},
+    { "FGPI", generic_well_rate< rt::well_potential_gas , false, true>},
+
 
     { "FWPRH", production_history< Phase::WATER > },
     { "FOPRH", production_history< Phase::OIL > },

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -655,21 +655,6 @@ quantity region_rate( const fn_args& args ) {
         return { -sum, rate_unit< phase >() };
 }
 
-/*template < rt phase, bool outputProducer = true, bool outputInjector = true>
-quantity generic_well_rate (const fn_args& args  ) {
-    const quantity zero = { 0, rate_unit< phase >() };
-    if( args.schedule_wells.empty() ) return zero;
-
-    const auto p = args.wells.find( args.schedule_wells.front()->name() );
-    if( p == args.wells.end() ) return zero;
-
-    if (args.schedule_wells.front()->isInjector(args.sim_step) && !outputInjector) return zero;
-
-    if (args.schedule_wells.front()->isProducer(args.sim_step) && !outputProducer) return zero;
-
-    return  p->second.rates.has(phase) ? quantity {p->second.rates.get(phase), rate_unit<phase>()} : zero;
-    //return { p->second.rates.get(phase), rate_unit< phase >() };
-}*/
 template < rt phase, bool outputProducer = true, bool outputInjector = true>
 inline quantity generic_potential_rate( const fn_args& args ) {
     double sum = 0.0;

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -656,7 +656,7 @@ quantity region_rate( const fn_args& args ) {
 }
 
 template < rt phase, bool outputProducer = true, bool outputInjector = true>
-inline quantity generic_potential_rate( const fn_args& args ) {
+inline quantity potential_rate( const fn_args& args ) {
     double sum = 0.0;
 
     for( const auto* sched_well : args.schedule_wells ) {
@@ -792,12 +792,12 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "GVPT", mul( sum( sum( rate< rt::reservoir_water, producer >, rate< rt::reservoir_oil, producer > ),
                         rate< rt::reservoir_gas, producer > ), duration ) },
     // Group potential
-    { "GWPP", generic_potential_rate< rt::well_potential_water , true, false>},
-    { "GOPP", generic_potential_rate< rt::well_potential_oil , true, false>},
-    { "GGPP", generic_potential_rate< rt::well_potential_gas , true, false>},
-    { "GWPI", generic_potential_rate< rt::well_potential_water , false, true>},
-    { "GOPI", generic_potential_rate< rt::well_potential_oil , false, true>},
-    { "GGPI", generic_potential_rate< rt::well_potential_gas , false, true>},
+    { "GWPP", potential_rate< rt::well_potential_water , true, false>},
+    { "GOPP", potential_rate< rt::well_potential_oil , true, false>},
+    { "GGPP", potential_rate< rt::well_potential_gas , true, false>},
+    { "GWPI", potential_rate< rt::well_potential_water , false, true>},
+    { "GOPI", potential_rate< rt::well_potential_oil , false, true>},
+    { "GGPI", potential_rate< rt::well_potential_gas , false, true>},
 
     { "WWPRH", production_history< Phase::WATER > },
     { "WOPRH", production_history< Phase::OIL > },
@@ -939,12 +939,12 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "FVIT", mul( sum( sum( rate< rt::reservoir_water, injector>, rate< rt::reservoir_oil, injector >),
                    rate< rt::reservoir_gas, injector>), duration)},
     // Field potential
-    { "FWPP", generic_potential_rate< rt::well_potential_water , true, false>},
-    { "FOPP", generic_potential_rate< rt::well_potential_oil , true, false>},
-    { "FGPP", generic_potential_rate< rt::well_potential_gas , true, false>},
-    { "FWPI", generic_potential_rate< rt::well_potential_water , false, true>},
-    { "FOPI", generic_potential_rate< rt::well_potential_oil , false, true>},
-    { "FGPI", generic_potential_rate< rt::well_potential_gas , false, true>},
+    { "FWPP", potential_rate< rt::well_potential_water , true, false>},
+    { "FOPP", potential_rate< rt::well_potential_oil , true, false>},
+    { "FGPP", potential_rate< rt::well_potential_gas , true, false>},
+    { "FWPI", potential_rate< rt::well_potential_water , false, true>},
+    { "FOPI", potential_rate< rt::well_potential_oil , false, true>},
+    { "FGPI", potential_rate< rt::well_potential_gas , false, true>},
 
 
     { "FWPRH", production_history< Phase::WATER > },
@@ -1002,17 +1002,17 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "SGFR", srate< rt::gas > },
     { "SPR",  spr }, 
     // Well productivity index
-    { "WPIW", generic_potential_rate< rt::productivity_index_water >},
-    { "WPIO", generic_potential_rate< rt::productivity_index_oil >},
-    { "WPIG", generic_potential_rate< rt::productivity_index_gas >},
-    { "WPIL", sum( generic_potential_rate< rt::productivity_index_water >, generic_potential_rate< rt::productivity_index_oil>)},
+    { "WPIW", potential_rate< rt::productivity_index_water >},
+    { "WPIO", potential_rate< rt::productivity_index_oil >},
+    { "WPIG", potential_rate< rt::productivity_index_gas >},
+    { "WPIL", sum( potential_rate< rt::productivity_index_water >, potential_rate< rt::productivity_index_oil>)},
     // Well potential
-    { "WWPP", generic_potential_rate< rt::well_potential_water , true, false>},
-    { "WOPP", generic_potential_rate< rt::well_potential_oil , true, false>},
-    { "WGPP", generic_potential_rate< rt::well_potential_gas , true, false>},
-    { "WWPI", generic_potential_rate< rt::well_potential_water , false, true>},
-    { "WOPI", generic_potential_rate< rt::well_potential_oil , false, true>},
-    { "WGPI", generic_potential_rate< rt::well_potential_gas , false, true>},
+    { "WWPP", potential_rate< rt::well_potential_water , true, false>},
+    { "WOPP", potential_rate< rt::well_potential_oil , true, false>},
+    { "WGPP", potential_rate< rt::well_potential_gas , true, false>},
+    { "WWPI", potential_rate< rt::well_potential_water , false, true>},
+    { "WOPI", potential_rate< rt::well_potential_oil , false, true>},
+    { "WGPI", potential_rate< rt::well_potential_gas , false, true>},
 };
 
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -655,7 +655,7 @@ quantity region_rate( const fn_args& args ) {
         return { -sum, rate_unit< phase >() };
 }
 
-template < rt phase, bool outputProducer = true, bool outputInjector = true>
+/*template < rt phase, bool outputProducer = true, bool outputInjector = true>
 quantity generic_well_rate (const fn_args& args  ) {
     const quantity zero = { 0, rate_unit< phase >() };
     if( args.schedule_wells.empty() ) return zero;
@@ -669,6 +669,26 @@ quantity generic_well_rate (const fn_args& args  ) {
 
     return  p->second.rates.has(phase) ? quantity {p->second.rates.get(phase), rate_unit<phase>()} : zero;
     //return { p->second.rates.get(phase), rate_unit< phase >() };
+}*/
+template < rt phase, bool outputProducer = true, bool outputInjector = true>
+inline quantity generic_potential_rate( const fn_args& args ) {
+    double sum = 0.0;
+
+    for( const auto* sched_well : args.schedule_wells ) {
+        const auto& name = sched_well->name();
+        if( args.wells.count( name ) == 0 ) continue;
+
+        if (sched_well->isInjector(args.sim_step) && outputInjector) {
+	    const auto v = args.wells.at(name).rates.get(phase, 0.0);
+	    sum += v;
+	}
+	else if (sched_well->isProducer(args.sim_step) && outputProducer) {
+	    const auto v = args.wells.at(name).rates.get(phase, 0.0);
+	    sum += v;
+	}
+    }
+
+    return { sum, rate_unit< phase >() };
 }
 
 template< typename F, typename G >
@@ -787,12 +807,12 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "GVPT", mul( sum( sum( rate< rt::reservoir_water, producer >, rate< rt::reservoir_oil, producer > ),
                         rate< rt::reservoir_gas, producer > ), duration ) },
     // Group potential
-    { "GWPP", generic_well_rate< rt::well_potential_water , true, false>},
-    { "GOPP", generic_well_rate< rt::well_potential_oil , true, false>},
-    { "GGPP", generic_well_rate< rt::well_potential_gas , true, false>},
-    { "GWPI", generic_well_rate< rt::well_potential_water , false, true>},
-    { "GOPI", generic_well_rate< rt::well_potential_oil , false, true>},
-    { "GGPI", generic_well_rate< rt::well_potential_gas , false, true>},
+    { "GWPP", generic_potential_rate< rt::well_potential_water , true, false>},
+    { "GOPP", generic_potential_rate< rt::well_potential_oil , true, false>},
+    { "GGPP", generic_potential_rate< rt::well_potential_gas , true, false>},
+    { "GWPI", generic_potential_rate< rt::well_potential_water , false, true>},
+    { "GOPI", generic_potential_rate< rt::well_potential_oil , false, true>},
+    { "GGPI", generic_potential_rate< rt::well_potential_gas , false, true>},
 
     { "WWPRH", production_history< Phase::WATER > },
     { "WOPRH", production_history< Phase::OIL > },
@@ -934,12 +954,12 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "FVIT", mul( sum( sum( rate< rt::reservoir_water, injector>, rate< rt::reservoir_oil, injector >),
                    rate< rt::reservoir_gas, injector>), duration)},
     // Field potential
-    { "FWPP", generic_well_rate< rt::well_potential_water , true, false>},
-    { "FOPP", generic_well_rate< rt::well_potential_oil , true, false>},
-    { "FGPP", generic_well_rate< rt::well_potential_gas , true, false>},
-    { "FWPI", generic_well_rate< rt::well_potential_water , false, true>},
-    { "FOPI", generic_well_rate< rt::well_potential_oil , false, true>},
-    { "FGPI", generic_well_rate< rt::well_potential_gas , false, true>},
+    { "FWPP", generic_potential_rate< rt::well_potential_water , true, false>},
+    { "FOPP", generic_potential_rate< rt::well_potential_oil , true, false>},
+    { "FGPP", generic_potential_rate< rt::well_potential_gas , true, false>},
+    { "FWPI", generic_potential_rate< rt::well_potential_water , false, true>},
+    { "FOPI", generic_potential_rate< rt::well_potential_oil , false, true>},
+    { "FGPI", generic_potential_rate< rt::well_potential_gas , false, true>},
 
 
     { "FWPRH", production_history< Phase::WATER > },
@@ -997,17 +1017,17 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "SGFR", srate< rt::gas > },
     { "SPR",  spr }, 
     // Well productivity index
-    { "WPIW", generic_well_rate< rt::productivity_index_water >},
-    { "WPIO", generic_well_rate< rt::productivity_index_oil >},
-    { "WPIG", generic_well_rate< rt::productivity_index_gas >},
-    { "WPIL", sum( generic_well_rate< rt::productivity_index_water >, generic_well_rate< rt::productivity_index_oil>)},
+    { "WPIW", generic_potential_rate< rt::productivity_index_water >},
+    { "WPIO", generic_potential_rate< rt::productivity_index_oil >},
+    { "WPIG", generic_potential_rate< rt::productivity_index_gas >},
+    { "WPIL", sum( generic_potential_rate< rt::productivity_index_water >, generic_potential_rate< rt::productivity_index_oil>)},
     // Well potential
-    { "WWPP", generic_well_rate< rt::well_potential_water , true, false>},
-    { "WOPP", generic_well_rate< rt::well_potential_oil , true, false>},
-    { "WGPP", generic_well_rate< rt::well_potential_gas , true, false>},
-    { "WWPI", generic_well_rate< rt::well_potential_water , false, true>},
-    { "WOPI", generic_well_rate< rt::well_potential_oil , false, true>},
-    { "WGPI", generic_well_rate< rt::well_potential_gas , false, true>},
+    { "WWPP", generic_potential_rate< rt::well_potential_water , true, false>},
+    { "WOPP", generic_potential_rate< rt::well_potential_oil , true, false>},
+    { "WGPP", generic_potential_rate< rt::well_potential_gas , true, false>},
+    { "WWPI", generic_potential_rate< rt::well_potential_water , false, true>},
+    { "WOPI", generic_potential_rate< rt::well_potential_oil , false, true>},
+    { "WGPI", generic_potential_rate< rt::well_potential_gas , false, true>},
 };
 
 

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -57,14 +57,16 @@ namespace {
         "FGIR",  "FGIT",  "FGOR", "FGPR",  "FGPT", "FOIP",  "FOIPG",
         "FOIPL", "FOIR",  "FOIT", "FOPR",  "FOPT", "FPR",   "FVIR",
         "FVIT",  "FVPR",  "FVPT", "FWCT",  "FWGR", "FWIP",  "FWIR",
-        "FWIT",  "FWPR",  "FWPT",
+        "FWIT",  "FWPR",  "FWPT", "FWPP",  "FOPP", "FGPP",  "FWPI",
+	"FOPI",  "FGPI",  
         "GGIR",  "GGIT",  "GGOR", "GGPR",  "GGPT", "GOIR",  "GOIT",
         "GOPR",  "GOPT",  "GVIR", "GVIT",  "GVPR", "GVPT",  "GWCT",
-        "GWGR",  "GWIR",  "GWIT", "GWPR",  "GWPT",
+        "GWGR",  "GWIR",  "GWIT", "GWPR",  "GWPT", "GWPP",  "GOPP",
+	"GGPP",  "GWPI",  "GOPI", "GGPI",  
         "WBHP",  "WGIR",  "WGIT", "WGOR",  "WGPR", "WGPT",  "WOIR",
         "WOIT",  "WOPR",  "WOPT", "WPI",   "WTHP", "WVIR",  "WVIT",
         "WVPR",  "WVPT",  "WWCT", "WWGR",  "WWIR", "WWIT",  "WWPR",
-        "WWPT",
+        "WWPT",  "WWPP",  "WOPP", "WGPP",  "WWPI", "WGPI",  "WOPI",
         // ALL will not expand to these keywords yet
         "AAQR",  "AAQRG", "AAQT", "AAQTG"
     };

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -351,14 +351,16 @@ static const auto ALL_keywords = {
     "FGIR",  "FGIT",  "FGOR", "FGPR",  "FGPT", "FOIP",  "FOIPG",
     "FOIPL", "FOIR",  "FOIT", "FOPR",  "FOPT", "FPR",   "FVIR",
     "FVIT",  "FVPR",  "FVPT", "FWCT",  "FWGR", "FWIP",  "FWIR",
-    "FWIT",  "FWPR",  "FWPT",
+    "FWIT",  "FWPR",  "FWPT", "FWPP",  "FOPP", "FGPP",  "FWPI",
+    "FOPI",  "FGPI",
     "GGIR",  "GGIT",  "GGOR", "GGPR",  "GGPT", "GOIR",  "GOIT",
     "GOPR",  "GOPT",  "GVIR", "GVIT",  "GVPR", "GVPT",  "GWCT",
-    "GWGR",  "GWIR",  "GWIT", "GWPR",  "GWPT",
+    "GWGR",  "GWIR",  "GWIT", "GWPR",  "GWPT", "GWPP",  "GOPP",
+    "GGPP",  "GWPI",  "GOPI", "GGPI",
     "WBHP",  "WGIR",  "WGIT", "WGOR",  "WGPR", "WGPT",  "WOIR",
     "WOIT",  "WOPR",  "WOPT", "WPI",   "WTHP", "WVIR",  "WVIT",
     "WVPR",  "WVPT",  "WWCT", "WWGR",  "WWIR", "WWIT",  "WWPR",
-    "WWPT",
+    "WWPT",  "WWPP",  "WOPP", "WGPP",  "WWPI", "WGPI",  "WOPI",
     // ALL will not expand to these keywords yet
     "AAQR",  "AAQRG", "AAQT", "AAQTG"
 };

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -23,7 +23,7 @@ WELLDIMS
 -- Item 3: NGMAX  (Maximum number of groups in model--excluding FIELD)
 -- Item 4: NWGMAX (Maximum number of wells or child groups per group)
 -- NWMAX  NCWMAX  NGMAX  NWGMAX
-   5      2       3      2
+   6      2       3      2
 /
 
 OIL
@@ -145,6 +145,12 @@ FGORH
 FMWPR
 FMWIN
 FOE
+
+FOPP
+FWPP
+FGPP
+FGPI
+FWPI
 
 -- Pressures
 FPR
@@ -337,6 +343,14 @@ GMCTP
 /
 GOPP
 /
+GWPP
+/
+GGPP
+/
+GGPI
+/
+GWPI
+/
 GVIR
 /
 GVIT
@@ -520,6 +534,14 @@ WVPRT
 /
 WOPP
 /
+WWPP
+/
+WGPP
+/
+WGPI
+/
+WWPI
+/
 WVIR
 /
 WVIT
@@ -617,6 +639,7 @@ WELSPECS
      'W_1'        'G_1'   1    1  3.33       'OIL'  7* /
      'W_2'        'G_1'   2    1  3.33       'OIL'  7* /
      'W_3'        'G_2'   3    1  3.92       'WATER'  7* /
+     'W_6'        'G_2'   8    8  3.92       'GAS'  7* /
      'W_5'        'G_3'   4    1  3.92       'OIL'  7* /
 /
 
@@ -628,6 +651,7 @@ COMPDAT
     W_2   0 0  1  1 2*              1*        5  20 0.5 /   -- Active index: 1
     W_2   0 0  2  2 2*              1*        5  10 0.2 /   -- Active index: 101
     W_3   0 0  1  1 2*              1*        2*    0.7 /   -- Active index: 2
+    W_6   0 0  2  2 2*              1*        2*    0.7 /   -- Active index: 2
 /
 
 WPOLYMER
@@ -645,6 +669,11 @@ WCONHIST
 WCONINJH
 -- Injection historical rates (water only, as we only support pure injectors)
     W_3 WATER STOP 30.0 2.1 2.2 /
+/
+
+WCONINJH
+-- Injection historical rates (water only, as we only support pure injectors)
+    W_6 GAS STOP 30000.0  /
 /
 
 WCONPROD

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -311,6 +311,14 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     BOOST_CHECK_CLOSE( (10.1 - 10.5), ecl_sum_get_well_var( resp, 1, "W_1", "WOPRF" ), 1e-5 );
     BOOST_CHECK_CLOSE( (20.1 - 20.5), ecl_sum_get_well_var( resp, 1, "W_2", "WOPRF" ), 1e-5 );
 
+    BOOST_CHECK_CLOSE( 10.13, ecl_sum_get_well_var( resp, 1, "W_1", "WWPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.14, ecl_sum_get_well_var( resp, 1, "W_1", "WOPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.15, ecl_sum_get_well_var( resp, 1, "W_1", "WGPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.13, ecl_sum_get_well_var( resp, 1, "W_2", "WWPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.14, ecl_sum_get_well_var( resp, 1, "W_2", "WOPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 20.15, ecl_sum_get_well_var( resp, 1, "W_2", "WGPP" ), 1e-5 );
+
+    
     /* Production totals */
     BOOST_CHECK_CLOSE( 10.0, ecl_sum_get_well_var( resp, 1, "W_1", "WWPT" ), 1e-5 );
     BOOST_CHECK_CLOSE( 20.0, ecl_sum_get_well_var( resp, 1, "W_2", "WWPT" ), 1e-5 );
@@ -490,6 +498,10 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     BOOST_CHECK_CLOSE( 10.6 + 10.7 + 10.8 + 20.6 + 20.7 + 20.8,
                                     ecl_sum_get_group_var( resp, 1, "G_1", "GVPR" ), 1e-5 );
 
+    BOOST_CHECK_CLOSE( 10.13 + 20.13, ecl_sum_get_group_var( resp, 1, "G_1", "GWPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.14 + 20.14, ecl_sum_get_group_var( resp, 1, "G_1", "GOPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.15 + 20.15, ecl_sum_get_group_var( resp, 1, "G_1", "GGPP" ), 1e-5 );
+    
     /* Production totals */
     BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_group_var( resp, 1, "G_1", "GWPT" ), 1e-5 );
     BOOST_CHECK_CLOSE( 10.1 + 20.1, ecl_sum_get_group_var( resp, 1, "G_1", "GOPT" ), 1e-5 );
@@ -734,6 +746,10 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
     BOOST_CHECK_CLOSE( 10.1 - 10.5 + 20.1 - 20.5,
                                     ecl_sum_get_field_var( resp, 1, "FOPRF" ), 1e-5 );
 
+    BOOST_CHECK_CLOSE( 10.13 + 20.13, ecl_sum_get_field_var( resp, 1, "FWPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.14 + 20.14, ecl_sum_get_field_var( resp, 1, "FOPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 10.15 + 20.15, ecl_sum_get_field_var( resp, 1, "FGPP" ), 1e-5 );
+    
     /* Production totals */
     BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_field_var( resp, 1, "FWPT" ), 1e-5 );
     BOOST_CHECK_CLOSE( 10.1 + 20.1, ecl_sum_get_field_var( resp, 1, "FOPT" ), 1e-5 );

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -136,11 +136,27 @@ static data::Wells result_wells() {
     rates3.set( rt::productivity_index_water, -30.9 / day );
     rates3.set( rt::productivity_index_oil, -30.11 / day );
     rates3.set( rt::productivity_index_gas, -30.12 / day );
-    rates3.set( rt::well_potential_water, -30.13 / day );
-    rates3.set( rt::well_potential_oil, -30.14 / day );
-    rates3.set( rt::well_potential_gas, -30.15 / day );
+    rates3.set( rt::well_potential_water, 30.13 / day );
+    rates3.set( rt::well_potential_oil, 30.14 / day );
+    rates3.set( rt::well_potential_gas, 30.15 / day );
 
-
+    
+    data::Rates rates6;
+    rates6.set( rt::wat, 60.0 / day );
+    rates6.set( rt::oil, 60.1 / day );
+    rates6.set( rt::gas, 60.2 / day );
+    rates6.set( rt::solvent, 60.3 / day );
+    rates6.set( rt::dissolved_gas, 60.4 / day );
+    rates6.set( rt::vaporized_oil, 60.5 / day );
+    rates6.set( rt::reservoir_water, 60.6 / day );
+    rates6.set( rt::reservoir_oil, 60.7 / day );
+    rates6.set( rt::reservoir_gas, 60.8 / day );
+    rates6.set( rt::productivity_index_water, -60.9 / day );
+    rates6.set( rt::productivity_index_oil, -60.11 / day );
+    rates6.set( rt::productivity_index_gas, -60.12 / day );
+    rates6.set( rt::well_potential_water, 60.13 / day );
+    rates6.set( rt::well_potential_oil, 60.14 / day );
+    rates6.set( rt::well_potential_gas, 60.15 / day );
     /* completion rates */
     data::Rates crates1;
     crates1.set( rt::wat, -100.0 / day );
@@ -175,6 +191,17 @@ static data::Wells result_wells() {
     crates3.set( rt::reservoir_oil, 300.7 / day );
     crates3.set( rt::reservoir_gas, 300.8 / day );
 
+    data::Rates crates6;
+    crates6.set( rt::wat, 600.0 / day );
+    crates6.set( rt::oil, 600.1 / day );
+    crates6.set( rt::gas, 600.2 / day );
+    crates6.set( rt::solvent, 600.3 / day );
+    crates6.set( rt::dissolved_gas, 600.4 / day );
+    crates6.set( rt::vaporized_oil, 600.5 / day );
+    crates6.set( rt::reservoir_water, 600.6 / day );
+    crates6.set( rt::reservoir_oil, 600.7 / day );
+    crates6.set( rt::reservoir_gas, 600.8 / day );
+    
     // Segment vectors
     auto segment = ::Opm::data::Segment{};
     segment.rates.set(rt::wat,  123.45*sm3_pr_day());
@@ -192,8 +219,7 @@ static data::Wells result_wells() {
     data::Connection well2_comp1 { 1  , crates2, 1.10 , 123.4, 212.1, 0.78, 0.0, 12.34};
     data::Connection well2_comp2 { 101, crates3, 1.11 , 123.4, 150.6, 0.001, 0.89, 100.0};
     data::Connection well3_comp1 { 2  , crates3, 1.11 , 123.4, 456.78, 0.0, 0.15, 432.1};
-
-
+	data::Connection well6_comp1 { 5  , crates6, 6.11 , 623.4, 656.78, 0.0, 0.65, 632.1};
     /*
       The completions
     */
@@ -207,12 +233,14 @@ static data::Wells result_wells() {
 
     data::Well well2 { rates2, 1.1 * ps, 1.2 * ps, 1.3 * ps, 2, { {well2_comp1 , well2_comp2} }, SegRes{} };
     data::Well well3 { rates3, 2.1 * ps, 2.2 * ps, 2.3 * ps, 3, { {well3_comp1} }, SegRes{} };
+    data::Well well6 { rates6, 2.1 * ps, 2.2 * ps, 2.3 * ps, 3, { {well6_comp1} }, SegRes{} };
 
     data::Wells wellrates;
 
     wellrates["W_1"] = well1;
     wellrates["W_2"] = well2;
     wellrates["W_3"] = well3;
+    wellrates["W_6"] = well6;
 
     wellrates["INJE01"] = SegmentResultHelpers::inje01_results();
     wellrates["PROD01"] = SegmentResultHelpers::prod01_results();
@@ -311,13 +339,14 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     BOOST_CHECK_CLOSE( (10.1 - 10.5), ecl_sum_get_well_var( resp, 1, "W_1", "WOPRF" ), 1e-5 );
     BOOST_CHECK_CLOSE( (20.1 - 20.5), ecl_sum_get_well_var( resp, 1, "W_2", "WOPRF" ), 1e-5 );
 
-    BOOST_CHECK_CLOSE( 10.13, ecl_sum_get_well_var( resp, 1, "W_1", "WWPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 10.14, ecl_sum_get_well_var( resp, 1, "W_1", "WOPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 10.15, ecl_sum_get_well_var( resp, 1, "W_1", "WGPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 20.13, ecl_sum_get_well_var( resp, 1, "W_2", "WWPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 20.14, ecl_sum_get_well_var( resp, 1, "W_2", "WOPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 20.15, ecl_sum_get_well_var( resp, 1, "W_2", "WGPP" ), 1e-5 );
-
+    BOOST_CHECK_CLOSE( -10.13, ecl_sum_get_well_var( resp, 1, "W_1", "WWPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -10.14, ecl_sum_get_well_var( resp, 1, "W_1", "WOPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -10.15, ecl_sum_get_well_var( resp, 1, "W_1", "WGPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -20.13, ecl_sum_get_well_var( resp, 1, "W_2", "WWPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -20.14, ecl_sum_get_well_var( resp, 1, "W_2", "WOPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -20.15, ecl_sum_get_well_var( resp, 1, "W_2", "WGPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE(  30.13, ecl_sum_get_well_var( resp, 1, "W_3", "WWPI" ), 1e-5 );
+    BOOST_CHECK_CLOSE(  60.15, ecl_sum_get_well_var( resp, 1, "W_6", "WGPI" ), 1e-5 );
     
     /* Production totals */
     BOOST_CHECK_CLOSE( 10.0, ecl_sum_get_well_var( resp, 1, "W_1", "WWPT" ), 1e-5 );
@@ -498,9 +527,11 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     BOOST_CHECK_CLOSE( 10.6 + 10.7 + 10.8 + 20.6 + 20.7 + 20.8,
                                     ecl_sum_get_group_var( resp, 1, "G_1", "GVPR" ), 1e-5 );
 
-    BOOST_CHECK_CLOSE( 10.13 + 20.13, ecl_sum_get_group_var( resp, 1, "G_1", "GWPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 10.14 + 20.14, ecl_sum_get_group_var( resp, 1, "G_1", "GOPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 10.15 + 20.15, ecl_sum_get_group_var( resp, 1, "G_1", "GGPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -10.13 - 20.13, ecl_sum_get_group_var( resp, 1, "G_1", "GWPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -10.14 - 20.14, ecl_sum_get_group_var( resp, 1, "G_1", "GOPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -10.15 - 20.15, ecl_sum_get_group_var( resp, 1, "G_1", "GGPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE(  30.13 + 60.13, ecl_sum_get_group_var( resp, 1, "G_2", "GWPI" ), 1e-5 );
+    BOOST_CHECK_CLOSE(  30.15 + 60.15, ecl_sum_get_group_var( resp, 1, "G_2", "GGPI" ), 1e-5 );
     
     /* Production totals */
     BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_group_var( resp, 1, "G_1", "GWPT" ), 1e-5 );
@@ -546,33 +577,33 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     BOOST_CHECK_CLOSE( 30.1 , ecl_sum_get_group_var( resp, 1, "G_3", "GVPRT" ), 1e-5 );
 
     /* Injection rates */
-    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_group_var( resp, 1, "G_2", "GWIR" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.2, ecl_sum_get_group_var( resp, 1, "G_2", "GGIR" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.3, ecl_sum_get_group_var( resp, 1, "G_2", "GNIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.0 + 60.0, ecl_sum_get_group_var( resp, 1, "G_2", "GWIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.2 + 60.2, ecl_sum_get_group_var( resp, 1, "G_2", "GGIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.3 + 60.3, ecl_sum_get_group_var( resp, 1, "G_2", "GNIR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.0 * 1.5, ecl_sum_get_group_var( resp, 1, "G_2", "GCIR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.0 * 2.5, ecl_sum_get_group_var( resp, 2, "G_2", "GCIR" ), 1e-5 );
-    BOOST_CHECK_CLOSE( (30.6 + 30.7 + 30.8),
+    BOOST_CHECK_CLOSE( (30.6 + 30.7 + 30.8 + 60.6 + 60.7 + 60.8),
                        ecl_sum_get_group_var( resp, 1, "G_2", "GVIR" ), 1e-5 );
 
     /* Injection totals */
-    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_group_var( resp, 1, "G_2", "GWIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.2, ecl_sum_get_group_var( resp, 1, "G_2", "GGIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.3, ecl_sum_get_group_var( resp, 1, "G_2", "GNIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.0 + 60.0, ecl_sum_get_group_var( resp, 1, "G_2", "GWIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.2 + 60.2, ecl_sum_get_group_var( resp, 1, "G_2", "GGIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.3 + 60.3, ecl_sum_get_group_var( resp, 1, "G_2", "GNIT" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.0 * 1.5, ecl_sum_get_group_var( resp, 1, "G_2", "GCIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( (30.6 + 30.7 + 30.8),
+    BOOST_CHECK_CLOSE( (30.6 + 30.7 + 30.8 + 60.6 + 60.7 + 60.8),
                        ecl_sum_get_group_var( resp, 1, "G_2", "GVIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 2 * 30.0, ecl_sum_get_group_var( resp, 2, "G_2", "GWIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 2 * 30.2, ecl_sum_get_group_var( resp, 2, "G_2", "GGIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 2 * 30.3, ecl_sum_get_group_var( resp, 2, "G_2", "GNIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (30.0 + 60.0), ecl_sum_get_group_var( resp, 2, "G_2", "GWIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (30.2 + 60.2), ecl_sum_get_group_var( resp, 2, "G_2", "GGIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (30.3 + 60.3), ecl_sum_get_group_var( resp, 2, "G_2", "GNIT" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.0 * 1.5 + 30.0 * 2.5, ecl_sum_get_group_var( resp, 2, "G_2", "GCIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 2 * (30.6 + 30.7 + 30.8),
+    BOOST_CHECK_CLOSE( 2 * (30.6 + 30.7 + 30.8 + 60.6 + 60.7 + 60.8),
                        ecl_sum_get_group_var( resp, 2, "G_2", "GVIT" ), 1e-5 );
 
     /* Injection totals (history) */
     BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_group_var( resp, 1, "G_2", "GWITH" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 0,    ecl_sum_get_group_var( resp, 1, "G_2", "GGITH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30000.,    ecl_sum_get_group_var( resp, 1, "G_2", "GGITH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 60.0, ecl_sum_get_group_var( resp, 2, "G_2", "GWITH" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 0,    ecl_sum_get_group_var( resp, 2, "G_2", "GGITH" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 60000.,    ecl_sum_get_group_var( resp, 2, "G_2", "GGITH" ), 1e-5 );
 
     /* gwct - water cut */
     const double gwcut1 = (10.0 + 20.0) / ( 10.0 + 10.1 + 20.0 + 20.1 );
@@ -603,7 +634,7 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
 
     BOOST_CHECK_EQUAL( 0, ecl_sum_get_group_var( resp, 1, "G_1", "GMWIN" ) );
     BOOST_CHECK_EQUAL( 2, ecl_sum_get_group_var( resp, 1, "G_1", "GMWPR" ) );
-    BOOST_CHECK_EQUAL( 1, ecl_sum_get_group_var( resp, 1, "G_2", "GMWIN" ) );
+    BOOST_CHECK_EQUAL( 2, ecl_sum_get_group_var( resp, 1, "G_2", "GMWIN" ) );
     BOOST_CHECK_EQUAL( 0, ecl_sum_get_group_var( resp, 1, "G_2", "GMWPR" ) );
 }
 
@@ -746,9 +777,11 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
     BOOST_CHECK_CLOSE( 10.1 - 10.5 + 20.1 - 20.5,
                                     ecl_sum_get_field_var( resp, 1, "FOPRF" ), 1e-5 );
 
-    BOOST_CHECK_CLOSE( 10.13 + 20.13, ecl_sum_get_field_var( resp, 1, "FWPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 10.14 + 20.14, ecl_sum_get_field_var( resp, 1, "FOPP" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 10.15 + 20.15, ecl_sum_get_field_var( resp, 1, "FGPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -10.13 - 20.13, ecl_sum_get_field_var( resp, 1, "FWPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -10.14 - 20.14, ecl_sum_get_field_var( resp, 1, "FOPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE( -10.15 - 20.15, ecl_sum_get_field_var( resp, 1, "FGPP" ), 1e-5 );
+    BOOST_CHECK_CLOSE(  30.15 + 60.15, ecl_sum_get_field_var( resp, 1, "FGPI" ), 1e-5 );
+    BOOST_CHECK_CLOSE(  30.13 + 60.13, ecl_sum_get_field_var( resp, 1, "FWPI" ), 1e-5 );
     
     /* Production totals */
     BOOST_CHECK_CLOSE( 10.0 + 20.0, ecl_sum_get_field_var( resp, 1, "FWPT" ), 1e-5 );
@@ -804,21 +837,21 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
                                           ecl_sum_get_field_var( resp, 2, "FLPTH" ), 1e-5 );
 
     /* Injection rates */
-    BOOST_CHECK_CLOSE( 30.0, ecl_sum_get_field_var( resp, 1, "FWIR" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.2, ecl_sum_get_field_var( resp, 1, "FGIR" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.6 + 30.7 + 30.8, ecl_sum_get_field_var( resp, 1, "FVIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.0 + 60., ecl_sum_get_field_var( resp, 1, "FWIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.2 + 60.2, ecl_sum_get_field_var( resp, 1, "FGIR" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.6 + 30.7 + 30.8 + 60.6 + 60.7 + 60.8, ecl_sum_get_field_var( resp, 1, "FVIR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.0 * 1.5, ecl_sum_get_field_var( resp, 1, "FCIR" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.0 * 2.5, ecl_sum_get_field_var( resp, 2, "FCIR" ), 1e-5 );
 
     /* Injection totals */
-    BOOST_CHECK_CLOSE( 30.0,     ecl_sum_get_field_var( resp, 1, "FWIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.2,     ecl_sum_get_field_var( resp, 1, "FGIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 30.6 + 30.7 + 30.8, ecl_sum_get_field_var( resp, 1, "FVIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.0 + 60.,     ecl_sum_get_field_var( resp, 1, "FWIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.2 + 60.2,    ecl_sum_get_field_var( resp, 1, "FGIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 30.6 + 30.7 + 30.8 + 60.6 + 60.7 + 60.8, ecl_sum_get_field_var( resp, 1, "FVIT" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.0 * 1.5,         ecl_sum_get_field_var( resp, 1, "FCIT" ), 1e-5 );
 
-    BOOST_CHECK_CLOSE( 2 * 30.0, ecl_sum_get_field_var( resp, 2, "FWIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 2 * 30.2, ecl_sum_get_field_var( resp, 2, "FGIT" ), 1e-5 );
-    BOOST_CHECK_CLOSE( 2 * (30.6 + 30.7 + 30.8), ecl_sum_get_field_var( resp, 2, "FVIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (30.0 + 60.0), ecl_sum_get_field_var( resp, 2, "FWIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (30.2 + 60.2), ecl_sum_get_field_var( resp, 2, "FGIT" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2 * (30.6 + 30.7 + 30.8 + 60.6 + 60.7 + 60.8), ecl_sum_get_field_var( resp, 2, "FVIT" ), 1e-5 );
     BOOST_CHECK_CLOSE( 30.0 * 1.5 + 30.0 * 2.5,  ecl_sum_get_field_var( resp, 2, "FCIT" ), 1e-5 );
 
     /* Injection totals (history) */
@@ -1623,12 +1656,12 @@ BOOST_AUTO_TEST_CASE(Group_Vectors_Correct)
         BOOST_CHECK_CLOSE(rstrt.get("GVPT:G_2"), 0.0, 1.0e-10);
 
         // Injection rates
-        BOOST_CHECK_CLOSE(rstrt.get("GWIR:G_2"), 30.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(rstrt.get("GGIR:G_2"), 30.2, 1.0e-10);
+        BOOST_CHECK_CLOSE(rstrt.get("GWIR:G_2"), 30.0 + 60.0, 1.0e-10);
+        BOOST_CHECK_CLOSE(rstrt.get("GGIR:G_2"), 30.2 + 60.2, 1.0e-10);
 
         // Injection totals
-        BOOST_CHECK_CLOSE(rstrt.get("GWIT:G_2"), 2 * 1.0 * 30.0, 1.0e-10);
-        BOOST_CHECK_CLOSE(rstrt.get("GGIT:G_2"), 2 * 1.0 * 30.2, 1.0e-10);
+        BOOST_CHECK_CLOSE(rstrt.get("GWIT:G_2"), 2 * 1.0 * (30.0 + 60.0), 1.0e-10);
+        BOOST_CHECK_CLOSE(rstrt.get("GGIT:G_2"), 2 * 1.0 * (30.2 + 60.2), 1.0e-10);
 
         // Water cut
         BOOST_CHECK_CLOSE(rstrt.get("GWCT:G_2"), 0.0, 1.0e-10);
@@ -1674,12 +1707,12 @@ BOOST_AUTO_TEST_CASE(Field_Vectors_Correct)
                        (20.6 + 20.7 + 20.8)), 1.0e-10);
 
     // Injection rates (F = G_2 = W_3)
-    BOOST_CHECK_CLOSE(rstrt.get("FWIR"), 30.0, 1.0e-10);
-    BOOST_CHECK_CLOSE(rstrt.get("FGIR"), 30.2, 1.0e-10);
+    BOOST_CHECK_CLOSE(rstrt.get("FWIR"), (30.0 + 60.0), 1.0e-10);
+    BOOST_CHECK_CLOSE(rstrt.get("FGIR"), (30.2 + 60.2), 1.0e-10);
 
     // Injection totals (F = G_2 = W_3)
-    BOOST_CHECK_CLOSE(rstrt.get("FWIT"), 2 * 1.0 * 30.0, 1.0e-10);
-    BOOST_CHECK_CLOSE(rstrt.get("FGIT"), 2 * 1.0 * 30.2, 1.0e-10);
+    BOOST_CHECK_CLOSE(rstrt.get("FWIT"), 2 * 1.0 * (30.0 + 60.0), 1.0e-10);
+    BOOST_CHECK_CLOSE(rstrt.get("FGIT"), 2 * 1.0 * (30.2 + 60.2), 1.0e-10);
 
     // Water cut (F = G_1 = W_1 + W_2)
     BOOST_CHECK_CLOSE(rstrt.get("FWCT"),


### PR DESCRIPTION
This pullrequest contains an extension of the output of phase potential injection and production rates to Summary file for group levels and field level. The work here is based on the same output for wells, done in pullrequest #554 by @totto82 who also is informed about this addition. 

I will thank my collaborator @bska for valuable discussions and advice during the work.