### PR TITLE
When writing deck output the UDAValue will write raw values

### DIFF
--- a/src/opm/parser/eclipse/Deck/DeckOutput.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckOutput.cpp
@@ -85,8 +85,12 @@ namespace Opm {
 
     template <>
     void DeckOutput::write_value( const UDAValue& value ) {
-        if (value.is<double>())
-            this->write_value(value.get<double>());
+        if (value.is<double>()) {
+            double si_value = value.get<double>();
+            const auto& dim = value.get_dim();
+            double deck_value = dim.convertSiToRaw(si_value);
+            this->write_value(deck_value);
+        }
         else
             this->write_value(value.get<std::string>());
     }


### PR DESCRIPTION
UDA values and dimensions - it is f...ng mess. I think this should "fix" it - and make #774 green.

:crossed_fingers: 