### PR TITLE
python: DeckKeyword constructor, w/ ParserKeyword arg.

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <utility>
 
+#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
 namespace Opm {
@@ -35,8 +36,8 @@ namespace Opm {
     public:
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
 
-        explicit DeckKeyword(const ParserKeyword * parserKeyword);
-        DeckKeyword(const ParserKeyword * parserKeyword, const std::string& keywordName);
+        explicit DeckKeyword(const ParserKeyword& parserKeyword);
+        DeckKeyword(const ParserKeyword& parserKeyword, const std::string& keywordName);
 
         const std::string& name() const;
         void setFixedSize();
@@ -88,7 +89,7 @@ namespace Opm {
         std::vector< DeckRecord > m_recordList;
         bool m_isDataKeyword;
         bool m_slashTerminated;
-        const ParserKeyword * parser_keyword;
+        ParserKeyword parser_keyword;
     };
 }
 

--- a/python/cxx/deck_keyword.cpp
+++ b/python/cxx/deck_keyword.cpp
@@ -1,5 +1,7 @@
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
+#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
+
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
@@ -58,6 +60,7 @@ struct DeckRecordIterator
 
 void python::common::export_DeckKeyword(py::module& module) {
     py::class_< DeckKeyword >( module, "DeckKeyword")
+        .def(py::init<const ParserKeyword& >())
         .def( "__repr__", &DeckKeyword::name )
         .def( "__str__", &str<DeckKeyword> )
         .def("__iter__",  [] (const DeckKeyword &keyword) { return py::make_iterator(keyword.begin(), keyword.end()); }, py::keep_alive<0,1>())

--- a/python/cxx/parser.cpp
+++ b/python/cxx/parser.cpp
@@ -47,8 +47,6 @@ namespace {
         parser->addParserKeyword(keyword);
     }
 
-
-
 }
 
 void python::common::export_Parser(py::module& module) {

--- a/python/python/opm/_common.py
+++ b/python/python/opm/_common.py
@@ -12,9 +12,12 @@ from __future__ import absolute_import
 from .libopmcommon_python import action
 
 from .libopmcommon_python import Parser, ParseContext
+from .libopmcommon_python import DeckKeyword
+
 from .libopmcommon_python import EclipseState
 from .libopmcommon_python import Schedule
 from .libopmcommon_python import OpmLog
+
 
 #from .schedule            import Well, Connection, Schedule
 #from .config     import EclipseConfig

--- a/python/python/opm/io/deck/__init__.py
+++ b/python/python/opm/io/deck/__init__.py
@@ -1,2 +1,1 @@
-from opm.parser import load_deck as parse
-from opm.parser import load_deck_string as parse_string
+from opm._common import DeckKeyword

--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -5,6 +5,8 @@ import sys
 from opm.io.parser import Parser
 from opm.io.parser import ParseContext
 
+from opm.io.deck import DeckKeyword
+
 
 class TestParser(unittest.TestCase):
 
@@ -31,16 +33,6 @@ FIPNUM
 1 1 2 3 /
 """
 
-    MANUALDATA = """
-START             -- 0
-10 MAI 2007 /
-RUNSPEC
-
-DIMENS
-2 2 1 /
-
-FIELD
-"""
 
     def setUp(self):
         self.spe3fn = 'tests/spe3/SPE3CASE1.DATA'
@@ -58,14 +50,16 @@ FIELD
         deck = parser.parse_string(string)
         deck = parser.parse_string(string, context)
 
-    def test_pyinput(self):
+    def test_create_deck_kw(self):
         parser = Parser()
-        deck = parser.parse_string(self.MANUALDATA)
         with self.assertRaises(ValueError):
             kw = parser["NOT_A_VALID_KEYWORD"]
 
         kw = parser["FIELD"]
         assert(kw.name == "FIELD")
+
+        dkw = DeckKeyword(kw)
+        assert(dkw.name == "FIELD")
 
 
 if __name__ == "__main__":

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -27,8 +27,8 @@
 
 namespace Opm {
 
-    DeckKeyword::DeckKeyword(const ParserKeyword * parserKeyword) :
-        m_keywordName(parserKeyword->getName()),
+    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword) :
+        m_keywordName(parserKeyword.getName()),
         m_lineNumber(-1),
         m_isDataKeyword(false),
         m_slashTerminated(true),
@@ -36,7 +36,7 @@ namespace Opm {
     {
     }
 
-    DeckKeyword::DeckKeyword(const ParserKeyword * parserKeyword, const std::string& keywordName) :
+    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::string& keywordName) :
         m_keywordName(keywordName),
         m_lineNumber(-1),
         m_isDataKeyword(false),
@@ -76,10 +76,7 @@ namespace Opm {
     }
 
     const ParserKeyword& DeckKeyword::parserKeyword() const {
-        if (this->parser_keyword)
-            return *this->parser_keyword;
-
-        throw std::logic_error("INTERNAL ERROR: The " + this->m_keywordName + " deck keyword has been instantiated without ParserKeyword information.");
+        return this->parser_keyword;
     }
 
     const std::string& DeckKeyword::name() const {
@@ -92,9 +89,6 @@ namespace Opm {
 
 
     void DeckKeyword::addRecord(DeckRecord&& record) {
-        if (!this->parser_keyword)
-            throw std::logic_error("INTERNAL ERROR: The " + this->m_keywordName + " deck keyword has been instantiated without ParserKeyword information - can not add data");
-
         this->m_recordList.push_back( std::move( record ) );
     }
 

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -506,7 +506,7 @@ void set_dimensions( ParserItem& item,
         if( !rawKeyword.isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword.getKeywordName());
 
-        DeckKeyword keyword( this, rawKeyword.getKeywordName() );
+        DeckKeyword keyword( *this, rawKeyword.getKeywordName() );
         keyword.setLocation( rawKeyword.getLocation( ) );
         keyword.setDataKeyword( isDataKeyword() );
 

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(getKeywordList_empty_list) {
 BOOST_AUTO_TEST_CASE(getKeyword_singlekeyword_outRange_throws) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     BOOST_CHECK_THROW(deck.getKeyword("GRID" , 10) , std::out_of_range);
 }
 
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(getKeyword_singlekeyword_outRange_throws) {
 BOOST_AUTO_TEST_CASE(getKeywordList_returnOK) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     BOOST_CHECK_NO_THROW( deck.getKeywordList("GRID") );
 }
 
@@ -71,14 +71,14 @@ BOOST_AUTO_TEST_CASE(getKeywordList_returnOK) {
 BOOST_AUTO_TEST_CASE(getKeyword_indexok_returnskeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     BOOST_CHECK_NO_THROW(deck.getKeyword(0));
 }
 
 BOOST_AUTO_TEST_CASE(numKeyword_singlekeyword_return1) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     BOOST_CHECK_EQUAL(1U , deck.count("GRID"));
 }
 
@@ -86,8 +86,8 @@ BOOST_AUTO_TEST_CASE(numKeyword_singlekeyword_return1) {
 BOOST_AUTO_TEST_CASE(numKeyword_twokeyword_return2) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     BOOST_CHECK_EQUAL(2U , deck.count("GRID"));
     BOOST_CHECK_EQUAL(0U , deck.count("GRID_BUG"));
 }
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(numKeyword_twokeyword_return2) {
 BOOST_AUTO_TEST_CASE(size_twokeyword_return2) {
     Deck deck;
     Parser parser;
-    DeckKeyword keyword( &parser.getKeyword("GRID"));
+    DeckKeyword keyword( parser.getKeyword("GRID"));
     deck.addKeyword(keyword);
     deck.addKeyword(keyword);
     BOOST_CHECK_EQUAL(2U , deck.size());
@@ -106,9 +106,9 @@ BOOST_AUTO_TEST_CASE(size_twokeyword_return2) {
 BOOST_AUTO_TEST_CASE(getKeywordList_OK) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
 
     const auto& keywordList = deck.getKeywordList("GRID");
     BOOST_CHECK_EQUAL( 3U , keywordList.size() );
@@ -119,9 +119,9 @@ BOOST_AUTO_TEST_CASE(keywordList_getbyindexoutofbounds_exceptionthrown) {
     Parser parser;
     Deck deck;
     BOOST_CHECK_THROW(deck.getKeyword(0), std::out_of_range);
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("INIT")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("INIT")));
     BOOST_CHECK_NO_THROW(deck.getKeyword(2));
     BOOST_CHECK_THROW(deck.getKeyword(3), std::out_of_range);
 }
@@ -129,9 +129,9 @@ BOOST_AUTO_TEST_CASE(keywordList_getbyindexoutofbounds_exceptionthrown) {
 BOOST_AUTO_TEST_CASE(keywordList_getbyindex_correctkeywordreturned) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("GRID")));
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("INIT")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("INIT")));
     BOOST_CHECK_EQUAL("GRID",  deck.getKeyword(0).name());
     BOOST_CHECK_EQUAL("GRID",  deck.getKeyword(1).name());
     BOOST_CHECK_EQUAL("INIT", deck.getKeyword(2).name());
@@ -504,7 +504,7 @@ BOOST_AUTO_TEST_CASE(StringsWithSpaceOK) {
 
 BOOST_AUTO_TEST_CASE(DataKeyword) {
     Parser parser;
-    DeckKeyword kw(&parser.getKeyword("GRID"));
+    DeckKeyword kw(parser.getKeyword("GRID"));
     BOOST_CHECK_EQUAL( false , kw.isDataKeyword());
     kw.setDataKeyword( );
     BOOST_CHECK_EQUAL( true , kw.isDataKeyword());
@@ -518,13 +518,13 @@ BOOST_AUTO_TEST_CASE(DataKeyword) {
 
 BOOST_AUTO_TEST_CASE(name_nameSetInConstructor_nameReturned) {
     Parser parser;
-    DeckKeyword deckKeyword( &parser.getKeyword("GRID"));
+    DeckKeyword deckKeyword( parser.getKeyword("GRID"));
     BOOST_CHECK_EQUAL("GRID", deckKeyword.name());
 }
 
 BOOST_AUTO_TEST_CASE(size_noRecords_returnszero) {
     Parser parser;
-    DeckKeyword deckKeyword( &parser.getKeyword("GRID"));;
+    DeckKeyword deckKeyword( parser.getKeyword("GRID"));;
     BOOST_CHECK_EQUAL(0U, deckKeyword.size());
     BOOST_CHECK_THROW(deckKeyword.getRecord(0), std::out_of_range);
 }

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -51,9 +51,9 @@
 BOOST_AUTO_TEST_CASE(CreateMissingDIMENS_throws) {
     Opm::Deck deck;
     Opm::Parser parser;
-    deck.addKeyword( Opm::DeckKeyword( &parser.getKeyword("RUNSPEC" )));
-    deck.addKeyword( Opm::DeckKeyword( &parser.getKeyword("GRID" )));
-    deck.addKeyword( Opm::DeckKeyword( &parser.getKeyword("EDIT" )));
+    deck.addKeyword( Opm::DeckKeyword( parser.getKeyword("RUNSPEC" )));
+    deck.addKeyword( Opm::DeckKeyword( parser.getKeyword("GRID" )));
+    deck.addKeyword( Opm::DeckKeyword( parser.getKeyword("EDIT" )));
 
     BOOST_CHECK_THROW(Opm::EclipseGrid{ deck } , std::invalid_argument);
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -356,7 +356,7 @@ static Deck createDeckRFTConfig() {
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("SCHEDULE" )));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("SCHEDULE" )));
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
-    deck.addKeyword( DeckKeyword( &parser.getKeyword("SCHEDULE" )));
+    deck.addKeyword( DeckKeyword( parser.getKeyword("SCHEDULE" )));
     Runspec runspec (deck);
 
     BOOST_CHECK_NO_THROW( Schedule( deck, grid , eclipseProperties, runspec));

--- a/tests/parser/SectionTests.cpp
+++ b/tests/parser/SectionTests.cpp
@@ -36,13 +36,13 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(SectionTest) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("START")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("RUNSPEC")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("WELLDIMS")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("GRID")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("PORO")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("SCHEDULE")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("WELSPECS")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("START")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("RUNSPEC")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("WELLDIMS")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("PORO")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("SCHEDULE")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("WELSPECS")));
 
     Section runspecSection(deck, "RUNSPEC");
     Section gridSection(deck, "GRID");
@@ -60,10 +60,10 @@ BOOST_AUTO_TEST_CASE(SectionTest) {
 BOOST_AUTO_TEST_CASE(IteratorTest) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("RUNSPEC")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("WELLDIMS")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("TABDIMS")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword("GRID")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("RUNSPEC")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("WELLDIMS")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("TABDIMS")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword("GRID")));
     Section section(deck, "RUNSPEC");
 
     int numberOfItems = 0;
@@ -84,12 +84,12 @@ BOOST_AUTO_TEST_CASE(RUNSPECSection_EmptyDeck) {
 BOOST_AUTO_TEST_CASE(RUNSPECSection_ReadSimpleDeck) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "START")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "RUNSPEC")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "WELLDIMS")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "TABDIMS")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "GRID")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PORO")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "START")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "RUNSPEC")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "WELLDIMS")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "TABDIMS")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "GRID")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "PORO")));
 
     RUNSPECSection section(deck);
     BOOST_CHECK(!section.hasKeyword("START"));
@@ -103,8 +103,8 @@ BOOST_AUTO_TEST_CASE(RUNSPECSection_ReadSimpleDeck) {
 BOOST_AUTO_TEST_CASE(RUNSPECSection_ReadSmallestPossibleDeck) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "RUNSPEC" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "GRID")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "RUNSPEC" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "GRID")));
     RUNSPECSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("RUNSPEC"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("GRID"));
@@ -113,8 +113,8 @@ BOOST_AUTO_TEST_CASE(RUNSPECSection_ReadSmallestPossibleDeck) {
 BOOST_AUTO_TEST_CASE(GRIDSection_TerminatedByEDITKeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "GRID" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "EDIT" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "GRID" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "EDIT" )));
     GRIDSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("GRID"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("EDIT"));
@@ -123,8 +123,8 @@ BOOST_AUTO_TEST_CASE(GRIDSection_TerminatedByEDITKeyword) {
 BOOST_AUTO_TEST_CASE(GRIDSection_TerminatedByPROPSKeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "GRID" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PROPS" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "GRID" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "PROPS" )));
     GRIDSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("GRID"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("PROPS"));
@@ -133,8 +133,8 @@ BOOST_AUTO_TEST_CASE(GRIDSection_TerminatedByPROPSKeyword) {
 BOOST_AUTO_TEST_CASE(EDITSection_TerminatedByPROPSKeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "EDIT" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PROPS" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "EDIT" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "PROPS" )));
     EDITSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("EDIT"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("PROPS"));
@@ -143,8 +143,8 @@ BOOST_AUTO_TEST_CASE(EDITSection_TerminatedByPROPSKeyword) {
 BOOST_AUTO_TEST_CASE(PROPSSection_TerminatedByREGIONSKeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PROPS" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "REGIONS" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "PROPS" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "REGIONS" )));
     PROPSSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("PROPS"));
     BOOST_CHECK_EQUAL(false, section.hasKeyword("REGIONS"));
@@ -153,8 +153,8 @@ BOOST_AUTO_TEST_CASE(PROPSSection_TerminatedByREGIONSKeyword) {
 BOOST_AUTO_TEST_CASE(PROPSSection_TerminatedBySOLUTIONKeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "PROPS" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SOLUTION" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "PROPS" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "SOLUTION" )));
 
     PROPSSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("PROPS"));
@@ -164,8 +164,8 @@ BOOST_AUTO_TEST_CASE(PROPSSection_TerminatedBySOLUTIONKeyword) {
 BOOST_AUTO_TEST_CASE(REGIONSSection_TerminatedBySOLUTIONKeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "REGIONS" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SOLUTION" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "REGIONS" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "SOLUTION" )));
 
     REGIONSSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("REGIONS"));
@@ -175,8 +175,8 @@ BOOST_AUTO_TEST_CASE(REGIONSSection_TerminatedBySOLUTIONKeyword) {
 BOOST_AUTO_TEST_CASE(SOLUTIONSection_TerminatedBySUMMARYKeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SOLUTION" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SUMMARY" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "SOLUTION" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "SUMMARY" )));
 
     SOLUTIONSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("SOLUTION"));
@@ -186,8 +186,8 @@ BOOST_AUTO_TEST_CASE(SOLUTIONSection_TerminatedBySUMMARYKeyword) {
 BOOST_AUTO_TEST_CASE(SOLUTIONSection_TerminatedBySCHEDULEKeyword) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SOLUTION" )));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SCHEDULE" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "SOLUTION" )));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "SCHEDULE" )));
 
     SOLUTIONSection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("SOLUTION"));
@@ -197,11 +197,11 @@ BOOST_AUTO_TEST_CASE(SOLUTIONSection_TerminatedBySCHEDULEKeyword) {
 BOOST_AUTO_TEST_CASE(SCHEDULESection_NotTerminated) {
     Deck deck;
     Parser parser;
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "SCHEDULE")));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "WELSPECS" ) ));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "COMPDAT" ) ));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "WCONHIST" ) ));
-    deck.addKeyword( DeckKeyword(&parser.getKeyword( "WCONPROD" ) ));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "SCHEDULE")));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "WELSPECS" ) ));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "COMPDAT" ) ));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "WCONHIST" ) ));
+    deck.addKeyword( DeckKeyword(parser.getKeyword( "WCONPROD" ) ));
 
     SCHEDULESection section(deck);
     BOOST_CHECK_EQUAL(true, section.hasKeyword("SCHEDULE"));

--- a/tests/parser/TimeMapTest.cpp
+++ b/tests/parser/TimeMapTest.cpp
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE( timeFromEclipseInputRecord ) {
 BOOST_AUTO_TEST_CASE( addDATESFromWrongKeywordThrows ) {
     Opm::Parser parser;
     Opm::TimeMap timeMap(startDateJan1st2010);
-    Opm::DeckKeyword deckKeyword(std::addressof(parser.getKeyword("GRID")));
+    Opm::DeckKeyword deckKeyword( parser.getKeyword("GRID") );
     BOOST_CHECK_THROW( timeMap.addFromDATESKeyword( deckKeyword ) , std::invalid_argument );
 }
 
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE( addDATESFromWrongKeywordThrows ) {
 BOOST_AUTO_TEST_CASE( addTSTEPFromWrongKeywordThrows ) {
     Opm::Parser parser;
     Opm::TimeMap timeMap(startDateJan1st2010);
-    Opm::DeckKeyword deckKeyword(&parser.getKeyword("GRID"));
+    Opm::DeckKeyword deckKeyword(parser.getKeyword("GRID"));
     BOOST_CHECK_THROW( timeMap.addFromTSTEPKeyword( deckKeyword ) , std::invalid_argument );
 }
 


### PR DESCRIPTION
parserkeyword can create deckkeyword.

python parserkeyword: removed create_deckkeyword.

DeckKeyword: member parser_keyword is shared_ptr.

python DeckKeyword constructor.

python: no exposure of ParserKeyword.

DeckKeyword: shared_ptr<ParserKeyword> -> ParskerKeyword.

python/cxx/deck_keyword.cpp: cosntructor takes arg const ParskerKeyword&.

test_parser.py: simplified test_pyinut.

...