### PR TITLE
Add "size" : 1 attribute to CARFIN keyword

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/CARFIN
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/CARFIN
@@ -1,4 +1,6 @@
-{"name" : "CARFIN" , "sections" : ["GRID"], "items" : [
+{"name" : "CARFIN" , "sections" : ["GRID"],
+ "size" : 1,
+ "items" : [
    {"name" : "NAME", "value_type": "STRING"},
    {"name" : "I1", "value_type" : "INT"},
    {"name" : "I2", "value_type" : "INT"},


### PR DESCRIPTION
The keyword `CARFIN` was configured top be slash terminated, it should rather have fixed size = 1. We will now *parse* the CARFIN keyword, but the LGR processing does not work at all ...