### PR TITLE
Changed EGrid API, function getCellCorners.

### DIFF
--- a/opm/io/eclipse/EGrid.hpp
+++ b/opm/io/eclipse/EGrid.hpp
@@ -44,8 +44,8 @@ public:
     std::array<int, 3> ijk_from_active_index(int actInd) const;
     std::array<int, 3> ijk_from_global_index(int globInd) const;
 
-    void getCellCorners(int globindex, std::vector<double>& X, std::vector<double>& Y, std::vector<double>& Z) const;
-    void getCellCorners(const std::array<int, 3>& ijk, std::vector<double>& X, std::vector<double>& Y, std::vector<double>& Z) const;
+    void getCellCorners(int globindex, std::array<double,8>& X, std::array<double,8>& Y, std::array<double,8>& Z) const;
+    void getCellCorners(const std::array<int, 3>& ijk, std::array<double,8>& X, std::array<double,8>& Y, std::array<double,8>& Z) const;
 
     int activeCells() const { return nactive; }
     int totalNumberOfCells() const { return nijk[0] * nijk[1] * nijk[2]; }

--- a/src/opm/io/eclipse/EGrid.cpp
+++ b/src/opm/io/eclipse/EGrid.cpp
@@ -127,21 +127,13 @@ std::array<int, 3> EGrid::ijk_from_global_index(int globInd) const
 
 
 void EGrid::getCellCorners(const std::array<int, 3>& ijk,
-                           std::vector<double>& X,
-                           std::vector<double>& Y,
-                           std::vector<double>& Z) const
+                           std::array<double,8>& X,
+                           std::array<double,8>& Y,
+                           std::array<double,8>& Z) const
 {
     std::vector<int> zind;
     std::vector<int> pind;
 
-    if (X.size() < 8 || Y.size() < 8 || Z.size() < 8) {
-        OPM_THROW(std::invalid_argument,
-                  "In routine cellConrner. X, Y and Z should be a vector of size 8");
-    }
-
-    if (ijk[0] < 0 || ijk[0] >= nijk[0] || ijk[1] < 0 || ijk[1] >= nijk[1] || ijk[2] < 0 || ijk[2] >= nijk[2]) {
-        OPM_THROW(std::invalid_argument, "i, j and/or k out of range");
-    }
 
    // calculate indices for grid pillars in COORD arrray
    pind.push_back(ijk[1]*(nijk[0]+1)*6 + ijk[0]*6);
@@ -181,8 +173,8 @@ void EGrid::getCellCorners(const std::array<int, 3>& ijk,
 }
 
 
-void EGrid::getCellCorners(int globindex, std::vector<double>& X,
-                           std::vector<double>& Y, std::vector<double>& Z) const
+void EGrid::getCellCorners(int globindex, std::array<double,8>& X,
+                           std::array<double,8>& Y, std::array<double,8>& Z) const
 {
     return getCellCorners(ijk_from_global_index(globindex),X,Y,Z);
 }

--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -407,8 +407,13 @@ void ECLRegressionTest::gridCompare()
 
         std::cout << "X, Y and Z coordinates " << " ... ";
 
-        std::vector<double> X1(8,0.0), Y1(8,0.0) , Z1(8,0.0);
-        std::vector<double> X2(8,0.0), Y2(8,0.0), Z2(8,0.0);
+        std::array<double,8> X1 = {0.0};
+        std::array<double,8> Y1 = {0.0};
+        std::array<double,8> Z1 = {0.0};
+
+        std::array<double,8> X2 = {0.0};
+        std::array<double,8> Y2 = {0.0};
+        std::array<double,8> Z2 = {0.0};
 
         for (int k = 0; k < dim1[2]; k++) {
             for (int j = 0; j < dim1[1]; j++) {

--- a/tests/test_EGrid.cpp
+++ b/tests/test_EGrid.cpp
@@ -156,15 +156,15 @@ BOOST_AUTO_TEST_CASE(getCellCorners) {
     
     std::string testFile="SPE1CASE1.EGRID";
 
-    std::vector<double> ref_X = {3000,4000,3000,4000,3000,4000,3000,4000};
-    std::vector<double> ref_Y = {2000,2000,3000,3000,2000,2000,3000,3000};
-    std::vector<double> ref_Z = {8345,8345,8345,8345,8375,8375,8375,8375};
+    std::array<double,8> ref_X = {3000,4000,3000,4000,3000,4000,3000,4000};
+    std::array<double,8> ref_Y = {2000,2000,3000,3000,2000,2000,3000,3000};
+    std::array<double,8> ref_Z = {8345,8345,8345,8345,8375,8375,8375,8375};
 
     EGrid grid1(testFile);
 
-    std::vector<double> X(8,0.0);
-    std::vector<double> Y(8,0.0);
-    std::vector<double> Z(8,0.0);
+    std::array<double,8> X = {0.0};
+    std::array<double,8> Y = {0.0};
+    std::array<double,8> Z = {0.0};
     
     // cell 4,3,2 => zero based 3,2,1
     grid1.getCellCorners({3, 2, 1}, X, Y, Z);
@@ -173,9 +173,9 @@ BOOST_AUTO_TEST_CASE(getCellCorners) {
     BOOST_CHECK_EQUAL(Y == ref_Y, true);
     BOOST_CHECK_EQUAL(Z == ref_Z, true);
 
-    X.assign(8,0.0);
-    Y.assign(8,0.0);
-    Z.assign(8,0.0);
+    X = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    Y = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    Z = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
     int globInd=grid1.global_index(3,2,1); 
 


### PR DESCRIPTION
The arguments in function `getCellCorners(...)` are changed from `std::vector<double>` to `std::array<double,8>`. This change was triggered by similar modification of function `calculateCellVol(...)`
```C++
double calculateCellVol(const std::array<double,8>& X, const std::array<double,8>& Y, const std::array<double,8>& Z);
```
The modification in `calculateCellVol `was part of PR #1009.  