### PR TITLE
Rm parsecontext

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <vector>
 
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp>
@@ -32,7 +33,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 
 namespace Opm {
@@ -67,7 +67,6 @@ namespace Opm {
 
         EclipseState(const Deck& deck , ParseContext parseContext = ParseContext());
 
-        const ParseContext& getParseContext() const;
         const IOConfig& getIOConfig() const;
         IOConfig& getIOConfig();
 
@@ -118,7 +117,6 @@ namespace Opm {
         void complainAboutAmbiguousKeyword(const Deck& deck,
                                            const std::string& keywordName);
 
-        ParseContext m_parseContext;
         const TableManager m_tables;
         Runspec m_runspec;
         EclipseConfig m_eclipseConfig;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -65,7 +65,7 @@ namespace Opm {
             AllProperties = IntProperties | DoubleProperties
         };
 
-        EclipseState(const Deck& deck , ParseContext parseContext = ParseContext());
+        EclipseState(const Deck& deck , const ParseContext& parseContext = ParseContext());
 
         const IOConfig& getIOConfig() const;
         IOConfig& getIOConfig();

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -50,7 +50,6 @@
 namespace Opm {
 
     EclipseState::EclipseState(const Deck& deck, ParseContext parseContext) :
-        m_parseContext(      parseContext ),
         m_tables(            deck ),
         m_runspec(           deck ),
         m_eclipseConfig(     deck, parseContext ),
@@ -113,9 +112,6 @@ namespace Opm {
         return m_tables;
     }
 
-    const ParseContext& EclipseState::getParseContext() const {
-        return m_parseContext;
-    }
 
     /// [[deprecated]] --- use cfg().io()
     const IOConfig& EclipseState::getIOConfig() const {

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -49,7 +49,7 @@
 
 namespace Opm {
 
-    EclipseState::EclipseState(const Deck& deck, ParseContext parseContext) :
+    EclipseState::EclipseState(const Deck& deck, const ParseContext& parseContext) :
         m_tables(            deck ),
         m_runspec(           deck ),
         m_eclipseConfig(     deck, parseContext ),


### PR DESCRIPTION
1. Remove `ParseContext` *member* from `EclipseState` class.
2. Change `EclipseState` constructor to take `const ParseContext&` argument instead of `ParseContext`