### PR TITLE
fixed unset return value causing segfault in release build on ubuntu …

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -241,7 +241,7 @@ namespace Opm {
     }
 
     bool Well::setProducer(size_t timeStep, bool producer) {
-        this->m_isProducer.update(timeStep, producer);
+        return this->m_isProducer.update(timeStep, producer);
     }
 
     bool Well::isProducer(size_t timeStep) const {


### PR DESCRIPTION
unset return value made strange behavoir.
flow segfault before parsing ends on all builds except debug on  18.10