### PR TITLE
Udq summary assign

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
@@ -34,6 +34,7 @@ public:
     UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value);
     const std::string& keyword() const;
     double value() const;
+    UDQVarType var_type() const;
     const std::vector<std::string>& selector() const;
     UDQWellSet eval_wells(const std::vector<std::string>& wells) const;
 private:

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
@@ -26,6 +26,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQExpression.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 
 
 namespace Opm {
@@ -38,6 +39,7 @@ namespace Opm {
         const std::string& unit(const std::string& key) const;
         void assign_unit(const std::string& keyword, const std::string& unit);
         const std::vector<UDQAssign>& assignments() const;
+        std::vector<UDQAssign> assignments(UDQVarType var_type) const;
     private:
         std::vector<UDQExpression> m_expressions;
         std::vector<UDQAssign> m_assignments;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
@@ -51,7 +51,7 @@ public:
 
 class UDQSet {
 public:
-    explicit UDQSet(std::size_t size);
+    UDQSet(const std::string& name, std::size_t size);
     void assign(double value);
     void assign(std::size_t index, double value);
 
@@ -71,7 +71,9 @@ public:
 
     std::vector<double> defined_values() const;
     std::size_t defined_size() const;
+    const std::string& name() const;
 private:
+    std::string m_name;
     std::vector<UDQScalar> values;
 };
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQWellSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQWellSet.hpp
@@ -31,7 +31,7 @@ namespace Opm {
 
 class UDQWellSet : public UDQSet {
 public:
-    explicit UDQWellSet(const std::vector<std::string>& wells);
+    UDQWellSet(const std::string& name, const std::vector<std::string>& wells);
     void assign(const std::string& well, double value);
     void assign(double value);
     const UDQScalar& operator[](const std::string& well) const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
@@ -43,7 +43,7 @@ double UDQAssign::value() const {
 }
 
 UDQWellSet UDQAssign::eval_wells(const std::vector<std::string>& wells) const {
-    UDQWellSet ws(wells);
+    UDQWellSet ws(m_keyword, wells);
 
     if (this->m_selector.empty())
         ws.assign(this->m_value);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
@@ -42,6 +42,10 @@ double UDQAssign::value() const {
     return this->m_value;
 }
 
+UDQVarType UDQAssign::var_type() const {
+    return this->m_var_type;
+}
+
 UDQWellSet UDQAssign::eval_wells(const std::vector<std::string>& wells) const {
     UDQWellSet ws(m_keyword, wells);
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunction.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunction.cpp
@@ -153,7 +153,7 @@ UDQSet UDQUnaryElementalFunction::DEF(const UDQSet& arg) {
 
 
 UDQSet UDQUnaryElementalFunction::UNDEF(const UDQSet& arg) {
-    UDQSet result(arg.size());
+    UDQSet result(arg.name(), arg.size());
     for (std::size_t index=0; index < result.size(); index++) {
         auto& udq_value = arg[index];
         if (!udq_value)
@@ -260,7 +260,7 @@ namespace {
         if (arg1.size() != arg2.size())
             throw std::invalid_argument("UDQ sets have incoimpatible size");
 
-        UDQSet result(arg1.size());
+        UDQSet result = arg1;
         for (std::size_t index = 0; index < result.size(); index++) {
             const auto& elm1 = arg1[index];
             const auto& elm2 = arg2[index];
@@ -485,7 +485,7 @@ UDQSet UDQBinaryFunction::DIV(const UDQSet& lhs, const UDQSet& rhs) {
 }
 
 UDQSet UDQBinaryFunction::POW(const UDQSet& lhs, const UDQSet& rhs) {
-    UDQSet result(lhs.size());
+    UDQSet result = lhs;
     for (std::size_t index = 0; index < result.size(); index++) {
         auto& lhs_elm = lhs[index];
         auto& rhs_elm = rhs[index];

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
+
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
 
@@ -56,6 +58,18 @@ namespace Opm {
 
     const std::vector<UDQAssign>& UDQInput::assignments() const {
         return this->m_assignments;
+    }
+
+
+    std::vector<UDQAssign> UDQInput::assignments(UDQVarType var_type) const {
+        std::vector<UDQAssign> filtered_assignments;
+
+        std::copy_if(this->m_assignments.begin(),
+                     this->m_assignments.end(),
+                     std::back_inserter(filtered_assignments),
+                     [&var_type](const UDQAssign& assignment) { return assignment.var_type() == var_type; });
+
+        return filtered_assignments;
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -96,7 +96,13 @@ UDQScalar::operator bool() const {
 }
 
 
-UDQSet::UDQSet(std::size_t size) {
+const std::string& UDQSet::name() const {
+    return this->m_name;
+}
+
+UDQSet::UDQSet(const std::string& name, std::size_t size) :
+    m_name(name)
+{
     this->values.resize(size);
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQWellSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQWellSet.cpp
@@ -23,8 +23,8 @@
 
 namespace Opm {
 
-UDQWellSet::UDQWellSet(const std::vector<std::string>& wells) :
-    UDQSet(wells.size())
+UDQWellSet::UDQWellSet(const std::string& name, const std::vector<std::string>& wells) :
+    UDQSet(name, wells.size())
 {
     for (std::size_t index = 0; index < wells.size(); index++)
         this->well_index.emplace( std::make_pair(wells[index], index));

--- a/tests/msim/actionx1.include
+++ b/tests/msim/actionx1.include
@@ -60,6 +60,9 @@ WELLDIMS
 
 UNIFOUT
 
+UDQDIMS
+ 50 25 0 50 50 0 0 50 0 20 /
+
 GRID
 
 -- The INIT keyword is used to request an .INIT file. The .INIT file
@@ -347,6 +350,10 @@ WWPR
 /
 WWPT
 /
+WUBHP
+/
+WUOPR
+/
 SCHEDULE
 -- -------------------------------------------------------------------------
 RPTSCHED
@@ -354,6 +361,17 @@ RPTSCHED
 
 RPTRST
 	'BASIC=1' /
+
+UDQ
+  ASSIGN WUBHP 11 /
+  ASSIGN WUOPR 20 /
+  ASSIGN WUBHP P2 12 /
+  ASSIGN WUBHP P3 13 /
+  ASSIGN WUBHP P4 14 /
+  UNITS  WUBHP 'BARSA' /
+  UNITS  WUOPR 'SM3/DAY' /
+/
+
 
 
 -- If no resolution (i.e. case 1), the two following lines must be added:

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(UDQ_CONTEXT) {
 }
 
 BOOST_AUTO_TEST_CASE(UDQ_SET) {
-    UDQSet s1(5);
+    UDQSet s1("NAME", 5);
 
     for (const auto& v : s1) {
         BOOST_CHECK_EQUAL(false, v.defined());
@@ -302,11 +302,11 @@ BOOST_AUTO_TEST_CASE(UDQ_SET) {
 
     s1.assign(0,0.0);
     {
-        UDQSet s2(6);
+        UDQSet s2("NAME", 6);
         BOOST_REQUIRE_THROW(s1 + s2, std::invalid_argument);
     }
     {
-        UDQSet s2(5);
+        UDQSet s2("NAME", 5);
         s2.assign(0, 25);
         auto s3 = s1 + s2;
 
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(UDQ_FUNCTION_TABLE) {
     UDQFunctionTable udqft(params);
     BOOST_CHECK(udqft.has_function("SUM"));
     BOOST_CHECK(!udqft.has_function("NO_SUCH_FUNCTION"));
-    UDQSet arg(5);
+    UDQSet arg("NAME", 5);
     arg.assign(0,1);
     arg.assign(2,2);
     arg.assign(4,4);
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(UDQ_FUNCTION_TABLE) {
         BOOST_CHECK_EQUAL(result.value(), 8.0);
     }
     {
-        UDQSet arg2(4);
+        UDQSet arg2("NAME", 4);
         arg2.assign(0,1);
         arg2.assign(2,4);
         arg2.assign(3,4);
@@ -407,9 +407,9 @@ BOOST_AUTO_TEST_CASE(UDQ_FUNCTION_TABLE) {
 BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
     UDQParams params;
     UDQFunctionTable udqft(params);
-    UDQSet arg1(5);
-    UDQSet arg2(5);
-    UDQSet arg3(3);
+    UDQSet arg1("NAME", 5);
+    UDQSet arg2("NAME", 5);
+    UDQSet arg3("NAME", 3);
     arg1.assign(1,1);
 
     arg1.assign(0,1);
@@ -460,8 +460,8 @@ BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
     }
     {
         const auto& func = dynamic_cast<const UDQBinaryFunction&>(udqft.get("^"));
-        UDQSet arg1(4);
-        UDQSet arg2(4);
+        UDQSet arg1("NAME", 4);
+        UDQSet arg2("NAME", 4);
 
         for (std::size_t i=0; i < arg1.size(); i++) {
             arg1.assign(i, i + 1);
@@ -495,21 +495,21 @@ BOOST_AUTO_TEST_CASE(BAD_CAST) {
     UDQParams params;
     UDQFunctionTable udqft(params);
 
-BOOST_CHECK_THROW( dynamic_cast<const UDQUnaryElementalFunction&>(udqft.get("==")), std::bad_cast);
+    BOOST_CHECK_THROW( dynamic_cast<const UDQUnaryElementalFunction&>(udqft.get("==")), std::bad_cast);
 }
 
 
 BOOST_AUTO_TEST_CASE(ELEMENTAL_UNARY_FUNCTIONS) {
     UDQParams params;
     UDQFunctionTable udqft(params);
-    UDQSet arg(5);
+    UDQSet arg("NAME", 5);
     arg.assign(0,1);
     arg.assign(2,2);
     arg.assign(4,4);
 
     {
         const auto& func = dynamic_cast<const UDQUnaryElementalFunction&>(udqft.get("ABS"));
-        UDQSet arg2(5);
+        UDQSet arg2("NAME", 5);
         arg2.assign(0,1);
         arg2.assign(2,-2);
         arg2.assign(4,4);
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(ELEMENTAL_UNARY_FUNCTIONS) {
     }
     {
         const auto& func = dynamic_cast<const UDQUnaryElementalFunction&>(udqft.get("LOG"));
-        UDQSet arg(3);
+        UDQSet arg("NAME", 3);
         arg.assign(0, 10);
         arg.assign(2,1000);
 
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE(ELEMENTAL_UNARY_FUNCTIONS) {
     }
     {
         const auto& func = dynamic_cast<const UDQUnaryElementalFunction&>(udqft.get("NINT"));
-        UDQSet arg(3);
+        UDQSet arg("NAME", 3);
         arg.assign(0, 0.75);
         arg.assign(2, 1.25);
 
@@ -572,7 +572,7 @@ BOOST_AUTO_TEST_CASE(ELEMENTAL_UNARY_FUNCTIONS) {
     }
     {
         const auto& func = dynamic_cast<const UDQUnaryElementalFunction&>(udqft.get("RANDN"));
-        UDQSet arg(3);
+        UDQSet arg("NAME", 3);
         arg.assign(0, -1.0);
         arg.assign(2, -1.0);
 
@@ -611,8 +611,8 @@ BOOST_AUTO_TEST_CASE(ELEMENTAL_UNARY_FUNCTIONS) {
 BOOST_AUTO_TEST_CASE(UNION_FUNCTIONS) {
     UDQParams params;
     UDQFunctionTable udqft(params);
-    UDQSet arg1(5);
-    UDQSet arg2(5);
+    UDQSet arg1("NAME", 5);
+    UDQSet arg2("NAME", 5);
 
     arg1.assign(0,1);
     arg1.assign(2,2);
@@ -632,7 +632,7 @@ BOOST_AUTO_TEST_CASE(UNION_FUNCTIONS) {
 
 
 BOOST_AUTO_TEST_CASE(FUNCTIONS_INVALID_ARGUMENT) {
-    UDQSet arg(3);
+    UDQSet arg("NAME",3);
     arg.assign(0, -1);
     BOOST_REQUIRE_THROW( UDQScalarFunction::AVEG(arg), std::invalid_argument);
     BOOST_REQUIRE_THROW( UDQUnaryElementalFunction::LOG(arg), std::invalid_argument);
@@ -640,7 +640,7 @@ BOOST_AUTO_TEST_CASE(FUNCTIONS_INVALID_ARGUMENT) {
 }
 
 BOOST_AUTO_TEST_CASE(UDQ_SET_DIV) {
-    UDQSet s(5);
+    UDQSet s("NAME", 5);
     s.assign(0,1);
     s.assign(2,2);
     s.assign(4,5);
@@ -656,7 +656,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SET_DIV) {
 
 BOOST_AUTO_TEST_CASE(UDQWellSetTest) {
     std::vector<std::string> wells = {"P1", "P2", "I1", "I2"};
-    UDQWellSet ws(wells);
+    UDQWellSet ws("NAME", wells);
 
     BOOST_CHECK_EQUAL(4, ws.size());
     ws.assign("P1", 1.0);


### PR DESCRIPTION
Lo and behold - the first actually working UDQ feature. If you request UDQ output in the summary section:

```
SUMMARY
...
WUBHP  -- Ask to get output of your personal BHP
/
..
SCHEDULE

UDQ
     ASSIGN WUBHP 100 /       -- Your personal BHP is fixed to 100 BARSA
     UNITS WUBHP 'BARSA' / 
/
```
and assign it to a *fixed* value in the SCHEDULE section you will get that value in the summary output file. Maybe not exactly a feature to kill for - but still :smile: 