### PR TITLE
Accept <= and >= in the ActionX::Condition

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
@@ -38,6 +38,8 @@ enum class Comparator {
     EQUAL,
     GREATER,
     LESS,
+    GREATER_EQUAL,
+    LESS_EQUAL,
     INVALID
 };
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
@@ -76,6 +76,12 @@ ActionX::ActionX(const DeckKeyword& kw, std::time_t start_time) :
 
                 if (token_type == TokenType::op_lt)
                     cond.cmp = Condition::Comparator::LESS;
+
+                if (token_type == TokenType::op_le)
+                    cond.cmp = Condition::Comparator::LESS_EQUAL;
+
+                if (token_type == TokenType::op_ge)
+                    cond.cmp = Condition::Comparator::GREATER_EQUAL;
             }
         }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
@@ -35,15 +35,11 @@ bool Actions::empty() const {
 
 
 void Actions::add(const ActionX& action) {
-    printf("Adding: %s\n", action.name().c_str());
     auto iter = std::find_if( this->actions.begin(), this->actions.end(), [&action](const ActionX& arg) { return arg.name() == action.name(); });
-    if (iter == this->actions.end()) {
-        printf("push_back\n");
+    if (iter == this->actions.end())
         this->actions.push_back(action);
-    } else {
-        printf("update\n");
+    else
         *iter = action;
-    }
 }
 
 

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -628,7 +628,7 @@ ENDACTIO
 
 ACTIONX
    'B' /
-   FWCT < 0.50 /
+   FWCT <= 0.50 /
 /
 
 
@@ -691,9 +691,9 @@ TSTEP
     const auto& actB = actions2.get("B");
     const auto& condB = actB.conditions();
     BOOST_CHECK_EQUAL(condB.size() , 1);
-    BOOST_CHECK_EQUAL(condB[0].expression, "FWCT < 0.50");
+    BOOST_CHECK_EQUAL(condB[0].expression, "FWCT <= 0.50");
     BOOST_CHECK_EQUAL(condB[0].quantity, "FWCT");
-    BOOST_CHECK(condB[0].cmp == Action::Condition::Comparator::LESS);
+    BOOST_CHECK(condB[0].cmp == Action::Condition::Comparator::LESS_EQUAL);
     BOOST_CHECK(condB[0].logic == Action::Condition::Logical::END);
 
     const auto& actA = actions2.get("A");


### PR DESCRIPTION
The internalization of ACTIONX conditions for restart did not accept <= and >= for some reason.