### PR TITLE
Set default commit to use for libecl to a known OPM-compatible commit

### DIFF
--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -13,6 +13,8 @@ EXTRA_MODULE_FLAGS[libecl]="-DCMAKE_POSITION_INDEPENDENT_CODE=1"
 #             'ghprbCommentBody',
 #             'CONFIGURATIONS', 'TOOLCHAINS'
 function parseRevisions {
+  # Set default for libecl to be last known good commit.
+  upstreamRev[libecl]=7abee4f1a19dbba0c845e3dc23f7950021e12059
   for upstream in ${upstreams[*]}
   do
     if grep -qi "$upstream=" <<< $ghprbCommentBody
@@ -149,11 +151,14 @@ function clone_module {
   if [ "$1" == "libecl" ]
   then
     git remote add origin https://github.com/Statoil/$1
+    git fetch origin master
+    git checkout $2
+    git checkout -b branch_to_build
   else
     git remote add origin https://github.com/OPM/$1
+    git fetch --depth 1 origin $2:branch_to_build
+    git checkout branch_to_build
   fi
-  git fetch --depth 1 origin $2:branch_to_build
-  git checkout branch_to_build
   git log HEAD -1 | cat
   test $? -eq 0 || exit 1
   popd


### PR DESCRIPTION
This is mostly just to see if it saves jenkins from libecl. If merged it would remove all ability to specify libecl PRs etc.