### PR TITLE
Add ParserKeyword member to DeckKeyword

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -28,15 +28,16 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
 namespace Opm {
-    class ParserKeyword;
     class DeckOutput;
+    class ParserKeyword;
 
     class DeckKeyword {
     public:
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
 
+        explicit DeckKeyword(const ParserKeyword * parserKeyword);
         explicit DeckKeyword(const std::string& keywordName);
-        DeckKeyword(const std::string& keywordName, bool knownKeyword);
+        DeckKeyword(const ParserKeyword * parserKeyword, const std::string& keywordName);
 
         const std::string& name() const;
         void setFixedSize();
@@ -59,6 +60,7 @@ namespace Opm {
         const std::vector<double>& getRawDoubleData() const;
         const std::vector<double>& getSIDoubleData() const;
         const std::vector<std::string>& getStringData() const;
+        const ParserKeyword& parserKeyword() const;
         size_t getDataSize() const;
         void write( DeckOutput& output ) const;
         void write_data( DeckOutput& output ) const;
@@ -86,9 +88,9 @@ namespace Opm {
         int m_lineNumber;
 
         std::vector< DeckRecord > m_recordList;
-        bool m_knownKeyword;
         bool m_isDataKeyword;
         bool m_slashTerminated;
+        const ParserKeyword * parser_keyword;
     };
 }
 

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -852,7 +852,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
                 throw std::invalid_argument(msg);
             }
         } else {
-            DeckKeyword deckKeyword( rawKeyword->getKeywordName(), false );
+            DeckKeyword deckKeyword( rawKeyword->getKeywordName() );
             const std::string msg = "The keyword " + rawKeyword->getKeywordName() + " is not recognized";
             deckKeyword.setLocation( rawKeyword->getLocation() );
             parserState.deck.addKeyword( std::move( deckKeyword ) );

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -506,7 +506,7 @@ void set_dimensions( ParserItem& item,
         if( !rawKeyword.isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword.getKeywordName());
 
-        DeckKeyword keyword( rawKeyword.getKeywordName() );
+        DeckKeyword keyword( this, rawKeyword.getKeywordName() );
         keyword.setLocation( rawKeyword.getLocation( ) );
         keyword.setDataKeyword( isDataKeyword() );
 

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -551,27 +551,12 @@ BOOST_AUTO_TEST_CASE(name_nameSetInConstructor_nameReturned) {
 BOOST_AUTO_TEST_CASE(size_noRecords_returnszero) {
     DeckKeyword deckKeyword( "KW" );
     BOOST_CHECK_EQUAL(0U, deckKeyword.size());
+    BOOST_CHECK_THROW(deckKeyword.getRecord(0), std::out_of_range);
 }
 
-
-BOOST_AUTO_TEST_CASE(addRecord_onerecord_recordadded) {
-    DeckKeyword deckKeyword( "KW" );
-    deckKeyword.addRecord( DeckRecord() );
-    BOOST_CHECK_EQUAL(1U, deckKeyword.size());
-    for (auto iter = deckKeyword.begin(); iter != deckKeyword.end(); ++iter) {
-        //
-    }
-
-}
-
-BOOST_AUTO_TEST_CASE(getRecord_outofrange_exceptionthrown) {
-    DeckKeyword deckKeyword( "KW" );
-    deckKeyword.addRecord(DeckRecord());
-    BOOST_CHECK_THROW(deckKeyword.getRecord(1), std::out_of_range);
-}
 
 BOOST_AUTO_TEST_CASE(setUnknown_wasknown_nowunknown) {
-    DeckKeyword deckKeyword( "KW", false );
+    DeckKeyword deckKeyword( "KW" );
     BOOST_CHECK(!deckKeyword.isKnown());
 }
 


### PR DESCRIPTION
This is a preparation to be able to create `DeckKeywords` from Python, and also a step to clean up some mess in the unit system handling which was introduced with the UDQ/UDA work.

Downstream: https://github.com/OPM/opm-upscaling/pull/274