### PR TITLE
Parsecontext rpt

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -29,11 +29,12 @@
 namespace Opm {
 
     class Deck;
+    class ParseContext;
 
     class EclipseConfig
     {
     public:
-        EclipseConfig(const Deck& deck);
+        EclipseConfig(const Deck& deck, const ParseContext& parseContext);
 
         const InitConfig& init() const;
         const IOConfig& io() const;

--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -200,7 +200,7 @@ namespace Opm {
     class SOLUTIONSection;
     class TimeMap;
     class Schedule;
-
+    class ParseContext;
 
     /*The IOConfig class holds data about input / ouput configurations
 
@@ -317,9 +317,10 @@ namespace Opm {
     public:
 
         RestartConfig();
-        explicit RestartConfig( const Deck& );
+        explicit RestartConfig( const Deck&, const ParseContext& parseContext );
         RestartConfig( const SCHEDULESection& schedule,
                        const SOLUTIONSection& solution,
+                       const ParseContext& parseContext,
                        TimeMap timemap );
 
 
@@ -329,7 +330,7 @@ namespace Opm {
         int getKeyword( const std::string& keyword, size_t timeStep) const;
 
         void overrideRestartWriteInterval(size_t interval);
-        void handleSolutionSection(const SOLUTIONSection& solutionSection);
+        void handleSolutionSection(const SOLUTIONSection& solutionSection, const ParseContext& parseContext);
         void setWriteInitialRestartFile(bool writeInitialRestartFile);
 
         RestartSchedule getNode( size_t timestep ) const;
@@ -356,7 +357,7 @@ namespace Opm {
         int     m_first_restart_step;
         bool    m_write_initial_RST_file = false;
 
-        void handleScheduleSection( const SCHEDULESection& schedule);
+        void handleScheduleSection( const SCHEDULESection& schedule, const ParseContext& parseContext);
         void update( size_t step, const RestartSchedule& rs);
         static RestartSchedule rptsched( const DeckKeyword& );
 

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -264,14 +264,46 @@ namespace Opm {
         const static std::string ACTIONX_ILLEGAL_KEYWORD;
 
 
-    private:
-        void initDefault();
-        void initEnv();
-        void envUpdate( const std::string& envVariable , InputError::Action action );
-        void patternUpdate( const std::string& pattern , InputError::Action action);
+        /*
+          The RPTSCH, RPTSOL and RPTSCHED keywords have two alternative forms,
+          in the old style all the items are set as integers, i.e. the RPTRST
+          keyword can be configured as:
+
+            RPTRST
+               0 0 0 1 0 1 0 2 0 0 0 0 0 1 0 0 2/
+
+          The new way is based on string mneomnics which can optionally have an
+          integer value, i.e something like:
+
+            RPTRST
+              BASIC=2  FLOWS  ALLPROS /
+
+          It is strictly illegal to mix the two ways to configure keywords. A
+          situation with mixed input style is identified if any of the items are
+          integers. To avoid that the values in the assignments like BASIC=2 are
+          interpreted as integers it is essential that there are no spaces
+          around the '=', and that is also documented in the manual. However -
+          it turns out that Eclipse actually handles e.g.
+
+             RPTRST
+                BASIC = 2 /
+
+          So we have introduced a error mode RPT_MIXED_STYLE which tries to
+          handle this situation. Observe that really mixed input style is
+          impossible to handle, and will lead to a hard exception, but with the
+          RPT_MIXED_STYLE error mode it is possible to configure lenient
+          behavior towards interpreting the input as new style string mneomnics.
+        */
+        const static std::string RPT_MIXED_STYLE;
+
+        const static std::string RPT_UNKNOWN_MNEMONIC;
+
+
+    private: void initDefault(); void initEnv(); void envUpdate( const
+        std::string& envVariable , InputError::Action action ); void
+        patternUpdate( const std::string& pattern , InputError::Action action);
         std::map<std::string , InputError::Action> m_errorContexts;
-        std::set<std::string> ignore_keywords;
-}; }
+        std::set<std::string> ignore_keywords; }; }
 
 
 #endif

--- a/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -28,10 +28,10 @@
 
 namespace Opm {
 
-    EclipseConfig::EclipseConfig(const Deck& deck) :
+    EclipseConfig::EclipseConfig(const Deck& deck, const ParseContext& parseContext) :
             m_ioConfig(        deck),
             m_initConfig(      deck),
-            m_restartConfig(   deck )
+            m_restartConfig(   deck, parseContext )
     {
     }
 

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -53,7 +53,7 @@ namespace Opm {
         m_parseContext(      parseContext ),
         m_tables(            deck ),
         m_runspec(           deck ),
-        m_eclipseConfig(     deck ),
+        m_eclipseConfig(     deck, parseContext ),
         m_deckUnitSystem(    deck.getActiveUnitSystem() ),
         m_inputNnc(          deck ),
         m_inputEditNnc(      deck ),

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -90,6 +90,9 @@ namespace Opm {
         addKey(SCHEDULE_INVALID_NAME, InputError::THROW_EXCEPTION);
 
         addKey(ACTIONX_ILLEGAL_KEYWORD, InputError::THROW_EXCEPTION);
+
+        addKey(RPT_MIXED_STYLE, InputError::WARN);
+        addKey(RPT_UNKNOWN_MNEMONIC, InputError::WARN);
     }
 
     void ParseContext::initEnv() {
@@ -284,6 +287,8 @@ namespace Opm {
     const std::string ParseContext::SUMMARY_UNKNOWN_GROUP = "SUMMARY_UNKNOWN_GROUP";
     const std::string ParseContext::SUMMARY_UNHANDLED_KEYWORD = "SUMMARY_UNHANDLED_KEYWORD";
 
+    const std::string ParseContext::RPT_MIXED_STYLE = "RPT_MIXED_STYLE";
+    const std::string ParseContext::RPT_UNKNOWN_MNEMONIC = "RPT_UNKNOWN_MNEMONIC";
 
     const std::string ParseContext::SCHEDULE_INVALID_NAME = "SCHEDULE_INVALID_NAME";
     const std::string ParseContext::ACTIONX_ILLEGAL_KEYWORD = "ACTIONX_ILLEGAL_KEYWORD";

--- a/tests/parser/IOConfigTests.cpp
+++ b/tests/parser/IOConfigTests.cpp
@@ -188,9 +188,10 @@ BOOST_AUTO_TEST_CASE(DefaultProperties) {
                         " 1 JAN 1986 /\n"
                        "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
+    ParseContext ctx;
+    auto deck = Parser().parseString( data, ctx );
     IOConfig ioConfig( deck );
-    RestartConfig rstConfig( deck );
+    RestartConfig rstConfig( deck, ctx );
 
     /*If no GRIDFILE nor NOGGF keywords are specified, default output an EGRID file*/
     BOOST_CHECK( ioConfig.getWriteEGRIDFile() );

--- a/tests/parser/RestartConfigTests.cpp
+++ b/tests/parser/RestartConfigTests.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED_INTEGER) {
     ParseContext ctx;
 
     auto deck1 = parser.parseString( deckData1, ctx );
-    RestartConfig rstConfig1( deck1 );
+    RestartConfig rstConfig1( deck1, ctx );
 
     BOOST_CHECK(  rstConfig1.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 1 ) );
@@ -254,8 +254,9 @@ BOOST_AUTO_TEST_CASE(RPTRST_mixed_mnemonics_int_list) {
                        "BASIC=1\n"
                        "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    BOOST_CHECK_THROW( RestartConfig c( deck ), std::runtime_error );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    BOOST_CHECK_THROW( RestartConfig c( deck, parseContext ), std::runtime_error );
 }
 
 BOOST_AUTO_TEST_CASE(RPTRST) {
@@ -327,7 +328,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     ParseContext ctx;
 
     auto deck1 = parser.parseString( deckData1, ctx );
-    RestartConfig rstConfig1( deck1 );
+    RestartConfig rstConfig1( deck1, ctx );
 
     // Observe that this is true due to some undocumented guessing that
     // the initial restart file should be written if a RPTRST keyword is
@@ -347,7 +348,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     BOOST_CHECK_EQUAL( rstConfig1.getKeyword( "ALLPROPS" , 2 ) , 0);
 
     auto deck2 = parser.parseString( deckData2, ctx );
-    RestartConfig rstConfig2( deck2 );
+    RestartConfig rstConfig2( deck2, ctx );
 
     const auto expected2 = { "BASIC", "FLOWS", "FREQ" };
     const auto kw_list2 = fun::map( fst, rstConfig2.getRestartKeywords( 2 ) );
@@ -360,7 +361,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 3 ) );
 
     auto deck3 = parser.parseString( deckData3, ctx );
-    RestartConfig rstConfig3( deck3 );
+    RestartConfig rstConfig3( deck3, ctx );
 
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 1 ) );
@@ -456,7 +457,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
     ParseContext ctx;
 
     auto deck1 = parser.parseString( deckData1, ctx );
-    RestartConfig rstConfig1( deck1 );
+    RestartConfig rstConfig1( deck1, ctx );
 
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 1 ) );
@@ -465,7 +466,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
 
 
     auto deck2 = parser.parseString( deckData2, ctx );
-    RestartConfig rstConfig2( deck2 );
+    RestartConfig rstConfig2( deck2, ctx );
 
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 1 ) );
@@ -479,7 +480,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
 
 
     auto deck3 = parser.parseString( deckData3, ctx );
-    RestartConfig rstConfig3( deck3 );
+    RestartConfig rstConfig3( deck3, ctx );
     //Older ECLIPSE 100 data set may use integer controls instead of mnemonics
     BOOST_CHECK(  rstConfig3.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 1 ) );
@@ -522,7 +523,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED_and_RPTRST) {
     ParseContext ctx;
 
     auto deck = parser.parseString( deckData, ctx );
-    RestartConfig rstConfig( deck );
+    RestartConfig rstConfig( deck, ctx );
 
     BOOST_CHECK( !rstConfig.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig.getWriteRestartFile( 1 ) );
@@ -551,8 +552,9 @@ BOOST_AUTO_TEST_CASE(NO_BASIC) {
                        "RPTSCHED\n"
                        "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     for( size_t ts = 0; ts < 4; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -582,8 +584,9 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_1) {
                        "BASIC=1\n"
                        "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     for( size_t ts = 0; ts < 3; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -617,8 +620,9 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_3) {
                         " 6 JAN 1982 14:56:45.123 /\n"  // timestep 11
                         "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     const size_t freq = 3;
 
@@ -654,8 +658,9 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_4) {
                         " 6 JAN 1983 14:56:45.123 /\n"  // timestep 12
                         "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     /* BASIC=4, restart file is written at the first report step of each year.
      */
@@ -692,8 +697,9 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_4_FREQ_2) {
                         " 1 JAN 1986 /\n" 
                         "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     /* BASIC=4, restart file is written at the first report step of each year.
      * Optionally, if the mnemonic FREQ is set >1 the restart is written only
@@ -729,13 +735,14 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_5) {
                         "  1 JAN 1982 /\n"
                         "  2 JAN 1982 /\n"
                         "  1 FEB 1982 /\n" // write
-                        "  1 MAR 1982 /\n" 
+                        "  1 MAR 1982 /\n"
                         "  1 APR 1983 /\n" //write
                         "  2 JUN 1983 /\n"
                         "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     /* BASIC=5, restart file is written at the first report step of each month.
      */
@@ -772,8 +779,9 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_0) {
                         "  2 JUN 1983 /\n"
                         "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext) ;
+    RestartConfig ioConfig( deck, parseContext );
 
     /* RESTART=0, no restart file is written
      */
@@ -808,8 +816,9 @@ BOOST_AUTO_TEST_CASE(RESTART_EQ_0) {
                         "  2 JUN 1983 /\n"
                         "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext);
+    RestartConfig ioConfig( deck, parseContext );
 
     /* RESTART=0, no restart file is written
      */
@@ -845,11 +854,12 @@ BOOST_AUTO_TEST_CASE(RESTART_BASIC_GT_2) {
                         " 26 MAY 1984 /\n"
                         " 26 MAY 1985 /\n" // write
                         " 27 MAY 1985 /\n"
-                        " 1 JAN 1986 /\n" 
+                        " 1 JAN 1986 /\n"
                        "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     for( size_t ts : { 1, 2, 3, 4, 5, 7, 8, 10, 11  } )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -889,8 +899,9 @@ BOOST_AUTO_TEST_CASE(RESTART_BASIC_LEQ_2) {
                         " 1 JAN 1986 /\n"
                        "/\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     BOOST_CHECK( ioConfig.getWriteRestartFile( 1 ) );
     for( size_t ts = 2; ts < 11; ++ts )
@@ -924,9 +935,9 @@ BOOST_AUTO_TEST_CASE(RESTART_SAVE) {
                         "SAVE \n"
                         "TSTEP \n"
                         " 1 /\n";
-
-    auto deck = Parser().parseString( data, ParseContext() );
-    RestartConfig ioConfig( deck );
+    ParseContext parseContext;
+    auto deck = Parser().parseString( data, parseContext );
+    RestartConfig ioConfig( deck, parseContext );
 
     for( size_t ts = 1; ts < 11; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );


### PR DESCRIPTION
We now handle:

```
RPTRST
   BASIC = 2 /
```
i.e. unquoted spaces around the "=". Regulated by the error mode `RPT_MIXED_STYLE` which defaults to `WARN`.

@alfbr: Please give this a spin and merge if appropriate.