### PR TITLE
Summary udq

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -125,6 +125,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
     src/opm/parser/eclipse/EclipseState/UDQParams.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/UDQContext.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQExpression.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
@@ -504,6 +505,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
        opm/parser/eclipse/EclipseState/checkDeck.hpp
        opm/parser/eclipse/EclipseState/Runspec.hpp
+       opm/parser/eclipse/EclipseState/Schedule/UDQContext.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ.hpp
        opm/parser/eclipse/EclipseState/UDQParams.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQExpression.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -508,6 +508,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/UDQContext.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ.hpp
        opm/parser/eclipse/EclipseState/UDQParams.hpp
+       opm/parser/eclipse/EclipseState/Schedule/UDQ.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQExpression.hpp
        opm/parser/eclipse/Deck/DeckItem.hpp
        opm/parser/eclipse/Deck/Deck.hpp

--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -156,26 +156,26 @@ private:
 
 
 class Runspec {
-   public:
-        explicit Runspec( const Deck& );
+public:
+    explicit Runspec( const Deck& );
 
-        const UDQParams& udqParams() const noexcept;
-        const Phases& phases() const noexcept;
-        const Tabdims&  tabdims() const noexcept;
-        const EndpointScaling& endpointScaling() const noexcept;
-        const Welldims& wellDimensions() const noexcept;
-        const WellSegmentDims& wellSegmentDimensions() const noexcept;
-        int eclPhaseMask( ) const noexcept;
-	const EclHysterConfig& hysterPar() const noexcept;
+    const UDQParams& udqParams() const noexcept;
+    const Phases& phases() const noexcept;
+    const Tabdims&  tabdims() const noexcept;
+    const EndpointScaling& endpointScaling() const noexcept;
+    const Welldims& wellDimensions() const noexcept;
+    const WellSegmentDims& wellSegmentDimensions() const noexcept;
+    int eclPhaseMask( ) const noexcept;
+    const EclHysterConfig& hysterPar() const noexcept;
 
-   private:
-        Phases active_phases;
-        Tabdims m_tabdims;
-        EndpointScaling endscale;
-        Welldims welldims;
-        WellSegmentDims wsegdims;
-        UDQParams udq_params;
-	EclHysterConfig hystpar;
+private:
+    Phases active_phases;
+    Tabdims m_tabdims;
+    EndpointScaling endscale;
+    Welldims welldims;
+    WellSegmentDims wsegdims;
+    UDQParams udq_params;
+    EclHysterConfig hystpar;
 };
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQContext.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQContext.hpp
@@ -1,0 +1,43 @@
+/*
+  Copyright 2019 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef UDQ_CONTEXT_HPP
+#define UDQ_CONTEXT_HPP
+
+#include <string>
+#include <unordered_map>
+
+namespace Opm {
+    class SummaryState;
+
+    class UDQContext{
+    public:
+        explicit UDQContext(const SummaryState& summary_state);
+        double get(const std::string& key) const;
+        void add(const std::string& key, double value);
+    private:
+        const SummaryState& summary_state;
+        std::unordered_map<std::string, double> values;
+    };
+}
+
+
+
+#endif

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQContext.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQContext.cpp
@@ -1,0 +1,60 @@
+/*
+  Copyright 2019 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQContext.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
+
+
+namespace Opm {
+
+    UDQContext::UDQContext(const SummaryState& summary_state) :
+        summary_state(summary_state)
+    {
+        for (const auto& pair : TimeMap::eclipseMonthIndices())
+            this->add(pair.first, pair.second);
+
+        /*
+          Simulator performance keywords which are expected to be available for
+          UDQ keywords; probably better to guarantee that they are present in
+          the underlying summary state object.
+        */
+
+        this->add("ELAPSED", 0.0);
+        this->add("MSUMLINS", 0.0);
+        this->add("MSUMNEWT", 0.0);
+        this->add("NEWTON", 0.0);
+        this->add("TCPU", 0.0);
+        this->add("TIME", 0.0);
+        this->add("TIMESTEP", 0.0);
+    }
+
+
+    void UDQContext::add(const std::string& key, double value) {
+        this->values[key] = value;
+    }
+
+    double UDQContext::get(const std::string& key) const {
+        const auto& pair_ptr = this->values.find(key);
+        if (pair_ptr == this->values.end())
+            return this->summary_state.get(key);
+
+        return pair_ptr->second;
+    }
+}

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -632,7 +632,15 @@ CTFAC
 ----'E-2H' /
 ----/
 
+WUBHP
+/
+
+
 SCHEDULE
+
+UDQ
+  UNITS  WUBHP  'BARSA' /
+/
 
 -- Three wells, two producers (so that we can form a group) and one injector
 WELSPECS

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -266,7 +266,7 @@ struct setup {
 
     /*-----------------------------------------------------------------*/
 
-    setup( const std::string& fname , const char* path = "summary_deck.DATA") : 
+    setup( const std::string& fname , const char* path = "summary_deck.DATA") :
         deck( Parser().parseFile( path) ),
         es( deck ),
         grid( es.getInputGrid() ),
@@ -499,6 +499,24 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     BOOST_CHECK_CLOSE( 0.2, ecl_sum_get_well_var( resp, 1, "W_1", "WTHPH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 1.2, ecl_sum_get_well_var( resp, 1, "W_2", "WTHPH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 2.2, ecl_sum_get_well_var( resp, 1, "W_3", "WTHPH" ), 1e-5 );
+}
+
+BOOST_AUTO_TEST_CASE(udq_keywords) {
+    setup cfg( "test_summary_udq" );
+
+    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
+    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.write();
+
+    auto res = readsum( cfg.name );
+    const auto* resp = res.get();
+
+    const auto& udq_params = cfg.es.runspec().udqParams();
+    BOOST_CHECK_CLOSE( ecl_sum_get_well_var(resp, 1, "W_1", "WUBHP"), udq_params.undefinedValue(), 1e-5 );
+    BOOST_CHECK_CLOSE( ecl_sum_get_well_var(resp, 1, "W_3", "WUBHP"), udq_params.undefinedValue(), 1e-5 );
+    BOOST_CHECK_EQUAL( std::string(ecl_sum_get_unit(resp, "WUBHP:W_1")), "BARSA");
 }
 
 BOOST_AUTO_TEST_CASE(group_keywords) {


### PR DESCRIPTION
This PR will hook the UDQ system up to the summary output system; i.e. if you have asked for summary output of UDQ variable `WUBHP` you will get entries n the summary file with the correct keyword, and unit . but the numerical value will just be the UDQ default value.