### PR TITLE
setup.py: package_data: readjusted target and origin of libopmcommon.so

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -81,15 +81,15 @@ setup(
     packages=[
                 'opm',
                 'opm.io',
+                'opm.io.config',
+                'opm.io.deck',
+                'opm.io.ecl_state',
                 'opm.io.parser',
                 'opm.io.schedule',
-                'opm.io.config',
                 'opm.tools'
             ],
     ext_modules=ext_modules,
-    package_data={
-        '': ['cxx/libopmcommon_python.so']
-    },
+    package_data={'opm': ['libopmcommon_python.so']},
     include_package_data=True,
     license='Open Source',
     zip_safe=False,


### PR DESCRIPTION
libopmcommon_python.so is not copied during install. This PR fixes it. 

setup.py: 

This is wrong: 
    package_data={
        '': ['cxx/libopmcommon_python.so']
    },

It should be:
    package_data={'opm': ['libopmcommon_python.so']},