### PR TITLE
Comment out UDQ related changes to DOUBHEAD

### DIFF
--- a/src/opm/output/eclipse/DoubHEAD.cpp
+++ b/src/opm/output/eclipse/DoubHEAD.cpp
@@ -486,8 +486,10 @@ Opm::RestartIO::DoubHEAD::DoubHEAD()
 
     this->data_[Index::dh_210] = 0.0;
     this->data_[Index::dh_211] = 0.0;
-    this->data_[UdqPar_2]      = 1.0E+20;
-    this->data_[UdqPar_3]      = 0.0;
+    /*
+      this->data_[UdqPar_2]      = 1.0E+20;
+      this->data_[UdqPar_3]      = 0.0;
+    */
     this->data_[UdqPar_4]      = 1.0e-4;
     this->data_[Index::dh_215] = -2.0e+20;
     this->data_[Index::dh_217] = 0.0;


### PR DESCRIPTION
Hopefully recover build after #967. The commented out changes should go back in, but with an accompanying `update_date`