### PR TITLE
Use tolerances from command line for restart array SWEL

### DIFF
--- a/test_util/EclRegressionTest.hpp
+++ b/test_util/EclRegressionTest.hpp
@@ -155,7 +155,7 @@ private:
 
     // keywords that triggers strict tolerances
     const std::vector<std::string> keywordsStrictTol = {"COORD", "ZCORN", "PORV", "DEPTH", "DX", "DY", "DZ", "PERMX", "PERMY", "PERMZ", "NTG",
-                                                        "TRANX", "TRANY", "TRANZ", "TRANNNC", "SGRP", "SWEL", "SCON", "DOUBHEAD"
+                                                        "TRANX", "TRANY", "TRANZ", "TRANNNC", "SGRP", "SCON", "DOUBHEAD"
                                                        };
 
     // Only compare last occurrence


### PR DESCRIPTION
Some Items in SWEL array stem from the reservoir voidage rate target item of producer wells on history controls (WCONHIST). Hence not only on static input data. 
