### PR TITLE
Generalize eclipse compatible restart to a broad set of PVT-options

### DIFF
--- a/src/opm/output/eclipse/CreateLogiHead.cpp
+++ b/src/opm/output/eclipse/CreateLogiHead.cpp
@@ -35,12 +35,31 @@ Opm::RestartIO::Helpers::
 createLogiHead(const EclipseState& es)
 {
     const auto& rspec = es.runspec();
+    const auto& tabMgr = es.getTableManager();
+    const auto& phases = rspec.phases();
     const auto& wsd   = rspec.wellSegmentDimensions();
     const auto& hystPar = rspec.hysterPar();
 
+    auto pvt = ::Opm::RestartIO::LogiHEAD::PVTModel{};
+
+    pvt.isLiveOil = phases.active(::Opm::Phase::OIL) &&
+        !tabMgr.getPvtoTables().empty();
+
+    pvt.isWetGas = phases.active(::Opm::Phase::GAS) &&
+        !tabMgr.getPvtgTables().empty();
+
+    pvt.constComprOil = phases.active(::Opm::Phase::OIL) &&
+        !(pvt.isLiveOil ||
+          tabMgr.hasTables("PVDO") ||
+          tabMgr.getPvcdoTable().empty());
+	
     const auto lh = LogiHEAD{}
         .variousParam(false, false, wsd.maxSegmentedWells(), hystPar.active())
         ;
 
+    // Sequenced after 'lh' constructor to ensure that any changes
+    // to live oil/wet gas elements are from this particular call.
+    lh.pvtModel(pvt);
+	
     return lh.data();
 }

--- a/src/opm/output/eclipse/CreateLogiHead.cpp
+++ b/src/opm/output/eclipse/CreateLogiHead.cpp
@@ -55,11 +55,8 @@ createLogiHead(const EclipseState& es)
 	
     const auto lh = LogiHEAD{}
         .variousParam(false, false, wsd.maxSegmentedWells(), hystPar.active())
+	.pvtModel(pvt)
         ;
-
-    // Sequenced after 'lh' constructor to ensure that any changes
-    // to live oil/wet gas elements are from this particular call.
-    lh.pvtModel(pvt);
 	
     return lh.data();
 }

--- a/src/opm/output/eclipse/LogiHEAD.cpp
+++ b/src/opm/output/eclipse/LogiHEAD.cpp
@@ -188,8 +188,6 @@ variousParam(const bool e300_radial,
              const int  nswlmx,
              const bool enableHyster)
 {
-    this -> data_[IsLiveOil]  = true;
-    this -> data_[IsWetGas]   = true;
     this -> data_[E300Radial] = e300_radial;
     this -> data_[E100Radial] = e100_radial;
     this -> data_[Hyster]     = enableHyster;

--- a/tests/test_LogiHEAD.cpp
+++ b/tests/test_LogiHEAD.cpp
@@ -39,8 +39,6 @@ BOOST_AUTO_TEST_CASE(Radial_Settings_and_Init)
 
     const auto& v = lh.data();
 
-    BOOST_CHECK_EQUAL(v[  0], true);  //
-    BOOST_CHECK_EQUAL(v[  1], true);  //
     BOOST_CHECK_EQUAL(v[  3], false); // E300 Radial
     BOOST_CHECK_EQUAL(v[  4], true);  // E100 Radial
     BOOST_CHECK_EQUAL(v[  6], true);  // enableHyster


### PR DESCRIPTION
This pull request makes it possible to write eclipse compatible restart files for various types of PVT data:
PVDO, PVDG
PVTO, PVDG
PVTO, PVTG
This pull request is necessary for the ecl-compatible restart file to work a number of relevant field models.

This pull request builds on pull request #707 which needs to be merges before this pull request can be merged.