### PR TITLE
Add rng to UDQParams

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_UDQ_PARAMS_HPP
 #define OPM_UDQ_PARAMS_HPP
 
+#include <random>
 
 namespace Opm {
 
@@ -31,18 +32,22 @@ namespace Opm {
         explicit UDQParams(const Deck& deck);
         UDQParams();
 
-        bool   reseedRNG() const noexcept;
-        int    randomSeed() const noexcept;
+        void   reseedRNG(int seed);
         double range() const noexcept;
         double undefinedValue() const noexcept;
         double cmpEpsilon() const noexcept;
 
+        std::mt19937& sim_rng();
+        std::mt19937& true_rng();
     private:
         bool reseed_rng;
         int random_seed;
         double value_range;
         double undefined_value;
         double cmp_eps;
+
+        std::mt19937 m_sim_rng;  // The sim_rng is seeded deterministiaclly at simulation start.
+        std::mt19937 m_true_rng; // The true_rng is seeded with a "true" random seed; this rng can be reset with reseedRNG()
     };
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
@@ -33,7 +33,11 @@ namespace Opm {
         value_range(ParserKeywords::UDQPARAM::RANGE::defaultValue),
         undefined_value(ParserKeywords::UDQPARAM::UNDEFINED_VALUE::defaultValue),
         cmp_eps(ParserKeywords::UDQPARAM::CMP_EPSILON::defaultValue)
-    {}
+    {
+        std::random_device r;
+        this->m_sim_rng.seed( this->random_seed );
+        this->m_true_rng.seed( r() );
+    }
 
 
     UDQParams::UDQParams(const Deck& deck) :
@@ -54,16 +58,21 @@ namespace Opm {
             undefined_value = record.getItem("UNDEFINED_VALUE").get<double>(0);
             cmp_eps = record.getItem("CMP_EPSILON").get<double>(0);
         }
+        this->m_sim_rng.seed( this->random_seed );
     }
 
 
-    bool UDQParams::reseedRNG() const noexcept {
-        return this->reseed_rng;
+    /*
+      If the internal flag reseed_rng is set to true, this method will reset the
+      rng true_rng with the seed applied; the purpose of this function is to be
+      able to ensure(?) that a restarted run gets the same sequence of random
+      numbers as the original run.
+    */
+    void UDQParams::reseedRNG(int seed) {
+        if (this->reseed_rng)
+            this->m_true_rng.seed( seed );
     }
 
-    int UDQParams::randomSeed() const noexcept {
-        return this->random_seed;
-    }
 
     double UDQParams::range() const noexcept {
         return this->value_range;
@@ -76,4 +85,13 @@ namespace Opm {
     double UDQParams::cmpEpsilon() const noexcept {
         return this->cmp_eps;
     }
+
+    std::mt19937& UDQParams::sim_rng() {
+        return this->m_sim_rng;
+    }
+
+    std::mt19937& UDQParams::true_rng() {
+        return this->m_true_rng;
+    }
+
 }


### PR DESCRIPTION
The UDQ machinery has support for *two* random number streams; one seeded deterministically at simulation start and one "truly" random; from both of these streams you can sample from either `N(0,1)` or `U(-1,1)`. J...sus the spread of abstraction in that simulator if f...ng insane.

Anyway - this PR adds support for this weird feature.

This PR is also part of #638 