### PR TITLE
Remove well events

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
@@ -45,7 +45,7 @@ namespace Opm
             WELL_WELSPECS_UPDATE = 2,
 
 
-            WELL_POLYMER_UPDATE = 4,
+            //WELL_POLYMER_UPDATE = 4,
             /*
                The NEW_GROUP event is triggered by the WELSPECS and
                GRUPTREE keywords.
@@ -61,7 +61,7 @@ namespace Opm
             */
             PRODUCTION_UPDATE = 16,
             INJECTION_UPDATE = 32,
-            POLYMER_UPDATES = 64,
+            //POLYMER_UPDATES = 64,
 
             /*
               This event is triggered if the well status is changed

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -154,6 +154,8 @@ namespace Opm
         void invalidNamePattern (const std::string& namePattern, const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword) const;
 
         const Events& getEvents() const;
+        const Events& getWellEvents(const std::string& well) const;
+        bool hasWellEvent(const std::string& well, uint64_t event_mask, size_t reportStep) const;
         const Deck& getModifierDeck(size_t timeStep) const;
         bool hasOilVaporizationProperties() const;
         const VFPProdTable& getVFPProdTable(int table_id, size_t timeStep) const;
@@ -190,6 +192,7 @@ namespace Opm
 
         std::vector< Well* > getWells(const std::string& wellNamePattern, const std::vector<std::string>& matching_wells = {});
         std::vector< Group* > getGroups(const std::string& groupNamePattern);
+        std::map<std::string,Events> well_events;
 
         void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( Group& newGroup , Well& well , size_t timeStep);
@@ -253,7 +256,7 @@ namespace Opm
                            const Eclipse3DProperties& eclipseProperties,
                            const UnitSystem& unit_system,
                            std::vector<std::pair<const DeckKeyword*, size_t > >& rftProperties);
-
+        void addWellEvent(const std::string& well, ScheduleEvents::Events event, size_t reportStep);
         static double convertInjectionRateToSI(double rawRate, WellInjector::TypeEnum wellType, const Opm::UnitSystem &unitSystem);
         static double convertInjectionRateToSI(double rawRate, Phase wellPhase, const Opm::UnitSystem &unitSystem);
         static bool convertEclipseStringToBool(const std::string& eclipseString);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -26,7 +26,6 @@
 #include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.hpp>
@@ -188,9 +187,6 @@ namespace Opm {
 
         void addWellSegments(size_t time_step, WellSegments new_segmentset);
 
-        const Events& getEvents() const;
-        void addEvent(ScheduleEvents::Events event, size_t reportStep);
-        bool hasEvent(uint64_t eventMask, size_t reportStep) const;
         void handleCOMPLUMP(const DeckRecord& record, size_t time_step);
         void handleCOMPDAT(size_t time_step, const DeckRecord& record, const EclipseGrid& grid, const Eclipse3DProperties& eclipseProperties);
         void handleCOMPSEGS(const DeckKeyword& keyword, const EclipseGrid& grid, size_t time_step);
@@ -242,7 +238,6 @@ namespace Opm {
         // flag indicating if the well is a multi-segment well
         DynamicState< WellSegments > m_segmentset;
         size_t timesteps;
-        Events events;
     };
 }
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -821,11 +821,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_CombineShutCompletionsAndAddN
   auto* well = schedule.getWell("OP_1");
   // timestep 3. Close all completions with WELOPEN and immediately open new completions with COMPDAT.
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(3));
-  BOOST_CHECK( !well->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 3 ));
+  BOOST_CHECK( !schedule.hasWellEvent( "OP_1", ScheduleEvents::WELL_STATUS_CHANGE , 3 ));
   // timestep 4. Close all completions with WELOPEN. The well will be shut since no completions
   // are open.
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(4));
-  BOOST_CHECK( well->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 4 ));
+  BOOST_CHECK( schedule.hasWellEvent( "OP_1", ScheduleEvents::WELL_STATUS_CHANGE , 4 ));
   // timestep 5. Open new completions. But keep the well shut,
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(5));
 }

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -927,20 +927,19 @@ BOOST_AUTO_TEST_CASE(TestWellEvents) {
     const auto& w2 = sched.getWell( "W_2");
 
 
-    BOOST_CHECK( w1->hasEvent( ScheduleEvents::NEW_WELL , 0 ));
-    BOOST_CHECK( w2->hasEvent( ScheduleEvents::NEW_WELL , 2 ));
-    BOOST_CHECK( !w2->hasEvent( ScheduleEvents::NEW_WELL , 3 ));
-    BOOST_CHECK( w2->hasEvent( ScheduleEvents::WELL_WELSPECS_UPDATE , 3 ));
+    BOOST_CHECK( sched.hasWellEvent( "W_1", ScheduleEvents::NEW_WELL , 0 ));
+    BOOST_CHECK( sched.hasWellEvent( "W_2", ScheduleEvents::NEW_WELL , 2 ));
+    BOOST_CHECK( !sched.hasWellEvent( "W_2", ScheduleEvents::NEW_WELL , 3 ));
+    BOOST_CHECK( sched.hasWellEvent( "W_2", ScheduleEvents::WELL_WELSPECS_UPDATE , 3 ));
 
+    BOOST_CHECK( sched.hasWellEvent( "W_1", ScheduleEvents::WELL_STATUS_CHANGE , 0 ));
+    BOOST_CHECK( sched.hasWellEvent( "W_1", ScheduleEvents::WELL_STATUS_CHANGE , 1 ));
+    BOOST_CHECK( sched.hasWellEvent( "W_1", ScheduleEvents::WELL_STATUS_CHANGE , 3 ));
+    BOOST_CHECK( sched.hasWellEvent( "W_1", ScheduleEvents::WELL_STATUS_CHANGE , 4 ));
+    BOOST_CHECK( !sched.hasWellEvent( "W_1", ScheduleEvents::WELL_STATUS_CHANGE , 5 ));
 
-    BOOST_CHECK( w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 0 ));
-    BOOST_CHECK( w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 1 ));
-    BOOST_CHECK( w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 3 ));
-    BOOST_CHECK( w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 4 ));
-    BOOST_CHECK( !w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 5 ));
-
-    BOOST_CHECK( w1->hasEvent( ScheduleEvents::COMPLETION_CHANGE , 0 ));
-    BOOST_CHECK( w1->hasEvent( ScheduleEvents::COMPLETION_CHANGE , 5 ));
+    BOOST_CHECK( sched.hasWellEvent( "W_1", ScheduleEvents::COMPLETION_CHANGE , 0 ));
+    BOOST_CHECK( sched.hasWellEvent( "W_1", ScheduleEvents::COMPLETION_CHANGE , 5 ));
 
     BOOST_CHECK_EQUAL( w1->firstTimeStep( ) , 0 );
     BOOST_CHECK_EQUAL( w2->firstTimeStep( ) , 2 );


### PR DESCRIPTION
With this PR the well events are moved from the well object to the Schedule object, to facilitate: #671 

This event code does not feel exactly right - but it works for now. Downstream PR in opm-simulators coming.