### PR TITLE
Temporarily remove warning about missing summary variables

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1483,8 +1483,10 @@ void Summary::add_timestep( int report_step,
             const std::string key = smspec_node.get_gen_key1();
             if (st.has(key))
                 ecl_sum_tstep_iset(tstep, smspec_node.get_params_index(), st.get(key));
-            else
-                OpmLog::warning("Have configured UDQ variable " + key + " for summary output - but it has not been calculated");
+            /*
+              else
+              OpmLog::warning("Have configured summary variable " + key + " for summary output - but it has not been calculated");
+            */
         }
     }
 


### PR DESCRIPTION
With #632 the behaviour with summary variables was somewhat changed; you configure the summary variables you want - and then subsequently the summary object asks for them. At the time I thought only the (not yet activated) `UDQ` variables would create these warnings, but that seems to not be the case.

Temporarily just removing the warning.