### PR TITLE
Use wellNames() instead of getWells()

### DIFF
--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -84,10 +84,10 @@ namespace {
 
     std::vector<int>
     serialize_OPM_IWEL(const data::Wells&              wells,
-                       const std::vector<const Well*>& sched_wells)
+                       const std::vector<std::string>& sched_wells)
     {
-        const auto getctrl = [&]( const Well* w ) {
-            const auto itr = wells.find( w->name() );
+      const auto getctrl = [&]( const std::string& wname ) {
+            const auto itr = wells.find( wname );
             return itr == wells.end() ? 0 : itr->second.control;
         };
 
@@ -325,7 +325,7 @@ namespace {
         write_kw(rst_file, "IGRP", groupData.getIGroup());
         write_kw(rst_file, "SGRP", groupData.getSGroup());
         write_kw(rst_file, "XGRP", groupData.getXGroup());
-	write_kw(rst_file, "ZGRP", serialize_ZWEL(groupData.getZGroup()));
+        write_kw(rst_file, "ZGRP", serialize_ZWEL(groupData.getZGroup()));
     }
 
     void writeMSWData(::Opm::RestartIO::ecl_rst_file_type* rst_file,
@@ -376,11 +376,12 @@ namespace {
         if (!ecl_compatible_rst)
         {
             const auto sched_wells = schedule.getWells(sim_step);
+            const auto sched_well_names = schedule.wellNames(sim_step);
 
             const auto opm_xwel =
                 serialize_OPM_XWEL(wells, sim_step, sched_wells, phases, grid);
 
-            const auto opm_iwel = serialize_OPM_IWEL(wells, sched_wells);
+            const auto opm_iwel = serialize_OPM_IWEL(wells, sched_well_names);
 
             write_kw(rst_file, "OPM_IWEL", opm_iwel);
             write_kw(rst_file, "OPM_XWEL", opm_xwel);

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -85,9 +85,7 @@ namespace {
             }
         };
 
-        for (const auto* well : sched.getWells()) {
-            const auto& well_name = well->name();
-
+        for (const auto& well_name : sched.wellNames()) {
             makeEntities('W', well_name);
 
             entities.emplace_back("WBHP" , well_name);
@@ -1125,8 +1123,8 @@ void eval_udq(const Schedule& schedule, std::size_t sim_step, SummaryState& st)
     const auto& func_table = udq.function_table();
     UDQContext context(func_table, st);
     std::vector<std::string> wells;
-    for (const auto* well : schedule.getWells())
-        wells.push_back(well->name());
+    for (const auto& well_name : schedule.wellNames())
+        wells.push_back(well_name);
 
     for (const auto& assign : udq.assignments(UDQVarType::WELL_VAR)) {
         auto ws = assign.eval_wells(wells);

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -168,8 +168,8 @@ inline void keywordW( SummaryConfig::keyword_list& list,
                 list.push_back( SummaryConfig::keyword_type( keyword.name(), well_name ));
         }
     } else
-        for (const auto* well : schedule.getWells())
-            list.push_back( SummaryConfig::keyword_type( keyword.name(),  well->name()));
+        for (const auto& wname : schedule.wellNames())
+            list.push_back( SummaryConfig::keyword_type( keyword.name(),  wname));
   }
 
 

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -388,7 +388,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
     void makeSegmentNodes(const std::size_t               last_timestep,
                           const int                       segID,
                           const DeckKeyword&              keyword,
-                          const std::vector<const Well*>& wells,
+                          const Well*                     well,
                           SummaryConfig::keyword_list&    list)
     {
         // Modifies 'list' in place.
@@ -398,30 +398,27 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
             list.push_back(SummaryConfig::keyword_type( keyword.name(), well, segNumber ));
         };
 
-        for (const auto* well : wells) {
-            if (! isMultiSegmentWell(last_timestep, well)) {
-                // Not an MSW.  Don't create summary vectors for segments.
-                continue;
-            }
+        if (! isMultiSegmentWell(last_timestep, well))
+            // Not an MSW.  Don't create summary vectors for segments.
+            return;
 
-            const auto& wname = well->name();
-            if (segID < 1) {
-                // Segment number defaulted.  Allocate a summary
-                // vector for each segment.
-                const auto nSeg = maxNumWellSegments(last_timestep, well);
+        const auto& wname = well->name();
+        if (segID < 1) {
+            // Segment number defaulted.  Allocate a summary
+            // vector for each segment.
+            const auto nSeg = maxNumWellSegments(last_timestep, well);
 
-                for (auto segNumber = 0*nSeg;
-                          segNumber <   nSeg; ++segNumber)
+            for (auto segNumber = 0*nSeg;
+                 segNumber <   nSeg; ++segNumber)
                 {
                     // One-based segment number.
                     makeNode(wname, segNumber + 1);
                 }
-            }
-            else {
-                // Segment number specified.  Allocate single
-                // summary vector for that segment number.
-                makeNode(wname, segID);
-            }
+        }
+        else {
+            // Segment number specified.  Allocate single
+            // summary vector for that segment number.
+            makeNode(wname, segID);
         }
     }
 
@@ -440,8 +437,9 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
 
         const auto segID = -1;
 
-        makeSegmentNodes(last_timestep, segID, keyword,
-                         schedule.getWells(), list);
+        for (const auto& well : schedule.getWells())
+            makeSegmentNodes(last_timestep, segID, keyword,
+                             well, list);
     }
 
     void keywordSWithRecords(const std::size_t            last_timestep,
@@ -481,11 +479,9 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
             // segment number in record implies all segments.
             const auto segID = record.getItem(1).defaultApplied(0)
                 ? -1 : record.getItem(1).get<int>(0);
-            std::vector<const Well*> wells;
-            for (const auto& well_name : well_names)
-                wells.push_back( schedule.getWell(well_name) );
 
-            makeSegmentNodes(last_timestep, segID, keyword, wells, list);
+            for (const auto& well_name : well_names)
+                makeSegmentNodes(last_timestep, segID, keyword, schedule.getWell(well_name), list);
         }
     }
 


### PR DESCRIPTION
Some sites calling: `Schedule::getWells()` only ever access the *name* of the well, these call sites have been updated to use `Schedule::wellNames()` instead.