### PR TITLE
improvements related to Aquifer modeling

### DIFF
--- a/opm/parser/eclipse/EclipseState/Aquancon.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquancon.hpp
@@ -56,14 +56,20 @@ namespace Opm {
 
         private:
 
-            std::vector<Aquancon::AquanconOutput> logic_application(const std::vector<Aquancon::AquanconOutput>& original_vector);
+            static std::vector<Aquancon::AquanconOutput> logic_application(const std::vector<Aquancon::AquanconOutput>& original_vector);
 
-            void collate_function(std::vector<Aquancon::AquanconOutput>& output_vector,
+            static void collate_function(std::vector<Aquancon::AquanconOutput>& output_vector,
                                   std::vector<Opm::AquanconRecord>& m_aqurecord,
-                                  std::vector<int> m_aquiferID_per_record, int m_maxAquID);
+                                  const std::vector<int>& m_aquiferID_per_record, int m_maxAquID);
 
-            void convert_record_id_to_aquifer_id(std::vector<int>& record_indices_matching_id, int i,
-                                                 std::vector<int> m_aquiferID_per_record);
+            static void convert_record_id_to_aquifer_id(std::vector<int>& record_indices_matching_id, int i,
+                                                        const std::vector<int>& m_aquiferID_per_record);
+
+            // for a cell to be inside reservoir, its indices need to be within the reservoir grid dimension range,
+            // and it needs to be active
+            static bool cellInsideReservoir(const EclipseGrid& grid, int i, int j, int k);
+
+            static bool neighborCellInsideReservoir(const EclipseGrid& grid, int i, int j, int k, FaceDir::DirEnum faceDir);
 
             std::vector<Aquancon::AquanconOutput> m_aquoutput;
     };

--- a/opm/parser/eclipse/EclipseState/Aquancon.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquancon.hpp
@@ -67,9 +67,9 @@ namespace Opm {
 
             // for a cell to be inside reservoir, its indices need to be within the reservoir grid dimension range,
             // and it needs to be active
-            static bool cellInsideReservoir(const EclipseGrid& grid, int i, int j, int k);
+            static bool cellInsideReservoirAndActive(const EclipseGrid& grid, int i, int j, int k);
 
-            static bool neighborCellInsideReservoir(const EclipseGrid& grid, int i, int j, int k, FaceDir::DirEnum faceDir);
+            static bool neighborCellInsideReservoirAndActive(const EclipseGrid& grid, int i, int j, int k, FaceDir::DirEnum faceDir);
 
             std::vector<Aquancon::AquanconOutput> m_aquoutput;
     };

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUFETP
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUFETP
@@ -6,6 +6,6 @@
         {"name" : "V0" ,              		"value_type" : "DOUBLE" ,                        "dimension" : "Length*Length*Length"},
         {"name" : "C_T" , 			"value_type" : "DOUBLE" ,                        "dimension" : "1/Pressure"},
         {"name" : "PI" ,              		"value_type" : "DOUBLE" ,                        "dimension" : "ReservoirVolume/Pressure*Time"},
-        {"name" : "TABLE_NUM_WATER_PRESS" ,     "value_type" : "INT"    , "default_value" : 1},
-        {"name" : "SALINITY" ,        		"value_type" : "DOUBLE" , "default_value" : 0 , "dimension" : "Salinity"},
+        {"name" : "TABLE_NUM_WATER_PRESS" ,     "value_type" : "INT"    , "default" : 1},
+        {"name" : "SALINITY" ,        		"value_type" : "DOUBLE" , "default" : 0 , "dimension" : "Salinity"},
         {"name" : "TEMP" ,            		"value_type" : "DOUBLE" , "                      dimension" : "Temperature"}]}

--- a/tests/parser/AquanconTests.cpp
+++ b/tests/parser/AquanconTests.cpp
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(AquanconTest_DEFAULT_INFLUX) {
 }
 
 // allowing aquifer exists inside the reservoir
-inline Deck createAQUANCONDeck_ALLOW_INSIDE_AQUAN() {
+inline Deck createAQUANCONDeck_ALLOW_INSIDE_AQUAN_OR_NOT() {
     const char *deckData =
         "DIMENS\n"
         "3 3 3 /\n"
@@ -197,21 +197,26 @@ inline Deck createAQUANCONDeck_ALLOW_INSIDE_AQUAN() {
         "\n"
         "AQUFETP\n"
         "  1 20.0 1000.0 2000. 0.000001 200.0 /\n"
+        "  2 20.0 1000.0 2000. 0.000001 200.0 /\n"
         "/\n"
         "AQUANCON\n"
         "   1      1  1   1   1   1  1  J-  2* YES /\n"
         "   1      2  2   1   1   1  1  J-  2* YES /\n"
         "   1      2  2   2   2   1  1  J-  2* YES /\n"
+        "   2      1  1   1   1   3  3  J-  2* NO /\n"
+        "   2      2  2   1   1   3  3  J-  2* NO /\n"
+        "   2      2  2   2   2   3  3  J-  2* NO /\n"
         "/ \n";
 
     Parser parser;
     return parser.parseString(deckData);
 }
 
-BOOST_AUTO_TEST_CASE(AquanconTest_ALLOW_AQUIFER_INSIDE) {
-    auto deck = createAQUANCONDeck_ALLOW_INSIDE_AQUAN();
+BOOST_AUTO_TEST_CASE(AquanconTest_ALLOW_AQUIFER_INSIDE_OR_NOT) {
+    auto deck = createAQUANCONDeck_ALLOW_INSIDE_AQUAN_OR_NOT();
     const EclipseState eclState( deck );
     const Aquancon aqucon( eclState.getInputGrid(), deck);
     const std::vector<Aquancon::AquanconOutput>& aquifer_cons = aqucon.getAquOutput();
     BOOST_CHECK_EQUAL(aquifer_cons[0].global_index.size(), 2);
+    BOOST_CHECK_EQUAL(aquifer_cons[1].global_index.size(), 1);
 }

--- a/tests/parser/AquanconTests.cpp
+++ b/tests/parser/AquanconTests.cpp
@@ -49,8 +49,8 @@ inline Deck createAQUANCONDeck_DEFAULT_INFLUX2() {
         "SOLUTION\n"
         "\n"
         "AQUANCON\n"
-        "   1      1  1  1    1   1  1  J-  1.0 /\n"
-        "   1      1  1  1    1   1  1  J-   /\n"
+        "   1      2  2  1    1   1  1  J-  1.0 /\n"
+        "   1      2  2  1    1   1  1  J-   /\n"
         "/ \n";
 
     Parser parser;
@@ -169,4 +169,49 @@ BOOST_AUTO_TEST_CASE(AquanconTest_DEFAULT_INFLUX) {
     auto deck2 = createAQUANCONDeck_DEFAULT_INFLUX2();
     EclipseState eclState2( deck2 );
     BOOST_CHECK_THROW(Aquancon( eclState2.getInputGrid(), deck2), std::invalid_argument);
+}
+
+// allowing aquifer exists inside the reservoir
+inline Deck createAQUANCONDeck_ALLOW_INSIDE_AQUAN() {
+    const char *deckData =
+        "DIMENS\n"
+        "3 3 3 /\n"
+        "\n"
+        "GRID\n"
+        "\n"
+        "ACTNUM\n"
+        " 0 8*1 0 8*1 0 8*1 /\n"
+        "DXV\n"
+        "1 1 1 /\n"
+        "\n"
+        "DYV\n"
+        "1 1 1 /\n"
+        "\n"
+        "DZV\n"
+        "1 1 1 /\n"
+        "\n"
+        "TOPS\n"
+        "9*100 /\n"
+        "\n"
+        "SOLUTION\n"
+        "\n"
+        "AQUFETP\n"
+        "  1 20.0 1000.0 2000. 0.000001 200.0 /\n"
+        "/\n"
+        "AQUANCON\n"
+        "   1      1  1   1   1   1  1  J-  2* YES /\n"
+        "   1      2  2   1   1   1  1  J-  2* YES /\n"
+        "   1      2  2   2   2   1  1  J-  2* YES /\n"
+        "/ \n";
+
+    Parser parser;
+    return parser.parseString(deckData);
+}
+
+BOOST_AUTO_TEST_CASE(AquanconTest_ALLOW_AQUIFER_INSIDE) {
+    auto deck = createAQUANCONDeck_ALLOW_INSIDE_AQUAN();
+    const EclipseState eclState( deck );
+    const Aquancon aqucon( eclState.getInputGrid(), deck);
+    const std::vector<Aquancon::AquanconOutput>& aquifer_cons = aqucon.getAquOutput();
+    BOOST_CHECK_EQUAL(aquifer_cons[0].global_index.size(), 2);
 }


### PR DESCRIPTION
By default, the aquifer connections can only be specified at the faces between active and inactive cells. 

The current implementation does not consider this logic, this PR is adding this part. 

It fixes running of some small test cases, while it looks there are still something missing for more larger and more complicated models. 

And also, when coming to active and inactive cells, some later grid processing might add more inactive cells. This PR does not consider these situations. 

Nevertheless, this PR is improving the implementation. 