### PR TITLE
Ignore character SOH (ASCII 1) while parsing

### DIFF
--- a/opm/parser/eclipse/RawDeck/RawConsts.hpp
+++ b/opm/parser/eclipse/RawDeck/RawConsts.hpp
@@ -48,7 +48,7 @@ namespace Opm {
          */
 
         constexpr bool sep_table[ 128 ] = {
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0,
+            0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -60,7 +60,7 @@ namespace Opm {
 
         struct is_separator {
             /*
-             * ch is space, comma, \r, \n, \t, \v or \f => true
+             * ch is SOH (ASCII 1), space, comma, \r, \n, \t, \v or \f => true
              * else false
              */
             constexpr bool operator()( int ch ) const {

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1980,6 +1980,25 @@ DENSITY
     BOOST_CHECK( pbub.defaultApplied( 0 ) );
 }
 
+BOOST_AUTO_TEST_CASE(IGNORE_SOH) {
+    // Check that parsing RSCONSTT does not bleed into next keyword.
+
+    const auto deck_string = std::string { R"(
+FIELD
+TABDIMS
+  1* 2
+/
+-- The ^A should be here - that is ASCII character 1 which is sometimes
+-- inserted by the windows editor Notepad++
+PROPS
+RSCONSTT
+  0.35  932 /
+  0.40  945 /
+)" };
+
+    const auto deck = Parser{}.parseString( deck_string );
+}
+
 
 BOOST_AUTO_TEST_CASE(ParseRSConstT) {
     // Check that parsing RSCONSTT does not bleed into next keyword.


### PR DESCRIPTION
Seems some windows edtiors (Notepad++) insert the character ASCII 1 (Start Of Header - SOH) when editing. Ignore it as whitespace.