### PR TITLE
Export SummaryState from EclipseIO object

### DIFF
--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -41,6 +41,7 @@ namespace Opm {
 class EclipseState;
 class SummaryConfig;
 class Schedule;
+class SummaryState;
 
 /*!
  * \brief A class to write the reservoir state and the well state of a
@@ -223,6 +224,8 @@ public:
 
     EclipseIO( const EclipseIO& ) = delete;
     ~EclipseIO();
+
+    const SummaryState& summaryState() const;
 
 private:
     class Impl;

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -527,6 +527,11 @@ EclipseIO::EclipseIO( const EclipseState& es,
 }
 
 
+const SummaryState& EclipseIO::summaryState() const {
+    return this->impl->summary.get_restart_vectors();
+}
+
+
 EclipseIO::~EclipseIO() {}
 
 } // namespace Opm


### PR DESCRIPTION
The `ACTIONX` needs access to the `SummaryState`object which has been properly initialized by the IO routine. The current PR is a not-very-elegant temporary fix, the slightly longer term fix to extract the `SummaryState`object out to application scope, but that will interfere with other ongoing work - so that can wait a bit.