### PR TITLE
convertECL, new option for unified restart file

### DIFF
--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -2,13 +2,16 @@
 #include <iomanip>
 #include <iostream>
 #include <tuple>
+#include <getopt.h>
 
 #include <opm/io/eclipse/EclFile.hpp>
+#include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/EclOutput.hpp>
 
 using namespace Opm::EclIO;
+using EclEntry = std::tuple<std::string, eclArrType, int>;
 
-template<typename T>
+template <typename T>
 void write(EclOutput& outFile, EclFile& file1,
            const std::string& name, int index)
 {
@@ -17,24 +20,97 @@ void write(EclOutput& outFile, EclFile& file1,
 }
 
 
+template<typename T>
+void write(EclOutput& outFile, ERst& file1,
+           const std::string& name, int reportStepNumber)
+{
+
+    auto vect = file1.getRst<T>(name, reportStepNumber);
+    outFile.write(name, vect);
+}
+
+template <typename T>
+void writeArray(std::string name, eclArrType arrType, T& file1, int index, EclOutput& outFile) {
+
+    if (arrType == INTE) {
+        write<int>(outFile, file1, name, index);
+    } else if (arrType == REAL) {
+        write<float>(outFile, file1, name,index);
+    } else if (arrType == DOUB) {
+        write<double>(outFile, file1, name, index);
+    } else if (arrType == LOGI) {
+        write<bool>(outFile, file1, name, index);
+    } else if (arrType == CHAR) {
+        write<std::string>(outFile, file1, name, index);
+    } else if (arrType == MESS) {
+        outFile.message(name);
+    } else {
+        std::cout << "unknown array type " << std::endl;
+        exit(1);
+    }
+}
+
+void writeArrayList(std::vector<EclEntry>& arrayList, EclFile file1, EclOutput& outFile) {
+
+    for (size_t index = 0; index < arrayList.size(); index++) {
+        std::string name = std::get<0>(arrayList[index]);
+        eclArrType arrType = std::get<1>(arrayList[index]);
+
+        writeArray(name, arrType, file1, index, outFile);
+    }
+}
+
+
+void writeArrayList(std::vector<EclEntry>& arrayList, ERst file1, int reportStepNumber, EclOutput& outFile) {
+
+    for (size_t index = 0; index < arrayList.size(); index++) {
+        std::string name = std::get<0>(arrayList[index]);
+        eclArrType arrType = std::get<1>(arrayList[index]);
+
+        writeArray(name, arrType, file1, reportStepNumber, outFile);
+    }
+}
+
+static void printHelp() {
+
+    std::cout << "\nconvertECL needs one argument which is the input file to be converted. If this is a binary file the output file will be formatted. If the input file is formatted the output will be binary. \n"
+              << "\nIn addition, the program takes these options (which must be given before the arguments):\n\n"
+              << "-h Print help and exit.\n"
+              << "-l list report step numbers in the selected restart file.\n"
+              << "-r extract and convert a spesific report time step number from a unified restart file. \n\n";
+}
+
 int main(int argc, char **argv) {
 
-    if (argc != 2) {
-       std::cout << "\nInvalid input, need 1 argument which should be the eclipse output file to be converted \n" << std::endl;
-       exit(1);
+    int c                          = 0;
+    int reportStepNumber           = -1;
+    bool specificReportStepNumber  = false;
+    bool listProperties            = false;
+
+    while ((c = getopt(argc, argv, "hr:l")) != -1) {
+        switch (c) {
+        case 'h':
+            printHelp();
+            return 0;
+        case 'l':
+            listProperties=true;
+            break;
+        case 'r':
+            specificReportStepNumber=true;
+            reportStepNumber = atoi(optarg);
+            break;
+        default:
+            return EXIT_FAILURE;
+        }
     }
+
+    int argOffset = optind;
 
     // start reading
     auto start = std::chrono::system_clock::now();
-    std::string filename = argv[1];
+    std::string filename = argv[argOffset];
 
     EclFile file1(filename);
-
-    file1.loadData();
-
-    auto end1 = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed_seconds1 = end1 - start;
-
     bool formattedOutput = file1.formattedInput() ? false : true;
 
     int p = filename.find_last_of(".");
@@ -44,45 +120,95 @@ int main(int argc, char **argv) {
     std::string extension = filename.substr(p,l-p);
     std::string resFile;
 
-    if (formattedOutput) {
-        resFile = rootN + ".F" + extension.substr(1, extension.length() - 1);
-    } else {
-        resFile = rootN + "." + extension.substr(2, extension.length() - 2);
+    if (listProperties) {
+
+        if (extension==".UNRST") {
+
+            ERst rst1(filename);
+            rst1.loadData("INTEHEAD");
+
+            std::vector<int> reportStepList=rst1.listOfReportStepNumbers();
+
+            for (auto seqn : reportStepList) {
+
+                std::vector<int> inteh = rst1.getRst<int>("INTEHEAD", seqn);
+
+                std::cout << "Report step number: "
+                          << std::setfill(' ') << std::setw(4) << seqn << "   Date: " << inteh[66] << "/"
+                          << std::setfill('0') << std::setw(2) << inteh[65] << "/"
+                          << std::setfill('0') << std::setw(2) << inteh[64] << std::endl;
+            }
+
+            std::cout << std::endl;
+
+        } else {
+            std::cout << "\n!ERROR, option -l only only available for unified restart files (*.UNRST) " << std::endl;
+            exit(1);
+        }
+
+        return 0;
     }
 
-    std::cout << "\033[1;31m" << "\nconverting  " << argv[1] << " -> " << resFile << "\033[0m\n" << std::endl;
+
+    if (formattedOutput) {
+        if (extension.substr(1,1)=="X"){
+            resFile = rootN + ".F" + extension.substr(2);
+        } else if (extension.substr(1,1)=="S"){
+            resFile = rootN + ".A" + extension.substr(2);
+        } else {
+            resFile = rootN + ".F" + extension.substr(1);
+        }
+        
+    } else {
+        if (extension.substr(1,1)=="F"){
+            resFile = rootN + ".X" + extension.substr(2);
+        } else if (extension.substr(1,1)=="A"){
+            resFile = rootN + ".S" + extension.substr(2);
+        } else {
+            resFile = rootN + "." + extension.substr(2);
+        }
+    }
+
+    std::cout << "\033[1;31m" << "\nconverting  " << argv[argOffset] << " -> " << resFile << "\033[0m\n" << std::endl;
+
+    auto end1 = std::chrono::system_clock::now();
+    std::chrono::duration<double> elapsed_seconds1 = end1 - start;
 
     EclOutput outFile(resFile, formattedOutput);
 
-    auto arrayList = file1.getList();
+    if (specificReportStepNumber) {
 
-    for (size_t index = 0; index < arrayList.size(); index++) {
-        std::string name = std::get<0>(arrayList[index]);
-        eclArrType arrType = std::get<1>(arrayList[index]);
-
-        if (arrType == INTE) {
-            write<int>(outFile, file1, name, index);
-        } else if (arrType == REAL) {
-            write<float>(outFile, file1, name,index);
-        } else if (arrType == DOUB) {
-            write<double>(outFile, file1, name, index);
-        } else if (arrType == LOGI) {
-            write<bool>(outFile, file1, name, index);
-        } else if (arrType == CHAR) {
-            write<std::string>(outFile, file1, name, index);
-        } else if (arrType == MESS) {
-            // shold not be any associated data
-            outFile.write(name,std::vector<char>());
-        } else {
-            std::cout << "unknown array type " << std::endl;
+        if (extension!=".UNRST") {
+            std::cout << "\n!ERROR, option -r only can only be used with unified restart files (*.UNRST) " << std::endl;
             exit(1);
         }
+
+        ERst rst1(filename);
+
+        if (!rst1.hasReportStepNumber(reportStepNumber)) {
+            std::cout << "\n!ERROR, selected unified restart file doesn't have report step number " << reportStepNumber << "\n" << std::endl;
+            exit(1);
+        }
+
+        rst1.loadReportStepNumber(reportStepNumber);
+
+        auto arrayList = rst1.listOfRstArrays(reportStepNumber);
+
+        writeArrayList(arrayList, rst1, reportStepNumber, outFile);
+
+    } else {
+
+        file1.loadData();
+        auto arrayList = file1.getList();
+
+        writeArrayList(arrayList, file1, outFile);
     }
+
 
     auto end2 = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds2 = end2-end1;
 
-    std::cout << "\ntime to load from file : " << argv[1] << ": " << elapsed_seconds1.count() << " seconds" << std::endl;
+    std::cout << "\ntime to load from file : " << argv[argOffset] << ": " << elapsed_seconds1.count() << " seconds" << std::endl;
     std::cout << "time to write to file  : " << resFile << ": " << elapsed_seconds2.count() << " seconds\n" << std::endl;
 
     return 0;


### PR DESCRIPTION
Added two new options for program convertECL. Both of these are valid for unified restart files.

 * `-r <restartNumber>`: select one specific report step and convert only this 
 * `-l `will list avaliable report step in selected unified restart file

Unified restart files are often huge and converting the entire file can be time consuming. After file is converted these huge formatted files are not easy to work with. 

This options will be useful especially for working with QC of restart functionality