### PR TITLE
Add small class ErrorGuard to store errors from parsing

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -122,6 +122,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/UDQExpression.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
+    src/opm/parser/eclipse/Parser/ErrorGuard.cpp
     src/opm/parser/eclipse/Parser/ParseContext.cpp
     src/opm/parser/eclipse/Parser/Parser.cpp
     src/opm/parser/eclipse/Parser/ParserEnums.cpp
@@ -354,6 +355,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/Units/UnitSystem.hpp
        opm/parser/eclipse/Units/Units.hpp
        opm/parser/eclipse/Units/Dimension.hpp
+       opm/parser/eclipse/Parser/ErrorGuard.hpp
        opm/parser/eclipse/Parser/ParserItem.hpp
        opm/parser/eclipse/Parser/Parser.hpp
        opm/parser/eclipse/Parser/ParserRecord.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -215,6 +215,7 @@ if(ENABLE_ECL_INPUT)
     tests/parser/MULTREGTScannerTests.cpp
     tests/parser/OrderedMapTests.cpp
     tests/parser/ParseContextTests.cpp
+    tests/parser/ParseContext_EXIT1.cpp
     tests/parser/PORVTests.cpp
     tests/parser/RawKeywordTests.cpp
     tests/parser/RestartConfigTests.cpp

--- a/GenerateKeywords.cmake
+++ b/GenerateKeywords.cmake
@@ -7,6 +7,7 @@ set(genkw_SOURCES src/opm/json/JsonObject.cpp
                   src/opm/parser/eclipse/Deck/DeckOutput.cpp
                   src/opm/parser/eclipse/Generator/KeywordGenerator.cpp
                   src/opm/parser/eclipse/Generator/KeywordLoader.cpp
+                  src/opm/parser/eclipse/Parser/ErrorGuard.cpp
                   src/opm/parser/eclipse/Parser/ParseContext.cpp
                   src/opm/parser/eclipse/Parser/ParserEnums.cpp
                   src/opm/parser/eclipse/Parser/ParserItem.cpp

--- a/examples/opmi.cpp
+++ b/examples/opmi.cpp
@@ -21,6 +21,7 @@
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -30,16 +31,16 @@
 
 inline void loadDeck( const char * deck_file) {
     Opm::ParseContext parseContext;
+    Opm::ErrorGuard errors;
     Opm::Parser parser;
 
     std::cout << "Loading deck: " << deck_file << " ..... "; std::cout.flush();
-    auto deck = parser.parseFile(deck_file, parseContext);
+    auto deck = parser.parseFile(deck_file, parseContext, errors);
     std::cout << "parse complete - creating EclipseState .... ";  std::cout.flush();
-    Opm::EclipseState state( deck, parseContext );
-    Opm::Schedule schedule( deck, state.getInputGrid(), state.get3DProperties(), state.runspec(), parseContext);
-    Opm::SummaryConfig summary( deck, schedule, state.getTableManager( ), parseContext );
+    Opm::EclipseState state( deck, parseContext, errors );
+    Opm::Schedule schedule( deck, state.getInputGrid(), state.get3DProperties(), state.runspec(), parseContext, errors);
+    Opm::SummaryConfig summary( deck, schedule, state.getTableManager( ), parseContext, errors );
     std::cout << "complete." << std::endl;
-
 }
 
 

--- a/examples/opmpack.cpp
+++ b/examples/opmpack.cpp
@@ -22,6 +22,7 @@
 #include <boost/filesystem.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -29,9 +30,10 @@
 
 inline void pack_deck( const char * deck_file, std::ostream& os) {
     Opm::ParseContext parseContext(Opm::InputError::WARN);
+    Opm::ErrorGuard errors;
     Opm::Parser parser;
 
-    auto deck = parser.parseFile(deck_file, parseContext);
+    auto deck = parser.parseFile(deck_file, parseContext, errors);
     os << deck;
 
 }

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -30,11 +30,12 @@ namespace Opm {
 
     class Deck;
     class ParseContext;
+    class ErrorGuard;
 
     class EclipseConfig
     {
     public:
-        EclipseConfig(const Deck& deck, const ParseContext& parseContext);
+        EclipseConfig(const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors);
 
         const InitConfig& init() const;
         const IOConfig& io() const;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <vector>
 
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
@@ -65,7 +66,7 @@ namespace Opm {
             AllProperties = IntProperties | DoubleProperties
         };
 
-        EclipseState(const Deck& deck , const ParseContext& parseContext = ParseContext());
+        EclipseState(const Deck& deck , const ParseContext& parseContext, ErrorGuard& errors);
 
         const IOConfig& getIOConfig() const;
         IOConfig& getIOConfig();

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -66,7 +66,10 @@ namespace Opm {
             AllProperties = IntProperties | DoubleProperties
         };
 
+        template<typename T>
+        EclipseState(const Deck& deck , const ParseContext& parseContext, T&& errors);
         EclipseState(const Deck& deck , const ParseContext& parseContext, ErrorGuard& errors);
+        EclipseState(const Deck& deck);
 
         const IOConfig& getIOConfig() const;
         IOConfig& getIOConfig();

--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -201,6 +201,7 @@ namespace Opm {
     class TimeMap;
     class Schedule;
     class ParseContext;
+    class ErrorGuard;
 
     /*The IOConfig class holds data about input / ouput configurations
 
@@ -317,10 +318,11 @@ namespace Opm {
     public:
 
         RestartConfig();
-        explicit RestartConfig( const Deck&, const ParseContext& parseContext );
+        RestartConfig( const Deck&, const ParseContext& parseContext, ErrorGuard& errors );
         RestartConfig( const SCHEDULESection& schedule,
                        const SOLUTIONSection& solution,
                        const ParseContext& parseContext,
+                       ErrorGuard& errors,
                        TimeMap timemap );
 
 
@@ -330,7 +332,7 @@ namespace Opm {
         int getKeyword( const std::string& keyword, size_t timeStep) const;
 
         void overrideRestartWriteInterval(size_t interval);
-        void handleSolutionSection(const SOLUTIONSection& solutionSection, const ParseContext& parseContext);
+        void handleSolutionSection(const SOLUTIONSection& solutionSection, const ParseContext& parseContext, ErrorGuard& errors);
         void setWriteInitialRestartFile(bool writeInitialRestartFile);
 
         RestartSchedule getNode( size_t timestep ) const;
@@ -357,7 +359,7 @@ namespace Opm {
         int     m_first_restart_step;
         bool    m_write_initial_RST_file = false;
 
-        void handleScheduleSection( const SCHEDULESection& schedule, const ParseContext& parseContext);
+        void handleScheduleSection( const SCHEDULESection& schedule, const ParseContext& parseContext, ErrorGuard& errors);
         void update( size_t step, const RestartSchedule& rs);
         static RestartSchedule rptsched( const DeckKeyword& );
 

--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -318,7 +318,13 @@ namespace Opm {
     public:
 
         RestartConfig();
+
+        template<typename T>
+        RestartConfig( const Deck&, const ParseContext& parseContext, T&& errors );
+
         RestartConfig( const Deck&, const ParseContext& parseContext, ErrorGuard& errors );
+        RestartConfig( const Deck& );
+
         RestartConfig( const SCHEDULESection& schedule,
                        const SOLUTIONSection& solution,
                        const ParseContext& parseContext,

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -68,10 +68,32 @@ namespace Opm
                  const ParseContext& parseContext,
                  ErrorGuard& errors);
 
+        template<typename T>
+        Schedule(const Deck& deck,
+                 const EclipseGrid& grid,
+                 const Eclipse3DProperties& eclipseProperties,
+                 const Runspec &runspec,
+                 const ParseContext& parseContext,
+                 T&& errors);
+
+        Schedule(const Deck& deck,
+                 const EclipseGrid& grid,
+                 const Eclipse3DProperties& eclipseProperties,
+                 const Runspec &runspec);
+
         Schedule(const Deck& deck,
                  const EclipseState& es,
                  const ParseContext& parseContext,
                  ErrorGuard& errors);
+
+        template <typename T>
+        Schedule(const Deck& deck,
+                 const EclipseState& es,
+                 const ParseContext& parseContext,
+                 T&& errors);
+
+        Schedule(const Deck& deck,
+                 const EclipseState& es);
 
         /*
          * If the input deck does not specify a start time, Eclipse's 1. Jan

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -57,6 +57,7 @@ namespace Opm
     class SummaryState;
     class TimeMap;
     class UnitSystem;
+    class ErrorGuard;
 
     class Schedule {
     public:
@@ -64,11 +65,13 @@ namespace Opm
                  const EclipseGrid& grid,
                  const Eclipse3DProperties& eclipseProperties,
                  const Runspec &runspec,
-                 const ParseContext& parseContext = ParseContext());
+                 const ParseContext& parseContext,
+                 ErrorGuard& errors);
 
         Schedule(const Deck& deck,
                  const EclipseState& es,
-                 const ParseContext& parseContext = ParseContext());
+                 const ParseContext& parseContext,
+                 ErrorGuard& errors);
 
         /*
          * If the input deck does not specify a start time, Eclipse's 1. Jan
@@ -120,7 +123,7 @@ namespace Opm
         std::vector< const Group* > getGroups(size_t timeStep) const;
         const Tuning& getTuning() const;
         const MessageLimits& getMessageLimits() const;
-        void invalidNamePattern (const std::string& namePattern, const ParseContext& parseContext, const DeckKeyword& keyword) const;
+        void invalidNamePattern (const std::string& namePattern, const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword) const;
 
         const Events& getEvents() const;
         const Deck& getModifierDeck(size_t timeStep) const;
@@ -158,41 +161,41 @@ namespace Opm
 
         void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( Group& newGroup , Well& well , size_t timeStep);
-        void iterateScheduleSection(const ParseContext& parseContext ,  const SCHEDULESection& , const EclipseGrid& grid,
+        void iterateScheduleSection(const ParseContext& parseContext ,  ErrorGuard& errors, const SCHEDULESection& , const EclipseGrid& grid,
                                     const Eclipse3DProperties& eclipseProperties);
         bool handleGroupFromWELSPECS(const std::string& groupName, GroupTree& newTree) const;
         void addGroup(const std::string& groupName , size_t timeStep);
         void addWell(const std::string& wellName, const DeckRecord& record, size_t timeStep, WellCompletion::CompletionOrderEnum wellCompletionOrder);
-        void handleCOMPORD(const ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t currentStep);
+        void handleCOMPORD(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& compordKeyword, size_t currentStep);
         void handleWELSPECS( const SCHEDULESection&, size_t, size_t  );
-        void handleWCONProducer( const DeckKeyword& keyword, size_t currentStep, bool isPredictionMode,  const ParseContext& parseContext);
-        void handleWCONHIST( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
+        void handleWCONProducer( const DeckKeyword& keyword, size_t currentStep, bool isPredictionMode,  const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWCONHIST( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWGRUPCON( const DeckKeyword& keyword, size_t currentStep);
-        void handleCOMPDAT( const DeckKeyword& keyword,  size_t currentStep, const EclipseGrid& grid, const Eclipse3DProperties& eclipseProperties, const ParseContext& parseContext);
+        void handleCOMPDAT( const DeckKeyword& keyword,  size_t currentStep, const EclipseGrid& grid, const Eclipse3DProperties& eclipseProperties, const ParseContext& parseContext, ErrorGuard& errors);
         void handleCOMPLUMP( const DeckKeyword& keyword,  size_t currentStep );
         void handleWELSEGS( const DeckKeyword& keyword, size_t currentStep);
         void handleCOMPSEGS( const DeckKeyword& keyword, size_t currentStep, const EclipseGrid& grid);
-        void handleWCONINJE( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWPOLYMER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWSOLVENT( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWTRACER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWPMITAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext);
-        void handleWSKPTAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext);
-        void handleWINJTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWCONINJH( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWELOPEN( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext );
-        void handleWELTARG( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleGCONINJE( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleGCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleGEFAC( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWEFAC( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
+        void handleWCONINJE( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWPOLYMER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWSOLVENT( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWTRACER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWPMITAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWSKPTAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWINJTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWCONINJH( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWELOPEN( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors );
+        void handleWELTARG( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleGCONINJE( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleGCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleGEFAC( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWEFAC( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleTUNING( const DeckKeyword& keyword, size_t currentStep);
         void handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep);
         void handleGRUPNET( const DeckKeyword& keyword, size_t currentStep);
         void handleWRFT( const DeckKeyword& keyword, size_t currentStep);
-        void handleWTEST( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
+        void handleWTEST( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWRFTPLT( const DeckKeyword& keyword, size_t currentStep);
         void handleWPIMULT( const DeckKeyword& keyword, size_t currentStep);
         void handleDRSDT( const DeckKeyword& keyword, size_t currentStep);
@@ -200,8 +203,8 @@ namespace Opm
         void handleDRSDTR( const DeckKeyword& keyword, size_t currentStep);
         void handleDRVDTR( const DeckKeyword& keyword, size_t currentStep);
         void handleVAPPARS( const DeckKeyword& keyword, size_t currentStep);
-        void handleWECON( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext);
-        void handleWHISTCTL(const ParseContext& parseContext, const DeckKeyword& keyword);
+        void handleWECON( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWHISTCTL(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword);
         void handleMESSAGES(const DeckKeyword& keyword, size_t currentStep);
         void handleVFPPROD(const DeckKeyword& vfpprodKeyword, const UnitSystem& unit_system, size_t currentStep);
         void handleVFPINJ(const DeckKeyword& vfpprodKeyword, const UnitSystem& unit_system, size_t currentStep);
@@ -211,7 +214,7 @@ namespace Opm
                            const SCHEDULESection& section,
                            size_t keywordIdx,
                            const DeckKeyword& keyword,
-                           const ParseContext& parseContext,
+                           const ParseContext& parseContext, ErrorGuard& errors,
                            const EclipseGrid& grid,
                            const Eclipse3DProperties& eclipseProperties,
                            const UnitSystem& unit_system,

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -99,6 +99,7 @@ namespace Opm {
     class EclipseState;
     class ParserKeyword;
     class Schedule;
+    class ErrorGuard;
     class ParseContext;
     class GridDims;
 
@@ -109,7 +110,7 @@ namespace Opm {
             typedef keyword_list::const_iterator const_iterator;
 
             SummaryConfig( const Deck&, const Schedule&,
-                           const TableManager&, const ParseContext&);
+                           const TableManager&, const ParseContext&, ErrorGuard&);
 
             const_iterator begin() const;
             const_iterator end() const;
@@ -141,6 +142,7 @@ namespace Opm {
                            const Schedule& schedule,
                            const TableManager& tables,
                            const ParseContext& parseContext,
+                           ErrorGuard& errors,
                            const GridDims& dims);
 
             /*

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -109,8 +109,24 @@ namespace Opm {
             typedef std::vector< keyword_type > keyword_list;
             typedef keyword_list::const_iterator const_iterator;
 
-            SummaryConfig( const Deck&, const Schedule&,
-                           const TableManager&, const ParseContext&, ErrorGuard&);
+            SummaryConfig( const Deck&,
+                           const Schedule&,
+                           const TableManager&,
+                           const ParseContext&,
+                           ErrorGuard&);
+
+            template <typename T>
+            SummaryConfig( const Deck&,
+                           const Schedule&,
+                           const TableManager&,
+                           const ParseContext&,
+                           T&&);
+
+            SummaryConfig( const Deck&,
+                           const Schedule&,
+                           const TableManager&);
+
+
 
             const_iterator begin() const;
             const_iterator end() const;

--- a/opm/parser/eclipse/Parser/ErrorGuard.hpp
+++ b/opm/parser/eclipse/Parser/ErrorGuard.hpp
@@ -40,6 +40,7 @@ public:
       stderr and throw std::runtime_error.
     */
     ~ErrorGuard();
+    void terminate() const;
 
 private:
     void dump() const;

--- a/opm/parser/eclipse/Parser/ErrorGuard.hpp
+++ b/opm/parser/eclipse/Parser/ErrorGuard.hpp
@@ -41,9 +41,9 @@ public:
     */
     ~ErrorGuard();
     void terminate() const;
+    void dump() const;
 
 private:
-    void dump() const;
 
     std::vector<std::pair<std::string, std::string>> error_list;
     std::vector<std::pair<std::string, std::string>> warning_list;

--- a/opm/parser/eclipse/Parser/ErrorGuard.hpp
+++ b/opm/parser/eclipse/Parser/ErrorGuard.hpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2019 Joakim Hove/datagr
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef ERROR_GUARD_HPP
+#define ERROR_GUARD_HPP
+
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+class ErrorGuard {
+public:
+    void addError(const std::string& errorKey, const std::string& msg);
+    void addWarning(const std::string& errorKey, const std::string &msg);
+    void clear();
+
+    explicit operator bool() const { return !this->error_list.empty(); }
+
+    /*
+      Observe that this desctructor has a somewhat special semantics. If there
+      are errors in the error list it will print all warnings and errors on
+      stderr and throw std::runtime_error.
+    */
+    ~ErrorGuard();
+
+private:
+    void dump() const;
+
+    std::vector<std::pair<std::string, std::string>> error_list;
+    std::vector<std::pair<std::string, std::string>> warning_list;
+};
+
+}
+
+#endif

--- a/opm/parser/eclipse/Parser/InputErrorAction.hpp
+++ b/opm/parser/eclipse/Parser/InputErrorAction.hpp
@@ -37,7 +37,8 @@ namespace Opm {
             THROW_EXCEPTION = 0,
             WARN = 1,
             IGNORE = 2,
-            EXIT1 = 3
+            EXIT1 = 3,
+            DELAYED_EXIT1 = 4
         };
     }
 }

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -79,14 +79,16 @@ namespace Opm {
        recognizd keys will be allowed.
     */
 
+    class ErrorGuard;
+
     class ParseContext {
     public:
         ParseContext();
         explicit ParseContext(InputError::Action default_action);
         explicit ParseContext(const std::vector<std::pair<std::string , InputError::Action>>& initial);
 
-        void handleError( const std::string& errorKey, const std::string& msg ) const;
-        void handleUnknownKeyword(const std::string& keyword) const;
+        void handleError( const std::string& errorKey, const std::string& msg, ErrorGuard& errors ) const;
+        void handleUnknownKeyword(const std::string& keyword, ErrorGuard& errors) const;
         bool hasKey(const std::string& key) const;
         ParseContext  withKey(const std::string& key, InputError::Action action = InputError::WARN) const;
         ParseContext& withKey(const std::string& key, InputError::Action action = InputError::WARN);

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -57,9 +57,12 @@ namespace Opm {
                        const ParseContext&,
                        ErrorGuard& errors) const;
 
+        Deck parseFile(const std::string& datafile);
+
         Deck parseString(const std::string &data,
                          const ParseContext&,
                          ErrorGuard& errors) const;
+        Deck parseString(const std::string &data) const;
 
         Deck parseStream(std::unique_ptr<std::istream>&& inputStream , const ParseContext& parseContext, ErrorGuard& errors) const;
 

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -39,6 +39,7 @@ namespace Opm {
 
     class Deck;
     class ParseContext;
+    class ErrorGuard;
     class RawKeyword;
 
     /// The hub of the parsing process.
@@ -53,10 +54,14 @@ namespace Opm {
 
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
         Deck parseFile(const std::string &dataFile,
-                       const ParseContext& = ParseContext()) const;
+                       const ParseContext&,
+                       ErrorGuard& errors) const;
+
         Deck parseString(const std::string &data,
-                         const ParseContext& = ParseContext()) const;
-        Deck parseStream(std::unique_ptr<std::istream>&& inputStream , const ParseContext& parseContext) const;
+                         const ParseContext&,
+                         ErrorGuard& errors) const;
+
+        Deck parseStream(std::unique_ptr<std::istream>&& inputStream , const ParseContext& parseContext, ErrorGuard& errors) const;
 
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addParserKeyword(const Json::JsonObject& jsonKeyword);
@@ -90,27 +95,30 @@ namespace Opm {
             addParserKeyword( std::unique_ptr< ParserKeyword >( new T ) );
         }
 
-        static EclipseState parse(const Deck& deck,            const ParseContext& context = ParseContext());
-        static EclipseState parse(const std::string &filename, const ParseContext& context = ParseContext());
-        static EclipseState parseData(const std::string &data, const ParseContext& context = ParseContext());
+        static EclipseState parse(const Deck& deck,            const ParseContext& context, ErrorGuard& errors);
+        static EclipseState parse(const std::string &filename, const ParseContext& context, ErrorGuard& errors);
+        static EclipseState parseData(const std::string &data, const ParseContext& context, ErrorGuard& errors);
 
         /// Parses the deck specified in filename.  If context contains ParseContext::PARSE_PARTIAL_DECK,
         /// we construct only a lean grid, otherwise, we construct a full EclipseState and return the
         /// fully constructed InputGrid
         static EclipseGrid parseGrid(const std::string &filename,
-                const ParseContext& context = ParseContext());
+                                     const ParseContext& context,
+                                     ErrorGuard& errors);
 
         /// Parses the provided deck.  If context contains ParseContext::PARSE_PARTIAL_DECK,
         /// we construct only a lean grid, otherwise, we construct a full EclipseState and return the
         /// fully constructed InputGrid
         static EclipseGrid parseGrid(const Deck& deck,
-                const ParseContext& context = ParseContext());
+                                     const ParseContext& context,
+                                     ErrorGuard& errors);
 
         /// Parses the provided deck string.  If context contains ParseContext::PARSE_PARTIAL_DECK,
         /// we construct only a lean grid, otherwise, we construct a full EclipseState and return the
         /// fully constructed InputGrid
         static EclipseGrid parseGridData(const std::string &data,
-                const ParseContext& context = ParseContext());
+                                         const ParseContext& context,
+                                         ErrorGuard& errors);
 
     private:
         // associative map of the parser internal name and the corresponding ParserKeyword object

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -37,9 +37,11 @@ namespace Opm {
     class Deck;
     class DeckKeyword;
     class ParseContext;
+    class ErrorGuard;
     class ParserDoubleItem;
     class RawKeyword;
     class string_view;
+    class ErrorGuard;
 
     /*
       Small helper struct to assemble the information needed to infer the size
@@ -122,7 +124,7 @@ namespace Opm {
         SectionNameSet::const_iterator validSectionNamesBegin() const;
         SectionNameSet::const_iterator validSectionNamesEnd() const;
 
-        DeckKeyword parse(const ParseContext& parseContext , std::shared_ptr< RawKeyword > rawKeyword) const;
+        DeckKeyword parse(const ParseContext& parseContext, ErrorGuard& errors, std::shared_ptr< RawKeyword > rawKeyword) const;
         enum ParserKeywordSizeEnum getSizeType() const;
         const KeywordSize& getKeywordSize() const;
         bool isDataKeyword() const;

--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -33,6 +33,7 @@ namespace Opm {
     class ParseContext;
     class ParserItem;
     class RawRecord;
+    class ErrorGuard;
 
     class ParserRecord {
     public:
@@ -42,7 +43,7 @@ namespace Opm {
         void addDataItem( ParserItem item );
         const ParserItem& get(size_t index) const;
         const ParserItem& get(const std::string& itemName) const;
-        DeckRecord parse( const ParseContext&, RawRecord& ) const;
+        DeckRecord parse( const ParseContext&, ErrorGuard&, RawRecord&) const;
         bool isDataRecord() const;
         bool equal(const ParserRecord& other) const;
         bool hasDimension() const;

--- a/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -28,10 +28,10 @@
 
 namespace Opm {
 
-    EclipseConfig::EclipseConfig(const Deck& deck, const ParseContext& parseContext) :
+    EclipseConfig::EclipseConfig(const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors) :
             m_ioConfig(        deck),
             m_initConfig(      deck),
-            m_restartConfig(   deck, parseContext )
+            m_restartConfig(   deck, parseContext, errors )
     {
     }
 

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -49,10 +49,10 @@
 
 namespace Opm {
 
-    EclipseState::EclipseState(const Deck& deck, const ParseContext& parseContext) :
+    EclipseState::EclipseState(const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors) :
         m_tables(            deck ),
         m_runspec(           deck ),
-        m_eclipseConfig(     deck, parseContext ),
+        m_eclipseConfig(     deck, parseContext, errors ),
         m_deckUnitSystem(    deck.getActiveUnitSystem() ),
         m_inputNnc(          deck ),
         m_inputEditNnc(      deck ),

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -49,7 +49,8 @@
 
 namespace Opm {
 
-    EclipseState::EclipseState(const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors) :
+
+    EclipseState::EclipseState(const Deck& deck , const ParseContext& parseContext, ErrorGuard& errors) :
         m_tables(            deck ),
         m_runspec(           deck ),
         m_eclipseConfig(     deck, parseContext, errors ),
@@ -77,6 +78,18 @@ namespace Opm {
         initTransMult();
         initFaults(deck);
     }
+
+
+    template<typename T>
+    EclipseState::EclipseState(const Deck& deck, const ParseContext& parseContext, T&& errors) :
+        EclipseState(deck, parseContext, errors)
+    {}
+
+
+    EclipseState::EclipseState(const Deck& deck) :
+        EclipseState(deck, ParseContext(), ErrorGuard())
+    {}
+
 
     const UnitSystem& EclipseState::getDeckUnitSystem() const {
         return m_deckUnitSystem;

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -29,6 +29,7 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
@@ -517,6 +518,15 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
                        parseContext,
                        errors,
                        TimeMap{ deck } )
+    {}
+
+    template<typename T>
+    RestartConfig::RestartConfig( const Deck& deck, const ParseContext& parseContext, T&& errors ) :
+        RestartConfig(deck, parseContext, errors)
+    {}
+
+    RestartConfig::RestartConfig( const Deck& deck) :
+        RestartConfig(deck, ParseContext(), ErrorGuard())
     {}
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -104,6 +104,25 @@ namespace Opm {
     }
 
 
+    template <typename T>
+    Schedule::Schedule( const Deck& deck,
+                        const EclipseGrid& grid,
+                        const Eclipse3DProperties& eclipseProperties,
+                        const Runspec &runspec,
+                        const ParseContext& parseContext,
+                        T&& errors) :
+        Schedule(deck, grid, eclipseProperties, runspec, parseContext, errors)
+    {}
+
+
+    Schedule::Schedule( const Deck& deck,
+                        const EclipseGrid& grid,
+                        const Eclipse3DProperties& eclipseProperties,
+                        const Runspec &runspec) :
+        Schedule(deck, grid, eclipseProperties, runspec, ParseContext(), ErrorGuard())
+    {}
+
+
     Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, ErrorGuard& errors) :
         Schedule(deck,
                  es.getInputGrid(),
@@ -114,6 +133,21 @@ namespace Opm {
     {}
 
 
+
+    template <typename T>
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, T&& errors) :
+        Schedule(deck,
+                 es.getInputGrid(),
+                 es.get3DProperties(),
+                 es.runspec(),
+                 parse_context,
+                 errors)
+    {}
+
+
+    Schedule::Schedule(const Deck& deck, const EclipseState& es) :
+        Schedule(deck, es, ParseContext(), ErrorGuard())
+    {}
 
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -70,7 +70,8 @@ namespace Opm {
                         const EclipseGrid& grid,
                         const Eclipse3DProperties& eclipseProperties,
                         const Runspec &runspec,
-                        const ParseContext& parseContext) :
+                        const ParseContext& parseContext,
+                        ErrorGuard& errors) :
         m_timeMap( deck ),
         m_rootGroupTree( this->m_timeMap, GroupTree{} ),
         m_oilvaporizationproperties( this->m_timeMap, OilVaporizationProperties(runspec.tabdims().getNumPVTTables()) ),
@@ -99,16 +100,17 @@ namespace Opm {
         }
 
         if (Section::hasSCHEDULE(deck))
-            iterateScheduleSection( parseContext, SCHEDULESection( deck ), grid, eclipseProperties );
+            iterateScheduleSection( parseContext, errors, SCHEDULESection( deck ), grid, eclipseProperties );
     }
 
 
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context) :
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, ErrorGuard& errors) :
         Schedule(deck,
                  es.getInputGrid(),
                  es.get3DProperties(),
                  es.runspec(),
-                 parse_context)
+                 parse_context,
+                 errors)
     {}
 
 
@@ -133,6 +135,7 @@ namespace Opm {
                                  size_t keywordIdx,
                                  const DeckKeyword& keyword,
                                  const ParseContext& parseContext,
+                                 ErrorGuard& errors,
                                  const EclipseGrid& grid,
                                  const Eclipse3DProperties& eclipseProperties,
                                  const UnitSystem& unit_system,
@@ -175,49 +178,49 @@ namespace Opm {
             handleWELSPECS( section, keywordIdx, currentStep );
 
         else if (keyword.name() == "WHISTCTL")
-            handleWHISTCTL(parseContext, keyword);
+            handleWHISTCTL(parseContext, errors, keyword);
 
         else if (keyword.name() == "WCONHIST")
-            handleWCONHIST(keyword, currentStep, parseContext);
+            handleWCONHIST(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WCONPROD")
-            handleWCONPROD(keyword, currentStep, parseContext);
+            handleWCONPROD(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WCONINJE")
-            handleWCONINJE(section, keyword, currentStep, parseContext);
+            handleWCONINJE(section, keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WPOLYMER")
-            handleWPOLYMER(keyword, currentStep, parseContext);
+            handleWPOLYMER(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WSOLVENT")
-            handleWSOLVENT(keyword, currentStep, parseContext);
+            handleWSOLVENT(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WTRACER")
-            handleWTRACER(keyword, currentStep, parseContext);
+            handleWTRACER(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WTEST")
-            handleWTEST(keyword, currentStep, parseContext);
+            handleWTEST(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WTEMP")
-            handleWTEMP(keyword, currentStep, parseContext);
+            handleWTEMP(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WPMITAB")
-            handleWPMITAB(keyword, currentStep, parseContext);
+            handleWPMITAB(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WSKPTAB")
-            handleWSKPTAB(keyword, currentStep, parseContext);
+            handleWSKPTAB(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WINJTEMP")
-            handleWINJTEMP(keyword, currentStep, parseContext);
+            handleWINJTEMP(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WCONINJH")
-            handleWCONINJH(section, keyword, currentStep, parseContext);
+            handleWCONINJH(section, keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WGRUPCON")
             handleWGRUPCON(keyword, currentStep);
 
         else if (keyword.name() == "COMPDAT")
-            handleCOMPDAT(keyword, currentStep, grid, eclipseProperties, parseContext);
+            handleCOMPDAT(keyword, currentStep, grid, eclipseProperties, parseContext, errors);
 
         else if (keyword.name() == "WELSEGS")
             handleWELSEGS(keyword, currentStep);
@@ -226,10 +229,10 @@ namespace Opm {
             handleCOMPSEGS(keyword, currentStep, grid);
 
         else if (keyword.name() == "WELOPEN")
-            handleWELOPEN(keyword, currentStep, parseContext);
+            handleWELOPEN(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WELTARG")
-            handleWELTARG(section, keyword, currentStep, parseContext);
+            handleWELTARG(section, keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "GRUPTREE")
             handleGRUPTREE(keyword, currentStep);
@@ -238,13 +241,13 @@ namespace Opm {
             handleGRUPNET(keyword, currentStep);
 
         else if (keyword.name() == "GCONINJE")
-            handleGCONINJE(section, keyword, currentStep, parseContext);
+            handleGCONINJE(section, keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "GCONPROD")
-            handleGCONPROD(keyword, currentStep, parseContext);
+            handleGCONPROD(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "GEFAC")
-            handleGEFAC(keyword, currentStep, parseContext);
+            handleGEFAC(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "TUNING")
             handleTUNING(keyword, currentStep);
@@ -259,7 +262,7 @@ namespace Opm {
             handleWPIMULT(keyword, currentStep);
 
         else if (keyword.name() == "COMPORD")
-            handleCOMPORD(parseContext , keyword, currentStep);
+            handleCOMPORD(parseContext, errors , keyword, currentStep);
 
         else if (keyword.name() == "COMPLUMP")
             handleCOMPLUMP(keyword, currentStep);
@@ -280,13 +283,13 @@ namespace Opm {
             handleVAPPARS(keyword, currentStep);
 
         else if (keyword.name() == "WECON")
-            handleWECON(keyword, currentStep, parseContext);
+            handleWECON(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "MESSAGES")
             handleMESSAGES(keyword, currentStep);
 
         else if (keyword.name() == "WEFAC")
-            handleWEFAC(keyword, currentStep, parseContext);
+            handleWEFAC(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "VFPINJ")
             handleVFPINJ(keyword, unit_system, currentStep);
@@ -301,13 +304,13 @@ namespace Opm {
                 m_events.addEvent( ScheduleEvents::GEO_MODIFIER , currentStep);
             } else {
                 std::string msg = "OPM does not support grid property modifier " + keyword.name() + " in the Schedule section. Error at report: " + std::to_string( currentStep );
-                parseContext.handleError( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , msg );
+                parseContext.handleError( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , msg, errors );
             }
         }
     }
 
 
-    void Schedule::iterateScheduleSection(const ParseContext& parseContext , const SCHEDULESection& section , const EclipseGrid& grid,
+    void Schedule::iterateScheduleSection(const ParseContext& parseContext , ErrorGuard& errors, const SCHEDULESection& section , const EclipseGrid& grid,
                                           const Eclipse3DProperties& eclipseProperties) {
         size_t currentStep = 0;
         const auto& unit_system = section.unitSystem();
@@ -329,13 +332,13 @@ namespace Opm {
 
                     if (actionx_whitelist.find(action_keyword.name()) == actionx_whitelist.end()) {
                         std::string msg = "The keyword " + action_keyword.name() + " is not supported in a ACTIONX block.";
-                        parseContext.handleError( ParseContext::ACTIONX_ILLEGAL_KEYWORD, msg);
+                        parseContext.handleError( ParseContext::ACTIONX_ILLEGAL_KEYWORD, msg, errors);
                     } else
                         action.addKeyword(action_keyword);
                 }
                 this->actions.add(action);
             } else
-                this->handleKeyword(currentStep, section, keywordIdx, keyword, parseContext, grid, eclipseProperties, unit_system, rftProperties);
+                this->handleKeyword(currentStep, section, keywordIdx, keyword, parseContext, errors, grid, eclipseProperties, unit_system, rftProperties);
 
             keywordIdx++;
             if (keywordIdx == section.size())
@@ -372,7 +375,7 @@ namespace Opm {
         return true;
     }
 
-    void Schedule::handleWHISTCTL(const ParseContext& parseContext, const DeckKeyword& keyword) {
+    void Schedule::handleWHISTCTL(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword) {
         for( const auto& record : keyword ) {
             const std::string& cmodeString = record.getItem("CMODE").getTrimmedString(0);
             const WellProducer::ControlModeEnum controlMode = WellProducer::ControlModeFromString( cmodeString );
@@ -390,20 +393,20 @@ namespace Opm {
             if (bhp_terminate == "YES") {
                 std::string msg = "The WHISTCTL keyword does not handle 'YES'. i.e. to terminate the run";
                 OpmLog::error(msg);
-                parseContext.handleError( ParseContext::UNSUPPORTED_TERMINATE_IF_BHP , msg );
+                parseContext.handleError( ParseContext::UNSUPPORTED_TERMINATE_IF_BHP , msg, errors );
             }
 
         }
     }
 
 
-    void Schedule::handleCOMPORD(const ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t /* currentStep */) {
+  void Schedule::handleCOMPORD(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& compordKeyword, size_t /* currentStep */) {
         for (const auto& record : compordKeyword) {
             const auto& methodItem = record.getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
             if ((methodItem.get< std::string >(0) != "TRACK")  && (methodItem.get< std::string >(0) != "INPUT")) {
                 std::string msg = "The COMPORD keyword only handles 'TRACK' or 'INPUT' order.";
                 OpmLog::error(msg);
-                parseContext.handleError( ParseContext::UNSUPPORTED_COMPORD_TYPE , msg );
+                parseContext.handleError( ParseContext::UNSUPPORTED_COMPORD_TYPE , msg, errors );
             }
         }
     }
@@ -591,7 +594,7 @@ namespace Opm {
         this->m_oilvaporizationproperties.update( currentStep, ovp );
     }
 
-    void Schedule::handleWCONProducer( const DeckKeyword& keyword, size_t currentStep, bool isPredictionMode, const ParseContext& parseContext) {
+    void Schedule::handleWCONProducer( const DeckKeyword& keyword, size_t currentStep, bool isPredictionMode, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern =
                 record.getItem("WELL").getTrimmedString(0);
@@ -601,7 +604,7 @@ namespace Opm {
 
             auto wells = getWells(wellNamePattern);
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             for( auto* well : wells ) {
                 WellProductionProperties properties;
@@ -637,12 +640,12 @@ namespace Opm {
     }
 
 
-    void Schedule::handleWCONHIST( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
-        handleWCONProducer(keyword, currentStep, false, parseContext);
+    void Schedule::handleWCONHIST( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
+        handleWCONProducer(keyword, currentStep, false, parseContext, errors);
     }
 
-    void Schedule::handleWCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
-        handleWCONProducer( keyword, currentStep, true, parseContext);
+    void Schedule::handleWCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
+        handleWCONProducer( keyword, currentStep, true, parseContext, errors);
     }
 
     void Schedule::handleWPIMULT( const DeckKeyword& keyword, size_t currentStep) {
@@ -657,13 +660,13 @@ namespace Opm {
 
 
 
-    void Schedule::handleWCONINJE( const SCHEDULESection& section, const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWCONINJE( const SCHEDULESection& section, const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
 
             auto wells = getWells(wellNamePattern);
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             for( auto* well : wells) {
                 WellInjector::TypeEnum injectorType = WellInjector::TypeFromString( record.getItem("TYPE").getTrimmedString(0) );
@@ -741,13 +744,13 @@ namespace Opm {
     }
 
 
-    void Schedule::handleWPOLYMER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWPOLYMER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             for( auto* well : wells) {
                 WellPolymerProperties properties(well->getPolymerPropertiesCopy(currentStep));
@@ -771,7 +774,7 @@ namespace Opm {
     }
 
 
-    void Schedule::handleWPMITAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWPMITAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
 
         for (const auto& record : keyword) {
 
@@ -779,7 +782,7 @@ namespace Opm {
             const auto wells = getWells(wellNamePattern);
 
             if (wells.empty()) {
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
             }
 
             for (auto* well : wells) {
@@ -794,7 +797,7 @@ namespace Opm {
     }
 
 
-    void Schedule::handleWSKPTAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWSKPTAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
 
 
         for (const auto& record : keyword) {
@@ -802,7 +805,7 @@ namespace Opm {
             const auto wells = getWells(wellNamePattern);
 
             if (wells.empty()) {
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
             }
 
             for (auto* well : wells) {
@@ -818,14 +821,14 @@ namespace Opm {
     }
 
 
-    void Schedule::handleWECON( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWECON( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             WellEconProductionLimits econ_production_limits(record);
             const auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             for( auto* well : wells ) {
                 well->setEconProductionLimits(currentStep, econ_production_limits);
@@ -833,14 +836,14 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleWEFAC( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWEFAC( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELLNAME").getTrimmedString(0);
             const double& efficiencyFactor = record.getItem("EFFICIENCY_FACTOR").get< double >(0);
             const auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             for( auto* well : wells ) {
                 well->setEfficiencyFactor(currentStep, efficiencyFactor);
@@ -849,14 +852,14 @@ namespace Opm {
     }
 
 
-    void Schedule::handleWTEST(const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWTEST(const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         const auto& current = *this->wtest_config.get(currentStep);
         std::shared_ptr<WellTestConfig> new_config(new WellTestConfig(current));
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const auto wells = getWells( wellNamePattern );
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             double test_interval = record.getItem("INTERVAL").getSIDouble(0);
             const std::string& reason = record.getItem("REASON").get<std::string>(0);
@@ -873,14 +876,14 @@ namespace Opm {
         this->wtest_config.update(currentStep, new_config);
     }
 
-    void Schedule::handleWSOLVENT( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWSOLVENT( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
 
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             for( auto* well : wells) {
                 WellInjectionProperties injectionProperties = well->getInjectionProperties( currentStep );
@@ -893,15 +896,15 @@ namespace Opm {
             }
         }
     }
-    
-    void Schedule::handleWTRACER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+
+    void Schedule::handleWTRACER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
 
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             for( auto* well : wells) {
                 WellTracerProperties wellTracerProperties = well->getTracerProperties( currentStep );
@@ -914,13 +917,13 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleWTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern( wellNamePattern, parseContext, keyword);
+                invalidNamePattern( wellNamePattern, parseContext, errors, keyword);
 
             for (auto* well : wells) {
                 // TODO: Is this the right approach? Setting the well temperature only
@@ -938,7 +941,7 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleWINJTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWINJTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         // we do not support the "enthalpy" field yet. how to do this is a more difficult
         // question.
         for( const auto& record : keyword ) {
@@ -946,7 +949,7 @@ namespace Opm {
             auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern( wellNamePattern, parseContext, keyword);
+                invalidNamePattern( wellNamePattern, parseContext, errors, keyword);
 
             for (auto* well : wells) {
                 // TODO: Is this the right approach? Setting the well temperature only
@@ -964,7 +967,7 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleWCONINJH( const SCHEDULESection& section,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleWCONINJH( const SCHEDULESection& section,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
 
@@ -978,7 +981,7 @@ namespace Opm {
             auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern( wellNamePattern, parseContext, keyword);
+                invalidNamePattern( wellNamePattern, parseContext, errors, keyword);
 
             for (auto* well : wells) {
                 updateWellStatus( *well, currentStep, status );
@@ -1029,7 +1032,7 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleWELOPEN( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext ) {
+    void Schedule::handleWELOPEN( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
 
         auto all_defaulted = []( const DeckRecord& rec ) {
             auto defaulted = []( const DeckItem& item ) {
@@ -1048,7 +1051,7 @@ namespace Opm {
             auto wells = getWells( wellNamePattern );
 
             if (wells.empty())
-                invalidNamePattern( wellNamePattern, parseContext, keyword);
+                invalidNamePattern( wellNamePattern, parseContext, errors, keyword);
 
             /* if all records are defaulted or just the status is set, only
              * well status is updated
@@ -1094,7 +1097,7 @@ namespace Opm {
     void Schedule::handleWELTARG( const SCHEDULESection& section ,
                                   const DeckKeyword& keyword,
                                   size_t currentStep,
-                                  const ParseContext& parseContext) {
+                                  const ParseContext& parseContext, ErrorGuard& errors) {
         Opm::UnitSystem unitSystem = section.unitSystem();
         double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
         double siFactorG = unitSystem.parse("GasSurfaceVolume/Time").getSIScaling();
@@ -1109,7 +1112,7 @@ namespace Opm {
             const auto wells = getWells( wellNamePattern );
 
             if( wells.empty() )
-                invalidNamePattern( wellNamePattern, parseContext, keyword);
+                invalidNamePattern( wellNamePattern, parseContext, errors, keyword);
 
             for( auto* well : wells ) {
                 if(well->isProducer(currentStep)){
@@ -1211,13 +1214,13 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleGCONINJE( const SCHEDULESection& section,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleGCONINJE( const SCHEDULESection& section,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& groupNamePattern = record.getItem("GROUP").getTrimmedString(0);
             auto groups = getGroups ( groupNamePattern );
 
             if (groups.empty())
-                invalidNamePattern(groupNamePattern, parseContext, keyword);
+                invalidNamePattern(groupNamePattern, parseContext, errors, keyword);
 
             for (auto* group : groups){
                 {
@@ -1246,13 +1249,13 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleGCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleGCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& groupNamePattern = record.getItem("GROUP").getTrimmedString(0);
             auto groups = getGroups ( groupNamePattern );
 
             if (groups.empty())
-                invalidNamePattern(groupNamePattern, parseContext, keyword);
+                invalidNamePattern(groupNamePattern, parseContext, errors, keyword);
 
             for (auto* group : groups){
                 {
@@ -1275,13 +1278,13 @@ namespace Opm {
     }
 
 
-    void Schedule::handleGEFAC( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext) {
+    void Schedule::handleGEFAC( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& groupNamePattern = record.getItem("GROUP").getTrimmedString(0);
             auto groups = getGroups ( groupNamePattern );
 
             if (groups.empty())
-                invalidNamePattern(groupNamePattern, parseContext, keyword);
+                invalidNamePattern(groupNamePattern, parseContext, errors, keyword);
 
             for (auto* group : groups){
                 group->setGroupEfficiencyFactor(currentStep, record.getItem("EFFICIENCY_FACTOR").get< double >(0));
@@ -1451,12 +1454,12 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleCOMPDAT( const DeckKeyword& keyword, size_t currentStep, const EclipseGrid& grid, const Eclipse3DProperties& eclipseProperties, const ParseContext& parseContext) {
+    void Schedule::handleCOMPDAT( const DeckKeyword& keyword, size_t currentStep, const EclipseGrid& grid, const Eclipse3DProperties& eclipseProperties, const ParseContext& parseContext, ErrorGuard& errors) {
         for (const auto& record : keyword) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             auto wells = getWells(wellNamePattern);
             if (wells.empty())
-                invalidNamePattern(wellNamePattern, parseContext, keyword);
+                invalidNamePattern(wellNamePattern, parseContext, errors, keyword);
 
             for (auto* well : wells) {
                 well->handleCOMPDAT(currentStep, record, grid, eclipseProperties);
@@ -1573,10 +1576,10 @@ namespace Opm {
         }
     }
 
-    void Schedule::invalidNamePattern( const std::string& namePattern,  const ParseContext& parseContext, const DeckKeyword& keyword ) const {
+    void Schedule::invalidNamePattern( const std::string& namePattern,  const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword ) const {
         std::string msg = "Error when handling " + keyword.name() +". No names match " +
                           namePattern;
-        parseContext.handleError( ParseContext::SCHEDULE_INVALID_NAME, msg );
+        parseContext.handleError( ParseContext::SCHEDULE_INVALID_NAME, msg, errors );
     }
 
     const TimeMap& Schedule::getTimeMap() const {

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -603,9 +603,26 @@ SummaryConfig::SummaryConfig( const Deck& deck,
                               const ParseContext& parseContext,
                               ErrorGuard& errors) :
     SummaryConfig( deck , schedule, tables, parseContext, errors, GridDims( deck ))
-{
+{ }
 
-}
+
+template <typename T>
+SummaryConfig::SummaryConfig( const Deck& deck,
+                              const Schedule& schedule,
+                              const TableManager& tables,
+                              const ParseContext& parseContext,
+                              T&& errors) :
+    SummaryConfig(deck, schedule, tables, parseContext, errors)
+{}
+
+
+SummaryConfig::SummaryConfig( const Deck& deck,
+               const Schedule& schedule,
+               const TableManager& tables) :
+    SummaryConfig(deck, schedule, tables, ParseContext(), ErrorGuard())
+{}
+
+
 
 SummaryConfig::const_iterator SummaryConfig::begin() const {
     return this->keywords.cbegin();

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -123,25 +123,26 @@ namespace {
 
 
 
-void handleMissingWell( const ParseContext& parseContext , const std::string& keyword, const std::string& well) {
+void handleMissingWell( const ParseContext& parseContext, ErrorGuard& errors, const std::string& keyword, const std::string& well) {
     std::string msg = std::string("Error in keyword:") + keyword + std::string(" No such well: ") + well;
     if (parseContext.get( ParseContext::SUMMARY_UNKNOWN_WELL) == InputError::WARN)
         std::cerr << "ERROR: " << msg << std::endl;
 
-    parseContext.handleError( ParseContext::SUMMARY_UNKNOWN_WELL , msg );
+    parseContext.handleError( ParseContext::SUMMARY_UNKNOWN_WELL , msg, errors );
 }
 
 
-void handleMissingGroup( const ParseContext& parseContext , const std::string& keyword, const std::string& group) {
+void handleMissingGroup( const ParseContext& parseContext , ErrorGuard& errors, const std::string& keyword, const std::string& group) {
     std::string msg = std::string("Error in keyword:") + keyword + std::string(" No such group: ") + group;
     if (parseContext.get( ParseContext::SUMMARY_UNKNOWN_GROUP) == InputError::WARN)
         std::cerr << "ERROR: " << msg << std::endl;
 
-    parseContext.handleError( ParseContext::SUMMARY_UNKNOWN_GROUP , msg );
+    parseContext.handleError( ParseContext::SUMMARY_UNKNOWN_GROUP , msg, errors );
 }
 
-  inline void keywordW( SummaryConfig::keyword_list& list,
+inline void keywordW( SummaryConfig::keyword_list& list,
                       const ParseContext& parseContext,
+                      ErrorGuard& errors,
                       const DeckKeyword& keyword,
                       const Schedule& schedule ) {
 
@@ -154,7 +155,7 @@ void handleMissingGroup( const ParseContext& parseContext , const std::string& k
             auto wells = schedule.getWellsMatching( pattern );
 
             if( wells.empty() )
-                handleMissingWell( parseContext, keyword.name(), pattern );
+                handleMissingWell( parseContext, errors, keyword.name(), pattern );
 
             for( const auto* well : wells )
                 list.push_back( SummaryConfig::keyword_type( keyword.name(), well->name() ));
@@ -167,6 +168,7 @@ void handleMissingGroup( const ParseContext& parseContext , const std::string& k
 
 inline void keywordG( SummaryConfig::keyword_list& list,
                       const ParseContext& parseContext,
+                      ErrorGuard& errors,
                       const DeckKeyword& keyword,
                       const Schedule& schedule ) {
 
@@ -188,7 +190,7 @@ inline void keywordG( SummaryConfig::keyword_list& list,
         if( schedule.hasGroup( group ) )
             list.push_back( SummaryConfig::keyword_type(keyword.name(), group ));
         else
-            handleMissingGroup( parseContext, keyword.name(), group );
+            handleMissingGroup( parseContext, errors, keyword.name(), group );
     }
 }
 
@@ -224,10 +226,11 @@ inline void keywordB( SummaryConfig::keyword_list& list,
 
 inline void keywordR2R( SummaryConfig::keyword_list& list,
                         const ParseContext& parseContext,
+                        ErrorGuard& errors,
                         const DeckKeyword& keyword)
 {
     std::string msg = "OPM/flow does not support region to region summary keywords - " + keyword.name() + " is ignored.";
-    parseContext.handleError(ParseContext::SUMMARY_UNHANDLED_KEYWORD, msg);
+    parseContext.handleError(ParseContext::SUMMARY_UNHANDLED_KEYWORD, msg, errors);
 }
 
 
@@ -272,6 +275,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
 
   inline void keywordC( SummaryConfig::keyword_list& list,
                         const ParseContext& parseContext,
+                        ErrorGuard& errors,
                         const DeckKeyword& keyword,
                         const Schedule& schedule,
                         const GridDims& dims) {
@@ -288,7 +292,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
                          : schedule.getWellsMatching( wellitem.getTrimmedString( 0 ) );
 
         if( wells.empty() )
-            handleMissingWell( parseContext, keyword.name(), wellitem.getTrimmedString( 0 ) );
+            handleMissingWell( parseContext, errors, keyword.name(), wellitem.getTrimmedString( 0 ) );
 
         for( const auto* well : wells ) {
             const auto& name = well->name();
@@ -436,6 +440,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
 
     void keywordSWithRecords(const std::size_t            last_timestep,
                              const ParseContext&          parseContext,
+                             ErrorGuard& errors,
                              const DeckKeyword&           keyword,
                              const Schedule&              schedule,
                              SummaryConfig::keyword_list& list)
@@ -463,7 +468,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
                 : schedule.getWellsMatching(wellitem.getTrimmedString(0));
 
             if (wells.empty()) {
-                handleMissingWell(parseContext, keyword.name(),
+                handleMissingWell(parseContext, errors, keyword.name(),
                                   wellitem.getTrimmedString(0));
             }
 
@@ -478,6 +483,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
 
     inline void keywordS(SummaryConfig::keyword_list& list,
                          const ParseContext&          parseContext,
+                         ErrorGuard& errors,
                          const DeckKeyword&           keyword,
                          const Schedule&              schedule)
     {
@@ -507,7 +513,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
         if (keyword.size() > 0) {
             // Keyword with explicit records.
             // Handle as alternatives SOFR and SPR above
-            keywordSWithRecords(last_timestep, parseContext,
+            keywordSWithRecords(last_timestep, parseContext, errors,
                                 keyword, schedule, list);
         }
         else {
@@ -522,23 +528,24 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
                         const Schedule& schedule,
                         const TableManager& tables,
                         const ParseContext& parseContext,
+                        ErrorGuard& errors,
                         const GridDims& dims) {
     const auto var_type = ecl_smspec_identify_var_type( keyword.name().c_str() );
 
     switch( var_type ) {
-        case ECL_SMSPEC_WELL_VAR: return keywordW( list, parseContext, keyword, schedule );
-        case ECL_SMSPEC_GROUP_VAR: return keywordG( list, parseContext, keyword, schedule );
+        case ECL_SMSPEC_WELL_VAR: return keywordW( list, parseContext, errors, keyword, schedule );
+        case ECL_SMSPEC_GROUP_VAR: return keywordG( list, parseContext, errors, keyword, schedule );
         case ECL_SMSPEC_FIELD_VAR: return keywordF( list, keyword );
         case ECL_SMSPEC_BLOCK_VAR: return keywordB( list, keyword, dims );
         case ECL_SMSPEC_REGION_VAR: return keywordR( list, keyword, tables );
-        case ECL_SMSPEC_REGION_2_REGION_VAR: return keywordR2R(list, parseContext, keyword);
-        case ECL_SMSPEC_COMPLETION_VAR: return keywordC( list, parseContext, keyword, schedule, dims);
-        case ECL_SMSPEC_SEGMENT_VAR: return keywordS( list, parseContext, keyword, schedule );
+        case ECL_SMSPEC_REGION_2_REGION_VAR: return keywordR2R(list, parseContext, errors, keyword);
+        case ECL_SMSPEC_COMPLETION_VAR: return keywordC( list, parseContext, errors, keyword, schedule, dims);
+        case ECL_SMSPEC_SEGMENT_VAR: return keywordS( list, parseContext, errors, keyword, schedule );
         case ECL_SMSPEC_MISC_VAR: return keywordMISC( list, keyword );
 
         default:
             std::string msg = "Summary keywords of type: " + std::string(ecl_smspec_get_var_type_name( var_type )) + " is not supported. Keyword: " + keyword.name() + " is ignored";
-            parseContext.handleError(ParseContext::SUMMARY_UNHANDLED_KEYWORD, msg);
+            parseContext.handleError(ParseContext::SUMMARY_UNHANDLED_KEYWORD, msg, errors);
             return;
     }
 }
@@ -564,22 +571,23 @@ SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
                               const TableManager& tables,
                               const ParseContext& parseContext,
+                              ErrorGuard& errors,
                               const GridDims& dims) {
     SUMMARYSection section( deck );
     for( auto& x : section )
-        handleKW( this->keywords, x, schedule, tables, parseContext, dims);
+        handleKW( this->keywords, x, schedule, tables, parseContext, errors, dims);
 
     if( section.hasKeyword( "ALL" ) )
-        this->merge( { ALL_keywords, schedule, tables, parseContext, dims} );
+        this->merge( { ALL_keywords, schedule, tables, parseContext, errors, dims} );
 
     if( section.hasKeyword( "GMWSET" ) )
-        this->merge( { GMWSET_keywords, schedule, tables, parseContext, dims} );
+        this->merge( { GMWSET_keywords, schedule, tables, parseContext, errors, dims} );
 
     if( section.hasKeyword( "FMWSET" ) )
-        this->merge( { FMWSET_keywords, schedule, tables, parseContext, dims} );
+        this->merge( { FMWSET_keywords, schedule, tables, parseContext, errors, dims} );
 
     if (section.hasKeyword( "PERFORMA" ) )
-        this->merge( { PERFORMA_keywords, schedule, tables, parseContext, dims} );
+        this->merge( { PERFORMA_keywords, schedule, tables, parseContext, errors, dims} );
 
     uniq( this->keywords );
     for (const auto& kw: this->keywords) {
@@ -592,8 +600,9 @@ SummaryConfig::SummaryConfig( const Deck& deck,
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
                               const TableManager& tables,
-                              const ParseContext& parseContext) :
-    SummaryConfig( deck , schedule, tables, parseContext, GridDims( deck ))
+                              const ParseContext& parseContext,
+                              ErrorGuard& errors) :
+    SummaryConfig( deck , schedule, tables, parseContext, errors, GridDims( deck ))
 {
 
 }

--- a/src/opm/parser/eclipse/Parser/ErrorGuard.cpp
+++ b/src/opm/parser/eclipse/Parser/ErrorGuard.cpp
@@ -53,11 +53,15 @@ namespace Opm {
         this->error_list.clear();
     }
 
+    void ErrorGuard::terminate() const {
+        this->dump();
+        std::terminate();
+    }
+
+
     ErrorGuard::~ErrorGuard() {
-        if (*this) {
-            this->dump();
-            std::terminate();
-        }
+        if (*this)
+            this->terminate();
     }
 
 }

--- a/src/opm/parser/eclipse/Parser/ErrorGuard.cpp
+++ b/src/opm/parser/eclipse/Parser/ErrorGuard.cpp
@@ -55,7 +55,7 @@ namespace Opm {
 
     void ErrorGuard::terminate() const {
         this->dump();
-        std::terminate();
+        std::exit(1);
     }
 
 

--- a/src/opm/parser/eclipse/Parser/ErrorGuard.cpp
+++ b/src/opm/parser/eclipse/Parser/ErrorGuard.cpp
@@ -1,0 +1,63 @@
+/*
+  Copyright 2019 Joakim Hove/datagr
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <iostream>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+
+
+namespace Opm {
+
+    void ErrorGuard::addError(const std::string& errorKey, const std::string& msg) {
+        this->error_list.emplace_back(errorKey, msg);
+    }
+
+
+    void ErrorGuard::addWarning(const std::string& errorKey, const std::string& msg) {
+        this->warning_list.emplace_back(errorKey, msg);
+    }
+
+
+    void ErrorGuard::dump() const {
+        if (!this->warning_list.empty()) {
+            std::cerr << "Warnings:" << std::endl;
+            for (const auto& pair : this->warning_list)
+                std::cerr << pair.first << ": " << pair.second << std::endl;
+        }
+
+        if (!this->error_list.empty()) {
+            std::cerr << std::endl << std::endl << "Errors:" << std::endl;
+            for (const auto& pair : this->error_list)
+                std::cerr << pair.first << ": " << pair.second << std::endl;
+        }
+    }
+
+
+    void ErrorGuard::clear() {
+        this->warning_list.clear();
+        this->error_list.clear();
+    }
+
+    ErrorGuard::~ErrorGuard() {
+        if (*this) {
+            this->dump();
+            std::terminate();
+        }
+    }
+
+}

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -23,6 +23,7 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
@@ -111,7 +112,8 @@ namespace Opm {
 
     void ParseContext::handleError(
             const std::string& errorKey,
-            const std::string& msg ) const {
+            const std::string& msg,
+            ErrorGuard& errors) const {
 
         InputError::Action action = get( errorKey );
 
@@ -133,10 +135,10 @@ namespace Opm {
         }
     }
 
-    void ParseContext::handleUnknownKeyword(const std::string& keyword) const {
+    void ParseContext::handleUnknownKeyword(const std::string& keyword, ErrorGuard& errors) const {
         if (this->ignore_keywords.find(keyword) == this->ignore_keywords.end()) {
             std::string msg = "Unknown keyword: " + keyword;
-            this->handleError(ParseContext::PARSE_UNKNOWN_KEYWORD, msg);
+            this->handleError(ParseContext::PARSE_UNKNOWN_KEYWORD, msg, errors);
         }
     }
 

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -206,8 +206,8 @@ void InputStack::push( std::string&& input, boost::filesystem::path p ) {
 
 class ParserState {
     public:
-        ParserState( const ParseContext& );
-        ParserState( const ParseContext&, boost::filesystem::path );
+        ParserState( const ParseContext&, ErrorGuard& );
+        ParserState( const ParseContext&, ErrorGuard&, boost::filesystem::path );
 
         void loadString( const std::string& );
         void loadFile( const boost::filesystem::path& );
@@ -234,10 +234,11 @@ class ParserState {
         std::shared_ptr< RawKeyword > rawKeyword;
         ParserKeywordSizeEnum lastSizeType = SLASH_TERMINATED;
         std::string lastKeyWord;
-        
+
         string_view nextKeyword = emptystr;
         Deck deck;
         const ParseContext& parseContext;
+        ErrorGuard& errors;
         bool unknown_keyword = false;
 };
 
@@ -272,14 +273,17 @@ void ParserState::closeFile() {
     this->input_stack.pop();
 }
 
-ParserState::ParserState(const ParseContext& __parseContext) :
-    parseContext( __parseContext )
+ParserState::ParserState(const ParseContext& __parseContext, ErrorGuard& errors) :
+    parseContext( __parseContext ),
+    errors( errors )
 {}
 
 ParserState::ParserState( const ParseContext& context,
+                          ErrorGuard& errors,
                           boost::filesystem::path p ) :
     rootPath( boost::filesystem::canonical( p ).parent_path() ),
-    parseContext( context )
+    parseContext( context ),
+    errors( errors )
 {
     openRootFile( p );
 }
@@ -295,7 +299,7 @@ void ParserState::loadFile(const boost::filesystem::path& inputFile) {
         inputFileCanonical = boost::filesystem::canonical(inputFile);
     } catch (boost::filesystem::filesystem_error fs_error) {
         std::string msg = "Could not open file: " + inputFile.string();
-        parseContext.handleError( ParseContext::PARSE_MISSING_INCLUDE , msg);
+        parseContext.handleError( ParseContext::PARSE_MISSING_INCLUDE , msg, errors);
         return;
     }
 
@@ -308,7 +312,8 @@ void ParserState::loadFile(const boost::filesystem::path& inputFile) {
     // make sure the file we'd like to parse is readable
     if( !ufp ) {
         std::string msg = "Could not read from file: " + inputFile.string();
-        parseContext.handleError( ParseContext::PARSE_MISSING_INCLUDE , msg);
+
+        parseContext.handleError( ParseContext::PARSE_MISSING_INCLUDE , msg, errors);
         return;
     }
 
@@ -368,7 +373,7 @@ void ParserState::handleRandomText(const string_view& keywordString ) const {
             << this->current_path()
             << ":" << this->line();
     }
-    parseContext.handleError( errorKey , msg.str() );
+    parseContext.handleError( errorKey , msg.str(), errors );
 }
 
 void ParserState::openRootFile( const boost::filesystem::path& inputFile) {
@@ -417,7 +422,7 @@ std::shared_ptr< RawKeyword > createRawKeyword( const string_view& kw, ParserSta
     if( !parser.isRecognizedKeyword( keywordString ) ) {
         if( ParserKeyword::validDeckName( keywordString ) ) {
             std::string msg = "Keyword " + keywordString + " not recognized.";
-            parserState.parseContext.handleUnknownKeyword( keywordString.string() );
+            parserState.parseContext.handleUnknownKeyword( keywordString.string(), parserState.errors );
             parserState.unknown_keyword = true;
             return {};
         }
@@ -467,7 +472,7 @@ std::shared_ptr< RawKeyword > createRawKeyword( const string_view& kw, ParserSta
 
     std::string msg = "Expected the kewyord: " +keyword_size.keyword 
                     + " to infer the number of records in: " + keywordString;
-    parserState.parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD , msg );
+    parserState.parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD , msg, parserState.errors );
 
     const auto* keyword = parser.getKeyword( keyword_size.keyword );
     const auto& record = keyword->getRecord(0);
@@ -582,7 +587,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
             const auto& kwname = parserState.rawKeyword->getKeywordName();
             const auto* parserKeyword = parser.getParserKeywordFromDeckName( kwname );
             try {
-                parserState.deck.addKeyword( parserKeyword->parse( parserState.parseContext, parserState.rawKeyword ) );
+                parserState.deck.addKeyword( parserKeyword->parse( parserState.parseContext, parserState.errors, parserState.rawKeyword ) );
             } catch (const std::exception& exc) {
                 /*
                   This catch-all of parsing errors is to be able to write a good
@@ -639,55 +644,55 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
             throw new std::logic_error("Cannot construct a state in partial deck context");
     }
 
-    EclipseState Parser::parse(const std::string &filename, const ParseContext& context) {
+    EclipseState Parser::parse(const std::string &filename, const ParseContext& context, ErrorGuard& errors) {
         assertFullDeck(context);
-        return EclipseState( Parser{}.parseFile( filename, context ), context );
+        return EclipseState( Parser{}.parseFile( filename, context, errors ), context, errors );
     }
 
-    EclipseState Parser::parse(const Deck& deck, const ParseContext& context) {
+    EclipseState Parser::parse(const Deck& deck, const ParseContext& context, ErrorGuard& errors) {
         assertFullDeck(context);
-        return EclipseState(deck, context);
+        return EclipseState(deck, context, errors);
     }
 
-    EclipseState Parser::parseData(const std::string &data, const ParseContext& context) {
+    EclipseState Parser::parseData(const std::string &data, const ParseContext& context, ErrorGuard& errors) {
         assertFullDeck(context);
         Parser p;
-        auto deck = p.parseString(data, context);
-        return parse(deck, context);
+        auto deck = p.parseString(data, context, errors);
+        return parse(deck, context, errors);
     }
 
-    EclipseGrid Parser::parseGrid(const std::string &filename, const ParseContext& context) {
+    EclipseGrid Parser::parseGrid(const std::string &filename, const ParseContext& context, ErrorGuard& errors) {
         if (context.hasKey(ParseContext::PARSE_MISSING_SECTIONS))
             return EclipseGrid{ filename };
-        return parse(filename, context).getInputGrid();
+        return parse(filename, context, errors).getInputGrid();
     }
 
-    EclipseGrid Parser::parseGrid(const Deck& deck, const ParseContext& context)
+    EclipseGrid Parser::parseGrid(const Deck& deck, const ParseContext& context, ErrorGuard& errors)
     {
         if (context.hasKey(ParseContext::PARSE_MISSING_SECTIONS))
             return EclipseGrid{ deck };
-        return parse(deck, context).getInputGrid();
+        return parse(deck, context, errors).getInputGrid();
     }
 
-    EclipseGrid Parser::parseGridData(const std::string &data, const ParseContext& context) {
+    EclipseGrid Parser::parseGridData(const std::string &data, const ParseContext& context, ErrorGuard& errors) {
         Parser parser;
-        auto deck = parser.parseString(data, context);
+        auto deck = parser.parseString(data, context, errors);
         if (context.hasKey(ParseContext::PARSE_MISSING_SECTIONS)) {
             return EclipseGrid{ deck };
         }
-        return parse(deck, context).getInputGrid();
+        return parse(deck, context, errors).getInputGrid();
     }
 
-    Deck Parser::parseFile(const std::string &dataFileName, const ParseContext& parseContext) const {
-        ParserState parserState( parseContext, dataFileName );
+    Deck Parser::parseFile(const std::string &dataFileName, const ParseContext& parseContext, ErrorGuard& errors) const {
+        ParserState parserState( parseContext, errors, dataFileName );
         parseState( parserState, *this );
         applyUnitsToDeck( parserState.deck );
 
         return std::move( parserState.deck );
     }
 
-    Deck Parser::parseString(const std::string &data, const ParseContext& parseContext) const {
-        ParserState parserState( parseContext );
+    Deck Parser::parseString(const std::string &data, const ParseContext& parseContext, ErrorGuard& errors) const {
+        ParserState parserState( parseContext, errors );
         parserState.loadString( data );
 
         parseState( parserState, *this );

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -36,6 +36,7 @@
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserItem.hpp>
@@ -691,6 +692,14 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
         return std::move( parserState.deck );
     }
 
+    Deck Parser::parseFile(const std::string& dataFileName) {
+        ErrorGuard errors;
+        return this->parseFile(dataFileName, ParseContext(), errors);
+    }
+
+
+
+
     Deck Parser::parseString(const std::string &data, const ParseContext& parseContext, ErrorGuard& errors) const {
         ParserState parserState( parseContext, errors );
         parserState.loadString( data );
@@ -699,6 +708,11 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
         applyUnitsToDeck( parserState.deck );
 
         return std::move( parserState.deck );
+    }
+
+    Deck Parser::parseString(const std::string &data) const {
+        ErrorGuard errors;
+        return this->parseString(data, ParseContext(), errors);
     }
 
     size_t Parser::size() const {

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -478,6 +478,7 @@ void set_dimensions( ParserItem& item,
     }
 
     DeckKeyword ParserKeyword::parse(const ParseContext& parseContext,
+                                     ErrorGuard& errors,
                                      std::shared_ptr< RawKeyword > rawKeyword) const {
         if( !rawKeyword->isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword->getKeywordName());
@@ -491,7 +492,7 @@ void set_dimensions( ParserItem& item,
             if( m_records.size() == 0 && rawRecord.size() > 0 )
                 throw std::invalid_argument("Missing item information " + rawKeyword->getKeywordName());
 
-            keyword.addRecord( getRecord( record_nr ).parse( parseContext, rawRecord ) );
+            keyword.addRecord( getRecord( record_nr ).parse( parseContext, errors, rawRecord ) );
             record_nr++;
         }
 

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -123,7 +123,7 @@ namespace {
         return *itr;
     }
 
-    DeckRecord ParserRecord::parse(const ParseContext& parseContext , RawRecord& rawRecord ) const {
+    DeckRecord ParserRecord::parse(const ParseContext& parseContext , ErrorGuard& errors , RawRecord& rawRecord) const {
         std::vector< DeckItem > items;
         items.reserve( this->size() + 20 );
         for( const auto& parserItem : *this )
@@ -133,7 +133,7 @@ namespace {
             std::string msg = "The RawRecord for keyword \""  + rawRecord.getKeywordName() + "\" in file\"" + rawRecord.getFileName() + "\" contained " +
                 std::to_string(rawRecord.size()) +
                 " too many items according to the spec. RawRecord was: " + rawRecord.getRecordString();
-            parseContext.handleError(ParseContext::PARSE_EXTRA_DATA , msg);
+            parseContext.handleError(ParseContext::PARSE_EXTRA_DATA , msg, errors);
         }
 
         return { std::move( items ) };

--- a/tests/parser/ADDREGTests.cpp
+++ b/tests/parser/ADDREGTests.cpp
@@ -29,7 +29,6 @@
 #include <opm/parser/eclipse/Units/Units.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -55,7 +54,7 @@ static Opm::Deck createDeckInvalidArray() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -73,7 +72,7 @@ static Opm::Deck createDeckInvalidRegion() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -93,7 +92,7 @@ static Opm::Deck createDeckInvalidValue() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -114,7 +113,7 @@ static Opm::Deck createDeckUnInitializedRegion() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -135,7 +134,7 @@ static Opm::Deck createDeckUnInitializedVector() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -175,7 +174,7 @@ static Opm::Deck createValidIntDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -223,7 +222,7 @@ static Opm::Deck createValidPERMXDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -234,31 +233,31 @@ static Opm::Deck createValidPERMXDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::Deck deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::Deck deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::Deck deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(UnInitializedRegionThrows) {
     Opm::Deck deck = createDeckUnInitializedRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::Deck deck = createDeckUnInitializedVector();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 

--- a/tests/parser/AquanconTests.cpp
+++ b/tests/parser/AquanconTests.cpp
@@ -57,7 +57,7 @@ inline Deck createAQUANCONDeck() {
         "/ \n";
 
     Parser parser;
-    return parser.parseString(deckData, ParseContext());
+    return parser.parseString(deckData);
 }
 
 inline std::vector<Aquancon::AquanconOutput> init_aquancon(){

--- a/tests/parser/AquiferCTTests.cpp
+++ b/tests/parser/AquiferCTTests.cpp
@@ -55,7 +55,7 @@ inline Deck createAquiferCTDeck() {
         "/ \n";
 
     Parser parser;
-    return parser.parseString(deckData, ParseContext());
+    return parser.parseString(deckData);
 }
 
 inline Deck createAquiferCTDeckDefaultP0() {
@@ -92,7 +92,7 @@ inline Deck createAquiferCTDeckDefaultP0() {
         "/ \n";
 
     Parser parser;
-    return parser.parseString(deckData, ParseContext());
+    return parser.parseString(deckData);
 }
 
 inline std::vector<AquiferCT::AQUCT_data> init_aquiferct(Deck& deck){

--- a/tests/parser/AquifetpTests.cpp
+++ b/tests/parser/AquifetpTests.cpp
@@ -55,7 +55,7 @@ inline Deck createAquifetpDeck() {
   "/\n";
 
   Parser parser;
-  return parser.parseString(deckData, ParseContext());
+  return parser.parseString(deckData);
 }
 
 inline Deck createNullAquifetpDeck(){
@@ -89,7 +89,7 @@ inline Deck createNullAquifetpDeck(){
   ;
 
   Parser parser;
-  return parser.parseString(deckData, ParseContext());
+  return parser.parseString(deckData);
 }
 
 inline Deck createAquifetpDeck_defaultPressure(){
@@ -126,7 +126,7 @@ inline Deck createAquifetpDeck_defaultPressure(){
   "/\n";
 
   Parser parser;
-  return parser.parseString(deckData, ParseContext());
+  return parser.parseString(deckData);
 }
 
 inline std::vector<Aquifetp::AQUFETP_data> init_aquifetp(Deck& deck){

--- a/tests/parser/COMPSEGUnits.cpp
+++ b/tests/parser/COMPSEGUnits.cpp
@@ -25,7 +25,6 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/C.hpp>
 
@@ -39,7 +38,7 @@ inline Deck createCOMPSEGSDeck() {
         "/\n";
 
     Parser parser;
-    return parser.parseString(deckData, ParseContext());
+    return parser.parseString(deckData);
 }
 
 

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -28,7 +28,6 @@
 
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
@@ -147,7 +146,7 @@ Opm::WellConnections loadCOMPDAT(const std::string& compdat_keyword) {
     Opm::EclipseGrid grid(10,10,10);
     Opm::TableManager tables;
     Opm::Parser parser;
-    const auto deck = parser.parseString(compdat_keyword, Opm::ParseContext());
+    const auto deck = parser.parseString(compdat_keyword);
     Opm::Eclipse3DProperties props(deck, tables, grid );
     const auto& keyword = deck.getKeyword("COMPDAT", 0);
     Opm::WellConnections connections;
@@ -197,12 +196,11 @@ COMPDAT
 
 
 BOOST_AUTO_TEST_CASE(loadCOMPDATTESTSPE1) {
-    Opm::ParseContext parseContext;
     Opm::Parser parser;
 
-    const auto deck = parser.parseFile("SPE1CASE1.DATA", parseContext);
-    Opm::EclipseState state(deck, parseContext);
-    Opm::Schedule sched(deck, state, parseContext);
+    const auto deck = parser.parseFile("SPE1CASE1.DATA");
+    Opm::EclipseState state(deck);
+    Opm::Schedule sched(deck, state);
     const auto& units = deck.getActiveUnitSystem();
 
     const auto& prod = sched.getWell("PROD");
@@ -222,12 +220,11 @@ struct exp_conn {
 };
 
 BOOST_AUTO_TEST_CASE(loadCOMPDATTESTSPE9) {
-    Opm::ParseContext parseContext;
     Opm::Parser parser;
 
-    const auto deck = parser.parseFile("SPE9_CP_PACKED.DATA", parseContext);
-    Opm::EclipseState state(deck, parseContext);
-    Opm::Schedule sched(deck, state, parseContext);
+    const auto deck = parser.parseFile("SPE9_CP_PACKED.DATA");
+    Opm::EclipseState state(deck);
+    Opm::Schedule sched(deck, state);
     const auto& units = deck.getActiveUnitSystem();
 /*
   The list of the expected values come from the PRT file in an ECLIPSE simulation.

--- a/tests/parser/CopyRegTests.cpp
+++ b/tests/parser/CopyRegTests.cpp
@@ -28,7 +28,6 @@
 
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -57,7 +56,7 @@ static Opm::Deck createDeckInvalidArray1() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 static Opm::Deck createDeckInvalidArray2() {
@@ -76,7 +75,7 @@ static Opm::Deck createDeckInvalidArray2() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -96,7 +95,7 @@ static Opm::Deck createDeckInvalidTypeMismatch() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -117,7 +116,7 @@ static Opm::Deck createDeckInvalidRegion() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -138,7 +137,7 @@ static Opm::Deck createDeckUnInitialized() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -175,7 +174,7 @@ static Opm::Deck createValidIntDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -183,19 +182,19 @@ static Opm::Deck createValidIntDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows1) {
     Opm::Deck deck = createDeckInvalidArray1();
-    BOOST_CHECK_THROW( Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState(deck) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows2) {
     Opm::Deck deck = createDeckInvalidArray2();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::Deck deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
@@ -203,13 +202,13 @@ BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::Deck deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(TypeMismatchThrows) {
     Opm::Deck deck = createDeckInvalidTypeMismatch();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -28,6 +28,7 @@
 #include <opm/parser/eclipse/Deck/DeckOutput.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserItem.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
@@ -520,10 +521,11 @@ BOOST_AUTO_TEST_CASE(StringsWithSpaceOK) {
     ParserRecord record1;
     RawRecord rawRecord( " ' VALUE ' " );
     ParseContext parseContext;
+    ErrorGuard errors;
     record1.addItem( itemString );
 
 
-    const auto deckRecord = record1.parse( parseContext , rawRecord );
+    const auto deckRecord = record1.parse( parseContext, errors , rawRecord );
     BOOST_CHECK_EQUAL(" VALUE " , deckRecord.getItem(0).get< std::string >(0));
 }
 

--- a/tests/parser/Eclipse3DPropertiesTests.cpp
+++ b/tests/parser/Eclipse3DPropertiesTests.cpp
@@ -33,7 +33,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
@@ -79,7 +78,7 @@ static Opm::Deck createDeck() {
             "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext() );
+    return parser.parseString(deckData);
 }
 
 
@@ -118,7 +117,7 @@ static Opm::Deck createValidIntDeck() {
             "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext() );
+    return parser.parseString(deckData);
 }
 
 static Opm::Deck createValidPERMXDeck() {
@@ -164,7 +163,7 @@ static Opm::Deck createValidPERMXDeck() {
             "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext() );
+    return parser.parseString(deckData);
 }
 
 static Opm::Deck createQuarterCircleDeck() {
@@ -253,14 +252,13 @@ MULTIPLY
 )";
 
     Opm::Parser parser;
-    return parser.parseString(input, Opm::ParseContext() );
+    return parser.parseString(input);
 }
 
 
 /// Setup fixture
 struct Setup
 {
-    Opm::ParseContext parseContext;
     Opm::Deck deck;
     Opm::TableManager tablemanager;
     Opm::EclipseGrid grid;
@@ -419,7 +417,7 @@ BOOST_AUTO_TEST_CASE(getRegions) {
             "FIPNUM\n"
             "1 1 2 3 /\n";
 
-    Setup s( Opm::Parser().parseString(input, Opm::ParseContext() ) );
+    Setup s( Opm::Parser().parseString(input) );
 
     std::vector< int > ref = { 1, 2, 3 };
     const auto& regions = s.props.getRegions( "FIPNUM" );
@@ -556,7 +554,7 @@ EQUALS
 )";
 
     Opm::Parser parser;
-    return parser.parseString(input, Opm::ParseContext() );
+    return parser.parseString(input);
 }
 
 
@@ -638,7 +636,7 @@ ADD
 )";
 
   Opm::Parser parser;
-  return parser.parseString(input, Opm::ParseContext() );
+  return parser.parseString(input);
 }
 
 BOOST_AUTO_TEST_CASE(TRANXADD) {
@@ -719,7 +717,7 @@ MULTIPLY
 )";
 
     Opm::Parser parser;
-    return parser.parseString(input, Opm::ParseContext() );
+    return parser.parseString(input);
 }
 
 
@@ -782,7 +780,7 @@ MULTIPLY
 
 )";
     Opm::Parser parser;
-    return parser.parseString(input, Opm::ParseContext() );
+    return parser.parseString(input);
 }
 
 

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -41,7 +41,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
 
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 
@@ -65,7 +64,7 @@ static Opm::Deck createDeckHeaders() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 static Opm::Deck createDeckDIMENS() {
@@ -78,7 +77,7 @@ static Opm::Deck createDeckDIMENS() {
         "EDIT\n"
         "\n";
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 static Opm::Deck createDeckSPECGRID() {
@@ -95,7 +94,7 @@ static Opm::Deck createDeckSPECGRID() {
         "EDIT\n"
         "\n";
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 static Opm::Deck createDeckMissingDIMS() {
@@ -107,7 +106,7 @@ static Opm::Deck createDeckMissingDIMS() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 BOOST_AUTO_TEST_CASE(MissingDimsThrows) {
@@ -184,7 +183,7 @@ static Opm::Deck createCPDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -207,7 +206,7 @@ static Opm::Deck createPinchedCPDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -232,7 +231,7 @@ static Opm::Deck createMinpvDefaultCPDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -255,7 +254,7 @@ static Opm::Deck createMinpvCPDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -279,7 +278,7 @@ static Opm::Deck createMinpvFilCPDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -302,7 +301,7 @@ static Opm::Deck createCARTDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -325,7 +324,7 @@ static Opm::Deck createCARTDeckDEPTHZ() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -346,7 +345,7 @@ static Opm::Deck createCARTInvalidDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 BOOST_AUTO_TEST_CASE(CREATE_SIMPLE) {
@@ -459,7 +458,7 @@ static Opm::Deck createInvalidDXYZCARTDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -489,7 +488,7 @@ static Opm::Deck createInvalidDXYZCARTDeckDEPTHZ() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -519,7 +518,7 @@ static Opm::Deck createOnlyTopDZCartGrid() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -542,7 +541,7 @@ static Opm::Deck createInvalidDEPTHZDeck1 () {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 
@@ -571,7 +570,7 @@ static Opm::Deck createInvalidDEPTHZDeck2 () {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext()) ;
+    return parser.parseString( deckData) ;
 }
 
 BOOST_AUTO_TEST_CASE(CreateCartesianGRIDInvalidDEPTHZ2) {
@@ -621,7 +620,7 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchCOORD) {
         "\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString( deckData, Opm::ParseContext()) ;
+    auto deck = parser.parseString( deckData) ;
     const auto& zcorn = deck.getKeyword("ZCORN");
     BOOST_CHECK_EQUAL( 8000U , zcorn.getDataSize( ));
 
@@ -646,7 +645,7 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchZCORN) {
         "\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString( deckData, Opm::ParseContext()) ;
+    auto deck = parser.parseString( deckData) ;
     BOOST_CHECK_THROW(Opm::EclipseGrid{ deck }, std::invalid_argument);
 }
 
@@ -666,7 +665,7 @@ BOOST_AUTO_TEST_CASE(ResetACTNUM) {
         "\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString( deckData, Opm::ParseContext()) ;
+    auto deck = parser.parseString( deckData) ;
 
     Opm::EclipseGrid grid( deck);
     BOOST_CHECK_EQUAL( 1000U , grid.getNumActive());
@@ -743,8 +742,8 @@ BOOST_AUTO_TEST_CASE(ACTNUM_BEST_EFFORT) {
         "\n";
 
     Opm::Parser parser;
-    auto deck1 = parser.parseString( deckData1, Opm::ParseContext()) ;
-    auto deck2 = parser.parseString( deckData2, Opm::ParseContext()) ;
+    auto deck1 = parser.parseString( deckData1) ;
+    auto deck2 = parser.parseString( deckData2) ;
 
     Opm::EclipseGrid grid1(deck1);
     // Actnum vector is too short - ignored
@@ -780,7 +779,7 @@ BOOST_AUTO_TEST_CASE(ConstructorNORUNSPEC) {
         "\n";
 
     Opm::Parser parser;
-    auto deck1 = parser.parseString( deckData, Opm::ParseContext()) ;
+    auto deck1 = parser.parseString( deckData) ;
     auto deck2 = createCPDeck();
 
     Opm::EclipseGrid grid1(deck1);
@@ -807,7 +806,7 @@ BOOST_AUTO_TEST_CASE(GDFILE) {
     }
     {
         Opm::Parser parser;
-        Opm::EclipseGrid grid2(parser.parseFile("ecl/DECK.DATA", Opm::ParseContext() ));
+        Opm::EclipseGrid grid2(parser.parseFile("ecl/DECK.DATA" ));
         BOOST_CHECK(grid1.equal(grid2));
     }
     test_work_area_free( work_area );
@@ -826,7 +825,7 @@ BOOST_AUTO_TEST_CASE(ConstructorNoSections) {
         "\n";
 
     Opm::Parser parser;
-    auto deck1 = parser.parseString( deckData, Opm::ParseContext()) ;
+    auto deck1 = parser.parseString( deckData) ;
     auto deck2 = createCPDeck();
 
     Opm::EclipseGrid grid1(deck1);
@@ -895,7 +894,7 @@ static Opm::Deck createActnumDeck() {
             "8*0 /\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 
@@ -938,12 +937,12 @@ static Opm::Deck createActnumBoxDeck() {
             "1000*0 /\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 BOOST_AUTO_TEST_CASE(GridBoxActnum) {
     auto deck = createActnumBoxDeck();
-    Opm::EclipseState es( deck, Opm::ParseContext());
+    Opm::EclipseState es( deck);
     auto ep = es.get3DProperties();
     const auto& grid = es.getInputGrid();
 
@@ -994,7 +993,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
 BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
     auto deck = createActnumDeck();
 
-    Opm::EclipseState es( deck, Opm::ParseContext());
+    Opm::EclipseState es( deck);
     auto ep = es.get3DProperties();
     const auto& grid = es.getInputGrid();
     Opm::EclipseGrid grid2( grid );
@@ -1010,8 +1009,8 @@ BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
 BOOST_AUTO_TEST_CASE(GridActnumViaState) {
     auto deck = createActnumDeck();
 
-    BOOST_CHECK_NO_THROW(Opm::EclipseState( deck, Opm::ParseContext()));
-    Opm::EclipseState es( deck, Opm::ParseContext());
+    BOOST_CHECK_NO_THROW( new Opm::EclipseState( deck));
+    Opm::EclipseState es( deck);
     BOOST_CHECK_EQUAL(es.getInputGrid().getNumActive(), 2 * 2 * 2 - 1);
 }
 
@@ -1144,7 +1143,7 @@ static Opm::Deck radial_missing_INRAD() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 
@@ -1170,7 +1169,7 @@ static Opm::Deck radial_keywords_OK() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 static Opm::Deck radial_keywords_OK_CIRCLE() {
@@ -1195,7 +1194,7 @@ static Opm::Deck radial_keywords_OK_CIRCLE() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 
@@ -1241,7 +1240,7 @@ static Opm::Deck radial_keywords_DRV_size_mismatch() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 
@@ -1266,7 +1265,7 @@ static Opm::Deck radial_keywords_DZV_size_mismatch() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 static Opm::Deck radial_keywords_DTHETAV_size_mismatch() {
@@ -1290,7 +1289,7 @@ static Opm::Deck radial_keywords_DTHETAV_size_mismatch() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 /*
@@ -1319,7 +1318,7 @@ static Opm::Deck radial_keywords_TOPS_size_mismatch() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 
@@ -1344,7 +1343,7 @@ static Opm::Deck radial_keywords_ANGLE_OVERFLOW() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 
@@ -1381,7 +1380,7 @@ static Opm::Deck radial_details() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString( deckData, Opm::ParseContext());
+    return parser.parseString( deckData);
 }
 
 

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -44,7 +44,6 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
@@ -93,12 +92,12 @@ static Deck createDeckTOP() {
 "\n";
 
     Parser parser;
-    return parser.parseString( deckData, ParseContext() );
+    return parser.parseString( deckData );
 }
 
 BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
     auto deck = createDeckTOP();
-    EclipseState state(deck , ParseContext());
+    EclipseState state(deck );
     const Eclipse3DProperties& props = state.get3DProperties();
 
     const GridProperty<double>& poro  = props.getDoubleGridProperty( "PORO" );
@@ -158,7 +157,7 @@ const char *deckData =
 "\n";
 
     Parser parser;
-    return parser.parseString( deckData, ParseContext() );
+    return parser.parseString( deckData );
 }
 
 
@@ -194,13 +193,13 @@ const char *deckData =
 "\n";
 
     Parser parser;
-    return parser.parseString( deckData, ParseContext() );
+    return parser.parseString( deckData );
 }
 
 BOOST_AUTO_TEST_CASE(CreateSchedule) {
     auto deck = createDeck();
-    EclipseState state(deck, ParseContext());
-    Schedule schedule(deck, state.getInputGrid(), state.get3DProperties(), state.runspec(), ParseContext( ));
+    EclipseState state(deck);
+    Schedule schedule(deck, state.getInputGrid(), state.get3DProperties(), state.runspec());
     BOOST_CHECK_EQUAL(schedule.getStartTime(), TimeMap::mkdate( 1998 , 3 , 8));
 }
 
@@ -236,13 +235,13 @@ const std::string& inputStr = "RUNSPEC\n"
 
 
     Parser parser;
-    return parser.parseString( inputStr, ParseContext() );
+    return parser.parseString( inputStr );
 }
 
 BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
 
     auto deck = createDeckSimConfig();
-    EclipseState state(deck, ParseContext());
+    EclipseState state(deck);
     const auto& simConf = state.getSimulationConfig();
 
     BOOST_CHECK(simConf.useThresholdPressure());
@@ -251,7 +250,7 @@ BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
 
 BOOST_AUTO_TEST_CASE(PhasesCorrect) {
     auto deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( deck );
     const auto& phases = state.runspec().phases();
     BOOST_CHECK(  phases.active( Phase::OIL ) );
     BOOST_CHECK(  phases.active( Phase::GAS ) );
@@ -260,14 +259,14 @@ BOOST_AUTO_TEST_CASE(PhasesCorrect) {
 
 BOOST_AUTO_TEST_CASE(TitleCorrect) {
     auto deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( deck );
 
     BOOST_CHECK_EQUAL( state.getTitle(), "The title" );
 }
 
 BOOST_AUTO_TEST_CASE(IntProperties) {
     auto deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( deck );
 
     BOOST_CHECK_EQUAL( false, state.get3DProperties().supportsGridProperty( "NONO" ) );
     BOOST_CHECK_EQUAL( true,  state.get3DProperties().supportsGridProperty( "SATNUM" ) );
@@ -277,7 +276,7 @@ BOOST_AUTO_TEST_CASE(IntProperties) {
 
 BOOST_AUTO_TEST_CASE(GetProperty) {
     auto deck = createDeck();
-    EclipseState state(deck, ParseContext());
+    EclipseState state(deck);
 
     const auto& satNUM = state.get3DProperties().getIntGridProperty( "SATNUM" );
 
@@ -290,7 +289,7 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
 
 BOOST_AUTO_TEST_CASE(GetTransMult) {
     auto deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( deck );
     const auto& transMult = state.getTransMult();
 
     BOOST_CHECK_EQUAL( 1.0, transMult.getMultiplier( 1, 0, 0, FaceDir::XPlus ) );
@@ -299,7 +298,7 @@ BOOST_AUTO_TEST_CASE(GetTransMult) {
 
 BOOST_AUTO_TEST_CASE(GetFaults) {
     auto deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( deck );
     const auto& faults = state.getFaults();
 
     BOOST_CHECK( faults.hasFault( "F1" ) );
@@ -320,7 +319,7 @@ BOOST_AUTO_TEST_CASE(GetFaults) {
 
 BOOST_AUTO_TEST_CASE(FaceTransMults) {
     auto deck = createDeckNoFaults();
-    EclipseState state(deck, ParseContext());
+    EclipseState state(deck);
     const auto& transMult = state.getTransMult();
 
     for (int i = 0; i < 10; ++ i) {
@@ -382,7 +381,7 @@ static Deck createDeckNoGridOpts() {
         "  1000*1 /\n";
 
     Parser parser;
-    return parser.parseString(deckData, ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -409,13 +408,13 @@ static Deck createDeckWithGridOpts() {
         "  1000*1 /\n";
 
     Parser parser;
-    return parser.parseString( deckData, ParseContext() );
+    return parser.parseString( deckData );
 }
 
 
 BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
     auto deck = createDeckNoGridOpts();
-    EclipseState state(deck, ParseContext());
+    EclipseState state(deck);
     const auto& props   = state.get3DProperties();
     const auto& multnum = props.getIntGridProperty("MULTNUM");
     const auto& fluxnum = props.getIntGridProperty("FLUXNUM");
@@ -429,7 +428,7 @@ BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
 
 BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
     auto deck = createDeckWithGridOpts();
-    EclipseState state(deck, ParseContext());
+    EclipseState state(deck);
     const auto& props   = state.get3DProperties();
     const auto& multnum = props.getIntGridProperty("MULTNUM");
     const auto& fluxnum = props.getIntGridProperty("FLUXNUM");
@@ -441,17 +440,16 @@ BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
 }
 
 BOOST_AUTO_TEST_CASE(TestIOConfigBaseName) {
-    ParseContext parseContext;
     Parser parser;
-    auto deck = parser.parseFile(prepath() + "IOConfig/SPE1CASE2.DATA", parseContext);
-    EclipseState state(deck, parseContext);
+    auto deck = parser.parseFile(prepath() + "IOConfig/SPE1CASE2.DATA");
+    EclipseState state(deck);
     const auto& io = state.cfg().io();
     BOOST_CHECK_EQUAL(io.getBaseName(), "SPE1CASE2");
     BOOST_CHECK_EQUAL(io.getOutputDir(), prepath() + "IOConfig");
 
     Parser parser2;
     auto deck2 = createDeckWithGridOpts();
-    EclipseState state2(deck2, parseContext);
+    EclipseState state2(deck2);
     const auto& io2 = state2.cfg().io();
     BOOST_CHECK_EQUAL(io2.getBaseName(), "");
     BOOST_CHECK_EQUAL(io2.getOutputDir(), ".");
@@ -491,8 +489,8 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
 
 
     Parser parser(new Parser());
-    auto deck = parser.parseString(deckData, ParseContext()) ;
-    EclipseState state(deck , ParseContext());
+    auto deck = parser.parseString(deckData) ;
+    EclipseState state(deck );
 
     const RestartConfig& rstConfig = state.cfg().restart();
 
@@ -540,10 +538,9 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
                           " 20  JAN 2011 / \n"
                           "/\n";
 
-    ParseContext parseContext;
     Parser parser;
-    auto deck = parser.parseString(deckData, parseContext) ;
-    EclipseState state(deck, parseContext);
+    auto deck = parser.parseString(deckData) ;
+    EclipseState state(deck);
 
     const RestartConfig& rstConfig = state.cfg().restart();
 
@@ -629,12 +626,11 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
                           "/\n";
 
 
-    ParseContext parseContext;
     Parser parser;
 
     {   //mnemnonics
-        auto deck = parser.parseString(deckData, parseContext) ;
-        EclipseState state(deck, parseContext);
+        auto deck = parser.parseString(deckData) ;
+        EclipseState state(deck);
 
         const RestartConfig& rstConfig = state.cfg().restart();
 
@@ -642,8 +638,8 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
     }
 
     {   //old fashion integer mnemonics
-        auto deck = parser.parseString(deckData2, parseContext) ;
-        EclipseState state(deck, parseContext);
+        auto deck = parser.parseString(deckData2) ;
+        EclipseState state(deck);
 
         const RestartConfig& rstConfig = state.cfg().restart();
 

--- a/tests/parser/EqualRegTests.cpp
+++ b/tests/parser/EqualRegTests.cpp
@@ -28,7 +28,6 @@
 
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -55,7 +54,7 @@ static Opm::Deck createDeckInvalidArray() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -73,7 +72,7 @@ static Opm::Deck createDeckInvalidRegion() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -91,7 +90,7 @@ static Opm::Deck createDeckInvalidValue() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -110,7 +109,7 @@ static Opm::Deck createDeckUnInitialized() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -153,7 +152,7 @@ static Opm::Deck createValidIntDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -203,7 +202,7 @@ static Opm::Deck createValidPERMXDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -211,23 +210,23 @@ static Opm::Deck createValidPERMXDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::Deck deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::Deck deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::Deck deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::Deck deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(IntSetCorrectly) {

--- a/tests/parser/GeomodifierTests.cpp
+++ b/tests/parser/GeomodifierTests.cpp
@@ -27,12 +27,13 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/parser/eclipse/Parser/InputErrorAction.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
@@ -69,10 +70,10 @@ BOOST_AUTO_TEST_CASE( CheckUnsoppertedInSCHEDULE ) {
         "   10 10/\n"
         "\n";
 
-    ParseContext parseContext;
     Parser parser(true);
-
-    auto deck = parser.parseString( deckString , parseContext );
+    ParseContext parseContext;
+    ErrorGuard errors;
+    auto deck = parser.parseString( deckString, parseContext, errors);
     EclipseGrid grid( deck );
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
@@ -80,7 +81,7 @@ BOOST_AUTO_TEST_CASE( CheckUnsoppertedInSCHEDULE ) {
     parseContext.update( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , InputError::IGNORE );
     {
         Runspec runspec ( deck );
-        Schedule schedule( deck, grid , eclipseProperties, runspec , parseContext);
+        Schedule schedule( deck, grid , eclipseProperties, runspec , parseContext, errors);
         auto events = schedule.getEvents( );
         BOOST_CHECK_EQUAL( false , events.hasEvent( ScheduleEvents::GEO_MODIFIER , 1 ));
         BOOST_CHECK_EQUAL( true  , events.hasEvent( ScheduleEvents::GEO_MODIFIER , 2 ));

--- a/tests/parser/GridPropertyTests.cpp
+++ b/tests/parser/GridPropertyTests.cpp
@@ -28,7 +28,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -46,7 +45,7 @@ static const Opm::DeckKeyword createSATNUMKeyword( ) {
     "\n";
 
     Opm::Parser parser;
-    Opm::Deck deck = parser.parseString(deckData, Opm::ParseContext());
+    Opm::Deck deck = parser.parseString(deckData);
     return deck.getKeyword("SATNUM");
 }
 
@@ -57,7 +56,7 @@ static const Opm::DeckKeyword createTABDIMSKeyword( ) {
     "\n";
 
     Opm::Parser parser;
-    Opm::Deck deck = parser.parseString(deckData, Opm::ParseContext());
+    Opm::Deck deck = parser.parseString(deckData);
     return deck.getKeyword("TABDIMS");
 }
 
@@ -345,10 +344,9 @@ BOOST_AUTO_TEST_CASE(GridPropertyInitialization) {
         "\n"
         "SCHEDULE\n";
 
-    Opm::ParseContext parseContext;
     Opm::Parser parser;
 
-    auto deck = parser.parseString(deckString, parseContext);
+    auto deck = parser.parseString(deckString);
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -278,13 +278,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithGEFAC) {
             " 'PRODUC' 0.85   / \n"
             "/\n";
 
-    Opm::ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck );
-    Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec , parseContext);
+    Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec);
 
     const auto& group1 = schedule.getGroup("PRODUC");
     BOOST_CHECK_EQUAL(group1.getGroupEfficiencyFactor(0), 0.85);
@@ -328,13 +327,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithWGRUPCONandWCONPROD) {
 
 
 
-    Opm::ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck );
-    Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec , parseContext);
+    Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec);
     const auto* currentWell = schedule.getWell("B-37T2");
     const Opm::WellProductionProperties& wellProductionProperties = currentWell->getProductionProperties(0);
     BOOST_CHECK_EQUAL(wellProductionProperties.controlMode, Opm::WellProducer::ControlModeEnum::GRUP);
@@ -420,13 +418,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithGRUPNET) {
         " 'MANI-E2'  1*    9  4* / \n"
         "/\n";
 
-        Opm::ParseContext parseContext;
-        auto deck = parser.parseString(input, parseContext);
+        auto deck = parser.parseString(input);
         EclipseGrid grid(10,10,10);
         TableManager table ( deck );
         Eclipse3DProperties eclipseProperties ( deck , table, grid);
         Runspec runspec (deck );
-        Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec , parseContext);
+        Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec);
 
         const auto& group1 = schedule.getGroup("PROD");
         const auto& group2 = schedule.getGroup("MANI-E2");

--- a/tests/parser/IOConfigTests.cpp
+++ b/tests/parser/IOConfigTests.cpp
@@ -25,7 +25,6 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 
 using namespace Opm;
@@ -188,10 +187,9 @@ BOOST_AUTO_TEST_CASE(DefaultProperties) {
                         " 1 JAN 1986 /\n"
                        "/\n";
 
-    ParseContext ctx;
-    auto deck = Parser().parseString( data, ctx );
+    auto deck = Parser().parseString( data);
     IOConfig ioConfig( deck );
-    RestartConfig rstConfig( deck, ctx );
+    RestartConfig rstConfig( deck);
 
     /*If no GRIDFILE nor NOGGF keywords are specified, default output an EGRID file*/
     BOOST_CHECK( ioConfig.getWriteEGRIDFile() );
@@ -224,7 +222,7 @@ BOOST_AUTO_TEST_CASE(OutputProperties) {
                         "SCHEDULE\n";
 
 
-    auto deck = Parser().parseString( data, ParseContext() );
+    auto deck = Parser().parseString( data );
     IOConfig ioConfig( deck );
 
     BOOST_CHECK( !ioConfig.getWriteEGRIDFile() );
@@ -246,7 +244,7 @@ BOOST_AUTO_TEST_CASE(NoGRIDFILE) {
                         " 0 0 /\n"
                         "\n";
 
-    auto deck = Parser().parseString( data, ParseContext() );
+    auto deck = Parser().parseString( data );
     IOConfig ioConfig( deck );
 
     /*If GRIDFILE 0 0 is specified, no EGRID file is written */

--- a/tests/parser/InitConfigTest.cpp
+++ b/tests/parser/InitConfigTest.cpp
@@ -26,7 +26,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
@@ -119,7 +118,7 @@ const std::string& deckWithEquil =
 
 static Deck createDeck(const std::string& input) {
     Opm::Parser parser;
-    return parser.parseString(input, Opm::ParseContext());
+    return parser.parseString(input);
 }
 
 BOOST_AUTO_TEST_CASE(InitConfigTest) {
@@ -211,22 +210,22 @@ BOOST_AUTO_TEST_CASE(RestartCWD) {
     }
     Opm::Parser parser;
     {
-        Opm::Deck deck = parser.parseFile("simulation/CASE.DATA", Opm::ParseContext());
+        Opm::Deck deck = parser.parseFile("simulation/CASE.DATA");
         Opm::InitConfig init_config(deck);
         BOOST_CHECK_EQUAL(init_config.getRestartRootName(), "simulation/BASE");
     }
     {
-      Opm::Deck deck = parser.parseFile("simulation/CASE5.DATA", Opm::ParseContext());
+      Opm::Deck deck = parser.parseFile("simulation/CASE5.DATA");
       Opm::InitConfig init_config(deck);
       BOOST_CHECK_EQUAL(init_config.getRestartRootName(), "/abs/path/BASE");
     }
     {
-        Opm::Deck deck = parser.parseFile("CWD_CASE.DATA", Opm::ParseContext());
+        Opm::Deck deck = parser.parseFile("CWD_CASE.DATA");
         Opm::InitConfig init_config(deck);
         BOOST_CHECK_EQUAL(init_config.getRestartRootName(), "BASE");
     }
     {
-      Opm::Deck deck = parser.parseFile("CASE5.DATA", Opm::ParseContext());
+      Opm::Deck deck = parser.parseFile("CASE5.DATA");
       Opm::InitConfig init_config(deck);
       BOOST_CHECK_EQUAL(init_config.getRestartRootName(), "/abs/path/BASE");
     }

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -26,7 +26,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -102,7 +101,7 @@ static Opm::Deck createInvalidMULTREGTDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -167,7 +166,7 @@ static Opm::Deck createNotSupportedMULTREGTDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -228,7 +227,7 @@ static Opm::Deck createDefaultedRegions() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -290,7 +289,7 @@ static Opm::Deck createCopyMULTNUMDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 BOOST_AUTO_TEST_CASE(MULTREGT_COPY_MULTNUM) {

--- a/tests/parser/MessageLimitTests.cpp
+++ b/tests/parser/MessageLimitTests.cpp
@@ -31,7 +31,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 using namespace Opm;
 
@@ -76,13 +75,12 @@ BOOST_AUTO_TEST_CASE(MESSAGES) {
             "  10 /\n"
         ;
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid, eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid, eclipseProperties, runspec);
     const MessageLimits limits = schedule.getMessageLimits();
 
     BOOST_CHECK_EQUAL( limits.getBugPrintLimit( 0 ) , 77 );   // The pre Schedule initialization

--- a/tests/parser/MultiRegTests.cpp
+++ b/tests/parser/MultiRegTests.cpp
@@ -26,7 +26,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -51,7 +50,7 @@ static Opm::Deck createDeckInvalidArray() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -72,7 +71,7 @@ static Opm::Deck createDeckInvalidRegion() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -93,7 +92,7 @@ static Opm::Deck createDeckInvalidValue() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -114,7 +113,7 @@ static Opm::Deck createDeckMissingVector() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -133,7 +132,7 @@ static Opm::Deck createDeckUnInitialized() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -193,7 +192,7 @@ static Opm::Deck createValidIntDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -203,29 +202,29 @@ static Opm::Deck createValidIntDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::Deck deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::Deck deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::Deck deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(MissingRegionVectorThrows) {
     Opm::Deck deck = createDeckMissingVector();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::Deck deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
 }
 
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -37,7 +37,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.hpp>
 
@@ -78,7 +77,7 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
         "/\n";
 
     Opm::Parser parser;
-    Opm::Deck deck = parser.parseString(compsegs_string, Opm::ParseContext());
+    Opm::Deck deck = parser.parseString(compsegs_string);
 
     const Opm::DeckKeyword compsegs = deck.getKeyword("COMPSEGS");
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );

--- a/tests/parser/PORVTests.cpp
+++ b/tests/parser/PORVTests.cpp
@@ -27,7 +27,6 @@
 
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -55,7 +54,7 @@ static Opm::Deck createCARTDeck() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 static Opm::Deck createDeckWithPORO() {
@@ -79,7 +78,7 @@ static Opm::Deck createDeckWithPORO() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 static Opm::Deck createDeckWithPORVPORO() {
@@ -108,7 +107,7 @@ static Opm::Deck createDeckWithPORVPORO() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -148,7 +147,7 @@ static Opm::Deck createDeckWithMULTPV() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -180,7 +179,7 @@ static Opm::Deck createDeckWithBOXPORV() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -215,7 +214,7 @@ static Opm::Deck createDeckWithNTG() {
 
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 static Opm::Deck createDeckWithMULTREGP() {
@@ -248,7 +247,7 @@ static Opm::Deck createDeckWithMULTREGP() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 BOOST_AUTO_TEST_CASE(PORV_cartesianDeck) {
@@ -399,7 +398,7 @@ static Opm::Deck createDeckNakedGRID() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 
@@ -441,13 +440,13 @@ static Opm::Deck createDeckWithPOROZero() {
         "\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext()) ;
+    return parser.parseString(deckData) ;
 }
 
 BOOST_AUTO_TEST_CASE(PORO_ZERO_ACTNUM_CORRECT) {
     /* Check that MULTIPLE Boxed PORV and MULTPV statements work and NTG */
     Opm::Deck deck = createDeckWithPOROZero();
-    Opm::EclipseState state( deck , Opm::ParseContext());
+    Opm::EclipseState state( deck);
     const auto& grid = state.getInputGrid( );
 
     /* Top layer is active */

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -59,33 +59,33 @@ BOOST_AUTO_TEST_CASE(TestUnkownKeyword) {
         "  10 10 10 /n"
         "\n";
 
-
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(false);
 
 
     parser.addKeyword<ParserKeywords::DIMENS>();
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext , errors) , std::invalid_argument);
 
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
-    BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext , errors) );
 
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::THROW_EXCEPTION );
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputError::IGNORE );
-    BOOST_CHECK_THROW( parser.parseString( deck2 , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck2 , parseContext , errors) , std::invalid_argument);
 
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputError::IGNORE );
-    BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext , errors) );
 
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( parser.parseString( deck2 , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck2 , parseContext , errors) , std::invalid_argument);
 
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputError::IGNORE );
-    BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext , errors) );
 }
 
 
@@ -97,15 +97,16 @@ BOOST_AUTO_TEST_CASE(TestUnkownKeywordII) {
         "\n";
 
 
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(false);
 
 
     parser.addKeyword<ParserKeywords::DIMENS>();
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext, errors ) , std::invalid_argument);
     parseContext.ignoreKeyword("RUNSPEC");
-    BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext, errors ) );
 }
 
 
@@ -120,20 +121,21 @@ BOOST_AUTO_TEST_CASE(Handle_extra_records) {
          "  2470   382.4   1705.0  0.0    500    0.0     1     1      20 /\n"
          "GRID\n";
 
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(false);
 
     parser.addKeyword<ParserKeywords::EQLDIMS>();
     parser.addKeyword<ParserKeywords::EQUIL>();
     parser.addKeyword<ParserKeywords::GRID>();
-    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ) , std::invalid_argument );
+    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext, errors ) , std::invalid_argument );
 
     parseContext.update(ParseContext::PARSE_EXTRA_RECORDS , InputError::IGNORE );
-    parser.parseString( deck_string , parseContext );
+    parser.parseString( deck_string , parseContext, errors );
     BOOST_CHECK( parser.hasKeyword( "GRID" ) );
 
     parseContext.update(ParseContext::PARSE_EXTRA_RECORDS , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext, errors ) , std::invalid_argument);
 }
 
 
@@ -150,6 +152,7 @@ BOOST_AUTO_TEST_CASE(Handle_extra_records_2) {
           " 10 10 3 /\n"
           " 5 3 2 /\n";
 
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(false);
 
@@ -159,7 +162,7 @@ BOOST_AUTO_TEST_CASE(Handle_extra_records_2) {
     parser.addKeyword<ParserKeywords::DIMENS>();
 
     parseContext.update(ParseContext::PARSE_EXTRA_RECORDS , InputError::IGNORE );
-    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ), std::invalid_argument );
+    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext, errors ), std::invalid_argument );
 }
 
 
@@ -201,6 +204,7 @@ BOOST_AUTO_TEST_CASE(TestUnkownKeyword_DATA) {
         "\n";
 
 
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(false);
 
@@ -210,11 +214,11 @@ BOOST_AUTO_TEST_CASE(TestUnkownKeyword_DATA) {
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputError::THROW_EXCEPTION );
     {
-        Deck deck = parser.parseString( deck_string1 , parseContext );
+        Deck deck = parser.parseString( deck_string1 , parseContext, errors );
         BOOST_CHECK( deck.hasKeyword( "RUNSPEC") );
         BOOST_CHECK( deck.hasKeyword( "DIMENS") );
     }
-    BOOST_CHECK_THROW( parser.parseString( deck_string2 , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck_string2 , parseContext, errors ) , std::invalid_argument);
 }
 
 
@@ -231,22 +235,23 @@ BOOST_AUTO_TEST_CASE(TEST_UNKNOWN_OPERATE) {
         "SGU    6* MULTA  SWL   -1.0   1.0  / SGU=1-SWL\n"
         "/\n";
 
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(false);
 
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( parser.parseString( deck , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck , parseContext, errors ) , std::invalid_argument);
 
     parseContext.update(ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE );
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
-    parser.parseString( deck , parseContext );
-    BOOST_CHECK_NO_THROW( parser.parseString( deck , parseContext ) );
+    parser.parseString( deck , parseContext, errors );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck , parseContext, errors ) );
 
     parser.addKeyword<ParserKeywords::OPERATE>();
-    parser.parseString( deck , parseContext );
+    parser.parseString( deck , parseContext, errors );
     parseContext.update(ParseContext::PARSE_RANDOM_SLASH , InputError::THROW_EXCEPTION );
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_NO_THROW( parser.parseString( deck , parseContext ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck , parseContext, errors ) );
 }
 
 
@@ -259,7 +264,7 @@ BOOST_AUTO_TEST_CASE( CheckMissingSizeKeyword) {
         "  10 10 10 10 / \n"
         "\n";
 
-
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(false);
 
@@ -268,10 +273,10 @@ BOOST_AUTO_TEST_CASE( CheckMissingSizeKeyword) {
     parser.addKeyword<ParserKeywords::SOLUTION>();
 
     parseContext.update( ParseContext::PARSE_MISSING_DIMS_KEYWORD , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( parser.parseString( deck , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck , parseContext, errors ) , std::invalid_argument);
 
     parseContext.update( ParseContext::PARSE_MISSING_DIMS_KEYWORD , InputError::IGNORE );
-    BOOST_CHECK_NO_THROW( parser.parseString( deck , parseContext ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck , parseContext, errors ) );
 }
 
 
@@ -317,24 +322,24 @@ BOOST_AUTO_TEST_CASE( CheckUnsupportedInSCHEDULE ) {
         "/\n"
         "\n";
 
-
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(true);
 
-    auto deckSupported = parser.parseString( deckStringSupported , parseContext );
-    auto deckUnSupported = parser.parseString( deckStringUnSupported , parseContext );
+    auto deckSupported = parser.parseString( deckStringSupported , parseContext, errors );
+    auto deckUnSupported = parser.parseString( deckStringUnSupported , parseContext, errors );
     EclipseGrid grid( deckSupported );
     TableManager table ( deckSupported );
     Eclipse3DProperties eclipseProperties ( deckSupported , table, grid);
     Runspec runspec(deckSupported);
 
     parseContext.update( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , InputError::IGNORE );
-    BOOST_CHECK_NO_THROW( Schedule( deckSupported  , grid , eclipseProperties, runspec, parseContext  ));
-    BOOST_CHECK_NO_THROW( Schedule( deckUnSupported, grid , eclipseProperties, runspec, parseContext  ));
+    BOOST_CHECK_NO_THROW( Schedule( deckSupported  , grid , eclipseProperties, runspec, parseContext, errors  ));
+    BOOST_CHECK_NO_THROW( Schedule( deckUnSupported, grid , eclipseProperties, runspec, parseContext, errors  ));
 
     parseContext.update( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( Schedule( deckUnSupported , grid , eclipseProperties, runspec , parseContext), std::invalid_argument );
-    BOOST_CHECK_NO_THROW( Schedule( deckSupported , grid , eclipseProperties, runspec , parseContext));
+    BOOST_CHECK_THROW( Schedule( deckUnSupported , grid , eclipseProperties, runspec , parseContext , errors), std::invalid_argument );
+    BOOST_CHECK_NO_THROW( Schedule( deckSupported , grid , eclipseProperties, runspec , parseContext, errors));
 }
 
 
@@ -353,7 +358,7 @@ BOOST_AUTO_TEST_CASE(TestRandomSlash) {
         "   /\n";
 
 
-
+    ErrorGuard errors;
     ParseContext parseContext;
     Parser parser(false);
 
@@ -363,14 +368,14 @@ BOOST_AUTO_TEST_CASE(TestRandomSlash) {
 
     parseContext.update(ParseContext::PARSE_RANDOM_SLASH , InputError::THROW_EXCEPTION);
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputError::IGNORE);
-    BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext ) , std::invalid_argument);
-    BOOST_CHECK_THROW( parser.parseString( deck2 , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck1 , parseContext, errors ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deck2 , parseContext, errors ) , std::invalid_argument);
 
 
     parseContext.update(ParseContext::PARSE_RANDOM_SLASH , InputError::IGNORE);
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputError::THROW_EXCEPTION);
-    BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext ) );
-    BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck1 , parseContext, errors ) );
+    BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext, errors ) );
 }
 
 
@@ -397,8 +402,9 @@ BOOST_AUTO_TEST_CASE(TestCOMPORD) {
         "/\n";
 
     ParseContext parseContext;
+    ErrorGuard errors;
     Parser parser(true);
-    auto deck = parser.parseString( deckString , parseContext );
+    auto deck = parser.parseString( deckString , parseContext, errors );
 
     EclipseGrid grid( deck );
     TableManager table ( deck );
@@ -406,10 +412,10 @@ BOOST_AUTO_TEST_CASE(TestCOMPORD) {
     Runspec runspec(deck);
 
     parseContext.update( ParseContext::UNSUPPORTED_COMPORD_TYPE , InputError::IGNORE);
-    BOOST_CHECK_NO_THROW( Schedule( deck , grid , eclipseProperties,  runspec, parseContext ));
+    BOOST_CHECK_NO_THROW( Schedule( deck , grid , eclipseProperties,  runspec, parseContext, errors ));
 
     parseContext.update( ParseContext::UNSUPPORTED_COMPORD_TYPE , InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW( Schedule( deck,  grid , eclipseProperties, runspec , parseContext), std::invalid_argument );
+    BOOST_CHECK_THROW( Schedule( deck,  grid , eclipseProperties, runspec , parseContext, errors), std::invalid_argument );
 }
 
 
@@ -479,13 +485,14 @@ BOOST_AUTO_TEST_CASE( test_too_much_data ) {
 
     ParseContext parseContext;
     Parser parser;
+    ErrorGuard errors;
 
 
     parseContext.update(ParseContext::PARSE_EXTRA_DATA , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( parser.parseString( deckString , parseContext ) , std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString( deckString , parseContext, errors ) , std::invalid_argument);
 
     parseContext.update(ParseContext::PARSE_EXTRA_DATA , InputError::IGNORE );
-    auto deck = parser.parseString( deckString , parseContext );
+    auto deck = parser.parseString( deckString , parseContext, errors );
 }
 
 
@@ -526,6 +533,7 @@ BOOST_AUTO_TEST_CASE( test_invalid_wtemplate_config ) {
 
     ParseContext parseContext;
     Parser parser;
+    ErrorGuard errors;
 
     parseContext.update(ParseContext::SCHEDULE_INVALID_NAME , InputError::THROW_EXCEPTION );
 
@@ -729,14 +737,14 @@ BOOST_AUTO_TEST_CASE( test_invalid_wtemplate_config ) {
     for (std::string sample : testSamples) {
 
         deckinput = defDeckString + sample;
-        auto deckUnSupported = parser.parseString( deckinput , parseContext );
+        auto deckUnSupported = parser.parseString( deckinput , parseContext, errors );
 
         EclipseGrid grid( deckUnSupported );
         TableManager table ( deckUnSupported );
         Eclipse3DProperties eclipseProperties ( deckUnSupported , table, grid);
         Runspec runspec( deckUnSupported);
 
-        BOOST_CHECK_THROW( Schedule( deckUnSupported , grid , eclipseProperties, runspec , parseContext), std::invalid_argument );
+        BOOST_CHECK_THROW( Schedule( deckUnSupported , grid , eclipseProperties, runspec , parseContext, errors), std::invalid_argument );
     }
 }
 

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -24,7 +24,7 @@
 #define BOOST_TEST_MODULE ParseContextTests
 #include <boost/test/unit_test.hpp>
 
-
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
@@ -747,4 +747,26 @@ BOOST_AUTO_TEST_CASE(Test_EXIT1) {
   would require the setup of an extra process and then check the exit status of
   the extra process - that kind of feelt a bit over the top.
 */
+}
+
+
+/*
+  If there are errors the ErrorGuard destructor will print error messages and
+  call std::terminate(); if you do not accept the std::terminate in the
+  destructor you should call the clear() method first.
+*/
+
+
+BOOST_AUTO_TEST_CASE(Test_ERRORGUARD) {
+    ErrorGuard eg;
+
+    BOOST_CHECK(!eg);
+
+    eg.addWarning(ParseContext::SUMMARY_UNKNOWN_WELL, "Unknown well");
+    BOOST_CHECK(!eg);
+
+    eg.addError(ParseContext::SUMMARY_UNKNOWN_GROUP, "Unknwon Group");
+    BOOST_CHECK(eg);
+    eg.clear();
+    BOOST_CHECK(!eg);
 }

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -749,15 +749,6 @@ BOOST_AUTO_TEST_CASE( test_invalid_wtemplate_config ) {
 }
 
 
-BOOST_AUTO_TEST_CASE(Test_EXIT1) {
-/*
-  The error handler EXIT1 is not tested at all. The reason is that testing that
-  would require the setup of an extra process and then check the exit status of
-  the extra process - that kind of feelt a bit over the top.
-*/
-}
-
-
 /*
   If there are errors the ErrorGuard destructor will print error messages and
   call std::terminate(); if you do not accept the std::terminate in the

--- a/tests/parser/ParseContext_EXIT1.cpp
+++ b/tests/parser/ParseContext_EXIT1.cpp
@@ -1,0 +1,51 @@
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+
+
+void exit1() {
+  const char * deckString =
+    "RUNSPEC\n"
+    "DIMENS\n"
+    "  10 10 10 10 /n"
+    "\n";
+
+  Opm::ParseContext parseContext;
+  Opm::Parser parser;
+  Opm::ErrorGuard errors;
+
+  parseContext.update(Opm::ParseContext::PARSE_EXTRA_DATA , Opm::InputError::EXIT1 );
+  parser.parseString( deckString , parseContext, errors );
+}
+
+
+
+/*
+  This test checks that the application will exit with status 1 - if that is
+  requested; since the boost test framework has registered atexit() handlers
+  which will unconditionally fail the complete test in the face of an exit(1) -
+  this test is implemented without the BOOST testing framework.
+*/
+
+int main() {
+    pid_t pid = fork();
+    if (pid == 0)
+        exit1();
+
+    int wait_status;
+    waitpid(pid, &wait_status, 0);
+
+    if (WIFEXITED(wait_status))
+        /*
+          We *want* the child process to terminate with status exit(1), here we
+          capture the exit status of the child process, and then we invert that
+          and return the inverted status as the status of the complete test.
+        */
+        std::exit( !WEXITSTATUS(wait_status) );
+    else
+        std::exit(EXIT_FAILURE);
+}

--- a/tests/parser/ParserIncludeTests.cpp
+++ b/tests/parser/ParserIncludeTests.cpp
@@ -37,12 +37,13 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_includeInvalid) {
 
     Opm::Parser parser;
     Opm::ParseContext parseContext;
+    Opm::ErrorGuard errors;
 
     parseContext.update(Opm::ParseContext::PARSE_MISSING_INCLUDE , Opm::InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW(parser.parseFile(inputFilePath.string() , parseContext) , std::invalid_argument);
+    BOOST_CHECK_THROW(parser.parseFile(inputFilePath.string() , parseContext, errors) , std::invalid_argument);
 
     parseContext.update(Opm::ParseContext::PARSE_MISSING_INCLUDE , Opm::InputError::IGNORE );
-    BOOST_CHECK_NO_THROW(parser.parseFile(inputFilePath.string() , parseContext));
+    BOOST_CHECK_NO_THROW(parser.parseFile(inputFilePath.string() , parseContext, errors));
 }
 
 
@@ -50,7 +51,7 @@ BOOST_AUTO_TEST_CASE(DATA_FILE_IS_SYMLINK) {
   boost::filesystem::path inputFilePath(prefix() + "includeSymlinkTestdata/symlink4/path/case.data");
   Opm::Parser parser;
   std::cout << "Input file: " << inputFilePath.string() << std::endl;
-  auto deck = parser.parseFile(inputFilePath.string() , Opm::ParseContext());
+  auto deck = parser.parseFile(inputFilePath.string());
 
   BOOST_CHECK_EQUAL(true , deck.hasKeyword("OIL"));
   BOOST_CHECK_EQUAL(false , deck.hasKeyword("WATER"));
@@ -60,7 +61,7 @@ BOOST_AUTO_TEST_CASE(DATA_FILE_IS_SYMLINK) {
 BOOST_AUTO_TEST_CASE(Verify_find_includes_Data_file_is_a_symlink) {
     boost::filesystem::path inputFilePath(prefix() + "includeSymlinkTestdata/symlink1/case_symlink.data");
     Opm::Parser parser;
-    auto deck = parser.parseFile(inputFilePath.string() , Opm::ParseContext());
+    auto deck = parser.parseFile(inputFilePath.string());
 
     BOOST_CHECK_EQUAL(true , deck.hasKeyword("OIL"));
     BOOST_CHECK_EQUAL(false , deck.hasKeyword("WATER"));
@@ -70,7 +71,7 @@ BOOST_AUTO_TEST_CASE(Verify_find_includes_Data_file_is_a_symlink) {
 BOOST_AUTO_TEST_CASE(Verify_find_includes_Data_file_has_include_that_is_a_symlink) {
     boost::filesystem::path inputFilePath(prefix() + "includeSymlinkTestdata/symlink2/caseWithIncludedSymlink.data");
     Opm::Parser parser;
-    auto deck = parser.parseFile(inputFilePath.string() , Opm::ParseContext());
+    auto deck = parser.parseFile(inputFilePath.string());
 
     BOOST_CHECK_EQUAL(true , deck.hasKeyword("OIL"));
     BOOST_CHECK_EQUAL(false , deck.hasKeyword("WATER"));
@@ -80,7 +81,7 @@ BOOST_AUTO_TEST_CASE(Verify_find_includes_Data_file_has_include_that_is_a_symlin
 BOOST_AUTO_TEST_CASE(Verify_find_includes_Data_file_has_include_file_that_again_includes_a_symlink) {
     boost::filesystem::path inputFilePath(prefix() + "includeSymlinkTestdata/symlink3/case.data");
     Opm::Parser parser;
-    auto deck = parser.parseFile(inputFilePath.string() , Opm::ParseContext());
+    auto deck = parser.parseFile(inputFilePath.string());
 
     BOOST_CHECK_EQUAL(true , deck.hasKeyword("OIL"));
     BOOST_CHECK_EQUAL(false , deck.hasKeyword("WATER"));
@@ -91,7 +92,7 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_includeValid) {
     boost::filesystem::path inputFilePath(prefix() + "includeValid.data");
 
     Opm::Parser parser;
-    auto deck = parser.parseFile(inputFilePath.string() , Opm::ParseContext());
+    auto deck = parser.parseFile(inputFilePath.string());
 
     BOOST_CHECK_EQUAL(true , deck.hasKeyword("OIL"));
     BOOST_CHECK_EQUAL(false , deck.hasKeyword("WATER"));
@@ -115,21 +116,22 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_includeWrongCase) {
     // to be a bit more relaxed when it comes to this, so we might
     // have to change the current behavior one not-so-fine day...
     Opm::ParseContext parseContext;
+    Opm::ErrorGuard errors;
     parseContext.update(Opm::ParseContext::PARSE_MISSING_INCLUDE , Opm::InputError::THROW_EXCEPTION );
 
-    BOOST_CHECK_THROW(parser.parseFile(inputFile1Path.string(), parseContext), std::invalid_argument);
-    BOOST_CHECK_THROW(parser.parseFile(inputFile2Path.string(), parseContext), std::invalid_argument);
-    BOOST_CHECK_THROW(parser.parseFile(inputFile3Path.string(), parseContext), std::invalid_argument);
+    BOOST_CHECK_THROW(parser.parseFile(inputFile1Path.string(), parseContext, errors), std::invalid_argument);
+    BOOST_CHECK_THROW(parser.parseFile(inputFile2Path.string(), parseContext, errors), std::invalid_argument);
+    BOOST_CHECK_THROW(parser.parseFile(inputFile3Path.string(), parseContext, errors), std::invalid_argument);
 #else
     // for case-insensitive filesystems, the include statement will
     // always work regardless of how the capitalization of the
     // included files is wrong...
-    BOOST_CHECK_EQUAL(true, parser.parseFile(inputFile1Path.string(), Opm::ParseContext()).hasKeyword("OIL"));
-    BOOST_CHECK_EQUAL(false, parser.parseFile(inputFile1Path.string(), Opm::ParseContext()).hasKeyword("WATER"));
-    BOOST_CHECK_EQUAL(true, parser.parseFile(inputFile2Path.string(), Opm::ParseContext()).hasKeyword("OIL"));
-    BOOST_CHECK_EQUAL(false, parser.parseFile(inputFile2Path.string(), Opm::ParseContext()).hasKeyword("WATER"));
-    BOOST_CHECK_EQUAL(true, parser.parseFile(inputFile3Path.string(), Opm::ParseContext()).hasKeyword("OIL"));
-    BOOST_CHECK_EQUAL(false, parser.parseFile(inputFile3Path.string(), Opm::ParseContext()).hasKeyword("WATER"));
+    BOOST_CHECK_EQUAL(true, parser.parseFile(inputFile1Path.string() ).hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser.parseFile(inputFile1Path.string()).hasKeyword("WATER"));
+    BOOST_CHECK_EQUAL(true, parser.parseFile(inputFile2Path.string() ).hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser.parseFile(inputFile2Path.string()).hasKeyword("WATER"));
+    BOOST_CHECK_EQUAL(true, parser.parseFile(inputFile3Path.string() ).hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser.parseFile(inputFile3Path.string()).hasKeyword("WATER"));
 #endif
 }
 

--- a/tests/parser/PvtxTableTests.cpp
+++ b/tests/parser/PvtxTableTests.cpp
@@ -23,7 +23,6 @@
 
 #include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
@@ -55,8 +54,7 @@ inline std::string prefix() {
 BOOST_AUTO_TEST_CASE( PvtxNumTables1 ) {
     Parser parser;
     boost::filesystem::path deckFile(prefix() + "TABLES/PVTX1.DATA");
-    ParseContext parseContext;
-    auto deck =  parser.parseFile(deckFile.string(), parseContext);
+    auto deck =  parser.parseFile(deckFile.string());
     BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword<ParserKeywords::PVTO>()) , 1);
 
     auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
@@ -69,8 +67,7 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables1 ) {
 BOOST_AUTO_TEST_CASE( PvtxNumTables2 ) {
     Parser parser;
     boost::filesystem::path deckFile(prefix() + "TABLES/PVTO2.DATA");
-    ParseContext parseContext;
-    auto deck =  parser.parseFile(deckFile.string(), parseContext);
+    auto deck =  parser.parseFile(deckFile.string());
     BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword<ParserKeywords::PVTO>()) , 3);
 
     auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
@@ -103,7 +100,7 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables3 ) {
         "/\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
 
     auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
     BOOST_CHECK_EQUAL( 2 ,ranges.size() );
@@ -122,8 +119,7 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables3 ) {
 BOOST_AUTO_TEST_CASE( PVTOSaturatedTable ) {
     Parser parser;
     boost::filesystem::path deckFile(prefix() + "TABLES/PVTX1.DATA");
-    ParseContext parseContext;
-    auto deck =  parser.parseFile(deckFile.string(), parseContext);
+    auto deck =  parser.parseFile(deckFile.string());
     Opm::TableManager tables(deck);
     const auto& pvtoTables = tables.getPvtoTables( );
     const auto& pvtoTable = pvtoTables[0];
@@ -169,8 +165,7 @@ BOOST_AUTO_TEST_CASE( PVTOSaturatedTable ) {
 BOOST_AUTO_TEST_CASE( PVTGSaturatedTable ) {
     Parser parser;
     boost::filesystem::path deckFile(prefix() + "TABLES/PVTX1.DATA");
-    ParseContext parseContext;
-    auto deck =  parser.parseFile(deckFile.string(), parseContext);
+    auto deck =  parser.parseFile(deckFile.string());
     Opm::TableManager tables(deck);
     const auto& pvtgTables = tables.getPvtgTables( );
     const auto& pvtgTable = pvtgTables[0];

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -50,9 +50,8 @@ BOOST_AUTO_TEST_CASE(TwoPhase) {
     )";
 
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
@@ -73,9 +72,8 @@ BOOST_AUTO_TEST_CASE(ThreePhase) {
     )";
 
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
@@ -98,9 +96,8 @@ BOOST_AUTO_TEST_CASE(TABDIMS) {
     )";
 
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
 
     Runspec runspec( deck );
     const auto& tabdims = runspec.tabdims();
@@ -117,7 +114,7 @@ BOOST_AUTO_TEST_CASE( EndpointScalingWithoutENDSCALE ) {
     RUNSPEC
     )";
 
-    Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
+    Runspec runspec( Parser{}.parseString( input ) );
     const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( !endscale );
@@ -136,7 +133,7 @@ BOOST_AUTO_TEST_CASE( EndpointScalingDefaulted ) {
         /
     )";
 
-    Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
+    Runspec runspec( Parser{}.parseString( input ) );
     const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( endscale );
@@ -153,7 +150,7 @@ BOOST_AUTO_TEST_CASE( EndpointScalingDIRECT ) {
         DIRECT /
     )";
 
-    Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
+    Runspec runspec( Parser{}.parseString( input ) );
     const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( endscale );
@@ -170,7 +167,7 @@ BOOST_AUTO_TEST_CASE( EndpointScalingDIRECT_IRREVERS ) {
         direct IRREVERS /
     )";
 
-    Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
+    Runspec runspec( Parser{}.parseString( input ) );
     const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( endscale );
@@ -187,7 +184,7 @@ BOOST_AUTO_TEST_CASE( SCALECRS_without_ENDSCALE ) {
         /
     )";
 
-    Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
+    Runspec runspec( Parser{}.parseString( input ) );
     const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( !endscale );
@@ -213,7 +210,7 @@ BOOST_AUTO_TEST_CASE( SCALECRS_N ) {
     )";
 
     for( const auto& input : { N, defaulted } ) {
-        Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
+        Runspec runspec( Parser{}.parseString( input ) );
         const auto& endscale = runspec.endpointScaling();
 
         BOOST_CHECK( endscale );
@@ -231,7 +228,7 @@ BOOST_AUTO_TEST_CASE( SCALECRS_Y ) {
         Y /
     )";
 
-    Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
+    Runspec runspec( Parser{}.parseString( input ) );
     const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( endscale );
@@ -267,7 +264,7 @@ BOOST_AUTO_TEST_CASE( endpoint_scaling_throw_invalid_argument ) {
     };
 
     for( auto&& input : inputs ) {
-        auto deck = Parser{}.parseString( input, ParseContext{} );
+        auto deck = Parser{}.parseString( input );
         BOOST_CHECK_THROW( Runspec{ deck }, std::invalid_argument );
     }
 }
@@ -283,7 +280,7 @@ WELLDIMS
 )" };
 
     const auto wd = Welldims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wd.maxConnPerWell(), 36);   // WELLDIMS(2)
@@ -302,7 +299,7 @@ WELLDIMS
 )" };
 
     const auto wd = Welldims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wd.maxConnPerWell(), 0);   // WELLDIMS(2), defaulted
@@ -321,7 +318,7 @@ WELLDIMS
 )" };
 
     const auto wd = Welldims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wd.maxConnPerWell(), 36);  // WELLDIMS(2)
@@ -340,7 +337,7 @@ WELLDIMS
 )" };
 
     const auto wd = Welldims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wd.maxConnPerWell(), 0);   // WELLDIMS(2), defaulted
@@ -359,7 +356,7 @@ WELLDIMS
 )" };
 
     const auto wd = Welldims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wd.maxConnPerWell(), 0);    // WELLDIMS(2), defaulted
@@ -375,7 +372,7 @@ RUNSPEC
 )" };
 
     const auto wsd = WellSegmentDims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 0);         // WSEGDIMS1), defaulted
@@ -394,7 +391,7 @@ WSEGDIMS
 )" };
 
     const auto wsd = WellSegmentDims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 0);         // WSEGDIMS1), defaulted
@@ -414,7 +411,7 @@ WSEGDIMS
 )" };
 
     const auto wsd = WellSegmentDims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 11);        // WSEGDIMS(1)
@@ -434,7 +431,7 @@ WSEGDIMS
 )" };
 
     const auto wsd = WellSegmentDims {
-        Parser{}.parseString(input, ParseContext{})
+        Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 0);         // WSEGDIMS(1), defaulted
@@ -454,7 +451,7 @@ WSEGDIMS
 )" };
 
     const auto wsd = WellSegmentDims {
-        Parser{}.parseString(input, ParseContext{})
+      Parser{}.parseString(input)
     };
 
     BOOST_CHECK_EQUAL(wsd.maxSegmentedWells(), 0);          // WSEGDIMS(1), defaulted
@@ -468,7 +465,7 @@ BOOST_AUTO_TEST_CASE( SWATINIT ) {
        1000*0.25 /
     )";
 
-    Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
+    Runspec runspec( Parser{}.parseString( input ) );
     const auto& endscale = runspec.endpointScaling();
     BOOST_CHECK( endscale );
     BOOST_CHECK( !endscale.directional() );
@@ -489,9 +486,8 @@ BOOST_AUTO_TEST_CASE(Solvent) {
     )";
 
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
@@ -515,9 +511,8 @@ BOOST_AUTO_TEST_CASE(Polymer) {
     )";
 
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
@@ -541,9 +536,8 @@ BOOST_AUTO_TEST_CASE(PolymerMolecularWeight) {
     )";
 
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();

--- a/tests/parser/SatfuncPropertyInitializersTests.cpp
+++ b/tests/parser/SatfuncPropertyInitializersTests.cpp
@@ -30,7 +30,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 using namespace Opm;
 
@@ -103,13 +102,12 @@ BOOST_AUTO_TEST_CASE(SaturationFunctionFamilyTests) {
         " .7  .8  .3\n"
         " .8 1.0  1.0/\n";
 
-    ParseContext parseContext;
     Parser parser;
 
     char family1Deck[500] = " ";
     strcat(family1Deck , deckdefault);
     strcat(family1Deck , family1);
-    Deck deck1 = parser.parseString(family1Deck, parseContext) ;
+    Deck deck1 = parser.parseString(family1Deck) ;
     Opm::TableManager tm1( deck1 );
     Opm::EclipseGrid grid1( deck1 );
     Opm::Eclipse3DProperties prop1( deck1, tm1, grid1 );
@@ -118,7 +116,7 @@ BOOST_AUTO_TEST_CASE(SaturationFunctionFamilyTests) {
     char family2Deck[700] = " ";
     strcat(family2Deck , deckdefault);
     strcat(family2Deck , family2);
-    Deck deck2 = parser.parseString(family2Deck, parseContext) ;
+    Deck deck2 = parser.parseString(family2Deck) ;
     Opm::TableManager tm2( deck2 );
     Opm::EclipseGrid grid2( deck2 );
     Opm::Eclipse3DProperties prop2( deck2, tm2, grid2 );
@@ -146,7 +144,7 @@ BOOST_AUTO_TEST_CASE(SaturationFunctionFamilyTests) {
     strcat(familyMixDeck , family1);
     strcat(familyMixDeck , family2);
 
-    Deck deckMix = parser.parseString(familyMixDeck, parseContext) ;
+    Deck deckMix = parser.parseString(familyMixDeck) ;
     Opm::TableManager tmMix( deckMix );
     Opm::EclipseGrid gridMix( deckMix );
     Opm::Eclipse3DProperties propMix( deckMix, tmMix, gridMix );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -41,7 +41,6 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
@@ -56,7 +55,7 @@ static Deck createDeck() {
         "SCHEDULE\n"
         "\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithWells() {
@@ -80,7 +79,7 @@ static Deck createDeckWithWells() {
             "     \'W_3\'        \'OP\'   20   51  3.92       \'OIL\'  7* /  \n"
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWTEST() {
@@ -154,7 +153,7 @@ static Deck createDeckWTEST() {
             "/\n";
 
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckForTestingCrossFlow() {
@@ -219,7 +218,7 @@ static Deck createDeckForTestingCrossFlow() {
             "/\n";
 
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithWellsOrdered() {
@@ -234,7 +233,7 @@ static Deck createDeckWithWellsOrdered() {
             "     \'AW_3\'        \'AG\'   20   51  3.92       \'OIL\'  7* /  \n"
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithWellsOrderedGRUPTREE() {
@@ -256,7 +255,7 @@ static Deck createDeckWithWellsOrderedGRUPTREE() {
             "     \'AW_3\'        \'CG2\'   20   51  3.92       \'OIL\'  7* /   \n"
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithWellsAndCompletionData() {
@@ -290,7 +289,7 @@ static Deck createDeckWithWellsAndCompletionData() {
       " 'OP_1'  0  *   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
       "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
@@ -300,7 +299,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec );
     BOOST_CHECK_EQUAL( schedule.getStartTime() , TimeMap::mkdate(1983, 1 , 1));
 }
 
@@ -310,7 +309,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     auto wells = schedule.getWells();
 
     BOOST_CHECK_EQUAL( "CW_1" , wells[0]->name());
@@ -341,7 +340,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
 
     BOOST_CHECK_THROW( schedule.getWells( "NO_SUCH_GROUP" , 1 ), std::invalid_argument);
 
@@ -390,7 +389,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
 
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK_EQUAL( schedule.getStartTime() , TimeMap::mkdate(1998, 3  , 8 ));
 }
 
@@ -402,7 +401,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     deck.addKeyword( DeckKeyword( "SCHEDULE" ) );
     Runspec runspec (deck);
 
-    BOOST_CHECK_NO_THROW( Schedule( deck, grid , eclipseProperties, runspec, ParseContext() ));
+    BOOST_CHECK_NO_THROW( Schedule( deck, grid , eclipseProperties, runspec));
 }
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
@@ -411,7 +410,7 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK_EQUAL( 0U , schedule.numWells() );
     BOOST_CHECK_EQUAL( false , schedule.hasWell("WELL1") );
     BOOST_CHECK_THROW( schedule.getWell("WELL2") , std::invalid_argument );
@@ -423,7 +422,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithoutGRUPTREE_HasRootGroupTreeNodeForT
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK(schedule.getGroupTree(0).exists("FIELD"));
 }
 
@@ -451,7 +450,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTime
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK( schedule.getGroupTree( 0 ).exists( "FIELD" ) );
     BOOST_CHECK( schedule.getGroupTree( 0 ).exists( "FAREN" ) );
     BOOST_CHECK_EQUAL( "FAREN", schedule.getGroupTree( 0 ).parent( "BARNET" ) );
@@ -463,7 +462,7 @@ BOOST_AUTO_TEST_CASE(GetGroups) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck , grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck , grid , eclipseProperties, runspec);
 
     auto groups = schedule.getGroups();
 
@@ -484,7 +483,7 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck , grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck , grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL( 1U , schedule.numGroups() );
     BOOST_CHECK_EQUAL( true , schedule.hasGroup("FIELD") );
@@ -498,7 +497,7 @@ BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck , grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck , grid , eclipseProperties, runspec);
     size_t timeStep = 0;
     const auto wells_alltimesteps = schedule.getWells();
     BOOST_CHECK_EQUAL(0U, wells_alltimesteps.size());
@@ -514,7 +513,7 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck , grid , eclipseProperties, runspec , ParseContext( ));
+    Schedule schedule(deck , grid , eclipseProperties, runspec);
     size_t timeStep = 0;
 
     const auto wells_alltimesteps = schedule.getWells();
@@ -531,7 +530,7 @@ BOOST_AUTO_TEST_CASE(WellsIteratorWithRegex_HasWells_WellsReturned) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     std::string wellNamePattern;
 
     wellNamePattern = "*";
@@ -553,7 +552,7 @@ BOOST_AUTO_TEST_CASE(ReturnNumWellsTimestep) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL(schedule.numWells(0), 1);
     BOOST_CHECK_EQUAL(schedule.numWells(1), 1);
@@ -567,7 +566,7 @@ BOOST_AUTO_TEST_CASE(ReturnMaxNumCompletionsForWellsInTimestep) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext() );
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL(schedule.getMaxNumConnectionsForWells(1), 7);
     BOOST_CHECK_EQUAL(schedule.getMaxNumConnectionsForWells(3), 9);
@@ -579,7 +578,7 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext() );
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
 
     auto well_ban = schedule.getWell("BAN");
     BOOST_CHECK_EQUAL(well_ban->getAllowCrossFlow(), false);
@@ -653,7 +652,7 @@ static Deck createDeckWithWellsAndConnectionDataWithWELOPEN() {
                     " 'OP_1' SHUT 0 0 0 0 0 / \n "
                     "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndConnectionDataWithWELOPEN) {
@@ -662,7 +661,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndConnectionDataWithWELOPEN) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck ,grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck ,grid , eclipseProperties, runspec);
     auto* well = schedule.getWell("OP_1");
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus( 0 ));
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus( 3 ));
@@ -737,12 +736,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
                   "/\n";
 
   EclipseGrid grid(10,10,10);
-  ParseContext parseContext;
-  auto deck = parser.parseString(input, parseContext);
+  auto deck = parser.parseString(input);
   TableManager table ( deck );
   Eclipse3DProperties eclipseProperties ( deck , table, grid);
   Runspec runspec (deck);
-  Schedule schedule(deck ,  grid , eclipseProperties, runspec , parseContext);
+  Schedule schedule(deck ,  grid , eclipseProperties, runspec);
   auto* well = schedule.getWell("OP_1");
   size_t currentStep = 3;
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
@@ -799,12 +797,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_CombineShutCompletionsAndAddN
                   "/\n";
 
   EclipseGrid grid(10,10,10);
-  ParseContext parseContext;
-  auto deck = parser.parseString(input, parseContext);
+  auto deck = parser.parseString(input);
   TableManager table ( deck );
   Eclipse3DProperties eclipseProperties ( deck , table, grid);
   Runspec runspec (deck);
-  Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+  Schedule schedule(deck, grid , eclipseProperties, runspec);
   auto* well = schedule.getWell("OP_1");
   // timestep 3. Close all completions with WELOPEN and immediately open new completions with COMPDAT.
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(3));
@@ -856,12 +853,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
 
 
     EclipseGrid grid(10,10,10);
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
 
     {
         auto* well = schedule.getWell("OP_1");
@@ -920,13 +916,12 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
                     "DATES             -- 5\n"
                     " 10  NOV 2008 / \n"
                     "/\n";
-    ParseContext parseContext;
     EclipseGrid grid(10,10,10);
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     auto* well = schedule.getWell("OP_1");
 
     size_t currentStep = 3;
@@ -970,13 +965,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
             " OP_1     GUID        2300.14 /\n"
             "/\n";
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck,  grid , eclipseProperties, runspec);
     auto* well = schedule.getWell("OP_1");
 
     size_t currentStep = 1;
@@ -1011,14 +1005,13 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException) {
             " OP_1     RESV        1801.05 /\n"
             "/\n";
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
 
-    BOOST_CHECK_THROW(Schedule(deck, grid , eclipseProperties, runspec , parseContext),
+    BOOST_CHECK_THROW(Schedule(deck, grid , eclipseProperties, runspec),
                       std::invalid_argument);
 }
 
@@ -1031,13 +1024,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException2) {
             " OP_1     RESV        1801.05 /\n"
             "/\n";
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    BOOST_CHECK_THROW(Schedule(deck, grid , eclipseProperties, runspec , parseContext), std::out_of_range);
+    BOOST_CHECK_THROW(Schedule(deck, grid , eclipseProperties, runspec), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_CASE(createDeckWithWPIMULT) {
@@ -1089,13 +1081,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithWPIMULT) {
                     " 'OP_1'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
                     "/\n";
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     auto* well = schedule.getWell("OP_1");
 
     const auto& cs2 = well->getConnections( 2 );
@@ -1151,13 +1142,12 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
         /
         )";
 
-        Opm::ParseContext parseContext;
-        auto deck = parser.parseString(input, parseContext);
+        auto deck = parser.parseString(input);
         EclipseGrid grid( deck );
         TableManager table ( deck );
         Eclipse3DProperties eclipseProperties ( deck , table, grid);
         Runspec runspec (deck);
-        Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec , parseContext);
+        Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec);
 
         Opm::UnitSystem unitSystem = deck.getActiveUnitSystem();
         double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
@@ -1189,13 +1179,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDT) {
             "0.0003\n"
             "/\n";
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     size_t currentStep = 1;
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), true);
     const auto& ovap = schedule.getOilVaporizationProperties(currentStep);
@@ -1223,13 +1212,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDTR) {
             "1 /\n"
             "2 /\n";
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     size_t currentStep = 1;
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), true);
     const auto& ovap = schedule.getOilVaporizationProperties(currentStep);
@@ -1271,13 +1259,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDTthenDRVDT) {
             "2 0.100\n"
             "/\n";
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), true);
 
     const OilVaporizationProperties& ovap1 = schedule.getOilVaporizationProperties(1);
@@ -1313,13 +1300,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithVAPPARS) {
             "2 0.100\n"
             "/\n";
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     size_t currentStep = 1;
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), true);
     const OilVaporizationProperties& ovap = schedule.getOilVaporizationProperties(currentStep);
@@ -1345,13 +1331,12 @@ BOOST_AUTO_TEST_CASE(createDeckWithOutOilVaporizationProperties) {
             "/\n";
 
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), false);
 
@@ -1407,13 +1392,12 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
             "/\n"
             ;
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     auto* well_p = schedule.getWell("P");
 
     BOOST_CHECK_EQUAL(well_p->getProductionProperties(0).BHPLimit, 0); //start
@@ -1497,13 +1481,12 @@ BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {
             "/\n"
             ;
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     auto* well_p1 = schedule.getWell("P1");
     auto* well_p2 = schedule.getWell("P2");
 
@@ -1564,13 +1547,12 @@ BOOST_AUTO_TEST_CASE(unsupportedOptionWHISTCTL) {
             " * YES / \n"
             ;
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    BOOST_CHECK_THROW(Schedule(deck, grid, eclipseProperties, runspec , parseContext), std::invalid_argument);
+    BOOST_CHECK_THROW(Schedule(deck, grid, eclipseProperties, runspec), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(move_HEAD_I_location) {
@@ -1594,13 +1576,12 @@ BOOST_AUTO_TEST_CASE(move_HEAD_I_location) {
             /
     )";
 
-    ParseContext ctx;
-    auto deck = Parser().parseString(input, ctx);
+    auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule( deck, grid, eclipseProperties,runspec , ctx);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& well = *schedule.getWell( "W1" );
     BOOST_CHECK_EQUAL( 3, well.getHeadI() );
@@ -1628,13 +1609,12 @@ BOOST_AUTO_TEST_CASE(change_ref_depth) {
             /
     )";
 
-    ParseContext ctx;
-    auto deck = Parser().parseString(input, ctx);
+    auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule( deck, grid, eclipseProperties,runspec  ,ctx);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& well = *schedule.getWell( "W1" );
     BOOST_CHECK_EQUAL( 12.0, well.getRefDepth() );
@@ -1669,13 +1649,12 @@ BOOST_AUTO_TEST_CASE(WTEMP_well_template) {
             /
     )";
 
-        ParseContext ctx;
-        auto deck = Parser().parseString(input, ctx);
+        auto deck = Parser().parseString(input);
         EclipseGrid grid(10,10,10);
         TableManager table ( deck );
         Eclipse3DProperties eclipseProperties ( deck , table, grid);
         Runspec runspec (deck);
-        Schedule schedule( deck, grid, eclipseProperties,runspec  ,ctx);
+        Schedule schedule( deck, grid, eclipseProperties,runspec);
 
         // Producerwell - currently setting temperature only acts on injectors.
         const auto& w1 = *schedule.getWell( "W1" );
@@ -1719,13 +1698,12 @@ BOOST_AUTO_TEST_CASE(WTEMPINJ_well_template) {
             /
     )";
 
-        ParseContext ctx;
-        auto deck = Parser().parseString(input, ctx);
+        auto deck = Parser().parseString(input);
         EclipseGrid grid(10,10,10);
         TableManager table ( deck );
         Eclipse3DProperties eclipseProperties ( deck , table, grid);
         Runspec runspec (deck);
-        Schedule schedule( deck, grid, eclipseProperties,runspec  ,ctx);
+        Schedule schedule( deck, grid, eclipseProperties,runspec);
 
         // Producerwell - currently setting temperature only acts on injectors.
         const auto& w1 = *schedule.getWell( "W1" );
@@ -1768,13 +1746,12 @@ BOOST_AUTO_TEST_CASE( COMPDAT_sets_automatic_complnum ) {
         /
     )";
 
-    ParseContext ctx;
-    auto deck = Parser().parseString(input, ctx);
+    auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule( deck, grid, eclipseProperties,runspec  ,ctx);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& cs1 = schedule.getWell( "W1" )->getConnections( 1 );
     BOOST_CHECK_EQUAL( -1, cs1.get( 0 ).complnum() );
@@ -1813,13 +1790,12 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_wells ) {
         /
     )";
 
-    ParseContext ctx;
-    auto deck = Parser().parseString( input, ctx );
+    auto deck = Parser().parseString( input);
     EclipseGrid grid( 10, 10, 10 );
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule( deck, grid, eclipseProperties,runspec  ,ctx);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& w1cs = schedule.getWell( "W1" )->getConnections();
     BOOST_CHECK_EQUAL( -1, w1cs.get( 0 ).complnum() );
@@ -1858,13 +1834,12 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_records_same_completion ) {
         /
     )";
 
-    ParseContext ctx;
-    auto deck = Parser().parseString(input, ctx);
+    auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule( deck, grid, eclipseProperties,runspec  ,ctx);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& cs = schedule.getWell( "W1" )->getConnections();
     BOOST_CHECK_EQUAL( 3U, cs.size() );
@@ -1892,13 +1867,12 @@ BOOST_AUTO_TEST_CASE( complump_less_than_1 ) {
             /
     )";
 
-    ParseContext ctx;
-    auto deck = Parser().parseString( input, ctx );
+    auto deck = Parser().parseString( input);
     EclipseGrid grid( 10, 10, 10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    BOOST_CHECK_THROW( Schedule( deck , grid, eclipseProperties, runspec , ctx), std::invalid_argument );
+    BOOST_CHECK_THROW( Schedule( deck , grid, eclipseProperties, runspec), std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE( complump ) {
@@ -1938,13 +1912,12 @@ BOOST_AUTO_TEST_CASE( complump ) {
     constexpr auto open = WellCompletion::StateEnum::OPEN;
     constexpr auto shut = WellCompletion::StateEnum::SHUT;
 
-    ParseContext ctx;
-    auto deck = Parser().parseString(input, ctx);
+    auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule( deck, grid, eclipseProperties,runspec  ,ctx);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& well = *schedule.getWell( "W1" );
     const auto& sc0  = well.getConnections( 0 );
@@ -2025,13 +1998,12 @@ BOOST_AUTO_TEST_CASE( COMPLUMP_specific_coordinates ) {
     constexpr auto open = WellCompletion::StateEnum::OPEN;
     constexpr auto shut = WellCompletion::StateEnum::SHUT;
 
-    ParseContext ctx;
-    auto deck = Parser().parseString( input, ctx );
+    auto deck = Parser().parseString( input);
     EclipseGrid grid( 10, 10, 10 );
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule( deck, grid, eclipseProperties,runspec  ,ctx);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& well = *schedule.getWell( "W1" );
     const auto& cs1 = well.getConnections( 1 );
@@ -2504,13 +2476,12 @@ BOOST_AUTO_TEST_CASE(handleWEFAC) {
             "/\n"
             ;
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     auto* well_p = schedule.getWell("P");
     auto* well_i = schedule.getWell("I");
 
@@ -2557,13 +2528,12 @@ BOOST_AUTO_TEST_CASE(historic_BHP_and_THP) {
         "/\n"
         ;
 
-    ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule( deck, grid, eclipseProperties,runspec  ,parseContext);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& prod = schedule.getWell("P")->getProductionProperties(1);
     const auto& pro1 = schedule.getWell("P1")->getProductionProperties(1);
@@ -2595,7 +2565,7 @@ BOOST_AUTO_TEST_CASE(FilterCompletions) {
   TableManager table ( deck );
   Eclipse3DProperties eclipseProperties ( deck , table, grid1);
   Runspec runspec (deck);
-  Schedule schedule(deck, grid1 , eclipseProperties, runspec , ParseContext() );
+  Schedule schedule(deck, grid1 , eclipseProperties, runspec);
   const auto& well = schedule.getWell("OP_1");
   const auto& c1_1 = well->getConnections(1);
   const auto& c1_3 = well->getConnections(3);
@@ -2656,12 +2626,12 @@ VFPINJ \n                                       \
 
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid1);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid1 , eclipseProperties, runspec , ParseContext() );
+    Schedule schedule(deck, grid1 , eclipseProperties, runspec);
 
     schedule.evalAction(SummaryState(), 5);
     BOOST_CHECK( schedule.getEvents().hasEvent(ScheduleEvents::VFPINJ_UPDATE, 0));
@@ -2772,12 +2742,12 @@ BOOST_AUTO_TEST_CASE(POLYINJ_TEST) {
         " 1 /\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid1);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid1 , eclipseProperties, runspec , ParseContext() );
+    Schedule schedule(deck, grid1 , eclipseProperties, runspec);
 
     const Opm::Well* well_inj01 = schedule.getWell("INJE01");
 
@@ -2813,7 +2783,7 @@ BOOST_AUTO_TEST_CASE(WTEST_CONFIG) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid1);
     Runspec runspec (deck);
-    Schedule schedule(deck, grid1 , eclipseProperties, runspec , ParseContext() );
+    Schedule schedule(deck, grid1 , eclipseProperties, runspec);
 
     const auto& wtest_config1 = schedule.wtestConfig(0);
     BOOST_CHECK_EQUAL(wtest_config1.size(), 2);

--- a/tests/parser/SectionTests.cpp
+++ b/tests/parser/SectionTests.cpp
@@ -209,6 +209,7 @@ BOOST_AUTO_TEST_CASE(Section_ValidDecks) {
 
     ParseContext mode { { { ParseContext::PARSE_UNKNOWN_KEYWORD, InputError::IGNORE } } };
     Parser parser;
+    ErrorGuard errors;
 
     const std::string minimal = "RUNSPEC\n"
                                 "TEST1\n"
@@ -221,7 +222,7 @@ BOOST_AUTO_TEST_CASE(Section_ValidDecks) {
                                 "SCHEDULE\n"
                                 "TEST5\n";
 
-    BOOST_CHECK( Opm::Section::checkSectionTopology( parser.parseString( minimal, mode ), parser) );
+    BOOST_CHECK( Opm::Section::checkSectionTopology( parser.parseString( minimal, mode, errors ), parser) );
 
     const std::string with_opt = "RUNSPEC\n"
                                 "TEST1\n"
@@ -240,13 +241,14 @@ BOOST_AUTO_TEST_CASE(Section_ValidDecks) {
                                 "SCHEDULE\n"
                                 "TEST8\n";
 
-    BOOST_CHECK(Opm::Section::checkSectionTopology( parser.parseString( with_opt, mode ), parser));
+    BOOST_CHECK(Opm::Section::checkSectionTopology( parser.parseString( with_opt, mode, errors ), parser));
 }
 
 BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
 
     Parser parser;
     ParseContext mode { { { ParseContext::PARSE_UNKNOWN_KEYWORD, InputError::IGNORE } } };
+    ErrorGuard errors;
 
     const std::string keyword_before_RUNSPEC =
                                 "WWCT \n /\n"
@@ -261,7 +263,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                 "SCHEDULE\n"
                                 "TEST5\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( keyword_before_RUNSPEC, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( keyword_before_RUNSPEC, mode, errors ), parser));
 
     const std::string wrong_order = "RUNSPEC\n"
                                     "TEST1\n"
@@ -280,7 +282,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                     "SCHEDULE\n"
                                     "TEST8\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( wrong_order, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( wrong_order, mode, errors ), parser));
 
     const std::string duplicate = "RUNSPEC\n"
                                   "TEST1\n"
@@ -301,7 +303,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                   "SCHEDULE\n"
                                   "TEST8\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( duplicate, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( duplicate, mode, errors ), parser));
 
     const std::string section_after_SCHEDULE = "RUNSPEC\n"
                                                "TEST1\n"
@@ -320,7 +322,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                                "EDIT\n"
                                                "TEST3\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( section_after_SCHEDULE, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( section_after_SCHEDULE, mode, errors ), parser));
 
     const std::string missing_runspec = "GRID\n"
                                         "TEST2\n"
@@ -331,7 +333,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                         "SCHEDULE\n"
                                         "TEST5\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_runspec, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_runspec, mode, errors ), parser));
 
 
     const std::string missing_GRID = "RUNSPEC\n"
@@ -343,7 +345,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                      "SCHEDULE\n"
                                      "TEST5\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_GRID, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_GRID, mode, errors ), parser));
 
    const std::string missing_PROPS = "RUNSPEC\n"
                                      "TEST1\n"
@@ -354,7 +356,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                      "SCHEDULE\n"
                                      "TEST5\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_PROPS, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_PROPS, mode, errors ), parser));
 
     const std::string missing_SOLUTION = "RUNSPEC\n"
                                          "TEST1\n"
@@ -365,7 +367,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                          "SCHEDULE\n"
                                          "TEST5\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_SOLUTION, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_SOLUTION, mode, errors ), parser));
 
     const std::string missing_SCHEDULE = "RUNSPEC\n"
                                          "TEST1\n"
@@ -376,5 +378,5 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                          "SOLUTION\n"
                                          "TEST4\n";
 
-    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_SCHEDULE, mode ), parser));
+    BOOST_CHECK(!Opm::Section::checkSectionTopology( parser.parseString( missing_SCHEDULE, mode, errors ), parser));
 }

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -26,7 +26,6 @@
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
@@ -130,15 +129,14 @@ DIMENS
     }
 }
 
-static Deck createDeck(const ParseContext& parseContext , const std::string& input) {
+static Deck createDeck(const std::string& input) {
     Opm::Parser parser;
-    return parser.parseString(input, parseContext);
+    return parser.parseString(input);
 }
 
 
 BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
-    ParseContext parseContext;
-    auto deck = createDeck(parseContext , inputStr);
+    auto deck = createDeck(inputStr);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
@@ -147,8 +145,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
 
 
 BOOST_AUTO_TEST_CASE(SimulationConfigNOTHPRES) {
-    ParseContext parseContext;
-    auto deck = createDeck(parseContext, inputStr_noTHPRES);
+    auto deck = createDeck(inputStr_noTHPRES);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
@@ -157,8 +154,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigNOTHPRES) {
 }
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
-    ParseContext parseContext;
-    auto deck = createDeck(parseContext, inputStr_noTHPRES);
+    auto deck = createDeck(inputStr_noTHPRES);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
@@ -167,8 +163,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
 }
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {
-    ParseContext parseContext;
-    auto deck = createDeck(parseContext, inputStr_cpr);
+    auto deck = createDeck(inputStr_cpr);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
@@ -180,8 +175,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {
 
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRInSUMMARYSection) {
-    ParseContext parseContext;
-    auto deck = createDeck(parseContext, inputStr_cpr_in_SUMMARY);
+    auto deck = createDeck(inputStr_cpr_in_SUMMARY);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
@@ -193,8 +187,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRInSUMMARYSection) {
 
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
-    ParseContext parseContext;
-    auto deck = createDeck(parseContext, inputStr_cpr_BOTH);
+    auto deck = createDeck(inputStr_cpr_BOTH);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
@@ -214,14 +207,12 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
 
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRRUnspecWithData) {
-    ParseContext parseContext;
-    BOOST_CHECK_THROW( createDeck(parseContext , inputStr_INVALID) , std::invalid_argument );
+    BOOST_CHECK_THROW( createDeck(inputStr_INVALID) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
-    ParseContext parseContext;
-    auto deck = createDeck(parseContext, inputStr);
+    auto deck = createDeck(inputStr);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(deck, tm, eg);
@@ -229,7 +220,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     BOOST_CHECK_EQUAL( false , simulationConfig.hasDISGAS());
     BOOST_CHECK_EQUAL( false , simulationConfig.hasVAPOIL());
 
-    auto deck_vd = createDeck(parseContext, inputStr_vap_dis);
+    auto deck_vd = createDeck(inputStr_vap_dis);
     TableManager tm_vd(deck_vd);
     EclipseGrid eg_vd(10, 3, 4);
     Eclipse3DProperties ep_vd(deck_vd, tm, eg);
@@ -241,10 +232,8 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
 
 BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
 {
-    const auto parseContext = Opm::ParseContext {};
-
     {
-        const auto deck = createDeck(parseContext, inputStr);
+        const auto deck = createDeck(inputStr);
         const auto tm = Opm::TableManager(deck);
         const auto eg = Opm::EclipseGrid(10, 3, 4);
         const auto ep = Opm::Eclipse3DProperties(deck, tm, eg);
@@ -254,7 +243,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
     }
 
     {
-        const auto deck = createDeck(parseContext, simDeckStringTEMP());
+        const auto deck = createDeck(simDeckStringTEMP());
         const auto tm = Opm::TableManager(deck);
         const auto eg = Opm::EclipseGrid(10, 3, 4);
         const auto ep = Opm::Eclipse3DProperties(deck, tm, eg);
@@ -264,7 +253,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
     }
 
     {
-        const auto deck = createDeck(parseContext, simDeckStringTHERMAL());
+        const auto deck = createDeck(simDeckStringTHERMAL());
         const auto tm = Opm::TableManager(deck);
         const auto eg = Opm::EclipseGrid(10, 3, 4);
         const auto ep = Opm::Eclipse3DProperties(deck, tm, eg);

--- a/tests/parser/TableContainerTests.cpp
+++ b/tests/parser/TableContainerTests.cpp
@@ -22,7 +22,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
@@ -43,7 +42,7 @@ inline Opm::Deck createSWOFDeck() {
         " 9 10 11 12 /\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext());
+    return parser.parseString(deckData);
 }
 
 BOOST_AUTO_TEST_CASE( CreateContainer ) {

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -22,7 +22,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 // generic table classes
@@ -67,7 +66,7 @@ Opm::Deck createSingleRecordDeck() {
         " 9 10 11 12 /\n";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext());
+    return parser.parseString(deckData);
 }
 
 
@@ -96,7 +95,7 @@ Opm::Deck createSingleRecordDeckWithVd() {
         "9000.0 0.22 0.22 1.0 0.0 0.04 1.0 0.18 0.22 /";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext());
+    return parser.parseString(deckData);
 }
 
 Opm::Deck createSingleRecordDeckWithJFunc() {
@@ -126,7 +125,7 @@ Opm::Deck createSingleRecordDeckWithJFunc() {
         "9000.0 0.22 0.22 1.0 0.0 0.04 1.0 0.18 0.22 /";
 
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext());
+    return parser.parseString(deckData);
 }
 
 Opm::Deck createSingleRecordDeckWithJFuncBoth() {
@@ -135,7 +134,7 @@ Opm::Deck createSingleRecordDeckWithJFuncBoth() {
         "JFUNC\n * 55.0 88.0 /\n" // ASTERISK MEANS DEFAULT VALUE
         "TABDIMS\n 2 /\n";
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext());
+    return parser.parseString(deckData);
 }
 
 Opm::Deck createSingleRecordDeckWithFullJFunc() {
@@ -144,7 +143,7 @@ Opm::Deck createSingleRecordDeckWithFullJFunc() {
         "JFUNC\n WATER 2.7182 3.1416 0.6 0.7 Z /\n"
         "TABDIMS\n 2 /\n";
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext());
+    return parser.parseString(deckData);
 }
 
 Opm::Deck createSingleRecordDeckWithJFuncBrokenFlag() {
@@ -153,7 +152,7 @@ Opm::Deck createSingleRecordDeckWithJFuncBrokenFlag() {
         "JFUNC\n GARBAGE 55.0 88.0 /\n"
         "TABDIMS\n 2 /\n";
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext());
+    return parser.parseString(deckData);
 }
 
 Opm::Deck createSingleRecordDeckWithJFuncBrokenDirection() {
@@ -162,7 +161,7 @@ Opm::Deck createSingleRecordDeckWithJFuncBrokenDirection() {
         "JFUNC\n * * * * * XZ /\n"
         "TABDIMS\n 2 /\n";
     Opm::Parser parser;
-    return parser.parseString(deckData, Opm::ParseContext());
+    return parser.parseString(deckData);
 }
 
 
@@ -246,7 +245,7 @@ BOOST_AUTO_TEST_CASE(SwofTable_Tests) {
         " 17 18 19 20/\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
 
     Opm::SwofTable swof1Table(deck.getKeyword("SWOF").getRecord(0).getItem(0), false);
     Opm::SwofTable swof2Table(deck.getKeyword("SWOF").getRecord(1).getItem(0), false);
@@ -288,7 +287,7 @@ BOOST_AUTO_TEST_CASE(PbvdTable_Tests) {
         " 1 2/\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
 
     Opm::PbvdTable pbvdTable1(deck.getKeyword("PBVD").getRecord(0).getItem(0));
 
@@ -316,7 +315,7 @@ BOOST_AUTO_TEST_CASE(PdvdTable_Tests) {
         " 1 2/\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
 
     Opm::PdvdTable pdvdTable1(deck.getKeyword("PDVD").getRecord(0).getItem(0));
 
@@ -343,7 +342,7 @@ BOOST_AUTO_TEST_CASE(SgwfnTable_Tests) {
         " 17 18 19 20/\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
 
 
     Opm::SgwfnTable sgwfn1Table(deck.getKeyword("SGWFN").getRecord(0).getItem(0));
@@ -386,7 +385,7 @@ BOOST_AUTO_TEST_CASE(SgofTable_Tests) {
         " 17 18 19 20/\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
 
     Opm::SgofTable sgof1Table(deck.getKeyword("SGOF").getRecord(0).getItem(0), false);
     Opm::SgofTable sgof2Table(deck.getKeyword("SGOF").getRecord(1).getItem(0), false);
@@ -432,7 +431,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "2.00    0.000030\n"
             "3.00    0.000030 /\n";
         Opm::Parser parser;
-        auto deck = parser.parseString(correctDeckData, Opm::ParseContext());
+        auto deck = parser.parseString(correctDeckData);
         const auto& plyadsKeyword = deck.getKeyword("PLYADS");
         Opm::PlyadsTable plyadsTable(plyadsKeyword.getRecord(0).getItem(0));
 
@@ -461,7 +460,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "2.00    0.000030\n"
             "3.00    0.000030 /\n";
         Opm::Parser parser;
-        auto deck = parser.parseString(incorrectDeckData, Opm::ParseContext());
+        auto deck = parser.parseString(incorrectDeckData);
         const auto& plyadsKeyword = deck.getKeyword("PLYADS");
 
         BOOST_CHECK_THROW(Opm::PlyadsTable(plyadsKeyword.getRecord(0).getItem(0)), std::invalid_argument);
@@ -484,7 +483,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "2.00    0.000030\n"
             "3.00    0.000029 /\n";
         Opm::Parser parser;
-        auto deck = parser.parseString(incorrectDeckData, Opm::ParseContext());
+        auto deck = parser.parseString(incorrectDeckData);
         const auto& plyadsKeyword = deck.getKeyword("PLYADS");
 
         BOOST_CHECK_THROW(Opm::PlyadsTable(plyadsKeyword.getRecord(0).getItem(0)), std::invalid_argument);
@@ -532,7 +531,7 @@ VFPPROD \n\
 2 2 2 2 46.5 47.5 48.5 / \n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     auto units = Opm::UnitSystem::newMETRIC();
     const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
 
@@ -658,7 +657,7 @@ VFPPROD \n\
 1 1 1 1 1.5 /    \n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
     auto units = Opm::UnitSystem::newMETRIC();
 
@@ -806,7 +805,7 @@ VFPPROD \n\
 1 1 1 1 1.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(missing_values, Opm::ParseContext());
+        auto deck = parser.parseString(missing_values);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
@@ -840,7 +839,7 @@ VFPPROD \n\
 1 1 1 1 1.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(missing_values, Opm::ParseContext());
+        auto deck = parser.parseString(missing_values);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
@@ -872,7 +871,7 @@ VFPPROD \n\
 1 1 1 1 1.5 2.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(missing_metadata, Opm::ParseContext());
+        auto deck = parser.parseString(missing_metadata);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
@@ -905,7 +904,7 @@ VFPPROD \n\
 1 1 1 1 1.5 2.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(wrong_metadata, Opm::ParseContext());
+        auto deck = parser.parseString(wrong_metadata);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
@@ -938,7 +937,7 @@ VFPPROD \n\
 1 1 1 1 1.5 2.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(missing_axes, Opm::ParseContext());
+        auto deck = parser.parseString(missing_axes);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
@@ -969,7 +968,7 @@ VFPINJ \n\
 2 4.5 5.5 6.5 /    \n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     const auto& vfpprodKeyword = deck.getKeyword("VFPINJ");
     auto units = Opm::UnitSystem::newMETRIC();
 
@@ -1069,7 +1068,7 @@ VFPINJ \n\
 2 4.5 5.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(missing_values, Opm::ParseContext());
+        auto deck = parser.parseString(missing_values);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
@@ -1097,7 +1096,7 @@ VFPINJ \n\
 1 1.5 2.5 3.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(missing_values, Opm::ParseContext());
+        auto deck = parser.parseString(missing_values);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
@@ -1124,7 +1123,7 @@ VFPINJ \n\
 2 4.5 5.5 6.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(missing_metadata, Opm::ParseContext());
+        auto deck = parser.parseString(missing_metadata);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
@@ -1152,7 +1151,7 @@ VFPINJ \n\
 2 4.5 5.5 6.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(wrong_metadata, Opm::ParseContext());
+        auto deck = parser.parseString(wrong_metadata);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
@@ -1180,7 +1179,7 @@ VFPINJ \n\
 2 4.5 5.5 6.5 /    \n";
 
         Opm::Parser parser;
-        auto deck = parser.parseString(missing_axes, Opm::ParseContext());
+        auto deck = parser.parseString(missing_axes);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
@@ -1211,7 +1210,7 @@ BOOST_AUTO_TEST_CASE( TestPLYMWINJ ) {
         "   20.    16.   14.   /\n";
 
     Opm::Parser parser;
-    const Opm::Deck deck = parser.parseString(inputstring, Opm::ParseContext());
+    const Opm::Deck deck = parser.parseString(inputstring);
     const Opm::TableManager tables( deck );
     const auto& plymwinjtables = tables.getPlymwinjTables();
 
@@ -1289,7 +1288,7 @@ BOOST_AUTO_TEST_CASE( TestSKPRWAT ) {
         "   20.    16.   14.   /\n";
 
     Opm::Parser parser;
-    const Opm::Deck deck = parser.parseString(inputstring, Opm::ParseContext());
+    const Opm::Deck deck = parser.parseString(inputstring);
     const Opm::TableManager tables( deck );
     const auto& skprwattables = tables.getSkprwatTables();
 
@@ -1369,7 +1368,7 @@ BOOST_AUTO_TEST_CASE( TestSKPRPOLY ) {
         "   20.    16.   14.   /\n";
 
     Opm::Parser parser;
-    const Opm::Deck deck = parser.parseString(inputstring, Opm::ParseContext());
+    const Opm::Deck deck = parser.parseString(inputstring);
     const Opm::TableManager tables( deck );
     const auto& skprpolytables = tables.getSkprpolyTables();
 
@@ -1440,7 +1439,7 @@ BOOST_AUTO_TEST_CASE( TestPLYROCK ) {
         " 10 20 30 40 50 /\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(data, Opm::ParseContext());
+    auto deck = parser.parseString(data);
     Opm::TableManager tables( deck );
     const Opm::TableContainer& plyrock = tables.getPlyrockTables();
 
@@ -1468,7 +1467,7 @@ BOOST_AUTO_TEST_CASE( TestPLYMAX ) {
         " 10 20 /\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(data, Opm::ParseContext());
+    auto deck = parser.parseString(data);
     Opm::TableManager tables( deck );
     const Opm::TableContainer& plymax = tables.getPlymaxTables();
 
@@ -1495,7 +1494,7 @@ BOOST_AUTO_TEST_CASE( TestParseDENSITY ) {
     )";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(data, Opm::ParseContext());
+    auto deck = parser.parseString(data);
     Opm::TableManager tables( deck );
     const auto& density = tables.getDensityTable();
     BOOST_CHECK_EQUAL( 1.1, density[0].oil );
@@ -1514,7 +1513,7 @@ BOOST_AUTO_TEST_CASE( TestParseROCK ) {
     )";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(data, Opm::ParseContext());
+    auto deck = parser.parseString(data);
     Opm::TableManager tables( deck );
     const auto& rock = tables.getRockTable();
     BOOST_CHECK_EQUAL( 1.1 * 1e5,  rock[0].reference_pressure );
@@ -1540,7 +1539,7 @@ BOOST_AUTO_TEST_CASE( TestParsePVCDO ) {
     )";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(data, Opm::ParseContext());
+    auto deck = parser.parseString(data);
     Opm::TableManager tables( deck );
     const auto& pvcdo = tables.getPvcdoTable();
 
@@ -1562,7 +1561,7 @@ BOOST_AUTO_TEST_CASE( TestParsePVCDO ) {
         3600 1* 1.6e-5 0.88 0.0 /
     )";
 
-    auto illegal_default = parser.parseString( malformed, ParseContext() );
+    auto illegal_default = parser.parseString( malformed );
     BOOST_CHECK_THROW( TableManager{ illegal_default }, std::invalid_argument );
 }
 
@@ -1571,7 +1570,7 @@ BOOST_AUTO_TEST_CASE( TestParseTABDIMS ) {
       "TABDIMS\n"
       "  1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 /\n";
     Opm::Parser parser;
-    BOOST_CHECK_NO_THROW( parser.parseString(data, Opm::ParseContext()));
+    BOOST_CHECK_NO_THROW( parser.parseString(data));
 }
 
 BOOST_AUTO_TEST_CASE (Regdims_Entries) {

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -200,13 +200,13 @@ const std::string& inputStrMissingPressure = "RUNSPEC\n"
 
 static Deck createDeck(const ParseContext& parseContext, const std::string& input) {
     Opm::Parser parser;
-    return parser.parseString(input, parseContext);
+    ErrorGuard errors;
+    return parser.parseString(input, parseContext, errors);
 }
 
 /// Setup fixture
 struct Setup
 {
-    ParseContext parseContext;
     Deck deck;
     TableManager tablemanager;
     EclipseGrid grid;
@@ -215,8 +215,7 @@ struct Setup
     ThresholdPressure threshPres;
 
     explicit Setup(const std::string& input) :
-            parseContext(),
-            deck(createDeck(parseContext, input)),
+            deck(createDeck(ParseContext(), input)),
             tablemanager(deck),
             grid(10, 3, 4),
             props(deck, tablemanager, grid),
@@ -224,8 +223,8 @@ struct Setup
             threshPres(initConfig.restartRequested(), deck, props)
     {
     }
-    explicit Setup(const std::string& input, ParseContext& parseContextArg) :
-            parseContext(), // not used
+
+    explicit Setup(const std::string& input, const ParseContext& parseContextArg) :
             deck(createDeck(parseContextArg, input)),
             tablemanager(deck),
             grid(10, 3, 4),

--- a/tests/parser/TimeMapTest.cpp
+++ b/tests/parser/TimeMapTest.cpp
@@ -34,7 +34,6 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 const std::time_t startDateJan1st2010 = Opm::TimeMap::mkdate(2010, 1, 1);
 
@@ -213,7 +212,7 @@ BOOST_AUTO_TEST_CASE(TimeStepsCorrect) {
         " 6 7 /\n";
 
     Opm::Parser parser( true );
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     Opm::TimeMap tmap(deck);
 
     BOOST_CHECK_EQUAL(tmap.getStartTime(0),Opm::TimeMap::mkdate( 1981 , 5 , 21 ));
@@ -285,7 +284,7 @@ BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
         " 6 7 /\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     const Opm::TimeMap tmap(deck);
 
     /*deckData timesteps:
@@ -336,7 +335,7 @@ BOOST_AUTO_TEST_CASE(initTimestepsLongStep) {
         " 25550 /\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     const Opm::TimeMap tmap(deck);
 
     /*deckData timesteps:
@@ -365,7 +364,7 @@ BOOST_AUTO_TEST_CASE(initTimestepsDistantDates) {
         "/\n";
 
     Opm::Parser parser;
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    auto deck = parser.parseString(deckData);
     const Opm::TimeMap tmap(deck);
 
     /*deckData timesteps:

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -24,7 +24,6 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
@@ -62,7 +61,7 @@ const std::string& deckStr =  "START\n"
 
 static Deck createDeck(const std::string& input) {
     Opm::Parser parser;
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 
@@ -74,7 +73,7 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   TableManager table ( deck );
   Eclipse3DProperties eclipseProperties ( deck , table, grid);
   Runspec runspec (deck);
-  Schedule schedule( deck, grid , eclipseProperties, runspec , ParseContext());
+  Schedule schedule( deck, grid , eclipseProperties, runspec);
   auto tuning = schedule.getTuning();
   auto event = schedule.getEvents();
 
@@ -333,7 +332,7 @@ BOOST_AUTO_TEST_CASE(TuningInitTest) {
   TableManager table ( deck );
   Eclipse3DProperties eclipseProperties ( deck , table, grid);
   Runspec runspec (deck);
-  Schedule schedule(deck , grid , eclipseProperties, runspec, ParseContext());
+  Schedule schedule(deck , grid , eclipseProperties, runspec);
   auto tuning = schedule.getTuning();
 
 
@@ -364,7 +363,7 @@ BOOST_AUTO_TEST_CASE(TuningResetTest) {
   TableManager table ( deck );
   Eclipse3DProperties eclipseProperties ( deck , table, grid);
   Runspec runspec (deck);
-  Schedule schedule(deck, grid , eclipseProperties, runspec, ParseContext());
+  Schedule schedule(deck, grid , eclipseProperties, runspec);
   auto tuning = schedule.getTuning();
 
 

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -40,9 +40,8 @@ UDQPARAM
 
 )";
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     auto runspec = Runspec(deck);
     auto udq_config = runspec.udqConfig();
 
@@ -71,9 +70,8 @@ UDQ
 )";
 
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     auto udq_config = UDQConfig(deck);
     auto udq = UDQ(udq_config, deck);
     BOOST_CHECK_EQUAL(3, udq.expressions().size());
@@ -110,9 +108,8 @@ DEFINE WUMW1 WBHP 'P*1*' UMAX WBHP 'P*4*' /
 
 )";
     Parser parser;
-    ParseContext parseContext;
 
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     auto udq_config = UDQConfig(deck);
     auto udq = UDQ(udq_config, deck);
     const auto& records = udq.expressions();

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -47,7 +47,7 @@ static Deck createDeckWithOutSolvent() {
             "WCONINJE\n"
             "     'W_1' 'WATER' 'OPEN' 'BHP' 1 2 3/\n/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithGasInjector() {
@@ -66,7 +66,7 @@ static Deck createDeckWithGasInjector() {
             "     'W_1'        1 / \n "
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithDynamicWSOLVENT() {
@@ -97,7 +97,7 @@ static Deck createDeckWithDynamicWSOLVENT() {
             "     'W_1'        0 / \n "
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithOilInjector() {
@@ -116,7 +116,7 @@ static Deck createDeckWithOilInjector() {
             "     'W_1'        1 / \n "
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithWaterInjector() {
@@ -135,7 +135,7 @@ static Deck createDeckWithWaterInjector() {
             "     'W_1'        1 / \n "
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 BOOST_AUTO_TEST_CASE(TestNoSolvent) {
     auto deck = createDeckWithOutSolvent();
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(TestNoSolvent) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec(deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK(!deck.hasKeyword("WSOLVENT"));
 }
 
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(TestGasInjector) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec(deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
 
 }
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec(deck);
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
     const auto& keyword = deck.getKeyword("WSOLVENT");
     BOOST_CHECK_EQUAL(keyword.size(),1);
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(TestOilInjector) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec(deck);
-    BOOST_CHECK_THROW (Schedule(deck , grid , eclipseProperties, runspec , ParseContext()), std::invalid_argument);
+    BOOST_CHECK_THROW (Schedule(deck , grid , eclipseProperties, runspec), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(TestWaterInjector) {
@@ -193,5 +193,5 @@ BOOST_AUTO_TEST_CASE(TestWaterInjector) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec(deck);
-    BOOST_CHECK_THROW (Schedule(deck, grid , eclipseProperties, runspec , ParseContext()), std::invalid_argument);
+    BOOST_CHECK_THROW (Schedule(deck, grid , eclipseProperties, runspec), std::invalid_argument);
 }

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -223,13 +223,12 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
                 "/\n";
 
 
-    Opm::ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Opm::Runspec runspec (deck);
-    Opm::Schedule schedule(deck, grid , eclipseProperties, runspec , Opm::ParseContext());
+    Opm::Schedule schedule(deck, grid , eclipseProperties, runspec);
     auto* op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;
@@ -265,13 +264,12 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestDefaultTRACK) {
                 "/\n";
 
 
-    Opm::ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Opm::Runspec runspec (deck);
-    Opm::Schedule schedule(deck, grid , eclipseProperties, runspec , Opm::ParseContext());
+    Opm::Schedule schedule(deck, grid , eclipseProperties, runspec);
     auto* op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;
@@ -309,13 +307,13 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestINPUT) {
                 "/\n";
 
 
-    Opm::ParseContext parseContext;
-    auto deck = parser.parseString(input, parseContext);
+    auto deck = parser.parseString(input);
     Opm::EclipseGrid grid(10,10,10);
+    Opm::ErrorGuard errors;
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Opm::Runspec runspec (deck);
-    Opm::Schedule schedule(deck, grid , eclipseProperties, runspec , Opm::ParseContext());
+    Opm::Schedule schedule(deck, grid , eclipseProperties, runspec, Opm::ParseContext(), errors);
     auto* op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;
@@ -761,7 +759,7 @@ namespace {
         Opm::WellProductionProperties properties(const std::string& input) {
             Opm::Parser parser;
 
-            auto deck = parser.parseString(input, Opm::ParseContext());
+            auto deck = parser.parseString(input);
             const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
             Opm::WellProductionProperties prev_p;
             prev_p.BHPLimit = 100.;
@@ -823,7 +821,7 @@ namespace {
         {
             Opm::Parser parser;
 
-            auto deck = parser.parseString(input, Opm::ParseContext());
+            auto deck = parser.parseString(input);
             const auto& kwd     = deck.getKeyword("WCONPROD");
             const auto&  record = kwd.getRecord(0);
             Opm::WellProductionProperties pred = Opm::WellProductionProperties::prediction( record, false );

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -30,7 +30,6 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 using namespace Opm;
 
@@ -47,7 +46,7 @@ static Deck createDeckWithOutTracer() {
             "WCONINJE\n"
             "     'W_1' 'WATER' 'OPEN' 'BHP' 1 2 3/\n/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 
@@ -83,7 +82,7 @@ static Deck createDeckWithDynamicWTRACER() {
             " 1  SEP 2000 / \n"
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 static Deck createDeckWithTracerInProducer() {
@@ -105,7 +104,7 @@ static Deck createDeckWithTracerInProducer() {
             "     'W_1' 'I2'       1 / \n "
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input);
 }
 
 
@@ -115,7 +114,7 @@ BOOST_AUTO_TEST_CASE(TestNoTracer) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec ( deck );
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK(!deck.hasKeyword("WTRACER"));
 }
 
@@ -126,7 +125,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec ( deck );
-    Schedule schedule(deck, grid , eclipseProperties, runspec , ParseContext());
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
     BOOST_CHECK(deck.hasKeyword("WTRACER"));
     const auto& keyword = deck.getKeyword("WTRACER");
     BOOST_CHECK_EQUAL(keyword.size(),1);
@@ -150,6 +149,6 @@ BOOST_AUTO_TEST_CASE(TestTracerInProducerTHROW) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec ( deck );
 
-    BOOST_CHECK_THROW(Schedule(deck, grid, eclipseProperties, runspec , ParseContext()), std::invalid_argument);
+    BOOST_CHECK_THROW(Schedule(deck, grid, eclipseProperties, runspec), std::invalid_argument);
 }
 

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -26,7 +26,6 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
@@ -42,8 +41,8 @@ inline std::string prefix() {
 inline EclipseState makeState(const std::string& fileName) {
     Parser parser;
     boost::filesystem::path boxFile(fileName);
-    auto deck =  parser.parseFile(boxFile.string(), ParseContext());
-    return EclipseState( deck, ParseContext() );
+    auto deck =  parser.parseFile(boxFile.string());
+    return EclipseState( deck );
 }
 
 BOOST_AUTO_TEST_CASE( PERMX ) {

--- a/tests/parser/integration/CheckDeckValidity.cpp
+++ b/tests/parser/integration/CheckDeckValidity.cpp
@@ -22,7 +22,6 @@
 #include <boost/test/test_tools.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
@@ -50,7 +49,7 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "SOLUTION\n"
             "SCHEDULE\n";
 
-        auto deck = parser.parseString(correctDeckString, Opm::ParseContext());
+        auto deck = parser.parseString(correctDeckString);
         BOOST_CHECK(Opm::checkDeck(deck, parser));
     }
 
@@ -63,7 +62,7 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "SOLUTION\n"
             "SCHEDULE\n";
 
-        auto deck = parser.parseString(correctDeckString, Opm::ParseContext());
+        auto deck = parser.parseString(correctDeckString);
         BOOST_CHECK(!Opm::checkDeck(deck, parser));
         BOOST_CHECK(Opm::checkDeck(deck, parser, ~Opm::SectionTopology));
     }
@@ -89,7 +88,7 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "SOLUTION\n"
             "SCHEDULE\n";
 
-        auto deck = parser.parseString(incorrectDeckString, Opm::ParseContext());
+        auto deck = parser.parseString(incorrectDeckString);
         BOOST_CHECK(!Opm::checkDeck(deck, parser));
 
         // this is supposed to succeed as we don't ensure that all keywords are in the

--- a/tests/parser/integration/EDITNNCTests.cpp
+++ b/tests/parser/integration/EDITNNCTests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(noNNC)
 BOOST_AUTO_TEST_CASE(readDeck)
 {
     Parser parser;
-    auto deck = parser.parseFile(pathprefix() + "NNC/noNNC.DATA");
+    auto deck = parser.parseFile(pathprefix() + "EDITNNC/EDITNNC.DATA");
     EclipseState eclipseState(deck);
     const auto& editnnc = eclipseState.getInputEDITNNC();
     BOOST_CHECK(!editnnc.empty());

--- a/tests/parser/integration/EDITNNCTests.cpp
+++ b/tests/parser/integration/EDITNNCTests.cpp
@@ -20,7 +20,6 @@
 
 #include <opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -38,7 +37,9 @@ inline std::string pathprefix() {
 
 BOOST_AUTO_TEST_CASE(noNNC)
 {
-    auto eclipseState = Parser::parse(pathprefix() + "NNC/noNNC.DATA");
+    Parser parser;
+    auto deck = parser.parseFile(pathprefix() + "NNC/noNNC.DATA");
+    EclipseState eclipseState(deck);
     const auto& editnnc = eclipseState.getInputEDITNNC();
     BOOST_CHECK(!eclipseState.hasInputEDITNNC());
     BOOST_CHECK(editnnc.empty());
@@ -46,7 +47,9 @@ BOOST_AUTO_TEST_CASE(noNNC)
 
 BOOST_AUTO_TEST_CASE(readDeck)
 {
-    auto eclipseState = Parser::parse(pathprefix() + "EDITNNC/EDITNNC.DATA");
+    Parser parser;
+    auto deck = parser.parseFile(pathprefix() + "NNC/noNNC.DATA");
+    EclipseState eclipseState(deck);
     const auto& editnnc = eclipseState.getInputEDITNNC();
     BOOST_CHECK(!editnnc.empty());
     const std::vector<NNCdata>& data = editnnc.data();

--- a/tests/parser/integration/EclipseGridCreateFromDeck.cpp
+++ b/tests/parser/integration/EclipseGridCreateFromDeck.cpp
@@ -29,7 +29,6 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
@@ -42,8 +41,8 @@ inline std::string prefix() {
 BOOST_AUTO_TEST_CASE(CreateCPGrid) {
     Parser parser;
     boost::filesystem::path scheduleFile(prefix() + "GRID/CORNERPOINT.DATA");
-    auto deck =  parser.parseFile(scheduleFile.string(), ParseContext());
-    EclipseState es(deck, ParseContext());
+    auto deck =  parser.parseFile(scheduleFile.string());
+    EclipseState es(deck);
     const auto& grid = es.getInputGrid();
 
     BOOST_CHECK_EQUAL( 10U  , grid.getNX( ));
@@ -56,8 +55,8 @@ BOOST_AUTO_TEST_CASE(CreateCPGrid) {
 BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
     Parser parser;
     boost::filesystem::path scheduleFile(prefix() + "GRID/CORNERPOINT_ACTNUM.DATA");
-    auto deck =  parser.parseFile(scheduleFile.string(), ParseContext());
-    EclipseState es(deck, ParseContext());
+    auto deck =  parser.parseFile(scheduleFile.string());
+    EclipseState es(deck);
     const auto& grid = es.getInputGrid();
 
     BOOST_CHECK_EQUAL(  10U , grid.getNX( ));
@@ -70,8 +69,8 @@ BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
 BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
     Parser parser;
     boost::filesystem::path scheduleFile(prefix() + "GRID/CORNERPOINT.DATA");
-    auto deck =  parser.parseFile(scheduleFile.string(), ParseContext());
-    EclipseState es(deck, ParseContext());
+    auto deck =  parser.parseFile(scheduleFile.string());
+    EclipseState es(deck);
     const auto& grid = es.getInputGrid();
 
     std::vector<int> actnum;
@@ -87,8 +86,8 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
 BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     Parser parser;
     boost::filesystem::path scheduleFile(prefix() + "GRID/CORNERPOINT_ACTNUM.DATA");
-    auto deck =  parser.parseFile(scheduleFile.string(), ParseContext());
-    EclipseState es(deck, ParseContext());
+    auto deck =  parser.parseFile(scheduleFile.string());
+    EclipseState es(deck);
     auto& grid = es.getInputGrid();
 
     std::vector<double> coord;

--- a/tests/parser/integration/IOConfigIntegrationTest.cpp
+++ b/tests/parser/integration/IOConfigIntegrationTest.cpp
@@ -31,7 +31,6 @@
 #include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 using namespace Opm;
@@ -305,10 +304,9 @@ BOOST_AUTO_TEST_CASE( NorneRestartConfig ) {
     rptConfig.push_back( std::make_tuple(241 , true , boost::gregorian::date( 2006,10,10)) );
 
     Parser parser;
-    ParseContext ctx;
-    auto deck = parser.parseFile( prefix() + "IOConfig/RPTRST_DECK.DATA" , ctx);
-    EclipseState state(deck, ctx);
-    Schedule schedule(deck, state.getInputGrid(), state.get3DProperties(), state.runspec(), ctx);
+    auto deck = parser.parseFile( prefix() + "IOConfig/RPTRST_DECK.DATA");
+    EclipseState state(deck);
+    Schedule schedule(deck, state.getInputGrid(), state.get3DProperties(), state.runspec());
 
     verifyRestartConfig(schedule.getTimeMap(), state.cfg().restart(), rptConfig);
 }
@@ -351,11 +349,10 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     }
 
 
-    ParseContext parseContext;
     Parser parser;
-    auto deck = parser.parseFile(prefix() + "IOConfig/RPT_TEST2.DATA", parseContext);
-    EclipseState state( deck , parseContext );
-    Schedule schedule(deck, state.getInputGrid(), state.get3DProperties(), state.runspec(), parseContext);
+    auto deck = parser.parseFile(prefix() + "IOConfig/RPT_TEST2.DATA");
+    EclipseState state( deck);
+    Schedule schedule(deck, state.getInputGrid(), state.get3DProperties(), state.runspec());
     const auto& rstConfig = state.cfg().restart();
     verifyRestartConfig(schedule.getTimeMap(), state.cfg().restart(), rptConfig);
 
@@ -365,8 +362,7 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
 
 
 BOOST_AUTO_TEST_CASE( SPE9END ) {
-    ParseContext parseContext;
     Parser parser;
-    auto deck = parser.parseFile(prefix() + "IOConfig/SPE9_END.DATA", parseContext);
-    BOOST_CHECK_NO_THROW( EclipseState state( deck , parseContext ) );
+    auto deck = parser.parseFile(prefix() + "IOConfig/SPE9_END.DATA");
+    BOOST_CHECK_NO_THROW( EclipseState state( deck) );
 }

--- a/tests/parser/integration/IncludeTest.cpp
+++ b/tests/parser/integration/IncludeTest.cpp
@@ -27,7 +27,6 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
 
 #include <opm/parser/eclipse/Parser/ParserEnums.hpp>
@@ -150,7 +149,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {
     path datafile;
     Parser parser;
     createDeckWithInclude (datafile, "");
-    auto deck =  parser.parseFile(datafile.string(), ParseContext());
+    auto deck =  parser.parseFile(datafile.string());
 
     BOOST_CHECK( deck.hasKeyword("START"));
     BOOST_CHECK( deck.hasKeyword("DIMENS"));
@@ -161,7 +160,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithENDINCKeyword_deckReturned) {
     path datafile;
     Parser parser;
     createDeckWithInclude (datafile, "ENDINC");
-    auto deck =  parser.parseFile(datafile.string(), ParseContext());
+    auto deck =  parser.parseFile(datafile.string());
 
     BOOST_CHECK( deck.hasKeyword("START"));
     BOOST_CHECK( !deck.hasKeyword("DIMENS"));
@@ -172,7 +171,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithENDKeyword_deckReturned) {
     path datafile;
     Parser parser;
     createDeckWithInclude (datafile, "END");
-    auto deck =  parser.parseFile(datafile.string(), ParseContext());
+    auto deck =  parser.parseFile(datafile.string());
 
     BOOST_CHECK( deck.hasKeyword("START"));
     BOOST_CHECK( !deck.hasKeyword("DIMENS"));
@@ -183,7 +182,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithPathsKeyword_IncludeExtendsPath) {
     path datafile;
     Parser parser;
     createDeckWithInclude (datafile, "");
-    auto deck =  parser.parseFile(datafile.string(), ParseContext());
+    auto deck =  parser.parseFile(datafile.string());
 
     BOOST_CHECK( deck.hasKeyword("TITLE"));
     BOOST_CHECK( deck.hasKeyword("BOX"));

--- a/tests/parser/integration/IntegrationTests.cpp
+++ b/tests/parser/integration/IntegrationTests.cpp
@@ -26,7 +26,6 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
@@ -75,7 +74,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {
     auto parser = createWWCTParser();
     BOOST_CHECK( parser.isRecognizedKeyword("WWCT"));
     BOOST_CHECK( parser.isRecognizedKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW( parser.parseFile(singleKeywordFile.string(), ParseContext()) );
+    BOOST_CHECK_NO_THROW( parser.parseFile(singleKeywordFile.string()) );
 }
 
 BOOST_AUTO_TEST_CASE(parse_stringWithWWCTKeyword_deckReturned) {
@@ -89,7 +88,7 @@ BOOST_AUTO_TEST_CASE(parse_stringWithWWCTKeyword_deckReturned) {
     auto parser = createWWCTParser();
     BOOST_CHECK( parser.isRecognizedKeyword("WWCT"));
     BOOST_CHECK( parser.isRecognizedKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW(parser.parseString(wwctString, ParseContext()));
+    BOOST_CHECK_NO_THROW(parser.parseString(wwctString));
 }
 
 BOOST_AUTO_TEST_CASE(parse_streamWithWWCTKeyword_deckReturned) {
@@ -103,13 +102,13 @@ BOOST_AUTO_TEST_CASE(parse_streamWithWWCTKeyword_deckReturned) {
     auto parser = createWWCTParser();
     BOOST_CHECK( parser.isRecognizedKeyword("WWCT"));
     BOOST_CHECK( parser.isRecognizedKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW(parser.parseString( wwctString, ParseContext()));
+    BOOST_CHECK_NO_THROW(parser.parseString( wwctString));
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {
     boost::filesystem::path singleKeywordFile(pathprefix() + "wwct.data");
     auto parser = createWWCTParser();
-    auto deck = parser.parseFile(singleKeywordFile.string(), ParseContext());
+    auto deck = parser.parseFile(singleKeywordFile.string());
     BOOST_CHECK(deck.hasKeyword("SUMMARY"));
     BOOST_CHECK(deck.hasKeyword("WWCT"));
 }
@@ -117,7 +116,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_dataIsCorrect) {
     boost::filesystem::path singleKeywordFile(pathprefix() + "wwct.data");
     auto parser = createWWCTParser();
-    auto deck = parser.parseFile(singleKeywordFile.string(), ParseContext());
+    auto deck = parser.parseFile(singleKeywordFile.string());
     BOOST_CHECK_EQUAL("WELL-1", deck.getKeyword("WWCT" , 0).getRecord(0).getItem(0).get< std::string >(0));
     BOOST_CHECK_EQUAL("WELL-2", deck.getKeyword("WWCT" , 0).getRecord(0).getItem(0).get< std::string >(1));
 }
@@ -159,14 +158,14 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_deckReturned) {
     boost::filesystem::path singleKeywordFile(pathprefix() + "bpr.data");
     auto parser = createBPRParser();
 
-    BOOST_CHECK_NO_THROW(parser.parseFile(singleKeywordFile.string(), ParseContext()));
+    BOOST_CHECK_NO_THROW(parser.parseFile(singleKeywordFile.string()));
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_DeckhasBRP) {
     boost::filesystem::path singleKeywordFile(pathprefix() + "bpr.data");
 
     auto parser = createBPRParser();
-    auto deck =  parser.parseFile(singleKeywordFile.string(), ParseContext());
+    auto deck =  parser.parseFile(singleKeywordFile.string());
 
     BOOST_CHECK_EQUAL(true, deck.hasKeyword("BPR"));
 }
@@ -175,7 +174,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
     boost::filesystem::path singleKeywordFile(pathprefix() + "bpr.data");
 
     auto parser = createBPRParser();
-    auto deck =  parser.parseFile(singleKeywordFile.string(), ParseContext());
+    auto deck =  parser.parseFile(singleKeywordFile.string());
 
     const auto& keyword = deck.getKeyword("BPR" , 0);
     BOOST_CHECK_EQUAL(2U, keyword.size());
@@ -197,7 +196,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
 /***************** Testing non-recognized keywords ********************/
 BOOST_AUTO_TEST_CASE(parse_unknownkeyword_exceptionthrown) {
     Parser parser;
-    BOOST_CHECK_THROW( parser.parseFile(pathprefix() + "someobscureelements.data", ParseContext()), std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseFile(pathprefix() + "someobscureelements.data"), std::invalid_argument);
 }
 
 /*********************Testing truncated (default) records ***************************/
@@ -206,7 +205,7 @@ BOOST_AUTO_TEST_CASE(parse_unknownkeyword_exceptionthrown) {
 // Datafile contains 3 RADFIN4 keywords. One fully specified, one with 2 out of 11 items, and one with no items.
 BOOST_AUTO_TEST_CASE(parse_truncatedrecords_deckFilledWithDefaults) {
     Parser parser;
-    auto deck =  parser.parseFile(pathprefix() + "truncated_records.data", ParseContext());
+    auto deck =  parser.parseFile(pathprefix() + "truncated_records.data");
     BOOST_CHECK_EQUAL(3U, deck.size());
     const auto& radfin4_0_full= deck.getKeyword("RADFIN4", 0);
     const auto& radfin4_1_partial= deck.getKeyword("RADFIN4", 1);

--- a/tests/parser/integration/NNCTests.cpp
+++ b/tests/parser/integration/NNCTests.cpp
@@ -19,7 +19,6 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -37,7 +36,9 @@ inline std::string pathprefix() {
 
 BOOST_AUTO_TEST_CASE(noNNC)
 {
-    auto eclipseState = Parser::parse(pathprefix() + "NNC/noNNC.DATA");
+    Parser parser;
+    auto deck = parser.parseFile(pathprefix() + "NNC/noNNC.DATA");
+    EclipseState eclipseState(deck);
     const auto& nnc = eclipseState.getInputNNC();
     BOOST_CHECK(!eclipseState.hasInputNNC());
     BOOST_CHECK(!nnc.hasNNC());
@@ -45,7 +46,9 @@ BOOST_AUTO_TEST_CASE(noNNC)
 
 BOOST_AUTO_TEST_CASE(readDeck)
 {
-    auto eclipseState = Parser::parse(pathprefix() + "NNC/NNC.DATA");
+    Parser parser;
+    auto deck = parser.parseFile(pathprefix() + "NNC/NNC.DATA");
+    EclipseState eclipseState(deck);
     const auto& nnc = eclipseState.getInputNNC();
     BOOST_CHECK(nnc.hasNNC());
     const std::vector<NNCdata>& nncdata = nnc.nncdata();
@@ -63,7 +66,9 @@ BOOST_AUTO_TEST_CASE(readDeck)
 
 BOOST_AUTO_TEST_CASE(addNNCfromDeck)
 {
-    auto eclipseState = Parser::parse(pathprefix() + "NNC/NNC.DATA");
+    Parser parser;
+    auto deck = parser.parseFile(pathprefix() + "NNC/NNC.DATA");
+    EclipseState eclipseState(deck);
     auto nnc = eclipseState.getInputNNC();
     BOOST_CHECK(nnc.hasNNC());
     const std::vector<NNCdata>& nncdata = nnc.nncdata();

--- a/tests/parser/integration/ParseDATAWithDefault.cpp
+++ b/tests/parser/integration/ParseDATAWithDefault.cpp
@@ -29,7 +29,6 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
 #include <opm/parser/eclipse/Parser/ParserEnums.hpp>
@@ -50,7 +49,7 @@ ENKRVD\n\
 
 BOOST_AUTO_TEST_CASE( ParseMissingRECORD_THrows) {
     Parser parser;
-    BOOST_CHECK_THROW( parser.parseString( dataMissingRecord, ParseContext() ), std::invalid_argument );
+    BOOST_CHECK_THROW( parser.parseString( dataMissingRecord ), std::invalid_argument );
 }
 
 
@@ -70,7 +69,7 @@ ENKRVD\n\
 
 BOOST_AUTO_TEST_CASE( parse_DATAWithDefult_OK ) {
     Parser parser;
-    auto deck = parser.parseString( data, ParseContext() );
+    auto deck = parser.parseString( data );
     const auto& keyword = deck.getKeyword( "ENKRVD" );
     const auto& rec0 = keyword.getRecord(0);
     const auto& rec1 = keyword.getRecord(1);

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -29,6 +29,8 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TlpmixpaTable.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 using namespace Opm;
 
@@ -71,7 +73,7 @@ GRID
 BOOST_AUTO_TEST_CASE( DENSITY ) {
     Parser parser;
     std::string file(pathprefix() + "DENSITY/DENSITY1");
-    auto deck =  parser.parseFile(file, ParseContext());
+    auto deck =  parser.parseFile(file);
     const auto& densityKw = deck.getKeyword("DENSITY" , 0);
 
 
@@ -91,7 +93,7 @@ BOOST_AUTO_TEST_CASE( DENSITY ) {
 BOOST_AUTO_TEST_CASE( END ) {
     Parser parser;
     std::string fileWithTitleKeyword = pathprefix() + "END/END1.txt";
-    auto deck = parser.parseFile(fileWithTitleKeyword, ParseContext());
+    auto deck = parser.parseFile(fileWithTitleKeyword);
 
     BOOST_CHECK_EQUAL(size_t(1), deck.size());
     BOOST_CHECK_EQUAL(true,  deck.hasKeyword("OIL"));
@@ -102,7 +104,7 @@ BOOST_AUTO_TEST_CASE( END ) {
 BOOST_AUTO_TEST_CASE( ENDINC ) {
     Parser parser;
     std::string fileWithTitleKeyword(pathprefix() + "END/ENDINC1.txt");
-    auto deck = parser.parseFile(fileWithTitleKeyword, ParseContext());
+    auto deck = parser.parseFile(fileWithTitleKeyword);
 
     BOOST_CHECK_EQUAL(size_t(1), deck.size());
     BOOST_CHECK_EQUAL(true,  deck.hasKeyword("OIL"));
@@ -112,11 +114,12 @@ BOOST_AUTO_TEST_CASE( ENDINC ) {
 
 BOOST_AUTO_TEST_CASE( EQUIL_MISSING_DIMS ) {
     Parser parser;
+    ErrorGuard errors;
     ParseContext parseContext;
     parseContext.update(ParseContext::PARSE_MISSING_DIMS_KEYWORD, InputError::IGNORE);
     const std::string equil = "EQUIL\n"
         "2469   382.4   1705.0  0.0    500    0.0     1     1      20 /";
-    auto deck = parser.parseString(equil, parseContext);
+    auto deck = parser.parseString(equil, parseContext, errors);
     const auto& kw1 = deck.getKeyword("EQUIL" , 0);
     BOOST_CHECK_EQUAL( 1U , kw1.size() );
 
@@ -132,7 +135,7 @@ BOOST_AUTO_TEST_CASE( EQUIL_MISSING_DIMS ) {
 BOOST_AUTO_TEST_CASE( EQUIL ) {
     Parser parser;
     std::string pvtgFile(pathprefix() + "EQUIL/EQUIL1");
-    auto deck =  parser.parseFile(pvtgFile, ParseContext());
+    auto deck =  parser.parseFile(pvtgFile);
     const auto& kw1 = deck.getKeyword("EQUIL" , 0);
     BOOST_CHECK_EQUAL( 3U , kw1.size() );
 
@@ -208,12 +211,12 @@ BOOST_AUTO_TEST_CASE( SORWMIS ) {
 
     Parser parser;
     // missing miscible keyword
-    BOOST_CHECK_THROW (parser.parseString(sorwmisData, ParseContext()), std::invalid_argument );
+    BOOST_CHECK_THROW (parser.parseString(sorwmisData), std::invalid_argument );
 
     //too many tables
-    BOOST_CHECK_THROW( parser.parseString(miscibleTightData + sorwmisData, ParseContext()), std::invalid_argument);
+    BOOST_CHECK_THROW( parser.parseString(miscibleTightData + sorwmisData), std::invalid_argument);
 
-    auto deck1 =  parser.parseString(miscibleData + sorwmisData, ParseContext());
+    auto deck1 =  parser.parseString(miscibleData + sorwmisData);
 
     const auto& sorwmis = deck1.getKeyword("SORWMIS");
     const auto& miscible = deck1.getKeyword("MISCIBLE");
@@ -243,7 +246,7 @@ BOOST_AUTO_TEST_CASE( SORWMIS ) {
 
 BOOST_AUTO_TEST_CASE( SGCWMIS ) {
     Parser parser;
-    auto deck1 =  parser.parseString(miscibleData + sgcwmisData, ParseContext());
+    auto deck1 =  parser.parseString(miscibleData + sgcwmisData);
 
     const auto& sgcwmis = deck1.getKeyword("SGCWMIS");
     const auto& miscible = deck1.getKeyword("MISCIBLE");
@@ -304,17 +307,17 @@ BOOST_AUTO_TEST_CASE( MISC ) {
     Parser parser;
 
     // out of range MISC keyword
-    auto deck1 = parser.parseString(miscOutOfRangeData, ParseContext());
+    auto deck1 = parser.parseString(miscOutOfRangeData);
     const auto& item = deck1.getKeyword("MISC").getRecord(0).getItem(0);
     Opm::MiscTable miscTable1(item);
 
     // too litle range of MISC keyword
-    auto deck2 = parser.parseString(miscTooSmallRangeData, ParseContext());
+    auto deck2 = parser.parseString(miscTooSmallRangeData);
     const auto& item2 = deck2.getKeyword("MISC").getRecord(0).getItem(0);
     Opm::MiscTable miscTable2(item2);
 
     // test table input
-    auto deck3 =  parser.parseString(miscData, ParseContext());
+    auto deck3 =  parser.parseString(miscData);
     const auto& item3 = deck3.getKeyword("MISC").getRecord(0).getItem(0);
     Opm::MiscTable miscTable3(item3);
     BOOST_CHECK_EQUAL(3U, miscTable3.getSolventFractionColumn().size());
@@ -334,7 +337,7 @@ PMISC
 
 BOOST_AUTO_TEST_CASE( PMISC ) {
     Parser parser;
-    auto deck =  parser.parseString(pmiscData, ParseContext());
+    auto deck =  parser.parseString(pmiscData);
     Opm::PmiscTable pmiscTable(deck.getKeyword("PMISC").getRecord(0).getItem(0));
     BOOST_CHECK_EQUAL(3U, pmiscTable.getOilPhasePressureColumn().size());
     BOOST_CHECK_EQUAL(200*1e5, pmiscTable.getOilPhasePressureColumn()[1]);
@@ -355,7 +358,7 @@ MSFN
 
 BOOST_AUTO_TEST_CASE( MSFN ) {
     Parser parser;
-    auto deck =  parser.parseString(msfnData, ParseContext());
+    auto deck =  parser.parseString(msfnData);
 
     Opm::MsfnTable msfnTable1(deck.getKeyword("MSFN").getRecord(0).getItem(0));
     BOOST_CHECK_EQUAL(2U, msfnTable1.getGasPhaseFractionColumn().size());
@@ -382,7 +385,7 @@ BOOST_AUTO_TEST_CASE( TLPMIXPA ) {
     )";
 
     Parser parser;
-    auto deck =  parser.parseString(tlpmixpa, ParseContext());
+    auto deck =  parser.parseString(tlpmixpa);
     Opm::TlpmixpaTable tlpmixpaTable(deck.getKeyword("TLPMIXPA").getRecord(0).getItem(0));
     BOOST_CHECK_EQUAL(3U, tlpmixpaTable.getOilPhasePressureColumn().size());
     BOOST_CHECK_EQUAL(200*1e5, tlpmixpaTable.getOilPhasePressureColumn()[1]);
@@ -390,10 +393,9 @@ BOOST_AUTO_TEST_CASE( TLPMIXPA ) {
 }
 
 BOOST_AUTO_TEST_CASE( MULTREGT_ECLIPSE_STATE ) {
-    ParseContext parseContext;
     Parser parser;
-    auto deck =  parser.parseFile(pathprefix() + "MULTREGT/MULTREGT.DATA", parseContext);
-    EclipseState state(deck , parseContext);
+    auto deck =  parser.parseFile(pathprefix() + "MULTREGT/MULTREGT.DATA");
+    EclipseState state(deck);
     const auto& transMult = state.getTransMult();
 
     // Test NONNC
@@ -441,10 +443,9 @@ BOOST_AUTO_TEST_CASE( MULTREGT_ECLIPSE_STATE ) {
 }
 
 BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
-    const Parser parser;
+    Parser parser;
     const std::string deckFile(pathprefix() + "SCHEDULE/SCHEDULE_MULTISEGMENT_WELL");
-    const ParseContext parseContext;
-    const auto deck =  parser.parseFile(deckFile, parseContext);
+    const auto deck =  parser.parseFile(deckFile);
 
     // for WELSEGS keyword
     const auto& kw = deck.getKeyword("WELSEGS");
@@ -563,12 +564,12 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
         BOOST_CHECK_EQUAL(  3237.5, distance_end );
     }
 
-    const EclipseState state(deck, parseContext);
+    const EclipseState state(deck);
     const auto& grid = state.getInputGrid();
     const TableManager table ( deck );
     const Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    const Schedule sched(deck, grid, eclipseProperties, runspec, parseContext );
+    const Schedule sched(deck, grid, eclipseProperties, runspec);
     // checking the relation between segments and completions
     // and also the depth of completions
     {
@@ -617,7 +618,7 @@ BOOST_AUTO_TEST_CASE( PLYADS ) {
 BOOST_AUTO_TEST_CASE( PLYADSS ) {
     Parser parser;
     std::string deckFile(pathprefix() + "POLYMER/plyadss.data");
-    auto deck =  parser.parseFile(deckFile, ParseContext());
+    auto deck =  parser.parseFile(deckFile);
     const auto& kw = deck.getKeyword("PLYADSS");
     BOOST_CHECK_EQUAL( kw.size() , 11U );
 }
@@ -625,7 +626,7 @@ BOOST_AUTO_TEST_CASE( PLYADSS ) {
 BOOST_AUTO_TEST_CASE( PLYDHFLF ) {
     Parser parser;
     std::string deckFile(pathprefix() + "POLYMER/plydhflf.data");
-    auto deck =  parser.parseFile(deckFile, ParseContext());
+    auto deck =  parser.parseFile(deckFile);
     const auto& kw = deck.getKeyword("PLYDHFLF");
     const auto& rec = kw.getRecord(0);
     const auto& item = rec.getItem(0);
@@ -638,7 +639,7 @@ BOOST_AUTO_TEST_CASE( PLYDHFLF ) {
 BOOST_AUTO_TEST_CASE( PLYSHLOG ) {
     Parser parser;
     std::string deckFile(pathprefix() + "POLYMER/plyshlog.data");
-    auto deck =  parser.parseFile(deckFile, ParseContext());
+    auto deck =  parser.parseFile(deckFile);
     const auto& kw = deck.getKeyword("PLYSHLOG");
     const auto& rec1 = kw.getRecord(0); // reference conditions
 
@@ -667,7 +668,7 @@ BOOST_AUTO_TEST_CASE( PLYSHLOG ) {
 BOOST_AUTO_TEST_CASE( PLYVISC ) {
     Parser parser;
     std::string deckFile(pathprefix() + "POLYMER/plyvisc.data");
-    auto deck =  parser.parseFile(deckFile, ParseContext());
+    auto deck =  parser.parseFile(deckFile);
     const auto& kw = deck.getKeyword("PLYVISC");
     const auto& rec = kw.getRecord(0);
     const auto& item = rec.getItem(0);
@@ -679,7 +680,7 @@ BOOST_AUTO_TEST_CASE( PLYVISC ) {
 BOOST_AUTO_TEST_CASE( PORO_PERMX ) {
     Parser parser;
     std::string poroFile(pathprefix() + "PORO/PORO1");
-    auto deck =  parser.parseFile(poroFile, ParseContext());
+    auto deck =  parser.parseFile(poroFile);
     const auto& kw1 = deck.getKeyword("PORO" , 0);
     const auto& kw2 = deck.getKeyword("PERMX" , 0);
 
@@ -721,7 +722,7 @@ PRORDER
 BOOST_AUTO_TEST_CASE( RSVD ) {
     Parser parser;
     std::string pvtgFile(pathprefix() + "RSVD/RSVD.txt");
-    auto deck =  parser.parseFile(pvtgFile, ParseContext());
+    auto deck =  parser.parseFile(pvtgFile);
     const auto& kw1 = deck.getKeyword("RSVD" , 0);
     BOOST_CHECK_EQUAL( 6U , kw1.size() );
 
@@ -760,7 +761,7 @@ PVTG
 )";
 
     Parser parser;
-    auto deck =  parser.parseString(pvtgData, ParseContext());
+    auto deck =  parser.parseString(pvtgData);
     const auto& kw1 = deck.getKeyword("PVTG" , 0);
     BOOST_CHECK_EQUAL(5U , kw1.size());
 
@@ -857,7 +858,7 @@ PVTO
 )";
 
     Parser parser;
-    auto deck =  parser.parseString(pvtoData, ParseContext());
+    auto deck =  parser.parseString(pvtoData);
     const auto& kw1 = deck.getKeyword("PVTO" , 0);
     BOOST_CHECK_EQUAL(5U , kw1.size());
 
@@ -935,7 +936,7 @@ SGOF
     1.0 1.0 0.1 9.0 /;
 )";
     Parser parser;
-    auto deck =  parser.parseString(parserData, ParseContext());
+    auto deck =  parser.parseString(parserData);
 
     const auto& kw1 = deck.getKeyword("SGOF");
     BOOST_CHECK_EQUAL(1U , kw1.size());
@@ -973,7 +974,7 @@ SWOF
     1.0  1* 0.1 9.0 /
 )";
     Parser parser;
-    auto deck =  parser.parseString(parserData, ParseContext());
+    auto deck =  parser.parseString(parserData);
 
     const auto& kw1 = deck.getKeyword("SWOF");
     const auto& record0 = kw1.getRecord(0);
@@ -1029,7 +1030,7 @@ SLGOF
 )";
 
     Parser parser;
-    auto deck =  parser.parseString(parserData, ParseContext());
+    auto deck =  parser.parseString(parserData);
 
     const auto& kw1 = deck.getKeyword("SLGOF");
     const auto& record0 = kw1.getRecord(0);
@@ -1051,7 +1052,7 @@ BOOST_AUTO_TEST_CASE( TITLE ) {
     Parser parser;
     std::string fileWithTitleKeyword(pathprefix() + "TITLE/TITLE1.txt");
 
-    auto deck = parser.parseFile(fileWithTitleKeyword, ParseContext());
+    auto deck = parser.parseFile(fileWithTitleKeyword);
 
     BOOST_CHECK_EQUAL(size_t(2), deck.size());
     BOOST_CHECK_EQUAL (true, deck.hasKeyword("TITLE"));
@@ -1070,9 +1071,8 @@ BOOST_AUTO_TEST_CASE( TITLE ) {
 BOOST_AUTO_TEST_CASE( TOPS ) {
     Parser parser;
     std::string deckFile(pathprefix() + "GRID/TOPS.DATA");
-    ParseContext parseContext;
-    auto deck =  parser.parseFile(deckFile, parseContext);
-    EclipseState state(deck, parseContext);
+    auto deck =  parser.parseFile(deckFile);
+    EclipseState state(deck);
     const auto& grid = state.getInputGrid();
 
     BOOST_CHECK_EQUAL( grid.getNX() , 9 );
@@ -1130,7 +1130,7 @@ TUNINGDP
 BOOST_AUTO_TEST_CASE( TVDP ) {
     Parser parser;
     std::string poroFile(pathprefix() + "TVDP/TVDP1");
-    auto deck =  parser.parseFile(poroFile, ParseContext());
+    auto deck =  parser.parseFile(poroFile);
 
     BOOST_CHECK(!deck.hasKeyword("TVDP*"));
     BOOST_CHECK( deck.hasKeyword("TVDPA"));
@@ -1144,7 +1144,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
     std::string file(pathprefix() + "VFPPROD/VFPPROD1");
     BOOST_CHECK( parser.isRecognizedKeyword("VFPPROD"));
 
-    auto deck =  parser.parseFile(file, ParseContext());
+    auto deck =  parser.parseFile(file);
     const auto& VFPPROD1 = deck.getKeyword("VFPPROD" , 0);
     const auto& BPR = deck.getKeyword("BPR" , 0);
     const auto& VFPPROD2 = deck.getKeyword("VFPPROD" , 1);
@@ -1273,7 +1273,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
 BOOST_AUTO_TEST_CASE( WCHONHIST ) {
     Parser parser;
     std::string wconhistFile(pathprefix() + "WCONHIST/WCONHIST1");
-    auto deck =  parser.parseFile(wconhistFile, ParseContext());
+    auto deck =  parser.parseFile(wconhistFile);
     const auto& kw1 = deck.getKeyword("WCONHIST" , 0);
     BOOST_CHECK_EQUAL( 3U , kw1.size() );
 
@@ -1336,7 +1336,7 @@ WOPR
     BOOST_CHECK_THROW(parser->parseString(invalidDeckString), std::invalid_argument);
 */
 
-    auto deck = parser.parseString(validDeckString, ParseContext());
+    auto deck = parser.parseString(validDeckString);
     BOOST_CHECK( !deck.hasKeyword("WELL_PROBE"));
     BOOST_CHECK(  deck.hasKeyword("WBHP"));
     BOOST_CHECK(  deck.hasKeyword("WOPR"));
@@ -1346,12 +1346,12 @@ WOPR
 BOOST_AUTO_TEST_CASE( WCONPROD ) {
     Parser parser;
     std::string wconprodFile(pathprefix() + "WellWithWildcards/WCONPROD1");
-    auto deck =  parser.parseFile(wconprodFile, ParseContext());
+    auto deck =  parser.parseFile(wconprodFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck, grid, eclipseProperties, runspec , ParseContext());
+    Schedule sched(deck, grid, eclipseProperties, runspec );
 
     BOOST_CHECK_EQUAL(5U, sched.numWells());
     BOOST_CHECK(sched.hasWell("INJE1"));
@@ -1381,15 +1381,14 @@ BOOST_AUTO_TEST_CASE( WCONPROD ) {
 
 
 BOOST_AUTO_TEST_CASE( WCONINJE ) {
-    ParseContext parseContext;
     Parser parser;
     std::string wconprodFile(pathprefix() + "WellWithWildcards/WCONINJE1");
-    auto deck = parser.parseFile(wconprodFile, parseContext);
+    auto deck = parser.parseFile(wconprodFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties( deck , table, grid );
     Runspec runspec (deck);
-    Schedule sched( deck, grid, eclipseProperties, runspec , parseContext);
+    Schedule sched( deck, grid, eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL(5U, sched.numWells());
     BOOST_CHECK(sched.hasWell("PROD1"));

--- a/tests/parser/integration/Polymer.cpp
+++ b/tests/parser/integration/Polymer.cpp
@@ -22,7 +22,6 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp>
@@ -37,7 +36,7 @@ inline std::string pathprefix() {
 
 BOOST_AUTO_TEST_CASE( parse_polymer_tables ) {
     Parser parser;
-    auto deck = parser.parseFile(pathprefix() + "POLYMER/POLY.inc", ParseContext());
+    auto deck = parser.parseFile(pathprefix() + "POLYMER/POLY.inc");
     Opm::TableManager tables( deck );
     const TableContainer& plymax = tables.getPlymaxTables();
     const TableContainer& plyrock = tables.getPlyrockTables();

--- a/tests/parser/integration/ResinsightTest.cpp
+++ b/tests/parser/integration/ResinsightTest.cpp
@@ -23,6 +23,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/F.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/G.hpp>
@@ -39,6 +40,7 @@ inline std::string pathprefix() {
 BOOST_AUTO_TEST_CASE( test_parse ) {
     Parser parser(false);
     ParseContext parseContext;
+    ErrorGuard errors;
 
     parseContext.update( ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
     parseContext.update( ParseContext::PARSE_RANDOM_TEXT , InputError::IGNORE );
@@ -47,7 +49,7 @@ BOOST_AUTO_TEST_CASE( test_parse ) {
     parser.addKeyword<ParserKeywords::SPECGRID>();
     parser.addKeyword<ParserKeywords::FAULTS>();
 
-    auto deck = parser.parseFile(pathprefix() + "Resinsight/DECK1.DATA" , parseContext);
+    auto deck = parser.parseFile(pathprefix() + "Resinsight/DECK1.DATA" , parseContext, errors);
 
     BOOST_CHECK( deck.hasKeyword<ParserKeywords::SPECGRID>() );
     BOOST_CHECK( deck.hasKeyword<ParserKeywords::FAULTS>() );
@@ -60,6 +62,8 @@ BOOST_AUTO_TEST_CASE( test_parse ) {
 BOOST_AUTO_TEST_CASE( test_state ) {
     Parser parser(false);
     ParseContext parseContext;
+    ErrorGuard errors;
+
 
     parseContext.update( ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
     parseContext.update( ParseContext::PARSE_RANDOM_TEXT , InputError::IGNORE );
@@ -68,7 +72,7 @@ BOOST_AUTO_TEST_CASE( test_state ) {
     parser.addKeyword<ParserKeywords::SPECGRID>();
     parser.addKeyword<ParserKeywords::FAULTS>();
     parser.addKeyword<ParserKeywords::GRID>();
-    auto deck = parser.parseFile(pathprefix() + "Resinsight/DECK1.DATA" , parseContext);
+    auto deck = parser.parseFile(pathprefix() + "Resinsight/DECK1.DATA" , parseContext, errors);
 
     GridDims grid(deck);
     GRIDSection gsec(deck);

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -26,7 +26,6 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
@@ -46,19 +45,18 @@ inline std::string pathprefix() {
 }
 
 BOOST_AUTO_TEST_CASE(CreateSchedule) {
-    ParseContext parseContext;
     Parser parser;
     EclipseGrid grid(10,10,10);
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE1");
-    auto deck1 =  parser.parseFile(scheduleFile, parseContext);
+    auto deck1 =  parser.parseFile(scheduleFile);
     std::stringstream ss;
     ss << deck1;
-    auto deck2 = parser.parseString( ss.str(), parseContext );
+    auto deck2 = parser.parseString( ss.str());
     for (const auto& deck : {deck1 , deck2}) {
         TableManager table ( deck );
         Eclipse3DProperties eclipseProperties ( deck , table, grid);
         Runspec runspec (deck);
-        Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+        Schedule sched(deck,  grid , eclipseProperties, runspec);
         const auto& timeMap = sched.getTimeMap();
         BOOST_CHECK_EQUAL(TimeMap::mkdate(2007 , 5 , 10), sched.getStartTime());
         BOOST_CHECK_EQUAL(9U, timeMap.size());
@@ -68,15 +66,14 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
 
 
 BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_COMMENTS_AFTER_KEYWORDS");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
     const auto& timeMap = sched.getTimeMap();
     BOOST_CHECK_EQUAL(TimeMap::mkdate(2007, 5 , 10) , sched.getStartTime());
     BOOST_CHECK_EQUAL(9U, timeMap.size());
@@ -84,42 +81,39 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
 
 
 BOOST_AUTO_TEST_CASE(WCONPROD_MissingCmode) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_MISSING_CMODE");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    BOOST_CHECK_NO_THROW( Schedule(deck, grid , eclipseProperties, runspec, parseContext ) );
+    BOOST_CHECK_NO_THROW( Schedule(deck, grid , eclipseProperties, runspec) );
 }
 
 
 BOOST_AUTO_TEST_CASE(WCONPROD_Missing_DATA) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_CMODE_MISSING_DATA");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    BOOST_CHECK_THROW( Schedule(deck, grid , eclipseProperties, runspec, parseContext ) , std::invalid_argument );
+    BOOST_CHECK_THROW( Schedule(deck, grid , eclipseProperties, runspec) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(WellTestRefDepth) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     BOOST_CHECK_EQUAL(3, 3);
     Runspec runspec (deck);
-    Schedule sched(deck , grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck , grid , eclipseProperties, runspec);
     BOOST_CHECK_EQUAL(4, 4);
 
     auto* well1 = sched.getWell("W_1");
@@ -132,15 +126,14 @@ BOOST_AUTO_TEST_CASE(WellTestRefDepth) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestOpen) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     auto well1 = sched.getWell( "W_1" );
     auto well2 = sched.getWell( "W_2" );
@@ -196,15 +189,14 @@ BOOST_AUTO_TEST_CASE(WellTestOpen) {
 
 
 BOOST_AUTO_TEST_CASE(WellTesting) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
     BOOST_CHECK(sched.hasWell("W_1"));
@@ -323,28 +315,26 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestCOMPDAT_DEFAULTED_ITEMS) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_COMPDAT1");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 }
 
 
 BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
     BOOST_CHECK(sched.hasWell("W_1"));
@@ -367,15 +357,14 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
 }
 
 BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_with_explicit_L0_parenting) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_GRUPTREE_EXPLICIT_PARENTING");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     const auto& grouptree = sched.getGroupTree( 0 );
 
@@ -394,15 +383,14 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_with_explicit_L0_parenting) {
 
 
 BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_correct) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELSPECS_GRUPTREE");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck,  grid , eclipseProperties, runspec);
 
     BOOST_CHECK( schedule.hasGroup( "FIELD" ));
     BOOST_CHECK( schedule.hasGroup( "PROD" ));
@@ -416,15 +404,14 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_correct) {
 
 
 BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_size ) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELSPECS_GROUPS");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck,  grid , eclipseProperties,runspec, parseContext);
+    Schedule schedule(deck,  grid , eclipseProperties,runspec);
 
     // Time 0, only from WELSPECS
     BOOST_CHECK_EQUAL( 2U, schedule.getGroupTree(0).children("FIELD").size() );
@@ -434,15 +421,14 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_size ) {
 }
 
 BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELSPECS_GROUPS");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule schedule(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule schedule(deck,  grid , eclipseProperties, runspec);
 
     // Time 0, only from WELSPECS
     const auto& tree0 = schedule.getGroupTree( 0 );
@@ -468,15 +454,14 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
 }
 
 BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_GROUPS_REPARENT");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
 
     const auto& tree0 = sched.getGroupTree( 0 );
@@ -490,15 +475,14 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
 }
 
 BOOST_AUTO_TEST_CASE( WellTestGroups ) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_GROUPS");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL( 3U , sched.numGroups() );
     BOOST_CHECK( sched.hasGroup( "INJ" ));
@@ -535,15 +519,14 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
 
 
 BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS_AND_GROUPS");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     auto& group1 = sched.getGroup("GROUP1");
     auto& group2 = sched.getGroup("GROUP2");
@@ -565,15 +548,14 @@ BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestWELSPECSDataLoaded) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WELLS2");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
     BOOST_CHECK(sched.hasWell("W_1"));
@@ -630,15 +612,14 @@ BOOST_AUTO_TEST_CASE(WellTestWELOPENControlsSet) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestWGRUPCONWellPropertiesSet) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WGRUPCON");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     const auto* well1 = sched.getWell("W_1");
     BOOST_CHECK(well1->isAvailableForGroupControl(0));
@@ -661,7 +642,6 @@ BOOST_AUTO_TEST_CASE(WellTestWGRUPCONWellPropertiesSet) {
 
 
 BOOST_AUTO_TEST_CASE(TestDefaultedCOMPDATIJ) {
-    ParseContext parseContext;
     Parser parser;
     const char * deckString = "\n\
 START\n\
@@ -675,12 +655,12 @@ WELSPECS \n\
 COMPDAT \n\
      'W1'   2*    1    1      'OPEN'  1*     32.948      0.311   3047.839  2*         'X'     22.100 /\n\
 /\n";
-    auto deck =  parser.parseString(deckString, parseContext);
+    auto deck =  parser.parseString(deckString);
     EclipseGrid grid(30,30,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
     const auto* well = sched.getWell("W1");
     const auto& connections = well->getConnections(0);
     BOOST_CHECK_EQUAL( 10 , connections.get(0).getI() );
@@ -693,29 +673,27 @@ COMPDAT \n\
    certain we can parse it.
 */
 BOOST_AUTO_TEST_CASE(OpmCode) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/wells_group.data");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    BOOST_CHECK_NO_THROW( Schedule(deck , grid , eclipseProperties, runspec, parseContext) );
+    BOOST_CHECK_NO_THROW( Schedule(deck , grid , eclipseProperties, runspec) );
 }
 
 
 
 BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_SHUT_WELL");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(20,40,1);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
 
     const auto* well1 = sched.getWell("W1");
@@ -734,15 +712,14 @@ BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_POLYMER");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
@@ -785,15 +762,14 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
 
 
 BOOST_AUTO_TEST_CASE(WellTestWECON) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WECON");
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck,  grid , eclipseProperties, runspec , parseContext);
+    Schedule sched(deck,  grid , eclipseProperties, runspec);
 
     BOOST_CHECK_EQUAL(3U, sched.numWells());
     BOOST_CHECK(sched.hasWell("INJE01"));
@@ -897,16 +873,15 @@ BOOST_AUTO_TEST_CASE(WellTestWECON) {
 
 
 BOOST_AUTO_TEST_CASE(TestEvents) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_EVENTS");
 
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,40,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    Schedule sched(deck , grid , eclipseProperties, runspec, parseContext);
+    Schedule sched(deck , grid , eclipseProperties, runspec);
     const Events& events = sched.getEvents();
 
     BOOST_CHECK(  events.hasEvent(ScheduleEvents::NEW_WELL , 0 ) );
@@ -932,16 +907,15 @@ BOOST_AUTO_TEST_CASE(TestEvents) {
 
 
 BOOST_AUTO_TEST_CASE(TestWellEvents) {
-    ParseContext parseContext;
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_EVENTS");
 
-    auto deck =  parser.parseFile(scheduleFile, parseContext);
+    auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,40,30);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec(deck);
-    Schedule sched(deck , grid , eclipseProperties, runspec, parseContext);
+    Schedule sched(deck , grid , eclipseProperties, runspec);
     const auto& w1 = sched.getWell( "W_1");
     const auto& w2 = sched.getWell( "W_2");
 

--- a/tests/parser/integration/TransMultIntegrationTests.cpp
+++ b/tests/parser/integration/TransMultIntegrationTests.cpp
@@ -22,7 +22,6 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
@@ -36,10 +35,10 @@ BOOST_AUTO_TEST_CASE(MULTFLT_IN_SCHEDULE) {
     Parser parser;
     std::string scheduleFile(pathprefix() + "TRANS/Deck1");
     ParseContext parseContext;
-    auto deck = parser.parseFile(scheduleFile, parseContext);
-    EclipseState state(deck, parseContext);
+    auto deck = parser.parseFile(scheduleFile);
+    EclipseState state(deck);
     const auto& trans = state.getTransMult();
-    Schedule schedule(deck, state.getInputGrid(), state.get3DProperties(), state.runspec(), parseContext);
+    Schedule schedule(deck, state.getInputGrid(), state.get3DProperties(), state.runspec());
     const Events& events = schedule.getEvents();
 
     BOOST_CHECK_EQUAL( 0.10 , trans.getMultiplier( 3,2,0,FaceDir::XPlus ));

--- a/tests/parser/integration/parse_write.cpp
+++ b/tests/parser/integration/parse_write.cpp
@@ -20,25 +20,23 @@
 #include <sstream>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 inline void loadDeck( const char * deck_file) {
-    Opm::ParseContext parseContext;
     Opm::Parser parser;
 
-    auto deck = parser.parseFile(deck_file, parseContext);
-    Opm::EclipseState state( deck, parseContext );
-    Opm::Schedule schedule( deck, state.getInputGrid(), state.get3DProperties(), state.runspec(), parseContext);
-    Opm::SummaryConfig summary( deck, schedule, state.getTableManager( ), parseContext );
+    auto deck = parser.parseFile(deck_file);
+    Opm::EclipseState state( deck);
+    Opm::Schedule schedule( deck, state.getInputGrid(), state.get3DProperties(), state.runspec());
+    Opm::SummaryConfig summary( deck, schedule, state.getTableManager( ));
     {
         std::stringstream ss;
 
         ss << deck;
-        auto deck2 = parser.parseString(ss.str(), parseContext);
+        auto deck2 = parser.parseString(ss.str());
         if (deck.size() != deck2.size()) {
             std::cerr << "Deck size mismatch original:" << deck.size() << " new: " << deck2.size( ) << std::endl;
             std::exit( 1 );

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -24,7 +24,6 @@
 #include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/output/data/Cells.hpp>
 
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
@@ -288,12 +287,11 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         "/\n";
 
     auto write_and_check = [&]( int first = 1, int last = 5 ) {
-        ParseContext parse_context;
-        auto deck = Parser().parseString( deckString, parse_context );
-        auto es = Parser::parse( deck );
+        auto deck = Parser().parseString( deckString);
+        auto es = EclipseState( deck );
         auto& eclGrid = es.getInputGrid();
-        Schedule schedule(deck, eclGrid, es.get3DProperties(), es.runspec(), parse_context);
-        SummaryConfig summary_config( deck, schedule, es.getTableManager( ), parse_context);
+        Schedule schedule(deck, eclGrid, es.get3DProperties(), es.runspec());
+        SummaryConfig summary_config( deck, schedule, es.getTableManager( ));
         es.getIOConfig().setBaseName( "FOO" );
 
         EclipseIO eclWriter( es, eclGrid , schedule, summary_config);

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -102,13 +102,12 @@ data::Solution createBlackoilState( int timeStepIdx, int numCells ) {
 }
 
 BOOST_AUTO_TEST_CASE(test_RFT) {
-    ParseContext parse_context;
     std::string eclipse_data_filename    = "testrft.DATA";
     test_work_area_type * test_area = test_work_area_alloc("test_RFT");
     test_work_area_copy_file( test_area, eclipse_data_filename.c_str() );
 
-    auto deck = Parser().parseFile( eclipse_data_filename, parse_context );
-    auto eclipseState = Parser::parse( deck );
+    auto deck = Parser().parseFile( eclipse_data_filename );
+    auto eclipseState = EclipseState(deck);
     {
         /* eclipseWriter is scoped here to ensure it is destroyed after the
          * file itself has been written, because we're going to reload it
@@ -118,8 +117,8 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
 
         const auto& grid = eclipseState.getInputGrid();
         const auto numCells = grid.getCartesianSize( );
-        Schedule schedule(deck, grid, eclipseState.get3DProperties(), eclipseState.runspec(), parse_context);
-        SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ), parse_context);
+        Schedule schedule(deck, eclipseState);
+        SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ));
         EclipseIO eclipseWriter( eclipseState, grid, schedule, summary_config );
         time_t start_time = schedule.posixStartTime();
         time_t step_time = ecl_util_make_date(10, 10, 2008 );
@@ -193,13 +192,12 @@ void verifyRFTFile2(const std::string& rft_filename) {
 
 
 BOOST_AUTO_TEST_CASE(test_RFT2) {
-    ParseContext parse_context;
     std::string eclipse_data_filename    = "testrft.DATA";
     test_work_area_type * test_area = test_work_area_alloc("test_RFT");
     test_work_area_copy_file( test_area, eclipse_data_filename.c_str());
 
-    auto deck = Parser().parseFile( eclipse_data_filename, parse_context );
-    auto eclipseState = Parser::parse( deck );
+    auto deck = Parser().parseFile( eclipse_data_filename);
+    auto eclipseState = EclipseState(deck);
     {
         /* eclipseWriter is scoped here to ensure it is destroyed after the
          * file itself has been written, because we're going to reload it
@@ -210,8 +208,8 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
         const auto& grid = eclipseState.getInputGrid();
         const auto numCells = grid.getCartesianSize( );
 
-        Schedule schedule(deck, grid, eclipseState.get3DProperties(), eclipseState.runspec(), parse_context);
-        SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ), parse_context);
+        Schedule schedule(deck, eclipseState);
+        SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ));
         time_t start_time = schedule.posixStartTime();
         const auto& time_map = schedule.getTimeMap( );
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -35,7 +35,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Utility/Functional.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
@@ -462,12 +461,12 @@ struct Setup {
     Schedule schedule;
     SummaryConfig summary_config;
 
-    Setup( const char* path, const ParseContext& parseContext = ParseContext( )) :
-        deck( Parser().parseFile( path, parseContext ) ),
-        es( deck, parseContext ),
+    Setup( const char* path) :
+        deck( Parser().parseFile( path) ),
+        es( deck),
         grid( es.getInputGrid( ) ),
-        schedule( deck, grid, es.get3DProperties(), es.runspec(), parseContext),
-        summary_config( deck, schedule, es.getTableManager( ), parseContext)
+        schedule( deck, grid, es.get3DProperties(), es.runspec()),
+        summary_config( deck, schedule, es.getTableManager( ))
     {
         auto& io_config = es.getIOConfig();
         io_config.setEclCompatibleRST(false);

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -43,7 +43,6 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
@@ -239,12 +238,12 @@ struct setup {
 
     /*-----------------------------------------------------------------*/
 
-    setup( const std::string& fname , const char* path = "summary_deck.DATA", const ParseContext& parseContext = ParseContext( )) :
-        deck( Parser().parseFile( path, parseContext ) ),
-        es( deck, ParseContext() ),
+    setup( const std::string& fname , const char* path = "summary_deck.DATA") : 
+        deck( Parser().parseFile( path) ),
+        es( deck ),
         grid( es.getInputGrid() ),
-        schedule( deck, grid, es.get3DProperties(), es.runspec(), parseContext),
-        config( deck, schedule, es.getTableManager(), parseContext ),
+        schedule( deck, grid, es.get3DProperties(), es.runspec()),
+        config( deck, schedule, es.getTableManager()),
         wells( result_wells() ),
         name( fname ),
         ta( test_work_area_alloc("summary_test"))

--- a/tests/test_Tables.cpp
+++ b/tests/test_Tables.cpp
@@ -44,7 +44,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 using namespace Opm;
@@ -55,9 +54,9 @@ struct setup {
     EclipseState es;
     test_work_area_type * ta;
 
-    setup( const std::string& path , const ParseContext& parseContext = ParseContext( )) :
-        deck( Parser().parseFile( path, parseContext ) ),
-        es( deck, ParseContext() ),
+    setup( const std::string& path) :
+        deck( Parser().parseFile( path) ),
+        es( deck ),
         ta( test_work_area_alloc( "test_tables"))
     {
     }
@@ -195,10 +194,10 @@ END
 )";
 
                     const auto deck = Opm::Deck{
-                        Opm::Parser{}.parseString(input, Opm::ParseContext{})
+                        Opm::Parser{}.parseString(input)
                     };
 
-                    return {deck, Opm::ParseContext{}};
+                    return {deck};
                 }
 
                 std::vector<double> expect_SGFN()
@@ -347,10 +346,10 @@ END
 )";
 
                     const auto deck = Opm::Deck{
-                        Opm::Parser{}.parseString(input, Opm::ParseContext{})
+                        Opm::Parser{}.parseString(input)
                     };
 
-                    return {deck, Opm::ParseContext{}};
+                    return {deck};
                 }
 
                 std::vector<double> expect_SOFN()
@@ -518,10 +517,10 @@ END
 )";
 
                 const auto deck = Opm::Deck{
-                    Opm::Parser{}.parseString(input, Opm::ParseContext{})
+                    Opm::Parser{}.parseString(input)
                 };
 
-                return {deck, Opm::ParseContext{}};
+                return {deck};
             }
 
             std::vector<double> expect_SGFN()
@@ -675,10 +674,10 @@ END
 )";
 
                     const auto deck = Opm::Deck{
-                        Opm::Parser{}.parseString(input, Opm::ParseContext{})
+                        Opm::Parser{}.parseString(input)
                     };
 
-                    return {deck, Opm::ParseContext{}};
+                    return {deck};
                 }
 
                 std::vector<double> expect_SGFN()
@@ -846,10 +845,10 @@ END
 )";
 
                     const auto deck = Opm::Deck{
-                        Opm::Parser{}.parseString(input, Opm::ParseContext{})
+                        Opm::Parser{}.parseString(input)
                     };
 
-                    return {deck, Opm::ParseContext{}};
+                    return {deck};
                 }
 
                 std::vector<double> expect_SOFN()
@@ -1030,10 +1029,10 @@ END
 )";
 
                 const auto deck = Opm::Deck{
-                    Opm::Parser{}.parseString(input, Opm::ParseContext{})
+                    Opm::Parser{}.parseString(input)
                 };
 
-                return {deck, Opm::ParseContext{}};
+                return {deck};
             }
 
             std::vector<double> expect_SGFN()

--- a/tests/test_regionCache.cpp
+++ b/tests/test_regionCache.cpp
@@ -39,12 +39,11 @@ const char* path = "summary_deck.DATA";
 
 
 BOOST_AUTO_TEST_CASE(create) {
-    ParseContext parseContext;
     Parser parser;
-    Deck deck( parser.parseFile( path, parseContext ));
-    EclipseState es(deck , parseContext );
+    Deck deck( parser.parseFile( path ));
+    EclipseState es(deck);
     const EclipseGrid& grid = es.getInputGrid();
-    Schedule schedule( deck, grid, es.get3DProperties(), es.runspec(), ParseContext() );
+    Schedule schedule( deck, es);
     out::RegionCache rc(es.get3DProperties() , grid, schedule);
 
     {

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -134,13 +134,12 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     test_work_area_type * test_area = test_work_area_alloc("TEST_EclipseWriteNumWells");
     test_work_area_copy_file(test_area, eclipse_data_filename.c_str());
 
-    ParseContext parseContext;
     Parser parser;
-    Deck deck( parser.parseFile( eclipse_data_filename, parseContext ));
-    EclipseState es(deck , parseContext );
+    Deck deck( parser.parseFile( eclipse_data_filename ));
+    EclipseState es(deck);
     const EclipseGrid& grid = es.getInputGrid();
-    Schedule schedule( deck, grid, es.get3DProperties(), es.runspec(), parseContext);
-    SummaryConfig summary_config( deck, schedule, es.getTableManager( ), parseContext);
+    Schedule schedule( deck, es);
+    SummaryConfig summary_config( deck, schedule, es.getTableManager( ));
     const auto num_cells = grid.getCartesianSize();
     EclipseIO eclipseWriter( es,  grid , schedule, summary_config);
     int countTimeStep = schedule.getTimeMap().numTimesteps();


### PR DESCRIPTION
1. Have added a small container `ErrorGuard` which can be used to assemble errors, this is an alternative to immediate throwing of an exception; so this still represents a serious problem! Unless very explicitly cleared the `ErrorGuard` will call `std::exit`when going out scope, if there are errors stored.

2. All functions which previously took a `ParseContext` argument now take an additional `ErrorGuard&` argument.

3. Have added overloads which do not take either `ParseContext` or `ErrorGuard`arguments - these overloads are mostly used in the tests (volume wise this is 90% of the PR).

The new behaviour is in principle in use with this PR; but there are no error modes which use the new `DELAYED_EXIT1` behaviour, so it will have no effect if merged today. Downstream PR's are coming.

And look ma: It uses *universal references*! 