### PR TITLE
fix warnings

### DIFF
--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -310,8 +310,8 @@ namespace {
 	int sumConn = 0;
 	if (noConnectionsSegment(compSet, segSet, segIndex) > 0) {
 	// add up the number of connections for å segments with lower segment index than current segment
-	    for (int ind = 0; ind <= segIndex; ind++) {
-		int addCon = (ind == static_cast<int>(segIndex)) ? 1 : noConnectionsSegment(compSet, segSet, ind);
+    for (size_t ind = 0; ind <= segIndex; ind++) {
+          size_t addCon = (ind == segIndex) ? 1 : noConnectionsSegment(compSet, segSet, ind);
 		sumConn += addCon;
 	    }
 	}

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -696,7 +696,6 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
     // RSEG (PROD)  + (WINJ)
     {
 	// well no 1 - PROD
-	int welNo = 1;
 	const std::string wname = "PROD";
 	int segNo = 1;
 	// 'stringSegNum' is one-based (1 .. #segments inclusive)
@@ -704,7 +703,6 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
 
         const auto  i0 = (segNo-1)*ih.nrsegz;
 	const auto&  units = simCase.es.getUnits();
-	using M = ::Opm::UnitSystem::measure;
 	const auto gfactor = (units.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD)
 		    ? 0.1781076 : 0.001;
         const auto& rseg = amswd.getRSeg();
@@ -731,7 +729,6 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
   
     {
     // well no 2 - WINJ
-	int welNo = 2;
 	const std::string wname = "WINJ";
 	int segNo = 1;
 	// 'stringSegNum' is one-based (1 .. #segments inclusive)


### PR DESCRIPTION
- signed/unsigned comparisons
- unused variables
- unused typedefs

The formatting that looks broken, is in fact correct. "Somebody" isn't following the surrounding code style (4 space indent, no tabs). If you prefer I can restore the original brokenness.