### PR TITLE
Workaround: LIQ preferred phase treated as OIL.

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1591,7 +1591,21 @@ namespace Opm {
         // We change from eclipse's 1 - n, to a 0 - n-1 solution
         int headI = record.getItem("HEAD_I").get< int >(0) - 1;
         int headJ = record.getItem("HEAD_J").get< int >(0) - 1;
-        Phase preferredPhase = get_phase(record.getItem("PHASE").getTrimmedString(0));
+
+        const std::string phaseStr = record.getItem("PHASE").getTrimmedString(0);
+        Phase preferredPhase;
+        if (phaseStr == "LIQ") {
+            // We need a workaround in case the preferred phase is "LIQ",
+            // which is not proper phase and will cause the get_phase()
+            // function to throw. In that case we choose to treat it as OIL.
+            preferredPhase = Phase::OIL;
+            OpmLog::warning("LIQ_PREFERRED_PHASE",
+                            "LIQ preferred phase not supported for well " + wellName + ", using OIL instead");
+        } else {
+            // Normal case.
+            preferredPhase = get_phase(phaseStr);
+        }
+
         const auto& refDepthItem = record.getItem("REF_DEPTH");
 
         double refDepth = refDepthItem.hasValue( 0 )


### PR DESCRIPTION
Making a well's preferred phase LIQ throws and terminates Flow. With this, we simply treat it as OIL and continue. Since it is a workaround, a warning is made.

(However due to other errors, no log messages from the parser are printed, so users will not see it, due to the logging system not being set up before the parsing happens. This seems to be a recurring error... Not to be fixed in this PR!)

I intend to self-merge this as soon as it is green, as it is a show stopper.