### PR TITLE
Initial completion number set to connection number

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WellConnections.cpp
@@ -172,7 +172,7 @@ namespace {
 					const double segDistEnd,
 					const bool defaultSatTabId)
     {
-        int complnum = -(this->m_connections.size() + 1);
+        int complnum = (this->m_connections.size() + 1);
         this->addConnection(i,
                             j,
                             k,

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -675,9 +675,9 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndConnectionDataWithWELOPEN) {
     constexpr auto open = WellCompletion::StateEnum::OPEN;
 
     BOOST_CHECK_EQUAL( 7U, cs.size() );
-    BOOST_CHECK_EQUAL(open, cs.getFromIJK( 7, 6, 2 ).state());
-    BOOST_CHECK_EQUAL(open, cs.getFromIJK( 7, 6, 3 ).state());
-    BOOST_CHECK_EQUAL(open, cs.getFromIJK( 7, 6, 4 ).state());
+    BOOST_CHECK_EQUAL(shut, cs.getFromIJK( 7, 6, 2 ).state());
+    BOOST_CHECK_EQUAL(shut, cs.getFromIJK( 7, 6, 3 ).state());
+    BOOST_CHECK_EQUAL(shut, cs.getFromIJK( 7, 6, 4 ).state());
     BOOST_CHECK_EQUAL(open, cs.getFromIJK( 7, 7, 2 ).state());
 
     const auto& cs2 = well->getConnections( 4 );
@@ -1775,16 +1775,16 @@ BOOST_AUTO_TEST_CASE( COMPDAT_sets_automatic_complnum ) {
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& cs1 = schedule.getWell( "W1" )->getConnections( 1 );
-    BOOST_CHECK_EQUAL( -1, cs1.get( 0 ).complnum() );
-    BOOST_CHECK_EQUAL( -2, cs1.get( 1 ).complnum() );
-    BOOST_CHECK_EQUAL( -3, cs1.get( 2 ).complnum() );
-    BOOST_CHECK_EQUAL( -4, cs1.get( 3 ).complnum() );
+    BOOST_CHECK_EQUAL( 1, cs1.get( 0 ).complnum() );
+    BOOST_CHECK_EQUAL( 2, cs1.get( 1 ).complnum() );
+    BOOST_CHECK_EQUAL( 3, cs1.get( 2 ).complnum() );
+    BOOST_CHECK_EQUAL( 4, cs1.get( 3 ).complnum() );
 
     const auto& cs2 = schedule.getWell( "W1" )->getConnections( 2 );
-    BOOST_CHECK_EQUAL( -1, cs2.get( 0 ).complnum() );
-    BOOST_CHECK_EQUAL( -2, cs2.get( 1 ).complnum() );
-    BOOST_CHECK_EQUAL( -3, cs2.get( 2 ).complnum() );
-    BOOST_CHECK_EQUAL( -4, cs2.get( 3 ).complnum() );
+    BOOST_CHECK_EQUAL( 1, cs2.get( 0 ).complnum() );
+    BOOST_CHECK_EQUAL( 2, cs2.get( 1 ).complnum() );
+    BOOST_CHECK_EQUAL( 3, cs2.get( 2 ).complnum() );
+    BOOST_CHECK_EQUAL( 4, cs2.get( 3 ).complnum() );
 }
 
 BOOST_AUTO_TEST_CASE( COMPDAT_multiple_wells ) {
@@ -1819,18 +1819,18 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_wells ) {
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
     const auto& w1cs = schedule.getWell( "W1" )->getConnections();
-    BOOST_CHECK_EQUAL( -1, w1cs.get( 0 ).complnum() );
-    BOOST_CHECK_EQUAL( -2, w1cs.get( 1 ).complnum() );
-    BOOST_CHECK_EQUAL( -3, w1cs.get( 2 ).complnum() );
-    BOOST_CHECK_EQUAL( -4, w1cs.get( 3 ).complnum() );
-    BOOST_CHECK_EQUAL( -5, w1cs.get( 4 ).complnum() );
+    BOOST_CHECK_EQUAL( 1, w1cs.get( 0 ).complnum() );
+    BOOST_CHECK_EQUAL( 2, w1cs.get( 1 ).complnum() );
+    BOOST_CHECK_EQUAL( 3, w1cs.get( 2 ).complnum() );
+    BOOST_CHECK_EQUAL( 4, w1cs.get( 3 ).complnum() );
+    BOOST_CHECK_EQUAL( 5, w1cs.get( 4 ).complnum() );
 
     const auto& w2cs = schedule.getWell( "W2" )->getConnections();
-    BOOST_CHECK_EQUAL( -1, w2cs.getFromIJK( 4, 4, 2 ).complnum() );
-    BOOST_CHECK_EQUAL( -2, w2cs.getFromIJK( 4, 4, 0 ).complnum() );
-    BOOST_CHECK_EQUAL( -3, w2cs.getFromIJK( 4, 4, 1 ).complnum() );
-    BOOST_CHECK_EQUAL( -4, w2cs.getFromIJK( 4, 4, 3 ).complnum() );
-    BOOST_CHECK_EQUAL( -5, w2cs.getFromIJK( 4, 4, 4 ).complnum() );
+    BOOST_CHECK_EQUAL( 1, w2cs.getFromIJK( 4, 4, 2 ).complnum() );
+    BOOST_CHECK_EQUAL( 2, w2cs.getFromIJK( 4, 4, 0 ).complnum() );
+    BOOST_CHECK_EQUAL( 3, w2cs.getFromIJK( 4, 4, 1 ).complnum() );
+    BOOST_CHECK_EQUAL( 4, w2cs.getFromIJK( 4, 4, 3 ).complnum() );
+    BOOST_CHECK_EQUAL( 5, w2cs.getFromIJK( 4, 4, 4 ).complnum() );
 
     BOOST_CHECK_THROW( w2cs.get( 5 ).complnum(), std::out_of_range );
 }
@@ -1864,9 +1864,9 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_records_same_completion ) {
 
     const auto& cs = schedule.getWell( "W1" )->getConnections();
     BOOST_CHECK_EQUAL( 3U, cs.size() );
-    BOOST_CHECK_EQUAL( -1, cs.get( 0 ).complnum() );
-    BOOST_CHECK_EQUAL( -2, cs.get( 1 ).complnum() );
-    BOOST_CHECK_EQUAL( -3, cs.get( 2 ).complnum() );
+    BOOST_CHECK_EQUAL( 1, cs.get( 0 ).complnum() );
+    BOOST_CHECK_EQUAL( 2, cs.get( 1 ).complnum() );
+    BOOST_CHECK_EQUAL( 3, cs.get( 2 ).complnum() );
 }
 
 BOOST_AUTO_TEST_CASE( complump_less_than_1 ) {
@@ -1947,7 +1947,6 @@ BOOST_AUTO_TEST_CASE( complump ) {
     BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 0 ).complnum() );
     BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 1 ).complnum() );
     BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 2 ).complnum() );
-    BOOST_CHECK( sc0.getFromIJK( 2, 2, 3 ).complnum() < 0);
 
     BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 0 ).state() );
     BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 1 ).state() );
@@ -1966,7 +1965,7 @@ BOOST_AUTO_TEST_CASE( complump ) {
     BOOST_CHECK_EQUAL(c1.size(), 3);
 
     for (const auto& pair : completions) {
-        if (pair.first > 0)
+        if (pair.first == 1)
             BOOST_CHECK(pair.second.size() > 1);
         else
             BOOST_CHECK_EQUAL(pair.second.size(), 1);


### PR DESCRIPTION
`COMPLNUM` is a method to join connections together as a *completion*, and then subsequently treat all those connections as one logical entity. If a completion number has not been explicitly assigned with the `COMPLNUM` keyword the connections get an automatically assigned completion number corresponding to the insert order of the connection. 

Previously we assigned negative numbers when assigning completion numbers automatically, to protect against mixing automatically assigned completion numbers and those which have been assigned with `COMPLUMP` - so although the explicit separation of manually and automatically assigned completions seem like a sane idea - in my opinion, it seems to be a feature that it should be possible, so now we implement this to. It should be noted that it is explicitly mentioned in the manual that when using the `COMPLUMP` keyword one should make certain that *all* connection numbers are reset. 

It seems we now reproduce Eclipse - so in that sense we are good; but the specifics we now reproduce are quite peculiar; quite possibly this is not really what the user intended. That is of course difficult to be certain about.

