### PR TITLE
Uda value reset

### DIFF
--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -41,6 +41,9 @@ public:
     template<typename T>
     bool is() const;
 
+
+    void assert_numeric() const;
+    void assert_numeric(const std::string& error_msg) const;
     void set_dim(const Dimension& dim) const;
     const Dimension& get_dim() const;
 

--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -41,6 +41,8 @@ public:
     template<typename T>
     bool is() const;
 
+    void reset(double value);
+    void reset(const std::string& value);
 
     void assert_numeric() const;
     void assert_numeric(const std::string& error_msg) const;

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -71,7 +71,14 @@ double UDAValue::get() const {
     return this->dim.convertRawToSi(this->double_value);
 }
 
-    throw std::invalid_argument("UDAValue does not hold a numerical value");
+void UDAValue::reset(double value) {
+    this->double_value = value;
+    this->numeric_value = true;
+}
+
+void UDAValue::reset(const std::string& value) {
+    this->string_value = value;
+    this->numeric_value = false;
 }
 
 template<>
@@ -96,6 +103,9 @@ bool UDAValue::operator==(const UDAValue& other) const {
     if (this->numeric_value != other.numeric_value)
         return false;
 
+    if (this->dim != other.dim)
+        return false;
+
     if (this->numeric_value)
         return (this->double_value == other.double_value);
 
@@ -114,4 +124,7 @@ std::ostream& operator<<( std::ostream& stream, const UDAValue& uda_value ) {
         stream << "'" << uda_value.get<std::string>() << "'";
     return stream;
 }
+
+
+
 }

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -40,6 +40,18 @@ UDAValue::UDAValue(const std::string& value):
 {
 }
 
+void UDAValue::assert_numeric() const {
+    std::string msg = "Internal error: The support for use of UDQ/UDA is not complete in opm/flow. The string: '" + this->string_value + "' must be numeric";
+    this->assert_numeric(msg);
+}
+
+
+void UDAValue::assert_numeric(const std::string& error_msg) const {
+    if (this->numeric_value)
+        return;
+
+    throw std::invalid_argument(error_msg);
+}
 
 template<>
 bool UDAValue::is<double>() const {

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -67,8 +67,9 @@ bool UDAValue::is<std::string>() const {
 
 template<>
 double UDAValue::get() const {
-    if (this->numeric_value)
-        return this->double_value;
+    this->assert_numeric();
+    return this->dim.convertRawToSi(this->double_value);
+}
 
     throw std::invalid_argument("UDAValue does not hold a numerical value");
 }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1041,6 +1041,12 @@ BOOST_AUTO_TEST_CASE(UDA_VALUE) {
     BOOST_CHECK(!value0.is<std::string>());
     BOOST_CHECK_EQUAL( value0.get<double>(), 0);
     BOOST_CHECK_THROW( value0.get<std::string>(), std::invalid_argument);
+    value0.reset( 10 );
+    BOOST_CHECK_EQUAL( value0.get<double>(), 10);
+    BOOST_CHECK_THROW( value0.get<std::string>(), std::invalid_argument);
+    value0.reset( "STRING" );
+    BOOST_CHECK_EQUAL( value0.get<std::string>(), std::string("STRING"));
+    BOOST_CHECK_THROW( value0.get<double>(), std::invalid_argument);
 
 
     UDAValue value1(10);

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1056,3 +1056,16 @@ BOOST_AUTO_TEST_CASE(UDA_VALUE) {
     BOOST_CHECK_EQUAL( value2.get<std::string>(), std::string("FUBHP"));
     BOOST_CHECK_THROW( value2.get<double>(), std::invalid_argument);
 }
+
+
+/*
+  The unit/dimension handling in the UDAvalue is hacky at best.
+*/
+
+BOOST_AUTO_TEST_CASE(UDA_VALUE_DIM) {
+    UDAValue value0(1);
+    Dimension dim("DUMMY", 10);
+    BOOST_CHECK_EQUAL( value0.get<double>(), 1);
+    value0.set_dim( dim );
+    BOOST_CHECK_EQUAL( value0.get<double>(), 10);
+}


### PR DESCRIPTION
The system for units does not really play nicely with the `UDAValue` class. This is a band aid fix.

The proper fix is to pass the dimension object along when constructing the UDAValue, but that will require quite invasive low-level changes to the deck construction code; will come back to that.