### PR TITLE
Prepare New Summary Writer

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -21,6 +21,7 @@
 
 #include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
+#include <opm/output/eclipse/Summary.hpp>
 #include <opm/output/data/Solution.hpp>
 #include <opm/output/data/Wells.hpp>
 

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -72,6 +72,7 @@ public:
     }
 
     void message(const std::string& msg);
+    void flushStream();
 
     friend class OutputStream::Restart;
     friend class OutputStream::SummarySpecification;

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -23,10 +23,9 @@
 #define OPM_ECLIPSE_WRITER_HPP
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-#include <array>
-#include <memory>
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
@@ -35,13 +34,16 @@
 #include <opm/output/data/Solution.hpp>
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
-#include <opm/output/eclipse/Summary.hpp>
+
+namespace Opm { namespace out {
+    class Summary;
+}} // namespace Opm::out
 
 namespace Opm {
 
 class EclipseState;
-class SummaryConfig;
 class Schedule;
+class SummaryConfig;
 class SummaryState;
 
 /*!

--- a/src/opm/io/eclipse/EclOutput.cpp
+++ b/src/opm/io/eclipse/EclOutput.cpp
@@ -86,6 +86,10 @@ void EclOutput::message(const std::string& msg)
     this->write(msg, std::vector<char>{});
 }
 
+void EclOutput::flushStream()
+{
+    this->ofileH.flush();
+}
 
 void EclOutput::writeBinaryHeader(const std::string&arrName, int size, eclArrType arrType)
 {

--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -744,8 +744,7 @@ void Opm::EclIO::OutputStream::SummarySpecification::rewindStream()
 
 void Opm::EclIO::OutputStream::SummarySpecification::flushStream()
 {
-    // Benefits from EclOutput friendship
-    this->stream().ofileH.flush();
+    this->stream().flushStream();
 }
 
 Opm::EclIO::EclOutput&

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -25,16 +25,18 @@
 #include <opm/output/eclipse/EclipseIO.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/parser/eclipse/Units/Dimension.hpp>
-#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
-#include <opm/parser/eclipse/Utility/Functional.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#include <opm/parser/eclipse/Units/Dimension.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/output/eclipse/RestartIO.hpp>
 #include <opm/output/eclipse/Summary.hpp>

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -478,6 +478,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
     auto param = SummaryNode {
         keyword.name(), SummaryNode::Category::Connection
     }
+    .parameterType( parseKeywordType( keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
 
     for( const auto& record : keyword ) {

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -31,6 +31,7 @@
 
 #include <ert/ecl/ecl_sum.h>
 #include <ert/ecl/smspec_node.h>
+#include <ert/util/ert_unique_ptr.hpp>
 #include <ert/util/util.h>
 #include <ert/util/test_work_area.h>
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -27,6 +27,7 @@
 #include <exception>
 #include <stdexcept>
 #include <unordered_map>
+#include <cctype>
 #include <ctime>
 
 #include <ert/ecl/ecl_sum.h>
@@ -56,6 +57,16 @@ namespace {
     double sm3_pr_day()
     {
        return unit::cubic(unit::meter) / unit::day;
+    }
+
+    std::string toupper(std::string input)
+    {
+        for (auto& c : input) {
+            const auto uc = std::toupper(static_cast<unsigned char>(c));
+            c = static_cast<std::string::value_type>(uc);
+        }
+
+        return input;
     }
 } // Anonymous
 
@@ -268,14 +279,14 @@ struct setup {
 
     /*-----------------------------------------------------------------*/
 
-    setup( const std::string& fname , const char* path = "summary_deck.DATA") :
+    setup(std::string fname, const std::string& path = "summary_deck.DATA") :
         deck( Parser().parseFile( path) ),
         es( deck ),
         grid( es.getInputGrid() ),
         schedule( deck, grid, es.get3DProperties(), es.runspec()),
         config( deck, schedule, es.getTableManager()),
         wells( result_wells() ),
-        name( fname ),
+        name( toupper(std::move(fname)) ),
         ta( test_work_area_alloc("summary_test"))
     {
     }


### PR DESCRIPTION
This PR consists of a few preparatory steps towards introducing a new writer for Flow's summary file (`*.UNSMRY` or `*.S000n`).

In particular, we

  * Add a stream flushing operation to class `EclOutput`

  * Ensure that connection keywords (e.g., `COPT`, `CWPR`) have correct types&mdash;especially cumulative totals vs. instantaneous rates&mdash;to fix an error in PR #1049 (commit 70daf0f2c)

  * Forward-declare the `out::Summary` class in `EclipseIO.cpp` since the `EclipseIO` class does not substantively use `out::Summary` in its public implementation.  This reduces the build coupling slightly.

  * Ensure that the files/result sets created in `test_Summary.cpp` always have uppercase filenames.