### PR TITLE
fixed: build using gcc 5 (ubuntu xenial)

### DIFF
--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -75,7 +75,7 @@ namespace {
             }
         }
 
-        return { "NoSuchKeyword", Opm::EclIO::eclArrType::MESS, 0 };
+        return EclIO::EclFile::EclEntry{ "NoSuchKeyword", Opm::EclIO::eclArrType::MESS, 0 };
     }
 
     EclIO::eclArrType ecl_kw_get_type(const EclIO::EclFile::EclEntry& vec)


### PR DESCRIPTION
the tuple-from-initializer-list constructor is explicit.

ref https://ci.opm-project.org/job/opm-nightly-xenial/131/console
in particular
```
/build/opm-common-2019-10-17-gite815194/tests/test_Restart.cpp: In function 'Opm::EclIO::EclFile::EclEntry {anonymous}::ecl_file_iget_named_kw(Opm::EclIO::ERst&, const string&, int)':
/build/opm-common-2019-10-17-gite815194/tests/test_Restart.cpp:78:67: error: converting to 'Opm::EclIO::EclFile::EclEntry {aka std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Opm::EclIO::eclArrType, int>}' from initializer list would use explicit constructor 'constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const char (&)[14], Opm::EclIO::eclArrType, int}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Opm::EclIO::eclArrType, int}]'
         return { "NoSuchKeyword", Opm::EclIO::eclArrType::MESS, 0 };
```