### PR TITLE
Array Dimension Checker: Correct Groupsize Criterion

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
@@ -114,7 +114,7 @@ namespace {
                 size = std::max(size, static_cast<std::size_t>(nwgmax));
             }
 
-            if (size >= static_cast<decltype(size)>(wdims.maxWellsPerGroup()))
+            if (size > static_cast<decltype(size)>(wdims.maxWellsPerGroup()))
             {
                 std::ostringstream os;
                 os << "Run uses maximum group size of " << size << ", but "


### PR DESCRIPTION
It is perfectly fine to have groups whose size (number of children) is equal to the declared maximum (Item 4 of WELLDIMS).  It is only questionable to have groups whose active size exceeds that of the declared maximum.

Pointy Hat: @bska