### PR TITLE
Fix bug with ouf of bounds access in UDQ parser

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
@@ -93,8 +93,11 @@ UDQParseNode UDQParser::current() const {
         return UDQParseNode(type, arg);
 
     std::size_t selector_size = this->current_size() - 1;
-    const auto * token_ptr = std::addressof(this->tokens[this->current_pos + 1]);
-    std::vector<std::string> selector(token_ptr, token_ptr + selector_size);
+    std::vector<std::string> selector;
+    if (selector_size > 0) {
+        const auto * token_ptr = std::addressof(this->tokens[this->current_pos + 1]);
+        selector.assign( token_ptr, token_ptr + selector_size);
+    }
     return UDQParseNode(type, arg, selector);
 }
 


### PR DESCRIPTION
See: https://github.com/OPM/opm-common/issues/682

@bska: There was clearly a bug in the code - by just looking, and I have fixed it now. But I had problems reproducing the bug - valgrind which is my usual tool for such problems was all happy even before the fix. 

