### PR TITLE
Warnings

### DIFF
--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -33,7 +33,7 @@ public:
     void well_rate(const std::string& well, data::Rates::opt rate, std::function<well_rate_function> func);
     void solution(const std::string& field, std::function<solution_function> func);
     void run(Schedule& schedule, EclipseIO& io, bool report_only);
-    void post_step(Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
+    void post_step(Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step) const;
 private:
 
     void run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -51,12 +51,12 @@ void msim::run(Schedule& schedule, EclipseIO& io, bool report_only) {
             double time_step = std::min(week, 0.5*schedule.stepLength(report_step - 1));
             run_step(schedule, st, sol, well_data, report_step, time_step, io);
         }
-        post_step(schedule, st, sol, well_data, report_step, io);
+        post_step(schedule, st, sol, well_data, report_step);
     }
 }
 
 
-void msim::post_step(Schedule& schedule, const SummaryState& st, data::Solution& /* sol */, data::Wells& /* well_data */, size_t report_step, EclipseIO& io) const {
+void msim::post_step(Schedule& schedule, const SummaryState& st, data::Solution& /* sol */, data::Wells& /* well_data */, size_t report_step) const {
     const auto& actions = schedule.actions();
     if (actions.empty())
         return;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -208,7 +208,7 @@ namespace Opm
         void handleCOMPLUMP( const DeckKeyword& keyword,  size_t currentStep );
         void handleWELSEGS( const DeckKeyword& keyword, size_t currentStep);
         void handleCOMPSEGS( const DeckKeyword& keyword, size_t currentStep, const EclipseGrid& grid, const ParseContext& parseContext, ErrorGuard& errors);
-        void handleWCONINJE( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWCONINJE( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWPOLYMER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWSOLVENT( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWTRACER( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
@@ -216,7 +216,7 @@ namespace Opm
         void handleWPMITAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWSKPTAB( const DeckKeyword& keyword,  const size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWINJTEMP( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
-        void handleWCONINJH( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWCONINJH(const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWELOPEN( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors, const std::vector<std::string>& matching_wells = {});
         void handleWELTARG( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleGCONINJE( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
@@ -148,8 +148,8 @@ std::size_t RFTConfig::firstRFTOutput() const {
             first_rft = std::min(first_rft, rft_pair.second);
     }
 
-    for (const auto& rft_pair : this->plt_config) {
-        const auto& dynamic_state = rft_pair.second;
+    for (const auto& plt_pair : this->plt_config) {
+        const auto& dynamic_state = plt_pair.second;
         /*
           We do not really output PLT, so this predictae will unconditionally
           return false.
@@ -163,12 +163,12 @@ std::size_t RFTConfig::firstRFTOutput() const {
     for (const auto& rft_pair : this->rft_config) {
       const auto& dynamic_state = rft_pair.second;
 
-      auto pred = [] (const std::pair<RFTConnections::RFTEnum, std::size_t>& rft_pair) {
-                    if (rft_pair.first == RFTConnections::RFTEnum::YES)
+      auto pred = [] (const std::pair<RFTConnections::RFTEnum, std::size_t>& pred_arg) {
+                    if (pred_arg.first == RFTConnections::RFTEnum::YES)
                         return true;
-                    if (rft_pair.first == RFTConnections::RFTEnum::REPT)
+                    if (pred_arg.first == RFTConnections::RFTEnum::REPT)
                         return true;
-                    if (rft_pair.first == RFTConnections::RFTEnum::TIMESTEP)
+                    if (pred_arg.first == RFTConnections::RFTEnum::TIMESTEP)
                         return true;
                     return false;
                   };

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -236,7 +236,7 @@ namespace Opm {
             handleWCONPROD(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WCONINJE")
-            handleWCONINJE(section, keyword, currentStep, parseContext, errors);
+            handleWCONINJE(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WPOLYMER")
             handleWPOLYMER(keyword, currentStep, parseContext, errors);
@@ -263,7 +263,7 @@ namespace Opm {
             handleWINJTEMP(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WCONINJH")
-            handleWCONINJH(section, keyword, currentStep, parseContext, errors);
+            handleWCONINJH(keyword, currentStep, parseContext, errors);
 
         else if (keyword.name() == "WGRUPCON")
             handleWGRUPCON(keyword, currentStep);
@@ -837,7 +837,7 @@ namespace Opm {
 
 
 
-    void Schedule::handleWCONINJE( const SCHEDULESection& section, const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
+    void Schedule::handleWCONINJE( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
 
@@ -853,7 +853,7 @@ namespace Opm {
                     auto& dynamic_state = this->wells_static.at(well_name);
                     auto well2 = std::make_shared<Well2>(*dynamic_state[currentStep]);
                     auto injection = std::make_shared<WellInjectionProperties>(well2->getInjectionProperties());
-                    injection->handleWCONINJE(record, well2->isAvailableForGroupControl(), well_name, section.unitSystem());
+                    injection->handleWCONINJE(record, well2->isAvailableForGroupControl(), well_name);
 
                     if (well2->updateProducer(false))
                         update_well = true;
@@ -896,7 +896,7 @@ namespace Opm {
         }
     }
 
-    void Schedule::handleWCONINJH( const SCHEDULESection& section,  const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
+    void Schedule::handleWCONINJH(const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             WellCommon::StatusEnum status = WellCommon::StatusFromString( record.getItem("STATUS").getTrimmedString(0));
@@ -912,7 +912,7 @@ namespace Opm {
                     auto& dynamic_state = this->wells_static.at(well_name);
                     auto well2 = std::make_shared<Well2>(*dynamic_state[currentStep]);
                     auto injection = std::make_shared<WellInjectionProperties>(well2->getInjectionProperties());
-                    injection->handleWCONINJH(record, well2->isProducer(), well_name, section.unitSystem());
+                    injection->handleWCONINJH(record, well2->isProducer(), well_name);
 
                     if (well2->updateProducer(false))
                         update_well = true;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
@@ -663,12 +663,12 @@ WellCompletion::CompletionOrderEnum Well2::getWellConnectionOrdering() const {
     return this->ordering;
 }
 
-double Well2::production_rate(const SummaryState& st, Phase phase) const {
+double Well2::production_rate(const SummaryState& st, Phase prod_phase) const {
     if( !this->isProducer() ) return 0.0;
 
     const auto controls = this->productionControls(st);
 
-    switch( phase ) {
+    switch( prod_phase ) {
         case Phase::WATER: return controls.water_rate;
         case Phase::OIL:   return controls.oil_rate;
         case Phase::GAS:   return controls.gas_rate;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
@@ -34,8 +34,8 @@
 namespace Opm {
 
 
-    WellInjectionProperties::WellInjectionProperties(const std::string& name)
-        : name(name),
+    WellInjectionProperties::WellInjectionProperties(const std::string& wname)
+        : name(wname),
           injectorType(WellInjector::WATER),
           controlMode(WellInjector::CMODE_UNDEFINED)
     {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
@@ -50,7 +50,7 @@ namespace Opm {
     }
 
 
-    void WellInjectionProperties::handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name, const UnitSystem& unit_system) {
+    void WellInjectionProperties::handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name) {
         this->injectorType = WellInjector::TypeFromString( record.getItem("TYPE").getTrimmedString(0) );
         this->predictionMode = true;
 
@@ -143,7 +143,7 @@ namespace Opm {
     }
 
 
-    void WellInjectionProperties::handleWCONINJH(const DeckRecord& record, bool is_producer, const std::string& well_name, const UnitSystem& unit_system) {
+    void WellInjectionProperties::handleWCONINJH(const DeckRecord& record, bool is_producer, const std::string& well_name) {
         // convert injection rates to SI
         const auto& typeItem = record.getItem("TYPE");
         if (typeItem.defaultApplied(0)) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp
@@ -52,8 +52,8 @@ namespace Opm {
 
         WellInjectionProperties(const std::string& wname);
         void handleWELTARG(WellTarget::ControlModeEnum cmode, double newValue, double siFactorG, double siFactorL, double siFactorP);
-        void handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name, const UnitSystem& unit_system);
-        void handleWCONINJH(const DeckRecord& record, bool is_producer, const std::string& well_name, const UnitSystem& unit_system);
+        void handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name);
+        void handleWCONINJH(const DeckRecord& record, bool is_producer, const std::string& well_name);
         bool hasInjectionControl(WellInjector::ControlModeEnum controlModeArg) const {
             if (injectionControls & controlModeArg)
                 return true;

--- a/test_util/EclFilesComparator.hpp
+++ b/test_util/EclFilesComparator.hpp
@@ -69,7 +69,6 @@ public:
     static double average(const std::vector<double>& vec);
 
 protected:
-    std::vector<std::string> keywords1, keywords2;
     bool throwOnError = true; //!< Throw on first error
     bool analysis = false; //!< Perform full error analysis
     std::map<std::string, std::vector<Deviation>> deviations;

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -109,8 +109,8 @@ double prod_wpr_P4(const EclipseState&  es, const Schedule& /* sched */, const S
 }
 
 
-double inj_wir_INJ(const EclipseState&  es, const Schedule& sched, const SummaryState& st, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
     printf("report_step:%ld  Has FUINJ: %d \n", report_step, st.has("FUINJ"));
+double inj_wir_INJ(const EclipseState& , const Schedule& sched, const SummaryState& st, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
     if (st.has("FUINJ")) {
         const auto& well = sched.getWell2("INJ", report_step);
         const auto controls = well.injectionControls(st);

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -109,12 +109,10 @@ double prod_wpr_P4(const EclipseState&  es, const Schedule& /* sched */, const S
 }
 
 
-    printf("report_step:%ld  Has FUINJ: %d \n", report_step, st.has("FUINJ"));
 double inj_wir_INJ(const EclipseState& , const Schedule& sched, const SummaryState& st, const data::Solution& /* sol */, size_t report_step, double /* seconds_elapsed */) {
     if (st.has("FUINJ")) {
         const auto& well = sched.getWell2("INJ", report_step);
         const auto controls = well.injectionControls(st);
-        printf("st[FUINJ] = %lg \n", st.get("FUINJ"));
         return controls.surface_rate;
     } else
         return -99;


### PR DESCRIPTION
With this PR opm-common compiles warning free under: #858 - on my machine.

Observe that for the `EclFilesComparator` class I actually ended up with removing the shadowed members completely - they were not used.; working my way through that code I realized that `-Wshadow` has some merit .... :smile: 