### PR TITLE
Correct ICON and SCON when flow has deacivated connection cell

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -516,7 +516,11 @@ namespace {
     }
 
 
-  void Schedule::handleCOMPORD(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& compordKeyword, size_t /* currentStep */) {
+    /*
+      The COMPORD keyword is handled together with the WELSPECS keyword in the
+      handleWELSPECS function.
+    */
+    void Schedule::handleCOMPORD(const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& compordKeyword, size_t /* currentStep */) {
         for (const auto& record : compordKeyword) {
             const auto& methodItem = record.getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
             if ((methodItem.get< std::string >(0) != "TRACK")  && (methodItem.get< std::string >(0) != "INPUT")) {


### PR DESCRIPTION
During the massive well refactor a bug had sneaked in for the situation that a well is completed in a cell which is subsequently deactived by flow; there was an error in the book keeping for the ICON and SCON restart vectors.

Thank you to @jalvestad for extremely good debugging.