### PR TITLE
Remove an unused call that is very slow.

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1432,7 +1432,6 @@ well_efficiency_factors( const ecl::smspec_node* node,
 
     const bool is_group = (var_type == ECL_SMSPEC_GROUP_VAR);
     const bool is_rate = !node->is_total();
-    const auto groupTree = schedule.groupTree(sim_step);
 
     for( const auto& well : schedule_wells ) {
         if (!well.hasBeenDefined(sim_step))


### PR DESCRIPTION
It turns out this is sufficient to fix issue #943.

The GTNode class returned by groupTree() as well as the function groupTree() can be removed as well, with only very minor changes otherwise. I will make a separate PR for that, so this can be merged in the meantime as a quick fix for the immediate problem.