### PR TITLE
Sort the child wells according to insert index

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2018,6 +2018,11 @@ namespace {
                         wells.push_back( this->getWell2( well_name, timeStep ));
                 }
             }
+
+            std::sort(wells.begin(), wells.end(), [](const Well2& well1, const Well2& well2)
+                                                  {
+                                                      return well1.seqIndex() < well2.seqIndex();
+                                                  });
             return wells;
         }
     }


### PR DESCRIPTION
The restart format imposes several ordering requirements which are not strictly required by the simulator itself, since the full eclipse restart capabilities have come a bit later in the process many of these ordering requirements are implemented as an afterthought, and not really integrated in the underlying datastructures.

In the ongoing `Group`&rightarrow; `Group2` transition I try respect the necessary ordering requirements from the outset, thereby reducing the need for impedance matching code (quitre significantly ...). As a precursor to this the current PR will sort the wells in `Schedule::getChildWells2()` according to appearance in the deck, previously this was the ordering imposed by `std::set`. The test failures from this PR is that the wells are now sorted differently, and hence `IGRP` is different. The `WELSPECS`section in SPE1CASE2 looks like this:

```
WELSPECS
    'PROD'  'G1'  .... /
    'INJ'   'G1'  ..../
/ 
```
i.e. the `PROD` well comes before the `INJ` well in the deck, but when sorted with `std::set` the wells will come out like: `["INJ", "PROD"]`. In conclusion:

**master**
```
Schedule.getChildWells2("G1") => ["INJ", "PROD"]
```

**This PR**
```
Schedule.getChildWells2("G1") => ["PROD", "INJ"]
```
This will lead to changes in IGRP.

@jalvestad and @bska - you are the experts on this - I would be grateful if you could quality check this PR - and hopefully approve the necessary `update_data`. 