### PR TITLE
Restart: Provide Continuous Cumulatives in OPM Extended Files

### DIFF
--- a/opm/output/eclipse/AggregateGroupData.hpp
+++ b/opm/output/eclipse/AggregateGroupData.hpp
@@ -61,7 +61,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 				      const std::vector<std::string>&      restart_field_keys,
 				      const std::map<std::string, size_t>& groupKeyToIndex,
 				      const std::map<std::string, size_t>& fieldKeyToIndex,
-				      const bool                           ecl_compatible_rst,
 				      const std::size_t                    simStep,
 				      const Opm::SummaryState&             sumState,
 				      const std::vector<int>&              inteHead);

--- a/opm/output/eclipse/AggregateWellData.hpp
+++ b/opm/output/eclipse/AggregateWellData.hpp
@@ -52,7 +52,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 
         void captureDynamicWellData(const Opm::Schedule&        sched,
                                     const std::size_t           sim_step,
-				    const bool ecl_compatible_rst,
                                     const Opm::data::WellRates& xw,
                                     const Opm::SummaryState&    smry);
 

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -369,31 +369,6 @@ namespace {
             };
         }
 
-        std::vector<std::string>
-        filter_cumulative(const bool     ecl_compatible_rst,
-                          const std::vector<std::string>& keys)
-        {
-            if (ecl_compatible_rst) {
-                // User wants ECLIPSE-compatible output.  Write all vectors.
-                return keys;
-            }
-
-            auto ret = std::vector<std::string>{};
-            ret.reserve(keys.size());
-
-            for (const auto& key : keys) {
-                if ((key[3] == 'T') && ((key[2] == 'I') || (key[2] == 'P'))) {
-                    // Don't write cumulative quantities in case of OPM
-                    // extended restart files.
-                    continue;
-                }
-
-                ret.push_back(key);
-            }
-
-            return ret;
-        }
-
         // here define the dynamic group quantities to be written to the restart file
         template <class XGrpArray>
         void dynamicContrib(const std::vector<std::string>&      restart_group_keys,
@@ -402,7 +377,6 @@ namespace {
 			    const std::map<std::string, size_t>& fieldKeyToIndex,
 			    const Opm::Group&                    group,
 			    const Opm::SummaryState&             sumState,
-			    const bool                           ecl_compatible_rst,
 			    XGrpArray&                           xGrp)
         {
 	  std::string groupName = group.name();
@@ -411,7 +385,7 @@ namespace {
 	  const std::map<std::string, size_t>& keyToIndex = (groupName == "FIELD")
 	  ? fieldKeyToIndex : groupKeyToIndex;
 
-	  for (const auto key : filter_cumulative(ecl_compatible_rst,keys)) {
+	  for (const auto& key : keys) {
 	      std::string compKey = (groupName == "FIELD")
 	      ? key : key + ":" + groupName;
 
@@ -517,7 +491,6 @@ captureDeclaredGroupData(const Opm::Schedule&                 sched,
 			 const std::vector<std::string>&      restart_field_keys,
 			 const std::map<std::string, size_t>& groupKeyToIndex,
 			 const std::map<std::string, size_t>& fieldKeyToIndex,
-			 const bool                           ecl_compatible_rst,
 			 const std::size_t                    simStep,
 			 const Opm::SummaryState&             sumState,
 			 const std::vector<int>&              inteHead)
@@ -554,14 +527,14 @@ captureDeclaredGroupData(const Opm::Schedule&                 sched,
     // Define Dynamic Contributions to XGrp Array.
     groupLoop(curGroups, [&restart_group_keys, &restart_field_keys,
                           &groupKeyToIndex, &fieldKeyToIndex,
-                          ecl_compatible_rst, &sumState, this]
+                          &sumState, this]
 	(const Group& group, const std::size_t groupID) -> void
     {
         auto xg = this->xGroup_[groupID];
 
         XGrp::dynamicContrib(restart_group_keys, restart_field_keys,
                              groupKeyToIndex, fieldKeyToIndex, group,
-                             sumState, ecl_compatible_rst, xg);
+                             sumState, xg);
     });
 
     // Define Static Contributions to ZGrp Array.

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -302,7 +302,6 @@ namespace {
 
     void writeGroup(::Opm::RestartIO::ecl_rst_file_type* rst_file,
                     int                                  sim_step,
-                    const bool                           ecl_compatible_rst,
                     const Schedule&                      schedule,
                     const Opm::SummaryState&             sumState,
                     const std::vector<int>&              ih)
@@ -320,8 +319,8 @@ namespace {
         groupData.captureDeclaredGroupData(schedule,
                                            rst_g_keys, rst_f_keys,
                                            grpKeyToInd, fldKeyToInd,
-                                           ecl_compatible_rst,
                                            simStep, sumState, ih);
+
         write_kw(rst_file, "IGRP", groupData.getIGroup());
         write_kw(rst_file, "SGRP", groupData.getSGroup());
         write_kw(rst_file, "XGRP", groupData.getXGroup());
@@ -364,7 +363,6 @@ namespace {
         auto wellData = Helpers::AggregateWellData(ih);
         wellData.captureDeclaredWellData(schedule, units, sim_step, sumState, ih);
         wellData.captureDynamicWellData(schedule, sim_step,
-                                        ecl_compatible_rst,
                                         wells, sumState);
 
         write_kw(rst_file, "IWEL", wellData.getIWell());
@@ -555,8 +553,7 @@ void save(const std::string&  filename,
                     nextStepSize(value), seconds_elapsed,
                     schedule, grid, es);
 
-    writeGroup(rst_file.get(), sim_step, ecl_compatible_rst,
-               schedule, sumState, inteHD);
+    writeGroup(rst_file.get(), sim_step, schedule, sumState, inteHD);
 
     // Write well and MSW data only when applicable (i.e., when present)
     {

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -503,11 +503,9 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data)
     const auto& rst_f_keys  = agrpd.restart_field_keys;
     const auto& grpKeyToInd = agrpd.groupKeyToIndex;
     const auto& fldKeyToInd = agrpd.fieldKeyToIndex;
-    const bool ecl_compatible_rst = true;
     agrpd.captureDeclaredGroupData(simCase.sched,
 				   rst_g_keys, rst_f_keys,
 				   grpKeyToInd, fldKeyToInd,
-				   ecl_compatible_rst,
 				   rptStep, smry,
 				   ih.value);
 

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE (Dynamic_Well_Data_Step1)
     const auto smry = sim_state();
     auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
 
-    awd.captureDynamicWellData(simCase.sched, rptStep, true, xw, smry);
+    awd.captureDynamicWellData(simCase.sched, rptStep, xw, smry);
 
     // IWEL (OP_1)
     {
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE (Dynamic_Well_Data_Step2)
     const auto smry = sim_state();
     auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
 
-    awd.captureDynamicWellData(simCase.sched, rptStep, true, xw, smry);
+    awd.captureDynamicWellData(simCase.sched, rptStep, xw, smry);
 
     // IWEL (OP_1) -- closed producer
     {


### PR DESCRIPTION
This commit removes the restriction that cumulative totals are not output in the case of creating OPM Extended Restart files.  There was a reason why we did not do this when the new restart facility was introduced, but that reason no longer applies.

This is an enabling step towards merging PR #703.