### PR TITLE
changed: use std::regex instead of boost::regex

### DIFF
--- a/GenerateKeywords.cmake
+++ b/GenerateKeywords.cmake
@@ -32,7 +32,7 @@ if(NOT cjson_FOUND)
 endif()
 add_executable(genkw ${genkw_SOURCES})
 
-target_link_libraries(genkw Boost::regex Boost::filesystem Boost::system)
+target_link_libraries(genkw Boost::filesystem Boost::system)
 
 # Generate keyword list
 include(src/opm/parser/eclipse/share/keywords/keyword_list.cmake)

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -17,7 +17,7 @@ if(ENABLE_ECL_INPUT)
   list(APPEND opm-common_DEPS
         # various runtime library enhancements
         "Boost 1.44.0
-          COMPONENTS system filesystem unit_test_framework regex REQUIRED")
+          COMPONENTS system filesystem unit_test_framework REQUIRED")
 else()
   list(APPEND opm-common_DEPS
         # various runtime library enhancements

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <set>
 
-#include <boost/regex.hpp>
+#include <regex>
 
 #include <opm/parser/eclipse/Parser/ParserEnums.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
@@ -148,7 +148,7 @@ namespace Opm {
         DeckNameSet m_deckNames;
         DeckNameSet m_validSectionNames;
         std::string m_matchRegexString;
-        boost::regex m_matchRegex;
+        std::regex m_matchRegex;
         std::vector< ParserRecord > m_records;
         enum ParserKeywordSizeEnum m_keywordSizeType;
         size_t m_fixedSize;

--- a/src/opm/io/eclipse/ERst.cpp
+++ b/src/opm/io/eclipse/ERst.cpp
@@ -23,6 +23,7 @@
 #include <exception>
 #include <iomanip>
 #include <iterator>
+#include <regex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -33,23 +34,19 @@
 namespace {
     int seqnumFromSeparateFilename(const std::string& filename)
     {
-        int p=0;
+        const auto re = std::regex {
+            R"~(\.[FX]([0-9]{4})$)~"
+        };
 
-        std::string errMessage="Unable to Determine Report Step Sequence Number From Restart Filename \"" + filename + '"'; 
-        
-        if (filename.find(".F") != std::string::npos) {
-            p = filename.find_last_of(".F");
-        } else if (filename.find(".X") != std::string::npos) {
-            p = filename.find_last_of(".X");
-        } else {
-            OPM_THROW(std::invalid_argument, errMessage);
+        auto match = std::smatch{};
+        if (std::regex_search(filename, match, re)) {
+            return std::stoi(match[1]);
         }
-        
-        try {
-            return std::stoi(filename.substr(p+1,filename.size() - p-1));
-        } catch (...) {
-            OPM_THROW(std::invalid_argument, errMessage);
-        }
+
+        throw std::invalid_argument {
+            "Unable to Determine Report Step Sequence Number "
+            "From Restart Filename \"" + filename + '"'
+        };
     }
 }
 

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -639,7 +639,7 @@ void set_dimensions( ParserItem& item,
 
     void ParserKeyword::setMatchRegex(const std::string& deckNameRegexp) {
         try {
-            m_matchRegex = boost::regex(deckNameRegexp);
+            m_matchRegex = std::regex(deckNameRegexp);
             m_matchRegexString = deckNameRegexp;
         }
         catch (const std::exception &e) {
@@ -659,7 +659,7 @@ void set_dimensions( ParserItem& item,
             return true;
 
         else if (hasMatchRegex())
-            return boost::regex_match( name.begin(), name.end(), m_matchRegex);
+            return std::regex_match( name.begin(), name.end(), m_matchRegex);
 
         return false;
     }


### PR DESCRIPTION
Just preparing this for when we decide to move to gcc 4.9 as minimum.