### PR TITLE
Simulator missing keyword

### DIFF
--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -301,6 +301,15 @@ namespace Opm {
         const static std::string RPT_UNKNOWN_MNEMONIC;
 
 
+        /*
+          The SIMULATOR_KEYWORD_ errormodes are for the situation where the
+          parser recognizes, and correctly parses a keyword, but we know that
+          the simulator does not support the intended use of the keyword. These
+          errormodes are invoked from the simulator.
+        */
+        const static std::string SIMULATOR_KEYWORD_NOT_SUPPORTED;
+        const static std::string SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED;
+
     private:
         void initDefault();
         void initEnv();

--- a/src/opm/parser/eclipse/Parser/ErrorGuard.cpp
+++ b/src/opm/parser/eclipse/Parser/ErrorGuard.cpp
@@ -53,7 +53,7 @@ namespace Opm {
         if (!this->error_list.empty()) {
             std::cerr << std::endl << std::endl << "Errors:" << std::endl;
             for (const auto& pair : this->error_list)
-                std::cerr << "  " << std::setw(width) << pair.first << ": " << pair.second << std::endl;
+                std::cerr << std::left << "  " << std::setw(width) << pair.first << ": " << pair.second << std::endl;
             std::cerr << std::endl;
         }
     }

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -94,6 +94,9 @@ namespace Opm {
 
         addKey(RPT_MIXED_STYLE, InputError::WARN);
         addKey(RPT_UNKNOWN_MNEMONIC, InputError::WARN);
+
+        addKey(SIMULATOR_KEYWORD_NOT_SUPPORTED, InputError::WARN);
+        addKey(SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED, InputError::WARN);
     }
 
     void ParseContext::initEnv() {
@@ -312,6 +315,9 @@ namespace Opm {
 
     const std::string ParseContext::SCHEDULE_INVALID_NAME = "SCHEDULE_INVALID_NAME";
     const std::string ParseContext::ACTIONX_ILLEGAL_KEYWORD = "ACTIONX_ILLEGAL_KEYWORD";
+
+    const std::string ParseContext::SIMULATOR_KEYWORD_NOT_SUPPORTED = "SIMULATOR_KEYWORD_NOT_SUPPORTED";
+    const std::string ParseContext::SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED = "SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED";
 }
 
 


### PR DESCRIPTION
Add `ParseContext` recognized errors for unsupported keywords.