### PR TITLE
Deckkeyword w/ records: also takes unit_system args.

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -41,8 +41,7 @@ namespace Opm {
 
         DeckKeyword(const ParserKeyword& parserKeyword, const std::string& keywordName);
 
-        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<std::vector<DeckValue>>& record_list);
-
+        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<std::vector<DeckValue>>& record_list, UnitSystem& system_active, UnitSystem& system_default);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data);
 

--- a/python/cxx/deck_keyword.cpp
+++ b/python/cxx/deck_keyword.cpp
@@ -1,5 +1,7 @@
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckValue.hpp>
@@ -143,7 +145,8 @@ void python::common::export_DeckKeyword(py::module& module) {
                  }
                  value_record_list.push_back( value_record );
              }
-             return DeckKeyword(parser_keyword, value_record_list);
+             UnitSystem unit_system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
+             return DeckKeyword(parser_keyword, value_record_list, unit_system, unit_system);
          }  )  )
 
         .def( "__repr__", &DeckKeyword::name )

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -69,7 +69,7 @@ namespace Opm {
     }
 
 
-    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword,  const std::vector<std::vector<DeckValue>>& record_list) :
+    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword,  const std::vector<std::vector<DeckValue>>& record_list, UnitSystem& system_active, UnitSystem& system_default) :
         DeckKeyword(parserKeyword)
     {
         if (parserKeyword.hasFixedSize() && (record_list.size() != parserKeyword.getFixedSize()))
@@ -95,12 +95,14 @@ namespace Opm {
                           break;
                       case type_tag::fdouble:
                           {
-                              // The arguments active_dim and default_dim are totally dummy,
-                              // and just added here to get this to compile after rebase.
-                              UnitSystem unit_system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
-                              auto active_dim = unit_system.getDimension("1");
-                              auto default_dim = unit_system.getDimension("1");
-                              DeckItem deck_item(parser_item.name(), double(), {active_dim}, {default_dim});
+                              auto& dim = parser_item.dimensions();
+                              std::vector<Dimension> active_dimensions;
+                              std::vector<Dimension> default_dimensions;
+                              if (dim.size() > 0) {
+                                 active_dimensions.push_back( system_active.getNewDimension(dim[0]) );
+                                 default_dimensions.push_back( system_default.getNewDimension(dim[0]) );
+                              }
+                              DeckItem deck_item(parser_item.name(), double(), active_dimensions, default_dimensions);
                               add_deckvalue<double>(std::move(deck_item), deck_record, parser_item, input_record, j);
                           }
                           break;


### PR DESCRIPTION
DeckKeyword constructor taking records as arguments will also take two extra arguments of type UnitSystem& active and default. 