### PR TITLE
Fix bug in RFTConfig first open - for WRFTPLT keyword

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
@@ -23,6 +23,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
@@ -150,12 +150,33 @@ std::size_t RFTConfig::firstRFTOutput() const {
 
     for (const auto& rft_pair : this->plt_config) {
         const auto& dynamic_state = rft_pair.second;
+        /*
+          We do not really output PLT, so this predictae will unconditionally
+          return false.
+        */
         auto pred = [] (const std::pair<PLTConnections::PLTEnum, std::size_t>& ) { return false; };
         int this_first_rft = dynamic_state.find_if(pred);
         if (this_first_rft >= 0)
             first_rft = std::min(first_rft, static_cast<std::size_t>(this_first_rft));
     }
 
+    for (const auto& rft_pair : this->rft_config) {
+      const auto& dynamic_state = rft_pair.second;
+
+      auto pred = [] (const std::pair<RFTConnections::RFTEnum, std::size_t>& rft_pair) {
+                    if (rft_pair.first == RFTConnections::RFTEnum::YES)
+                        return true;
+                    if (rft_pair.first == RFTConnections::RFTEnum::REPT)
+                        return true;
+                    if (rft_pair.first == RFTConnections::RFTEnum::TIMESTEP)
+                        return true;
+                    return false;
+                  };
+
+      int this_first_rft = dynamic_state.find_if(pred);
+      if (this_first_rft >= 0)
+        first_rft = std::min(first_rft, static_cast<std::size_t>(this_first_rft));
+    }
     return first_rft;
 }
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -312,7 +312,47 @@ static Deck createDeckWithWellsAndCompletionData() {
     return parser.parseString(input);
 }
 
+static Deck createDeckRFTConfig() {
+    Opm::Parser parser;
+    std::string input =
+      "START             -- 0 \n"
+      "1 NOV 1979 / \n"
+      "SCHEDULE\n"
+      "DATES             -- 1\n"
+      " 1 DES 1979/ \n"
+      "/\n"
+      "WELSPECS\n"
+      "    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+      "    'OP_2'       'OP'   8   8 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+      "    'OP_3'       'OP'   7   7 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+      "/\n"
+      "COMPDAT\n"
+      " 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+      " 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
+      " 'OP_2'  8  8   1   3 'OPEN' 1*    1.168   0.311   107.872 1*  1*  'Y'  21.925 / \n"
+      " 'OP_2'  8  7   3   3 'OPEN' 1*   15.071   0.311  1391.859 1*  1*  'Y'  21.920 / \n"
+      " 'OP_2'  8  7   3   6 'OPEN' 1*    6.242   0.311   576.458 1*  1*  'Y'  21.915 / \n"
+      " 'OP_3'  7  7   1   1 'OPEN' 1*   27.412   0.311  2445.337 1*  1*  'Y'  18.521 / \n"
+      " 'OP_3'  7  7   2   2 'OPEN' 1*   55.195   0.311  4923.842 1*  1*  'Y'  18.524 / \n"
+      "/\n"
+      "WELOPEN\n"
+      " 'OP_2' 'OPEN' /\n"
+      "/\n"
+      "DATES\n"
+      " 10  JUL 2007 / \n"
+      "/\n"
+      "WRFTPLT"
+      "  'OP_2'       'YES'        'NO'        'NO' / \n"
+      "/\n"
+      "DATES \n"
+      " 10  AUG 2007 / \n"
+      "/\n"
+      "COMPDAT\n" // with defaulted I and J
+      " 'OP_1'  0  *   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+      "/\n";
 
+    return parser.parseString(input);
+}
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     Deck deck;
     deck.addKeyword( DeckKeyword( "SCHEDULE" ) );
@@ -3196,4 +3236,16 @@ BOOST_AUTO_TEST_CASE(RFT_CONFIG) {
 
     conf.addWellOpen("W10", 2);
     conf.addWellOpen("W100", 3);
+}
+
+
+BOOST_AUTO_TEST_CASE(RFT_CONFIG2) {
+    auto deck = createDeckRFTConfig();
+    EclipseGrid grid1(10,10,10);
+    TableManager table ( deck );
+    Eclipse3DProperties eclipseProperties ( deck , table, grid1);
+    Runspec runspec (deck);
+    Schedule schedule(deck, grid1 , eclipseProperties, runspec);
+    const auto& rft_config = schedule.rftConfig();
+    BOOST_CHECK_EQUAL(1, rft_config.firstRFTOutput());
 }


### PR DESCRIPTION
The RFT configuration is surprisingly complex; the first open timestep was wrong when RFT was requested through the WRFTPLT keyword