### PR TITLE
Turn on -Wextra and -Wshadow warning flags.

### DIFF
--- a/cmake/Modules/UseWarnings.cmake
+++ b/cmake/Modules/UseWarnings.cmake
@@ -6,7 +6,7 @@ is_compiler_gcc_compatible ()
 
 if (CXX_COMPAT_GCC)
   # default warnings flags, if not set by user
-  set_default_option (CXX _warn_flag "-Wall" "(^|\ )-W")
+  set_default_option (CXX _warn_flag "-Wall -Wextra -Wshadow" "(^|\ )-W")
   if (_warn_flag)
 	message (STATUS "All warnings enabled: ${_warn_flag}")
 	add_options (ALL_LANGUAGES ALL_BUILDS "${_warn_flag}")


### PR DESCRIPTION
This turns on more warning flags by default in the OPM build system. The idea is to have fewer annoying warnings for developers, and that the original developer of some new code is better able to address warnings from that code than others. For some, this will make opm a lot more noisy when it comes to warnings, but that will also serve as motivation to address them... In the longer term, stricter warning flags should put us in the situation where OPM compiles warning-clean all the time, so any time you see a warning it is from the code you are working on right now. That is an ideal that might not be met, as compilers and platforms differ, but stricter defaults should push us in that direction.

The "master plan" is something like this:
 - Find an appropriate but rich set of warning options to activate by default. That discussion should take place in this PR, starting from the proposal: "`-Wall -Wextra -Wshadow`". Other candidates from my side include "`-Wformat-nonliteral -Wcast-align -Wpointer-arith -Wmissing-declarations -Wcast-qual -Wwrite-strings -Wchar-subscripts -Wredundant-decls`". We might discover that some options should be explicitly disabled, too. Candidates for that include "`-Wno-unused-local-typedef -Wno-keyword-macro -Wno-missing-braces -Wno-gnu-zero-variadic-macro-arguments -Wno-format-nonliteral -Wno-cast-align`".
 - At the latest after merging this or a similar PR, we should fix all warnings in the master branches (it is probably fine to do this in parallel with the discussion on which options to use).
 - From that point, maintainers should require PRs to be warning-clean before merging (exceptions should be made only for urgent reasons such as restoring Jenkins, and always be temporary and the warnings addressed some way).

Please discuss the appropriate options, as well as what you think of the "master plan"!