### PR TITLE
An improvement / correction of the writing of MSW data to Eclipse compatible restart file

### DIFF
--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -207,10 +207,18 @@ namespace {
 	    const auto& segNo = openConnections[connID]->segment();
 	    const auto& segInd = segSet.segmentNumberToIndex(segNo);
 	    const auto& Q = rateConns[connID].rates;
-	    qosc[segInd] += -units.from_si(M::liquid_surface_rate, Q.get(R::oil));
-	    qwsc[segInd] += -units.from_si(M::liquid_surface_rate, Q.get(R::wat));
-	    qgsc[segInd] += -units.from_si(M::gas_surface_rate,    Q.get(R::gas));
+	    
+	    auto get = [&units, &Q](const M u, const R q) -> double
+	    {
+		const auto val = Q.has(q) ? Q.get(q) : 0.0;
 
+		return - units.from_si(u, val);
+	    };
+
+	    qosc[segInd] += get(M::liquid_surface_rate, R::oil);
+	    qwsc[segInd] += get(M::liquid_surface_rate, R::wat);
+	    qgsc[segInd] += get(M::gas_surface_rate,    R::gas);
+	    
 	}
 
 	return {


### PR DESCRIPTION
This Improvement / correction enables handling more general MSW data  for writing to
Eclipse compatible restart file.

I will thank Baard Skaflestad for good assistance and collaboration.