### PR TITLE
Silence various warnings discovered with new version of clang.

### DIFF
--- a/src/opm/output/eclipse/Tables.cpp
+++ b/src/opm/output/eclipse/Tables.cpp
@@ -189,7 +189,7 @@ namespace { namespace SatFunc {
                     const auto& pc = t.getPcogColumn();
                     std::transform(std::begin(pc), std::end(pc),
                                    linTable.column(tableID, primID, 2),
-                                   [&units, uPress](const double Pc) -> double
+                                   [&units](const double Pc) -> double
                                    {
                                        return units.from_si(uPress, Pc);
                                    });
@@ -264,7 +264,7 @@ namespace { namespace SatFunc {
                     const auto& pc = t.getPcogColumn();
                     std::transform(std::begin(pc), std::end(pc),
                                    linTable.column(tableID, primID, 2),
-                                   [&units, uPress](const double Pc) -> double
+                                   [&units](const double Pc) -> double
                                    {
                                        return units.from_si(uPress, Pc);
                                    });
@@ -916,7 +916,7 @@ namespace { namespace SatFunc {
                     const auto& pc = t.getPcowColumn();
                     std::transform(std::begin(pc), std::end(pc),
                                    linTable.column(tableID, primID, 2),
-                                   [&units, uPress](const double Pc) -> double
+                                   [&units](const double Pc) -> double
                                    {
                                        return units.from_si(uPress, Pc);
                                    });
@@ -991,7 +991,7 @@ namespace { namespace SatFunc {
                     const auto& pc = t.getPcowColumn();
                     std::transform(std::begin(pc), std::end(pc),
                                    linTable.column(tableID, primID, 2),
-                                   [&units, uPress](const double Pc) -> double
+                                   [&units](const double Pc) -> double
                                    {
                                        return units.from_si(uPress, Pc);
                                    });

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -327,8 +327,8 @@ inline std::map< std::string, int > RPT( const DeckKeyword& keyword,
             if (is_int(deck_items[index])) {
 
                 if (stack.size() < 2) {
-                    std::string msg = "Can not interpret " + keyword.name() + " at " + keyword.getFileName() + "(" + std::to_string( keyword.getLineNumber() ) + ")";
-                    throw std::invalid_argument(msg);
+                    std::string errmsg = "Can not interpret " + keyword.name() + " at " + keyword.getFileName() + "(" + std::to_string( keyword.getLineNumber() ) + ")";
+                    throw std::invalid_argument(errmsg);
                 }
 
                 if (stack.back() == "=") {
@@ -340,8 +340,8 @@ inline std::map< std::string, int > RPT( const DeckKeyword& keyword,
                     stack.clear();
                     items.push_back( mnemonic + "=" + deck_items[index]);
                 } else {
-                    std::string msg = "Can not interpret " + keyword.name() + " at " + keyword.getFileName() + "(" + std::to_string( keyword.getLineNumber() ) + ")";
-                    throw std::invalid_argument(msg);
+                    std::string errmsg = "Can not interpret " + keyword.name() + " at " + keyword.getFileName() + "(" + std::to_string( keyword.getLineNumber() ) + ")";
+                    throw std::invalid_argument(errmsg);
                 }
 
             } else

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -224,7 +224,7 @@ inline void keywordB( SummaryConfig::keyword_list& list,
   }
 }
 
-inline void keywordR2R( SummaryConfig::keyword_list& list,
+inline void keywordR2R( SummaryConfig::keyword_list& /* list */,
                         const ParseContext& parseContext,
                         ErrorGuard& errors,
                         const DeckKeyword& keyword)

--- a/tests/parser/ParseContext_EXIT1.cpp
+++ b/tests/parser/ParseContext_EXIT1.cpp
@@ -50,7 +50,7 @@ void test_exit(Opm::InputError::Action action) {
         std::exit(EXIT_FAILURE);
 }
 
-int main(int argc, char ** argv) {
+int main() {
     test_exit(Opm::InputError::Action::EXIT1);
     test_exit(Opm::InputError::Action::DELAYED_EXIT1);
 }

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1199,7 +1199,7 @@ struct MessageBuffer
   template <class T>
   void write( const T& value )
   {
-    str_.write( (char *) &value, sizeof(value) );
+    str_.write( (const char *) &value, sizeof(value) );
   }
 
   void write( const std::string& str)


### PR DESCRIPTION
The most exotic new one is related to the lambdas in Tables.cpp. The explanation is that, according to https://en.cppreference.com/w/cpp/language/lambda:

"A lambda expression can read the value of a variable without capturing it if the variable
 - has const non-volatile integral or enumeration type and has been initialized with a constant expression, or 
 - is constexpr and trivially copy constructible."