### PR TITLE
Turn on the mock simulator by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(OPM_MACROS_ROOT ${PROJECT_SOURCE_DIR})
 
 option(ENABLE_ECL_INPUT "Enable eclipse input support?" ON)
 option(ENABLE_ECL_OUTPUT "Enable eclipse output support?" ON)
-option(ENABLE_MOCKSIM "Build the mock simulator for io testing" OFF)
+option(ENABLE_MOCKSIM "Build the mock simulator for io testing" ON)
 
 # Output implies input
 if(ENABLE_ECL_OUTPUT)

--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <map>
 
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -18,7 +19,8 @@
 namespace Opm {
 
 class EclipseIO;
-
+class ParseContext;
+class Parser;
 
 class msim {
 
@@ -26,23 +28,19 @@ public:
     using well_rate_function = double(const EclipseState&, const Schedule&, const data::Solution&, size_t report_step, double seconds_elapsed);
     using solution_function = void(const EclipseState&, const Schedule&, data::Solution&, size_t report_step, double seconds_elapsed);
 
-    msim(const std::string& deck_file);
-    msim(const std::string& deck_file, const Parser& parser, const ParseContext& parse_context);
+    msim(const EclipseState& state);
 
     void well_rate(const std::string& well, data::Rates::opt rate, std::function<well_rate_function> func);
     void solution(const std::string& field, std::function<solution_function> func);
-    void run();
+    void run(const Schedule& schedule, EclipseIO& io);
 private:
 
-    void run_step(data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
-    void run_step(data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const;
     void output(size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const;
-    void simulate(data::Solution& sol, data::Wells& well_data, size_t report_step, double seconds_elapsed, double time_step) const;
+    void simulate(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, double seconds_elapsed, double time_step) const;
 
-    Deck deck;
     EclipseState state;
-    Schedule schedule;
-    SummaryConfig summary_config;
 
     std::map<std::string, std::map<data::Rates::opt, std::function<well_rate_function>>> well_rates;
     std::map<std::string, std::function<solution_function>> solutions;


### PR DESCRIPTION
Since ~October the opm-common codebase has had a mock simulator class `msim` - which has been added to simplify testing of `Schedule` / simulator interaction, in particualar inspired by the ongoing `ACTIONX` efforts.

The `msim` simulator has been hidden behind a CMake setting `ENABLE_MOCKSIM` which has been defaulted to `OFF`. With this PR the `ENABLE_MOCKSIM`defaults to `ON`, in addition there are some changes in the `msim` implementation - specifically it does *not* hold on to a `Schedule` object.

The first commit was just a minor reformatting I "needed" in a debugging effort; happy to skip that commit.