### PR TITLE
Schedule: Add Query For Particular Group at Particular Time

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -190,6 +190,7 @@ namespace Opm
         size_t numGroups() const;
         size_t numGroups(size_t timeStep) const;
         bool hasGroup(const std::string& groupName) const;
+        bool hasGroup(const std::string& groupName, std::size_t timeStep) const;
         const Group2& getGroup2(const std::string& groupName, size_t timeStep) const;
 
         const Tuning& getTuning() const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2369,6 +2369,15 @@ void Schedule::handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep, c
         return groups.count(groupName) > 0;
     }
 
+    bool Schedule::hasGroup(const std::string& groupName, std::size_t timeStep) const {
+        if (timeStep >= this->size())
+            return false;
+
+        auto grpMap = this->groups.find(groupName);
+
+        return (grpMap != this->groups.end())
+            && grpMap->second.at(timeStep);
+    }
 
     void Schedule::addGroupToGroup( const std::string& parent_group, const Group2& child_group, size_t timeStep) {
         // Add to new parent


### PR DESCRIPTION
This commit adds a new query method,
```C++
bool Schedule::hasGroup(groupName, timeStep)
```
which report whether or not a particular named group exists at a particular time step (zero-based report step index).  If this function returns 'true', then it is always safe to call
```C++
Schedule::getGroup2(groupName, timeStep)
```
with the same arguments.  Otherwise, the latter will throw an exception.

The new `hasGroup` overload thus enables the same query types as the existing `hasWell` overload set.  The immediate use case for this new overload is a reworking of the system for evaluating derived summary parameters (e.g., FOPT or GGLR).

Add a new unit test to exercise the new overload.