### PR TITLE
DeckItem - use same store for both si and raw

### DIFF
--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -121,8 +121,12 @@ namespace Opm {
         std::string item_name;
         std::vector< bool > defaulted;
         std::vector< Dimension > dimensions;
-        mutable std::vector< double > SIdata;
-
+        /*
+          To save space we mutate the dval object in place when asking for SI
+          data; the current state of of the dval member is tracked with the
+          raw_data bool member.
+        */
+        mutable bool raw_data = true;
         template< typename T > std::vector< T >& value_ref();
         template< typename T > const std::vector< T >& value_ref() const;
         template< typename T > void push( T );

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -361,8 +361,11 @@ void DeckItem::write(DeckOutput& stream) const {
         this->write_vector( stream, this->ival );
         break;
     case type_tag::fdouble:
-        this->write_vector( stream,  this->dval );
-        break;
+        {
+            const auto& data = this->getData<double>();
+            this->write_vector( stream,  data );
+            break;
+        }
     case type_tag::string:
         this->write_vector( stream,  this->sval );
         break;

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -425,15 +425,20 @@ bool DeckItem::equal(const DeckItem& other, bool cmp_default, bool cmp_numeric) 
         break;
     case type_tag::fdouble:
         if (cmp_numeric) {
-            const std::vector<double>& this_data = this->dval;
-            const std::vector<double>& other_data = other.dval;
+            const auto& this_data = this->getData<double>();
+            const auto& other_data = other.getData<double>();
             for (size_t i=0; i < this_data.size(); i++) {
                 if (!double_equal( this_data[i] , other_data[i], rel_eps, abs_eps))
                     return false;
             }
         } else {
-            if (this->dval != other.dval)
-                return false;
+            if (this->raw_data == other.raw_data)
+                return (this->dval == other.dval);
+            else {
+                const auto& this_data = this->getData<double>();
+                const auto& other_data = other.getData<double>();
+                return (this_data == other_data);
+            }
         }
         break;
     default:

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -697,10 +697,8 @@ BOOST_AUTO_TEST_CASE( PORO_PERMX ) {
     BOOST_CHECK_EQUAL( 0.251224369 , poro[1]);
     BOOST_CHECK_EQUAL( 0.155628711 , poro[439]);
 
-    const std::vector<double>& permx = kw2.getSIDoubleData();
-    const std::vector<double>& permxRAW = kw2.getRawDoubleData();
+    const auto& permx = kw2.getSIDoubleData();
     BOOST_CHECK_EQUAL( 1000U , permx.size() );
-    BOOST_CHECK_EQUAL( 1000U , permxRAW.size() );
 
     BOOST_CHECK_CLOSE( Metric::Permeability * 1 , permx[0] , 0.001);
     BOOST_CHECK_CLOSE( Metric::Permeability * 2 , permx[1] , 0.001);


### PR DESCRIPTION
For dimensionsfull input properties like `PERMX` and `PORO` the `DeckItem` class used to have two `std::vector<double>`members, holding both the raw input values and the SI converted values. With this PR only one `std::vector<double>` is used and the data is transparently converted after what the user wants. 

This is in many ways less elegant; in particular the state changes in the `DeckItem` object - whcih are hidden behind a `mutable`modifier. The reason for doing this is that it is a quite low hanging fruit in reducing the memory consumption of the `Deck` datastructure; the absolute best case limit is 50% reduction memory; realistically 30%???