### PR TITLE
Use eval timestep

### DIFF
--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -21,7 +21,7 @@ namespace Opm {
 class EclipseIO;
 class ParseContext;
 class Parser;
-
+class SummaryState;
 class msim {
 
 public:
@@ -33,12 +33,12 @@ public:
     void well_rate(const std::string& well, data::Rates::opt rate, std::function<well_rate_function> func);
     void solution(const std::string& field, std::function<solution_function> func);
     void run(Schedule& schedule, EclipseIO& io);
-    void post_step(Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
+    void post_step(Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
 private:
 
-    void run_step(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
-    void run_step(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const;
-    void output(size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const;
+    void output(const SummaryState& st, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const;
     void simulate(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, double seconds_elapsed, double time_step) const;
 
     EclipseState state;

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -41,23 +41,23 @@ void msim::run(Schedule& schedule, EclipseIO& io) {
     const double week = 7 * 86400;
     data::Solution sol;
     data::Wells well_data;
+    SummaryState st;
 
     io.writeInitial();
     for (size_t report_step = 1; report_step < schedule.size(); report_step++) {
         double time_step = std::min(week, 0.5*schedule.stepLength(report_step - 1));
-        run_step(schedule, sol, well_data, report_step, time_step, io);
-        post_step(schedule, sol, well_data, report_step, io);
+        run_step(schedule, st, sol, well_data, report_step, time_step, io);
+        post_step(schedule, st, sol, well_data, report_step, io);
     }
 }
 
 
-void msim::post_step(Schedule& schedule, data::Solution& /* sol */, data::Wells& /* well_data */, size_t report_step, EclipseIO& io) const {
+void msim::post_step(Schedule& schedule, const SummaryState& st, data::Solution& /* sol */, data::Wells& /* well_data */, size_t report_step, EclipseIO& io) const {
     const auto& actions = schedule.actions();
     if (actions.empty())
         return;
 
-    const SummaryState& summary_state = io.summaryState();
-    ActionContext context( summary_state );
+    ActionContext context( st );
     std::vector<std::string> matching_wells;
 
     auto sim_time = schedule.simTime(report_step);
@@ -69,12 +69,12 @@ void msim::post_step(Schedule& schedule, data::Solution& /* sol */, data::Wells&
 
 
 
-void msim::run_step(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const {
-    this->run_step(schedule, sol, well_data, report_step, schedule.stepLength(report_step - 1), io);
+void msim::run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const {
+    this->run_step(schedule, st, sol, well_data, report_step, schedule.stepLength(report_step - 1), io);
 }
 
 
-void msim::run_step(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const {
+void msim::run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const {
     double start_time = schedule.seconds(report_step - 1);
     double end_time = schedule.seconds(report_step);
     double seconds_elapsed = start_time;
@@ -87,7 +87,17 @@ void msim::run_step(const Schedule& schedule, data::Solution& sol, data::Wells& 
         this->simulate(schedule, sol, well_data, report_step, seconds_elapsed, time_step);
 
         seconds_elapsed += time_step;
-        this->output(report_step,
+
+        io.summary().eval(st,
+                          report_step,
+                          seconds_elapsed,
+                          this->state,
+                          schedule,
+                          well_data,
+                          {});
+
+        this->output(st,
+                     report_step,
                      (seconds_elapsed < end_time),
                      seconds_elapsed,
                      sol,
@@ -98,9 +108,10 @@ void msim::run_step(const Schedule& schedule, data::Solution& sol, data::Wells& 
 
 
 
-void msim::output(size_t report_step, bool /* substep */, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const {
+void msim::output(const SummaryState& st, size_t report_step, bool /* substep */, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const {
     RestartValue value(sol, well_data);
-    io.writeTimeStep(report_step,
+    io.writeTimeStep(st,
+                     report_step,
                      false,
                      seconds_elapsed,
                      value,

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -35,6 +35,7 @@
 #include <opm/output/data/Solution.hpp>
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
+#include <opm/output/eclipse/Summary.hpp>
 
 namespace Opm {
 
@@ -171,7 +172,8 @@ public:
      *     hardcoded static map misc_units in Summary.cpp.
      */
 
-    void writeTimeStep( int report_step,
+    void writeTimeStep( const SummaryState& st,
+                        int report_step,
                         bool isSubstep,
                         double seconds_elapsed,
                         RestartValue value,
@@ -219,13 +221,11 @@ public:
       missing, if the bool is false missing keywords will be ignored
       (there will *not* be an empty vector in the return value).
     */
-    RestartValue loadRestart(const std::vector<RestartKey>& solution_keys, const std::vector<RestartKey>& extra_keys = {}) const;
-
+    RestartValue loadRestart(SummaryState& summary_state, const std::vector<RestartKey>& solution_keys, const std::vector<RestartKey>& extra_keys = {}) const;
+    const out::Summary& summary();
 
     EclipseIO( const EclipseIO& ) = delete;
     ~EclipseIO();
-
-    const SummaryState& summaryState() const;
 
 private:
     class Impl;

--- a/opm/output/eclipse/RestartIO.hpp
+++ b/opm/output/eclipse/RestartIO.hpp
@@ -91,14 +91,15 @@ namespace Opm { namespace RestartIO {
               const SummaryState&           sumState,
               bool                          write_double = false);
 
-    std::pair<RestartValue, SummaryState>
-    load(const std::string&             filename,
-         int                            report_step,
-         const std::vector<RestartKey>& solution_keys,
-         const EclipseState&            es,
-         const EclipseGrid&             grid,
-         const Schedule&                schedule,
-         const std::vector<RestartKey>& extra_keys = {});
+
+    RestartValue load(const std::string&             filename,
+                      int                            report_step,
+                      SummaryState&                  summary_state,
+                      const std::vector<RestartKey>& solution_keys,
+                      const EclipseState&            es,
+                      const EclipseGrid&             grid,
+                      const Schedule&                schedule,
+                      const std::vector<RestartKey>& extra_keys = {});
 
 }} // namespace Opm::RestartIO
 

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -48,14 +48,8 @@ public:
     Summary( const EclipseState&, const SummaryConfig&, const EclipseGrid&, const Schedule&, const std::string& );
     Summary( const EclipseState&, const SummaryConfig&, const EclipseGrid&, const Schedule&, const char* basename );
 
-    void add_timestep(int report_step,
-                      double secs_elapsed,
-                      const EclipseState& es,
-                      const Schedule& schedule,
-                      const data::Wells&,
-                      const std::map<std::string, double>& single_values,
-                      const std::map<std::string, std::vector<double>>& region_values = {},
-                      const std::map<std::pair<std::string, int>, double>& block_values = {});
+    void add_timestep(const SummaryState& st,
+                      int report_step);
 
 
     void eval(SummaryState& summary_state,
@@ -71,14 +65,10 @@ public:
 
 
     ~Summary();
-
-    const SummaryState& get_restart_vectors() const;
-
-    void reset_cumulative_quantities(const SummaryState& rstrt);
     void write() const;
 
 private:
-    void internal_store(const SummaryState& summary_state, int report_step, double seconds_elapsed);
+    void internal_store(const SummaryState& summary_state, int report_step);
 
 
     class keyword_handlers;
@@ -87,8 +77,6 @@ private:
     out::RegionCache regionCache;
     ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free > ecl_sum;
     std::unique_ptr< keyword_handlers > handlers;
-    double prev_time_elapsed = 0;
-    SummaryState prev_state;
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -98,7 +98,7 @@ public:
     std::size_t num_wells() const;
     std::size_t size() const;
 private:
-    double elapsed;
+    double elapsed = 0;
     std::unordered_map<std::string,double> values;
 
     // The first key is the variable and the second key is the well.

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -292,6 +292,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         auto& eclGrid = es.getInputGrid();
         Schedule schedule(deck, eclGrid, es.get3DProperties(), es.runspec());
         SummaryConfig summary_config( deck, schedule, es.getTableManager( ));
+        SummaryState st;
         es.getIOConfig().setBaseName( "FOO" );
 
         EclipseIO eclWriter( es, eclGrid , schedule, summary_config);
@@ -329,7 +330,8 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
 
             RestartValue restart_value(sol, wells);
             auto first_step = ecl_util_make_date( 10 + i, 11, 2008 );
-            eclWriter.writeTimeStep( i,
+            eclWriter.writeTimeStep( st,
+                                     i,
                                      false,
                                      first_step - start_time,
                                      restart_value,

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -121,6 +121,7 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
         EclipseIO eclipseWriter( eclipseState, grid, schedule, summary_config );
         time_t start_time = schedule.posixStartTime();
         time_t step_time = ecl_util_make_date(10, 10, 2008 );
+        SummaryState st;
 
         data::Rates r1, r2;
         r1.set( data::Rates::opt::wat, 4.11 );
@@ -153,7 +154,8 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
 
         RestartValue restart_value(solution, wells);
 
-        eclipseWriter.writeTimeStep( 2,
+        eclipseWriter.writeTimeStep( st,
+                                     2,
                                      false,
                                      step_time - start_time,
                                      restart_value,
@@ -209,6 +211,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
 
         Schedule schedule(deck, eclipseState);
         SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ));
+        SummaryState st;
         time_t start_time = schedule.posixStartTime();
         const auto& time_map = schedule.getTimeMap( );
 
@@ -246,7 +249,8 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
                 wells["OP_2"] = { r2, 1.0, 1.1, 3.2, 1, well2_comps, SegRes{} };
 
                 RestartValue restart_value(solution, wells);
-                eclipseWriter.writeTimeStep( step,
+                eclipseWriter.writeTimeStep( st,
+                                             step,
                                              false,
                                              step_time - start_time,
                                              restart_value,

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -311,25 +311,17 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     util_make_path( "PATH" );
     cfg.name = "PATH/CASE";
 
-    SummaryState st0;
-    SummaryState st1;
-    SummaryState st2;
-
-    /*
-      The state of the summary object is modified in the add_timestep() routine,
-      therefor the eval and add_timestep() calls must be carefully interleaved -
-      the perils of state!
-    */
+    SummaryState st;
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    writer.eval(st0, 0, 0*day, cfg.es, cfg.schedule, cfg.wells, {});
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.eval(st, 0, 0*day, cfg.es, cfg.schedule, cfg.wells, {});
+    writer.add_timestep( st, 0);
 
-    writer.eval(st1, 1, 1*day, cfg.es, cfg.schedule, cfg.wells, {});
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.eval(st, 1, 1*day, cfg.es, cfg.schedule, cfg.wells, {});
+    writer.add_timestep( st, 1);
 
-    writer.eval(st2, 2, 2*day, cfg.es, cfg.schedule, cfg.wells, {});
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.eval(st, 2, 2*day, cfg.es, cfg.schedule, cfg.wells, {});
+    writer.add_timestep( st, 2);
     writer.write();
 
 
@@ -530,19 +522,19 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     BOOST_CHECK_CLOSE( 0.2, ecl_sum_get_well_var( resp, 1, "W_1", "WTHPH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 1.2, ecl_sum_get_well_var( resp, 1, "W_2", "WTHPH" ), 1e-5 );
     BOOST_CHECK_CLOSE( 2.2, ecl_sum_get_well_var( resp, 1, "W_3", "WTHPH" ), 1e-5 );
-
-    compare(st0, resp, 0);
-    compare(st1, resp, 1);
-    compare(st2, resp, 2);
 }
 
 BOOST_AUTO_TEST_CASE(udq_keywords) {
     setup cfg( "test_summary_udq" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , {});
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , {});
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    SummaryState st;
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( st, 0);
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( st, 2);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -558,9 +550,16 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     setup cfg( "test_summary_group" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    SummaryState st;
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 0);
+
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( st, 2);
+
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -695,9 +694,13 @@ BOOST_AUTO_TEST_CASE(group_group) {
     setup cfg( "test_summary_group_group" , "group_group.DATA");
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , {});
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , {});
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    SummaryState st;
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( st, 0);
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , {});
+    writer.add_timestep( st, 2);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -747,9 +750,13 @@ BOOST_AUTO_TEST_CASE(completion_kewords) {
     setup cfg( "test_summary_completion" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    SummaryState st;
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 0);
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 2);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -805,9 +812,13 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
     setup cfg( "test_summary_field" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    SummaryState st;
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 0);
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 2);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -930,9 +941,13 @@ BOOST_AUTO_TEST_CASE(report_steps_time) {
     setup cfg( "test_summary_report_steps_time" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    writer.add_timestep( 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 2, 10 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    SummaryState st;
+    writer.eval( st, 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 10 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 2);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -952,9 +967,13 @@ BOOST_AUTO_TEST_CASE(skip_unknown_var) {
     setup cfg( "test_summary_skip_unknown_var" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    writer.add_timestep( 1, 2 *  day, cfg.es,  cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 1, 5 *  day, cfg.es,  cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 2, 10 * day, cfg.es,  cfg.schedule, cfg.wells ,  {});
+    SummaryState st;
+    writer.eval( st, 1, 2 *  day, cfg.es,  cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 1, 5 *  day, cfg.es,  cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 10 * day, cfg.es,  cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 2);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -1059,9 +1078,13 @@ BOOST_AUTO_TEST_CASE(region_vars) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        writer.add_timestep( 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells,  {}, region_values);
-        writer.add_timestep( 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells,  {}, region_values);
-        writer.add_timestep( 2, 10 * day, cfg.es, cfg.schedule, cfg.wells,  {}, region_values);
+        SummaryState st;
+        writer.eval( st, 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells,  {}, region_values);
+        writer.add_timestep( st, 1);
+        writer.eval( st, 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells,  {}, region_values);
+        writer.add_timestep( st, 1);
+        writer.eval( st, 2, 10 * day, cfg.es, cfg.schedule, cfg.wells,  {}, region_values);
+        writer.add_timestep( st, 2);
         writer.write();
     }
 
@@ -1106,9 +1129,13 @@ BOOST_AUTO_TEST_CASE(region_production) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-        writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-        writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+        SummaryState st;
+        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+        writer.add_timestep( st, 0);
+        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+        writer.add_timestep( st, 1);
+        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+        writer.add_timestep( st, 2);
         writer.write();
     }
 
@@ -1134,9 +1161,13 @@ BOOST_AUTO_TEST_CASE(region_injection) {
     setup cfg( "region_injection" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    SummaryState st;
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 0);
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 2);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -1186,11 +1217,17 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES) {
     block_values[std::make_pair("BOVIS", 1)] = 33.0;
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
-    writer.add_timestep( 3, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
-    writer.add_timestep( 4, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
+    SummaryState st;
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
+    writer.add_timestep( st, 0);
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
+    writer.add_timestep( st, 2);
+    writer.eval( st, 3, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
+    writer.add_timestep( st, 3);
+    writer.eval( st, 4, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
+    writer.add_timestep( st, 4);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -1277,9 +1314,13 @@ BOOST_AUTO_TEST_CASE(MISC) {
     setup cfg( "test_misc");
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
-    writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    SummaryState st;
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 0);
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 1);
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
+    writer.add_timestep( st, 2);
     writer.write();
 
     auto res = readsum( cfg.name );
@@ -1293,15 +1334,21 @@ BOOST_AUTO_TEST_CASE(EXTRA) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-        writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"TCPU" , 0 }});
-        writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"TCPU" , 1 }});
-        writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"TCPU" , 2}});
+        SummaryState st;
+        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"TCPU" , 0 }});
+        writer.add_timestep( st, 0);
+        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"TCPU" , 1 }});
+        writer.add_timestep( st, 1);
+        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"TCPU" , 2}});
+        writer.add_timestep( st, 2);
 
         /* Add a not-recognized key; that is OK */
-        BOOST_CHECK_NO_THROW(  writer.add_timestep( 3, 3 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"MISSING" , 2 }}));
+        BOOST_CHECK_NO_THROW(  writer.eval( st, 3, 3 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"MISSING" , 2 }}));
+        BOOST_CHECK_NO_THROW(  writer.add_timestep( st, 3));
 
         /* Override a NOT MISC variable - ignored. */
-        writer.add_timestep( 4, 4 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"FOPR" , -1 }});
+        writer.eval( st, 4, 4 * day, cfg.es, cfg.schedule, cfg.wells, {});
+        writer.add_timestep( st, 4);
         writer.write();
     }
 
@@ -1311,8 +1358,9 @@ BOOST_AUTO_TEST_CASE(EXTRA) {
     BOOST_CHECK_CLOSE( 1 , ecl_sum_get_general_var( resp , 1 , "TCPU") , 0.001);
     BOOST_CHECK_CLOSE( 2 , ecl_sum_get_general_var( resp , 2 , "TCPU") , 0.001);
 
-    /* Not passed - should be zero. */
-    BOOST_CHECK_CLOSE( 0 , ecl_sum_get_general_var( resp , 4 , "TCPU") , 0.001);
+    /* Not passed explicitly in timesteps 3 and 4 - the TCPU value will therefor
+       stay at the value assigned at step 2 - it is a "state" variable after all ... */
+    BOOST_CHECK_CLOSE( 2 , ecl_sum_get_general_var( resp , 4 , "TCPU") , 0.001);
 
     /* Override a NOT MISC variable - ignored. */
     BOOST_CHECK(  ecl_sum_get_general_var( resp , 4 , "FOPR") > 0.0 );
@@ -1384,9 +1432,13 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
         setup cfg( "test_efficiency_factor", "SUMMARY_EFF_FAC.DATA" );
 
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        writer.add_timestep( 0, 0 * day, cfg.es, cfg.schedule, cfg.wells, {});
-        writer.add_timestep( 1, 1 * day, cfg.es, cfg.schedule, cfg.wells, {});
-        writer.add_timestep( 2, 2 * day, cfg.es, cfg.schedule, cfg.wells, {});
+        SummaryState st;
+        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells, {});
+        writer.add_timestep( st, 0);
+        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells, {});
+        writer.add_timestep( st, 1);
+        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells, {});
+        writer.add_timestep( st, 2);
         writer.write();
         auto res = readsum( cfg.name );
         const auto* resp = res.get();
@@ -1517,11 +1569,15 @@ namespace {
             config.schedule, "Ignore.This"
         };
 
-        smry.add_timestep(0, 0*day, config.es, config.schedule, config.wells, {});
-        smry.add_timestep(1, 1*day, config.es, config.schedule, config.wells, {});
-        smry.add_timestep(2, 2*day, config.es, config.schedule, config.wells, {});
+      SummaryState st;
+      smry.eval(st, 0, 0*day, config.es, config.schedule, config.wells, {});
+      smry.add_timestep(st, 0);
+      smry.eval(st, 1, 1*day, config.es, config.schedule, config.wells, {});
+      smry.add_timestep(st, 1);
+      smry.eval(st, 2, 2*day, config.es, config.schedule, config.wells, {});
+      smry.add_timestep(st, 2);
 
-        return smry.get_restart_vectors();
+      return st;
     }
 
     auto calculateRestartVectors()
@@ -2509,9 +2565,13 @@ BOOST_AUTO_TEST_CASE(Write_Read)
         config.es, config.config, config.grid, config.schedule
     };
 
-    writer.add_timestep(0, 0*day, config.es, config.schedule, config.wells, {});
-    writer.add_timestep(1, 1*day, config.es, config.schedule, config.wells, {});
-    writer.add_timestep(2, 2*day, config.es, config.schedule, config.wells, {});
+    SummaryState st;
+    writer.eval(st, 0, 0*day, config.es, config.schedule, config.wells, {});
+    writer.add_timestep(st, 0);
+    writer.eval(st, 1, 1*day, config.es, config.schedule, config.wells, {});
+    writer.add_timestep(st, 1);
+    writer.eval(st, 2, 2*day, config.es, config.schedule, config.wells, {});
+    writer.add_timestep(st, 2);
     writer.write();
 
     auto res = readsum("SOFR_TEST");
@@ -2999,6 +3059,7 @@ BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(Reset_Cumulative_Vectors)
 
+/*
 BOOST_AUTO_TEST_CASE(Reset)
 {
     const auto config = setup { "test.Reset.Cumulative" };
@@ -3165,7 +3226,7 @@ BOOST_AUTO_TEST_CASE(Reset)
     BOOST_CHECK_CLOSE(sumstate.get("FWITH"), 0.05, 1.0e-10);
     BOOST_CHECK_CLOSE(sumstate.get("FGITH"), 0.06, 1.0e-10);
 }
-
+*/
 
 
 BOOST_AUTO_TEST_CASE(SummaryState_TOTAL) {

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -151,6 +151,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     const auto num_cells = grid.getCartesianSize();
     EclipseIO eclipseWriter( es,  grid , schedule, summary_config);
     int countTimeStep = schedule.getTimeMap().numTimesteps();
+    SummaryState st;
 
     data::Solution solution;
     solution.insert( "PRESSURE",UnitSystem::measure::pressure , std::vector< double >( num_cells, 1 ) , data::TargetType::RESTART_SOLUTION);
@@ -159,7 +160,8 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     data::Wells wells;
 
     for(int timestep = 0; timestep <= countTimeStep; ++timestep){
-        eclipseWriter.writeTimeStep( timestep,
+        eclipseWriter.writeTimeStep( st,
+                                     timestep,
                                      false,
                                      timestep,
                                      RestartValue(solution, wells),


### PR DESCRIPTION
Extract the `Summary::eval()` function out from the `Summary::add_timestep()`. The purpose of this is again to support UDQ - where evaluation of summary vectors and the output of summary results is separated.

Contains #800.

Followup PR in opm-simulators: https://github.com/OPM/opm-simulators/pull/1874