### PR TITLE
Add ParseContext::PARSE_LONG_KEYWORD

### DIFF
--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -196,6 +196,13 @@ namespace Opm {
 
 
         /*
+          Should we allow keywords of length more than eight characters? If the
+          keyword is too long it will be internalized using only the eight first
+          characters.
+        */
+        const static std::string PARSE_LONG_KEYWORD;
+
+        /*
           Some property modfiers can be modified in the Schedule
           section; this effectively means that Eclipse supports time
           dependent geology. This is marked as an exocit special

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -77,6 +77,7 @@ namespace Opm {
         addKey(PARSE_MISSING_DIMS_KEYWORD, InputError::THROW_EXCEPTION);
         addKey(PARSE_EXTRA_DATA, InputError::THROW_EXCEPTION);
         addKey(PARSE_MISSING_INCLUDE, InputError::EXIT1);
+        addKey(PARSE_LONG_KEYWORD, InputError::WARN);
 
         addKey(UNSUPPORTED_SCHEDULE_GEO_MODIFIER, InputError::THROW_EXCEPTION);
         addKey(UNSUPPORTED_COMPORD_TYPE, InputError::THROW_EXCEPTION);
@@ -298,6 +299,7 @@ namespace Opm {
     const std::string ParseContext::PARSE_EXTRA_DATA = "PARSE_EXTRA_DATA";
     const std::string ParseContext::PARSE_MISSING_SECTIONS = "PARSE_MISSING_SECTIONS";
     const std::string ParseContext::PARSE_MISSING_INCLUDE = "PARSE_MISSING_INCLUDE";
+    const std::string ParseContext::PARSE_LONG_KEYWORD = "PARSE_LONG_KEYWORD";
 
     const std::string ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER = "UNSUPPORTED_SCHEDULE_GEO_MODIFIER";
     const std::string ParseContext::UNSUPPORTED_COMPORD_TYPE = "UNSUPPORTED_COMPORD_TYPE";

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -207,9 +207,6 @@ namespace Opm {
 
 
     bool ParserKeyword::validNameStart( const string_view& name) {
-        if (name.length() > ParserConst::maxKeywordLength)
-            return false;
-
         if (!isalpha(name[0]))
             return false;
 
@@ -228,12 +225,8 @@ namespace Opm {
     string_view ParserKeyword::getDeckName( const string_view& str ) {
 
         auto first_sep = std::find_if( str.begin(), str.end(), RawConsts::is_separator() );
+        return { str.begin(), first_sep };
 
-        // only look at the first 8 characters (at most)
-        if( std::distance( str.begin(), first_sep ) < 9 )
-            return { str.begin(), first_sep };
-
-        return { str.begin(), str.begin() + 9 };
     }
 
     bool ParserKeyword::validDeckName( const string_view& name) {

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -769,3 +769,23 @@ BOOST_AUTO_TEST_CASE(Test_ERRORGUARD) {
     eg.clear();
     BOOST_CHECK(!eg);
 }
+
+
+
+
+
+BOOST_AUTO_TEST_CASE(LONG_KEYWORDS) {
+    const std::string deck_string = R"(
+RPTRUNSPEC
+)";
+    Parser parser;
+    ParseContext context;
+    ErrorGuard error;
+
+    context.update(ParseContext::PARSE_LONG_KEYWORD, InputError::IGNORE);
+    auto deck = parser.parseString(deck_string, context, error);
+    BOOST_CHECK( deck.hasKeyword("RPTRUNSP") );
+
+    context.update(ParseContext::PARSE_LONG_KEYWORD, InputError::THROW_EXCEPTION);
+    BOOST_CHECK_THROW( parser.parseString(deck_string, context, error), std::invalid_argument);
+}

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -278,7 +278,6 @@ BOOST_AUTO_TEST_CASE(WildCardTest) {
     BOOST_CHECK(!parser.isRecognizedKeyword("TVDP*"));
     BOOST_CHECK(!parser.isRecognizedKeyword("TVDP"));
     BOOST_CHECK(parser.isRecognizedKeyword("TVDPXXX"));
-    BOOST_CHECK(!parser.isRecognizedKeyword("TVDPIAMTOOLONG"));
     BOOST_CHECK(!parser.isRecognizedKeyword("TVD"));
 
     BOOST_CHECK(!parser.isRecognizedKeyword("TVDP"));
@@ -1327,7 +1326,6 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_withOtherSize_SizeTypeOTHER) {
 BOOST_AUTO_TEST_CASE(ParserKeyword_validDeckName) {
     BOOST_CHECK_EQUAL( true , ParserKeyword::validDeckName("SUMMARY"));
     BOOST_CHECK_EQUAL( true , ParserKeyword::validDeckName("MixeCase"));
-    BOOST_CHECK_EQUAL( false , ParserKeyword::validDeckName("NAMETOOLONG"));
     BOOST_CHECK_EQUAL( true , ParserKeyword::validDeckName("STRING88"));
     BOOST_CHECK_EQUAL( false , ParserKeyword::validDeckName("88STRING"));
     BOOST_CHECK_EQUAL( false , ParserKeyword::validDeckName("KEY.EXT"));
@@ -1368,7 +1366,6 @@ BOOST_AUTO_TEST_CASE(ParserKeywordMatches) {
     BOOST_CHECK_EQUAL( false , parserKeyword->matches("WORLD"));
     BOOST_CHECK_EQUAL( true , parserKeyword->matches("WORLDABC"));
     BOOST_CHECK_EQUAL( false , parserKeyword->matches("WORLD#BC"));
-    BOOST_CHECK_EQUAL( false , parserKeyword->matches("WORLDIAMTOOLONG"));
 }
 
 BOOST_AUTO_TEST_CASE(AddDataKeyword_correctlyConfigured) {


### PR DESCRIPTION
The ParserContext error mode PARSE_LONG_KEYWORD is used to handle keywords
longer than 8 characters. The lenient option is to only consider the first 8
characters.