### PR TITLE
[bugfix] Fix influence of logging on return of getWriteRestartFile

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -505,9 +505,11 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule) {
         if (0 == timestep)
             return m_write_initial_RST_file;
 
-        if (save_keywords[timestep] && log) {
-            std::string logstring = "Fast restart using SAVE is not supported. Standard restart file is written instead";
-            Opm::OpmLog::warning("Unhandled output keyword", logstring);
+        if (save_keywords[timestep]) {
+            if ( log ) {
+                std::string logstring = "Fast restart using SAVE is not supported. Standard restart file is written instead";
+                Opm::OpmLog::warning("Unhandled output keyword", logstring);
+            }
             return true;
         }
 


### PR DESCRIPTION
In PR #578 a bool was introduced that should determine whether we log warnings
during RestartConfig::getWriteRestartFile. Unfortunately, it introduced a bug that
made a false value of log return false from the function. This is fixed by this commit.

The bug fixed here made some parallel runs segfault. Sorry for the inconvenience.