### PR TITLE
Remove Schedule::getWells(group, step)

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -124,20 +124,7 @@ namespace Opm
         std::vector< const Well* > getOpenWells(size_t timeStep) const;
         std::vector< const Well* > getWells() const;
         std::vector< const Well* > getWells(size_t timeStep) const;
-
-        /*
-          The overload with a group name argument will return all
-          wells beneath that particular group; i.e.
-
-             getWells("FIELD",t);
-
-          is an inefficient way to get all the wells defined at time
-          't'.
-        */
-        //std::vector< const Group& > getChildGroups(const std::string& group_name, size_t timeStep) const;
-        std::vector< const Group* > getChildGroups(const std::string& group_name, size_t timeStep) const;
-        std::vector< const Well* > getWells(const std::string& group, size_t timeStep) const;
-        std::vector< const Well* > getChildWells(const std::string& group_name, size_t timeStep) const;
+        std::vector< const Well* > getChildWells(const std::string& group_name, size_t timeStep, GroupWellQueryMode query_mode) const;
         const OilVaporizationProperties& getOilVaporizationProperties(size_t timestep) const;
 
         const WellTestConfig& wtestConfig(size_t timestep) const;
@@ -147,6 +134,7 @@ namespace Opm
         void evalAction(const SummaryState& summary_state, size_t timeStep);
 
         const GroupTree& getGroupTree(size_t t) const;
+        std::vector< const Group* > getChildGroups(const std::string& group_name, size_t timeStep) const;
         size_t numGroups() const;
         size_t numGroups(size_t timeStep) const;
         bool hasGroup(const std::string& groupName) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
@@ -310,6 +310,11 @@ namespace Opm {
     }
 
 
+    enum class GroupWellQueryMode {
+        Immediate,
+        Recursive
+    };
+
 }
 
 #endif

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -178,7 +178,7 @@ namespace {
 	  // location nwgmax +1 in the iGrp array
 
 	    const auto childGroups = sched.getChildGroups(group.name(), simStep);
-	    const auto childWells  = sched.getChildWells(group.name(), simStep);
+	    const auto childWells  = sched.getChildWells(group.name(), simStep, Opm::GroupWellQueryMode::Immediate);
 	    const auto groupMapNameIndex =  currentGroupMapNameIndex(sched, simStep, inteHead);
 	    const auto mapIndexGroup = currentGroupMapIndexGroup(sched, simStep, inteHead);
 	    if ((childGroups.size() != 0) && (childWells.size()!=0))

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1086,7 +1086,7 @@ inline std::vector< const Well* > find_wells( const Schedule& schedule,
     if( type == ECL_SMSPEC_GROUP_VAR ) {
         if( !schedule.hasGroup( name ) ) return {};
 
-        return schedule.getWells( name, sim_step );
+        return schedule.getChildWells( name, sim_step, GroupWellQueryMode::Recursive);
     }
 
     if( type == ECL_SMSPEC_FIELD_VAR )

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1661,7 +1661,7 @@ namespace Opm {
       This will recursively go all the way down through the group tree
       until the well leaf-nodes are encountered.
     */
-    std::vector< const Well* > Schedule::getWells(const std::string& group_name, size_t timeStep) const {
+    std::vector< const Well* > Schedule::getChildWells(const std::string& group_name, size_t timeStep, GroupWellQueryMode query_mode) const {
         if (!hasGroup(group_name))
             throw std::invalid_argument("No such group: " + group_name);
         {
@@ -1672,15 +1672,14 @@ namespace Opm {
                 const GroupTree& group_tree = getGroupTree( timeStep );
                 const auto& child_groups = group_tree.children( group_name );
 
-                if (child_groups.size()) {
+                if (child_groups.size() && query_mode == GroupWellQueryMode::Recursive) {
                     for (const auto& child : child_groups) {
-                        const auto& child_wells = getWells( child, timeStep );
+                        const auto& child_wells = getChildWells( child, timeStep, query_mode);
                         wells.insert( wells.end() , child_wells.begin() , child_wells.end());
                     }
                 } else {
-                    for (const auto& well_name : group.getWells( timeStep )) {
+                    for (const auto& well_name : group.getWells( timeStep ))
                         wells.push_back( getWell( well_name ));
-                    }
                 }
             }
             return wells;
@@ -1692,44 +1691,19 @@ namespace Opm {
             throw std::invalid_argument("No such group: " + group_name);
         {
             const auto& group = getGroup( group_name );
-	    std::vector<const Group*> child_groups;
+            std::vector<const Group*> child_groups;
 
             if (group.hasBeenDefined( timeStep )) {
                 const GroupTree& group_tree = getGroupTree( timeStep );
                 const auto& ch_grps = group_tree.children( group_name );
-		//for (const std::string& group_name : ch_grps) {
-		for ( auto it = ch_grps.begin() ; it != ch_grps.end(); it++) {
-                        child_groups.push_back( &getGroup(*it));
-                    }
-	    }
-	    return child_groups;
-	}
-    }
-
-        std::vector< const Well* > Schedule::getChildWells(const std::string& group_name, size_t timeStep) const {
-        if (!hasGroup(group_name))
-            throw std::invalid_argument("No such group: " + group_name);
-        {
-            const auto& group = getGroup( group_name );
-            std::vector<const Well*> wells;
-
-            if (group.hasBeenDefined( timeStep )) {
-                const GroupTree& group_tree = getGroupTree( timeStep );
-                const auto& child_groups = group_tree.children( group_name );
-
-                if (!child_groups.size()) {
-                    //for (const auto& well_name : group.getWells( timeStep )) {
-                    const auto& ch_wells = group.getWells( timeStep );
-                    for (auto it= ch_wells.begin(); it != ch_wells.end(); it++) {
-                        wells.push_back( getWell( *it ));
-                    }
+                //for (const std::string& group_name : ch_grps) {
+                for ( auto it = ch_grps.begin() ; it != ch_grps.end(); it++) {
+                    child_groups.push_back( &getGroup(*it));
                 }
             }
-            return wells;
+            return child_groups;
         }
     }
-
-
 
 
     std::vector< const Well* > Schedule::getWells(size_t timeStep) const {

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -359,10 +359,10 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
 
-    BOOST_CHECK_THROW( schedule.getWells( "NO_SUCH_GROUP" , 1 ), std::invalid_argument);
+    BOOST_CHECK_THROW( schedule.getChildWells( "NO_SUCH_GROUP" , 1 , GroupWellQueryMode::Recursive), std::invalid_argument);
 
     {
-        auto field_wells = schedule.getWells("FIELD" , 0);
+      auto field_wells = schedule.getChildWells("FIELD" , 0, GroupWellQueryMode::Recursive);
         BOOST_CHECK_EQUAL( field_wells.size() , 4U);
 
         BOOST_CHECK( has_well( field_wells, "DW_0" ));
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
     }
 
     {
-        auto platform_wells = schedule.getWells("PLATFORM" , 0);
+      auto platform_wells = schedule.getChildWells("PLATFORM" , 0, GroupWellQueryMode::Recursive);
         BOOST_CHECK_EQUAL( platform_wells.size() , 4U);
 
         BOOST_CHECK( has_well( platform_wells, "DW_0" ));
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
     }
 
     {
-        auto child_wells1 = schedule.getWells("CG1" , 0);
+      auto child_wells1 = schedule.getChildWells("CG1" , 0, GroupWellQueryMode::Recursive);
         BOOST_CHECK_EQUAL( child_wells1.size() , 2U);
 
         BOOST_CHECK( has_well( child_wells1, "DW_0" ));
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
     }
 
     {
-        auto parent_wells2 = schedule.getWells("PG2" , 0);
+      auto parent_wells2 = schedule.getChildWells("PG2" , 0, GroupWellQueryMode::Recursive);
         BOOST_CHECK_EQUAL( parent_wells2.size() , 2U);
 
         BOOST_CHECK( has_well( parent_wells2, "BW_2" ));


### PR DESCRIPTION
The `Schedule`class had two methods
```C++
Schedule::getWells(const std::string& group_name, size_t time_step);
```
and
```C++
Schedule::getChildWells(const std::string& group_name, size_t time_step);
```
the former was recursive, the latter only returned the wells which were immediate children of the `group_name` group. These two functions have been combined in one:
```C++
Schedule::getChildWells(..., Enum query_mode);
```