### PR TITLE
Compressed property vectors

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -440,6 +440,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Util/Value.hpp
        opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp
        opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
+       opm/parser/eclipse/EclipseState/Util/CompressedVector.hpp
        opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
        opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp
        opm/parser/eclipse/EclipseState/Grid/GridDims.hpp

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -24,6 +24,8 @@
 #include <utility>
 #include <vector>
 
+#include <opm/parser/eclipse/EclipseState/Util/CompressedVector.hpp>
+
 /*
   This class implemenents a class representing properties which are
   define over an ECLIPSE grid, i.e. with one value for each logical
@@ -153,9 +155,9 @@ public:
     void iset(size_t i , size_t j , size_t k , T value);
 
 
-    const std::vector<bool>& wasDefaulted() const;
-    const std::vector<T>& getData() const;
-    std::vector<T>& getData();
+    std::vector<bool> wasDefaulted() const;
+    std::vector<T> getData() const;
+    void assignData(const std::vector<T>& data);
 
     bool containsNaN() const;
     const std::string& getDimensionString() const;
@@ -315,8 +317,8 @@ private:
 
     size_t m_nx, m_ny, m_nz;
     SupportedKeywordInfo m_kwInfo;
-    std::vector<T> m_data;
-    std::vector<bool> m_defaulted;
+    CompressedVector<T> m_data;
+    CompressedVector<bool> m_defaulted;
     bool m_hasRunPostProcessor = false;
     bool assigned = false;
 };

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -149,11 +149,11 @@ public:
     size_t getNZ() const;
 
 
-    T iget(size_t index) const;
+    /*T iget(size_t index) const;
     T iget(size_t i , size_t j , size_t k) const;
     void iset(size_t index, T value);
     void iset(size_t i , size_t j , size_t k , T value);
-
+    */
 
     std::vector<bool> wasDefaulted() const;
     std::vector<T> getData() const;
@@ -310,11 +310,12 @@ public:
 
 private:
     const DeckItem& getDeckItem( const DeckKeyword& );
-    void setDataPoint(size_t sourceIdx, size_t targetIdx, const DeckItem& deckItem);
-    void setElement(const typename std::vector<T>::size_type i,
-                    const T                                  value,
-                    const bool                               defaulted = false);
-
+    /*
+      void setDataPoint(size_t sourceIdx, size_t targetIdx, const DeckItem& deckItem);
+      void setElement(const typename std::vector<T>::size_type i,
+      const T                                  value,
+      const bool                               defaulted = false);
+    */
     size_t m_nx, m_ny, m_nz;
     SupportedKeywordInfo m_kwInfo;
     CompressedVector<T> m_data;

--- a/opm/parser/eclipse/EclipseState/Util/CompressedVector.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/CompressedVector.hpp
@@ -1,0 +1,98 @@
+/*
+  Copyright 2019 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_COMPRESSED_VECTOR_HPP
+#define OPM_COMPRESSED_VECTOR_HPP
+
+#include <cstddef>
+#include <vector>
+
+namespace Opm {
+
+template <typename T>
+class CompressedVector {
+public:
+
+    CompressedVector(std::size_t size) :
+        data_size(size)
+    {
+        this->extent_data.emplace_back(0, size, 0);
+    }
+
+    std::size_t size() const {
+        return this->data_size;
+    };
+
+
+    std::vector<T> data() const {
+        std::vector<T> d(this->data_size);
+        for (const auto& ext : this->extent_data)
+            std::fill_n(d.begin() + ext.start, ext.size, ext.value);
+        return d;
+    }
+
+
+    void assign(const std::vector<T>& v) {
+        if(v.size() != this->data_size)
+            throw std::invalid_argument("Size mismatch");
+
+
+        this->extent_data.clear();
+        std::size_t start = 0;
+        std::size_t sz = 0;
+        T value = v[0];
+        while (true) {
+            if (start + sz == this->data_size) {
+                this->extent_data.emplace_back(start, sz, value);
+                break;
+            }
+
+            if (v[start + sz] != value) {
+                this->extent_data.emplace_back(start, sz, value);
+                start += sz;
+                sz = 0;
+                value = v[start];
+            }
+            sz += 1;
+        }
+    }
+
+
+private:
+
+    struct extent {
+        extent(std::size_t st, std::size_t sz, T v):
+            start(st),
+            size(sz),
+            value(v)
+        {};
+
+
+        std::size_t start;
+        std::size_t size;
+        T value;
+    };
+
+    std::size_t data_size;
+    std::vector<extent> extent_data;
+};
+
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Util/CompressedVector.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/CompressedVector.hpp
@@ -49,6 +49,7 @@ public:
 
 
     void assign(const std::vector<T>& v) {
+        printf("Starting assign ..... \n");
         if(v.size() != this->data_size)
             throw std::invalid_argument("Size mismatch");
 
@@ -71,6 +72,8 @@ public:
             }
             sz += 1;
         }
+
+        printf("Done %ld/%ld\n", this->extent_data.size(), v.size());
     }
 
 

--- a/src/opm/output/eclipse/RegionCache.cpp
+++ b/src/opm/output/eclipse/RegionCache.cpp
@@ -31,7 +31,7 @@ namespace Opm {
 namespace out {
 
 RegionCache::RegionCache(const Eclipse3DProperties& properties, const EclipseGrid& grid, const Schedule& schedule) {
-    const auto& fipnum = properties.getIntGridProperty("FIPNUM");
+    const auto& fipnum_data = properties.getIntGridProperty("FIPNUM").getData();
 
     const auto& wells = schedule.getWells2atEnd();
     for (const auto& well : wells) {
@@ -40,7 +40,7 @@ RegionCache::RegionCache(const Eclipse3DProperties& properties, const EclipseGri
             size_t global_index = grid.getGlobalIndex( c.getI() , c.getJ() , c.getK());
             if (grid.cellActive( global_index )) {
                 size_t active_index = grid.activeIndex( global_index );
-                int region_id =fipnum.iget( global_index );
+                int region_id = fipnum_data[global_index];
                 auto& well_index_list = this->connection_map[ region_id ];
                 well_index_list.push_back( { well.name() , active_index } );
             }

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -78,15 +78,15 @@ namespace Opm {
             if ( doubleGridProperties->hasKeyword("PORO") ) {
                 const auto& poro = doubleGridProperties->getKeyword("PORO");
                 const auto& ntg =  doubleGridProperties->getKeyword("NTG");
-
                 const auto& poroData = poro.getData();
+                const auto& ntg_data = ntg.getData();
                 for (size_t globalIndex = 0; globalIndex < poro.getCartesianSize(); globalIndex++) {
                     if (!std::isfinite(values[globalIndex])) {
                         double cell_poro = poroData[globalIndex];
                         if (std::isnan(cell_poro))
                             throw std::logic_error("Some cells neither specify the PORV keyword nor PORO");
 
-                        double cell_ntg = ntg.iget(globalIndex);
+                        double cell_ntg = ntg_data[globalIndex];
                         double cell_volume = eclipseGrid->getCellVolume(globalIndex);
                         values[globalIndex] = cell_poro * cell_volume * cell_ntg;
                     }

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -630,9 +630,8 @@ namespace Opm {
         if( !this->hasDeckIntGridProperty( keyword ) ) return {};
 
         const auto& property = this->getIntGridProperty( keyword );
-
-        std::set< int > regions( property.getData().begin(),
-                                 property.getData().end() );
+        auto data = property.getData();
+        std::set< int > regions( data.begin(), data.end() );
 
         return { regions.begin(), regions.end() };
     }

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperties.cpp
@@ -517,13 +517,15 @@ namespace Opm {
                     result_prop.runPostProcessor();
             }
 
-            std::vector<T>& targetData= result_prop.getData();
+            std::vector<T> targetData = result_prop.getData();
             const std::vector<T>& srcData = getKeyword( srcArray ).getData();
             operate_fptr func = operations.at( operation );
 
             setKeywordBox(record, boxManager);
             for (auto index : boxManager.getActiveBox())
                 targetData[index] = func( targetData[index] , srcData[index] , alpha, beta );
+
+            result_prop.assignData(targetData);
         }
     }
 
@@ -548,7 +550,7 @@ namespace Opm {
                     result_prop.runPostProcessor();
             }
 
-            std::vector<T>& result_data = result_prop.getData();
+            std::vector<T> result_data = result_prop.getData();
             const std::vector<T>& parameter_data = getKeyword( parameter_array ).getData();
             operate_fptr func = operations.at( operation );
             std::vector<bool> mask;
@@ -558,6 +560,8 @@ namespace Opm {
                 if (mask[index])
                     result_data[index] = func(result_data[index], parameter_data[index], alpha, beta);
             }
+
+            result_prop.assignData(result_data);
         }
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -33,6 +33,24 @@
 
 namespace Opm {
 
+
+namespace {
+
+template<typename T>
+void set_element(const std::size_t i,
+                 std::vector<T>& data,
+                 std::vector<bool>& defaulted,
+                 const T value,
+                 const bool def = false) {
+    data[i] = value;
+    defaulted[i] = def;
+}
+
+
+
+}
+
+
     template< typename T >
     static std::function< std::vector< T >( size_t ) > constant( T val ) {
         return [=]( size_t size ) { return std::vector< T >( size, val ); };
@@ -130,10 +148,13 @@ namespace Opm {
         m_ny( ny ),
         m_nz( nz ),
         m_kwInfo( kwInfo ),
-        m_data( kwInfo.initializer()( nx * ny * nz ) ),
-        m_defaulted( nx * ny * nz, true ),
+        m_data(nx*ny*nz),
+        m_defaulted( nx * ny * nz ),
         m_hasRunPostProcessor( false )
-    {}
+    {
+        m_data.assign( kwInfo.initializer()(nx*ny*nz));
+        m_defaulted.assign( std::vector<bool>(nx*ny*nz, true));
+    }
 
     template< typename T >
     size_t GridProperty< T >::getCartesianSize() const {
@@ -162,7 +183,8 @@ namespace Opm {
 
     template< typename T >
     T GridProperty< T >::iget( size_t index ) const {
-        return this->m_data.at( index );
+        auto data = this->m_data.data();
+        return data.at(index);
     }
 
     template< typename T >
@@ -173,7 +195,13 @@ namespace Opm {
 
     template< typename T >
     void GridProperty< T >::iset(size_t index, T value) {
-        this->setElement(index, value);
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+
+        set_element(index, data, defaulted, value);
+
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
     }
 
     template< typename T >
@@ -183,101 +211,163 @@ namespace Opm {
     }
 
     template< typename T >
-    const std::vector< bool >& GridProperty< T >::wasDefaulted() const {
-        return this->m_defaulted;
+    std::vector< bool > GridProperty< T >::wasDefaulted() const {
+        return this->m_defaulted.data();
     }
 
     template< typename T >
-    const std::vector< T >& GridProperty< T >::getData() const {
-        return m_data;
+    std::vector< T > GridProperty< T >::getData() const {
+        return m_data.data();
     }
-
 
     template< typename T >
-    std::vector< T >& GridProperty< T >::getData() {
-        return m_data;
+    void GridProperty< T >::assignData(const std::vector<T>& data) {
+        this->m_data.assign(data);
     }
+
 
     template< typename T >
     void GridProperty< T >::multiplyWith( const GridProperty< T >& other ) {
         if ((m_nx == other.m_nx) && (m_ny == other.m_ny) && (m_nz == other.m_nz)) {
-            for (size_t g=0; g < m_data.size(); g++)
-                m_data[g] *= other.m_data[g];
+            auto data = this->m_data.data();
+            auto other_data = other.m_data.data();
+            for (size_t g=0; g < data.size(); g++)
+                data[g] *= other_data[g];
+
+            this->m_data.assign(data);
         } else
             throw std::invalid_argument("Size mismatch between properties in mulitplyWith.");
     }
 
+
     template< typename T >
     void GridProperty< T >::multiplyValueAtIndex(size_t index, T factor) {
-        m_data[index] *= factor;
+        auto data = this->m_data.data();
+        data[index] *= factor;
+        this->m_data.assign(data);
     }
 
 
 
     template< typename T >
     void GridProperty< T >::maskedSet( T value, const std::vector< bool >& mask ) {
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+
         for (size_t g = 0; g < getCartesianSize(); g++) {
             if (mask[g])
-                this->setElement(g, value);
+                set_element(g, data, defaulted, value);
         }
+
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
         this->assigned = true;
     }
 
     template< typename T >
     void GridProperty< T >::maskedMultiply( T value, const std::vector<bool>& mask ) {
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+
         for (size_t g = 0; g < getCartesianSize(); g++) {
             if (mask[g])
-                m_data[g] *= value;
+                set_element(g, data, defaulted, value * data[g]);
         }
-    }
 
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
+    }
 
     template< typename T >
     void GridProperty< T >::maskedAdd( T value, const std::vector<bool>& mask ) {
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+
         for (size_t g = 0; g < getCartesianSize(); g++) {
             if (mask[g])
-                m_data[g] += value;
+                set_element(g, data, defaulted, value + data[g]);
         }
+
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
     }
 
     template< typename T >
     void GridProperty< T >::maskedCopy( const GridProperty< T >& other, const std::vector< bool >& mask) {
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+        const auto other_data = other.m_data.data();
+        const auto other_defaulted = other.m_defaulted.data();
+
         for (size_t g = 0; g < getCartesianSize(); g++) {
             if (mask[g])
-                this->setElement(g, other.m_data[g], other.m_defaulted[g]);
+                set_element(g, data, defaulted, other_data[g], other_defaulted[g]);
         }
+
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
         this->assigned = other.deckAssigned();
     }
 
     template< typename T >
     void GridProperty< T >::initMask( T value, std::vector< bool >& mask ) const {
+        const auto data = this->m_data.data();
         mask.resize(getCartesianSize());
         for (size_t g = 0; g < getCartesianSize(); g++) {
-            if (m_data[g] == value)
+            if (data[g] == value)
                 mask[g] = true;
             else
                 mask[g] = false;
         }
     }
 
-    template< typename T >
-    void GridProperty< T >::loadFromDeckKeyword( const DeckKeyword& deckKeyword ) {
+    template<>
+    void GridProperty<int>::loadFromDeckKeyword( const DeckKeyword& deckKeyword ) {
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
         const auto& deckItem = getDeckItem(deckKeyword);
         const auto size = deckItem.size();
+        const auto& deck_data = deckItem.getData<int>();
+
         for (size_t dataPointIdx = 0; dataPointIdx < size; ++dataPointIdx) {
             if (!deckItem.defaultApplied(dataPointIdx))
-                setDataPoint(dataPointIdx, dataPointIdx, deckItem);
+                set_element(dataPointIdx, data, defaulted, deck_data[dataPointIdx]);
         }
 
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
         this->assigned = true;
     }
 
-    template< typename T >
-    void GridProperty< T >::loadFromDeckKeyword( const Box& inputBox, const DeckKeyword& deckKeyword) {
+
+    template<>
+    void GridProperty<double>::loadFromDeckKeyword( const DeckKeyword& deckKeyword ) {
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+        const auto& deckItem = getDeckItem(deckKeyword);
+        const auto size = deckItem.size();
+        const auto& deck_data = deckItem.getSIDoubleData();
+
+        for (size_t dataPointIdx = 0; dataPointIdx < size; ++dataPointIdx) {
+            if (!deckItem.defaultApplied(dataPointIdx))
+                set_element(dataPointIdx, data, defaulted, deck_data[dataPointIdx]);
+        }
+
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
+        this->assigned = true;
+    }
+
+
+    template<>
+    void GridProperty<int>::loadFromDeckKeyword( const Box& inputBox, const DeckKeyword& deckKeyword) {
         if (inputBox.isGlobal())
             loadFromDeckKeyword( deckKeyword );
         else {
+            auto data = this->m_data.data();
+            auto defaulted = this->m_defaulted.data();
             const auto& deckItem = getDeckItem(deckKeyword);
+            const auto& deck_data = deckItem.getData<int>();
             const std::vector<size_t>& indexList = inputBox.getIndexList();
             if (indexList.size() == deckItem.size()) {
                 for (size_t sourceIdx = 0; sourceIdx < indexList.size(); sourceIdx++) {
@@ -285,7 +375,7 @@ namespace Opm {
                     if (sourceIdx < deckItem.size()
                         && !deckItem.defaultApplied(sourceIdx))
                         {
-                            setDataPoint(sourceIdx, targetIdx, deckItem);
+                            set_element(targetIdx, data, defaulted, deck_data[sourceIdx]);
                         }
                 }
             } else {
@@ -294,76 +384,142 @@ namespace Opm {
 
                 throw std::invalid_argument("Size mismatch: Box:" + boxSize + "  DeckKeyword:" + keywordSize);
             }
+            this->m_data.assign(data);
+            this->m_defaulted.assign(defaulted);
+        }
+    }
+
+    template<>
+    void GridProperty<double>::loadFromDeckKeyword( const Box& inputBox, const DeckKeyword& deckKeyword) {
+        if (inputBox.isGlobal())
+            loadFromDeckKeyword( deckKeyword );
+        else {
+            auto data = this->m_data.data();
+            auto defaulted = this->m_defaulted.data();
+            const auto& deckItem = getDeckItem(deckKeyword);
+            const auto& deck_data = deckItem.getSIDoubleData();
+            const std::vector<size_t>& indexList = inputBox.getIndexList();
+            if (indexList.size() == deckItem.size()) {
+                for (size_t sourceIdx = 0; sourceIdx < indexList.size(); sourceIdx++) {
+                    size_t targetIdx = indexList[sourceIdx];
+                    if (sourceIdx < deckItem.size()
+                        && !deckItem.defaultApplied(sourceIdx))
+                    {
+                        set_element(targetIdx, data, defaulted, deck_data[sourceIdx]);
+                    }
+                }
+            } else {
+                std::string boxSize = std::to_string(static_cast<long long>(indexList.size()));
+                std::string keywordSize = std::to_string(static_cast<long long>(deckItem.size()));
+
+                throw std::invalid_argument("Size mismatch: Box:" + boxSize + "  DeckKeyword:" + keywordSize);
+            }
+            this->m_data.assign(data);
+            this->m_defaulted.assign(defaulted);
         }
     }
 
     template< typename T >
     void GridProperty< T >::copyFrom( const GridProperty< T >& src, const Box& inputBox ) {
-        if (inputBox.isGlobal())
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+        const auto other_data = src.m_data.data();
+        const auto other_defaulted = src.m_defaulted.data();
+
+        if (inputBox.isGlobal()) {
             for (size_t i = 0; i < src.getCartesianSize(); ++i)
-                this->setElement(i, src.m_data[i], src.m_defaulted[i]);
-        else
+                set_element(i, data, defaulted, other_data[i], other_defaulted[i]);
+        } else {
             for (const auto& i : inputBox.getIndexList())
-                this->setElement(i, src.m_data[i], src.m_defaulted[i]);
+                set_element(i, data, defaulted, other_data[i], other_defaulted[i]);
+        }
+
         this->assigned = src.deckAssigned();
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
     }
 
     template< typename T >
     void GridProperty< T >::maxvalue( T value, const Box& inputBox ) {
-        if (inputBox.isGlobal())
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+
+        if (inputBox.isGlobal()) {
             for (size_t i = 0; i < m_data.size(); ++i)
-                this->setElement(i, std::min(value, this->m_data[i]));
-        else
+                set_element(i, data, defaulted, std::min(value, data[i]));
+        } else {
             for (const auto& i : inputBox.getIndexList())
-                this->setElement(i, std::min(value, this->m_data[i]));
+                set_element(i, data, defaulted, std::min(value, data[i]));
+        }
+
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
     }
 
     template< typename T >
     void GridProperty< T >::minvalue( T value, const Box& inputBox ) {
-        if (inputBox.isGlobal())
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+
+        if (inputBox.isGlobal()) {
             for (size_t i = 0; i < m_data.size(); ++i)
-                this->setElement(i, std::max(value, this->m_data[i]));
-        else
+                set_element(i, data, defaulted, std::max(value, data[i]));
+        } else {
             for (const auto& i : inputBox.getIndexList())
-                this->setElement(i, std::max(value, this->m_data[i]));
+                set_element(i, data, defaulted, std::max(value, data[i]));
+        }
+
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
     }
 
     template< typename T >
     void GridProperty< T >::scale( T scaleFactor, const Box& inputBox ) {
+        auto data = this->m_data.data();
         if (inputBox.isGlobal()) {
-            for (size_t i = 0; i < m_data.size(); ++i)
-                m_data[i] *= scaleFactor;
+            for (size_t i = 0; i < data.size(); ++i)
+                data[i] *= scaleFactor;
         } else {
             const std::vector<size_t>& indexList = inputBox.getIndexList();
             for (size_t i = 0; i < indexList.size(); i++) {
                 size_t targetIndex = indexList[i];
-                m_data[targetIndex] *= scaleFactor;
+                data[targetIndex] *= scaleFactor;
             }
         }
+        this->m_data.assign(data);
     }
 
     template< typename T >
     void GridProperty< T >::add( T shiftValue, const Box& inputBox ) {
+        auto data = this->m_data.data();
         if (inputBox.isGlobal()) {
-            for (size_t i = 0; i < m_data.size(); ++i)
-                m_data[i] += shiftValue;
+            for (size_t i = 0; i < data.size(); ++i)
+                data[i] += shiftValue;
         } else {
             const std::vector<size_t>& indexList = inputBox.getIndexList();
             for (size_t i = 0; i < indexList.size(); i++) {
                 size_t targetIndex = indexList[i];
-                m_data[targetIndex] += shiftValue;
+                data[targetIndex] += shiftValue;
             }
         }
+        this->m_data.assign(data);
     }
 
     template< typename T >
     void GridProperty< T >::setScalar( T value, const Box& inputBox ) {
+        auto data = this->m_data.data();
+        auto defaulted = this->m_defaulted.data();
+
         if (inputBox.isGlobal()) {
-            std::fill(m_data.begin(), m_data.end(), value);
-            m_defaulted.assign(m_defaulted.size(), false);
-        } else
+            std::fill(data.begin(), data.end(), value);
+            defaulted.assign(defaulted.size(), false);
+        } else {
             for (const auto& i : inputBox.getIndexList())
-                this->setElement(i, value);
+                set_element(i, data, defaulted, value);
+        }
+
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
         this->assigned = true;
     }
 
@@ -382,13 +538,19 @@ namespace Opm {
     void GridProperty< T >::runPostProcessor() {
         if( this->m_hasRunPostProcessor ) return;
         this->m_hasRunPostProcessor = true;
-        this->m_kwInfo.postProcessor()( m_defaulted, m_data );
+
+        auto defaulted = this->m_defaulted.data();
+        auto data = this->m_data.data();
+        this->m_kwInfo.postProcessor()( defaulted, data );
+        this->m_data.assign(data);
+        this->m_defaulted.assign(defaulted);
     }
 
     template< typename T >
     void GridProperty< T >::checkLimits( T min, T max ) const {
-        for (size_t g=0; g < m_data.size(); g++) {
-            T value = m_data[g];
+        auto data = this->m_data.data();
+        for (size_t g=0; g < data.size(); g++) {
+            T value = data[g];
             if ((value < min) || (value > max))
                 throw std::invalid_argument("Property element " + std::to_string( value) + " in " + getKeywordName() + " outside valid limits: [" + std::to_string(min) + ", " + std::to_string(max) + "]");
         }
@@ -416,23 +578,6 @@ namespace Opm {
     }
 
 template<>
-void GridProperty<int>::setDataPoint(size_t sourceIdx, size_t targetIdx, const DeckItem& deckItem) {
-    this->setElement(targetIdx, deckItem.get< int >(sourceIdx));
-}
-
-template<>
-void GridProperty<double>::setDataPoint(size_t sourceIdx, size_t targetIdx, const DeckItem& deckItem) {
-    this->setElement(targetIdx, deckItem.getSIDouble(sourceIdx));
-}
-
-    template <typename T>
-    void GridProperty<T>::setElement(const typename std::vector<T>::size_type i, const T value, const bool defaulted) {
-        this->m_data[i] = value;
-        this->m_defaulted[i] = defaulted;
-    }
-
-
-template<>
 bool GridProperty<int>::containsNaN( ) const {
     throw std::logic_error("Only <double> and can be meaningfully queried for nan");
 }
@@ -440,10 +585,11 @@ bool GridProperty<int>::containsNaN( ) const {
 template<>
 bool GridProperty<double>::containsNaN( ) const {
     bool return_value = false;
-    size_t size = m_data.size();
+    auto data = this->m_data.data();
+    size_t size = data.size();
     size_t index = 0;
     while (true) {
-        if (std::isnan(m_data[index])) {
+        if (std::isnan(data[index])) {
             return_value = true;
             break;
         }
@@ -468,10 +614,11 @@ const std::string& GridProperty<double>::getDimensionString() const {
 
 template<typename T>
 std::vector<T> GridProperty<T>::compressedCopy(const EclipseGrid& grid) const {
+    auto data = this->m_data.data();
     if (grid.allActive())
-        return m_data;
+        return data;
     else {
-        return grid.compressedVector( m_data );
+        return grid.compressedVector( data );
     }
 }
 
@@ -480,9 +627,10 @@ std::vector<T> GridProperty<T>::compressedCopy(const EclipseGrid& grid) const {
 template<typename T>
 std::vector<size_t> GridProperty<T>::cellsEqual(T value, const std::vector<int>& activeMap) const {
     std::vector<size_t> cells;
+    auto data = this->m_data.data();
     for (size_t active_index = 0; active_index < activeMap.size(); active_index++) {
         size_t global_index = activeMap[ active_index ];
-        if (m_data[global_index] == value)
+        if (data[global_index] == value)
             cells.push_back( active_index );
     }
     return cells;
@@ -492,8 +640,9 @@ std::vector<size_t> GridProperty<T>::cellsEqual(T value, const std::vector<int>&
 template<typename T>
 std::vector<size_t> GridProperty<T>::indexEqual(T value) const {
     std::vector<size_t> index_list;
-    for (size_t index = 0; index < m_data.size(); index++) {
-        if (m_data[index] == value)
+    auto data = this->m_data.data();
+    for (size_t index = 0; index < data.size(); index++) {
+        if (data[index] == value)
             index_list.push_back( index );
     }
     return index_list;

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -166,6 +166,7 @@ void set_element(const std::size_t i,
         return m_nx;
     }
 
+
     template< typename T >
     size_t GridProperty< T >::getNY() const {
         return m_ny;
@@ -179,35 +180,6 @@ void set_element(const std::size_t i,
     template< typename T >
     bool GridProperty<T>::deckAssigned() const {
         return this->assigned;
-    }
-
-    template< typename T >
-    T GridProperty< T >::iget( size_t index ) const {
-        auto data = this->m_data.data();
-        return data.at(index);
-    }
-
-    template< typename T >
-    T GridProperty< T >::iget(size_t i , size_t j , size_t k) const {
-        size_t g = i + j*m_nx + k*m_nx*m_ny;
-        return iget(g);
-    }
-
-    template< typename T >
-    void GridProperty< T >::iset(size_t index, T value) {
-        auto data = this->m_data.data();
-        auto defaulted = this->m_defaulted.data();
-
-        set_element(index, data, defaulted, value);
-
-        this->m_data.assign(data);
-        this->m_defaulted.assign(defaulted);
-    }
-
-    template< typename T >
-    void GridProperty< T >::iset(size_t i , size_t j , size_t k , T value) {
-        size_t g = i + j*m_nx + k*m_nx*m_ny;
-        iset(g,value);
     }
 
     template< typename T >

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -224,9 +224,10 @@ namespace Opm {
         for (auto iter = m_searchMap.begin(); iter != m_searchMap.end(); iter++) {
             const Opm::GridProperty<int>& region = m_e3DProps.getIntGridProperty( (*iter).first );
             const MULTREGTSearchMap& map = (*iter).second;
+            const auto& region_data = region.getData();
 
-            int regionId1 = region.iget(globalIndex1);
-            int regionId2 = region.iget(globalIndex2);
+            int regionId1 = region_data[globalIndex1];
+            int regionId2 = region_data[globalIndex2];
 
             std::pair<int,int> pair{ regionId1, regionId2 };
             if (map.count(pair) != 1 || !(map.at(pair)->directions & faceDir)) {

--- a/src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
@@ -759,11 +759,13 @@ namespace Opm {
         // assign a NaN in this case...
         const bool useEnptvd = tableManager->useEnptvd();
         const auto& enptvdTables = tableManager->getEnptvdTables();
+        const auto& satnum_data = satnum.getData();
+        const auto& endnum_data = endnum.getData();
 
         const auto gridsize = eclipseGrid->getCartesianSize();
         for( size_t cellIdx = 0; cellIdx < gridsize; cellIdx++ ) {
-            int satTableIdx = satnum.iget( cellIdx ) - 1;
-            int endNum = endnum.iget( cellIdx ) - 1;
+            int satTableIdx = satnum_data[cellIdx] - 1;
+            int endNum = endnum_data[cellIdx] - 1;
 
             if (! eclipseGrid->cellActive(cellIdx)) {
                 // Pick from appropriate saturation region if defined
@@ -824,9 +826,11 @@ namespace Opm {
         const bool useImptvd = tableManager->useImptvd();
         const TableContainer& imptvdTables = tableManager->getImptvdTables();
         const auto gridsize = eclipseGrid->getCartesianSize();
+        const auto& imbnum_data = imbnum.getData();
+        const auto& endnum_data = endnum.getData();
         for( size_t cellIdx = 0; cellIdx < gridsize; cellIdx++ ) {
-            int imbTableIdx = imbnum.iget( cellIdx ) - 1;
-            int endNum = endnum.iget( cellIdx ) - 1;
+            int imbTableIdx = imbnum_data[ cellIdx ] - 1;
+            int endNum = endnum_data[ cellIdx ] - 1;
 
             if (! eclipseGrid->cellActive(cellIdx)) {
                 // Pick from appropriate saturation region if defined

--- a/src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
@@ -67,7 +67,8 @@ namespace Opm {
 
     double TransMult::getMultiplier__(size_t globalIndex,  FaceDir::DirEnum faceDir) const {
         if (hasDirectionProperty( faceDir )) {
-            return m_trans.at(faceDir).iget( globalIndex );
+            const auto& data = m_trans.at(faceDir).getData();
+            return data[globalIndex];
         } else
             return 1.0;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -209,7 +209,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         int K2 = record.getItem("K2").get< int >(0) - 1;
         Connection::State state = Connection::StateFromString( record.getItem("STATE").getTrimmedString(0) );
 
-        const auto& satnum = eclipseProperties.getIntGridProperty("SATNUM");
+        const auto& satnum_data = eclipseProperties.getIntGridProperty("SATNUM").getData();
         int satTableId = -1;
         bool defaultSatTable = true;
         const auto& CFItem = record.getItem("CONNECTION_TRANSMISSIBILITY_FACTOR");
@@ -242,7 +242,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
             double Kh = -1;
 
             if (defaultSatTable)
-                satTableId = satnum.iget(grid.getGlobalIndex(I,J,k));
+                satTableId = satnum_data[grid.getGlobalIndex(I,J,k)];
 
             auto same_ijk = [&]( const Connection& c ) {
                 return c.sameCoordinate( I,J,k );

--- a/tests/parser/ADDREGTests.cpp
+++ b/tests/parser/ADDREGTests.cpp
@@ -267,14 +267,14 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    const auto& property = props.getIntGridProperty("SATNUM");
+    const auto& property_data = props.getIntGridProperty("SATNUM").getData();
 
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_EQUAL( 12 , property.iget(i,j,0));
+                BOOST_CHECK_EQUAL( 12 , property_data[eg.getGlobalIndex(i,j,0)]);
             else
-                BOOST_CHECK_EQUAL( 21 , property.iget(i,j,0));
+                BOOST_CHECK_EQUAL( 21 , property_data[eg.getGlobalIndex(i,j,0)]);
         }
 
 }
@@ -285,13 +285,13 @@ BOOST_AUTO_TEST_CASE(UnitAppliedCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    const auto& permx = props.getDoubleGridProperty("PERMX");
+    const auto& permx_data = props.getDoubleGridProperty("PERMX").getData();
 
     for (size_t j=0; j< 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_CLOSE( 2 * Opm::Metric::Permeability , permx.iget(i,j,0), 0.0001);
+                BOOST_CHECK_CLOSE( 2 * Opm::Metric::Permeability , permx_data[eg.getGlobalIndex(i,j,0)], 0.0001);
             else
-                BOOST_CHECK_CLOSE( 4 * Opm::Metric::Permeability , permx.iget(i,j,0), 0.0001);
+                BOOST_CHECK_CLOSE( 4 * Opm::Metric::Permeability , permx_data[eg.getGlobalIndex(i,j,0)], 0.0001);
         }
 }

--- a/tests/parser/CopyRegTests.cpp
+++ b/tests/parser/CopyRegTests.cpp
@@ -218,13 +218,14 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    auto& property = props.getIntGridProperty("FLUXNUM");
+    const auto& property = props.getIntGridProperty("FLUXNUM").getData();
 
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
+            std::size_t g = eg.getGlobalIndex(i,j,0);
             if (i < 2)
-                BOOST_CHECK_EQUAL( 10 , property.iget(i,j,0));
+                BOOST_CHECK_EQUAL( 10 , property[g]);
             else
-                BOOST_CHECK_EQUAL( 3 , property.iget(i,j,0));
+                BOOST_CHECK_EQUAL( 3 , property[g]);
         }
 }

--- a/tests/parser/Eclipse3DPropertiesTests.cpp
+++ b/tests/parser/Eclipse3DPropertiesTests.cpp
@@ -322,31 +322,33 @@ BOOST_AUTO_TEST_CASE(IntGridProperty) {
 
 BOOST_AUTO_TEST_CASE(AddregIntSetCorrectly) {
     Setup s(createValidIntDeck());
-    const auto& property = s.props.getIntGridProperty("SATNUM");
+    const auto& grid = s.grid;
+    const auto& property = s.props.getIntGridProperty("SATNUM").getData();
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_EQUAL(12, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(12, property[grid.getGlobalIndex(i, j, 0)]);
             else
-                BOOST_CHECK_EQUAL(21, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(21, property[grid.getGlobalIndex(i, j, 0)]);
         }
 
 }
 
 BOOST_AUTO_TEST_CASE(RocknumTest) {
     Setup s(createDeck());
-    const auto& rocknum = s.props.getIntGridProperty("ROCKNUM");
+    const auto& grid = s.grid;
+    const auto& rocknum = s.props.getIntGridProperty("ROCKNUM").getData();
     for (size_t i = 0; i < 10; i++) {
         for (size_t j = 0; j < 10; j++) {
             for (size_t k = 0; k < 10; k++) {
                 if (k < 2)
-                    BOOST_CHECK_EQUAL(1, rocknum.iget(i, j, k));
+                    BOOST_CHECK_EQUAL(1, rocknum[grid.getGlobalIndex(i, j, k)]);
                 else if (k < 4)
-                    BOOST_CHECK_EQUAL(2, rocknum.iget(i, j, k));
+                    BOOST_CHECK_EQUAL(2, rocknum[grid.getGlobalIndex(i, j, k)]);
                 else if (k < 6)
-                    BOOST_CHECK_EQUAL(3, rocknum.iget(i, j, k));
+                    BOOST_CHECK_EQUAL(3, rocknum[grid.getGlobalIndex(i, j, k)]);
                 else
-                    BOOST_CHECK_EQUAL(4, rocknum.iget(i, j, k));
+                    BOOST_CHECK_EQUAL(4, rocknum[grid.getGlobalIndex(i, j, k)]);
             }
         }
     }
@@ -354,14 +356,15 @@ BOOST_AUTO_TEST_CASE(RocknumTest) {
 
 BOOST_AUTO_TEST_CASE(PermxUnitAppliedCorrectly) {
     Setup s( createValidPERMXDeck() );
-    const auto& permx = s.props.getDoubleGridProperty("PermX");
+    const auto& grid = s.grid;
+    const auto& permx = s.props.getDoubleGridProperty("PermX").getData();
 
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_CLOSE(2 * Opm::Metric::Permeability, permx.iget(i, j, 0), 0.0001);
+                BOOST_CHECK_CLOSE(2 * Opm::Metric::Permeability, permx[grid.getGlobalIndex(i, j, 0)], 0.0001);
             else
-                BOOST_CHECK_CLOSE(4 * Opm::Metric::Permeability, permx.iget(i, j, 0), 0.0001);
+                BOOST_CHECK_CLOSE(4 * Opm::Metric::Permeability, permx[grid.getGlobalIndex(i, j, 0)], 0.0001);
         }
 }
 
@@ -439,25 +442,26 @@ BOOST_AUTO_TEST_CASE(getRegions) {
 
 BOOST_AUTO_TEST_CASE(RadialPermeabilityTensor) {
     const Setup s(createQuarterCircleDeck());
-
-    const auto& permr   = s.props.getDoubleGridProperty("PERMR");
-    const auto& permtht = s.props.getDoubleGridProperty("PERMTHT");
-    const auto& permz   = s.props.getDoubleGridProperty("PERMZ");
-    const auto& poro    = s.props.getDoubleGridProperty("PORO");
+    const auto& grid = s.grid;
+    const auto& permr   = s.props.getDoubleGridProperty("PERMR").getData();
+    const auto& permtht = s.props.getDoubleGridProperty("PERMTHT").getData();
+    const auto& permz   = s.props.getDoubleGridProperty("PERMZ").getData();
+    const auto& poro    = s.props.getDoubleGridProperty("PORO").getData();
 
     const double check_tol = 1.0e-6;
 
     // Top layer (explicitly assigned)
-    BOOST_CHECK_CLOSE(100.0*Opm::Metric::Permeability, permr.iget(0, 0, 0), check_tol);
-    BOOST_CHECK_CLOSE(permtht.iget(0, 0, 0), permr.iget(0, 0, 0), check_tol);
-    BOOST_CHECK_CLOSE(permz.iget(0, 0, 0), 0.1 * permr.iget(0, 0, 0), check_tol);
-    BOOST_CHECK_CLOSE(0.3, poro.iget(0, 0, 0), check_tol);
+    BOOST_CHECK_CLOSE(100.0*Opm::Metric::Permeability, permr[0], check_tol);
+    BOOST_CHECK_CLOSE(permtht[0], permr[0], check_tol);
+    BOOST_CHECK_CLOSE(permz[0], 0.1 * permr[0], check_tol);
+    BOOST_CHECK_CLOSE(0.3, poro[0], check_tol);
 
     // Middle layer (copied ultimately form top)
-    BOOST_CHECK_CLOSE(100.0*Opm::Metric::Permeability, permr.iget(49, 10, 9), check_tol);
-    BOOST_CHECK_CLOSE(permtht.iget(49, 10, 9), permr.iget(49, 10, 9), check_tol);
-    BOOST_CHECK_CLOSE(permz.iget(49, 10, 9), 0.1 * permr.iget(49, 10, 9), check_tol);
-    BOOST_CHECK_CLOSE(0.3, poro.iget(49, 10, 9), check_tol);
+    std::size_t g = grid.getGlobalIndex(49,10,9);
+    BOOST_CHECK_CLOSE(100.0*Opm::Metric::Permeability, permr[g], check_tol);
+    BOOST_CHECK_CLOSE(permtht[g], permr[g], check_tol);
+    BOOST_CHECK_CLOSE(permz[g], 0.1 * permr[g], check_tol);
+    BOOST_CHECK_CLOSE(0.3, poro[g], check_tol);
 
     {
         const auto& d1 = s.deck.getKeyword("PERMR");
@@ -562,6 +566,7 @@ EQUALS
 
 BOOST_AUTO_TEST_CASE(DefaultedBox) {
   const Setup s(createMultiplyDeck());
+  const auto& grid = s.grid;
 
   const auto& permx   = s.props.getDoubleGridProperty("PERMX");
   const auto& permz   = s.props.getDoubleGridProperty("PERMZ");
@@ -569,8 +574,16 @@ BOOST_AUTO_TEST_CASE(DefaultedBox) {
   const auto& trany   = s.props.getDoubleGridProperty("TRANY");
   const auto& tranz   = s.props.getDoubleGridProperty("TRANZ");
 
-  BOOST_CHECK_EQUAL( permx.iget(0,0,0)        , permz.iget(0,0,0));
-  BOOST_CHECK_EQUAL( permx.iget(0,0,1) * 0.10 , permz.iget(0,0,1));
+  const auto& permx_data   = s.props.getDoubleGridProperty("PERMX").getData();
+  const auto& permz_data   = s.props.getDoubleGridProperty("PERMZ").getData();
+  const auto& tranx_data   = s.props.getDoubleGridProperty("TRANX").getData();
+  const auto& trany_data   = s.props.getDoubleGridProperty("TRANY").getData();
+  const auto& tranz_data   = s.props.getDoubleGridProperty("TRANZ").getData();
+
+  std::size_t g1 = grid.getGlobalIndex(0,0,0);
+  std::size_t g2 = grid.getGlobalIndex(0,0,1);
+  BOOST_CHECK_EQUAL( permx_data[g1]        , permz_data[g1]);
+  BOOST_CHECK_EQUAL( permx_data[g2] * 0.10 , permz_data[g2]);
 
   BOOST_CHECK( permx.deckAssigned() );
   BOOST_CHECK( permz.deckAssigned() );
@@ -723,12 +736,12 @@ MULTIPLY
 
 BOOST_AUTO_TEST_CASE(DefaultedBoxMultiplyPorv) {
     const Setup s(createMultiplyPorvDeck());
-    const auto& porv   = s.props.getDoubleGridProperty("PORV");
-
-    BOOST_CHECK_CLOSE( porv.iget(9,9,4), 100, 1e-5);
-    BOOST_CHECK_CLOSE( porv.iget(0,0,1), 20, 1e-5);
-    BOOST_CHECK_CLOSE( porv.iget(0,0,0), 10, 1e-5);
-    BOOST_CHECK_CLOSE( porv.iget(1,0,0), 11, 1e-5);
+    const auto& porv   = s.props.getDoubleGridProperty("PORV").getData();
+    const auto& grid = s.grid;
+    BOOST_CHECK_CLOSE( porv[grid.getGlobalIndex(9,9,4)], 100, 1e-5);
+    BOOST_CHECK_CLOSE( porv[grid.getGlobalIndex(0,0,1)], 20, 1e-5);
+    BOOST_CHECK_CLOSE( porv[grid.getGlobalIndex(0,0,0)], 10, 1e-5);
+    BOOST_CHECK_CLOSE( porv[grid.getGlobalIndex(1,0,0)], 11, 1e-5);
 }
 
 static Opm::Deck createMultiplyPorvFailDeck() {

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -104,9 +104,11 @@ BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
 
     BOOST_CHECK_EQUAL(1000U , poro.getCartesianSize() );
     BOOST_CHECK_EQUAL(1000U , permx.getCartesianSize() );
+    const auto& poro_data  = poro.getData();
+    const auto& permx_data = permx.getData();
     for (size_t i=0; i < poro.getCartesianSize(); i++) {
-        BOOST_CHECK_EQUAL( 0.10 , poro.iget(i) );
-        BOOST_CHECK_EQUAL( 0.25 * Metric::Permeability , permx.iget(i) );
+        BOOST_CHECK_EQUAL( 0.10 , poro_data[i]);
+        BOOST_CHECK_EQUAL( 0.25 * Metric::Permeability , permx_data[i]);
     }
 }
 
@@ -278,12 +280,10 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
     EclipseState state(deck);
 
     const auto& satNUM = state.get3DProperties().getIntGridProperty( "SATNUM" );
-
+    const auto& satnum_data = satNUM.getData();
     BOOST_CHECK_EQUAL(1000U , satNUM.getCartesianSize() );
     for (size_t i=0; i < satNUM.getCartesianSize(); i++)
-        BOOST_CHECK_EQUAL( 2 , satNUM.iget(i) );
-
-    BOOST_CHECK_THROW( satNUM.iget(100000) , std::out_of_range );
+        BOOST_CHECK_EQUAL( 2 , satnum_data[i]);
 }
 
 BOOST_AUTO_TEST_CASE(GetTransMult) {

--- a/tests/parser/EqualRegTests.cpp
+++ b/tests/parser/EqualRegTests.cpp
@@ -234,13 +234,14 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    auto& property = props.getIntGridProperty("SATNUM");
+    const auto& property = props.getIntGridProperty("SATNUM").getData();
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
+            std::size_t g = eg.getGlobalIndex(i,j,0);
             if (i < 2)
-                BOOST_CHECK_EQUAL(11, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(11, property[g]);
             else
-                BOOST_CHECK_EQUAL(20, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(20, property[g]);
         }
 }
 
@@ -249,11 +250,11 @@ BOOST_AUTO_TEST_CASE(UnitAppliedCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    const auto& permx = props.getDoubleGridProperty("PERMX");
-    const auto& permy = props.getDoubleGridProperty("PERMY");
-    const auto& permz = props.getDoubleGridProperty("PERMZ");
+    const auto& permx = props.getDoubleGridProperty("PERMX").getData();
+    const auto& permy = props.getDoubleGridProperty("PERMY").getData();
+    const auto& permz = props.getDoubleGridProperty("PERMZ").getData();
     for (size_t g = 0; g < 25; g++) {
-        BOOST_CHECK_EQUAL(permz.iget(g), permx.iget(g));
-        BOOST_CHECK_EQUAL(permy.iget(g), permx.iget(g));
+        BOOST_CHECK_EQUAL(permz[g], permx[g]);
+        BOOST_CHECK_EQUAL(permy[g], permx[g]);
     }
 }

--- a/tests/parser/GridPropertyTests.cpp
+++ b/tests/parser/GridPropertyTests.cpp
@@ -61,7 +61,6 @@ static const Opm::DeckKeyword createTABDIMSKeyword( ) {
     return deck.getKeyword("TABDIMS");
 }
 
-BOOST_AUTO_TEST_SUITE(Basic_Proprty_Contents)
 
 BOOST_AUTO_TEST_CASE(Empty) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
@@ -78,8 +77,6 @@ BOOST_AUTO_TEST_CASE(Empty) {
             for (size_t i=0; i < 5; i++) {
                 size_t g = i + j*5 + k*25;
                 BOOST_CHECK_EQUAL( 77 , data[g] );
-                BOOST_CHECK_EQUAL( 77 , gridProperty.iget( g ));
-                BOOST_CHECK_EQUAL( 77 , gridProperty.iget( i,j,k ));
             }
         }
     }
@@ -93,11 +90,15 @@ BOOST_AUTO_TEST_CASE(HasNAN) {
     Opm::GridProperty<double> poro( 2 , 2 , 1 , keywordInfo);
 
     BOOST_CHECK( poro.containsNaN() );
-    poro.iset(0,0.15);
-    poro.iset(1,0.15);
-    poro.iset(2,0.15);
+    auto data = poro.getData();
+    data[0] = 0.15;
+    data[1] = 0.15;
+    data[2] = 0.15;
+    poro.assignData(data);
     BOOST_CHECK( poro.containsNaN() );
-    poro.iset(3,0.15);
+
+    data[3] = 0.15;
+    poro.assignData(data);
     BOOST_CHECK( !poro.containsNaN() );
 }
 
@@ -146,8 +147,6 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword) {
                 size_t g = i + j*4 + k*16;
 
                 BOOST_CHECK_EQUAL( g , data[g] );
-                BOOST_CHECK_EQUAL( g , gridProperty.iget(g) );
-                BOOST_CHECK_EQUAL( g , gridProperty.iget(i,j,k) );
 
             }
         }
@@ -165,12 +164,15 @@ BOOST_AUTO_TEST_CASE(copy) {
     Opm::Box layer0(global, 0, 3, 0, 3, 0, 0);
 
     prop2.copyFrom(prop1, layer0);
+    const auto& prop2_data = prop2.getData();
 
     for (size_t j = 0; j < 4; j++) {
         for (size_t i = 0; i < 4; i++) {
+            std::size_t g1 = i + j*4;
+            std::size_t g2 = g1 + 16;
 
-            BOOST_CHECK_EQUAL(prop2.iget(i, j, 0), 0);
-            BOOST_CHECK_EQUAL(prop2.iget(i, j, 1), 9);
+            BOOST_CHECK_EQUAL(prop2_data[g1], 0);
+            BOOST_CHECK_EQUAL(prop2_data[g2], 9);
         }
     }
 }
@@ -190,12 +192,15 @@ BOOST_AUTO_TEST_CASE(SCALE) {
     prop2.copyFrom( prop1, layer0 );
     prop2.scale( 2, global );
     prop2.scale( 2, layer0 );
+    const auto& prop2_data = prop2.getData();
 
     for (size_t j = 0; j < 4; j++) {
         for (size_t i = 0; i < 4; i++) {
+            std::size_t g1 = i + j*4;
+            std::size_t g2 = g1 + 16;
 
-            BOOST_CHECK_EQUAL( prop2.iget( i, j, 0 ), 4 );
-            BOOST_CHECK_EQUAL( prop2.iget( i, j, 1 ), 18 );
+            BOOST_CHECK_EQUAL( prop2_data[g1], 4 );
+            BOOST_CHECK_EQUAL( prop2_data[g2], 18 );
         }
     }
 }
@@ -210,12 +215,15 @@ BOOST_AUTO_TEST_CASE(SET) {
 
     prop.setScalar( 2, global );
     prop.setScalar( 4, layer0 );
+    const auto& prop_data = prop.getData();
 
     for (size_t j = 0; j < 4; j++) {
         for (size_t i = 0; i < 4; i++) {
+            std::size_t g1 = i + j*4;
+            std::size_t g2 = g1 + 16;
 
-            BOOST_CHECK_EQUAL( prop.iget( i, j, 0 ), 4 );
-            BOOST_CHECK_EQUAL( prop.iget( i, j, 1 ), 2 );
+            BOOST_CHECK_EQUAL( prop_data[g1], 4 );
+            BOOST_CHECK_EQUAL( prop_data[g2], 18 );
         }
     }
 }
@@ -233,12 +241,15 @@ BOOST_AUTO_TEST_CASE(ADD) {
     prop2.copyFrom( prop1, layer0 );
     prop2.add( 2, global );
     prop2.add( 2, layer0 );
+    const auto& prop2_data = prop2.getData();
 
     for (size_t j = 0; j < 4; j++) {
         for (size_t i = 0; i < 4; i++) {
+            std::size_t g1 = i + j*4;
+            std::size_t g2 = g1 + 16;
 
-            BOOST_CHECK_EQUAL( prop2.iget( i, j, 0 ), 5 );
-            BOOST_CHECK_EQUAL( prop2.iget( i, j, 1 ), 11 );
+            BOOST_CHECK_EQUAL( prop2_data[g1], 5 );
+            BOOST_CHECK_EQUAL( prop2_data[g2], 11 );
         }
     }
 }
@@ -453,10 +464,10 @@ BOOST_AUTO_TEST_CASE(GridPropertyInitialization) {
     {
         const auto& double_props = props.getDoubleProperties( );
         const auto& units = deck.getActiveUnitSystem();
-        const auto& permx = double_props.getKeyword("PERMX");
-        BOOST_CHECK_EQUAL(permx.iget(0,0,0), units.to_si(Opm::UnitSystem::measure::permeability, 100));
-        BOOST_CHECK_EQUAL(permx.iget(0,0,1), units.to_si(Opm::UnitSystem::measure::permeability, 1000));
-        BOOST_CHECK_EQUAL(permx.iget(0,0,2), units.to_si(Opm::UnitSystem::measure::permeability, 10000));
+        const auto& permx = double_props.getKeyword("PERMX").getData();
+        BOOST_CHECK_EQUAL(permx[0], units.to_si(Opm::UnitSystem::measure::permeability, 100));
+        BOOST_CHECK_EQUAL(permx[9], units.to_si(Opm::UnitSystem::measure::permeability, 1000));
+        BOOST_CHECK_EQUAL(permx[18], units.to_si(Opm::UnitSystem::measure::permeability, 10000));
     }
 }
 
@@ -482,8 +493,9 @@ BOOST_AUTO_TEST_CASE(multiply) {
     BOOST_CHECK_THROW( p1.multiplyWith(p2) , std::invalid_argument );
     p1.multiplyWith(p3);
 
+    const auto& data = p1.getData();
     for (size_t g = 0; g < p1.getCartesianSize(); g++)
-        BOOST_CHECK_EQUAL( 100 , p1.iget(g));
+        BOOST_CHECK( 100 == data[g]);
 
 }
 
@@ -500,9 +512,9 @@ BOOST_AUTO_TEST_CASE(mask_test) {
 
     p1.initMask(10 , mask);
     p2.maskedSet( 10 , mask);
-
-    for (size_t g = 0; g < p1.getCartesianSize(); g++)
-        BOOST_CHECK_EQUAL( p1.iget(g) , p2.iget(g));
+    const auto& d1 = p1.getData();
+    const auto& d2 = p2.getData();
+    BOOST_CHECK(d1 == d2);
 }
 
 BOOST_AUTO_TEST_CASE(CheckLimits) {
@@ -573,11 +585,8 @@ BOOST_AUTO_TEST_CASE(hasKeyword_assertKeyword) {
     BOOST_CHECK_THROW( gridProperties.getKeyword( "NOT-SUPPORTED" ), std::invalid_argument );
 }
 
-BOOST_AUTO_TEST_SUITE_END()
 
 // =====================================================================
-
-BOOST_AUTO_TEST_SUITE(Defaulted_Flag)
 
 namespace {
 
@@ -738,4 +747,4 @@ END)" };
     }
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+

--- a/tests/parser/MultiRegTests.cpp
+++ b/tests/parser/MultiRegTests.cpp
@@ -234,13 +234,13 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
 
-    const auto& property = props.getIntGridProperty("SATNUM");
+    const auto& property_data = props.getIntGridProperty("SATNUM").getData();
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_EQUAL(11, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(11, property_data[eg.getGlobalIndex(i,j,0)]);
             else
-                BOOST_CHECK_EQUAL(40, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(40, property_data[eg.getGlobalIndex(i,j,0)]);
         }
 }
 
@@ -251,12 +251,12 @@ BOOST_AUTO_TEST_CASE(Test_OPERATER) {
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
 
-    const auto& porv  = props.getDoubleGridProperty("PORV");
-    const auto& permx = props.getDoubleGridProperty("PERMX");
-    const auto& permy = props.getDoubleGridProperty("PERMY");
+    const auto& porv_data  = props.getDoubleGridProperty("PORV").getData();
+    const auto& permx_data = props.getDoubleGridProperty("PERMX").getData();
+    const auto& permy_data = props.getDoubleGridProperty("PERMY").getData();
 
-    BOOST_CHECK_EQUAL( porv.iget(0,0,0), 0.50 );
-    BOOST_CHECK_EQUAL( permx.iget(0) / permy.iget(0), 0.50 );
-    BOOST_CHECK_EQUAL( permx.iget(1), permy.iget(1));
+    BOOST_CHECK_EQUAL( porv_data[0], 0.50 );
+    BOOST_CHECK_EQUAL( permx_data[0] / permy_data[0], 0.50 );
+    BOOST_CHECK_EQUAL( permx_data[1], permy_data[1]);
 }
 

--- a/tests/parser/OrderedMapTests.cpp
+++ b/tests/parser/OrderedMapTests.cpp
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Util/CompressedVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp>
 
@@ -170,3 +171,23 @@ BOOST_AUTO_TEST_CASE(test_IOrderSet) {
     BOOST_CHECK_EQUAL(iset3[0], "BBB");
 }
 
+
+
+
+BOOST_AUTO_TEST_CASE(CompVectorTest) {
+    Opm::CompressedVector<int> v(1000);
+    BOOST_CHECK_EQUAL(v.size(), 1000);
+    std::vector<int> small(10,0);
+    std::vector<int> expected(1000,0);
+    auto data = v.data();
+    BOOST_CHECK(data == expected);
+    BOOST_CHECK_THROW(v.assign(small), std::invalid_argument);
+
+
+    std::vector<int> new_v(1000);
+    for (int i=0; i < 10; i++)
+        std::fill_n(new_v.begin() + i*100, 100, i + 1);
+    v.assign(new_v);
+    auto new_data = v.data();
+    BOOST_CHECK(new_data == new_v);
+}

--- a/tests/parser/PORVTests.cpp
+++ b/tests/parser/PORVTests.cpp
@@ -270,17 +270,17 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoro) {
     const auto& poro = props.getDoubleGridProperty("PORO");
     BOOST_CHECK( !poro.containsNaN() );
 
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
     double cell_volume = 0.25 * 0.25 * 0.25;
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv.iget(9,9,0) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv_data[grid.getGlobalIndex(9,9,0)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(0,0,4) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(9,9,4) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(0,0,4)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(9,9,4)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv.iget(0,0,9) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv_data[grid.getGlobalIndex(0,0,9)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
@@ -289,17 +289,17 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
     Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
     double cell_volume = 0.25 * 0.25 * 0.25;
 
-    BOOST_CHECK_CLOSE( 77.0 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( 77.0 , porv.iget(9,9,0) , 0.001);
+    BOOST_CHECK_CLOSE( 77.0 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( 77.0 , porv_data[grid.getGlobalIndex(9,9,0)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(0,0,4) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(9,9,4) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(0,0,4)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(9,9,4)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv.iget(0,0,9) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv_data[grid.getGlobalIndex(0,0,9)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_multpv) {
@@ -308,21 +308,21 @@ BOOST_AUTO_TEST_CASE(PORV_multpv) {
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
     Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
     double cell_volume = 0.25 * 0.25 * 0.25;
 
-    BOOST_CHECK_CLOSE( 770.0 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( 770.0 , porv.iget(4,4,0) , 0.001);
-    BOOST_CHECK_CLOSE( 77.0 , porv.iget(9,9,0) , 0.001);
+    BOOST_CHECK_CLOSE( 770.0 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( 770.0 , porv_data[grid.getGlobalIndex(4,4,0)] , 0.001);
+    BOOST_CHECK_CLOSE( 77.0 , porv_data[grid.getGlobalIndex(9,9,0)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(0,0,4) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(9,9,4) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(0,0,4)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(9,9,4)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.90 , porv.iget(0,0,8) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.90 , porv.iget(9,9,8) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.90 , porv_data[grid.getGlobalIndex(0,0,8)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.90 , porv_data[grid.getGlobalIndex(9,9,8)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 10.00 , porv.iget(0,0,9) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 10.00 , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 10.00 , porv_data[grid.getGlobalIndex(0,0,9)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 10.00 , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
@@ -331,13 +331,13 @@ BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
     Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
 
-    BOOST_CHECK_CLOSE( 1234.56 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( 1234.56 , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( 1234.56 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( 1234.56 , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 
-    BOOST_CHECK_CLOSE( 7890.12 , porv.iget(1,1,1) , 0.001);
-    BOOST_CHECK_CLOSE( 7890.12 , porv.iget(2,2,2) , 0.001);
+    BOOST_CHECK_CLOSE( 7890.12 , porv_data[grid.getGlobalIndex(1,1,1)] , 0.001);
+    BOOST_CHECK_CLOSE( 7890.12 , porv_data[grid.getGlobalIndex(2,2,2)] , 0.001);
 
 }
 
@@ -347,15 +347,15 @@ BOOST_AUTO_TEST_CASE(PORV_multpvAndNtg) {
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
     Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
     double cell_volume = 0.25 * 0.25 * 0.25;
     double poro = 0.20;
     double multpv = 10;
     double NTG = 2;
     double PORV = 10;
 
-    BOOST_CHECK_CLOSE( PORV * multpv                 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * poro*multpv*NTG , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( PORV * multpv                 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * poro*multpv*NTG , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_multregp) {

--- a/tests/parser/SatfuncPropertyInitializersTests.cpp
+++ b/tests/parser/SatfuncPropertyInitializersTests.cpp
@@ -1,18 +1,18 @@
 /*
   Copyright 2015 IRIS
-  
+
   This file is part of the Open Porous Media project (OPM).
-  
+
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -36,8 +36,8 @@ using namespace Opm;
 inline void check_property(const Eclipse3DProperties& props1,
                            const Eclipse3DProperties& props2,
                            const std::string& propertyName) {
-    auto& data1 = props1.getDoubleGridProperty(propertyName).getData();
-    auto& data2 = props2.getDoubleGridProperty(propertyName).getData();
+    auto data1 = props1.getDoubleGridProperty(propertyName).getData();
+    auto data2 = props2.getDoubleGridProperty(propertyName).getData();
 
     BOOST_CHECK_CLOSE(data1[0], data2[0], 1e-12);
 }

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -47,18 +47,19 @@ inline EclipseState makeState(const std::string& fileName) {
 
 BOOST_AUTO_TEST_CASE( PERMX ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& permx = state.get3DProperties().getDoubleGridProperty( "PERMX" );
-    const auto& permy = state.get3DProperties().getDoubleGridProperty( "PERMY" );
-    const auto& permz = state.get3DProperties().getDoubleGridProperty( "PERMZ" );
+    const auto& permx = state.get3DProperties().getDoubleGridProperty( "PERMX" ).getData();
+    const auto& permy = state.get3DProperties().getDoubleGridProperty( "PERMY" ).getData();
+    const auto& permz = state.get3DProperties().getDoubleGridProperty( "PERMZ" ).getData();
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
     for (k = 0; k < grid.getNZ(); k++) {
         for (j = 0; j < grid.getNY(); j++) {
             for (i = 0; i < grid.getNX(); i++) {
+                std::size_t g = grid.getGlobalIndex(i,j,k);
 
-                BOOST_CHECK_CLOSE( permx.iget( i, j, k ) * 0.25, permz.iget( i, j, k ), 0.001 );
-                BOOST_CHECK_EQUAL( permx.iget( i, j, k ) * 2, permy.iget( i, j, k ) );
+                BOOST_CHECK_CLOSE( permx[g] * 0.25, permz[g], 0.001 );
+                BOOST_CHECK_EQUAL( permx[g] * 2   , permy[g] );
 
             }
         }
@@ -69,7 +70,7 @@ BOOST_AUTO_TEST_CASE( PERMX ) {
 
 BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" );
+    const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" ).getData();
     {
         size_t i, j, k;
         const EclipseGrid& grid = state.getInputGrid();
@@ -79,9 +80,9 @@ BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
 
                     size_t g = i + j * grid.getNX() + k * grid.getNX() * grid.getNY();
                     if (i <= 1 && j <= 1 && k <= 1)
-                        BOOST_CHECK_EQUAL( satnum.iget( g ), 10 );
+                        BOOST_CHECK_EQUAL( satnum[ g ], 10 );
                     else
-                        BOOST_CHECK_EQUAL( satnum.iget( g ), 2 );
+                        BOOST_CHECK_EQUAL( satnum[g], 2 );
 
                 }
             }
@@ -91,8 +92,8 @@ BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
 
 BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" );
-    const auto& fipnum = state.get3DProperties().getIntGridProperty( "FIPNUM" );
+    const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" ).getData();
+    const auto& fipnum = state.get3DProperties().getIntGridProperty( "FIPNUM" ).getData();
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
@@ -100,11 +101,11 @@ BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
         for (j = 0; j < grid.getNY(); j++) {
             for (i = 0; i < grid.getNX(); i++) {
 
-                size_t g = i + j * grid.getNX() + k * grid.getNX() * grid.getNY();
+                size_t g = grid.getGlobalIndex(i,j,k);
                 if (i <= 1 && j <= 1 && k <= 1)
-                    BOOST_CHECK_EQUAL( 4 * satnum.iget( g ), fipnum.iget( g ) );
+                    BOOST_CHECK_EQUAL( 4 * satnum[g], fipnum[g] );
                 else
-                    BOOST_CHECK_EQUAL( 2 * satnum.iget( i, j, k ), fipnum.iget( i, j, k ) );
+                    BOOST_CHECK_EQUAL( 2 * satnum[g], fipnum[g] );
 
             }
         }
@@ -120,20 +121,20 @@ BOOST_AUTO_TEST_CASE( KEYWORD_BOX_TOO_SMALL) {
 
 BOOST_AUTO_TEST_CASE( EQUALS ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& pvtnum = state.get3DProperties().getIntGridProperty( "PVTNUM" );
-    const auto& eqlnum = state.get3DProperties().getIntGridProperty( "EQLNUM" );
-    const auto& poro = state.get3DProperties().getDoubleGridProperty( "PORO" );
+    const auto& pvtnum = state.get3DProperties().getIntGridProperty( "PVTNUM" ).getData();
+    const auto& eqlnum = state.get3DProperties().getIntGridProperty( "EQLNUM" ).getData();
+    const auto& poro = state.get3DProperties().getDoubleGridProperty( "PORO" ).getData();
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
     for (k = 0; k < grid.getNZ(); k++) {
         for (j = 0; j < grid.getNY(); j++) {
             for (i = 0; i < grid.getNX(); i++) {
+                size_t g = grid.getGlobalIndex(i,j,k);
 
-                BOOST_CHECK_EQUAL( pvtnum.iget( i, j, k ), k );
-                BOOST_CHECK_EQUAL( eqlnum.iget( i, j, k ), 77 + 2 * k );
-                BOOST_CHECK_EQUAL( poro.iget( i, j, k ), 0.25 );
-
+                BOOST_CHECK_EQUAL( pvtnum[g], k );
+                BOOST_CHECK_EQUAL( eqlnum[g], 77 + 2 * k );
+                BOOST_CHECK_EQUAL( poro[g], 0.25 );
             }
         }
     }
@@ -142,18 +143,15 @@ BOOST_AUTO_TEST_CASE( EQUALS ) {
 
 BOOST_AUTO_TEST_CASE( OPERATE ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& ntg = state.get3DProperties().getDoubleGridProperty( "NTG" );
+    const EclipseGrid& grid = state.getInputGrid();
+    const auto& ntg = state.get3DProperties().getDoubleGridProperty( "NTG" ).getData();
 
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,0) , 8.50 );  // MULTA
-    BOOST_CHECK_EQUAL( ntg.iget( 0,5,0) , 5.00 );  // POLY
-
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,1) , 4.0 );  // COPY
-    BOOST_CHECK_EQUAL( ntg.iget( 0,5,1) , 4.0 );  // MINLIM
-
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,2) , 2.0 );  // MAXLIM
-
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,3) , 0.5 );  // MAXVALUE
-
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,4) , 1.5 );  // MINVALUE
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,0)], 8.50 );  // MULTA
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,5,0)], 5.00 );  // POLY
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,1)], 4.0 );  // COPY
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,5,1)], 4.0 );  // MINLIM
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,2)], 2.0 );  // MAXLIM
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,3)], 0.5 );  // MAXVALUE
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,4)], 1.5 );  // MINVALUE
 }
 


### PR DESCRIPTION
This is a *desperate hack* to try to reduce the memory requirements of the property fields. The PR is based on modelling the data for fields as a list of `{offset, count, value}` triplets, which should compress data with many repeated values quite well. It is quite easy to point weirdness with this code; but it has been interesting to work with - and maybe an avenue to explore further. 

The PR works in opm-common, with the following caveats:

1. The parsing time increases - on norne it increases with ~50%; simulator runtime is not affected.
2. I lost steam when I came to opm-material - so this not ready for actual testing. I will be away for a couple of days, so I do not have ability to look into the downstream before next week.
3. In the case of large models with many inactive cells this should significantly reduce memory consumption, for small SPE style models the memory use will go up. I have briefly tried some other approaches which should have better memory performance also for small models - but the initial attempts had very long parsing time. (~ norne increased with a factor 3).
 
An obvious alternative way to do this is to use the active cells from the grid to do the mapping; that is probably a better solution - but also a more significant refactoring.
