### PR TITLE
Implement FILEUNIT

### DIFF
--- a/opm/parser/eclipse/EclipseState/checkDeck.hpp
+++ b/opm/parser/eclipse/EclipseState/checkDeck.hpp
@@ -26,6 +26,8 @@ namespace Opm {
 
     class Deck;
     class Parser;
+    class ParseContext;
+    class ErrorGuard;
 
 enum DeckChecks {
     SectionTopology = 0x0001,
@@ -40,7 +42,7 @@ enum DeckChecks {
 
 // some semantical correctness checks of the deck. this method adds a warning to
 // the deck object if any issue is found ...
-bool checkDeck( const Deck& deck, const Parser&, size_t enabledChecks = AllChecks);
+bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& parseContext, ErrorGuard& errorGuard, size_t enabledChecks  = AllChecks);
 
 }
 

--- a/opm/parser/eclipse/EclipseState/checkDeck.hpp
+++ b/opm/parser/eclipse/EclipseState/checkDeck.hpp
@@ -40,7 +40,7 @@ enum DeckChecks {
 
 // some semantical correctness checks of the deck. this method adds a warning to
 // the deck object if any issue is found ...
-bool checkDeck( Deck& deck, const Parser&, size_t enabledChecks = AllChecks);
+bool checkDeck( const Deck& deck, const Parser&, size_t enabledChecks = AllChecks);
 
 }
 

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -218,6 +218,12 @@ namespace Opm {
         const static std::string PARSE_LONG_KEYWORD;
 
         /*
+          The unit system specified via the FILEUNIT keyword is different from the unit
+          system used by the deck.
+        */
+        const static std::string UNIT_SYSTEM_MISMATCH;
+
+        /*
           Some property modfiers can be modified in the Schedule
           section; this effectively means that Eclipse supports time
           dependent geology. This is marked as an exocit special

--- a/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -24,9 +24,11 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 namespace Opm {
-bool checkDeck( const Deck& deck, const Parser& parser, size_t enabledChecks) {
+bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& parseContext, ErrorGuard& errorGuard, size_t enabledChecks) {
     bool deckValid = true;
 
     // make sure that the deck does not contain unknown keywords

--- a/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -50,6 +50,21 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
         deckValid = deckValid && Section::checkSectionTopology(deck, parser, ensureKeywordSection);
     }
 
+    const std::string& deckUnitSystem = deck.getActiveUnitSystem().getName();
+    for (const auto& keyword : deck.getKeywordList("FILEUNIT")) {
+        const std::string& fileUnitSystem =
+            keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0);
+        if (fileUnitSystem != deckUnitSystem) {
+            std::string msg =
+                "Unit system " + fileUnitSystem + " specified via the FILEUNIT keyword at "
+                + keyword->getFileName() + ":" + std::to_string(keyword->getLineNumber())
+                + " does not correspond to the unit system used by the deck ("
+                + deckUnitSystem + ")";
+            parseContext.handleError(ParseContext::UNIT_SYSTEM_MISMATCH, msg, errorGuard);
+            deckValid = false;
+        }
+    }
+
     return deckValid;
 }
 }

--- a/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -26,7 +26,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 namespace Opm {
-bool checkDeck( Deck& deck, const Parser& parser, size_t enabledChecks) {
+bool checkDeck( const Deck& deck, const Parser& parser, size_t enabledChecks) {
     bool deckValid = true;
 
     // make sure that the deck does not contain unknown keywords

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -79,6 +79,8 @@ namespace Opm {
         addKey(PARSE_MISSING_INCLUDE, InputError::EXIT1);
         addKey(PARSE_LONG_KEYWORD, InputError::WARN);
 
+        addKey(UNIT_SYSTEM_MISMATCH, InputError::THROW_EXCEPTION);
+
         this->addKey(RUNSPEC_NUMWELLS_TOO_LARGE, InputError::DELAYED_EXIT1);
         this->addKey(RUNSPEC_CONNS_PER_WELL_TOO_LARGE, InputError::DELAYED_EXIT1);
         this->addKey(RUNSPEC_NUMGROUPS_TOO_LARGE, InputError::DELAYED_EXIT1);
@@ -309,6 +311,8 @@ namespace Opm {
     const std::string ParseContext::PARSE_MISSING_SECTIONS = "PARSE_MISSING_SECTIONS";
     const std::string ParseContext::PARSE_MISSING_INCLUDE = "PARSE_MISSING_INCLUDE";
     const std::string ParseContext::PARSE_LONG_KEYWORD = "PARSE_LONG_KEYWORD";
+
+    const std::string ParseContext::UNIT_SYSTEM_MISMATCH = "UNIT_SYSTEM_MISMATCH";
 
     const std::string ParseContext::RUNSPEC_NUMWELLS_TOO_LARGE = "RUNSPEC_NUMWELLS_TOO_LARGE";
     const std::string ParseContext::RUNSPEC_CONNS_PER_WELL_TOO_LARGE = "RUNSPEC_CONNS_PER_WELL_TOO_LARGE";

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FILEUNIT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FILEUNIT
@@ -1,0 +1,8 @@
+{
+ "name": "FILEUNIT",
+ "sections": ["GRID", "EDIT", "PROPS", "REGIONS", "SOLUTION", "SCHEDULE"],
+ "size":1,
+ "items":[
+ {"name" : "FILE_UNIT_SYSTEM", "value_type" : "STRING"}
+]}
+

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -98,6 +98,7 @@ set( keywords
      000_Eclipse100/F/FAULTS
      000_Eclipse100/F/FIELD
      000_Eclipse100/F/FIELD_PROBE
+     000_Eclipse100/F/FILEUNIT
      000_Eclipse100/F/FILLEPS
      000_Eclipse100/F/FIPOWG
      000_Eclipse100/F/FIP_PROBE

--- a/tests/parser/integration/CheckDeckValidity.cpp
+++ b/tests/parser/integration/CheckDeckValidity.cpp
@@ -28,6 +28,8 @@
 
 BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
     Opm::Parser parser;
+    Opm::ParseContext parseContext;
+    Opm::ErrorGuard errorGuard;
 
     {
         const char *correctDeckString =
@@ -50,7 +52,7 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "SCHEDULE\n";
 
         auto deck = parser.parseString(correctDeckString);
-        BOOST_CHECK(Opm::checkDeck(deck, parser));
+        BOOST_CHECK(Opm::checkDeck(deck, parser, parseContext, errorGuard));
     }
 
     {
@@ -63,8 +65,8 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "SCHEDULE\n";
 
         auto deck = parser.parseString(correctDeckString);
-        BOOST_CHECK(!Opm::checkDeck(deck, parser));
-        BOOST_CHECK(Opm::checkDeck(deck, parser, ~Opm::SectionTopology));
+        BOOST_CHECK(!Opm::checkDeck(deck, parser, parseContext, errorGuard));
+        BOOST_CHECK(Opm::checkDeck(deck, parser, parseContext, errorGuard, ~Opm::SectionTopology));
     }
 
     {
@@ -89,13 +91,13 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "SCHEDULE\n";
 
         auto deck = parser.parseString(incorrectDeckString);
-        BOOST_CHECK(!Opm::checkDeck(deck, parser));
+        BOOST_CHECK(!Opm::checkDeck(deck, parser, parseContext, errorGuard));
 
         // this is supposed to succeed as we don't ensure that all keywords are in the
         // correct section
-        BOOST_CHECK(Opm::checkDeck(deck, parser, Opm::SectionTopology));
+        BOOST_CHECK(Opm::checkDeck(deck, parser, parseContext, errorGuard, Opm::SectionTopology));
 
         // this fails because of the incorrect BOX keyword
-        BOOST_CHECK(!Opm::checkDeck(deck, parser, Opm::SectionTopology | Opm::KeywordSection));
+        BOOST_CHECK(!Opm::checkDeck(deck, parser, parseContext, errorGuard, Opm::SectionTopology | Opm::KeywordSection));
     }
 }


### PR DESCRIPTION
This PR is incomplete as a full implementation would imply a major rewrite of the core parser. the rationale for this is to make it easier to use deck editors which like to add this keyword to all files (petrel?): it causes the parser not to trip if it encounters FILEUNIT and also, the `Opm::checkDeck()` function prints a warning if a unit system specified via FILEUNIT is not identical to the unit system of the deck.