### PR TITLE
Add alternative well implementation Well2

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -102,6 +102,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/WList.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.cpp
@@ -506,6 +507,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
        opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
        opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp
+       opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
        opm/parser/eclipse/EclipseState/Schedule/Well/WList.hpp
        opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp
        opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
@@ -90,6 +90,7 @@ namespace Opm {
         // storage index in the vector
         std::map<int, int> segment_number_to_index;
     };
+    std::ostream& operator<<( std::ostream&, const WellSegments& );
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
 
@@ -120,6 +121,9 @@ namespace Opm
         std::vector<std::string> wellNames(size_t timeStep) const;
         std::vector<std::string> wellNames() const;
 
+        void updateWell(std::shared_ptr<Well2> well, size_t reportStep);
+        const Well2& getWell2(const std::string& wellName, size_t timeStep) const;
+        std::vector< const Well2* > getChildWells2(const std::string& group_name, size_t timeStep, GroupWellQueryMode query_mode) const;
         const Well* getWell(const std::string& wellName) const;
         std::vector< const Well* > getOpenWells(size_t timeStep) const;
         std::vector< const Well* > getWells() const;
@@ -167,6 +171,7 @@ namespace Opm
         TimeMap m_timeMap;
         OrderedMap< std::string, Well > m_wells;
         OrderedMap< std::string, Group > m_groups;
+        OrderedMap< std::string, DynamicState<std::shared_ptr<Well2>>> wells_static;
         DynamicState< GroupTree > m_rootGroupTree;
         DynamicState< OilVaporizationProperties > m_oilvaporizationproperties;
         Events m_events;
@@ -188,8 +193,8 @@ namespace Opm
         std::vector< Group* > getGroups(const std::string& groupNamePattern);
         std::map<std::string,Events> well_events;
 
-        void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
-        void addWellToGroup( Group& newGroup , Well& well , size_t timeStep);
+        bool updateWellStatus( const std::string& well, size_t reportStep , WellCommon::StatusEnum status);
+        void addWellToGroup( Group& newGroup , const std::string& wellName , size_t timeStep);
         void iterateScheduleSection(const ParseContext& parseContext ,  ErrorGuard& errors, const SCHEDULESection& , const EclipseGrid& grid,
                                     const Eclipse3DProperties& eclipseProperties);
         bool handleGroupFromWELSPECS(const std::string& groupName, GroupTree& newTree) const;
@@ -199,7 +204,6 @@ namespace Opm
         void handleWLIST(const DeckKeyword& keyword, size_t currentStep);
         void handleCOMPORD(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& compordKeyword, size_t currentStep);
         void handleWELSPECS( const SCHEDULESection&, size_t, size_t  );
-        void handleWCONProducer( const DeckKeyword& keyword, size_t currentStep, bool isPredictionMode,  const ParseContext& parseContext, ErrorGuard& errors);
         void handleWCONHIST( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWCONPROD( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWGRUPCON( const DeckKeyword& keyword, size_t currentStep);
@@ -251,7 +255,7 @@ namespace Opm
                            const UnitSystem& unit_system,
                            std::vector<std::pair<const DeckKeyword*, size_t > >& rftProperties);
         void addWellEvent(const std::string& well, ScheduleEvents::Events event, size_t reportStep);
-#ifdef CHECK_WELLS
+#ifdef WELL_TEST
         bool checkWells(const ParseContext& parseContext, ErrorGuard& errors) const;
 #endif
     };

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
@@ -1,0 +1,169 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef WELL2_HPP
+#define WELL2_HPP
+
+#include <string>
+
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTracerProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.hpp>
+
+
+namespace Opm {
+
+class DeckRecord;
+class EclipseGrid;
+class DeckKeyword;
+
+struct WellGuideRate {
+    bool available;
+    double guide_rate;
+    GuideRate::GuideRatePhaseEnum guide_phase;
+    double scale_factor;
+};
+
+
+class Well2 {
+public:
+    Well2(const std::string& wname,
+          const std::string& gname,
+          std::size_t init_step,
+          std::size_t insert_index,
+          int headI,
+          int headJ,
+          double ref_depth,
+          Phase phase,
+          WellProducer::ControlModeEnum whistctl_cmode,
+          WellCompletion::CompletionOrderEnum ordering);
+
+    bool isMultiSegment() const;
+    bool isAvailableForGroupControl() const;
+    double getGuideRate() const;
+    GuideRate::GuideRatePhaseEnum getGuideRatePhase() const;
+    double getGuideRateScalingFactor() const;
+
+    std::size_t firstTimeStep() const;
+    bool canOpen() const;
+    bool isProducer() const;
+    size_t seqIndex() const;
+    bool getAutomaticShutIn() const;
+    bool getAllowCrossFlow() const;
+    const std::string& name() const;
+    int getHeadI() const;
+    int getHeadJ() const;
+    double getRefDepth() const;
+    double getDrainageRadius() const;
+    double getEfficiencyFactor() const;
+    WellCompletion::CompletionOrderEnum getWellConnectionOrdering() const;
+    const WellProductionProperties& getProductionProperties() const;
+    const WellInjectionProperties& getInjectionProperties() const;
+    const WellEconProductionLimits& getEconLimits() const;
+    const WellPolymerProperties& getPolymerProperties() const;
+    const WellTracerProperties& getTracerProperties() const;
+    const WellConnections& getConnections() const;
+    const WellSegments& getSegments() const;
+    double getSolventFraction() const;
+    WellCommon::StatusEnum getStatus() const;
+    const std::string& groupName() const;
+    Phase getPreferredPhase() const;
+    /*
+      The getCompletions() function will return a map:
+
+      {
+        1 : [Connection, Connection],
+        2 : [Connection, Connection, Connecton],
+        3 : [Connection],
+        4 : [Connection]
+      }
+
+      The integer ID's correspond to the COMPLETION id given by the COMPLUMP
+      keyword.
+    */
+    std::map<int, std::vector<Connection>> getCompletions() const;
+
+    bool updateAutoShutin(bool auto_shutin);
+    bool updateCrossFlow(bool allow_cross_flow);
+    bool updateHead(int I, int J);
+    bool updateRefDepth(double ref_dpeth);
+    bool updateDrainageRadius(double drainage_radius);
+    bool updateConnections(const std::shared_ptr<WellConnections> connections);
+    bool updateStatus(WellCommon::StatusEnum status);
+    bool updateGroup(const std::string& group);
+    bool updateProducer(bool is_producer);
+    bool updateWellGuideRate(bool available, double guide_rate, GuideRate::GuideRatePhaseEnum guide_phase, double scale_factor);
+    bool updateWellGuideRate(double guide_rate);
+    bool updateEfficiencyFactor(double efficiency_factor);
+    bool updateSolventFraction(double solvent_fraction);
+    bool updateTracer(std::shared_ptr<WellTracerProperties> tracer_properties);
+    bool updatePolymerProperties(std::shared_ptr<WellPolymerProperties> polymer_properties);
+    bool updateEconLimits(std::shared_ptr<WellEconProductionLimits> econ_limits);
+    bool updateProduction(std::shared_ptr<WellProductionProperties> production);
+    bool updateInjection(std::shared_ptr<WellInjectionProperties> injection);
+    void switchToProducer();
+    void switchToInjector();
+
+    bool handleWELSEGS(const DeckKeyword& keyword);
+    bool handleCOMPSEGS(const DeckKeyword& keyword, const EclipseGrid& grid);
+    bool handleWELOPEN(const DeckRecord& record, WellCompletion::StateEnum status);
+    bool handleCOMPLUMP(const DeckRecord& record);
+    bool handleWPIMULT(const DeckRecord& record);
+
+    void filterConnections(const EclipseGrid& grid);
+private:
+    std::string wname;
+    std::string group_name;
+    std::size_t init_step;
+    std::size_t insert_index;
+    int headI;
+    int headJ;
+    double ref_depth;
+    Phase phase;
+    WellCompletion::CompletionOrderEnum ordering;
+
+    WellCommon::StatusEnum status;
+    double drainage_radius;
+    bool allow_cross_flow;
+    bool automatic_shutin;
+    bool producer;
+    WellGuideRate guide_rate;
+    double efficiency_factor;
+    double solvent_fraction;
+
+    std::shared_ptr<const WellEconProductionLimits> econ_limits;
+    std::shared_ptr<const WellPolymerProperties> polymer_properties;
+    std::shared_ptr<const WellTracerProperties> tracer_properties;
+    std::shared_ptr<WellConnections> connections; // The WellConnections object can not be const because of the filterConnections method - would be beneficial to rewrite to enable const
+    std::shared_ptr<const WellProductionProperties> production;
+    std::shared_ptr<const WellInjectionProperties> injection;
+    std::shared_ptr<const WellSegments> segments;
+};
+
+
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -28,7 +28,6 @@ namespace Opm {
     class Eclipse3DProperties;
     class WellConnections {
     public:
-        WellConnections() = default;
         WellConnections(int headI, int headJ);
         // cppcheck-suppress noExplicitConstructor
         WellConnections(const WellConnections& src, const EclipseGrid& grid);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.hpp
@@ -23,6 +23,8 @@
 
 namespace Opm {
 
+    class DeckRecord;
+
     struct WellPolymerProperties {
         double m_polymerConcentration;
         double m_saltConcentration;
@@ -33,6 +35,9 @@ namespace Opm {
         bool operator==(const WellPolymerProperties& other) const;
         bool operator!=(const WellPolymerProperties& other) const;
         WellPolymerProperties();
+        void handleWPOLYMER(const DeckRecord& record);
+        void handleWPMITAB(const DeckRecord& record);
+        void handleWSKPTAB(const DeckRecord& record);
     };
 }
 

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -331,6 +331,7 @@ namespace Opm {
 
         const static std::string RPT_UNKNOWN_MNEMONIC;
 
+        const static std::string SCHEDULE_WELL_ERROR;
 
         /*
           The SIMULATOR_KEYWORD_ errormodes are for the situation where the

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
@@ -420,4 +420,13 @@ namespace Opm {
     bool WellSegments::operator!=( const WellSegments& rhs ) const {
         return !( *this == rhs );
     }
+
+    std::ostream& operator<<( std::ostream& stream, const WellSegments& well_segments) {
+        return stream
+            << well_segments.wellName() << " { top: {" <<
+            " L: " << well_segments.lengthTopSegment() <<
+            " D: " << well_segments.depthTopSegment() <<
+            " V: " << well_segments.volumeTopSegment() << " }}";
+    }
+
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -20,6 +20,8 @@
 #include <algorithm>
 #include <cassert>
 #include <vector>
+#include <sstream>
+#include <iostream>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
@@ -103,15 +105,15 @@ namespace Opm {
     bool Connection::attachedToSegment() const {
         return (segment_number > 0);
     }
-    
+
     const std::size_t& Connection::getSeqIndex() const {
         return m_seqIndex;
     }
-    
+
     const bool& Connection::getDefaultSatTabId() const {
         return m_defaultSatTabId;
     }
-    
+
     const std::size_t& Connection::getCompSegSeqIndex() const {
         return m_compSeg_seqIndex;
     }
@@ -128,15 +130,15 @@ namespace Opm {
         return m_segDistEnd;
     }
 
-    
+
     void Connection::setCompSegSeqIndex(std::size_t index) {
         m_compSeg_seqIndex = index;
     }
-    
+
     void Connection::setDefaultSatTabId(bool id) {
         m_defaultSatTabId = id;
     }
-    
+
     void Connection::setSegDistStart(const double& distStart) {
         m_segDistStart = distStart;
     }
@@ -144,7 +146,7 @@ namespace Opm {
     void Connection::setSegDistEnd(const double& distEnd) {
         m_segDistEnd = distEnd;
     }
-    
+
     double Connection::depth() const {
         return this->center_depth;
     }
@@ -207,8 +209,30 @@ namespace Opm {
         return this->wPi;
     }
 
+
+
+    std::string Connection::str() const {
+        std::stringstream ss;
+        ss << "ijk: " << this->ijk[0] << ","  << this->ijk[1] << "," << this->ijk[2] << std::endl;
+        ss << "COMPLNUM " << this->m_complnum << std::endl;
+        ss << "CF " << this->m_CF << std::endl;
+        ss << "RW " << this->m_rw << std::endl;
+        ss << "R0 " << this->m_r0 << std::endl;
+        ss << "skinf " << this->m_skin_factor << std::endl;
+        ss << "wPi " << this->wPi << std::endl;
+        ss << "kh " << this->m_Kh << std::endl;
+        ss << "sat_tableId " << this->sat_tableId << std::endl;
+        ss << "open_state " << this->open_state << std::endl;
+        ss << "direction " << this->direction << std::endl;
+        ss << "segment_nr " << this->segment_number << std::endl;
+        ss << "center_depth " << this->center_depth << std::endl;
+        ss << "seqIndex " << this->m_seqIndex << std::endl;
+
+        return ss.str();
+}
+
     bool Connection::operator==( const Connection& rhs ) const {
-        return this->ijk == rhs.ijk
+        bool eq = this->ijk == rhs.ijk
             && this->m_complnum == rhs.m_complnum
             && this->m_CF == rhs.m_CF
             && this->m_rw == rhs.m_rw
@@ -222,6 +246,10 @@ namespace Opm {
             && this->segment_number == rhs.segment_number
             && this->center_depth == rhs.center_depth
             && this->m_seqIndex == rhs.m_seqIndex;
+        if (!eq) {
+            //std::cout << this->str() << rhs.str() << std::endl;
+        }
+        return eq;
     }
 
     bool Connection::operator!=( const Connection& rhs ) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -481,7 +481,10 @@ namespace Opm {
             const auto headJ = this->m_headJ[ time_step ];
             new_set->orderConnections( headI, headJ );
         }
-
+        //This breaks test at line 824 in ScheduleTests
+        /*if (new_set->allConnectionsShut())
+            this->setStatus(time_step, WellCommon::SHUT );
+        */
         m_completions.update( time_step, std::shared_ptr<WellConnections>( new_set ));
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
@@ -1,0 +1,608 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
+
+
+namespace Opm {
+
+namespace {
+
+    bool defaulted(const DeckRecord& rec, const std::string& s) {
+        const auto& item = rec.getItem( s );
+        if (item.defaultApplied(0))
+            return true;
+
+        if (item.get<int>(0) == 0)
+            return true;
+
+        return false;
+    }
+
+
+    int limit(const DeckRecord& rec, const std::string&s , int shift) {
+        const auto& item = rec.getItem( s );
+        return shift + item.get<int>(0);
+    }
+
+    bool match_le(int value, const DeckRecord& rec, const std::string& s, int shift = 0) {
+        if (defaulted(rec,s))
+            return true;
+
+        return (value <= limit(rec,s,shift));
+    }
+
+    bool match_ge(int value, const DeckRecord& rec, const std::string& s, int shift = 0) {
+        if (defaulted(rec,s))
+            return true;
+
+        return (value >= limit(rec,s,shift));
+    }
+
+
+    bool match_eq(int value, const DeckRecord& rec, const std::string& s, int shift = 0) {
+        if (defaulted(rec,s))
+            return true;
+
+        return (limit(rec,s,shift) == value);
+    }
+
+}
+
+
+Well2::Well2(const std::string& wname,
+             const std::string& gname,
+             std::size_t init_step,
+             std::size_t insert_index,
+             int headI,
+             int headJ,
+             double ref_depth,
+             Phase phase,
+             WellProducer::ControlModeEnum whistctl_cmode,
+             WellCompletion::CompletionOrderEnum ordering):
+    wname(wname),
+    group_name(gname),
+    init_step(init_step),
+    insert_index(insert_index),
+    headI(headI),
+    headJ(headJ),
+    ref_depth(ref_depth),
+    phase(phase),
+    ordering(ordering),
+    status(WellCommon::SHUT),
+    drainage_radius(ParserKeywords::WELSPECS::D_RADIUS::defaultValue),
+    allow_cross_flow(DeckItem::to_bool(ParserKeywords::WELSPECS::CROSSFLOW::defaultValue)),
+    automatic_shutin( ParserKeywords::WELSPECS::CROSSFLOW::defaultValue == "SHUT"),
+    producer(true),
+    guide_rate({true, -1, GuideRate::UNDEFINED,ParserKeywords::WGRUPCON::SCALING_FACTOR::defaultValue}),
+    efficiency_factor(1.0),
+    solvent_fraction(0.0),
+    econ_limits(std::make_shared<WellEconProductionLimits>()),
+    polymer_properties(std::make_shared<WellPolymerProperties>()),
+    tracer_properties(std::make_shared<WellTracerProperties>()),
+    connections(std::make_shared<WellConnections>(headI, headJ)),
+    production(std::make_shared<WellProductionProperties>()),
+    injection(std::make_shared<WellInjectionProperties>())
+{
+    WellProductionProperties * p = new WellProductionProperties(*this->production);
+    p->whistctl_cmode = whistctl_cmode;
+    this->production.reset( p );
+}
+
+bool Well2::updateEfficiencyFactor(double efficiency_factor) {
+    if (this->efficiency_factor != efficiency_factor) {
+        this->efficiency_factor = efficiency_factor;
+        return true;
+    }
+
+    return false;
+}
+
+bool Well2::updateWellGuideRate(double guide_rate) {
+    if (this->guide_rate.guide_rate != guide_rate) {
+        this->guide_rate.guide_rate = guide_rate;
+        return true;
+    }
+
+    return false;
+}
+
+
+bool Well2::updatePolymerProperties(std::shared_ptr<WellPolymerProperties> polymer_properties) {
+    if (*this->polymer_properties != *polymer_properties) {
+        this->polymer_properties = polymer_properties;
+        this->producer = false;
+        return true;
+    }
+
+    return false;
+}
+
+
+bool Well2::updateEconLimits(std::shared_ptr<WellEconProductionLimits> econ_limits) {
+    if (*this->econ_limits != *econ_limits) {
+        this->econ_limits = econ_limits;
+        return true;
+    }
+
+    return false;
+}
+
+
+void Well2::switchToProducer() {
+    auto p = std::make_shared<WellInjectionProperties>(this->getInjectionProperties());
+
+    p->BHPLimit = 0;
+    p->dropInjectionControl( Opm::WellInjector::BHP );
+    this->updateInjection( p );
+    this->updateProducer(true);
+}
+
+
+void Well2::switchToInjector() {
+    auto p = std::make_shared<WellProductionProperties>(getProductionProperties());
+
+    p->BHPLimit = 0;
+    p->dropProductionControl( Opm::WellProducer::BHP );
+    this->updateProduction( p );
+    this->updateProducer( false );
+}
+
+bool Well2::updateInjection(std::shared_ptr<WellInjectionProperties> injection) {
+    if (this->producer)
+        this->switchToInjector( );
+
+    if (*this->injection != *injection) {
+        this->injection = injection;
+        return true;
+    }
+
+    return false;
+}
+
+bool Well2::updateProduction(std::shared_ptr<WellProductionProperties> production) {
+    if (!this->producer)
+        this->switchToProducer( );
+
+    if (*this->production != *production) {
+        this->production = production;
+        return true;
+    }
+
+    return false;
+}
+
+bool Well2::updateTracer(std::shared_ptr<WellTracerProperties> tracer_properties) {
+    if (*this->tracer_properties != *tracer_properties) {
+        this->tracer_properties = tracer_properties;
+        return true;
+    }
+
+    return false;
+}
+
+bool Well2::updateWellGuideRate(bool available, double guide_rate, GuideRate::GuideRatePhaseEnum guide_phase, double scale_factor) {
+    bool update = false;
+    if (this->guide_rate.available != available) {
+        this->guide_rate.available = available;
+        update = true;
+    }
+
+    if(this->guide_rate.guide_rate != guide_rate) {
+        this->guide_rate.guide_rate = guide_rate;
+        update = true;
+    }
+
+    if(this->guide_rate.guide_phase != guide_phase) {
+        this->guide_rate.guide_phase = guide_phase;
+        update = true;
+    }
+
+    if(this->guide_rate.scale_factor != scale_factor) {
+        this->guide_rate.scale_factor = scale_factor;
+        update = true;
+    }
+
+    return update;
+}
+
+
+bool Well2::updateProducer(bool producer) {
+    if (this->producer != producer) {
+        this->producer = producer;
+        return true;
+    }
+    return false;
+}
+
+
+bool Well2::updateGroup(const std::string& group) {
+    if (this->group_name != group) {
+        this->group_name = group;
+        return true;
+    }
+    return false;
+}
+
+
+bool Well2::updateHead(int I, int J) {
+    bool update = false;
+    if (this->headI != I) {
+        this->headI = I;
+        update = true;
+    }
+
+    if (this->headJ != J) {
+        this->headJ = J;
+        update = true;
+    }
+
+    return update;
+}
+
+
+bool Well2::updateStatus(WellCommon::StatusEnum status) {
+    if (this->status != status) {
+        this->status = status;
+        return true;
+    }
+
+    return false;
+}
+
+
+bool Well2::updateRefDepth(double ref_depth) {
+    if (this->ref_depth != ref_depth) {
+        this->ref_depth = ref_depth;
+        return true;
+    }
+
+    return false;
+}
+
+bool Well2::updateDrainageRadius(double drainage_radius) {
+    if (this->drainage_radius != drainage_radius) {
+        this->drainage_radius = drainage_radius;
+        return true;
+    }
+
+    return false;
+}
+
+
+bool Well2::updateCrossFlow(bool allow_cross_flow) {
+    if (this->allow_cross_flow != allow_cross_flow) {
+        this->allow_cross_flow = allow_cross_flow;
+        return true;
+    }
+
+    return false;
+}
+
+bool Well2::updateAutoShutin(bool auto_shutin) {
+    if (this->automatic_shutin != auto_shutin) {
+        this->automatic_shutin = auto_shutin;
+        return true;
+    }
+
+    return false;
+}
+
+
+bool Well2::updateConnections(const std::shared_ptr<WellConnections> connections) {
+    if( this->ordering  == WellCompletion::TRACK)
+        connections->orderConnections( this->headI, this->headJ );
+
+    if (*this->connections != *connections) {
+        this->connections = connections;
+        //if (this->connections->allConnectionsShut()) {}
+        // This status update breaks line 825 in ScheduleTests
+        //this->status = WellCommon::StatusEnum::SHUT;
+        return true;
+    }
+
+    return false;
+}
+
+
+bool Well2::updateSolventFraction(double solvent_fraction) {
+    if (this->solvent_fraction != solvent_fraction) {
+        this->solvent_fraction = solvent_fraction;
+        return true;
+    }
+
+    return false;
+}
+
+
+bool Well2::handleCOMPSEGS(const DeckKeyword& keyword, const EclipseGrid& grid) {
+    std::shared_ptr<WellConnections> new_connection_set( newConnectionsWithSegments(keyword, *this->connections, *this->segments , grid) );
+    return this->updateConnections(new_connection_set);
+}
+
+const std::string& Well2::groupName() const {
+    return this->group_name;
+}
+
+
+bool Well2::isMultiSegment() const {
+    if (this->segments)
+        return true;
+    return false;
+}
+
+bool Well2::isProducer() const {
+    return this->producer;
+}
+
+bool Well2::isAvailableForGroupControl() const {
+    return this->guide_rate.available;
+}
+
+double Well2::getGuideRate() const {
+    return this->guide_rate.guide_rate;
+};
+
+GuideRate::GuideRatePhaseEnum Well2::getGuideRatePhase() const {
+    return this->guide_rate.guide_phase;
+};
+
+double Well2::getGuideRateScalingFactor() const {
+    return this->guide_rate.scale_factor;
+};
+
+
+double Well2::getEfficiencyFactor() const {
+    return this->efficiency_factor;
+}
+
+double Well2::getSolventFraction() const {
+    return this->solvent_fraction;
+}
+
+
+
+std::size_t Well2::seqIndex() const {
+    return this->insert_index;
+}
+
+int Well2::getHeadI() const {
+    return this->headI;
+}
+
+int Well2::getHeadJ() const {
+    return this->headJ;
+}
+
+bool Well2::getAutomaticShutIn() const {
+    return this->automatic_shutin;
+}
+
+bool Well2::getAllowCrossFlow() const {
+    return this->allow_cross_flow;
+}
+
+double Well2::getRefDepth() const {
+    if( this->ref_depth >= 0.0 )
+        return this->ref_depth;
+
+    // ref depth was defaulted and we get the depth of the first completion
+    if( this->connections->size() == 0 ) {
+        throw std::invalid_argument( "No completions defined for well: "
+                                     + name()
+                                     + ". Can not infer reference depth" );
+    }
+    return this->connections->get(0).depth();
+}
+
+
+double Well2::getDrainageRadius() const {
+    return this->drainage_radius;
+}
+
+
+const std::string& Well2::name() const {
+    return this->wname;
+}
+
+
+const WellConnections& Well2::getConnections() const {
+    return *this->connections;
+}
+
+const WellPolymerProperties& Well2::getPolymerProperties() const {
+    return *this->polymer_properties;
+}
+
+
+const WellTracerProperties& Well2::getTracerProperties() const {
+    return *this->tracer_properties;
+}
+
+const WellEconProductionLimits& Well2::getEconLimits() const {
+    return *this->econ_limits;
+}
+
+const WellProductionProperties& Well2::getProductionProperties() const {
+    return *this->production;
+}
+
+const WellSegments& Well2::getSegments() const {
+    if (this->segments)
+        return *this->segments;
+    else
+        throw std::logic_error("Asked for segment information in not MSW well: " + this->name());
+}
+
+const WellInjectionProperties& Well2::getInjectionProperties() const {
+    return *this->injection;
+}
+
+WellCommon::StatusEnum Well2::getStatus() const {
+    return this->status;
+}
+
+
+std::map<int, std::vector<Connection>> Well2::getCompletions() const {
+    std::map<int, std::vector<Connection>> completions;
+
+    for (const auto& conn : *this->connections) {
+        auto pair = completions.find( conn.complnum() );
+        if (pair == completions.end())
+            completions[conn.complnum()] = {};
+
+        pair = completions.find(conn.complnum());
+        pair->second.push_back(conn);
+    }
+
+    return completions;
+}
+
+Phase Well2::getPreferredPhase() const {
+    return this->phase;
+}
+
+bool Well2::handleWELOPEN(const DeckRecord& record, WellCompletion::StateEnum status) {
+
+    auto match = [=]( const Connection &c) -> bool {
+        if (!match_eq(c.getI(), record, "I" , -1)) return false;
+        if (!match_eq(c.getJ(), record, "J" , -1)) return false;
+        if (!match_eq(c.getK(), record, "K", -1))  return false;
+        if (!match_ge(c.complnum(), record, "C1")) return false;
+        if (!match_le(c.complnum(), record, "C2")) return false;
+
+        return true;
+    };
+
+    auto new_connections = std::make_shared<WellConnections>(this->headI, this->headJ);
+
+    for (auto c : *this->connections) {
+        if (match(c))
+            c.setState( status );
+
+        new_connections->add(c);
+    }
+    return this->updateConnections(new_connections);
+}
+
+bool Well2::handleCOMPLUMP(const DeckRecord& record) {
+
+    auto match = [=]( const Connection &c) -> bool {
+        if (!match_eq(c.getI(), record, "I" , -1))  return false;
+        if (!match_eq(c.getJ(), record, "J" , -1))  return false;
+        if (!match_ge(c.getK(), record, "K1", -1)) return false;
+        if (!match_le(c.getK(), record, "K2", -1)) return false;
+
+        return true;
+    };
+
+    auto new_connections = std::make_shared<WellConnections>(this->headI, this->headJ);
+    const int complnum = record.getItem("N").get<int>(0);
+    if (complnum <= 0)
+        throw std::invalid_argument("Completion number must be >= 1. COMPLNUM=" + std::to_string(complnum) + "is invalid");
+
+    for (auto c : *this->connections) {
+        if (match(c))
+            c.setComplnum( complnum );
+
+        new_connections->add(c);
+    }
+
+    return this->updateConnections(new_connections);
+}
+
+
+
+bool Well2::handleWPIMULT(const DeckRecord& record) {
+
+    auto match = [=]( const Connection &c) -> bool {
+        if (!match_ge(c.complnum(), record, "FIRST")) return false;
+        if (!match_le(c.complnum(), record, "LAST"))  return false;
+        if (!match_eq(c.getI()  , record, "I", -1)) return false;
+        if (!match_eq(c.getJ()  , record, "J", -1)) return false;
+        if (!match_eq(c.getK()  , record, "K", -1)) return false;
+
+        return true;
+    };
+
+    auto new_connections = std::make_shared<WellConnections>(this->headI, this->headJ);
+    double wellPi = record.getItem("WELLPI").get< double >(0);
+
+    for (auto c : *this->connections) {
+        if (match(c))
+            c.scaleWellPi( wellPi );
+
+        new_connections->add(c);
+    }
+
+    return this->updateConnections(new_connections);
+}
+
+
+bool Well2::handleWELSEGS(const DeckKeyword& keyword) {
+    if( this->segments )
+        throw std::logic_error("re-entering WELSEGS for a well is not supported yet!!.");
+
+    auto new_segmentset = std::make_shared<WellSegments>();
+    new_segmentset->loadWELSEGS(keyword);
+
+    new_segmentset->process(true);
+    if (new_segmentset != this->segments) {
+        this->segments = new_segmentset;
+        this->ref_depth = new_segmentset->depthTopSegment();
+        return true;
+    } else
+        return false;
+}
+
+void Well2::filterConnections(const EclipseGrid& grid) {
+    this->connections->filter(grid);
+}
+
+
+std::size_t Well2::firstTimeStep() const {
+    return this->init_step;
+}
+
+
+
+bool Well2::canOpen() const {
+    if (this->allow_cross_flow)
+        return true;
+
+    if (this->producer) {
+        const auto& prod = *this->production;
+        return (prod.WaterRate + prod.OilRate + prod.GasRate) != 0;
+    } else {
+        const auto& inj = *this->injection;
+        return inj.surfaceInjectionRate != 0;
+    }
+}
+
+WellCompletion::CompletionOrderEnum Well2::getWellConnectionOrdering() const {
+    return this->ordering;
+}
+
+
+}
+

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -457,8 +457,9 @@ namespace {
     }
 
     bool WellConnections::operator==( const WellConnections& rhs ) const {
-        return this->size() == rhs.size()
-            && std::equal( this->begin(), this->end(), rhs.begin() );
+        return this->size() == rhs.size() &&
+            this->num_removed == rhs.num_removed &&
+            std::equal( this->begin(), this->end(), rhs.begin() );
     }
 
     bool WellConnections::operator!=( const WellConnections& rhs ) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
 #include <string>
 #include <vector>
@@ -41,6 +42,30 @@ namespace Opm {
         else
             return false;
 
+    }
+
+
+    void WellPolymerProperties::handleWPOLYMER(const DeckRecord& record) {
+        this->m_polymerConcentration = record.getItem("POLYMER_CONCENTRATION").getSIDouble(0);
+        this->m_saltConcentration = record.getItem("SALT_CONCENTRATION").getSIDouble(0);
+
+        const auto& group_polymer_item = record.getItem("GROUP_POLYMER_CONCENTRATION");
+        const auto& group_salt_item = record.getItem("GROUP_SALT_CONCENTRATION");
+
+        if (!group_polymer_item.defaultApplied(0))
+            throw std::logic_error("Sorry explicit setting of \'GROUP_POLYMER_CONCENTRATION\' is not supported!");
+
+        if (!group_salt_item.defaultApplied(0))
+            throw std::logic_error("Sorry explicit setting of \'GROUP_SALT_CONCENTRATION\' is not supported!");
+    }
+
+    void WellPolymerProperties::handleWPMITAB(const DeckRecord& record) {
+        this->m_plymwinjtable = record.getItem("TABLE_NUMBER").get<int>(0);
+    }
+
+    void WellPolymerProperties::handleWSKPTAB(const DeckRecord& record) {
+        this->m_skprwattable = record.getItem("TABLE_NUMBER_WATER").get<int>(0);
+        this->m_skprpolytable = record.getItem("TABLE_NUMBER_POLYMER").get<int>(0);
     }
 
     bool WellPolymerProperties::operator!=(const WellPolymerProperties& other) const {

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -109,6 +109,7 @@ namespace Opm {
         addKey(SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED, InputError::WARN);
 
         addKey(UDQ_PARSE_ERROR, InputError::THROW_EXCEPTION);
+        this->addKey(SCHEDULE_WELL_ERROR, InputError::THROW_EXCEPTION);
     }
 
     void ParseContext::initEnv() {
@@ -342,4 +343,5 @@ namespace Opm {
     const std::string ParseContext::SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED = "SIMULATOR_KEYWORD_ITEM_NOT_SUPPORTED";
 
     const std::string ParseContext::UDQ_PARSE_ERROR = "UDQ_PARSE_ERROR";
+    const std::string ParseContext::SCHEDULE_WELL_ERROR = "SCHEDULE_WELL_ERROR";
 }

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(CreateWellConnectionsOK) {
 
 BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
-    Opm::WellConnections completionSet;
+    Opm::WellConnections completionSet(1,1);
     Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::WellCompletion::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir,0, 0., 0., true);
     Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::WellCompletion::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir,0, 0., 0., true);
     completionSet.add( completion1 );
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
     Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::WellCompletion::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir,0,0., 0., true);
     Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::WellCompletion::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir,0,0., 0., true);
-    Opm::WellConnections completionSet;
+    Opm::WellConnections completionSet(1,1);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
 
 
 BOOST_AUTO_TEST_CASE(AddCompletionCopy) {
-    Opm::WellConnections completionSet;
+  Opm::WellConnections completionSet(10,10);
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
 
     Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::WellCompletion::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir,0,0., 0., true);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(AddCompletionCopy) {
 BOOST_AUTO_TEST_CASE(ActiveCompletions) {
     Opm::EclipseGrid grid(10,20,20);
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
-    Opm::WellConnections completions;
+    Opm::WellConnections completions(10,10);
     Opm::Connection completion1( 0,0,0, 1, 0.0, Opm::WellCompletion::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir,0,0., 0., true);
     Opm::Connection completion2( 0,0,1, 1, 0.0, Opm::WellCompletion::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir,0,0., 0., true);
     Opm::Connection completion3( 0,0,2, 1, 0.0, Opm::WellCompletion::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir,0,0., 0., true);
@@ -150,7 +150,7 @@ Opm::WellConnections loadCOMPDAT(const std::string& compdat_keyword) {
     const auto deck = parser.parseString(compdat_keyword);
     Opm::Eclipse3DProperties props(deck, tables, grid );
     const auto& keyword = deck.getKeyword("COMPDAT", 0);
-    Opm::WellConnections connections;
+    Opm::WellConnections connections(10,10);
     for (const auto& rec : keyword)
         connections.loadCOMPDAT(rec, grid, props);
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -42,7 +42,7 @@
 
 BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     Opm::WellCompletion::DirectionEnum dir = Opm::WellCompletion::DirectionEnum::Z;
-    Opm::WellConnections connection_set;
+    Opm::WellConnections connection_set(10,10);
     Opm::EclipseGrid grid(20,20,20);
     connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::WellCompletion::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir,0, 0., 0., true) );
     connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::WellCompletion::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir,0, 0., 0., true) );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -328,11 +329,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
-    auto wells = schedule.getWells();
+    auto well_names = schedule.wellNames();
 
-    BOOST_CHECK_EQUAL( "CW_1" , wells[0]->name());
-    BOOST_CHECK_EQUAL( "BW_2" , wells[1]->name());
-    BOOST_CHECK_EQUAL( "AW_3" , wells[2]->name());
+    BOOST_CHECK_EQUAL( "CW_1" , well_names[0]);
+    BOOST_CHECK_EQUAL( "BW_2" , well_names[1]);
+    BOOST_CHECK_EQUAL( "AW_3" , well_names[2]);
 
     auto groups = schedule.getGroups();
     // groups[0] is 'FIELD'
@@ -341,9 +342,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     BOOST_CHECK_EQUAL( "AG", groups[3]->name());
 }
 
-bool has_well( const std::vector<const Well*> wells, const std::string& well_name);
+template <typename WellT>
+bool has_well( const std::vector<const WellT*> wells, const std::string& well_name);
 
-bool has_well( const std::vector<const Well*> wells, const std::string& well_name) {
+template <typename WellT>
+bool has_well( const std::vector<const WellT*> wells, const std::string& well_name) {
     for (const auto& well : wells )
         if (well->name( ) == well_name)
             return true;
@@ -392,6 +395,42 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
 
     {
         auto parent_wells2 = schedule.getChildWells("PG2" , 0, GroupWellQueryMode::Recursive);
+        BOOST_CHECK_EQUAL( parent_wells2.size() , 2U);
+
+        BOOST_CHECK( has_well( parent_wells2, "BW_2" ));
+        BOOST_CHECK( has_well( parent_wells2, "AW_3" ));
+    }
+
+    {
+        auto field_wells = schedule.getChildWells2("FIELD" , 0, GroupWellQueryMode::Recursive);
+        BOOST_CHECK_EQUAL( field_wells.size() , 4U);
+
+        BOOST_CHECK( has_well( field_wells, "DW_0" ));
+        BOOST_CHECK( has_well( field_wells, "CW_1" ));
+        BOOST_CHECK( has_well( field_wells, "BW_2" ));
+        BOOST_CHECK( has_well( field_wells, "AW_3" ));
+    }
+
+    {
+        auto platform_wells = schedule.getChildWells2("PLATFORM" , 0, GroupWellQueryMode::Recursive);
+        BOOST_CHECK_EQUAL( platform_wells.size() , 4U);
+
+        BOOST_CHECK( has_well( platform_wells, "DW_0" ));
+        BOOST_CHECK( has_well( platform_wells, "CW_1" ));
+        BOOST_CHECK( has_well( platform_wells, "BW_2" ));
+        BOOST_CHECK( has_well( platform_wells, "AW_3" ));
+    }
+
+    {
+        auto child_wells1 = schedule.getChildWells2("CG1" , 0, GroupWellQueryMode::Recursive);
+        BOOST_CHECK_EQUAL( child_wells1.size() , 2U);
+
+        BOOST_CHECK( has_well( child_wells1, "DW_0" ));
+        BOOST_CHECK( has_well( child_wells1, "CW_1" ));
+    }
+
+    {
+        auto parent_wells2 = schedule.getChildWells2("PG2" , 0, GroupWellQueryMode::Recursive);
         BOOST_CHECK_EQUAL( parent_wells2.size() , 2U);
 
         BOOST_CHECK( has_well( parent_wells2, "BW_2" ));
@@ -566,24 +605,37 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
 
-    auto well_ban = schedule.getWell("BAN");
-    BOOST_CHECK_EQUAL(well_ban->getAllowCrossFlow(), false);
-
-
-    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_ban->getStatus(0));
-    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban->getStatus(1));
-    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban->getStatus(2));
-    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_ban->getStatus(3));
-    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_ban->getStatus(4)); // not allow to open
-    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban->getStatus(5));
-
-
     {
-        auto well_allow = schedule.getWell("ALLOW");
-        auto well_default = schedule.getWell("DEFAULT");
+        auto well_ban = schedule.getWell("BAN");
+        BOOST_CHECK_EQUAL(well_ban->getAllowCrossFlow(), false);
 
-        BOOST_CHECK_EQUAL(well_default->getAllowCrossFlow(), true);
-        BOOST_CHECK_EQUAL(well_allow->getAllowCrossFlow(), true);
+
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_ban->getStatus(0));
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban->getStatus(1));
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban->getStatus(2));
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_ban->getStatus(3));
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_ban->getStatus(4)); // not allow to open
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban->getStatus(5));
+
+
+        {
+            auto well_allow = schedule.getWell("ALLOW");
+            auto well_default = schedule.getWell("DEFAULT");
+
+            BOOST_CHECK_EQUAL(well_default->getAllowCrossFlow(), true);
+            BOOST_CHECK_EQUAL(well_allow->getAllowCrossFlow(), true);
+        }
+    }
+    {
+        BOOST_CHECK_EQUAL(schedule.getWell2("BAN", 0).getAllowCrossFlow(), false);
+        BOOST_CHECK_EQUAL(schedule.getWell2("ALLOW", 0).getAllowCrossFlow(), true);
+        BOOST_CHECK_EQUAL(schedule.getWell2("DEFAULT", 0).getAllowCrossFlow(), true);
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, schedule.getWell2("BAN", 0).getStatus());
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, schedule.getWell2("BAN", 1).getStatus());
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, schedule.getWell2("BAN", 2).getStatus());
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, schedule.getWell2("BAN", 3).getStatus());
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, schedule.getWell2("BAN", 4).getStatus()); // not allow to open
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, schedule.getWell2("BAN", 5).getStatus());
     }
 }
 
@@ -686,52 +738,60 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndConnectionDataWithWELOPEN) {
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompletionsDoNotOpenWell) {
-  Opm::Parser parser;
-  std::string input =
-          "START             -- 0 \n"
-                  "1 NOV 1979 / \n"
-                  "SCHEDULE\n"
-                  "DATES             -- 1\n"
-                  " 1 DES 1979/ \n"
-                  "/\n"
-                  "WELSPECS\n"
-                  "    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
-                  "/\n"
-                  "COMPDAT\n"
-                  " 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
-                  " 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
-                  " 'OP_1'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
-                  "/\n"
-                  "DATES             -- 2\n"
-                  " 10  JUL 2008 / \n"
-                  "/\n"
-                  "WELOPEN\n"
-                  " 'OP_1' OPEN / \n"
-                  "/\n"
-                  "DATES             -- 3\n"
-                  " 10  OKT 2008 / \n"
-                  "/\n"
-                  "WELOPEN\n"
-                  " 'OP_1' SHUT 0 0 0 0 0 / \n "
-                  "/\n"
-                  "DATES             -- 4\n"
-                  " 10  NOV 2008 / \n"
-                  "/\n"
-                  "WELOPEN\n"
-                  " 'OP_1' OPEN / \n "
-                  "/\n";
+    Opm::Parser parser;
+    std::string input =
+        "START             -- 0 \n"
+        "1 NOV 1979 / \n"
+        "SCHEDULE\n"
+        "DATES             -- 1\n"
+        " 1 DES 1979/ \n"
+        "/\n"
+        "WELSPECS\n"
+        "    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+        "/\n"
+        "COMPDAT\n"
+        " 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+        " 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
+        " 'OP_1'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+        "/\n"
+        "DATES             -- 2\n"
+        " 10  JUL 2008 / \n"
+        "/\n"
+        "WELOPEN\n"
+        " 'OP_1' OPEN / \n"
+        "/\n"
+        "DATES             -- 3\n"
+        " 10  OKT 2008 / \n"
+        "/\n"
+        "WELOPEN\n"
+        " 'OP_1' SHUT 0 0 0 0 0 / \n "
+        "/\n"
+        "DATES             -- 4\n"
+        " 10  NOV 2008 / \n"
+        "/\n"
+        "WELOPEN\n"
+        " 'OP_1' OPEN / \n "
+        "/\n";
 
-  EclipseGrid grid(10,10,10);
-  auto deck = parser.parseString(input);
-  TableManager table ( deck );
-  Eclipse3DProperties eclipseProperties ( deck , table, grid);
-  Runspec runspec (deck);
-  Schedule schedule(deck ,  grid , eclipseProperties, runspec);
-  auto* well = schedule.getWell("OP_1");
-  size_t currentStep = 3;
-  BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
-  currentStep = 4;
-  BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
+    EclipseGrid grid(10,10,10);
+    auto deck = parser.parseString(input);
+    TableManager table ( deck );
+    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    Runspec runspec (deck);
+    Schedule schedule(deck ,  grid , eclipseProperties, runspec);
+    {
+        auto* well = schedule.getWell("OP_1");
+        size_t currentStep = 3;
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
+        currentStep = 4;
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
+    }
+    {
+        const auto& well2_3 = schedule.getWell2("OP_1",3);
+        const auto& well2_4 = schedule.getWell2("OP_1",4);
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well2_3.getStatus());
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well2_4.getStatus());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_CombineShutCompletionsAndAddNewCompletionsDoNotShutWell) {
@@ -788,16 +848,32 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_CombineShutCompletionsAndAddN
   Eclipse3DProperties eclipseProperties ( deck , table, grid);
   Runspec runspec (deck);
   Schedule schedule(deck, grid , eclipseProperties, runspec);
-  auto* well = schedule.getWell("OP_1");
-  // timestep 3. Close all completions with WELOPEN and immediately open new completions with COMPDAT.
-  BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(3));
-  BOOST_CHECK( !schedule.hasWellEvent( "OP_1", ScheduleEvents::WELL_STATUS_CHANGE , 3 ));
-  // timestep 4. Close all completions with WELOPEN. The well will be shut since no completions
-  // are open.
-  BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(4));
-  BOOST_CHECK( schedule.hasWellEvent( "OP_1", ScheduleEvents::WELL_STATUS_CHANGE , 4 ));
-  // timestep 5. Open new completions. But keep the well shut,
-  BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(5));
+  {
+      auto* well = schedule.getWell("OP_1");
+      // timestep 3. Close all completions with WELOPEN and immediately open new completions with COMPDAT.
+      BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(3));
+      BOOST_CHECK( !schedule.hasWellEvent( "OP_1", ScheduleEvents::WELL_STATUS_CHANGE , 3 ));
+      // timestep 4. Close all completions with WELOPEN. The well will be shut since no completions
+      // are open.
+      BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(4));
+      BOOST_CHECK( schedule.hasWellEvent( "OP_1", ScheduleEvents::WELL_STATUS_CHANGE , 4 ));
+      // timestep 5. Open new completions. But keep the well shut,
+      BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(5));
+  }
+  {
+      const auto& well_3 = schedule.getWell2("OP_1", 3);
+      const auto& well_4 = schedule.getWell2("OP_1", 4);
+      const auto& well_5 = schedule.getWell2("OP_1", 5);
+      // timestep 3. Close all completions with WELOPEN and immediately open new completions with COMPDAT.
+      BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_3.getStatus());
+      BOOST_CHECK( !schedule.hasWellEvent( "OP_1", ScheduleEvents::WELL_STATUS_CHANGE , 3 ));
+      // timestep 4. Close all completions with WELOPEN. The well will be shut since no completions
+      // are open.
+      BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_4.getStatus());
+      BOOST_CHECK( schedule.hasWellEvent( "OP_1", ScheduleEvents::WELL_STATUS_CHANGE , 4 ));
+      // timestep 5. Open new completions. But keep the well shut,
+      BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_5.getStatus());
+  }
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
@@ -902,17 +978,19 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
+    {
+        auto* well = schedule.getWell("OP_1");
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(4));
+    }
+    {
+        const auto& well = schedule.getWell2("OP_1", 4);
+        BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well.getStatus());
+    }
+
     const auto& rft_config = schedule.rftConfig();
-    auto* well = schedule.getWell("OP_1");
-
-    size_t currentStep = 3;
-    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", currentStep),false);
-    currentStep = 4;
-    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", currentStep),true);
-    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(currentStep));
-
-    currentStep = 5;
-    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", currentStep),false);
+    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", 3),false);
+    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", 4),true);
+    BOOST_CHECK_EQUAL(rft_config.rft("OP_1", 5),false);
 }
 
 BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
@@ -953,28 +1031,46 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck,  grid , eclipseProperties, runspec);
-    auto* well = schedule.getWell("OP_1");
-
-    size_t currentStep = 1;
-    WellProductionProperties wpp = well->getProductionProperties(currentStep);
-    BOOST_CHECK_EQUAL(wpp.WaterRate,0);
-
     Opm::UnitSystem unitSystem = deck.getActiveUnitSystem();
     double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
     double siFactorG = unitSystem.parse("GasSurfaceVolume/Time").getSIScaling();
     double siFactorP = unitSystem.parse("Pressure").getSIScaling();
 
-    currentStep = 2;
-    wpp = well->getProductionProperties(currentStep);
-    BOOST_CHECK_EQUAL(wpp.OilRate, 1300 * siFactorL);
-    BOOST_CHECK_EQUAL(wpp.WaterRate, 1400 * siFactorL);
-    BOOST_CHECK_EQUAL(wpp.GasRate, 1500.52 * siFactorG);
-    BOOST_CHECK_EQUAL(wpp.LiquidRate, 1600.58 * siFactorL);
-    BOOST_CHECK_EQUAL(wpp.ResVRate, 1801.05 * siFactorL);
-    BOOST_CHECK_EQUAL(wpp.BHPLimit, 1900 * siFactorP);
-    BOOST_CHECK_EQUAL(wpp.THPLimit, 2000 * siFactorP);
-    BOOST_CHECK_EQUAL(wpp.VFPTableNumber, 2100);
-    BOOST_CHECK_EQUAL(well->getGuideRate(2), 2300.14);
+    {
+        auto* well = schedule.getWell("OP_1");
+        size_t currentStep = 1;
+        WellProductionProperties wpp = well->getProductionProperties(currentStep);
+        BOOST_CHECK_EQUAL(wpp.WaterRate,0);
+
+        currentStep = 2;
+        wpp = well->getProductionProperties(currentStep);
+        BOOST_CHECK_EQUAL(wpp.OilRate, 1300 * siFactorL);
+        BOOST_CHECK_EQUAL(wpp.WaterRate, 1400 * siFactorL);
+        BOOST_CHECK_EQUAL(wpp.GasRate, 1500.52 * siFactorG);
+        BOOST_CHECK_EQUAL(wpp.LiquidRate, 1600.58 * siFactorL);
+        BOOST_CHECK_EQUAL(wpp.ResVRate, 1801.05 * siFactorL);
+        BOOST_CHECK_EQUAL(wpp.BHPLimit, 1900 * siFactorP);
+        BOOST_CHECK_EQUAL(wpp.THPLimit, 2000 * siFactorP);
+        BOOST_CHECK_EQUAL(wpp.VFPTableNumber, 2100);
+        BOOST_CHECK_EQUAL(well->getGuideRate(2), 2300.14);
+    }
+    {
+        const auto& well_1 = schedule.getWell2("OP_1", 1);
+        const auto wpp_1 = well_1.getProductionProperties();
+        BOOST_CHECK_EQUAL(wpp_1.WaterRate, 0);
+
+        const auto& well_2 = schedule.getWell2("OP_1", 2);
+        const auto wpp_2 = well_2.getProductionProperties();
+        BOOST_CHECK_EQUAL(wpp_2.OilRate, 1300 * siFactorL);
+        BOOST_CHECK_EQUAL(wpp_2.WaterRate, 1400 * siFactorL);
+        BOOST_CHECK_EQUAL(wpp_2.GasRate, 1500.52 * siFactorG);
+        BOOST_CHECK_EQUAL(wpp_2.LiquidRate, 1600.58 * siFactorL);
+        BOOST_CHECK_EQUAL(wpp_2.ResVRate, 1801.05 * siFactorL);
+        BOOST_CHECK_EQUAL(wpp_2.BHPLimit, 1900 * siFactorP);
+        BOOST_CHECK_EQUAL(wpp_2.THPLimit, 2000 * siFactorP);
+        BOOST_CHECK_EQUAL(wpp_2.VFPTableNumber, 2100);
+        BOOST_CHECK_EQUAL(well_2.getGuideRate(), 2300.14);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException) {
@@ -1058,24 +1154,37 @@ BOOST_AUTO_TEST_CASE(createDeckWithWPIMULT) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
-    auto* well = schedule.getWell("OP_1");
+    {
+        auto* well = schedule.getWell("OP_1");
 
-    const auto& cs2 = well->getConnections( 2 );
-    for(size_t i = 0; i < cs2.size(); i++) {
-      BOOST_CHECK_EQUAL(cs2.get( i ).wellPi(), 1.3);
+        const auto& cs2 = well->getConnections( 2 );
+        for(size_t i = 0; i < cs2.size(); i++) {
+            BOOST_CHECK_EQUAL(cs2.get( i ).wellPi(), 1.3);
+        }
+
+        const auto& cs3 = well->getConnections( 3 );
+        for(size_t i = 0; i < cs3.size(); i++ ) {
+            BOOST_CHECK_EQUAL(cs3.get( i ).wellPi(), (1.3*1.3));
+        }
+
+        const auto& cs4 = well->getConnections( 4 );
+        for(size_t i = 0; i < cs4.size(); i++ ) {
+            BOOST_CHECK_EQUAL(cs4.get( i ).wellPi(), 1.0);
+        }
     }
+    {
+        const auto& cs2 = schedule.getWell2("OP_1", 2).getConnections();
+        const auto& cs3 = schedule.getWell2("OP_1", 3).getConnections();
+        const auto& cs4 = schedule.getWell2("OP_1", 4).getConnections();
+        for(size_t i = 0; i < cs2.size(); i++)
+            BOOST_CHECK_EQUAL(cs2.get( i ).wellPi(), 1.3);
 
-    const auto& cs3 = well->getConnections( 3 );
-    for(size_t i = 0; i < cs3.size(); i++ ) {
-      BOOST_CHECK_EQUAL(cs3.get( i ).wellPi(), (1.3*1.3));
+        for(size_t i = 0; i < cs3.size(); i++ )
+            BOOST_CHECK_EQUAL(cs3.get( i ).wellPi(), (1.3*1.3));
+
+        for(size_t i = 0; i < cs4.size(); i++ )
+            BOOST_CHECK_EQUAL(cs4.get( i ).wellPi(), 1.0);
     }
-
-    const auto& cs4 = well->getConnections( 4 );
-    for(size_t i = 0; i < cs4.size(); i++ ) {
-      BOOST_CHECK_EQUAL(cs4.get( i ).wellPi(), 1.0);
-    }
-
-
     BOOST_CHECK_THROW(schedule.simTime(10000), std::invalid_argument);
     auto sim_time1 = schedule.simTime(1);
     int day, month,year;
@@ -1477,46 +1586,87 @@ BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
-    auto* well_p1 = schedule.getWell("P1");
-    auto* well_p2 = schedule.getWell("P2");
+    {
+        auto* well_p1 = schedule.getWell("P1");
+        auto* well_p2 = schedule.getWell("P2");
+
+        //Start
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(0).controlMode, Opm::WellProducer::CMODE_UNDEFINED);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(0).controlMode, Opm::WellProducer::CMODE_UNDEFINED);
+
+        //10  OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(1).controlMode, Opm::WellProducer::ORAT);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(1).controlMode, Opm::WellProducer::ORAT);
+
+        //15  OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+        // under history mode, a producing well should have only one rate target/limit or have no rate target/limit.
+        // the rate target/limit from previous report step should not be kept.
+        BOOST_CHECK( !well_p1->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+        BOOST_CHECK( !well_p2->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+
+        //18  OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
+        BOOST_CHECK( !well_p1->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+        BOOST_CHECK( !well_p2->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+
+        // 20 OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
+        BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
+        BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
+        BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+        BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+
+        // 25 OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
+        BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
+        BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
+        BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+        BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+    }
 
     //Start
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(0).controlMode, Opm::WellProducer::CMODE_UNDEFINED);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(0).controlMode, Opm::WellProducer::CMODE_UNDEFINED);
+    BOOST_CHECK_THROW(schedule.getWell2("P1", 0), std::invalid_argument);
+    BOOST_CHECK_THROW(schedule.getWell2("P2", 0), std::invalid_argument);
 
     //10  OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(1).controlMode, Opm::WellProducer::ORAT);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(1).controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 1).getProductionProperties().controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 1).getProductionProperties().controlMode, Opm::WellProducer::ORAT);
 
     //15  OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 2).getProductionProperties().controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 2).getProductionProperties().controlMode, Opm::WellProducer::RESV);
     // under history mode, a producing well should have only one rate target/limit or have no rate target/limit.
     // the rate target/limit from previous report step should not be kept.
-    BOOST_CHECK( !well_p1->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
-    BOOST_CHECK( !well_p2->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P1", 2).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P2", 2).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+
 
     //18  OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
-    BOOST_CHECK( !well_p1->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
-    BOOST_CHECK( !well_p2->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 3).getProductionProperties().controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 3).getProductionProperties().controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK( !schedule.getWell2("P1", 3).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P2", 3).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
 
     // 20 OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
-    BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
-    BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
-    BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
-    BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 4).getProductionProperties().controlMode, Opm::WellProducer::LRAT);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 4).getProductionProperties().controlMode, Opm::WellProducer::LRAT);
+    BOOST_CHECK( !schedule.getWell2("P1", 4).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P2", 4).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P1", 4).getProductionProperties().hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !schedule.getWell2("P2", 4).getProductionProperties().hasProductionControl(Opm::WellProducer::RESV) );
 
     // 25 OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
-    BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
-    BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
-    BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
-    BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 5).getProductionProperties().controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 5).getProductionProperties().controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK( !schedule.getWell2("P1", 5).getProductionProperties().hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !schedule.getWell2("P2", 5).getProductionProperties().hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !schedule.getWell2("P1", 5).getProductionProperties().hasProductionControl(Opm::WellProducer::LRAT) );
+    BOOST_CHECK( !schedule.getWell2("P2", 5).getProductionProperties().hasProductionControl(Opm::WellProducer::LRAT) );
 }
 
 BOOST_AUTO_TEST_CASE(WHISTCTL_NEW_WELL) {
@@ -1588,43 +1738,81 @@ BOOST_AUTO_TEST_CASE(WHISTCTL_NEW_WELL) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
-    auto* well_p1 = schedule.getWell("P1");
-    auto* well_p2 = schedule.getWell("P2");
+    {
+        auto* well_p1 = schedule.getWell("P1");
+        auto* well_p2 = schedule.getWell("P2");
+
+        //10  OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(1).controlMode, Opm::WellProducer::GRAT);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(1).controlMode, Opm::WellProducer::GRAT);
+
+        //15  OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+        // under history mode, a producing well should have only one rate target/limit or have no rate target/limit.
+        // the rate target/limit from previous report step should not be kept.
+        BOOST_CHECK( !well_p1->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+        BOOST_CHECK( !well_p2->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+
+        //18  OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
+        BOOST_CHECK( !well_p1->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+        BOOST_CHECK( !well_p2->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+
+        // 20 OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
+        BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
+        BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
+        BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+        BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+
+        // 25 OKT 2008
+        BOOST_CHECK_EQUAL(well_p1->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
+        BOOST_CHECK_EQUAL(well_p2->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
+        BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
+        BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
+        BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+        BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+    }
 
     //10  OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(1).controlMode, Opm::WellProducer::GRAT);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(1).controlMode, Opm::WellProducer::GRAT);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 1).getProductionProperties().controlMode, Opm::WellProducer::GRAT);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 1).getProductionProperties().controlMode, Opm::WellProducer::GRAT);
 
     //15  OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 2).getProductionProperties().controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 2).getProductionProperties().controlMode, Opm::WellProducer::RESV);
     // under history mode, a producing well should have only one rate target/limit or have no rate target/limit.
     // the rate target/limit from previous report step should not be kept.
-    BOOST_CHECK( !well_p1->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
-    BOOST_CHECK( !well_p2->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P1", 2).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P2", 2).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
 
     //18  OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
-    BOOST_CHECK( !well_p1->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
-    BOOST_CHECK( !well_p2->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 3).getProductionProperties().controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 3).getProductionProperties().controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK( !schedule.getWell2("P1", 3).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P2", 3).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
 
     // 20 OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
-    BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
-    BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
-    BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
-    BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 4).getProductionProperties().controlMode, Opm::WellProducer::LRAT);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 4).getProductionProperties().controlMode, Opm::WellProducer::LRAT);
+    BOOST_CHECK( !schedule.getWell2("P1", 4).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P2", 4).getProductionProperties().hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !schedule.getWell2("P1", 4).getProductionProperties().hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !schedule.getWell2("P2", 4).getProductionProperties().hasProductionControl(Opm::WellProducer::RESV) );
 
     // 25 OKT 2008
-    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
-    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
-    BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
-    BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
-    BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
-    BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+    BOOST_CHECK_EQUAL(schedule.getWell2("P1", 5).getProductionProperties().controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P2", 5).getProductionProperties().controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK( !schedule.getWell2("P1", 5).getProductionProperties().hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !schedule.getWell2("P2", 5).getProductionProperties().hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !schedule.getWell2("P1", 5).getProductionProperties().hasProductionControl(Opm::WellProducer::LRAT) );
+    BOOST_CHECK( !schedule.getWell2("P2", 5).getProductionProperties().hasProductionControl(Opm::WellProducer::LRAT) );
 }
+
+
 
 BOOST_AUTO_TEST_CASE(unsupportedOptionWHISTCTL) {
     Opm::Parser parser;
@@ -1694,9 +1882,15 @@ BOOST_AUTO_TEST_CASE(move_HEAD_I_location) {
     Runspec runspec (deck);
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
-    const auto& well = *schedule.getWell( "W1" );
-    BOOST_CHECK_EQUAL( 3, well.getHeadI() );
-    BOOST_CHECK_EQUAL( 2, well.getHeadI( 1 ) );
+    {
+        const auto& well = *schedule.getWell( "W1" );
+        BOOST_CHECK_EQUAL( 3, well.getHeadI() );
+        BOOST_CHECK_EQUAL( 2, well.getHeadI( 1 ) );
+    }
+    {
+        BOOST_CHECK_EQUAL(2, schedule.getWell2("W1", 1).getHeadI());
+        BOOST_CHECK_EQUAL(3, schedule.getWell2("W1", 2).getHeadI());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(change_ref_depth) {
@@ -1727,13 +1921,20 @@ BOOST_AUTO_TEST_CASE(change_ref_depth) {
     Runspec runspec (deck);
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
-    const auto& well = *schedule.getWell( "W1" );
-    BOOST_CHECK_EQUAL( 12.0, well.getRefDepth() );
-    BOOST_CHECK_CLOSE( 2873.94, well.getRefDepth( 1 ), 1e-5 );
+    {
+        const auto& well = *schedule.getWell( "W1" );
+        BOOST_CHECK_EQUAL( 12.0, well.getRefDepth() );
+        BOOST_CHECK_CLOSE( 2873.94, well.getRefDepth( 1 ), 1e-5 );
+    }
+    {
+        BOOST_CHECK_CLOSE(2873.94, schedule.getWell2("W1", 1).getRefDepth(), 1e-5);
+        BOOST_CHECK_EQUAL(12.0, schedule.getWell2("W1", 2).getRefDepth());
+    }
 }
 
+
 BOOST_AUTO_TEST_CASE(WTEMP_well_template) {
-        std::string input = R"(
+    std::string input = R"(
             START             -- 0
             19 JUN 2007 /
             SCHEDULE
@@ -1760,17 +1961,18 @@ BOOST_AUTO_TEST_CASE(WTEMP_well_template) {
             /
     )";
 
-        auto deck = Parser().parseString(input);
-        EclipseGrid grid(10,10,10);
-        TableManager table ( deck );
-        Eclipse3DProperties eclipseProperties ( deck , table, grid);
-        Runspec runspec (deck);
-        Schedule schedule( deck, grid, eclipseProperties,runspec);
+    auto deck = Parser().parseString(input);
+    EclipseGrid grid(10,10,10);
+    TableManager table ( deck );
+    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    Runspec runspec (deck);
+    Schedule schedule( deck, grid, eclipseProperties,runspec);
 
+    {
         // Producerwell - currently setting temperature only acts on injectors.
         const auto& w1 = *schedule.getWell( "W1" );
         BOOST_CHECK_CLOSE( 288.71, w1.getInjectionProperties( 1 ).temperature, 1e-5 ); // Default value
-        BOOST_CHECK_CLOSE( 288.71, w1.getInjectionProperties( 1 ).temperature, 1e-5 ); // Default value Remains
+        BOOST_CHECK_CLOSE( 288.71, w1.getInjectionProperties( 2 ).temperature, 1e-5 ); // Default value Remains
 
         const auto& w2 = *schedule.getWell( "W2" );
         BOOST_CHECK_CLOSE( 288.71, w2.getInjectionProperties( 1 ).temperature, 1e-5 );
@@ -1779,7 +1981,17 @@ BOOST_AUTO_TEST_CASE(WTEMP_well_template) {
         const auto& w3 = *schedule.getWell( "W3" );
         BOOST_CHECK_CLOSE( 288.71, w3.getInjectionProperties( 1 ).temperature, 1e-5 );
         BOOST_CHECK_CLOSE( 313.15, w3.getInjectionProperties( 2 ).temperature, 1e-5 );
+    }
+    BOOST_CHECK_CLOSE(288.71, schedule.getWell2("W1", 1).getInjectionProperties().temperature, 1e-5);
+    BOOST_CHECK_CLOSE(288.71, schedule.getWell2("W1", 2).getInjectionProperties().temperature, 1e-5);
+
+    BOOST_CHECK_CLOSE(288.71, schedule.getWell2("W2", 1).getInjectionProperties().temperature, 1e-5);
+    BOOST_CHECK_CLOSE(313.15, schedule.getWell2("W2", 2).getInjectionProperties().temperature, 1e-5);
+
+    BOOST_CHECK_CLOSE(288.71, schedule.getWell2("W3", 1).getInjectionProperties().temperature, 1e-5);
+    BOOST_CHECK_CLOSE(313.15, schedule.getWell2("W3", 2).getInjectionProperties().temperature, 1e-5);
 }
+
 
 BOOST_AUTO_TEST_CASE(WTEMPINJ_well_template) {
         std::string input = R"(
@@ -1817,17 +2029,27 @@ BOOST_AUTO_TEST_CASE(WTEMPINJ_well_template) {
         Schedule schedule( deck, grid, eclipseProperties,runspec);
 
         // Producerwell - currently setting temperature only acts on injectors.
-        const auto& w1 = *schedule.getWell( "W1" );
-        BOOST_CHECK_CLOSE( 288.71, w1.getInjectionProperties( 1 ).temperature, 1e-5 ); // Default value
-        BOOST_CHECK_CLOSE( 288.71, w1.getInjectionProperties( 1 ).temperature, 1e-5 ); // Default value Remains
+        {
+            const auto& w1 = *schedule.getWell( "W1" );
+            BOOST_CHECK_CLOSE( 288.71, w1.getInjectionProperties( 1 ).temperature, 1e-5 ); // Default value
+            BOOST_CHECK_CLOSE( 288.71, w1.getInjectionProperties( 1 ).temperature, 1e-5 ); // Default value Remains
 
-        const auto& w2 = *schedule.getWell( "W2" );
-        BOOST_CHECK_CLOSE( 288.71, w2.getInjectionProperties( 1 ).temperature, 1e-5 );
-        BOOST_CHECK_CLOSE( 313.15, w2.getInjectionProperties( 2 ).temperature, 1e-5 );
+            const auto& w2 = *schedule.getWell( "W2" );
+            BOOST_CHECK_CLOSE( 288.71, w2.getInjectionProperties( 1 ).temperature, 1e-5 );
+            BOOST_CHECK_CLOSE( 313.15, w2.getInjectionProperties( 2 ).temperature, 1e-5 );
 
-        const auto& w3 = *schedule.getWell( "W3" );
-        BOOST_CHECK_CLOSE( 288.71, w3.getInjectionProperties( 1 ).temperature, 1e-5 );
-        BOOST_CHECK_CLOSE( 313.15, w3.getInjectionProperties( 2 ).temperature, 1e-5 );
+            const auto& w3 = *schedule.getWell( "W3" );
+            BOOST_CHECK_CLOSE( 288.71, w3.getInjectionProperties( 1 ).temperature, 1e-5 );
+            BOOST_CHECK_CLOSE( 313.15, w3.getInjectionProperties( 2 ).temperature, 1e-5 );
+        }
+        BOOST_CHECK_CLOSE(288.71, schedule.getWell2("W1", 1).getInjectionProperties().temperature, 1e-5);
+        BOOST_CHECK_CLOSE(288.71, schedule.getWell2("W1", 2).getInjectionProperties().temperature, 1e-5);
+
+        BOOST_CHECK_CLOSE(288.71, schedule.getWell2("W2", 1).getInjectionProperties().temperature, 1e-5);
+        BOOST_CHECK_CLOSE(313.15, schedule.getWell2("W2", 2).getInjectionProperties().temperature, 1e-5);
+
+        BOOST_CHECK_CLOSE(288.71, schedule.getWell2("W3", 1).getInjectionProperties().temperature, 1e-5);
+        BOOST_CHECK_CLOSE(313.15, schedule.getWell2("W3", 2).getInjectionProperties().temperature, 1e-5);
 }
 
 BOOST_AUTO_TEST_CASE( COMPDAT_sets_automatic_complnum ) {
@@ -1871,17 +2093,32 @@ BOOST_AUTO_TEST_CASE( COMPDAT_sets_automatic_complnum ) {
     Runspec runspec (deck);
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
-    const auto& cs1 = schedule.getWell( "W1" )->getConnections( 1 );
-    BOOST_CHECK_EQUAL( 1, cs1.get( 0 ).complnum() );
-    BOOST_CHECK_EQUAL( 2, cs1.get( 1 ).complnum() );
-    BOOST_CHECK_EQUAL( 3, cs1.get( 2 ).complnum() );
-    BOOST_CHECK_EQUAL( 4, cs1.get( 3 ).complnum() );
+    {
+        const auto& cs1 = schedule.getWell( "W1" )->getConnections( 1 );
+        BOOST_CHECK_EQUAL( 1, cs1.get( 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, cs1.get( 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, cs1.get( 2 ).complnum() );
+        BOOST_CHECK_EQUAL( 4, cs1.get( 3 ).complnum() );
 
-    const auto& cs2 = schedule.getWell( "W1" )->getConnections( 2 );
-    BOOST_CHECK_EQUAL( 1, cs2.get( 0 ).complnum() );
-    BOOST_CHECK_EQUAL( 2, cs2.get( 1 ).complnum() );
-    BOOST_CHECK_EQUAL( 3, cs2.get( 2 ).complnum() );
-    BOOST_CHECK_EQUAL( 4, cs2.get( 3 ).complnum() );
+        const auto& cs2 = schedule.getWell( "W1" )->getConnections( 2 );
+        BOOST_CHECK_EQUAL( 1, cs2.get( 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, cs2.get( 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, cs2.get( 2 ).complnum() );
+        BOOST_CHECK_EQUAL( 4, cs2.get( 3 ).complnum() );
+    }
+    {
+        const auto& cs1 = schedule.getWell2( "W1", 1 ).getConnections(  );
+        BOOST_CHECK_EQUAL( 1, cs1.get( 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, cs1.get( 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, cs1.get( 2 ).complnum() );
+        BOOST_CHECK_EQUAL( 4, cs1.get( 3 ).complnum() );
+
+        const auto& cs2 = schedule.getWell2( "W1", 2 ).getConnections(  );
+        BOOST_CHECK_EQUAL( 1, cs2.get( 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, cs2.get( 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, cs2.get( 2 ).complnum() );
+        BOOST_CHECK_EQUAL( 4, cs2.get( 3 ).complnum() );
+    }
 }
 
 BOOST_AUTO_TEST_CASE( COMPDAT_multiple_wells ) {
@@ -1922,21 +2159,41 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_wells ) {
     Runspec runspec (deck);
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
-    const auto& w1cs = schedule.getWell( "W1" )->getConnections();
-    BOOST_CHECK_EQUAL( 1, w1cs.get( 0 ).complnum() );
-    BOOST_CHECK_EQUAL( 2, w1cs.get( 1 ).complnum() );
-    BOOST_CHECK_EQUAL( 3, w1cs.get( 2 ).complnum() );
-    BOOST_CHECK_EQUAL( 4, w1cs.get( 3 ).complnum() );
-    BOOST_CHECK_EQUAL( 5, w1cs.get( 4 ).complnum() );
+    {
+        const auto& w1cs = schedule.getWell( "W1" )->getConnections();
+        BOOST_CHECK_EQUAL( 1, w1cs.get( 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, w1cs.get( 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, w1cs.get( 2 ).complnum() );
+        BOOST_CHECK_EQUAL( 4, w1cs.get( 3 ).complnum() );
+        BOOST_CHECK_EQUAL( 5, w1cs.get( 4 ).complnum() );
 
-    const auto& w2cs = schedule.getWell( "W2" )->getConnections();
-    BOOST_CHECK_EQUAL( 1, w2cs.getFromIJK( 4, 4, 2 ).complnum() );
-    BOOST_CHECK_EQUAL( 2, w2cs.getFromIJK( 4, 4, 0 ).complnum() );
-    BOOST_CHECK_EQUAL( 3, w2cs.getFromIJK( 4, 4, 1 ).complnum() );
-    BOOST_CHECK_EQUAL( 4, w2cs.getFromIJK( 4, 4, 3 ).complnum() );
-    BOOST_CHECK_EQUAL( 5, w2cs.getFromIJK( 4, 4, 4 ).complnum() );
+        const auto& w2cs = schedule.getWell( "W2" )->getConnections();
+        BOOST_CHECK_EQUAL( 1, w2cs.getFromIJK( 4, 4, 2 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, w2cs.getFromIJK( 4, 4, 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, w2cs.getFromIJK( 4, 4, 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 4, w2cs.getFromIJK( 4, 4, 3 ).complnum() );
+        BOOST_CHECK_EQUAL( 5, w2cs.getFromIJK( 4, 4, 4 ).complnum() );
 
-    BOOST_CHECK_THROW( w2cs.get( 5 ).complnum(), std::out_of_range );
+        BOOST_CHECK_THROW( w2cs.get( 5 ).complnum(), std::out_of_range );
+    }
+
+    {
+        const auto& w1cs = schedule.getWell2( "W1", 1 ).getConnections();
+        BOOST_CHECK_EQUAL( 1, w1cs.get( 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, w1cs.get( 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, w1cs.get( 2 ).complnum() );
+        BOOST_CHECK_EQUAL( 4, w1cs.get( 3 ).complnum() );
+        BOOST_CHECK_EQUAL( 5, w1cs.get( 4 ).complnum() );
+
+        const auto& w2cs = schedule.getWell2( "W2", 1 ).getConnections();
+        BOOST_CHECK_EQUAL( 1, w2cs.getFromIJK( 4, 4, 2 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, w2cs.getFromIJK( 4, 4, 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, w2cs.getFromIJK( 4, 4, 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 4, w2cs.getFromIJK( 4, 4, 3 ).complnum() );
+        BOOST_CHECK_EQUAL( 5, w2cs.getFromIJK( 4, 4, 4 ).complnum() );
+
+        BOOST_CHECK_THROW( w2cs.get( 5 ).complnum(), std::out_of_range );
+    }
 }
 
 BOOST_AUTO_TEST_CASE( COMPDAT_multiple_records_same_completion ) {
@@ -1972,13 +2229,22 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_records_same_completion ) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, eclipseProperties,runspec);
-
-    const auto& cs = schedule.getWell( "W1" )->getConnections();
-    BOOST_CHECK_EQUAL( 3U, cs.size() );
-    BOOST_CHECK_EQUAL( 1, cs.get( 0 ).complnum() );
-    BOOST_CHECK_EQUAL( 2, cs.get( 1 ).complnum() );
-    BOOST_CHECK_EQUAL( 3, cs.get( 2 ).complnum() );
+    {
+        const auto& cs = schedule.getWell( "W1" )->getConnections();
+        BOOST_CHECK_EQUAL( 3U, cs.size() );
+        BOOST_CHECK_EQUAL( 1, cs.get( 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, cs.get( 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, cs.get( 2 ).complnum() );
+    }
+    {
+        const auto& cs = schedule.getWell2( "W1", 1 ).getConnections();
+        BOOST_CHECK_EQUAL( 3U, cs.size() );
+        BOOST_CHECK_EQUAL( 1, cs.get( 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 2, cs.get( 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 3, cs.get( 2 ).complnum() );
+    }
 }
+
 
 BOOST_AUTO_TEST_CASE( complump_less_than_1 ) {
     std::string input = R"(
@@ -2065,35 +2331,67 @@ BOOST_AUTO_TEST_CASE( complump ) {
     Runspec runspec (deck);
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
-    const auto& well = *schedule.getWell( "W1" );
-    const auto& sc0  = well.getConnections( 0 );
+    {
+        const auto& well = *schedule.getWell( "W1" );
+        const auto& sc0  = well.getConnections( 0 );
 
-    /* complnum should be modified by COMPLNUM */
-    BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 0 ).complnum() );
-    BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 1 ).complnum() );
-    BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 2 ).complnum() );
+        /* complnum should be modified by COMPLNUM */
+        BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 2 ).complnum() );
 
-    BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 0 ).state() );
-    BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 1 ).state() );
-    BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 2 ).state() );
+        BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 0 ).state() );
+        BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 1 ).state() );
+        BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 2 ).state() );
 
-    const auto& sc1  = well.getConnections( 1 );
-    BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 0 ).state() );
-    BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 1 ).state() );
-    BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 2 ).state() );
-    BOOST_CHECK_EQUAL( shut, sc1.getFromIJK( 2, 2, 3 ).state() );
+        const auto& sc1  = well.getConnections( 1 );
+        BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 0 ).state() );
+        BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 1 ).state() );
+        BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 2 ).state() );
+        BOOST_CHECK_EQUAL( shut, sc1.getFromIJK( 2, 2, 3 ).state() );
 
-    const auto completions = well.getCompletions(1);
-    BOOST_CHECK_EQUAL(completions.size(), 4);
+        const auto completions = well.getCompletions(1);
+        BOOST_CHECK_EQUAL(completions.size(), 4);
 
-    const auto& c1 = completions.at(1);
-    BOOST_CHECK_EQUAL(c1.size(), 3);
+        const auto& c1 = completions.at(1);
+        BOOST_CHECK_EQUAL(c1.size(), 3);
 
-    for (const auto& pair : completions) {
-        if (pair.first == 1)
-            BOOST_CHECK(pair.second.size() > 1);
-        else
-            BOOST_CHECK_EQUAL(pair.second.size(), 1);
+        for (const auto& pair : completions) {
+            if (pair.first == 1)
+                BOOST_CHECK(pair.second.size() > 1);
+            else
+                BOOST_CHECK_EQUAL(pair.second.size(), 1);
+        }
+    }
+    {
+        const auto& sc0 = schedule.getWell2("W1", 0).getConnections();
+        /* complnum should be modified by COMPLNUM */
+        BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 0 ).complnum() );
+        BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 1 ).complnum() );
+        BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 2 ).complnum() );
+
+        BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 0 ).state() );
+        BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 1 ).state() );
+        BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 2 ).state() );
+
+        const auto& sc1  = schedule.getWell2("W1", 1).getConnections();
+        BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 0 ).state() );
+        BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 1 ).state() );
+        BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 2 ).state() );
+        BOOST_CHECK_EQUAL( shut, sc1.getFromIJK( 2, 2, 3 ).state() );
+
+        const auto& completions = schedule.getWell2("W1", 1).getCompletions();
+        BOOST_CHECK_EQUAL(completions.size(), 4);
+
+        const auto& c1 = completions.at(1);
+        BOOST_CHECK_EQUAL(c1.size(), 3);
+
+        for (const auto& pair : completions) {
+            if (pair.first == 1)
+                BOOST_CHECK(pair.second.size() > 1);
+            else
+                BOOST_CHECK_EQUAL(pair.second.size(), 1);
+        }
     }
 }
 
@@ -2157,10 +2455,32 @@ BOOST_AUTO_TEST_CASE( COMPLUMP_specific_coordinates ) {
     Runspec runspec (deck);
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
-    const auto& well = *schedule.getWell( "W1" );
-    const auto& cs1 = well.getConnections( 1 );
-    const auto& cs2 = well.getConnections( 2 );
+    {
+        const auto& well = *schedule.getWell( "W1" );
+        const auto& cs1 = well.getConnections( 1 );
+        const auto& cs2 = well.getConnections( 2 );
 
+        BOOST_CHECK_EQUAL( 9U, cs1.size() );
+        BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 0, 0, 1 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 2, 2, 0 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 2, 2, 1 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 2, 2, 2 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 1, 1, 0 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 1, 1, 3 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 1, 1, 4 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 1, 1, 5 ).state() );
+
+        BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 0, 0, 1 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs2.getFromIJK( 2, 2, 0 ).state() );
+        BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 2, 2, 1 ).state() );
+        BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 2, 2, 2 ).state() );
+        BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 1, 1, 0 ).state() );
+        BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 1, 1, 3 ).state() );
+        BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 1, 1, 4 ).state() );
+        BOOST_CHECK_EQUAL( shut, cs2.getFromIJK( 1, 1, 5 ).state() );
+    }
+    const auto& cs1 = schedule.getWell2("W1", 1).getConnections();
+    const auto& cs2 = schedule.getWell2("W1", 2).getConnections();
     BOOST_CHECK_EQUAL( 9U, cs1.size() );
     BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 0, 0, 1 ).state() );
     BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 2, 2, 0 ).state() );
@@ -2634,25 +2954,37 @@ BOOST_AUTO_TEST_CASE(handleWEFAC) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , eclipseProperties, runspec);
-    auto* well_p = schedule.getWell("P");
-    auto* well_i = schedule.getWell("I");
+    {
+        auto* well_p = schedule.getWell("P");
+        auto* well_i = schedule.getWell("I");
 
-    //start
-    BOOST_CHECK_EQUAL(well_p->getEfficiencyFactor(0), 1.0);
-    BOOST_CHECK_EQUAL(well_i->getEfficiencyFactor(0), 1.0);
+        //start
+        BOOST_CHECK_EQUAL(well_p->getEfficiencyFactor(0), 1.0);
+        BOOST_CHECK_EQUAL(well_i->getEfficiencyFactor(0), 1.0);
 
+        //1
+        BOOST_CHECK_EQUAL(well_p->getEfficiencyFactor(1), 0.5);
+        BOOST_CHECK_EQUAL(well_i->getEfficiencyFactor(1), 0.9);
+
+        //2
+        BOOST_CHECK_EQUAL(well_p->getEfficiencyFactor(2), 0.5);
+        BOOST_CHECK_EQUAL(well_i->getEfficiencyFactor(2), 0.9);
+
+        //3
+        BOOST_CHECK_EQUAL(well_p->getEfficiencyFactor(3), 1.0);
+        BOOST_CHECK_EQUAL(well_i->getEfficiencyFactor(3), 0.9);
+    }
     //1
-    BOOST_CHECK_EQUAL(well_p->getEfficiencyFactor(1), 0.5);
-    BOOST_CHECK_EQUAL(well_i->getEfficiencyFactor(1), 0.9);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P", 1).getEfficiencyFactor(), 0.5);
+    BOOST_CHECK_EQUAL(schedule.getWell2("I", 1).getEfficiencyFactor(), 0.9);
 
     //2
-    BOOST_CHECK_EQUAL(well_p->getEfficiencyFactor(2), 0.5);
-    BOOST_CHECK_EQUAL(well_i->getEfficiencyFactor(2), 0.9);
+    BOOST_CHECK_EQUAL(schedule.getWell2("P", 2).getEfficiencyFactor(), 0.5);
+    BOOST_CHECK_EQUAL(schedule.getWell2("I", 2).getEfficiencyFactor(), 0.9);
 
     //3
-    BOOST_CHECK_EQUAL(well_p->getEfficiencyFactor(3), 1.0);
-    BOOST_CHECK_EQUAL(well_i->getEfficiencyFactor(3), 0.9);
-
+    BOOST_CHECK_EQUAL(schedule.getWell2("P", 3).getEfficiencyFactor(), 1.0);
+    BOOST_CHECK_EQUAL(schedule.getWell2("I", 3).getEfficiencyFactor(), 0.9);
 }
 
 BOOST_AUTO_TEST_CASE(historic_BHP_and_THP) {
@@ -2665,9 +2997,9 @@ BOOST_AUTO_TEST_CASE(historic_BHP_and_THP) {
         " 10  OKT 2008 / \n"
         "/\n"
         "WELSPECS\n"
-        " 'P' 'OP' 9 9 1* 'OIL' 1* / \n"
-        " 'P1' 'OP' 9 9 1* 'OIL' 1* / \n"
-        " 'I' 'OP' 9 9 1* 'WATER' 1* / \n"
+        " 'P' 'OP' 9 9 1 'OIL' 1* / \n"
+        " 'P1' 'OP' 9 9 1 'OIL' 1* / \n"
+        " 'I' 'OP' 9 9 1 'WATER' 1* / \n"
         "/\n"
         "WCONHIST\n"
         " P SHUT ORAT 6  500 0 0 0 1.2 1.1 / \n"
@@ -2687,28 +3019,51 @@ BOOST_AUTO_TEST_CASE(historic_BHP_and_THP) {
     Runspec runspec (deck);
     Schedule schedule( deck, grid, eclipseProperties,runspec);
 
-    const auto& prod = schedule.getWell("P")->getProductionProperties(1);
-    const auto& pro1 = schedule.getWell("P1")->getProductionProperties(1);
-    const auto& inje = schedule.getWell("I")->getInjectionProperties(1);
-
-    BOOST_CHECK_CLOSE( 1.1 * 1e5,  prod.BHPH, 1e-5 );
-    BOOST_CHECK_CLOSE( 1.2 * 1e5,  prod.THPH, 1e-5 );
-    BOOST_CHECK_CLOSE( 2.1 * 1e5,  inje.BHPH, 1e-5 );
-    BOOST_CHECK_CLOSE( 2.2 * 1e5,  inje.THPH, 1e-5 );
-    BOOST_CHECK_CLOSE( 0.0 * 1e5,  pro1.BHPH, 1e-5 );
-    BOOST_CHECK_CLOSE( 0.0 * 1e5,  pro1.THPH, 1e-5 );
-
     {
-        const auto& wtest_config = schedule.wtestConfig(0);
-        BOOST_CHECK_EQUAL(wtest_config.size(), 0);
+        const auto& prod = schedule.getWell("P")->getProductionProperties(1);
+        const auto& pro1 = schedule.getWell("P1")->getProductionProperties(1);
+        const auto& inje = schedule.getWell("I")->getInjectionProperties(1);
+
+        BOOST_CHECK_CLOSE( 1.1 * 1e5,  prod.BHPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 1.2 * 1e5,  prod.THPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 2.1 * 1e5,  inje.BHPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 2.2 * 1e5,  inje.THPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 0.0 * 1e5,  pro1.BHPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 0.0 * 1e5,  pro1.THPH, 1e-5 );
+
+        {
+            const auto& wtest_config = schedule.wtestConfig(0);
+            BOOST_CHECK_EQUAL(wtest_config.size(), 0);
+        }
+
+        {
+            const auto& wtest_config = schedule.wtestConfig(1);
+            BOOST_CHECK_EQUAL(wtest_config.size(), 0);
+        }
     }
-
     {
-        const auto& wtest_config = schedule.wtestConfig(1);
-        BOOST_CHECK_EQUAL(wtest_config.size(), 0);
+        const auto& prod = schedule.getWell2("P", 1).getProductionProperties();
+        const auto& pro1 = schedule.getWell2("P1", 1).getProductionProperties();
+        const auto& inje = schedule.getWell2("I", 1).getInjectionProperties();
+
+        BOOST_CHECK_CLOSE( 1.1 * 1e5,  prod.BHPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 1.2 * 1e5,  prod.THPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 2.1 * 1e5,  inje.BHPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 2.2 * 1e5,  inje.THPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 0.0 * 1e5,  pro1.BHPH, 1e-5 );
+        BOOST_CHECK_CLOSE( 0.0 * 1e5,  pro1.THPH, 1e-5 );
+
+        {
+            const auto& wtest_config = schedule.wtestConfig(0);
+            BOOST_CHECK_EQUAL(wtest_config.size(), 0);
+        }
+
+        {
+            const auto& wtest_config = schedule.wtestConfig(1);
+            BOOST_CHECK_EQUAL(wtest_config.size(), 0);
+        }
     }
 }
-
 
 BOOST_AUTO_TEST_CASE(FilterCompletions) {
   EclipseGrid grid1(10,10,10);
@@ -2741,6 +3096,37 @@ BOOST_AUTO_TEST_CASE(FilterCompletions) {
       BOOST_CHECK_EQUAL( well->getTotNoConn(), 9);
   }
 }
+
+BOOST_AUTO_TEST_CASE(FilterCompletions2) {
+    EclipseGrid grid1(10,10,10);
+    std::vector<int> actnum(1000,1);
+    auto deck = createDeckWithWellsAndCompletionData();
+    TableManager table ( deck );
+    Eclipse3DProperties eclipseProperties ( deck , table, grid1);
+    Runspec runspec (deck);
+    Schedule schedule(deck, grid1 , eclipseProperties, runspec);
+    {
+        const auto& c1_1 = schedule.getWell2("OP_1", 1).getConnections();
+        const auto& c1_3 = schedule.getWell2("OP_1", 3).getConnections();
+        BOOST_CHECK_EQUAL(2, c1_1.size());
+        BOOST_CHECK_EQUAL(9, c1_3.size());
+    }
+    actnum[grid1.getGlobalIndex(8,8,1)] = 0;
+    {
+        EclipseGrid grid2(grid1, actnum);
+        schedule.filterConnections(grid2);
+
+        const auto& c1_1 = schedule.getWell2("OP_1", 1).getConnections();
+        const auto& c1_3 = schedule.getWell2("OP_1", 3).getConnections();
+        BOOST_CHECK_EQUAL(1, c1_1.size());
+        BOOST_CHECK_EQUAL(8, c1_3.size());
+
+        BOOST_CHECK_EQUAL(2, c1_1.inputSize());
+        BOOST_CHECK_EQUAL(9, c1_3.inputSize());
+    }
+}
+
+
 
 
 BOOST_AUTO_TEST_CASE(VFPINJ_TEST) {
@@ -2892,7 +3278,7 @@ BOOST_AUTO_TEST_CASE(POLYINJ_TEST) {
         "PROPS\n \n"
         "SCHEDULE\n"
         "WELSPECS\n"
-        "'INJE01' 'I'    1  1 1* 'WATER'     /\n"
+        "'INJE01' 'I'    1  1 1 'WATER'     /\n"
         "/\n"
         "TSTEP\n"
         " 1/\n"
@@ -2924,31 +3310,48 @@ BOOST_AUTO_TEST_CASE(POLYINJ_TEST) {
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , eclipseProperties, runspec);
 
-    const Opm::Well* well_inj01 = schedule.getWell("INJE01");
-
-    // start
     {
-        const auto wpolymer = well_inj01->getPolymerProperties(0);
-        BOOST_CHECK_EQUAL(wpolymer.m_plymwinjtable, -1);
-        BOOST_CHECK_EQUAL(wpolymer.m_skprwattable, -1);
-        BOOST_CHECK_EQUAL(wpolymer.m_skprpolytable, -1);
-    }
+        const Opm::Well* well_inj01 = schedule.getWell("INJE01");
 
-    // report step 1
-    {
-        const auto wpolymer = well_inj01->getPolymerProperties(1);
-        BOOST_CHECK_EQUAL(wpolymer.m_plymwinjtable, 2);
-        BOOST_CHECK_EQUAL(wpolymer.m_skprwattable, 1);
-        BOOST_CHECK_EQUAL(wpolymer.m_skprpolytable, 1);
-    }
+        // start
+        {
+            const auto wpolymer = well_inj01->getPolymerProperties(0);
+            BOOST_CHECK_EQUAL(wpolymer.m_plymwinjtable, -1);
+            BOOST_CHECK_EQUAL(wpolymer.m_skprwattable, -1);
+            BOOST_CHECK_EQUAL(wpolymer.m_skprpolytable, -1);
+        }
 
-    // report step 3
-    {
-        const auto wpolymer = well_inj01->getPolymerProperties(3);
-        BOOST_CHECK_EQUAL(wpolymer.m_plymwinjtable, 3);
-        BOOST_CHECK_EQUAL(wpolymer.m_skprwattable, 2);
-        BOOST_CHECK_EQUAL(wpolymer.m_skprpolytable, 2);
+        // report step 1
+        {
+            const auto wpolymer = well_inj01->getPolymerProperties(1);
+            BOOST_CHECK_EQUAL(wpolymer.m_plymwinjtable, 2);
+            BOOST_CHECK_EQUAL(wpolymer.m_skprwattable, 1);
+            BOOST_CHECK_EQUAL(wpolymer.m_skprpolytable, 1);
+        }
+
+        // report step 3
+        {
+            const auto wpolymer = well_inj01->getPolymerProperties(3);
+            BOOST_CHECK_EQUAL(wpolymer.m_plymwinjtable, 3);
+            BOOST_CHECK_EQUAL(wpolymer.m_skprwattable, 2);
+            BOOST_CHECK_EQUAL(wpolymer.m_skprpolytable, 2);
+        }
     }
+    const auto& poly0 = schedule.getWell2("INJE01", 0).getPolymerProperties();
+    const auto& poly1 = schedule.getWell2("INJE01", 1).getPolymerProperties();
+    const auto& poly3 = schedule.getWell2("INJE01", 3).getPolymerProperties();
+
+    BOOST_CHECK_EQUAL(poly0.m_plymwinjtable, -1);
+    BOOST_CHECK_EQUAL(poly0.m_skprwattable, -1);
+    BOOST_CHECK_EQUAL(poly0.m_skprpolytable, -1);
+
+    BOOST_CHECK_EQUAL(poly1.m_plymwinjtable, 2);
+    BOOST_CHECK_EQUAL(poly1.m_skprwattable, 1);
+    BOOST_CHECK_EQUAL(poly1.m_skprpolytable, 1);
+
+    BOOST_CHECK_EQUAL(poly3.m_plymwinjtable, 3);
+    BOOST_CHECK_EQUAL(poly3.m_skprwattable, 2);
+    BOOST_CHECK_EQUAL(poly3.m_skprpolytable, 2);
 }
 
 
@@ -2979,6 +3382,54 @@ bool has(const std::vector<std::string>& l, const std::string& s) {
     return (f != l.end());
 }
 
+
+
+BOOST_AUTO_TEST_CASE(WELL_STATIC) {
+    auto deck = createDeckWithWells();
+    EclipseGrid grid1(10,10,10);
+    TableManager table ( deck );
+    Eclipse3DProperties eclipseProperties ( deck , table, grid1);
+    Runspec runspec (deck);
+    Schedule schedule(deck, grid1 , eclipseProperties, runspec);
+    BOOST_CHECK_THROW( schedule.getWell2("NO_SUCH_WELL", 0), std::invalid_argument);
+    BOOST_CHECK_THROW( schedule.getWell2("W_3", 0), std::invalid_argument);
+
+    auto ws = schedule.getWell2("W_3", 3);
+    {
+        // Make sure the copy constructor works.
+        Well2 ws_copy(ws);
+    }
+    BOOST_CHECK_EQUAL(ws.name(), "W_3");
+
+    BOOST_CHECK(!ws.updateHead(19, 50));
+    BOOST_CHECK(ws.updateHead(1,50));
+    BOOST_CHECK(!ws.updateHead(1,50));
+    BOOST_CHECK(ws.updateHead(1,1));
+    BOOST_CHECK(!ws.updateHead(1,1));
+
+    BOOST_CHECK(ws.updateRefDepth(1.0));
+    BOOST_CHECK(!ws.updateRefDepth(1.0));
+
+    ws.updateStatus(WellCommon::OPEN);
+    BOOST_CHECK(!ws.updateStatus(WellCommon::OPEN));
+    BOOST_CHECK(ws.updateStatus(WellCommon::SHUT));
+
+    const auto& connections = ws.getConnections();
+    BOOST_CHECK_EQUAL(connections.size(), 0);
+    auto c2 = std::make_shared<WellConnections>(1,1);
+    c2->addConnection(1,1,1,
+                      100,
+                      WellCompletion::StateEnum::OPEN,
+                      10,
+                      10,
+                      10,
+                      10,
+                      10,
+                      100);
+
+    BOOST_CHECK(  ws.updateConnections(c2) );
+    BOOST_CHECK( !ws.updateConnections(c2) );
+}
 
 
 BOOST_AUTO_TEST_CASE(WellNames) {

--- a/tests/parser/data/integration_tests/IOConfig/RPT_TEST2.DATA
+++ b/tests/parser/data/integration_tests/IOConfig/RPT_TEST2.DATA
@@ -40,7 +40,7 @@ RPTRST
 --NORST=1  --> output for visualization only 
 
 WELSPECS
-     'F-14A'    'FIELD'   12   85  1*       'OIL'  7* /
+     'F-14A'    'FIELD'   12   85  99.00       'OIL'  7* /
 /
 
 DATES

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -572,6 +572,7 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
     const Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     const Schedule sched(deck, grid, eclipseProperties, runspec);
+
     // checking the relation between segments and completions
     // and also the depth of completions
     {

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -320,7 +320,7 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT_DEFAULTED_ITEMS) {
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_COMPDAT1");
     auto deck =  parser.parseFile(scheduleFile);
-    EclipseGrid grid(40,60,30);
+    EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
@@ -685,7 +685,7 @@ BOOST_AUTO_TEST_CASE(OpmCode) {
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/wells_group.data");
     auto deck =  parser.parseFile(scheduleFile);
-    EclipseGrid grid(10,10,3);
+    EclipseGrid grid(10,10,5);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);


### PR DESCRIPTION
[This is #674 which was accidentally closed due to some git fat fingering]

This is the first step of an implementation of: #624 - which again is part of the UDQ / UDA work; it should now be ~ready for review. Observe that when this is merged it will have no immediately visible effect - the new well implementation Well2 will exist side by side with the existing implementation Well - and downstream will exclusively use the old Well. As part of this PR an system for well integration testing is integrated into the Schedule constructor - this is briefly described here: #680. When this is merged I encourage all developers to configure opm-common with:
```
bash% cmake .. -DENABLE_WELL_TEST=ON
```
then the automatic "Well ≡ Well2" test will be run as part of Schedule construction; please report any errors you encounter!

When the Well2 implementation has worked silently for some time it is actually time to start using it - that is the subject of this PR: #731 - that is into a moderately distant future.

I quite often preach about the value of small PR's - and I mean it - this PR contains one atomic unit - a new well implementation, and in that sense I feel it is reasonable as one large PR, but to practice as I preach I am willing to split it in subatmoic units to facilitate simpler review. 