### PR TITLE
Make Summary Comparison Able to Ignore Different Number of Keywords

### DIFF
--- a/examples/test_util/compareECL.cpp
+++ b/examples/test_util/compareECL.cpp
@@ -281,6 +281,7 @@ int main(int argc, char** argv) {
                 compare.doAnalysis(analysis);
                 compare.setPrintKeywords(printKeywords);
                 compare.setIsRestartFile(restartFile);
+                compare.setAllowDifferentNumberOfKeywords(acceptExtraKeywords);
                 if(specificKeyword){
                     compare.getRegressionTest(keyword);
                 }

--- a/examples/test_util/summaryRegressionTest.cpp
+++ b/examples/test_util/summaryRegressionTest.cpp
@@ -28,7 +28,9 @@ void SummaryRegressionTest::getRegressionTest(){
     setDataSets(timeVec1, timeVec2); //Figures which dataset that contains more/less values pr keyword vector.
     std::cout << "Comparing " << timeVec1.size() << " steps." << std::endl;
     int ivar = 0;
-    if(stringlist_get_size(keysShort) != stringlist_get_size(keysLong)){
+    if((! this->allowDifferentNumberOfKeywords) &&
+        (stringlist_get_size(keysShort) != stringlist_get_size(keysLong)))
+    {
         int missing_count = 0;
         std::cout << "Keywords missing from one case: " << std::endl;
 
@@ -168,4 +170,9 @@ bool SummaryRegressionTest::startTest(const char* keyword){
     }
 
     return result;
+}
+
+void SummaryRegressionTest::setAllowDifferentNumberOfKeywords(const bool allow)
+{
+    this->allowDifferentNumberOfKeywords = allow;
 }

--- a/examples/test_util/summaryRegressionTest.hpp
+++ b/examples/test_util/summaryRegressionTest.hpp
@@ -48,6 +48,12 @@ class SummaryRegressionTest: public SummaryComparator {
         bool checkDeviation(Deviation deviation, const char* keyword, int refIndex, int checkIndex);
 
         bool isRestartFile = false; //!< Private member variable, when true the files that are being compared is a restart file vs a normal file
+
+        /// Whether or not to require that the two files have the same
+        /// number of keywords.  Throw exception if not.
+        /// Default value: false (don't allow different number of keywords).
+        bool allowDifferentNumberOfKeywords = false;
+
     public:
         //! \brief Constructor, creates an object of RefressionTest class.
         //! \param[in] basename1 Path to file1 without extension.
@@ -69,6 +75,13 @@ class SummaryRegressionTest: public SummaryComparator {
         //! \brief This function sets the private member variable isRestartFiles
         //! \param[in] boolean Boolean value
         void setIsRestartFile(bool boolean){this->isRestartFile = boolean;}
+
+        /// \brief Dynamically control whether or not to require equal
+        ///    number of keywords (vectors) in the two result sets.
+        ///
+        /// \param[in] allow Whether or not to allow different number of
+        ///    summary keywords in the two result sets.
+        void setAllowDifferentNumberOfKeywords(const bool allow);
 };
 
 #endif


### PR DESCRIPTION
This commit adds the ability of `SummaryRegressionTest` to bypass the check for equal number keywords/summary vectors in the two result sets being compared.  The primary purpose of this is to continue comparing contents of existing summary vectors if new summary keywords are introduced in a GitHub Pull Request.

Extend the `compareECL` utility to take advantage of this ability.