### PR TITLE
Add File Manager Stream for Summary Specification

### DIFF
--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -29,6 +29,7 @@
 
 namespace Opm { namespace EclIO { namespace OutputStream {
     class Restart;
+    class SummarySpecification;
 }}}
 
 namespace Opm { namespace EclIO {
@@ -73,6 +74,7 @@ public:
     void message(const std::string& msg);
 
     friend class OutputStream::Restart;
+    friend class OutputStream::SummarySpecification;
 
 private:
     void writeBinaryHeader(const std::string& arrName, int size, eclArrType arrType);


### PR DESCRIPTION
This commit introduces a new `OutputStream` class for representing the summary specification file (`.SMSPEC`).  The stream is constructed with constant data (output directory, basename, start date &c), and provides a single `write()` member function that outputs a summary specification.

Each call to write rewinds the underlying stream's output position.  Class `EclOutput` grants friendship to the new output stream class in order to support easy stream rewinding.

Add a unit test to exercise the new class.