### PR TITLE
remove unused opm-common module specific OPM_PREFIX_PATH option

### DIFF
--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -4,7 +4,7 @@ declare -A configurations
 
 declare -A EXTRA_MODULE_FLAGS
 EXTRA_MODULE_FLAGS[opm-simulators]="-DBUILD_EBOS_EXTENSIONS=ON -DBUILD_EBOS_DEBUG_EXTENSIONS=ON"
-EXTRA_MODULE_FLAGS[opm-common]="-DOPM_ENABLE_PYTHON=ON -DOPM_PREFIX_PATH=$WORKSPACE/$configuration/install"
+EXTRA_MODULE_FLAGS[opm-common]="-DOPM_ENABLE_PYTHON=ON"
 EXTRA_MODULE_FLAGS[libecl]="-DCMAKE_POSITION_INDEPENDENT_CODE=1"
 
 # Parse revisions from trigger comment and setup arrays


### PR DESCRIPTION
Leftover from a previous iteration of the python binding building.