### PR TITLE
Make UnitSystem Independent of LibECL

### DIFF
--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -25,8 +25,6 @@
 #include <vector>
 #include <memory>
 
-#include <ert/ecl/ecl_util.h>
-
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 
 namespace Opm {
@@ -77,11 +75,9 @@ namespace Opm {
 
         explicit UnitSystem(UnitType unit = UnitType::UNIT_TYPE_METRIC);
         explicit UnitSystem(const std::string& deck_name);
-        explicit UnitSystem(ert_ecl_unit_enum ecl_type);
 
         const std::string& getName() const;
         UnitType getType() const;
-        ert_ecl_unit_enum getEclType( ) const;
 
         void addDimension(const std::string& dimension, double SIfactor, double SIoffset = 0.0);
         void addDimension( Dimension );
@@ -103,7 +99,6 @@ namespace Opm {
         std::string deck_name() const;
 
         static bool valid_name(const std::string& deck_name);
-        static ert_ecl_unit_enum ecl_units(UnitType opm_unit);
         static UnitSystem newMETRIC();
         static UnitSystem newFIELD();
         static UnitSystem newLAB();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
@@ -26,6 +26,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
 
+#include <ert/util/util.h>
+
 namespace Opm {
 
 namespace {

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -957,17 +957,6 @@ namespace {
 
     namespace {
 
-        UnitSystem::UnitType fromEclType(ert_ecl_unit_enum unit_type) {
-            switch ( unit_type ) {
-            case(ECL_METRIC_UNITS): return UnitSystem::UnitType::UNIT_TYPE_METRIC;
-            case(ECL_FIELD_UNITS):  return UnitSystem::UnitType::UNIT_TYPE_FIELD;
-            case(ECL_LAB_UNITS):    return UnitSystem::UnitType::UNIT_TYPE_LAB;
-            case(ECL_PVT_M_UNITS):  return UnitSystem::UnitType::UNIT_TYPE_PVT_M;
-            default:
-                throw std::runtime_error("What has happened here?");
-            }
-        }
-
         UnitSystem::UnitType fromDeckName(const std::string& deck_name) {
             if (deck_name == "FIELD")
                 return UnitSystem::UnitType::UNIT_TYPE_FIELD;
@@ -1012,11 +1001,6 @@ namespace {
         }
     }
 
-    UnitSystem::UnitSystem(const ert_ecl_unit_enum unit_type)
-        : UnitSystem( fromEclType( unit_type ))
-    {
-    }
-
 
     UnitSystem::UnitSystem(const std::string& deck_name) :
         UnitSystem( fromDeckName(deck_name) )
@@ -1059,25 +1043,6 @@ namespace {
     UnitSystem::UnitType UnitSystem::getType() const {
         return m_unittype;
     }
-
-
-    ert_ecl_unit_enum UnitSystem::ecl_units(UnitSystem::UnitType opm_type) {
-        switch ( opm_type ) {
-        case UnitType::UNIT_TYPE_METRIC: return ECL_METRIC_UNITS;
-        case UnitType::UNIT_TYPE_FIELD:  return ECL_FIELD_UNITS;
-        case UnitType::UNIT_TYPE_LAB:    return ECL_LAB_UNITS;
-        case UnitType::UNIT_TYPE_PVT_M:  return ECL_PVT_M_UNITS;
-        case UnitType::UNIT_TYPE_INPUT:  throw std::runtime_error("UNIT_TYPE_INPUT has no counterpart in the ert_ecl_unit_enum type.");
-        default:
-            throw std::runtime_error("What has happened here?");
-        }
-    }
-
-
-    ert_ecl_unit_enum UnitSystem::getEclType() const {
-        return UnitSystem::ecl_units( this->m_unittype );
-    }
-
 
 
     Dimension UnitSystem::parseFactor(const std::string& dimension) const {

--- a/tests/parser/TimeMapTest.cpp
+++ b/tests/parser/TimeMapTest.cpp
@@ -35,6 +35,8 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
+#include <ert/util/util.h>
+
 const std::time_t startDateJan1st2010 = Opm::TimeMap::mkdate(2010, 1, 1);
 
 Opm::DeckRecord createDeckRecord(int day, const std::string &month, int year, const std::string &time = "00:00:00.000");

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -83,20 +83,6 @@ BOOST_AUTO_TEST_CASE(UnitSystemGetNewOK) {
 }
 
 
-BOOST_AUTO_TEST_CASE(UnitSystemFromECL_TYPE) {
-    UnitSystem system(ECL_METRIC_UNITS);
-    system.addDimension("Length" , 10 );
-    system.addDimension("Time" , 100);
-
-    BOOST_CHECK( !system.hasDimension("Length*Length/Time"));
-    Dimension comp = system.getNewDimension( "Length*Length/Time" );
-    BOOST_CHECK( system.hasDimension("Length*Length/Time"));
-    BOOST_CHECK_EQUAL(1 , comp.getSIScaling());
-}
-
-
-
-
 BOOST_AUTO_TEST_CASE(UnitSystemAddDimensions) {
     UnitSystem system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
     system.addDimension("Length" , 1 );
@@ -153,8 +139,6 @@ BOOST_AUTO_TEST_CASE(CreateMetricSystem) {
     BOOST_CHECK_EQUAL( Metric::Time         , system.getDimension("Time").getSIScaling() );
     BOOST_CHECK_EQUAL( Metric::Permeability , system.getDimension("Permeability").getSIScaling() );
     BOOST_CHECK_EQUAL( Metric::Pressure     , system.getDimension("Pressure").getSIScaling() );
-
-    BOOST_CHECK_EQUAL( system.getEclType( ) , ECL_METRIC_UNITS );
 }
 
 
@@ -168,8 +152,6 @@ BOOST_AUTO_TEST_CASE(CreateFieldSystem) {
     BOOST_CHECK_EQUAL( Field::Time         , system.getDimension("Time").getSIScaling() );
     BOOST_CHECK_EQUAL( Field::Permeability , system.getDimension("Permeability").getSIScaling() );
     BOOST_CHECK_EQUAL( Field::Pressure     , system.getDimension("Pressure").getSIScaling() );
-
-    BOOST_CHECK_EQUAL( system.getEclType( ) , ECL_FIELD_UNITS );
 }
 
 
@@ -185,7 +167,6 @@ BOOST_AUTO_TEST_CASE(CreateInputSystem) {
     BOOST_CHECK_EQUAL( 1.0, system.getDimension("Permeability").getSIScaling() );
     BOOST_CHECK_EQUAL( 1.0, system.getDimension("Pressure").getSIScaling() );
 
-    BOOST_CHECK_THROW( system.getEclType( ), std::runtime_error );
     BOOST_CHECK_EQUAL( static_cast<long int>(system.getType( )) , static_cast<long int>(UnitSystem::UnitType::UNIT_TYPE_INPUT) );
 }
 
@@ -306,7 +287,6 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     auto metric = UnitSystem::newMETRIC();
 
     BOOST_CHECK( metric.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC );
-    BOOST_CHECK( metric.getEclType() == ECL_METRIC_UNITS );
 
     // ----------------------------------------------------------------
     // METRIC -> SI
@@ -382,7 +362,6 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     auto field = UnitSystem::newFIELD();
 
     BOOST_CHECK( field.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD );
-    BOOST_CHECK( field.getEclType() == ECL_FIELD_UNITS );
 
     // ----------------------------------------------------------------
     // FIELD -> SI
@@ -456,7 +435,6 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     auto lab = UnitSystem::newLAB();
 
     BOOST_CHECK( lab.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_LAB );
-    BOOST_CHECK( lab.getEclType() == ECL_LAB_UNITS );
 
     // ----------------------------------------------------------------
     // LAB -> SI
@@ -530,7 +508,6 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     auto pvt_m = UnitSystem::newPVT_M();
 
     BOOST_CHECK( pvt_m.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_PVT_M );
-    BOOST_CHECK( pvt_m.getEclType() == ECL_PVT_M_UNITS );
 
     // ----------------------------------------------------------------
     // PVT-M -> SI


### PR DESCRIPTION
This commit decouples the `UnitSystem` class from the LibECL type `ert_ecl_unit_enum`.  This, in turn, makes `UnitSystem` independent of LibECL.

Update the unit test accordingly, and include `<ert/util/util.h>` where needed.  This header was included transitively through `UnitSystem.hpp` before. 