### PR TITLE
Add std::time start_time argument to SummaryState

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -41,7 +41,7 @@ void msim::run(Schedule& schedule, EclipseIO& io, bool report_only) {
     const double week = 7 * 86400;
     data::Solution sol;
     data::Wells well_data;
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::from_time_t(schedule.getStartTime()));
 
     io.writeInitial();
     for (size_t report_step = 1; report_step < schedule.size(); report_step++) {

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -21,6 +21,7 @@
 #define SUMMARY_STATE_H
 
 #include <string>
+#include <chrono>
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
@@ -66,6 +67,7 @@ namespace Opm{
 class SummaryState {
 public:
     typedef std::unordered_map<std::string, double>::const_iterator const_iterator;
+    explicit SummaryState(std::chrono::system_clock::time_point sim_start_arg);
 
     /*
       The set() function has to be retained temporarily to support updating of
@@ -99,6 +101,7 @@ public:
     std::size_t num_wells() const;
     std::size_t size() const;
 private:
+    std::chrono::system_clock::time_point sim_start;
     double elapsed = 0;
     std::unordered_map<std::string,double> values;
 

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -154,7 +154,6 @@ namespace {
 
         int wellVFPTab(const Opm::Well2& well, const Opm::SummaryState& st)
         {
-            Opm::SummaryState summaryState;
             if (well.isInjector()) {
                 return well.injectionControls(st).vfp_table_number;
             }

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1269,7 +1269,7 @@ Summary::Summary( const EclipseState& st,
      * entry.
      */
     std::set< std::string > unsupported_keywords;
-
+    SummaryState summary_state(std::chrono::system_clock::from_time_t(schedule.getStartTime()));
     for( const auto& node : sum ) {
         ecl_smspec_type * smspec = ecl_sum_get_smspec(this->ecl_sum.get());
         std::string keyword = node.keyword();
@@ -1318,13 +1318,13 @@ Summary::Summary( const EclipseState& st,
             const auto handle = funs_pair->second;
             const std::vector< Well2 > dummy_wells;
 
-            const fn_args no_args { dummy_wells, // Wells from Schedule object
-                                    0,           // Duration of time step
-                                    0,           // Simulation step
+            const fn_args no_args { dummy_wells,   // Wells from Schedule object
+                                    0,             // Duration of time step
+                                    0,             // Simulation step
                                     node.num(),
-                                    {},          // SummaryState
-                                    {},          // Well results - data::Wells
-                                    {},          // Region <-> cell mappings.
+                                    summary_state, // SummaryState
+                                    {},            // Well results - data::Wells
+                                    {},            // Region <-> cell mappings.
                                     this->grid,
                                     {}};
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -19,6 +19,7 @@
 
 #include <unordered_map>
 #include <cstring>
+#include <ctime>
 #include <iostream>
 #include <iomanip>
 
@@ -55,11 +56,22 @@ namespace {
     SummaryState::SummaryState(std::chrono::system_clock::time_point sim_start_arg):
         sim_start(sim_start_arg)
     {
+        this->update_elapsed(0);
     }
 
 
     void SummaryState::update_elapsed(double delta) {
         this->elapsed += delta;
+        std::time_t sim_time = std::chrono::system_clock::to_time_t( this->sim_start + std::chrono::microseconds(static_cast<std::size_t>(1000000*delta)));
+        struct tm ts;
+        gmtime_r(&sim_time, &ts);
+        int year = ts.tm_year + 1900;
+        int month = ts.tm_mon;
+        int day = ts.tm_mday;
+
+        this->update("YEAR", year);
+        this->update("MNTH", month);
+        this->update("DAY", day);
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -51,6 +51,13 @@ namespace {
     }
 
 }
+
+    SummaryState::SummaryState(std::chrono::system_clock::time_point sim_start_arg):
+        sim_start(sim_start_arg)
+    {
+    }
+
+
     void SummaryState::update_elapsed(double delta) {
         this->elapsed += delta;
     }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells2) {
 
 BOOST_AUTO_TEST_CASE(TestMatchingWells_AND) {
     Action::AST ast({"WOPR", "*", ">", "1.0", "AND", "WWCT", "*", "<", "0.50"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
 
     st.update_well_var("OPX", "WOPR", 0);
     st.update_well_var("OPY", "WOPR", 0.50);
@@ -546,7 +546,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells_AND) {
 
 BOOST_AUTO_TEST_CASE(TestMatchingWells_OR) {
     Action::AST ast({"WOPR", "*", ">", "1.0", "OR", "WWCT", "*", "<", "0.50"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
 
     st.update_well_var("OPX", "WOPR", 0);
     st.update_well_var("OPY", "WOPR", 0.50);
@@ -571,7 +571,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells_OR) {
 
 BOOST_AUTO_TEST_CASE(TestFieldAND) {
     Action::AST ast({"FMWPR", ">=", "4", "AND", "WUPR3", "OP*", "=", "1"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     Action::Context context(st);
 
     st.update_well_var("OP1", "WUPR3", 3);

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(CreateGroup_SetInjectorProducer_CorrectStatusSet) {
 
 BOOST_AUTO_TEST_CASE(ControlModeOK) {
     Opm::Group2 group("G1" , 1, 0, 0, UnitSystem::newMETRIC());
-    Opm::SummaryState st;
+    Opm::SummaryState st(std::chrono::system_clock::now());
     const auto& inj = group.injectionControls(st);
     BOOST_CHECK( Opm::Group2::InjectionCMode::NONE == inj.cmode);
 }
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(ControlModeOK) {
 
 BOOST_AUTO_TEST_CASE(GroupChangePhaseSameTimeThrows) {
     Opm::Group2 group("G1" , 1, 0, 0, UnitSystem::newMETRIC());
-    Opm::SummaryState st;
+    Opm::SummaryState st(std::chrono::system_clock::now());
     const auto& inj = group.injectionControls(st);
     BOOST_CHECK_EQUAL( Opm::Phase::WATER , inj.phase); // Default phase - assumed WATER
 }
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGCONPROD) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck );
     Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec);
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
 
     const auto& group1 = schedule.getGroup2("G1", 0);
     const auto& group2 = schedule.getGroup2("G2", 0);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1193,7 +1193,7 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
         Eclipse3DProperties eclipseProperties ( deck , table, grid);
         Runspec runspec (deck);
         Opm::Schedule schedule(deck,  grid, eclipseProperties, runspec);
-        Opm::SummaryState st;
+        Opm::SummaryState st(std::chrono::system_clock::now());
 
         Opm::UnitSystem unitSystem = deck.getActiveUnitSystem();
         double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(MIX_SCALAR) {
     UDQFunctionTable udqft;
     UDQParams udqp;
     UDQDefine def_add(udqp, "WU", {"WOPR", "+", "1"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     UDQContext context(udqft, st);
 
     st.update_well_var("P1", "WOPR", 1);
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(UDQFieldSetTest) {
     UDQFunctionTable udqft(udqp);
     UDQDefine def_fxxx(udqp, "FU_SCALAR", {"123"});
     UDQDefine def_fopr(udqp, "FUOPR", {"SUM", "(", "WOPR", ")"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     UDQContext context(udqft, st);
 
     st.update_well_var("P1", "WOPR", 1.0);
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(UDQ_GROUP_TEST) {
         UDQParams udqp;
         UDQFunctionTable udqft(udqp);
         UDQDefine def_fopr(udqp, "FUOPR", {"SUM", "(", "GOPR", ")"});
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         UDQContext context(udqft, st);
 
         st.update_group_var("G1", "GOPR", 1.0);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     UDQFunctionTable udqft(udqp);
     {
         UDQDefine def(udqp, "WUBHP", {"WBHP"});
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         UDQContext context(udqft, st);
 
         st.update_well_var("W1", "WBHP", 11);
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     }
     {
         UDQDefine def(udqp, "WUBHP", {"WBHP" , "'P*'"});
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         UDQContext context(udqft, st);
 
 
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     }
     {
         UDQDefine def(udqp, "WUBHP", {"NINT" , "(", "WBHP", ")"});
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         UDQContext context(udqft, st);
         st.update_well_var("P1", "WBHP", 4);
         st.update_well_var("P2", "WBHP", 3);
@@ -437,7 +437,7 @@ ASSIGN WU2 8.0 /
 
 
 BOOST_AUTO_TEST_CASE(UDQ_CONTEXT) {
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     UDQFunctionTable func_table;
     UDQParams udqp;
     UDQContext ctx(func_table, st);
@@ -846,7 +846,7 @@ BOOST_AUTO_TEST_CASE(UDQ_POW_TEST) {
     UDQParams udqp;
     UDQDefine def_pow1(udqp, "WU", {"WOPR", "+", "WWPR", "*", "WGOR", "^", "WWIR"});
     UDQDefine def_pow2(udqp, "WU", {"(", "WOPR", "+", "WWPR", ")", "^", "(", "WOPR", "+" , "WGOR", "*", "WWIR", "-", "WOPT", ")"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     UDQContext context(udqft, st);
 
     st.update_well_var("P1", "WOPR", 1);
@@ -865,7 +865,7 @@ BOOST_AUTO_TEST_CASE(UDQ_CMP_TEST) {
     UDQFunctionTable udqft;
     UDQParams udqp;
     UDQDefine def_cmp(udqp, "WU", {"WOPR", ">", "WWPR", "+", "WGOR", "*", "WWIR"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     UDQContext context(udqft, st);
 
     st.update_well_var("P1", "WOPR",  0);
@@ -892,7 +892,7 @@ BOOST_AUTO_TEST_CASE(UDQ_CMP_TEST) {
 BOOST_AUTO_TEST_CASE(UDQ_SCALAR_SET) {
     UDQParams udqp;
     UDQFunctionTable udqft;
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     UDQContext context(udqft, st);
 
     st.update_well_var("P1", "WOPR", 1);
@@ -963,7 +963,7 @@ BOOST_AUTO_TEST_CASE(UDQ_BASIC_MATH_TEST) {
     UDQDefine def_div(udqp, "WU2OPR", {"WOPR", "/", "WOPR"});
     UDQDefine def_muladd(udqp , "WUX", {"WOPR", "+", "WOPR", "*", "WOPR"});
     UDQDefine def_wuwct(udqp , "WUWCT", {"WWPR", "/", "(", "WOPR", "+", "WWPR", ")"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     UDQContext context(udqft, st);
 
     st.update_well_var("P1", "WOPR", 1);
@@ -1023,7 +1023,7 @@ BOOST_AUTO_TEST_CASE(DECK_TEST) {
     UDQParams udqp;
     UDQFunctionTable udqft(udqp);
     UDQDefine def(udqp, "WUOPRL", {"(", "WOPR", "OP1", "-", "150", ")", "*", "0.90"});
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     UDQContext context(udqft, st);
 
     st.update_well_var("OP1", "WOPR", 300);
@@ -1055,7 +1055,7 @@ BOOST_AUTO_TEST_CASE(UDQ_PARSE_ERROR) {
     parseContext.update(ParseContext::UDQ_PARSE_ERROR, InputError::IGNORE);
     {
         UDQDefine def1(udqp, "WUBHP", tokens, parseContext, errors);
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         UDQFunctionTable udqft(udqp);
         UDQContext context(udqft, st);
         st.update_well_var("P1", "WBHP", 1);
@@ -1079,7 +1079,7 @@ BOOST_AUTO_TEST_CASE(UDQ_TYPE_ERROR) {
         UDQDefine def1(udqp, "FUBHP", tokens1, parseContext, errors);
         UDQDefine def2(udqp, "WUBHP", tokens2, parseContext, errors);
 
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         UDQFunctionTable udqft(udqp);
         UDQContext context(udqft, st);
         st.update_well_var("P1", "WBHP", 1);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -759,7 +759,7 @@ BOOST_AUTO_TEST_CASE(CMODE_DEFAULT) {
 BOOST_AUTO_TEST_CASE(WELL_CONTROLS) {
     Opm::Well2 well("WELL", "GROUP", 0, 0, 0, 0, 1000, Opm::Phase::OIL, Opm::Well2::ProducerCMode::CMODE_UNDEFINED, Opm::Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0);
     Opm::Well2::WellProductionProperties prod("OP1");
-    Opm::SummaryState st;
+    Opm::SummaryState st(std::chrono::system_clock::now());
     well.productionControls(st);
 
     // Use a scalar FIELD variable - that should work; although it is a bit weird.

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -1396,7 +1396,7 @@ BOOST_AUTO_TEST_CASE( WCONINJE ) {
     Eclipse3DProperties eclipseProperties( deck , table, grid );
     Runspec runspec (deck);
     Schedule sched( deck, grid, eclipseProperties, runspec);
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
 
     BOOST_CHECK_EQUAL(5U, sched.numWells());
     BOOST_CHECK(sched.hasWell("PROD1"));

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
         BOOST_CHECK( sched.getWell2("W_1", 9).isInjector());
         {
-            SummaryState st;
+            SummaryState st(std::chrono::system_clock::now());
             const auto controls = sched.getWell2("W_1", 9).injectionControls(st);
             BOOST_CHECK_CLOSE(20000/Metric::Time ,  controls.surface_rate  , 0.001);
             BOOST_CHECK_CLOSE(200000/Metric::Time , controls.reservoir_rate, 0.001);
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
         BOOST_CHECK( Well2::Status::SHUT == sched.getWell2("W_1", 13).getStatus( ));
         BOOST_CHECK( Well2::Status::OPEN == sched.getWell2("W_1", 14).getStatus( ));
         {
-            SummaryState st;
+            SummaryState st(std::chrono::system_clock::now());
             const auto controls = sched.getWell2("W_1", 12).injectionControls(st);
             BOOST_CHECK(  controls.hasControl(Well2::InjectorCMode::RATE ));
             BOOST_CHECK( !controls.hasControl(Well2::InjectorCMode::RESV));
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , eclipseProperties, runspec);
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
 
     BOOST_CHECK_EQUAL( 3U , sched.numGroups() );
     BOOST_CHECK( sched.hasGroup( "INJ" ));

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -430,7 +430,7 @@ END
 
     Opm::SummaryState sim_state()
     {
-        auto state = Opm::SummaryState{};
+        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
 
         state.update("GOPR:GRP1",   235.);
         state.update("GGPR:GRP1",   100237.);

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -496,7 +496,7 @@ END
 
         Opm::SummaryState sim_state()
     {
-        auto state = Opm::SummaryState{};
+        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
 
 	state.update("SPR:PROD:1",   235.);
 	state.update("SPR:PROD:2",   237.);

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -216,7 +216,7 @@ TSTEP            -- 8
 
     Opm::SummaryState sim_state()
     {
-        auto state = Opm::SummaryState{};
+        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
 
         state.update("WOPR:OP_1" ,    1.0);
         state.update("WWPR:OP_1" ,    2.0);

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         auto& eclGrid = es.getInputGrid();
         Schedule schedule(deck, eclGrid, es.get3DProperties(), es.runspec());
         SummaryConfig summary_config( deck, schedule, es.getTableManager( ));
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         es.getIOConfig().setBaseName( "FOO" );
 
         EclipseIO eclWriter( es, eclGrid , schedule, summary_config);

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         const auto start_time = schedule.posixStartTime();
         const auto step_time  = timeStamp(::Opm::EclIO::ERft::RftDate{ 2008, 10, 10 });
 
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
 
         data::Rates r1, r2;
         r1.set( data::Rates::opt::wat, 4.11 );
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
 
         Schedule schedule(deck, eclipseState);
         SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ));
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
 
         const auto  start_time = schedule.posixStartTime();
         const auto& time_map   = schedule.getTimeMap( );

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -349,7 +349,7 @@ data::Solution mkSolution( int numCells ) {
 
 Opm::SummaryState sim_state()
 {
-    auto state = Opm::SummaryState{};
+    auto state = Opm::SummaryState{std::chrono::system_clock::now()};
 
     state.update("WOPR:OP_1" ,    1.0);
     state.update("WWPR:OP_1" ,    2.0);
@@ -546,7 +546,7 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData) {
 
     Setup setup("FIRST_SIM.DATA");
     EclipseIO eclWriter( setup.es, setup.grid, setup.schedule, setup.summary_config);
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     auto state1 = first_sim( setup.es , eclWriter , st, false );
     auto state2 = second_sim( eclWriter , st , keys );
     compare(state1, state2 , keys);
@@ -680,7 +680,7 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData_double) {
     test_work_area_copy_file( test_area, "FIRST_SIM.DATA");
     Setup setup("FIRST_SIM.DATA");
     EclipseIO eclWriter( setup.es, setup.grid, setup.schedule, setup.summary_config);
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
 
     auto state1 = first_sim( setup.es , eclWriter , st, true);
     auto state2 = second_sim( eclWriter ,st, solution_keys );
@@ -698,7 +698,7 @@ BOOST_AUTO_TEST_CASE(WriteWrongSOlutionSize) {
         auto num_cells = setup.grid.getNumActive( ) + 1;
         auto cells = mkSolution( num_cells );
         auto wells = mkWells();
-        Opm::SummaryState sumState;
+        Opm::SummaryState sumState(std::chrono::system_clock::now());
 
         const auto seqnum = 1;
         auto rstFile = OS::Restart {
@@ -751,7 +751,7 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
         const auto& units = setup.es.getUnits();
         {
             RestartValue restart_value(cells, wells);
-            SummaryState st;
+            SummaryState st(std::chrono::system_clock::now());
             const auto sumState = sim_state();
 
             restart_value.addExtra("EXTRA", UnitSystem::measure::pressure, {10,1,2,3});
@@ -947,7 +947,7 @@ BOOST_AUTO_TEST_CASE(Restore_Cumulatives)
                         setup.es, setup.grid, setup.schedule, sumState);
     }
 
-    SummaryState rstSumState;
+    SummaryState rstSumState(std::chrono::system_clock::now());
     RestartIO::load(OS::outputFileName(rset, "UNRST"), seqnum, rstSumState,
                     /* solution_keys = */ {
                                            RestartKey("SWAT", UnitSystem::measure::identity),

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     util_make_path( "PATH" );
     cfg.name = "PATH/CASE";
 
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
     writer.eval(st, 0, 0*day, cfg.es, cfg.schedule, cfg.wells, {});
@@ -528,7 +528,7 @@ BOOST_AUTO_TEST_CASE(udq_keywords) {
     setup cfg( "test_summary_udq" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , {});
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     setup cfg( "test_summary_group" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
     writer.add_timestep( st, 0);
 
@@ -694,7 +694,7 @@ BOOST_AUTO_TEST_CASE(group_group) {
     setup cfg( "test_summary_group_group" , "group_group.DATA");
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , {});
@@ -750,7 +750,7 @@ BOOST_AUTO_TEST_CASE(completion_kewords) {
     setup cfg( "test_summary_completion" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
@@ -812,7 +812,7 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
     setup cfg( "test_summary_field" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
@@ -941,7 +941,7 @@ BOOST_AUTO_TEST_CASE(report_steps_time) {
     setup cfg( "test_summary_report_steps_time" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells ,  {});
     writer.add_timestep( st, 1);
     writer.eval( st, 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells ,  {});
@@ -967,7 +967,7 @@ BOOST_AUTO_TEST_CASE(skip_unknown_var) {
     setup cfg( "test_summary_skip_unknown_var" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 1, 2 *  day, cfg.es,  cfg.schedule, cfg.wells ,  {});
     writer.add_timestep( st, 1);
     writer.eval( st, 1, 5 *  day, cfg.es,  cfg.schedule, cfg.wells ,  {});
@@ -1078,7 +1078,7 @@ BOOST_AUTO_TEST_CASE(region_vars) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         writer.eval( st, 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells,  {}, region_values);
         writer.add_timestep( st, 1);
         writer.eval( st, 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells,  {}, region_values);
@@ -1129,7 +1129,7 @@ BOOST_AUTO_TEST_CASE(region_production) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
         writer.add_timestep( st, 0);
         writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
@@ -1161,7 +1161,7 @@ BOOST_AUTO_TEST_CASE(region_injection) {
     setup cfg( "region_injection" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
@@ -1217,7 +1217,7 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES) {
     block_values[std::make_pair("BOVIS", 1)] = 33.0;
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {},{}, block_values);
@@ -1314,7 +1314,7 @@ BOOST_AUTO_TEST_CASE(MISC) {
     setup cfg( "test_misc");
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  {});
@@ -1334,7 +1334,7 @@ BOOST_AUTO_TEST_CASE(EXTRA) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"TCPU" , 0 }});
         writer.add_timestep( st, 0);
         writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells ,  { {"TCPU" , 1 }});
@@ -1432,7 +1432,7 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
         setup cfg( "test_efficiency_factor", "SUMMARY_EFF_FAC.DATA" );
 
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        SummaryState st;
+        SummaryState st(std::chrono::system_clock::now());
         writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells, {});
         writer.add_timestep( st, 0);
         writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells, {});
@@ -1504,7 +1504,7 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
 
 
 BOOST_AUTO_TEST_CASE(Test_SummaryState) {
-    Opm::SummaryState st;
+    Opm::SummaryState st(std::chrono::system_clock::now());
     st.update("WWCT:OP_2", 100);
     BOOST_CHECK_CLOSE(st.get("WWCT:OP_2"), 100, 1e-5);
     BOOST_CHECK_THROW(st.get("NO_SUCH_KEY"), std::out_of_range);
@@ -1569,7 +1569,7 @@ namespace {
             config.schedule, "Ignore.This"
         };
 
-      SummaryState st;
+      SummaryState st(std::chrono::system_clock::now());
       smry.eval(st, 0, 0*day, config.es, config.schedule, config.wells, {});
       smry.add_timestep(st, 0);
       smry.eval(st, 1, 1*day, config.es, config.schedule, config.wells, {});
@@ -2565,7 +2565,7 @@ BOOST_AUTO_TEST_CASE(Write_Read)
         config.es, config.config, config.grid, config.schedule
     };
 
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     writer.eval(st, 0, 0*day, config.es, config.schedule, config.wells, {});
     writer.add_timestep(st, 0);
     writer.eval(st, 1, 1*day, config.es, config.schedule, config.wells, {});
@@ -3061,7 +3061,7 @@ BOOST_AUTO_TEST_SUITE(Reset_Cumulative_Vectors)
 
 
 BOOST_AUTO_TEST_CASE(SummaryState_TOTAL) {
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     st.update("FOPR", 100);
     BOOST_CHECK_EQUAL(st.get("FOPR"), 100);
     st.update("FOPR", 100);
@@ -3162,7 +3162,7 @@ bool equal(const SummaryState& st1 , const SummaryState& st2) {
 
 
 void test_serialize(const SummaryState& st) {
-    SummaryState st2;
+    SummaryState st2(std::chrono::system_clock::now());
     auto serial = st.serialize();
     st2.deserialize(serial);
     BOOST_CHECK( equal(st, st2));
@@ -3175,7 +3175,7 @@ void test_serialize(const SummaryState& st) {
 
 
 BOOST_AUTO_TEST_CASE(serialize_sumary_state) {
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
     test_serialize(st);
 
     st.update_elapsed(1000);

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -27,6 +27,7 @@
 #include <exception>
 #include <stdexcept>
 #include <unordered_map>
+#include <ctime>
 
 #include <ert/ecl/ecl_sum.h>
 #include <ert/ecl/smspec_node.h>
@@ -1550,7 +1551,7 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
     BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP2"), 1);
     BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP3"), 1);
 
-    BOOST_CHECK_EQUAL(st.size(), 8);
+    BOOST_CHECK_EQUAL(st.size(), 11); // Size = 8 + 3 - where the the three are DAY, MNTH and YEAR
 
     // The well 'OP_2' which was indirectly added with the
     // st.update("WWCT:OP_2", 100) call is *not* counted as a well!
@@ -3199,6 +3200,32 @@ BOOST_AUTO_TEST_CASE(serialize_sumary_state) {
     st.update_group_var("G2", "GGOR", 0.67);
     test_serialize(st);
 
+}
+
+
+BOOST_AUTO_TEST_CASE(SummaryState__TIME) {
+    struct tm ts;
+    ts.tm_year = 100;
+    ts.tm_mon = 1;
+    ts.tm_mday = 1;
+    ts.tm_hour = 0;
+    ts.tm_min = 0;
+    ts.tm_sec = 0;
+    auto start_time = timegm(&ts);
+    SummaryState st(std::chrono::system_clock::from_time_t(start_time));
+    BOOST_CHECK_EQUAL(st.get("YEAR"), 2000);
+    BOOST_CHECK_EQUAL(st.get("DAY"), 1);
+    BOOST_CHECK_EQUAL(st.get("MNTH"), 1);
+
+    // Next day
+    st.update_elapsed(100000);
+    BOOST_CHECK_EQUAL(st.get("YEAR"), 2000);
+    BOOST_CHECK_EQUAL(st.get("DAY"), 2);
+    BOOST_CHECK_EQUAL(st.get("MNTH"), 1);
+
+    // Well into 2001
+    st.update_elapsed(400 * 86400);
+    BOOST_CHECK_EQUAL(st.get("YEAR"), 2001);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_writenumwells.cpp
+++ b/tests/test_writenumwells.cpp
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     const auto num_cells = grid.getCartesianSize();
     EclipseIO eclipseWriter( es,  grid , schedule, summary_config);
     int countTimeStep = schedule.getTimeMap().numTimesteps();
-    SummaryState st;
+    SummaryState st(std::chrono::system_clock::now());
 
     data::Solution solution;
     solution.insert( "PRESSURE",UnitSystem::measure::pressure , std::vector< double >( num_cells, 1 ) , data::TargetType::RESTART_SOLUTION);


### PR DESCRIPTION
To be able to keep track of how far the simulation has progressed - in true date. This is ultimately needed in the `ACTIONX` implementation, where you can check the simulation date with statements of the type:
```
...
'MNTH = 6' AND 'YEAR > 2020' ...
```

Downstream: https://github.com/OPM/opm-simulators/pull/2018