### PR TITLE
Ecl file

### DIFF
--- a/src/opm/io/eclipse/EclFile.cpp
+++ b/src/opm/io/eclipse/EclFile.cpp
@@ -380,18 +380,10 @@ std::vector<std::string> readFormattedCharArray(const std::string& file_str, con
     arr.reserve(size);
 
     long int p1=fromPos;
-    long int p2=0;
 
     for (int i=0; i< size; i++) {
         p1 = file_str.find_first_of('\'',p1);
-        p2 = file_str.find_first_of('\'', p1+1);
-
-        std::string value = file_str.substr(p1 + 1, p2 - p1 - 1);
-
-        if (value.size() != 8) {
-            std::string message="Reading formatted char array, all strings should have 8 characters";
-            OPM_THROW(std::runtime_error, message);
-        }
+        std::string value = file_str.substr(p1 + 1, 8);
 
         if (value == "        ") {
             arr.push_back("");
@@ -399,7 +391,7 @@ std::vector<std::string> readFormattedCharArray(const std::string& file_str, con
             arr.push_back(Opm::EclIO::trimr(value));
         }
 
-        p1 = p2+1;
+        p1 = p1+10;
     }
 
     return arr;

--- a/tests/test_EclIO.cpp
+++ b/tests/test_EclIO.cpp
@@ -67,7 +67,6 @@ bool operator==(const std::vector<T> & t1, const std::vector<T> & t2)
     return std::equal(t1.begin(), t1.end(), t2.begin(), t2.end());
 }
 
-
 BOOST_AUTO_TEST_CASE(TestEclFile_BINARY) {
 
     std::string testFile="ECLFILE.INIT";
@@ -305,4 +304,31 @@ BOOST_AUTO_TEST_CASE(TestEcl_getList) {
     if (remove(testFile.c_str())==-1) {
         std::cout << " > Warning! temporary file was not deleted" << std::endl;
     };
+}
+
+
+BOOST_AUTO_TEST_CASE(TestEcl_Write_CHAR) {
+
+    std::string testFile="TEST.FDAT";
+    std::vector<std::string> refStrList = {"This", "is", "a test.", "", "charact", "er >'<", "can be", "part of", "a string"};
+
+    {
+        EclOutput eclTest(testFile, true);
+        eclTest.write("TEST",refStrList);
+    }
+    
+    {
+        EclFile file1(testFile);
+        std::vector<std::string> strList=file1.get<std::string>("TEST");
+        
+        for (size_t n = 0; n < refStrList.size(); n++) {
+            BOOST_CHECK(refStrList[n] == strList[n]);
+        }
+    }
+
+    if (remove(testFile.c_str())==-1) {
+        std::cout << " > Warning! temporary file was not deleted" << std::endl;
+    };
+    
+    
 }


### PR DESCRIPTION
I have just learned, through testing with restart support for UDQ's, that character strings in a `EclFile` can include character single quote (`'`). This triggered an exception with current implementation of `EclFile` class.