### PR TITLE
Use slash termination to determine size of keywords SKPRPOLY SKPRWAT

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/900_OPM/P/PLYMWINJ
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/P/PLYMWINJ
@@ -1,4 +1,4 @@
-{"name" : "PLYMWINJ" , "sections" : ["PROPS"], "size" : "UNKNOWN",
+{"name" : "PLYMWINJ" , "sections" : ["PROPS"],
  "records"  : [
 [{"name" : "TABLE_NUMBER" , "value_type" : "INT"}],
 [{"name" : "THROUGHPUT", "value_type" : "DOUBLE", "dimension" : "Length", "size_type" : "ALL"}],

--- a/src/opm/parser/eclipse/share/keywords/900_OPM/S/SKPRPOLY
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/S/SKPRPOLY
@@ -1,4 +1,4 @@
-{"name" : "SKPRPOLY" , "sections" : ["PROPS"], "size" : "UNKNOWN",
+{"name" : "SKPRPOLY" , "sections" : ["PROPS"],
  "records"  : [
 [{"name" : "TABLE_NUMBER" , "value_type" : "INT"},
 {"name" : "POLYMERCONCENTRATION" , "value_type" : "DOUBLE", "dimension" : "PolymerDensity"}],

--- a/src/opm/parser/eclipse/share/keywords/900_OPM/S/SKPRWAT
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/S/SKPRWAT
@@ -1,4 +1,4 @@
-{"name" : "SKPRWAT" , "sections" : ["PROPS"], "size" : "UNKNOWN",
+{"name" : "SKPRWAT" , "sections" : ["PROPS"],
  "records"  : [
 [{"name" : "TABLE_NUMBER" , "value_type" : "INT"}],
 [{"name" : "THROUGHPUT", "value_type" : "DOUBLE", "dimension" : "Length", "size_type" : "ALL"}],

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -1200,6 +1200,7 @@ BOOST_AUTO_TEST_CASE( TestPLYMWINJ ) {
         "   20.    19.   18.   16. /\n"
         "   20.    16.   14.   12. /\n"
         "   20.    12.   8.    4. /\n"
+        "/\n"
         "PLYMWINJ \n"
         "   3   /    -- table number \n"
         "   0.0     100.0  / -- throughput values \n"
@@ -1207,7 +1208,8 @@ BOOST_AUTO_TEST_CASE( TestPLYMWINJ ) {
         "   -- the rest will be the polymer molecular weight \n"
         "   -- each row corresponds to one sample points in the throughput direction \n"
         "   20.    19.   18.   /\n"
-        "   20.    16.   14.   /\n";
+        "   20.    16.   14.   /\n"
+        "/\n";
 
     Opm::Parser parser;
     const Opm::Deck deck = parser.parseString(inputstring);
@@ -1278,6 +1280,7 @@ BOOST_AUTO_TEST_CASE( TestSKPRWAT ) {
         "   20.    19.   18.   16. /\n"
         "   20.    16.   14.   12. /\n"
         "   20.    12.   8.    4. /\n"
+        "/\n"
         "SKPRWAT \n"
         "   2   /    -- table number \n"
         "   0.0     100.0  / -- throughput values \n"
@@ -1285,7 +1288,10 @@ BOOST_AUTO_TEST_CASE( TestSKPRWAT ) {
         "   -- the rest will be the skin pressure \n"
         "   -- each row corresponds to one sample points in the throughput direction \n"
         "   20.    19.   18.   /\n"
-        "   20.    16.   14.   /\n";
+        "   20.    16.   14.   /\n"
+        "/\n";
+
+
 
     Opm::Parser parser;
     const Opm::Deck deck = parser.parseString(inputstring);
@@ -1358,6 +1364,7 @@ BOOST_AUTO_TEST_CASE( TestSKPRPOLY ) {
         "   20.    19.   18.   16. /\n"
         "   20.    16.   14.   12. /\n"
         "   20.    12.   8.    4. /\n"
+        "/\n"
         "SKPRPOLY \n"
         "   2   3.0 /    -- table number & reference concentration \n"
         "   0.0     100.0  / -- throughput values \n"
@@ -1365,7 +1372,8 @@ BOOST_AUTO_TEST_CASE( TestSKPRPOLY ) {
         "   -- the rest will be the skin pressure \n"
         "   -- each row corresponds to one sample points in the throughput direction \n"
         "   20.    19.   18.   /\n"
-        "   20.    16.   14.   /\n";
+        "   20.    16.   14.   /\n"
+        "/\n";
 
     Opm::Parser parser;
     const Opm::Deck deck = parser.parseString(inputstring);


### PR DESCRIPTION
@GitPaean: 

The keywords `SKRPOLY` and `SKPRWAT` use the size type `UNKNOWN` to determine the number of records; the `UNKNOWN` size type is very weakly structured and if the things are not 100% correct that chance of problems is quite large - see e.g.: https://github.com/OPM/opm-common/pull/644

Have changed to `SLASH_TERMINATED` in this; if this way makes sense we will also have to add trailing `/` to the keywords in the `2D_POLYMER_INJECTIVITY` testcase.

