### PR TITLE
Allow building a module with dependencies installed (backport of #1110)

### DIFF
--- a/cmake/Modules/OpmSiblingSearch.cmake
+++ b/cmake/Modules/OpmSiblingSearch.cmake
@@ -23,7 +23,8 @@ macro(create_module_dir_var module)
           AND IS_DIRECTORY ${_parent_full_dir}/${_module_leaf})
         # We are using build directories named <prefix><module-name><postfix>
         set(${module}_DIR ${_parent_full_dir}/${_module_leaf})
-      elseif(IS_DIRECTORY ${_parent_full_dir}/${_clone_dir})
+      elseif(IS_DIRECTORY ${_parent_full_dir}/${_clone_dir} AND
+          EXISTS ${_parent_full_dir}/${_clone_dir}/CMakeCache.txt)
         # All modules are in a common build dir
         set(${module}_DIR "${_parent_full_dir}/${_clone_dir}")
       endif()


### PR DESCRIPTION
but source lying around.

If you set CMAKE_INSTALL_PREFIX, have the dependencies installed there, but
the source of them lying around in the parent directory of the build
directory, then the build will fail starting with opm-models because
we assume that ../opm-material is a build directory and set opm-material_DIR
to it. CMake will complain about not finding opm-material-config.cmake or
Opm-materialConfig.cmake. With this commit we will only set opm-material_DIR
if the directory contains a file CMakeCache.txt (which should be the case in
a configured build directory.

Directory outline of the failing situation is
```
- ${CMAKE_INSTALL_PREFIX} # where all dependencies are installed
- parent_dir
|____ opm-common #source dir
|____ opm-material #source dir
|____ ...
|____ build #build directory for current module (e.g. opm-modules)
```

Change is tested with sibling build
```
- build
|___ opm-common #build dir
|___ opm-material #build dir
|___ ...
```
and the dune version of it
```
- parent_dir
|___ opm-common # source dir
    |____ build # build dir opm-common

|___ opm-material # source dir
    |____ build # build dir opm-material
...
```