### PR TITLE
Multregt direction

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -109,6 +109,9 @@ namespace Opm {
             if (e3DProps.hasDeckIntGridProperty( record->region_name)) {
                 int srcRegion    = record->src_value;
                 int targetRegion = record->target_value;
+                if (srcRegion > targetRegion)
+                    std::swap(srcRegion, targetRegion);
+
                 if (srcRegion != targetRegion) {
                     std::pair<int,int> pair{ srcRegion, targetRegion };
                     searchPairs[pair] = &(*record);

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -109,8 +109,6 @@ namespace Opm {
             if (e3DProps.hasDeckIntGridProperty( record->region_name)) {
                 int srcRegion    = record->src_value;
                 int targetRegion = record->target_value;
-                if (srcRegion > targetRegion)
-                    std::swap(srcRegion, targetRegion);
 
                 if (srcRegion != targetRegion) {
                     std::pair<int,int> pair{ srcRegion, targetRegion };

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -247,7 +247,11 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   keywords0.push_back( &multregtKeyword0 );
   Opm::MULTREGTScanner scanner0(props, keywords0);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(0,0,1), grid.getGlobalIndex(1,0,1), Opm::FaceDir::XPlus ), 1.25);
-  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(2,0,0), Opm::FaceDir::XPlus ), 1.0);
+
+  /* NB here we get different trans multiplier depending on the direction XPlus og XMinus. Slightly pathological? */
+  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(2,0,0), Opm::FaceDir::XPlus ), 0.0);
+  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(1,0,0), Opm::FaceDir::XMinus ), 1.0);
+
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,1), grid.getGlobalIndex(2,0,0), Opm::FaceDir::ZMinus ), 0.0);
 
   std::vector<const Opm::DeckKeyword*> keywords1;

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -219,7 +219,9 @@ static Opm::Deck createDefaultedRegions() {
         "/\n"
         "MULTREGT\n"
         "3  4   1.25   XYZ   ALL    F /\n"
-        "*  2   0.50   XYZ   ALL    F / -- Defaulted from region value \n"
+        "2  -1   0   XYZ   ALL    F / -- Defaulted from region value \n"
+        "1  -1   0   XYZ   ALL    F / -- Defaulted from region value \n"
+        "2  1   1      XYZ   ALL    F / Override default  \n"
         "/\n"
         "MULTREGT\n"
         "2  *   0.75   XYZ   ALL    F / -- Defaulted to region value \n"
@@ -245,8 +247,8 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   keywords0.push_back( &multregtKeyword0 );
   Opm::MULTREGTScanner scanner0(props, keywords0);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(0,0,1), grid.getGlobalIndex(1,0,1), Opm::FaceDir::XPlus ), 1.25);
-  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(2,0,0), Opm::FaceDir::XPlus ), 0.50);
-  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,1), grid.getGlobalIndex(2,0,0), Opm::FaceDir::ZMinus ), 0.50);
+  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(2,0,0), Opm::FaceDir::XPlus ), 1.0);
+  BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,1), grid.getGlobalIndex(2,0,0), Opm::FaceDir::ZMinus ), 0.0);
 
   std::vector<const Opm::DeckKeyword*> keywords1;
   const Opm::DeckKeyword& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );


### PR DESCRIPTION
My take on this.

I think the "problem/point" is that the lookup function: `MULTREGTScanner::getRegionMultiplier()` has a direction argument.

I don't have the manual now and can not really contribute much more to this at the moment. I think we all agree things should eventually be symmetric - but ...