### PR TITLE
Udq eval set

### DIFF
--- a/examples/msim.cpp
+++ b/examples/msim.cpp
@@ -48,6 +48,6 @@ int main(int /* argc */, char** argv) {
 
     Opm::msim msim(state);
     Opm::EclipseIO io(state, state.getInputGrid(), schedule, summary_config);
-    msim.run(schedule, io);
+    msim.run(schedule, io, false);
 }
 

--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -25,24 +25,23 @@ class SummaryState;
 class msim {
 
 public:
-    using well_rate_function = double(const EclipseState&, const Schedule&, const data::Solution&, size_t report_step, double seconds_elapsed);
+    using well_rate_function = double(const EclipseState&, const Schedule&, const SummaryState& st, const data::Solution&, size_t report_step, double seconds_elapsed);
     using solution_function = void(const EclipseState&, const Schedule&, data::Solution&, size_t report_step, double seconds_elapsed);
 
     msim(const EclipseState& state);
 
     void well_rate(const std::string& well, data::Rates::opt rate, std::function<well_rate_function> func);
     void solution(const std::string& field, std::function<solution_function> func);
-    void run(Schedule& schedule, EclipseIO& io);
+    void run(Schedule& schedule, EclipseIO& io, bool report_only);
     void post_step(Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
 private:
 
     void run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
     void run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const;
-    void output(const SummaryState& st, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const;
-    void simulate(const Schedule& schedule, data::Solution& sol, data::Wells& well_data, size_t report_step, double seconds_elapsed, double time_step) const;
+    void output(SummaryState& st, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const;
+    void simulate(const Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, double seconds_elapsed, double time_step) const;
 
     EclipseState state;
-
     std::map<std::string, std::map<data::Rates::opt, std::function<well_rate_function>>> well_rates;
     std::map<std::string, std::function<solution_function>> solutions;
 };

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -113,6 +113,7 @@ namespace UDQ {
     bool scalarFunc(UDQTokenType token_type);
     bool cmpFunc(UDQTokenType token_type);
 
+    std::string typeName(UDQVarType var_type);
 }
 }
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -292,6 +292,7 @@ struct fn_args {
     double duration;
     const int sim_step;
     int  num;
+    const SummaryState& st;
     const data::Wells& wells;
     const out::RegionCache& regionCache;
     const EclipseGrid& grid;
@@ -1323,6 +1324,7 @@ Summary::Summary( const EclipseState& st,
                                     0,           // Duration of time step
                                     0,           // Simulation step
                                     node.num(),
+                                    {},          // SummaryState
                                     {},          // Well results - data::Wells
                                     {},          // Region <-> cell mappings.
                                     this->grid,
@@ -1511,6 +1513,7 @@ void Summary::eval( SummaryState& st,
                                              duration,
                                              sim_step,
                                              num,
+                                             st,
                                              wells,
                                              this->regionCache,
                                              this->grid,
@@ -1522,6 +1525,7 @@ void Summary::eval( SummaryState& st,
                                         duration,
                                         sim_step,
                                         num,
+                                        st,
                                         {},
                                         this->regionCache,
                                         this->grid,

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -41,7 +41,7 @@ std::vector< T >& DeckItem::value_ref() {
 template<>
 const std::vector< int >& DeckItem::value_ref< int >() const {
     if( this->type != get_type< int >() )
-        throw std::invalid_argument( "DekcItem::velut_ref<int> Item of wrong type." );
+        throw std::invalid_argument( "DeckItem::value_ref<int> Item of wrong type. this->type: " + tag_name(this->type) + " " + this->name());
 
     return this->ival;
 }
@@ -57,7 +57,7 @@ const std::vector< double >& DeckItem::value_ref< double >() const {
 template<>
 const std::vector< std::string >& DeckItem::value_ref< std::string >() const {
     if( this->type != get_type< std::string >() )
-        throw std::invalid_argument( "DeckItem::value_ref<std::string> Item of wrong type." );
+        throw std::invalid_argument( "DeckItem::value_ref<std::string> Item of wrong type. this->type: " + tag_name(this->type) + " " + this->name());
 
     return this->sval;
 }
@@ -65,7 +65,7 @@ const std::vector< std::string >& DeckItem::value_ref< std::string >() const {
 template<>
 const std::vector< UDAValue >& DeckItem::value_ref< UDAValue >() const {
     if( this->type != get_type< UDAValue >() )
-        throw std::invalid_argument( "DeckItem::value_ref<UDAValue> Item of wrong type." );
+        throw std::invalid_argument( "DeckItem::value_ref<UDAValue> Item of wrong type. this->type: " + tag_name(this->type) + " " + this->name());
 
     return this->uval;
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -121,8 +121,7 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
 
         }
     }
-    std::cout << keyword << " = ";
-    this->ast = std::make_shared<UDQASTNode>( UDQParser::parse(this->udq_params, this->m_var_type, tokens, parseContext, errors) );
+    this->ast = std::make_shared<UDQASTNode>( UDQParser::parse(this->udq_params, this->m_var_type, this->m_keyword, tokens, parseContext, errors) );
     this->input_tokens = tokens;
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -241,6 +241,33 @@ bool compatibleTypes(UDQVarType lhs, UDQVarType rhs) {
     return false;
 }
 
+std::string typeName(UDQVarType var_type) {
+    switch (var_type) {
+    case UDQVarType::NONE:
+        return "NONE";
+    case UDQVarType::SCALAR:
+        return "SCALAR";
+    case UDQVarType::WELL_VAR:
+        return "WELL_VAR";
+    case UDQVarType::CONNECTION_VAR:
+        return "CONNECTION_VAR";
+    case UDQVarType::FIELD_VAR:
+        return "FIELD_VAR";
+    case UDQVarType::GROUP_VAR:
+        return "GROUP_VAR";
+    case UDQVarType::REGION_VAR:
+        return "REGION_VAR";
+    case UDQVarType::SEGMENT_VAR:
+        return "SEGMENT_VAR";
+    case UDQVarType::AQUIFER_VAR:
+        return "AQUIFER_VAR";
+    case UDQVarType::BLOCK_VAR:
+        return "BLOCK_VAR";
+    default:
+        throw std::runtime_error("Should not be here");
+    }
+}
+
 
 }
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -235,7 +235,7 @@ bool compatibleTypes(UDQVarType lhs, UDQVarType rhs) {
     if (lhs == rhs)
         return true;
 
-    if (lhs == UDQVarType::FIELD_VAR && rhs == UDQVarType::SCALAR)
+    if (rhs == UDQVarType::SCALAR)
         return true;
 
     return false;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
@@ -63,7 +63,7 @@ struct UDQParseNode {
 
 class UDQParser {
 public:
-    static UDQASTNode parse(const UDQParams& udq_params, UDQVarType target_type, const std::vector<std::string>& tokens, const ParseContext& parseContext, ErrorGuard& errors);
+  static UDQASTNode parse(const UDQParams& udq_params, UDQVarType target_type, const std::string& target_var, const std::vector<std::string>& tokens, const ParseContext& parseContext, ErrorGuard& errors);
 
 private:
     UDQParser(const UDQParams& udq_params, const std::vector<std::string>& tokens) :

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -44,7 +44,7 @@
 using namespace Opm;
 
 
-double prod_opr(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double seconds_elapsed) {
+double prod_opr(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double seconds_elapsed) {
     const auto& units = es.getUnits();
     return -units.to_si(UnitSystem::measure::rate, seconds_elapsed);
 }
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
         test_work_area_type * work_area = test_work_area_alloc("test_msim");
         EclipseIO io(state, state.getInputGrid(), schedule, summary_config);
 
-        msim.run(schedule, io);
+        msim.run(schedule, io, false);
 
         for (const auto& fname : {"SPE1CASE1.INIT", "SPE1CASE1.UNRST", "SPE1CASE1.EGRID", "SPE1CASE1.SMSPEC", "SPE1CASE1.UNSMRY"})
             BOOST_CHECK( util_is_file( fname ));

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -66,25 +66,25 @@ struct test_data {
 };
 
 
-double prod_opr(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
+double prod_opr(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double oil_rate = 1.0;
     return -units.to_si(UnitSystem::measure::rate, oil_rate);
 }
 
-double prod_opr_low(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
+double prod_opr_low(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double oil_rate = 0.5;
     return -units.to_si(UnitSystem::measure::rate, oil_rate);
 }
 
-double prod_wpr_P1(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
+double prod_wpr_P1(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double water_rate = 0.0;
     return -units.to_si(UnitSystem::measure::rate, water_rate);
 }
 
-double prod_wpr_P2(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
+double prod_wpr_P2(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double water_rate = 0.0;
     if (report_step > 5)
@@ -93,13 +93,13 @@ double prod_wpr_P2(const EclipseState&  es, const Schedule& /* sched */, const d
     return -units.to_si(UnitSystem::measure::rate, water_rate);
 }
 
-double prod_wpr_P3(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
+double prod_wpr_P3(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t /* report_step */, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double water_rate = 0.0;
     return -units.to_si(UnitSystem::measure::rate, water_rate);
 }
 
-double prod_wpr_P4(const EclipseState&  es, const Schedule& /* sched */, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
+double prod_wpr_P4(const EclipseState&  es, const Schedule& /* sched */, const SummaryState&, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
     const auto& units = es.getUnits();
     double water_rate = 0.0;
     if (report_step > 10)
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SORTA_EXAMPLE) {
         sim.well_rate("P3", data::Rates::opt::oil, prod_opr);
         sim.well_rate("P4", data::Rates::opt::oil, prod_opr_low);
 
-        sim.run(td.schedule, io);
+        sim.run(td.schedule, io, false);
         {
             const auto& w1 = td.schedule.getWell2("P1", 1);
             const auto& w4 = td.schedule.getWell2("P4", 1);
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(WELL_CLOSE_EXAMPLE) {
         }
 
 
-        sim.run(td.schedule, io);
+        sim.run(td.schedule, io, false);
         {
             const auto& w1 = td.schedule.getWell2("P1", 15);
             const auto& w3 = td.schedule.getWell2("P3", 15);
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(UDQ_ASSIGN) {
         sim.well_rate("P3", data::Rates::opt::wat, prod_wpr_P3);
         sim.well_rate("P4", data::Rates::opt::wat, prod_wpr_P4);
 
-        sim.run(td.schedule, io);
+        sim.run(td.schedule, io, false);
 
         const auto& base_name = td.state.getIOConfig().getBaseName();
 
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE(UDQ_WUWCT) {
         sim.well_rate("P3", data::Rates::opt::wat, prod_wpr_P3);
         sim.well_rate("P4", data::Rates::opt::wat, prod_wpr_P4);
 
-        sim.run(td.schedule, io);
+        sim.run(td.schedule, io, false);
 
         const auto& base_name = td.state.getIOConfig().getBaseName();
         ecl_sum_type * ecl_sum = ecl_sum_fread_alloc_case( base_name.c_str(), ":");


### PR DESCRIPTION
The first six commits are trivial - and part of #812. The purpose of the final commit is to ensure that scalar UDQ values are correctly scattered all wells/groups in a set.