### PR TITLE
Execute tests in parallel for the 'check' target

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -261,9 +261,13 @@ macro (cond_disable_test name)
 	endif ((NOT DEFINED HAVE_${name}) OR (NOT HAVE_${name}))
 endmacro (cond_disable_test name)
 
-# use this target to run all tests
+# use this target to run all tests, with parallel execution
+cmake_host_system_information(RESULT TESTJOBS QUERY NUMBER_OF_PHYSICAL_CORES)
+if(TESTJOBS EQUAL 0)
+	set(TESTJOBS 1)
+endif()
 add_custom_target (check
-	COMMAND ${CMAKE_CTEST_COMMAND}
+	COMMAND ${CMAKE_CTEST_COMMAND} -j${TESTJOBS}
 	DEPENDS test-suite
 	COMMENT "Checking if library is functional"
 	VERBATIM

--- a/cmake/Scripts/CheckCommits.cmake
+++ b/cmake/Scripts/CheckCommits.cmake
@@ -31,28 +31,13 @@ if(NOT check_target)
 endif()
 
 # Build threads
+include(ProcessorCount)
 set(build_threads $ENV{CHECK_THREADS})
 if(NOT build_threads)
-  if(UNIX)
-    if(APPLE)
-      execute_process(COMMAND sysctl hw.ncpu
-                      OUTPUT_VARIABLE build_threads)
-      string(REPLACE " " ";" build_threads_list ${build_threads)
-      list(GET build_threads_list 1 build_threads)
-    else()
-      find_program(NPROC_COMMAND nproc)
-      if(NPROC_COMMAND)
-        execute_process(COMMAND ${NPROC_COMMAND}
-                        OUTPUT_VARIABLE build_threads)
-        string(REGEX REPLACE "(\r?\n)+$" "" build_threads "${build_threads}")
-      endif()
-    endif()
+  ProcessorCount(build_threads)
+  if(build_threads EQUAL 0)
+    set(build_threads 1)
   endif()
-endif()
-
-# If for some reason we could not find the info - e.g. centos5 where nproc is missing
-if(NOT build_threads)
-  set(build_threads 1)
 endif()
 
 # Record current HEAD


### PR DESCRIPTION
I was tasked with enabling parallel test execution by default. Sadly CMake does not allow use to customize the built-in test target.

You can run tests in parallel using 'make test ARGS=-jN' , or equivalently using 'ctest -jN'. But you cannot set a default value for the ARGS environment variable for the test target.

The 'check' target, however, is our custom target to build and execute tests. Here I can enable this by default. This is the closest I can get to automated parallel execution.

@alfbr 