### PR TITLE
Will not attempt to internalize invalid keywords

### DIFF
--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -852,10 +852,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
                 throw std::invalid_argument(msg);
             }
         } else {
-            DeckKeyword deckKeyword( rawKeyword->getKeywordName() );
-            const std::string msg = "The keyword " + rawKeyword->getKeywordName() + " is not recognized";
-            deckKeyword.setLocation( rawKeyword->getLocation() );
-            parserState.deck.addKeyword( std::move( deckKeyword ) );
+            const std::string msg = "The keyword " + rawKeyword->getKeywordName() + " is not recognized - ignored";
             OpmLog::warning(Log::fileMessage(parserState.current_path().string(), parserState.line(), msg));
         }
     }


### PR DESCRIPTION
Currently a Deck keyword can be instantiated without a parserkeyword - this is a step in the direction of *requiring* a `ParserKeyword`instance.