### PR TITLE
Prepare New Summary Writer

### DIFF
--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -428,6 +428,12 @@ namespace Opm { namespace EclIO { namespace OutputStream {
         EclOutput& stream();
     };
 
+    std::unique_ptr<EclOutput>
+    createSummaryFile(const ResultSet& rset,
+                      const int        seqnum,
+                      const Formatted& fmt,
+                      const Unified&   unif);
+
     /// Derive filename corresponding to output stream of particular result
     /// set, with user-specified file extension.
     ///

--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -43,27 +43,37 @@
 namespace {
     namespace FileExtension
     {
+        std::string separate(const int   rptStep,
+                             const bool  formatted,
+                             const char* fmt_prefix,
+                             const char* unfmt_prefix)
+        {
+            std::ostringstream ext;
+
+            const int cycle = 10 * 1000;
+            const int p_ix  = rptStep / cycle;
+            const int n     = rptStep % cycle;
+
+            ext << (formatted ? fmt_prefix[p_ix] : unfmt_prefix[p_ix])
+                << std::setw(4) << std::setfill('0') << n;
+
+            return ext.str();
+        }
+
         std::string init(const bool formatted)
         {
             return formatted ? "FINIT" : "INIT";
         }
 
-        std::string
-        restart(const int  rptStep,
-                const bool formatted,
-                const bool unified)
+        std::string restart(const int  rptStep,
+                            const bool formatted,
+                            const bool unified)
         {
             if (unified) {
                 return formatted ? "FUNRST" : "UNRST";
             }
 
-            std::ostringstream ext;
-
-            ext << (formatted ? 'F' : 'X')
-                << std::setw(4) << std::setfill('0')
-                << rptStep;
-
-            return ext.str();
+            return separate(rptStep, formatted, "FGH", "XYZ");
         }
 
         std::string rft(const bool formatted)

--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -85,6 +85,17 @@ namespace {
         {
             return formatted ? "FSMSPEC" : "SMSPEC";
         }
+
+        std::string summary(const int  rptStep,
+                            const bool formatted,
+                            const bool unified)
+        {
+            if (unified) {
+                return formatted ? "FUNSMRY" : "UNSMRY";
+            }
+
+            return separate(rptStep, formatted, "ABC", "STU");
+        }
     } // namespace FileExtension
 
     namespace Open
@@ -761,6 +772,24 @@ Opm::EclIO::EclOutput&
 Opm::EclIO::OutputStream::SummarySpecification::stream()
 {
     return *this->stream_;
+}
+
+// =====================================================================
+
+std::unique_ptr<Opm::EclIO::EclOutput>
+Opm::EclIO::OutputStream::createSummaryFile(const ResultSet& rset,
+                                            const int        seqnum,
+                                            const Formatted& fmt,
+                                            const Unified&   unif)
+{
+    const auto ext = FileExtension::summary(seqnum, fmt.set, unif.set);
+
+    return std::unique_ptr<Opm::EclIO::EclOutput> {
+        new Opm::EclIO::EclOutput {
+            outputFileName(rset, ext),
+            fmt.set, std::ios_base::out
+        }
+    };
 }
 
 // =====================================================================

--- a/src/opm/output/eclipse/WriteRFT.cpp
+++ b/src/opm/output/eclipse/WriteRFT.cpp
@@ -137,7 +137,7 @@ namespace {
         {
             using M = ::Opm::UnitSystem::measure;
 
-            welletc[etcIx::Time]      = centre(std::string{usys.name(M::time)} + 'S');
+            welletc[etcIx::Time]      = centre(usys.name(M::time));
             welletc[etcIx::Depth]     = centre(usys.name(M::length));
             welletc[etcIx::Pressure]  = centre(usys.name(M::pressure));
             welletc[etcIx::LiqRate]   = centre(usys.name(M::liquid_surface_rate));

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -150,7 +150,7 @@ namespace {
     static constexpr const char* metric_names[] = {
         "",
         "M",
-        "DAY",
+        "DAYS",
         "KG/M3",
         "BARSA",
         "K",
@@ -292,7 +292,7 @@ namespace {
     static constexpr const char* field_names[] = {
         "",
         "FT",
-        "DAY",
+        "DAYS",
         "LB/FT3",
         "PSIA",
         "R",
@@ -434,7 +434,7 @@ namespace {
     static constexpr const char* lab_names[] = {
         "",
         "CM",
-        "HR",
+        "HRS",
         "G/CC",
         "ATM",
         "K",
@@ -576,7 +576,7 @@ namespace {
     static constexpr const char* pvt_m_names[] = {
         "",
         "M",
-        "DAY",
+        "DAYS",
         "KG/M3",
         "ATM",
         "K",


### PR DESCRIPTION
This PR is the next in a sequence to enable new writer functionality for summary files.  The most important change here is switching to plurals for time units.  We also add support generating separate (non-unified) summary/restart files for simulation models with more than 10,000 report steps.  We do, however, not expect to ever encounter such models.