### PR TITLE
[discucssion] fixing the indices of COMPDAT in COMPLUMP test in scheduleTests

### DIFF
--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2105,11 +2105,11 @@ BOOST_AUTO_TEST_CASE( complump ) {
             /
 
             COMPDAT
-                'W1' 0 0 1 2 'SHUT' 1*    /
+                'W1' 0 0 1 1 'SHUT' 1*    /
                 'W1' 0 0 2 3 'SHUT' 1*    /
                 'W1' 0 0 4 6 'SHUT' 1*    /
                 'W2' 0 0 3 4 'SHUT' 1*    /
-                'W2' 0 0 1 4 'SHUT' 1*    /
+                'W2' 0 0 1 2 'SHUT' 1*    /
             /
 
             COMPLUMP


### PR DESCRIPTION
It is not actually a fix, since nothing was broken. I ran into it this with other developments. It is kind of interesting to discuss a little bit. 

Basically, should we allow overlapping indices when using `COMPDAT`.  The only consequence I can see is the ones declared later will overwrite the ones declared earlier. 