### PR TITLE
fix FILEUNIT

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -50,10 +50,10 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
         deckValid = deckValid && Section::checkSectionTopology(deck, parser, ensureKeywordSection);
     }
 
-    const std::string& deckUnitSystem = deck.getActiveUnitSystem().getName();
+    const std::string& deckUnitSystem = boost::to_upper_copy(deck.getActiveUnitSystem().getName());
     for (const auto& keyword : deck.getKeywordList("FILEUNIT")) {
         const std::string& fileUnitSystem =
-            keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0);
+            boost::to_upper_copy(keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0));
         if (fileUnitSystem != deckUnitSystem) {
             std::string msg =
                 "Unit system " + fileUnitSystem + " specified via the FILEUNIT keyword at "


### PR DESCRIPTION
the FILEUNIT functionality currently does not work because the name of the unit system specified by the keyword is almost always fully capitalized (e.g., "FIELD"), while the name of the unit system returned by the parser isn't (e.g., "Field"). This patch "fixes" this by simply capitalizing all strings.