### PR TITLE
Don't Infer Number of AQUFETP Records from AQUDIMS

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUFETP
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUFETP
@@ -1,4 +1,4 @@
-{"name" : "AQUFETP" , "sections" : ["SOLUTION" , "SCHEDULE"], "size" : {"keyword":"AQUDIMS" , "item":"NANAQU"},
+{"name" : "AQUFETP" , "sections" : ["SOLUTION" , "SCHEDULE"],
         "items" : [
         {"name" : "AQUIFER_ID" ,              	"value_type" : "INT"},
         {"name" : "DAT_DEPTH" ,     		"value_type" : "DOUBLE" ,                        "dimension" : "Length"},

--- a/tests/parser/AquifetpTests.cpp
+++ b/tests/parser/AquifetpTests.cpp
@@ -51,7 +51,7 @@ inline Deck createAquifetpDeck() {
   "SOLUTION\n"
   "\n"
   "AQUFETP\n"
-  "1  70000.0  4.0e3 2.0e9 1.0e-5	500 1 0	0\n"
+  "1  70000.0  4.0e3 2.0e9 1.0e-5	500 1 0	0 /\n"
   "/\n";
 
   Parser parser;
@@ -122,7 +122,7 @@ inline Deck createAquifetpDeck_defaultPressure(){
   "SOLUTION\n"
   "\n"
   "AQUFETP\n"
-  "1  70000.0  1* 2.0e9 1.0e-5	500 1 0	0\n"
+  "1  70000.0  1* 2.0e9 1.0e-5	500 1 0	0 /\n"
   "/\n";
 
   Parser parser;


### PR DESCRIPTION
Original (and incorrect) description:

Without this you get
```sh
$ opmpack path/to/opm-tests/flow_diagnostic_test/SIMPLE_SUMMARY2.DATA > /dev/null
terminate called after throwing an instance of 'std::invalid_argument'
  what():  
Failed to parse keyword: AQUCT
Starting at location: path/to/opm-tests/flow_diagnostic_test/SIMPLE_SUMMARY2.DATA(189)

Inner exception: Malformed integer 'AQUANCON'

Aborted
```
This PR makes the `opmpack` command succeed.

---

Updated description:

The number of records is unrelated to AQUDIMS Item 5 (NANAQU).  That item sets the maximum aquifer ID permissible as Item 1 of AQUFETP (and other keywords related to analytic aquifers).

Update unit test accordingly.