### PR TITLE
[Disussion]using global_index in serialize_OPM_XWEL()

### DIFF
--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -136,14 +136,14 @@ namespace {
                     continue;
                 }
 
-                const auto active_index = grid.activeIndex(i, j, k);
+                const auto global_index = grid.getGlobalIndex(i, j, k);
 
                 const auto& connection =
                     std::find_if(well.connections.begin(),
                                  well.connections.end(),
-                        [active_index](const data::Connection& c)
+                        [global_index](const data::Connection& c)
                     {
-                        return c.index == active_index;
+                        return c.index == global_index;
                     });
 
                 if (connection == well.connections.end()) {


### PR DESCRIPTION
it looks like in data::Wells the index is global index.

The symptom is that for cases with non-active cells, which are the most of the practical cases, perforation rates and perforation pressure are not written in the UNRST file. 

Not saying this is the most proper way to fix the problem, while it points to the cause of the problem. 

In https://github.com/OPM/ewoms/pull/283 , we have already removed the perforations that locate in the inactive cells in the `schedule`, not sure whether this information can be used in the this part. 

I believe @bska has all the insight about this issue. 