### PR TITLE
python: new DeckKeyword constructor takes DeckRecords

### DIFF
--- a/python/cxx/deck_keyword.cpp
+++ b/python/cxx/deck_keyword.cpp
@@ -2,6 +2,7 @@
 
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 
+#include <opm/parser/eclipse/Deck/DeckValue.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
@@ -9,6 +10,8 @@
 
 #include "export.hpp"
 #include "converters.hpp"
+
+#include <iostream>
 
 
 namespace {
@@ -56,11 +59,80 @@ struct DeckRecordIterator
     }
 };
 
+
+bool is_number(const std::string& s)
+{
+    return !s.empty() && std::find_if(s.begin(), 
+        s.end(), [](char c) { return !std::isdigit(c); }) == s.end();
+}
+
+
+void push_string_as_deck_value(std::vector<DeckValue>& record, const std::string str) {
+
+    int max_indx = str.length() - 1;
+    if (str[max_indx] == '*') {
+        int it;
+
+        if (max_indx == 0)
+            it = 1;
+        else {
+            std::string substr = str.substr(0, max_indx);
+            if (is_number(substr)) {
+                it = std::stoi(substr);
+            }
+            else
+                throw py::type_error("DeckKeyword: string values ending in '*' can only be preceeded by a number.");
+        }
+
+        for (int i = 0; i < it; i++)
+            record.push_back( DeckValue() );
+    }
+    else
+        record.push_back( DeckValue(str) );
+}
+
+
 }
 
 void python::common::export_DeckKeyword(py::module& module) {
     py::class_< DeckKeyword >( module, "DeckKeyword")
         .def(py::init<const ParserKeyword& >())
+
+        .def(py::init([](const ParserKeyword& parser_keyword, py::list record_list) {
+
+            std::vector< std::vector<DeckValue> > value_record_list;
+
+            for (py::handle record_obj : record_list) {
+                 py::list record = record_obj.cast<py::list>();
+                 std::vector<DeckValue> value_record;
+
+                 for (py::handle value_obj : record) { 
+
+                      try {
+                          int val_int = value_obj.cast<int>();
+                          value_record.push_back( DeckValue(val_int) );
+                      }
+                      catch (std::exception e_int) {
+                          try {
+                              double val_double = value_obj.cast<double>();
+                              value_record.push_back( DeckValue(val_double) );
+                          }
+                          catch(std::exception e_double) {
+                               try {
+                                   std::string val_string = value_obj.cast<std::string>();                                      
+                                   push_string_as_deck_value(value_record, val_string);
+                               }
+                               catch(std::exception e_string) {
+                                    throw py::type_error("DeckKeyword: tried to add unkown type to record.");
+                               }
+                          }                          
+                      }
+                 }
+                 value_record_list.push_back( value_record );
+             }
+             return DeckKeyword(parser_keyword, value_record_list);
+         }  )  )
+
         .def( "__repr__", &DeckKeyword::name )
         .def( "__str__", &str<DeckKeyword> )
         .def("__iter__",  [] (const DeckKeyword &keyword) { return py::make_iterator(keyword.begin(), keyword.end()); }, py::keep_alive<0,1>())

--- a/python/cxx/deck_keyword.cpp
+++ b/python/cxx/deck_keyword.cpp
@@ -60,23 +60,46 @@ struct DeckRecordIterator
 };
 
 
+bool is_int(const std::string& s)
+{
+    return !s.empty() && std::find_if(s.begin(), 
+        s.end(), [](char c) { return !std::isdigit(c); }) == s.end();
+}
+
+
 void push_string_as_deck_value(std::vector<DeckValue>& record, const std::string str) {
 
-    if (str.back() == '*') {
-        int it;
+    std::size_t star_pos = str.find('*');
+    if (star_pos != std::string::npos) {
+        int multiplier = 1;
+        
+        std::string mult_str = str.substr(0, star_pos);
 
-        if (str.length() == 1)
-            it = 1;
-        else
-            it = stod( str.substr(0, str.length() - 1) );
+        if (mult_str.length() > 0) {
+            if (is_int(mult_str))
+                multiplier = std::stoi( mult_str );
+            else
+                throw py::type_error();
+        }
 
-        for (int i = 0; i < it; i++)
-            record.push_back( DeckValue() );
+        std::string value_str = str.substr(star_pos + 1, str.length());
+        DeckValue value;
+
+        if (value_str.length() > 0) {
+            if (is_int(value_str))
+                value = DeckValue( stoi(value_str) );
+            else
+                value = DeckValue( stod(value_str) );
+        }
+
+        for (int i = 0; i < multiplier; i++)
+            record.push_back( value );
+      
     }
     else
         record.push_back( DeckValue(str) );
-}
 
+}
 
 }
 

--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -55,11 +55,51 @@ FIPNUM
         with self.assertRaises(ValueError):
             kw = parser["NOT_A_VALID_KEYWORD"]
 
-        kw = parser["FIELD"]
-        assert(kw.name == "FIELD")
+        field = parser["FIELD"]
+        assert(field.name == "FIELD")
 
-        dkw = DeckKeyword(kw)
-        assert(dkw.name == "FIELD")
+        dkw_field = DeckKeyword(field)
+        assert(dkw_field.name == "FIELD")
+
+        DeckKeyword(parser["AQUCWFAC"], [[]])
+
+        with self.assertRaises(TypeError):
+            dkw_wrong =  DeckKeyword(parser["AQUCWFAC"], [22.2, 0.25])
+
+        dkw_aqannc = DeckKeyword(parser["AQANNC"], [[12, 1, 2, 3, 0.89], [13, 4, 5, 6, 0.625]])
+        assert( len(dkw_aqannc[0]) == 5 )
+        assert( dkw_aqannc[0][2][0] == 2 )
+        assert( dkw_aqannc[1][1][0] == 4 )
+        assert( dkw_aqannc[1][4][0] == 0.625 )
+
+        dkw_aqantrc = DeckKeyword(parser["AQANTRC"], [[12, "ABC", 8]])
+        assert( dkw_aqantrc[0][1][0] == "ABC" )
+        assert( dkw_aqantrc[0][2][0] == 8.0 )
+
+        dkw1 = DeckKeyword(parser["AQUCWFAC"], [["*", 0.25]])
+        assert( dkw1[0][0][0] == 0.0 )
+        assert( dkw1[0][1][0] == 0.25 )
+
+        dkw2 = DeckKeyword(parser["AQUCWFAC"], [[0.25, "*"]])
+        assert( dkw2[0][0][0] == 0.25 )
+        assert( dkw2[0][1][0] == 1.0 )
+
+        dkw3 = DeckKeyword(parser["AQUCWFAC"], [[0.50]])
+        assert( dkw3[0][0][0] == 0.50 )
+        assert( dkw3[0][1][0] == 1.0 )
+
+        dkw4 = DeckKeyword(parser["CBMOPTS"], [["3*", "A", "B", "C", "2*", 0.375]])
+        assert( dkw4[0][0][0] == "TIMEDEP" )
+        assert( dkw4[0][2][0] == "NOKRMIX" )
+        assert( dkw4[0][3][0] == "A" )
+        assert( dkw4[0][6][0] == "PMPVK" )
+        assert( dkw4[0][8][0] == 0.375 )
+
+        with self.assertRaises(TypeError):
+            DeckKeyword(parser["CBMOPTS"], [["3*", "A", "B", "C", "R2*", 0.77]])
+
+
+        
 
 
 if __name__ == "__main__":

--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -98,7 +98,15 @@ FIPNUM
         with self.assertRaises(TypeError):
             DeckKeyword(parser["CBMOPTS"], [["3*", "A", "B", "C", "R2*", 0.77]])
 
+        with self.assertRaises(TypeError):
+            DeckKeyword(parser["CBMOPTS"], [["3*", "A", "B", "C", "2.2*", 0.77]])
 
+        dkw5 = DeckKeyword(parser["AQUCWFAC"], [["2*5.5"]])
+        assert( dkw5[0][0][0] == 5.5 )
+        assert( dkw5[0][1][0] == 5.5 )
+
+        with self.assertRaises(ValueError):
+            raise DeckKeyword(parser["AQANTRC"], [["1*2.2", "ABC", 8]])
         
 
 


### PR DESCRIPTION
Python:
Introducing a new `DeckKeyword` constructor:
```Python
DeckKeyword(Parserkeyword, [ record1, record2, .. etc] )
record1 = [value1, value2, ... etc.]
```
Possible use:
```Python
dkw = DeckKeyword(parser["CBMOPTS"], [["3*", "A", "B", "C", "2*", 0.375]])
```