### PR TITLE
mark constructor explicit

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
@@ -28,7 +28,7 @@ namespace Opm {
 
 class Group2 {
 public:
-    Group2(const std::string& group_name);
+    explicit Group2(const std::string& group_name);
 
 private:
     std::string name;


### PR DESCRIPTION
Just some everyday janitoring. It seems no code relies on implicit conversions yet at least.