### PR TITLE
Changed EquilRecord to take SI values instead of DeckRecord

### DIFF
--- a/opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp
@@ -1,17 +1,13 @@
 #ifndef OPM_EQUIL_HPP
 #define OPM_EQUIL_HPP
 
+#include <cstddef>
 #include <vector>
 
 namespace Opm {
-
     class DeckKeyword;
-    class DeckRecord;
-
     class EquilRecord {
         public:
-            explicit EquilRecord( const DeckRecord& );
-
             double datumDepth() const;
             double datumDepthPressure() const;
             double waterOilContactDepth() const;
@@ -23,7 +19,9 @@ namespace Opm {
             bool wetGasInitConstantRv() const;
             int initializationTargetAccuracy() const;
 
+            EquilRecord( double datum_depth_arg, double datum_depth_pc_arg, double woc_depth, double woc_pc, double goc_depth, double goc_pc, bool live_oil_init, bool wet_gas_init, int target_accuracy);
         private:
+
             double datum_depth;
             double datum_depth_ps;
             double water_oil_contact_depth;

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/Equil.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/Equil.cpp
@@ -1,20 +1,18 @@
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp>
 
 namespace Opm {
 
-    EquilRecord::EquilRecord( const DeckRecord& record ) :
-            datum_depth( record.getItem( 0 ).getSIDouble( 0 ) ),
-            datum_depth_ps( record.getItem( 1 ).getSIDouble( 0 ) ),
-            water_oil_contact_depth( record.getItem( 2 ).getSIDouble( 0 ) ),
-            water_oil_contact_capillary_pressure( record.getItem( 3 ).getSIDouble( 0 ) ),
-            gas_oil_contact_depth( record.getItem( 4 ).getSIDouble( 0 ) ),
-            gas_oil_contact_capillary_pressure( record.getItem( 5 ).getSIDouble( 0 ) ),
-            live_oil_init_proc( record.getItem( 6 ).get< int >( 0 ) <= 0 ),
-            wet_gas_init_proc( record.getItem( 7 ).get< int >( 0 ) <= 0 ),
-            init_target_accuracy( record.getItem( 8 ).get< int >( 0 ) )
+   EquilRecord::EquilRecord( double datum_depth_arg, double datum_depth_pc_arg, double woc_depth, double woc_pc, double goc_depth, double goc_pc, bool live_oil_init, bool wet_gas_init, int target_accuracy) :
+       datum_depth(datum_depth_arg),
+       datum_depth_ps(datum_depth_pc_arg),
+       water_oil_contact_depth(woc_depth),
+       water_oil_contact_capillary_pressure(woc_pc),
+       gas_oil_contact_depth(goc_depth),
+       gas_oil_contact_capillary_pressure(goc_pc),
+       live_oil_init_proc(live_oil_init),
+       wet_gas_init_proc(wet_gas_init),
+       init_target_accuracy(target_accuracy)
     {}
 
     double EquilRecord::datumDepth() const {
@@ -55,9 +53,22 @@ namespace Opm {
 
     /* */
 
-    Equil::Equil( const DeckKeyword& keyword ) :
-        records( keyword.begin(), keyword.end() )
-    {}
+    Equil::Equil( const DeckKeyword& keyword )
+    {
+        for (const auto& record : keyword) {
+            auto datum_depth_arg = record.getItem( 0 ).getSIDouble( 0 );
+            auto datum_depth_pc_arg = record.getItem( 1 ).getSIDouble( 0 );
+            auto woc_depth = record.getItem(2).getSIDouble(0);
+            auto woc_pc = record.getItem(3).getSIDouble(0);
+            auto goc_depth = record.getItem(4).getSIDouble(0);
+            auto goc_pc = record.getItem(5).getSIDouble(0);
+            auto live_oil_init = record.getItem(6).get<int>(0) <= 0;
+            auto wet_gas_init = record.getItem(7).get<int>(0) <= 0;
+            auto target_accuracy = record.getItem(8).get<int>(0);
+
+            this->records.push_back( EquilRecord(datum_depth_arg, datum_depth_pc_arg, woc_depth, woc_pc, goc_depth, goc_pc, live_oil_init, wet_gas_init, target_accuracy) );
+        }
+    }
 
     const EquilRecord& Equil::getRecord( size_t id ) const {
         return this->records.at( id );


### PR DESCRIPTION
A small refactor to avoid spreading `Deckxxx`datastructures. 

Followup: https://github.com/OPM/opm-simulators/pull/2020