### PR TITLE
INTEHEAD: Store Actual Maximum Number of Groups in Item 21

### DIFF
--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -71,6 +71,7 @@ namespace {
 
     Opm::RestartIO::InteHEAD::WellTableDim
     getWellTableDims(const int              nwgmax,
+                     const int              ngmax,
                      const ::Opm::Runspec&  rspec,
                      const ::Opm::Schedule& sched,
                      const std::size_t      lookup_step)
@@ -86,7 +87,8 @@ namespace {
         const auto maxWellInGroup =
             std::max(wd.maxWellsPerGroup(), nwgmax);
 
-        const auto maxGroupInField = wd.maxGroupsInField();
+        const auto maxGroupInField =
+            std::max(wd.maxGroupsInField(), ngmax);
 
         return {
             numWells,
@@ -258,7 +260,8 @@ createInteHead(const EclipseState& es,
         .dimensions         (grid.getNXYZ())
         .numActive          (static_cast<int>(grid.getNumActive()))
         .unitConventions    (getUnitConvention(es.getDeckUnitSystem()))
-        .wellTableDimensions(getWellTableDims(nwgmax, rspec, sched, lookup_step))
+        .wellTableDimensions(getWellTableDims(nwgmax, ngmax, rspec,
+                                              sched, lookup_step))
         .calendarDate       (getSimulationTimePoint(sched.posixStartTime(), simTime))
         .activePhases       (getActivePhases(rspec))
              // The numbers below have been determined experimentally to work


### PR DESCRIPTION
Commit 7986e99e (PR #640) intended to make OPM Flow able to run simulation cases whose active number of groups might exceed the declared maximum number of (non-FIELD) groups (Item 3 of RUNSPEC keyword `WELLDIMS`).  However, the commit failed to ensure that Item 21 of INTEHEAD always contained the larger of `WELLDIMS(3)` and the actual number of active groups.

This, in turn, meant that downstream consumers&mdash;such as the code to [enumerate groups according to their order of appearance](https://github.com/OPM/opm-common/blob/599ed7136fbfaeeee61379e4dfe94a002e2b98f0/src/opm/output/eclipse/AggregateGroupData.cpp#L92-L104) in the simulation deck&mdash;would generate subscripts/indices that were out of bounds for the allocated tables.  Flow's restart code would then not produce any output and the user would not be aware of the problem until attempting to restart a simulation or trying to visualise 3D simulation results.

This commit corrects the situation by ensuring that we always store the larger of the two sizes in [`INTEHEAD(21)`](https://github.com/OPM/opm-common/blob/599ed7136fbfaeeee61379e4dfe94a002e2b98f0/src/opm/output/eclipse/InteHEAD.cpp#L503).

Pointy Hat: @bska