### PR TITLE
Remove functions to filter connections

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -212,7 +212,6 @@ namespace Opm
           Will remove all completions which are connected to cell which is not
           active. Will scan through all wells and all timesteps.
         */
-        void filterConnections(const EclipseGrid& grid);
         size_t size() const;
 
         void applyAction(size_t reportStep, const Action::ActionX& action, const Action::Result& result);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp
@@ -429,7 +429,6 @@ public:
     bool handleCOMPLUMP(const DeckRecord& record);
     bool handleWPIMULT(const DeckRecord& record);
 
-    void filterConnections(const EclipseGrid& grid);
     void switchToInjector();
     void switchToProducer();
     ProductionControls productionControls(const SummaryState& st) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -61,7 +61,6 @@ namespace Opm {
 
         const_iterator begin() const { return this->m_connections.begin(); }
         const_iterator end() const { return this->m_connections.end(); }
-        void filter(const EclipseGrid& grid);
         bool allConnectionsShut() const;
         /// Order connections irrespective of input order.
         /// The algorithm used is the following:

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2483,32 +2483,6 @@ void Schedule::handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep, c
     }
 
 
-    void Schedule::filterConnections(const EclipseGrid& grid) {
-        for (auto& dynamic_pair : this->wells_static) {
-            auto& dynamic_state = dynamic_pair.second;
-            for (auto& well_pair : dynamic_state.unique()) {
-                if (well_pair.second)
-                    well_pair.second->filterConnections(grid);
-            }
-        }
-
-        for (auto& dynamic_pair : this->wells_static) {
-            auto& dynamic_state = dynamic_pair.second;
-            for (auto& well_pair : dynamic_state.unique()) {
-                if (well_pair.second)
-                    well_pair.second->filterConnections(grid);
-            }
-        }
-
-        for (auto& dynamic_pair : this->wells_static) {
-            auto& dynamic_state = dynamic_pair.second;
-            for (auto& well_pair : dynamic_state.unique()) {
-                if (well_pair.second)
-                    well_pair.second->filterConnections(grid);
-            }
-        }
-    }
-
     const VFPProdTable& Schedule::getVFPProdTable(int table_id, size_t timeStep) const {
         const auto pair = vfpprod_tables.find(table_id);
         if (pair == vfpprod_tables.end())

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well2.cpp
@@ -621,11 +621,6 @@ bool Well2::handleWELSEGS(const DeckKeyword& keyword) {
         return false;
 }
 
-void Well2::filterConnections(const EclipseGrid& grid) {
-    this->connections->filter(grid);
-}
-
-
 std::size_t Well2::firstTimeStep() const {
     return this->init_step;
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -465,12 +465,4 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         return !( *this == rhs );
     }
 
-
-    void WellConnections::filter(const EclipseGrid& grid) {
-        auto new_end = std::remove_if(m_connections.begin(),
-                                      m_connections.end(),
-                                      [&grid](const Connection& c) { return !grid.cellActive(c.getI(), c.getJ(), c.getK()); });
-        this->num_removed += std::distance(new_end, m_connections.end());
-        m_connections.erase(new_end, m_connections.end());
-    }
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -278,39 +278,6 @@ static Deck createDeckWithWellsOrderedGRUPTREE() {
     return parser.parseString(input);
 }
 
-static Deck createDeckWithWellsAndCompletionData() {
-    Opm::Parser parser;
-    std::string input =
-      "START             -- 0 \n"
-      "1 NOV 1979 / \n"
-      "SCHEDULE\n"
-      "DATES             -- 1\n"
-      " 1 DES 1979/ \n"
-      "/\n"
-      "WELSPECS\n"
-      "    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
-      "    'OP_2'       'OP'   8   8 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
-      "    'OP_3'       'OP'   7   7 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
-      "/\n"
-      "COMPDAT\n"
-      " 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
-      " 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
-      " 'OP_2'  8  8   1   3 'OPEN' 1*    1.168   0.311   107.872 1*  1*  'Y'  21.925 / \n"
-      " 'OP_2'  8  7   3   3 'OPEN' 1*   15.071   0.311  1391.859 1*  1*  'Y'  21.920 / \n"
-      " 'OP_2'  8  7   3   6 'OPEN' 1*    6.242   0.311   576.458 1*  1*  'Y'  21.915 / \n"
-      " 'OP_3'  7  7   1   1 'OPEN' 1*   27.412   0.311  2445.337 1*  1*  'Y'  18.521 / \n"
-      " 'OP_3'  7  7   2   2 'OPEN' 1*   55.195   0.311  4923.842 1*  1*  'Y'  18.524 / \n"
-      "/\n"
-      "DATES             -- 2,3\n"
-      " 10  JUL 2007 / \n"
-      " 10  AUG 2007 / \n"
-      "/\n"
-      "COMPDAT\n" // with defaulted I and J
-      " 'OP_1'  0  *   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
-      "/\n";
-
-    return parser.parseString(input);
-}
 
 static Deck createDeckRFTConfig() {
     Opm::Parser parser;
@@ -2921,35 +2888,6 @@ BOOST_AUTO_TEST_CASE(historic_BHP_and_THP) {
             const auto& wtest_config = schedule.wtestConfig(1);
             BOOST_CHECK_EQUAL(wtest_config.size(), 0);
         }
-    }
-}
-
-BOOST_AUTO_TEST_CASE(FilterCompletions2) {
-    EclipseGrid grid1(10,10,10);
-    std::vector<int> actnum(1000,1);
-    auto deck = createDeckWithWellsAndCompletionData();
-    TableManager table ( deck );
-    Eclipse3DProperties eclipseProperties ( deck , table, grid1);
-    Runspec runspec (deck);
-    Schedule schedule(deck, grid1 , eclipseProperties, runspec);
-    {
-        const auto& c1_1 = schedule.getWell2("OP_1", 1).getConnections();
-        const auto& c1_3 = schedule.getWell2("OP_1", 3).getConnections();
-        BOOST_CHECK_EQUAL(2, c1_1.size());
-        BOOST_CHECK_EQUAL(9, c1_3.size());
-    }
-    actnum[grid1.getGlobalIndex(8,8,1)] = 0;
-    {
-        EclipseGrid grid2(grid1, actnum);
-        schedule.filterConnections(grid2);
-
-        const auto& c1_1 = schedule.getWell2("OP_1", 1).getConnections();
-        const auto& c1_3 = schedule.getWell2("OP_1", 3).getConnections();
-        BOOST_CHECK_EQUAL(1, c1_1.size());
-        BOOST_CHECK_EQUAL(8, c1_3.size());
-
-        BOOST_CHECK_EQUAL(2, c1_1.inputSize());
-        BOOST_CHECK_EQUAL(9, c1_3.inputSize());
     }
 }
 


### PR DESCRIPTION
It is all about active cells!

**Background**

The first implementation of the EclipseGrid in opm-common only took the `ACTNUM` values from the deck into account. Then at a later stage the grid processing code would calculate `PORV` and possibly deactivate some additional cells. When assembling the `WellConnections`object the cells will be checked, and connections to inactive cells will be ignored. However, because the downstream grid processing might deactivate addition cells we must check the connections in a second pass. This is the purpose of the `Schedule::filterConnections()` method.

Since the original implementation of the EclipseGrid the PORV calculations have been moved to opm-common, we should therefor now be in a situation where the ACTNUM in the original EclipseGrid is complete, and no further cells should be deactivated. This PR removes the `filterConnections()` functionality and downstream PR's remove the calls to `filterConnections()`. This will be one step further to get an immutable `Schedule` object, and should also help in currently ongoing parallellizing efforts.

**Disclaimer**
The grid processing code is complex, and not very well tested in terms of unit tests. I might have misunderstood things, this set of PR's should be tested on relevant industrial models beyond the testcases found in jenkins.





https://github.com/OPM/opm-upscaling/pull/279
https://github.com/OPM/opm-simulators/pull/2041
https://github.com/OPM/opm-grid/pull/393