### PR TITLE
Default ENABLE_WELL_TEST to ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(OPM_MACROS_ROOT ${PROJECT_SOURCE_DIR})
 option(ENABLE_ECL_INPUT "Enable eclipse input support?" ON)
 option(ENABLE_ECL_OUTPUT "Enable eclipse output support?" ON)
 option(ENABLE_MOCKSIM "Build the mock simulator for io testing" ON)
-option(ENABLE_WELL_TEST "Enable testing of well code when building Schedule object" OFF)
+option(ENABLE_WELL_TEST "Enable testing of well code when building Schedule object" ON)
 
 if (ENABLE_WELL_TEST)
   add_definitions(-DWELL_TEST)


### PR DESCRIPTION
The new well model in opm-common - `Well2`- would benefit from some more real-case testing. If the cmake switch `ENABLE_WELL_TEST` is set to `ON` the `Schedule`constructor will end with a comparison of the old well model and the new well model, before simulations starts - still with the old well model.

I have encouraged people to build with `-DENABLE_WELL_TEST=ON` but so far have received very few test reports[1] - I therefor suggest pushing it a bit further by changing the default. 

[1]: Jenkins has already built with `-DEANBLE_WELL_TEST=ON` for quite some time.