### PR TITLE
changed: remove ADD_DISABLED_CTEST option

### DIFF
--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -1,8 +1,5 @@
 # - Build satellites that are dependent of main library
 
-option(ADD_DISABLED_CTESTS "Add the tests which are disabled due to failed preconditions to the ctest output (this makes ctest return an error if such a test is present)" ON)
-mark_as_advanced(ADD_DISABLED_CTESTS)
-
 #
 # Enumerate all source code in a "satellite" directory such as tests/,
 # compile each of them and optionally set them as a test for CTest to
@@ -365,13 +362,6 @@ macro(opm_add_test TestName)
         add_custom_target(test-suite)
       endif()
       add_dependencies(test-suite "${CURTEST_EXE_NAME}")
-    endif()
-  else() # test is skipped
-    # the following causes the test to appear as 'skipped' in the
-    # CDash dashboard. it this is removed, the test is just silently
-    # ignored.
-    if (NOT CURTEST_ONLY_COMPILE AND ADD_DISABLED_CTESTS)
-      add_test(${_FANCY} skip_test_dummy)
     endif()
   endif()
 endmacro()


### PR DESCRIPTION
a disabled test is disabled. end of story.

i never saw the point to this option. if a test is disabled, it is disabled.