### PR TITLE
Table Linearisation: Remove Original PVT Functions

### DIFF
--- a/opm/output/eclipse/Tables.hpp
+++ b/opm/output/eclipse/Tables.hpp
@@ -24,11 +24,6 @@
 
 #include <vector>
 
-#include <ert/ecl/FortIO.hpp>
-#include <ert/ecl/EclKW.hpp>
-
-#include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/FlatTable.hpp>
 
 namespace Opm {
@@ -39,9 +34,6 @@ namespace Opm {
     public:
         explicit Tables( const UnitSystem& units);
 
-        void addPVTO(const std::vector<PvtoTable>& pvtoTables);
-        void addPVTG(const std::vector<PvtgTable>& pvtgTables);
-        void addPVTW(const PvtwTable& pvtwTable);
         void addDensity(const DensityTable& density);
 
         /// Add normalised PVT function tables to INIT file's TAB vector.
@@ -137,20 +129,6 @@ namespace Opm {
         ///    TableManager sub-object.
         void addWaterPVTTables(const EclipseState& es);
     };
-
-    /// Emit normalised tabular information (TABDIMS and TAB vectors) to
-    /// ECL-like result set file (typically INIT file).
-    ///
-    /// \param[in] tables Collection of normalised tables.  Its \code
-    ///    tabdims() \endcode and \code tab() \endcode vectors will be
-    ///    emitted to \p fortio as ECL keywords "TABDIMS" and "TAB",
-    ///    respectively.
-    ///
-    /// \param[in,out] fortio ECL-like result set file.  Typically
-    ///    corresponds to a preopened stream attached to the INIT file.
-    void fwrite(const Tables& tables,
-                ERT::FortIO&  fortio);
 }
 
-
-#endif
+#endif // OUTPUT_TABLES_HPP


### PR DESCRIPTION
This commit removes the original member functions
```
void Tables::addPVTO()
void Tables::addPVTW()
void Tables::addPVTG()
```
since these are no longer needed.  The PVT tables are now defined in terms of the `addPVTTables()` member function

While here, also remove the fwrite() free function which was defined in terms of LibECL types.

Update the unit test accordingly.