### PR TITLE
Add Restart I/O Operations to New ECLIPSE I/O Classes

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -171,6 +171,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/io/eclipse/ERft.cpp
           src/opm/io/eclipse/ERst.cpp
           src/opm/io/eclipse/ESmry.cpp
+          src/opm/io/eclipse/OutputStream.cpp
           src/opm/output/eclipse/AggregateConnectionData.cpp
           src/opm/output/eclipse/AggregateGroupData.cpp
           src/opm/output/eclipse/AggregateMSWData.cpp
@@ -286,6 +287,7 @@ if(ENABLE_ECL_OUTPUT)
           tests/test_InteHEAD.cpp
           tests/test_LinearisedOutputTable.cpp
           tests/test_LogiHEAD.cpp
+          tests/test_OutputStream.cpp
           tests/test_regionCache.cpp
           tests/test_Restart.cpp
           tests/test_RFT.cpp
@@ -577,6 +579,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/io/eclipse/ERft.hpp
         opm/io/eclipse/ERst.hpp
         opm/io/eclipse/ESmry.hpp
+        opm/io/eclipse/OutputStream.hpp
         opm/output/data/Cells.hpp
         opm/output/data/Solution.hpp
         opm/output/data/Wells.hpp

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -27,6 +27,10 @@
 #include <unordered_map>
 #include <vector>
 
+namespace Opm { namespace ecl { namespace OutputStream {
+    class Restart;
+}}}
+
 namespace Opm { namespace ecl {
 
 class ERst : public EclFile
@@ -43,6 +47,8 @@ public:
     const std::vector<int>& listOfReportStepNumbers() const { return seqnum; }
 
     std::vector<EclEntry> listOfRstArrays(int reportStepNumber);
+
+    friend class OutputStream::Restart;
 
 private:
     int nReports;

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -21,6 +21,7 @@
 
 #include <opm/io/eclipse/EclFile.hpp>
 
+#include <ios>
 #include <map>
 #include <string>
 #include <unordered_map>
@@ -50,6 +51,9 @@ private:
     std::map<int, std::pair<int,int>> arrIndexRange;   // mapping report step number to array indeces (start and end)
 
     int getArrayIndex(const std::string& name, int seqnum) const;
+
+    std::streampos
+    restartStepWritePosition(const int seqnumValue) const;
 };
 
 }} // namespace Opm::ecl

--- a/opm/io/eclipse/EclFile.hpp
+++ b/opm/io/eclipse/EclFile.hpp
@@ -23,7 +23,7 @@
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 
-#include <fstream>
+#include <ios>
 #include <string>
 #include <stdexcept>
 #include <tuple>
@@ -99,6 +99,9 @@ protected:
 
         return array.at(arrIndex);
     }
+
+    std::streampos
+    seekPosition(const std::vector<std::string>::size_type arrIndex) const;
 
 private:
     std::vector<bool> arrayLoaded;

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -32,7 +32,9 @@ namespace Opm { namespace ecl {
 class EclOutput
 {
 public:
-    EclOutput(const std::string& inputFile, bool formatted);
+    EclOutput(const std::string&            filename,
+              const bool                    formatted,
+              const std::ios_base::openmode mode = std::ios::out);
 
     template<typename T>
     void write(const std::string& name,
@@ -84,8 +86,8 @@ private:
     std::string make_real_string(float value) const;
     std::string make_doub_string(double value) const;
 
-    std::ofstream ofileH;
     bool isFormatted;
+    std::ofstream ofileH;
 };
 
 

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -64,6 +64,8 @@ public:
         }
     }
 
+    void message(const std::string& msg);
+
 private:
     void writeBinaryHeader(const std::string& arrName, int size, eclArrType arrType);
 
@@ -90,7 +92,6 @@ private:
 template<>
 void EclOutput::write<std::string>(const std::string& name,
                                    const std::vector<std::string>& data);
-
 }} // namespace Opm::ecl
 
 #endif // OPM_IO_ECLOUTPUT_HPP

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -27,6 +27,10 @@
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 
+namespace Opm { namespace ecl { namespace OutputStream {
+    class Restart;
+}}}
+
 namespace Opm { namespace ecl {
 
 class EclOutput
@@ -67,6 +71,8 @@ public:
     }
 
     void message(const std::string& msg);
+
+    friend class OutputStream::Restart;
 
 private:
     void writeBinaryHeader(const std::string& arrName, int size, eclArrType arrType);

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -52,12 +52,23 @@ namespace Opm { namespace ecl { namespace OutputStream {
     public:
         /// Constructor.
         ///
+        /// Opens file stream pertaining to restart of particular report
+        /// step and also outputs a SEQNUM record in the case of a unified
+        /// output stream.
+        ///
+        /// Must be called before accessing the stream object through the
+        /// stream() member function.
+        ///
         /// \param[in] rset Output directory and base name of output stream.
+        ///
+        /// \param[in] seqnum Sequence number of new report.  One-based
+        ///    report step ID.
         ///
         /// \param[in] fmt Whether or not to create formatted output files.
         ///
         /// \param[in] unif Whether or not to create unified output files.
-        explicit Restart(ResultSet        rset,
+        explicit Restart(const ResultSet& rset,
+                         const int        seqnum,
                          const Formatted& fmt,
                          const Unified&   unif);
 
@@ -68,32 +79,6 @@ namespace Opm { namespace ecl { namespace OutputStream {
 
         Restart& operator=(const Restart& rhs) = delete;
         Restart& operator=(Restart&& rhs);
-
-        /// Opens file stream pertaining to restart of particular report
-        /// step and also outputs a SEQNUM record in the case of a unified
-        /// output stream.
-        ///
-        /// Must be called before accessing the stream object through the
-        /// stream() member function.
-        ///
-        /// \param[in] seqnum Sequence number of new report.  One-based
-        ///    report step ID.
-        void prepareStep(const int seqnum);
-
-        const ResultSet& resultSetDescriptor() const
-        {
-            return this->rset_;
-        }
-
-        bool formatted() const
-        {
-            return this->formatted_;
-        }
-
-        bool unified() const
-        {
-            return this->unified_;
-        }
 
         /// Generate a message string (keyword type 'MESS') in underlying
         /// output stream.
@@ -156,10 +141,6 @@ namespace Opm { namespace ecl { namespace OutputStream {
                    const std::vector<std::string>& data);
 
     private:
-        ResultSet rset_;
-        bool      formatted_;
-        bool      unified_;
-
         /// Restart output stream.
         std::unique_ptr<EclOutput> stream_;
 
@@ -170,9 +151,13 @@ namespace Opm { namespace ecl { namespace OutputStream {
         ///
         /// \param[in] fname Filename of output stream.
         ///
+        /// \param[in] formatted Whether or not to create a
+        ///    formatted output file.
+        ///
         /// \param[in] seqnum Sequence number of new report.  One-based
         ///    report step ID.
         void openUnified(const std::string& fname,
+                         const bool         formatted,
                          const int          seqnum);
 
         /// Open new output stream.
@@ -181,7 +166,11 @@ namespace Opm { namespace ecl { namespace OutputStream {
         /// that does not already exist.  Writes to \c stream_.
         ///
         /// \param[in] fname Filename of new output stream.
-        void openNew(const std::string& fname);
+        ///
+        /// \param[in] formatted Whether or not to create a
+        ///    formatted output file.
+        void openNew(const std::string& fname,
+                     const bool         formatted);
 
         /// Open existing output file and place stream's output indicator
         /// in appropriate location.
@@ -194,6 +183,7 @@ namespace Opm { namespace ecl { namespace OutputStream {
         ///    indicator.  Use \code streampos{ streamoff{-1} } \endcode to
         ///    place output indicator at end of file (i.e, simple append).
         void openExisting(const std::string&   fname,
+                          const bool           formatted,
                           const std::streampos writePos);
 
         /// Access writable output stream.
@@ -222,19 +212,6 @@ namespace Opm { namespace ecl { namespace OutputStream {
     /// \return outputDir/baseName.ext
     std::string outputFileName(const ResultSet&   rsetDescriptor,
                                const std::string& ext);
-
-    /// Derive filename of restart output stream.
-    ///
-    /// Knows the rules for formatted vs. unformatted, and separate vs.
-    /// unified output files.
-    ///
-    /// \param[in] rst Previously configured restart stream.
-    ///
-    /// \param[in] seqnum Sequence number (1-based report step ID).
-    ///
-    /// \return Filename corresponding to stream's configuration.
-    std::string outputFileName(const Restart& rst,
-                               const int      seqnum);
 
 }}} // namespace Opm::ecl::OutputStream
 

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -1,0 +1,175 @@
+/*
+  Copyright (c) 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_IO_OUTPUTSTREAM_HPP_INCLUDED
+#define OPM_IO_OUTPUTSTREAM_HPP_INCLUDED
+
+#include <ios>
+#include <memory>
+#include <string>
+
+namespace Opm { namespace ecl {
+
+    class EclOutput;
+
+}} // namespace Opm::ecl
+
+namespace Opm { namespace ecl { namespace OutputStream {
+
+    struct Formatted { bool set; };
+    struct Unified   { bool set; };
+
+    /// Abstract representation of an ECLIPSE-style result set.
+    struct ResultSet
+    {
+        /// Output directory.  Commonly "." or location of run's .DATA file.
+        std::string outputDir;
+
+        /// Base name of simulation run.
+        std::string baseName;
+    };
+
+    /// File manager for restart output streams.
+    class Restart
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] rset Output directory and base name of output stream.
+        ///
+        /// \param[in] fmt Whether or not to create formatted output files.
+        ///
+        /// \param[in] unif Whether or not to create unified output files.
+        explicit Restart(ResultSet        rset,
+                         const Formatted& fmt,
+                         const Unified&   unif);
+
+        ~Restart();
+
+        Restart(const Restart& rhs) = delete;
+        Restart(Restart&& rhs);
+
+        Restart& operator=(const Restart& rhs) = delete;
+        Restart& operator=(Restart&& rhs);
+
+        /// Opens file stream pertaining to restart of particular report
+        /// step and also outputs a SEQNUM record in the case of a unified
+        /// output stream.
+        ///
+        /// Must be called before accessing the stream object through the
+        /// stream() member function.
+        ///
+        /// \param[in] seqnum Sequence number of new report.  One-based
+        ///    report step ID.
+        void prepareStep(const int seqnum);
+
+        const ResultSet& resultSetDescriptor() const
+        {
+            return this->rset_;
+        }
+
+        bool formatted() const
+        {
+            return this->formatted_;
+        }
+
+        bool unified() const
+        {
+            return this->unified_;
+        }
+
+        /// Access writable output stream.
+        ///
+        /// Must not be called prior to \c prepareStep.
+        EclOutput& stream();
+
+    private:
+        ResultSet rset_;
+        bool      formatted_;
+        bool      unified_;
+
+        /// Restart output stream.
+        std::unique_ptr<EclOutput> stream_;
+
+        /// Open unified output file and place stream's output indicator
+        /// in appropriate location.
+        ///
+        /// Writes to \c stream_.
+        ///
+        /// \param[in] fname Filename of output stream.
+        ///
+        /// \param[in] seqnum Sequence number of new report.  One-based
+        ///    report step ID.
+        void openUnified(const std::string& fname,
+                         const int          seqnum);
+
+        /// Open new output stream.
+        ///
+        /// Handles the case of separate output files or unified output file
+        /// that does not already exist.  Writes to \c stream_.
+        ///
+        /// \param[in] fname Filename of new output stream.
+        void openNew(const std::string& fname);
+
+        /// Open existing output file and place stream's output indicator
+        /// in appropriate location.
+        ///
+        /// Writes to \c stream_.
+        ///
+        /// \param[in] fname Filename of output stream.
+        ///
+        /// \param[in] writePos Position at which to place stream's output
+        ///    indicator.  Use \code streampos{ streamoff{-1} } \endcode to
+        ///    place output indicator at end of file (i.e, simple append).
+        void openExisting(const std::string&   fname,
+                          const std::streampos writePos);
+    };
+
+    /// Derive filename corresponding to output stream of particular result
+    /// set, with user-specified file extension.
+    ///
+    /// Low-level string concatenation routine that does not know specific
+    /// relations between base names and file extensions.  Handles details
+    /// of base name ending in a period (full stop) or having a name that
+    /// might otherwise appear to contain a file extension (e.g., CASE.01).
+    ///
+    /// \param[in] rsetDescriptor Output directory and base name of result set.
+    ///
+    /// \param[in] ext Filename extension.
+    ///
+    /// \return outputDir/baseName.ext
+    std::string outputFileName(const ResultSet&   rsetDescriptor,
+                               const std::string& ext);
+
+    /// Derive filename of restart output stream.
+    ///
+    /// Knows the rules for formatted vs. unformatted, and separate vs.
+    /// unified output files.
+    ///
+    /// \param[in] rst Previously configured restart stream.
+    ///
+    /// \param[in] seqnum Sequence number (1-based report step ID).
+    ///
+    /// \return Filename corresponding to stream's configuration.
+    std::string outputFileName(const Restart& rst,
+                               const int      seqnum);
+
+}}} // namespace Opm::ecl::OutputStream
+
+#endif //  OPM_IO_OUTPUTSTREAM_HPP_INCLUDED

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -23,6 +23,7 @@
 #include <ios>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace Opm { namespace ecl {
 
@@ -94,10 +95,65 @@ namespace Opm { namespace ecl { namespace OutputStream {
             return this->unified_;
         }
 
-        /// Access writable output stream.
+        /// Generate a message string (keyword type 'MESS') in underlying
+        /// output stream.
         ///
-        /// Must not be called prior to \c prepareStep.
-        EclOutput& stream();
+        /// Must not be called prior to \c prepareStep
+        ///
+        /// \param[in] msg Message string (e.g., "STARTSOL").
+        void message(const std::string& msg);
+
+        /// Write integer data to underlying output stream.
+        ///
+        /// Must not be called prior to \c prepareStep
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&      kw,
+                   const std::vector<int>& data);
+
+        /// Write boolean data to underlying output stream.
+        ///
+        /// Must not be called prior to \c prepareStep
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&       kw,
+                   const std::vector<bool>& data);
+
+        /// Write single precision floating point data to underlying
+        /// output stream.
+        ///
+        /// Must not be called prior to \c prepareStep
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&        kw,
+                   const std::vector<float>& data);
+
+        /// Write double precision floating point data to underlying
+        /// output stream.
+        ///
+        /// Must not be called prior to \c prepareStep
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&         kw,
+                   const std::vector<double>& data);
+
+        /// Write unpadded string data to underlying output stream.
+        ///
+        /// Must not be called prior to \c prepareStep
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&              kw,
+                   const std::vector<std::string>& data);
 
     private:
         ResultSet rset_;
@@ -139,6 +195,16 @@ namespace Opm { namespace ecl { namespace OutputStream {
         ///    place output indicator at end of file (i.e, simple append).
         void openExisting(const std::string&   fname,
                           const std::streampos writePos);
+
+        /// Access writable output stream.
+        ///
+        /// Must not be called prior to \c prepareStep.
+        EclOutput& stream();
+
+        /// Implementation function for public \c write overload set.
+        template <typename T>
+        void writeImpl(const std::string&    kw,
+                       const std::vector<T>& data);
     };
 
     /// Derive filename corresponding to output stream of particular result

--- a/src/opm/io/eclipse/ERst.cpp
+++ b/src/opm/io/eclipse/ERst.cpp
@@ -61,7 +61,7 @@ ERst::ERst(const std::string& filename)
     for (int i = 0; i < nReports; i++) {
         reportLoaded[seqnum[i]] = false;
     }
-};
+}
 
 
 bool ERst::hasReportStepNumber(int number) const
@@ -110,7 +110,6 @@ std::vector<EclFile::EclEntry> ERst::listOfRstArrays(int reportStepNumber)
     return list;
 }
 
-
 int ERst::getArrayIndex(const std::string& name, int number) const
 {
     if (!hasReportStepNumber(number)) {
@@ -140,6 +139,15 @@ int ERst::getArrayIndex(const std::string& name, int number) const
     return std::distance(array_name.begin(), it);
 }
 
+std::streampos
+ERst::restartStepWritePosition(const int seqnumValue) const
+{
+    auto pos = this->arrIndexRange.lower_bound(seqnumValue);
+
+    return (pos == this->arrIndexRange.end())
+        ? std::streampos(std::streamoff(-1))
+        : this->seekPosition(pos->second.first);
+}
 
 template<>
 const std::vector<int>& ERst::getRst<int>(const std::string& name, int reportStepNumber)

--- a/src/opm/io/eclipse/EclOutput.cpp
+++ b/src/opm/io/eclipse/EclOutput.cpp
@@ -59,6 +59,16 @@ void EclOutput::write<std::string>(const std::string& name,
 }
 
 
+void EclOutput::message(const std::string& msg)
+{
+    // Generate message, i.e., output vector of type eclArrType::MESS,
+    // by passing an empty std::vector of element type 'char'.  Entire
+    // contents of message contained in the 'msg' string.
+
+    this->write(msg, std::vector<char>{});
+}
+
+
 void EclOutput::writeBinaryHeader(const std::string&arrName, int size, eclArrType arrType)
 {
     std::string name = arrName + std::string(8 - arrName.size(),' ');

--- a/src/opm/io/eclipse/EclOutput.cpp
+++ b/src/opm/io/eclipse/EclOutput.cpp
@@ -35,10 +35,14 @@
 
 namespace Opm { namespace ecl {
 
-EclOutput::EclOutput(const std::string& inputFile, bool formatted) :
-  isFormatted(formatted)
+EclOutput::EclOutput(const std::string&            filename,
+                     const bool                    formatted,
+                     const std::ios_base::openmode mode)
+    : isFormatted{formatted}
 {
-    ofileH.open(inputFile, isFormatted ? std::ios::out : std::ios::out | std::ios::binary);
+    const auto binmode = mode | std::ios_base::binary;
+
+    this->ofileH.open(filename, this->isFormatted ? mode : binmode);
 }
 
 

--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -1,0 +1,267 @@
+/*
+  Copyright (c) 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/io/eclipse/OutputStream.hpp>
+
+#include <opm/io/eclipse/EclOutput.hpp>
+#include <opm/io/eclipse/ERst.hpp>
+
+#include <exception>
+#include <fstream>
+#include <iomanip>
+#include <ios>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <boost/filesystem.hpp>
+
+namespace {
+    namespace FileExtension
+    {
+        std::string
+        restart(const int  rptStep,
+                const bool formatted,
+                const bool unified)
+        {
+            if (unified) {
+                return formatted ? "FUNRST" : "UNRST";
+            }
+
+            std::ostringstream ext;
+
+            ext << (formatted ? 'F' : 'X')
+                << std::setw(4) << std::setfill('0')
+                << rptStep;
+
+            return ext.str();
+        }
+    } // namespace FileExtension
+
+    namespace Open
+    {
+        namespace Restart
+        {
+            std::unique_ptr<Opm::ecl::ERst>
+            read(const std::string& filename)
+            {
+                // Bypass some of the internal logic of the ERst constructor.
+                //
+                // Specifically, the base class EclFile's constructor throws
+                // and outputs a highly visible diagnostic message if it is
+                // unable to open the file.  The diagnostic message is very
+                // confusing to users if they are running a simulation case
+                // for the first time and will likely provoke a reaction along
+                // the lines of "well of course the restart file doesn't exist".
+                {
+                    std::ifstream is(filename);
+
+                    if (! is) {
+                        // Unable to open (does not exist?).  Return null.
+                        return {};
+                    }
+                }
+
+                // File exists and can (could?) be opened.  Attempt to form
+                // an ERst object on top of it.
+                return std::unique_ptr<Opm::ecl::ERst> {
+                    new Opm::ecl::ERst{filename}
+                };
+            }
+
+            std::unique_ptr<Opm::ecl::EclOutput>
+            writeNew(const std::string& filename,
+                     const bool         isFmt)
+            {
+                return std::unique_ptr<Opm::ecl::EclOutput> {
+                    new Opm::ecl::EclOutput {
+                        filename, isFmt, std::ios_base::out
+                    }
+                };
+            }
+
+            std::unique_ptr<Opm::ecl::EclOutput>
+            writeExisting(const std::string& filename,
+                          const bool         isFmt)
+            {
+                return std::unique_ptr<Opm::ecl::EclOutput> {
+                    new Opm::ecl::EclOutput {
+                        filename, isFmt, std::ios_base::app
+                    }
+                };
+            }
+        } // namespace Restart
+    } // namespace Open
+} // Anonymous namespace
+
+Opm::ecl::OutputStream::Restart::
+Restart(ResultSet        rset,
+        const Formatted& fmt,
+        const Unified&   unif)
+    : rset_     (std::move(rset))
+    , formatted_{fmt.set}
+    , unified_  {unif.set}
+{}
+
+Opm::ecl::OutputStream::Restart::~Restart()
+{}
+
+Opm::ecl::OutputStream::Restart::Restart(Restart&& rhs)
+    : rset_     (std::move(rhs.rset_))
+    , formatted_{rhs.formatted_}
+    , unified_  {rhs.unified_}
+{}
+
+Opm::ecl::OutputStream::Restart&
+Opm::ecl::OutputStream::Restart::operator=(Restart&& rhs)
+{
+    this->rset_      = std::move(rhs.rset_);
+    this->formatted_ = rhs.formatted_;
+    this->unified_   = rhs.unified_;
+
+    return *this;
+}
+
+void Opm::ecl::OutputStream::Restart::prepareStep(const int seqnum)
+{
+    const auto fname = outputFileName(*this, seqnum);
+
+    if (this->unified_) {
+        // Run uses unified restart files.
+        this->openUnified(fname, seqnum);
+
+        // Write SEQNUM value to stream to start new output sequence.
+        this->stream_->write("SEQNUM", std::vector<int>{ seqnum });
+    }
+    else {
+        // Run uses separate, not unified, restart files.  Create a
+        // new output file and open an output stream on it.
+        this->openNew(fname);
+    }
+}
+
+Opm::ecl::EclOutput&
+Opm::ecl::OutputStream::Restart::stream()
+{
+    return *this->stream_;
+}
+
+void
+Opm::ecl::OutputStream::Restart::
+openUnified(const std::string& fname,
+            const int          seqnum)
+{
+    // Determine if we're creating a new output/restart file or
+    // if we're opening an existing one, possibly at a specific
+    // write position.
+    auto rst = Open::Restart::read(fname);
+
+    if (rst == nullptr) {
+        // No such unified restart file exists.  Create new file.
+        this->openNew(fname);
+    }
+    else if (! rst->hasKey("SEQNUM")) {
+        // File with correct filename exists but does not appear
+        // to be an actual unified restart file.
+        throw std::invalid_argument {
+            "Purported existing unified restart file '"
+            + boost::filesystem::path{fname}.filename().string()
+            + "' does not appear to be a unified restart file"
+        };
+    }
+    else {
+        // Restart file exists and appears to be a unified restart
+        // resource.  Open writable restart stream backed by the
+        // specific file.
+        this->openExisting(fname, rst->restartStepWritePosition(seqnum));
+    }
+}
+
+void
+Opm::ecl::OutputStream::Restart::openNew(const std::string& fname)
+{
+    this->stream_ = Open::Restart::writeNew(fname, this->formatted_);
+}
+
+void
+Opm::ecl::OutputStream::Restart::
+openExisting(const std::string&   fname,
+             const std::streampos writePos)
+{
+    this->stream_ = Open::Restart::
+        writeExisting(fname, this->formatted_);
+
+    if (writePos == std::streampos(-1)) {
+        // No specified initial write position.  Typically the case if
+        // requested SEQNUM value exceeds all existing SEQNUM values in
+        // 'fname'.  This is effectively a simple append operation so
+        // no further actions required.
+        return;
+    }
+
+    // The user specified an initial write position.  Resize existing
+    // file (as if by POSIX function ::truncate()) to requested size,
+    // and place output position at that position (i.e., new EOF).  This
+    // case typically corresponds to reopening a unified restart file at
+    // the start of a particular SEQNUM keyword.
+    //
+    // Note that this intentionally operates on the file/path backing the
+    // already opened 'stream_'.  In other words, 'open' followed by
+    // resize_file() followed by seekp() is the intended and expected
+    // order of operations.
+
+    boost::filesystem::resize_file(fname, writePos);
+
+    if (! this->stream_->ofileH.seekp(0, std::ios_base::end)) {
+        throw std::invalid_argument {
+            "Unable to Seek to Write Position " +
+            std::to_string(writePos) + " of File '"
+            + fname + "'"
+        };
+    }
+}
+
+std::string
+Opm::ecl::OutputStream::outputFileName(const ResultSet&   rsetDescriptor,
+                                       const std::string& ext)
+{
+    namespace fs = boost::filesystem;
+
+    // Allow baseName = "CASE", "CASE.", "CASE.N", or "CASE.N.".
+    auto fname = fs::path {
+        rsetDescriptor.baseName
+        + (rsetDescriptor.baseName.back() == '.' ? "" : ".")
+        + "REPLACE"
+    }.replace_extension(ext);
+
+    return (fs::path { rsetDescriptor.outputDir } / fname)
+        .generic().string();
+}
+
+std::string
+Opm::ecl::OutputStream::outputFileName(const Restart& rst,
+                                       const int      seqnum)
+{
+    const auto ext = FileExtension::
+        restart(seqnum, rst.formatted(), rst.unified());
+
+    return outputFileName(rst.resultSetDescriptor(), ext);
+}

--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -158,10 +158,44 @@ void Opm::ecl::OutputStream::Restart::prepareStep(const int seqnum)
     }
 }
 
-Opm::ecl::EclOutput&
-Opm::ecl::OutputStream::Restart::stream()
+void Opm::ecl::OutputStream::Restart::message(const std::string& msg)
 {
-    return *this->stream_;
+    this->stream().message(msg);
+}
+
+void
+Opm::ecl::OutputStream::Restart::
+write(const std::string& kw, const std::vector<int>& data)
+{
+    this->writeImpl(kw, data);
+}
+
+void
+Opm::ecl::OutputStream::Restart::
+write(const std::string& kw, const std::vector<bool>& data)
+{
+    this->writeImpl(kw, data);
+}
+
+void
+Opm::ecl::OutputStream::Restart::
+write(const std::string& kw, const std::vector<float>& data)
+{
+    this->writeImpl(kw, data);
+}
+
+void
+Opm::ecl::OutputStream::Restart::
+write(const std::string& kw, const std::vector<double>& data)
+{
+    this->writeImpl(kw, data);
+}
+
+void
+Opm::ecl::OutputStream::Restart::
+write(const std::string& kw, const std::vector<std::string>& data)
+{
+    this->writeImpl(kw, data);
 }
 
 void
@@ -238,6 +272,24 @@ openExisting(const std::string&   fname,
         };
     }
 }
+
+Opm::ecl::EclOutput&
+Opm::ecl::OutputStream::Restart::stream()
+{
+    return *this->stream_;
+}
+
+namespace Opm { namespace ecl { namespace OutputStream {
+
+    template <typename T>
+    void Restart::writeImpl(const std::string&    kw,
+                            const std::vector<T>& data)
+    {
+        this->stream().write(kw, data);
+    }
+
+}}}
+
 
 std::string
 Opm::ecl::OutputStream::outputFileName(const ResultSet&   rsetDescriptor,

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -1,0 +1,1017 @@
+/*
+  Copyright 2019 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE OutputStream
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/io/eclipse/OutputStream.hpp>
+
+#include <opm/io/eclipse/EclFile.hpp>
+#include <opm/io/eclipse/EclOutput.hpp>
+#include <opm/io/eclipse/ERst.hpp>
+
+#include <opm/io/eclipse/EclIOdata.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <ostream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+
+namespace Opm { namespace ecl {
+
+    // Needed by BOOST_CHECK_EQUAL_COLLECTIONS.
+    std::ostream&
+    operator<<(std::ostream& os, const EclFile::EclEntry& e)
+    {
+        os << "{ " << std::get<0>(e)
+           << ", " << static_cast<int>(std::get<1>(e))
+           << ", " << std::get<2>(e)
+           << " }";
+
+        return os;
+    }
+}} // Namespace Opm::ecl
+
+namespace {
+    template <class Coll>
+    void check_is_close(const Coll& c1, const Coll& c2)
+    {
+        using ElmType = typename std::remove_cv<
+            typename std::remove_reference<
+                typename std::iterator_traits<
+                    decltype(std::begin(c1))
+                >::value_type
+            >::type
+        >::type;
+
+        for (auto b1  = c1.begin(), e1 = c1.end(), b2 = c2.begin();
+                  b1 != e1; ++b1, ++b2)
+        {
+            BOOST_CHECK_CLOSE(*b1, *b2, static_cast<ElmType>(1.0e-7));
+        }
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(RestartStream)
+
+BOOST_AUTO_TEST_SUITE(FileName)
+
+BOOST_AUTO_TEST_CASE(ResultSetDescriptor)
+{
+    const auto odir = std::string{"/x/y/z///"};
+    const auto ext  = std::string{"F0123"};
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE"
+        };
+
+        const auto fname = outputFileName(rset, ext);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.F0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE." // CASE DOT
+        };
+
+        const auto fname = outputFileName(rset, ext);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.F0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01"
+        };
+
+        const auto fname = outputFileName(rset, ext);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.F0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01." // CASE.01 DOT
+        };
+
+        const auto fname = outputFileName(rset, ext);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.F0123");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Formatted_Separate)
+{
+    const auto odir   = std::string{"/x/y/z///"};
+    const auto seqnum = 123;
+    const auto fmt    = ::Opm::ecl::OutputStream::Formatted{ true };
+    const auto unif   = ::Opm::ecl::OutputStream::Unified  { false };
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE"
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.F0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE."  // CASE DOT
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.F0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01"
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.F0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01."  // CASE.01 DOT
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.F0123");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Formatted_Unified)
+{
+    const auto odir   = std::string{"/x/y/z///"};
+    const auto seqnum = 123;
+    const auto fmt    = ::Opm::ecl::OutputStream::Formatted{ true };
+    const auto unif   = ::Opm::ecl::OutputStream::Unified  { true };
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE"
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.FUNRST");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE."  // CASE DOT
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.FUNRST");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01"
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.FUNRST");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01."  // CASE.01 DOT
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.FUNRST");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Unformatted_Separate)
+{
+    const auto odir   = std::string{"/x/y/z///"};
+    const auto seqnum = 123;
+    const auto fmt    = ::Opm::ecl::OutputStream::Formatted{ false };
+    const auto unif   = ::Opm::ecl::OutputStream::Unified  { false };
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE"
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.X0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE."  // CASE DOT
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.X0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01"
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.X0123");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01."  // CASE.01 DOT
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.X0123");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Unformatted_Unified)
+{
+    const auto odir   = std::string{"/x/y/z///"};
+    const auto seqnum = 123;
+    const auto fmt    = ::Opm::ecl::OutputStream::Formatted{ false };
+    const auto unif   = ::Opm::ecl::OutputStream::Unified  { true };
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE"
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.UNRST");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE."  // CASE DOT
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.UNRST");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01"
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.UNRST");
+    }
+
+    {
+        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+            odir, "CASE.01."  // CASE.01 DOT
+        };
+
+        const auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, fmt, unif
+        };
+
+        const auto fname = outputFileName(rst, seqnum);
+
+        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.UNRST");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // FileName
+
+// ==========================================================================
+
+BOOST_AUTO_TEST_SUITE(Class_Restart)
+
+class RSet
+{
+public:
+    explicit RSet(std::string base)
+        : odir_(boost::filesystem::temp_directory_path() /
+                boost::filesystem::unique_path("rset-%%%%"))
+        , base_(std::move(base))
+    {
+        boost::filesystem::create_directories(this->odir_);
+    }
+
+    ~RSet()
+    {
+        boost::filesystem::remove_all(this->odir_);
+    }
+
+    operator ::Opm::ecl::OutputStream::ResultSet() const
+    {
+        return { this->odir_.string(), this->base_ };
+    }
+
+private:
+    boost::filesystem::path odir_;
+    std::string             base_;
+};
+
+BOOST_AUTO_TEST_CASE(Unformatted_Unified)
+{
+    const auto rset = RSet("CASE");
+    const auto fmt  = ::Opm::ecl::OutputStream::Formatted{ false };
+    const auto unif = ::Opm::ecl::OutputStream::Unified  { true };
+
+    {
+        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
+
+        rst.prepareStep(1);
+
+        auto& rstFile = rst.stream();
+
+        rstFile.write("I", std::vector<int>        {1, 7, 2, 9});
+        rstFile.write("L", std::vector<bool>       {true, false, false, true});
+        rstFile.write("S", std::vector<float>      {3.1f, 4.1f, 59.265f});
+        rstFile.write("D", std::vector<double>     {2.71, 8.21});
+        rstFile.write("Z", std::vector<std::string>{"W1", "W2"});
+    }
+
+    {
+        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
+
+        rst.prepareStep(13);
+
+        auto& rstFile = rst.stream();
+
+        rstFile.write("I", std::vector<int>        {35, 51, 13});
+        rstFile.write("L", std::vector<bool>       {true, true, true, false});
+        rstFile.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
+        rstFile.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
+        rstFile.write("Z", std::vector<std::string>{"G1", "FIELD"});
+    }
+
+    {
+        const auto fname = ::Opm::ecl::OutputStream::
+            outputFileName(rset, "UNRST");
+
+        auto rst = ::Opm::ecl::ERst{fname};
+
+        BOOST_CHECK(rst.hasReportStepNumber( 1));
+        BOOST_CHECK(rst.hasReportStepNumber(13));
+
+        {
+            const auto seqnum        = rst.listOfReportStepNumbers();
+            const auto expect_seqnum = std::vector<int>{1, 13};
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(seqnum.begin(), seqnum.end(),
+                                          expect_seqnum.begin(),
+                                          expect_seqnum.end());
+        }
+
+        {
+            const auto vectors        = rst.listOfRstArrays(13);
+            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+                Opm::ecl::EclFile::EclEntry{"SEQNUM", Opm::ecl::eclArrType::INTE, 1},
+                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 3},
+                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
+                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 2},
+                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 3},
+                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 2},
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
+                                          expect_vectors.begin(),
+                                          expect_vectors.end());
+        }
+
+        rst.loadReportStepNumber(13);
+
+        {
+            const auto& I = rst.getRst<int>("I", 13);
+            const auto  expect_I = std::vector<int>{ 35, 51, 13};
+            BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
+                                          expect_I.begin(),
+                                          expect_I.end());
+        }
+
+        {
+            const auto& L = rst.getRst<bool>("L", 13);
+            const auto  expect_L = std::vector<bool> {
+                true, true, true, false,
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(L.begin(), L.end(),
+                                          expect_L.begin(),
+                                          expect_L.end());
+        }
+
+        {
+            const auto& S = rst.getRst<float>("S", 13);
+            const auto  expect_S = std::vector<float>{
+                17.29e-02f, 1.4142f,
+            };
+
+            check_is_close(S, expect_S);
+        }
+
+        {
+            const auto& D = rst.getRst<double>("D", 13);
+            const auto  expect_D = std::vector<double>{
+                0.6931, 1.6180, 123.45e6,
+            };
+
+            check_is_close(D, expect_D);
+        }
+
+        {
+            const auto& Z = rst.getRst<std::string>("Z", 13);
+            const auto  expect_Z = std::vector<std::string>{
+                "G1", "FIELD",  // ERst trims trailing blanks
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(Z.begin(), Z.end(),
+                                          expect_Z.begin(),
+                                          expect_Z.end());
+        }
+    }
+
+    {
+        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
+
+        rst.prepareStep(5);  // Before 13.  Should overwrite 13
+
+        auto& rstFile = rst.stream();
+
+        rstFile.write("I", std::vector<int>        {1, 2, 3, 4});
+        rstFile.write("L", std::vector<bool>       {false, false, false, true});
+        rstFile.write("S", std::vector<float>      {1.23e-04f, 1.234e5f, -5.4321e-9f});
+        rstFile.write("D", std::vector<double>     {0.6931, 1.6180});
+        rstFile.write("Z", std::vector<std::string>{"HELLO", ", ", "WORLD"});
+    }
+
+    {
+        const auto fname = ::Opm::ecl::OutputStream::
+            outputFileName(rset, "UNRST");
+
+        auto rst = ::Opm::ecl::ERst{fname};
+
+        BOOST_CHECK( rst.hasReportStepNumber( 1));
+        BOOST_CHECK( rst.hasReportStepNumber( 5));
+        BOOST_CHECK(!rst.hasReportStepNumber(13));
+
+        {
+            const auto seqnum        = rst.listOfReportStepNumbers();
+            const auto expect_seqnum = std::vector<int>{1, 5};
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(seqnum.begin(), seqnum.end(),
+                                          expect_seqnum.begin(),
+                                          expect_seqnum.end());
+        }
+
+        {
+            const auto vectors        = rst.listOfRstArrays(5);
+            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+                Opm::ecl::EclFile::EclEntry{"SEQNUM", Opm::ecl::eclArrType::INTE, 1},
+                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 4},
+                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
+                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 3},
+                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 2},
+                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 3},
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
+                                          expect_vectors.begin(),
+                                          expect_vectors.end());
+        }
+
+        rst.loadReportStepNumber(5);
+
+        {
+            const auto& I = rst.getRst<int>("I", 5);
+            const auto  expect_I = std::vector<int>{ 1, 2, 3, 4 };
+            BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
+                                          expect_I.begin(),
+                                          expect_I.end());
+        }
+
+        {
+            const auto& L = rst.getRst<bool>("L", 5);
+            const auto  expect_L = std::vector<bool> {
+                false, false, false, true,
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(L.begin(), L.end(),
+                                          expect_L.begin(),
+                                          expect_L.end());
+        }
+
+        {
+            const auto& S = rst.getRst<float>("S", 5);
+            const auto  expect_S = std::vector<float>{
+                1.23e-04f, 1.234e5f, -5.4321e-9f,
+            };
+
+            check_is_close(S, expect_S);
+        }
+
+        {
+            const auto& D = rst.getRst<double>("D", 5);
+            const auto  expect_D = std::vector<double>{
+                0.6931, 1.6180,
+            };
+
+            check_is_close(D, expect_D);
+        }
+
+        {
+            const auto& Z = rst.getRst<std::string>("Z", 5);
+            const auto  expect_Z = std::vector<std::string>{
+                "HELLO", ",", "WORLD",  // ERst trims trailing blanks
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(Z.begin(), Z.end(),
+                                          expect_Z.begin(),
+                                          expect_Z.end());
+        }
+    }
+
+    {
+        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
+
+        rst.prepareStep(13);
+
+        auto& rstFile = rst.stream();
+
+        rstFile.write("I", std::vector<int>        {35, 51, 13});
+        rstFile.write("L", std::vector<bool>       {true, true, true, false});
+        rstFile.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
+        rstFile.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
+        rstFile.write("Z", std::vector<std::string>{"G1", "FIELD"});
+    }
+
+    {
+        const auto fname = ::Opm::ecl::OutputStream::
+            outputFileName(rset, "UNRST");
+
+        auto rst = ::Opm::ecl::ERst{fname};
+
+        BOOST_CHECK(rst.hasReportStepNumber( 1));
+        BOOST_CHECK(rst.hasReportStepNumber( 5));
+        BOOST_CHECK(rst.hasReportStepNumber(13));
+
+        {
+            const auto seqnum        = rst.listOfReportStepNumbers();
+            const auto expect_seqnum = std::vector<int>{1, 5, 13};
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(seqnum.begin(), seqnum.end(),
+                                          expect_seqnum.begin(),
+                                          expect_seqnum.end());
+        }
+
+        {
+            const auto vectors        = rst.listOfRstArrays(13);
+            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+                Opm::ecl::EclFile::EclEntry{"SEQNUM", Opm::ecl::eclArrType::INTE, 1},
+                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 3},
+                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
+                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 2},
+                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 3},
+                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 2},
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
+                                          expect_vectors.begin(),
+                                          expect_vectors.end());
+        }
+
+        rst.loadReportStepNumber(13);
+
+        {
+            const auto& I = rst.getRst<int>("I", 13);
+            const auto  expect_I = std::vector<int>{ 35, 51, 13};
+            BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
+                                          expect_I.begin(),
+                                          expect_I.end());
+        }
+
+        {
+            const auto& L = rst.getRst<bool>("L", 13);
+            const auto  expect_L = std::vector<bool> {
+                true, true, true, false,
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(L.begin(), L.end(),
+                                          expect_L.begin(),
+                                          expect_L.end());
+        }
+
+        {
+            const auto& S = rst.getRst<float>("S", 13);
+            const auto  expect_S = std::vector<float>{
+                17.29e-02f, 1.4142f,
+            };
+
+            check_is_close(S, expect_S);
+        }
+
+        {
+            const auto& D = rst.getRst<double>("D", 13);
+            const auto  expect_D = std::vector<double>{
+                0.6931, 1.6180, 123.45e6,
+            };
+
+            check_is_close(D, expect_D);
+        }
+
+        {
+            const auto& Z = rst.getRst<std::string>("Z", 13);
+            const auto  expect_Z = std::vector<std::string>{
+                "G1", "FIELD",  // ERst trims trailing blanks
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(Z.begin(), Z.end(),
+                                          expect_Z.begin(),
+                                          expect_Z.end());
+        }
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(Formatted_Separate)
+{
+    const auto rset = RSet("CASE.T01.");
+    const auto fmt  = ::Opm::ecl::OutputStream::Formatted{ true };
+    const auto unif = ::Opm::ecl::OutputStream::Unified  { false };
+
+    {
+        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
+
+        rst.prepareStep(1);
+
+        auto& rstFile = rst.stream();
+
+        rstFile.write("I", std::vector<int>        {1, 7, 2, 9});
+        rstFile.write("L", std::vector<bool>       {true, false, false, true});
+        rstFile.write("S", std::vector<float>      {3.1f, 4.1f, 59.265f});
+        rstFile.write("D", std::vector<double>     {2.71, 8.21});
+        rstFile.write("Z", std::vector<std::string>{"W1", "W2"});
+    }
+
+    {
+        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
+
+        rst.prepareStep(13);
+
+        auto& rstFile = rst.stream();
+
+        rstFile.write("I", std::vector<int>        {35, 51, 13});
+        rstFile.write("L", std::vector<bool>       {true, true, true, false});
+        rstFile.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
+        rstFile.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
+        rstFile.write("Z", std::vector<std::string>{"G1", "FIELD"});
+    }
+
+    {
+        using ::Opm::ecl::OutputStream::Restart;
+
+        const auto fname = ::Opm::ecl::OutputStream::
+            outputFileName(Restart{rset, fmt, unif}, 13);
+
+        auto rst = ::Opm::ecl::EclFile{fname};
+
+        {
+            const auto vectors        = rst.getList();
+            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+                // No SEQNUM in separate output files
+                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 3},
+                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
+                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 2},
+                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 3},
+                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 2},
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
+                                          expect_vectors.begin(),
+                                          expect_vectors.end());
+        }
+
+        rst.loadData();
+
+        {
+            const auto& I = rst.get<int>("I");
+            const auto  expect_I = std::vector<int>{ 35, 51, 13 };
+            BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
+                                          expect_I.begin(),
+                                          expect_I.end());
+        }
+
+        {
+            const auto& L = rst.get<bool>("L");
+            const auto  expect_L = std::vector<bool> {
+                true, true, true, false,
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(L.begin(), L.end(),
+                                          expect_L.begin(),
+                                          expect_L.end());
+        }
+
+        {
+            const auto& S = rst.get<float>("S");
+            const auto  expect_S = std::vector<float>{
+                17.29e-02f, 1.4142f,
+            };
+
+            check_is_close(S, expect_S);
+        }
+
+        {
+            const auto& D = rst.get<double>("D");
+            const auto  expect_D = std::vector<double>{
+                0.6931, 1.6180, 123.45e6,
+            };
+
+            check_is_close(D, expect_D);
+        }
+
+        {
+            const auto& Z = rst.get<std::string>("Z");
+            const auto  expect_Z = std::vector<std::string>{
+                "G1", "FIELD",  // ERst trims trailing blanks
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(Z.begin(), Z.end(),
+                                          expect_Z.begin(),
+                                          expect_Z.end());
+        }
+    }
+
+    {
+        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
+
+        rst.prepareStep(5);  // Separate output.  Step 13 should be unaffected.
+
+        auto& rstFile = rst.stream();
+
+        rstFile.write("I", std::vector<int>        {1, 2, 3, 4});
+        rstFile.write("L", std::vector<bool>       {false, false, false, true});
+        rstFile.write("S", std::vector<float>      {1.23e-04f, 1.234e5f, -5.4321e-9f});
+        rstFile.write("D", std::vector<double>     {0.6931, 1.6180});
+        rstFile.write("Z", std::vector<std::string>{"HELLO", ", ", "WORLD"});
+    }
+
+    {
+        using ::Opm::ecl::OutputStream::Restart;
+
+        const auto fname = ::Opm::ecl::OutputStream::
+            outputFileName(Restart{rset, fmt, unif}, 5);
+
+        auto rst = ::Opm::ecl::EclFile{fname};
+
+        {
+            const auto vectors        = rst.getList();
+            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+                // No SEQNUM in separate output files
+                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 4},
+                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
+                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 3},
+                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 2},
+                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 3},
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
+                                          expect_vectors.begin(),
+                                          expect_vectors.end());
+        }
+
+        rst.loadData();
+
+        {
+            const auto& I = rst.get<int>("I");
+            const auto  expect_I = std::vector<int>{ 1, 2, 3, 4 };
+            BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
+                                          expect_I.begin(),
+                                          expect_I.end());
+        }
+
+        {
+            const auto& L = rst.get<bool>("L");
+            const auto  expect_L = std::vector<bool> {
+                false, false, false, true,
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(L.begin(), L.end(),
+                                          expect_L.begin(),
+                                          expect_L.end());
+        }
+
+        {
+            const auto& S = rst.get<float>("S");
+            const auto  expect_S = std::vector<float>{
+                1.23e-04f, 1.234e5f, -5.4321e-9f,
+            };
+
+            check_is_close(S, expect_S);
+        }
+
+        {
+            const auto& D = rst.get<double>("D");
+            const auto  expect_D = std::vector<double>{
+                0.6931, 1.6180,
+            };
+
+            check_is_close(D, expect_D);
+        }
+
+        {
+            const auto& Z = rst.get<std::string>("Z");
+            const auto  expect_Z = std::vector<std::string>{
+                "HELLO", ",", "WORLD",  // ERst trims trailing blanks
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(Z.begin(), Z.end(),
+                                          expect_Z.begin(),
+                                          expect_Z.end());
+        }
+    }
+
+    // -------------------------------------------------------
+    // Don't rewrite step 13.  Output file should still exist.
+    // -------------------------------------------------------
+
+    {
+        using ::Opm::ecl::OutputStream::Restart;
+
+        const auto fname = ::Opm::ecl::OutputStream::
+            outputFileName(Restart{rset, fmt, unif}, 13);
+
+        auto rst = ::Opm::ecl::EclFile{fname};
+
+        {
+            const auto vectors        = rst.getList();
+            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+                // No SEQNUM in separate output files.
+                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 3},
+                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
+                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 2},
+                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 3},
+                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 2},
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
+                                          expect_vectors.begin(),
+                                          expect_vectors.end());
+        }
+
+        rst.loadData();
+
+        {
+            const auto& I = rst.get<int>("I");
+            const auto  expect_I = std::vector<int>{ 35, 51, 13 };
+            BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
+                                          expect_I.begin(),
+                                          expect_I.end());
+        }
+
+        {
+            const auto& L = rst.get<bool>("L");
+            const auto  expect_L = std::vector<bool> {
+                true, true, true, false,
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(L.begin(), L.end(),
+                                          expect_L.begin(),
+                                          expect_L.end());
+        }
+
+        {
+            const auto& S = rst.get<float>("S");
+            const auto  expect_S = std::vector<float>{
+                17.29e-02f, 1.4142f,
+            };
+
+            check_is_close(S, expect_S);
+        }
+
+        {
+            const auto& D = rst.get<double>("D");
+            const auto  expect_D = std::vector<double>{
+                0.6931, 1.6180, 123.45e6,
+            };
+
+            check_is_close(D, expect_D);
+        }
+
+        {
+            const auto& Z = rst.get<std::string>("Z");
+            const auto  expect_Z = std::vector<std::string>{
+                "G1", "FIELD",  // ERst trims trailing blanks
+            };
+
+            BOOST_CHECK_EQUAL_COLLECTIONS(Z.begin(), Z.end(),
+                                          expect_Z.begin(),
+                                          expect_Z.end());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Class_Restart
+
+BOOST_AUTO_TEST_SUITE_END() // RestartStream

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -424,13 +424,11 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
         rst.prepareStep(1);
 
-        auto& rstFile = rst.stream();
-
-        rstFile.write("I", std::vector<int>        {1, 7, 2, 9});
-        rstFile.write("L", std::vector<bool>       {true, false, false, true});
-        rstFile.write("S", std::vector<float>      {3.1f, 4.1f, 59.265f});
-        rstFile.write("D", std::vector<double>     {2.71, 8.21});
-        rstFile.write("Z", std::vector<std::string>{"W1", "W2"});
+        rst.write("I", std::vector<int>        {1, 7, 2, 9});
+        rst.write("L", std::vector<bool>       {true, false, false, true});
+        rst.write("S", std::vector<float>      {3.1f, 4.1f, 59.265f});
+        rst.write("D", std::vector<double>     {2.71, 8.21});
+        rst.write("Z", std::vector<std::string>{"W1", "W2"});
     }
 
     {
@@ -438,13 +436,11 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
         rst.prepareStep(13);
 
-        auto& rstFile = rst.stream();
-
-        rstFile.write("I", std::vector<int>        {35, 51, 13});
-        rstFile.write("L", std::vector<bool>       {true, true, true, false});
-        rstFile.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
-        rstFile.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
-        rstFile.write("Z", std::vector<std::string>{"G1", "FIELD"});
+        rst.write("I", std::vector<int>        {35, 51, 13});
+        rst.write("L", std::vector<bool>       {true, true, true, false});
+        rst.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
+        rst.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
+        rst.write("Z", std::vector<std::string>{"G1", "FIELD"});
     }
 
     {
@@ -537,13 +533,11 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
         rst.prepareStep(5);  // Before 13.  Should overwrite 13
 
-        auto& rstFile = rst.stream();
-
-        rstFile.write("I", std::vector<int>        {1, 2, 3, 4});
-        rstFile.write("L", std::vector<bool>       {false, false, false, true});
-        rstFile.write("S", std::vector<float>      {1.23e-04f, 1.234e5f, -5.4321e-9f});
-        rstFile.write("D", std::vector<double>     {0.6931, 1.6180});
-        rstFile.write("Z", std::vector<std::string>{"HELLO", ", ", "WORLD"});
+        rst.write("I", std::vector<int>        {1, 2, 3, 4});
+        rst.write("L", std::vector<bool>       {false, false, false, true});
+        rst.write("S", std::vector<float>      {1.23e-04f, 1.234e5f, -5.4321e-9f});
+        rst.write("D", std::vector<double>     {0.6931, 1.6180});
+        rst.write("Z", std::vector<std::string>{"HELLO", ", ", "WORLD"});
     }
 
     {
@@ -637,13 +631,11 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
         rst.prepareStep(13);
 
-        auto& rstFile = rst.stream();
-
-        rstFile.write("I", std::vector<int>        {35, 51, 13});
-        rstFile.write("L", std::vector<bool>       {true, true, true, false});
-        rstFile.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
-        rstFile.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
-        rstFile.write("Z", std::vector<std::string>{"G1", "FIELD"});
+        rst.write("I", std::vector<int>        {35, 51, 13});
+        rst.write("L", std::vector<bool>       {true, true, true, false});
+        rst.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
+        rst.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
+        rst.write("Z", std::vector<std::string>{"G1", "FIELD"});
     }
 
     {
@@ -745,13 +737,11 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
 
         rst.prepareStep(1);
 
-        auto& rstFile = rst.stream();
-
-        rstFile.write("I", std::vector<int>        {1, 7, 2, 9});
-        rstFile.write("L", std::vector<bool>       {true, false, false, true});
-        rstFile.write("S", std::vector<float>      {3.1f, 4.1f, 59.265f});
-        rstFile.write("D", std::vector<double>     {2.71, 8.21});
-        rstFile.write("Z", std::vector<std::string>{"W1", "W2"});
+        rst.write("I", std::vector<int>        {1, 7, 2, 9});
+        rst.write("L", std::vector<bool>       {true, false, false, true});
+        rst.write("S", std::vector<float>      {3.1f, 4.1f, 59.265f});
+        rst.write("D", std::vector<double>     {2.71, 8.21});
+        rst.write("Z", std::vector<std::string>{"W1", "W2"});
     }
 
     {
@@ -759,13 +749,11 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
 
         rst.prepareStep(13);
 
-        auto& rstFile = rst.stream();
-
-        rstFile.write("I", std::vector<int>        {35, 51, 13});
-        rstFile.write("L", std::vector<bool>       {true, true, true, false});
-        rstFile.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
-        rstFile.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
-        rstFile.write("Z", std::vector<std::string>{"G1", "FIELD"});
+        rst.write("I", std::vector<int>        {35, 51, 13});
+        rst.write("L", std::vector<bool>       {true, true, true, false});
+        rst.write("S", std::vector<float>      {17.29e-02f, 1.4142f});
+        rst.write("D", std::vector<double>     {0.6931, 1.6180, 123.45e6});
+        rst.write("Z", std::vector<std::string>{"G1", "FIELD"});
     }
 
     {
@@ -848,13 +836,11 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
 
         rst.prepareStep(5);  // Separate output.  Step 13 should be unaffected.
 
-        auto& rstFile = rst.stream();
-
-        rstFile.write("I", std::vector<int>        {1, 2, 3, 4});
-        rstFile.write("L", std::vector<bool>       {false, false, false, true});
-        rstFile.write("S", std::vector<float>      {1.23e-04f, 1.234e5f, -5.4321e-9f});
-        rstFile.write("D", std::vector<double>     {0.6931, 1.6180});
-        rstFile.write("Z", std::vector<std::string>{"HELLO", ", ", "WORLD"});
+        rst.write("I", std::vector<int>        {1, 2, 3, 4});
+        rst.write("L", std::vector<bool>       {false, false, false, true});
+        rst.write("S", std::vector<float>      {1.23e-04f, 1.234e5f, -5.4321e-9f});
+        rst.write("D", std::vector<double>     {0.6931, 1.6180});
+        rst.write("Z", std::vector<std::string>{"HELLO", ", ", "WORLD"});
     }
 
     {

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -125,262 +125,6 @@ BOOST_AUTO_TEST_CASE(ResultSetDescriptor)
     }
 }
 
-BOOST_AUTO_TEST_CASE(Formatted_Separate)
-{
-    const auto odir   = std::string{"/x/y/z///"};
-    const auto seqnum = 123;
-    const auto fmt    = ::Opm::ecl::OutputStream::Formatted{ true };
-    const auto unif   = ::Opm::ecl::OutputStream::Unified  { false };
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE"
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.F0123");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE."  // CASE DOT
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.F0123");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE.01"
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.F0123");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE.01."  // CASE.01 DOT
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.F0123");
-    }
-}
-
-BOOST_AUTO_TEST_CASE(Formatted_Unified)
-{
-    const auto odir   = std::string{"/x/y/z///"};
-    const auto seqnum = 123;
-    const auto fmt    = ::Opm::ecl::OutputStream::Formatted{ true };
-    const auto unif   = ::Opm::ecl::OutputStream::Unified  { true };
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE"
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.FUNRST");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE."  // CASE DOT
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.FUNRST");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE.01"
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.FUNRST");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE.01."  // CASE.01 DOT
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.FUNRST");
-    }
-}
-
-BOOST_AUTO_TEST_CASE(Unformatted_Separate)
-{
-    const auto odir   = std::string{"/x/y/z///"};
-    const auto seqnum = 123;
-    const auto fmt    = ::Opm::ecl::OutputStream::Formatted{ false };
-    const auto unif   = ::Opm::ecl::OutputStream::Unified  { false };
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE"
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.X0123");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE."  // CASE DOT
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.X0123");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE.01"
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.X0123");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE.01."  // CASE.01 DOT
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.X0123");
-    }
-}
-
-BOOST_AUTO_TEST_CASE(Unformatted_Unified)
-{
-    const auto odir   = std::string{"/x/y/z///"};
-    const auto seqnum = 123;
-    const auto fmt    = ::Opm::ecl::OutputStream::Formatted{ false };
-    const auto unif   = ::Opm::ecl::OutputStream::Unified  { true };
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE"
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.UNRST");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE."  // CASE DOT
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.UNRST");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE.01"
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.UNRST");
-    }
-
-    {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
-            odir, "CASE.01."  // CASE.01 DOT
-        };
-
-        const auto rst = ::Opm::ecl::OutputStream::Restart {
-            rset, fmt, unif
-        };
-
-        const auto fname = outputFileName(rst, seqnum);
-
-        BOOST_CHECK_EQUAL(fname, odir + "CASE.01.UNRST");
-    }
-}
-
 BOOST_AUTO_TEST_SUITE_END() // FileName
 
 // ==========================================================================
@@ -420,9 +164,10 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
     const auto unif = ::Opm::ecl::OutputStream::Unified  { true };
 
     {
-        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
-
-        rst.prepareStep(1);
+        const auto seqnum = 1;
+        auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, seqnum, fmt, unif
+        };
 
         rst.write("I", std::vector<int>        {1, 7, 2, 9});
         rst.write("L", std::vector<bool>       {true, false, false, true});
@@ -432,9 +177,10 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
     }
 
     {
-        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
-
-        rst.prepareStep(13);
+        const auto seqnum = 13;
+        auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, seqnum, fmt, unif
+        };
 
         rst.write("I", std::vector<int>        {35, 51, 13});
         rst.write("L", std::vector<bool>       {true, true, true, false});
@@ -529,9 +275,10 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
     }
 
     {
-        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
-
-        rst.prepareStep(5);  // Before 13.  Should overwrite 13
+        const auto seqnum = 5;  // Before 13.  Should overwrite 13
+        auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, seqnum, fmt, unif
+        };
 
         rst.write("I", std::vector<int>        {1, 2, 3, 4});
         rst.write("L", std::vector<bool>       {false, false, false, true});
@@ -627,9 +374,10 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
     }
 
     {
-        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
-
-        rst.prepareStep(13);
+        const auto seqnum = 13;
+        auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, seqnum, fmt, unif
+        };
 
         rst.write("I", std::vector<int>        {35, 51, 13});
         rst.write("L", std::vector<bool>       {true, true, true, false});
@@ -723,7 +471,6 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
                                           expect_Z.end());
         }
     }
-
 }
 
 BOOST_AUTO_TEST_CASE(Formatted_Separate)
@@ -733,9 +480,10 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
     const auto unif = ::Opm::ecl::OutputStream::Unified  { false };
 
     {
-        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
-
-        rst.prepareStep(1);
+        const auto seqnum = 1;
+        auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, seqnum, fmt, unif
+        };
 
         rst.write("I", std::vector<int>        {1, 7, 2, 9});
         rst.write("L", std::vector<bool>       {true, false, false, true});
@@ -745,9 +493,10 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
     }
 
     {
-        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
-
-        rst.prepareStep(13);
+        const auto seqnum = 13;
+        auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, seqnum, fmt, unif
+        };
 
         rst.write("I", std::vector<int>        {35, 51, 13});
         rst.write("L", std::vector<bool>       {true, true, true, false});
@@ -760,7 +509,7 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
         using ::Opm::ecl::OutputStream::Restart;
 
         const auto fname = ::Opm::ecl::OutputStream::
-            outputFileName(Restart{rset, fmt, unif}, 13);
+            outputFileName(rset, "F0013");
 
         auto rst = ::Opm::ecl::EclFile{fname};
 
@@ -832,9 +581,11 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
     }
 
     {
-        auto rst = ::Opm::ecl::OutputStream::Restart{ rset, fmt, unif };
-
-        rst.prepareStep(5);  // Separate output.  Step 13 should be unaffected.
+        // Separate output.  Step 13 should be unaffected.
+        const auto seqnum = 5;
+        auto rst = ::Opm::ecl::OutputStream::Restart {
+            rset, seqnum, fmt, unif
+        };
 
         rst.write("I", std::vector<int>        {1, 2, 3, 4});
         rst.write("L", std::vector<bool>       {false, false, false, true});
@@ -847,7 +598,7 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
         using ::Opm::ecl::OutputStream::Restart;
 
         const auto fname = ::Opm::ecl::OutputStream::
-            outputFileName(Restart{rset, fmt, unif}, 5);
+            outputFileName(rset, "F0005");
 
         auto rst = ::Opm::ecl::EclFile{fname};
 
@@ -926,7 +677,7 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
         using ::Opm::ecl::OutputStream::Restart;
 
         const auto fname = ::Opm::ecl::OutputStream::
-            outputFileName(Restart{rset, fmt, unif}, 13);
+            outputFileName(rset, "F0013");
 
         auto rst = ::Opm::ecl::EclFile{fname};
 


### PR DESCRIPTION
This change-set equips the ECLIPSE I/O classes introduced in PR #699 with additional operations to enable writing formatted/unformatted and unified/separate restart files in terms of class `EclOutput`.

In particular, we introduce a new file manager
```C++
class Opm::ecl::OutputStream::Restart;
```
that knows about the high-level structure of a sequence of restart steps and is responsible for opening writable streams a appropriate write positions&mdash;specified in terms of sequence numbers (SEQNUM values).  The intended use of the `Restart` class is
```C++
{
    Restart rst(resultSet, formatted, unified);
    rst.prepareStep(17);
    auto& rstFile = rst.stream();

    rstFile.write("INTEHEAD", ihead)
    // ... other headers, and group/well/segment &c arrays ...

    message("STARTSOL", rstFile);
    rstFile.write("PRESSURE", press);
    // ... more solution arrays ...
    message("ENDSOL", rstFile);
} // Close/finalise step and/or file by 'rst' going out of scope.
```
in which the `prepareStep()` operation ensures that the `stream()` is opened, the internal output stream's output indicator is appropriately positioned and also that any requisite `SEQNUM` header is already output. In other words, the client code does not need to be aware the differences between unified and separate restart files.

A possible extension to this protocol is to introduce a `finishStep()` operation that would allow client code to keep a `Restart` instance alive across multiple restart steps&mdash;e.g., throughout an entire simulation run&mdash;to reduce the cost of file operations.  Another possible extension is to add an index of the stream's vectors which could be the start of adding support for the `.RSSPEC` file (see Issue OPM/opm-simulators#1063 for context).

Note that the `Restart::prepareStep()` function needs access to internal implementation details of the `ERst` and `EclFile` classes in order to translate a sequence number to a file position so the latter two classes now declare that `Restart` is a `friend`.