### PR TITLE
Restart Output Code Reformatting

### DIFF
--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -78,7 +78,6 @@ namespace {
     template <class ConnOp>
     void connectionLoop(const std::vector<Opm::Well2>& wells,
                         const Opm::EclipseGrid&        grid,
-                        const std::size_t              sim_step,
                         ConnOp&&                       connOp)
     {
         for (auto nWell = wells.size(), wellID = 0*nWell;
@@ -336,7 +335,7 @@ captureDeclaredConnData(const Schedule&        sched,
         }
     }
 
-    connectionLoop(wells, grid, sim_step, [&units, &allWellConnections, this]
+    connectionLoop(wells, grid, [&units, &allWellConnections, this]
                    (const Well2&      well, const std::size_t wellID,
                     const Connection& conn, const std::size_t connID) -> void
                                           {

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -82,36 +82,36 @@ namespace {
     {
         for (auto nWell = wells.size(), wellID = 0*nWell;
              wellID < nWell; ++wellID)
-            {
-                const auto& well = wells[wellID];
-                const auto& conn0 = well.getConnections();
-                const auto& conns = Opm::WellConnections( conn0, grid );
-                const int niSI = static_cast<int>(conn0.size());
-                std::map <std::size_t, const Opm::Connection*> sIToConn;
+        {
+            const auto& well = wells[wellID];
+            const auto& conn0 = well.getConnections();
+            const auto& conns = Opm::WellConnections( conn0, grid );
+            const int niSI = static_cast<int>(conn0.size());
+            std::map <std::size_t, const Opm::Connection*> sIToConn;
 
-                //Branch according to MSW well or not and
-                //sort active connections according to appropriate seqIndex
-                if (well.isMultiSegment()) {
-                    //sort connections according to input sequence in COMPSEGS
-                    sIToConn = mapCompSegSeqIndexToConnection(conns);
-                } else {
-                    //sort connections according to input sequence in COMPDAT
-                    sIToConn = mapSeqIndexToConnection(conns);
-                }
-
-                std::vector<const Opm::Connection*> connSI;
-                for (int iSI = 0; iSI < niSI; iSI++) {
-                    const auto searchSI = sIToConn.find(static_cast<std::size_t>(iSI));
-                    if (searchSI != sIToConn.end()) {
-                        connSI.push_back(searchSI->second);
-                    }
-                }
-                for (auto nConn = connSI.size(), connID = 0*nConn;
-                     connID < nConn; ++connID)
-                    {
-                        connOp(well, wellID, *(connSI[connID]), connID);
-                    }
+            //Branch according to MSW well or not and
+            //sort active connections according to appropriate seqIndex
+            if (well.isMultiSegment()) {
+                //sort connections according to input sequence in COMPSEGS
+                sIToConn = mapCompSegSeqIndexToConnection(conns);
+            } else {
+                //sort connections according to input sequence in COMPDAT
+                sIToConn = mapSeqIndexToConnection(conns);
             }
+
+            std::vector<const Opm::Connection*> connSI;
+            for (int iSI = 0; iSI < niSI; iSI++) {
+                const auto searchSI = sIToConn.find(static_cast<std::size_t>(iSI));
+                if (searchSI != sIToConn.end()) {
+                    connSI.push_back(searchSI->second);
+                }
+            }
+            for (auto nConn = connSI.size(), connID = 0*nConn;
+                 connID < nConn; ++connID)
+            {
+                connOp(well, wellID, *(connSI[connID]), connID);
+            }
+        }
     }
 
     namespace IConn {
@@ -127,8 +127,8 @@ namespace {
 
             return WM {
                 WM::NumRows   { numWells(inteHead) },
-                    WM::NumCols   { maxNumConn(inteHead) },
-                        WM::WindowSize{ entriesPerConn(inteHead) }
+                WM::NumCols   { maxNumConn(inteHead) },
+                WM::WindowSize{ entriesPerConn(inteHead) }
             };
         }
 
@@ -179,8 +179,8 @@ namespace {
 
             return WM {
                 WM::NumRows   { numWells(inteHead) },
-                    WM::NumCols   { maxNumConn(inteHead) },
-                        WM::WindowSize{ entriesPerConn(inteHead) }
+                WM::NumCols   { maxNumConn(inteHead) },
+                WM::WindowSize{ entriesPerConn(inteHead) }
             };
         }
 
@@ -193,9 +193,9 @@ namespace {
             using Ix = ::Opm::RestartIO::Helpers::VectorItems::SConn::index;
 
             auto scprop = [&units](const M u, const double x) -> float
-                          {
-                              return static_cast<float>(units.from_si(u, x));
-                          };
+            {
+                return static_cast<float>(units.from_si(u, x));
+            };
 
             sConn[Ix::ConnTrans] =
                 scprop(M::transmissibility, conn.CF());
@@ -229,8 +229,8 @@ namespace {
 
             return WM {
                 WM::NumRows   { numWells(inteHead) },
-                    WM::NumCols   { maxNumConn(inteHead) },
-                        WM::WindowSize{ entriesPerConn(inteHead) }
+                WM::NumCols   { maxNumConn(inteHead) },
+                WM::WindowSize{ entriesPerConn(inteHead) }
             };
         }
 
@@ -327,33 +327,32 @@ captureDeclaredConnData(const Schedule&        sched,
                 else if ((conns[connID].state() == Opm::WellCompletion::StateEnum::OPEN) && (rCInd >= xr->second.connections.size())) {
                     throw std::invalid_argument {
                         "Inconsistent number of open connections I in vector<Opm::data::Connection*> (" +
-                            std::to_string(xr->second.connections.size()) + ") in Well " + wl.name()
-                            };
-
+                        std::to_string(xr->second.connections.size()) + ") in Well " + wl.name()
+                    };
                 }
             }
         }
     }
 
     connectionLoop(wells, grid, [&units, &allWellConnections, this]
-                   (const Well2&      well, const std::size_t wellID,
-                    const Connection& conn, const std::size_t connID) -> void
-                                          {
-                                              auto ic = this->iConn_(wellID, connID);
-                                              auto sc = this->sConn_(wellID, connID);
+        (const Well2&      well, const std::size_t wellID,
+         const Connection& conn, const std::size_t connID) -> void
+    {
+        auto ic = this->iConn_(wellID, connID);
+        auto sc = this->sConn_(wellID, connID);
 
-                                              IConn::staticContrib(conn, connID, ic);
-                                              SConn::staticContrib(conn, units, sc);
+        IConn::staticContrib(conn, connID, ic);
+        SConn::staticContrib(conn, units, sc);
 
-                                              auto xi = allWellConnections.find(well.name());
-                                              if ((xi != allWellConnections.end()) &&
-                                                  (connID < xi->second.size()))
-                                                  //(connID < xi->second.connections.size()))
-                                                  {
-                                                      auto xc = this->xConn_(wellID, connID);
+        auto xi = allWellConnections.find(well.name());
+        if ((xi != allWellConnections.end()) &&
+            (connID < xi->second.size()))
+            //(connID < xi->second.connections.size()))
+        {
+            auto xc = this->xConn_(wellID, connID);
 
-                                                      //XConn::dynamicContrib(xi->second.connections[connID],
-                                                      if (xi->second[connID]) XConn::dynamicContrib(*(xi->second[connID]), units, xc);
-                                                  }
-                                          });
+            //XConn::dynamicContrib(xi->second.connections[connID],
+            if (xi->second[connID]) XConn::dynamicContrib(*(xi->second[connID]), units, xc);
+        }
+    });
 }

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -103,11 +103,11 @@ namespace {
 
         return {
             outletS,
-                noSegInBranch,
-                firstSeg,
-                lastSeg,
-                branch
-                };
+            noSegInBranch,
+            firstSeg,
+            lastSeg,
+            branch
+        };
     }
 
     std::vector <std::size_t> segmentIndFromOrderedSegmentInd(const Opm::WellSegments& segSet, const std::vector<std::size_t>& ordSegNo) {
@@ -186,45 +186,44 @@ namespace {
     getSegmentSetSSTerms(const Opm::WellSegments& segSet, const std::vector<Opm::data::Connection>& rateConns,
                          const Opm::WellConnections& welConns, const Opm::UnitSystem& units)
     {
-      std::vector<double> qosc (segSet.size(), 0.);
-      std::vector<double> qwsc (segSet.size(), 0.);
-      std::vector<double> qgsc (segSet.size(), 0.);
-      std::vector<const Opm::Connection* > openConnections;
-      using M  = ::Opm::UnitSystem::measure;
-      using R  = ::Opm::data::Rates::opt;
-      for (auto nConn = welConns.size(), connID = 0*nConn; connID < nConn; connID++) {
-        if (welConns[connID].state() == Opm::WellCompletion::StateEnum::OPEN) openConnections.push_back(&welConns[connID]);
-      }
-      if (openConnections.size() != rateConns.size()) {
-        throw std::invalid_argument {
-          "Inconsistent number of open connections I in Opm::WellConnections (" +
-            std::to_string(welConns.size()) + ") and vector<Opm::data::Connection> (" +
-            std::to_string(rateConns.size()) + ") in Well " + segSet.wellName()
+        std::vector<double> qosc (segSet.size(), 0.);
+        std::vector<double> qwsc (segSet.size(), 0.);
+        std::vector<double> qgsc (segSet.size(), 0.);
+        std::vector<const Opm::Connection* > openConnections;
+        using M  = ::Opm::UnitSystem::measure;
+        using R  = ::Opm::data::Rates::opt;
+        for (auto nConn = welConns.size(), connID = 0*nConn; connID < nConn; connID++) {
+            if (welConns[connID].state() == Opm::WellCompletion::StateEnum::OPEN) openConnections.push_back(&welConns[connID]);
+        }
+        if (openConnections.size() != rateConns.size()) {
+            throw std::invalid_argument {
+                "Inconsistent number of open connections I in Opm::WellConnections (" +
+                std::to_string(welConns.size()) + ") and vector<Opm::data::Connection> (" +
+                std::to_string(rateConns.size()) + ") in Well " + segSet.wellName()
             };
-      }
-      for (auto nConn = openConnections.size(), connID = 0*nConn; connID < nConn; connID++) {
-        const auto& segNo = openConnections[connID]->segment();
-        const auto& segInd = segSet.segmentNumberToIndex(segNo);
-        const auto& Q = rateConns[connID].rates;
+        }
+        for (auto nConn = openConnections.size(), connID = 0*nConn; connID < nConn; connID++) {
+            const auto& segNo = openConnections[connID]->segment();
+            const auto& segInd = segSet.segmentNumberToIndex(segNo);
+            const auto& Q = rateConns[connID].rates;
 
-        auto get = [&units, &Q](const M u, const R q) -> double
-                   {
-                     const auto val = Q.has(q) ? Q.get(q) : 0.0;
+            auto get = [&units, &Q](const M u, const R q) -> double
+            {
+                const auto val = Q.has(q) ? Q.get(q) : 0.0;
 
-                     return - units.from_si(u, val);
-                   };
+                return - units.from_si(u, val);
+            };
 
-        qosc[segInd] += get(M::liquid_surface_rate, R::oil);
-        qwsc[segInd] += get(M::liquid_surface_rate, R::wat);
-        qgsc[segInd] += get(M::gas_surface_rate,    R::gas);
+            qosc[segInd] += get(M::liquid_surface_rate, R::oil);
+            qwsc[segInd] += get(M::liquid_surface_rate, R::wat);
+            qgsc[segInd] += get(M::gas_surface_rate,    R::gas);
+        }
 
-      }
-
-      return {
-              qosc,
-              qwsc,
-              qgsc
-      };
+        return {
+            qosc,
+            qwsc,
+            qgsc
+        };
     }
 
     Opm::RestartIO::Helpers::SegmentSetFlowRates
@@ -261,9 +260,9 @@ namespace {
         }
         return {
             sofr,
-                swfr,
-                sgfr
-                };
+            swfr,
+            sgfr
+        };
     }
 
 
@@ -415,7 +414,7 @@ namespace {
 
             return WV {
                 WV::NumWindows{ nswlmx(inteHead) },
-                    WV::WindowSize{ entriesPerMSW(inteHead) }
+                WV::WindowSize{ entriesPerMSW(inteHead) }
             };
         }
 
@@ -469,19 +468,19 @@ namespace {
 
             return WV {
                 WV::NumWindows{ nswlmx(inteHead) },
-                    WV::WindowSize{ entriesPerMSW(inteHead) }
+                WV::WindowSize{ entriesPerMSW(inteHead) }
             };
         }
 
         template <class RSegArray>
-        void staticContrib_useMSW(const Opm::Well2&  	well,
-                                  const std::size_t          		rptStep,
-                                  const std::vector<int>&    		inteHead,
-                                  const Opm::EclipseGrid&    		grid,
-                                  const Opm::UnitSystem&     		units,
-                                  const ::Opm::SummaryState& 		smry,
-                                  const Opm::data::WellRates&  	wr,
-                                  RSegArray&                 		rSeg)
+        void staticContrib_useMSW(const Opm::Well2&           well,
+                                  const std::size_t           rptStep,
+                                  const std::vector<int>&     inteHead,
+                                  const Opm::EclipseGrid&     grid,
+                                  const Opm::UnitSystem&      units,
+                                  const ::Opm::SummaryState&  smry,
+                                  const Opm::data::WellRates& wr,
+                                  RSegArray&                  rSeg)
         {
             if (well.isMultiSegment()) {
                 // use segment index as counter  - zero-based
@@ -516,14 +515,13 @@ namespace {
                 auto sSFR = Opm::RestartIO::Helpers::SegmentSetFlowRates{};
                 if (haveWellRes) {
                     sSFR = getSegmentSetFlowRates(welSegSet, wRatesIt->second.connections, welConns, units);
-
                 }
                 auto get = [&smry, &wname, &stringSegNum](const std::string& vector)
-                    {
-                        // 'stringSegNum' is one-based (1 .. #segments inclusive)
-                        const auto key = vector + ':' + wname + ':' + stringSegNum;
-                        return smry.has(key) ? smry.get(key) : 0.0;
-                    };
+                {
+                    // 'stringSegNum' is one-based (1 .. #segments inclusive)
+                    const auto key = vector + ':' + wname + ':' + stringSegNum;
+                    return smry.has(key) ? smry.get(key) : 0.0;
+                };
 
                 // Treat the top segment individually
                 rSeg[0] = units.from_si(M::length, welSegSet.lengthTopSegment());
@@ -644,7 +642,7 @@ namespace {
 
             return WV {
                 WV::NumWindows{ nswlmx(inteHead) },
-                    WV::WindowSize{ entriesPerMSW(inteHead) }
+                WV::WindowSize{ entriesPerMSW(inteHead) }
             };
         }
 
@@ -684,7 +682,7 @@ namespace {
 
             return WV {
                 WV::NumWindows{ nswlmx(inteHead) },
-                    WV::WindowSize{ entriesPerMSW(inteHead) }
+                WV::WindowSize{ entriesPerMSW(inteHead) }
             };
         }
 
@@ -751,41 +749,41 @@ captureDeclaredMSWData(const Schedule&         sched,
     // Extract Contributions to ISeg Array
     {
         MSWLoop(msw, [rptStep, inteHead, &grid, this]
-                (const Well2& well, const std::size_t mswID) -> void
-                {
-                    auto imsw = this->iSeg_[mswID];
+            (const Well2& well, const std::size_t mswID) -> void
+        {
+            auto imsw = this->iSeg_[mswID];
 
-                    ISeg::staticContrib(well, rptStep, inteHead, grid, imsw);
-                });
+            ISeg::staticContrib(well, rptStep, inteHead, grid, imsw);
+        });
     }
     // Extract Contributions to RSeg Array
     {
         MSWLoop(msw, [&units, rptStep, inteHead, &grid, &smry, this, &wr]
-                (const Well2& well, const std::size_t mswID) -> void
-                {
-                    auto rmsw = this->rSeg_[mswID];
+            (const Well2& well, const std::size_t mswID) -> void
+        {
+            auto rmsw = this->rSeg_[mswID];
 
-                    RSeg::staticContrib_useMSW(well, rptStep, inteHead, grid, units, smry, wr, rmsw);
-                });
+            RSeg::staticContrib_useMSW(well, rptStep, inteHead, grid, units, smry, wr, rmsw);
+        });
     }
     // Extract Contributions to ILBS Array
     {
         MSWLoop(msw, [rptStep, this]
-                (const Well2& well, const std::size_t mswID) -> void
-                {
-                    auto ilbs_msw = this->iLBS_[mswID];
+            (const Well2& well, const std::size_t mswID) -> void
+        {
+            auto ilbs_msw = this->iLBS_[mswID];
 
-                    ILBS::staticContrib(well, rptStep, ilbs_msw);
-                });
+            ILBS::staticContrib(well, rptStep, ilbs_msw);
+        });
     }
     // Extract Contributions to ILBR Array
     {
         MSWLoop(msw, [rptStep, inteHead, this]
-                (const Well2& well, const std::size_t mswID) -> void
-                {
-                    auto ilbr_msw = this->iLBR_[mswID];
+            (const Well2& well, const std::size_t mswID) -> void
+        {
+            auto ilbr_msw = this->iLBR_[mswID];
 
-                    ILBR::staticContrib(well, rptStep, inteHead, ilbr_msw);
-                });
+            ILBR::staticContrib(well, rptStep, inteHead, ilbr_msw);
+        });
     }
 }

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -133,8 +133,7 @@ namespace {
             return ind;
         }
 
-        int wellType(const Opm::Well2&  well,
-                     const std::size_t sim_step)
+        int wellType(const Opm::Well2& well)
         {
             using WTypeVal = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellType;
             Opm::SummaryState summaryState;
@@ -155,8 +154,7 @@ namespace {
             }
         }
 
-        int wellVFPTab(const Opm::Well2&  well,
-                       const std::size_t sim_step)
+        int wellVFPTab(const Opm::Well2& well)
         {
             Opm::SummaryState summaryState;
             if (well.isInjector()) {
@@ -165,8 +163,7 @@ namespace {
             return well.productionControls(summaryState).vfp_table_number;
         }
 
-        int ctrlMode(const Opm::Well2&  well,
-                     const std::size_t sim_step)
+        int ctrlMode(const Opm::Well2& well)
         {
             using WMCtrlVal = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
             Opm::SummaryState summaryState;
@@ -261,9 +258,6 @@ namespace {
         void staticContrib(const Opm::Well2&               well,
                            const std::size_t               msWellID,
                            const std::map <const std::string, size_t>&  GroupMapNameInd,
-                           /*const std::vector<std::string>& groupNames,*/
-                           const int                       /* maxGroups */,
-                           const std::size_t               sim_step,
                            IWellArray&                     iWell)
         {
             using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
@@ -295,8 +289,8 @@ namespace {
             iWell[Ix::Group] =
                 groupIndex(trim(well.groupName()), GroupMapNameInd);
 
-            iWell[Ix::WType]  = wellType  (well, sim_step);
-            iWell[Ix::VFPTab] = wellVFPTab(well, sim_step);
+            iWell[Ix::WType]  = wellType  (well);
+            iWell[Ix::VFPTab] = wellVFPTab(well);
             iWell[Ix::XFlow]  = well.getAllowCrossFlow() ? 1 : 0;
 
             // The following items aren't fully characterised yet, but
@@ -310,7 +304,7 @@ namespace {
             // the target control mode requested in the simulation deck.
             // This item is supposed to be the well's actual, active target
             // control mode in the simulator.
-            iWell[Ix::ActWCtrl] = ctrlMode(well, sim_step);
+            iWell[Ix::ActWCtrl] = ctrlMode(well);
 
             if (well.predictionMode()) {
                 // Well in prediction mode (WCONPROD, WCONINJE).  Assign
@@ -452,7 +446,6 @@ namespace {
         template <class SWellArray>
         void staticContrib(const Opm::Well2&      well,
                            const Opm::UnitSystem& units,
-                           const std::size_t      sim_step,
                            const ::Opm::SummaryState& smry,
                            SWellArray&            sWell)
         {
@@ -581,9 +574,8 @@ namespace {
         }
 
         template <class XWellArray>
-        void staticContrib(const ::Opm::Well2&     well,
+        void staticContrib(const ::Opm::Well2&    well,
                            const Opm::UnitSystem& units,
-                           const std::size_t      sim_step,
                            XWellArray&            xWell)
         {
             using M  = ::Opm::UnitSystem::measure;
@@ -717,7 +709,6 @@ namespace {
         template <class XWellArray>
         void dynamicContrib(const ::Opm::Well2&        well,
                             const ::Opm::SummaryState& smry,
-                            const std::size_t          sim_step,
                             XWellArray&                xWell)
         {
             if (well.isProducer()) {
@@ -812,33 +803,32 @@ captureDeclaredWellData(const Schedule&   sched,
         const auto groupMapNameIndex = IWell::currentGroupMapNameIndex(sched, sim_step, inteHead);
         auto msWellID       = std::size_t{0};
 
-        wellLoop(wells, [&groupMapNameIndex, &msWellID, sim_step, this]
+        wellLoop(wells, [&groupMapNameIndex, &msWellID, this]
                  (const Well2& well, const std::size_t wellID) -> void
                  {
                      msWellID += well.isMultiSegment();  // 1-based index.
                      auto iw   = this->iWell_[wellID];
 
-                     IWell::staticContrib(well, msWellID, groupMapNameIndex,
-                                          this->nWGMax_, sim_step, iw);
+                     IWell::staticContrib(well, msWellID, groupMapNameIndex, iw);
                  });
     }
 
     // Static contributions to SWEL array.
-    wellLoop(wells, [&units, sim_step, &smry, this]
+    wellLoop(wells, [&units, &smry, this]
              (const Well2& well, const std::size_t wellID) -> void
              {
                  auto sw = this->sWell_[wellID];
 
-                 SWell::staticContrib(well, units, sim_step, smry, sw);
+                 SWell::staticContrib(well, units, smry, sw);
              });
 
     // Static contributions to XWEL array.
-    wellLoop(wells, [&units, sim_step, this]
+    wellLoop(wells, [&units, this]
              (const Well2& well, const std::size_t wellID) -> void
              {
                  auto xw = this->xWell_[wellID];
 
-                 XWell::staticContrib(well, units, sim_step, xw);
+                 XWell::staticContrib(well, units, xw);
              });
 
     // Static contributions to ZWEL array.
@@ -878,11 +868,11 @@ captureDynamicWellData(const Schedule&             sched,
              });
 
     // Dynamic contributions to XWEL array.
-    wellLoop(wells, [this, sim_step, &smry]
+    wellLoop(wells, [this, &smry]
         (const Well2& well, const std::size_t wellID) -> void
     {
         auto xw = this->xWell_[wellID];
 
-        XWell::dynamicContrib(well, smry, sim_step, xw);
+        XWell::dynamicContrib(well, smry, xw);
     });
 }

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -98,7 +98,6 @@ namespace {
 
     std::vector<double>
     serialize_OPM_XWEL(const data::Wells&             wells,
-                       int                            sim_step,
                        const std::vector<Opm::Well2>& sched_wells,
                        const Phases&                  phase_spec,
                        const EclipseGrid&             grid)
@@ -375,7 +374,7 @@ namespace {
             const auto sched_well_names = schedule.wellNames(sim_step);
 
             const auto opm_xwel =
-                serialize_OPM_XWEL(wells, sim_step, sched_wells, phases, grid);
+                serialize_OPM_XWEL(wells, sched_wells, phases, grid);
 
             const auto opm_iwel = serialize_OPM_IWEL(wells, sched_well_names);
 
@@ -560,7 +559,7 @@ void save(const std::string&  filename,
         if (! wells.empty()) {
             const auto haveMSW =
                 std::any_of(std::begin(wells), std::end(wells),
-                    [sim_step](const Well2& well)
+                    [](const Well2& well)
             {
                 return well.isMultiSegment();
             });


### PR DESCRIPTION
This change-set is a brief intermission in the work towards using the ECLIPSE I/O classes introduced in PR #699 as the fundamental components for Flow's restart I/O functionality.  Briefly, we remove function (and lambda) arguments that became unused in the output code as of commit 94b160258 (PR #731) and also restore the original indentation levels from before that PR.