### PR TITLE
Udq input def

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -144,6 +144,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunction.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
     src/opm/parser/eclipse/Parser/ErrorGuard.cpp
@@ -567,6 +568,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp
+       opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunction.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -140,7 +140,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
-    src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunction.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.cpp
@@ -564,10 +564,9 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp
-       opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
+       opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp
-       opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunction.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -104,7 +104,7 @@ namespace Opm
     class UnitSystem;
     class ErrorGuard;
     class WListManager;
-    class UDQInput;
+    class UDQConfig;
 
     class Schedule {
     public:
@@ -181,7 +181,7 @@ namespace Opm
 
         const WellTestConfig& wtestConfig(size_t timestep) const;
         const WListManager& getWListManager(size_t timeStep) const;
-        const UDQInput& getUDQConfig(size_t timeStep) const;
+        const UDQConfig& getUDQConfig(size_t timeStep) const;
         const Actions& actions() const;
         void evalAction(const SummaryState& summary_state, size_t timeStep);
 
@@ -234,7 +234,7 @@ namespace Opm
         std::map<int, DynamicState<std::shared_ptr<VFPInjTable>>> vfpinj_tables;
         DynamicState<std::shared_ptr<WellTestConfig>> wtest_config;
         DynamicState<std::shared_ptr<WListManager>> wlist_manager;
-        DynamicState<std::shared_ptr<UDQInput>> udq_config;
+        DynamicState<std::shared_ptr<UDQConfig>> udq_config;
         DynamicState<WellProducer::ControlModeEnum> global_whistctl_mode;
         RFTConfig rft_config;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -53,6 +53,11 @@ namespace Opm {
         std::vector<UDQDefine> definitions(UDQVarType var_type) const;
         std::vector<UDQInput> input() const;
 
+        // The size() method will return the number of active DEFINE and ASSIGN
+        // statements; this will correspond to the length of the vector returned
+        // from input().
+        size_t size() const;
+
         std::vector<UDQAssign> assignments() const;
         std::vector<UDQAssign> assignments(UDQVarType var_type) const;
         const UDQParams& params() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -38,8 +38,6 @@ namespace Opm {
 
     class DeckRecord;
     class Deck;
-
-
     class UDQConfig {
     public:
         explicit UDQConfig(const Deck& deck);
@@ -80,7 +78,8 @@ namespace Opm {
         std::unordered_map<std::string, UDQAssign> m_assignments;
         std::unordered_map<std::string, std::string> units;
 
-        OrderedMap<std::string, std::pair<size_t, UDQAction>> input_index;
+        OrderedMap<std::string, UDQIndex> input_index;
+        std::unordered_map<UDQVarType, std::size_t> type_count;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -38,9 +38,9 @@ namespace Opm {
     class DeckRecord;
     class Deck;
 
-    class UDQInput {
+    class UDQConfig {
     public:
-        explicit UDQInput(const Deck& deck);
+        explicit UDQConfig(const Deck& deck);
         const std::string& unit(const std::string& key) const;
         bool has_unit(const std::string& keyword) const;
         bool has_keyword(const std::string& keyword) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -56,6 +56,8 @@ namespace Opm {
         // from input().
         size_t size() const;
 
+        const UDQInput operator[](const std::string& keyword) const;
+
         std::vector<UDQAssign> assignments() const;
         std::vector<UDQAssign> assignments(UDQVarType var_type) const;
         const UDQParams& params() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
@@ -38,6 +39,7 @@ namespace Opm {
     class DeckRecord;
     class Deck;
 
+
     class UDQConfig {
     public:
         explicit UDQConfig(const Deck& deck);
@@ -49,34 +51,7 @@ namespace Opm {
 
         std::vector<UDQDefine> definitions() const;
         std::vector<UDQDefine> definitions(UDQVarType var_type) const;
-
-        /*
-          The input_definitions() function is written to supply the information
-          needed when writing the restart file. The return value is a list of
-          pairs, where the first element in the pair is the index in the deck
-          for a particular UDQ keyword, and then the corresponding keyword.
-          Assume a deck keyword which looks like this:
-
-          UDQ
-            ASSIGN WUX 10 /
-            UNITS  WUX 'BARSA' /
-            DEFINE WUPR SUM(WOPR) * 0.75 /
-            DEFINE FUCK MAX(WOPR) * 1.25 /
-            ASSIGN FUX 100 /
-            DEFINE BUPR ?? /
-          /
-
-         Then the return value from input_definitions() will be:
-
-          {{1, UDQDefine("WUPR")},
-           {2, UDQDefine("FUCK")},
-           {4, UDQDefine("BUPR")}
-
-
-         Where the the numerical index is the index in a fictious vector
-         consisting of only the ASSIGN and DEFINE keywords, in input order.
-        */
-        std::vector<std::pair<size_t, UDQDefine>> input_definitions() const;
+        std::vector<UDQInput> input() const;
 
         std::vector<UDQAssign> assignments() const;
         std::vector<UDQAssign> assignments(UDQVarType var_type) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
@@ -50,8 +50,8 @@ public:
 
 class UDQInput{
 public:
-    UDQInput(const UDQIndex& index, const UDQDefine& udq_define);
-    UDQInput(const UDQIndex& index, const UDQAssign& udq_assign);
+    UDQInput(const UDQIndex& index, const UDQDefine& udq_define, const std::string& unit);
+    UDQInput(const UDQIndex& index, const UDQAssign& udq_assign, const std::string& unit);
 
     template<typename T>
     const T& get() const;
@@ -61,12 +61,14 @@ public:
 
     const std::string& keyword() const;
     UDQVarType var_type() const;
+    const std::string& unit() const;
 private:
     UDQIndex index;
     const UDQDefine * define;
     const UDQAssign * assign;
     const std::string m_keyword;
     UDQVarType m_var_type;
+    const std::string m_unit;
 };
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
@@ -23,6 +23,8 @@
 
 #include <memory>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
+
 namespace Opm {
 
 class UDQAssign;
@@ -40,11 +42,12 @@ public:
     bool is() const;
 
     const std::string& keyword() const;
-
+    UDQVarType var_type() const;
 private:
     const UDQDefine * define;
     const UDQAssign * assign;
     const std::string m_keyword;
+    UDQVarType m_var_type;
 };
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
@@ -30,10 +30,28 @@ namespace Opm {
 class UDQAssign;
 class UDQDefine;
 
+class UDQIndex {
+public:
+    UDQIndex() = default;
+
+    UDQIndex(std::size_t insert_index_arg, std::size_t typed_insert_index_arg, UDQAction action_arg) :
+        insert_index(insert_index_arg),
+        typed_insert_index(typed_insert_index_arg),
+        action(action_arg)
+    {
+    }
+
+
+    std::size_t insert_index;
+    std::size_t typed_insert_index;
+    UDQAction action;
+};
+
+
 class UDQInput{
 public:
-    UDQInput(const UDQDefine& udq_define);
-    UDQInput(const UDQAssign& udq_assign);
+    UDQInput(const UDQIndex& index, const UDQDefine& udq_define);
+    UDQInput(const UDQIndex& index, const UDQAssign& udq_assign);
 
     template<typename T>
     const T& get() const;
@@ -44,6 +62,7 @@ public:
     const std::string& keyword() const;
     UDQVarType var_type() const;
 private:
+    UDQIndex index;
     const UDQDefine * define;
     const UDQAssign * assign;
     const std::string m_keyword;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef UDQINPUT__HPP_
+#define UDQINPUT__HPP_
+
+#include <memory>
+
+namespace Opm {
+
+class UDQAssign;
+class UDQDefine;
+
+class UDQInput{
+public:
+    UDQInput(const UDQDefine& udq_define);
+    UDQInput(const UDQAssign& udq_assign);
+
+    template<typename T>
+    const T& get() const;
+
+    template<typename T>
+    bool is() const;
+
+    const std::string& keyword() const;
+
+private:
+    const UDQDefine * define;
+    const UDQAssign * assign;
+    const std::string m_keyword;
+};
+}
+
+
+
+#endif

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -36,7 +36,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
@@ -1166,7 +1166,7 @@ bool is_udq(const std::string& keyword) {
 
 void eval_udq(const Schedule& schedule, std::size_t sim_step, SummaryState& st)
 {
-    const UDQInput& udq = schedule.getUDQConfig(sim_step);
+    const UDQConfig& udq = schedule.getUDQConfig(sim_step);
     const auto& func_table = udq.function_table();
     UDQContext context(udq.params(), func_table, st);
     std::vector<std::string> wells;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -47,7 +47,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
@@ -93,7 +93,7 @@ namespace {
         m_runspec( runspec ),
         wtest_config(this->m_timeMap, std::make_shared<WellTestConfig>() ),
         wlist_manager( this->m_timeMap, std::make_shared<WListManager>()),
-        udq_config(this->m_timeMap, std::make_shared<UDQInput>(deck)),
+        udq_config(this->m_timeMap, std::make_shared<UDQConfig>(deck)),
         global_whistctl_mode(this->m_timeMap, WellProducer::CMODE_UNDEFINED),
         rft_config(this->m_timeMap)
     {
@@ -1127,7 +1127,7 @@ namespace {
 
     void Schedule::handleUDQ(const DeckKeyword& keyword, size_t currentStep) {
         const auto& current = *this->udq_config.get(currentStep);
-        std::shared_ptr<UDQInput> new_udq = std::make_shared<UDQInput>(current);
+        std::shared_ptr<UDQConfig> new_udq = std::make_shared<UDQConfig>(current);
         for (const auto& record : keyword)
             new_udq->add_record(record);
 
@@ -2489,7 +2489,7 @@ namespace {
         return *ptr;
     }
 
-    const UDQInput& Schedule::getUDQConfig(size_t timeStep) const {
+    const UDQConfig& Schedule::getUDQConfig(size_t timeStep) const {
         const auto& ptr = this->udq_config.get(timeStep);
         return *ptr;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -22,6 +22,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
 
 namespace Opm {
 
@@ -41,9 +42,11 @@ namespace Opm {
     {
     }
 
+
     const UDQParams& UDQConfig::params() const {
         return this->udq_params;
     }
+
 
     void UDQConfig::add_record(const DeckRecord& record) {
         auto action = UDQ::actionType(record.getItem("ACTION").get<std::string>(0));
@@ -105,12 +108,15 @@ namespace Opm {
     }
 
 
-    std::vector<std::pair<size_t, UDQDefine>> UDQConfig::input_definitions() const {
-        std::vector<std::pair<size_t, UDQDefine>> res;
+    std::vector<UDQInput> UDQConfig::input() const {
+        std::vector<UDQInput> res;
         for (const auto& index_pair : this->input_index) {
             if (index_pair.second.second == UDQAction::DEFINE) {
                 const std::string& key = index_pair.first;
-                res.emplace_back(index_pair.second.first, this->m_definitions.at(key));
+                res.push_back(UDQInput(this->m_definitions.at(key)));
+            } else if (index_pair.second.second == UDQAction::ASSIGN) {
+                const std::string& key = index_pair.first;
+                res.push_back(UDQInput(this->m_assignments.at(key)));
             }
         }
         return res;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -60,10 +60,12 @@ namespace Opm {
             this->assign_unit( quantity, data[0] );
         else {
             auto index_iter = this->input_index.find(quantity);
-            if (this->input_index.find(quantity) == this->input_index.end())
-                this->input_index[quantity] = std::make_pair(this->input_index.size(), action);
-            else
-                index_iter->second.second = action;
+            if (this->input_index.find(quantity) == this->input_index.end()) {
+                auto var_type = UDQ::varType(quantity);
+                this->type_count[var_type] += 1;
+                this->input_index[quantity] = UDQIndex(this->input_index.size(), this->type_count[var_type], action);
+            } else
+                index_iter->second.action = action;
 
 
             if (action == UDQAction::ASSIGN) {
@@ -85,7 +87,7 @@ namespace Opm {
     std::vector<UDQDefine> UDQConfig::definitions() const {
         std::vector<UDQDefine> ret;
         for (const auto& index_pair : this->input_index) {
-            if (index_pair.second.second == UDQAction::DEFINE) {
+            if (index_pair.second.action == UDQAction::DEFINE) {
                 const std::string& key = index_pair.first;
                 ret.push_back(this->m_definitions.at(key));
             }
@@ -97,7 +99,7 @@ namespace Opm {
     std::vector<UDQDefine> UDQConfig::definitions(UDQVarType var_type) const {
         std::vector<UDQDefine> filtered_defines;
         for (const auto& index_pair : this->input_index) {
-            if (index_pair.second.second == UDQAction::DEFINE) {
+            if (index_pair.second.action == UDQAction::DEFINE) {
                 const std::string& key = index_pair.first;
                 const auto& udq_define = this->m_definitions.at(key);
                 if (udq_define.var_type() == var_type)
@@ -111,12 +113,13 @@ namespace Opm {
     std::vector<UDQInput> UDQConfig::input() const {
         std::vector<UDQInput> res;
         for (const auto& index_pair : this->input_index) {
-            if (index_pair.second.second == UDQAction::DEFINE) {
+            const UDQIndex& index = index_pair.second;
+            if (index.action == UDQAction::DEFINE) {
                 const std::string& key = index_pair.first;
-                res.push_back(UDQInput(this->m_definitions.at(key)));
-            } else if (index_pair.second.second == UDQAction::ASSIGN) {
+                res.push_back(UDQInput(index, this->m_definitions.at(key)));
+            } else if (index_pair.second.action == UDQAction::ASSIGN) {
                 const std::string& key = index_pair.first;
-                res.push_back(UDQInput(this->m_assignments.at(key)));
+                res.push_back(UDQInput(index, this->m_assignments.at(key)));
             }
         }
         return res;
@@ -125,9 +128,9 @@ namespace Opm {
     std::size_t UDQConfig::size() const {
         std::size_t s = 0;
         for (const auto& index_pair : this->input_index) {
-            if (index_pair.second.second == UDQAction::DEFINE)
+            if (index_pair.second.action == UDQAction::DEFINE)
                 s += 1;
-            else if (index_pair.second.second == UDQAction::ASSIGN)
+            else if (index_pair.second.action == UDQAction::ASSIGN)
                 s += 1;
         }
         return s;
@@ -137,7 +140,7 @@ namespace Opm {
     std::vector<UDQAssign> UDQConfig::assignments() const {
         std::vector<UDQAssign> ret;
         for (const auto& index_pair : this->input_index) {
-            if (index_pair.second.second == UDQAction::ASSIGN) {
+            if (index_pair.second.action == UDQAction::ASSIGN) {
                 const std::string& key = index_pair.first;
                 ret.push_back(this->m_assignments.at(key));
             }
@@ -149,7 +152,7 @@ namespace Opm {
     std::vector<UDQAssign> UDQConfig::assignments(UDQVarType var_type) const {
         std::vector<UDQAssign> filtered_defines;
         for (const auto& index_pair : this->input_index) {
-            if (index_pair.second.second == UDQAction::ASSIGN) {
+            if (index_pair.second.action == UDQAction::ASSIGN) {
                 const std::string& key = index_pair.first;
                 const auto& udq_define = this->m_assignments.at(key);
                 if (udq_define.var_type() == var_type)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -62,8 +62,9 @@ namespace Opm {
             auto index_iter = this->input_index.find(quantity);
             if (this->input_index.find(quantity) == this->input_index.end()) {
                 auto var_type = UDQ::varType(quantity);
+                auto insert_index = this->input_index.size();
                 this->type_count[var_type] += 1;
-                this->input_index[quantity] = UDQIndex(this->input_index.size(), this->type_count[var_type], action);
+                this->input_index[quantity] = UDQIndex(insert_index, this->type_count[var_type], action);
             } else
                 index_iter->second.action = action;
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -114,12 +114,16 @@ namespace Opm {
         std::vector<UDQInput> res;
         for (const auto& index_pair : this->input_index) {
             const UDQIndex& index = index_pair.second;
+            std::string u;
+            if (this->has_unit(index_pair.first))
+                u = this->unit(index_pair.first);
+
             if (index.action == UDQAction::DEFINE) {
                 const std::string& key = index_pair.first;
-                res.push_back(UDQInput(index, this->m_definitions.at(key)));
+                res.push_back(UDQInput(index, this->m_definitions.at(key), u));
             } else if (index_pair.second.action == UDQAction::ASSIGN) {
                 const std::string& key = index_pair.first;
-                res.push_back(UDQInput(index, this->m_assignments.at(key)));
+                res.push_back(UDQInput(index, this->m_assignments.at(key), u));
             }
         }
         return res;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -122,6 +122,17 @@ namespace Opm {
         return res;
     }
 
+    std::size_t UDQConfig::size() const {
+        std::size_t s = 0;
+        for (const auto& index_pair : this->input_index) {
+            if (index_pair.second.second == UDQAction::DEFINE)
+                s += 1;
+            else if (index_pair.second.second == UDQAction::ASSIGN)
+                s += 1;
+        }
+        return s;
+    }
+
 
     std::vector<UDQAssign> UDQConfig::assignments() const {
         std::vector<UDQAssign> ret;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -20,7 +20,7 @@
 #include <algorithm>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 
 namespace Opm {
@@ -35,17 +35,17 @@ namespace Opm {
 
     }
 
-    UDQInput::UDQInput(const Deck& deck) :
+    UDQConfig::UDQConfig(const Deck& deck) :
         udq_params(deck),
         udqft(this->udq_params)
     {
     }
 
-    const UDQParams& UDQInput::params() const {
+    const UDQParams& UDQConfig::params() const {
         return this->udq_params;
     }
 
-    void UDQInput::add_record(const DeckRecord& record) {
+    void UDQConfig::add_record(const DeckRecord& record) {
         auto action = UDQ::actionType(record.getItem("ACTION").get<std::string>(0));
         const auto& quantity = record.getItem("QUANTITY").get<std::string>(0);
         const auto& data = record.getItem("DATA").getData<std::string>();
@@ -79,7 +79,7 @@ namespace Opm {
     }
 
 
-    std::vector<UDQDefine> UDQInput::definitions() const {
+    std::vector<UDQDefine> UDQConfig::definitions() const {
         std::vector<UDQDefine> ret;
         for (const auto& index_pair : this->input_index) {
             if (index_pair.second.second == UDQAction::DEFINE) {
@@ -91,7 +91,7 @@ namespace Opm {
     }
 
 
-    std::vector<UDQDefine> UDQInput::definitions(UDQVarType var_type) const {
+    std::vector<UDQDefine> UDQConfig::definitions(UDQVarType var_type) const {
         std::vector<UDQDefine> filtered_defines;
         for (const auto& index_pair : this->input_index) {
             if (index_pair.second.second == UDQAction::DEFINE) {
@@ -105,7 +105,7 @@ namespace Opm {
     }
 
 
-    std::vector<std::pair<size_t, UDQDefine>> UDQInput::input_definitions() const {
+    std::vector<std::pair<size_t, UDQDefine>> UDQConfig::input_definitions() const {
         std::vector<std::pair<size_t, UDQDefine>> res;
         for (const auto& index_pair : this->input_index) {
             if (index_pair.second.second == UDQAction::DEFINE) {
@@ -117,7 +117,7 @@ namespace Opm {
     }
 
 
-    std::vector<UDQAssign> UDQInput::assignments() const {
+    std::vector<UDQAssign> UDQConfig::assignments() const {
         std::vector<UDQAssign> ret;
         for (const auto& index_pair : this->input_index) {
             if (index_pair.second.second == UDQAction::ASSIGN) {
@@ -129,7 +129,7 @@ namespace Opm {
     }
 
 
-    std::vector<UDQAssign> UDQInput::assignments(UDQVarType var_type) const {
+    std::vector<UDQAssign> UDQConfig::assignments(UDQVarType var_type) const {
         std::vector<UDQAssign> filtered_defines;
         for (const auto& index_pair : this->input_index) {
             if (index_pair.second.second == UDQAction::ASSIGN) {
@@ -144,7 +144,7 @@ namespace Opm {
 
 
 
-    const std::string& UDQInput::unit(const std::string& key) const {
+    const std::string& UDQConfig::unit(const std::string& key) const {
         const auto pair_ptr = this->units.find(key);
         if (pair_ptr == this->units.end())
             throw std::invalid_argument("No such UDQ quantity: " + key);
@@ -153,7 +153,7 @@ namespace Opm {
     }
 
 
-    void UDQInput::assign_unit(const std::string& keyword, const std::string& quoted_unit) {
+    void UDQConfig::assign_unit(const std::string& keyword, const std::string& quoted_unit) {
         const std::string unit = strip_quotes(quoted_unit);
         const auto pair_ptr = this->units.find(keyword);
         if (pair_ptr != this->units.end()) {
@@ -165,12 +165,12 @@ namespace Opm {
         this->units[keyword] = unit;
     }
 
-    bool UDQInput::has_unit(const std::string& keyword) const {
+    bool UDQConfig::has_unit(const std::string& keyword) const {
         return (this->units.count(keyword) > 0);
     }
 
 
-    bool UDQInput::has_keyword(const std::string& keyword) const {
+    bool UDQConfig::has_keyword(const std::string& keyword) const {
         if (this->m_assignments.count(keyword) > 0)
             return true;
 
@@ -188,7 +188,7 @@ namespace Opm {
     }
 
 
-    const UDQFunctionTable& UDQInput::function_table() const {
+    const UDQFunctionTable& UDQConfig::function_table() const {
         return this->udqft;
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -77,9 +77,13 @@ namespace Opm {
                     this->m_assignments.insert( std::make_pair(quantity, UDQAssign(quantity, selector, value )));
                 else
                     assignment->second.add_record(selector, value);
-            } else if (action == UDQAction::DEFINE)
+            } else if (action == UDQAction::DEFINE) {
+                auto defined_iter = this->m_definitions.find( quantity );
+                if (defined_iter != this->m_definitions.end())
+                    this->m_definitions.erase( defined_iter );
+
                 this->m_definitions.insert( std::make_pair(quantity, UDQDefine(this->udq_params, quantity, data)));
-            else
+            } else
                 throw std::runtime_error("Internal error - should not be here");
         }
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -203,12 +203,31 @@ namespace Opm {
 
         /*
           That a keyword is mentioned with UNITS is enough to consider it
-           as a keyword which is present.
+          as a keyword which is present.
         */
         if (this->units.count(keyword) > 0)
             return true;
 
         return false;
+    }
+
+
+    const UDQInput UDQConfig::operator[](const std::string& keyword) const {
+        const auto index_iter = this->input_index.find(keyword);
+        if (index_iter == this->input_index.end())
+            throw std::invalid_argument("Keyword: " + keyword + " not recognized as ASSIGN/DEFINE UDQ");
+
+        std::string u;
+        if (this->has_unit(keyword))
+            u = this->unit(keyword);
+
+        if (index_iter->second.action == UDQAction::ASSIGN)
+            return UDQInput(this->input_index.at(keyword), this->m_assignments.at(keyword), u);
+
+        if (index_iter->second.action == UDQAction::DEFINE)
+            return UDQInput(this->input_index.at(keyword), this->m_definitions.at(keyword), u);
+
+        throw std::logic_error("Internal error - should not be here");
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
@@ -1,0 +1,83 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
+
+namespace Opm {
+
+
+UDQInput::UDQInput(const UDQDefine& udq_define) :
+    define(std::addressof(udq_define)),
+    assign(nullptr),
+    m_keyword(udq_define.keyword())
+{}
+
+
+UDQInput::UDQInput(const UDQAssign& udq_assign):
+    define(nullptr),
+    assign(std::addressof(udq_assign)),
+    m_keyword(udq_assign.keyword())
+{}
+
+
+const std::string& UDQInput::keyword() const {
+    return this->m_keyword;
+}
+
+template<>
+bool UDQInput::is<UDQAssign>() const {
+    if (this->assign)
+        return true;
+    return false;
+}
+
+
+template<>
+bool UDQInput::is<UDQDefine>() const {
+    if (this->define)
+        return true;
+    return false;
+}
+
+template<>
+const UDQAssign& UDQInput::get<UDQAssign>() const {
+    if (this->assign)
+        return *this->assign;
+
+    throw std::runtime_error("Invalid get");
+}
+
+
+template<>
+const UDQDefine& UDQInput::get<UDQDefine>() const {
+    if (this->define)
+        return *this->define;
+
+    throw std::runtime_error("Invalid get");
+}
+
+
+
+
+}
+
+

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
@@ -25,23 +25,28 @@
 namespace Opm {
 
 
-UDQInput::UDQInput(const UDQIndex& index_arg, const UDQDefine& udq_define) :
+UDQInput::UDQInput(const UDQIndex& index_arg, const UDQDefine& udq_define, const std::string& unit_arg) :
     index(index_arg),
     define(std::addressof(udq_define)),
     assign(nullptr),
     m_keyword(udq_define.keyword()),
-    m_var_type(udq_define.var_type())
+    m_var_type(udq_define.var_type()),
+    m_unit(unit_arg)
 {}
 
 
-UDQInput::UDQInput(const UDQIndex& index_arg, const UDQAssign& udq_assign):
+UDQInput::UDQInput(const UDQIndex& index_arg, const UDQAssign& udq_assign, const std::string& unit_arg):
     index(index_arg),
     define(nullptr),
     assign(std::addressof(udq_assign)),
     m_keyword(udq_assign.keyword()),
-    m_var_type(udq_assign.var_type())
+    m_var_type(udq_assign.var_type()),
+    m_unit(unit_arg)
 {}
 
+const std::string& UDQInput::unit() const {
+    return this->m_unit;
+}
 
 const std::string& UDQInput::keyword() const {
     return this->m_keyword;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
@@ -28,14 +28,16 @@ namespace Opm {
 UDQInput::UDQInput(const UDQDefine& udq_define) :
     define(std::addressof(udq_define)),
     assign(nullptr),
-    m_keyword(udq_define.keyword())
+    m_keyword(udq_define.keyword()),
+    m_var_type(udq_define.var_type())
 {}
 
 
 UDQInput::UDQInput(const UDQAssign& udq_assign):
     define(nullptr),
     assign(std::addressof(udq_assign)),
-    m_keyword(udq_assign.keyword())
+    m_keyword(udq_assign.keyword()),
+    m_var_type(udq_assign.var_type())
 {}
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
@@ -25,7 +25,8 @@
 namespace Opm {
 
 
-UDQInput::UDQInput(const UDQDefine& udq_define) :
+UDQInput::UDQInput(const UDQIndex& index_arg, const UDQDefine& udq_define) :
+    index(index_arg),
     define(std::addressof(udq_define)),
     assign(nullptr),
     m_keyword(udq_define.keyword()),
@@ -33,7 +34,8 @@ UDQInput::UDQInput(const UDQDefine& udq_define) :
 {}
 
 
-UDQInput::UDQInput(const UDQAssign& udq_assign):
+UDQInput::UDQInput(const UDQIndex& index_arg, const UDQAssign& udq_assign):
+    index(index_arg),
     define(nullptr),
     assign(std::addressof(udq_assign)),
     m_keyword(udq_assign.keyword()),

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -34,7 +34,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -26,7 +26,7 @@ Copyright 2018 Statoil ASA.
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp>

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1197,6 +1197,8 @@ UDQ
     BOOST_CHECK_EQUAL( input[6].get<UDQDefine>().keyword(), "FUOPRX");
 
     BOOST_CHECK( udq.has_keyword("FUXXX") );
+    const auto wubhp1 = udq["WUBHP1"];
+    BOOST_CHECK( wubhp1.is<UDQAssign>() );
 }
 
 
@@ -1232,5 +1234,8 @@ UDQ
 
     BOOST_CHECK( input[0].is<UDQDefine>());
     BOOST_CHECK_EQUAL( input[0].keyword(), "WUBHP1");
+
+    const auto wubhp1 = udq["WUBHP1"];
+    BOOST_CHECK( wubhp1.is<UDQDefine>() );
 }
 

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1186,6 +1186,7 @@ UDQ
     BOOST_CHECK( input[5].is<UDQAssign>() );
     BOOST_CHECK( input[6].is<UDQDefine>() );
 
+    BOOST_CHECK_EQUAL( input[4].unit(), "SM3/DAY" );
 
     BOOST_CHECK_EQUAL(def[0].keyword(), "WUWCT");
     BOOST_CHECK_EQUAL(def[1].keyword(), "FUOPR");

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1220,6 +1220,7 @@ UDQ
 
 UDQ
     DEFINE WUBHP1 SUM(WOPR) /
+    DEFINE FUOPR MAX(WOPR) /
 /
 
 )";
@@ -1235,7 +1236,9 @@ UDQ
     BOOST_CHECK( input[0].is<UDQDefine>());
     BOOST_CHECK_EQUAL( input[0].keyword(), "WUBHP1");
 
-    const auto wubhp1 = udq["WUBHP1"];
-    BOOST_CHECK( wubhp1.is<UDQDefine>() );
+    const auto fuopr = udq["FUOPR"];
+    BOOST_CHECK( fuopr.is<UDQDefine>() );
+    const auto& def2 = fuopr.get<UDQDefine>();
+    BOOST_CHECK_EQUAL(def2.input_string(), "MAX(WOPR)");
 }
 

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1173,20 +1173,26 @@ UDQ
     const auto& udq = schedule.getUDQConfig(0);
 
 
-    const auto& def_input = udq.input_definitions();
+    const auto& input = udq.input();
     const auto& def = udq.definitions();
-    BOOST_CHECK_EQUAL(def_input.size(), 3);
-    for (std::size_t i = 0; i < def_input.size(); i++)
-        BOOST_CHECK_EQUAL(def[i].input_string(), def_input[i].second.input_string());
+    BOOST_CHECK_EQUAL(input.size(), 7);
 
-    BOOST_CHECK_EQUAL(def_input[0].first, 3);
-    BOOST_CHECK_EQUAL(def_input[1].first, 4);
-    BOOST_CHECK_EQUAL(def_input[2].first, 6);
+    BOOST_CHECK( input[0].is<UDQAssign>() );
+    BOOST_CHECK( input[1].is<UDQAssign>() );
+    BOOST_CHECK( input[2].is<UDQAssign>() );
+    BOOST_CHECK( input[3].is<UDQDefine>() );
+    BOOST_CHECK( input[4].is<UDQDefine>() );
+    BOOST_CHECK( input[5].is<UDQAssign>() );
+    BOOST_CHECK( input[6].is<UDQDefine>() );
 
 
     BOOST_CHECK_EQUAL(def[0].keyword(), "WUWCT");
     BOOST_CHECK_EQUAL(def[1].keyword(), "FUOPR");
     BOOST_CHECK_EQUAL(def[2].keyword(), "FUOPRX");
+
+    BOOST_CHECK_EQUAL( input[3].get<UDQDefine>().keyword(), "WUWCT");
+    BOOST_CHECK_EQUAL( input[4].get<UDQDefine>().keyword(), "FUOPR");
+    BOOST_CHECK_EQUAL( input[6].get<UDQDefine>().keyword(), "FUOPRX");
 
     BOOST_CHECK( udq.has_keyword("FUXXX") );
 }
@@ -1217,14 +1223,11 @@ UDQ
     const auto& udq = schedule.getUDQConfig(0);
 
 
-    const auto& def_input = udq.input_definitions();
+    const auto& input = udq.input();
     const auto& def = udq.definitions();
-    BOOST_CHECK_EQUAL(def_input.size(), 3);
-    for (std::size_t i = 0; i < def_input.size(); i++)
-        BOOST_CHECK_EQUAL(def[i].input_string(), def_input[i].second.input_string());
+    BOOST_CHECK_EQUAL(input.size(), 5);
 
-    BOOST_CHECK_EQUAL(def_input[0].first, 0);
-    BOOST_CHECK_EQUAL(def_input[1].first, 3);
-    BOOST_CHECK_EQUAL(def_input[2].first, 4);
+    BOOST_CHECK( input[0].is<UDQDefine>());
+    BOOST_CHECK_EQUAL( input[0].keyword(), "WUBHP1");
 }
 

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1176,6 +1176,7 @@ UDQ
     const auto& input = udq.input();
     const auto& def = udq.definitions();
     BOOST_CHECK_EQUAL(input.size(), 7);
+    BOOST_CHECK_EQUAL(udq.size(), 7);
 
     BOOST_CHECK( input[0].is<UDQAssign>() );
     BOOST_CHECK( input[1].is<UDQAssign>() );
@@ -1226,6 +1227,7 @@ UDQ
     const auto& input = udq.input();
     const auto& def = udq.definitions();
     BOOST_CHECK_EQUAL(input.size(), 5);
+    BOOST_CHECK_EQUAL(udq.size(), 5);
 
     BOOST_CHECK( input[0].is<UDQDefine>());
     BOOST_CHECK_EQUAL( input[0].keyword(), "WUBHP1");


### PR DESCRIPTION
This will combine `UDQDefine`and `UDQAssign` in a variant like struct `UDQInput` - to simplify looping over UDQS:

```C++
auto conf = sched.getUDQConfig(time_step);
for (const auto udq : conf.input()) {
      if (udq.is<UDQDefine>()) {
           const auto& udq_define = udq.get<UDQDefine>();
           ...
       } else {
            const auto& udq_assign = udq.get<UDQAssign>();
            ...
       }
}
```

@jalvestad : This is for you!
