### PR TITLE
Internalize a global WHISTCTL setting in the Schedule object

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -179,6 +179,7 @@ namespace Opm
         DynamicState<std::shared_ptr<WellTestConfig>> wtest_config;
         DynamicState<std::shared_ptr<WListManager>> wlist_manager;
         DynamicState<std::shared_ptr<UDQInput>> udq_config;
+        DynamicState<WellProducer::ControlModeEnum> global_whistctl_mode;
         RFTConfig rft_config;
 
         Actions m_actions;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -52,6 +52,7 @@ namespace Opm {
     public:
         Well(const std::string& name, const size_t& seqIndex, int headI,
              int headJ, double refDepth, double drainageRadius, Phase preferredPhase,
+             WellProducer::ControlModeEnum whist_ctl,
              const TimeMap& timeMap, size_t creationTimeStep,
              WellCompletion::CompletionOrderEnum completionOrdering = WellCompletion::TRACK,
              bool allowCrossFlow = true, bool automaticShutIn = true);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -87,6 +87,7 @@ namespace Opm {
         wtest_config(this->m_timeMap, std::make_shared<WellTestConfig>() ),
         wlist_manager( this->m_timeMap, std::make_shared<WListManager>()),
         udq_config(this->m_timeMap, std::make_shared<UDQInput>(deck)),
+        global_whistctl_mode(this->m_timeMap, WellProducer::CMODE_UNDEFINED),
         rft_config(this->m_timeMap)
     {
         addGroup( "FIELD", 0 );
@@ -436,7 +437,8 @@ namespace Opm {
                 std::string msg = "The WHISTCTL keyword specifies an un-supported control mode " + cmodeString
                     + ", which makes WHISTCTL keyword not affect the simulation at all";
                 OpmLog::warning(msg);
-            }
+            } else
+                this->global_whistctl_mode.update(currentStep, controlMode);
         }
 
         const std::string bhp_terminate = record.getItem("BPH_TERMINATE").getTrimmedString(0);
@@ -1628,10 +1630,9 @@ namespace Opm {
         }
 
         const size_t wseqIndex = m_wells.size();
-
         Well well(wellName, wseqIndex,
                   headI, headJ, refDepth, drainageRadius,
-                  preferredPhase, m_timeMap,
+                  preferredPhase, this->global_whistctl_mode[timeStep], m_timeMap,
                   timeStep,
                   wellConnectionOrder, allowCrossFlow, automaticShutIn);
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -35,6 +35,7 @@ namespace Opm {
 
     Well::Well(const std::string& name_, const size_t& seqIndex_, int headI,
                int headJ, double refDepth , double drainageRadius, Phase preferredPhase,
+               WellProducer::ControlModeEnum whist_ctl,
                const TimeMap& timeMap, size_t creationTimeStep,
                WellCompletion::CompletionOrderEnum completionOrdering,
                bool allowCrossFlow, bool automaticShutIn)
@@ -67,6 +68,9 @@ namespace Opm {
           m_segmentset( timeMap, WellSegments{} ),
           timesteps( timeMap.numTimesteps() )
     {
+        WellProductionProperties p;
+        p.whistctl_cmode = whist_ctl;
+        this->m_productionProperties = DynamicState<WellProductionProperties>(timeMap, p);
     }
 
     const std::string& Well::name() const {

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -156,8 +156,8 @@ BOOST_AUTO_TEST_CASE(GroupAddWell) {
 
     auto timeMap = createXDaysTimeMap( 10 );
     Opm::Group group("G1" , 1, timeMap , 0);
-    auto well1 = std::make_shared< Well >("WELL1", 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap, 0);
-    auto well2 = std::make_shared< Well >("WELL2", 2, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap, 0);
+    auto well1 = std::make_shared< Well >("WELL1", 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
+    auto well2 = std::make_shared< Well >("WELL2", 2, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
     group.addWell( 3 , well1->name() );
@@ -193,8 +193,8 @@ BOOST_AUTO_TEST_CASE(GroupAddAndDelWell) {
 
     auto timeMap = createXDaysTimeMap( 10 );
     Opm::Group group("G1" , 1, timeMap , 0);
-    auto well1 = std::make_shared< Well >("WELL1", 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap, 0);
-    auto well2 = std::make_shared< Well >("WELL2", 2, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap, 0);
+    auto well1 = std::make_shared< Well >("WELL1", 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
+    auto well2 = std::make_shared< Well >("WELL2", 2, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
     group.addWell( 3 , well1->name() );
@@ -226,8 +226,8 @@ BOOST_AUTO_TEST_CASE(GroupAddAndDelWell) {
 BOOST_AUTO_TEST_CASE(getWells) {
     auto timeMap = createXDaysTimeMap( 10 );
     Opm::Group group("G1" , 1, timeMap , 0);
-    auto well1 = std::make_shared< Well >("WELL1", 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap, 0);
-    auto well2 = std::make_shared< Well >("WELL2", 2, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap, 0);
+    auto well1 = std::make_shared< Well >("WELL1", 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
+    auto well2 = std::make_shared< Well >("WELL2", 2, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
     group.addWell( 2 , well1->name() );
     group.addWell( 3 , well1->name() );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1519,6 +1519,113 @@ BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {
     BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
 }
 
+BOOST_AUTO_TEST_CASE(WHISTCTL_NEW_WELL) {
+    Opm::Parser parser;
+    std::string input =
+            "START             -- 0 \n"
+            "19 JUN 2007 / \n"
+            "SCHEDULE\n"
+            "WHISTCTL\n"
+            " GRAT/ \n"
+            "DATES             -- 1\n"
+            " 10  OKT 2008 / \n"
+            "/\n"
+            "WELSPECS\n"
+            "    'P1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+            "    'P2'       'OP'   5   5 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+            "    'I'       'OP'   1   1 1*     'WATER' 1*      1*  1*   1*  1*   1*  1*  / \n"
+            "/\n"
+            "COMPDAT\n"
+            " 'P1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+            " 'P1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
+            " 'P2'  5  5   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+            " 'P2'  5  5   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
+            " 'I'  1  1   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+            "/\n"
+            "WCONHIST\n"
+            " 'P1' 'OPEN' 'ORAT' 5*/ \n"
+            " 'P2' 'OPEN' 'ORAT' 5*/ \n"
+            "/\n"
+            "DATES             -- 2\n"
+            " 15  OKT 2008 / \n"
+            "/\n"
+            "WHISTCTL\n"
+            " RESV / \n"
+            "WCONHIST\n"
+            " 'P1' 'OPEN' 'ORAT' 5*/ \n"
+            " 'P2' 'OPEN' 'ORAT' 5*/ \n"
+            "/\n"
+            "DATES             -- 3\n"
+            " 18  OKT 2008 / \n"
+            "/\n"
+            "WCONHIST\n"
+            " 'P1' 'OPEN' 'ORAT' 5*/ \n"
+            " 'P2' 'OPEN' 'ORAT' 5*/ \n"
+            "/\n"
+            "DATES             -- 4\n"
+            " 20  OKT 2008 / \n"
+            "/\n"
+            "WHISTCTL\n"
+            " LRAT / \n"
+            "WCONHIST\n"
+            " 'P1' 'OPEN' 'ORAT' 5*/ \n"
+            " 'P2' 'OPEN' 'ORAT' 5*/ \n"
+            "/\n"
+            "DATES             -- 5\n"
+            " 25  OKT 2008 / \n"
+            "/\n"
+            "WHISTCTL\n"
+            " NONE / \n"
+            "WCONHIST\n"
+            " 'P1' 'OPEN' 'ORAT' 5*/ \n"
+            " 'P2' 'OPEN' 'ORAT' 5*/ \n"
+            "/\n"
+            ;
+
+    auto deck = parser.parseString(input);
+    EclipseGrid grid(10,10,10);
+    TableManager table ( deck );
+    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    Runspec runspec (deck);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
+    auto* well_p1 = schedule.getWell("P1");
+    auto* well_p2 = schedule.getWell("P2");
+
+    //10  OKT 2008
+    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(1).controlMode, Opm::WellProducer::GRAT);
+    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(1).controlMode, Opm::WellProducer::GRAT);
+
+    //15  OKT 2008
+    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(2).controlMode, Opm::WellProducer::RESV);
+    // under history mode, a producing well should have only one rate target/limit or have no rate target/limit.
+    // the rate target/limit from previous report step should not be kept.
+    BOOST_CHECK( !well_p1->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !well_p2->getProductionProperties(2).hasProductionControl(Opm::WellProducer::ORAT) );
+
+    //18  OKT 2008
+    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(3).controlMode, Opm::WellProducer::RESV);
+    BOOST_CHECK( !well_p1->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !well_p2->getProductionProperties(3).hasProductionControl(Opm::WellProducer::ORAT) );
+
+    // 20 OKT 2008
+    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
+    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(4).controlMode, Opm::WellProducer::LRAT);
+    BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::ORAT) );
+    BOOST_CHECK( !well_p1->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !well_p2->getProductionProperties(4).hasProductionControl(Opm::WellProducer::RESV) );
+
+    // 25 OKT 2008
+    BOOST_CHECK_EQUAL(well_p1->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK_EQUAL(well_p2->getProductionProperties(5).controlMode, Opm::WellProducer::ORAT);
+    BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::RESV) );
+    BOOST_CHECK( !well_p1->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+    BOOST_CHECK( !well_p2->getProductionProperties(5).hasProductionControl(Opm::WellProducer::LRAT) );
+}
+
 BOOST_AUTO_TEST_CASE(unsupportedOptionWHISTCTL) {
     Opm::Parser parser;
     std::string input =

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -63,31 +63,15 @@ inline std::ostream& operator<<( std::ostream& stream, const Well& well ) {
 
 BOOST_AUTO_TEST_CASE(CreateWell_CorrectNameAndDefaultValues) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
     BOOST_CHECK_EQUAL( "WELL1" , well.name() );
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).OilRate);
-}
-
-BOOST_AUTO_TEST_CASE(CreateWell_Equals) {
-    auto timeMap = createXDaysTimeMap(10);
-    auto timeMap2 = createXDaysTimeMap(11);
-    Opm::Well well1("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
-    Opm::Well well2("WELL1" ,  2, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
-    Opm::Well well3("WELL3" ,  3, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
-    Opm::Well well4("WELL3" ,  4, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap2 , 0);
-    BOOST_CHECK_EQUAL( well1, well1 );
-    BOOST_CHECK_EQUAL( well2, well1 );
-    BOOST_CHECK( well1 == well2 );
-    BOOST_CHECK( well1 != well3 );
-    BOOST_CHECK( well3 != well2 );
-    BOOST_CHECK( well3 == well3 );
-    BOOST_CHECK( well4 != well3 );
 }
 
 
 BOOST_AUTO_TEST_CASE(CreateWell_GetProductionPropertiesShouldReturnSameObject) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(&(well.getProductionProperties(5)), &(well.getProductionProperties(5)));
     BOOST_CHECK_EQUAL(&(well.getProductionProperties(8)), &(well.getProductionProperties(8)));
@@ -96,7 +80,7 @@ BOOST_AUTO_TEST_CASE(CreateWell_GetProductionPropertiesShouldReturnSameObject) {
 
 BOOST_AUTO_TEST_CASE(CreateWell_GetInjectionPropertiesShouldReturnSameObject) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, timeMap , 0);
+    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(&(well.getInjectionProperties(5)), &(well.getInjectionProperties(5)));
     BOOST_CHECK_EQUAL(&(well.getInjectionProperties(8)), &(well.getInjectionProperties(8)));
@@ -105,7 +89,7 @@ BOOST_AUTO_TEST_CASE(CreateWell_GetInjectionPropertiesShouldReturnSameObject) {
 
 BOOST_AUTO_TEST_CASE(CreateWellCreateTimeStepOK) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 5);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 5);
     BOOST_CHECK_EQUAL( false , well.hasBeenDefined(0) );
     BOOST_CHECK_EQUAL( false , well.hasBeenDefined(4) );
     BOOST_CHECK_EQUAL( true , well.hasBeenDefined(5) );
@@ -116,7 +100,7 @@ BOOST_AUTO_TEST_CASE(CreateWellCreateTimeStepOK) {
 
 BOOST_AUTO_TEST_CASE(setWellProductionProperties_PropertiesSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy( 5 ).OilRate);
     Opm::WellProductionProperties props;
@@ -149,7 +133,7 @@ BOOST_AUTO_TEST_CASE(setWellProductionProperties_PropertiesSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setOilRate_RateSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).OilRate);
     Opm::WellProductionProperties props;
@@ -161,7 +145,7 @@ BOOST_AUTO_TEST_CASE(setOilRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(seLiquidRate_RateSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).LiquidRate);
     Opm::WellProductionProperties props;
@@ -174,7 +158,7 @@ BOOST_AUTO_TEST_CASE(seLiquidRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setPredictionModeProduction_ModeSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL( true, well.getProductionPropertiesCopy(5).predictionMode);
     Opm::WellProductionProperties props;
@@ -187,7 +171,7 @@ BOOST_AUTO_TEST_CASE(setPredictionModeProduction_ModeSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setpredictionModeInjection_ModeSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL( true, well.getInjectionPropertiesCopy(5).predictionMode);
     Opm::WellInjectionProperties props;
@@ -334,13 +318,13 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestINPUT) {
 
 BOOST_AUTO_TEST_CASE(NewWellZeroCompletions) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
     BOOST_CHECK_EQUAL( 0U , well.getConnections( 0 ).size() );
 }
 
 BOOST_AUTO_TEST_CASE(setGasRate_RateSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::GAS, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::GAS, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).GasRate);
     Opm::WellProductionProperties properties;
@@ -354,7 +338,7 @@ BOOST_AUTO_TEST_CASE(setGasRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setWaterRate_RateSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).WaterRate);
     Opm::WellProductionProperties properties;
@@ -367,7 +351,7 @@ BOOST_AUTO_TEST_CASE(setWaterRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setSurfaceInjectionRate_RateSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(0.0 , well.getInjectionPropertiesCopy(5).surfaceInjectionRate);
     Opm::WellInjectionProperties props(well.getInjectionPropertiesCopy(5));
@@ -386,7 +370,7 @@ BOOST_AUTO_TEST_CASE(setSurfaceInjectionRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setReservoirInjectionRate_RateSetCorrect) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, timeMap , 0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap , 0);
 
     BOOST_CHECK_EQUAL(0.0 , well.getInjectionPropertiesCopy(5).reservoirInjectionRate);
     Opm::WellInjectionProperties properties(well.getInjectionPropertiesCopy(5));
@@ -401,7 +385,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
     // HACK: This test checks correctly setting of isProducer/isInjector. This property depends on which of
     //       WellProductionProperties/WellInjectionProperties is set last, independent of actual values.
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, timeMap ,0);
+    Opm::Well well("WELL1" , 1, 0, 0, 0.0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap ,0);
 
     /* 1: Well is created as producer */
     BOOST_CHECK_EQUAL( false , well.isInjector(0));
@@ -457,7 +441,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
 
 BOOST_AUTO_TEST_CASE(GroupnameCorretlySet) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, timeMap ,0);
+    Opm::Well well("WELL1" ,  1, 0, 0, 0.0, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap ,0);
 
     BOOST_CHECK_EQUAL("" , well.getGroupName(2));
 
@@ -471,7 +455,7 @@ BOOST_AUTO_TEST_CASE(GroupnameCorretlySet) {
 
 BOOST_AUTO_TEST_CASE(addWELSPECS_setData_dataSet) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1", 1, 23, 42, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 3);
+    Opm::Well well("WELL1", 1, 23, 42, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 3);
 
     BOOST_CHECK(!well.hasBeenDefined(2));
     BOOST_CHECK(well.hasBeenDefined(3));
@@ -484,7 +468,7 @@ BOOST_AUTO_TEST_CASE(addWELSPECS_setData_dataSet) {
 
 BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
 
     Opm::WellProductionProperties productionProps(well.getProductionPropertiesCopy(1));
@@ -505,7 +489,7 @@ BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
 
 BOOST_AUTO_TEST_CASE(InjectorType) {
     auto timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
     Opm::WellInjectionProperties injectionProps(well.getInjectionPropertiesCopy(1));
     injectionProps.injectorType = Opm::WellInjector::WATER;
@@ -523,7 +507,7 @@ BOOST_AUTO_TEST_CASE(InjectorType) {
 BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
 
     auto timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::OIL, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
 
     BOOST_CHECK( !well.getProductionPropertiesCopy(1).hasProductionControl( Opm::WellProducer::ORAT ));
@@ -573,7 +557,7 @@ BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
 BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
 
     auto timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
     BOOST_CHECK( !well.getInjectionPropertiesCopy(1).hasInjectionControl( Opm::WellInjector::RATE ));
     BOOST_CHECK( !well.getInjectionPropertiesCopy(1).hasInjectionControl( Opm::WellInjector::RESV ));
@@ -617,7 +601,7 @@ BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
 
 BOOST_AUTO_TEST_CASE(WellSetAvailableForGroupControl_ControlSet) {
     auto timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
     BOOST_CHECK(well.isAvailableForGroupControl(10));
     well.setAvailableForGroupControl(12, false);
@@ -628,7 +612,7 @@ BOOST_AUTO_TEST_CASE(WellSetAvailableForGroupControl_ControlSet) {
 
 BOOST_AUTO_TEST_CASE(WellSetGuideRate_GuideRateSet) {
     auto timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
 
     BOOST_CHECK_LT(well.getGuideRate(0), 0);
     well.setGuideRate(1, 32.2);
@@ -638,7 +622,7 @@ BOOST_AUTO_TEST_CASE(WellSetGuideRate_GuideRateSet) {
 
 BOOST_AUTO_TEST_CASE(WellGuideRatePhase_GuideRatePhaseSet) {
     auto timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
     BOOST_CHECK_EQUAL(Opm::GuideRate::UNDEFINED, well.getGuideRatePhase(0));
     well.setGuideRatePhase(3, Opm::GuideRate::RAT);
     BOOST_CHECK_EQUAL(Opm::GuideRate::UNDEFINED, well.getGuideRatePhase(2));
@@ -647,7 +631,7 @@ BOOST_AUTO_TEST_CASE(WellGuideRatePhase_GuideRatePhaseSet) {
 
 BOOST_AUTO_TEST_CASE(WellEfficiencyFactorSet) {
     auto timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
     BOOST_CHECK_EQUAL(1.0, well.getEfficiencyFactor(0));
     well.setEfficiencyFactor(3, 0.9);
     BOOST_CHECK_EQUAL(1.0, well.getEfficiencyFactor(0));
@@ -656,7 +640,7 @@ BOOST_AUTO_TEST_CASE(WellEfficiencyFactorSet) {
 
 BOOST_AUTO_TEST_CASE(WellSetScalingFactor_ScalingFactorSetSet) {
     auto timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, timeMap, 0);
+    Opm::Well well("WELL1", 1, 1, 2, 2334.32, 0.0, Opm::Phase::WATER, Opm::WellProducer::CMODE_UNDEFINED, timeMap, 0);
     BOOST_CHECK_EQUAL(1.0, well.getGuideRateScalingFactor(0));
     well.setGuideRateScalingFactor(4, 0.6);
     BOOST_CHECK_EQUAL(1.0, well.getGuideRateScalingFactor(3));


### PR DESCRIPTION
As part of: https://github.com/OPM/opm-common/pull/711 a regression was introduced which has broken a relevant field case. The bug is in the interaction between the `WHISTCTL, WELSPECS` and `WCONHIST` keywords, and arises in the situation where the `WHISTCTL`keyword is entered *before* the well is specified with `WELSPECS`. That worked - by accident - prior to https://github.com/OPM/opm-common/pull/711 - now it should work again - and continue to do so.

Thank you to @totto82 for actually identifing the problem.


@atgeirr / @totto82 I am grateful if you can take this for a spin.