### PR TITLE
Remove unused arguments from EclipseIO::writeTimestep()

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -114,10 +114,7 @@ void msim::output(const SummaryState& st, size_t report_step, bool /* substep */
                      report_step,
                      false,
                      seconds_elapsed,
-                     value,
-                     {},
-                     {},
-                     {});
+                     value);
 }
 
 

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -177,9 +177,6 @@ public:
                         bool isSubstep,
                         double seconds_elapsed,
                         RestartValue value,
-                        const std::map<std::string, double>& single_summary_values,
-                        const std::map<std::string, std::vector<double>>& region_summary_values,
-                        const std::map<std::pair<std::string, int>, double>& block_summary_values,
                         const bool write_double = false);
 
 

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -493,9 +493,6 @@ void EclipseIO::writeTimeStep(const SummaryState& st,
                               bool  isSubstep,
                               double secs_elapsed,
                               RestartValue value,
-                              const std::map<std::string, double>& single_summary_values,
-                              const std::map<std::string, std::vector<double> >& region_summary_values,
-                              const std::map<std::pair<std::string, int>, double>& block_summary_values,
                               const bool write_double)
  {
 

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -334,12 +334,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
                                      i,
                                      false,
                                      first_step - start_time,
-                                     restart_value,
-                                     {},
-                                     {},
-                                     {});
-
-
+                                     restart_value);
 
             checkRestartFile( i );
         }

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -158,10 +158,7 @@ BOOST_AUTO_TEST_CASE(test_RFT) {
                                      2,
                                      false,
                                      step_time - start_time,
-                                     restart_value,
-                                     {},
-                                     {},
-                                     {});
+                                     restart_value);
     }
 
     verifyRFTFile("TESTRFT.RFT");
@@ -253,10 +250,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2) {
                                              step,
                                              false,
                                              step_time - start_time,
-                                             restart_value,
-                                             {},
-                                             {},
-                                             {});
+                                             restart_value);
             }
             verifyRFTFile2("TESTRFT.RFT");
         }

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -483,7 +483,7 @@ RestartValue first_sim(const EclipseState& es, EclipseIO& eclWriter, SummaryStat
                              false,
                              first_step - start_time,
                              restart_value,
-			     {}, {}, {}, write_double);
+                             write_double);
 
     return restart_value;
 }

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -164,10 +164,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
                                      timestep,
                                      false,
                                      timestep,
-                                     RestartValue(solution, wells),
-                                     {},
-                                     {},
-                                     {} );
+                                     RestartValue(solution, wells));
     }
 
     verifyWellState(eclipse_restart_filename, grid, schedule);


### PR DESCRIPTION
Remove unused arguments to `Summary::add_timestep()`