### PR TITLE
Make RestartKey default contructable.

### DIFF
--- a/opm/output/eclipse/RestartValue.hpp
+++ b/opm/output/eclipse/RestartValue.hpp
@@ -34,7 +34,9 @@ namespace Opm {
 
         std::string key;
         UnitSystem::measure dim;
-        bool required;
+        bool required = false;
+
+        RestartKey() = default;
 
         RestartKey( const std::string& _key, UnitSystem::measure _dim)
             : key(_key),


### PR DESCRIPTION
Otherwise we cannot even resize a vector of it and this will be needed for restart when getting rid off the global grid on all processes.

I guess this should be uncontroversial?