### PR TITLE
Structurally Correct PVT Tables in INIT File (Part 2)

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -568,6 +568,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/VectorItems/connection.hpp
         opm/output/eclipse/VectorItems/group.hpp
         opm/output/eclipse/VectorItems/intehead.hpp
+        opm/output/eclipse/VectorItems/logihead.hpp
         opm/output/eclipse/VectorItems/msw.hpp
         opm/output/eclipse/VectorItems/well.hpp
         opm/output/eclipse/AggregateGroupData.hpp

--- a/opm/output/eclipse/LogiHEAD.hpp
+++ b/opm/output/eclipse/LogiHEAD.hpp
@@ -1,4 +1,5 @@
 /*
+  Copyright 2019 Equinor ASA.
   Copyright 2016, 2017 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
@@ -27,6 +28,49 @@ namespace Opm { namespace RestartIO {
     class LogiHEAD
     {
     public:
+        /// Key characteristics of simulation run's PVT model.
+        struct PVTModel
+        {
+            /// Whether or not simulation run uses a live oil model (with
+            /// dissolved gas).
+            bool isLiveOil { false };
+
+            /// Whether or not simulation run uses a wet gas model (with
+            /// vaporised oil).
+            bool isWetGas { false };
+
+            /// Whether or not simulation run uses a constant
+            /// compressibility oil model (keyword PVCDO).
+            bool constComprOil { false };
+        };
+
+        /// Key characteristics of simulation model's saturation functions.
+        struct SatfuncFlags
+        {
+            /// Whether or not simulation run uses directionally dependent
+            /// relative permeability.
+            bool useDirectionalRelPerm { false };
+
+            /// Whether or not simulation run uses reversible relative
+            /// permeability functions.
+            bool useReversibleRelPerm { true };
+
+            /// Whether or not simulation run uses end-point scaling.
+            bool useEndScale { false };
+
+            /// Whether or not simulation run uses directionally dependent
+            /// end-point scaling.
+            bool useDirectionalEPS { false };
+
+            /// Whether or not simulation run uses reversible end-point
+            /// scaling.
+            bool useReversibleEPS { true  };
+
+            /// Whether or not simulation run activates the alternative
+            /// (three-point) end-point scaling feature.
+            bool useAlternateEPS { false };
+        };
+
         LogiHEAD();
         ~LogiHEAD() = default;
 
@@ -41,6 +85,21 @@ namespace Opm { namespace RestartIO {
                                const int  nswlmx,
 			       const bool enableHyster
 			      );
+
+        /// Assign PVT model characteristics.
+        ///
+        /// \param[in] pvt Current run's PVT model characteristics.
+        ///
+        /// \return \code *this \endcode.
+        LogiHEAD& pvtModel(const PVTModel& pvt);
+
+        /// Assign saturation function characteristics.
+        ///
+        /// \param[in] satfunc Current run's saturation function
+        ///    characteristics.
+        ///
+        /// \return \code *this \endcode.
+        LogiHEAD& saturationFunction(const SatfuncFlags& satfunc);
 
         const std::vector<bool>& data() const
         {

--- a/opm/output/eclipse/VectorItems/logihead.hpp
+++ b/opm/output/eclipse/VectorItems/logihead.hpp
@@ -1,0 +1,48 @@
+/*
+  Copyright (c) 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_ECLIPSE_VECTOR_LOGIHEAD_HPP
+#define OPM_OUTPUT_ECLIPSE_VECTOR_LOGIHEAD_HPP
+
+#include <vector>
+
+namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+
+    // This is a subset of the items in src/opm/output/eclipse/LogiHEAD.cpp .
+    // Promote items from that list to this in order to make them public.
+    enum logihead : std::vector<bool>::size_type {
+        IsLiveOil  =  0,    // Oil phase w/dissolved gas
+        IsWetGas   =  1,    // Gas phase w/vaporised oil
+        DirKr      =  2,    // Directional relative permeability
+        E100RevKr  =  3,    // Reversible rel. perm. (E100)
+        E100Radial =  4,    // Radial model (E100)
+        E300Radial =  3,    // Radial model (E300, others)
+        E300RevKr  =  4,    // Reversible rel. perm. (E300, others)
+        Hyster     =  6,    // Enable hysteresis
+        DualPoro   = 14,    // Enable dual porosity
+        EndScale   = 16,    // Enable end-point scaling
+        DirEPS     = 17,    // Directional end-point scaling
+        RevEPS     = 18,    // Reversible end-point scaling
+        AltEPS     = 19,    // Alternative (3-pt) end-point scaling
+        ConstCo    = 38,    // Constant oil compressibility (PVCDO)
+        HasMSWells = 75,    // Whether or not model has MS Wells.
+    };
+}}}} // Opm::RestartIO::Helpers::VectorItems
+
+#endif // OPM_OUTPUT_ECLIPSE_VECTOR_LOGIHEAD_HPP

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -156,6 +156,11 @@ void writeKeyword( ERT::FortIO& fortio ,
             pvt.isWetGas = phases.active(::Opm::Phase::GAS) &&
                 !tabMgr.getPvtgTables().empty();
 
+            pvt.constComprOil = phases.active(::Opm::Phase::OIL) &&
+                !(pvt.isLiveOil ||
+                  tabMgr.hasTables("PVDO") ||
+                  tabMgr.getPvcdoTable().empty());
+
             auto lh = ::Opm::RestartIO::LogiHEAD{}
                  .variousParam(false, false,
                                wsd.maxSegmentedWells(),

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -50,6 +50,7 @@
 #include <ert/ecl/EclFilename.hpp>
 
 #include <ert/ecl/ecl_kw_magic.h>
+#include <ert/ecl/ecl_kw.h>
 #include <ert/ecl/ecl_init_file.h>
 #include <ert/ecl/ecl_file.h>
 #include <ert/ecl/ecl_grid.h>
@@ -92,6 +93,32 @@ void writeKeyword( ERT::FortIO& fortio ,
 
 }
 
+    void writeKeyword(ERT::FortIO&             fortio,
+                      const std::string&       keywordName,
+                      const std::vector<bool>& data)
+    {
+        auto freeKw = [](ecl_kw_type* kw)
+        {
+            if (kw != nullptr) { ecl_kw_free(kw); }
+        };
+
+        using KWPtr =
+            std::unique_ptr<ecl_kw_type, decltype(freeKw)>;
+
+        auto kw = KWPtr {
+            ecl_kw_alloc(keywordName.c_str(), data.size(), ECL_BOOL),
+            freeKw
+        };
+
+        if (kw == nullptr) { return; }
+
+        const auto n = data.size();
+        for (auto i = 0*n; i < n; ++i) {
+            ecl_kw_iset_bool(kw.get(), static_cast<int>(i), data[i]);
+        }
+
+        ecl_kw_fwrite(kw.get(), fortio.get());
+    }
 
 
 

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -31,15 +31,18 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/Utility/Functional.hpp>
 
+#include <opm/output/eclipse/LogiHEAD.hpp>
 #include <opm/output/eclipse/RestartIO.hpp>
 #include <opm/output/eclipse/Summary.hpp>
 #include <opm/output/eclipse/Tables.hpp>
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <cstdlib>
 #include <memory>     // unique_ptr
@@ -120,7 +123,63 @@ void writeKeyword( ERT::FortIO& fortio ,
         ecl_kw_fwrite(kw.get(), fortio.get());
     }
 
+    void writeInitFileHeader(const ::Opm::EclipseState& es,
+                             const ::Opm::EclipseGrid&  grid,
+                             const ::Opm::Schedule&     sched,
+                             ERT::FortIO&               fortio)
+    {
+        // Expected order of header vectors:
+        //   1. INTEHEAD
+        //   2. LOGIHEAD
+        //   3. DOUBHEAD
 
+        // INTEHEAD
+        {
+            const auto ih = ::Opm::RestartIO::Helpers::
+                createInteHead(es, grid, sched, 0.0, 0, 0);
+
+            writeKeyword(fortio, "INTEHEAD", ih);
+        }
+
+        // LOGIHEAD
+        {
+            const auto& tabMgr = es.getTableManager();
+            const auto& rspec  = es.runspec();
+            const auto& phases = rspec.phases();
+            const auto& wsd    = rspec.wellSegmentDimensions();
+
+            auto pvt = ::Opm::RestartIO::LogiHEAD::PVTModel{};
+
+            pvt.isLiveOil = phases.active(::Opm::Phase::OIL) &&
+                !tabMgr.getPvtoTables().empty();
+
+            pvt.isWetGas = phases.active(::Opm::Phase::GAS) &&
+                !tabMgr.getPvtgTables().empty();
+
+            auto lh = ::Opm::RestartIO::LogiHEAD{}
+                 .variousParam(false, false,
+                               wsd.maxSegmentedWells(),
+                               rspec.hysterPar().active());
+
+            // Sequenced after 'lh' constructor to ensure that any changes
+            // to live oil/wet gas elements are from this particular call.
+            lh.pvtModel(pvt);
+
+            writeKeyword(fortio, "LOGIHEAD", lh.data());
+        }
+
+        // DOUBHEAD
+        {
+            const auto dh = ::Opm::RestartIO::Helpers::
+                createDoubHead(es, sched, 0, 0.0, 0.0);
+
+            // DOUBHEAD must be output as double precision so we can't use
+            // writeKeyword() here (double -> float conversion).
+            ERT::EclKW<double> kw("DOUBHEAD", dh);
+
+            kw.fwrite(fortio);
+        }
+    }
 
 
 class RFT {
@@ -270,29 +329,20 @@ void EclipseIO::Impl::writeINITFile( const data::Solution& simProps, std::map<st
                         ioConfig.getFMTOUT(),
                         ECL_ENDIAN_FLIP );
 
+    writeInitFileHeader(this->es, this->grid, this->schedule, fortio);
 
-    // Write INIT header. Observe that the PORV vector is treated
-    // specially; that is because for this particulat vector we write
-    // a total of nx*ny*nz values, where the PORV vector has been
-    // explicitly set to zero for inactive cells. The convention is
-    // that the active/inactive cell mapping can be inferred by
-    // reading the PORV vector.
+    // The PORV vector is a special case.  This particular vector always
+    // holds a total of nx*ny*nz elements, and the elements are explicitly
+    // set to zero for inactive cells.  This treatment implies that the
+    // active/inactive cell mapping can be inferred by reading the PORV
+    // vector from the result set.
     {
-
         const auto& opm_data = this->es.get3DProperties().getDoubleGridProperty("PORV").getData();
         auto ecl_data = opm_data;
 
         for (size_t global_index = 0; global_index < opm_data.size(); global_index++)
             if (!this->grid.cellActive( global_index ))
                 ecl_data[global_index] = 0;
-
-
-        ecl_init_file_fwrite_header( fortio.get(),
-                                     this->grid.c_ptr(),
-                                     NULL,
-                                     units.getEclType(),
-                                     this->es.runspec( ).eclPhaseMask( ),
-                                     this->schedule.posixStartTime( ));
 
         units.from_si( UnitSystem::measure::volume, ecl_data );
         writeKeyword( fortio, "PORV" , ecl_data );
@@ -345,9 +395,7 @@ void EclipseIO::Impl::writeINITFile( const data::Solution& simProps, std::map<st
     // Write tables
     {
         Tables tables( this->es.getUnits() );
-        tables.addPVTO( this->es.getTableManager().getPvtoTables() );
-        tables.addPVTG( this->es.getTableManager().getPvtgTables() );
-        tables.addPVTW( this->es.getTableManager().getPvtwTable() );
+        tables.addPVTTables(this->es);
         tables.addDensity( this->es.getTableManager().getDensityTable( ) );
         tables.addSatFunc(this->es);
         fwrite(tables, fortio);

--- a/src/opm/output/eclipse/LogiHEAD.cpp
+++ b/src/opm/output/eclipse/LogiHEAD.cpp
@@ -1,16 +1,39 @@
 #include <opm/output/eclipse/LogiHEAD.hpp>
 
+#include <opm/output/eclipse/VectorItems/logihead.hpp>
+
 #include <utility>
 #include <vector>
 
+namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
+
 enum index : std::vector<int>::size_type {
-lh_000	=	0	,		//	TRUE
-lh_001	=	1	,		//	TRUE
-lh_002	=	2	,		//	FALSE
-lh_003	=	3	,		//	FALSE		Flag set to FALSE for a non-radial model, TRUE for a radial model (ECLIPSE 300 and other simulators)
-lh_004	=	4	,		//	FALSE		Flag set to FALSE for a non-radial model, TRUE for a radial model (ECLIPSE 100)
+    // Flag to signify live oil (dissolved gas) PVT
+    IsLiveOil = VI::logihead::IsLiveOil,
+
+    // Flag to signify wet gas (vaporised oil) PVT
+    IsWetGas = VI::logihead::IsWetGas,
+
+    // Flag to signify directional relative permeability.
+    DirKr = VI::logihead::DirKr,
+
+    // ECLIPSE 100 flag for reversible rel.perm.
+    E100RevKr = VI::logihead::E100RevKr,
+
+    // ECLIPSE 100 flag for radial geometry.
+    E100Radial = VI::logihead::E100Radial,
+
+    // ECLIPSE 300 flag for radial geometry.
+    E300Radial = VI::logihead::E300Radial,
+
+    // ECLIPSE 300 flag for reversible rel.perm.
+    E300RevKr = VI::logihead::E300RevKr,
+
 lh_005	=	5	,		//	FALSE
-lh_006	=	6	,		//	FALSE 		Flag set to FALSE when no hysteresis, TRUE when hysteresis option is used
+
+    // Flag to enable hysteresis
+    Hyster = VI::logihead::Hyster,
+
 lh_007	=	7	,		//	FALSE
 lh_008	=	8	,		//	FALSE
 lh_009	=	9	,		//	FALSE
@@ -18,12 +41,24 @@ lh_010	=	10	,		//	FALSE
 lh_011	=	11	,		//	FALSE
 lh_012	=	12	,		//	FALSE
 lh_013	=	13	,		//	FALSE
-lh_014	=	14	,		//	FALSE		Flag for dual porosity model
+
+    // Flag to activate dual porosity.
+    DualPoro = VI::logihead::DualPoro,
+
 lh_015	=	15	,		//	FALSE
-lh_016	=	16	,		//	TRUE
-lh_017	=	17	,		//	FALSE
-lh_018	=	18	,		//	TRUE
-lh_019	=	19	,		//
+
+    // Flag to activate saturation function end-point scaling.
+    EndScale = VI::logihead::EndScale,
+
+    // Flag to activate directional end-point scaling.
+    DirEPS = VI::logihead::DirEPS,
+
+    // Flag to activate reversible end-point scaling.  Typically True.
+    RevEPS = VI::logihead::RevEPS,		//	TRUE
+
+    // Flag to activate alternative end-point scaling (3-pt option)
+    AltEPS = VI::logihead::AltEPS,
+
 lh_020	=	20	,		//	FALSE
 lh_021	=	21	,		//	FALSE
 lh_022	=	22	,		//	FALSE
@@ -42,7 +77,10 @@ lh_034	=	34	,		//	FALSE
 lh_035	=	35	,		//	FALSE
 lh_036	=	36	,		//	FALSE
 lh_037	=	37	,		//
-lh_038	=	38	,		//	FALSE
+
+    // Flag to signify constant oil compressibility
+    ConstCo = VI::logihead::ConstCo,
+
 lh_039	=	39	,		//	FALSE
 lh_040	=	40	,		//	FALSE
 lh_041	=	41	,		//	FALSE
@@ -79,7 +117,10 @@ lh_071	=	71	,		//	FALSE
 lh_072	=	72	,		//	FALSE
 lh_073	=	73	,		//	FALSE
 lh_074	=	74	,		//	FALSE
-lh_075	=	75	,		//	TRUE	If segmented well model is used
+
+    // TRUE if segmented well model is used
+    HasMSWells = VI::logihead::HasMSWells,
+
 lh_076	=	76	,		//	TRUE
 lh_077	=	77	,		//	FALSE
 lh_078	=	78	,		//	FALSE
@@ -126,10 +167,10 @@ lh_118	=	118	,		//	FALSE
 lh_119	=	119	,		//	FALSE
 lh_120	=	120	,		//	FALSE
 
-  // ---------------------------------------------------------------------
-  // ---------------------------------------------------------------------
+// ---------------------------------------------------------------------
+// ---------------------------------------------------------------------
 
-  LOGIHEAD_NUMBER_OF_ITEMS        // MUST be last element of enum.
+    LOGIHEAD_NUMBER_OF_ITEMS        // MUST be last element of enum.
 };
 
 // =====================================================================
@@ -142,25 +183,17 @@ Opm::RestartIO::LogiHEAD::LogiHEAD()
 
 Opm::RestartIO::LogiHEAD&
 Opm::RestartIO::LogiHEAD::
-variousParam(const bool e300_radial, const bool e100_radial, const int nswlmx, const bool enableHyster)
+variousParam(const bool e300_radial,
+             const bool e100_radial,
+             const int  nswlmx,
+             const bool enableHyster)
 {
-    this -> data_[lh_000] = true;
-    this -> data_[lh_001] = true;
-    this -> data_[lh_003] = e300_radial;
-    this -> data_[lh_004] = e100_radial;
-    this -> data_[lh_006] = enableHyster;
-    //this -> data_[lh_016] = true;
-    //this -> data_[lh_018] = true;
-    //this -> data_[lh_031] = true;
-    //this -> data_[lh_044] = true;
-    this -> data_[lh_075] = nswlmx >= 1; // True if MS Wells exist.
-    //this -> data_[lh_076] = true;
-    //this -> data_[lh_087] = true;
-    //this -> data_[lh_099] = true;
-    //this -> data_[lh_113] = true;
-    //this -> data_[lh_114] = true;
-    //this -> data_[lh_115] = true;
-    //this -> data_[lh_117] = true;
+    this -> data_[IsLiveOil]  = true;
+    this -> data_[IsWetGas]   = true;
+    this -> data_[E300Radial] = e300_radial;
+    this -> data_[E100Radial] = e100_radial;
+    this -> data_[Hyster]     = enableHyster;
+    this -> data_[HasMSWells] = nswlmx >= 1; // True if MS Wells exist.
 
     return *this;
 }

--- a/src/opm/output/eclipse/LogiHEAD.cpp
+++ b/src/opm/output/eclipse/LogiHEAD.cpp
@@ -197,3 +197,26 @@ variousParam(const bool e300_radial,
 
     return *this;
 }
+
+Opm::RestartIO::LogiHEAD&
+Opm::RestartIO::LogiHEAD::pvtModel(const PVTModel& pvt)
+{
+    this->data_[IsLiveOil] = pvt.isLiveOil;
+    this->data_[IsWetGas ] = pvt.isWetGas;
+    this->data_[ConstCo  ] = pvt.constComprOil;
+
+    return *this;
+}
+
+Opm::RestartIO::LogiHEAD&
+Opm::RestartIO::LogiHEAD::saturationFunction(const SatfuncFlags& satfunc)
+{
+    this->data_[DirKr]     = satfunc.useDirectionalRelPerm;
+    this->data_[E100RevKr] = satfunc.useReversibleRelPerm;
+    this->data_[EndScale]  = satfunc.useEndScale;
+    this->data_[DirEPS]    = satfunc.useDirectionalEPS;
+    this->data_[RevEPS]    = satfunc.useReversibleEPS;
+    this->data_[AltEPS]    = satfunc.useAlternateEPS;
+
+    return *this;
+}

--- a/tests/test_LogiHEAD.cpp
+++ b/tests/test_LogiHEAD.cpp
@@ -1,4 +1,5 @@
 /*
+  Copyright 2019 Equinor
   Copyright 2018 Statoil IT
 
   This file is part of the Open Porous Media project (OPM).
@@ -23,6 +24,8 @@
 
 #include <opm/output/eclipse/LogiHEAD.hpp>
 
+#include <opm/output/eclipse/VectorItems/logihead.hpp>
+
 BOOST_AUTO_TEST_SUITE(Member_Functions)
 
 BOOST_AUTO_TEST_CASE(Radial_Settings_and_Init)
@@ -42,6 +45,211 @@ BOOST_AUTO_TEST_CASE(Radial_Settings_and_Init)
     BOOST_CHECK_EQUAL(v[  4], true);  // E100 Radial
     BOOST_CHECK_EQUAL(v[  6], true);  // enableHyster
     BOOST_CHECK_EQUAL(v[ 75], true);  // MS Well Simulation Case
+}
+
+BOOST_AUTO_TEST_CASE(PVTModel)
+{
+    namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
+
+    // Defaulted => dead oil, dry gas, non-constant Co.
+    {
+        auto pvt = ::Opm::RestartIO::LogiHEAD::PVTModel{};
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.pvtModel(pvt);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::IsLiveOil ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::IsWetGas  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::ConstCo   ], false);
+    }
+
+    // Live oil, others defaulted
+    {
+        auto pvt = ::Opm::RestartIO::LogiHEAD::PVTModel{};
+
+        pvt.isLiveOil = true;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.pvtModel(pvt);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::IsLiveOil ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::IsWetGas  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::ConstCo   ], false);
+    }
+
+    // Wet gas, others defaulted
+    {
+        auto pvt = ::Opm::RestartIO::LogiHEAD::PVTModel{};
+
+        pvt.isWetGas = true;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.pvtModel(pvt);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::IsLiveOil ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::IsWetGas  ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::ConstCo   ], false);
+    }
+
+    // Constant oil compressibility, others defaulted
+    {
+        auto pvt = ::Opm::RestartIO::LogiHEAD::PVTModel{};
+
+        pvt.constComprOil = true;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.pvtModel(pvt);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::IsLiveOil ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::IsWetGas  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::ConstCo   ], true);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(SaturationFunction)
+{
+    namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
+
+    // Defaulted => non-directional and reversible Kr, no EPS but
+    // reversible if actually enabled.
+    {
+        auto sfunc = ::Opm::RestartIO::LogiHEAD::SatfuncFlags{};
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.saturationFunction(sfunc);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirKr     ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::E100RevKr ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::EndScale  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirEPS    ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::RevEPS    ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::AltEPS    ], false);
+    }
+
+    // Directionally dependent relative permeability, all other defaulted.
+    {
+        auto sfunc = ::Opm::RestartIO::LogiHEAD::SatfuncFlags {};
+
+        sfunc.useDirectionalRelPerm = true;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.saturationFunction(sfunc);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirKr     ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::E100RevKr ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::EndScale  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirEPS    ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::RevEPS    ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::AltEPS    ], false);
+    }
+
+    // Irreversible relative permeability, all other defaulted.
+    {
+        auto sfunc = ::Opm::RestartIO::LogiHEAD::SatfuncFlags {};
+
+        sfunc.useReversibleRelPerm = false;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.saturationFunction(sfunc);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirKr     ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::E100RevKr ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::EndScale  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirEPS    ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::RevEPS    ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::AltEPS    ], false);
+    }
+
+    // End-point scaling activated, all other defaulted.
+    {
+        auto sfunc = ::Opm::RestartIO::LogiHEAD::SatfuncFlags {};
+
+        sfunc.useEndScale = true;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.saturationFunction(sfunc);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirKr     ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::E100RevKr ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::EndScale  ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirEPS    ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::RevEPS    ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::AltEPS    ], false);
+    }
+
+    // Directionally dependent end-point scaling, all other defaulted.
+    {
+        auto sfunc = ::Opm::RestartIO::LogiHEAD::SatfuncFlags {};
+
+        sfunc.useDirectionalEPS = true;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.saturationFunction(sfunc);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirKr     ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::E100RevKr ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::EndScale  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirEPS    ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::RevEPS    ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::AltEPS    ], false);
+    }
+
+    // Irreversible end-point scaling, all other defaulted.
+    {
+        auto sfunc = ::Opm::RestartIO::LogiHEAD::SatfuncFlags {};
+
+        sfunc.useReversibleEPS = false;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.saturationFunction(sfunc);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirKr     ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::E100RevKr ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::EndScale  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirEPS    ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::RevEPS    ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::AltEPS    ], false);
+    }
+
+    // Alternative end-point scaling option (three-point method), all other
+    // defaulted.
+    {
+        auto sfunc = ::Opm::RestartIO::LogiHEAD::SatfuncFlags {};
+
+        sfunc.useAlternateEPS = true;
+
+        const auto lh =
+            ::Opm::RestartIO::LogiHEAD{}.saturationFunction(sfunc);
+
+        const auto& v = lh.data();
+
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirKr     ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::E100RevKr ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::EndScale  ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::DirEPS    ], false);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::RevEPS    ], true);
+        BOOST_CHECK_EQUAL(v[ VI::logihead::AltEPS    ], true);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull request&mdash;the second of two and the follow-up to PR #700 &mdash;hooks the code to normalise ~~prepares OPM Flow's INIT file output code for writing structurally correct PVT table entries to the TAB vector.~~ input PVT tables into the INIT file's `TAB` vector up to Flow's INIT file writer.

In particular, we switch to using
```C++
void Tables::addPVTTables(const EclipseState& es)
```
in place of the existing `addPVTO()`, `addPVTG()`, and `addPVTW()` functions.  This, in turn, activates table normalisation for all `PV{D,T}{G,O}`, `PVCDO`, and `PVTW` keywords and produces ECLIPSE compatibly sized and structured TAB vector representations for these data sources and changes the contents and size of the `TAB` vector in the INIT file. 

As a prerequisite for this work, to enable users such as ResInsight to correctly interpret the table contents, we need to ensure that the contents of `LOGIHEAD` reflect the data sources used to form TAB.  As a consequence, we now control the contents of `INTEHEAD`, `LOGIHEAD`, and `DOUBHEAD` directly from `EclipseIO.cpp` rather than from LibECL library function `ecl_init_file_fwrite_header()`.

We reuse header creation functionality that was created for the restart files.  This changes the size (number of elements) of the *HEAD vectors in the init file:

Vector| Old | New
-----|-------|--------
INTEHEAD| 95 | 411
LOGIHEAD | 80 | 121
DOUBHEAD | 1 | 229

which matches ECLIPSE 2017.2.  Doing this is taking a bit of a shortcut, because there are items in restart files that differ from those of the init file.  However for the items that affect tables the items are the same in both init and restart files.  We will need to refine this at a later point.

Note that this PR explicitly depends on Part 1 (PR #700), and must not be merged before that is installed.

---

### ResInsight Plotting Example ###

I ran the new table output code on the Norne model from [opm-tests](https://github.com/OPM/opm-tests/tree/aff36efe2d7929fd2131e45ca8fbbe6ffcbb336c/norne) to create `.INIT` files for comparisons between the current master, this PR, and loaded the result sets into ResInsight.  I then selected cell (29, 44, 1) to compare the oil and gas PVT functions using ResInsight's PVT plotting window.  The plots below show that with the new normalisation code we produce the same visual output as for the case of ECLIPSE.  Before (i.e., in the current master) we were producing confusing results.

Generator | Oil PVT | Gas PVT
---------|-----------|-----------
Current Master | ![PVTO Master](https://user-images.githubusercontent.com/1871438/55426121-4b5de700-5584-11e9-852d-b2dcfee02502.PNG) | ![PVTG Master](https://user-images.githubusercontent.com/1871438/55426136-53b62200-5584-11e9-910f-cdbe9db43945.PNG)
This PR | ![PVTO Dev](https://user-images.githubusercontent.com/1871438/55426167-67618880-5584-11e9-83e7-7b299888ba89.PNG) | ![PVTG Dev](https://user-images.githubusercontent.com/1871438/55426183-70eaf080-5584-11e9-8ead-27d59ef7043e.PNG)
ECLIPSE | ![PVTO Eclipse](https://user-images.githubusercontent.com/1871438/55426198-7cd6b280-5584-11e9-9f72-665c3196e931.PNG) | ![PVTG Eclipse](https://user-images.githubusercontent.com/1871438/55426215-83652a00-5584-11e9-948a-771500491380.PNG)

