### PR TITLE
fixing the BHP limit for the history matching wells

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
@@ -36,6 +36,8 @@ namespace Opm {
         double  THPH;
         int     VFPTableNumber;
         bool    predictionMode;
+        // whether the BHP limit is obtained through WELTARG
+        bool BHPLimitFromWeltarg;
         int     injectionControls;
         WellInjector::TypeEnum injectorType;
         WellInjector::ControlModeEnum controlMode;

--- a/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
@@ -36,8 +36,6 @@ namespace Opm {
         double  THPH;
         int     VFPTableNumber;
         bool    predictionMode;
-        // whether the BHP limit is obtained through WELTARG
-        bool BHPLimitFromWeltarg;
         int     injectionControls;
         WellInjector::TypeEnum injectorType;
         WellInjector::ControlModeEnum controlMode;

--- a/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
@@ -60,6 +60,10 @@ namespace Opm {
             if ((injectionControls & controlModeArg) == 0)
                 injectionControls += controlModeArg;
         }
+
+        void resetDefaultHistoricalBHPLimit();
+
+        void setBHPLimit(const double limit);
     };
 
     std::ostream& operator<<( std::ostream&, const WellInjectionProperties& );

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -83,6 +83,12 @@ namespace Opm {
         int m_productionControls = 0;
 
         WellProductionProperties(const DeckRecord& record);
+
+        void resetDefaultBHPLimit();
+
+        void setBHPLimit(const double limit);
+
+        double getBHPLimit() const;
     };
 
     std::ostream& operator<<( std::ostream&, const WellProductionProperties& );

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -57,7 +57,8 @@ namespace Opm {
 
         static WellProductionProperties history(const WellProductionProperties& prevProperties,
                                                 const DeckRecord& record,
-                                                const WellProducer::ControlModeEnum controlModeWHISTCL);
+                                                const WellProducer::ControlModeEnum controlModeWHISTCL,
+                                                const bool switching_from_injector);
 
         static WellProductionProperties prediction( const DeckRecord& record, bool addGroupProductionControl );
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -706,7 +706,7 @@ namespace Opm {
                   current behavoir agrees with the behovir of Eclipse when BHPLimit is not
                   specified while employed during group control.
                 */
-                properties.BHPLimit = record.getItem("BHP").getSIDouble(0);
+                properties.setBHPLimit(record.getItem("BHP").getSIDouble(0));
                 // BHP control should always be there.
                 properties.addInjectionControl(WellInjector::BHP);
 
@@ -1012,22 +1012,20 @@ namespace Opm {
 
                 // when well is under BHP control, we use its historical BHP value as BHP limit
                 if (controlMode == WellInjector::BHP) {
-                    properties.BHPLimit = properties.BHPH;
+                    properties.setBHPLimit(properties.BHPH);
                 } else {
                     const bool switching_from_producer = well->isProducer(currentStep);
                     const bool switching_from_prediction = properties.predictionMode;
-                    const bool switching_from_BHP_control = properties.controlMode == WellInjector::BHP;
+                    const bool switching_from_BHP_control = (properties.controlMode == WellInjector::BHP);
                     if (switching_from_prediction ||
                         switching_from_BHP_control ||
                         switching_from_producer) {
-                        // we use defaulted BHP value, it is from simulation, without finding any related document
-                        properties.BHPLimit = 6891.2 * unit::barsa;
+                        properties.resetDefaultHistoricalBHPLimit();
                     }
                     // otherwise, we keep its previous BHP limit
                 }
 
                 properties.addInjectionControl(WellInjector::BHP);
-
                 properties.addInjectionControl(controlMode);
                 properties.controlMode = controlMode;
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -986,6 +986,9 @@ namespace Opm {
                 updateWellStatus( *well, currentStep, status );
                 WellInjectionProperties properties(well->getInjectionPropertiesCopy(currentStep));
 
+                std::cout << " well " << well->name() << " currentStep " << currentStep << " prev_properties " << std::endl
+                          << properties << std::endl;
+
                 properties.injectorType = injectorType;
 
                 if (!record.getItem("RATE").defaultApplied(0)) {
@@ -1004,6 +1007,8 @@ namespace Opm {
                 // Otherwise, we need to make a decision
                 // TODO: some tests are required to check how WELTARG interacts with WCONINJH BHP control
                 const bool switching_from_producer = well->isProducer(currentStep);
+                std::cout << " well " << well->name() << " switching_from_producer " << switching_from_producer
+                          << " at report step " << currentStep << std::endl;
                 if (properties.predictionMode || properties.controlMode == WellInjector::BHP || switching_from_producer) {
                     // there is no document about what value the default BHP limit should be
                     // we use the one from WCONINJE for now
@@ -1024,6 +1029,9 @@ namespace Opm {
                 if (VFPTableNumber > 0) {
                     properties.VFPTableNumber = VFPTableNumber;
                 }
+
+                std::cout << " well " << well->name() << " currentStep " << currentStep << " new_properties " << std::endl
+                          << properties << std::endl;
 
                 if (well->setInjectionProperties(currentStep, properties))
                     m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , currentStep );

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
@@ -66,6 +66,16 @@ namespace Opm {
         return !(*this == other);
     }
 
+    void WellInjectionProperties::resetDefaultHistoricalBHPLimit() {
+        // this default BHP value is from simulation result,
+        // without finding any related document
+        BHPLimit = 6891.2 * unit::barsa;
+    }
+
+    void WellInjectionProperties::setBHPLimit(const double limit) {
+        BHPLimit = limit;
+    }
+
     std::ostream& operator<<( std::ostream& stream,
                               const WellInjectionProperties& wp ) {
         return stream

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
@@ -40,7 +40,6 @@ namespace Opm {
         THPH=0.0;
         VFPTableNumber=0;
         predictionMode=true;
-        BHPLimitFromWeltarg = false;
         injectionControls=0;
     }
 
@@ -55,7 +54,6 @@ namespace Opm {
             (THPH == other.THPH) &&
             (VFPTableNumber == other.VFPTableNumber) &&
             (predictionMode == other.predictionMode) &&
-            (BHPLimitFromWeltarg == other.BHPLimitFromWeltarg) &&
             (injectionControls == other.injectionControls) &&
             (injectorType == other.injectorType) &&
             (controlMode == other.controlMode))
@@ -81,7 +79,6 @@ namespace Opm {
             << "THPH: "             << wp.THPH << ", "
             << "VFP table: "        << wp.VFPTableNumber << ", "
             << "prediction mode: "  << wp.predictionMode << ", "
-            << "BHP limit is from WELTARG: "  << wp.BHPLimitFromWeltarg << ", "
             << "injection ctrl: "   << wp.injectionControls << ", "
             << "injector type: "    << wp.injectorType << ", "
             << "control mode: "     << wp.controlMode << " }";

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
@@ -40,6 +40,7 @@ namespace Opm {
         THPH=0.0;
         VFPTableNumber=0;
         predictionMode=true;
+        BHPLimitFromWeltarg = false;
         injectionControls=0;
     }
 
@@ -54,6 +55,7 @@ namespace Opm {
             (THPH == other.THPH) &&
             (VFPTableNumber == other.VFPTableNumber) &&
             (predictionMode == other.predictionMode) &&
+            (BHPLimitFromWeltarg == other.BHPLimitFromWeltarg) &&
             (injectionControls == other.injectionControls) &&
             (injectorType == other.injectorType) &&
             (controlMode == other.controlMode))
@@ -79,6 +81,7 @@ namespace Opm {
             << "THPH: "             << wp.THPH << ", "
             << "VFP table: "        << wp.VFPTableNumber << ", "
             << "prediction mode: "  << wp.predictionMode << ", "
+            << "BHP limit is from WELTARG: "  << wp.BHPLimitFromWeltarg << ", "
             << "injection ctrl: "   << wp.injectionControls << ", "
             << "injector type: "    << wp.injectorType << ", "
             << "control mode: "     << wp.controlMode << " }";

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -59,7 +59,6 @@ namespace Opm {
             p.THPH = record.getItem("THP").getSIDouble(0);
 
         const auto& cmodeItem = record.getItem("CMODE");
-
         if ( cmodeItem.defaultApplied(0) ) {
             const std::string msg = "control mode can not be defaulted for keyword WCONHIST";
             throw std::invalid_argument(msg);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -25,6 +25,7 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp>
+#include <opm/parser/eclipse/Units/Units.hpp>
 
 
 namespace Opm {
@@ -75,11 +76,16 @@ namespace Opm {
             if ( !p.hasProductionControl( wp::BHP ) )
                 p.addProductionControl( wp::BHP );
 
-
-            if (cmode == wp::BHP)
+            if (cmode == wp::BHP) {
                 p.BHPLimit = record.getItem( "BHP" ).getSIDouble( 0 );
-            else
-                p.BHPLimit = prev_properties.BHPLimit;
+            } else {
+                if (!prev_properties.predictionMode) {
+                    p.BHPLimit = prev_properties.BHPLimit;
+                } else {
+                    // by default the BHP limit is 1 atm
+                    p.BHPLimit = 1. * unit::atm;
+                }
+            }
         }
 
         if ( record.getItem( "BHP" ).hasValue(0) )

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -44,7 +44,8 @@ namespace Opm {
 
     WellProductionProperties WellProductionProperties::history(const WellProductionProperties& prev_properties,
                                                                const DeckRecord& record,
-                                                               const WellProducer::ControlModeEnum controlModeWHISTCL)
+                                                               const WellProducer::ControlModeEnum controlModeWHISTCL,
+                                                               const bool switching_from_injector)
     {
         WellProductionProperties p(record);
         p.predictionMode = false;
@@ -79,7 +80,7 @@ namespace Opm {
             if (cmode == wp::BHP) {
                 p.BHPLimit = record.getItem( "BHP" ).getSIDouble( 0 );
             } else {
-                if (!prev_properties.predictionMode) {
+                if (!prev_properties.predictionMode && !switching_from_injector) {
                     p.BHPLimit = prev_properties.BHPLimit;
                 } else {
                     // by default the BHP limit is 1 atm

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -87,18 +87,17 @@ namespace Opm {
             p.addProductionControl( wp::BHP );
 
         if (cmode == wp::BHP) {
-            p.BHPLimit = p.BHPH;
+            p.setBHPLimit(p.BHPH);
         } else {
-            // when first time the well is claimed to be history matching producer
+            // when the well is switching to history matching producer from prediction mode
             // or switching from injector to producer
-            // or switching from BHP control to RATE control
+            // or switching from BHP control to RATE control (under history matching mode)
             // we use the defaulted BHP limit, otherwise, we use the previous BHP limit
             if ( prev_properties.predictionMode || switching_from_injector
               || prev_properties.controlMode == wp::BHP ) {
-                // by default the BHP limit is 1 atm
-                p.BHPLimit = 1. * unit::atm;
+                p.resetDefaultBHPLimit();
             } else {
-                p.BHPLimit = prev_properties.BHPLimit;
+                p.setBHPLimit(prev_properties.getBHPLimit());
             }
         }
 
@@ -214,6 +213,18 @@ namespace Opm {
         namespace wp = WellProducer;
         return ( (cmode == wp::LRAT || cmode == wp::RESV || cmode == wp::ORAT ||
                   cmode == wp::WRAT || cmode == wp::GRAT || cmode == wp::BHP) );
+    }
+
+    void WellProductionProperties::resetDefaultBHPLimit() {
+        BHPLimit = 1. * unit::atm;
+    }
+
+    void WellProductionProperties::setBHPLimit(const double limit) {
+        BHPLimit = limit;
+    }
+
+    double WellProductionProperties::getBHPLimit() const {
+        return BHPLimit;
     }
 
 } // namespace Opm

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1397,9 +1397,8 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
             "DATES             -- 3\n"
             " 18  OKT 2008 / \n"
             "/\n"
-            "WCONINJH\n"
-            " 'I' 'WATER' 1* 100 250 / \n"
-            "/\n"
+            "WCONHIST\n"
+            "   'I' 'OPEN' 'RESV' 6*  /\n/\n"
             "DATES             -- 4\n"
             " 20  OKT 2008 / \n"
             "/\n"
@@ -1429,11 +1428,15 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(2).BHPLimit, 600 * 1e5); // 2
 
     // Check that the BHP limit is reset when changing between injector and producer.
-    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 600 * 1e5); // 3
-    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(4).BHPLimit, 600 * 1e5); // 4
+    // well_i is a producer for this report step
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 0); // 3
+    // well_i changes from producer to injector
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(4).BHPLimit, 6895 * 1e5); // 4
 
-    BOOST_CHECK_EQUAL( true  , well_i->getInjectionProperties(2).hasInjectionControl(Opm::WellInjector::BHP) );
-    BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(3).hasInjectionControl(Opm::WellInjector::BHP) );
+    BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(2).hasInjectionControl(Opm::WellInjector::BHP) );
+    // it is a producer
+    BOOST_CHECK_EQUAL( false , well_i->getInjectionProperties(3).hasInjectionControl(Opm::WellInjector::BHP) );
+    BOOST_CHECK_EQUAL( true , well_i->getProductionProperties(3).hasProductionControl(Opm::WellProducer::BHP) );
     BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(4).hasInjectionControl(Opm::WellInjector::BHP) );
 }
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1397,9 +1397,10 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
             "DATES             -- 3\n"
             " 18  OKT 2008 / \n"
             "/\n"
-            "WCONHIST\n"
-            "   'I' 'OPEN' 'RESV' 6*  /\n/\n"
-            "DATES             -- 3\n"
+            "WCONINJH\n"
+            " 'I' 'WATER' 1* 100 250 / \n"
+            "/\n"
+            "DATES             -- 4\n"
             " 20  OKT 2008 / \n"
             "/\n"
             "WCONINJH\n"
@@ -1428,12 +1429,12 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(2).BHPLimit, 600 * 1e5); // 2
 
     // Check that the BHP limit is reset when changing between injector and producer.
-    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 0); // 3
-    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(4).BHPLimit, 0); // 4
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 600 * 1e5); // 3
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(4).BHPLimit, 600 * 1e5); // 4
 
     BOOST_CHECK_EQUAL( true  , well_i->getInjectionProperties(2).hasInjectionControl(Opm::WellInjector::BHP) );
-    BOOST_CHECK_EQUAL( false , well_i->getInjectionProperties(3).hasInjectionControl(Opm::WellInjector::BHP) );
-    BOOST_CHECK_EQUAL( false , well_i->getInjectionProperties(4).hasInjectionControl(Opm::WellInjector::BHP) );
+    BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(3).hasInjectionControl(Opm::WellInjector::BHP) );
+    BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(4).hasInjectionControl(Opm::WellInjector::BHP) );
 }
 
 BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1431,7 +1431,7 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
     // well_i is a producer for this report step
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 0); // 3
     // well_i changes from producer to injector
-    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(4).BHPLimit, 6895 * 1e5); // 4
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(4).BHPLimit, 6891.2 * 1e5); // 4
 
     BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(2).hasInjectionControl(Opm::WellInjector::BHP) );
     // it is a producer

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -773,7 +773,7 @@ namespace {
                 const std::string& cmode_string = whistctl_record.getItem("CMODE").getTrimmedString(0);
                 whistctl_cmode = Opm::WellProducer::ControlModeFromString(cmode_string);
             }
-            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(prev_p, record, whistctl_cmode);;
+            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(prev_p, record, whistctl_cmode, false);;
 
             return hist;
         }

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -850,7 +850,7 @@ BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
     BOOST_CHECK_EQUAL(p.ALQValue, 18.);
-    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 101325.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
@@ -868,7 +868,7 @@ BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
     BOOST_CHECK_EQUAL(p.ALQValue, 18.);
-    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 101325.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
@@ -886,7 +886,7 @@ BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
     BOOST_CHECK_EQUAL(p.ALQValue, 18.);
-    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 101325.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
@@ -904,7 +904,7 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
     BOOST_CHECK_EQUAL(p.ALQValue, 18.);
-    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 101325.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
@@ -923,7 +923,7 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
     BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 12);
     BOOST_CHECK_EQUAL(p.ALQValue, 18.);
-    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 101325.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_NON_Defaulted_VFP)
@@ -942,7 +942,7 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_NON_Defaulted_VFP)
     BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 3);
     BOOST_CHECK_EQUAL(p.ALQValue, 10.);
-    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 101325.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Whistctl)
@@ -963,7 +963,7 @@ BOOST_AUTO_TEST_CASE(WCH_Whistctl)
     BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 3);
     BOOST_CHECK_EQUAL(p.ALQValue, 10.);
-    BOOST_CHECK_EQUAL(p.BHPLimit, 100.);
+    BOOST_CHECK_EQUAL(p.BHPLimit, 101325.);
 }
 
 BOOST_AUTO_TEST_CASE(WCH_BHP_Specified)

--- a/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_SHUT_WELL
+++ b/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_SHUT_WELL
@@ -70,7 +70,7 @@ WELOPEN
 /
 
 WCONHIST
-   'W3'      'SHUT' /
+   'W3'      'SHUT' 'ORAT'/
 /
 
 


### PR DESCRIPTION
Otherwise, we will get zero value BHP limits for history matching wells. 

With WELTARG and a well switching between injector and producer, the answer is unknown at this stage. 

It should be addressed in another PR with testing cases. 

In anyway, this PR makes things `more` correct and address some issue originally thought to be related to `ORAT`. It is a BHP limit problem. 

The downstream PR is https://github.com/OPM/opm-simulators/pull/1362 . 