### PR TITLE
Add small struct DeckKeyword::Location to simplify error reporting

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -429,6 +429,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/OpmLog/LogUtil.hpp
       opm/common/OpmLog/MessageFormatter.hpp
       opm/common/OpmLog/MessageLimiter.hpp
+      opm/common/OpmLog/Location.hpp
       opm/common/OpmLog/OpmLog.hpp
       opm/common/OpmLog/StreamLog.hpp
       opm/common/OpmLog/TimerLog.hpp

--- a/examples/opmhash.cpp
+++ b/examples/opmhash.cpp
@@ -64,9 +64,10 @@ std::vector<keyword> load_deck(const char * deck_file) {
     auto deck = parser.parseFile(deck_file, parseContext, errors);
     for (const auto& kw : deck) {
         std::stringstream ss;
+        const auto& location = kw.location();
         ss << kw;
 
-        keywords.emplace_back(kw.name(), kw.getFileName(), kw.getLineNumber(), std::hash<std::string>{}(ss.str()));
+        keywords.emplace_back(kw.name(), location.filename, location.lineno, std::hash<std::string>{}(ss.str()));
     }
     return keywords;
 }

--- a/opm/common/OpmLog/Location.hpp
+++ b/opm/common/OpmLog/Location.hpp
@@ -1,0 +1,35 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LOCATION_HPP
+#define LOCATION_HPP
+
+class Location {
+public:
+    std::string filename = "<memory string>";
+    std::size_t lineno = 0;
+
+    Location() = default;
+    Location(std::string fname, std::size_t lno) :
+        filename(std::move(fname)),
+        lineno(lno)
+    {}
+};
+
+#endif

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -23,7 +23,10 @@
 #include <cstdint>
 #include <string>
 
+#include <opm/common/OpmLog/Location.hpp>
+
 namespace Opm {
+
 namespace Log {
     namespace MessageType {
         const int64_t Debug     =  1;   /* Excessive information */
@@ -56,8 +59,8 @@ namespace Log {
 
 
     bool isPower2(int64_t x);
-    std::string fileMessage(const std::string& path, int line , const std::string& msg);
-    std::string fileMessage(int64_t messageType , const std::string& path, int line , const std::string& msg);
+    std::string fileMessage(const Location& location, const std::string& msg);
+    std::string fileMessage(int64_t messageType , const Location& location , const std::string& msg);
     std::string prefixMessage(int64_t messageType , const std::string& msg);
     std::string colorCodeMessage(int64_t messageType , const std::string& msg);
 

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -35,6 +35,20 @@ namespace Opm {
 
     class DeckKeyword {
     public:
+
+        class Location {
+        public:
+            std::string filename;
+            std::size_t lineno;
+
+            Location() = default;
+            Location(std::string fname, std::size_t lno) :
+                filename(std::move(fname)),
+                lineno(lno)
+            {}
+        };
+
+
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
 
         explicit DeckKeyword(const ParserKeyword& parserKeyword);
@@ -51,7 +65,7 @@ namespace Opm {
         void setLocation(const std::pair<const std::string&, std::size_t>& location);
         const std::string& getFileName() const;
         int getLineNumber() const;
-        std::pair<std::string, std::size_t> location() const;
+        const Location& location() const;
 
 
         size_t size() const;
@@ -90,8 +104,7 @@ namespace Opm {
         friend std::ostream& operator<<(std::ostream& os, const DeckKeyword& keyword);
     private:
         std::string m_keywordName;
-        std::string m_fileName;
-        int m_lineNumber;
+        Location m_location;
 
         std::vector< DeckRecord > m_recordList;
         bool m_isDataKeyword;

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -28,6 +28,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckValue.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/common/OpmLog/Location.hpp>
 
 namespace Opm {
     class DeckOutput;
@@ -35,18 +36,6 @@ namespace Opm {
 
     class DeckKeyword {
     public:
-
-        class Location {
-        public:
-            std::string filename;
-            std::size_t lineno;
-
-            Location() = default;
-            Location(std::string fname, std::size_t lno) :
-                filename(std::move(fname)),
-                lineno(lno)
-            {}
-        };
 
 
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
@@ -63,8 +52,6 @@ namespace Opm {
         const std::string& name() const;
         void setFixedSize();
         void setLocation(const std::pair<const std::string&, std::size_t>& location);
-        const std::string& getFileName() const;
-        int getLineNumber() const;
         const Location& location() const;
 
 

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -41,17 +41,13 @@ namespace Opm {
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
 
         explicit DeckKeyword(const ParserKeyword& parserKeyword);
-
-        DeckKeyword(const ParserKeyword& parserKeyword, const std::string& keywordName);
-
+        DeckKeyword(const ParserKeyword& parserKeyword, const Location& location, const std::string& keywordName);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<std::vector<DeckValue>>& record_list);
-
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data);
 
         const std::string& name() const;
         void setFixedSize();
-        void setLocation(const std::pair<const std::string&, std::size_t>& location);
         const Location& location() const;
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/common/OpmLog/Location.hpp>
 
 namespace Opm {
 
@@ -64,7 +64,7 @@ enum class Comparator {
 };
 
 
-    Condition(const std::vector<std::string>& tokens, const DeckKeyword::Location& location);
+    Condition(const std::vector<std::string>& tokens, const Location& location);
 
 
     Quantity lhs;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
 namespace Opm {
 
 namespace Action {
@@ -62,7 +64,7 @@ enum class Comparator {
 };
 
 
-    Condition(const std::vector<std::string>& tokens, const std::pair<std::string, std::size_t>& location);
+    Condition(const std::vector<std::string>& tokens, const DeckKeyword::Location& location);
 
 
     Quantity lhs;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -299,7 +299,8 @@ namespace Opm {
                     // should be copied...
                     if (tableIdx == 0) {
                         std::string msg = "The first table for keyword "+keywordName+" must be explicitly defined! Ignoring keyword";
-                        OpmLog::warning(Log::fileMessage(tableKeyword.getFileName(), tableKeyword.getLineNumber(), msg));
+                        const auto& location = tableKeyword.location();
+                        OpmLog::warning(Log::fileMessage(location, msg));
                         return;
                     }
                     tableVector.push_back(tableVector.back());

--- a/src/opm/common/OpmLog/LogUtil.cpp
+++ b/src/opm/common/OpmLog/LogUtil.cpp
@@ -32,16 +32,16 @@ namespace Log {
 
 
 
-    std::string fileMessage(const std::string& filename , int line , const std::string& message) {
+    std::string fileMessage(const Location& location, const std::string& message) {
         std::ostringstream oss;
 
-        oss << message << "\n" << "In file " << filename << ", line " << line << "\n";
+        oss << message << "\n" << "In file " << location.filename << ", line " << location.lineno << "\n";
 
         return oss.str();
     }
 
-    std::string fileMessage(int64_t messageType , const std::string& filename , int line , const std::string& message) {
-        return fileMessage( filename , line , prefixMessage( messageType , message ));
+    std::string fileMessage(int64_t messageType , const Location& location, const std::string& message) {
+        return fileMessage( location , prefixMessage( messageType , message ));
     }
 
 
@@ -86,8 +86,8 @@ namespace Log {
         case MessageType::Warning:
             return AnsiTerminalColors::blue_strong + message + AnsiTerminalColors::none;
         case MessageType::Problem:
-            return AnsiTerminalColors::magenta_strong + message + AnsiTerminalColors::none;  
-        case MessageType::Error:  
+            return AnsiTerminalColors::magenta_strong + message + AnsiTerminalColors::none;
+        case MessageType::Error:
         case MessageType::Bug:
             return AnsiTerminalColors::red_strong + message + AnsiTerminalColors::none;
         default:

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -39,8 +39,9 @@ namespace Opm {
     {
     }
 
-    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::string& keywordName) :
+    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const Location& location, const std::string& keywordName) :
         m_keywordName(keywordName),
+        m_location(location),
         m_isDataKeyword(false),
         m_slashTerminated(true),
         parser_keyword(parserKeyword)
@@ -187,9 +188,6 @@ namespace Opm {
         m_slashTerminated = false;
     }
 
-    void DeckKeyword::setLocation(const std::pair<const std::string&, std::size_t>& location) {
-        this->m_location = Location(location.first, location.second);
-    }
 
     const Location& DeckKeyword::location() const {
         return this->m_location;

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -191,15 +191,7 @@ namespace Opm {
         this->m_location = Location(location.first, location.second);
     }
 
-    const std::string& DeckKeyword::getFileName() const {
-        return this->m_location.filename;
-    }
-
-    int DeckKeyword::getLineNumber() const {
-        return this->m_location.lineno;
-    }
-
-    const DeckKeyword::Location& DeckKeyword::location() const {
+    const Location& DeckKeyword::location() const {
         return this->m_location;
     }
 

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -33,7 +33,6 @@ namespace Opm {
 
     DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword) :
         m_keywordName(parserKeyword.getName()),
-        m_lineNumber(-1),
         m_isDataKeyword(false),
         m_slashTerminated(true),
         parser_keyword(parserKeyword)
@@ -42,7 +41,6 @@ namespace Opm {
 
     DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::string& keywordName) :
         m_keywordName(keywordName),
-        m_lineNumber(-1),
         m_isDataKeyword(false),
         m_slashTerminated(true),
         parser_keyword(parserKeyword)
@@ -190,20 +188,19 @@ namespace Opm {
     }
 
     void DeckKeyword::setLocation(const std::pair<const std::string&, std::size_t>& location) {
-        m_fileName = location.first;
-        m_lineNumber = location.second;
+        this->m_location = Location(location.first, location.second);
     }
 
     const std::string& DeckKeyword::getFileName() const {
-        return m_fileName;
+        return this->m_location.filename;
     }
 
     int DeckKeyword::getLineNumber() const {
-        return m_lineNumber;
+        return this->m_location.lineno;
     }
 
-    std::pair<std::string, std::size_t> DeckKeyword::location() const {
-        return std::make_pair( this->getFileName(), this->getLineNumber() );
+    const DeckKeyword::Location& DeckKeyword::location() const {
+        return this->m_location;
     }
 
     void DeckKeyword::setDataKeyword(bool isDataKeyword_) {

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -232,7 +232,7 @@ namespace Opm {
         auto keywords = deck.getKeywordList(keywordName);
         for (size_t i = 0; i < keywords.size(); ++i) {
             std::string msg = "Ambiguous keyword "+keywordName+" defined here";
-            OpmLog::error(Log::fileMessage(keywords[i]->getFileName(), keywords[i]->getLineNumber(), msg));
+            OpmLog::error(Log::fileMessage(keywords[i]->location(), msg));
         }
     }
 

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -322,7 +322,8 @@ inline std::map< std::string, int > RPT( const DeckKeyword& keyword,
 
 
     if (ints && strs) {
-        std::string msg = "Mixed style input is not allowed for keyword: " + keyword.name() + " at " + keyword.getFileName() + "(" + std::to_string( keyword.getLineNumber() ) + ")";
+        const auto& location = keyword.location();
+        std::string msg = "Mixed style input is not allowed for keyword: " + keyword.name() + " at " + location.filename + "(" + std::to_string( location.lineno ) + ")";
         parseContext.handleError(ParseContext::RPT_MIXED_STYLE, msg, errors);
 
         std::vector<std::string> stack;
@@ -330,7 +331,7 @@ inline std::map< std::string, int > RPT( const DeckKeyword& keyword,
             if (is_int(deck_items[index])) {
 
                 if (stack.size() < 2) {
-                    std::string errmsg = "Can not interpret " + keyword.name() + " at " + keyword.getFileName() + "(" + std::to_string( keyword.getLineNumber() ) + ")";
+                    std::string errmsg = "Can not interpret " + keyword.name() + " at " + location.filename + "(" + std::to_string( location.lineno ) + ")";
                     throw std::invalid_argument(errmsg);
                 }
 
@@ -343,7 +344,7 @@ inline std::map< std::string, int > RPT( const DeckKeyword& keyword,
                     stack.clear();
                     items.push_back( mnemonic + "=" + deck_items[index]);
                 } else {
-                    std::string errmsg = "Can not interpret " + keyword.name() + " at " + keyword.getFileName() + "(" + std::to_string( keyword.getLineNumber() ) + ")";
+                    std::string errmsg = "Can not interpret " + keyword.name() + " at " + location.filename + "(" + std::to_string( location.lineno ) + ")";
                     throw std::invalid_argument(errmsg);
                 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
@@ -84,7 +84,7 @@ void Quantity::add_arg(const std::string& arg) {
     this->args.push_back(strip_quotes(arg));
 }
 
-Condition::Condition(const std::vector<std::string>& tokens, const DeckKeyword::Location& location) {
+Condition::Condition(const std::vector<std::string>& tokens, const Location& location) {
     this->lhs = Quantity(tokens[0]);
     std::size_t token_index = 1;
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
@@ -84,7 +84,7 @@ void Quantity::add_arg(const std::string& arg) {
     this->args.push_back(strip_quotes(arg));
 }
 
-Condition::Condition(const std::vector<std::string>& tokens, const std::pair<std::string, std::size_t>& location) {
+Condition::Condition(const std::vector<std::string>& tokens, const DeckKeyword::Location& location) {
     this->lhs = Quantity(tokens[0]);
     std::size_t token_index = 1;
 
@@ -105,7 +105,7 @@ Condition::Condition(const std::vector<std::string>& tokens, const std::pair<std
     }
 
     if (token_index >= tokens.size())
-        throw std::invalid_argument("Could not determine right hand side / comparator for ACTIONX keyword at " + location.first + ":" + std::to_string(location.second));
+        throw std::invalid_argument("Could not determine right hand side / comparator for ACTIONX keyword at " + location.filename + ":" + std::to_string(location.lineno));
 
     this->rhs = Quantity(tokens[token_index]);
     token_index++;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -95,7 +95,8 @@ namespace {
     std::string trim_wgname(const DeckKeyword& keyword, const std::string& wgname_arg, const ParseContext& parseContext, ErrorGuard errors) {
         std::string wgname = boost::algorithm::trim_copy(wgname_arg);
         if (wgname != wgname_arg)  {
-            std::string msg = "Illegal space: \"" + wgname_arg + "\" found when defining WELL/GROUP in keyword: " + keyword.name() + " at " + keyword.getFileName() + ":" + std::to_string(keyword.getLineNumber());
+            const auto& location = keyword.location();
+            std::string msg = "Illegal space: \"" + wgname_arg + "\" found when defining WELL/GROUP in keyword: " + keyword.name() + " at " + location.filename + ":" + std::to_string(location.lineno);
             parseContext.handleError(ParseContext::PARSE_WGNAME_SPACE, msg, errors);
         }
         return wgname;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
@@ -399,13 +399,14 @@ void VFPProdTable::check(const DeckKeyword& keyword, const double table_scaling_
     }
 
     if (!points.empty()) {
-        OpmLog::warning("VFP table for production wells has BHP versus THP not " 
+        const auto& location = keyword.location();
+        OpmLog::warning("VFP table for production wells has BHP versus THP not "
                            + std::string("monotonically increasing.\nThis may cause convergence ")
                            + "issues due to switching between BHP and THP control mode."
-                           + std::string("\nIn keyword VFPPROD table number ") 
+                           + std::string("\nIn keyword VFPPROD table number ")
                            + std::to_string(m_table_num)
-                           + ", file " + keyword.getFileName()
-                           + ", line " + std::to_string(keyword.getLineNumber())
+                           + ", file " + location.filename
+                           + ", line " + std::to_string(location.lineno)
                            + "\n");
         OpmLog::note(points);
     }

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -895,7 +895,7 @@ namespace Opm {
         const auto& keywords = deck.getKeywordList(keywordName);
         for (size_t i = 0; i < keywords.size(); ++i) {
             std::string msg = "Ambiguous keyword "+keywordName+" defined here";
-            OpmLog::error(Log::fileMessage(keywords[i]->getFileName(), keywords[i]->getLineNumber(), msg));
+            OpmLog::error(Log::fileMessage(keywords[i]->location(), msg));
         }
     }
 

--- a/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -38,7 +38,8 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
             const auto& keyword = deck.getKeyword(keywordIdx);
             if (!parser.isRecognizedKeyword( keyword.name() ) ) {
                 std::string msg("Keyword '" + keyword.name() + "' is unknown.");
-                OpmLog::warning( Log::fileMessage(keyword.getFileName(), keyword.getLineNumber(), msg) );
+                const auto& location = keyword.location();
+                OpmLog::warning( Log::fileMessage(location, msg) );
                 deckValid = false;
             }
         }
@@ -55,9 +56,10 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
         const std::string& fileUnitSystem =
             boost::to_upper_copy(keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0));
         if (fileUnitSystem != deckUnitSystem) {
+            const auto& location = keyword->location();
             std::string msg =
                 "Unit system " + fileUnitSystem + " specified via the FILEUNIT keyword at "
-                + keyword->getFileName() + ":" + std::to_string(keyword->getLineNumber())
+                + location.filename + ":" + std::to_string(location.lineno)
                 + " does not correspond to the unit system used by the deck ("
                 + deckUnitSystem + ")";
             parseContext.handleError(ParseContext::UNIT_SYSTEM_MISMATCH, msg, errorGuard);

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -310,7 +310,7 @@ struct file {
 
 class InputStack : public std::stack< file, std::vector< file > > {
     public:
-        void push( std::string&& input, boost::filesystem::path p = "" );
+        void push( std::string&& input, boost::filesystem::path p = "<memory string>" );
 
     private:
         std::list< std::string > string_storage;
@@ -829,10 +829,10 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
             {
                 std::stringstream ss;
 
-                const auto& location = rawKeyword->getLocation();
+                const auto& location = rawKeyword->location();
                 ss << std::setw(5) << parserState.deck.size()
                    << " Reading " << std::setw(8) << std::left << rawKeyword->getKeywordName()
-                   << " in file " << location.first << ", line " << std::to_string(location.second);
+                   << " in file " << location.filename << ", line " << std::to_string(location.lineno);
                 OpmLog::info(ss.str());
             }
             try {
@@ -848,9 +848,9 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
                   error message; the parser is quite confused at this state and
                   we should not be tempted to continue the parsing.
                 */
-                const auto& location = rawKeyword->getLocation();
+                const auto& location = rawKeyword->location();
                 std::string msg = "\nFailed to parse keyword: " + rawKeyword->getKeywordName() + "\n" +
-                                  "In file " + location.first + ", line " +  std::to_string(location.second) + "\n\n" +
+                                  "In file " + location.filename + ", line " +  std::to_string(location.lineno) + "\n\n" +
                                   "Error message: " + exc.what() + "\n";
 
                 throw std::invalid_argument(msg);

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -857,7 +857,8 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
             }
         } else {
             const std::string msg = "The keyword " + rawKeyword->getKeywordName() + " is not recognized - ignored";
-            OpmLog::warning(Log::fileMessage(parserState.current_path().string(), parserState.line(), msg));
+            Location location(parserState.current_path().string(), parserState.line());
+            OpmLog::warning(Log::fileMessage(location, msg));
         }
     }
 
@@ -1159,7 +1160,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
         if( deck.getKeyword(0).name() != "RUNSPEC" ) {
             std::string msg = "The first keyword of a valid deck must be RUNSPEC\n";
             auto curKeyword = deck.getKeyword(0);
-            OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+            OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
             deckValid = false;
         }
 
@@ -1179,7 +1180,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                     std::string msg =
                         "The keyword '"+curKeywordName+"' is located in the '"+curSectionName
                         +"' section where it is invalid";
-                    OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1190,7 +1191,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "GRID") {
                     std::string msg =
                         "The RUNSPEC section must be followed by GRID instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1200,7 +1201,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "EDIT" && curKeywordName != "PROPS") {
                     std::string msg =
                         "The GRID section must be followed by EDIT or PROPS instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1210,7 +1211,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "PROPS") {
                     std::string msg =
                         "The EDIT section must be followed by PROPS instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1220,7 +1221,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "REGIONS" && curKeywordName != "SOLUTION") {
                     std::string msg =
                         "The PROPS section must be followed by REGIONS or SOLUTION instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1230,7 +1231,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "SOLUTION") {
                     std::string msg =
                         "The REGIONS section must be followed by SOLUTION instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1240,7 +1241,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "SUMMARY" && curKeywordName != "SCHEDULE") {
                     std::string msg =
                         "The SOLUTION section must be followed by SUMMARY or SCHEDULE instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1250,7 +1251,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "SCHEDULE") {
                     std::string msg =
                         "The SUMMARY section must be followed by SCHEDULE instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1261,7 +1262,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 std::string msg =
                     "The SCHEDULE section must be the last one ("
                     +curKeywordName+" specified after SCHEDULE)";
-                OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+                OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
                 deckValid = false;
             }
         }
@@ -1271,7 +1272,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
             const auto& curKeyword = deck.getKeyword(deck.size() - 1);
             std::string msg =
                 "The last section of a valid deck must be SCHEDULE (is "+curSectionName+")";
-            OpmLog::warning(Log::fileMessage(curKeyword.getFileName(), curKeyword.getLineNumber(), msg) );
+            OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
             deckValid = false;
         }
 

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -508,8 +508,7 @@ void set_dimensions( ParserItem& item,
         if( !rawKeyword.isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword.getKeywordName());
 
-        DeckKeyword keyword( *this, rawKeyword.getKeywordName() );
-        keyword.setLocation( rawKeyword.getLocation( ) );
+        DeckKeyword keyword( *this, rawKeyword.location(), rawKeyword.getKeywordName() );
         keyword.setDataKeyword( isDataKeyword() );
 
         size_t record_nr = 0;

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
@@ -49,8 +49,7 @@ namespace {
 
     RawKeyword::RawKeyword(const std::string& name, const std::string& filename, std::size_t lineNR, bool raw_string, Raw::KeywordSizeEnum sizeType, std::size_t size_arg) :
         m_name(keyword_name(name)),
-        m_filename(filename),
-        m_lineNR(lineNR),
+        m_location(filename, lineNR),
         raw_string_keyword(raw_string),
         m_sizeType(sizeType)
     {
@@ -131,8 +130,8 @@ namespace {
         return m_isFinished;
     }
 
-    std::pair<std::string, std::size_t> RawKeyword::getLocation() const {
-        return std::make_pair(this->m_filename, this->m_lineNR);
+    const Location& RawKeyword::location() const {
+        return this->m_location;
     }
 
     RawKeyword::const_iterator RawKeyword::begin() const {

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp
@@ -25,6 +25,8 @@
 #include <vector>
 #include <cstddef>
 
+#include <opm/common/OpmLog/Location.hpp>
+
 #include "RawEnums.hpp"
 #include "RawConsts.hpp"
 
@@ -51,7 +53,7 @@ namespace Opm {
         bool isFinished() const;
         bool unKnownSize() const;
         bool rawStringKeyword() const;
-        std::pair<std::string, std::size_t> getLocation() const;
+        const Location& location() const;
 
         using const_iterator = std::vector< RawRecord >::const_iterator;
         using iterator = std::vector< RawRecord >::iterator;
@@ -62,9 +64,7 @@ namespace Opm {
         const_iterator end() const;
     private:
         std::string m_name;
-        std::string m_filename;
-
-        size_t m_lineNR;
+        Location m_location;
         bool raw_string_keyword;
         Raw::KeywordSizeEnum m_sizeType;
 

--- a/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -30,6 +30,7 @@ namespace Opm {
     static const std::string emptystr = "";
 
     RawKeyword::RawKeyword(const string_view& name, Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR, bool slash_terminated) :
+        m_location(filename, lineNR),
         slash_terminated_records(slash_terminated),
         m_partialRecordString( emptystr )
     {
@@ -41,6 +42,7 @@ namespace Opm {
     }
 
     RawKeyword::RawKeyword(const string_view& name , const std::string& filename, size_t lineNR , size_t inputSize, bool slash_terminated, bool isTableCollection ) :
+        m_location(filename, lineNR),
         slash_terminated_records(slash_terminated)
     {
         commonInit(name.string(),filename,lineNR);
@@ -176,14 +178,6 @@ namespace Opm {
 
     bool RawKeyword::isFinished() const {
         return m_isFinished;
-    }
-
-    const std::string& RawKeyword::getFilename() const {
-        return m_filename;
-    }
-
-    size_t RawKeyword::getLineNR() const {
-        return m_lineNR;
     }
 
     RawKeyword::const_iterator RawKeyword::begin() const {

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -26,6 +26,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <opm/common/OpmLog/Location.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
@@ -597,7 +598,7 @@ BOOST_AUTO_TEST_CASE(TestFieldAND) {
 
 
 BOOST_AUTO_TEST_CASE(Conditions) {
-    auto location = DeckKeyword::Location("File", 100);
+    auto location = Location("File", 100);
 
     // Missing comparator
     BOOST_CHECK_THROW(Action::Condition cond({"WWCT", "OPX"}, location), std::invalid_argument);

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -34,6 +34,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
@@ -596,7 +597,7 @@ BOOST_AUTO_TEST_CASE(TestFieldAND) {
 
 
 BOOST_AUTO_TEST_CASE(Conditions) {
-    auto location = std::make_pair<std::string, std::size_t>("FILE", 0);
+    auto location = DeckKeyword::Location("File", 100);
 
     // Missing comparator
     BOOST_CHECK_THROW(Action::Condition cond({"WWCT", "OPX"}, location), std::invalid_argument);

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -36,6 +36,7 @@
 #include <opm/common/OpmLog/TimerLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/OpmLog/Location.hpp>
 
 using namespace Opm;
 
@@ -47,7 +48,7 @@ BOOST_AUTO_TEST_CASE(DoLogging) {
 
 
 BOOST_AUTO_TEST_CASE(Test_Format) {
-    BOOST_CHECK_EQUAL( "There is an error here?\nIn file /path/to/file, line 100\n" , Log::fileMessage("/path/to/file" , 100 , "There is an error here?"));
+    BOOST_CHECK_EQUAL( "There is an error here?\nIn file /path/to/file, line 100\n" , Log::fileMessage(Location("/path/to/file" , 100) , "There is an error here?"));
 
     BOOST_CHECK_EQUAL( "\nError: This is the error" ,     Log::prefixMessage(Log::MessageType::Error , "This is the error"));
     BOOST_CHECK_EQUAL( "\nWarning: This is the warning" , Log::prefixMessage(Log::MessageType::Warning , "This is the warning"));
@@ -251,8 +252,8 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
     BOOST_CHECK(isPower2(1ul << 62));
 
     // fileMessage
-    BOOST_CHECK_EQUAL(fileMessage("foo/bar", 1, "message"), "message\nIn file foo/bar, line 1\n");
-    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, "foo/bar", 1, "message"), "\nError: message\nIn file foo/bar, line 1\n");
+    BOOST_CHECK_EQUAL(fileMessage(Location("foo/bar", 1), "message"), "message\nIn file foo/bar, line 1\n");
+    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, Location("foo/bar", 1), "message"), "\nError: message\nIn file foo/bar, line 1\n");
 
     // prefixMessage
     BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "\nError: message");


### PR DESCRIPTION
Created a smal struct to keep track of the position of a keyword in the input deck; file and linenumber. For keywords which are created by parsing a string the filename will be `<memory string>`.

The location is passed as constructor argument to `DeckKeyword`so that the `DeckKeyword::setLocation()` could be removed - we all love immutable Riiigght?! 