### PR TITLE
Fix memory error during EclipseGrid creation with Actnum. (backport PR #1125)

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -1152,10 +1152,11 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
             const std::vector<double>& coord = COORDKeyWord.getSIDoubleData();
 
             int * actnum = nullptr;
+            std::vector<int> actnumVector;
 
             if (deck.hasKeyword<ParserKeywords::ACTNUM>()) {
                 const auto& actnumKeyword = deck.getKeyword<ParserKeywords::ACTNUM>();
-                std::vector<int> actnumVector = actnumKeyword.getIntData();
+                actnumVector = actnumKeyword.getIntData();
 
                 actnum=actnumVector.data();
              }


### PR DESCRIPTION
We pass an int pointer to the function initCornerPointGrid.
With ACTNUM  this pointer was initialized with data pointer
of an int vector that we threw away before the function call
(otherwise it was null). To fix this we move the int-vector up one
scope.