### PR TITLE
Add WList implementation

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -97,6 +97,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WList.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/WListManager.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellEconProductionLimits.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.cpp
@@ -467,6 +468,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/Well.hpp
        opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
        opm/parser/eclipse/EclipseState/Schedule/WList.hpp
+       opm/parser/eclipse/EclipseState/Schedule/WListManager.hpp
        opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp
        opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
        opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -96,6 +96,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/WList.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellEconProductionLimits.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.cpp
@@ -243,6 +244,7 @@ if(ENABLE_ECL_INPUT)
     tests/parser/WellSolventTests.cpp
     tests/parser/WellTracerTests.cpp
     tests/parser/WellTests.cpp
+    tests/parser/WLIST.cpp
     tests/parser/WTEST.cpp)
 endif()
 if(ENABLE_ECL_OUTPUT)
@@ -464,6 +466,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp
        opm/parser/eclipse/EclipseState/Schedule/Well.hpp
        opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
+       opm/parser/eclipse/EclipseState/Schedule/WList.hpp
        opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp
        opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
        opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -58,6 +58,7 @@ namespace Opm
     class TimeMap;
     class UnitSystem;
     class ErrorGuard;
+    class WListManager;
 
     class Schedule {
     public:
@@ -133,6 +134,7 @@ namespace Opm
         const OilVaporizationProperties& getOilVaporizationProperties(size_t timestep) const;
 
         const WellTestConfig& wtestConfig(size_t timestep) const;
+        const WListManager& getWListManager(size_t timeStep) const;
         const Actions& actionConfig() const;
         void evalAction(const SummaryState& summary_state, size_t timeStep);
 
@@ -174,6 +176,7 @@ namespace Opm
         std::map<int, DynamicState<std::shared_ptr<VFPProdTable>>> vfpprod_tables;
         std::map<int, DynamicState<std::shared_ptr<VFPInjTable>>> vfpinj_tables;
         DynamicState<std::shared_ptr<WellTestConfig>> wtest_config;
+        DynamicState<std::shared_ptr<WListManager>> wlist_manager;
 
         WellProducer::ControlModeEnum m_controlModeWHISTCTL;
         Actions actions;
@@ -188,6 +191,7 @@ namespace Opm
         bool handleGroupFromWELSPECS(const std::string& groupName, GroupTree& newTree) const;
         void addGroup(const std::string& groupName , size_t timeStep);
         void addWell(const std::string& wellName, const DeckRecord& record, size_t timeStep, WellCompletion::CompletionOrderEnum wellCompletionOrder);
+        void handleWLIST(const DeckKeyword& keyword, size_t currentStep);
         void handleCOMPORD(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& compordKeyword, size_t currentStep);
         void handleWELSPECS( const SCHEDULESection&, size_t, size_t  );
         void handleWCONProducer( const DeckKeyword& keyword, size_t currentStep, bool isPredictionMode,  const ParseContext& parseContext, ErrorGuard& errors);

--- a/opm/parser/eclipse/EclipseState/Schedule/WList.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WList.hpp
@@ -1,0 +1,40 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+#include <string>
+
+namespace Opm {
+
+class WList {
+public:
+    using storage = std::unordered_set<std::string>;
+    std::size_t size() const;
+    void add(const std::string& well);
+    void del(const std::string& well);
+
+    std::vector<std::string> wells() const;
+    storage::const_iterator begin() const;
+    storage::const_iterator end() const;
+private:
+    storage well_list;
+};
+
+}

--- a/opm/parser/eclipse/EclipseState/Schedule/WList.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WList.hpp
@@ -29,6 +29,7 @@ public:
     std::size_t size() const;
     void add(const std::string& well);
     void del(const std::string& well);
+    bool has(const std::string& well) const;
 
     std::vector<std::string> wells() const;
     storage::const_iterator begin() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/WListManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WListManager.hpp
@@ -1,0 +1,38 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <cstddef>
+#include <map>
+#include <vector>
+#include <string>
+
+namespace Opm {
+
+class WList;
+
+class WListManager {
+public:
+    bool hasList(const std::string&) const;
+    WList& getList(const std::string& name);
+    WList& newList(const std::string& name);
+    void delWell(const std::string& well);
+private:
+    std::map<std::string, WList> wlists;
+};
+
+}

--- a/opm/parser/eclipse/EclipseState/Schedule/WListManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WListManager.hpp
@@ -29,6 +29,7 @@ class WListManager {
 public:
     bool hasList(const std::string&) const;
     WList& getList(const std::string& name);
+    const WList& getList(const std::string& name) const;
     WList& newList(const std::string& name);
     void delWell(const std::string& well);
 private:

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WList.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WList.cpp
@@ -1,0 +1,50 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WList.hpp>
+
+namespace Opm {
+
+
+std::size_t WList::size() const {
+    return this->well_list.size();
+}
+
+
+void WList::add(const std::string& well) {
+    this->well_list.insert(well);
+}
+
+void WList::del(const std::string& well) {
+    this->well_list.erase(well);
+}
+
+std::vector<std::string> WList::wells() const {
+    return { this->well_list.begin(), this->well_list.end() };
+}
+
+WList::storage::const_iterator WList::begin() const {
+    return this->well_list.begin();
+}
+
+WList::storage::const_iterator WList::end() const {
+    return this->well_list.end();
+}
+
+}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WList.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WList.cpp
@@ -27,6 +27,10 @@ std::size_t WList::size() const {
 }
 
 
+bool WList::has(const std::string& well) const {
+    return (this->well_list.find(well) != this->well_list.end());
+}
+
 void WList::add(const std::string& well) {
     this->well_list.insert(well);
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WListManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WListManager.cpp
@@ -38,6 +38,10 @@ namespace Opm {
         return this->wlists.at(name);
     }
 
+    const WList& WListManager::getList(const std::string& name) const {
+        return this->wlists.at(name);
+    }
+
     void WListManager::delWell(const std::string& well) {
         for (auto& pair: this->wlists) {
             auto& wlist = pair.second;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WListManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WListManager.cpp
@@ -1,0 +1,48 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WList.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/WListManager.hpp>
+
+namespace Opm {
+
+    bool WListManager::hasList(const std::string& name) const {
+        return (this->wlists.find(name) != this->wlists.end());
+    }
+
+
+    WList& WListManager::newList(const std::string& name) {
+        this->wlists.erase(name);
+        this->wlists.insert( {name, WList() });
+        return this->getList(name);
+    }
+
+
+    WList& WListManager::getList(const std::string& name) {
+        return this->wlists.at(name);
+    }
+
+    void WListManager::delWell(const std::string& well) {
+        for (auto& pair: this->wlists) {
+            auto& wlist = pair.second;
+            wlist.del(well);
+        }
+    }
+
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WLIST
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WLIST
@@ -1,0 +1,5 @@
+{"name" : "WLIST", "sections" : ["SCHEDULE"], "items" :
+      [{"name" : "NAME"         , "value_type" : "STRING"},
+       {"name" : "ACTION"       , "value_type" : "STRING"},
+       {"name" : "WELLS"        , "value_type" : "STRING", "size_type" : "ALL"}]}
+

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -389,6 +389,7 @@ set( keywords
      000_Eclipse100/W/WINJMULT
      000_Eclipse100/W/WLIFT
      000_Eclipse100/W/WLIMTOL
+     000_Eclipse100/W/WLIST
      000_Eclipse100/W/WORKLIM
      000_Eclipse100/W/WORKTHP
      000_Eclipse100/W/WPAVE

--- a/tests/parser/WLIST.cpp
+++ b/tests/parser/WLIST.cpp
@@ -24,8 +24,15 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WList.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WListManager.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+using namespace Opm;
 
 BOOST_AUTO_TEST_CASE(CreateWLIST) {
     Opm::WList wlist;
@@ -72,6 +79,7 @@ BOOST_AUTO_TEST_CASE(WLISTManager) {
         wlist1.add("B");
         wlist1.add("C");
     }
+
     // If a new list is added with the same name as an existing list the old
     // list is dropped and a new list is created.
     {
@@ -93,4 +101,154 @@ BOOST_AUTO_TEST_CASE(WLISTManager) {
     wlm.delWell("W1");
     BOOST_CHECK( std::find(wlist1.begin(), wlist1.end(), "W1") == wlist1.end());
     BOOST_CHECK( std::find(wlist2.begin(), wlist2.end(), "W1") == wlist2.end());
+}
+
+
+static std::string WELSPECS() {
+    return
+        "WELSPECS\n"
+        "  \'W1\'  \'OP\'  1 1 1.0 \'OIL\' 7* /\n"
+        "  \'W2\'  \'OP\'  2 1 1.0 \'OIL\' 7* /\n"
+        "  \'W3\'  \'OP\'  3 1 1.0 \'OIL\' 7* /\n"
+        "  \'W4\'  \'OP\'  4 1 1.0 \'OIL\' 7* /\n"
+        "/\n";
+}
+
+static Opm::Schedule createSchedule(const std::string& schedule) {
+    Opm::Parser parser;
+    std::string input =
+        "START             -- 0 \n"
+        "10 MAI 2007 / \n"
+        "SCHEDULE\n"+ schedule;
+
+    /*
+        "SCHEDULE\n"
+        "WELSPECS\n"
+        "     \'W_1\'        \'OP\'   30   37  3.33       \'OIL\'  7* /   \n"
+        "/ \n"
+        "DATES             -- 1\n"
+        " 10  \'JUN\'  2007 / \n"
+        "/\n"
+        "DATES             -- 2,3\n"
+        "  10  JLY 2007 / \n"
+        "   10  AUG 2007 / \n"
+        "/\n"
+        "WELSPECS\n"
+        "     \'WX2\'        \'OP\'   30   37  3.33       \'OIL\'  7* /   \n"
+        "     \'W_3\'        \'OP\'   20   51  3.92       \'OIL\'  7* /  \n"
+        "/\n";
+    */
+
+    auto deck = parser.parseString(input);
+    EclipseGrid grid(10,10,10);
+    TableManager table ( deck );
+    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    Runspec runspec (deck);
+    return Schedule(deck, grid , eclipseProperties, runspec );
+}
+
+
+BOOST_AUTO_TEST_CASE(WlistFromDeck) {
+    std::string no_wlist = WELSPECS();
+    no_wlist +=
+        "DATES\n"
+        "10 JLY 2007 /\n"
+        "10 AUG 2007 /\n"
+        "/\n";
+
+
+    Opm::Schedule sched = createSchedule(no_wlist);
+    auto& wlm = sched.getWListManager(1);
+    BOOST_CHECK(!wlm.hasList("LIST1"));
+}
+
+BOOST_AUTO_TEST_CASE(WlistInvalid) {
+  std::string wlist_invalid_well = WELSPECS() +
+    "WLIST\n"
+    " \'*LIST1\' \'NEW\' WELLX /\n"
+    "/\n"
+    "DATES\n"
+    "10 JLY 2007 /\n"
+    "10 AUG 2007 /\n"
+    "/\n";
+
+  std::string wlist_invalid_action = WELSPECS() +
+    "WLIST\n"
+    " \'*LIST1\' \'NEWX\' W1 /\n"
+    "/\n"
+    "DATES\n"
+    "10 JLY 2007 /\n"
+    "10 AUG 2007 /\n"
+    "/\n";
+
+  std::string wlist_invalid_list1 = WELSPECS() +
+    "WLIST\n"
+    " \'LIST1\' \'NEW\' W1 /\n"
+    "/\n"
+    "DATES\n"
+    "10 JLY 2007 /\n"
+    "10 AUG 2007 /\n"
+    "/\n";
+
+  std::string wlist_invalid_list2 = WELSPECS() +
+    "WLIST\n"
+    " \'*LIST1\' \'NEW\' W1 /\n"
+    " \'*LIST2\' \'ADD\' W2 /\n"
+    "/\n"
+    "DATES\n"
+    "10 JLY 2007 /\n"
+    "10 AUG 2007 /\n"
+    "/\n";
+
+  BOOST_CHECK_THROW( createSchedule(wlist_invalid_well), std::invalid_argument);
+  BOOST_CHECK_THROW( createSchedule(wlist_invalid_well), std::invalid_argument);
+  BOOST_CHECK_THROW( createSchedule(wlist_invalid_action), std::invalid_argument);
+  BOOST_CHECK_THROW( createSchedule(wlist_invalid_list1), std::invalid_argument);
+  BOOST_CHECK_THROW( createSchedule(wlist_invalid_list2), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(Wlist) {
+  std::string wlist = WELSPECS() +
+      "WLIST\n"
+      " \'*LIST1\' \'NEW\' W1 W2 /\n"
+      " \'*LIST1\' \'ADD\' W3 W4 /\n"
+      " \'*LIST2\' \'NEW\' W1 W3 /\n"
+      "/\n"
+      "DATES\n"
+      "10 JLY 2007 /\n"
+      "10 AUG 2007 /\n"
+      "/\n"
+      "WLIST\n"
+      " \'*LIST3\' \'NEW\' /\n"
+      " \'*LIST3\' \'MOV\' W1 W3 /\n"
+      "/\n";
+
+  auto sched = createSchedule(wlist);
+  {
+      const auto& wlm = sched.getWListManager(1);
+      const auto& wl1 = wlm.getList("*LIST1");
+      const auto& wl2 = wlm.getList("*LIST2");
+
+      BOOST_CHECK_EQUAL(wl1.wells().size(), 4 );
+      BOOST_CHECK_EQUAL(wl2.wells().size(), 2 );
+  }
+  {
+      const auto& wlm = sched.getWListManager(2);
+      const auto& wl1 = wlm.getList("*LIST1");
+      const auto& wl2 = wlm.getList("*LIST2");
+      const auto& wl3 = wlm.getList("*LIST3");
+
+      BOOST_CHECK_EQUAL(wl1.wells().size(), 2 );
+      BOOST_CHECK_EQUAL(wl2.wells().size(), 0 );
+      BOOST_CHECK_EQUAL(wl3.wells().size(), 2 );
+
+      BOOST_CHECK( wl1.has("W2"));
+      BOOST_CHECK( wl1.has("W4"));
+
+      BOOST_CHECK( !wl2.has("W1"));
+      BOOST_CHECK( !wl2.has("W3"));
+
+      BOOST_CHECK( wl3.has("W1"));
+      BOOST_CHECK( wl3.has("W3"));
+  }
 }

--- a/tests/parser/WLIST.cpp
+++ b/tests/parser/WLIST.cpp
@@ -1,0 +1,61 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdexcept>
+#include <algorithm>
+
+#define BOOST_TEST_MODULE WLIST_TEST
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WList.hpp>
+
+BOOST_AUTO_TEST_CASE(CreateWLIST) {
+    Opm::WList wlist;
+    BOOST_CHECK_EQUAL(wlist.size(), 0);
+    wlist.add("W1");
+    BOOST_CHECK_EQUAL(wlist.size(), 1);
+
+
+    wlist.del("NO_SUCH_WELL");
+    BOOST_CHECK_EQUAL(wlist.size(), 1);
+
+    wlist.del("W1");
+    BOOST_CHECK_EQUAL(wlist.size(), 0);
+
+    wlist.add("W1");
+    wlist.add("W2");
+    wlist.add("W3");
+
+    auto wells = wlist.wells();
+    BOOST_CHECK_EQUAL(wells.size(), 3);
+    BOOST_CHECK( std::find(wells.begin(), wells.end(), "W1") != wells.end());
+    BOOST_CHECK( std::find(wells.begin(), wells.end(), "W2") != wells.end());
+    BOOST_CHECK( std::find(wells.begin(), wells.end(), "W3") != wells.end());
+
+    std::vector<std::string> wells2;
+    for (const auto& well : wlist)
+        wells2.push_back(well);
+
+    BOOST_CHECK_EQUAL(wells2.size(), 3);
+    BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W1") != wells2.end());
+    BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W2") != wells2.end());
+    BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W3") != wells2.end());
+
+}

--- a/tests/parser/WLIST.cpp
+++ b/tests/parser/WLIST.cpp
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/WList.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/WListManager.hpp>
 
 BOOST_AUTO_TEST_CASE(CreateWLIST) {
     Opm::WList wlist;
@@ -57,5 +58,39 @@ BOOST_AUTO_TEST_CASE(CreateWLIST) {
     BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W1") != wells2.end());
     BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W2") != wells2.end());
     BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W3") != wells2.end());
+}
 
+
+BOOST_AUTO_TEST_CASE(WLISTManager) {
+    Opm::WListManager wlm;
+    BOOST_CHECK(!wlm.hasList("NO_SUCH_LIST"));
+
+
+    {
+        auto& wlist1 = wlm.newList("LIST1");
+        wlist1.add("A");
+        wlist1.add("B");
+        wlist1.add("C");
+    }
+    // If a new list is added with the same name as an existing list the old
+    // list is dropped and a new list is created.
+    {
+        auto& wlist1 = wlm.newList("LIST1");
+        BOOST_CHECK_EQUAL(wlist1.size(), 0);
+    }
+    auto& wlist1 = wlm.newList("LIST1");
+    auto& wlist2 = wlm.newList("LIST2");
+
+    wlist1.add("W1");
+    wlist1.add("W2");
+    wlist1.add("W3");
+
+    wlist2.add("W1");
+    wlist2.add("W2");
+    wlist2.add("W3");
+
+    // The delWell operation will work across all well lists.
+    wlm.delWell("W1");
+    BOOST_CHECK( std::find(wlist1.begin(), wlist1.end(), "W1") == wlist1.end());
+    BOOST_CHECK( std::find(wlist2.begin(), wlist2.end(), "W1") == wlist2.end());
 }


### PR DESCRIPTION
The `WLIST` keyword is used to manage lists of wells. The motivation for implementing it here is to support the `ACTIONX` keyword where it is used - but I think that well lists can be used also in many of the other SCHEDULE keywords, but we have not encountered them in the wild yet,