### PR TITLE
Refactor WellProductionProperties construction

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -194,7 +194,6 @@ namespace Opm
         DynamicState<std::shared_ptr<UDQInput>> udq_config;
         RFTConfig rft_config;
 
-        WellProducer::ControlModeEnum m_controlModeWHISTCTL;
         Actions m_actions;
 
         std::vector< Well* > getWells(const std::string& wellNamePattern, const std::vector<std::string>& matching_wells = {});
@@ -248,7 +247,7 @@ namespace Opm
         void handleDRVDTR( const DeckKeyword& keyword, size_t currentStep);
         void handleVAPPARS( const DeckKeyword& keyword, size_t currentStep);
         void handleWECON( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
-        void handleWHISTCTL(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword);
+        void handleWHISTCTL(const DeckKeyword& keyword, std::size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleMESSAGES(const DeckKeyword& keyword, size_t currentStep);
         void handleVFPPROD(const DeckKeyword& vfpprodKeyword, const UnitSystem& unit_system, size_t currentStep);
         void handleVFPINJ(const DeckKeyword& vfpprodKeyword, const UnitSystem& unit_system, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp
@@ -48,19 +48,12 @@ namespace Opm {
         int     VFPTableNumber = 0;
         double  ALQValue    = 0.0;
         bool    predictionMode = false;
-
         WellProducer::ControlModeEnum controlMode = WellProducer::CMODE_UNDEFINED;
+        WellProducer::ControlModeEnum whistctl_cmode = WellProducer::CMODE_UNDEFINED;
 
         bool operator==(const WellProductionProperties& other) const;
         bool operator!=(const WellProductionProperties& other) const;
         WellProductionProperties();
-        WellProductionProperties (const DeckRecord& record,
-                                  bool prediction_mode,
-                                  const WellProductionProperties& prev_properties,
-                                  WellProducer::ControlModeEnum controlModeWHISTCTL,
-                                  bool switching_from_injector,
-                                  bool addGrupProductionControl);
-
 
         bool hasProductionControl(WellProducer::ControlModeEnum controlModeArg) const {
             return (m_productionControls & controlModeArg) != 0;
@@ -78,20 +71,17 @@ namespace Opm {
 
         // this is used to check whether the specified control mode is an effective history matching production mode
         static bool effectiveHistoryProductionControl(const WellProducer::ControlModeEnum cmode);
+        void handleWCONPROD( const DeckRecord& record);
+        void handleWCONHIST( const DeckRecord& record);
+        void resetDefaultBHPLimit();
 
     private:
         int m_productionControls = 0;
         void init_rates( const DeckRecord& record );
 
-        void init_history(const WellProductionProperties& prevProperties,
-                          const DeckRecord& record,
-                          const WellProducer::ControlModeEnum controlModeWHISTCL,
-                          const bool switching_from_injector);
+        void init_history(const DeckRecord& record);
 
-        void init_prediction( const DeckRecord& record, bool addGroupProductionControl );
         WellProductionProperties(const DeckRecord& record);
-
-        void resetDefaultBHPLimit();
 
         void setBHPLimit(const double limit);
 


### PR DESCRIPTION
Use default copy constructor and handleWCONPROD() and handleWCONHIST() for
prediction and history wells respectively. With this PR the carrying of state from one timestep to the next has (hopefully) become clearer and less error prone.

Purpose is again simplification of "the big well refactor".