### PR TITLE
Do not import ParserKeyword in Python

### DIFF
--- a/python/python/opm/_common.py
+++ b/python/python/opm/_common.py
@@ -11,7 +11,7 @@
 from __future__ import absolute_import
 from .libopmcommon_python import action
 
-from .libopmcommon_python import Parser, ParseContext, ParserKeyword
+from .libopmcommon_python import Parser, ParseContext
 from .libopmcommon_python import EclipseState
 
 #from .schedule            import Well, Connection, Schedule

--- a/python/python/opm/io/parser/__init__.py
+++ b/python/python/opm/io/parser/__init__.py
@@ -1,6 +1,5 @@
 from opm._common import action
 from opm._common import Parser
 from opm._common import ParseContext
-from opm._common import ParserKeyword
 
 from .parser_module import parse, load_deck, load_deck_string, parse_string

--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -4,7 +4,6 @@ import sys
 
 from opm.io.parser import Parser
 from opm.io.parser import ParseContext
-from opm.io.parser import ParserKeyword
 
 
 class TestParser(unittest.TestCase):


### PR DESCRIPTION
Does not have a Python constructor (yet at least)