### PR TITLE
Updates of ESmry - now supporting non-unified result files.

### DIFF
--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -21,14 +21,17 @@
 
 #include <string>
 #include <vector>
+#include <boost/filesystem.hpp> 
 
 namespace Opm { namespace EclIO {
 
 class ESmry
 {
 public:
-    explicit ESmry(const std::string& filename, bool loadBaseRunData=false);   // filename (smspec file) or file root name
 
+    // input is smspec (or fsmspec file)     
+    explicit ESmry(const std::string& filename, bool loadBaseRunData=false);
+    
     int numberOfVectors() const { return nVect; }
 
     bool hasKey(const std::string& key) const;
@@ -43,7 +46,6 @@ public:
 
 private:
     int nVect, nI, nJ, nK;
-    std::string path="";
 
     void ijk_from_global_index(int glob, int &i, int &j, int &k) const;
     std::vector<std::vector<float>> param;
@@ -51,9 +53,14 @@ private:
 
     std::vector<int> seqIndex;
     std::vector<float> seqTime;
+    
+    std::vector<std::string> checkForMultipleResultFiles(const boost::filesystem::path& rootN, bool formatted) const;
+    
+    void getRstString(const std::vector<std::string>& restartArray, 
+                      boost::filesystem::path& pathRst, 
+                      boost::filesystem::path& rootN) const;    
 
-    void getRstString(const std::vector<std::string> &restartArray, std::string &path, std::string &rootN) const;
-    void updatePathAndRootName(std::string &path, std::string &rootN) const;
+    void updatePathAndRootName(boost::filesystem::path& dir, boost::filesystem::path& rootN) const;
 
     std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num) const;
 };

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -144,7 +144,6 @@ std::vector<float> getFrom(const std::vector<float> &ref_vect,int from){
     return vect;
 }
 
-
 BOOST_AUTO_TEST_CASE(TestESmry_1) {
 
     std::vector <float> time_ref, wgpr_prod_ref, wbhp_prod_ref, wbhp_inj_ref, fgor_ref, bpr_111_ref, bpr_10103_ref;
@@ -351,6 +350,7 @@ BOOST_AUTO_TEST_CASE(TestESmry_4) {
     BOOST_CHECK_EQUAL(smryVect_rstep==time_ref, true);
 
 }
+
 
 
 


### PR DESCRIPTION
Also notice the functionality for loading base run data has been improved 

```C++
    explicit ESmry(const std::string& filename, bool loadBaseRunData=false);
```

This now support cases where restart run has unified results files but are restarted from a base runs with non-unified result files (and restart run with non-unified and base run with unified). 

The current version of ESmry have bugs with respect to base run with formatted result files and restart run with unformatted/binary (and visa versa). These bugs are now fixed. 

