### PR TITLE
Rename cmake symbol ENABLE_PYTHON -> OPM_ENABLE_PYTHON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(OPM_MACROS_ROOT ${PROJECT_SOURCE_DIR})
 option(ENABLE_ECL_INPUT "Enable eclipse input support?" ON)
 option(ENABLE_ECL_OUTPUT "Enable eclipse output support?" ON)
 option(ENABLE_MOCKSIM "Build the mock simulator for io testing" ON)
-option(ENABLE_PYTHON "Enable python bindings?" OFF)
+option(OPM_ENABLE_PYTHON "Enable python bindings?" OFF)
 
 # Output implies input
 if(ENABLE_ECL_OUTPUT)
@@ -210,7 +210,7 @@ install(DIRECTORY cmake DESTINATION share/opm)
 # Install tab completion skeleton
 install(FILES etc/opm_bash_completion.sh.in DESTINATION share/opm/etc)
 
-if (ENABLE_PYTHON)
+if (OPM_ENABLE_PYTHON)
   set_target_properties(opmcommon PROPERTIES POSITION_INDEPENDENT_CODE ON)
   add_subdirectory(python)
 endif()


### PR DESCRIPTION
Cmake symbol `ENABLE_PYTHON` was in conflict with ... libecl? 