### PR TITLE
UDQSet::eval - make sure to return well node

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.cpp
@@ -108,12 +108,7 @@ UDQSet UDQASTNode::eval(UDQVarType target_type, const UDQContext& context) const
                 int fnmatch_flags = 0;
                 const std::string& well_pattern = this->selector[0];
                 if (well_pattern.find("*") == std::string::npos)
-                    /*
-                      The well name has been fully qualified - i.e. this
-                       evaulates to a scalar, which will then subsequently be
-                       scattered to all wells.
-                    */
-                    return UDQSet::scalar(this->string_value, context.get_well_var(well_pattern, this->string_value));
+                    return UDQSet::wells(this->string_value, wells, context.get_well_var(well_pattern, this->string_value));
                 else {
                     auto res = UDQSet::wells(this->string_value, wells);
                     for (const auto& well : wells) {
@@ -137,12 +132,7 @@ UDQSet UDQASTNode::eval(UDQVarType target_type, const UDQContext& context) const
                 int fnmatch_flags = 0;
                 const std::string& group_pattern = this->selector[0];
                 if (group_pattern.find("*") == std::string::npos)
-                    /*
-                      The group name has been fully qualified - i.e. this
-                       evaulates to a scalar, which will then subsequently be
-                       scattered to all groups.
-                    */
-                    return UDQSet::scalar(this->string_value, context.get_group_var(group_pattern, this->string_value));
+                    return UDQSet::groups(this->string_value, groups, context.get_group_var(group_pattern, this->string_value));
                 else {
                     auto res = UDQSet::groups(this->string_value, groups);
                     for (const auto& group : groups) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -213,7 +213,7 @@ UDQVarType UDQSet::var_type() const {
 
 void UDQSet::operator+=(const UDQSet& rhs) {
     if (this->size() != rhs.size())
-        throw std::invalid_argument("Incompatible size");
+        throw std::invalid_argument("Incompatible size in UDQSet operator+");
 
     for (std::size_t index = 0; index < this->size(); index++)
         this->values[index] += rhs[index];

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1017,6 +1017,23 @@ BOOST_AUTO_TEST_CASE(UDQ_BASIC_MATH_TEST) {
     BOOST_CHECK_EQUAL( res_wuwct["P4"].value(),0.50);
 }
 
+BOOST_AUTO_TEST_CASE(DECK_TEST) {
+    UDQParams udqp;
+    UDQFunctionTable udqft(udqp);
+    UDQDefine def(udqp, "WUOPRL", {"(", "WOPR", "OP1", "-", "150", ")", "*", "0.90"});
+    SummaryState st;
+    UDQContext context(udqft, st);
+
+    st.update_well_var("OP1", "WOPR", 300);
+    st.update_well_var("OP2", "WOPR", 3000);
+    st.update_well_var("OP3", "WOPR", 30000);
+
+    auto res = def.eval(context);
+    BOOST_CHECK_EQUAL(res.size(), 3);
+    for (std::size_t index = 0; index < res.size(); index++)
+        BOOST_CHECK( res[index].value() == (300 - 150)*0.90);
+}
+
 
 BOOST_AUTO_TEST_CASE(UDQPARSE_TEST1) {
     UDQParams udqp;


### PR DESCRIPTION
In a UDQ expression where the well has been fully qualified:
```
UDQ  
   DEFINE WUOPRU (WOPR OP1 - 150) * 0.90 /
/
```
the return value should be a wellset where all wells have the same value.
