### PR TITLE
Two small but critical fixes

### DIFF
--- a/examples/test_util/EclFile.cpp
+++ b/examples/test_util/EclFile.cpp
@@ -19,6 +19,7 @@
 #include "EclFile.hpp"
 #include "EclUtil.hpp"
 
+#include <array>
 #include <functional>
 #include <string>
 #include <string.h>

--- a/examples/test_util/EclUtil.hpp
+++ b/examples/test_util/EclUtil.hpp
@@ -19,6 +19,7 @@
 #ifndef ECL_UTIL_HPP
 #define ECL_UTIL_HPP
 
+#include <string>
 #include <tuple>
 #include <examples/test_util/data/EclIOdata.hpp>
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -67,6 +67,7 @@ namespace Opm {
         else
             cmode = wp::ControlModeFromString( cmodeItem.getTrimmedString( 0 ) );
 
+        m_productionControls = 0;
         if (effectiveHistoryProductionControl(cmode)) {
             this->addProductionControl( cmode );
             this->controlMode = cmode;


### PR DESCRIPTION
1. Fix compile error due to missing includes (might just bite clang users though)
2. Fix for control mode bug that cause Norne to fail (or rather worse: run but produce totally wrong results).

The control mode bug fix might not be completely sufficient, but at least it recovers the running of Norne.

@akva2 the second commit should be picked to the release branch (sorry for the extra work), unless @joakim-hove has a better alternative.