### PR TITLE
adding function getCompletionsByConnectionIndices to Well2

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
@@ -127,6 +127,21 @@ public:
     */
     std::map<int, std::vector<Connection>> getCompletions() const;
 
+    /*
+      The getCompletionsByConnnectionIndices() function will return a map:
+
+      {
+        1 : [ConnectionIndex, ConnectioniIndex],
+        2 : [ConnectionIndex, ConnectionIndex, ConnectoniIndex],
+        3 : [ConnectionIndex],
+        4 : [ConnectionIndex]
+      }
+
+      The integer ID's correspond to the COMPLETION id given by the COMPLUMP
+      keyword.
+    */
+    std::map<int, std::vector<int>> getCompletionsByConnectionIndices() const;
+
     bool updatePrediction(bool prediction_mode);
     bool updateAutoShutin(bool auto_shutin);
     bool updateCrossFlow(bool allow_cross_flow);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
@@ -497,6 +497,25 @@ std::map<int, std::vector<Connection>> Well2::getCompletions() const {
     return completions;
 }
 
+
+std::map<int, std::vector<int>> Well2::getCompletionsByConnectionIndices() const {
+    std::map<int, std::vector<int>> completions;
+
+    const auto& conns = *this->connections;
+    const int num_conns = conns.size();
+
+    for (int c = 0; c < num_conns; c++) {
+        auto pair = completions.find( conns[c].complnum() );
+        if (pair == completions.end())
+            completions[conns[c].complnum()] = {};
+
+        pair = completions.find(conns[c].complnum());
+        pair->second.push_back(c);
+    }
+
+    return completions;
+}
+
 Phase Well2::getPreferredPhase() const {
     return this->phase;
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2153,17 +2153,35 @@ BOOST_AUTO_TEST_CASE( complump ) {
     BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 2 ).state() );
     BOOST_CHECK_EQUAL( shut, sc1.getFromIJK( 2, 2, 3 ).state() );
 
-    const auto& completions = schedule.getWell2("W1", 1).getCompletions();
-    BOOST_CHECK_EQUAL(completions.size(), 4);
 
-    const auto& c1 = completions.at(1);
-    BOOST_CHECK_EQUAL(c1.size(), 3);
+    {
+        const auto& completions = schedule.getWell2("W1", 1).getCompletions();
+        BOOST_CHECK_EQUAL(completions.size(), 4);
 
-    for (const auto& pair : completions) {
-        if (pair.first == 1)
-            BOOST_CHECK(pair.second.size() > 1);
-        else
-            BOOST_CHECK_EQUAL(pair.second.size(), 1);
+        const auto& c1 = completions.at(1);
+        BOOST_CHECK_EQUAL(c1.size(), 3);
+
+        for (const auto& pair : completions) {
+            if (pair.first == 1)
+                BOOST_CHECK(pair.second.size() > 1);
+            else
+                BOOST_CHECK_EQUAL(pair.second.size(), 1);
+        }
+    }
+
+    {
+        const auto& completions = schedule.getWell2("W1", 1).getCompletionsByConnectionIndices();
+        BOOST_CHECK_EQUAL(completions.size(), 4);
+
+        const auto& c1 = completions.at(1);
+        BOOST_CHECK_EQUAL(c1.size(), 3);
+
+        for (const auto& pair : completions) {
+            if (pair.first == 1)
+                BOOST_CHECK_EQUAL(pair.second.size(), 3);
+            else
+                BOOST_CHECK_EQUAL(pair.second.size(), 1);
+        }
     }
 }
 


### PR DESCRIPTION
The function name is pretty bad. 

Basically, `getCompletions` returns `std::map<int, std::vector<Connection>> `, which is not easy to use in the simulator code, since we have to search to find the `connection number/index` for this `Connection`. 

A function return `std::map<int, std::vector<int>>` is added for the ease to handle COMPLUMP related in the simulator code. 

Please suggest what is the best way to do this. 