### PR TITLE
Group2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ option(ENABLE_ECL_INPUT "Enable eclipse input support?" ON)
 option(ENABLE_ECL_OUTPUT "Enable eclipse output support?" ON)
 option(ENABLE_MOCKSIM "Build the mock simulator for io testing" ON)
 option(OPM_ENABLE_PYTHON "Enable python bindings?" OFF)
+option(ENABLE_GROUP_TEST "" ON)
+
+if (ENABLE_GROUP_TEST)
+  add_definitions(-DGROUP_TEST)
+endif()
 
 # Output implies input
 if(ENABLE_ECL_OUTPUT)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -88,6 +88,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/Events.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Group/GroupTree.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/injection.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.cpp
@@ -543,6 +544,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
        opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+       opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
        opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
        opm/parser/eclipse/EclipseState/Schedule/Events.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
@@ -203,6 +203,10 @@ class DynamicState {
     }
 
 
+    std::size_t size() const {
+        return this->m_data.size();
+    }
+
     private:
         std::vector< T > m_data;
         size_t initial_range;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
@@ -1,0 +1,52 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <vector>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
+
+#ifndef GROUPTREE2
+#define GROUPTREE2
+
+namespace Opm {
+
+class GTNode {
+public:
+    GTNode(const Group2& group, const GTNode* parent);
+
+    void add_group(const GTNode& child_group);
+    void add_well(const Well2& well);
+
+    const std::vector<Well2>& wells() const;
+    const std::vector<GTNode>& groups() const;
+    const std::string& name() const;
+    const GTNode& parent() const;
+    const Group2& group() const;
+private:
+    const Group2 m_group;
+    const GTNode * m_parent;
+    std::vector<GTNode> m_child_groups;
+    std::vector<Well2> m_wells;
+};
+
+}
+#endif
+
+

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
@@ -42,6 +42,10 @@ public:
 private:
     const Group2 m_group;
     const GTNode * m_parent;
+    /*
+      Class T with a stl container <T> - supposedly undefined behavior before
+      C++17 - but it compiles without warnings.
+    */
     std::vector<GTNode> m_child_groups;
     std::vector<Well2> m_wells;
 };

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
@@ -23,15 +23,87 @@
 
 #include <string>
 
+#include <opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 namespace Opm {
 
 class Group2 {
 public:
-    explicit Group2(const std::string& group_name);
 
+struct GroupInjectionProperties {
+    Phase phase = Phase::WATER;
+    GroupInjection::ControlEnum cmode = GroupInjection::NONE;
+    double surface_max_rate = 0;
+    double resv_max_rate = 0;
+    double target_reinj_fraction = 0;
+    double target_void_fraction = 0;
+
+    bool operator==(const GroupInjectionProperties& other) const;
+    bool operator!=(const GroupInjectionProperties& other) const;
+};
+
+
+struct GroupProductionProperties {
+    GroupProduction::ControlEnum cmode = GroupProduction::NONE;
+    GroupProductionExceedLimit::ActionEnum exceed_action = GroupProductionExceedLimit::NONE;
+    double oil_target = 0;
+    double water_target = 0;
+    double gas_target = 0;
+    double liquid_target = 0;
+    double resv_target = 0;
+
+    bool operator==(const GroupProductionProperties& other) const;
+    bool operator!=(const GroupProductionProperties& other) const;
+};
+
+    Group2(const std::string& group_name, std::size_t insert_index_arg, std::size_t init_step_arg);
+
+    bool defined(std::size_t timeStep) const;
+    std::size_t insert_index() const;
+    const std::string& name() const;
+    const GroupProductionProperties& productionProperties() const;
+    const GroupInjectionProperties& injectionProperties() const;
+    int getGroupNetVFPTable() const;
+    bool updateNetVFPTable(int vfp_arg);
+    bool update_gefac(double gefac, bool transfer_gefac);
+    bool updateInjection(const GroupInjectionProperties& injection);
+    bool updateProduction(const GroupProductionProperties& production);
+    bool isProductionGroup() const;
+    bool isInjectionGroup() const;
+    void setProductionGroup();
+    void setInjectionGroup();
+    double getGroupEfficiencyFactor() const;
+    bool   getTransferGroupEfficiencyFactor() const;
+
+    std::size_t numWells() const;
+    bool addGroup(const std::string& group_name);
+    bool hasGroup(const std::string& group_name) const;
+    void delGroup(const std::string& group_name);
+    bool addWell(const std::string& well_name);
+    bool hasWell(const std::string& well_name) const;
+    void delWell(const std::string& well_name);
+
+    const std::vector<std::string>& wells() const;
+    const std::vector<std::string>& groups() const;
 private:
-    std::string name;
+    bool hasType(GroupType gtype) const;
+    void addType(GroupType new_gtype);
+
+    std::string m_name;
+    std::size_t m_insert_index;
+    std::size_t init_step;
+    GroupType group_type;
+    double gefac;
+    bool transfer_gefac;
+    int vfp_table;
+
+    IOrderSet<std::string> m_wells;
+    IOrderSet<std::string> m_groups;
+
+    GroupInjectionProperties injection_properties;
+    GroupProductionProperties production_properties;
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
@@ -90,6 +90,7 @@ struct GroupProductionProperties {
 
     const std::vector<std::string>& wells() const;
     const std::vector<std::string>& groups() const;
+    bool wellgroup() const;
 private:
     bool hasType(GroupType gtype) const;
     void addType(GroupType new_gtype);

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp
@@ -68,6 +68,9 @@ struct GroupProductionProperties {
     int getGroupNetVFPTable() const;
     bool updateNetVFPTable(int vfp_arg);
     bool update_gefac(double gefac, bool transfer_gefac);
+
+    const std::string& parent() const;
+    bool updateParent(const std::string& parent);
     bool updateInjection(const GroupInjectionProperties& injection);
     bool updateProduction(const GroupProductionProperties& production);
     bool isProductionGroup() const;
@@ -99,6 +102,7 @@ private:
     bool transfer_gefac;
     int vfp_table;
 
+    std::string parent_group;
     IOrderSet<std::string> m_wells;
     IOrderSet<std::string> m_groups;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -29,6 +29,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GroupTree.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
@@ -148,6 +149,8 @@ namespace Opm
         bool hasGroup(const std::string& groupName) const;
         const Group& getGroup(const std::string& groupName) const;
         Group& getGroup(const std::string& groupName);
+        const Group2& getGroup2(const std::string& groupName, size_t timeStep) const;
+
         const Tuning& getTuning() const;
         const MessageLimits& getMessageLimits() const;
         void invalidNamePattern (const std::string& namePattern, const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword) const;
@@ -174,6 +177,7 @@ namespace Opm
         TimeMap m_timeMap;
         OrderedMap< std::string, Group > m_groups;
         OrderedMap< std::string, DynamicState<std::shared_ptr<Well2>>> wells_static;
+        OrderedMap< std::string, DynamicState<std::shared_ptr<Group2>>> groups;
         DynamicState< GroupTree > m_rootGroupTree;
         DynamicState< OilVaporizationProperties > m_oilvaporizationproperties;
         Events m_events;
@@ -194,6 +198,8 @@ namespace Opm
         std::vector< Group* > getGroups(const std::string& groupNamePattern);
         std::map<std::string,Events> well_events;
 
+        void updateGroup(std::shared_ptr<Group2> group, size_t reportStep);
+        bool checkGroups(const ParseContext& parseContext, ErrorGuard& errors);
         bool updateWellStatus( const std::string& well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( Group& newGroup , const std::string& wellName , size_t timeStep);
         void iterateScheduleSection(const ParseContext& parseContext ,  ErrorGuard& errors, const SCHEDULESection& , const EclipseGrid& grid,

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -45,6 +45,48 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
 
+
+/*
+  The DynamicState<std::shared_ptr<T>> pattern: The quantities in the Schedule
+  section like e.g. wellrates and completion properties are typically
+  characterized by the following behaviour:
+
+    1. They can be updated repeatedly at arbitrary points in the Schedule
+       section.
+
+    2. The value set at one timestep will apply until is explicitly set again at
+       a later timestep.
+
+  These properties are typically stored in a DynamicState<T> container; the
+  DynamicState<T> class is a container which implements this semantics:
+
+    1. It is legitimate to ask for an out-of-range value, you will then get the
+       last value which has been set.
+
+    2. When assigning an out-of-bounds value the container will append the
+       currently set value until correct length has been reached, and then the
+       new value will be assigned.
+
+    3. The DynamicState<T> has an awareness of the total length of the time
+       axis, trying to access values beyound that is illegal.
+
+  For many of the non-trival objects like eg Well2 and Group2 the DynamicState<>
+  contains a shared pointer to an underlying object, that way the fill operation
+  when the vector is resized is quite fast. The following pattern is quite
+  common for the Schedule implementation:
+
+
+       // Create a new well object.
+       std::shared_ptr<Well> new_well = this->getWell2( well_name, time_step );
+
+       // Update the new well object with new settings from the deck, the
+       // updateXXXX() method will return true if the well object was actually
+       // updated:
+       if (new_well->updateRate( new_rate ))
+           this->dynamic_state.update( time_step, new_well);
+
+*/
+
 namespace Opm
 {
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -31,6 +31,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GroupTree.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
@@ -142,6 +143,8 @@ namespace Opm
         const Actions& actions() const;
         void evalAction(const SummaryState& summary_state, size_t timeStep);
 
+        GTNode groupTree(const std::string& root_node, size_t time_step) const;
+        GTNode groupTree(std::size_t report_step) const;
         const GroupTree& getGroupTree(size_t t) const;
         std::vector< const Group* > getChildGroups(const std::string& group_name, size_t timeStep) const;
         size_t numGroups() const;
@@ -198,13 +201,16 @@ namespace Opm
         std::vector< Group* > getGroups(const std::string& groupNamePattern);
         std::map<std::string,Events> well_events;
 
+        GTNode groupTree(const std::string& root_node, std::size_t report_step, const GTNode * parent) const;
         void updateGroup(std::shared_ptr<Group2> group, size_t reportStep);
         bool checkGroups(const ParseContext& parseContext, ErrorGuard& errors);
         bool updateWellStatus( const std::string& well, size_t reportStep , WellCommon::StatusEnum status);
-        void addWellToGroup( Group& newGroup , const std::string& wellName , size_t timeStep);
+        void addWellToGroup( const std::string& group_name, const std::string& well_name , size_t timeStep);
         void iterateScheduleSection(const ParseContext& parseContext ,  ErrorGuard& errors, const SCHEDULESection& , const EclipseGrid& grid,
                                     const Eclipse3DProperties& eclipseProperties);
         bool handleGroupFromWELSPECS(const std::string& groupName, GroupTree& newTree) const;
+        void addGroupToGroup( const std::string& parent_group, const std::string& child_group, size_t timeStep);
+        void addGroupToGroup( const std::string& parent_group, const Group2& child_group, size_t timeStep);
         void addGroup(const std::string& groupName , size_t timeStep);
         void addWell(const std::string& wellName, const DeckRecord& record, size_t timeStep, WellCompletion::CompletionOrderEnum wellCompletionOrder, const UnitSystem& unit_system);
         void handleUDQ(const DeckKeyword& keyword, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp
@@ -25,7 +25,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
-#include <list>
+#include <vector>
 
 namespace Opm {
 

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -332,7 +332,7 @@ namespace Opm {
 
         const static std::string RPT_UNKNOWN_MNEMONIC;
 
-        const static std::string SCHEDULE_WELL_ERROR;
+        const static std::string SCHEDULE_GROUP_ERROR;
 
         const static std::string SCHEDULE_COMPSEGS_INVALID;
         const static std::string SCHEDULE_COMPSEGS_NOT_SUPPORTED;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.cpp
@@ -1,0 +1,62 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp>
+
+namespace Opm {
+
+GTNode::GTNode(const Group2& group_arg, const GTNode * parent_arg) :
+    m_group(group_arg),
+    m_parent(parent_arg)
+{}
+
+const std::string& GTNode::name() const {
+    return this->m_group.name();
+}
+
+const Group2& GTNode::group() const {
+    return this->m_group;
+}
+
+const GTNode& GTNode::parent() const {
+    if (this->m_parent)
+        return *this->m_parent;
+
+    throw std::invalid_argument("Tried to access parent of root in GroupTree. Root: " + this->name());
+}
+
+
+void GTNode::add_well(const Well2& well) {
+    this->m_wells.push_back(well);
+}
+
+void GTNode::add_group(const GTNode& child_group) {
+    this->m_child_groups.push_back(child_group);
+}
+
+const std::vector<Well2>& GTNode::wells() const {
+    return this->m_wells;
+}
+
+const std::vector<GTNode>& GTNode::groups() const {
+    return this->m_child_groups;
+}
+
+
+}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.cpp
@@ -41,10 +41,7 @@ std::size_t Group2::insert_index() const {
 }
 
 bool Group2::defined(size_t timeStep) const {
-    if (timeStep < this->init_step)
-        return false;
-    else
-        return true;
+    return (timeStep >= this->init_step);
 }
 
 const std::string& Group2::name() const {
@@ -190,6 +187,11 @@ const std::vector<std::string>& Group2::groups() const {
     return this->m_groups.data();
 }
 
+bool Group2::wellgroup() const {
+    if (this->m_groups.size() > 0)
+        return false;
+    return true;
+}
 
 bool Group2::addWell(const std::string& well_name) {
     if (!this->m_groups.empty())

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.cpp
@@ -30,7 +30,11 @@ Group2::Group2(const std::string& name, std::size_t insert_index_arg, std::size_
     gefac(1),
     transfer_gefac(true),
     vfp_table(0)
-{}
+{
+    // All groups are initially created as children of the "FIELD" group.
+    if (name != "FIELD")
+        this->parent_group = "FIELD";
+}
 
 std::size_t Group2::insert_index() const {
     return this->m_insert_index;
@@ -99,6 +103,22 @@ bool Group2::updateProduction(const GroupProductionProperties& production) {
 
     return update;
 }
+
+
+const std::string& Group2::parent() const {
+    return this->parent_group;
+}
+
+
+bool Group2::updateParent(const std::string& parent) {
+    if (this->parent_group != parent) {
+        this->parent_group = parent;
+        return true;
+    }
+
+    return false;
+}
+
 
 
 bool Group2::GroupInjectionProperties::operator==(const GroupInjectionProperties& other) const {
@@ -173,7 +193,7 @@ const std::vector<std::string>& Group2::groups() const {
 
 bool Group2::addWell(const std::string& well_name) {
     if (!this->m_groups.empty())
-        throw std::logic_error("Groups can not mix group and well children");
+        throw std::logic_error("Groups can not mix group and well children. Trying to add well: " + well_name + " to group: " + this->name());
 
     if (this->m_wells.count(well_name) == 0) {
         this->m_wells.insert(well_name);
@@ -189,13 +209,13 @@ bool Group2::hasWell(const std::string& well_name) const  {
 void Group2::delWell(const std::string& well_name) {
     auto rm_count = this->m_wells.erase(well_name);
     if (rm_count == 0)
-        throw std::invalid_argument("Group does not have well: " + well_name);
+        throw std::invalid_argument("Group: " + this->name() + " does not have well: " + well_name);
 }
 
 
 bool Group2::addGroup(const std::string& group_name) {
     if (!this->m_wells.empty())
-        throw std::logic_error("Groups can not mix group and well children");
+        throw std::logic_error("Groups can not mix group and well children. Trying to add group: " + group_name + " to group: " + this->name());
 
     if (this->m_groups.count(group_name) == 0) {
         this->m_groups.insert(group_name);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group2.cpp
@@ -22,9 +22,219 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp>
 
 namespace Opm {
-
-Group2::Group2(const std::string& group_name) :
-    name(group_name)
+Group2::Group2(const std::string& name, std::size_t insert_index_arg, std::size_t init_step_arg) :
+    m_name(name),
+    m_insert_index(insert_index_arg),
+    init_step(init_step_arg),
+    group_type(GroupType::NONE),
+    gefac(1),
+    transfer_gefac(true),
+    vfp_table(0)
 {}
+
+std::size_t Group2::insert_index() const {
+    return this->m_insert_index;
+}
+
+bool Group2::defined(size_t timeStep) const {
+    if (timeStep < this->init_step)
+        return false;
+    else
+        return true;
+}
+
+const std::string& Group2::name() const {
+    return this->m_name;
+}
+
+const Group2::GroupProductionProperties& Group2::productionProperties() const {
+    return this->production_properties;
+}
+
+const Group2::GroupInjectionProperties& Group2::injectionProperties() const {
+    return this->injection_properties;
+}
+
+int Group2::getGroupNetVFPTable() const {
+    return this->vfp_table;
+}
+
+bool Group2::updateNetVFPTable(int vfp_arg) {
+    if (this->vfp_table != vfp_arg) {
+        this->vfp_table = vfp_arg;
+        return true;
+    } else
+        return false;
+}
+
+bool Group2::updateInjection(const GroupInjectionProperties& injection) {
+    bool update = false;
+
+    if (this->injection_properties != injection) {
+        this->injection_properties = injection;
+        update = true;
+    }
+
+    if (!this->hasType(GroupType::INJECTION)) {
+        this->addType(GroupType::INJECTION);
+        update = true;
+    }
+
+    return update;
+}
+
+
+bool Group2::updateProduction(const GroupProductionProperties& production) {
+    bool update = false;
+
+    if (this->production_properties != production) {
+        this->production_properties = production;
+        update = true;
+    }
+
+    if (!this->hasType(GroupType::PRODUCTION)) {
+        this->addType(GroupType::PRODUCTION);
+        update = true;
+    }
+
+    return update;
+}
+
+
+bool Group2::GroupInjectionProperties::operator==(const GroupInjectionProperties& other) const {
+    return
+        this->phase                 == other.phase &&
+        this->cmode                 == other.cmode &&
+        this->surface_max_rate      == other.surface_max_rate &&
+        this->resv_max_rate         == other.resv_max_rate &&
+        this->target_reinj_fraction == other.target_reinj_fraction &&
+        this->target_void_fraction  == other.target_void_fraction;
+}
+
+
+bool Group2::GroupInjectionProperties::operator!=(const GroupInjectionProperties& other) const {
+    return !(*this == other);
+}
+
+
+bool Group2::GroupProductionProperties::operator==(const GroupProductionProperties& other) const {
+    return
+        this->cmode         == other.cmode &&
+        this->exceed_action == other.exceed_action &&
+        this->oil_target    == other.oil_target &&
+        this->water_target  == other.oil_target &&
+        this->gas_target    == other.gas_target &&
+        this->liquid_target == other.liquid_target &&
+        this->resv_target   == other.resv_target;
+}
+
+
+bool Group2::GroupProductionProperties::operator!=(const GroupProductionProperties& other) const {
+    return !(*this == other);
+}
+
+bool Group2::hasType(GroupType gtype) const {
+    return ((this->group_type & gtype) == gtype);
+}
+
+void Group2::addType(GroupType new_gtype) {
+    this->group_type = this->group_type | new_gtype;
+}
+
+bool Group2::isProductionGroup() const {
+    return this->hasType(GroupType::PRODUCTION);
+}
+
+bool Group2::isInjectionGroup() const {
+    return this->hasType(GroupType::INJECTION);
+}
+
+void Group2::setProductionGroup() {
+    this->addType(GroupType::PRODUCTION);
+}
+
+void Group2::setInjectionGroup() {
+    this->addType(GroupType::INJECTION);
+}
+
+
+std::size_t Group2::numWells() const {
+    return this->m_wells.size();
+}
+
+const std::vector<std::string>& Group2::wells() const {
+    return this->m_wells.data();
+}
+
+const std::vector<std::string>& Group2::groups() const {
+    return this->m_groups.data();
+}
+
+
+bool Group2::addWell(const std::string& well_name) {
+    if (!this->m_groups.empty())
+        throw std::logic_error("Groups can not mix group and well children");
+
+    if (this->m_wells.count(well_name) == 0) {
+        this->m_wells.insert(well_name);
+        return true;
+    }
+    return false;
+}
+
+bool Group2::hasWell(const std::string& well_name) const  {
+    return (this->m_wells.count(well_name) == 1);
+}
+
+void Group2::delWell(const std::string& well_name) {
+    auto rm_count = this->m_wells.erase(well_name);
+    if (rm_count == 0)
+        throw std::invalid_argument("Group does not have well: " + well_name);
+}
+
+
+bool Group2::addGroup(const std::string& group_name) {
+    if (!this->m_wells.empty())
+        throw std::logic_error("Groups can not mix group and well children");
+
+    if (this->m_groups.count(group_name) == 0) {
+        this->m_groups.insert(group_name);
+        return true;
+    }
+    return false;
+}
+
+bool Group2::hasGroup(const std::string& group_name) const  {
+    return (this->m_groups.count(group_name) == 1);
+}
+
+void Group2::delGroup(const std::string& group_name) {
+    auto rm_count = this->m_groups.erase(group_name);
+    if (rm_count == 0)
+        throw std::invalid_argument("Group does not have group: " + group_name);
+}
+
+bool Group2::update_gefac(double gf, bool transfer_gf) {
+    bool update = false;
+    if (this->gefac != gf) {
+        this->gefac = gf;
+        update = true;
+    }
+
+    if (this->transfer_gefac != transfer_gf) {
+        this->transfer_gefac = transfer_gf;
+        update = true;
+    }
+
+    return update;
+}
+
+double Group2::getGroupEfficiencyFactor() const {
+    return this->gefac;
+}
+
+bool Group2::getTransferGroupEfficiencyFactor() const {
+    return this->transfer_gefac;
+}
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1446,7 +1446,7 @@ namespace {
                     injection.target_void_fraction = voidage_target;
 
                     if (group_ptr->updateInjection(injection))
-                        this->updateGroup(group_ptr, currentStep);
+                        this->updateGroup(std::move(group_ptr), currentStep);
                 }
             }
         }
@@ -1492,7 +1492,7 @@ namespace {
                     production.exceed_action = exceedAction;
 
                     if (group_ptr->updateProduction(production))
-                        this->updateGroup(group_ptr, currentStep);
+                        this->updateGroup(std::move(group_ptr), currentStep);
                 }
             }
         }
@@ -1519,7 +1519,7 @@ namespace {
                 {
                     auto group_ptr = std::make_shared<Group2>(this->getGroup2(group_name, currentStep));
                     if (group_ptr->update_gefac(gefac, transfer))
-                        this->updateGroup(group_ptr, currentStep);
+                        this->updateGroup(std::move(group_ptr), currentStep);
                 }
             }
         }
@@ -1729,6 +1729,8 @@ namespace {
                         OpmLog::note(msg);
                     }
 
+                    if (well2->updateConnections(connections))
+                        this->updateWell(well2, currentStep);
                 }
                 this->addWellEvent(name, ScheduleEvents::COMPLETION_CHANGE, currentStep);
             }
@@ -1820,7 +1822,7 @@ namespace {
             {
                 auto group_ptr = std::make_shared<Group2>( this->getGroup2(groupName, currentStep) );
                 if (group_ptr->updateNetVFPTable(table))
-                    this->updateGroup(group_ptr, currentStep);
+                    this->updateGroup(std::move(group_ptr), currentStep);
             }
         }
     }
@@ -2089,7 +2091,7 @@ namespace {
 
     void Schedule::updateGroup(std::shared_ptr<Group2> group, size_t reportStep) {
         auto& dynamic_state = this->groups.at(group->name());
-        dynamic_state.update(reportStep, group);
+        dynamic_state.update(reportStep, std::move(group));
     }
 
     /*
@@ -2292,17 +2294,17 @@ namespace {
         auto& dynamic_state = this->groups.at(parent_group);
         auto parent_ptr = std::make_shared<Group2>( *dynamic_state[timeStep] );
         if (parent_ptr->addGroup(child_group.name()))
-            this->updateGroup(parent_ptr, timeStep);
+            this->updateGroup(std::move(parent_ptr), timeStep);
 
         // Check and update backreference in child
         if (child_group.parent() != parent_group) {
             auto old_parent = std::make_shared<Group2>( this->getGroup2(child_group.parent(), timeStep) );
             old_parent->delGroup(child_group.name());
-            this->updateGroup(old_parent, timeStep);
+            this->updateGroup(std::move(old_parent), timeStep);
 
             auto child_ptr = std::make_shared<Group2>( child_group );
             child_ptr->updateParent(parent_group);
-            this->updateGroup(child_ptr, timeStep);
+            this->updateGroup(std::move(child_ptr), timeStep);
 
         }
     }
@@ -2332,7 +2334,7 @@ namespace {
             {
                 auto group = std::make_shared<Group2>(this->getGroup2(old_gname, timeStep));
                 group->delWell(well_name);
-                this->updateGroup(group, timeStep);
+                this->updateGroup(std::move(group), timeStep);
             }
         }
 
@@ -2344,7 +2346,7 @@ namespace {
         {
             auto group = std::make_shared<Group2>(this->getGroup2(group_name, timeStep));
             group->addWell(well_name);
-            this->updateGroup(group, timeStep);
+            this->updateGroup(std::move(group), timeStep);
         }
    }
 

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -110,7 +110,7 @@ namespace Opm {
 
         this->addKey(UDQ_PARSE_ERROR, InputError::THROW_EXCEPTION);
         this->addKey(UDQ_TYPE_ERROR, InputError::THROW_EXCEPTION);
-        this->addKey(SCHEDULE_WELL_ERROR, InputError::THROW_EXCEPTION);
+        this->addKey(SCHEDULE_GROUP_ERROR, InputError::THROW_EXCEPTION);
         this->addKey(SCHEDULE_COMPSEGS_INVALID, InputError::THROW_EXCEPTION);
         this->addKey(SCHEDULE_COMPSEGS_NOT_SUPPORTED, InputError::THROW_EXCEPTION);
     }
@@ -347,7 +347,7 @@ namespace Opm {
 
     const std::string ParseContext::UDQ_PARSE_ERROR = "UDQ_PARSE_ERROR";
     const std::string ParseContext::UDQ_TYPE_ERROR = "UDQ_TYPE_ERROR";
-    const std::string ParseContext::SCHEDULE_WELL_ERROR = "SCHEDULE_WELL_ERROR";
+    const std::string ParseContext::SCHEDULE_GROUP_ERROR = "SCHEDULE_GROUP_ERROR";
 
     const std::string ParseContext::SCHEDULE_COMPSEGS_INVALID = "SCHEDULE_COMPSEG_INVALID";
     const std::string ParseContext::SCHEDULE_COMPSEGS_NOT_SUPPORTED = "SCHEDULE_COMPSEGS_NOT_SUPPORTED";

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -82,15 +82,6 @@ BOOST_AUTO_TEST_CASE(CreateGroup_SetInjectorProducer_CorrectStatusSet) {
 
     group2.setProductionGroup(3);
     BOOST_CHECK(group2.isProductionGroup(4));
-
-    group2.setInjectionGroup(4);
-    BOOST_CHECK(group2.isInjectionGroup(5));
-
-
-    // Testing that a group can be both; that seems slightly dubious - but was the old behavior
-    group2.setProductionGroup(4);
-    BOOST_CHECK(group2.isProductionGroup(5));
-    BOOST_CHECK(group2.isInjectionGroup(5));
 }
 
 
@@ -435,5 +426,18 @@ BOOST_AUTO_TEST_CASE(createDeckWithGRUPNET) {
 
 
 BOOST_AUTO_TEST_CASE(Group2Create) {
-    Opm::Group2 group("NAME");
+    Opm::Group2 g1("NAME", 1, 1);
+    Opm::Group2 g2("NAME", 1, 1);
+
+    BOOST_CHECK( g1.addWell("W1") );
+    BOOST_CHECK( !g1.addWell("W1") );
+    BOOST_CHECK( g1.addWell("W2") );
+
+    BOOST_CHECK( g2.addGroup("G1") );
+    BOOST_CHECK( !g2.addGroup("G1") );
+    BOOST_CHECK( g2.addGroup("G2") );
+
+    // The children must be either all wells - or all groups.
+    BOOST_CHECK_THROW(g1.addGroup("G1"), std::logic_error);
+    BOOST_CHECK_THROW(g2.addWell("W1"), std::logic_error);
 }

--- a/tests/parser/OrderedMapTests.cpp
+++ b/tests/parser/OrderedMapTests.cpp
@@ -137,6 +137,8 @@ BOOST_AUTO_TEST_CASE(test_IOrderSet) {
 
 
     Opm::IOrderSet<int> iset2;
+
+
     for (int i=10; i >= 0; i--)
         iset2.insert(i);
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -444,6 +444,36 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
 }
 
 
+BOOST_AUTO_TEST_CASE(GroupTree2TEST) {
+    auto deck = createDeckWithWellsOrderedGRUPTREE();
+    EclipseGrid grid(100,100,100);
+    TableManager table ( deck );
+    Eclipse3DProperties eclipseProperties ( deck , table, grid);
+    Runspec runspec (deck);
+    Schedule schedule(deck, grid , eclipseProperties, runspec);
+
+    BOOST_CHECK_THROW( schedule.groupTree("NO_SUCH_GROUP", 0), std::invalid_argument);
+    auto cg1 = schedule.getGroup2("CG1", 0);
+    BOOST_CHECK( cg1.hasWell("DW_0"));
+    BOOST_CHECK( cg1.hasWell("CW_1"));
+
+    auto cg1_tree = schedule.groupTree("CG1", 0);
+    BOOST_CHECK_EQUAL(cg1_tree.wells().size(), 2);
+
+    auto gt = schedule.groupTree(0);
+    BOOST_CHECK_EQUAL(gt.wells().size(), 0);
+    BOOST_CHECK_EQUAL(gt.group().name(), "FIELD");
+    BOOST_CHECK_THROW(gt.parent(), std::invalid_argument);
+
+    auto cg = gt.groups();
+    auto pg = cg[0];
+    BOOST_CHECK_EQUAL(cg.size(), 1);
+    BOOST_CHECK_EQUAL(pg.group().name(), "PLATFORM");
+    BOOST_CHECK_EQUAL(pg.parent().name(), "FIELD");
+}
+
+
+
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
     auto deck = createDeck();
     EclipseGrid grid(10,10,10);

--- a/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GROUPS
+++ b/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GROUPS
@@ -21,9 +21,9 @@ COPY
 SCHEDULE
 
 WELSPECS 
-    'W_1'        'GROUP_BJARNE'   30   37  1*       'OIL'  7* /
+    'W_1'        'GROUP_BIRGER'   30   37  1*       'OIL'  7* /
     'W_3'        'GROUP_ODD'   31   18  1*       'OIL'  7* /
-    'W_2'        'GROUP_BJARNE'   20   51  1*       'OIL'  7* /
+    'W_2'        'GROUP_NILS'   20   51  1*       'OIL'  7* /
 
 /
 

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_size ) {
     Schedule schedule(deck,  grid , eclipseProperties,runspec);
 
     // Time 0, only from WELSPECS
-    BOOST_CHECK_EQUAL( 2U, schedule.getGroupTree(0).children("FIELD").size() );
+    BOOST_CHECK_EQUAL( 3U, schedule.getGroupTree(0).children("FIELD").size() );
 
     // Time 1, a new group added in tree
     BOOST_CHECK_EQUAL( 3U, schedule.getGroupTree(1).children("FIELD").size() );
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
     // Time 0, only from WELSPECS
     const auto& tree0 = schedule.getGroupTree( 0 );
     BOOST_CHECK( tree0.exists( "FIELD" ) );
-    BOOST_CHECK_EQUAL( "FIELD", tree0.parent( "GROUP_BJARNE" ) );
+    BOOST_CHECK_EQUAL( "FIELD", tree0.parent( "GROUP_NILS" ) );
     BOOST_CHECK( tree0.exists("GROUP_ODD") );
 
     // Time 1, now also from GRUPTREE
@@ -399,6 +399,16 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
     BOOST_CHECK_EQUAL( "FIELD", tree0.parent( "GROUP_BJARNE" ) );
     BOOST_CHECK_EQUAL( "GROUP_BJARNE", tree0.parent( "GROUP_BIRGER" ) );
     BOOST_CHECK_EQUAL( "GROUP_NEW", tree0.parent( "GROUP_NILS" ) );
+
+    const auto& field_group = sched.getGroup2("FIELD", 1);
+    const auto& new_group = sched.getGroup2("GROUP_NEW", 1);
+    const auto& nils_group = sched.getGroup2("GROUP_NILS", 1);
+    BOOST_CHECK_EQUAL(field_group.groups().size(), 2);
+    BOOST_CHECK( field_group.hasGroup("GROUP_NEW"));
+    BOOST_CHECK( field_group.hasGroup("GROUP_BJARNE"));
+    BOOST_CHECK_EQUAL( new_group.parent(), "FIELD");
+    BOOST_CHECK( new_group.hasGroup("GROUP_NILS"));
+    BOOST_CHECK_EQUAL( nils_group.parent(), "GROUP_NEW");
 }
 
 BOOST_AUTO_TEST_CASE( WellTestGroups ) {


### PR DESCRIPTION
This PR implements a class `Group2` which should replace the current `Group` class in opm-common. The main difference between `Group` and `Group2` is that the `Group2`class only applies at one point in time - time is handled at `Schedule` level, whereas the old `Group` had internal time management. This is 100% analogous to the `Well` &rightarrow; `Well2` transition from earlier, and again motivated by the ability to use UDA values in the group control rates.

This PR just adds a new class - the existing `Group` class is unmodified, and there are no downstream changes. The `Schedule`constructor now has a built in integration test which compares the internalized `Group` and `Group2` datastructures, this integration test is enabled with the cmake switch `ENABLE_GROUP_TEST` - which defaults to `ON`.

In addition to the new `Group2` class this PR also contains a new class `GTNode`which is used top assemble a group/well tree - on demand.

Followup PR's actually *using* the new `Group2` class will come in due time.