### PR TITLE
Add class RFTConfig

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -94,6 +94,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -510,6 +511,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
        opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp
        opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+       opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
        opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 #include <vector>
 #include <algorithm>
+#include <utility>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 
@@ -147,6 +148,14 @@ class DynamicState {
     /// -1 if @value is not found.
     int find(const T& value) const {
         auto iter = std::find( m_data.begin() , m_data.end() , value);
+        if( iter == this->m_data.end() ) return -1;
+
+        return std::distance( m_data.begin() , iter );
+    }
+
+    template<typename P>
+    int find_if(P&& pred) const {
+        auto iter = std::find_if(m_data.begin(), m_data.end(), std::forward<P>(pred));
         if( iter == this->m_data.end() ) return -1;
 
         return std::distance( m_data.begin() , iter );

--- a/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
@@ -1,0 +1,57 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef RFT_CONFIG_HPP
+#define RFT_CONFIG_HPP
+
+#include <cstddef>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
+
+namespace Opm {
+
+class TimeMap;
+class RFTConfig {
+public:
+    explicit RFTConfig(const TimeMap& time_map);
+    bool rft(const std::string& well, std::size_t report_step) const;
+    bool plt(const std::string& well, std::size_t report_step) const;
+    bool getWellOpenRFT(const std::string& well_name, std::size_t report_step) const;
+    void setWellOpenRFT(std::size_t report_step);
+    void setWellOpenRFT(const std::string& well_name);
+
+    bool active(std::size_t report_step) const;
+    std::size_t firstRFTOutput() const;
+    void updateRFT(const std::string& well, std::size_t report_step, RFTConnections::RFTEnum value);
+    void updatePLT(const std::string& well, std::size_t report_step, PLTConnections::PLTEnum value);
+    void addWellOpen(const std::string& well, std::size_t report_step);
+private:
+    const TimeMap& tm;
+    std::pair<bool, std::size_t> well_open_rft_time;
+    std::unordered_set<std::string> well_open_rft_name;
+    std::unordered_map<std::string, std::size_t> well_open;
+    std::unordered_map<std::string, DynamicState<std::pair<RFTConnections::RFTEnum, std::size_t>>> rft_config;
+    std::unordered_map<std::string, DynamicState<std::pair<PLTConnections::PLTEnum, std::size_t>>> plt_config;
+};
+
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -36,6 +36,7 @@
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
@@ -157,6 +158,7 @@ namespace Opm
         const MessageLimits& getMessageLimits() const;
         void invalidNamePattern (const std::string& namePattern, const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword) const;
 
+        const RFTConfig& rftConfig() const;
         const Events& getEvents() const;
         const Events& getWellEvents(const std::string& well) const;
         bool hasWellEvent(const std::string& well, uint64_t event_mask, size_t reportStep) const;
@@ -190,6 +192,7 @@ namespace Opm
         DynamicState<std::shared_ptr<WellTestConfig>> wtest_config;
         DynamicState<std::shared_ptr<WListManager>> wlist_manager;
         DynamicState<std::shared_ptr<UDQInput>> udq_config;
+        RFTConfig rft_config;
 
         WellProducer::ControlModeEnum m_controlModeWHISTCTL;
         Actions m_actions;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -158,11 +158,6 @@ namespace Opm {
         bool                            setEconProductionLimits(const size_t timeStep, const WellEconProductionLimits& productionlimits);
         const WellEconProductionLimits& getEconProductionLimits(const size_t timeStep) const;
 
-        int  firstRFTOutput( ) const;
-        bool getRFTActive(size_t time_step) const;
-        void updateRFTActive(size_t time_step, RFTConnections::RFTEnum mode);
-        bool getPLTActive(size_t time_step) const;
-        void updatePLTActive(size_t time_step, PLTConnections::PLTEnum mode);
         int  findWellFirstOpen(int startTimeStep) const;
 
         /*
@@ -170,7 +165,6 @@ namespace Opm {
           WELSPECS, actually opening the well might be later.
         */
         size_t firstTimeStep( ) const;
-        void setRFTForWellWhenFirstOpen(size_t currentStep);
 
         static bool wellNameInWellNamePattern(const std::string& wellName, const std::string& wellNamePattern);
 
@@ -193,7 +187,6 @@ namespace Opm {
         void handleWELOPEN(const DeckRecord& record, size_t time_step, WellCompletion::StateEnum status);
         void handleWPIMULT(const DeckRecord& record, size_t time_step);
         void handleWELSEGS(const DeckKeyword& keyword, size_t time_step);
-
 
         /*
           Will remove all completions which are attached to inactive cells. Will
@@ -222,8 +215,6 @@ namespace Opm {
         DynamicState< double > m_solventFraction;
         DynamicState< WellTracerProperties > m_tracerProperties;
         DynamicState< std::string > m_groupName;
-        DynamicState< int > m_rft;
-        DynamicState< int > m_plt;
 
         DynamicState< int > m_headI;
         DynamicState< int > m_headJ;

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -149,7 +149,7 @@ void RFT::writeTimeStep( const Schedule& schedule,
             continue;
 
         auto* well = schedule.getWell(well_name);
-        auto* rft_node = ecl_rft_node_alloc_new( well_name.c_str(), "RFT", current_time, days );
+        rft rft_node(ecl_rft_node_alloc_new( well_name.c_str(), "RFT", current_time, days ));
         const auto& wellData = wellDatas.at(well_name);
 
         if (wellData.connections.empty())
@@ -180,11 +180,10 @@ void RFT::writeTimeStep( const Schedule& schedule,
             auto* cell = ecl_rft_cell_alloc_RFT(
                             i, j, k, depth, press, satwat, satgas );
 
-            ecl_rft_node_append_cell( rft_node, cell );
+            ecl_rft_node_append_cell( rft_node.get(), cell );
         }
 
-        rft ecl_node( rft_node );
-        ecl_rft_node_fwrite( ecl_node.get(), fortio, units.getEclType() );
+        ecl_rft_node_fwrite( rft_node.get(), fortio, units.getEclType() );
     }
 
     fortio_fclose( fortio );

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -102,9 +102,9 @@ class RFT {
          const std::string&  basename,
          bool format );
 
-        void writeTimeStep( std::vector< const Well* >,
+        void writeTimeStep( const Schedule& schedule,
                             const EclipseGrid& grid,
-                            int report_step,
+                            std::size_t report_step,
                             time_t current_time,
                             double days,
                             const UnitSystem& units,
@@ -123,35 +123,34 @@ class RFT {
 {}
 
 
-void RFT::writeTimeStep( std::vector< const Well* > wells,
+void RFT::writeTimeStep( const Schedule& schedule,
                          const EclipseGrid& grid,
-                         int report_step,
+                         std::size_t report_step,
                          time_t current_time,
                          double days,
                          const UnitSystem& units,
                          data::Wells wellDatas) {
     using rft = ERT::ert_unique_ptr< ecl_rft_node_type, ecl_rft_node_free >;
+    const auto& rft_config = schedule.rftConfig();
+    auto well_names = schedule.wellNames(report_step);
+    if (!rft_config.active(report_step))
+        return;
 
     fortio_type * fortio;
-    int first_report_step = report_step;
 
-    for (const auto* well : wells)
-        first_report_step = std::min( first_report_step, well->firstRFTOutput());
-
-    if (report_step > first_report_step)
+    if (report_step > rft_config.firstRFTOutput())
         fortio = fortio_open_append( filename.c_str() , fmt_file , ECL_ENDIAN_FLIP );
     else
         fortio = fortio_open_writer( filename.c_str() , fmt_file , ECL_ENDIAN_FLIP );
 
-    for ( const auto& well : wells ) {
-        if( !( well->getRFTActive( report_step )
-            || well->getPLTActive( report_step ) ) )
+    for ( const auto& well_name : well_names ) {
+
+        if (!(rft_config.rft(well_name, report_step) || rft_config.plt(well_name, report_step)))
             continue;
 
-        auto* rft_node = ecl_rft_node_alloc_new( well->name().c_str(), "RFT",
-                current_time, days );
-
-        const auto& wellData = wellDatas.at(well->name());
+        auto* well = schedule.getWell(well_name);
+        auto* rft_node = ecl_rft_node_alloc_new( well_name.c_str(), "RFT", current_time, days );
+        const auto& wellData = wellDatas.at(well_name);
 
         if (wellData.connections.empty())
             continue;
@@ -471,19 +470,13 @@ void EclipseIO::writeTimeStep(int report_step,
     if( isSubstep )
         return;
 
-    {
-        std::vector<const Well*> sched_wells = this->impl->schedule.getWells( report_step );
-        const auto rft_active = [report_step] (const Well* w) { return w->getRFTActive( report_step ) || w->getPLTActive( report_step ); };
-        if (std::any_of(sched_wells.begin(), sched_wells.end(), rft_active)) {
-            this->impl->rft.writeTimeStep( sched_wells,
-                                           grid,
-                                           report_step,
-                                           secs_elapsed + this->impl->schedule.posixStartTime(),
-                                           units.from_si( UnitSystem::measure::time, secs_elapsed ),
-                                           units,
-                                           value.wells );
-        }
-    }
+    this->impl->rft.writeTimeStep( schedule,
+                                   grid,
+                                   report_step,
+                                   secs_elapsed + this->impl->schedule.posixStartTime(),
+                                   units.from_si( UnitSystem::measure::time, secs_elapsed ),
+                                   units,
+                                   value.wells );
 
  }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
@@ -1,0 +1,176 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp>
+
+namespace Opm {
+
+RFTConfig::RFTConfig(const TimeMap& time_map) :
+    tm(time_map)
+{
+}
+
+bool RFTConfig::rft(const std::string& well_name, std::size_t report_step) const {
+    if (report_step >= this->tm.size())
+        throw std::invalid_argument("Invalid ");
+
+    const auto well_iter = this->well_open.find(well_name);
+    if (well_iter != this->well_open.end()) {
+
+        // A general "Output RFT when the well is opened" has been configured with WRFT
+        if (this->well_open_rft_time.first && this->well_open_rft_time.second <= report_step) {
+            if (well_iter->second == report_step)
+                return true;
+        }
+
+
+        // A FOPN setting has been configured with the WRFTPLT keyword
+        if (this->well_open_rft_name.count(well_name) > 0) {
+            if (well_iter->second == report_step)
+                return true;
+        }
+    }
+
+    if (this->rft_config.count(well_name) == 0)
+        return false;
+
+    auto rft_pair = this->rft_config.at(well_name)[report_step];
+    if (rft_pair.first == RFTConnections::YES)
+        return (rft_pair.second == report_step);
+
+    if (rft_pair.first == RFTConnections::NO)
+        return false;
+
+    if (rft_pair.first == RFTConnections::REPT)
+        return true;
+
+    if (rft_pair.first == RFTConnections::TIMESTEP)
+        return true;
+
+    return false;
+}
+
+bool RFTConfig::plt(const std::string& well_name, std::size_t report_step) const {
+    if (report_step >= this->tm.size())
+        throw std::invalid_argument("Invalid ");
+
+    if (this->plt_config.count(well_name) == 0)
+        return false;
+
+    auto plt_pair = this->plt_config.at(well_name)[report_step];
+    if (plt_pair.first == PLTConnections::YES)
+        return (plt_pair.second == report_step);
+
+    if (plt_pair.first == PLTConnections::NO)
+        return false;
+
+    if (plt_pair.first == PLTConnections::REPT)
+        return true;
+
+    if (plt_pair.first == PLTConnections::TIMESTEP)
+        return true;
+
+    return false;
+}
+
+void RFTConfig::updateRFT(const std::string& well_name, std::size_t report_step, RFTConnections::RFTEnum value) {
+    if (value == RFTConnections::FOPN)
+        this->setWellOpenRFT(well_name);
+    else {
+        if (this->rft_config.count(well_name) == 0) {
+            auto state = DynamicState<std::pair<RFTConnections::RFTEnum, std::size_t>>(this->tm, std::make_pair(RFTConnections::NO, 0));
+            this->rft_config.emplace( well_name, state );
+        }
+        this->rft_config.at(well_name).update(report_step, std::make_pair(value, report_step));
+    }
+}
+
+void RFTConfig::updatePLT(const std::string& well_name, std::size_t report_step, PLTConnections::PLTEnum value) {
+    if (this->plt_config.count(well_name) == 0) {
+        auto state = DynamicState<std::pair<PLTConnections::PLTEnum, std::size_t>>(this->tm, std::make_pair(PLTConnections::NO, 0));
+        this->plt_config.emplace( well_name, state );
+    }
+    this->plt_config.at(well_name).update(report_step, std::make_pair(value, report_step));
+}
+
+
+bool RFTConfig::getWellOpenRFT(const std::string& well_name, std::size_t report_step) const {
+    if (this->well_open_rft_name.count(well_name) > 0)
+        return true;
+
+    return (this->well_open_rft_time.first && this->well_open_rft_time.second <= report_step);
+}
+
+
+void RFTConfig::setWellOpenRFT(std::size_t report_step) {
+    this->well_open_rft_time = std::make_pair(true, report_step);
+}
+
+void RFTConfig::setWellOpenRFT(const std::string& well_name) {
+    this->well_open_rft_name.insert( well_name );
+}
+
+
+void RFTConfig::addWellOpen(const std::string& well_name, std::size_t report_step) {
+    if (this->well_open.count(well_name) == 0)
+        this->well_open[well_name] = report_step;
+}
+
+std::size_t RFTConfig::firstRFTOutput() const {
+    std::size_t first_rft = this->tm.size();
+    if (this->well_open_rft_time.first) {
+        // The WRFT keyword has been used to request RFT output at well open for all wells.
+        std::size_t rft_time = this->well_open_rft_time.second;
+        for (const auto& rft_pair : this->well_open) {
+            if (rft_pair.second >= rft_time)
+                first_rft = std::min(first_rft, rft_pair.second);
+        }
+    } else {
+        // Go through the individual wells and look for first open settings
+        for (const auto& rft_pair : this->well_open)
+            first_rft = std::min(first_rft, rft_pair.second);
+    }
+
+    for (const auto& rft_pair : this->plt_config) {
+        const auto& dynamic_state = rft_pair.second;
+        auto pred = [] (const std::pair<PLTConnections::PLTEnum, std::size_t>& elm) { return false; };
+        int this_first_rft = dynamic_state.find_if(pred);
+        if (this_first_rft >= 0)
+            first_rft = std::min(first_rft, static_cast<std::size_t>(this_first_rft));
+    }
+
+    return first_rft;
+}
+
+bool RFTConfig::active(std::size_t report_step) const {
+    for (const auto& rft_pair : this->rft_config) {
+        if (this->rft(rft_pair.first, report_step))
+            return true;
+    }
+
+    for (const auto& plt_pair : this->plt_config) {
+        if (this->rft(plt_pair.first, report_step))
+            return true;
+    }
+
+    return false;
+}
+
+}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -86,7 +86,8 @@ namespace Opm {
         m_runspec( runspec ),
         wtest_config(this->m_timeMap, std::make_shared<WellTestConfig>() ),
         wlist_manager( this->m_timeMap, std::make_shared<WListManager>()),
-        udq_config(this->m_timeMap, std::make_shared<UDQInput>(deck))
+        udq_config(this->m_timeMap, std::make_shared<UDQInput>(deck)),
+        rft_config(this->m_timeMap)
     {
         m_controlModeWHISTCTL = WellProducer::CMODE_UNDEFINED;
         addGroup( "FIELD", 0 );
@@ -402,13 +403,11 @@ namespace Opm {
         for (auto rftPair = rftProperties.begin(); rftPair != rftProperties.end(); ++rftPair) {
             const DeckKeyword& keyword = *rftPair->first;
             size_t timeStep = rftPair->second;
-            if (keyword.name() == "WRFT") {
+            if (keyword.name() == "WRFT")
                 handleWRFT(keyword,  timeStep);
-            }
 
-            if (keyword.name() == "WRFTPLT"){
+            if (keyword.name() == "WRFTPLT")
                 handleWRFTPLT(keyword, timeStep);
-            }
         }
 
         checkUnhandledKeywords(section);
@@ -1076,7 +1075,7 @@ namespace Opm {
 
     void Schedule::handleWELOPEN( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors, const std::vector<std::string>& matching_wells) {
 
-        auto all_defaulted = []( const DeckRecord& rec ) {
+        auto conn_defaulted = []( const DeckRecord& rec ) {
             auto defaulted = []( const DeckItem& item ) {
                 return item.defaultApplied( 0 );
             };
@@ -1098,7 +1097,7 @@ namespace Opm {
             /* if all records are defaulted or just the status is set, only
              * well status is updated
              */
-            if( all_defaulted( record ) ) {
+            if( conn_defaulted( record ) ) {
                 const auto well_status = WellCommon::StatusFromString( status_str );
                 for(const auto& well_name : well_names) {
                     auto& well = this->m_wells.at(well_name);
@@ -1111,6 +1110,8 @@ namespace Opm {
                         OpmLog::note(msg);
                     } else {
                         this->updateWellStatus( well, currentStep, well_status );
+                        if (well_status == open)
+                            this->rft_config.addWellOpen(well_name, currentStep);
                     }
                 }
 
@@ -1588,14 +1589,11 @@ namespace Opm {
             const auto well_names = wellNames(wellNamePattern, currentStep);
             for(const auto& well_name : well_names) {
                 auto& well = this->m_wells.at(well_name);
-                well.updateRFTActive( currentStep, RFTConnections::RFTEnum::YES);
+                this->rft_config.updateRFT(well_name, currentStep, RFTConnections::RFTEnum::YES);
             }
         }
 
-        for( auto& well_pair : this->m_wells ) {
-            auto& well = well_pair.second;
-            well.setRFTForWellWhenFirstOpen( currentStep );
-        }
+        this->rft_config.setWellOpenRFT(currentStep);
     }
 
     void Schedule::handleWRFTPLT( const DeckKeyword& keyword,  size_t currentStep) {
@@ -1607,11 +1605,14 @@ namespace Opm {
             PLTConnections::PLTEnum PLTKey = PLTConnections::PLTEnumFromString(record.getItem("OUTPUT_PLT").getTrimmedString(0));
             const auto well_names = wellNames(wellNamePattern, currentStep);
             for(const auto& well_name : well_names) {
-                auto& well = this->m_wells.at(well_name);
-                well.updateRFTActive( currentStep, RFTKey );
-                well.updatePLTActive( currentStep, PLTKey );
+                this->rft_config.updateRFT(well_name, currentStep, RFTKey);
+                this->rft_config.updatePLT(well_name, currentStep, PLTKey);
             }
         }
+    }
+
+    const RFTConfig& Schedule::rftConfig() const {
+        return this->rft_config;
     }
 
     void Schedule::invalidNamePattern( const std::string& namePattern,  const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword ) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -56,8 +56,6 @@ namespace Opm {
           m_solventFraction( timeMap, 0.0 ),
           m_tracerProperties( timeMap, WellTracerProperties() ),
           m_groupName( timeMap, "" ),
-          m_rft( timeMap, false ),
-          m_plt( timeMap, false ),
           m_headI( timeMap, headI ),
           m_headJ( timeMap, headJ ),
           m_refDepth( timeMap, refDepth ),
@@ -401,96 +399,8 @@ namespace Opm {
 
 
 
-    void Well::updateRFTActive(size_t time_step, RFTConnections::RFTEnum mode) {
-        switch(mode) {
-        case RFTConnections::RFTEnum::YES:
-            m_rft.update_elm(time_step, true);
-            break;
-        case RFTConnections::RFTEnum::TIMESTEP:
-            m_rft.update_elm(time_step, true);
-            break;
-        case RFTConnections::RFTEnum::REPT:
-            m_rft.update(time_step, true);
-            break;
-        case RFTConnections::RFTEnum::FOPN:
-            setRFTForWellWhenFirstOpen(time_step);
-            break;
-        case RFTConnections::RFTEnum::NO:
-            m_rft.update(time_step, false);
-            break;
-        default:
-            break;
-        }
-    }
-
-    void Well::updatePLTActive(size_t time_step, PLTConnections::PLTEnum mode){
-        switch(mode) {
-        case PLTConnections::PLTEnum::YES:
-            m_plt.update_elm(time_step, true);
-            break;
-        case PLTConnections::PLTEnum::REPT:
-            m_plt.update(time_step, true);
-            break;
-        case PLTConnections::PLTEnum::NO:
-            m_plt.update(time_step, false);
-            break;
-        default:
-            break;
-        }
-    }
-
-    bool Well::getRFTActive(size_t time_step) const{
-        return bool( m_rft.get(time_step) );
-    }
-
-    bool Well::getPLTActive(size_t time_step) const{
-     return bool( m_plt.get(time_step) );
-    }
-
-    /*
-      The first report step where *either* RFT or PLT output is active.
-    */
-    int Well::firstRFTOutput( ) const {
-        int rft_output = m_rft.find( true );
-        int plt_output = m_plt.find( true );
-
-        if (rft_output < plt_output) {
-            if (rft_output >= 0)
-                return rft_output;
-            else
-                return plt_output;
-        } else {
-            if (plt_output >= 0)
-                return plt_output;
-            else
-                return rft_output;
-        }
-    }
-
-
     size_t Well::firstTimeStep( ) const {
         return m_creationTimeStep;
-    }
-
-
-    int Well::findWellFirstOpen(int startTimeStep) const{
-        for( size_t i = startTimeStep; i < this->timesteps ;i++){
-            if(getStatus(i)==WellCommon::StatusEnum::OPEN){
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    void Well::setRFTForWellWhenFirstOpen(size_t currentStep){
-        int time;
-        if(getStatus(currentStep)==WellCommon::StatusEnum::OPEN ){
-            time = currentStep;
-        }else {
-            time = findWellFirstOpen(currentStep);
-        }
-        if (time > -1)
-            updateRFTActive(time, RFTConnections::RFTEnum::YES);
     }
 
     WellCompletion::CompletionOrderEnum Well::getWellConnectionOrdering() const {

--- a/tests/parser/DynamicStateTests.cpp
+++ b/tests/parser/DynamicStateTests.cpp
@@ -248,6 +248,10 @@ BOOST_AUTO_TEST_CASE( find ) {
     BOOST_CHECK_EQUAL( state.find( 300 ) ,  2 );
     BOOST_CHECK_EQUAL( state.find( 400 ) ,  4 );
     BOOST_CHECK_EQUAL( state.find( 500 ) ,  -1 );
+
+
+    auto pred = [] (const int& elm) { return elm == 400 ;};
+    BOOST_CHECK_EQUAL( state.find_if(pred), 4);
 }
 
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -855,19 +855,13 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
+    const auto& rft_config = schedule.rftConfig();
 
-    {
-        auto* well = schedule.getWell("OP_1");
-        BOOST_CHECK_EQUAL(well->getRFTActive(2),true);
-        BOOST_CHECK_EQUAL(2 , well->firstRFTOutput( ));
-    }
-
-    {
-        auto* well = schedule.getWell("OP_2");
-        BOOST_CHECK_EQUAL(well->getRFTActive(3),true);
-        BOOST_CHECK_EQUAL(3 , well->firstRFTOutput( ));
-    }
+    BOOST_CHECK_EQUAL(2 , rft_config.firstRFTOutput());
+    BOOST_CHECK_EQUAL(true, rft_config.rft("OP_1", 2));
+    BOOST_CHECK_EQUAL(true, rft_config.rft("OP_2", 3));
 }
+
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
     Opm::Parser parser;
@@ -919,15 +913,17 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
+    const auto& rft_config = schedule.rftConfig();
     auto* well = schedule.getWell("OP_1");
 
     size_t currentStep = 3;
-    BOOST_CHECK_EQUAL(well->getRFTActive(currentStep),false);
+    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", currentStep),false);
     currentStep = 4;
-    BOOST_CHECK_EQUAL(well->getRFTActive(currentStep),true);
+    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", currentStep),true);
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(currentStep));
+
     currentStep = 5;
-    BOOST_CHECK_EQUAL(well->getRFTActive(currentStep),false);
+    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", currentStep),false);
 }
 
 BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -205,15 +205,17 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
     {
         auto* well2 = sched.getWell("W_2");
+        const auto& rft_config = sched.rftConfig();
         BOOST_CHECK_EQUAL( 0 , well2->getProductionPropertiesCopy(2).ResVRate);
         BOOST_CHECK_CLOSE( 777/Metric::Time , well2->getProductionPropertiesCopy(7).ResVRate , 0.0001);
         BOOST_CHECK_EQUAL( 0 , well2->getProductionPropertiesCopy(8).ResVRate);
 
         BOOST_CHECK_EQUAL( WellCommon::SHUT , well2->getStatus(3));
-        BOOST_CHECK( !well2->getRFTActive( 2 ) );
-        BOOST_CHECK( well2->getRFTActive( 3 ) );
-        BOOST_CHECK( well2->getRFTActive( 4 ) );
-        BOOST_CHECK( !well2->getRFTActive( 5 ) );
+
+        BOOST_CHECK( !rft_config.rft("W_2", 2));
+        BOOST_CHECK( rft_config.rft("W_2", 3));
+        BOOST_CHECK( rft_config.rft("W_2", 4));
+        BOOST_CHECK( !rft_config.rft("W_2", 5));
         {
             const WellProductionProperties& prop3 = well2->getProductionProperties(3);
             BOOST_CHECK_EQUAL( WellProducer::ORAT , prop3.controlMode);
@@ -243,9 +245,9 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
     {
         auto* well1 = sched.getWell("W_1");
+        const auto& rft_config = sched.rftConfig();
 
-        BOOST_CHECK_EQUAL( well1->firstRFTOutput( ) , 3);
-        BOOST_CHECK( well1->getRFTActive( 3 ) );
+        BOOST_CHECK(rft_config.rft("W_1", 3));
         BOOST_CHECK(well1->getProductionPropertiesCopy(0).predictionMode);
         BOOST_CHECK_EQUAL(0, well1->getProductionPropertiesCopy(0).OilRate);
 


### PR DESCRIPTION
Most of the settings in the Schedule section work as: "Set X=Y - and it will apply until explicitly set to Z", and for this use case the `DynamicState<T>` datastructure has served us well, however when configuring RFT output we have both the alternatives:

1. Set this setting exactly once.
2. Set this setting - *when the well opens*

These two do not fit that well with the `DynamicState<T>` - to facilitate the big well refactor: #681 this PR extracts the rft configuration out from the well object.

https://github.com/OPM/opm-simulators/pull/1779