### PR TITLE
Add method bool Well2::predictionMode()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
@@ -68,6 +68,7 @@ public:
     double getGuideRateScalingFactor() const;
 
     std::size_t firstTimeStep() const;
+    bool predictionMode() const;
     bool canOpen() const;
     bool isProducer() const;
     size_t seqIndex() const;
@@ -106,6 +107,7 @@ public:
     */
     std::map<int, std::vector<Connection>> getCompletions() const;
 
+    bool updatePrediction(bool prediction_mode);
     bool updateAutoShutin(bool auto_shutin);
     bool updateCrossFlow(bool allow_cross_flow);
     bool updateHead(int I, int J);
@@ -153,6 +155,7 @@ private:
     WellGuideRate guide_rate;
     double efficiency_factor;
     double solvent_fraction;
+    bool prediction_mode = true;
 
     std::shared_ptr<const WellEconProductionLimits> econ_limits;
     std::shared_ptr<const WellPolymerProperties> polymer_properties;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
@@ -599,6 +599,22 @@ bool Well2::canOpen() const {
     }
 }
 
+
+bool Well2::predictionMode() const {
+    return this->prediction_mode;
+}
+
+
+bool Well2::updatePrediction(bool prediction_mode) {
+    if (this->prediction_mode != prediction_mode) {
+        this->prediction_mode = prediction_mode;
+        return true;
+    }
+
+    return false;
+}
+
+
 WellCompletion::CompletionOrderEnum Well2::getWellConnectionOrdering() const {
     return this->ordering;
 }


### PR DESCRIPTION
This PR adds a new method:
```
bool Well2::predictionMode() const;
```
which can be used to query if the well is currently in prediction mode.