### PR TITLE
Add optional code for well testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ set(OPM_MACROS_ROOT ${PROJECT_SOURCE_DIR})
 option(ENABLE_ECL_INPUT "Enable eclipse input support?" ON)
 option(ENABLE_ECL_OUTPUT "Enable eclipse output support?" ON)
 option(ENABLE_MOCKSIM "Build the mock simulator for io testing" ON)
+option(ENABLE_WELL_TEST "Enable testing of well code when building Schedule object" OFF)
+
+if (ENABLE_WELL_TEST)
+  add_definitions(-DWELL_TEST)
+endif()
 
 # Output implies input
 if(ENABLE_ECL_OUTPUT)

--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -232,7 +232,7 @@ function build_module_full {
     mkdir -p $configuration/build-$1
     cd $configuration/build-$1
     echo "Building main module $1=$sha1 configuration=$configuration"
-    build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install -DOPM_TESTS_ROOT=$OPM_TESTS_ROOT" 1 $WORKSPACE
+    build_module "-DENABLE_WELL_TEST=ON -DCMAKE_INSTALL_PREFIX=$WORKSPACE/$configuration/install -DOPM_TESTS_ROOT=$OPM_TESTS_ROOT" 1 $WORKSPACE
     test $? -eq 0 || exit 1
     cmake --build . --target install
     test $? -eq 0 || exit 1

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -257,6 +257,9 @@ namespace Opm
         static double convertInjectionRateToSI(double rawRate, Phase wellPhase, const Opm::UnitSystem &unitSystem);
         static bool convertEclipseStringToBool(const std::string& eclipseString);
 
+#ifdef CHECK_WELLS
+        bool checkWells(const ParseContext& parseContext, ErrorGuard& errors) const;
+#endif
     };
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -104,6 +104,11 @@ namespace Opm {
 
         if (Section::hasSCHEDULE(deck))
             iterateScheduleSection( parseContext, errors, SCHEDULESection( deck ), grid, eclipseProperties );
+
+#ifdef CHECK_WELLS
+        checkWells(parseContext, errors);
+#endif
+
     }
 
 
@@ -2214,5 +2219,10 @@ namespace Opm {
 
     }
 
-}
 
+#ifdef CHECK_WELLS
+    bool checkWells(const ParseContext& parseContext, ErrorGuard& errors) const {
+        return true;
+    }
+#endif
+}


### PR DESCRIPTION
A refactoring of the wells in the opm-common repository has started:  https://github.com/OPM/opm-common/issues/624

The intention is to create a new well implementation side by side with the existing old implementation, and then switch over to use the new implementation when everything is ready. The new well code will be tested the normal way with unit tests, but the well code is complex - and it would be valuable to have some integration testing as early as possible - this PR is an attempt to address that.

The PR is based on a cmake option `ENABLE_WELL_TESTING` which will define the preprocessor symbol `WELL_TESTING` - and then if the `WELL_TESTING` symbol is defined a method `checkWells()` is added to the `Schedule` object - the `checkWells()` method will be called at the end of the `Schedule` constructor.

The cmake switch `ENABLE_WELL_TESTING` defaults to OFF, I will of course compile with the switch set to ON - ~~I also intend to submit a PR which will pass `-DENABLE_WELL_TESTING=ON` when configuring opm-common in the integration testing~~, and also hope other developers will build with this setting. The downside of beeing a volunteer integration tester is that some extra code will run as part of the `Schedule` construction, and *iff* there is a discrepancy in the results between the new well code and the old well code the program execution will stop. **Update**: iff there is an error - there will be a ParseContext switch to determine exactly how the error should be handeled.

The switch will of course be removed again when the work is complete - I guesstimate to months of work. If there are other suggestions to how this should be achieved I am all ears!

