### PR TITLE
Add method Schedule::groupNames()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -148,8 +148,6 @@ namespace Opm
         bool hasGroup(const std::string& groupName) const;
         const Group& getGroup(const std::string& groupName) const;
         Group& getGroup(const std::string& groupName);
-        std::vector< const Group* > getGroups() const;
-        std::vector< const Group* > getGroups(size_t timeStep) const;
         const Tuning& getTuning() const;
         const MessageLimits& getMessageLimits() const;
         void invalidNamePattern (const std::string& namePattern, const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -147,6 +147,7 @@ namespace Opm
         size_t numGroups(size_t timeStep) const;
         bool hasGroup(const std::string& groupName) const;
         const Group& getGroup(const std::string& groupName) const;
+        Group& getGroup(const std::string& groupName);
         std::vector< const Group* > getGroups() const;
         std::vector< const Group* > getGroups(size_t timeStep) const;
         const Tuning& getTuning() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -121,6 +121,11 @@ namespace Opm
         std::vector<std::string> wellNames(size_t timeStep) const;
         std::vector<std::string> wellNames() const;
 
+        std::vector<std::string> groupNames(const std::string& pattern, size_t timeStep) const;
+        std::vector<std::string> groupNames(size_t timeStep) const;
+        std::vector<std::string> groupNames(const std::string& pattern) const;
+        std::vector<std::string> groupNames() const;
+
         void updateWell(std::shared_ptr<Well2> well, size_t reportStep);
         const Well2& getWell2(const std::string& wellName, size_t timeStep) const;
         const Well2& getWell2atEnd(const std::string& well_name) const;

--- a/python/sunbeam/schedule.cpp
+++ b/python/sunbeam/schedule.cpp
@@ -73,8 +73,9 @@ namespace {
 
     std::vector<Group> get_groups( const Schedule& sch ) {
         std::vector< Group > groups;
-        for( const auto& g : sch.getGroups() )
-            groups.push_back( *g );
+        for( const auto& group_name : sch.groupNames())
+            groups.push_back( sch.getGroup(group_name) );
+
         return groups;
     }
 

--- a/python/sunbeam/schedule.cpp
+++ b/python/sunbeam/schedule.cpp
@@ -82,6 +82,11 @@ namespace {
         return sch.hasWell( wellName );
     }
 
+    const Group& get_group(const Schedule& sch, const std::string group_name) {
+        return sch.getGroup(group_name);
+    }
+
+
 }
 
 void sunbeam::export_Schedule(py::module& module) {
@@ -94,7 +99,7 @@ void sunbeam::export_Schedule(py::module& module) {
     .def( "_get_wells", &Schedule::getWells2)
     .def("_getwell", &get_well)
     .def( "__contains__", &has_well )
-    .def( "_group", &Schedule::getGroup, ref_internal)
+    .def( "_group", &get_group, ref_internal)
     .def( "_group_tree", &get_grouptree, ref_internal);
 
 }

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -91,58 +91,58 @@ namespace {
 
     std::map <size_t, const Opm::Group*>  currentGroupMapIndexGroup(const Opm::Schedule& sched, const size_t simStep, const std::vector<int>& inteHead)
     {
-	const auto& groups = sched.getGroups(simStep);
-	// make group index for current report step
-	std::map <size_t, const Opm::Group*> indexGroupMap;
-	for (const auto* group : groups) {
-	    int ind = (group->name() == "FIELD")
-	    ? ngmaxz(inteHead)-1 : group->seqIndex()-1;
-	    const std::pair<size_t, const Opm::Group*> groupPair = std::make_pair(static_cast<size_t>(ind), group);
-	    indexGroupMap.insert(groupPair);
-	}
-	return indexGroupMap;
+        // make group index for current report step
+        std::map <size_t, const Opm::Group*> indexGroupMap;
+        for (const auto& group_name : sched.groupNames(simStep)) {
+            const auto& group = sched.getGroup(group_name);
+            int ind = (group.name() == "FIELD")
+                ? ngmaxz(inteHead)-1 : group.seqIndex()-1;
+
+            const std::pair<size_t, const Opm::Group*> groupPair = std::make_pair(static_cast<size_t>(ind), std::addressof(group));
+            indexGroupMap.insert(groupPair);
+        }
+        return indexGroupMap;
     }
 
     std::map <const std::string, size_t>  currentGroupMapNameIndex(const Opm::Schedule& sched, const size_t simStep, const std::vector<int>& inteHead)
     {
-	const auto& groups = sched.getGroups(simStep);
-	// make group name to index map for the current time step
-	std::map <const std::string, size_t> groupIndexMap;
-	for (const auto* group : groups) {
-	    int ind = (group->name() == "FIELD")
-                    ? ngmaxz(inteHead)-1 : group->seqIndex()-1;
-	    std::pair<const std::string, size_t> groupPair = std::make_pair(group->name(), ind);
-	    groupIndexMap.insert(groupPair);
-	}
-	return groupIndexMap;
+        // make group name to index map for the current time step
+        std::map <const std::string, size_t> groupIndexMap;
+        for (const auto& group_name : sched.groupNames(simStep)) {
+            const auto& group = sched.getGroup(group_name);
+            int ind = (group.name() == "FIELD")
+                ? ngmaxz(inteHead)-1 : group.seqIndex()-1;
+            std::pair<const std::string, size_t> groupPair = std::make_pair(group.name(), ind);
+            groupIndexMap.insert(groupPair);
+        }
+        return groupIndexMap;
     }
 
     int currentGroupLevel(const Opm::Schedule& sched, const Opm::Group& group, const size_t simStep)
     {
-	int level = 0;
-	const std::vector< const Opm::Group* >  groups = sched.getGroups(simStep);
-      	const std::string& groupName = group.name();
-	if (!sched.hasGroup(groupName))
+        int level = 0;
+        const std::string& groupName = group.name();
+        if (!sched.hasGroup(groupName))
             throw std::invalid_argument("No such group: " + groupName);
         {
             if (group.hasBeenDefined( simStep )) {
                 const auto& groupTree = sched.getGroupTree( simStep );
-		//find group level - field level is 0
-		std::string tstGrpName = groupName;
-		while (((tstGrpName.size())>0) && (!(tstGrpName=="FIELD"))) {
-		    std::string curParent = groupTree.parent(tstGrpName);
-		    level+=1;
-		    tstGrpName = curParent;
-		}
-		return level;
-	    }
-	    else {
-		std::stringstream str;
-		str << "actual group has not been defined at report time: " << simStep;
-		throw std::invalid_argument(str.str());
-	    }
-	}
-	return level;
+                //find group level - field level is 0
+                std::string tstGrpName = groupName;
+                while (((tstGrpName.size())>0) && (!(tstGrpName=="FIELD"))) {
+                    std::string curParent = groupTree.parent(tstGrpName);
+                    level+=1;
+                    tstGrpName = curParent;
+                }
+                return level;
+            }
+            else {
+                std::stringstream str;
+                str << "actual group has not been defined at report time: " << simStep;
+                throw std::invalid_argument(str.str());
+            }
+        }
+        return level;
     }
 
 

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -104,32 +104,32 @@ namespace {
             };
         }
 
-	std::map <const std::string, size_t>  currentGroupMapNameIndex(const Opm::Schedule& sched, const size_t simStep, const std::vector<int>& inteHead)
-	{
-	    const auto& groups = sched.getGroups(simStep);
-	    // make group name to index map for the current time step
-	    std::map <const std::string, size_t> groupIndexMap;
-	    for (const auto* group : groups) {
-		int ind = (group->name() == "FIELD")
-			? inteHead[VI::intehead::NGMAXZ]-1 : group->seqIndex()-1;
-		std::pair<const std::string, size_t> groupPair = std::make_pair(group->name(), ind);
-		groupIndexMap.insert(groupPair);
-	    }
-	    return groupIndexMap;
+        std::map <const std::string, size_t>  currentGroupMapNameIndex(const Opm::Schedule& sched, const size_t simStep, const std::vector<int>& inteHead)
+        {
+            // make group name to index map for the current time step
+            std::map <const std::string, size_t> groupIndexMap;
+            for (const auto& group_name : sched.groupNames(simStep)) {
+                const auto& group = sched.getGroup(group_name);
+                int ind = (group.name() == "FIELD")
+                    ? inteHead[VI::intehead::NGMAXZ]-1 : group.seqIndex()-1;
+                std::pair<const std::string, size_t> groupPair = std::make_pair(group.name(), ind);
+                groupIndexMap.insert(groupPair);
+            }
+            return groupIndexMap;
         }
 
         int groupIndex(const std::string&              grpName,
                        const std::map <const std::string, size_t>&  currentGroupMapNameIndex)
         {
-	    int ind = 0;
-	    auto searchGTName = currentGroupMapNameIndex.find(grpName);
-	    if (searchGTName != currentGroupMapNameIndex.end()) {
-		ind = searchGTName->second + 1;
-	    }
-	    else {
-		std::cout << "group Name: " << grpName << std::endl;
-		throw std::invalid_argument( "Invalid group name" );
-	    }
+            int ind = 0;
+            auto searchGTName = currentGroupMapNameIndex.find(grpName);
+            if (searchGTName != currentGroupMapNameIndex.end()) {
+                ind = searchGTName->second + 1;
+            }
+            else {
+                std::cout << "group Name: " << grpName << std::endl;
+                throw std::invalid_argument( "Invalid group name" );
+            }
             return ind;
         }
 

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -1181,9 +1181,8 @@ namespace {
                 intehead, std::move(rst_view)
             };
 
-            for (const auto* group : schedule.getGroups(sim_step)) {
-                const auto& gname = group->name();
-
+            for (const auto& gname : schedule.groupNames(sim_step)) {
+                const auto& group = schedule.getGroup(gname);
                 // Note: Order of group values in {I,X}GRP arrays mostly
                 // matches group's order of occurrence in .DATA file.
                 // Values pertaining to FIELD are stored at zero-based order
@@ -1196,7 +1195,7 @@ namespace {
                 // proofing and robustness in case that ever changes.
                 const auto groupOrderIx = (gname == "FIELD")
                     ? groupData.maxGroups() // NGMAXZ -- Item 3 of WELLDIMS
-                    : std::max(group->seqIndex(), std::size_t{1}) - 1;
+                    : std::max(group.seqIndex(), std::size_t{1}) - 1;
 
                 assign_group_cumulatives(gname, groupOrderIx, groupData, smry);
             }

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -94,12 +94,9 @@ namespace {
             entities.emplace_back("WWVIR", well_name);
         }
 
-        for (const auto* grp : sched.getGroups()) {
-            const auto& grp_name = grp->name();
-
-            if (grp_name != "FIELD") {
+        for (const auto& grp_name : sched.groupNames()) {
+            if (grp_name != "FIELD")
                 makeEntities('G', grp_name);
-            }
         }
 
         makeEntities('F', "FIELD");

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2190,53 +2190,6 @@ namespace {
             throw std::invalid_argument("Group: " + groupName + " does not exist");
     }
 
-    std::vector< const Group* > Schedule::getGroups() const {
-        std::vector< const Group* > groups;
-
-        for( const auto& group : m_groups )
-            groups.push_back( std::addressof(group.second) );
-
-        return groups;
-    }
-
-    std::vector< Group* > Schedule::getGroups(const std::string& groupNamePattern) {
-        size_t wildcard_pos = groupNamePattern.find("*");
-
-        if( wildcard_pos != groupNamePattern.length()-1 ) {
-            if( m_groups.count( groupNamePattern ) == 0) return {};
-            return { std::addressof( m_groups.get( groupNamePattern ) ) };
-        }
-
-        std::vector< Group* > groups;
-        for( auto& group_pair : this->m_groups ) {
-            auto& group = group_pair.second;
-            if( Group::groupNameInGroupNamePattern( group.name(), groupNamePattern ) ) {
-                groups.push_back( std::addressof( group ) );
-            }
-        }
-
-        return groups;
-    }
-
-    std::vector< const Group* > Schedule::getGroups(size_t timeStep) const {
-
-        if (timeStep >= m_timeMap.size()) {
-            throw std::invalid_argument("Timestep to large");
-        }
-
-        auto defined = [=]( const Group& g ) {
-            return g.hasBeenDefined( timeStep );
-        };
-
-        std::vector< const Group* > groups;
-
-        for( const auto& group_pair : m_groups ) {
-            const auto& group = group_pair.second;
-            if( !defined( group) ) continue;
-            groups.push_back( &group );
-        }
-        return groups;
-    }
 
     void Schedule::addWellToGroup( Group& newGroup, const std::string& wellName , size_t timeStep) {
         auto& dynamic_state = this->wells_static.at(wellName);

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -198,9 +198,9 @@ inline void keywordG( SummaryConfig::keyword_list& list,
     if( keyword.size() == 0 ||
         !keyword.getDataRecord().getDataItem().hasValue( 0 ) ) {
 
-        for( const auto& group : schedule.getGroups() ) {
-            if( group->name() == "FIELD" ) continue;
-            list.push_back( SummaryConfig::keyword_type(keyword.name(), group->name() ));
+        for( const auto& group : schedule.groupNames() ) {
+            if( group == "FIELD" ) continue;
+            list.push_back( SummaryConfig::keyword_type(keyword.name(), group ));
         }
         return;
     }

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -288,6 +288,10 @@ BOOST_AUTO_TEST_CASE(createDeckWithGEFAC) {
     Runspec runspec (deck );
     Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec);
 
+    auto group_names = schedule.groupNames("PRODUC");
+    BOOST_CHECK_EQUAL(group_names.size(), 1);
+    BOOST_CHECK_EQUAL(group_names[0], "PRODUC");
+
     const auto& group1 = schedule.getGroup("PRODUC");
     BOOST_CHECK_EQUAL(group1.getGroupEfficiencyFactor(0), 0.85);
     BOOST_CHECK(group1.getTransferGroupEfficiencyFactor(0));

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -382,6 +382,12 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     BOOST_CHECK_EQUAL( "CG", groups[1]->name());
     BOOST_CHECK_EQUAL( "BG", groups[2]->name());
     BOOST_CHECK_EQUAL( "AG", groups[3]->name());
+
+    auto group_names = schedule.groupNames();
+    BOOST_CHECK_EQUAL( "FIELD", group_names[0]);
+    BOOST_CHECK_EQUAL( "CG", group_names[1]);
+    BOOST_CHECK_EQUAL( "BG", group_names[2]);
+    BOOST_CHECK_EQUAL( "AG", group_names[3]);
 }
 
 
@@ -437,6 +443,10 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
         BOOST_CHECK( has_well( parent_wells2, "BW_2" ));
         BOOST_CHECK( has_well( parent_wells2, "AW_3" ));
     }
+    auto group_names = schedule.groupNames("P*", 0);
+    BOOST_CHECK( std::find(group_names.begin(), group_names.end(), "PG1") != group_names.end() );
+    BOOST_CHECK( std::find(group_names.begin(), group_names.end(), "PG2") != group_names.end() );
+    BOOST_CHECK( std::find(group_names.begin(), group_names.end(), "PLATFORM") != group_names.end() );
 }
 
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -377,12 +377,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     BOOST_CHECK_EQUAL( "BW_2" , well_names[1]);
     BOOST_CHECK_EQUAL( "AW_3" , well_names[2]);
 
-    auto groups = schedule.getGroups();
-    // groups[0] is 'FIELD'
-    BOOST_CHECK_EQUAL( "CG", groups[1]->name());
-    BOOST_CHECK_EQUAL( "BG", groups[2]->name());
-    BOOST_CHECK_EQUAL( "AG", groups[3]->name());
-
     auto group_names = schedule.groupNames();
     BOOST_CHECK_EQUAL( "FIELD", group_names[0]);
     BOOST_CHECK_EQUAL( "CG", group_names[1]);
@@ -522,27 +516,6 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTime
     BOOST_CHECK( schedule.getGroupTree( 0 ).exists( "FIELD" ) );
     BOOST_CHECK( schedule.getGroupTree( 0 ).exists( "FAREN" ) );
     BOOST_CHECK_EQUAL( "FAREN", schedule.getGroupTree( 0 ).parent( "BARNET" ) );
-}
-
-BOOST_AUTO_TEST_CASE(GetGroups) {
-    auto deck = deckWithGRUPTREE();
-    EclipseGrid grid(10,10,10);
-    TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid);
-    Runspec runspec (deck);
-    Schedule schedule(deck , grid , eclipseProperties, runspec);
-
-    auto groups = schedule.getGroups();
-
-    BOOST_CHECK_EQUAL( 3, groups.size() );
-
-    std::vector< std::string > names;
-    for( const auto group : groups ) names.push_back( group->name() );
-    std::sort( names.begin(), names.end() );
-
-    BOOST_CHECK_EQUAL( "BARNET", names[ 0 ] );
-    BOOST_CHECK_EQUAL( "FAREN",  names[ 1 ] );
-    BOOST_CHECK_EQUAL( "FIELD",  names[ 2 ] );
 }
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {


### PR DESCRIPTION
First step on group rewrite:

1. Add method `Schedule::groupNames()`
2. Remove `Schedule::getGroups()`

This is to align with the way it is done for the wells - where it has worked reasonably well.

Downstream: https://github.com/OPM/opm-simulators/pull/1939