### PR TITLE
Make StreamLog throw if it fails to open file.

### DIFF
--- a/src/opm/common/OpmLog/StreamLog.cpp
+++ b/src/opm/common/OpmLog/StreamLog.cpp
@@ -29,6 +29,9 @@ StreamLog::StreamLog(const std::string& logFile , int64_t messageMask, bool appe
     } else {
         m_ofstream.open( logFile.c_str() ,  std::ofstream::out );
     }
+    if (!m_ofstream) {
+        throw std::runtime_error("Failed opening file " + logFile + " for StreamLog.");
+    }
     m_streamOwner = true;
     m_ostream = &m_ofstream;
 }
@@ -44,7 +47,7 @@ StreamLog::StreamLog(std::ostream& os , int64_t messageMask) : LogBackend(messag
 void StreamLog::close() {
     if (m_streamOwner && m_ofstream.is_open()) {
         m_ofstream.close();
-        m_ostream = NULL;
+        m_ostream = nullptr;
     }
 }
 

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -61,6 +61,7 @@ BOOST_AUTO_TEST_CASE(Test_Logger) {
     std::ostringstream log_stream;
     std::shared_ptr<CounterLog> counter = std::make_shared<CounterLog>();
     std::shared_ptr<StreamLog> streamLog = std::make_shared<StreamLog>( log_stream , Log::MessageType::Warning );
+    BOOST_CHECK_THROW( StreamLog( "/non/existing/directory/logfile", Log::MessageType::Warning ) , std::runtime_error );
     BOOST_CHECK_EQUAL( false , logger.hasBackend("NO"));
 
     logger.addBackend("COUNTER" , counter);


### PR DESCRIPTION
A minor improvement, promised in OPM/opm-simulators#1995.