### PR TITLE
fixed: build using gcc 5 (ubuntu xenial) (backport of PR #1116

### DIFF
--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -75,7 +75,7 @@ namespace {
             }
         }
 
-        return { "NoSuchKeyword", Opm::EclIO::eclArrType::MESS, 0 };
+        return EclIO::EclFile::EclEntry{ "NoSuchKeyword", Opm::EclIO::eclArrType::MESS, 0 };
     }
 
     EclIO::eclArrType ecl_kw_get_type(const EclIO::EclFile::EclEntry& vec)


### PR DESCRIPTION
the tuple-from-initializer-list constructor is explicit.

Backport of #1116 to release.