### PR TITLE
remove unused variables

### DIFF
--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -38,7 +38,6 @@ namespace {
 
 constexpr ParserItem::itype INT = ParserItem::itype::INT;
 constexpr ParserItem::itype STRING= ParserItem::itype::STRING;
-constexpr ParserItem::itype RAW_STRING = ParserItem::itype::RAW_STRING;
 constexpr ParserItem::itype DOUBLE = ParserItem::itype::DOUBLE;
 
 
@@ -959,9 +958,6 @@ BOOST_AUTO_TEST_CASE(ParserDoubleItemGetDimension) {
     BOOST_CHECK_EQUAL( "Length*Length*Length" , doubleItem.getDimension(2));
     BOOST_CHECK_THROW( doubleItem.getDimension( 3 ) , std::out_of_range );
 }
-
-const static auto SINGLE = ParserItem::item_size::SINGLE;
-const static auto ALL = ParserItem::item_size::ALL;
 
 BOOST_AUTO_TEST_CASE(DefaultConstructor_NoParams_NoThrow) {
     BOOST_CHECK_NO_THROW(ParserRecord record);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -757,5 +757,5 @@ BOOST_AUTO_TEST_CASE(CMODE_DEFAULT) {
 BOOST_AUTO_TEST_CASE(WELL_CONTROLS) {
     Opm::Well2 well("WELL", "GROUP", 0, 0, 0, 0, 1000, Opm::Phase::OIL, Opm::WellProducer::CMODE_UNDEFINED, Opm::WellCompletion::DEPTH, UnitSystem::newMETRIC());
     Opm::SummaryState st;
-    const auto prod_controls = well.productionControls(st);
+    well.productionControls(st);
 }


### PR DESCRIPTION
quell warnings