### PR TITLE
not removing the well from WellTestState when testing is successful

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp
@@ -53,6 +53,8 @@ public:
     const WTESTWell& get(const std::string& well, Reason reason) const;
     size_t size() const;
 
+    static std::string reasonToString(const Reason reason);
+
 private:
     std::vector<WTESTWell> wells;
 };

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
@@ -86,14 +86,6 @@ public:
     */
     std::vector<std::pair<std::string, int>> updateCompletion(const WellTestConfig& config, double sim_time);
 
-
-    /*
-      If the simulator decides that a constraint is no longer met the dropWell()
-      method should be called to indicate that this reason for keeping the well
-      closed is no longer active.
-    */
-    void dropWell(const std::string& well_name, WellTestConfig::Reason reason);
-
     /*
       If the simulator decides that a constraint is no longer met the dropCompletion()
       method should be called to indicate that this reason for keeping the well

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
@@ -39,9 +39,13 @@ public:
 
 
 
-    struct ClosedWell {
+    struct WTestWell {
         std::string name;
         WellTestConfig::Reason reason;
+        // the well can be re-opened if the well testing is successful. We only test when it is closed.
+        bool closed;
+        // it can be the time of last test,
+        // or the time that the well is closed if not test has not been performed after
         double last_test;
         int num_attempt;
     };
@@ -58,7 +62,7 @@ public:
       The simulator has decided to close a particular well; we then add it here
       as a closed well with a particualar reason.
     */
-    void addClosedWell(const std::string& well_name, WellTestConfig::Reason reason, double sim_time);
+    void closeWell(const std::string& well_name, WellTestConfig::Reason reason, double sim_time);
 
     /*
       The simulator has decided to close a particular completion in a well; we then add it here
@@ -97,8 +101,9 @@ public:
     */
     void dropCompletion(const std::string& well_name, int complnum);
 
-    bool hasWell(const std::string& well_name, WellTestConfig::Reason reason) const;
-    void openWell(const std::string& well_name);
+    bool hasWellClosed(const std::string& well_name, WellTestConfig::Reason reason) const;
+
+    void openWell(const std::string& well_name, WellTestConfig::Reason reason);
 
     bool hasCompletion(const std::string& well_name, const int complnum) const;
 
@@ -111,8 +116,11 @@ public:
     double lastTestTime(const std::string& well_name) const;
 
 private:
-    std::vector<ClosedWell> wells;
+    std::vector<WTestWell> wells;
     std::vector<ClosedCompletion> completions;
+
+
+    WTestWell* getWell(const std::string& well_name, WellTestConfig::Reason reason);
 };
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.cpp
@@ -102,6 +102,23 @@ const WellTestConfig::WTESTWell& WellTestConfig::get(const std::string& well, Re
 
 
 
+std::string WellTestConfig::reasonToString(const Reason reason) {
+    switch(reason) {
+    case PHYSICAL:
+        return std::string("PHYSICAL");
+    case ECONOMIC:
+        return std::string("ECONOMIC");
+    case GROUP:
+        return std::string("GROUP");
+    case THP_DESIGN:
+        return std::string("THP_DESIGN");
+    case COMPLETION:
+        return std::string("COMPLETION");
+    default:
+        throw std::runtime_error("unknown closure reason");
+    }
+}
+
 
 
 size_t WellTestConfig::size() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
@@ -52,14 +52,6 @@ namespace Opm {
     }
 
 
-    void WellTestState::dropWell(const std::string& well_name, WellTestConfig::Reason reason) {
-        wells.erase(std::remove_if(wells.begin(),
-                                   wells.end(),
-                                   [&well_name, reason](const WTestWell& well) { return (well.name == well_name && well.reason == reason); }),
-                    wells.end());
-    }
-
-
     bool WellTestState::hasWellClosed(const std::string& well_name, WellTestConfig::Reason reason) const {
         const auto well_iter = std::find_if(wells.begin(),
                                             wells.end(),

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
@@ -19,44 +19,67 @@
 #include <stdexcept>
 #include <algorithm>
 
+#include <cassert>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
 
 namespace Opm {
 
-    void WellTestState::addClosedWell(const std::string& well_name, WellTestConfig::Reason reason, double sim_time) {
-        if (this->hasWell(well_name, reason))
-            return;
+    void WellTestState::closeWell(const std::string& well_name, WellTestConfig::Reason reason, double sim_time) {
 
-        this->wells.push_back({well_name, reason, sim_time, 0});
+        WTestWell* well_ptr = getWell(well_name, reason);
+
+        if (well_ptr) {
+            // the well exists already, we just update it with action of closing
+            well_ptr->closed = true;
+            well_ptr->last_test = sim_time;
+        } else
+            this->wells.push_back({well_name, reason, true, sim_time, 0});
     }
 
 
-    void WellTestState::openWell(const std::string& well_name) {
-        wells.erase(std::remove_if(wells.begin(),
-                                   wells.end(),
-                                   [&well_name](const ClosedWell& well) { return (well.name == well_name); }),
-                    wells.end());
+    void WellTestState::openWell(const std::string& well_name, WellTestConfig::Reason reason) {
+
+        WTestWell* well_ptr = getWell(well_name, reason);
+
+        if (well_ptr)
+            well_ptr->closed = false;
+        else
+            throw std::runtime_error("No well named " + well_name + " with close reason "
+                                    + WellTestConfig::reasonToString(reason)
+                                    + " found in WellTestState.");
     }
 
 
     void WellTestState::dropWell(const std::string& well_name, WellTestConfig::Reason reason) {
         wells.erase(std::remove_if(wells.begin(),
                                    wells.end(),
-                                   [&well_name, reason](const ClosedWell& well) { return (well.name == well_name && well.reason == reason); }),
+                                   [&well_name, reason](const WTestWell& well) { return (well.name == well_name && well.reason == reason); }),
                     wells.end());
     }
 
 
-    bool WellTestState::hasWell(const std::string& well_name, WellTestConfig::Reason reason) const {
+    bool WellTestState::hasWellClosed(const std::string& well_name, WellTestConfig::Reason reason) const {
         const auto well_iter = std::find_if(wells.begin(),
                                             wells.end(),
-                                            [&well_name, &reason](const ClosedWell& well)
-                                             {
-                                                return (reason == well.reason && well.name == well_name);
+                                            [&well_name, &reason](const WTestWell& well)
+                                            {
+                                                return (reason == well.reason && well.name == well_name && well.closed);
                                             });
         return (well_iter != wells.end());
     }
+
+
+    WellTestState::WTestWell* WellTestState::getWell(const std::string& well_name, WellTestConfig::Reason reason)
+    {
+        const auto well_iter = std::find_if(wells.begin(), wells.end(), [&well_name, &reason](const WTestWell& well) {
+            return (reason == well.reason && well.name == well_name);
+        });
+
+        return (well_iter == wells.end() ? nullptr : &(*well_iter) );
+    }
+
 
     size_t WellTestState::sizeWells() const {
         return this->wells.size();
@@ -64,25 +87,25 @@ namespace Opm {
 
     std::vector<std::pair<std::string, WellTestConfig::Reason>> WellTestState::updateWell(const WellTestConfig& config, double sim_time) {
         std::vector<std::pair<std::string, WellTestConfig::Reason>> output;
-        for (auto& closed_well : this->wells) {
-            if (config.has(closed_well.name, closed_well.reason)) {
-                const auto& well_config = config.get(closed_well.name, closed_well.reason);
-                double elapsed = sim_time - closed_well.last_test;
+        for (auto& well : this->wells) {
+            if (well.closed && config.has(well.name, well.reason)) {
+                const auto& well_config = config.get(well.name, well.reason);
+                double elapsed = sim_time - well.last_test;
 
                 if (elapsed >= well_config.test_interval)
-                    if (well_config.num_test == 0 || (closed_well.num_attempt < well_config.num_test)) {
-                        closed_well.last_test = sim_time;
-                        closed_well.num_attempt += 1;
-                        output.push_back(std::make_pair(closed_well.name, closed_well.reason));
+                    if (well_config.num_test == 0 || (well.num_attempt < well_config.num_test)) {
+                        well.last_test = sim_time;
+                        well.num_attempt ++;
+                        output.emplace_back(std::make_pair(well.name, well.reason));
+                        if ( (well_config.num_test != 0) && (well.num_attempt >= well_config.num_test) ) {
+                            OpmLog::info(well.name + " will be tested for " + WellTestConfig::reasonToString(well.reason)
+                                        + " reason for the last time! " );
+                        }
                     }
-
             }
         }
         return output;
     }
-
-
-
 
 
     void WellTestState::addClosedCompletion(const std::string& well_name, int complnum, double sim_time) {
@@ -136,7 +159,7 @@ namespace Opm {
     double WellTestState::lastTestTime(const std::string& well_name) const {
         const auto well_iter = std::find_if(wells.begin(),
                                             wells.end(),
-                                            [&well_name](const ClosedWell& well)
+                                            [&well_name](const WTestWell& well)
                                             {
                                                 return (well.name == well_name);
                                             });

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -123,10 +123,6 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
 
     // Too many attempts:
     BOOST_CHECK_EQUAL( st.updateWell(wc, 24000. * day).size(), 0);
-
-    st.dropWell("WELL_NAME", WellTestConfig::Reason::ECONOMIC);
-
-    BOOST_CHECK_EQUAL(st.sizeWells(), 2);
 }
 
 


### PR DESCRIPTION
The main thing this PR is trying to fix is that, the number of testing attempts need to be counted even a well is re-opened. 

Basically it means, the total number of attempts need to be counted regardless how many times we re-open or re-close a well. 

In the current master, it will be re-counted every time a well is closed. 

The downstream PRs are coming, but please begin suggesting whether you want it to be done in a different way. I do realize the full support of WTEST can be rather not easy, let us do it step by step. 

This issue is reported by @tskille . 