### PR TITLE
 Default error handler for WELLDIMS errors is exception

### DIFF
--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -82,10 +82,10 @@ namespace Opm {
 
         addKey(UNIT_SYSTEM_MISMATCH, InputError::THROW_EXCEPTION);
 
-        this->addKey(RUNSPEC_NUMWELLS_TOO_LARGE, InputError::DELAYED_EXIT1);
-        this->addKey(RUNSPEC_CONNS_PER_WELL_TOO_LARGE, InputError::DELAYED_EXIT1);
-        this->addKey(RUNSPEC_NUMGROUPS_TOO_LARGE, InputError::DELAYED_EXIT1);
-        this->addKey(RUNSPEC_GROUPSIZE_TOO_LARGE, InputError::DELAYED_EXIT1);
+        this->addKey(RUNSPEC_NUMWELLS_TOO_LARGE, InputError::THROW_EXCEPTION);
+        this->addKey(RUNSPEC_CONNS_PER_WELL_TOO_LARGE, InputError::THROW_EXCEPTION);
+        this->addKey(RUNSPEC_NUMGROUPS_TOO_LARGE, InputError::THROW_EXCEPTION);
+        this->addKey(RUNSPEC_GROUPSIZE_TOO_LARGE, InputError::THROW_EXCEPTION);
 
         addKey(UNSUPPORTED_SCHEDULE_GEO_MODIFIER, InputError::THROW_EXCEPTION);
         addKey(UNSUPPORTED_COMPORD_TYPE, InputError::THROW_EXCEPTION);


### PR DESCRIPTION
The `ParseContext::EXIT1` and `ParseContext::DELAYED_EXIT1` tells the simulator to terminate with `std::exit(1)` - this is a quite brutal exit, and in particular a traceback
is sometimes presented[1,2]. This draws the users attention away from the error message, this PR changes the error handling mode to `ParseContext::THROW_EXCEPTION` - this will still stop the execution - but sligtly less brutal; and in particular the traceback is no longer displayed.


[1]: opm/flow does not explicitly request this traceback in any way, looking at the symbols involved it seems to come from the `pthreads` runtime system, probably from the io thread. I do not know if we can disable this traceback in any way.

[2]: Just to illustrate the lack of control of this traceback - I can not reproduce it on my machine; so maybe @alfbr could paste in what it looks like on a Equinor workstation.