### PR TITLE
Store both injection and production controls

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -151,7 +151,8 @@ namespace Opm {
         double bhp;
         double thp;
         double temperature;
-        int control;
+        int injectionControl;
+        int productionControl;
         std::vector< Connection > connections;
         std::unordered_map<std::size_t, Segment> segments;
         inline bool flowing() const noexcept;
@@ -351,7 +352,8 @@ namespace Opm {
         buffer.write(this->bhp);
         buffer.write(this->thp);
         buffer.write(this->temperature);
-        buffer.write(this->control);
+        buffer.write(this->injectionControl);
+        buffer.write(this->productionControl);
         unsigned int size = this->connections.size();
         buffer.write(size);
         for (const Connection& comp : this->connections)
@@ -415,7 +417,8 @@ namespace Opm {
         buffer.read(this->bhp);
         buffer.read(this->thp);
         buffer.read(this->temperature);
-        buffer.read(this->control);
+        buffer.read(this->injectionControl);
+        buffer.read(this->productionControl);
 
         // Connection information
         unsigned int size = 0.0; //this->connections.size();

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -718,7 +718,7 @@ namespace {
             };
         }
 
-        if (opm_iwel.size() != sched_wells.size()) {
+        if (opm_iwel.size() != sched_wells.size() * 2) {
             throw std::runtime_error {
                 "Mismatch between OPM_IWEL and deck; "
                 "OPM_IWEL size was " + std::to_string(opm_iwel.size()) +
@@ -765,7 +765,8 @@ namespace {
 
             well.bhp         = *opm_xwel_data;  ++opm_xwel_data;
             well.temperature = *opm_xwel_data;  ++opm_xwel_data;
-            well.control     = *opm_iwel_data;  ++opm_iwel_data;
+            well.injectionControl = *opm_iwel_data;  ++opm_iwel_data;
+            well.productionControl = *opm_iwel_data;  ++opm_iwel_data;
 
             for (const auto& phase : phases) {
                 well.rates.set(phase, *opm_xwel_data);

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -292,8 +292,8 @@ BOOST_AUTO_TEST_CASE(test_RFT)
 
         using SegRes = decltype(wells["w"].segments);
 
-        wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{} };
-        wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{} };
+        wells["OP_1"] = { r1, 1.0, 1.1, 3.1, 1, 2, well1_comps, SegRes{} };
+        wells["OP_2"] = { r2, 1.0, 1.1, 3.2, 1, 2, well2_comps, SegRes{} };
 
         RestartValue restart_value(std::move(solution), std::move(wells));
 
@@ -414,8 +414,8 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
 
                 using SegRes = decltype(wells["w"].segments);
 
-                wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{} };
-                wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{} };
+                wells["OP_1"] = { r1, 1.0, 1.1, 3.1, 1, 2, well1_comps, SegRes{} };
+                wells["OP_2"] = { r2, 1.0, 1.1, 3.2, 1, 2, well2_comps, SegRes{} };
 
                 RestartValue restart_value(std::move(solution), std::move(wells));
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -257,7 +257,9 @@ bool operator==( const Well& lhs, const Well& rhs ) {
     BOOST_CHECK_EQUAL( lhs.rates, rhs.rates );
     BOOST_CHECK_EQUAL( lhs.bhp, rhs.bhp );
     BOOST_CHECK_EQUAL( lhs.temperature, rhs.temperature );
-    BOOST_CHECK_EQUAL( lhs.control, rhs.control );
+    BOOST_CHECK_EQUAL( lhs.productionControl, rhs.productionControl );
+    BOOST_CHECK_EQUAL( lhs.injectionControl, rhs.injectionControl );
+
 
     BOOST_CHECK_EQUAL_COLLECTIONS(
             lhs.connections.begin(), lhs.connections.end(),
@@ -295,7 +297,8 @@ data::Wells mkWells() {
     w1.rates = r1;
     w1.bhp = 1.23;
     w1.temperature = 3.45;
-    w1.control = 1;
+    w1.injectionControl = 1;
+    w1.productionControl = 1;
 
     /*
      *  the completion keys (active indices) and well names correspond to the
@@ -307,7 +310,8 @@ data::Wells mkWells() {
     w2.rates = r2;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
-    w2.control = 2;
+    w2.injectionControl = 1;
+    w2.productionControl = 1;
     w2.connections.push_back( { 188, rc3, 36.22, 123.4, 256.1, 0.55, 0.0125, 314.15 } );
 
     {

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -224,16 +224,16 @@ static data::Wells result_wells() {
       The completions
     */
     data::Well well1 {
-        rates1, 0.1 * ps, 0.2 * ps, 0.3 * ps, 1,
+        rates1, 0.1 * ps, 0.2 * ps, 0.3 * ps, 1,2,
         { {well1_comp1} },
         { { segment.segNumber, segment } },
     };
 
     using SegRes = decltype(well1.segments);
 
-    data::Well well2 { rates2, 1.1 * ps, 1.2 * ps, 1.3 * ps, 2, { {well2_comp1 , well2_comp2} }, SegRes{} };
-    data::Well well3 { rates3, 2.1 * ps, 2.2 * ps, 2.3 * ps, 3, { {well3_comp1} }, SegRes{} };
-    data::Well well6 { rates6, 2.1 * ps, 2.2 * ps, 2.3 * ps, 3, { {well6_comp1} }, SegRes{} };
+    data::Well well2 { rates2, 1.1 * ps, 1.2 * ps, 1.3 * ps, 2, 2,{ {well2_comp1 , well2_comp2} }, SegRes{} };
+    data::Well well3 { rates3, 2.1 * ps, 2.2 * ps, 2.3 * ps, 3, 3,{ {well3_comp1} }, SegRes{} };
+    data::Well well6 { rates6, 2.1 * ps, 2.2 * ps, 2.3 * ps, 3, 3,{ {well6_comp1} }, SegRes{} };
 
     data::Wells wellrates;
 
@@ -2427,7 +2427,8 @@ data::Well SegmentResultHelpers::prod01_results()
     res.bhp         = 123.45*unit::barsa;
     res.thp         = 60.221409*unit::barsa;
     res.temperature = 298.15;
-    res.control     = 0;
+    res.injectionControl = 0;
+    res.productionControl = 0;
 
     res.connections = prod01_conn_results();
     res.segments    = prod01_seg_results();
@@ -2444,8 +2445,8 @@ data::Well SegmentResultHelpers::inje01_results()
     res.bhp         = 543.21*unit::barsa;
     res.thp         = 256.821*unit::barsa;
     res.temperature = 298.15;
-    res.control     = 0;
-
+    res.injectionControl = 0;
+    res.productionControl = 0;
     res.connections = inje01_conn_results();
 
     return res;

--- a/tests/test_Wells.cpp
+++ b/tests/test_Wells.cpp
@@ -97,7 +97,8 @@ BOOST_AUTO_TEST_CASE(get_completions) {
     w1.rates = r1;
     w1.bhp = 1.23;
     w1.temperature = 3.45;
-    w1.control = 1;
+    w1.injectionControl = 1;
+    w1.productionControl = 2;
 
     /*
      *  the completion keys (active indices) and well names correspond to the
@@ -109,7 +110,8 @@ BOOST_AUTO_TEST_CASE(get_completions) {
     w2.rates = r2;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
-    w2.control = 2;
+    w2.injectionControl = 1;
+    w2.productionControl = 2;
     w2.connections.push_back( { 188, rc3, 36.22, 19.28, 28.91, 0.125, 0.125, 3.141 } );
 
     data::Wells wellRates;


### PR DESCRIPTION
Motivation. Injectors and producers have different enums for safety store them in separate containers.  