### PR TITLE
modifying the ScheduleTests to handle control mode change with WCONHIST

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -67,6 +67,7 @@ namespace Opm {
         else
             cmode = wp::ControlModeFromString( cmodeItem.getTrimmedString( 0 ) );
 
+        // clearing the existing targets/limits
         m_productionControls = 0;
         if (effectiveHistoryProductionControl(cmode)) {
             this->addProductionControl( cmode );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1491,18 +1491,32 @@ BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {
     //15  OKT 2008
     BOOST_CHECK_EQUAL(well_p1->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
     BOOST_CHECK_EQUAL(well_p2->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+    // under history mode, a producing well should have only one rate target/limit or have no rate target/limit.
+    // the rate target/limit from previous report step should not be kept.
+    BOOST_CHECK( !well_p1->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !well_p2->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
 
     //18  OKT 2008
     BOOST_CHECK_EQUAL(well_p1->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
     BOOST_CHECK_EQUAL(well_p2->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK( !well_p1->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !well_p2->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
 
     // 20 OKT 2008
     BOOST_CHECK_EQUAL(well_p1->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
     BOOST_CHECK_EQUAL(well_p2->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
+    BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
 
     // 25 OKT 2008
     BOOST_CHECK_EQUAL(well_p1->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
     BOOST_CHECK_EQUAL(well_p2->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+    BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
 }
 
 BOOST_AUTO_TEST_CASE(unsupportedOptionWHISTCTL) {


### PR DESCRIPTION
@joakim-hove , please suggest whether it is something you want. It covers the correction introduced in https://github.com/OPM/opm-common/pull/746 , while it is included in a test specified for WHISCTL. 