### PR TITLE
Multregt edit

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -67,12 +67,11 @@ namespace Opm {
     class MULTREGTScanner {
 
     public:
-        MULTREGTScanner(const Eclipse3DProperties& e3DProps,
-                        const std::vector< const DeckKeyword* >& keywords);
+        MULTREGTScanner(const Eclipse3DProperties& e3DProps);
+        void addKeywords(const std::vector<const DeckKeyword *>& keywords);
         double getRegionMultiplier(size_t globalCellIdx1, size_t globalCellIdx2, FaceDir::DirEnum faceDir) const;
-
     private:
-        void addKeyword( const Eclipse3DProperties& props, const DeckKeyword& deckKeyword, const std::string& defaultRegion);
+        void addKeyword(const DeckKeyword& deckKeyword);
         void assertKeywordSupported(const DeckKeyword& deckKeyword, const std::string& defaultRegion);
         std::vector< MULTREGTRecord > m_records;
         std::map<std::string , MULTREGTSearchMap> m_searchMap;

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -97,16 +97,18 @@ namespace Opm {
       Then it will go through the different regions and looking for
       interface with the wanted region values.
     */
-    MULTREGTScanner::MULTREGTScanner(const Eclipse3DProperties& e3DProps,
-                                     const std::vector< const DeckKeyword* >& keywords) :
-                m_e3DProps(e3DProps) {
+    MULTREGTScanner::MULTREGTScanner(const Eclipse3DProperties& e3DProps) :
+        m_e3DProps(e3DProps)
+    {
+    }
 
-        for (size_t idx = 0; idx < keywords.size(); idx++)
-            this->addKeyword(e3DProps, *keywords[idx] , e3DProps.getDefaultRegionKeyword());
+    void MULTREGTScanner::addKeywords(const std::vector<const DeckKeyword *>& keywords) {
+        for (const auto& kw : keywords)
+            this->addKeyword(*kw);
 
         MULTREGTSearchMap searchPairs;
         for (std::vector<MULTREGTRecord>::const_iterator record = m_records.begin(); record != m_records.end(); ++record) {
-            if (e3DProps.hasDeckIntGridProperty( record->region_name)) {
+            if (this->m_e3DProps.hasDeckIntGridProperty( record->region_name)) {
                 int srcRegion    = record->src_value;
                 int targetRegion = record->target_value;
 
@@ -156,13 +158,13 @@ namespace Opm {
 
 
 
-    void MULTREGTScanner::addKeyword( const Eclipse3DProperties& props, const DeckKeyword& deckKeyword , const std::string& defaultRegion) {
-        assertKeywordSupported( deckKeyword , defaultRegion );
+    void MULTREGTScanner::addKeyword(const DeckKeyword& deckKeyword) {
+        assertKeywordSupported( deckKeyword , this->m_e3DProps.getDefaultRegionKeyword());
 
         for (const auto& deckRecord : deckKeyword) {
             std::vector<int> src_regions;
             std::vector<int> target_regions;
-            std::string region_name = defaultRegion;
+            std::string region_name = this->m_e3DProps.getDefaultRegionKeyword();
 
             const auto& srcItem = deckRecord.getItem("SRC_REGION");
             const auto& targetItem = deckRecord.getItem("TARGET_REGION");
@@ -179,12 +181,12 @@ namespace Opm {
                 region_name = MULTREGT::RegionNameFromDeckValue( regionItem.get<std::string>(0) );
 
             if (srcItem.defaultApplied(0) || srcItem.get<int>(0) < 0)
-                src_regions = props.getRegions( region_name );
+                src_regions = this->m_e3DProps.getRegions( region_name );
             else
                 src_regions.push_back(srcItem.get<int>(0));
 
             if (targetItem.defaultApplied(0) || targetItem.get<int>(0) < 0)
-                target_regions = props.getRegions(region_name);
+                target_regions = this->m_e3DProps.getRegions(region_name);
             else
                 target_regions.push_back(targetItem.get<int>(0));
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -122,10 +122,9 @@ namespace Opm {
                 }
             }
             else
-                throw std::logic_error(
-                                "MULTREGT record is based on region: "
-                                +  record->region_name
-                                + " which is not in the deck");
+                throw std::invalid_argument("MULTREGT record is based on region: "
+                                            +  record->region_name
+                                            + " which is not in the deck");
         }
 
         for (auto iter = searchPairs.begin(); iter != searchPairs.end(); ++iter) {

--- a/src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
@@ -42,8 +42,9 @@ namespace Opm {
                    { FaceDir::XMinus, "MULTX-" },
                    { FaceDir::YMinus, "MULTY-" },
                    { FaceDir::ZMinus, "MULTZ-" }}),
-        m_multregtScanner( props, deck.getKeywordList( "MULTREGT" ))
+        m_multregtScanner(props)
     {
+        this->m_multregtScanner.addKeywords(deck.getKeywordList("MULTREGT"));
     }
 
     void TransMult::assertIJK(size_t i , size_t j , size_t k) const {

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -117,19 +117,22 @@ BOOST_AUTO_TEST_CASE(InvalidInput) {
     std::vector<const Opm::DeckKeyword*> keywords0;
     const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
     keywords0.push_back( &multregtKeyword0 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords0 ); , std::invalid_argument );
+    Opm::MULTREGTScanner scanner0(props);
+    BOOST_CHECK_THROW( scanner0.addKeywords( keywords0 ) , std::invalid_argument );
 
     // Not supported region
     std::vector<const Opm::DeckKeyword*> keywords1;
     const auto& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
     keywords1.push_back( &multregtKeyword1 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords1 ); , std::invalid_argument );
+    Opm::MULTREGTScanner scanner1(props);
+    BOOST_CHECK_THROW( scanner1.addKeywords( keywords1 ) , std::invalid_argument );
 
     // The keyword is ok; but it refers to a region which is not in the deck.
     std::vector<const Opm::DeckKeyword*> keywords2;
     const auto& multregtKeyword2 = deck.getKeyword( "MULTREGT", 2 );
     keywords2.push_back( &multregtKeyword2 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords2 ); , std::logic_error );
+    Opm::MULTREGTScanner scanner2(props);
+    BOOST_CHECK_THROW( scanner2.addKeywords( keywords2 ) , std::invalid_argument );
 }
 
 
@@ -184,13 +187,16 @@ BOOST_AUTO_TEST_CASE(NotSupported) {
     std::vector<const Opm::DeckKeyword*> keywords0;
     const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
     keywords0.push_back( &multregtKeyword0 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords0 ); , std::invalid_argument );
+    Opm::MULTREGTScanner scanner0(props);
+    BOOST_CHECK_THROW( scanner0.addKeywords( keywords0 ); , std::invalid_argument );
 
     // srcValue == targetValue - not supported
     std::vector<const Opm::DeckKeyword*> keywords1;
     const Opm::DeckKeyword& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
     keywords1.push_back( &multregtKeyword1 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords1 ); , std::invalid_argument );
+
+    Opm::MULTREGTScanner scanner1(props);
+    BOOST_CHECK_THROW( scanner1.addKeywords( keywords1 ); , std::invalid_argument );
 }
 
 static Opm::Deck createDefaultedRegions() {
@@ -244,7 +250,7 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   std::vector<const Opm::DeckKeyword*> keywords0;
   const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
   keywords0.push_back( &multregtKeyword0 );
-  Opm::MULTREGTScanner scanner0(props, keywords0);
+  Opm::MULTREGTScanner scanner0(props);  scanner0.addKeywords(keywords0);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(0,0,1), grid.getGlobalIndex(1,0,1), Opm::FaceDir::XPlus ), 1.25);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(2,0,0), Opm::FaceDir::XPlus ), 1.0);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,1), grid.getGlobalIndex(2,0,0), Opm::FaceDir::ZMinus ), 0.0);
@@ -252,7 +258,7 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   std::vector<const Opm::DeckKeyword*> keywords1;
   const Opm::DeckKeyword& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
   keywords1.push_back( &multregtKeyword1 );
-  Opm::MULTREGTScanner scanner1( props, keywords1 );
+  Opm::MULTREGTScanner scanner1( props ); scanner1.addKeywords(keywords1);
   BOOST_CHECK_EQUAL( scanner1.getRegionMultiplier(grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(1,0,0), Opm::FaceDir::XMinus ), 0.75);
   BOOST_CHECK_EQUAL( scanner1.getRegionMultiplier(grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(2,0,1), Opm::FaceDir::ZPlus), 0.75);
 }


### PR DESCRIPTION
Comment from second commit:

        /*
          This is a quite contrived piece of code to work around a peculiarity
          in Eclipse: If the MULTREGT keyword is present in the EDIT section it
          will *only* be taken into account if the EDIT section also contains
          the keywords TRANX, TRANZ and TRANZ - otherwise it will be ignored.
        */