### PR TITLE
Re-implement RestartIO::save() in Terms of OutputStream::Restart

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -280,7 +280,6 @@ if(ENABLE_ECL_OUTPUT)
           tests/test_AggregateMSWData.cpp
           tests/test_AggregateConnectionData.cpp
           tests/test_ArrayDimChecker.cpp
-          tests/test_CharArrayNullTerm.cpp
           tests/test_EclipseIO.cpp
           tests/test_DoubHEAD.cpp
           tests/test_InteHEAD.cpp
@@ -288,6 +287,7 @@ if(ENABLE_ECL_OUTPUT)
           tests/test_LogiHEAD.cpp
           tests/test_OutputStream.cpp
           tests/test_regionCache.cpp
+          tests/test_PaddedOutputString.cpp
           tests/test_Restart.cpp
           tests/test_RFT.cpp
           tests/test_Solution.cpp
@@ -577,6 +577,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/io/eclipse/ERft.hpp
         opm/io/eclipse/ERst.hpp
         opm/io/eclipse/ESmry.hpp
+        opm/io/eclipse/PaddedOutputString.hpp
         opm/io/eclipse/OutputStream.hpp
         opm/output/data/Cells.hpp
         opm/output/data/Solution.hpp
@@ -591,7 +592,6 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/AggregateConnectionData.hpp
         opm/output/eclipse/AggregateMSWData.hpp
         opm/output/eclipse/AggregateWellData.hpp
-        opm/output/eclipse/CharArrayNullTerm.hpp
         opm/output/eclipse/DoubHEAD.hpp
         opm/output/eclipse/EclipseGridInspector.hpp
         opm/output/eclipse/EclipseIO.hpp

--- a/opm/io/eclipse/EGrid.hpp
+++ b/opm/io/eclipse/EGrid.hpp
@@ -29,7 +29,7 @@
 #include <ctime>
 #include <map>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 class EGrid : public EclFile
 {
@@ -60,6 +60,6 @@ private:
     std::vector<float> zcorn_array;
 };
 
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_EGRID_HPP

--- a/opm/io/eclipse/ERft.hpp
+++ b/opm/io/eclipse/ERft.hpp
@@ -29,7 +29,7 @@
 #include <utility>
 #include <vector>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 class ERft : public EclFile
 {
@@ -79,6 +79,6 @@ private:
                       const RftDate& date) const;
 };
 
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_ERFT_HPP

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -27,11 +27,11 @@
 #include <unordered_map>
 #include <vector>
 
-namespace Opm { namespace ecl { namespace OutputStream {
+namespace Opm { namespace EclIO { namespace OutputStream {
     class Restart;
 }}}
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 class ERst : public EclFile
 {
@@ -62,6 +62,6 @@ private:
     restartStepWritePosition(const int seqnumValue) const;
 };
 
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_ERST_HPP

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 class ESmry
 {
@@ -53,6 +53,6 @@ private:
     std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num);
 };
 
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_ESMRY_HPP

--- a/opm/io/eclipse/EclFile.hpp
+++ b/opm/io/eclipse/EclFile.hpp
@@ -30,7 +30,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 class EclFile
 {
@@ -109,6 +109,6 @@ private:
     void loadArray(std::fstream& fileH, int arrIndex);
 };
 
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_ECLFILE_HPP

--- a/opm/io/eclipse/EclIOdata.hpp
+++ b/opm/io/eclipse/EclIOdata.hpp
@@ -22,7 +22,7 @@
 
 #include <tuple>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
     // type MESS have no assisiated data 
     enum eclArrType {
@@ -64,6 +64,6 @@ namespace Opm { namespace ecl {
     const int columnWidthLogi = 3;       // number of characters fore each Inte Element 
     const int columnWidthChar = 11;      // number of characters fore each Inte Element 
 
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_ECLIODATA_HPP

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -27,11 +27,11 @@
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 
-namespace Opm { namespace ecl { namespace OutputStream {
+namespace Opm { namespace EclIO { namespace OutputStream {
     class Restart;
 }}}
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 class EclOutput
 {
@@ -100,6 +100,6 @@ private:
 template<>
 void EclOutput::write<std::string>(const std::string& name,
                                    const std::vector<std::string>& data);
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_ECLOUTPUT_HPP

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -18,14 +18,14 @@
 #ifndef OPM_IO_ECLOUTPUT_HPP
 #define OPM_IO_ECLOUTPUT_HPP
 
-#include <iostream>
-#include <ios>
 #include <fstream>
-#include <vector>
-#include <iomanip>
+#include <ios>
+#include <string>
 #include <typeinfo>
+#include <vector>
 
 #include <opm/io/eclipse/EclIOdata.hpp>
+#include <opm/io/eclipse/PaddedOutputString.hpp>
 
 namespace Opm { namespace EclIO { namespace OutputStream {
     class Restart;
@@ -81,6 +81,7 @@ private:
     void writeBinaryArray(const std::vector<T>& data);
 
     void writeBinaryCharArray(const std::vector<std::string>& data);
+    void writeBinaryCharArray(const std::vector<PaddedOutputString<8>>& data);
 
     void writeFormattedHeader(const std::string& arrName, int size, eclArrType arrType);
 
@@ -88,6 +89,7 @@ private:
     void writeFormattedArray(const std::vector<T>& data);
 
     void writeFormattedCharArray(const std::vector<std::string>& data);
+    void writeFormattedCharArray(const std::vector<PaddedOutputString<8>>& data);
 
     std::string make_real_string(float value) const;
     std::string make_doub_string(double value) const;
@@ -100,6 +102,12 @@ private:
 template<>
 void EclOutput::write<std::string>(const std::string& name,
                                    const std::vector<std::string>& data);
+
+template <>
+void EclOutput::write<PaddedOutputString<8>>
+    (const std::string&                        name,
+     const std::vector<PaddedOutputString<8>>& data);
+
 }} // namespace Opm::EclIO
 
 #endif // OPM_IO_ECLOUTPUT_HPP

--- a/opm/io/eclipse/EclUtil.hpp
+++ b/opm/io/eclipse/EclUtil.hpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <tuple>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
     int flipEndianInt(int num);
     float flipEndianFloat(float num);
@@ -35,6 +35,6 @@ namespace Opm { namespace ecl {
 
     std::string trimr(const std::string &str1);
 
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_ECLUTIL_HPP

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -25,13 +25,13 @@
 #include <string>
 #include <vector>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
     class EclOutput;
 
-}} // namespace Opm::ecl
+}} // namespace Opm::EclIO
 
-namespace Opm { namespace ecl { namespace OutputStream {
+namespace Opm { namespace EclIO { namespace OutputStream {
 
     struct Formatted { bool set; };
     struct Unified   { bool set; };
@@ -213,6 +213,6 @@ namespace Opm { namespace ecl { namespace OutputStream {
     std::string outputFileName(const ResultSet&   rsetDescriptor,
                                const std::string& ext);
 
-}}} // namespace Opm::ecl::OutputStream
+}}} // namespace Opm::EclIO::OutputStream
 
 #endif //  OPM_IO_OUTPUTSTREAM_HPP_INCLUDED

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -85,14 +85,10 @@ namespace Opm { namespace EclIO { namespace OutputStream {
         /// Generate a message string (keyword type 'MESS') in underlying
         /// output stream.
         ///
-        /// Must not be called prior to \c prepareStep
-        ///
         /// \param[in] msg Message string (e.g., "STARTSOL").
         void message(const std::string& msg);
 
         /// Write integer data to underlying output stream.
-        ///
-        /// Must not be called prior to \c prepareStep
         ///
         /// \param[in] kw Name of output vector (keyword).
         ///
@@ -101,8 +97,6 @@ namespace Opm { namespace EclIO { namespace OutputStream {
                    const std::vector<int>& data);
 
         /// Write boolean data to underlying output stream.
-        ///
-        /// Must not be called prior to \c prepareStep
         ///
         /// \param[in] kw Name of output vector (keyword).
         ///
@@ -113,8 +107,6 @@ namespace Opm { namespace EclIO { namespace OutputStream {
         /// Write single precision floating point data to underlying
         /// output stream.
         ///
-        /// Must not be called prior to \c prepareStep
-        ///
         /// \param[in] kw Name of output vector (keyword).
         ///
         /// \param[in] data Output values.
@@ -124,8 +116,6 @@ namespace Opm { namespace EclIO { namespace OutputStream {
         /// Write double precision floating point data to underlying
         /// output stream.
         ///
-        /// Must not be called prior to \c prepareStep
-        ///
         /// \param[in] kw Name of output vector (keyword).
         ///
         /// \param[in] data Output values.
@@ -133,8 +123,6 @@ namespace Opm { namespace EclIO { namespace OutputStream {
                    const std::vector<double>& data);
 
         /// Write unpadded string data to underlying output stream.
-        ///
-        /// Must not be called prior to \c prepareStep
         ///
         /// \param[in] kw Name of output vector (keyword).
         ///
@@ -144,8 +132,6 @@ namespace Opm { namespace EclIO { namespace OutputStream {
 
         /// Write padded character data (8 characters per string)
         /// to underlying output stream.
-        ///
-        /// Must not be called prior to \c prepareStep
         ///
         /// \param[in] kw Name of output vector (keyword).
         ///

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -20,6 +20,8 @@
 #ifndef OPM_IO_OUTPUTSTREAM_HPP_INCLUDED
 #define OPM_IO_OUTPUTSTREAM_HPP_INCLUDED
 
+#include <opm/io/eclipse/PaddedOutputString.hpp>
+
 #include <ios>
 #include <memory>
 #include <string>
@@ -139,6 +141,17 @@ namespace Opm { namespace EclIO { namespace OutputStream {
         /// \param[in] data Output values.
         void write(const std::string&              kw,
                    const std::vector<std::string>& data);
+
+        /// Write padded character data (8 characters per string)
+        /// to underlying output stream.
+        ///
+        /// Must not be called prior to \c prepareStep
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&                        kw,
+                   const std::vector<PaddedOutputString<8>>& data);
 
     private:
         /// Restart output stream.

--- a/opm/io/eclipse/PaddedOutputString.hpp
+++ b/opm/io/eclipse/PaddedOutputString.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OPM_CHARARRAY_HEADER_HPP
-#define OPM_CHARARRAY_HEADER_HPP
+#ifndef OPM_PADDEDOUTPUTSTRING_HEADER_HPP
+#define OPM_PADDEDOUTPUTSTRING_HEADER_HPP
 
 #include <algorithm>
 #include <array>
@@ -26,7 +26,7 @@
 #include <cstddef>
 #include <string>
 
-namespace Opm { namespace RestartIO { namespace Helpers {
+namespace Opm { namespace EclIO {
 
     /// Null-terminated, left adjusted, space padded array of N characters.
     ///
@@ -36,30 +36,30 @@ namespace Opm { namespace RestartIO { namespace Helpers {
     ///
     /// \tparam N Number of characters.
     template <std::size_t N>
-    class CharArrayNullTerm
+    class PaddedOutputString
     {
     public:
-        CharArrayNullTerm()
+        PaddedOutputString()
         {
             this->clear();
         }
 
-        explicit CharArrayNullTerm(const std::string& s)
-            : CharArrayNullTerm()
+        explicit PaddedOutputString(const std::string& s)
+            : PaddedOutputString()
         {
             this->copy_in(s.c_str(), s.size());
         }
 
-        ~CharArrayNullTerm() = default;
+        ~PaddedOutputString() = default;
 
-        CharArrayNullTerm(const CharArrayNullTerm& rhs) = default;
-        CharArrayNullTerm(CharArrayNullTerm&& rhs) = default;
+        PaddedOutputString(const PaddedOutputString& rhs) = default;
+        PaddedOutputString(PaddedOutputString&& rhs) = default;
 
-        CharArrayNullTerm& operator=(const CharArrayNullTerm& rhs) = default;
-        CharArrayNullTerm& operator=(CharArrayNullTerm&& rhs) = default;
+        PaddedOutputString& operator=(const PaddedOutputString& rhs) = default;
+        PaddedOutputString& operator=(PaddedOutputString&& rhs) = default;
 
         /// Assign from \code std::string \endcode.
-        CharArrayNullTerm& operator=(const std::string& s)
+        PaddedOutputString& operator=(const std::string& s)
         {
             this->clear();
             this->copy_in(s.data(), s.size());
@@ -99,5 +99,5 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         }
     };
 
-}}} // Opm::RestartIO::Helpers
-#endif // CHARARRAY_HEADER
+}} // Opm::EclIO
+#endif // OPM_PADDEDOUTPUTSTRING_HEADER_HPP

--- a/opm/output/eclipse/AggregateGroupData.hpp
+++ b/opm/output/eclipse/AggregateGroupData.hpp
@@ -20,8 +20,9 @@
 #ifndef OPM_AGGREGATE_GROUP_DATA_HPP
 #define OPM_AGGREGATE_GROUP_DATA_HPP
 
-#include <opm/output/eclipse/CharArrayNullTerm.hpp>
 #include <opm/output/eclipse/WindowedArray.hpp>
+
+#include <opm/io/eclipse/PaddedOutputString.hpp>
 
 #include <cstddef>
 #include <string>
@@ -80,7 +81,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
             return this->xGroup_.data();
         }
 
-        const std::vector<CharArrayNullTerm<8>>& getZGroup() const
+        const std::vector<EclIO::PaddedOutputString<8>>& getZGroup() const
         {
             return this->zGroup_.data();
         }
@@ -158,7 +159,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         WindowedArray<double> xGroup_;
 
         /// Aggregate 'ZWEL' array (Character) for all wells.
-        WindowedArray<CharArrayNullTerm<8>> zGroup_;
+        WindowedArray<EclIO::PaddedOutputString<8>> zGroup_;
 
         /// Maximum number of wells in a group.
         int nWGMax_;

--- a/opm/output/eclipse/AggregateMSWData.hpp
+++ b/opm/output/eclipse/AggregateMSWData.hpp
@@ -21,7 +21,6 @@
 #define OPM_AGGREGATE_MSW_DATA_HPP
 
 #include <opm/output/data/Wells.hpp>
-#include <opm/output/eclipse/CharArrayNullTerm.hpp>
 #include <opm/output/eclipse/WindowedArray.hpp>
 
 #include <string>

--- a/opm/output/eclipse/AggregateWellData.hpp
+++ b/opm/output/eclipse/AggregateWellData.hpp
@@ -20,8 +20,9 @@
 #ifndef OPM_AGGREGATE_WELL_DATA_HPP
 #define OPM_AGGREGATE_WELL_DATA_HPP
 
-#include <opm/output/eclipse/CharArrayNullTerm.hpp>
 #include <opm/output/eclipse/WindowedArray.hpp>
+
+#include <opm/io/eclipse/PaddedOutputString.hpp>
 
 #include <cstddef>
 #include <string>
@@ -74,7 +75,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         }
 
         /// Retrieve Character Well Data Array.
-        const std::vector<CharArrayNullTerm<8>>& getZWell() const
+        const std::vector<EclIO::PaddedOutputString<8>>& getZWell() const
         {
             return this->zWell_.data();
         }
@@ -92,7 +93,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         WindowedArray<double> xWell_;
 
         /// Aggregate 'ZWEL' array (Character) for all wells.
-        WindowedArray<CharArrayNullTerm<8>> zWell_;
+        WindowedArray<EclIO::PaddedOutputString<8>> zWell_;
 
         /// Maximum number of groups in model.
         int nWGMax_;

--- a/opm/output/eclipse/RestartIO.hpp
+++ b/opm/output/eclipse/RestartIO.hpp
@@ -52,6 +52,11 @@ namespace Opm {
 
 } // namespace Opm
 
+namespace Opm { namespace EclIO { namespace OutputStream {
+
+    class Restart;
+
+}}}
 
 /*
   The two free functions RestartIO::save() and RestartIO::load() can
@@ -76,15 +81,15 @@ namespace Opm {
 */
 namespace Opm { namespace RestartIO {
 
-    void save(const std::string&  filename,
-              int                 report_step,
-              double              seconds_elapsed,
-              RestartValue        value,
-              const EclipseState& es,
-              const EclipseGrid&  grid,
-              const Schedule&     schedule,
-              const SummaryState& sumState,
-              bool                write_double = false);
+    void save(EclIO::OutputStream::Restart& rstFile,
+              int                           report_step,
+              double                        seconds_elapsed,
+              RestartValue                  value,
+              const EclipseState&           es,
+              const EclipseGrid&            grid,
+              const Schedule&               schedule,
+              const SummaryState&           sumState,
+              bool                          write_double = false);
 
     std::pair<RestartValue, SummaryState>
     load(const std::string&             filename,

--- a/src/opm/io/eclipse/EGrid.cpp
+++ b/src/opm/io/eclipse/EGrid.cpp
@@ -28,7 +28,7 @@
 #include <string>
 #include <sstream>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 EGrid::EGrid(const std::string &filename) : EclFile(filename)
 {

--- a/src/opm/io/eclipse/ERft.cpp
+++ b/src/opm/io/eclipse/ERft.cpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <sstream>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 ERft::ERft(const std::string &filename) : EclFile(filename)
 {

--- a/src/opm/io/eclipse/ERst.cpp
+++ b/src/opm/io/eclipse/ERst.cpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <sstream>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 ERst::ERst(const std::string& filename)
     : EclFile(filename)

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -50,7 +50,7 @@
 
  */
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 ESmry::ESmry(const std::string &filename, bool loadBaseRunData)
 {

--- a/src/opm/io/eclipse/EclOutput.cpp
+++ b/src/opm/io/eclipse/EclOutput.cpp
@@ -33,7 +33,7 @@
 #include <stdexcept>
 #include <typeinfo>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
 EclOutput::EclOutput(const std::string&            filename,
                      const bool                    formatted,

--- a/src/opm/io/eclipse/EclUtil.cpp
+++ b/src/opm/io/eclipse/EclUtil.cpp
@@ -24,14 +24,14 @@
 #include <stdexcept>
 
 
-int Opm::ecl::flipEndianInt(int num)
+int Opm::EclIO::flipEndianInt(int num)
 {
     unsigned int tmp = __builtin_bswap32(num);
     return static_cast<int>(tmp);
 }
 
 
-float Opm::ecl::flipEndianFloat(float num)
+float Opm::EclIO::flipEndianFloat(float num)
 {
     float value = num;
 
@@ -42,7 +42,7 @@ float Opm::ecl::flipEndianFloat(float num)
 }
 
 
-double Opm::ecl::flipEndianDouble(double num)
+double Opm::EclIO::flipEndianDouble(double num)
 {
     double value = num;
 
@@ -53,7 +53,7 @@ double Opm::ecl::flipEndianDouble(double num)
 }
 
 
-std::tuple<int, int> Opm::ecl::block_size_data_binary(eclArrType arrType)
+std::tuple<int, int> Opm::EclIO::block_size_data_binary(eclArrType arrType)
 {
     using BlockSizeTuple = std::tuple<int, int>;
 
@@ -83,7 +83,7 @@ std::tuple<int, int> Opm::ecl::block_size_data_binary(eclArrType arrType)
 }
 
 
-std::tuple<int, int, int> Opm::ecl::block_size_data_formatted(eclArrType arrType)
+std::tuple<int, int, int> Opm::EclIO::block_size_data_formatted(eclArrType arrType)
 {
     using BlockSizeTuple = std::tuple<int, int, int>;
 
@@ -113,7 +113,7 @@ std::tuple<int, int, int> Opm::ecl::block_size_data_formatted(eclArrType arrType
 }
 
 
-std::string Opm::ecl::trimr(const std::string &str1)
+std::string Opm::EclIO::trimr(const std::string &str1)
 {
     if (str1 == "        ") {
         return "";

--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -60,7 +60,7 @@ namespace {
     {
         namespace Restart
         {
-            std::unique_ptr<Opm::ecl::ERst>
+            std::unique_ptr<Opm::EclIO::ERst>
             read(const std::string& filename)
             {
                 // Bypass some of the internal logic of the ERst constructor.
@@ -82,28 +82,28 @@ namespace {
 
                 // File exists and can (could?) be opened.  Attempt to form
                 // an ERst object on top of it.
-                return std::unique_ptr<Opm::ecl::ERst> {
-                    new Opm::ecl::ERst{filename}
+                return std::unique_ptr<Opm::EclIO::ERst> {
+                    new Opm::EclIO::ERst{filename}
                 };
             }
 
-            std::unique_ptr<Opm::ecl::EclOutput>
+            std::unique_ptr<Opm::EclIO::EclOutput>
             writeNew(const std::string& filename,
                      const bool         isFmt)
             {
-                return std::unique_ptr<Opm::ecl::EclOutput> {
-                    new Opm::ecl::EclOutput {
+                return std::unique_ptr<Opm::EclIO::EclOutput> {
+                    new Opm::EclIO::EclOutput {
                         filename, isFmt, std::ios_base::out
                     }
                 };
             }
 
-            std::unique_ptr<Opm::ecl::EclOutput>
+            std::unique_ptr<Opm::EclIO::EclOutput>
             writeExisting(const std::string& filename,
                           const bool         isFmt)
             {
-                return std::unique_ptr<Opm::ecl::EclOutput> {
-                    new Opm::ecl::EclOutput {
+                return std::unique_ptr<Opm::EclIO::EclOutput> {
+                    new Opm::EclIO::EclOutput {
                         filename, isFmt, std::ios_base::app
                     }
                 };
@@ -112,7 +112,7 @@ namespace {
     } // namespace Open
 } // Anonymous namespace
 
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 Restart(const ResultSet& rset,
         const int        seqnum,
         const Formatted& fmt,
@@ -137,63 +137,63 @@ Restart(const ResultSet& rset,
     }
 }
 
-Opm::ecl::OutputStream::Restart::~Restart()
+Opm::EclIO::OutputStream::Restart::~Restart()
 {}
 
-Opm::ecl::OutputStream::Restart::Restart(Restart&& rhs)
+Opm::EclIO::OutputStream::Restart::Restart(Restart&& rhs)
     : stream_{ std::move(rhs.stream_) }
 {}
 
-Opm::ecl::OutputStream::Restart&
-Opm::ecl::OutputStream::Restart::operator=(Restart&& rhs)
+Opm::EclIO::OutputStream::Restart&
+Opm::EclIO::OutputStream::Restart::operator=(Restart&& rhs)
 {
     this->stream_ = std::move(rhs.stream_);
 
     return *this;
 }
 
-void Opm::ecl::OutputStream::Restart::message(const std::string& msg)
+void Opm::EclIO::OutputStream::Restart::message(const std::string& msg)
 {
     this->stream().message(msg);
 }
 
 void
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 write(const std::string& kw, const std::vector<int>& data)
 {
     this->writeImpl(kw, data);
 }
 
 void
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 write(const std::string& kw, const std::vector<bool>& data)
 {
     this->writeImpl(kw, data);
 }
 
 void
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 write(const std::string& kw, const std::vector<float>& data)
 {
     this->writeImpl(kw, data);
 }
 
 void
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 write(const std::string& kw, const std::vector<double>& data)
 {
     this->writeImpl(kw, data);
 }
 
 void
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 write(const std::string& kw, const std::vector<std::string>& data)
 {
     this->writeImpl(kw, data);
 }
 
 void
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 openUnified(const std::string& fname,
             const bool         formatted,
             const int          seqnum)
@@ -226,7 +226,7 @@ openUnified(const std::string& fname,
 }
 
 void
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 openNew(const std::string& fname,
         const bool         formatted)
 {
@@ -234,7 +234,7 @@ openNew(const std::string& fname,
 }
 
 void
-Opm::ecl::OutputStream::Restart::
+Opm::EclIO::OutputStream::Restart::
 openExisting(const std::string&   fname,
              const bool           formatted,
              const std::streampos writePos)
@@ -271,13 +271,13 @@ openExisting(const std::string&   fname,
     }
 }
 
-Opm::ecl::EclOutput&
-Opm::ecl::OutputStream::Restart::stream()
+Opm::EclIO::EclOutput&
+Opm::EclIO::OutputStream::Restart::stream()
 {
     return *this->stream_;
 }
 
-namespace Opm { namespace ecl { namespace OutputStream {
+namespace Opm { namespace EclIO { namespace OutputStream {
 
     template <typename T>
     void Restart::writeImpl(const std::string&    kw,
@@ -290,8 +290,8 @@ namespace Opm { namespace ecl { namespace OutputStream {
 
 
 std::string
-Opm::ecl::OutputStream::outputFileName(const ResultSet&   rsetDescriptor,
-                                       const std::string& ext)
+Opm::EclIO::OutputStream::outputFileName(const ResultSet&   rsetDescriptor,
+                                         const std::string& ext)
 {
     namespace fs = boost::filesystem;
 

--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -194,6 +194,14 @@ write(const std::string& kw, const std::vector<std::string>& data)
 
 void
 Opm::EclIO::OutputStream::Restart::
+write(const std::string&                        kw,
+      const std::vector<PaddedOutputString<8>>& data)
+{
+    this->writeImpl(kw, data);
+}
+
+void
+Opm::EclIO::OutputStream::Restart::
 openUnified(const std::string& fname,
             const bool         formatted,
             const int          seqnum)

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -410,12 +410,12 @@ namespace {
         }
 
         Opm::RestartIO::Helpers::WindowedArray<
-            Opm::RestartIO::Helpers::CharArrayNullTerm<8>
+            Opm::EclIO::PaddedOutputString<8>
         >
         allocate(const std::vector<int>& inteHead)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<
-                Opm::RestartIO::Helpers::CharArrayNullTerm<8>
+                Opm::EclIO::PaddedOutputString<8>
             >;
 
             return WV {

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -750,12 +750,12 @@ namespace {
         }
 
         Opm::RestartIO::Helpers::WindowedArray<
-            Opm::RestartIO::Helpers::CharArrayNullTerm<8>
+            Opm::EclIO::PaddedOutputString<8>
         >
         allocate(const std::vector<int>& inteHead)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<
-                Opm::RestartIO::Helpers::CharArrayNullTerm<8>
+                Opm::EclIO::PaddedOutputString<8>
             >;
 
             return WV {

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -43,6 +43,8 @@
 #include <opm/output/eclipse/Tables.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
+#include <opm/io/eclipse/OutputStream.hpp>
+
 #include <cstdlib>
 #include <memory>     // unique_ptr
 #include <unordered_map>
@@ -532,12 +534,15 @@ void EclipseIO::writeTimeStep(int report_step,
     */
     if(!isSubstep && restart.getWriteRestartFile(report_step))
     {
-        std::string filename = ERT::EclFilename( this->impl->outputDir,
-                                                 this->impl->baseName,
-                                                 ioConfig.getUNIFOUT() ? ECL_UNIFIED_RESTART_FILE : ECL_RESTART_FILE,
-                                                 report_step,
-                                                 ioConfig.getFMTOUT() );
-        RestartIO::save(filename, report_step, secs_elapsed, value, es, grid, schedule,
+        EclIO::OutputStream::Restart rstFile {
+            EclIO::OutputStream::ResultSet { this->impl->outputDir,
+                                             this->impl->baseName },
+            report_step,
+            EclIO::OutputStream::Formatted { ioConfig.getFMTOUT() },
+            EclIO::OutputStream::Unified   { ioConfig.getUNIFOUT() }
+        };
+
+        RestartIO::save(rstFile, report_step, secs_elapsed, value, es, grid, schedule,
                         this->impl->summary.get_restart_vectors(), write_double);
     }
 

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -32,6 +32,8 @@
 
 #include <opm/output/eclipse/libECLRestart.hpp>
 
+#include <opm/io/eclipse/PaddedOutputString.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -168,7 +170,7 @@ namespace {
     }
 
     std::vector<const char*>
-    serialize_ZWEL(const std::vector<Opm::RestartIO::Helpers::CharArrayNullTerm<8>>& zwel)
+    serialize_ZWEL(const std::vector<EclIO::PaddedOutputString<8>>& zwel)
     {
         std::vector<const char*> data(zwel.size(), nullptr);
         std::size_t it = 0;

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -30,8 +30,7 @@
 #include <opm/output/eclipse/AggregateMSWData.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
-#include <opm/output/eclipse/libECLRestart.hpp>
-
+#include <opm/io/eclipse/OutputStream.hpp>
 #include <opm/io/eclipse/PaddedOutputString.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
@@ -39,19 +38,18 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
+#include <fstream>
 #include <initializer_list>
 #include <iterator>
 #include <string>
 #include <unordered_set>
 #include <vector>
-
-#include <ert/ecl/FortIO.hpp>
-#include <ert/ecl/EclFilename.hpp>
-#include <ert/ecl/fortio.h>
 
 namespace Opm { namespace RestartIO {
 
@@ -169,20 +167,6 @@ namespace {
         return xwel;
     }
 
-    std::vector<const char*>
-    serialize_ZWEL(const std::vector<EclIO::PaddedOutputString<8>>& zwel)
-    {
-        std::vector<const char*> data(zwel.size(), nullptr);
-        std::size_t it = 0;
-
-        for (const auto& well : zwel) {
-            data[it] = well.c_str();
-            it += 1;
-        }
-
-        return data;
-    }
-
     void checkSaveArguments(const EclipseState& es,
                             const RestartValue& restart_value,
                             const EclipseGrid&  grid)
@@ -208,102 +192,37 @@ namespace {
         }
     }
 
-    ert_unique_ptr<ecl_rst_file_type, ecl_rst_file_close>
-    openRestartFile(const std::string& filename,
-                    const int          report_step)
-    {
-        auto rst_file = ::Opm::RestartIO::
-            ert_unique_ptr< ::Opm::RestartIO::ecl_rst_file_type,
-                            ::Opm::RestartIO::ecl_rst_file_close>{};
-
-        if (::Opm::RestartIO::EclFiletype(filename) == ECL_UNIFIED_RESTART_FILE)
-            rst_file.reset(::Opm::RestartIO::ecl_rst_file_open_write_seek(filename.c_str(),
-                                                                          report_step));
-        else
-            rst_file.reset(::Opm::RestartIO::ecl_rst_file_open_write(filename.c_str()));
-
-        return rst_file;
-    }
-
-    ert_unique_ptr<ecl_kw_type, ecl_kw_free>
-    make_ecl_kw_pointer(const std::string&         kw,
-                        const std::vector<double>& data,
-                        const bool                 write_double)
-    {
-        auto kw_ptr = Opm::RestartIO::
-            ert_unique_ptr< ::Opm::RestartIO::ecl_kw_type, ecl_kw_free>{};
-
-        if (write_double) {
-            ::Opm::RestartIO::ecl_kw_type* ecl_kw =
-                ::Opm::RestartIO::ecl_kw_alloc(kw.c_str(), data.size(), ECL_DOUBLE);
-
-            ::Opm::RestartIO::ecl_kw_set_memcpy_data(ecl_kw , data.data());
-
-            kw_ptr.reset(ecl_kw);
-        }
-        else {
-            ::Opm::RestartIO::ecl_kw_type* ecl_kw = ::Opm::RestartIO::
-                ecl_kw_alloc(kw.c_str(), data.size(), ECL_FLOAT);
-
-            float* float_data = ecl_kw_get_type_ptr<float>(ecl_kw, ECL_FLOAT_TYPE);
-
-            for (auto n = data.size(), i = 0*n; i < n; ++i) {
-                float_data[i] = static_cast<float>(data[i]);
-            }
-
-            kw_ptr.reset(ecl_kw);
-        }
-
-        return kw_ptr;
-    }
-
-    template <typename T>
-    void write_kw(::Opm::RestartIO::ecl_rst_file_type* rst_file,
-                  const std::string&                   keyword,
-                  const std::vector<T>&                data)
-    {
-        const auto kw = EclKW<T>(keyword, data);
-
-        ::Opm::RestartIO::ecl_rst_file_add_kw(rst_file, kw.get());
-    }
-
     std::vector<int>
-    writeHeader(::Opm::RestartIO::ecl_rst_file_type* rst_file,
-                const int                            sim_step,
-                const int                            report_step,
-                const double                         next_step_size,
-                const double                         simTime,
-                const Schedule&                      schedule,
-                const EclipseGrid&                   grid,
-                const EclipseState&                  es)
+    writeHeader(const int                     sim_step,
+                const double                  next_step_size,
+                const double                  simTime,
+                const Schedule&               schedule,
+                const EclipseGrid&            grid,
+                const EclipseState&           es,
+                EclIO::OutputStream::Restart& rstFile)
     {
-        if (rst_file->unified) {
-            ::Opm::RestartIO::ecl_rst_file_fwrite_SEQNUM(rst_file, report_step);
-        }
-
         // write INTEHEAD to restart file
         const auto ih = Helpers::createInteHead(es, grid, schedule,
                                                 simTime, sim_step, sim_step);
-        write_kw(rst_file, "INTEHEAD", ih);
+        rstFile.write("INTEHEAD", ih);
 
         // write LOGIHEAD to restart file
-        const auto lh = Helpers::createLogiHead(es);
-        write_kw(rst_file, "LOGIHEAD", lh);
+        rstFile.write("LOGIHEAD", Helpers::createLogiHead(es));
 
         // write DOUBHEAD to restart file
         const auto dh = Helpers::createDoubHead(es, schedule, sim_step,
                                                 simTime, next_step_size);
-        write_kw(rst_file, "DOUBHEAD", dh);
+        rstFile.write("DOUBHEAD", dh);
 
         // return the inteHead vector
         return ih;
     }
 
-    void writeGroup(::Opm::RestartIO::ecl_rst_file_type* rst_file,
-                    int                                  sim_step,
-                    const Schedule&                      schedule,
-                    const Opm::SummaryState&             sumState,
-                    const std::vector<int>&              ih)
+    void writeGroup(int                           sim_step,
+                    const Schedule&               schedule,
+                    const Opm::SummaryState&      sumState,
+                    const std::vector<int>&       ih,
+                    EclIO::OutputStream::Restart& rstFile)
     {
         // write IGRP to restart file
         const size_t simStep = static_cast<size_t> (sim_step);
@@ -320,20 +239,20 @@ namespace {
                                            grpKeyToInd, fldKeyToInd,
                                            simStep, sumState, ih);
 
-        write_kw(rst_file, "IGRP", groupData.getIGroup());
-        write_kw(rst_file, "SGRP", groupData.getSGroup());
-        write_kw(rst_file, "XGRP", groupData.getXGroup());
-        write_kw(rst_file, "ZGRP", serialize_ZWEL(groupData.getZGroup()));
+        rstFile.write("IGRP", groupData.getIGroup());
+        rstFile.write("SGRP", groupData.getSGroup());
+        rstFile.write("XGRP", groupData.getXGroup());
+        rstFile.write("ZGRP", groupData.getZGroup());
     }
 
-    void writeMSWData(::Opm::RestartIO::ecl_rst_file_type* rst_file,
-                      int                                  sim_step,
-                      const UnitSystem&                    units,
-                      const Schedule&                      schedule,
-                      const EclipseGrid&                   grid,
-                      const Opm::SummaryState&             sumState,
-                      const Opm::data::Wells&              wells,
-                      const std::vector<int>&              ih)
+    void writeMSWData(int                           sim_step,
+                      const UnitSystem&             units,
+                      const Schedule&               schedule,
+                      const EclipseGrid&            grid,
+                      const Opm::SummaryState&      sumState,
+                      const Opm::data::Wells&       wells,
+                      const std::vector<int>&       ih,
+                      EclIO::OutputStream::Restart& rstFile)
     {
         // write ISEG, RSEG, ILBS and ILBR to restart file
         const auto simStep = static_cast<std::size_t> (sim_step);
@@ -342,32 +261,32 @@ namespace {
         MSWData.captureDeclaredMSWData(schedule, simStep, units,
                                        ih, grid, sumState, wells);
 
-        write_kw(rst_file, "ISEG", MSWData.getISeg());
-        write_kw(rst_file, "ILBS", MSWData.getILBs());
-        write_kw(rst_file, "ILBR", MSWData.getILBr());
-        write_kw(rst_file, "RSEG", MSWData.getRSeg());
+        rstFile.write("ISEG", MSWData.getISeg());
+        rstFile.write("ILBS", MSWData.getILBs());
+        rstFile.write("ILBR", MSWData.getILBr());
+        rstFile.write("RSEG", MSWData.getRSeg());
     }
 
-    void writeWell(::Opm::RestartIO::ecl_rst_file_type* rst_file,
-                   int                                  sim_step,
-                   const bool                           ecl_compatible_rst,
-                   const Phases&                        phases,
-                   const UnitSystem&                    units,
-                   const EclipseGrid&                   grid,
-                   const Schedule&                      schedule,
-                   const data::Wells&                   wells,
-                   const Opm::SummaryState&             sumState,
-                   const std::vector<int>&              ih)
+    void writeWell(int                           sim_step,
+                   const bool                    ecl_compatible_rst,
+                   const Phases&                 phases,
+                   const UnitSystem&             units,
+                   const EclipseGrid&            grid,
+                   const Schedule&               schedule,
+                   const data::Wells&            wells,
+                   const Opm::SummaryState&      sumState,
+                   const std::vector<int>&       ih,
+                   EclIO::OutputStream::Restart& rstFile)
     {
         auto wellData = Helpers::AggregateWellData(ih);
         wellData.captureDeclaredWellData(schedule, units, sim_step, sumState, ih);
         wellData.captureDynamicWellData(schedule, sim_step,
                                         wells, sumState);
 
-        write_kw(rst_file, "IWEL", wellData.getIWell());
-        write_kw(rst_file, "SWEL", wellData.getSWell());
-        write_kw(rst_file, "XWEL", wellData.getXWell());
-        write_kw(rst_file, "ZWEL", serialize_ZWEL(wellData.getZWell()));
+        rstFile.write("IWEL", wellData.getIWell());
+        rstFile.write("SWEL", wellData.getSWell());
+        rstFile.write("XWEL", wellData.getXWell());
+        rstFile.write("ZWEL", wellData.getZWell());
 
         // Extended set of OPM well vectors
         if (!ecl_compatible_rst)
@@ -380,17 +299,17 @@ namespace {
 
             const auto opm_iwel = serialize_OPM_IWEL(wells, sched_well_names);
 
-            write_kw(rst_file, "OPM_IWEL", opm_iwel);
-            write_kw(rst_file, "OPM_XWEL", opm_xwel);
+            rstFile.write("OPM_IWEL", opm_iwel);
+            rstFile.write("OPM_XWEL", opm_xwel);
         }
 
         auto connectionData = Helpers::AggregateConnectionData(ih);
         connectionData.captureDeclaredConnData(schedule, grid, units,
                                                wells, sim_step);
 
-        write_kw(rst_file, "ICON", connectionData.getIConn());
-        write_kw(rst_file, "SCON", connectionData.getSConn());
-        write_kw(rst_file, "XCON", connectionData.getXConn());
+        rstFile.write("ICON", connectionData.getIConn());
+        rstFile.write("SCON", connectionData.getSConn());
+        rstFile.write("XCON", connectionData.getXConn());
     }
 
     bool haveHysteresis(const RestartValue& value)
@@ -456,20 +375,26 @@ namespace {
         }
     }
 
-    void writeSolution(ecl_rst_file_type*  rst_file,
-                       const RestartValue& value,
-                       const bool          ecl_compatible_rst,
-                       const bool          write_double_arg)
+    void writeSolution(const RestartValue&           value,
+                       const bool                    ecl_compatible_rst,
+                       const bool                    write_double_arg,
+                       EclIO::OutputStream::Restart& rstFile)
     {
-        ecl_rst_file_start_solution(rst_file);
+        rstFile.message("STARTSOL");
 
-        auto write = [rst_file]
+        auto write = [&rstFile]
             (const std::string&         key,
              const std::vector<double>& data,
              const bool                 write_double) -> void
         {
-            auto kw = make_ecl_kw_pointer(key, data, write_double);
-            ::Opm::RestartIO::ecl_rst_file_add_kw(rst_file, kw.get());
+            if (write_double) {
+                rstFile.write(key, data);
+            }
+            else {
+                rstFile.write(key, std::vector<float> {
+                    data.begin(), data.end()
+                });
+            }
         };
 
         for (const auto& elm : value.solution) {
@@ -492,7 +417,7 @@ namespace {
             writeEclipseCompatHysteresis(value, write_double_arg, write);
         }
 
-        ecl_rst_file_end_solution(rst_file);
+        rstFile.message("ENDSOL");
 
         if (ecl_compatible_rst) {
             return;
@@ -505,41 +430,38 @@ namespace {
         }
     }
 
-    void writeExtraData(::Opm::RestartIO::ecl_rst_file_type* rst_file,
-                        const RestartValue::ExtraVector&     extra_data)
+    void writeExtraData(const RestartValue::ExtraVector& extra_data,
+                        EclIO::OutputStream::Restart&    rstFile)
     {
         for (const auto& extra_value : extra_data) {
             const std::string& key = extra_value.first.key;
-            const std::vector<double>& data = extra_value.second;
-            if (! extraInSolution(key)) {
-                ecl_kw_type * ecl_kw = ecl_kw_alloc_new_shared( key.c_str() , data.size() , ECL_DOUBLE , const_cast<double *>(data.data()));
-                ecl_rst_file_add_kw( rst_file , ecl_kw);
-                ecl_kw_free( ecl_kw );
-            }
 
+            if (! extraInSolution(key)) {
+                rstFile.write(key, extra_value.second);
+            }
         }
     }
 
 } // Anonymous namespace
 
-void save(const std::string&  filename,
-          int                 report_step,
-          double              seconds_elapsed,
-          RestartValue        value,
-          const EclipseState& es,
-          const EclipseGrid&  grid,
-          const Schedule&     schedule,
-          const SummaryState& sumState,
-          bool                write_double)
+void save(EclIO::OutputStream::Restart& rstFile,
+          int                           report_step,
+          double                        seconds_elapsed,
+          RestartValue                  value,
+          const EclipseState&           es,
+          const EclipseGrid&            grid,
+          const Schedule&               schedule,
+          const SummaryState&           sumState,
+          bool                          write_double)
 {
     ::Opm::RestartIO::checkSaveArguments(es, value, grid);
 
-    const auto ecl_compatible_rst = es.getIOConfig().getEclCompatibleRST();
+    const auto& ioCfg = es.getIOConfig();
+    const auto ecl_compatible_rst = ioCfg.getEclCompatibleRST();
 
     const auto  sim_step = std::max(report_step - 1, 0);
     const auto& units    = es.getUnits();
 
-    auto rst_file = openRestartFile(filename, report_step);
     if (ecl_compatible_rst) {
         write_double = false;
     }
@@ -548,11 +470,10 @@ void save(const std::string&  filename,
     value.convertFromSI(units);
 
     const auto inteHD =
-        writeHeader(rst_file.get(), sim_step, report_step,
-                    nextStepSize(value), seconds_elapsed,
-                    schedule, grid, es);
+        writeHeader(sim_step, nextStepSize(value), seconds_elapsed,
+                    schedule, grid, es, rstFile);
 
-    writeGroup(rst_file.get(), sim_step, schedule, sumState, inteHD);
+    writeGroup(sim_step, schedule, sumState, inteHD, rstFile);
 
     // Write well and MSW data only when applicable (i.e., when present)
     {
@@ -567,20 +488,20 @@ void save(const std::string&  filename,
             });
 
             if (haveMSW) {
-                writeMSWData(rst_file.get(), sim_step, units,
-                             schedule, grid, sumState, value.wells, inteHD);
+                writeMSWData(sim_step, units, schedule, grid, sumState,
+                             value.wells, inteHD, rstFile);
             }
 
-            writeWell(rst_file.get(), sim_step, ecl_compatible_rst,
+            writeWell(sim_step, ecl_compatible_rst,
                       es.runspec().phases(), units, grid, schedule,
-                      value.wells, sumState, inteHD);
+                      value.wells, sumState, inteHD, rstFile);
         }
     }
 
-    writeSolution(rst_file.get(), value, ecl_compatible_rst, write_double);
+    writeSolution(value, ecl_compatible_rst, write_double, rstFile);
 
     if (! ecl_compatible_rst) {
-        writeExtraData(rst_file.get(), value.extra);
+        writeExtraData(value.extra, rstFile);
     }
 }
 

--- a/test_util/EclFilesComparator.cpp
+++ b/test_util/EclFilesComparator.cpp
@@ -43,7 +43,7 @@
     } \
   }
 
-using Opm::ecl::EGrid;
+using Opm::EclIO::EGrid;
 
 template <typename T>
 void ECLFilesComparator::printValuesForCell(const std::string& keyword, const std::string& reference, size_t kw_size, size_t cell, EGrid *grid, const T& value1, const T& value2) const {

--- a/test_util/EclFilesComparator.hpp
+++ b/test_util/EclFilesComparator.hpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
     class EGrid;
 }} // namespace Opm::ecl
 
@@ -82,7 +82,7 @@ protected:
                             const std::string& reference,
                             size_t kw_size,
                             size_t cell,
-                            Opm::ecl::EGrid *grid,
+                            Opm::EclIO::EGrid *grid,
                             const T& value1,
                             const T& value2) const;
 

--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -46,7 +46,7 @@
     } \
   }
 
-using namespace Opm::ecl;
+using namespace Opm::EclIO;
 
 ECLRegressionTest::~ECLRegressionTest()
 {

--- a/test_util/EclRegressionTest.hpp
+++ b/test_util/EclRegressionTest.hpp
@@ -24,11 +24,11 @@
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
     class EGrid;
 }}
 
-namespace EIOD = Opm::ecl;
+namespace EIOD = Opm::EclIO;
 
 
 /*! \brief A class for executing a regression test for two ECLIPSE files.
@@ -176,8 +176,8 @@ private:
     // Accept extra keywords in the restart file of the 'new' simulation.
     bool acceptExtraKeywords = false;
 
-    Opm::ecl::EGrid* grid1 = nullptr;
-    Opm::ecl::EGrid* grid2 = nullptr;
+    Opm::EclIO::EGrid* grid1 = nullptr;
+    Opm::EclIO::EGrid* grid2 = nullptr;
 };
 
 #endif

--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -6,7 +6,7 @@
 #include <opm/io/eclipse/EclFile.hpp>
 #include <opm/io/eclipse/EclOutput.hpp>
 
-using namespace Opm::ecl;
+using namespace Opm::EclIO;
 
 template<typename T>
 void write(EclOutput& outFile, EclFile& file1,

--- a/tests/test_EGrid.cpp
+++ b/tests/test_EGrid.cpp
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <tuple>
 
-using Opm::ecl::EGrid;
+using Opm::EclIO::EGrid;
 
 template<typename InputIterator1, typename InputIterator2>
 bool

--- a/tests/test_ERft.cpp
+++ b/tests/test_ERft.cpp
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <tuple>
 
-using namespace Opm::ecl;
+using namespace Opm::EclIO;
 
 template<typename InputIterator1, typename InputIterator2>
 bool

--- a/tests/test_ERst.cpp
+++ b/tests/test_ERst.cpp
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <tuple>
 
-using namespace Opm::ecl;
+using namespace Opm::EclIO;
 
 template<typename InputIterator1, typename InputIterator2>
 bool

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <tuple>
 
-using Opm::ecl::ESmry;
+using Opm::EclIO::ESmry;
 
 template<typename InputIterator1, typename InputIterator2>
 bool

--- a/tests/test_EclIO.cpp
+++ b/tests/test_EclIO.cpp
@@ -32,7 +32,7 @@
 #define BOOST_TEST_MODULE Test EclIO
 #include <boost/test/unit_test.hpp>
 
-using namespace Opm::ecl;
+using namespace Opm::EclIO;
 
 template<typename InputIterator1, typename InputIterator2>
 bool

--- a/tests/test_EclRegressionTest.cpp
+++ b/tests/test_EclRegressionTest.cpp
@@ -30,9 +30,9 @@
 
 #include <iomanip>
 
-using Opm::ecl::EGrid;
-using Opm::ecl::ESmry;
-using Opm::ecl::EclOutput;
+using Opm::EclIO::EGrid;
+using Opm::EclIO::ESmry;
+using Opm::EclIO::EclOutput;
 
 void makeEgridFile(const std::string &fileName, const std::vector<float> &coord,
                    const std::vector<float> &zcorn, const std::vector<int> &gridhead,

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -40,7 +40,7 @@
 
 #include <boost/filesystem.hpp>
 
-namespace Opm { namespace ecl {
+namespace Opm { namespace EclIO {
 
     // Needed by BOOST_CHECK_EQUAL_COLLECTIONS.
     std::ostream&
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(ResultSetDescriptor)
     const auto ext  = std::string{"F0123"};
 
     {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+        const auto rset = ::Opm::EclIO::OutputStream::ResultSet {
             odir, "CASE"
         };
 
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(ResultSetDescriptor)
     }
 
     {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+        const auto rset = ::Opm::EclIO::OutputStream::ResultSet {
             odir, "CASE." // CASE DOT
         };
 
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(ResultSetDescriptor)
     }
 
     {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+        const auto rset = ::Opm::EclIO::OutputStream::ResultSet {
             odir, "CASE.01"
         };
 
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(ResultSetDescriptor)
     }
 
     {
-        const auto rset = ::Opm::ecl::OutputStream::ResultSet {
+        const auto rset = ::Opm::EclIO::OutputStream::ResultSet {
             odir, "CASE.01." // CASE.01 DOT
         };
 
@@ -147,7 +147,7 @@ public:
         boost::filesystem::remove_all(this->odir_);
     }
 
-    operator ::Opm::ecl::OutputStream::ResultSet() const
+    operator ::Opm::EclIO::OutputStream::ResultSet() const
     {
         return { this->odir_.string(), this->base_ };
     }
@@ -160,12 +160,12 @@ private:
 BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 {
     const auto rset = RSet("CASE");
-    const auto fmt  = ::Opm::ecl::OutputStream::Formatted{ false };
-    const auto unif = ::Opm::ecl::OutputStream::Unified  { true };
+    const auto fmt  = ::Opm::EclIO::OutputStream::Formatted{ false };
+    const auto unif = ::Opm::EclIO::OutputStream::Unified  { true };
 
     {
         const auto seqnum = 1;
-        auto rst = ::Opm::ecl::OutputStream::Restart {
+        auto rst = ::Opm::EclIO::OutputStream::Restart {
             rset, seqnum, fmt, unif
         };
 
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
     {
         const auto seqnum = 13;
-        auto rst = ::Opm::ecl::OutputStream::Restart {
+        auto rst = ::Opm::EclIO::OutputStream::Restart {
             rset, seqnum, fmt, unif
         };
 
@@ -190,10 +190,10 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
     }
 
     {
-        const auto fname = ::Opm::ecl::OutputStream::
+        const auto fname = ::Opm::EclIO::OutputStream::
             outputFileName(rset, "UNRST");
 
-        auto rst = ::Opm::ecl::ERst{fname};
+        auto rst = ::Opm::EclIO::ERst{fname};
 
         BOOST_CHECK(rst.hasReportStepNumber( 1));
         BOOST_CHECK(rst.hasReportStepNumber(13));
@@ -209,13 +209,13 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
         {
             const auto vectors        = rst.listOfRstArrays(13);
-            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
-                Opm::ecl::EclFile::EclEntry{"SEQNUM", Opm::ecl::eclArrType::INTE, 1},
-                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 3},
-                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
-                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 2},
-                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 3},
-                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 2},
+            const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
+                Opm::EclIO::EclFile::EclEntry{"SEQNUM", Opm::EclIO::eclArrType::INTE, 1},
+                Opm::EclIO::EclFile::EclEntry{"I", Opm::EclIO::eclArrType::INTE, 3},
+                Opm::EclIO::EclFile::EclEntry{"L", Opm::EclIO::eclArrType::LOGI, 4},
+                Opm::EclIO::EclFile::EclEntry{"S", Opm::EclIO::eclArrType::REAL, 2},
+                Opm::EclIO::EclFile::EclEntry{"D", Opm::EclIO::eclArrType::DOUB, 3},
+                Opm::EclIO::EclFile::EclEntry{"Z", Opm::EclIO::eclArrType::CHAR, 2},
             };
 
             BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
     {
         const auto seqnum = 5;  // Before 13.  Should overwrite 13
-        auto rst = ::Opm::ecl::OutputStream::Restart {
+        auto rst = ::Opm::EclIO::OutputStream::Restart {
             rset, seqnum, fmt, unif
         };
 
@@ -288,10 +288,10 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
     }
 
     {
-        const auto fname = ::Opm::ecl::OutputStream::
+        const auto fname = ::Opm::EclIO::OutputStream::
             outputFileName(rset, "UNRST");
 
-        auto rst = ::Opm::ecl::ERst{fname};
+        auto rst = ::Opm::EclIO::ERst{fname};
 
         BOOST_CHECK( rst.hasReportStepNumber( 1));
         BOOST_CHECK( rst.hasReportStepNumber( 5));
@@ -308,13 +308,13 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
         {
             const auto vectors        = rst.listOfRstArrays(5);
-            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
-                Opm::ecl::EclFile::EclEntry{"SEQNUM", Opm::ecl::eclArrType::INTE, 1},
-                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 4},
-                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
-                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 3},
-                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 2},
-                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 3},
+            const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
+                Opm::EclIO::EclFile::EclEntry{"SEQNUM", Opm::EclIO::eclArrType::INTE, 1},
+                Opm::EclIO::EclFile::EclEntry{"I", Opm::EclIO::eclArrType::INTE, 4},
+                Opm::EclIO::EclFile::EclEntry{"L", Opm::EclIO::eclArrType::LOGI, 4},
+                Opm::EclIO::EclFile::EclEntry{"S", Opm::EclIO::eclArrType::REAL, 3},
+                Opm::EclIO::EclFile::EclEntry{"D", Opm::EclIO::eclArrType::DOUB, 2},
+                Opm::EclIO::EclFile::EclEntry{"Z", Opm::EclIO::eclArrType::CHAR, 3},
             };
 
             BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
@@ -375,7 +375,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
     {
         const auto seqnum = 13;
-        auto rst = ::Opm::ecl::OutputStream::Restart {
+        auto rst = ::Opm::EclIO::OutputStream::Restart {
             rset, seqnum, fmt, unif
         };
 
@@ -387,10 +387,10 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
     }
 
     {
-        const auto fname = ::Opm::ecl::OutputStream::
+        const auto fname = ::Opm::EclIO::OutputStream::
             outputFileName(rset, "UNRST");
 
-        auto rst = ::Opm::ecl::ERst{fname};
+        auto rst = ::Opm::EclIO::ERst{fname};
 
         BOOST_CHECK(rst.hasReportStepNumber( 1));
         BOOST_CHECK(rst.hasReportStepNumber( 5));
@@ -407,13 +407,13 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 
         {
             const auto vectors        = rst.listOfRstArrays(13);
-            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
-                Opm::ecl::EclFile::EclEntry{"SEQNUM", Opm::ecl::eclArrType::INTE, 1},
-                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 3},
-                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
-                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 2},
-                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 3},
-                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 2},
+            const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
+                Opm::EclIO::EclFile::EclEntry{"SEQNUM", Opm::EclIO::eclArrType::INTE, 1},
+                Opm::EclIO::EclFile::EclEntry{"I", Opm::EclIO::eclArrType::INTE, 3},
+                Opm::EclIO::EclFile::EclEntry{"L", Opm::EclIO::eclArrType::LOGI, 4},
+                Opm::EclIO::EclFile::EclEntry{"S", Opm::EclIO::eclArrType::REAL, 2},
+                Opm::EclIO::EclFile::EclEntry{"D", Opm::EclIO::eclArrType::DOUB, 3},
+                Opm::EclIO::EclFile::EclEntry{"Z", Opm::EclIO::eclArrType::CHAR, 2},
             };
 
             BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
@@ -476,12 +476,12 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
 BOOST_AUTO_TEST_CASE(Formatted_Separate)
 {
     const auto rset = RSet("CASE.T01.");
-    const auto fmt  = ::Opm::ecl::OutputStream::Formatted{ true };
-    const auto unif = ::Opm::ecl::OutputStream::Unified  { false };
+    const auto fmt  = ::Opm::EclIO::OutputStream::Formatted{ true };
+    const auto unif = ::Opm::EclIO::OutputStream::Unified  { false };
 
     {
         const auto seqnum = 1;
-        auto rst = ::Opm::ecl::OutputStream::Restart {
+        auto rst = ::Opm::EclIO::OutputStream::Restart {
             rset, seqnum, fmt, unif
         };
 
@@ -494,7 +494,7 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
 
     {
         const auto seqnum = 13;
-        auto rst = ::Opm::ecl::OutputStream::Restart {
+        auto rst = ::Opm::EclIO::OutputStream::Restart {
             rset, seqnum, fmt, unif
         };
 
@@ -506,22 +506,22 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
     }
 
     {
-        using ::Opm::ecl::OutputStream::Restart;
+        using ::Opm::EclIO::OutputStream::Restart;
 
-        const auto fname = ::Opm::ecl::OutputStream::
+        const auto fname = ::Opm::EclIO::OutputStream::
             outputFileName(rset, "F0013");
 
-        auto rst = ::Opm::ecl::EclFile{fname};
+        auto rst = ::Opm::EclIO::EclFile{fname};
 
         {
             const auto vectors        = rst.getList();
-            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+            const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
                 // No SEQNUM in separate output files
-                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 3},
-                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
-                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 2},
-                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 3},
-                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 2},
+                Opm::EclIO::EclFile::EclEntry{"I", Opm::EclIO::eclArrType::INTE, 3},
+                Opm::EclIO::EclFile::EclEntry{"L", Opm::EclIO::eclArrType::LOGI, 4},
+                Opm::EclIO::EclFile::EclEntry{"S", Opm::EclIO::eclArrType::REAL, 2},
+                Opm::EclIO::EclFile::EclEntry{"D", Opm::EclIO::eclArrType::DOUB, 3},
+                Opm::EclIO::EclFile::EclEntry{"Z", Opm::EclIO::eclArrType::CHAR, 2},
             };
 
             BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
     {
         // Separate output.  Step 13 should be unaffected.
         const auto seqnum = 5;
-        auto rst = ::Opm::ecl::OutputStream::Restart {
+        auto rst = ::Opm::EclIO::OutputStream::Restart {
             rset, seqnum, fmt, unif
         };
 
@@ -595,22 +595,22 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
     }
 
     {
-        using ::Opm::ecl::OutputStream::Restart;
+        using ::Opm::EclIO::OutputStream::Restart;
 
-        const auto fname = ::Opm::ecl::OutputStream::
+        const auto fname = ::Opm::EclIO::OutputStream::
             outputFileName(rset, "F0005");
 
-        auto rst = ::Opm::ecl::EclFile{fname};
+        auto rst = ::Opm::EclIO::EclFile{fname};
 
         {
             const auto vectors        = rst.getList();
-            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+            const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
                 // No SEQNUM in separate output files
-                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 4},
-                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
-                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 3},
-                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 2},
-                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 3},
+                Opm::EclIO::EclFile::EclEntry{"I", Opm::EclIO::eclArrType::INTE, 4},
+                Opm::EclIO::EclFile::EclEntry{"L", Opm::EclIO::eclArrType::LOGI, 4},
+                Opm::EclIO::EclFile::EclEntry{"S", Opm::EclIO::eclArrType::REAL, 3},
+                Opm::EclIO::EclFile::EclEntry{"D", Opm::EclIO::eclArrType::DOUB, 2},
+                Opm::EclIO::EclFile::EclEntry{"Z", Opm::EclIO::eclArrType::CHAR, 3},
             };
 
             BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),
@@ -674,22 +674,22 @@ BOOST_AUTO_TEST_CASE(Formatted_Separate)
     // -------------------------------------------------------
 
     {
-        using ::Opm::ecl::OutputStream::Restart;
+        using ::Opm::EclIO::OutputStream::Restart;
 
-        const auto fname = ::Opm::ecl::OutputStream::
+        const auto fname = ::Opm::EclIO::OutputStream::
             outputFileName(rset, "F0013");
 
-        auto rst = ::Opm::ecl::EclFile{fname};
+        auto rst = ::Opm::EclIO::EclFile{fname};
 
         {
             const auto vectors        = rst.getList();
-            const auto expect_vectors = std::vector<Opm::ecl::EclFile::EclEntry>{
+            const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
                 // No SEQNUM in separate output files.
-                Opm::ecl::EclFile::EclEntry{"I", Opm::ecl::eclArrType::INTE, 3},
-                Opm::ecl::EclFile::EclEntry{"L", Opm::ecl::eclArrType::LOGI, 4},
-                Opm::ecl::EclFile::EclEntry{"S", Opm::ecl::eclArrType::REAL, 2},
-                Opm::ecl::EclFile::EclEntry{"D", Opm::ecl::eclArrType::DOUB, 3},
-                Opm::ecl::EclFile::EclEntry{"Z", Opm::ecl::eclArrType::CHAR, 2},
+                Opm::EclIO::EclFile::EclEntry{"I", Opm::EclIO::eclArrType::INTE, 3},
+                Opm::EclIO::EclFile::EclEntry{"L", Opm::EclIO::eclArrType::LOGI, 4},
+                Opm::EclIO::EclFile::EclEntry{"S", Opm::EclIO::eclArrType::REAL, 2},
+                Opm::EclIO::EclFile::EclEntry{"D", Opm::EclIO::eclArrType::DOUB, 3},
+                Opm::EclIO::EclFile::EclEntry{"Z", Opm::EclIO::eclArrType::CHAR, 2},
             };
 
             BOOST_CHECK_EQUAL_COLLECTIONS(vectors.begin(), vectors.end(),

--- a/tests/test_PaddedOutputString.cpp
+++ b/tests/test_PaddedOutputString.cpp
@@ -1,36 +1,36 @@
-#define BOOST_TEST_MODULE Aggregate_Well_Data
+#define BOOST_TEST_MODULE Padded_Output_String
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/output/eclipse/CharArrayNullTerm.hpp>
+#include <opm/io/eclipse/PaddedOutputString.hpp>
 
 // Convenience alias.
 template <std::size_t N>
-using AChar = ::Opm::RestartIO::Helpers::CharArrayNullTerm<N>;
+using PadString = ::Opm::EclIO::PaddedOutputString<N>;
 
 // =====================================================================
 
-BOOST_AUTO_TEST_SUITE(AChar8)
+BOOST_AUTO_TEST_SUITE(PadString8)
 
 BOOST_AUTO_TEST_CASE (Basic_Operations)
 {
     // Default Constructor
     {
-        const auto s = AChar<8>{};
+        const auto s = PadString<8>{};
 
         BOOST_CHECK_EQUAL(s.c_str(), std::string(8, ' '));
     }
 
     // Construct from Constant String
     {
-        const auto s = AChar<8>{"Inj-1"};
+        const auto s = PadString<8>{"Inj-1"};
 
         BOOST_CHECK_EQUAL(s.c_str(), std::string{"Inj-1   "});
     }
 
     // Copy Construction
     {
-        const auto s1 = AChar<8>{"Inj-1"};
+        const auto s1 = PadString<8>{"Inj-1"};
         const auto s2 = s1;
 
         BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Move Construction
     {
-        auto s1 = AChar<8>{"Inj-1"};
+        auto s1 = PadString<8>{"Inj-1"};
         const auto s2 = std::move(s1);
 
         BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
@@ -46,8 +46,8 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Assignment Operator
     {
-        const auto s1 = AChar<8>{"Inj-1"};
-        auto s2 = AChar<8>{"Prod-2"};
+        const auto s1 = PadString<8>{"Inj-1"};
+        auto s2 = PadString<8>{"Prod-2"};
 
         s2 = s1;
         BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
@@ -55,8 +55,8 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Move Assignment Operator
     {
-        auto s1 = AChar<8>{"Inj-1"};
-        auto s2 = AChar<8>{"Prod-2"};
+        auto s1 = PadString<8>{"Inj-1"};
+        auto s2 = PadString<8>{"Prod-2"};
 
         s2 = std::move(s1);
         BOOST_CHECK_EQUAL(s2.c_str(), std::string{"Inj-1   "});
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE (Basic_Operations)
 
     // Assign std::string
     {
-        auto s = AChar<8>{"@Hi Hoo@"};
+        auto s = PadString<8>{"@Hi Hoo@"};
 
         s = "Prod-2";
         BOOST_CHECK_EQUAL(s.c_str(), std::string{"Prod-2  "});
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE (String_Shortening)
 {
     // Construct from string of more than N characters
     {
-        const auto s = AChar<10>{
+        const auto s = PadString<10>{
             "String too long"
         };
 
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE (String_Shortening)
 
     // Assign string of more than N characters
     {
-        auto s = AChar<11>{};
+        auto s = PadString<11>{};
 
         s = "This string has too many characters";
 


### PR DESCRIPTION
This change-set switches the file handling operations of the gateway function `RestartIO::save()` to using the `OutputStream::Restart` component.  Briefly, this means replacing `write_kw()` function calls with calls to `Restart::write()` throughout `RestartIO.cpp`.

We promote the `CharArrayNullTerm` helper class in `RestartIO::Helpers` to the more accessible location `opm/io/eclipse` and rename the class to `PaddedOutputString` to better reflect its purpose. We also add a special purpose overload `Restart::write()` for `PaddedOutputString`s of exactly eight characters to enable outputting these objects directly from the `Aggregate*` classes.  The original `write()` overload for `std::string` remains in place for more general problems (e.g., `C0nn`-like character data).

Finally, incur one more round of repository churn by renaming the `Opm::ecl` nested namespace (PR #763) to `Opm::EclIO`. This avoids naming conflicts in cases when symbols from LibECL's `ecl` namespace are used inside Opm's implementation&mdash;e.g., as part of writing summary output.