### PR TITLE
Remove index access to GridProperty<T>

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -147,15 +147,11 @@ public:
     size_t getNZ() const;
 
 
-    T iget(size_t index) const;
-    T iget(size_t i , size_t j , size_t k) const;
-    void iset(size_t index, T value);
-    void iset(size_t i , size_t j , size_t k , T value);
-
 
     const std::vector<bool>& wasDefaulted() const;
-    const std::vector<T>& getData() const;
-    std::vector<T>& getData();
+    const std::vector< T >& getData() const;
+    void assignData(std::vector<T>&& data);
+    void assignData(const std::vector<T>& data);
 
     bool containsNaN() const;
     const std::string& getDimensionString() const;

--- a/src/opm/output/eclipse/RegionCache.cpp
+++ b/src/opm/output/eclipse/RegionCache.cpp
@@ -31,7 +31,7 @@ namespace Opm {
 namespace out {
 
 RegionCache::RegionCache(const Eclipse3DProperties& properties, const EclipseGrid& grid, const Schedule& schedule) {
-    const auto& fipnum = properties.getIntGridProperty("FIPNUM");
+    const auto& fipnum_data = properties.getIntGridProperty("FIPNUM").getData();
 
     const auto& wells = schedule.getWells2atEnd();
     for (const auto& well : wells) {
@@ -40,7 +40,7 @@ RegionCache::RegionCache(const Eclipse3DProperties& properties, const EclipseGri
             size_t global_index = grid.getGlobalIndex( c.getI() , c.getJ() , c.getK());
             if (grid.cellActive( global_index )) {
                 size_t active_index = grid.activeIndex( global_index );
-                int region_id =fipnum.iget( global_index );
+                int region_id = fipnum_data[global_index];
                 auto& well_index_list = this->connection_map[ region_id ];
                 well_index_list.push_back( { well.name() , active_index } );
             }

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -78,15 +78,15 @@ namespace Opm {
             if ( doubleGridProperties->hasKeyword("PORO") ) {
                 const auto& poro = doubleGridProperties->getKeyword("PORO");
                 const auto& ntg =  doubleGridProperties->getKeyword("NTG");
-
                 const auto& poroData = poro.getData();
+                const auto& ntg_data = ntg.getData();
                 for (size_t globalIndex = 0; globalIndex < poro.getCartesianSize(); globalIndex++) {
                     if (!std::isfinite(values[globalIndex])) {
                         double cell_poro = poroData[globalIndex];
                         if (std::isnan(cell_poro))
                             throw std::logic_error("Some cells neither specify the PORV keyword nor PORO");
 
-                        double cell_ntg = ntg.iget(globalIndex);
+                        double cell_ntg = ntg_data[globalIndex];
                         double cell_volume = eclipseGrid->getCellVolume(globalIndex);
                         values[globalIndex] = cell_poro * cell_volume * cell_ntg;
                     }
@@ -630,9 +630,8 @@ namespace Opm {
         if( !this->hasDeckIntGridProperty( keyword ) ) return {};
 
         const auto& property = this->getIntGridProperty( keyword );
-
-        std::set< int > regions( property.getData().begin(),
-                                 property.getData().end() );
+        auto data = property.getData();
+        std::set< int > regions( data.begin(), data.end() );
 
         return { regions.begin(), regions.end() };
     }

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperties.cpp
@@ -517,13 +517,15 @@ namespace Opm {
                     result_prop.runPostProcessor();
             }
 
-            std::vector<T>& targetData= result_prop.getData();
+            std::vector<T> targetData = result_prop.getData();
             const std::vector<T>& srcData = getKeyword( srcArray ).getData();
             operate_fptr func = operations.at( operation );
 
             setKeywordBox(record, boxManager);
             for (auto index : boxManager.getActiveBox().getIndexList())
                 targetData[index] = func( targetData[index] , srcData[index] , alpha, beta );
+
+            result_prop.assignData(targetData);
         }
     }
 
@@ -548,7 +550,7 @@ namespace Opm {
                     result_prop.runPostProcessor();
             }
 
-            std::vector<T>& result_data = result_prop.getData();
+            std::vector<T> result_data = result_prop.getData();
             const std::vector<T>& parameter_data = getKeyword( parameter_array ).getData();
             operate_fptr func = operations.at( operation );
             std::vector<bool> mask;
@@ -558,6 +560,8 @@ namespace Opm {
                 if (mask[index])
                     result_data[index] = func(result_data[index], parameter_data[index], alpha, beta);
             }
+
+            result_prop.assignData(result_data);
         }
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -160,27 +160,6 @@ namespace Opm {
         return this->assigned;
     }
 
-    template< typename T >
-    T GridProperty< T >::iget( size_t index ) const {
-        return this->m_data.at( index );
-    }
-
-    template< typename T >
-    T GridProperty< T >::iget(size_t i , size_t j , size_t k) const {
-        size_t g = i + j*m_nx + k*m_nx*m_ny;
-        return iget(g);
-    }
-
-    template< typename T >
-    void GridProperty< T >::iset(size_t index, T value) {
-        this->setElement(index, value);
-    }
-
-    template< typename T >
-    void GridProperty< T >::iset(size_t i , size_t j , size_t k , T value) {
-        size_t g = i + j*m_nx + k*m_nx*m_ny;
-        iset(g,value);
-    }
 
     template< typename T >
     const std::vector< bool >& GridProperty< T >::wasDefaulted() const {
@@ -192,10 +171,14 @@ namespace Opm {
         return m_data;
     }
 
+    template< typename T >
+    void GridProperty< T >::assignData(std::vector<T>&& data) {
+        this->m_data = std::move(data);
+    }
 
     template< typename T >
-    std::vector< T >& GridProperty< T >::getData() {
-        return m_data;
+    void GridProperty< T >::assignData(const std::vector<T>& data) {
+        this->m_data = data;
     }
 
     template< typename T >

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -224,9 +224,10 @@ namespace Opm {
         for (auto iter = m_searchMap.begin(); iter != m_searchMap.end(); iter++) {
             const Opm::GridProperty<int>& region = m_e3DProps.getIntGridProperty( (*iter).first );
             const MULTREGTSearchMap& map = (*iter).second;
+            const auto& region_data = region.getData();
 
-            int regionId1 = region.iget(globalIndex1);
-            int regionId2 = region.iget(globalIndex2);
+            int regionId1 = region_data[globalIndex1];
+            int regionId2 = region_data[globalIndex2];
 
             std::pair<int,int> pair{ regionId1, regionId2 };
             if (map.count(pair) != 1 || !(map.at(pair)->directions & faceDir)) {

--- a/src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
@@ -759,11 +759,13 @@ namespace Opm {
         // assign a NaN in this case...
         const bool useEnptvd = tableManager->useEnptvd();
         const auto& enptvdTables = tableManager->getEnptvdTables();
+        const auto& satnum_data = satnum.getData();
+        const auto& endnum_data = endnum.getData();
 
         const auto gridsize = eclipseGrid->getCartesianSize();
         for( size_t cellIdx = 0; cellIdx < gridsize; cellIdx++ ) {
-            int satTableIdx = satnum.iget( cellIdx ) - 1;
-            int endNum = endnum.iget( cellIdx ) - 1;
+            int satTableIdx = satnum_data[cellIdx] - 1;
+            int endNum = endnum_data[cellIdx] - 1;
 
             if (! eclipseGrid->cellActive(cellIdx)) {
                 // Pick from appropriate saturation region if defined
@@ -824,9 +826,11 @@ namespace Opm {
         const bool useImptvd = tableManager->useImptvd();
         const TableContainer& imptvdTables = tableManager->getImptvdTables();
         const auto gridsize = eclipseGrid->getCartesianSize();
+        const auto& imbnum_data = imbnum.getData();
+        const auto& endnum_data = endnum.getData();
         for( size_t cellIdx = 0; cellIdx < gridsize; cellIdx++ ) {
-            int imbTableIdx = imbnum.iget( cellIdx ) - 1;
-            int endNum = endnum.iget( cellIdx ) - 1;
+            int imbTableIdx = imbnum_data[ cellIdx ] - 1;
+            int endNum = endnum_data[ cellIdx ] - 1;
 
             if (! eclipseGrid->cellActive(cellIdx)) {
                 // Pick from appropriate saturation region if defined

--- a/src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
@@ -67,7 +67,8 @@ namespace Opm {
 
     double TransMult::getMultiplier__(size_t globalIndex,  FaceDir::DirEnum faceDir) const {
         if (hasDirectionProperty( faceDir )) {
-            return m_trans.at(faceDir).iget( globalIndex );
+            const auto& data = m_trans.at(faceDir).getData();
+            return data[globalIndex];
         } else
             return 1.0;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -209,7 +209,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         int K2 = record.getItem("K2").get< int >(0) - 1;
         Connection::State state = Connection::StateFromString( record.getItem("STATE").getTrimmedString(0) );
 
-        const auto& satnum = eclipseProperties.getIntGridProperty("SATNUM");
+        const auto& satnum_data = eclipseProperties.getIntGridProperty("SATNUM").getData();
         int satTableId = -1;
         bool defaultSatTable = true;
         const auto& CFItem = record.getItem("CONNECTION_TRANSMISSIBILITY_FACTOR");
@@ -242,7 +242,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
             double Kh = -1;
 
             if (defaultSatTable)
-                satTableId = satnum.iget(grid.getGlobalIndex(I,J,k));
+                satTableId = satnum_data[grid.getGlobalIndex(I,J,k)];
 
             auto same_ijk = [&]( const Connection& c ) {
                 return c.sameCoordinate( I,J,k );

--- a/tests/parser/ADDREGTests.cpp
+++ b/tests/parser/ADDREGTests.cpp
@@ -267,14 +267,14 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    const auto& property = props.getIntGridProperty("SATNUM");
+    const auto& property_data = props.getIntGridProperty("SATNUM").getData();
 
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_EQUAL( 12 , property.iget(i,j,0));
+                BOOST_CHECK_EQUAL( 12 , property_data[eg.getGlobalIndex(i,j,0)]);
             else
-                BOOST_CHECK_EQUAL( 21 , property.iget(i,j,0));
+                BOOST_CHECK_EQUAL( 21 , property_data[eg.getGlobalIndex(i,j,0)]);
         }
 
 }
@@ -285,13 +285,13 @@ BOOST_AUTO_TEST_CASE(UnitAppliedCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    const auto& permx = props.getDoubleGridProperty("PERMX");
+    const auto& permx_data = props.getDoubleGridProperty("PERMX").getData();
 
     for (size_t j=0; j< 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_CLOSE( 2 * Opm::Metric::Permeability , permx.iget(i,j,0), 0.0001);
+                BOOST_CHECK_CLOSE( 2 * Opm::Metric::Permeability , permx_data[eg.getGlobalIndex(i,j,0)], 0.0001);
             else
-                BOOST_CHECK_CLOSE( 4 * Opm::Metric::Permeability , permx.iget(i,j,0), 0.0001);
+                BOOST_CHECK_CLOSE( 4 * Opm::Metric::Permeability , permx_data[eg.getGlobalIndex(i,j,0)], 0.0001);
         }
 }

--- a/tests/parser/CopyRegTests.cpp
+++ b/tests/parser/CopyRegTests.cpp
@@ -218,13 +218,14 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    auto& property = props.getIntGridProperty("FLUXNUM");
+    const auto& property = props.getIntGridProperty("FLUXNUM").getData();
 
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
+            std::size_t g = eg.getGlobalIndex(i,j,0);
             if (i < 2)
-                BOOST_CHECK_EQUAL( 10 , property.iget(i,j,0));
+                BOOST_CHECK_EQUAL( 10 , property[g]);
             else
-                BOOST_CHECK_EQUAL( 3 , property.iget(i,j,0));
+                BOOST_CHECK_EQUAL( 3 , property[g]);
         }
 }

--- a/tests/parser/Eclipse3DPropertiesTests.cpp
+++ b/tests/parser/Eclipse3DPropertiesTests.cpp
@@ -322,31 +322,33 @@ BOOST_AUTO_TEST_CASE(IntGridProperty) {
 
 BOOST_AUTO_TEST_CASE(AddregIntSetCorrectly) {
     Setup s(createValidIntDeck());
-    const auto& property = s.props.getIntGridProperty("SATNUM");
+    const auto& grid = s.grid;
+    const auto& property = s.props.getIntGridProperty("SATNUM").getData();
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_EQUAL(12, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(12, property[grid.getGlobalIndex(i, j, 0)]);
             else
-                BOOST_CHECK_EQUAL(21, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(21, property[grid.getGlobalIndex(i, j, 0)]);
         }
 
 }
 
 BOOST_AUTO_TEST_CASE(RocknumTest) {
     Setup s(createDeck());
-    const auto& rocknum = s.props.getIntGridProperty("ROCKNUM");
+    const auto& grid = s.grid;
+    const auto& rocknum = s.props.getIntGridProperty("ROCKNUM").getData();
     for (size_t i = 0; i < 10; i++) {
         for (size_t j = 0; j < 10; j++) {
             for (size_t k = 0; k < 10; k++) {
                 if (k < 2)
-                    BOOST_CHECK_EQUAL(1, rocknum.iget(i, j, k));
+                    BOOST_CHECK_EQUAL(1, rocknum[grid.getGlobalIndex(i, j, k)]);
                 else if (k < 4)
-                    BOOST_CHECK_EQUAL(2, rocknum.iget(i, j, k));
+                    BOOST_CHECK_EQUAL(2, rocknum[grid.getGlobalIndex(i, j, k)]);
                 else if (k < 6)
-                    BOOST_CHECK_EQUAL(3, rocknum.iget(i, j, k));
+                    BOOST_CHECK_EQUAL(3, rocknum[grid.getGlobalIndex(i, j, k)]);
                 else
-                    BOOST_CHECK_EQUAL(4, rocknum.iget(i, j, k));
+                    BOOST_CHECK_EQUAL(4, rocknum[grid.getGlobalIndex(i, j, k)]);
             }
         }
     }
@@ -354,14 +356,15 @@ BOOST_AUTO_TEST_CASE(RocknumTest) {
 
 BOOST_AUTO_TEST_CASE(PermxUnitAppliedCorrectly) {
     Setup s( createValidPERMXDeck() );
-    const auto& permx = s.props.getDoubleGridProperty("PermX");
+    const auto& grid = s.grid;
+    const auto& permx = s.props.getDoubleGridProperty("PermX").getData();
 
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_CLOSE(2 * Opm::Metric::Permeability, permx.iget(i, j, 0), 0.0001);
+                BOOST_CHECK_CLOSE(2 * Opm::Metric::Permeability, permx[grid.getGlobalIndex(i, j, 0)], 0.0001);
             else
-                BOOST_CHECK_CLOSE(4 * Opm::Metric::Permeability, permx.iget(i, j, 0), 0.0001);
+                BOOST_CHECK_CLOSE(4 * Opm::Metric::Permeability, permx[grid.getGlobalIndex(i, j, 0)], 0.0001);
         }
 }
 
@@ -439,25 +442,26 @@ BOOST_AUTO_TEST_CASE(getRegions) {
 
 BOOST_AUTO_TEST_CASE(RadialPermeabilityTensor) {
     const Setup s(createQuarterCircleDeck());
-
-    const auto& permr   = s.props.getDoubleGridProperty("PERMR");
-    const auto& permtht = s.props.getDoubleGridProperty("PERMTHT");
-    const auto& permz   = s.props.getDoubleGridProperty("PERMZ");
-    const auto& poro    = s.props.getDoubleGridProperty("PORO");
+    const auto& grid = s.grid;
+    const auto& permr   = s.props.getDoubleGridProperty("PERMR").getData();
+    const auto& permtht = s.props.getDoubleGridProperty("PERMTHT").getData();
+    const auto& permz   = s.props.getDoubleGridProperty("PERMZ").getData();
+    const auto& poro    = s.props.getDoubleGridProperty("PORO").getData();
 
     const double check_tol = 1.0e-6;
 
     // Top layer (explicitly assigned)
-    BOOST_CHECK_CLOSE(100.0*Opm::Metric::Permeability, permr.iget(0, 0, 0), check_tol);
-    BOOST_CHECK_CLOSE(permtht.iget(0, 0, 0), permr.iget(0, 0, 0), check_tol);
-    BOOST_CHECK_CLOSE(permz.iget(0, 0, 0), 0.1 * permr.iget(0, 0, 0), check_tol);
-    BOOST_CHECK_CLOSE(0.3, poro.iget(0, 0, 0), check_tol);
+    BOOST_CHECK_CLOSE(100.0*Opm::Metric::Permeability, permr[0], check_tol);
+    BOOST_CHECK_CLOSE(permtht[0], permr[0], check_tol);
+    BOOST_CHECK_CLOSE(permz[0], 0.1 * permr[0], check_tol);
+    BOOST_CHECK_CLOSE(0.3, poro[0], check_tol);
 
     // Middle layer (copied ultimately form top)
-    BOOST_CHECK_CLOSE(100.0*Opm::Metric::Permeability, permr.iget(49, 10, 9), check_tol);
-    BOOST_CHECK_CLOSE(permtht.iget(49, 10, 9), permr.iget(49, 10, 9), check_tol);
-    BOOST_CHECK_CLOSE(permz.iget(49, 10, 9), 0.1 * permr.iget(49, 10, 9), check_tol);
-    BOOST_CHECK_CLOSE(0.3, poro.iget(49, 10, 9), check_tol);
+    std::size_t g = grid.getGlobalIndex(49,10,9);
+    BOOST_CHECK_CLOSE(100.0*Opm::Metric::Permeability, permr[g], check_tol);
+    BOOST_CHECK_CLOSE(permtht[g], permr[g], check_tol);
+    BOOST_CHECK_CLOSE(permz[g], 0.1 * permr[g], check_tol);
+    BOOST_CHECK_CLOSE(0.3, poro[g], check_tol);
 
     {
         const auto& d1 = s.deck.getKeyword("PERMR");
@@ -562,6 +566,7 @@ EQUALS
 
 BOOST_AUTO_TEST_CASE(DefaultedBox) {
   const Setup s(createMultiplyDeck());
+  const auto& grid = s.grid;
 
   const auto& permx   = s.props.getDoubleGridProperty("PERMX");
   const auto& permz   = s.props.getDoubleGridProperty("PERMZ");
@@ -569,8 +574,16 @@ BOOST_AUTO_TEST_CASE(DefaultedBox) {
   const auto& trany   = s.props.getDoubleGridProperty("TRANY");
   const auto& tranz   = s.props.getDoubleGridProperty("TRANZ");
 
-  BOOST_CHECK_EQUAL( permx.iget(0,0,0)        , permz.iget(0,0,0));
-  BOOST_CHECK_EQUAL( permx.iget(0,0,1) * 0.10 , permz.iget(0,0,1));
+  const auto& permx_data   = s.props.getDoubleGridProperty("PERMX").getData();
+  const auto& permz_data   = s.props.getDoubleGridProperty("PERMZ").getData();
+  const auto& tranx_data   = s.props.getDoubleGridProperty("TRANX").getData();
+  const auto& trany_data   = s.props.getDoubleGridProperty("TRANY").getData();
+  const auto& tranz_data   = s.props.getDoubleGridProperty("TRANZ").getData();
+
+  std::size_t g1 = grid.getGlobalIndex(0,0,0);
+  std::size_t g2 = grid.getGlobalIndex(0,0,1);
+  BOOST_CHECK_EQUAL( permx_data[g1]        , permz_data[g1]);
+  BOOST_CHECK_EQUAL( permx_data[g2] * 0.10 , permz_data[g2]);
 
   BOOST_CHECK( permx.deckAssigned() );
   BOOST_CHECK( permz.deckAssigned() );
@@ -723,12 +736,12 @@ MULTIPLY
 
 BOOST_AUTO_TEST_CASE(DefaultedBoxMultiplyPorv) {
     const Setup s(createMultiplyPorvDeck());
-    const auto& porv   = s.props.getDoubleGridProperty("PORV");
-
-    BOOST_CHECK_CLOSE( porv.iget(9,9,4), 100, 1e-5);
-    BOOST_CHECK_CLOSE( porv.iget(0,0,1), 20, 1e-5);
-    BOOST_CHECK_CLOSE( porv.iget(0,0,0), 10, 1e-5);
-    BOOST_CHECK_CLOSE( porv.iget(1,0,0), 11, 1e-5);
+    const auto& porv   = s.props.getDoubleGridProperty("PORV").getData();
+    const auto& grid = s.grid;
+    BOOST_CHECK_CLOSE( porv[grid.getGlobalIndex(9,9,4)], 100, 1e-5);
+    BOOST_CHECK_CLOSE( porv[grid.getGlobalIndex(0,0,1)], 20, 1e-5);
+    BOOST_CHECK_CLOSE( porv[grid.getGlobalIndex(0,0,0)], 10, 1e-5);
+    BOOST_CHECK_CLOSE( porv[grid.getGlobalIndex(1,0,0)], 11, 1e-5);
 }
 
 static Opm::Deck createMultiplyPorvFailDeck() {

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -104,9 +104,11 @@ BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
 
     BOOST_CHECK_EQUAL(1000U , poro.getCartesianSize() );
     BOOST_CHECK_EQUAL(1000U , permx.getCartesianSize() );
+    const auto& poro_data  = poro.getData();
+    const auto& permx_data = permx.getData();
     for (size_t i=0; i < poro.getCartesianSize(); i++) {
-        BOOST_CHECK_EQUAL( 0.10 , poro.iget(i) );
-        BOOST_CHECK_EQUAL( 0.25 * Metric::Permeability , permx.iget(i) );
+        BOOST_CHECK_EQUAL( 0.10 , poro_data[i]);
+        BOOST_CHECK_EQUAL( 0.25 * Metric::Permeability , permx_data[i]);
     }
 }
 
@@ -278,12 +280,10 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
     EclipseState state(deck);
 
     const auto& satNUM = state.get3DProperties().getIntGridProperty( "SATNUM" );
-
+    const auto& satnum_data = satNUM.getData();
     BOOST_CHECK_EQUAL(1000U , satNUM.getCartesianSize() );
     for (size_t i=0; i < satNUM.getCartesianSize(); i++)
-        BOOST_CHECK_EQUAL( 2 , satNUM.iget(i) );
-
-    BOOST_CHECK_THROW( satNUM.iget(100000) , std::out_of_range );
+        BOOST_CHECK_EQUAL( 2 , satnum_data[i]);
 }
 
 BOOST_AUTO_TEST_CASE(GetTransMult) {

--- a/tests/parser/EqualRegTests.cpp
+++ b/tests/parser/EqualRegTests.cpp
@@ -234,13 +234,14 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    auto& property = props.getIntGridProperty("SATNUM");
+    const auto& property = props.getIntGridProperty("SATNUM").getData();
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
+            std::size_t g = eg.getGlobalIndex(i,j,0);
             if (i < 2)
-                BOOST_CHECK_EQUAL(11, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(11, property[g]);
             else
-                BOOST_CHECK_EQUAL(20, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(20, property[g]);
         }
 }
 
@@ -249,11 +250,11 @@ BOOST_AUTO_TEST_CASE(UnitAppliedCorrectly) {
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
-    const auto& permx = props.getDoubleGridProperty("PERMX");
-    const auto& permy = props.getDoubleGridProperty("PERMY");
-    const auto& permz = props.getDoubleGridProperty("PERMZ");
+    const auto& permx = props.getDoubleGridProperty("PERMX").getData();
+    const auto& permy = props.getDoubleGridProperty("PERMY").getData();
+    const auto& permz = props.getDoubleGridProperty("PERMZ").getData();
     for (size_t g = 0; g < 25; g++) {
-        BOOST_CHECK_EQUAL(permz.iget(g), permx.iget(g));
-        BOOST_CHECK_EQUAL(permy.iget(g), permx.iget(g));
+        BOOST_CHECK_EQUAL(permz[g], permx[g]);
+        BOOST_CHECK_EQUAL(permy[g], permx[g]);
     }
 }

--- a/tests/parser/MultiRegTests.cpp
+++ b/tests/parser/MultiRegTests.cpp
@@ -234,13 +234,13 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
 
-    const auto& property = props.getIntGridProperty("SATNUM");
+    const auto& property_data = props.getIntGridProperty("SATNUM").getData();
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_EQUAL(11, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(11, property_data[eg.getGlobalIndex(i,j,0)]);
             else
-                BOOST_CHECK_EQUAL(40, property.iget(i, j, 0));
+                BOOST_CHECK_EQUAL(40, property_data[eg.getGlobalIndex(i,j,0)]);
         }
 }
 
@@ -251,12 +251,12 @@ BOOST_AUTO_TEST_CASE(Test_OPERATER) {
     Opm::EclipseGrid eg(deck);
     Opm::Eclipse3DProperties props(deck, tm, eg);
 
-    const auto& porv  = props.getDoubleGridProperty("PORV");
-    const auto& permx = props.getDoubleGridProperty("PERMX");
-    const auto& permy = props.getDoubleGridProperty("PERMY");
+    const auto& porv_data  = props.getDoubleGridProperty("PORV").getData();
+    const auto& permx_data = props.getDoubleGridProperty("PERMX").getData();
+    const auto& permy_data = props.getDoubleGridProperty("PERMY").getData();
 
-    BOOST_CHECK_EQUAL( porv.iget(0,0,0), 0.50 );
-    BOOST_CHECK_EQUAL( permx.iget(0) / permy.iget(0), 0.50 );
-    BOOST_CHECK_EQUAL( permx.iget(1), permy.iget(1));
+    BOOST_CHECK_EQUAL( porv_data[0], 0.50 );
+    BOOST_CHECK_EQUAL( permx_data[0] / permy_data[0], 0.50 );
+    BOOST_CHECK_EQUAL( permx_data[1], permy_data[1]);
 }
 

--- a/tests/parser/PORVTests.cpp
+++ b/tests/parser/PORVTests.cpp
@@ -270,17 +270,17 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoro) {
     const auto& poro = props.getDoubleGridProperty("PORO");
     BOOST_CHECK( !poro.containsNaN() );
 
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
     double cell_volume = 0.25 * 0.25 * 0.25;
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv.iget(9,9,0) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv_data[grid.getGlobalIndex(9,9,0)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(0,0,4) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(9,9,4) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(0,0,4)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(9,9,4)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv.iget(0,0,9) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv_data[grid.getGlobalIndex(0,0,9)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
@@ -289,17 +289,17 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
     Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
     double cell_volume = 0.25 * 0.25 * 0.25;
 
-    BOOST_CHECK_CLOSE( 77.0 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( 77.0 , porv.iget(9,9,0) , 0.001);
+    BOOST_CHECK_CLOSE( 77.0 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( 77.0 , porv_data[grid.getGlobalIndex(9,9,0)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(0,0,4) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(9,9,4) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(0,0,4)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(9,9,4)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv.iget(0,0,9) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv_data[grid.getGlobalIndex(0,0,9)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 1.00 , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_multpv) {
@@ -308,21 +308,21 @@ BOOST_AUTO_TEST_CASE(PORV_multpv) {
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
     Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
     double cell_volume = 0.25 * 0.25 * 0.25;
 
-    BOOST_CHECK_CLOSE( 770.0 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( 770.0 , porv.iget(4,4,0) , 0.001);
-    BOOST_CHECK_CLOSE( 77.0 , porv.iget(9,9,0) , 0.001);
+    BOOST_CHECK_CLOSE( 770.0 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( 770.0 , porv_data[grid.getGlobalIndex(4,4,0)] , 0.001);
+    BOOST_CHECK_CLOSE( 77.0 , porv_data[grid.getGlobalIndex(9,9,0)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(0,0,4) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv.iget(9,9,4) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(0,0,4)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.50 , porv_data[grid.getGlobalIndex(9,9,4)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 0.90 , porv.iget(0,0,8) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 0.90 , porv.iget(9,9,8) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.90 , porv_data[grid.getGlobalIndex(0,0,8)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 0.90 , porv_data[grid.getGlobalIndex(9,9,8)] , 0.001);
 
-    BOOST_CHECK_CLOSE( cell_volume * 10.00 , porv.iget(0,0,9) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * 10.00 , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 10.00 , porv_data[grid.getGlobalIndex(0,0,9)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * 10.00 , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
@@ -331,13 +331,13 @@ BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
     Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
 
-    BOOST_CHECK_CLOSE( 1234.56 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( 1234.56 , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( 1234.56 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( 1234.56 , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 
-    BOOST_CHECK_CLOSE( 7890.12 , porv.iget(1,1,1) , 0.001);
-    BOOST_CHECK_CLOSE( 7890.12 , porv.iget(2,2,2) , 0.001);
+    BOOST_CHECK_CLOSE( 7890.12 , porv_data[grid.getGlobalIndex(1,1,1)] , 0.001);
+    BOOST_CHECK_CLOSE( 7890.12 , porv_data[grid.getGlobalIndex(2,2,2)] , 0.001);
 
 }
 
@@ -347,15 +347,15 @@ BOOST_AUTO_TEST_CASE(PORV_multpvAndNtg) {
     Opm::TableManager tm( deck );
     Opm::EclipseGrid grid( deck );
     Opm::Eclipse3DProperties props( deck, tm, grid );
-    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porv_data = props.getDoubleGridProperty("PORV").getData();
     double cell_volume = 0.25 * 0.25 * 0.25;
     double poro = 0.20;
     double multpv = 10;
     double NTG = 2;
     double PORV = 10;
 
-    BOOST_CHECK_CLOSE( PORV * multpv                 , porv.iget(0,0,0) , 0.001);
-    BOOST_CHECK_CLOSE( cell_volume * poro*multpv*NTG , porv.iget(9,9,9) , 0.001);
+    BOOST_CHECK_CLOSE( PORV * multpv                 , porv_data[grid.getGlobalIndex(0,0,0)] , 0.001);
+    BOOST_CHECK_CLOSE( cell_volume * poro*multpv*NTG , porv_data[grid.getGlobalIndex(9,9,9)] , 0.001);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_multregp) {

--- a/tests/parser/SatfuncPropertyInitializersTests.cpp
+++ b/tests/parser/SatfuncPropertyInitializersTests.cpp
@@ -1,18 +1,18 @@
 /*
   Copyright 2015 IRIS
-  
+
   This file is part of the Open Porous Media project (OPM).
-  
+
   OPM is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   OPM is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -36,8 +36,8 @@ using namespace Opm;
 inline void check_property(const Eclipse3DProperties& props1,
                            const Eclipse3DProperties& props2,
                            const std::string& propertyName) {
-    auto& data1 = props1.getDoubleGridProperty(propertyName).getData();
-    auto& data2 = props2.getDoubleGridProperty(propertyName).getData();
+    auto data1 = props1.getDoubleGridProperty(propertyName).getData();
+    auto data2 = props2.getDoubleGridProperty(propertyName).getData();
 
     BOOST_CHECK_CLOSE(data1[0], data2[0], 1e-12);
 }

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -47,18 +47,19 @@ inline EclipseState makeState(const std::string& fileName) {
 
 BOOST_AUTO_TEST_CASE( PERMX ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& permx = state.get3DProperties().getDoubleGridProperty( "PERMX" );
-    const auto& permy = state.get3DProperties().getDoubleGridProperty( "PERMY" );
-    const auto& permz = state.get3DProperties().getDoubleGridProperty( "PERMZ" );
+    const auto& permx = state.get3DProperties().getDoubleGridProperty( "PERMX" ).getData();
+    const auto& permy = state.get3DProperties().getDoubleGridProperty( "PERMY" ).getData();
+    const auto& permz = state.get3DProperties().getDoubleGridProperty( "PERMZ" ).getData();
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
     for (k = 0; k < grid.getNZ(); k++) {
         for (j = 0; j < grid.getNY(); j++) {
             for (i = 0; i < grid.getNX(); i++) {
+                std::size_t g = grid.getGlobalIndex(i,j,k);
 
-                BOOST_CHECK_CLOSE( permx.iget( i, j, k ) * 0.25, permz.iget( i, j, k ), 0.001 );
-                BOOST_CHECK_EQUAL( permx.iget( i, j, k ) * 2, permy.iget( i, j, k ) );
+                BOOST_CHECK_CLOSE( permx[g] * 0.25, permz[g], 0.001 );
+                BOOST_CHECK_EQUAL( permx[g] * 2   , permy[g] );
 
             }
         }
@@ -69,7 +70,7 @@ BOOST_AUTO_TEST_CASE( PERMX ) {
 
 BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" );
+    const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" ).getData();
     {
         size_t i, j, k;
         const EclipseGrid& grid = state.getInputGrid();
@@ -79,9 +80,9 @@ BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
 
                     size_t g = i + j * grid.getNX() + k * grid.getNX() * grid.getNY();
                     if (i <= 1 && j <= 1 && k <= 1)
-                        BOOST_CHECK_EQUAL( satnum.iget( g ), 10 );
+                        BOOST_CHECK_EQUAL( satnum[ g ], 10 );
                     else
-                        BOOST_CHECK_EQUAL( satnum.iget( g ), 2 );
+                        BOOST_CHECK_EQUAL( satnum[g], 2 );
 
                 }
             }
@@ -91,8 +92,8 @@ BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
 
 BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" );
-    const auto& fipnum = state.get3DProperties().getIntGridProperty( "FIPNUM" );
+    const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" ).getData();
+    const auto& fipnum = state.get3DProperties().getIntGridProperty( "FIPNUM" ).getData();
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
@@ -100,11 +101,11 @@ BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
         for (j = 0; j < grid.getNY(); j++) {
             for (i = 0; i < grid.getNX(); i++) {
 
-                size_t g = i + j * grid.getNX() + k * grid.getNX() * grid.getNY();
+                size_t g = grid.getGlobalIndex(i,j,k);
                 if (i <= 1 && j <= 1 && k <= 1)
-                    BOOST_CHECK_EQUAL( 4 * satnum.iget( g ), fipnum.iget( g ) );
+                    BOOST_CHECK_EQUAL( 4 * satnum[g], fipnum[g] );
                 else
-                    BOOST_CHECK_EQUAL( 2 * satnum.iget( i, j, k ), fipnum.iget( i, j, k ) );
+                    BOOST_CHECK_EQUAL( 2 * satnum[g], fipnum[g] );
 
             }
         }
@@ -120,20 +121,20 @@ BOOST_AUTO_TEST_CASE( KEYWORD_BOX_TOO_SMALL) {
 
 BOOST_AUTO_TEST_CASE( EQUALS ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& pvtnum = state.get3DProperties().getIntGridProperty( "PVTNUM" );
-    const auto& eqlnum = state.get3DProperties().getIntGridProperty( "EQLNUM" );
-    const auto& poro = state.get3DProperties().getDoubleGridProperty( "PORO" );
+    const auto& pvtnum = state.get3DProperties().getIntGridProperty( "PVTNUM" ).getData();
+    const auto& eqlnum = state.get3DProperties().getIntGridProperty( "EQLNUM" ).getData();
+    const auto& poro = state.get3DProperties().getDoubleGridProperty( "PORO" ).getData();
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
     for (k = 0; k < grid.getNZ(); k++) {
         for (j = 0; j < grid.getNY(); j++) {
             for (i = 0; i < grid.getNX(); i++) {
+                size_t g = grid.getGlobalIndex(i,j,k);
 
-                BOOST_CHECK_EQUAL( pvtnum.iget( i, j, k ), k );
-                BOOST_CHECK_EQUAL( eqlnum.iget( i, j, k ), 77 + 2 * k );
-                BOOST_CHECK_EQUAL( poro.iget( i, j, k ), 0.25 );
-
+                BOOST_CHECK_EQUAL( pvtnum[g], k );
+                BOOST_CHECK_EQUAL( eqlnum[g], 77 + 2 * k );
+                BOOST_CHECK_EQUAL( poro[g], 0.25 );
             }
         }
     }
@@ -142,18 +143,15 @@ BOOST_AUTO_TEST_CASE( EQUALS ) {
 
 BOOST_AUTO_TEST_CASE( OPERATE ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& ntg = state.get3DProperties().getDoubleGridProperty( "NTG" );
+    const EclipseGrid& grid = state.getInputGrid();
+    const auto& ntg = state.get3DProperties().getDoubleGridProperty( "NTG" ).getData();
 
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,0) , 8.50 );  // MULTA
-    BOOST_CHECK_EQUAL( ntg.iget( 0,5,0) , 5.00 );  // POLY
-
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,1) , 4.0 );  // COPY
-    BOOST_CHECK_EQUAL( ntg.iget( 0,5,1) , 4.0 );  // MINLIM
-
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,2) , 2.0 );  // MAXLIM
-
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,3) , 0.5 );  // MAXVALUE
-
-    BOOST_CHECK_EQUAL( ntg.iget( 0,0,4) , 1.5 );  // MINVALUE
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,0)], 8.50 );  // MULTA
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,5,0)], 5.00 );  // POLY
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,1)], 4.0 );  // COPY
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,5,1)], 4.0 );  // MINLIM
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,2)], 2.0 );  // MAXLIM
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,3)], 0.5 );  // MAXVALUE
+    BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,4)], 1.5 );  // MINVALUE
 }
 


### PR DESCRIPTION
The PR #1046 was a late night hack to reduce memory usage in the 3D property system; that implementation was quite rushed and should probably die a silent death in `/dev/null` - but the point still remains that a refactoring of the property system is overdue, see also discussion here: https://github.com/OPM/opm-common/issues/929.

One of the commits from #1046 was to remove the `GridProperty::iget()` and `GridProperty::iset()` methods; that commit is recovered from #1046 in this PR. The reason I want to merge this is that the `iget()` - and in particular the `iget(i,j,k)` overload "peeks to much into" the implementation; and removing these methods should buy some freedom in changing the internals of the `GridProperty` class.

Downstream: 
https://github.com/OPM/opm-grid/pull/390
https://github.com/OPM/opm-simulators/pull/2028