### PR TITLE
Enabling load on the demand for class ERst

### DIFF
--- a/src/opm/io/eclipse/ERst.cpp
+++ b/src/opm/io/eclipse/ERst.cpp
@@ -166,14 +166,7 @@ int ERst::getArrayIndex(const std::string& name, int number) const
         std::string message = "Trying to get vector " + name + " from non existing sequence " + std::to_string(number);
         OPM_THROW(std::invalid_argument, message);
     }
-
-    auto search = reportLoaded.find(number);
-
-    if (!search->second) {
-        std::string message = "Data not loaded for sequence " + std::to_string(number);
-        OPM_THROW(std::runtime_error, message);
-    }
-
+    
     auto range_it = arrIndexRange.find(number);
 
     std::pair<int,int> indexRange = range_it->second;


### PR DESCRIPTION
"Load on demand" means that vectors are automatically loaded from disk when using member function getRst (if not already loaded by available member function loadReportStepNumber(int number) ).

Base class EclFile already have this functionality. So all that is needed for this is to remove if statement and throw in current version of ERst