### PR TITLE
Opm pack units

### DIFF
--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -131,6 +131,8 @@ namespace Opm {
         template< typename T > void push( T, size_t );
         template< typename T > void push_default( T );
         template< typename T > void write_vector(DeckOutput& writer, const std::vector<T>& data) const;
+        void write_double_vector(DeckOutput& stream) const;
+        void write_UDA_vector(DeckOutput& stream) const;
     };
 }
 #endif  /* DECKITEM_HPP */

--- a/opm/parser/eclipse/Deck/DeckOutput.hpp
+++ b/opm/parser/eclipse/Deck/DeckOutput.hpp
@@ -25,10 +25,11 @@
 #include <cstddef>
 
 namespace Opm {
+    class UnitSystem;
 
     class DeckOutput {
     public:
-        explicit DeckOutput(std::ostream& s, int precision = 10);
+        explicit DeckOutput(std::ostream& s, int precision = 10, const UnitSystem * output_units_arg = nullptr);
         ~DeckOutput();
         void stash_default( );
 
@@ -42,6 +43,8 @@ namespace Opm {
         void endl();
         void write_string(const std::string& s);
         template <typename T> void write(const T& value);
+        const UnitSystem* output_units() const;
+
 
         std::string item_sep = " ";        // Separator between items on a row.
         size_t      columns = 16;          // The maximum number of columns on a record.
@@ -53,6 +56,7 @@ namespace Opm {
         size_t row_count;
         bool record_on;
         int org_precision;
+        const UnitSystem* m_output_units;
 
         template <typename T> void write_value(const T& value);
         void write_sep( );

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -21,6 +21,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 namespace Opm {
 
@@ -150,9 +151,24 @@ namespace Opm {
         if (this->name() == "TITLE")
             this->write_TITLE( output );
         else {
+            /*
+              If unit conversion is requested on output we must capture the unit
+              system keyword from the deck and then write the keyword for the
+              requested unit system; the requested unit system will always be
+              the keyword immediately following the 'RUNSPEC' keyword.
+            */
+            const auto * output_units = output.output_units();
+            if (output_units && UnitSystem::valid_name(this->name()))
+                return;
+
             output.start_keyword( this->name( ) );
             this->write_data( output );
             output.end_keyword( this->m_slashTerminated );
+
+            if (output_units && this->name() == "RUNSPEC") {
+                output.start_keyword( output_units->deck_name() );
+                output.end_keyword(false);
+            }
         }
     }
 

--- a/src/opm/parser/eclipse/Deck/DeckOutput.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckOutput.cpp
@@ -19,25 +19,30 @@
 
 #include <ostream>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/parser/eclipse/Deck/DeckOutput.hpp>
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 
 namespace Opm {
 
-    DeckOutput::DeckOutput( std::ostream& s, int precision) :
+    DeckOutput::DeckOutput( std::ostream& s, int precision, const UnitSystem* output_units_arg) :
         os( s ),
         default_count( 0 ),
         row_count( 0 ),
         record_on( false ),
-        org_precision( os.precision(precision) )
+        org_precision( os.precision(precision) ),
+        m_output_units(output_units_arg)
     {}
-
 
     DeckOutput::~DeckOutput() {
         this->set_precision(this->org_precision);
     }
 
+    const UnitSystem* DeckOutput::output_units() const {
+        return this->m_output_units;
+    }
 
     void DeckOutput::set_precision(int precision) {
         this->os.precision(precision);
@@ -101,6 +106,11 @@ namespace Opm {
 
 
     void DeckOutput::start_keyword(const std::string& kw) {
+        if (this->m_output_units) {
+            if (kw == "FILEUNIT" || kw == "GRIDUNIT")
+                OpmLog::warning("The content of the " + kw + " keywords is not updated when doing unit conversion");
+        }
+
         this->os << kw << std::endl;
     }
 


### PR DESCRIPTION
The `opmpack` utility now accepts a `-u $UNIT_SYSTEM` to do on-the fly unit conversion on output; i.e.

```bash
opmpack FIELD.DATA -o METRIC.DATA -u METRIC
```
will give you a METRIC version of the deck. Depends on: #897 