### PR TITLE
Add Well2::injectorType() accessor

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
@@ -78,6 +78,7 @@ public:
     bool canOpen() const;
     bool isProducer() const;
     bool isInjector() const;
+    WellInjector::TypeEnum injectorType() const;
     size_t seqIndex() const;
     bool getAutomaticShutIn() const;
     bool getAllowCrossFlow() const;
@@ -157,6 +158,10 @@ public:
     void switchToProducer();
     ProductionControls productionControls(const SummaryState& st) const;
     InjectionControls injectionControls(const SummaryState& st) const;
+
+    int vfp_table_number() const;
+    double alq_value() const;
+    double temperature() const;
 private:
     std::string wname;
     std::string group_name;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
@@ -365,6 +365,15 @@ bool Well2::isInjector() const {
 }
 
 
+WellInjector::TypeEnum Well2::injectorType() const {
+    if (this->producer)
+        throw std::runtime_error("Can not access injectorType attribute of a producer");
+
+    return this->injection->injectorType;
+}
+
+
+
 bool Well2::isAvailableForGroupControl() const {
     return this->guide_rate.available;
 }
@@ -699,6 +708,37 @@ InjectionControls Well2::injectionControls(const SummaryState& st) const {
     } else
         throw std::logic_error("Trying to get injection data from a producer");
 }
+
+
+/*
+  These three accessor functions are at the "wrong" level of abstraction;
+  the same properties are part of the InjectionControls and
+  ProductionControls structs. They are made available here to avoid passing
+  a SummaryState instance in situations where it is not really needed.
+*/
+
+
+int Well2::vfp_table_number() const {
+    if (this->producer)
+        return this->production->VFPTableNumber;
+    else
+        return this->injection->VFPTableNumber;
+}
+
+double Well2::alq_value() const {
+    if (this->producer)
+        return this->production->ALQValue;
+
+    throw std::runtime_error("Can not ask for ALQ value in an injector");
+}
+
+double Well2::temperature() const {
+    if (!this->producer)
+        return this->injection->temperature;
+
+    throw std::runtime_error("Can not ask for temperature in a producer");
+}
+
 
 }
 

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -759,3 +759,22 @@ BOOST_AUTO_TEST_CASE(WELL_CONTROLS) {
     Opm::SummaryState st;
     const auto prod_controls = well.productionControls(st);
 }
+
+
+BOOST_AUTO_TEST_CASE(ExtraAccessors) {
+    Opm::Well2 inj("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, WellCompletion::DEPTH, UnitSystem::newMETRIC());
+    Opm::Well2 prod("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, WellCompletion::DEPTH, UnitSystem::newMETRIC());
+
+    auto inj_props= std::make_shared<Opm::WellInjectionProperties>(inj.getInjectionProperties());
+    inj_props->VFPTableNumber = 100;
+    inj.updateInjection(inj_props);
+
+    auto prod_props = std::make_shared<Opm::WellProductionProperties>( prod.getProductionProperties() );
+    prod_props->VFPTableNumber = 200;
+    prod.updateProduction(prod_props);
+
+    BOOST_CHECK_THROW(inj.alq_value(), std::runtime_error);
+    BOOST_CHECK_THROW(prod.temperature(), std::runtime_error);
+    BOOST_CHECK_EQUAL(inj.vfp_table_number(), 100);
+    BOOST_CHECK_EQUAL(prod.vfp_table_number(), 200);
+}


### PR DESCRIPTION
This PR adds some accessors to the Well object bypassing the `SummaryState`object. This is slightly hacky, possibly the properties should be split in two structs - one which is UDQ aware and one which is not?

This will do for now though.

The downstream pr: https://github.com/OPM/opm-simulators/pull/1888 depends on this.