### PR TITLE
Internalize UDQ tokens in the UDQ define keyword

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
@@ -58,12 +58,10 @@ public:
     UDQWellSet eval_wells(const UDQContext& context) const;
     UDQSet eval(const UDQContext& context) const;
     const std::string& keyword() const;
-    /*
-      Should not be internalized at all - and will go away; but temporarily needed for testing.
-    */
-    std::vector<std::string> tokens;
+    const std::vector<std::string>& tokens() const;
     UDQVarType  var_type() const;
 private:
+    std::vector<std::string> input_tokens;
     const UDQParams& udq_params;  // Beacuse of the shared RNG stream this must be a reference.
     std::string m_keyword;
     std::shared_ptr<UDQASTNode> ast;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -122,7 +122,7 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
         }
     }
     this->ast = std::make_shared<UDQASTNode>( UDQParser::parse(this->udq_params, tokens, parseContext, errors) );
-    this->tokens = tokens;
+    this->input_tokens = tokens;
 }
 
 
@@ -143,6 +143,9 @@ UDQVarType UDQDefine::var_type() const {
     return this->m_var_type;
 }
 
+const std::vector<std::string>& UDQDefine::tokens() const {
+    return this->input_tokens;
+}
 
 const std::string& UDQDefine::keyword() const {
     return this->m_keyword;

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -924,13 +924,13 @@ BOOST_AUTO_TEST_CASE(UDQPARSE_TEST1) {
     UDQDefine def1(udqp, "WUBHP", {"1/(WWCT", "'W1*')"});
     std::vector<std::string> tokens1 = {"1", "/", "(", "WWCT", "W1*", ")"};
     BOOST_CHECK_EQUAL_COLLECTIONS(tokens1.begin(), tokens1.end(),
-                                  def1.tokens.begin(), def1.tokens.end());
+                                  def1.tokens().begin(), def1.tokens().end());
 
 
     UDQDefine def2(udqp, "WUBHP", {"2*(1",  "+" , "WBHP)"});
     std::vector<std::string> tokens2 = {"2", "*", "(", "1", "+", "WBHP", ")"};
     BOOST_CHECK_EQUAL_COLLECTIONS(tokens2.begin(), tokens2.end(),
-                                  def2.tokens.begin(), def2.tokens.end());
+                                  def2.tokens().begin(), def2.tokens().end());
 }
 
 


### PR DESCRIPTION
@jalvestad : With this you should get the udq tokens in a reasonably digestiible form, the tokens returned here assumed to space separated - i.e. the output string should be something like
```python
s = " ".join(tokens)
```
in Python speak. The tokens do not replicate the input exactly - in particular:

1. Quotes around string identifiers has been removed.
2. The input string has been split on separators - i.e. `"'FOPT'*2"` &rightarrow; `{"FOPT", "*", "2"}`

I *think* this is the form that should be used when storing in the `ZUDL` vector.
```C++
const auto& udq_input = schedule.getUDQConfig( time_step );
const auto& udq_defs = udq_input.definitions();

for (const auto& udq_def : udq_defs) {
     const std::vector<std::string>& tokens = udq_def.tokens();
     ....
}
```