### PR TITLE
New summary writer

### DIFF
--- a/src/opm/io/eclipse/OutputStream.cpp
+++ b/src/opm/io/eclipse/OutputStream.cpp
@@ -593,6 +593,7 @@ namespace {
         auto ret = std::vector<PaddedOutputString<substrLength>>{};
 
         if (restart.root.empty()) {
+            ret.resize(maxSubstrings);
             return ret;
         }
 
@@ -605,6 +606,7 @@ namespace {
 
             Opm::OpmLog::warning(msg);
 
+            ret.resize(maxSubstrings);
             return ret;
         }
 
@@ -738,7 +740,7 @@ SummarySpecification::write(const Parameters& params)
     // Pretend to be ECLIPSE 100
     smspec.write("INTEHEAD", std::vector<int>{ this->unit_, 100 });
 
-    if (! this->restart_.empty())
+    // if (! this->restart_.empty())
         smspec.write("RESTART", this->restart_);
 
     smspec.write("DIMENS",

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -1863,12 +1863,13 @@ BOOST_AUTO_TEST_CASE(Unformatted_Base)
 
         auto smspec = ::Opm::EclIO::EclFile{fname};
 
-        BOOST_CHECK_MESSAGE(! smspec.hasKey("RESTART"), "SMSPEC File must NOT have 'RESTART'");
+        //BOOST_CHECK_MESSAGE(! smspec.hasKey("RESTART"), "SMSPEC File must NOT have 'RESTART'");
 
         {
             const auto vectors        = smspec.getList();
             const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
                 Opm::EclIO::EclFile::EclEntry{"INTEHEAD", Opm::EclIO::eclArrType::INTE, 2},
+                Opm::EclIO::EclFile::EclEntry{"RESTART", Opm::EclIO::eclArrType::CHAR, 9},
                 Opm::EclIO::EclFile::EclEntry{"DIMENS", Opm::EclIO::eclArrType::INTE, 6},
                 Opm::EclIO::EclFile::EclEntry{"KEYWORDS", Opm::EclIO::eclArrType::CHAR, 4},
                 Opm::EclIO::EclFile::EclEntry{"WGNAMES", Opm::EclIO::eclArrType::CHAR, 4},
@@ -1974,6 +1975,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Base)
             const auto vectors        = smspec.getList();
             const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
                 Opm::EclIO::EclFile::EclEntry{"INTEHEAD", Opm::EclIO::eclArrType::INTE, 2},
+                Opm::EclIO::EclFile::EclEntry{"RESTART", Opm::EclIO::eclArrType::CHAR, 9},
                 Opm::EclIO::EclFile::EclEntry{"DIMENS", Opm::EclIO::eclArrType::INTE, 6},
                 Opm::EclIO::EclFile::EclEntry{"KEYWORDS", Opm::EclIO::eclArrType::CHAR, 4},
                 Opm::EclIO::EclFile::EclEntry{"WGNAMES", Opm::EclIO::eclArrType::CHAR, 4},
@@ -2079,6 +2081,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Base)
             const auto vectors        = smspec.getList();
             const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
                 Opm::EclIO::EclFile::EclEntry{"INTEHEAD", Opm::EclIO::eclArrType::INTE, 2},
+                Opm::EclIO::EclFile::EclEntry{"RESTART", Opm::EclIO::eclArrType::CHAR, 9},
                 Opm::EclIO::EclFile::EclEntry{"DIMENS", Opm::EclIO::eclArrType::INTE, 6},
                 Opm::EclIO::EclFile::EclEntry{"KEYWORDS", Opm::EclIO::eclArrType::CHAR, 4},
                 Opm::EclIO::EclFile::EclEntry{"WGNAMES", Opm::EclIO::eclArrType::CHAR, 4},
@@ -2184,6 +2187,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Base)
             const auto vectors        = smspec.getList();
             const auto expect_vectors = std::vector<Opm::EclIO::EclFile::EclEntry>{
                 Opm::EclIO::EclFile::EclEntry{"INTEHEAD", Opm::EclIO::eclArrType::INTE, 2},
+                Opm::EclIO::EclFile::EclEntry{"RESTART", Opm::EclIO::eclArrType::CHAR, 9},
                 Opm::EclIO::EclFile::EclEntry{"DIMENS", Opm::EclIO::eclArrType::INTE, 6},
                 Opm::EclIO::EclFile::EclEntry{"KEYWORDS", Opm::EclIO::eclArrType::CHAR, 4},
                 Opm::EclIO::EclFile::EclEntry{"WGNAMES", Opm::EclIO::eclArrType::CHAR, 4},
@@ -2296,9 +2300,11 @@ BOOST_AUTO_TEST_CASE(Formatted_Restarted)
 
         auto smspec = ::Opm::EclIO::EclFile{fname};
 
+#if 0
         BOOST_CHECK_MESSAGE(! smspec.hasKey("RESTART"),
                             "SMSPEC file must NOT have RESTART "
                             "data if root name is too long");
+#endif
     }
 
     // ========================= METRIC =======================


### PR DESCRIPTION
This PR replaces the existing system for writing summary and specification (SMSPEC) files with a new implementation based on class `EclOutput`.  We package the evaluators of individual parameters in a set of classes determined by the parameter's category which each implement a virtual `update()` function.  This update function ultimately writes new values into a `SummaryState` object.

Add a factory-like system for instantiating the appropriate class depending on a `SummaryNode`'s `category()`.  Also, add a helper class for managing the parameters that a configured in a simulation
model's SUMMARY section in order to distinguish these from those parameters that are merely needed for restart purposes.  The summary class's `eval()` function then becomes a loop over the evaluators for parameters in SUMMARY followed by a loop over the evaluators for restart vectors.

We reimplement the `internal_store()` function in terms of an `std::vector` of a helper structure `MiniStep` which holds a ministep ID (contiguous counter started at zero), a report step ID, and all the evaluated parameters of this ministep.  The final `write` function then consists of outputting those 
ministep structures that have accumulated since the previous call to `write()`.  If a simulation does not call write at all, then this will accumulate all parameters for all ministeps throughout the simulation history.

We create the SMSPEC file at most once, and write to it at most each report step.  We create the summary file once (if unified) or at each report step (if separate).

---

We also temporarily restore the unconditional write of the `RESTART` vector to the SMSPEC file.  This is only to ensure that the new writer function generates the same output files as the existing system.  We will revert this behaviour once the new system is in place and we can afford to update the reference solutions.

---

Finally, this PR depends on #1081 and must not be merged before that is in place.