### PR TITLE
Add method wells() to the SummaryState class

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -21,6 +21,7 @@
 #define SUMMARY_STATE_H
 
 #include <string>
+#include <vector>
 #include <unordered_map>
 
 #include <ert/ecl/smspec_node.hpp>
@@ -73,10 +74,13 @@ public:
     bool has_well_var(const std::string& well, const std::string& var) const;
     double get_well_var(const std::string& well, const std::string& var) const;
 
+    std::vector<std::string> wells(const std::string& var) const;
     const_iterator begin() const;
     const_iterator end() const;
 private:
     std::unordered_map<std::string,double> values;
+
+    // The first key is the variable and the second key is the well.
     std::unordered_map<std::string, std::unordered_map<std::string, double>> well_values;
 };
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -50,23 +50,23 @@ namespace Opm{
 
     void SummaryState::add_well_var(const std::string& well, const std::string& var, double value) {
         this->add(var + ":" + well, value);
-        this->well_values[well][var] = value;
+        this->well_values[var][well] = value;
     }
 
     bool SummaryState::has_well_var(const std::string& well, const std::string& var) const {
-        const auto& well_iter = this->well_values.find(well);
-        if (well_iter == this->well_values.end())
+        const auto& var_iter = this->well_values.find(var);
+        if (var_iter == this->well_values.end())
             return false;
 
-        const auto& var_iter = well_iter->second.find(var);
-        if (var_iter == well_iter->second.end())
+        const auto& well_iter = var_iter->second.find(well);
+        if (well_iter == var_iter->second.end())
             return false;
 
         return true;
     }
 
     double SummaryState::get_well_var(const std::string& well, const std::string& var) const {
-        return this->well_values.at(well).at(var);
+        return this->well_values.at(var).at(well);
     }
 
 
@@ -77,6 +77,18 @@ namespace Opm{
 
     SummaryState::const_iterator SummaryState::end() const {
         return this->values.end();
+    }
+
+
+    std::vector<std::string> SummaryState::wells(const std::string& var) const {
+        const auto& var_iter = this->well_values.find(var);
+        if (var_iter == this->well_values.end())
+            return {};
+
+        std::vector<std::string> wells;
+        for (const auto& pair : var_iter->second)
+            wells.push_back(pair.first);
+        return wells;
     }
 
 }

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1330,9 +1330,18 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
 
 
     st.add_well_var("OP1", "WWCT", 0.75);
+    st.add_well_var("OP2", "WWCT", 0.75);
     BOOST_CHECK( st.has_well_var("OP1", "WWCT"));
     BOOST_CHECK_EQUAL( st.get_well_var("OP1", "WWCT"), 0.75);
     BOOST_CHECK_EQUAL( st.get_well_var("OP1", "WWCT"), st.get("WWCT:OP1"));
+
+
+    const auto& wopr_wells = st.wells("WOPR");
+    BOOST_CHECK_EQUAL( wopr_wells.size() , 0);
+
+    const auto& wwct_wells = st.wells("WWCT");
+    BOOST_CHECK_EQUAL(std::count(wwct_wells.begin(), wwct_wells.end(), "OP1"), 1);
+    BOOST_CHECK_EQUAL(std::count(wwct_wells.begin(), wwct_wells.end(), "OP2"), 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR adds a small method: `SummaryState::wells(const std::string&var)` which can be used to get a list of all the wells which are registered with a certain variable, i.e.
```C++
const auto& wwct_wells = summary_state.wells("WWCT");
```
will give you a `std::vector<std::string>` of all the wells which have a registered `WWCT` value in the `SummaryState` object. 

This functionality is needed for the `ACTIONX` implementation here: #566