### PR TITLE
Add missing <string> include.

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/WellSet.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/WellSet.hpp
@@ -6,6 +6,7 @@
 #ifndef ACTION_WELLSET
 #define ACTION_WELLSET
 
+#include <string>
 #include <unordered_set>
 #include <vector>
 


### PR DESCRIPTION
This is necessary to avoid compile errors with clang. I guess <unordered_set> transitively includes <string> when using gcc's libstdc++.