### PR TITLE
Raw strings

### DIFF
--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -128,6 +128,7 @@ namespace Opm {
         enum ParserKeywordSizeEnum getSizeType() const;
         const KeywordSize& getKeywordSize() const;
         bool isDataKeyword() const;
+        bool slashTerminatedRecords() const;
 
         std::string createDeclaration(const std::string& indent) const;
         std::string createDecl() const;
@@ -149,6 +150,7 @@ namespace Opm {
         size_t m_fixedSize;
         bool m_isTableCollection;
         std::string m_Description;
+        bool slash_terminated_records = true;
 
         static bool validNameStart(const string_view& name);
         void initDeckNames( const Json::JsonObject& jsonConfig );

--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -54,10 +54,12 @@ namespace Opm {
 
         bool operator==( const ParserRecord& ) const;
         bool operator!=( const ParserRecord& ) const;
+        bool slashTerminatedRecords() const;
 
     private:
         bool m_dataRecord;
         std::vector< ParserItem > m_items;
+        bool slash_terminated_records = true;
     };
 
 std::ostream& operator<<( std::ostream&, const ParserRecord& );

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -72,7 +72,7 @@ namespace Opm {
         iterator end();
 
         bool is_title() const;
-
+        bool slash_terminated_records = true;
     private:
         Raw::KeywordSizeEnum m_sizeType;
         bool m_isFinished = false;

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -423,6 +423,8 @@ void set_dimensions( ParserItem& item,
 
     void ParserKeyword::addRecord( ParserRecord record ) {
         m_records.push_back( std::move( record ) );
+        if (!record.slashTerminatedRecords())
+            this->slash_terminated_records = false;
     }
 
 
@@ -517,6 +519,9 @@ void set_dimensions( ParserItem& item,
         return m_keywordSizeType;
     }
 
+    bool ParserKeyword::slashTerminatedRecords() const {
+        return this->slash_terminated_records;
+    }
 
     const KeywordSize& ParserKeyword::getKeywordSize() const {
         return keyword_size;

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -46,6 +46,10 @@ namespace {
         return m_items.size();
     }
 
+    bool ParserRecord::slashTerminatedRecords() const {
+        return this->slash_terminated_records;
+    }
+
     void ParserRecord::addItem( ParserItem item ) {
         if (m_dataRecord)
             throw std::invalid_argument("Record is already marked as DataRecord - can not add items");
@@ -56,6 +60,9 @@ namespace {
 
         if( itr != this->m_items.end() )
             throw std::invalid_argument("Itemname: " + item.name() + " already exists.");
+
+        if (item.parseRaw())
+            this->slash_terminated_records = false;
 
         this->m_items.push_back( std::move( item ) );
     }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -229,6 +229,27 @@ DEFINE WUMW1 WBHP 'P*1*' UMAX WBHP 'P*4*' /
     BOOST_CHECK_EQUAL_COLLECTIONS(rec1.tokens().begin(), rec1.tokens().end(), exp1.begin(), exp1.end());
 }
 
+
+BOOST_AUTO_TEST_CASE(UDQ_DEFINE_WITH_SLASH) {
+    const std::string input = R"(
+UDQ
+ DEFINE WUWCT WWPR / ( WWPR + WOPR ) /
+/
+
+
+)";
+    Parser parser;
+    auto deck = parser.parseString(input);
+    const auto& udq = deck.getKeyword("UDQ");
+    const auto& record = udq.getRecord(0);
+    const auto& data_item = record.getItem("DATA");
+    const auto& data = data_item.getData<std::string>();
+    std::vector<std::string> exp = {"WWPR", "/", "(", "WWPR", "+", "WOPR", ")"};
+    BOOST_CHECK_EQUAL_COLLECTIONS(data.begin(), data.end(),
+                                  exp.begin(), exp.end());
+}
+
+
 BOOST_AUTO_TEST_CASE(UDQ_ASSIGN_DATA) {
     const std::string input = R"(
 RUNSPEC


### PR DESCRIPTION
All since the very first fumbling commits in opm-parser in 2013 the assumption that input records are terminated on `/` has held up; but now comes the `UDQ` and `ACTIONX` keywords which allow for general mathematical expressions - and hey presto: Here comes `/` which should *not* terminate the parsing.

This PR adds support for - on a per keyword basis - to terminate the record on the last `/` on the line instead of the first. The new behavior is coupled to the data property `RAW_STRING`(https://github.com/OPM/opm-common/pull/369) which does not strip quotes and retains `*`. Currently the new behavior only affects the keywords `UDQ` and `ACTIONX`.