### PR TITLE
Silence shadowing warnings

### DIFF
--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -29,7 +29,7 @@ class ESmry
 public:
     explicit ESmry(const std::string& filename, bool loadBaseRunData=false);   // filename (smspec file) or file root name
 
-    const int numberOfVectors() const { return nVect; }
+    int numberOfVectors() const { return nVect; }
 
     bool hasKey(const std::string& key) const;
 
@@ -40,7 +40,7 @@ private:
     int nVect, nI, nJ, nK;
     std::string path="";
 
-    void ijk_from_global_index(int glob, int &i, int &j, int &k);
+    void ijk_from_global_index(int glob, int &i, int &j, int &k) const;
     std::vector<std::vector<float>> param;
     std::vector<std::string> keyword;
 
@@ -50,7 +50,7 @@ private:
     void getRstString(const std::vector<std::string> &restartArray, std::string &path, std::string &rootN) const;
     void updatePathAndRootName(std::string &path, std::string &rootN) const;
 
-    std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num);
+    std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num) const;
 };
 
 }} // namespace Opm::EclIO

--- a/opm/output/eclipse/AggregateGroupData.hpp
+++ b/opm/output/eclipse/AggregateGroupData.hpp
@@ -58,10 +58,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 	explicit AggregateGroupData(const std::vector<int>& inteHead);
 
 	void captureDeclaredGroupData(const Opm::Schedule&                 sched,
-				      const std::vector<std::string>&      restart_group_keys,
-				      const std::vector<std::string>&      restart_field_keys,
-				      const std::map<std::string, size_t>& groupKeyToIndex,
-				      const std::map<std::string, size_t>& fieldKeyToIndex,
 				      const std::size_t                    simStep,
 				      const Opm::SummaryState&             sumState,
 				      const std::vector<int>&              inteHead);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/InjectionControls.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/InjectionControls.hpp
@@ -40,8 +40,8 @@ public:
     int    vfp_table_number;
     bool   prediction_mode;
 
-    bool hasControl(WellInjector::ControlModeEnum cmode) const {
-        return (this->controls & cmode) != 0;
+    bool hasControl(WellInjector::ControlModeEnum cmode_arg) const {
+        return (this->controls & cmode_arg) != 0;
     }
 private:
     int controls;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/ProductionControls.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/ProductionControls.hpp
@@ -43,8 +43,8 @@ public:
     int    vfp_table_number;
     bool   prediction_mode;
 
-    bool hasControl(WellProducer::ControlModeEnum cmode) const {
-        return (this->controls & cmode) != 0;
+    bool hasControl(WellProducer::ControlModeEnum cmode_arg) const {
+        return (this->controls & cmode_arg) != 0;
     }
 
 private:

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -486,10 +486,6 @@ AggregateGroupData(const std::vector<int>& inteHead)
 void
 Opm::RestartIO::Helpers::AggregateGroupData::
 captureDeclaredGroupData(const Opm::Schedule&                 sched,
-			 const std::vector<std::string>&      restart_group_keys,
-			 const std::vector<std::string>&      restart_field_keys,
-			 const std::map<std::string, size_t>& groupKeyToIndex,
-			 const std::map<std::string, size_t>& fieldKeyToIndex,
 			 const std::size_t                    simStep,
 			 const Opm::SummaryState&             sumState,
 			 const std::vector<int>&              inteHead)
@@ -524,15 +520,13 @@ captureDeclaredGroupData(const Opm::Schedule&                 sched,
     });
 
     // Define Dynamic Contributions to XGrp Array.
-    groupLoop(curGroups, [&restart_group_keys, &restart_field_keys,
-                          &groupKeyToIndex, &fieldKeyToIndex,
-                          &sumState, this]
+    groupLoop(curGroups, [&sumState, this]
 	(const Group& group, const std::size_t groupID) -> void
     {
         auto xg = this->xGroup_[groupID];
 
-        XGrp::dynamicContrib(restart_group_keys, restart_field_keys,
-                             groupKeyToIndex, fieldKeyToIndex, group,
+        XGrp::dynamicContrib(this->restart_group_keys, this->restart_field_keys,
+                             this->groupKeyToIndex, this->fieldKeyToIndex, group,
                              sumState, xg);
     });
 

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -420,11 +420,8 @@ namespace {
 
         template <class ISegArray>
         void staticContrib(const Opm::Well2&       well,
-                           const std::size_t       rptStep,
                            const std::vector<int>& inteHead,
-                           const Opm::EclipseGrid&  /* grid */,
-                           ISegArray&              iSeg
-                           )
+                           ISegArray&              iSeg)
         {
             if (well.isMultiSegment()) {
                 //loop over segment set and print out information
@@ -474,7 +471,6 @@ namespace {
 
         template <class RSegArray>
         void staticContrib_useMSW(const Opm::Well2&           well,
-                                  const std::size_t           rptStep,
                                   const std::vector<int>&     inteHead,
                                   const Opm::EclipseGrid&     grid,
                                   const Opm::UnitSystem&      units,
@@ -492,10 +488,7 @@ namespace {
                 //loop over segment set and print out information
                 const auto&  noElmSeg  = nrsegz(inteHead);
                 const auto& welSegSet = well.getSegments();
-                const auto& segNumber  = welSegSet[segIndex].segmentNumber();
-
-                // 'stringSegNum' is one-based (1 .. #segments inclusive)
-                std::string stringSegNum = std::to_string(segNumber);
+                auto segNumber = welSegSet[segIndex].segmentNumber();
 
                 const auto& conn0 = well.getConnections();
                 const auto& welConns = Opm::WellConnections(conn0, grid);
@@ -516,6 +509,8 @@ namespace {
                 if (haveWellRes) {
                     sSFR = getSegmentSetFlowRates(welSegSet, wRatesIt->second.connections, welConns, units);
                 }
+                // 'stringSegNum' is one-based (1 .. #segments inclusive)
+                std::string stringSegNum = std::to_string(segNumber);
                 auto get = [&smry, &wname, &stringSegNum](const std::string& vector)
                 {
                     // 'stringSegNum' is one-based (1 .. #segments inclusive)
@@ -569,7 +564,7 @@ namespace {
                 //Treat subsequent segments
                 for (segIndex = 1; segIndex < welSegSet.size(); segIndex++) {
 
-                    const auto& segNumber = welSegSet[segIndex].segmentNumber();
+                    segNumber = welSegSet[segIndex].segmentNumber();
                     // 'stringSegNum' is one-based (1 .. #segments inclusive)
                     stringSegNum = std::to_string(segNumber);
 
@@ -648,7 +643,6 @@ namespace {
 
         template <class ILBSArray>
         void staticContrib(const Opm::Well2& well,
-                           const std::size_t rptStep,
                            ILBSArray&        iLBS)
         {
             if (well.isMultiSegment()) {
@@ -688,7 +682,6 @@ namespace {
 
         template <class ILBRArray>
         void staticContrib(const Opm::Well2&  well,
-                           const std::size_t rptStep,
                            const std::vector<int>& inteHead,
                            ILBRArray&        iLBR)
         {
@@ -748,42 +741,42 @@ captureDeclaredMSWData(const Schedule&         sched,
     }
     // Extract Contributions to ISeg Array
     {
-        MSWLoop(msw, [rptStep, inteHead, &grid, this]
+        MSWLoop(msw, [&inteHead, this]
             (const Well2& well, const std::size_t mswID) -> void
         {
             auto imsw = this->iSeg_[mswID];
 
-            ISeg::staticContrib(well, rptStep, inteHead, grid, imsw);
+            ISeg::staticContrib(well, inteHead, imsw);
         });
     }
     // Extract Contributions to RSeg Array
     {
-        MSWLoop(msw, [&units, rptStep, inteHead, &grid, &smry, this, &wr]
+        MSWLoop(msw, [&units, &inteHead, &grid, &smry, this, &wr]
             (const Well2& well, const std::size_t mswID) -> void
         {
             auto rmsw = this->rSeg_[mswID];
 
-            RSeg::staticContrib_useMSW(well, rptStep, inteHead, grid, units, smry, wr, rmsw);
+            RSeg::staticContrib_useMSW(well, inteHead, grid, units, smry, wr, rmsw);
         });
     }
     // Extract Contributions to ILBS Array
     {
-        MSWLoop(msw, [rptStep, this]
+        MSWLoop(msw, [this]
             (const Well2& well, const std::size_t mswID) -> void
         {
             auto ilbs_msw = this->iLBS_[mswID];
 
-            ILBS::staticContrib(well, rptStep, ilbs_msw);
+            ILBS::staticContrib(well, ilbs_msw);
         });
     }
     // Extract Contributions to ILBR Array
     {
-        MSWLoop(msw, [rptStep, inteHead, this]
+        MSWLoop(msw, [&inteHead, this]
             (const Well2& well, const std::size_t mswID) -> void
         {
             auto ilbr_msw = this->iLBR_[mswID];
 
-            ILBR::staticContrib(well, rptStep, inteHead, ilbr_msw);
+            ILBR::staticContrib(well, inteHead, ilbr_msw);
         });
     }
 }

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -229,15 +229,7 @@ namespace {
 
         auto  groupData = Helpers::AggregateGroupData(ih);
 
-        const auto& rst_g_keys  = groupData.restart_group_keys;
-        const auto& rst_f_keys  = groupData.restart_field_keys;
-        const auto& grpKeyToInd = groupData.groupKeyToIndex;
-        const auto& fldKeyToInd = groupData.fieldKeyToIndex;
-
-        groupData.captureDeclaredGroupData(schedule,
-                                           rst_g_keys, rst_f_keys,
-                                           grpKeyToInd, fldKeyToInd,
-                                           simStep, sumState, ih);
+        groupData.captureDeclaredGroupData(schedule, simStep, sumState, ih);
 
         rstFile.write("IGRP", groupData.getIGroup());
         rstFile.write("SGRP", groupData.getSGroup());

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1580,8 +1580,7 @@ void Summary::eval( SummaryState& st,
 
 void Summary::internal_store(const SummaryState& st, int report_step) {
     auto* tstep = ecl_sum_add_tstep( this->ecl_sum.get(), report_step, st.get_elapsed() );
-    const ecl_sum_type * ecl_sum = this->ecl_sum.get();
-    const ecl_smspec_type * smspec = ecl_sum_get_smspec(ecl_sum);
+    const ecl_smspec_type * smspec = ecl_sum_get_smspec(this->ecl_sum.get());
     auto num_nodes = ecl_smspec_num_nodes(smspec);
     for (int node_index = 0; node_index < num_nodes; node_index++) {
         const auto& smspec_node = ecl_smspec_iget_node(smspec, node_index);

--- a/src/opm/output/eclipse/Tables.cpp
+++ b/src/opm/output/eclipse/Tables.cpp
@@ -2355,13 +2355,13 @@ namespace Opm {
             const auto numPrimary =
                 std::max(numPressNodes, PVTFunc::Gas::maxNumPressNodes(pvtg));
 
-            const auto data = PVTFunc::Gas::
+            const auto tableData = PVTFunc::Gas::
                 fromPVTG(numCompNodes, numPrimary, this->units, pvtg);
 
             const auto pressData = PVTFunc::Gas::
                 pressureNodes(numPrimary, this->units, pvtg);
 
-            this->addData(TABDIMS_IBPVTG_OFFSET_ITEM, data);
+            this->addData(TABDIMS_IBPVTG_OFFSET_ITEM, tableData);
             this->addData(TABDIMS_JBPVTG_OFFSET_ITEM, pressData);
 
             this->m_tabdims[TABDIMS_NPPVTG_ITEM] = numPrimary;
@@ -2375,9 +2375,9 @@ namespace Opm {
             const auto numRows =
                 std::max(numPressNodes, PVTFunc::Gas::maxNumPressNodes(pvdg));
 
-            const auto data = PVTFunc::Gas::fromPVDG(numRows, this->units, pvdg);
+            const auto tableData = PVTFunc::Gas::fromPVDG(numRows, this->units, pvdg);
 
-            this->addData(TABDIMS_IBPVTG_OFFSET_ITEM, data);
+            this->addData(TABDIMS_IBPVTG_OFFSET_ITEM, tableData);
             this->m_tabdims[TABDIMS_NPPVTG_ITEM] = numRows;
             this->m_tabdims[TABDIMS_NTPVTG_ITEM] = pvdg.size();
         }
@@ -2409,13 +2409,13 @@ namespace Opm {
             const auto numRows =
                 std::max(numPressNodes, PVTFunc::Oil::maxNumPressNodes(pvto));
 
-            const auto data = PVTFunc::Oil::
+            const auto tableData = PVTFunc::Oil::
                 fromPVTO(numCompNodes, numRows, this->units, pvto);
 
             const auto rsData = PVTFunc::Oil::
                 compositionNodes(numCompNodes, this->units, pvto);
 
-            this->addData(TABDIMS_IBPVTO_OFFSET_ITEM, data);
+            this->addData(TABDIMS_IBPVTO_OFFSET_ITEM, tableData);
             this->addData(TABDIMS_JBPVTO_OFFSET_ITEM, rsData);
 
             this->m_tabdims[TABDIMS_NPPVTO_ITEM] = numRows;
@@ -2429,9 +2429,9 @@ namespace Opm {
             const auto numRows =
                 std::max(numPressNodes, PVTFunc::Oil::maxNumPressNodes(pvdo));
 
-            const auto data = PVTFunc::Oil::fromPVDO(numRows, this->units, pvdo);
+            const auto tableData = PVTFunc::Oil::fromPVDO(numRows, this->units, pvdo);
 
-            this->addData(TABDIMS_IBPVTO_OFFSET_ITEM, data);
+            this->addData(TABDIMS_IBPVTO_OFFSET_ITEM, tableData);
             this->m_tabdims[TABDIMS_NPPVTO_ITEM] = numRows;
             this->m_tabdims[TABDIMS_NTPVTO_ITEM] = pvdo.size();
         }
@@ -2441,9 +2441,9 @@ namespace Opm {
 
             const auto numRows = std::max(numPressNodes, pvcdo.size());
 
-            const auto data = PVTFunc::Oil::fromPVCDO(numRows, this->units, pvcdo);
+            const auto tableData = PVTFunc::Oil::fromPVCDO(numRows, this->units, pvcdo);
 
-            this->addData(TABDIMS_IBPVTO_OFFSET_ITEM, data);
+            this->addData(TABDIMS_IBPVTO_OFFSET_ITEM, tableData);
             this->m_tabdims[TABDIMS_NPPVTO_ITEM] = numRows;
             this->m_tabdims[TABDIMS_NTPVTO_ITEM] = pvcdo.size();
         }
@@ -2459,9 +2459,9 @@ namespace Opm {
             return;
         }
 
-        const auto data = PVTFunc::Water::fromPVTW(this->units, pvtw);
+        const auto tableData = PVTFunc::Water::fromPVTW(this->units, pvtw);
 
-        this->addData(TABDIMS_IBPVTW_OFFSET_ITEM, data);
+        this->addData(TABDIMS_IBPVTW_OFFSET_ITEM, tableData);
         this->m_tabdims[TABDIMS_NTPVTW_ITEM] = pvtw.size();
     }
 

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -90,8 +90,8 @@ std::string UDAValue::get() const {
 }
 
 
-void UDAValue::set_dim(const Dimension& dim) const {
-    this->dim = dim;
+void UDAValue::set_dim(const Dimension& dim_arg) const {
+    this->dim = dim_arg;
 }
 
 const Dimension& UDAValue::get_dim() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.cpp
@@ -32,8 +32,8 @@
 namespace Opm {
 
 ActionAST::ActionAST(const std::vector<std::string>& tokens) {
-    auto condition = ActionParser::parse(tokens);
-    this->condition.reset( new ASTNode(condition) );
+    auto condition_node = ActionParser::parse(tokens);
+    this->condition.reset( new ASTNode(condition_node) );
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1975,7 +1975,6 @@ namespace Opm {
 
 
     std::vector<std::string> Schedule::wellNames(const std::string& pattern, size_t timeStep, const std::vector<std::string>& matching_wells) const {
-        std::vector<std::string> names;
         if (pattern.size() == 0)
             return {};
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
@@ -115,18 +115,18 @@ Well2::Well2(const std::string& wname,
     this->updateProduction(p);
 }
 
-bool Well2::updateEfficiencyFactor(double efficiency_factor) {
-    if (this->efficiency_factor != efficiency_factor) {
-        this->efficiency_factor = efficiency_factor;
+bool Well2::updateEfficiencyFactor(double efficiency_factor_arg) {
+    if (this->efficiency_factor != efficiency_factor_arg) {
+        this->efficiency_factor = efficiency_factor_arg;
         return true;
     }
 
     return false;
 }
 
-bool Well2::updateWellGuideRate(double guide_rate) {
-    if (this->guide_rate.guide_rate != guide_rate) {
-        this->guide_rate.guide_rate = guide_rate;
+bool Well2::updateWellGuideRate(double guide_rate_arg) {
+    if (this->guide_rate.guide_rate != guide_rate_arg) {
+        this->guide_rate.guide_rate = guide_rate_arg;
         return true;
     }
 
@@ -134,9 +134,9 @@ bool Well2::updateWellGuideRate(double guide_rate) {
 }
 
 
-bool Well2::updatePolymerProperties(std::shared_ptr<WellPolymerProperties> polymer_properties) {
-    if (*this->polymer_properties != *polymer_properties) {
-        this->polymer_properties = polymer_properties;
+bool Well2::updatePolymerProperties(std::shared_ptr<WellPolymerProperties> polymer_properties_arg) {
+    if (*this->polymer_properties != *polymer_properties_arg) {
+        this->polymer_properties = polymer_properties_arg;
         this->producer = false;
         return true;
     }
@@ -145,9 +145,9 @@ bool Well2::updatePolymerProperties(std::shared_ptr<WellPolymerProperties> polym
 }
 
 
-bool Well2::updateEconLimits(std::shared_ptr<WellEconProductionLimits> econ_limits) {
-    if (*this->econ_limits != *econ_limits) {
-        this->econ_limits = econ_limits;
+bool Well2::updateEconLimits(std::shared_ptr<WellEconProductionLimits> econ_limits_arg) {
+    if (*this->econ_limits != *econ_limits_arg) {
+        this->econ_limits = econ_limits_arg;
         return true;
     }
 
@@ -173,48 +173,48 @@ void Well2::switchToInjector() {
     this->updateProducer( false );
 }
 
-bool Well2::updateInjection(std::shared_ptr<WellInjectionProperties> injection) {
+bool Well2::updateInjection(std::shared_ptr<WellInjectionProperties> injection_arg) {
     if (this->producer)
         this->switchToInjector( );
 
-    if (*this->injection != *injection) {
-        this->injection = injection;
+    if (*this->injection != *injection_arg) {
+        this->injection = injection_arg;
         return true;
     }
 
     return false;
 }
 
-bool Well2::updateProduction(std::shared_ptr<WellProductionProperties> production) {
+bool Well2::updateProduction(std::shared_ptr<WellProductionProperties> production_arg) {
     if (!this->producer)
         this->switchToProducer( );
 
-    if (*this->production != *production) {
-        this->production = production;
+    if (*this->production != *production_arg) {
+        this->production = production_arg;
         return true;
     }
 
     return false;
 }
 
-bool Well2::updateTracer(std::shared_ptr<WellTracerProperties> tracer_properties) {
-    if (*this->tracer_properties != *tracer_properties) {
-        this->tracer_properties = tracer_properties;
+bool Well2::updateTracer(std::shared_ptr<WellTracerProperties> tracer_properties_arg) {
+    if (*this->tracer_properties != *tracer_properties_arg) {
+        this->tracer_properties = tracer_properties_arg;
         return true;
     }
 
     return false;
 }
 
-bool Well2::updateWellGuideRate(bool available, double guide_rate, GuideRate::GuideRatePhaseEnum guide_phase, double scale_factor) {
+bool Well2::updateWellGuideRate(bool available, double guide_rate_arg, GuideRate::GuideRatePhaseEnum guide_phase, double scale_factor) {
     bool update = false;
     if (this->guide_rate.available != available) {
         this->guide_rate.available = available;
         update = true;
     }
 
-    if(this->guide_rate.guide_rate != guide_rate) {
-        this->guide_rate.guide_rate = guide_rate;
+    if(this->guide_rate.guide_rate != guide_rate_arg) {
+        this->guide_rate.guide_rate = guide_rate_arg;
         update = true;
     }
 
@@ -232,18 +232,18 @@ bool Well2::updateWellGuideRate(bool available, double guide_rate, GuideRate::Gu
 }
 
 
-bool Well2::updateProducer(bool producer) {
-    if (this->producer != producer) {
-        this->producer = producer;
+bool Well2::updateProducer(bool producer_arg) {
+    if (this->producer != producer_arg) {
+        this->producer = producer_arg;
         return true;
     }
     return false;
 }
 
 
-bool Well2::updateGroup(const std::string& group) {
-    if (this->group_name != group) {
-        this->group_name = group;
+bool Well2::updateGroup(const std::string& group_arg) {
+    if (this->group_name != group_arg) {
+        this->group_name = group_arg;
         return true;
     }
     return false;
@@ -266,9 +266,9 @@ bool Well2::updateHead(int I, int J) {
 }
 
 
-bool Well2::updateStatus(WellCommon::StatusEnum status) {
-    if (this->status != status) {
-        this->status = status;
+bool Well2::updateStatus(WellCommon::StatusEnum status_arg) {
+    if (this->status != status_arg) {
+        this->status = status_arg;
         return true;
     }
 
@@ -276,18 +276,18 @@ bool Well2::updateStatus(WellCommon::StatusEnum status) {
 }
 
 
-bool Well2::updateRefDepth(double ref_depth) {
-    if (this->ref_depth != ref_depth) {
-        this->ref_depth = ref_depth;
+bool Well2::updateRefDepth(double ref_depth_arg) {
+    if (this->ref_depth != ref_depth_arg) {
+        this->ref_depth = ref_depth_arg;
         return true;
     }
 
     return false;
 }
 
-bool Well2::updateDrainageRadius(double drainage_radius) {
-    if (this->drainage_radius != drainage_radius) {
-        this->drainage_radius = drainage_radius;
+bool Well2::updateDrainageRadius(double drainage_radius_arg) {
+    if (this->drainage_radius != drainage_radius_arg) {
+        this->drainage_radius = drainage_radius_arg;
         return true;
     }
 
@@ -295,9 +295,9 @@ bool Well2::updateDrainageRadius(double drainage_radius) {
 }
 
 
-bool Well2::updateCrossFlow(bool allow_cross_flow) {
-    if (this->allow_cross_flow != allow_cross_flow) {
-        this->allow_cross_flow = allow_cross_flow;
+bool Well2::updateCrossFlow(bool allow_cross_flow_arg) {
+    if (this->allow_cross_flow != allow_cross_flow_arg) {
+        this->allow_cross_flow = allow_cross_flow_arg;
         return true;
     }
 
@@ -314,12 +314,12 @@ bool Well2::updateAutoShutin(bool auto_shutin) {
 }
 
 
-bool Well2::updateConnections(const std::shared_ptr<WellConnections> connections) {
+bool Well2::updateConnections(const std::shared_ptr<WellConnections> connections_arg) {
     if( this->ordering  == WellCompletion::TRACK)
-        connections->orderConnections( this->headI, this->headJ );
+        connections_arg->orderConnections( this->headI, this->headJ );
 
-    if (*this->connections != *connections) {
-        this->connections = connections;
+    if (*this->connections != *connections_arg) {
+        this->connections = connections_arg;
         //if (this->connections->allConnectionsShut()) {}
         // This status update breaks line 825 in ScheduleTests
         //this->status = WellCommon::StatusEnum::SHUT;
@@ -330,9 +330,9 @@ bool Well2::updateConnections(const std::shared_ptr<WellConnections> connections
 }
 
 
-bool Well2::updateSolventFraction(double solvent_fraction) {
-    if (this->solvent_fraction != solvent_fraction) {
-        this->solvent_fraction = solvent_fraction;
+bool Well2::updateSolventFraction(double solvent_fraction_arg) {
+    if (this->solvent_fraction != solvent_fraction_arg) {
+        this->solvent_fraction = solvent_fraction_arg;
         return true;
     }
 
@@ -503,7 +503,7 @@ Phase Well2::getPreferredPhase() const {
     return this->phase;
 }
 
-bool Well2::handleWELOPEN(const DeckRecord& record, WellCompletion::StateEnum status) {
+bool Well2::handleWELOPEN(const DeckRecord& record, WellCompletion::StateEnum status_arg) {
 
     auto match = [=]( const Connection &c) -> bool {
         if (!match_eq(c.getI(), record, "I" , -1)) return false;
@@ -519,7 +519,7 @@ bool Well2::handleWELOPEN(const DeckRecord& record, WellCompletion::StateEnum st
 
     for (auto c : *this->connections) {
         if (match(c))
-            c.setState( status );
+            c.setState( status_arg );
 
         new_connections->add(c);
     }
@@ -633,9 +633,9 @@ bool Well2::predictionMode() const {
 }
 
 
-bool Well2::updatePrediction(bool prediction_mode) {
-    if (this->prediction_mode != prediction_mode) {
-        this->prediction_mode = prediction_mode;
+bool Well2::updatePrediction(bool prediction_mode_arg) {
+    if (this->prediction_mode != prediction_mode_arg) {
+        this->prediction_mode = prediction_mode_arg;
         return true;
     }
 
@@ -647,12 +647,12 @@ WellCompletion::CompletionOrderEnum Well2::getWellConnectionOrdering() const {
     return this->ordering;
 }
 
-double Well2::production_rate( Phase phase) const {
+double Well2::production_rate( Phase phase_arg) const {
     if( !this->isProducer() ) return 0.0;
 
     const auto& p = this->getProductionProperties();
 
-    switch( phase ) {
+    switch( phase_arg ) {
         case Phase::WATER: return p.WaterRate;
         case Phase::OIL:   return p.OilRate;
         case Phase::GAS:   return p.GasRate;
@@ -670,15 +670,15 @@ double Well2::production_rate( Phase phase) const {
                             "This is likely a programming error." );
 }
 
-double Well2::injection_rate( Phase phase) const {
+double Well2::injection_rate( Phase phase_arg) const {
     if( !this->isInjector() ) return 0.0;
 
     const auto& i = this->getInjectionProperties();
     const auto type = i.injectorType;
 
-    if( phase == Phase::WATER && type != WellInjector::WATER ) return 0.0;
-    if( phase == Phase::OIL   && type != WellInjector::OIL   ) return 0.0;
-    if( phase == Phase::GAS   && type != WellInjector::GAS   ) return 0.0;
+    if( phase_arg == Phase::WATER && type != WellInjector::WATER ) return 0.0;
+    if( phase_arg == Phase::OIL   && type != WellInjector::OIL   ) return 0.0;
+    if( phase_arg == Phase::GAS   && type != WellInjector::GAS   ) return 0.0;
 
     return i.surfaceInjectionRate;
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -269,7 +269,7 @@ namespace Opm {
     }
 
 
-    ProductionControls WellProductionProperties::controls(const SummaryState& st) const {
+    ProductionControls WellProductionProperties::controls(const SummaryState&) const {
         ProductionControls controls(this->m_productionControls);
 
         controls.oil_rate = this->OilRate;

--- a/src/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -130,11 +130,11 @@ T& ParserItem::value_ref() {
 }
 
 
-ParserItem::ParserItem( const std::string& itemName, ParserItem::itype input_type) :
+ParserItem::ParserItem( const std::string& itemName, ParserItem::itype input_type_arg) :
     m_name(itemName),
     m_defaultSet(false)
 {
-    this->setInputType(input_type);
+    this->setInputType(input_type_arg);
 }
 
 ParserItem::ParserItem( const Json::JsonObject& json ) :
@@ -201,8 +201,8 @@ void ParserItem::setDefault( T val ) {
 }
 
 
-void ParserItem::setInputType(ParserItem::itype input_type) {
-    this->input_type = input_type;
+void ParserItem::setInputType(ParserItem::itype input_type_arg) {
+    this->input_type = input_type_arg;
 
     if (input_type == itype::INT)
         this->setDataType(int());

--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -353,8 +353,8 @@ void ECLRegressionTest::gridCompare()
 
         std::cout << "comparing grids " << std::endl;
     
-        const auto& ijk1 = grid1->dimension();
-        const auto& ijk2 = grid2->dimension();
+        const auto& dim1 = grid1->dimension();
+        const auto& dim2 = grid2->dimension();
 
         if (printKeywordOnly) {
 
@@ -385,19 +385,19 @@ void ECLRegressionTest::gridCompare()
 
         std::cout << "Dimensions             " << " ... ";
 
-        if (ijk1[0] != ijk2[0]  || ijk1[1] != ijk2[1] || ijk1[2] != ijk2[2]) {
+        if (dim1[0] != dim2[0]  || dim1[1] != dim2[1] || dim1[2] != dim2[2]) {
             OPM_THROW(std::runtime_error, "\n Grid1 and grid2 have different dimensions.  "
-                      << "\n grid1 : "  << ijk1[0] << "x" << ijk1[1] << "x"<< ijk1[2]
-                      << "\n grid2 : "  << ijk2[0] << "x" << ijk2[1] << "x"<< ijk2[2]);
+                      << "\n grid1 : "  << dim1[0] << "x" << dim1[1] << "x"<< dim1[2]
+                      << "\n grid2 : "  << dim2[0] << "x" << dim2[1] << "x"<< dim2[2]);
         }
 
         std::cout << " done." << std::endl;
 
         std::cout << "Active cells           " << " ... ";
 
-        for (int k = 0; k < ijk1[2]; k++) {
-            for (int j=0; j < ijk1[1]; j++) {
-                for (int i = 0; i < ijk2[0]; i++) {
+        for (int k = 0; k < dim1[2]; k++) {
+            for (int j=0; j < dim1[1]; j++) {
+                for (int i = 0; i < dim2[0]; i++) {
                     if (grid1->active_index(i,j,k) != grid2->active_index(i,j,k)) {
                         OPM_THROW(std::runtime_error, "\nGrid1 and grid2 have different definition of active cells. "
                                   " First difference found for cell i="<< i+1 << " j=" << j+1 << " k=" << k+1);
@@ -413,9 +413,9 @@ void ECLRegressionTest::gridCompare()
         std::vector<double> X1(8,0.0), Y1(8,0.0) , Z1(8,0.0);
         std::vector<double> X2(8,0.0), Y2(8,0.0), Z2(8,0.0);
 
-        for (int k = 0; k < ijk1[2]; k++) {
-            for (int j = 0; j < ijk1[1]; j++) {
-                for (int i = 0; i < ijk1[0]; i++) {
+        for (int k = 0; k < dim1[2]; k++) {
+            for (int j = 0; j < dim1[1]; j++) {
+                for (int i = 0; i < dim1[0]; i++) {
                     if (grid1->active_index(i,j,k) > -1) {
                         grid1->getCellCorners({i,j,k}, X1, Y1, Z1);
                         grid2->getCellCorners({i,j,k}, X2, Y2, Z2);

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -499,13 +499,7 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data)
 
     const auto smry = sim_state();
     auto agrpd = Opm::RestartIO::Helpers::AggregateGroupData{ih.value};
-    const auto& rst_g_keys  = agrpd.restart_group_keys;
-    const auto& rst_f_keys  = agrpd.restart_field_keys;
-    const auto& grpKeyToInd = agrpd.groupKeyToIndex;
-    const auto& fldKeyToInd = agrpd.fieldKeyToIndex;
     agrpd.captureDeclaredGroupData(simCase.sched,
-				   rst_g_keys, rst_f_keys,
-				   grpKeyToInd, fldKeyToInd,
 				   rptStep, smry,
 				   ih.value);
 


### PR DESCRIPTION
This silences many, but not all shadowing warnings in opm-common.

Includes minor refactoring of ESMry and AggregateGroupData undertaken with the aid of the original authors to ensure correctness.