### PR TITLE
WIP Add OPM keyword for setting massrate for the boundary

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/900_OPM/B/BCRATE
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/B/BCRATE
@@ -1,0 +1,18 @@
+{
+  "name": "BCRATE",
+  "sections": ["SOLUTION"],
+  "items": [
+  {"name": "I1", "value_type": "INT"},
+  {"name": "I2", "value_type": "INT"},
+  {"name": "J1", "value_type": "INT"},
+  {"name": "J2", "value_type": "INT"},
+  {"name": "K1", "value_type": "INT"},
+  {"name": "K2", "value_type": "INT"},
+  {"name": "DIRECTION", "value_type": "STRING"},
+  {"name": "COMPONENT", "value_type": "STRING"},
+  {"name": "RATE",
+  "value_type": "DOUBLE",
+  "dimension": "Mass/Time*Length*Length",
+  "default": 0.0 }
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -451,6 +451,7 @@ set( keywords
      001_Eclipse300/Z/ZFACTORS
      002_Frontsim/N/NOGRAV
 
+     900_OPM/B/BCRATE
      900_OPM/F/FREEBC
      900_OPM/G/GCOMPIDX
      900_OPM/G/GRUPRIG


### PR DESCRIPTION
Question? Can I use more than 8 characters for the OPM specific keywords?  I may want to add a MOLRATEBC keyword in the future and want reasonable names.  

This is currently not used, but a similar implementation as for FREEBC is planned in the simulator. 