### PR TITLE
fixed: avoid usage of boost::filesystem::path::generic()

### DIFF
--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -303,5 +303,5 @@ Opm::ecl::OutputStream::outputFileName(const ResultSet&   rsetDescriptor,
     }.replace_extension(ext);
 
     return (fs::path { rsetDescriptor.outputDir } / fname)
-        .generic().string();
+        .generic_string();
 }


### PR DESCRIPTION
this is not supported in older version of boost::filesystem.
furthermore, it was always an experimental feature and
and has been deprecated in newer versions.

generic_string is available in all versions, so use that.