### PR TITLE
Decouple Table Linearisation from LibECL

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -651,6 +651,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/VectorItems/intehead.hpp
         opm/output/eclipse/VectorItems/logihead.hpp
         opm/output/eclipse/VectorItems/msw.hpp
+        opm/output/eclipse/VectorItems/tabdims.hpp
         opm/output/eclipse/VectorItems/well.hpp
         opm/output/eclipse/AggregateGroupData.hpp
         opm/output/eclipse/AggregateConnectionData.hpp

--- a/opm/output/eclipse/VectorItems/tabdims.hpp
+++ b/opm/output/eclipse/VectorItems/tabdims.hpp
@@ -1,0 +1,76 @@
+/*
+  Copyright (c) 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_ECLIPSE_VECTOR_TABDIMS_HPP
+#define OPM_OUTPUT_ECLIPSE_VECTOR_TABDIMS_HPP
+
+#include <vector>
+
+namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+
+    namespace TabDims {
+        enum index : std::vector<int>::size_type {
+            // Number of elements in 'TAB' array
+            TabSize           = 0,
+
+            // Oil PVT table
+            PvtoMainStart     =  6,
+            PvtoCompStart     =  7,
+            NumPvtoCompNodes  =  8,
+            NumPvtoPressNodes =  9,
+            NumPvtoTables     = 10,
+
+            // Water PVT table
+            PvtwStart         = 11,
+            NumPvtwTables     = 12,
+
+            // Gas PVT tables
+            PvtgMainStart     = 13,
+            PvtgPressStart    = 14,
+            NumPvtgCompNodes  = 15,
+            NumPvtgPressNodes = 16,
+            NumPvtgTables     = 17,
+
+            // Density tables
+            DensityTableStart = 18,
+            DensityNumTables  = 19,
+
+            // SWFN tables
+            SwfnTableStart    = 20,
+            SwfnNumSatNodes   = 21,
+            SwfnNumTables     = 22,
+
+            // SGFN tables
+            SgfnTableStart    = 23,
+            SgfnNumSatNodes   = 24,
+            SgfnNumTables     = 25,
+
+            // SOFN tables
+            SofnTableStart    = 26,
+            SofnNumSatNodes   = 28,
+            SofnNumTables     = 29,
+
+            // Size of TABDIMS array
+            TabDimsNumElems  = 100,
+        };
+    } // namespace TabDims
+
+}}}} // namespace Opm::RestartIO::Helpers::VectorItems
+
+#endif // OPM_OUTPUT_ECLIPSE_VECTOR_TABDIMS_HPP

--- a/tests/test_Tables.cpp
+++ b/tests/test_Tables.cpp
@@ -31,8 +31,6 @@
 #include <stdexcept>
 #include <vector>
 
-#include <ert/ecl/ecl_kw_magic.h>
-
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
@@ -40,7 +38,9 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
+#include <opm/output/eclipse/VectorItems/tabdims.hpp>
 
+using Ix = ::Opm::RestartIO::Helpers::VectorItems::TabDims::index;
 
 namespace {
     template <class Collection1, class Collection2>
@@ -1172,9 +1172,9 @@ BOOST_AUTO_TEST_CASE (Oil_Water_Family_One)
 
     // SOFN
     {
-        const auto ibsofn = tabdims[ TABDIMS_IBSOFN_OFFSET_ITEM ] - 1;
-        const auto nssofn = tabdims[ TABDIMS_NSSOFN_ITEM ];
-        const auto ntsofn = tabdims[ TABDIMS_NTSOFN_ITEM ];
+        const auto ibsofn = tabdims[ Ix::SofnTableStart ] - 1;
+        const auto nssofn = tabdims[ Ix::SofnNumSatNodes ];
+        const auto ntsofn = tabdims[ Ix::SofnNumTables ];
         const auto ncol   = 3;
 
         const auto sofn = std::vector<double> {
@@ -1190,9 +1190,9 @@ BOOST_AUTO_TEST_CASE (Oil_Water_Family_One)
 
     // SWFN
     {
-        const auto ibswfn = tabdims[ TABDIMS_IBSWFN_OFFSET_ITEM ] - 1;
-        const auto nsswfn = tabdims[ TABDIMS_NSSWFN_ITEM ];
-        const auto ntswfn = tabdims[ TABDIMS_NTSWFN_ITEM ];
+        const auto ibswfn = tabdims[ Ix::SwfnTableStart ] - 1;
+        const auto nsswfn = tabdims[ Ix::SwfnNumSatNodes ];
+        const auto ntswfn = tabdims[ Ix::SwfnNumTables ];
         const auto ncol   = 5;
 
         const auto swfn = std::vector<double> {
@@ -1219,9 +1219,9 @@ BOOST_AUTO_TEST_CASE (Oil_Water_Family_Two)
 
     // SOFN
     {
-        const auto ibsofn = tabdims[ TABDIMS_IBSOFN_OFFSET_ITEM ] - 1;
-        const auto nssofn = tabdims[ TABDIMS_NSSOFN_ITEM ];
-        const auto ntsofn = tabdims[ TABDIMS_NTSOFN_ITEM ];
+        const auto ibsofn = tabdims[ Ix::SofnTableStart ] - 1;
+        const auto nssofn = tabdims[ Ix::SofnNumSatNodes ];
+        const auto ntsofn = tabdims[ Ix::SofnNumTables ];
         const auto ncol   = 3;
 
         const auto sofn = std::vector<double> {
@@ -1237,9 +1237,9 @@ BOOST_AUTO_TEST_CASE (Oil_Water_Family_Two)
 
     // SWFN
     {
-        const auto ibswfn = tabdims[ TABDIMS_IBSWFN_OFFSET_ITEM ] - 1;
-        const auto nsswfn = tabdims[ TABDIMS_NSSWFN_ITEM ];
-        const auto ntswfn = tabdims[ TABDIMS_NTSWFN_ITEM ];
+        const auto ibswfn = tabdims[ Ix::SwfnTableStart ] - 1;
+        const auto nsswfn = tabdims[ Ix::SwfnNumSatNodes ];
+        const auto ntswfn = tabdims[ Ix::SwfnNumTables ];
         const auto ncol   = 5;
 
         const auto swfn = std::vector<double> {
@@ -1266,9 +1266,9 @@ BOOST_AUTO_TEST_CASE (Gas_Oil_Familiy_One)
 
     // SGFN
     {
-        const auto ibsgfn = tabdims[ TABDIMS_IBSGFN_OFFSET_ITEM ] - 1;
-        const auto nssgfn = tabdims[ TABDIMS_NSSGFN_ITEM ];
-        const auto ntsgfn = tabdims[ TABDIMS_NTSGFN_ITEM ];
+        const auto ibsgfn = tabdims[ Ix::SgfnTableStart ] - 1;
+        const auto nssgfn = tabdims[ Ix::SgfnNumSatNodes ];
+        const auto ntsgfn = tabdims[ Ix::SgfnNumTables ];
         const auto ncol   = 5;
 
         const auto sgfn = std::vector<double> {
@@ -1284,9 +1284,9 @@ BOOST_AUTO_TEST_CASE (Gas_Oil_Familiy_One)
 
     // SOFN
     {
-        const auto ibsofn = tabdims[ TABDIMS_IBSOFN_OFFSET_ITEM ] - 1;
-        const auto nssofn = tabdims[ TABDIMS_NSSOFN_ITEM ];
-        const auto ntsofn = tabdims[ TABDIMS_NTSOFN_ITEM ];
+        const auto ibsofn = tabdims[ Ix::SofnTableStart ] - 1;
+        const auto nssofn = tabdims[ Ix::SofnNumSatNodes ];
+        const auto ntsofn = tabdims[ Ix::SofnNumTables ];
         const auto ncol   = 3;
 
         const auto sofn = std::vector<double> {
@@ -1313,9 +1313,9 @@ BOOST_AUTO_TEST_CASE (Gas_Oil_Familiy_Two)
 
     // SGFN
     {
-        const auto ibsgfn = tabdims[ TABDIMS_IBSGFN_OFFSET_ITEM ] - 1;
-        const auto nssgfn = tabdims[ TABDIMS_NSSGFN_ITEM ];
-        const auto ntsgfn = tabdims[ TABDIMS_NTSGFN_ITEM ];
+        const auto ibsgfn = tabdims[ Ix::SgfnTableStart ] - 1;
+        const auto nssgfn = tabdims[ Ix::SgfnNumSatNodes ];
+        const auto ntsgfn = tabdims[ Ix::SgfnNumTables ];
         const auto ncol   = 5;
 
         const auto sgfn = std::vector<double> {
@@ -1331,9 +1331,9 @@ BOOST_AUTO_TEST_CASE (Gas_Oil_Familiy_Two)
 
     // SOFN
     {
-        const auto ibsofn = tabdims[ TABDIMS_IBSOFN_OFFSET_ITEM ] - 1;
-        const auto nssofn = tabdims[ TABDIMS_NSSOFN_ITEM ];
-        const auto ntsofn = tabdims[ TABDIMS_NTSOFN_ITEM ];
+        const auto ibsofn = tabdims[ Ix::SofnTableStart ] - 1;
+        const auto nssofn = tabdims[ Ix::SofnNumSatNodes ];
+        const auto ntsofn = tabdims[ Ix::SofnNumTables ];
         const auto ncol   = 3;
 
         const auto sofn = std::vector<double> {
@@ -1366,9 +1366,9 @@ BOOST_AUTO_TEST_CASE (Serialize_Family_One)
 
     // SGFN
     {
-        const auto ibsgfn = tabdims[ TABDIMS_IBSGFN_OFFSET_ITEM ] - 1;
-        const auto nssgfn = tabdims[ TABDIMS_NSSGFN_ITEM ];
-        const auto ntsgfn = tabdims[ TABDIMS_NTSGFN_ITEM ];
+        const auto ibsgfn = tabdims[ Ix::SgfnTableStart ] - 1;
+        const auto nssgfn = tabdims[ Ix::SgfnNumSatNodes ];
+        const auto ntsgfn = tabdims[ Ix::SgfnNumTables ];
         const auto ncol   = 5;
 
         const auto sgfn = std::vector<double> {
@@ -1384,9 +1384,9 @@ BOOST_AUTO_TEST_CASE (Serialize_Family_One)
 
     // SOFN
     {
-        const auto ibsofn = tabdims[ TABDIMS_IBSOFN_OFFSET_ITEM ] - 1;
-        const auto nssofn = tabdims[ TABDIMS_NSSOFN_ITEM ];
-        const auto ntsofn = tabdims[ TABDIMS_NTSOFN_ITEM ];
+        const auto ibsofn = tabdims[ Ix::SofnTableStart ] - 1;
+        const auto nssofn = tabdims[ Ix::SofnNumSatNodes ];
+        const auto ntsofn = tabdims[ Ix::SofnNumTables ];
         const auto ncol   = 5;
 
         const auto sofn = std::vector<double> {
@@ -1402,9 +1402,9 @@ BOOST_AUTO_TEST_CASE (Serialize_Family_One)
 
     // SWFN
     {
-        const auto ibswfn = tabdims[ TABDIMS_IBSWFN_OFFSET_ITEM ] - 1;
-        const auto nsswfn = tabdims[ TABDIMS_NSSWFN_ITEM ];
-        const auto ntswfn = tabdims[ TABDIMS_NTSWFN_ITEM ];
+        const auto ibswfn = tabdims[ Ix::SwfnTableStart ] - 1;
+        const auto nsswfn = tabdims[ Ix::SwfnNumSatNodes ];
+        const auto ntswfn = tabdims[ Ix::SwfnNumTables ];
         const auto ncol   = 5;
 
         const auto swfn = std::vector<double> {
@@ -1431,9 +1431,9 @@ BOOST_AUTO_TEST_CASE (Serialize_Family_Two)
 
     // SGFN
     {
-        const auto ibsgfn = tabdims[ TABDIMS_IBSGFN_OFFSET_ITEM ] - 1;
-        const auto nssgfn = tabdims[ TABDIMS_NSSGFN_ITEM ];
-        const auto ntsgfn = tabdims[ TABDIMS_NTSGFN_ITEM ];
+        const auto ibsgfn = tabdims[ Ix::SgfnTableStart ] - 1;
+        const auto nssgfn = tabdims[ Ix::SgfnNumSatNodes ];
+        const auto ntsgfn = tabdims[ Ix::SgfnNumTables ];
         const auto ncol   = 5;
 
         const auto sgfn = std::vector<double> {
@@ -1449,9 +1449,9 @@ BOOST_AUTO_TEST_CASE (Serialize_Family_Two)
 
     // SOFN
     {
-        const auto ibsofn = tabdims[ TABDIMS_IBSOFN_OFFSET_ITEM ] - 1;
-        const auto nssofn = tabdims[ TABDIMS_NSSOFN_ITEM ];
-        const auto ntsofn = tabdims[ TABDIMS_NTSOFN_ITEM ];
+        const auto ibsofn = tabdims[ Ix::SofnTableStart ] - 1;
+        const auto nssofn = tabdims[ Ix::SofnNumSatNodes ];
+        const auto ntsofn = tabdims[ Ix::SofnNumTables ];
         const auto ncol   = 5;
 
         const auto sofn = std::vector<double> {
@@ -1467,9 +1467,9 @@ BOOST_AUTO_TEST_CASE (Serialize_Family_Two)
 
     // SWFN
     {
-        const auto ibswfn = tabdims[ TABDIMS_IBSWFN_OFFSET_ITEM ] - 1;
-        const auto nsswfn = tabdims[ TABDIMS_NSSWFN_ITEM ];
-        const auto ntswfn = tabdims[ TABDIMS_NTSWFN_ITEM ];
+        const auto ibswfn = tabdims[ Ix::SwfnTableStart ] - 1;
+        const auto nsswfn = tabdims[ Ix::SwfnNumSatNodes ];
+        const auto ntswfn = tabdims[ Ix::SwfnNumTables ];
         const auto ncol   = 5;
 
         const auto swfn = std::vector<double> {
@@ -1589,14 +1589,14 @@ PVDG
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvtg = tabdims[ TABDIMS_IBPVTG_OFFSET_ITEM ] - 1;
-    const auto nppvtg = tabdims[ TABDIMS_NPPVTG_ITEM ];
-    const auto ntpvtg = tabdims[ TABDIMS_NTPVTG_ITEM ];
+    const auto ibpvtg = tabdims[ Ix::PvtgMainStart ] - 1;
+    const auto nppvtg = tabdims[ Ix::NumPvtgPressNodes ];
+    const auto ntpvtg = tabdims[ Ix::NumPvtgTables ];
     const auto ncol   = 5;
 
     // Pg table defaulted
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_JBPVTG_OFFSET_ITEM], 1);
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_NRPVTG_ITEM], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::PvtgPressStart], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::NumPvtgCompNodes], 1);
 
     BOOST_CHECK_EQUAL(nppvtg, 16);
     BOOST_CHECK_EQUAL(ntpvtg,  2);
@@ -1712,14 +1712,14 @@ PVDG
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvtg = tabdims[ TABDIMS_IBPVTG_OFFSET_ITEM ] - 1;
-    const auto nppvtg = tabdims[ TABDIMS_NPPVTG_ITEM ];
-    const auto ntpvtg = tabdims[ TABDIMS_NTPVTG_ITEM ];
+    const auto ibpvtg = tabdims[ Ix::PvtgMainStart ] - 1;
+    const auto nppvtg = tabdims[ Ix::NumPvtgPressNodes ];
+    const auto ntpvtg = tabdims[ Ix::NumPvtgTables ];
     const auto ncol   = 5;
 
     // Pg table defaulted
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_JBPVTG_OFFSET_ITEM], 1);
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_NRPVTG_ITEM], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::PvtgPressStart], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::NumPvtgCompNodes], 1);
 
     BOOST_CHECK_EQUAL(nppvtg, 14); // Table 2
     BOOST_CHECK_EQUAL(ntpvtg,  2);
@@ -1825,11 +1825,11 @@ PVTG
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvtg = tabdims[ TABDIMS_IBPVTG_OFFSET_ITEM ] - 1;
-    const auto jbpvtg = tabdims[ TABDIMS_JBPVTG_OFFSET_ITEM ] - 1;
-    const auto nppvtg = tabdims[ TABDIMS_NPPVTG_ITEM ];
-    const auto nrpvtg = tabdims[ TABDIMS_NRPVTG_ITEM ];
-    const auto ntpvtg = tabdims[ TABDIMS_NTPVTG_ITEM ];
+    const auto ibpvtg = tabdims[ Ix::PvtgMainStart ] - 1;
+    const auto jbpvtg = tabdims[ Ix::PvtgPressStart ] - 1;
+    const auto nppvtg = tabdims[ Ix::NumPvtgPressNodes ];
+    const auto nrpvtg = tabdims[ Ix::NumPvtgCompNodes ];
+    const auto ntpvtg = tabdims[ Ix::NumPvtgTables ];
     const auto ncol   = 5;
 
     BOOST_CHECK_EQUAL(nppvtg, 7);
@@ -1976,11 +1976,11 @@ PVTG
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvtg = tabdims[ TABDIMS_IBPVTG_OFFSET_ITEM ] - 1;
-    const auto jbpvtg = tabdims[ TABDIMS_JBPVTG_OFFSET_ITEM ] - 1;
-    const auto nppvtg = tabdims[ TABDIMS_NPPVTG_ITEM ];
-    const auto nrpvtg = tabdims[ TABDIMS_NRPVTG_ITEM ];
-    const auto ntpvtg = tabdims[ TABDIMS_NTPVTG_ITEM ];
+    const auto ibpvtg = tabdims[ Ix::PvtgMainStart ] - 1;
+    const auto jbpvtg = tabdims[ Ix::PvtgPressStart ] - 1;
+    const auto nppvtg = tabdims[ Ix::NumPvtgPressNodes ];
+    const auto nrpvtg = tabdims[ Ix::NumPvtgCompNodes ];
+    const auto ntpvtg = tabdims[ Ix::NumPvtgTables ];
     const auto ncol   = 5;
 
     BOOST_CHECK_EQUAL(nppvtg, 7);
@@ -2122,11 +2122,11 @@ PVTG
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvtg = tabdims[ TABDIMS_IBPVTG_OFFSET_ITEM ] - 1;
-    const auto jbpvtg = tabdims[ TABDIMS_JBPVTG_OFFSET_ITEM ] - 1;
-    const auto nppvtg = tabdims[ TABDIMS_NPPVTG_ITEM ];
-    const auto nrpvtg = tabdims[ TABDIMS_NRPVTG_ITEM ];
-    const auto ntpvtg = tabdims[ TABDIMS_NTPVTG_ITEM ];
+    const auto ibpvtg = tabdims[ Ix::PvtgMainStart ] - 1;
+    const auto jbpvtg = tabdims[ Ix::PvtgPressStart ] - 1;
+    const auto nppvtg = tabdims[ Ix::NumPvtgPressNodes ];
+    const auto nrpvtg = tabdims[ Ix::NumPvtgCompNodes ];
+    const auto ntpvtg = tabdims[ Ix::NumPvtgTables ];
     const auto ncol   = 5;
 
     BOOST_CHECK_EQUAL(nppvtg, 5); // Table 1
@@ -2260,14 +2260,14 @@ PVCDO
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvto = tabdims[ TABDIMS_IBPVTO_OFFSET_ITEM ] - 1;
-    const auto nppvto = tabdims[ TABDIMS_NPPVTO_ITEM ];
-    const auto ntpvto = tabdims[ TABDIMS_NTPVTO_ITEM ];
+    const auto ibpvto = tabdims[ Ix::PvtoMainStart ] - 1;
+    const auto nppvto = tabdims[ Ix::NumPvtoPressNodes ];
+    const auto ntpvto = tabdims[ Ix::NumPvtoTables ];
     const auto ncol   = 5;
 
     // Rs table defaulted
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_JBPVTO_OFFSET_ITEM], 1);
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_NRPVTO_ITEM], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::PvtoCompStart], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::NumPvtoCompNodes], 1);
 
     BOOST_CHECK_EQUAL(nppvto, 4);
     BOOST_CHECK_EQUAL(ntpvto, 2);
@@ -2345,14 +2345,14 @@ PVDO
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvto = tabdims[ TABDIMS_IBPVTO_OFFSET_ITEM ] - 1;
-    const auto nppvto = tabdims[ TABDIMS_NPPVTO_ITEM ];
-    const auto ntpvto = tabdims[ TABDIMS_NTPVTO_ITEM ];
+    const auto ibpvto = tabdims[ Ix::PvtoMainStart ] - 1;
+    const auto nppvto = tabdims[ Ix::NumPvtoPressNodes ];
+    const auto ntpvto = tabdims[ Ix::NumPvtoTables ];
     const auto ncol   = 5;
 
     // Rs table defaulted
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_JBPVTO_OFFSET_ITEM], 1);
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_NRPVTO_ITEM], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::PvtoCompStart], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::NumPvtoCompNodes], 1);
 
     BOOST_CHECK_EQUAL(nppvto, 8);
     BOOST_CHECK_EQUAL(ntpvto, 2);
@@ -2442,14 +2442,14 @@ PVDO
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvto = tabdims[ TABDIMS_IBPVTO_OFFSET_ITEM ] - 1;
-    const auto nppvto = tabdims[ TABDIMS_NPPVTO_ITEM ];
-    const auto ntpvto = tabdims[ TABDIMS_NTPVTO_ITEM ];
+    const auto ibpvto = tabdims[ Ix::PvtoMainStart ] - 1;
+    const auto nppvto = tabdims[ Ix::NumPvtoPressNodes ];
+    const auto ntpvto = tabdims[ Ix::NumPvtoTables ];
     const auto ncol   = 5;
 
     // Rs table defaulted
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_JBPVTO_OFFSET_ITEM], 1);
-    BOOST_CHECK_EQUAL(tabdims[TABDIMS_NRPVTO_ITEM], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::PvtoCompStart], 1);
+    BOOST_CHECK_EQUAL(tabdims[Ix::NumPvtoCompNodes], 1);
 
     BOOST_CHECK_EQUAL(nppvto, 10); // Table 1
     BOOST_CHECK_EQUAL(ntpvto,  2);
@@ -2541,11 +2541,11 @@ PVTO
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvto = tabdims[ TABDIMS_IBPVTO_OFFSET_ITEM ] - 1;
-    const auto jbpvto = tabdims[ TABDIMS_JBPVTO_OFFSET_ITEM ] - 1;
-    const auto nppvto = tabdims[ TABDIMS_NPPVTO_ITEM ];
-    const auto nrpvto = tabdims[ TABDIMS_NRPVTO_ITEM ];
-    const auto ntpvto = tabdims[ TABDIMS_NTPVTO_ITEM ];
+    const auto ibpvto = tabdims[ Ix::PvtoMainStart ] - 1;
+    const auto jbpvto = tabdims[ Ix::PvtoCompStart ] - 1;
+    const auto nppvto = tabdims[ Ix::NumPvtoPressNodes ];
+    const auto nrpvto = tabdims[ Ix::NumPvtoCompNodes ];
+    const auto ntpvto = tabdims[ Ix::NumPvtoTables ];
     const auto ncol   = 5;
 
     BOOST_CHECK_EQUAL(nppvto, 4);
@@ -2690,11 +2690,11 @@ PVTO
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvto = tabdims[ TABDIMS_IBPVTO_OFFSET_ITEM ] - 1;
-    const auto jbpvto = tabdims[ TABDIMS_JBPVTO_OFFSET_ITEM ] - 1;
-    const auto nppvto = tabdims[ TABDIMS_NPPVTO_ITEM ];
-    const auto nrpvto = tabdims[ TABDIMS_NRPVTO_ITEM ];
-    const auto ntpvto = tabdims[ TABDIMS_NTPVTO_ITEM ];
+    const auto ibpvto = tabdims[ Ix::PvtoMainStart ] - 1;
+    const auto jbpvto = tabdims[ Ix::PvtoCompStart ] - 1;
+    const auto nppvto = tabdims[ Ix::NumPvtoPressNodes ];
+    const auto nrpvto = tabdims[ Ix::NumPvtoCompNodes ];
+    const auto ntpvto = tabdims[ Ix::NumPvtoTables ];
     const auto ncol   = 5;
 
     BOOST_CHECK_EQUAL(nppvto, 5);
@@ -2848,11 +2848,11 @@ PVTO
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvto = tabdims[ TABDIMS_IBPVTO_OFFSET_ITEM ] - 1;
-    const auto jbpvto = tabdims[ TABDIMS_JBPVTO_OFFSET_ITEM ] - 1;
-    const auto nppvto = tabdims[ TABDIMS_NPPVTO_ITEM ];
-    const auto nrpvto = tabdims[ TABDIMS_NRPVTO_ITEM ];
-    const auto ntpvto = tabdims[ TABDIMS_NTPVTO_ITEM ];
+    const auto ibpvto = tabdims[ Ix::PvtoMainStart ] - 1;
+    const auto jbpvto = tabdims[ Ix::PvtoCompStart ] - 1;
+    const auto nppvto = tabdims[ Ix::NumPvtoPressNodes ];
+    const auto nrpvto = tabdims[ Ix::NumPvtoCompNodes ];
+    const auto ntpvto = tabdims[ Ix::NumPvtoTables ];
     const auto ncol   = 5;
 
     // Verify declared TABDIMS from input
@@ -2999,8 +2999,8 @@ PVTW
     const auto& tabdims = tables.tabdims();
     const auto& tab     = tables.tab();
 
-    const auto ibpvtw = tabdims[ TABDIMS_IBPVTW_OFFSET_ITEM ] - 1;
-    const auto ntpvtw = tabdims[ TABDIMS_NTPVTW_ITEM ];
+    const auto ibpvtw = tabdims[ Ix::PvtwStart ] - 1;
+    const auto ntpvtw = tabdims[ Ix::NumPvtwTables ];
     const auto ncol   = 5;
 
     BOOST_CHECK_EQUAL(ntpvtw, 2);


### PR DESCRIPTION
This commit makes the table linearisation code independent of LibECL's `ecl_kw_magic.h` header.  In particular, we add a new set of vector items (`tabdims.hpp`) that describe the items we currently define and reimplement the member functions of the `Tables` class in terms of these items.

Update the unit test accordingly.