### PR TITLE
Make the ordering of MULTREGT arbitary

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -109,9 +109,14 @@ namespace Opm {
             if (e3DProps.hasDeckIntGridProperty( record->region_name)) {
                 int srcRegion    = record->src_value;
                 int targetRegion = record->target_value;
+
+                // the MULTREGT keyword is directional independent
+                // i.e. we add it both ways to the lookup map.
                 if (srcRegion != targetRegion) {
-                    std::pair<int,int> pair{ srcRegion, targetRegion };
-                    searchPairs[pair] = &(*record);
+                    std::pair<int,int> pair1{ srcRegion, targetRegion };
+                    std::pair<int,int> pair2{ targetRegion, srcRegion };
+                    searchPairs[pair1] = &(*record);
+                    searchPairs[pair2] = &(*record);
                 }
             }
             else

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -219,7 +219,9 @@ static Opm::Deck createDefaultedRegions() {
         "/\n"
         "MULTREGT\n"
         "3  4   1.25   XYZ   ALL    F /\n"
-        "*  2   0.50   XYZ   ALL    F / -- Defaulted from region value \n"
+        "2  -1   0   XYZ   ALL    F / -- Defaulted from region value \n"
+        "1  -1   0   XYZ   ALL    F / -- Defaulted from region value \n"
+        "2  1   1      XYZ   ALL    F / Override default  \n"
         "/\n"
         "MULTREGT\n"
         "2  *   0.75   XYZ   ALL    F / -- Defaulted to region value \n"
@@ -245,8 +247,8 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   keywords0.push_back( &multregtKeyword0 );
   Opm::MULTREGTScanner scanner0(props, keywords0);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(0,0,1), grid.getGlobalIndex(1,0,1), Opm::FaceDir::XPlus ), 1.25);
-  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(2,0,0), Opm::FaceDir::XPlus ), 0.50);
-  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,1), grid.getGlobalIndex(2,0,0), Opm::FaceDir::ZMinus ), 0.50);
+  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(2,0,0), Opm::FaceDir::XPlus ), 1.0);
+  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,1), grid.getGlobalIndex(2,0,0), Opm::FaceDir::ZMinus ), 0.0);
 
   std::vector<const Opm::DeckKeyword*> keywords1;
   const Opm::DeckKeyword& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -397,10 +397,12 @@ BOOST_AUTO_TEST_CASE( MULTREGT_ECLIPSE_STATE ) {
     const auto& transMult = state.getTransMult();
 
     // Test NONNC
-    // cell 0 and 1 are neigbours
-    BOOST_CHECK_EQUAL( 0.10 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::XPlus));
+    // cell 0 and 1 are neigbour
+    // The last occurence of multiplier between region 1 and 2 is 0.2.
+    // Note that MULTREGT is not direction dependent
+    BOOST_CHECK_EQUAL( 0.20 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::XPlus));
     // cell 0 and 3 are not neigbours ==> 1
-    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 3 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 0.20 , transMult.getRegionMultiplier( 0 , 3 , FaceDir::DirEnum::XPlus));
 
     // Test NNC
     // cell 4 and 5 are neigbours ==> 1
@@ -411,7 +413,7 @@ BOOST_AUTO_TEST_CASE( MULTREGT_ECLIPSE_STATE ) {
     // Test direction X, returns 1 for directions other than +-X
     BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::YPlus));
     BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::ZPlus));
-    BOOST_CHECK_EQUAL( 0.10 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::XMinus));
+    BOOST_CHECK_EQUAL( 0.20 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::XMinus));
     BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::YMinus));
     BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::ZMinus));
     BOOST_CHECK_EQUAL( 0.20 , transMult.getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::XPlus));
@@ -431,9 +433,9 @@ BOOST_AUTO_TEST_CASE( MULTREGT_ECLIPSE_STATE ) {
     BOOST_CHECK_EQUAL( 1.50 , transMult.getRegionMultiplier( 0 , 4 , FaceDir::DirEnum::ZPlus));
     BOOST_CHECK_EQUAL( 1.50 , transMult.getRegionMultiplier( 4 , 0 , FaceDir::DirEnum::XPlus));
 
-    // The first record is overwritten by the second
-    BOOST_CHECK_EQUAL( 2.50 , transMult.getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::XPlus));
-    BOOST_CHECK_EQUAL( 2.50 , transMult.getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::YPlus));
+    // The first record is overwritten by the third since MULTREGT is direction dependent
+    BOOST_CHECK_EQUAL( 0.60 , transMult.getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 0.60 , transMult.getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::YPlus));
 
     // The 2 4 0.75 Z input is overwritten by 2 4 2.5 XY, ==) that 2 4 Z returns the 4 2 value = 0.6
     BOOST_CHECK_EQUAL( 0.60 , transMult.getRegionMultiplier( 7 , 3 , FaceDir::DirEnum::XPlus));


### PR DESCRIPTION
With this 
```
MULTREGT
1 2 1 /
2 1 2 /
/
```
will multiply transmissibilities between region 1 and 2 with 2.