### PR TITLE
Add FOAMROCK including FoamConfig support and test.

### DIFF
--- a/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
@@ -23,44 +23,54 @@
 #include <cstddef>
 #include <vector>
 
-namespace Opm {
+namespace Opm
+{
 
-    class Deck;
-    class DeckRecord;
+class Deck;
+class DeckRecord;
 
-    class FoamRecord {
-        public:
-            explicit FoamRecord( const DeckRecord& );
+/// Foam behaviour data for a single SATNUM region.
+class FoamData
+{
+public:
+    explicit FoamData(const DeckRecord& FOAMFSC_record, const DeckRecord& FOAMROCK_record);
 
-            double referenceSurfactantConcentration() const;
-            double exponent() const;
-            double minimumSurfactantConcentration() const;
+    double referenceSurfactantConcentration() const;
+    double exponent() const;
+    double minimumSurfactantConcentration() const;
 
-        private:
-            double reference_surfactant_concentration_;
-            double exponent_;
-            double minimum_surfactant_concentration_;
-    };
+    enum class FoamAllowDesorption { Yes = 1, No = 2 };
+    FoamAllowDesorption allowDesorption() const;
+    double rockDensity() const;
 
-    class FoamConfig {
-        public:
-            using const_iterator = std::vector< FoamRecord >::const_iterator;
+private:
+    double reference_surfactant_concentration_;
+    double exponent_;
+    double minimum_surfactant_concentration_;
+    FoamAllowDesorption allow_desorption_;
+    double rock_density_;
+};
 
-            FoamConfig() = default;
-            explicit FoamConfig( const Deck& );
+/// Foam behaviour data for all SATNUM regions.
+class FoamConfig
+{
+public:
+    FoamConfig() = default;
+    explicit FoamConfig(const Deck&);
 
-            const FoamRecord& getRecord( std::size_t index ) const;
+    const FoamData& getRecord(std::size_t index) const;
 
-            std::size_t size() const;
-            bool empty() const;
+    std::size_t size() const;
+    bool empty() const;
 
-            const_iterator begin() const;
-            const_iterator end() const;
+    using const_iterator = std::vector<FoamData>::const_iterator;
+    const_iterator begin() const;
+    const_iterator end() const;
 
-        private:
-            std::vector< FoamRecord > records;
-    };
+private:
+    std::vector<FoamData> data_;
+};
 
-}
+} // end namespace Opm
 
 #endif // OPM_FOAMCONFIG_HPP

--- a/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
@@ -39,15 +39,14 @@ public:
     double exponent() const;
     double minimumSurfactantConcentration() const;
 
-    enum class FoamAllowDesorption { Yes = 1, No = 2 };
-    FoamAllowDesorption allowDesorption() const;
+    bool allowDesorption() const;
     double rockDensity() const;
 
 private:
     double reference_surfactant_concentration_;
     double exponent_;
     double minimum_surfactant_concentration_;
-    FoamAllowDesorption allow_desorption_;
+    bool allow_desorption_;
     double rock_density_;
 };
 

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
@@ -33,14 +33,15 @@ FoamData::FoamData(const DeckRecord& FOAMFSC_record, const DeckRecord& FOAMROCK_
     : reference_surfactant_concentration_(FOAMFSC_record.getItem(0).getSIDouble(0))
     , exponent_(FOAMFSC_record.getItem(1).getSIDouble(0))
     , minimum_surfactant_concentration_(FOAMFSC_record.getItem(2).getSIDouble(0))
-    , allow_desorption_(static_cast<FoamAllowDesorption>(FOAMROCK_record.getItem(0).get<int>(0)))
+    , allow_desorption_(true) // will be overwritten below
     , rock_density_(FOAMROCK_record.getItem(1).getSIDouble(0))
 {
-    // Check validity of adsorption index.
+    // Check validity of adsorption index and set allow_desorption_ member.
     const int ads_ind = FOAMROCK_record.getItem(0).get<int>(0);
     if (ads_ind < 1 || ads_ind > 2) {
         throw std::runtime_error("Illegal adsorption index in FOAMROCK, must be 1 or 2.");
     }
+    allow_desorption_ = (ads_ind == 1);
 }
 
 double
@@ -61,7 +62,7 @@ FoamData::minimumSurfactantConcentration() const
     return this->minimum_surfactant_concentration_;
 }
 
-FoamData::FoamAllowDesorption
+bool
 FoamData::allowDesorption() const
 {
     return this->allow_desorption_;
@@ -87,9 +88,8 @@ FoamConfig::FoamConfig(const Deck& deck)
             throw std::runtime_error("FOAMFSC and FOAMROCK keywords have different number of records.");
         }
         const int num_records = kw_foamfsc.size();
-        this->data_.reserve(num_records);
-        for (int record = 0; record < num_records; ++record) {
-            this->data_.emplace_back(kw_foamfsc.getRecord(record), kw_foamrock.getRecord(record));
+        for (int record_index = 0; record_index < num_records; ++record_index) {
+            this->data_.emplace_back(kw_foamfsc.getRecord(record_index), kw_foamrock.getRecord(record_index));
         }
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
@@ -17,62 +17,110 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/F.hpp>
 
-namespace Opm {
+namespace Opm
+{
 
-    // FoamRecord member functions.
+// FoamData member functions.
 
-    FoamRecord::FoamRecord( const DeckRecord& record )
-        : reference_surfactant_concentration_( record.getItem( 0 ).getSIDouble( 0 ) )
-        , exponent_( record.getItem( 1 ).getSIDouble( 0 ) )
-        , minimum_surfactant_concentration_( record.getItem( 2 ).getSIDouble( 0 ) )
-    {}
-
-    double FoamRecord::referenceSurfactantConcentration() const {
-        return this->reference_surfactant_concentration_;
+FoamData::FoamData(const DeckRecord& FOAMFSC_record, const DeckRecord& FOAMROCK_record)
+    : reference_surfactant_concentration_(FOAMFSC_record.getItem(0).getSIDouble(0))
+    , exponent_(FOAMFSC_record.getItem(1).getSIDouble(0))
+    , minimum_surfactant_concentration_(FOAMFSC_record.getItem(2).getSIDouble(0))
+    , allow_desorption_(static_cast<FoamAllowDesorption>(FOAMROCK_record.getItem(0).get<int>(0)))
+    , rock_density_(FOAMROCK_record.getItem(1).getSIDouble(0))
+{
+    // Check validity of adsorption index.
+    const int ads_ind = FOAMROCK_record.getItem(0).get<int>(0);
+    if (ads_ind < 1 || ads_ind > 2) {
+        throw std::runtime_error("Illegal adsorption index in FOAMROCK, must be 1 or 2.");
     }
+}
 
-    double FoamRecord::exponent() const {
-        return this->exponent_;
-    }
+double
+FoamData::referenceSurfactantConcentration() const
+{
+    return this->reference_surfactant_concentration_;
+}
 
-    double FoamRecord::minimumSurfactantConcentration() const {
-        return this->minimum_surfactant_concentration_;
-    }
+double
+FoamData::exponent() const
+{
+    return this->exponent_;
+}
 
-    // FoamConfig member functions.
+double
+FoamData::minimumSurfactantConcentration() const
+{
+    return this->minimum_surfactant_concentration_;
+}
 
-    FoamConfig::FoamConfig( const Deck& deck )
-    {
-        if (deck.hasKeyword<ParserKeywords::FOAMFSC>()) {
-            const auto& kw = deck.getKeyword<ParserKeywords::FOAMFSC>();
-            this->records = std::vector<FoamRecord>(kw.begin(), kw.end());
+FoamData::FoamAllowDesorption
+FoamData::allowDesorption() const
+{
+    return this->allow_desorption_;
+}
+
+double
+FoamData::rockDensity() const
+{
+    return this->rock_density_;
+}
+
+// FoamConfig member functions.
+
+FoamConfig::FoamConfig(const Deck& deck)
+{
+    if (deck.hasKeyword<ParserKeywords::FOAMFSC>()) {
+        const auto& kw_foamfsc = deck.getKeyword<ParserKeywords::FOAMFSC>();
+        if (!deck.hasKeyword<ParserKeywords::FOAMROCK>()) {
+            throw std::runtime_error("FOAMFSC present but no FOAMROCK keyword found.");
+        }
+        const auto& kw_foamrock = deck.getKeyword<ParserKeywords::FOAMROCK>();
+        if (kw_foamfsc.size() != kw_foamrock.size()) {
+            throw std::runtime_error("FOAMFSC and FOAMROCK keywords have different number of records.");
+        }
+        const int num_records = kw_foamfsc.size();
+        this->data_.reserve(num_records);
+        for (int record = 0; record < num_records; ++record) {
+            this->data_.emplace_back(kw_foamfsc.getRecord(record), kw_foamrock.getRecord(record));
         }
     }
+}
 
-    const FoamRecord& FoamConfig::getRecord( std::size_t index ) const {
-        return this->records.at( index );
-    }
+const FoamData&
+FoamConfig::getRecord(std::size_t index) const
+{
+    return this->data_.at(index);
+}
 
-    std::size_t FoamConfig::size() const {
-        return this->records.size();
-    }
+std::size_t
+FoamConfig::size() const
+{
+    return this->data_.size();
+}
 
-    bool FoamConfig::empty() const {
-        return this->records.empty();
-    }
+bool
+FoamConfig::empty() const
+{
+    return this->data_.empty();
+}
 
-    FoamConfig::const_iterator FoamConfig::begin() const {
-        return this->records.begin();
-    }
+FoamConfig::const_iterator
+FoamConfig::begin() const
+{
+    return this->data_.begin();
+}
 
-    FoamConfig::const_iterator FoamConfig::end() const {
-        return this->records.end();
-    }
+FoamConfig::const_iterator
+FoamConfig::end() const
+{
+    return this->data_.end();
+}
 } // namespace Opm

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMROCK
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMROCK
@@ -1,0 +1,6 @@
+{"name" : "FOAMROCK" , "sections" : ["SPECIAL", "PROPS"], "size" : {"keyword":"TABDIMS" , "item":"NTSFUN"}, "items":
+    [   {"name" : "ADSORPTION_INDEX", "value_type" : "INT", "default" : 1},
+        {"name" : "ROCK_DENSITY", "value_type" : "DOUBLE", "dimension" : "Density"}
+    ]
+}
+

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -111,6 +111,7 @@ set( keywords
      000_Eclipse100/F/FOAM
      000_Eclipse100/F/FOAMADS
      000_Eclipse100/F/FOAMFSC
+     000_Eclipse100/F/FOAMROCK
      000_Eclipse100/F/FRICTION
      000_Eclipse100/F/FULLIMP
      000_Eclipse100/G/GAS

--- a/tests/parser/FoamTests.cpp
+++ b/tests/parser/FoamTests.cpp
@@ -95,6 +95,70 @@ SATNUM
     return parser.parseString( deckData );
 }
 
+static Deck createFailingDeck() {
+    // Using a raw string literal with xxx as delimiter.
+    const char *deckData = R"xxx(
+RUNSPEC
+
+DIMENS
+ 10 10 10 /
+TABDIMS
+3 /
+GRID
+DX
+1000*0.25 /
+DY
+1000*0.25 /
+DZ
+1000*0.25 /
+TOPS
+100*0.25 /
+FAULTS
+  'F1'  1  1  1  4   1  4  'X' /
+  'F2'  5  5  1  4   1  4  'X-' /
+/
+MULTFLT
+  'F1' 0.50 /
+  'F2' 0.50 /
+/
+EDIT
+MULTFLT /
+  'F2' 0.25 /
+/
+WATER
+
+OIL
+
+GAS
+
+FOAM
+
+TITLE
+The title
+
+START
+8 MAR 1998 /
+
+PROPS
+FOAMFSC
+1 2 0.3 /
+4 5 /
+6 /
+
+-- This will fail, as FOAMROCK is missing
+
+REGIONS
+SWAT
+1000*1 /
+SATNUM
+1000*2 /
+)xxx"; // End of raw string literal with xxx as delimiter.
+    Parser parser;
+    return parser.parseString( deckData );
+}
+
+
+
 
 BOOST_AUTO_TEST_CASE(FoamConfigTest) {
     auto deck = createDeck();
@@ -104,19 +168,24 @@ BOOST_AUTO_TEST_CASE(FoamConfigTest) {
     BOOST_CHECK_EQUAL(fc.getRecord(0).referenceSurfactantConcentration(), 1.0);
     BOOST_CHECK_EQUAL(fc.getRecord(0).exponent(), 2.0);
     BOOST_CHECK_EQUAL(fc.getRecord(0).minimumSurfactantConcentration(), 0.3);
-    BOOST_CHECK(fc.getRecord(0).allowDesorption() == FoamData::FoamAllowDesorption::Yes);
+    BOOST_CHECK(fc.getRecord(0).allowDesorption());
     BOOST_CHECK_EQUAL(fc.getRecord(0).rockDensity(), 2000.0);
 
     BOOST_CHECK_EQUAL(fc.getRecord(1).referenceSurfactantConcentration(), 4.0);
     BOOST_CHECK_EQUAL(fc.getRecord(1).exponent(), 5.0);
     BOOST_CHECK_EQUAL(fc.getRecord(1).minimumSurfactantConcentration(), 1e-20); // Defaulted.
-    BOOST_CHECK(fc.getRecord(1).allowDesorption() == FoamData::FoamAllowDesorption::No);
+    BOOST_CHECK(!fc.getRecord(1).allowDesorption());
     BOOST_CHECK_EQUAL(fc.getRecord(1).rockDensity(), 1800.0);
 
     BOOST_CHECK_EQUAL(fc.getRecord(2).referenceSurfactantConcentration(), 6.0);
     BOOST_CHECK_EQUAL(fc.getRecord(2).exponent(), 1.0); // Defaulted.
     BOOST_CHECK_EQUAL(fc.getRecord(2).minimumSurfactantConcentration(), 1e-20); // Defaulted.
-    BOOST_CHECK(fc.getRecord(2).allowDesorption() == FoamData::FoamAllowDesorption::No);
+    BOOST_CHECK(!fc.getRecord(2).allowDesorption());
     BOOST_CHECK_EQUAL(fc.getRecord(2).rockDensity(), 2400.0);
+}
+
+BOOST_AUTO_TEST_CASE(FoamConfigFailureTest) {
+    auto deck = createFailingDeck();
+    BOOST_CHECK_THROW(EclipseState state(deck), std::runtime_error);
 }
 

--- a/tests/parser/FoamTests.cpp
+++ b/tests/parser/FoamTests.cpp
@@ -80,6 +80,11 @@ FOAMFSC
 4 5 /
 6 /
 
+FOAMROCK
+1 2000 /
+2 1800 /
+2 2400 /
+
 REGIONS
 SWAT
 1000*1 /
@@ -99,11 +104,19 @@ BOOST_AUTO_TEST_CASE(FoamConfigTest) {
     BOOST_CHECK_EQUAL(fc.getRecord(0).referenceSurfactantConcentration(), 1.0);
     BOOST_CHECK_EQUAL(fc.getRecord(0).exponent(), 2.0);
     BOOST_CHECK_EQUAL(fc.getRecord(0).minimumSurfactantConcentration(), 0.3);
+    BOOST_CHECK(fc.getRecord(0).allowDesorption() == FoamData::FoamAllowDesorption::Yes);
+    BOOST_CHECK_EQUAL(fc.getRecord(0).rockDensity(), 2000.0);
+
     BOOST_CHECK_EQUAL(fc.getRecord(1).referenceSurfactantConcentration(), 4.0);
     BOOST_CHECK_EQUAL(fc.getRecord(1).exponent(), 5.0);
     BOOST_CHECK_EQUAL(fc.getRecord(1).minimumSurfactantConcentration(), 1e-20); // Defaulted.
+    BOOST_CHECK(fc.getRecord(1).allowDesorption() == FoamData::FoamAllowDesorption::No);
+    BOOST_CHECK_EQUAL(fc.getRecord(1).rockDensity(), 1800.0);
+
     BOOST_CHECK_EQUAL(fc.getRecord(2).referenceSurfactantConcentration(), 6.0);
     BOOST_CHECK_EQUAL(fc.getRecord(2).exponent(), 1.0); // Defaulted.
     BOOST_CHECK_EQUAL(fc.getRecord(2).minimumSurfactantConcentration(), 1e-20); // Defaulted.
+    BOOST_CHECK(fc.getRecord(2).allowDesorption() == FoamData::FoamAllowDesorption::No);
+    BOOST_CHECK_EQUAL(fc.getRecord(2).rockDensity(), 2400.0);
 }
 


### PR DESCRIPTION
Adding FOAMROCK made it necessary to refactor FoamConfig, and add code to ensure consistency of FOAMROCK and FOAMFSC (same number of records). This was helped by the constructor for FoamConfig taking a Deck rather than a keyword, thanks for the advice before! Before refactoring I ran clang-format on the class to prevent annoyance, the PR therefore looks bigger than it really is.