### PR TITLE
Removes nearly all warnings experienced with g++-8.3

### DIFF
--- a/examples/msim.cpp
+++ b/examples/msim.cpp
@@ -30,7 +30,7 @@
 #include <opm/msim/msim.hpp>
 
 
-int main(int argc, char** argv) {
+int main(int /* argc */, char** argv) {
     std::string deck_file = argv[1];
     Opm::Parser parser;
     Opm::ParseContext parse_context;

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -51,7 +51,7 @@ void msim::run(Schedule& schedule, EclipseIO& io) {
 }
 
 
-void msim::post_step(Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const {
+void msim::post_step(Schedule& schedule, data::Solution& /* sol */, data::Wells& /* well_data */, size_t report_step, EclipseIO& io) const {
     const auto& actions = schedule.actions();
     if (actions.empty())
         return;
@@ -98,7 +98,7 @@ void msim::run_step(const Schedule& schedule, data::Solution& sol, data::Wells& 
 
 
 
-void msim::output(size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const {
+void msim::output(size_t report_step, bool /* substep */, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const {
     RestartValue value(sol, well_data);
     io.writeTimeStep(report_step,
                      false,

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -53,9 +53,9 @@ namespace {
         return inteHead[19];
     }
 
-    const int groupType(const Opm::Schedule& sched,
+    int groupType(const Opm::Schedule& sched,
 		      const Opm::Group& group,
-		      const std::size_t simStep)
+		      std::size_t simStep)
     {
 	const std::string& groupName = group.name();
 	if (!sched.hasGroup(groupName))
@@ -118,7 +118,7 @@ namespace {
 	return groupIndexMap;
     }
 
-    const int currentGroupLevel(const Opm::Schedule& sched, const Opm::Group& group, const size_t simStep)
+    int currentGroupLevel(const Opm::Schedule& sched, const Opm::Group& group, size_t simStep)
     {
 	int level = 0;
 	const std::vector< const Opm::Group* >  groups = sched.getGroups(simStep);
@@ -462,8 +462,8 @@ namespace {
 void
 Opm::RestartIO::Helpers::groupMaps::
 currentGrpTreeNameSeqIndMap(const Opm::Schedule&                        sched,
-                            const size_t                                simStep,
-                            const std::map<const std::string , size_t>& GnIMap,
+                            size_t                                      simStep,
+                            const std::map<const std::string , size_t>& /* GnIMap */,
                             const std::map<size_t, const Opm::Group*>&  IGMap)
     {
 	const auto& grpTreeNSIMap = (sched.getGroupTree(simStep)).nameSeqIndMap();
@@ -545,7 +545,7 @@ captureDeclaredGroupData(const Opm::Schedule&                 sched,
 
     // Define Static Contributions to SGrp Array.
     groupLoop(curGroups,
-        [this](const Group& group, const std::size_t groupID) -> void
+              [this](const Group& /* group */, std::size_t groupID) -> void
     {
         auto sw = this->sGroup_[groupID];
         SGrp::staticContrib(sw);

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -55,7 +55,7 @@ namespace {
 
     int groupType(const Opm::Schedule& sched,
 		      const Opm::Group& group,
-		      std::size_t simStep)
+                      const std::size_t simStep)
     {
 	const std::string& groupName = group.name();
 	if (!sched.hasGroup(groupName))
@@ -118,7 +118,7 @@ namespace {
 	return groupIndexMap;
     }
 
-    int currentGroupLevel(const Opm::Schedule& sched, const Opm::Group& group, size_t simStep)
+    int currentGroupLevel(const Opm::Schedule& sched, const Opm::Group& group, const size_t simStep)
     {
 	int level = 0;
 	const std::vector< const Opm::Group* >  groups = sched.getGroups(simStep);
@@ -462,7 +462,7 @@ namespace {
 void
 Opm::RestartIO::Helpers::groupMaps::
 currentGrpTreeNameSeqIndMap(const Opm::Schedule&                        sched,
-                            size_t                                      simStep,
+                            const size_t                                      simStep,
                             const std::map<const std::string , size_t>& /* GnIMap */,
                             const std::map<size_t, const Opm::Group*>&  IGMap)
     {
@@ -545,7 +545,7 @@ captureDeclaredGroupData(const Opm::Schedule&                 sched,
 
     // Define Static Contributions to SGrp Array.
     groupLoop(curGroups,
-              [this](const Group& /* group */, std::size_t groupID) -> void
+              [this](const Group& /* group */, const std::size_t groupID) -> void
     {
         auto sw = this->sGroup_[groupID];
         SGrp::staticContrib(sw);

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -416,7 +416,7 @@ namespace {
         void staticContrib(const Opm::Well&        well,
                            const std::size_t       rptStep,
                            const std::vector<int>& inteHead,
-			   const Opm::EclipseGrid&  grid,
+			   const Opm::EclipseGrid&  /* grid */,
                            ISegArray&              iSeg
 			  )
         {

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -265,7 +265,7 @@ namespace {
                            const std::size_t               msWellID,
                            const std::map <const std::string, size_t>&  GroupMapNameInd,
 			   /*const std::vector<std::string>& groupNames,*/
-                           const int                       maxGroups,
+                           const int                       /* maxGroups */,
                            const std::size_t               sim_step,
                            IWellArray&                     iWell)
         {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
@@ -41,7 +41,7 @@ namespace {
                            const Opm::ParseContext& ctxt,
                            Opm::ErrorGuard&         guard)
         {
-            const auto nWells = sched.numWells();
+            auto nWells = sched.numWells();
 
             if (nWells > static_cast<decltype(nWells)>(wdims.maxWellsInField()))
             {
@@ -83,7 +83,7 @@ namespace {
                             const Opm::ParseContext& ctxt,
                             Opm::ErrorGuard&         guard)
         {
-            const auto nGroups = sched.numGroups();
+            auto nGroups = sched.numGroups();
 
             // Note: "1 +" to account for FIELD group being in 'sched.numGroups()'
             //   but excluded from WELLDIMS(3).

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
@@ -41,9 +41,9 @@ namespace {
                            const Opm::ParseContext& ctxt,
                            Opm::ErrorGuard&         guard)
         {
-            auto nWells = sched.numWells();
+            const auto nWells = sched.numWells();
 
-            if (nWells > static_cast<decltype(nWells)>(wdims.maxWellsInField()))
+            if (nWells > std::size_t(wdims.maxWellsInField()))
             {
                 std::ostringstream os;
                 os << "Run uses " << nWells << " wells, but allocates at "
@@ -83,11 +83,11 @@ namespace {
                             const Opm::ParseContext& ctxt,
                             Opm::ErrorGuard&         guard)
         {
-            auto nGroups = sched.numGroups();
+            const auto nGroups = sched.numGroups();
 
             // Note: "1 +" to account for FIELD group being in 'sched.numGroups()'
             //   but excluded from WELLDIMS(3).
-            if (nGroups > 1 + static_cast<decltype(nGroups)>(wdims.maxGroupsInField()))
+            if (nGroups > 1U + wdims.maxGroupsInField())
             {
                 std::ostringstream os;
                 os << "Run uses " << (nGroups - 1) << " non-FIELD groups, but "

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
@@ -150,7 +150,7 @@ std::size_t RFTConfig::firstRFTOutput() const {
 
     for (const auto& rft_pair : this->plt_config) {
         const auto& dynamic_state = rft_pair.second;
-        auto pred = [] (const std::pair<PLTConnections::PLTEnum, std::size_t>& elm) { return false; };
+        auto pred = [] (const std::pair<PLTConnections::PLTEnum, std::size_t>& ) { return false; };
         int this_first_rft = dynamic_state.find_if(pred);
         if (this_first_rft >= 0)
             first_rft = std::min(first_rft, static_cast<std::size_t>(this_first_rft));

--- a/src/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.cpp
@@ -29,7 +29,7 @@ namespace Opm {
         {
         }
 
-        void Rock2dTable::init(const DeckRecord& record, size_t tableIdx)
+        void Rock2dTable::init(const DeckRecord& record, size_t /* tableIdx */)
         {
             m_pressureValues.push_back(record.getItem("PRESSURE").getSIDoubleData()[0]);
             m_pvmultValues.push_back(record.getItem("PVMULT").getSIDoubleData());

--- a/src/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
@@ -29,7 +29,7 @@ namespace Opm {
         {
         }
 
-        void Rock2dtrTable::init(const DeckRecord& record, size_t tableIdx)
+        void Rock2dtrTable::init(const DeckRecord& record, size_t /* tableIdx */)
         {
             m_pressureValues.push_back(record.getItem("PRESSURE").getSIDoubleData()[0]);
             m_transMultValues.push_back(record.getItem("TRANSMULT").getSIDoubleData());

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -322,7 +322,7 @@ void ParserState::loadFile(const boost::filesystem::path& inputFile) {
     boost::filesystem::path inputFileCanonical;
     try {
         inputFileCanonical = boost::filesystem::canonical(inputFile);
-    } catch (boost::filesystem::filesystem_error fs_error) {
+    } catch (const boost::filesystem::filesystem_error& fs_error) {
         std::string msg = "Could not open file: " + inputFile.string();
         parseContext.handleError( ParseContext::PARSE_MISSING_INCLUDE , msg, errors);
         return;

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -44,12 +44,12 @@
 using namespace Opm;
 
 
-double prod_opr(const EclipseState&  es, const Schedule& sched, const data::Solution& sol, size_t report_step, double seconds_elapsed) {
+double prod_opr(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double seconds_elapsed) {
     const auto& units = es.getUnits();
     return -units.to_si(UnitSystem::measure::rate, seconds_elapsed);
 }
 
-void pressure(const EclipseState& es, const Schedule& sched, data::Solution& sol, size_t report_step, double seconds_elapsed) {
+void pressure(const EclipseState& es, const Schedule& /* sched */, data::Solution& sol, size_t /* report_step */, double seconds_elapsed) {
     const auto& grid = es.getInputGrid();
     const auto& units = es.getUnits();
     if (!sol.has("PRESSURE"))

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -66,25 +66,25 @@ struct test_data {
 };
 
 
-double prod_opr(const EclipseState&  es, const Schedule& sched, const data::Solution& sol, size_t report_step, double seconds_elapsed) {
+double prod_opr(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double oil_rate = 1.0;
     return -units.to_si(UnitSystem::measure::rate, oil_rate);
 }
 
-double prod_opr_low(const EclipseState&  es, const Schedule& sched, const data::Solution& sol, size_t report_step, double seconds_elapsed) {
+double prod_opr_low(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double oil_rate = 0.5;
     return -units.to_si(UnitSystem::measure::rate, oil_rate);
 }
 
-double prod_wpr_P1(const EclipseState&  es, const Schedule& sched, const data::Solution& sol, size_t report_step, double seconds_elapsed) {
+double prod_wpr_P1(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double water_rate = 0.0;
     return -units.to_si(UnitSystem::measure::rate, water_rate);
 }
 
-double prod_wpr_P2(const EclipseState&  es, const Schedule& sched, const data::Solution& sol, size_t report_step, double seconds_elapsed) {
+double prod_wpr_P2(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double water_rate = 0.0;
     if (report_step > 5)
@@ -93,13 +93,13 @@ double prod_wpr_P2(const EclipseState&  es, const Schedule& sched, const data::S
     return -units.to_si(UnitSystem::measure::rate, water_rate);
 }
 
-double prod_wpr_P3(const EclipseState&  es, const Schedule& sched, const data::Solution& sol, size_t report_step, double seconds_elapsed) {
+double prod_wpr_P3(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double water_rate = 0.0;
     return -units.to_si(UnitSystem::measure::rate, water_rate);
 }
 
-double prod_wpr_P4(const EclipseState&  es, const Schedule& sched, const data::Solution& sol, size_t report_step, double seconds_elapsed) {
+double prod_wpr_P4(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double water_rate = 0.0;
     if (report_step > 10)

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -71,7 +71,7 @@ struct MockIH
 
 MockIH::MockIH(const int numWells,
 	       const int nsegWell,
-	       const int ncwMax,
+	       const int /* ncwMax */,
 	       const int iConnPerConn,
 	       const int sConnPerConn,
 	       const int xConnPerConn)


### PR DESCRIPTION
Namely:
- unused parameter
- type qualifiers ignored ...
- catchinhg polymorphic type ... by value