### PR TITLE
Include <string>

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
@@ -22,6 +22,7 @@
 
 #include <stdexcept>
 #include <vector>
+#include <string>
 
 namespace Opm {
 


### PR DESCRIPTION
Include string to avoid a compile error with `Apple LLVM version 10.0.0 (clang-1000.10.44.4)` 