### PR TITLE
UDA values in the deck

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -45,6 +45,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/Deck/DeckRecord.cpp
     src/opm/parser/eclipse/Deck/DeckOutput.cpp
     src/opm/parser/eclipse/Deck/Section.cpp
+    src/opm/parser/eclipse/Deck/UDAValue.cpp
     src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
     src/opm/parser/eclipse/EclipseState/Aquifetp.cpp
     src/opm/parser/eclipse/EclipseState/Aquancon.cpp
@@ -552,6 +553,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/Deck/DeckOutput.hpp
        opm/parser/eclipse/Deck/DeckKeyword.hpp
        opm/parser/eclipse/Deck/DeckRecord.hpp
+       opm/parser/eclipse/Deck/UDAValue.hpp
        opm/parser/eclipse/RawDeck/StarToken.hpp
        opm/parser/eclipse/RawDeck/RawEnums.hpp
        opm/parser/eclipse/RawDeck/RawRecord.hpp

--- a/GenerateKeywords.cmake
+++ b/GenerateKeywords.cmake
@@ -1,5 +1,6 @@
 set(genkw_SOURCES src/opm/json/JsonObject.cpp
                   src/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
+                  src/opm/parser/eclipse/Deck/UDAValue.cpp
                   src/opm/parser/eclipse/Deck/Deck.cpp
                   src/opm/parser/eclipse/Deck/DeckItem.cpp
                   src/opm/parser/eclipse/Deck/DeckKeyword.cpp

--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -27,6 +27,7 @@
 
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 #include <opm/parser/eclipse/Utility/Typetools.hpp>
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
 
 namespace Opm {
     class DeckOutput;
@@ -39,6 +40,7 @@ namespace Opm {
         DeckItem( const std::string&, int, size_t size_hint = 8 );
         DeckItem( const std::string&, double, size_t size_hint = 8 );
         DeckItem( const std::string&, std::string, size_t size_hint = 8 );
+        DeckItem( const std::string&, UDAValue, size_t size_hint = 8 );
 
         const std::string& name() const;
 
@@ -58,6 +60,7 @@ namespace Opm {
         size_t size() const;
         size_t out_size() const;
 
+        //template< typename T > T& get( size_t ) ;
         template< typename T > const T& get( size_t ) const;
         double getSIDouble( size_t ) const;
         std::string getTrimmedString( size_t ) const;
@@ -65,12 +68,15 @@ namespace Opm {
         template< typename T > const std::vector< T >& getData() const;
         const std::vector< double >& getSIDoubleData() const;
 
+        void push_back( UDAValue );
         void push_back( int );
         void push_back( double );
         void push_back( std::string );
+        void push_back( UDAValue, size_t );
         void push_back( int, size_t );
         void push_back( double, size_t );
         void push_back( std::string, size_t );
+        void push_backDefault( UDAValue );
         void push_backDefault( int );
         void push_backDefault( double );
         void push_backDefault( std::string );
@@ -107,9 +113,10 @@ namespace Opm {
         bool operator!=(const DeckItem& other) const;
         static bool to_bool(std::string string_value);
     private:
-        std::vector< double > dval;
+        mutable std::vector< double > dval;
         std::vector< int > ival;
         std::vector< std::string > sval;
+        std::vector< UDAValue > uval;
 
         type_tag type = type_tag::unknown;
 

--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -1,0 +1,61 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef UDA_VALUE_HPP
+#define UDA_VALUE_HPP
+
+#include <stdexcept>
+#include <vector>
+#include <string>
+
+#include <opm/parser/eclipse/Units/Dimension.hpp>
+
+namespace Opm {
+
+class UDAValue {
+public:
+    UDAValue();
+    UDAValue(double);
+    UDAValue(const std::string&);
+
+    template<typename T>
+    T get() const;
+
+    template<typename T>
+    bool is() const;
+
+    void set_dim(const Dimension& dim) const;
+    const Dimension& get_dim() const;
+
+    bool operator==(const UDAValue& other) const;
+    bool operator!=(const UDAValue& other) const;
+private:
+    bool numeric_value;
+    double double_value;
+    std::string string_value;
+
+    /* This 'mutable' modifier is a hack to avoid tampering with the overall
+       const-ness of the data in a deck item. */
+    mutable Dimension dim;
+};
+}
+
+
+
+#endif

--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -80,6 +80,7 @@ namespace Opm {
         size_t numDimensions() const;
         const std::string& name() const;
         item_size sizeType() const;
+        type_tag dataType() const;
         void setSizeType(item_size size_type);
         std::string getDescription() const;
         bool scalar() const;
@@ -108,6 +109,7 @@ namespace Opm {
         double dval;
         int ival;
         std::string sval;
+        UDAValue uval;
         std::vector< std::string > dimensions;
 
         std::string m_name;

--- a/opm/parser/eclipse/Units/Dimension.hpp
+++ b/opm/parser/eclipse/Units/Dimension.hpp
@@ -26,7 +26,7 @@ namespace Opm {
 
     class Dimension {
     public:
-        Dimension() = default;
+        Dimension();
         Dimension(const std::string& name, double SIfactor, double SIoffset = 0.0);
 
         double getSIScaling() const;

--- a/opm/parser/eclipse/Utility/Typetools.hpp
+++ b/opm/parser/eclipse/Utility/Typetools.hpp
@@ -1,16 +1,15 @@
 #ifndef OPM_TYPETOOLS_HPP
 #define OPM_TYPETOOLS_HPP
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
 
 namespace Opm {
 
 enum class type_tag {
-    /* for python interop as well as queries, must be manually synchronised
-     * with cdeck_item.cc and opm/deck/item_type_enum.py
-     */
     unknown = 0,
     integer = 1,
     string  = 2,
     fdouble = 3,
+    uda     = 4,
 };
 
 inline std::string tag_name( type_tag x ) {
@@ -18,21 +17,28 @@ inline std::string tag_name( type_tag x ) {
         case type_tag::integer: return "int";
         case type_tag::string:  return "std::string";
         case type_tag::fdouble: return "double";
+        case type_tag::uda:     return "UDAValue";
         case type_tag::unknown: return "unknown";
-
     }
     return "unknown";
 }
 
 template< typename T > type_tag get_type();
+
 template<> inline type_tag get_type< int >() {
     return type_tag::integer;
 }
+
 template<> inline type_tag get_type< double >() {
     return type_tag::fdouble;
 }
+
 template<> inline type_tag get_type< std::string >() {
     return type_tag::string;
+}
+
+template<> inline type_tag get_type<UDAValue>() {
+  return type_tag::uda;
 }
 
 }

--- a/src/opm/parser/eclipse/Deck/DeckOutput.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckOutput.cpp
@@ -20,6 +20,7 @@
 #include <ostream>
 
 #include <opm/parser/eclipse/Deck/DeckOutput.hpp>
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
 
 
 namespace Opm {
@@ -82,6 +83,14 @@ namespace Opm {
         this->os << value;
     }
 
+    template <>
+    void DeckOutput::write_value( const UDAValue& value ) {
+        if (value.is<double>())
+            this->write_value(value.get<double>());
+        else
+            this->write_value(value.get<std::string>());
+    }
+
     void DeckOutput::stash_default( ) {
         this->default_count++;
     }
@@ -132,4 +141,5 @@ namespace Opm {
     template void DeckOutput::write( const int& value);
     template void DeckOutput::write( const double& value);
     template void DeckOutput::write( const std::string& value);
+    template void DeckOutput::write( const UDAValue& value);
 }

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -1,0 +1,96 @@
+/*
+  Copyright 2019 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
+
+
+namespace Opm {
+
+UDAValue::UDAValue(double value):
+    numeric_value(true),
+    double_value(value)
+{
+}
+
+
+UDAValue::UDAValue() :
+    UDAValue(0)
+{}
+
+UDAValue::UDAValue(const std::string& value):
+    numeric_value(false),
+    string_value(value)
+{
+}
+
+
+template<>
+bool UDAValue::is<double>() const {
+    return this->numeric_value;
+}
+
+
+template<>
+bool UDAValue::is<std::string>() const {
+  return !this->numeric_value;
+}
+
+
+template<>
+double UDAValue::get() const {
+    if (this->numeric_value)
+        return this->double_value;
+
+    throw std::invalid_argument("UDAValue does not hold a numerical value");
+}
+
+template<>
+std::string UDAValue::get() const {
+    if (!this->numeric_value)
+        return this->string_value;
+
+    throw std::invalid_argument("UDAValue does not hold a string value");
+}
+
+
+void UDAValue::set_dim(const Dimension& dim) const {
+    this->dim = dim;
+}
+
+const Dimension& UDAValue::get_dim() const {
+    return this->dim;
+}
+
+
+bool UDAValue::operator==(const UDAValue& other) const {
+    if (this->numeric_value != other.numeric_value)
+        return false;
+
+    if (this->numeric_value)
+        return (this->double_value == other.double_value);
+
+    return this->string_value == other.string_value;
+}
+
+
+bool UDAValue::operator!=(const UDAValue& other) const {
+    return !(*this == other);
+}
+
+}

--- a/src/opm/parser/eclipse/Generator/KeywordGenerator.cpp
+++ b/src/opm/parser/eclipse/Generator/KeywordGenerator.cpp
@@ -49,6 +49,7 @@ const std::string testHeader =
     "auto unitSystem =  UnitSystem::newMETRIC();\n";
 
 const std::string sourceHeader =
+    "#include <opm/parser/eclipse/Deck/UDAValue.hpp>\n"
     "#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>\n"
     "#include <opm/parser/eclipse/Parser/ParserItem.hpp>\n"
     "#include <opm/parser/eclipse/Parser/ParserRecord.hpp>\n"

--- a/src/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -293,6 +293,18 @@ void ParserItem::push_backDimension( const std::string& dim ) {
 
 
     void ParserItem::setSizeType(item_size size_type) {
+        /*
+          The restriction that data type UDA can only be combined with size_type
+          SINGLE is due to the way units are bolted on to the Deck
+          datastructures after the parsing has completed. UDA values are
+          currently only used as scalars in well/group control and the
+          restriction does not have any effect. If at some stage in the future
+          this should change the way units are applied to the deck must be
+          refactored.
+         */
+        if (this->data_type == type_tag::uda && size_type != item_size::SINGLE)
+            throw std::invalid_argument("Sorry - the UDA datatype can only be used with size type SINGLE");
+
         this->m_sizeType = size_type;
     }
 

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -648,8 +648,6 @@ void set_dimensions( ParserItem& item,
                         {
                             std::string indent3 = local_indent + "   ";
                             ss << item.createCode(indent3);
-                            for (size_t idim=0; idim < item.numDimensions(); idim++)
-                                ss << indent3 <<"item.push_backDimension(\"" << item.getDimension( idim ) << "\");" << '\n';
                             {
                                 std::string addItemMethod = "addItem";
                                 if (isDataKeyword())

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -95,14 +95,14 @@ namespace {
 
 
     void ParserRecord::applyUnitsToDeck( Deck& deck, DeckRecord& deckRecord ) const {
-        for( const auto& item : *this ) {
-            if( !item.hasDimension() ) continue;
+        for( const auto& parser_item : *this ) {
+            if( !parser_item.hasDimension() ) continue;
 
-            auto& deckItem = deckRecord.getItem( item.name() );
+            auto& deckItem = deckRecord.getItem( parser_item.name() );
 
-            for (size_t idim = 0; idim < item.numDimensions(); idim++) {
-                auto activeDimension  = deck.getActiveUnitSystem().getNewDimension( item.getDimension(idim) );
-                auto defaultDimension = deck.getDefaultUnitSystem().getNewDimension( item.getDimension(idim) );
+            for (size_t idim = 0; idim < parser_item.numDimensions(); idim++) {
+                auto activeDimension  = deck.getActiveUnitSystem().getNewDimension( parser_item.getDimension(idim) );
+                auto defaultDimension = deck.getDefaultUnitSystem().getNewDimension( parser_item.getDimension(idim) );
                 deckItem.push_backDimension( activeDimension , defaultDimension );
             }
         }

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -99,11 +99,25 @@ namespace {
             if( !parser_item.hasDimension() ) continue;
 
             auto& deckItem = deckRecord.getItem( parser_item.name() );
-
             for (size_t idim = 0; idim < parser_item.numDimensions(); idim++) {
                 auto activeDimension  = deck.getActiveUnitSystem().getNewDimension( parser_item.getDimension(idim) );
                 auto defaultDimension = deck.getDefaultUnitSystem().getNewDimension( parser_item.getDimension(idim) );
                 deckItem.push_backDimension( activeDimension , defaultDimension );
+            }
+
+            /*
+              A little special casing ... the UDAValue elements in the deck must
+              carry their own dimension. Observe that the
+              ParserItem::setSizeType() method guarantees that UDA data is
+              scalar, i.e. this special case loop can be simpler than the
+              general code in the block above.
+            */
+            if (parser_item.dataType() == type_tag::uda && deckItem.size() > 0) {
+                auto uda = deckItem.get<UDAValue>(0);
+                if (deckItem.defaultApplied(0))
+                    uda.set_dim( deck.getDefaultUnitSystem().getNewDimension( parser_item.getDimension(0)));
+                else
+                    uda.set_dim( deck.getActiveUnitSystem().getNewDimension( parser_item.getDimension(0)));
             }
         }
     }

--- a/src/opm/parser/eclipse/RawDeck/StarToken.cpp
+++ b/src/opm/parser/eclipse/RawDeck/StarToken.cpp
@@ -28,6 +28,7 @@
 
 #include <opm/parser/eclipse/RawDeck/StarToken.hpp>
 #include <opm/parser/eclipse/Utility/Stringview.hpp>
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
 
 namespace qi = boost::spirit::qi;
 
@@ -105,6 +106,7 @@ namespace Opm {
         throw std::invalid_argument( "Malformed floating point number '" + view + "'" );
     }
 
+
     template <>
     std::string readValueToken< std::string >( string_view view ) {
         if( view.size() == 0 || view[ 0 ] != '\'' )
@@ -114,6 +116,17 @@ namespace Opm {
             throw std::invalid_argument("Unable to parse string '" + view + "' as a string token");
 
         return view.substr( 1, view.size() - 1 );
+    }
+
+    template<>
+    UDAValue readValueToken< UDAValue >( string_view view ) {
+        double n = 0;
+        qi::real_parser< double, fortran_double< double > > double_;
+        auto cursor = view.begin();
+        const auto ok = qi::parse( cursor, view.end(), double_, n );
+
+        if( ok && cursor == view.end() ) return UDAValue(n);
+        return UDAValue( readValueToken<std::string>(view) );
     }
 
     void StarToken::init_( const string_view& token ) {

--- a/src/opm/parser/eclipse/Units/Dimension.cpp
+++ b/src/opm/parser/eclipse/Units/Dimension.cpp
@@ -25,6 +25,14 @@
 
 namespace Opm {
 
+    Dimension::Dimension()
+    {
+        this->m_name = "Unit";
+        this->m_SIfactor = 1.0;
+        this->m_SIoffset = 0.0;
+
+    }
+
     Dimension::Dimension(const std::string& name, double SIfactor, double SIoffset)
     {
         for (auto iter = name.begin(); iter != name.end(); ++iter) {

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -24,6 +24,7 @@
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
@@ -953,4 +954,32 @@ BOOST_AUTO_TEST_CASE(UDQPARSE_PARSECONTEXT) {
 
     parseContext.update(ParseContext::UDQ_PARSE_ERROR, InputError::THROW_EXCEPTION);
     BOOST_CHECK_THROW( UDQDefine(udqp, "WUBHP", tokens, parseContext, errors), std::invalid_argument);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(UDA_VALUE) {
+    UDAValue value0;
+    BOOST_CHECK(value0.is<double>());
+    BOOST_CHECK(!value0.is<std::string>());
+    BOOST_CHECK_EQUAL( value0.get<double>(), 0);
+    BOOST_CHECK_THROW( value0.get<std::string>(), std::invalid_argument);
+
+
+    UDAValue value1(10);
+    BOOST_CHECK(value1.is<double>());
+    BOOST_CHECK(!value1.is<std::string>());
+    BOOST_CHECK_EQUAL( value1.get<double>(), 10);
+    BOOST_CHECK_THROW( value1.get<std::string>(), std::invalid_argument);
+
+
+    UDAValue value2("FUBHP");
+    BOOST_CHECK(!value2.is<double>());
+    BOOST_CHECK(value2.is<std::string>());
+    BOOST_CHECK_EQUAL( value2.get<std::string>(), std::string("FUBHP"));
+    BOOST_CHECK_THROW( value2.get<double>(), std::invalid_argument);
+
+
+    std::vector<UDAValue> values;
+    values.resize(100, UDAValue(1000));
 }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -978,8 +978,4 @@ BOOST_AUTO_TEST_CASE(UDA_VALUE) {
     BOOST_CHECK(value2.is<std::string>());
     BOOST_CHECK_EQUAL( value2.get<std::string>(), std::string("FUBHP"));
     BOOST_CHECK_THROW( value2.get<double>(), std::invalid_argument);
-
-
-    std::vector<UDAValue> values;
-    values.resize(100, UDAValue(1000));
 }

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -30,6 +30,12 @@
 
 using namespace Opm;
 
+BOOST_AUTO_TEST_CASE(DefDim) {
+    Dimension dim;
+    BOOST_CHECK_EQUAL(1.0, dim.getSIScaling());
+    BOOST_CHECK( dim.isCompositable() );
+}
+
 BOOST_AUTO_TEST_CASE(CreateDimension) {
     Dimension length("Length" , 1);
     BOOST_CHECK_EQUAL("Length" , length.getName());


### PR DESCRIPTION
*Starting* to use the UDA values. Have introduced a type `UDAValue`which can be string or double, and then use that in the `DeckItem` datastructure. With this work the UDA values are carried all the way into the `Deck` - but the `Schedule`datastructures still ask for double values - updating the `Schedule` layer will be the next step.

Working with this has revealed some less-than-elegant elements of the `{Parser, Deck, UnitSystem}` interaction - the unit system handling in the `UDAValue` implementation is *not* particularly elegant - but it works for now. 

Happy to get some review, but I will go :skier: for a couple of days now and will not respond to review comments.
