### PR TITLE
Remove superfluos check in RawKeyword assembly

### DIFF
--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -124,7 +124,7 @@ namespace Opm {
         SectionNameSet::const_iterator validSectionNamesBegin() const;
         SectionNameSet::const_iterator validSectionNamesEnd() const;
 
-        DeckKeyword parse(const ParseContext& parseContext, ErrorGuard& errors, std::shared_ptr< RawKeyword > rawKeyword) const;
+        DeckKeyword parse(const ParseContext& parseContext, ErrorGuard& errors, std::shared_ptr< RawKeyword > rawKeyword, const std::string& filename) const;
         enum ParserKeywordSizeEnum getSizeType() const;
         const KeywordSize& getKeywordSize() const;
         bool isDataKeyword() const;

--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -43,7 +43,7 @@ namespace Opm {
         void addDataItem( ParserItem item );
         const ParserItem& get(size_t index) const;
         const ParserItem& get(const std::string& itemName) const;
-        DeckRecord parse( const ParseContext&, ErrorGuard&, RawRecord&) const;
+        DeckRecord parse( const ParseContext&, ErrorGuard&, RawRecord&, const std::string& keyword, const std::string& filename) const;
         bool isDataRecord() const;
         bool equal(const ParserRecord& other) const;
         bool hasDimension() const;

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -59,6 +59,7 @@ namespace Opm {
         bool isFinished() const;
         bool unKnownSize() const;
         void finalizeUnknownSize();
+        void terminateRecord();
 
         const std::string& getFilename() const;
         size_t getLineNR() const;

--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -35,7 +35,7 @@ namespace Opm {
 
     class RawRecord {
     public:
-        RawRecord( const string_view&, const std::string& fileName = "", const std::string& keywordName = "");
+        explicit RawRecord( const string_view&);
 
         inline string_view pop_front();
         void push_front( string_view token );
@@ -44,8 +44,6 @@ namespace Opm {
 
         std::string getRecordString() const;
         inline string_view getItem(size_t index) const;
-        const std::string& getFileName() const;
-        const std::string& getKeywordName() const;
 
         static bool isTerminatedRecordString( const string_view& );
 
@@ -54,8 +52,6 @@ namespace Opm {
     private:
         string_view m_sanitizedRecordString;
         std::deque< string_view > m_recordItems;
-        const std::string m_fileName;
-        const std::string m_keywordName;
 
         void setRecordString(const std::string& singleRecordString);
     };

--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -52,8 +52,6 @@ namespace Opm {
     private:
         string_view m_sanitizedRecordString;
         std::deque< string_view > m_recordItems;
-
-        void setRecordString(const std::string& singleRecordString);
     };
 
     /*

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -615,6 +615,7 @@ bool tryParseKeyword( ParserState& parserState, const Parser& parser ) {
         && parserState.rawKeyword->getSizeType() == Raw::UNKNOWN)
     {
         parserState.rawKeyword->finalizeUnknownSize();
+        return true;
     }
 
     return false;

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -469,7 +469,8 @@ void set_dimensions( ParserItem& item,
 
     DeckKeyword ParserKeyword::parse(const ParseContext& parseContext,
                                      ErrorGuard& errors,
-                                     std::shared_ptr< RawKeyword > rawKeyword) const {
+                                     std::shared_ptr< RawKeyword > rawKeyword,
+                                     const std::string& filename) const {
         if( !rawKeyword->isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword->getKeywordName());
 
@@ -482,7 +483,7 @@ void set_dimensions( ParserItem& item,
             if( m_records.size() == 0 && rawRecord.size() > 0 )
                 throw std::invalid_argument("Missing item information " + rawKeyword->getKeywordName());
 
-            keyword.addRecord( getRecord( record_nr ).parse( parseContext, errors, rawRecord ) );
+            keyword.addRecord( getRecord( record_nr ).parse( parseContext, errors, rawRecord, rawKeyword->getKeywordName(), filename ) );
             record_nr++;
         }
 

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -144,14 +144,14 @@ namespace {
         return *itr;
     }
 
-    DeckRecord ParserRecord::parse(const ParseContext& parseContext , ErrorGuard& errors , RawRecord& rawRecord) const {
+    DeckRecord ParserRecord::parse(const ParseContext& parseContext , ErrorGuard& errors , RawRecord& rawRecord, const std::string& keyword, const std::string& filename) const {
         std::vector< DeckItem > items;
         items.reserve( this->size() + 20 );
         for( const auto& parserItem : *this )
             items.emplace_back( parserItem.scan( rawRecord ) );
 
         if (rawRecord.size() > 0) {
-            std::string msg = "The RawRecord for keyword \""  + rawRecord.getKeywordName() + "\" in file\"" + rawRecord.getFileName() + "\" contained " +
+            std::string msg = "The RawRecord for keyword \""  + keyword + "\" in file\"" + filename + "\" contained " +
                 std::to_string(rawRecord.size()) +
                 " too many items according to the spec. RawRecord was: " + rawRecord.getRecordString();
             parseContext.handleError(ParseContext::PARSE_EXTRA_DATA , msg, errors);

--- a/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -115,10 +115,7 @@ namespace Opm {
 
         if( RawRecord::isTerminatedRecordString( partialRecordString ) ) {
 
-            auto recstr = partialRecordString.back() == '/'
-                ? string_view{ m_partialRecordString.begin(), m_partialRecordString.end() - 1 }
-                : m_partialRecordString;
-
+            auto recstr = string_view{ m_partialRecordString.begin(), m_partialRecordString.end() - 1 };
             m_records.emplace_back( recstr, m_filename, m_name );
             m_partialRecordString = emptystr;
 

--- a/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -109,7 +109,7 @@ namespace Opm {
                                ? "untitled"
                                : m_partialRecordString;
 
-            m_records.emplace_back( recstr, m_filename, m_name );
+            m_records.emplace_back( recstr );
             m_partialRecordString = emptystr;
             m_isFinished = true;
             return;
@@ -123,7 +123,7 @@ namespace Opm {
 
 
     void RawKeyword::terminateRecord() {
-        this->m_records.emplace_back( this->m_partialRecordString, this->m_filename, this->m_name );
+        this->m_records.emplace_back( this->m_partialRecordString );
         m_partialRecordString = emptystr;
 
         if( m_sizeType == Raw::FIXED && m_records.size() == m_fixedSize )

--- a/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -114,15 +114,19 @@ namespace Opm {
         }
 
         if( RawRecord::isTerminatedRecordString( partialRecordString ) ) {
-
-            auto recstr = string_view{ m_partialRecordString.begin(), m_partialRecordString.end() - 1 };
-            m_records.emplace_back( recstr, m_filename, m_name );
-            m_partialRecordString = emptystr;
-
-            if( m_sizeType == Raw::FIXED && m_records.size() == m_fixedSize )
-                m_isFinished = true;
+            this->m_partialRecordString = string_view{ this->m_partialRecordString.begin(), this->m_partialRecordString.end() - 1 };
+            this->terminateRecord();
         }
     }
+
+
+    void RawKeyword::terminateRecord() {
+        this->m_records.emplace_back( this->m_partialRecordString, this->m_filename, this->m_name );
+        m_partialRecordString = emptystr;
+
+        if( m_sizeType == Raw::FIXED && m_records.size() == m_fixedSize )
+            m_isFinished = true;
+    };
 
     const RawRecord& RawKeyword::getFirstRecord() const {
         return *m_records.begin();

--- a/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -80,8 +80,10 @@ namespace Opm {
     /// it is added to the list of records, and a new record is started.
 
     void RawKeyword::addRawRecordString(const string_view& partialRecordString) {
-        if( m_partialRecordString == emptystr ) m_partialRecordString = partialRecordString;
-        else m_partialRecordString = { m_partialRecordString.begin(), partialRecordString.end() };
+        if( m_partialRecordString == emptystr )
+            m_partialRecordString = partialRecordString;
+        else
+            m_partialRecordString = { m_partialRecordString.begin(), partialRecordString.end() };
 
 
         if( isTerminator( m_partialRecordString ) ) {

--- a/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -84,7 +84,7 @@ namespace Opm {
         else m_partialRecordString = { m_partialRecordString.begin(), partialRecordString.end() };
 
 
-        if( m_sizeType != Raw::FIXED && isTerminator( m_partialRecordString ) ) {
+        if( isTerminator( m_partialRecordString ) ) {
             if (m_sizeType == Raw::TABLE_COLLECTION) {
                 m_currentNumTables += 1;
                 if (m_currentNumTables == m_numTables) {
@@ -92,7 +92,7 @@ namespace Opm {
                     m_partialRecordString = emptystr;
                     return;
                 }
-            } else if( m_sizeType != Raw::UNKNOWN ) {
+            } else if( m_sizeType == Raw::SLASH_TERMINATED) {
                 m_isFinished = true;
                 m_partialRecordString = emptystr;
                 return;

--- a/src/opm/parser/eclipse/RawDeck/RawRecord.cpp
+++ b/src/opm/parser/eclipse/RawDeck/RawRecord.cpp
@@ -76,13 +76,9 @@ inline bool even_quotes( const T& str ) {
 
 }
 
-    RawRecord::RawRecord(const string_view& singleRecordString,
-                         const std::string& fileName,
-                         const std::string& keywordName) :
+    RawRecord::RawRecord(const string_view& singleRecordString) :
         m_sanitizedRecordString( singleRecordString ),
-        m_recordItems( splitSingleRecordString( m_sanitizedRecordString ) ),
-        m_fileName(fileName),
-        m_keywordName(keywordName)
+        m_recordItems( splitSingleRecordString( m_sanitizedRecordString ) )
     {
 
         if( !even_quotes( singleRecordString ) )
@@ -92,13 +88,6 @@ inline bool even_quotes( const T& str ) {
             );
     }
 
-    const std::string& RawRecord::getFileName() const {
-        return m_fileName;
-    }
-
-    const std::string& RawRecord::getKeywordName() const {
-        return m_keywordName;
-    }
 
     void RawRecord::prepend( size_t count, string_view tok ) {
         this->m_recordItems.insert( this->m_recordItems.begin(), count, tok );

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -525,7 +525,7 @@ BOOST_AUTO_TEST_CASE(StringsWithSpaceOK) {
     record1.addItem( itemString );
 
 
-    const auto deckRecord = record1.parse( parseContext, errors , rawRecord );
+    const auto deckRecord = record1.parse( parseContext, errors , rawRecord, "KEYWORD", "filename" );
     BOOST_CHECK_EQUAL(" VALUE " , deckRecord.getItem(0).get< std::string >(0));
 }
 

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1031,7 +1031,7 @@ BOOST_AUTO_TEST_CASE(parse_validRecord_noThrow) {
     ParseContext parseContext;
     ErrorGuard errors;
     RawRecord raw( string_view( "100 443" ) );
-    BOOST_CHECK_NO_THROW(record.parse(parseContext, errors, raw ) );
+    BOOST_CHECK_NO_THROW(record.parse(parseContext, errors, raw , "KEYWORD", "filename") );
 }
 
 BOOST_AUTO_TEST_CASE(parse_validRecord_deckRecordCreated) {
@@ -1039,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(parse_validRecord_deckRecordCreated) {
     RawRecord rawRecord( string_view( "100 443" ) );
     ParseContext parseContext;
     ErrorGuard errors;
-    const auto deckRecord = record.parse(parseContext , errors, rawRecord);
+    const auto deckRecord = record.parse(parseContext , errors, rawRecord, "KEYWORD", "filename");
     BOOST_CHECK_EQUAL(2U, deckRecord.size());
 }
 
@@ -1070,7 +1070,7 @@ BOOST_AUTO_TEST_CASE(parse_validMixedRecord_noThrow) {
     RawRecord rawRecord( string_view( "1 2 10.0 20.0 4 90.0") );
     ParseContext parseContext;
     ErrorGuard errors;
-    BOOST_CHECK_NO_THROW(record.parse(parseContext, errors, rawRecord));
+    BOOST_CHECK_NO_THROW(record.parse(parseContext, errors, rawRecord, "KEYWORD", "filename"));
 }
 
 BOOST_AUTO_TEST_CASE(Equal_Equal_ReturnsTrue) {
@@ -1211,13 +1211,13 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooManyItems_Throws) {
 
     RawRecord rawRecord(  "3 3 3 " );
 
-    BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord));
+    BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord, "KEYWORD", "filename"));
 
     RawRecord rawRecordOneExtra(  "3 3 3 4 " );
-    BOOST_CHECK_THROW(parserRecord.parse(parseContext, errors, rawRecordOneExtra), std::invalid_argument);
+    BOOST_CHECK_THROW(parserRecord.parse(parseContext, errors, rawRecordOneExtra, "KEYWORD", "filename"), std::invalid_argument);
 
     RawRecord rawRecordForgotRecordTerminator(  "3 3 3 \n 4 4 4 " );
-    BOOST_CHECK_THROW(parserRecord.parse(parseContext, errors, rawRecordForgotRecordTerminator), std::invalid_argument);
+    BOOST_CHECK_THROW(parserRecord.parse(parseContext, errors, rawRecordForgotRecordTerminator, "KEYWORD", "filename"), std::invalid_argument);
 
 }
 
@@ -1237,8 +1237,8 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooFewItems) {
     RawRecord rawRecord(  "3 3  " );
     // no default specified for the third item, record can be parsed just fine but trying
     // to access the data will raise an exception...;
-    BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord));
-    auto record = parserRecord.parse(parseContext, errors , rawRecord);
+    BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord, "KEWYORD", "filename"));
+    auto record = parserRecord.parse(parseContext, errors , rawRecord, "KEYWORD", "filename");
     BOOST_CHECK_NO_THROW(record.getItem(2));
     BOOST_CHECK_THROW(record.getItem(2).get< int >(0), std::out_of_range);
 }
@@ -1621,7 +1621,7 @@ BOOST_AUTO_TEST_CASE(ParseEmptyRecord) {
     record.addItem(item);
     tabdimsKeyword->addRecord( record );
 
-    const auto deckKeyword = tabdimsKeyword->parse( parseContext, errors, rawkeyword );
+    const auto deckKeyword = tabdimsKeyword->parse( parseContext, errors, rawkeyword , "filename");
     BOOST_REQUIRE_EQUAL( 1U , deckKeyword.size());
 
     const auto& deckRecord = deckKeyword.getRecord(0);

--- a/tests/parser/RawKeywordTests.cpp
+++ b/tests/parser/RawKeywordTests.cpp
@@ -250,16 +250,4 @@ BOOST_AUTO_TEST_CASE(Rawrecord_spaceOnlyEmpty_OK) {
     BOOST_CHECK_EQUAL(0U, record.size());
 }
 
-BOOST_AUTO_TEST_CASE(Rawrecord_noFileAndKeywordGiven_EmptyStringUsed) {
-    Opm::RawRecord record("32 33  ");
-    BOOST_CHECK_EQUAL("", record.getKeywordName());
-    BOOST_CHECK_EQUAL("", record.getFileName());
-}
 
-BOOST_AUTO_TEST_CASE(Rawrecord_FileAndKeywordGiven_CorrectStringsReturned) {
-    const std::string fileName = "/this/is/it";
-    const std::string keywordName = "KEYWD";
-    Opm::RawRecord record("32 33  ", fileName, keywordName);
-    BOOST_CHECK_EQUAL(keywordName, record.getKeywordName());
-    BOOST_CHECK_EQUAL(fileName, record.getFileName());
-}


### PR DESCRIPTION
Deep down in the ancient text-handling code of the parser; not a friendly place ... :-(