### PR TITLE
Deck constructor

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -124,10 +124,6 @@ namespace Opm {
             using iterator = std::vector< DeckKeyword >::iterator;
 
             Deck();
-            // cppcheck-suppress noExplicitConstructor
-            Deck( std::initializer_list< DeckKeyword > );
-            // cppcheck-suppress noExplicitConstructor
-            Deck( std::initializer_list< std::string > );
 
             Deck( const Deck& );
 

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -36,7 +36,6 @@ namespace Opm {
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
 
         explicit DeckKeyword(const ParserKeyword * parserKeyword);
-        explicit DeckKeyword(const std::string& keywordName);
         DeckKeyword(const ParserKeyword * parserKeyword, const std::string& keywordName);
 
         const std::string& name() const;
@@ -53,7 +52,6 @@ namespace Opm {
         DeckRecord& getRecord(size_t index);
         const DeckRecord& getDataRecord() const;
         void setDataKeyword(bool isDataKeyword = true);
-        bool isKnown() const;
         bool isDataKeyword() const;
 
         const std::vector<int>& getIntData() const;

--- a/src/opm/parser/eclipse/Deck/Deck.cpp
+++ b/src/opm/parser/eclipse/Deck/Deck.cpp
@@ -156,14 +156,6 @@ namespace Opm {
             this->activeUnits = UnitSystem::newMETRIC();
     }
 
-    Deck::Deck( std::initializer_list< DeckKeyword > ilist ) :
-        Deck( std::vector< DeckKeyword >( ilist ) )
-    {}
-
-    Deck::Deck( std::initializer_list< std::string > ilist ) :
-        Deck( std::vector< DeckKeyword >( ilist.begin(), ilist.end() ) )
-    {}
-
     Deck::Deck( const Deck& d ) :
         DeckView( d.begin(), d.begin() ),
         keywordList( d.keywordList ),

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -27,15 +27,6 @@
 
 namespace Opm {
 
-DeckKeyword::DeckKeyword(const std::string& keyword) :
-        m_keywordName(keyword),
-        m_lineNumber(-1),
-        m_isDataKeyword(false),
-        m_slashTerminated(true),
-        parser_keyword(nullptr)
-    {
-    }
-
     DeckKeyword::DeckKeyword(const ParserKeyword * parserKeyword) :
         m_keywordName(parserKeyword->getName()),
         m_lineNumber(-1),
@@ -99,9 +90,6 @@ DeckKeyword::DeckKeyword(const std::string& keyword) :
         return m_recordList.size();
     }
 
-    bool DeckKeyword::isKnown() const {
-        return (this->parser_keyword != nullptr);
-    }
 
     void DeckKeyword::addRecord(DeckRecord&& record) {
         if (!this->parser_keyword)

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -87,7 +87,7 @@ namespace {
 
     const Deck PERFORMA_keywords = {
         "SUMMARY",
-        "TCPU", "ELAPSED","NEWTON","NLINERS","NLINSMIN", "NLINSMAX","MLINEARS",
+        "TCPU", "ELAPSED","NEWTON","NLINEARS","NLINSMIN", "NLINSMAX","MLINEARS",
         "MSUMLINS","MSUMNEWT","TIMESTEP","TCPUTS","TCPUDAY","STEPTYPE","TELAPLIN"
     };
 

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserItem.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
 
@@ -37,28 +38,12 @@
 
 using namespace Opm;
 
-BOOST_AUTO_TEST_CASE(Initializer_lists) {
-    DeckKeyword foo( "foo" );
-    DeckKeyword bar( "bar" );
-
-    std::string foostr( "foo" );
-    std::string barstr( "bar" );
-
-    BOOST_REQUIRE_NO_THROW( Deck( { foo, bar } ) );
-    BOOST_REQUIRE_NO_THROW( Deck( { foostr, barstr } ) );
-    BOOST_REQUIRE_NO_THROW( Deck( { "Kappa", "Phi" } ) );
-}
-
 BOOST_AUTO_TEST_CASE(hasKeyword_empty_returnFalse) {
     Deck deck;
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("Bjarne"));
     BOOST_CHECK_THROW( deck.getKeyword("Bjarne") , std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE(addKeyword_singlekeyword_keywordAdded) {
-    Deck deck;
-    BOOST_CHECK_NO_THROW(deck.addKeyword( DeckKeyword( "BJARNE" ) ) );
-}
 
 
 BOOST_AUTO_TEST_CASE(getKeywordList_empty_list) {
@@ -69,100 +54,87 @@ BOOST_AUTO_TEST_CASE(getKeywordList_empty_list) {
 
 BOOST_AUTO_TEST_CASE(getKeyword_singlekeyword_outRange_throws) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "BJARNE" ) );
-    BOOST_CHECK_THROW(deck.getKeyword("BJARNE" , 10) , std::out_of_range);
+    Parser parser;
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    BOOST_CHECK_THROW(deck.getKeyword("GRID" , 10) , std::out_of_range);
 }
 
 
 BOOST_AUTO_TEST_CASE(getKeywordList_returnOK) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "BJARNE" ) );
-    BOOST_CHECK_NO_THROW( deck.getKeywordList("BJARNE") );
+    Parser parser;
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    BOOST_CHECK_NO_THROW( deck.getKeywordList("GRID") );
 }
 
 
 BOOST_AUTO_TEST_CASE(getKeyword_indexok_returnskeyword) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "BJARNE" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
     BOOST_CHECK_NO_THROW(deck.getKeyword(0));
 }
 
 BOOST_AUTO_TEST_CASE(numKeyword_singlekeyword_return1) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "BJARNE" ) );
-    BOOST_CHECK_EQUAL(1U , deck.count("BJARNE"));
+    Parser parser;
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    BOOST_CHECK_EQUAL(1U , deck.count("GRID"));
 }
 
 
 BOOST_AUTO_TEST_CASE(numKeyword_twokeyword_return2) {
     Deck deck;
-    DeckKeyword keyword("BJARNE");
-    deck.addKeyword(keyword);
-    deck.addKeyword(keyword);
-    BOOST_CHECK_EQUAL(2U , deck.count("BJARNE"));
-}
-
-
-BOOST_AUTO_TEST_CASE(numKeyword_nokeyword_return0) {
-    Deck deck;
-    deck.addKeyword( DeckKeyword( "BJARNE" ) );
-    BOOST_CHECK_EQUAL(0U , deck.count("BJARNEX"));
+    Parser parser;
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    BOOST_CHECK_EQUAL(2U , deck.count("GRID"));
+    BOOST_CHECK_EQUAL(0U , deck.count("GRID_BUG"));
 }
 
 
 BOOST_AUTO_TEST_CASE(size_twokeyword_return2) {
     Deck deck;
-    DeckKeyword keyword ("BJARNE");
+    Parser parser;
+    DeckKeyword keyword( &parser.getKeyword("GRID"));
     deck.addKeyword(keyword);
     deck.addKeyword(keyword);
     BOOST_CHECK_EQUAL(2U , deck.size());
-}
-
-BOOST_AUTO_TEST_CASE(getKeyword_outOfRange_throws) {
-    Deck deck;
-    deck.addKeyword(DeckKeyword( "TRULS" ) );
-    BOOST_CHECK_THROW( deck.getKeyword("TRULS" , 3) , std::out_of_range);
+    BOOST_CHECK_THROW( deck.getKeyword("GRID" , 3) , std::out_of_range);
 }
 
 BOOST_AUTO_TEST_CASE(getKeywordList_OK) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
 
-    const auto& keywordList = deck.getKeywordList("TRULS");
+    const auto& keywordList = deck.getKeywordList("GRID");
     BOOST_CHECK_EQUAL( 3U , keywordList.size() );
 }
 
-BOOST_AUTO_TEST_CASE(keywordList_getnum_OK) {
-    Deck deck;
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
-    deck.addKeyword( DeckKeyword( "TRULSX" ) );
-
-    BOOST_CHECK_EQUAL( 0U , deck.count( "TRULSY" ));
-    BOOST_CHECK_EQUAL( 2U , deck.count( "TRULS" ));
-    BOOST_CHECK_EQUAL( 1U , deck.count( "TRULSX" ));
-}
 
 BOOST_AUTO_TEST_CASE(keywordList_getbyindexoutofbounds_exceptionthrown) {
+    Parser parser;
     Deck deck;
     BOOST_CHECK_THROW(deck.getKeyword(0), std::out_of_range);
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
-    deck.addKeyword( DeckKeyword( "TRULSX" ) );
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("INIT")));
     BOOST_CHECK_NO_THROW(deck.getKeyword(2));
     BOOST_CHECK_THROW(deck.getKeyword(3), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_CASE(keywordList_getbyindex_correctkeywordreturned) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
-    deck.addKeyword( DeckKeyword( "TRULS" ) );
-    deck.addKeyword( DeckKeyword( "TRULSX" ) );
-    BOOST_CHECK_EQUAL("TRULS",  deck.getKeyword(0).name());
-    BOOST_CHECK_EQUAL("TRULS",  deck.getKeyword(1).name());
-    BOOST_CHECK_EQUAL("TRULSX", deck.getKeyword(2).name());
+    Parser parser;
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("INIT")));
+    BOOST_CHECK_EQUAL("GRID",  deck.getKeyword(0).name());
+    BOOST_CHECK_EQUAL("GRID",  deck.getKeyword(1).name());
+    BOOST_CHECK_EQUAL("INIT", deck.getKeyword(2).name());
 }
 
 BOOST_AUTO_TEST_CASE(set_and_get_data_file) {
@@ -531,7 +503,8 @@ BOOST_AUTO_TEST_CASE(StringsWithSpaceOK) {
 }
 
 BOOST_AUTO_TEST_CASE(DataKeyword) {
-    DeckKeyword kw("KW");
+    Parser parser;
+    DeckKeyword kw(&parser.getKeyword("GRID"));
     BOOST_CHECK_EQUAL( false , kw.isDataKeyword());
     kw.setDataKeyword( );
     BOOST_CHECK_EQUAL( true , kw.isDataKeyword());
@@ -544,21 +517,18 @@ BOOST_AUTO_TEST_CASE(DataKeyword) {
 
 
 BOOST_AUTO_TEST_CASE(name_nameSetInConstructor_nameReturned) {
-    DeckKeyword deckKeyword( "KW" );
-    BOOST_CHECK_EQUAL("KW", deckKeyword.name());
+    Parser parser;
+    DeckKeyword deckKeyword( &parser.getKeyword("GRID"));
+    BOOST_CHECK_EQUAL("GRID", deckKeyword.name());
 }
 
 BOOST_AUTO_TEST_CASE(size_noRecords_returnszero) {
-    DeckKeyword deckKeyword( "KW" );
+    Parser parser;
+    DeckKeyword deckKeyword( &parser.getKeyword("GRID"));;
     BOOST_CHECK_EQUAL(0U, deckKeyword.size());
     BOOST_CHECK_THROW(deckKeyword.getRecord(0), std::out_of_range);
 }
 
-
-BOOST_AUTO_TEST_CASE(setUnknown_wasknown_nowunknown) {
-    DeckKeyword deckKeyword( "KW" );
-    BOOST_CHECK(!deckKeyword.isKnown());
-}
 
 
 

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -46,9 +46,10 @@
 
 BOOST_AUTO_TEST_CASE(CreateMissingDIMENS_throws) {
     Opm::Deck deck;
-    deck.addKeyword( Opm::DeckKeyword( "RUNSPEC" ) );
-    deck.addKeyword( Opm::DeckKeyword( "GRID" ) );
-    deck.addKeyword( Opm::DeckKeyword( "EDIT" ) );
+    Opm::Parser parser;
+    deck.addKeyword( Opm::DeckKeyword( &parser.getKeyword("RUNSPEC" )));
+    deck.addKeyword( Opm::DeckKeyword( &parser.getKeyword("GRID" )));
+    deck.addKeyword( Opm::DeckKeyword( &parser.getKeyword("EDIT" )));
 
     BOOST_CHECK_THROW(Opm::EclipseGrid{ deck } , std::invalid_argument);
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -353,7 +353,8 @@ static Deck createDeckRFTConfig() {
 }
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "SCHEDULE" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("SCHEDULE" )));
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
@@ -484,11 +485,12 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
+    Parser parser;
     Deck deck;
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
-    deck.addKeyword( DeckKeyword( "SCHEDULE" ) );
+    deck.addKeyword( DeckKeyword( &parser.getKeyword("SCHEDULE" )));
     Runspec runspec (deck);
 
     BOOST_CHECK_NO_THROW( Schedule( deck, grid , eclipseProperties, runspec));

--- a/tests/parser/SectionTests.cpp
+++ b/tests/parser/SectionTests.cpp
@@ -35,33 +35,35 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE(SectionTest) {
     Deck deck;
-    deck.addKeyword( DeckKeyword("TEST0") );
-    deck.addKeyword( DeckKeyword("RUNSPEC") );
-    deck.addKeyword( DeckKeyword("TEST1") );
-    deck.addKeyword( DeckKeyword("GRID") );
-    deck.addKeyword( DeckKeyword("TEST2") );
-    deck.addKeyword( DeckKeyword("SCHEDULE") );
-    deck.addKeyword( DeckKeyword("TEST3") );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("START")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("RUNSPEC")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("WELLDIMS")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("PORO")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("SCHEDULE")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("WELSPECS")));
 
     Section runspecSection(deck, "RUNSPEC");
     Section gridSection(deck, "GRID");
-    BOOST_CHECK(runspecSection.hasKeyword("TEST1"));
-    BOOST_CHECK(gridSection.hasKeyword("TEST2"));
+    BOOST_CHECK(runspecSection.hasKeyword("WELLDIMS"));
+    BOOST_CHECK(gridSection.hasKeyword("PORO"));
 
-    BOOST_CHECK(!runspecSection.hasKeyword("TEST0"));
-    BOOST_CHECK(!gridSection.hasKeyword("TEST0"));
-    BOOST_CHECK(!runspecSection.hasKeyword("TEST3"));
-    BOOST_CHECK(!gridSection.hasKeyword("TEST3"));
-    BOOST_CHECK(!runspecSection.hasKeyword("TEST2"));
-    BOOST_CHECK(!gridSection.hasKeyword("TEST1"));
+    BOOST_CHECK(!runspecSection.hasKeyword("START"));
+    BOOST_CHECK(!gridSection.hasKeyword("START"));
+    BOOST_CHECK(!runspecSection.hasKeyword("WELSPECS"));
+    BOOST_CHECK(!gridSection.hasKeyword("WELSPECS"));
+    BOOST_CHECK(!runspecSection.hasKeyword("PORO"));
+    BOOST_CHECK(!gridSection.hasKeyword("WELLDIMS"));
 }
 
 BOOST_AUTO_TEST_CASE(IteratorTest) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "RUNSPEC" ) );
-    deck.addKeyword( DeckKeyword("TEST2") );
-    deck.addKeyword( DeckKeyword( "TEST3" ) );
-    deck.addKeyword( DeckKeyword( "GRID" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("RUNSPEC")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("WELLDIMS")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("TABDIMS")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword("GRID")));
     Section section(deck, "RUNSPEC");
 
     int numberOfItems = 0;
@@ -70,7 +72,7 @@ BOOST_AUTO_TEST_CASE(IteratorTest) {
         numberOfItems++;
     }
 
-    // the keywords expected here are RUNSPEC, TEST2 and TEST3...
+    // the keywords expected here are RUNSPEC, WELLDIMS and TABDIMS
     BOOST_CHECK_EQUAL(3, numberOfItems);
 }
 
@@ -81,26 +83,28 @@ BOOST_AUTO_TEST_CASE(RUNSPECSection_EmptyDeck) {
 
 BOOST_AUTO_TEST_CASE(RUNSPECSection_ReadSimpleDeck) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "TEST1") );
-    deck.addKeyword( DeckKeyword( "RUNSPEC") );
-    deck.addKeyword( DeckKeyword( "TEST2") );
-    deck.addKeyword( DeckKeyword( "TEST3") );
-    deck.addKeyword( DeckKeyword( "GRID") );
-    deck.addKeyword( DeckKeyword( "TEST4") );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "START")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "RUNSPEC")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "WELLDIMS")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "TABDIMS")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "GRID")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PORO")));
 
     RUNSPECSection section(deck);
-    BOOST_CHECK(!section.hasKeyword("TEST1"));
+    BOOST_CHECK(!section.hasKeyword("START"));
     BOOST_CHECK(section.hasKeyword("RUNSPEC"));
-    BOOST_CHECK(section.hasKeyword("TEST2"));
-    BOOST_CHECK(section.hasKeyword("TEST3"));
+    BOOST_CHECK(section.hasKeyword("WELLDIMS"));
+    BOOST_CHECK(section.hasKeyword("TABDIMS"));
     BOOST_CHECK(!section.hasKeyword("GRID"));
-    BOOST_CHECK(!section.hasKeyword("TEST4"));
+    BOOST_CHECK(!section.hasKeyword("PORO"));
 }
 
 BOOST_AUTO_TEST_CASE(RUNSPECSection_ReadSmallestPossibleDeck) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "RUNSPEC" ) );
-    deck.addKeyword( DeckKeyword( "GRID") );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "RUNSPEC" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "GRID")));
     RUNSPECSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("RUNSPEC"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("GRID"));
@@ -108,8 +112,9 @@ BOOST_AUTO_TEST_CASE(RUNSPECSection_ReadSmallestPossibleDeck) {
 
 BOOST_AUTO_TEST_CASE(GRIDSection_TerminatedByEDITKeyword) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "GRID" ) );
-    deck.addKeyword( DeckKeyword( "EDIT" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "GRID" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "EDIT" )));
     GRIDSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("GRID"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("EDIT"));
@@ -117,8 +122,9 @@ BOOST_AUTO_TEST_CASE(GRIDSection_TerminatedByEDITKeyword) {
 
 BOOST_AUTO_TEST_CASE(GRIDSection_TerminatedByPROPSKeyword) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "GRID" ) );
-    deck.addKeyword( DeckKeyword( "PROPS" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "GRID" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PROPS" )));
     GRIDSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("GRID"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("PROPS"));
@@ -126,8 +132,9 @@ BOOST_AUTO_TEST_CASE(GRIDSection_TerminatedByPROPSKeyword) {
 
 BOOST_AUTO_TEST_CASE(EDITSection_TerminatedByPROPSKeyword) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "EDIT" ) );
-    deck.addKeyword( DeckKeyword( "PROPS" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "EDIT" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PROPS" )));
     EDITSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("EDIT"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("PROPS"));
@@ -135,8 +142,9 @@ BOOST_AUTO_TEST_CASE(EDITSection_TerminatedByPROPSKeyword) {
 
 BOOST_AUTO_TEST_CASE(PROPSSection_TerminatedByREGIONSKeyword) {
     Deck deck;
-    deck.addKeyword( DeckKeyword( "PROPS" ) );
-    deck.addKeyword( DeckKeyword( "REGIONS" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PROPS" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "REGIONS" )));
     PROPSSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("PROPS"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("REGIONS"));
@@ -144,9 +152,9 @@ BOOST_AUTO_TEST_CASE(PROPSSection_TerminatedByREGIONSKeyword) {
 
 BOOST_AUTO_TEST_CASE(PROPSSection_TerminatedBySOLUTIONKeyword) {
     Deck deck;
-
-    deck.addKeyword( DeckKeyword( "PROPS" ) );
-    deck.addKeyword( DeckKeyword( "SOLUTION" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PROPS" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SOLUTION" )));
 
     PROPSSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("PROPS"));
@@ -155,9 +163,9 @@ BOOST_AUTO_TEST_CASE(PROPSSection_TerminatedBySOLUTIONKeyword) {
 
 BOOST_AUTO_TEST_CASE(REGIONSSection_TerminatedBySOLUTIONKeyword) {
     Deck deck;
-
-    deck.addKeyword( DeckKeyword( "REGIONS" ) );
-    deck.addKeyword( DeckKeyword( "SOLUTION" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "REGIONS" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SOLUTION" )));
 
     REGIONSSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("REGIONS"));
@@ -166,9 +174,9 @@ BOOST_AUTO_TEST_CASE(REGIONSSection_TerminatedBySOLUTIONKeyword) {
 
 BOOST_AUTO_TEST_CASE(SOLUTIONSection_TerminatedBySUMMARYKeyword) {
     Deck deck;
-
-    deck.addKeyword( DeckKeyword( "SOLUTION" ) );
-    deck.addKeyword( DeckKeyword( "SUMMARY" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SOLUTION" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SUMMARY" )));
 
     SOLUTIONSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("SOLUTION"));
@@ -177,9 +185,9 @@ BOOST_AUTO_TEST_CASE(SOLUTIONSection_TerminatedBySUMMARYKeyword) {
 
 BOOST_AUTO_TEST_CASE(SOLUTIONSection_TerminatedBySCHEDULEKeyword) {
     Deck deck;
-
-    deck.addKeyword( DeckKeyword( "SOLUTION" ) );
-    deck.addKeyword( DeckKeyword( "SCHEDULE" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SOLUTION" )));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SCHEDULE" )));
 
     SOLUTIONSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("SOLUTION"));
@@ -188,18 +196,18 @@ BOOST_AUTO_TEST_CASE(SOLUTIONSection_TerminatedBySCHEDULEKeyword) {
 
 BOOST_AUTO_TEST_CASE(SCHEDULESection_NotTerminated) {
     Deck deck;
-
-    deck.addKeyword( DeckKeyword( "SCHEDULE" ) );
-    deck.addKeyword( DeckKeyword( "TEST1" ) );
-    deck.addKeyword( DeckKeyword( "TEST2" ) );
-    deck.addKeyword( DeckKeyword( "TEST3" ) );
-    deck.addKeyword( DeckKeyword( "TEST4" ) );
+    Parser parser;
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SCHEDULE")));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "WELSPECS" ) ));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "COMPDAT" ) ));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "WCONHIST" ) ));
+    deck.addKeyword( DeckKeyword(&parser.getKeyword( "WCONPROD" ) ));
 
     SCHEDULESection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("SCHEDULE"));
-    BOOST_CHECK_EQUAL(true, section.hasKeyword("TEST1"));
-    BOOST_CHECK_EQUAL(true, section.hasKeyword("TEST2"));
-    BOOST_CHECK_EQUAL(true, section.hasKeyword("TEST3"));
+    BOOST_CHECK_EQUAL(true, section.hasKeyword("WELSPECS"));
+    BOOST_CHECK_EQUAL(true, section.hasKeyword("COMPDAT"));
+    BOOST_CHECK_EQUAL(true, section.hasKeyword("WCONHIST"));
 
     BOOST_CHECK( Section::hasSCHEDULE(deck ));
     BOOST_CHECK( !Section::hasREGIONS(deck ));

--- a/tests/parser/TimeMapTest.cpp
+++ b/tests/parser/TimeMapTest.cpp
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE( timeFromEclipseInputRecord ) {
     Opm::DeckRecord  startRecord;
     Opm::DeckItem dayItem( "DAY", int() );
     Opm::DeckItem monthItem( "MONTH", std::string() );
-    Opm::DeckItem yearItem("YEAR", int() );
+    Opm::DeckItem yearItem("YEAR", int());
     Opm::DeckItem timeItem("TIME", std::string() );
 
     dayItem.push_back( 10 );
@@ -181,16 +181,18 @@ BOOST_AUTO_TEST_CASE( timeFromEclipseInputRecord ) {
 
 
 BOOST_AUTO_TEST_CASE( addDATESFromWrongKeywordThrows ) {
+    Opm::Parser parser;
     Opm::TimeMap timeMap(startDateJan1st2010);
-    Opm::DeckKeyword deckKeyword("NOTDATES");
+    Opm::DeckKeyword deckKeyword(std::addressof(parser.getKeyword("GRID")));
     BOOST_CHECK_THROW( timeMap.addFromDATESKeyword( deckKeyword ) , std::invalid_argument );
 }
 
 
 
 BOOST_AUTO_TEST_CASE( addTSTEPFromWrongKeywordThrows ) {
+    Opm::Parser parser;
     Opm::TimeMap timeMap(startDateJan1st2010);
-    Opm::DeckKeyword deckKeyword("NOTTSTEP");
+    Opm::DeckKeyword deckKeyword(&parser.getKeyword("GRID"));
     BOOST_CHECK_THROW( timeMap.addFromTSTEPKeyword( deckKeyword ) , std::invalid_argument );
 }
 


### PR DESCRIPTION
The `DeckKeyword::DeckKeyword(const std::string&)` constructor has been removed
and the `DeckKeyword` now requires a `ParserKeyword` pointer in the constructor.
