### PR TITLE
Fix ArrayDimsChecker's Maximum Group Size (WELLDIMS) Check

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -318,6 +318,7 @@ list (APPEND TEST_DATA_FILES
 )
 if(ENABLE_ECL_OUTPUT)
   list (APPEND TEST_DATA_FILES
+          tests/expect-wdims.chldg.err.out
           tests/expect-wdims.err.out
           tests/FIRST_SIM.DATA
           tests/FIRST_SIM_THPRES.DATA

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
@@ -27,7 +27,6 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group2.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp>
@@ -138,20 +137,6 @@ namespace {
         WellDims::checkNumGroups  (wdims, sched, ctxt, guard);
         WellDims::checkGroupSize  (wdims, sched, ctxt, guard);
     }
-
-    std::size_t groupSize(const Opm::GTNode& tree) {
-        auto nwgmax = std::size_t{0};
-        for (const auto& node : tree.groups()) {
-            const auto& group = node.group();
-            if (group.wellgroup())
-                nwgmax = std::max(nwgmax, group.wells().size());
-            else
-                nwgmax = std::max(nwgmax, groupSize(node));
-        }
-        return nwgmax;
-    }
-
-
 } // Anonymous
 
 void
@@ -170,6 +155,15 @@ int
 Opm::maxGroupSize(const Opm::Schedule& sched,
                   const std::size_t    step)
 {
-    const auto& gt = sched.groupTree(step);
-    return static_cast<int>(groupSize(gt));
+    int nwgmax = 0;
+
+    for (const auto& gnm : sched.groupNames(step)) {
+        const auto& grp = sched.getGroup2(gnm, step);
+        const auto  gsz = grp.wellgroup()
+            ? grp.numWells() : grp.groups().size();
+
+        nwgmax = std::max(nwgmax, static_cast<int>(gsz));
+    }
+
+    return nwgmax;
 }

--- a/tests/expect-wdims.chldg.err.out
+++ b/tests/expect-wdims.chldg.err.out
@@ -1,0 +1,6 @@
+
+
+Errors:
+  RUNSPEC_GROUPSIZE_TOO_LARGE: Run uses maximum group size of 6, but allocates at most 4 in RUNSPEC section.  Increase item 4 of WELLDIMS accordingly.
+
+

--- a/tests/test_ArrayDimChecker.cpp
+++ b/tests/test_ArrayDimChecker.cpp
@@ -244,6 +244,17 @@ RedirectCERR::~RedirectCERR()
 
 BOOST_AUTO_TEST_SUITE(WellDimensions)
 
+namespace {
+    void setWellDimsContext(const Opm::InputError::Action action,
+                            Opm::ParseContext&            ctxt)
+    {
+        ctxt.update(Opm::ParseContext::RUNSPEC_NUMWELLS_TOO_LARGE,       action);
+        ctxt.update(Opm::ParseContext::RUNSPEC_CONNS_PER_WELL_TOO_LARGE, action);
+        ctxt.update(Opm::ParseContext::RUNSPEC_NUMGROUPS_TOO_LARGE,      action);
+        ctxt.update(Opm::ParseContext::RUNSPEC_GROUPSIZE_TOO_LARGE,      action);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(MaxGroupSize)
 {
     Opm::ParseContext parseContext;
@@ -256,10 +267,7 @@ BOOST_AUTO_TEST_CASE(MaxGroupSize)
 BOOST_AUTO_TEST_CASE(WellDims)
 {
     Opm::ParseContext parseContext;
-    parseContext.update(Opm::ParseContext::RUNSPEC_NUMWELLS_TOO_LARGE, Opm::InputError::THROW_EXCEPTION);
-    parseContext.update(Opm::ParseContext::RUNSPEC_CONNS_PER_WELL_TOO_LARGE, Opm::InputError::THROW_EXCEPTION);
-    parseContext.update(Opm::ParseContext::RUNSPEC_NUMGROUPS_TOO_LARGE, Opm::InputError::THROW_EXCEPTION);
-    parseContext.update(Opm::ParseContext::RUNSPEC_GROUPSIZE_TOO_LARGE, Opm::InputError::THROW_EXCEPTION);
+    setWellDimsContext(Opm::InputError::THROW_EXCEPTION, parseContext);
 
     auto cse = CaseObjects{ simCaseWellDims(),  parseContext};
 
@@ -270,10 +278,7 @@ BOOST_AUTO_TEST_CASE(WellDims)
                                                            parseContext, cse.guard),
                        std::invalid_argument);
 
-    parseContext.update(Opm::ParseContext::RUNSPEC_NUMWELLS_TOO_LARGE, Opm::InputError::DELAYED_EXIT1);
-    parseContext.update(Opm::ParseContext::RUNSPEC_CONNS_PER_WELL_TOO_LARGE, Opm::InputError::DELAYED_EXIT1);
-    parseContext.update(Opm::ParseContext::RUNSPEC_NUMGROUPS_TOO_LARGE, Opm::InputError::DELAYED_EXIT1);
-    parseContext.update(Opm::ParseContext::RUNSPEC_GROUPSIZE_TOO_LARGE, Opm::InputError::DELAYED_EXIT1);
+    setWellDimsContext(Opm::InputError::DELAYED_EXIT1, parseContext);
     Opm::checkConsistentArrayDimensions(cse.es  , cse.sched,
                                         parseContext, cse.guard);
 


### PR DESCRIPTION
This PR extends the `maxGroupSize` function to also consider the sizes of node groups (i.e., the number of child nodes/child groups) when determining what the largest group size is on a particular step.

Prompted by [discussion](https://github.com/OPM/opm-common/pull/947#issuecomment-528284603) in PR #947.