### PR TITLE
Replace LibECL Backend in Flow's INIT File Writing

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -191,6 +191,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/output/eclipse/Tables.cpp
           src/opm/output/eclipse/RegionCache.cpp
           src/opm/output/eclipse/RestartValue.cpp
+          src/opm/output/eclipse/WriteInit.cpp
           src/opm/output/data/Solution.cpp
       )
 endif()
@@ -607,6 +608,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/Summary.hpp
         opm/output/eclipse/Tables.hpp
         opm/output/eclipse/WindowedArray.hpp
+        opm/output/eclipse/WriteInit.hpp
         opm/output/eclipse/WriteRestartHelpers.hpp
         opm/output/OutputWriter.hpp
         )

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -48,6 +48,86 @@ namespace Opm { namespace EclIO { namespace OutputStream {
         std::string baseName;
     };
 
+    /// File manager for "init" output streams.
+    class Init
+    {
+    public:
+        /// Constructor.
+        ///
+        /// Opens file stream for writing.
+        ///
+        /// \param[in] rset Output directory and base name of output stream.
+        ///
+        /// \param[in] fmt Whether or not to create formatted output files.
+        explicit Init(const ResultSet& rset,
+                      const Formatted& fmt);
+
+        ~Init();
+
+        Init(const Init& rhs) = delete;
+        Init(Init&& rhs);
+
+        Init& operator=(const Init& rhs) = delete;
+        Init& operator=(Init&& rhs);
+
+        /// Write integer data to underlying output stream.
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&      kw,
+                   const std::vector<int>& data);
+
+        /// Write boolean data to underlying output stream.
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&       kw,
+                   const std::vector<bool>& data);
+
+        /// Write single precision floating point data to underlying
+        /// output stream.
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&        kw,
+                   const std::vector<float>& data);
+
+        /// Write double precision floating point data to underlying
+        /// output stream.
+        ///
+        /// \param[in] kw Name of output vector (keyword).
+        ///
+        /// \param[in] data Output values.
+        void write(const std::string&         kw,
+                   const std::vector<double>& data);
+
+    private:
+        /// Init file output stream.
+        std::unique_ptr<EclOutput> stream_;
+
+        /// Open output stream.
+        ///
+        /// Writes to \c stream_.
+        ///
+        /// \param[in] fname Filename of new output stream.
+        ///
+        /// \param[in] formatted Whether or not to create a
+        ///    formatted output file.
+        void open(const std::string& fname,
+                  const bool         formatted);
+
+        /// Access writable output stream.
+        EclOutput& stream();
+
+        /// Implementation function for public \c write overload set.
+        template <typename T>
+        void writeImpl(const std::string&    kw,
+                       const std::vector<T>& data);
+    };
+
     /// File manager for restart output streams.
     class Restart
     {

--- a/opm/output/eclipse/WriteInit.hpp
+++ b/opm/output/eclipse/WriteInit.hpp
@@ -1,0 +1,60 @@
+/*
+  Copyright (c) 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WRITE_INIT_HPP
+#define OPM_WRITE_INIT_HPP
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+    class EclipseGrid;
+    class EclipseState;
+    class NNC;
+    class Schedule;
+
+} // namespace Opm
+
+namespace Opm { namespace data {
+
+    class Solution;
+
+}} // namespace Opm::data
+
+namespace Opm { namespace EclIO { namespace OutputStream {
+
+    class Init;
+
+}}} // namespace Opm::EclIO::OutputStream
+
+namespace Opm { namespace InitIO {
+
+    void write(const ::Opm::EclipseState&              es,
+               const ::Opm::EclipseGrid&               grid,
+               const ::Opm::Schedule&                  schedule,
+               const ::Opm::data::Solution&            simProps,
+               std::map<std::string, std::vector<int>> int_data,
+               const ::Opm::NNC&                       nnc,
+               ::Opm::EclIO::OutputStream::Init&       initFile);
+
+}} // namespace Opm::InitIO
+
+#endif // OPM_WRITE_INIT_HPP

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -479,7 +479,7 @@ void EclipseIO::writeInitial( data::Solution simProps, std::map<std::string, std
 
         simProps.convertFromSI( es.getUnits() );
         if( ioConfig.getWriteINITFile() )
-            this->impl->writeINITFile( simProps , int_data, nnc );
+            this->impl->writeINITFile( simProps , std::move(int_data), nnc );
 
         if( ioConfig.getWriteEGRIDFile( ) )
             this->impl->writeEGRIDFile( nnc );

--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -1,0 +1,282 @@
+/*
+  Copyright (c) 2019 Equinor ASA
+  Copyright (c) 2016 Statoil ASA
+  Copyright (c) 2013-2015 Andreas Lauser
+  Copyright (c) 2013 SINTEF ICT, Applied Mathematics.
+  Copyright (c) 2013 Uni Research AS
+  Copyright (c) 2015 IRIS AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/WriteInit.hpp>
+
+#include <opm/io/eclipse/OutputStream.hpp>
+
+#include <opm/output/data/Solution.hpp>
+#include <opm/output/eclipse/Tables.hpp>
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+#include <cstddef>
+#include <exception>
+#include <stdexcept>
+#include <utility>
+
+namespace {
+    std::vector<float> singlePrecision(const std::vector<double>& x)
+    {
+        return { x.begin(), x.end() };
+    }
+
+    void writeInitFileHeader(const ::Opm::EclipseState&      es,
+                             const ::Opm::EclipseGrid&       grid,
+                             const ::Opm::Schedule&          sched,
+                             Opm::EclIO::OutputStream::Init& initFile)
+    {
+        {
+            const auto ih = ::Opm::RestartIO::Helpers::
+                createInteHead(es, grid, sched, 0.0, 0, 0);
+
+            initFile.write("INTEHEAD", ih);
+        }
+
+        {
+            const auto lh = ::Opm::RestartIO::Helpers::
+                createLogiHead(es);
+
+            initFile.write("LOGIHEAD", lh);
+        }
+
+        {
+            const auto dh = ::Opm::RestartIO::Helpers::
+                createDoubHead(es, sched, 0, 0.0, 0.0);
+
+            initFile.write("DOUBHEAD", dh);
+        }
+    }
+
+    void writePoreVolume(const ::Opm::EclipseState&        es,
+                         const ::Opm::EclipseGrid&         grid,
+                         const ::Opm::UnitSystem&          units,
+                         ::Opm::EclIO::OutputStream::Init& initFile)
+    {
+        auto porv = es.get3DProperties()
+            .getDoubleGridProperty("PORV").getData();
+
+        for (auto nGlob    = porv.size(),
+                  globCell = 0*nGlob; globCell < nGlob; ++globCell)
+        {
+            if (! grid.cellActive(globCell)) {
+                porv[globCell] = 0.0;
+            }
+        }
+
+        units.from_si(::Opm::UnitSystem::measure::volume, porv);
+
+        initFile.write("PORV", singlePrecision(porv));
+    }
+
+    void writeGridGeometry(const ::Opm::EclipseGrid&         grid,
+                           const ::Opm::UnitSystem&          units,
+                           ::Opm::EclIO::OutputStream::Init& initFile)
+    {
+        const auto length = ::Opm::UnitSystem::measure::length;
+        const auto nAct   = grid.getNumActive();
+
+        auto dx    = std::vector<float>{};  dx   .reserve(nAct);
+        auto dy    = std::vector<float>{};  dy   .reserve(nAct);
+        auto dz    = std::vector<float>{};  dz   .reserve(nAct);
+        auto depth = std::vector<float>{};  depth.reserve(nAct);
+
+        for (auto cell = 0*nAct; cell < nAct; ++cell) {
+            const auto  globCell = grid.getGlobalIndex(cell);
+            const auto& dims     = grid.getCellDims(globCell);
+
+            dx   .push_back(units.from_si(length, dims[0]));
+            dy   .push_back(units.from_si(length, dims[1]));
+            dz   .push_back(units.from_si(length, dims[2]));
+            depth.push_back(units.from_si(length, grid.getCellDepth(globCell)));
+        }
+
+        initFile.write("DEPTH", depth);
+        initFile.write("DX"   , dx);
+        initFile.write("DY"   , dy);
+        initFile.write("DZ"   , dz);
+    }
+
+    void writeDoubleCellProperties(const ::Opm::EclipseState&        es,
+                                   const ::Opm::EclipseGrid&         grid,
+                                   const ::Opm::UnitSystem&          units,
+                                   ::Opm::EclIO::OutputStream::Init& initFile)
+    {
+        using double_kw = std::pair<std::string, ::Opm::UnitSystem::measure>;
+
+        // This is a rather arbitrary hardcoded list of 3D keywords
+        // which are written to the INIT file, if they are in the
+        // current EclipseState.
+        const auto doubleKeywords = std::vector<double_kw> {
+            {"PORO"  , ::Opm::UnitSystem::measure::identity },
+            {"PERMX" , ::Opm::UnitSystem::measure::permeability },
+            {"PERMY" , ::Opm::UnitSystem::measure::permeability },
+            {"PERMZ" , ::Opm::UnitSystem::measure::permeability },
+            {"NTG"   , ::Opm::UnitSystem::measure::identity },
+        };
+
+        // The INIT file should always contain the NTG property, we
+        // therefore invoke the auto create functionality to ensure
+        // that "NTG" is included in the properties container.
+        const auto& properties = es.get3DProperties().getDoubleProperties();
+        properties.assertKeyword("NTG");
+
+        for (const auto& kw_pair : doubleKeywords) {
+            if (! properties.hasKeyword( kw_pair.first)) {
+                continue;
+            }
+
+            const auto& opm_property = properties.getKeyword(kw_pair.first);
+            auto ecl_data = opm_property.compressedCopy(grid);
+            units.from_si(kw_pair.second, ecl_data);
+
+            initFile.write(kw_pair.first, singlePrecision(ecl_data));
+        }
+    }
+
+    void writeIntegerCellProperties(const ::Opm::EclipseState&        es,
+                                    const ::Opm::EclipseGrid&         grid,
+                                    ::Opm::EclIO::OutputStream::Init& initFile)
+    {
+        const auto& properties = es.get3DProperties().getIntProperties();
+
+        // The INIT file should always contain PVT, saturation function,
+        // equilibration, and fluid-in-place region vectors.  Call
+        // assertKeyword() here--on a 'const' GridProperties object--to
+        // invoke the autocreation property, and ensure that the keywords
+        // exist in the properties container.
+        properties.assertKeyword("PVTNUM");
+        properties.assertKeyword("SATNUM");
+        properties.assertKeyword("EQLNUM");
+        properties.assertKeyword("FIPNUM");
+
+        for (const auto& property : properties) {
+            auto ecl_data = property.compressedCopy(grid);
+
+            initFile.write(property.getKeywordName(), ecl_data);
+        }
+    }
+
+    void writeSimulatorProperties(const ::Opm::EclipseGrid&         grid,
+                                  const ::Opm::data::Solution&      simProps,
+                                  ::Opm::EclIO::OutputStream::Init& initFile)
+    {
+        for (const auto& prop : simProps) {
+            const auto& value = grid.compressedVector(prop.second.data);
+
+            initFile.write(prop.first, singlePrecision(value));
+        }
+    }
+
+    void writeTableData(const ::Opm::EclipseState&        es,
+                        const ::Opm::UnitSystem&          units,
+                        ::Opm::EclIO::OutputStream::Init& initFile)
+    {
+        ::Opm::Tables tables(units);
+
+        tables.addPVTTables(es);
+        tables.addDensity(es.getTableManager().getDensityTable());
+        tables.addSatFunc(es);
+
+        initFile.write("TABDIMS", tables.tabdims());
+        initFile.write("TAB"    , tables.tab());
+    }
+
+    void writeIntegerMaps(std::map<std::string, std::vector<int>> mapData,
+                          ::Opm::EclIO::OutputStream::Init&       initFile)
+    {
+        for (const auto& pair : mapData) {
+            const auto& key = pair.first;
+
+            if (key.size() > std::size_t{8}) {
+                throw std::invalid_argument {
+                    "Keyword '" + key + "'is too long."
+                };
+            }
+
+            initFile.write(key, pair.second);
+        }
+    }
+
+    void writeNonNeighbourConnections(const ::Opm::NNC&                 nnc,
+                                      const ::Opm::UnitSystem&          units,
+                                      ::Opm::EclIO::OutputStream::Init& initFile)
+    {
+        auto tran = std::vector<double>{};
+        tran.reserve(nnc.numNNC());
+
+        for (const auto& nd : nnc.nncdata()) {
+            tran.push_back(nd.trans);
+        }
+
+        units.from_si(::Opm::UnitSystem::measure::transmissibility, tran);
+
+        initFile.write("TRANNNC", singlePrecision(tran));
+    }
+} // Anonymous namespace
+
+void Opm::InitIO::write(const ::Opm::EclipseState&              es,
+                        const ::Opm::EclipseGrid&               grid,
+                        const ::Opm::Schedule&                  schedule,
+                        const ::Opm::data::Solution&            simProps,
+                        std::map<std::string, std::vector<int>> int_data,
+                        const ::Opm::NNC&                       nnc,
+                        ::Opm::EclIO::OutputStream::Init&       initFile)
+{
+    const auto& units = es.getUnits();
+
+    writeInitFileHeader(es, grid, schedule, initFile);
+
+    // The PORV vector is a special case.  This particular vector always
+    // holds a total of nx*ny*nz elements, and the elements are explicitly
+    // set to zero for inactive cells.  This treatment implies that the
+    // active/inactive cell mapping can be inferred by reading the PORV
+    // vector from the result set.
+    writePoreVolume(es, grid, units, initFile);
+
+    writeGridGeometry(grid, units, initFile);
+
+    writeDoubleCellProperties(es, grid, units, initFile);
+
+    writeSimulatorProperties(grid, simProps, initFile);
+
+    writeTableData(es, units, initFile);
+
+    writeIntegerCellProperties(es, grid, initFile);
+
+    writeIntegerMaps(std::move(int_data), initFile);
+
+    if (true || (nnc.numNNC() > std::size_t{0})) {
+        writeNonNeighbourConnections(nnc, units, initFile);
+    }
+}


### PR DESCRIPTION
This Pull Request introduces a new file manager,
```C++
class Opm::EclIO::OutputStream::Init
```
that replaces the low-level operations of Flow's INIT file writer.  The implementation uses the [`EclOutput`](https://github.com/OPM/opm-common/blob/bf752c81a572f91a81cdb5668c1922d975a25bc4/opm/io/eclipse/EclOutput.hpp#L36) class and is very similar to that of the `Restart` stream introduced in commit 992d3b0.  It handles both formatted (`*.FINIT`) and unformatted (`*.INIT`) outputfiles.  The commonality between the two file managers might possibly be extracted to a base class at a later time.

We furthermore add a new free function, `void Opm::InitIO::write()`, that extracts the current known outputs from `Opm::EclipseIO::Impl::writeINITFile()` into a separate file (`WriteInit.cpp`) and writes those outputs in terms of `Opm::EclIO::OutputStream::Init`.  Finally we switch the implementation of `EclipseIO::Impl::writeINITFile()` to using `Opm::InitIO::write()`.

Collectively, these changes replace the existing LibECL-based backend of Flow's INIT-file writer with a backend based on `EclOutput`.