### PR TITLE
add the S[WG]LPC and IS[WG]LPC keywords

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -271,13 +271,25 @@ namespace Opm {
 
         std::vector< GridProperties< double >::SupportedKeywordInfo > supportedDoubleKeywords;
 
-        // keywords to specify the scaled connate gas saturations.
+        // keywords to specify the scaled connate gas saturations: this is slighly wrong for
+        // SGLPC because it is supposed to default to SGL: If SGL is explicitly
+        // specified, but SGLPC is defaulted for a cell, the value for SGLPC will be the
+        // default value for SGL, not the explicitly specified one. Fixing this would
+        // probably require access to the EclipseState object in the initializer for
+        // SGLPC and would thus lead to a cyclic dependency of the property initializer
+        // and EclipseState. (an analogous statement applies to ISGLPC.)
         for( const auto& kw : { "SGLPC", "SGL", "SGLX", "SGLX-", "SGLY", "SGLY-", "SGLZ", "SGLZ-" } )
             supportedDoubleKeywords.emplace_back( kw, SGLLookup, "1" );
         for( const auto& kw : { "ISGLPC", "ISGL", "ISGLX", "ISGLX-", "ISGLY", "ISGLY-", "ISGLZ", "ISGLZ-" } )
             supportedDoubleKeywords.emplace_back( kw, ISGLLookup, "1" );
 
-        // keywords to specify the connate water saturation.
+        // keywords to specify the connate water saturation: this is slighly wrong for
+        // SWLPC because it is supposed to default to SWL: If SWL is explicitly
+        // specified, but SWLPC is defaulted for a cell, the value for SWLPC will be the
+        // default value for SWL, not the explicitly specified one. Fixing this would
+        // probably require access to the EclipseState object in the initializer for
+        // SWLPC and would thus lead to a cyclic dependency of the property initializer
+        // and EclipseState. (an analogous statement applies to ISWLPC.)
         for( const auto& kw : { "SWLPC", "SWL", "SWLX", "SWLX-", "SWLY", "SWLY-", "SWLZ", "SWLZ-" } )
             supportedDoubleKeywords.emplace_back( kw, SWLLookup, "1" );
         for( const auto& kw : { "ISWLPC", "ISWL", "ISWLX", "ISWLX-", "ISWLY", "ISWLY-", "ISWLZ", "ISWLZ-" } )

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -272,15 +272,15 @@ namespace Opm {
         std::vector< GridProperties< double >::SupportedKeywordInfo > supportedDoubleKeywords;
 
         // keywords to specify the scaled connate gas saturations.
-        for( const auto& kw : { "SGL", "SGLX", "SGLX-", "SGLY", "SGLY-", "SGLZ", "SGLZ-" } )
+        for( const auto& kw : { "SGLPC", "SGL", "SGLX", "SGLX-", "SGLY", "SGLY-", "SGLZ", "SGLZ-" } )
             supportedDoubleKeywords.emplace_back( kw, SGLLookup, "1" );
-        for( const auto& kw : { "ISGL", "ISGLX", "ISGLX-", "ISGLY", "ISGLY-", "ISGLZ", "ISGLZ-" } )
+        for( const auto& kw : { "ISGLPC", "ISGL", "ISGLX", "ISGLX-", "ISGLY", "ISGLY-", "ISGLZ", "ISGLZ-" } )
             supportedDoubleKeywords.emplace_back( kw, ISGLLookup, "1" );
 
         // keywords to specify the connate water saturation.
-        for( const auto& kw : { "SWL", "SWLX", "SWLX-", "SWLY", "SWLY-", "SWLZ", "SWLZ-" } )
+        for( const auto& kw : { "SWLPC", "SWL", "SWLX", "SWLX-", "SWLY", "SWLY-", "SWLZ", "SWLZ-" } )
             supportedDoubleKeywords.emplace_back( kw, SWLLookup, "1" );
-        for( const auto& kw : { "ISWL", "ISWLX", "ISWLX-", "ISWLY", "ISWLY-", "ISWLZ", "ISWLZ-" } )
+        for( const auto& kw : { "ISWLPC", "ISWL", "ISWLX", "ISWLX-", "ISWLY", "ISWLY-", "ISWLZ", "ISWLZ-" } )
             supportedDoubleKeywords.emplace_back( kw, ISWLLookup, "1" );
 
         // keywords to specify the maximum gas saturation.

--- a/src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
@@ -55,8 +55,12 @@ namespace Opm {
         const TableContainer& sgfnTables = tm->getSgfnTables();
 
 
-        bool family1 = (!sgofTables.empty() || !slgofTables.empty()) && !swofTables.empty();
-        bool family2 = !swfnTables.empty() && !sgfnTables.empty() && !sof3Tables.empty();
+        bool family1 = !sgofTables.empty() || !swofTables.empty() || !slgofTables.empty();
+        bool family2 = !swfnTables.empty() || !sgfnTables.empty() || !sof3Tables.empty();
+
+        if (!swofTables.empty() && !slgofTables.empty()) {
+            throw std::invalid_argument("Both, the SGOF and SLGOF have been specified but they are mutually exclusive!");
+        }
 
         if (family1 && family2) {
             throw std::invalid_argument("Saturation families should not be mixed \n"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/ISGLPC
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/ISGLPC
@@ -1,0 +1,1 @@
+{"name" : "ISGLPC" , "sections" : ["PROPS"], "data" : {"value_type" : "DOUBLE", "dimension" : "1"}}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/ISWLPC
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/ISWLPC
@@ -1,0 +1,1 @@
+{"name" : "ISWLPC" , "sections" : ["PROPS"], "data" : {"value_type" : "DOUBLE", "dimension" : "1"}}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/ROCK
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/ROCK
@@ -1,3 +1,9 @@
-{"name" : "ROCK" , "sections" : ["PROPS"], "size" : {"keyword":"TABDIMS" , "item":"NTPVT"}, "items" : [
-        {"name" : "PREF"  , "value_type" : "DOUBLE" , "default" : 1.0132 , "dimension" : "Pressure"},
-        {"name" : "COMPRESSIBILITY" , "value_type" : "DOUBLE" , "default" : 0 , "dimension" : "1/Pressure"}]}
+{
+  "name": "ROCK",
+  "sections": ["PROPS"],
+  "size": {"keyword":"TABDIMS", "item":"NTPVT"},
+  "items": [
+        {"name": "PREF", "value_type": "DOUBLE", "default": 1.0132, "dimension": "Pressure"},
+        {"name": "COMPRESSIBILITY", "value_type": "DOUBLE", "default": 0, "dimension": "1/Pressure"}
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGLPC
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGLPC
@@ -1,0 +1,1 @@
+{"name" : "SGLPC" , "sections" : ["PROPS"], "data" : {"value_type" : "DOUBLE", "dimension" : "1"}}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SWLPC
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SWLPC
@@ -1,0 +1,1 @@
+{"name" : "SWLPC" , "sections" : ["PROPS"], "data" : {"value_type" : "DOUBLE", "dimension" : "1"}}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -137,11 +137,13 @@ set( keywords
      000_Eclipse100/I/IPCW
      000_Eclipse100/I/ISGCR
      000_Eclipse100/I/ISGL
+     000_Eclipse100/I/ISGLPC
      000_Eclipse100/I/ISGU
      000_Eclipse100/I/ISOGCR
      000_Eclipse100/I/ISOWCR
      000_Eclipse100/I/ISWCR
      000_Eclipse100/I/ISWL
+     000_Eclipse100/I/ISWLPC
      000_Eclipse100/I/ISWU
      000_Eclipse100/J/JFUNC
      000_Eclipse100/L/LAB
@@ -296,6 +298,7 @@ set( keywords
      000_Eclipse100/S/SGCWMIS
      000_Eclipse100/S/SGFN
      000_Eclipse100/S/SGL
+     000_Eclipse100/S/SGLPC
      000_Eclipse100/S/SGOF
      000_Eclipse100/S/SGU
      000_Eclipse100/S/SGWFN
@@ -332,6 +335,7 @@ set( keywords
      000_Eclipse100/S/SWCR
      000_Eclipse100/S/SWFN
      000_Eclipse100/S/SWL
+     000_Eclipse100/S/SWLPC
      000_Eclipse100/S/SWOF
      000_Eclipse100/S/SWU
      000_Eclipse100/T/TABDIMS


### PR DESCRIPTION
they are just like their non-PC postfixed counterparts, except that they only apply to capillary pressures, not to the relperms and they seem to overwrite the values specified via S[WG]L for the capillary pressures but not for relperms.