### PR TITLE
fixed: dereferencing string at index -1 is not adviced.

### DIFF
--- a/src/opm/io/eclipse/EclFile.cpp
+++ b/src/opm/io/eclipse/EclFile.cpp
@@ -49,12 +49,11 @@ namespace {
 
 bool isFormatted(const std::string& filename)
 {
-    int p = filename.find_last_of(".");
-    int l = filename.length();
-
-    std::string extension = filename.substr(p,l-p);
-
-    return extension.substr(1,1) == "F" || extension.substr(1,1) == "A";
+    const auto p = filename.find_last_of(".");
+    if (p == std::string::npos)
+      OPM_THROW(std::invalid_argument,
+                "Purported ECLIPSE Filename'" + filename + "'does not contain extension");
+    return std::strchr("ABCFGH", static_cast<int>(filename[p+1])) != nullptr;
 }
 
 


### PR DESCRIPTION
if there is no dot, p is -1 which leads to an exception thrown