### PR TITLE
Add enum GroupType

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -71,8 +71,8 @@ namespace Opm {
 	const size_t& seqIndex() const;
         bool isProductionGroup(size_t timeStep) const;
         bool isInjectionGroup(size_t timeStep) const;
-        void setProductionGroup(size_t timeStep, bool isProductionGroup);
-        void setInjectionGroup(size_t timeStep, bool isInjectionGroup_);
+        void setProductionGroup(size_t timeStep);
+        void setInjectionGroup(size_t timeStep);
 
         /******************************************************************/
         void             setInjectionPhase(size_t time_step, Phase);
@@ -128,14 +128,16 @@ namespace Opm {
         void delWell(size_t time_step, const std::string& wellName );
 
     private:
+        bool hasType(size_t timeStep, GroupType gtype) const;
+        void addType(size_t timeStep, GroupType new_gtype);
+
         size_t m_creationTimeStep;
         std::string m_name;
 	size_t m_seqIndex;
         GroupInjection::InjectionData m_injection;
         GroupProduction::ProductionData m_production;
         DynamicState< std::set< std::string > > m_wells;
-        DynamicState<int> m_isProductionGroup;
-        DynamicState<int> m_isInjectionGroup;
+        DynamicState<GroupType> group_type;
         DynamicState<double> m_efficiencyFactor;
         DynamicState<int> m_transferEfficiencyFactor;
         DynamicState<int> m_groupNetVFPTable;

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
@@ -191,7 +191,17 @@ namespace Opm {
         ActionEnum ActionEnumFromString( const std::string& stringValue );
     }
 
+    // A group can have both injection controls and production controls set at
+    // the same time, i.e. this enum is used as a bitmask.
+    enum class GroupType : unsigned {
+        NONE = 0,
+        PRODUCTION = 1,
+        INJECTION = 2,
+        MIXED = 3
+    };
 
+    GroupType operator |(GroupType lhs, GroupType rhs);
+    GroupType operator &(GroupType lhs, GroupType rhs);
 
     namespace GroupProduction {
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -55,8 +55,7 @@ namespace Opm {
         m_injection( timeMap ),
         m_production( timeMap ),
         m_wells( timeMap, {} ),
-        m_isProductionGroup( timeMap, false),
-        m_isInjectionGroup( timeMap, false),
+        group_type(timeMap, GroupType::NONE),
         m_efficiencyFactor( timeMap, 1.0),
         m_transferEfficiencyFactor( timeMap, 1),
         m_groupNetVFPTable( timeMap, 0 )
@@ -78,20 +77,30 @@ namespace Opm {
             return true;
     }
 
+
+    bool Group::hasType(size_t timeStep, GroupType gtype) const {
+        return ((this->group_type.get(timeStep) & gtype) == gtype);
+    }
+
+    void Group::addType(size_t timeStep, GroupType new_gtype) {
+        auto gt = this->group_type.get(timeStep);
+        this->group_type.update(timeStep, gt | new_gtype );
+    }
+
     bool Group::isProductionGroup(size_t timeStep) const {
-        return bool( m_isProductionGroup.get(timeStep) );
+        return this->hasType(timeStep, GroupType::PRODUCTION);
     }
 
     bool Group::isInjectionGroup(size_t timeStep) const {
-        return bool( m_isInjectionGroup.get(timeStep) );
+        return this->hasType(timeStep, GroupType::INJECTION);
     }
 
-    void Group::setProductionGroup(size_t timeStep, bool isProductionGroup_) {
-        m_isProductionGroup.update(timeStep, isProductionGroup_);
+    void Group::setProductionGroup(size_t timeStep) {
+        this->addType(timeStep, GroupType::PRODUCTION);
     }
 
-    void Group::setInjectionGroup(size_t timeStep, bool isInjectionGroup_) {
-        m_isInjectionGroup.update(timeStep, isInjectionGroup_);
+    void Group::setInjectionGroup(size_t timeStep) {
+        this->addType(timeStep, GroupType::INJECTION);
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1439,7 +1439,7 @@ namespace {
                 group.setTargetReinjectFraction( currentStep , record.getItem("REINJ_TARGET").get<UDAValue>(0).get<double>());
                 group.setTargetVoidReplacementFraction( currentStep , record.getItem("VOIDAGE_TARGET").get<UDAValue>(0).get<double>());
 
-                group.setInjectionGroup(currentStep, true);
+                group.setInjectionGroup(currentStep);
             }
         }
     }
@@ -1468,7 +1468,7 @@ namespace {
                     group.setProductionExceedLimitAction( currentStep , exceedAction );
                 }
 
-                group.setProductionGroup(currentStep, true);
+                group.setProductionGroup(currentStep);
             }
         }
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
@@ -724,5 +724,12 @@ namespace Opm {
 
     }
 
+    GroupType operator|(GroupType lhs, GroupType rhs) {
+        return static_cast<GroupType>(static_cast<std::underlying_type<GroupType>::type>(lhs) | static_cast<std::underlying_type<GroupType>::type>(rhs));
+    }
+
+    GroupType operator&(GroupType lhs, GroupType rhs) {
+        return static_cast<GroupType>(static_cast<std::underlying_type<GroupType>::type>(lhs) & static_cast<std::underlying_type<GroupType>::type>(rhs));
+    }
 
 }

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -72,23 +72,25 @@ BOOST_AUTO_TEST_CASE(CreateGroup_SetInjectorProducer_CorrectStatusSet) {
     Opm::Group group1("IGROUP" , 1, timeMap , 0);
     Opm::Group group2("PGROUP" , 2, timeMap , 0);
 
-    group1.setProductionGroup(0, true);
+    group1.setProductionGroup(0);
     BOOST_CHECK(group1.isProductionGroup(1));
     BOOST_CHECK(!group1.isInjectionGroup(1));
-    group1.setProductionGroup(3, false);
-    BOOST_CHECK(!group1.isProductionGroup(3));
-    BOOST_CHECK(!group1.isInjectionGroup(3));
 
-    group2.setProductionGroup(0, false);
+    group2.setInjectionGroup(0);
     BOOST_CHECK(!group2.isProductionGroup(1));
-    BOOST_CHECK(!group2.isInjectionGroup(1));
-    group2.setProductionGroup(3, true);
+    BOOST_CHECK(group2.isInjectionGroup(1));
+
+    group2.setProductionGroup(3);
     BOOST_CHECK(group2.isProductionGroup(4));
-    BOOST_CHECK(!group2.isInjectionGroup(4));
-    group2.setInjectionGroup(4, true);
-    BOOST_CHECK(group2.isProductionGroup(5));
+
+    group2.setInjectionGroup(4);
     BOOST_CHECK(group2.isInjectionGroup(5));
 
+
+    // Testing that a group can be both; that seems slightly dubious - but was the old behavior
+    group2.setProductionGroup(4);
+    BOOST_CHECK(group2.isProductionGroup(5));
+    BOOST_CHECK(group2.isInjectionGroup(5));
 }
 
 


### PR DESCRIPTION
Introduce an enum GroupType to designate the type of a group. This was previously implemented with *two* boolean fields, hence the API allowed a situation where a group was both a producer and an injector - seems the SPE9_CP_GROUP test relied on this behavior, so it is retained through the use of bitmask behavior - but it seems slightly dubious. Maybe the SPE9_CP_GROUP test should get some scrutiny?