### PR TITLE
Aquancon: don't segfault if an element's influx_coeff is a null pointer

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
@@ -223,7 +223,15 @@ namespace Opm {
                                     {
                                         if (element1.global_index == element2.global_index)
                                         {
-                                            *(element1.influx_coeff) += *(element2.influx_coeff);
+                                            if (element1.influx_coeff != nullptr && element2.influx_coeff != nullptr)
+                                                *(element1.influx_coeff) += *(element2.influx_coeff);
+                                            else {
+                                                static bool warningPrinted = false;
+                                                if (!warningPrinted) {
+                                                    std::cerr << "WARNING: there's something fishy with AQCON\n";
+                                                    warningPrinted = true;
+                                                }
+                                            }
                                             return true;
                                         }
 


### PR DESCRIPTION
I'm not sure when this happens, but it can definitely happen. Possibly if a cell is inactive?