### PR TITLE
jenkins: allow modules to specify a pre-build check

### DIFF
--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -83,6 +83,16 @@ function build_module {
   test $? -eq 0 || exit 1
   if test $2 -eq 1
   then
+
+    pushd "$CWD"
+    cd "$1"
+    if test -x "./jenkins/pre-build.sh"; then
+        if ! "./jenkins/pre-build.sh"; then
+            exit 1
+        fi
+    fi
+    popd
+
     if [ ! -z $BUILDTHREADS ]
     then
       cmake --build . -- -j$BUILDTHREADS


### PR DESCRIPTION
this is purely optional. opm-material will use this to make sure that auto-generated code does not get manually modified.