### PR TITLE
Support Automatic Generation of Saturation Function Properties

### DIFF
--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -41,12 +41,18 @@ namespace Opm {
         bool hasEquil() const;
         const Equil& getEquil() const;
 
+        bool filleps() const
+        {
+            return this->m_filleps;
+        }
+
     private:
+        Equil equil;
+        bool m_filleps;
+
         bool m_restartRequested = false;
         int m_restartStep = 0;
         std::string m_restartRootName;
-
-        Equil equil;
     };
 
 } //namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -279,9 +279,9 @@ namespace Opm {
         // SGLPC and would thus lead to a cyclic dependency of the property initializer
         // and EclipseState. (an analogous statement applies to ISGLPC.)
         for( const auto& kw : { "SGLPC", "SGL", "SGLX", "SGLX-", "SGLY", "SGLY-", "SGLZ", "SGLZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, SGLLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, SGLLookup, "1", true );
         for( const auto& kw : { "ISGLPC", "ISGL", "ISGLX", "ISGLX-", "ISGLY", "ISGLY-", "ISGLZ", "ISGLZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, ISGLLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, ISGLLookup, "1", true );
 
         // keywords to specify the connate water saturation: this is slighly wrong for
         // SWLPC because it is supposed to default to SWL: If SWL is explicitly
@@ -291,102 +291,102 @@ namespace Opm {
         // SWLPC and would thus lead to a cyclic dependency of the property initializer
         // and EclipseState. (an analogous statement applies to ISWLPC.)
         for( const auto& kw : { "SWLPC", "SWL", "SWLX", "SWLX-", "SWLY", "SWLY-", "SWLZ", "SWLZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, SWLLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, SWLLookup, "1", true );
         for( const auto& kw : { "ISWLPC", "ISWL", "ISWLX", "ISWLX-", "ISWLY", "ISWLY-", "ISWLZ", "ISWLZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, ISWLLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, ISWLLookup, "1", true );
 
         // keywords to specify the maximum gas saturation.
         for( const auto& kw : { "SGU", "SGUX", "SGUX-", "SGUY", "SGUY-", "SGUZ", "SGUZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, SGULookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, SGULookup, "1", true );
         for( const auto& kw : { "ISGU", "ISGUX", "ISGUX-", "ISGUY", "ISGUY-", "ISGUZ", "ISGUZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, ISGULookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, ISGULookup, "1", true );
 
         // keywords to specify the maximum water saturation.
         for( const auto& kw : { "SWU", "SWUX", "SWUX-", "SWUY", "SWUY-", "SWUZ", "SWUZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, SWULookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, SWULookup, "1", true );
         for( const auto& kw : { "ISWU", "ISWUX", "ISWUX-", "ISWUY", "ISWUY-", "ISWUZ", "ISWUZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, ISWULookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, ISWULookup, "1", true );
 
         // keywords to specify the scaled critical gas saturation.
         for( const auto& kw : { "SGCR", "SGCRX", "SGCRX-", "SGCRY", "SGCRY-", "SGCRZ", "SGCRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, SGCRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, SGCRLookup, "1", true );
         for( const auto& kw : { "ISGCR", "ISGCRX", "ISGCRX-", "ISGCRY", "ISGCRY-", "ISGCRZ", "ISGCRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, ISGCRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, ISGCRLookup, "1", true );
 
         // keywords to specify the scaled critical oil-in-water saturation.
         for( const auto& kw : { "SOWCR", "SOWCRX", "SOWCRX-", "SOWCRY", "SOWCRY-", "SOWCRZ", "SOWCRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, SOWCRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, SOWCRLookup, "1", true );
         for( const auto& kw : { "ISOWCR", "ISOWCRX", "ISOWCRX-", "ISOWCRY", "ISOWCRY-", "ISOWCRZ", "ISOWCRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, ISOWCRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, ISOWCRLookup, "1", true );
 
         // keywords to specify the scaled critical oil-in-gas saturation.
         for( const auto& kw : { "SOGCR", "SOGCRX", "SOGCRX-", "SOGCRY", "SOGCRY-", "SOGCRZ", "SOGCRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, SOGCRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, SOGCRLookup, "1", true );
         for( const auto& kw : { "ISOGCR", "ISOGCRX", "ISOGCRX-", "ISOGCRY", "ISOGCRY-", "ISOGCRZ", "ISOGCRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, ISOGCRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, ISOGCRLookup, "1", true );
 
         // keywords to specify the scaled critical water saturation.
         for( const auto& kw : { "SWCR", "SWCRX", "SWCRX-", "SWCRY", "SWCRY-", "SWCRZ", "SWCRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, SWCRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, SWCRLookup, "1", true );
         for( const auto& kw : { "ISWCR", "ISWCRX", "ISWCRX-", "ISWCRY", "ISWCRY-", "ISWCRZ", "ISWCRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, ISWCRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, ISWCRLookup, "1", true );
 
         // keywords to specify the scaled oil-water capillary pressure
         for( const auto& kw : { "PCW", "PCWX", "PCWX-", "PCWY", "PCWY-", "PCWZ", "PCWZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, PCWLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, PCWLookup, "1", true );
         for( const auto& kw : { "IPCW", "IPCWX", "IPCWX-", "IPCWY", "IPCWY-", "IPCWZ", "IPCWZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IPCWLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IPCWLookup, "1", true );
 
         // keywords to specify the scaled gas-oil capillary pressure
         for( const auto& kw : { "PCG", "PCGX", "PCGX-", "PCGY", "PCGY-", "PCGZ", "PCGZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, PCGLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, PCGLookup, "1", true );
         for( const auto& kw : { "IPCG", "IPCGX", "IPCGX-", "IPCGY", "IPCGY-", "IPCGZ", "IPCGZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IPCGLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IPCGLookup, "1", true );
 
         // keywords to specify the scaled water relative permeability
         for( const auto& kw : { "KRW", "KRWX", "KRWX-", "KRWY", "KRWY-", "KRWZ", "KRWZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, KRWLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, KRWLookup, "1", true );
         for( const auto& kw : { "IKRW", "IKRWX", "IKRWX-", "IKRWY", "IKRWY-", "IKRWZ", "IKRWZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IKRWLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IKRWLookup, "1", true );
 
         // keywords to specify the scaled water relative permeability at the critical
         // saturation
         for( const auto& kw : { "KRWR" , "KRWRX" , "KRWRX-" , "KRWRY" , "KRWRY-" , "KRWRZ" , "KRWRZ-"  } )
-            supportedDoubleKeywords.emplace_back( kw, KRWRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, KRWRLookup, "1", true );
         for( const auto& kw : { "IKRWR" , "IKRWRX" , "IKRWRX-" , "IKRWRY" , "IKRWRY-" , "IKRWRZ" , "IKRWRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IKRWRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IKRWRLookup, "1", true );
 
         // keywords to specify the scaled oil relative permeability
         for( const auto& kw : { "KRO", "KROX", "KROX-", "KROY", "KROY-", "KROZ", "KROZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, KROLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, KROLookup, "1", true );
         for( const auto& kw : { "IKRO", "IKROX", "IKROX-", "IKROY", "IKROY-", "IKROZ", "IKROZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IKROLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IKROLookup, "1", true );
 
         // keywords to specify the scaled water relative permeability at the critical
         // water saturation
         for( const auto& kw : { "KRORW", "KRORWX", "KRORWX-", "KRORWY", "KRORWY-", "KRORWZ", "KRORWZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, KRORWLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, KRORWLookup, "1", true );
         for( const auto& kw : { "IKRORW", "IKRORWX", "IKRORWX-", "IKRORWY", "IKRORWY-", "IKRORWZ", "IKRORWZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IKRORWLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IKRORWLookup, "1", true );
 
         // keywords to specify the scaled water relative permeability at the critical
         // water saturation
         for( const auto& kw : { "KRORG", "KRORGX", "KRORGX-", "KRORGY", "KRORGY-", "KRORGZ", "KRORGZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, KRORGLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, KRORGLookup, "1", true );
         for( const auto& kw : { "IKRORG", "IKRORGX", "IKRORGX-", "IKRORGY", "IKRORGY-", "IKRORGZ", "IKRORGZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IKRORGLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IKRORGLookup, "1", true );
 
         // keywords to specify the scaled gas relative permeability
         for( const auto& kw : { "KRG", "KRGX", "KRGX-", "KRGY", "KRGY-", "KRGZ", "KRGZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, KRGLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, KRGLookup, "1", true );
         for( const auto& kw : { "IKRG", "IKRGX", "IKRGX-", "IKRGY", "IKRGY-", "IKRGZ", "IKRGZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IKRGLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IKRGLookup, "1", true );
 
         // keywords to specify the scaled gas relative permeability
         for( const auto& kw : { "KRGR", "KRGRX", "KRGRX-", "KRGRY", "KRGRY-", "KRGRZ", "KRGRZ-" } )
-             supportedDoubleKeywords.emplace_back( kw, KRGRLookup, "1" );
+             supportedDoubleKeywords.emplace_back( kw, KRGRLookup, "1", true );
         for( const auto& kw : { "IKRGR", "IKRGRX", "IKRGRX-", "IKRGRY", "IKRGRY-", "IKRGRZ", "IKRGRZ-" } )
-            supportedDoubleKeywords.emplace_back( kw, IKRGRLookup, "1" );
+            supportedDoubleKeywords.emplace_back( kw, IKRGRLookup, "1", true );
 
         // Solution keywords - required fror enumerated restart.
         supportedDoubleKeywords.emplace_back( "PRESSURE", 0.0 , "Pressure", true );

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -23,6 +23,7 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp>
 
@@ -37,7 +38,10 @@ namespace Opm {
         return Equil( deck.getKeyword<ParserKeywords::EQUIL>(  ) );
     }
 
-    InitConfig::InitConfig(const Deck& deck) : equil(equils(deck)) {
+    InitConfig::InitConfig(const Deck& deck)
+        : equil(equils(deck))
+        , m_filleps(PROPSSection{deck}.hasKeyword("FILLEPS"))
+    {
         if( !deck.hasKeyword( "RESTART" ) ) {
             if( deck.hasKeyword( "SKIPREST" ) ) {
                 std::cout << "Deck has SKIPREST, but no RESTART. "

--- a/tests/parser/InitConfigTest.cpp
+++ b/tests/parser/InitConfigTest.cpp
@@ -233,4 +233,306 @@ BOOST_AUTO_TEST_CASE(RestartCWD) {
     test_work_area_free(work_area);
 }
 
+// --------------------------------------------------------------------
 
+BOOST_AUTO_TEST_SUITE (FILLEPS)
+
+BOOST_AUTO_TEST_CASE(WrongSection)
+{
+    // FILLEPS in GRID section (should ideally be caught at load time)
+    auto input = std::string { R"(
+RUNSPEC
+
+DIMENS
+  5 5 3 /
+
+TITLE
+Break FILLEPS Keyword
+
+START
+  24 'JUN' 2019 /
+
+GAS
+OIL
+WATER
+DISGAS
+METRIC
+
+TABDIMS
+/
+
+GRID
+INIT
+
+DXV
+  5*100 /
+
+DYV
+  5*100 /
+
+DZV
+  3*10 /
+
+TOPS
+  25*2000 /
+
+EQUALS
+  PERMX 100 /
+/
+
+COPY
+  PERMX PERMY /
+  PERMX PERMZ /
+/
+
+MULTIPLY
+  PERMZ 0.1 /
+/
+
+PORO
+  75*0.3 /
+
+-- Wrong section (should be in PROPS)
+FILLEPS
+
+PROPS
+
+SWOF
+  0 0 1 0
+  1 1 0 0 /
+
+SGOF
+  0 0 1 0
+  1 1 0 0 /
+
+DENSITY
+  900 1000 1 /
+
+PVTW
+  400 1 1.0E-06 1 0 /
+
+PVDG
+   30  0.04234     0.01344
+  530  0.003868    0.02935
+/
+
+PVTO
+    0.000       1.0    1.07033 0.645
+              500.0    1.02339 1.029  /
+   17.345      25.0    1.14075 0.484
+              500.0    1.07726 0.834  /
+   31.462      50.0    1.18430 0.439
+              500.0    1.11592 0.757  /
+   45.089      75.0    1.22415 0.402
+              500.0    1.15223 0.689  /
+/
+
+END
+)" };
+
+    const auto es = ::Opm::EclipseState {
+        ::Opm::Parser{}.parseString(input)
+    };
+
+    // Keyword present but placed in wrong section => treat as absent
+    BOOST_CHECK(! es.cfg().init().filleps());
+}
+
+BOOST_AUTO_TEST_CASE(Present)
+{
+    auto input = std::string { R"(
+RUNSPEC
+
+DIMENS
+  5 5 3 /
+
+TITLE
+Break FILLEPS Keyword
+
+START
+  24 'JUN' 2019 /
+
+GAS
+OIL
+WATER
+DISGAS
+METRIC
+
+TABDIMS
+/
+
+GRID
+INIT
+
+DXV
+  5*100 /
+
+DYV
+  5*100 /
+
+DZV
+  3*10 /
+
+TOPS
+  25*2000 /
+
+EQUALS
+  PERMX 100 /
+/
+
+COPY
+  PERMX PERMY /
+  PERMX PERMZ /
+/
+
+MULTIPLY
+  PERMZ 0.1 /
+/
+
+PORO
+  75*0.3 /
+
+PROPS
+
+SWOF
+  0 0 1 0
+  1 1 0 0 /
+
+SGOF
+  0 0 1 0
+  1 1 0 0 /
+
+DENSITY
+  900 1000 1 /
+
+PVTW
+  400 1 1.0E-06 1 0 /
+
+PVDG
+   30  0.04234     0.01344
+  530  0.003868    0.02935
+/
+
+PVTO
+    0.000       1.0    1.07033 0.645
+              500.0    1.02339 1.029  /
+   17.345      25.0    1.14075 0.484
+              500.0    1.07726 0.834  /
+   31.462      50.0    1.18430 0.439
+              500.0    1.11592 0.757  /
+   45.089      75.0    1.22415 0.402
+              500.0    1.15223 0.689  /
+/
+
+FILLEPS
+
+END
+)" };
+
+    const auto es = ::Opm::EclipseState {
+        ::Opm::Parser{}.parseString(input)
+    };
+
+    BOOST_CHECK(es.cfg().init().filleps());
+}
+
+BOOST_AUTO_TEST_CASE(Absent)
+{
+    auto input = std::string { R"(
+RUNSPEC
+
+DIMENS
+  5 5 3 /
+
+TITLE
+Break FILLEPS Keyword
+
+START
+  24 'JUN' 2019 /
+
+GAS
+OIL
+WATER
+DISGAS
+METRIC
+
+TABDIMS
+/
+
+GRID
+INIT
+
+DXV
+  5*100 /
+
+DYV
+  5*100 /
+
+DZV
+  3*10 /
+
+TOPS
+  25*2000 /
+
+EQUALS
+  PERMX 100 /
+/
+
+COPY
+  PERMX PERMY /
+  PERMX PERMZ /
+/
+
+MULTIPLY
+  PERMZ 0.1 /
+/
+
+PORO
+  75*0.3 /
+
+PROPS
+
+SWOF
+  0 0 1 0
+  1 1 0 0 /
+
+SGOF
+  0 0 1 0
+  1 1 0 0 /
+
+DENSITY
+  900 1000 1 /
+
+PVTW
+  400 1 1.0E-06 1 0 /
+
+PVDG
+   30  0.04234     0.01344
+  530  0.003868    0.02935
+/
+
+PVTO
+    0.000       1.0    1.07033 0.645
+              500.0    1.02339 1.029  /
+   17.345      25.0    1.14075 0.484
+              500.0    1.07726 0.834  /
+   31.462      50.0    1.18430 0.439
+              500.0    1.11592 0.757  /
+   45.089      75.0    1.22415 0.402
+              500.0    1.15223 0.689  /
+/
+
+-- No FILLEPS here
+-- FILLEPS
+
+END
+)" };
+
+    const auto es = ::Opm::EclipseState {
+        ::Opm::Parser{}.parseString(input)
+    };
+
+    BOOST_CHECK(! es.cfg().init().filleps());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The endpoint arrays (SWLPC, SGU, KRORW etc) can all be automatically generated from the unscaled input saturation function tables.  This PR marks them as such, which is useful if the input deck specifies `FILLEPS`.

While testing this I also came across a model for which SATNUM was zero in decativated cells (i.e., those for which ACTNUM is also explicitly zero in the input deck).  This PR therefore also allows SATNUM and IMBNUM to be zero in inactive cells when running the saturation function property initialisation functions.