### PR TITLE
Move .gitmodules to root

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,8 @@
+[submodule "pycmake"]
+    path = python/pycmake
+    url = git://github.com/Statoil/pycmake.git
+    branch = 21f1eb9
+[submodule "pybind11"]
+    path = python/pybind11
+    url = git://github.com/pybind/pybind11.git
+    branch = add56ccdcac23a6c522a2c1174a866e293c61dab

--- a/python/.gitmodules
+++ b/python/.gitmodules
@@ -1,8 +1,0 @@
-[submodule "pycmake"]
-    path = pycmake
-    url = git://github.com/Statoil/pycmake.git
-    branch = 21f1eb9
-[submodule "pybind11"]
-	path = pybind11
-	url = git://github.com/pybind/pybind11.git
-	branch = add56ccdcac23a6c522a2c1174a866e293c61dab


### PR DESCRIPTION
Suggested patch for #803.

You can observe the changed behavior by comparing cloning opm-common master recursively:
```
git clone -q --recursive git@github.com:OPM/opm-common.git
```

with cloning this branch recursively:
```
git clone -b submodule_fix -q --recursive git@github.com:markusdregi/opm-common.git
```