### PR TITLE
Allow FOAM without FOAMFSC

### DIFF
--- a/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
@@ -33,7 +33,8 @@ class DeckRecord;
 class FoamData
 {
 public:
-    explicit FoamData(const DeckRecord& FOAMFSC_record, const DeckRecord& FOAMROCK_record);
+    FoamData(const DeckRecord& FOAMFSC_record, const DeckRecord& FOAMROCK_record);
+    explicit FoamData(const DeckRecord& FOAMROCK_record);
 
     double referenceSurfactantConcentration() const;
     double exponent() const;

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -101,7 +101,8 @@ namespace Opm {
     }
 
     bool InitConfig::hasFoamConfig() const {
-        return !this->foamconfig.empty();
+        // return !this->foamconfig.empty();
+        return true;
     }
 
     const FoamConfig& InitConfig::getFoamConfig() const {


### PR DESCRIPTION
I know I said the previous PR would be the last... However, now I have connected all the dots and of course some logic was off.

This is necessary to support the table-based gas mobility reduction model (using FOAMMOB) which is the only one we will support initially. In order to extend support to the function-based model the FOAMFSC-related things have been kept.