### PR TITLE
Multiply MULT(XYZ) keywords in the EDIT section

### DIFF
--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
@@ -77,7 +77,8 @@ namespace Opm {
                                    const EclipseGrid& eclipseGrid);
 
         void scanSection(const Section& section,
-                         const EclipseGrid& eclipseGrid);
+                         const EclipseGrid& eclipseGrid,
+                         bool edit_section);
 
         void handleADDKeyword(     const DeckKeyword& deckKeyword, BoxManager& boxManager);
         void handleBOXKeyword(     const DeckKeyword& deckKeyword, BoxManager& boxManager);
@@ -96,7 +97,8 @@ namespace Opm {
         void handleOPERATERKeyword( const DeckKeyword& deckKeyword);
 
         void loadGridPropertyFromDeckKeyword(const Box& inputBox,
-                                             const DeckKeyword& deckKeyword);
+                                             const DeckKeyword& deckKeyword,
+                                             bool edity_section);
 
         void adjustSOGCRwithSWL();
 

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -171,8 +171,8 @@ public:
        DeckKeyword equals nx*ny*nz.
     */
 
-    void loadFromDeckKeyword( const DeckKeyword& );
-    void loadFromDeckKeyword( const Box&, const DeckKeyword& );
+    void loadFromDeckKeyword( const DeckKeyword& , bool);
+    void loadFromDeckKeyword( const Box&, const DeckKeyword& , bool);
 
     void copyFrom( const GridProperty< T >&, const Box& );
     void scale( T scaleFactor, const Box& );
@@ -305,6 +305,7 @@ public:
 private:
     const DeckItem& getDeckItem( const DeckKeyword& );
     void setDataPoint(size_t sourceIdx, size_t targetIdx, const DeckItem& deckItem);
+    void mulDataPoint(size_t sourceIdx, size_t targetIdx, const DeckItem& deckItem);
     void setElement(const typename std::vector<T>::size_type i,
                     const T                                  value,
                     const bool                               defaulted = false);

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -641,14 +641,35 @@ namespace Opm {
     ///  m_doubleGridProperties fields directly and *NOT* use the public methods
     ///  getIntGridProperty / getDoubleGridProperty.
     void Eclipse3DProperties::loadGridPropertyFromDeckKeyword(const Box& inputBox,
-                                                              const DeckKeyword& deckKeyword) {
+                                                              const DeckKeyword& deckKeyword,
+                                                              bool edit_section) {
+        static std::set<std::string> multiply_keywords = {"MULTX",
+                                                          "MULTY",
+                                                          "MULTZ",
+                                                          "MULTX-",
+                                                          "MULTY-",
+                                                          "MULTZ-"};
+        /*
+          The opm input handling is not really section aware, some keywords
+          should be handled differently in the EDIT section and the GRID
+          section. In particular this applies top the transmissibility
+          multipliers MULT(XYZ) where they should be assigned and reassigned in
+          the GRID section, and applied multiplicatively in the EDIT section.
+
+          Here we have special cased hack for the MULT(XYZ) keywords, there are
+          probably other keywords as well which also should be handled
+          differently in the GRID and EDIT sections, but this is handled on a
+          bug by bug basis.
+        */
+
         const std::string& keyword = deckKeyword.name();
+        bool multiply = (edit_section && (multiply_keywords.count(keyword) == 1));
         if (m_intGridProperties.supportsKeyword( keyword )) {
             auto& gridProperty = m_intGridProperties.getOrCreateProperty( keyword );
-            gridProperty.loadFromDeckKeyword( inputBox, deckKeyword );
+            gridProperty.loadFromDeckKeyword( inputBox, deckKeyword , false );
         } else if (m_doubleGridProperties.supportsKeyword( keyword )) {
             auto& gridProperty = m_doubleGridProperties.getOrCreateProperty( keyword );
-            gridProperty.loadFromDeckKeyword( inputBox, deckKeyword );
+            gridProperty.loadFromDeckKeyword( inputBox, deckKeyword, multiply );
         } else {
             throw std::logic_error( "Tried to load unsupported grid property from keyword: " + deckKeyword.name() );
         }
@@ -746,31 +767,33 @@ namespace Opm {
                                                      const EclipseGrid& eclipseGrid) {
 
         if (Section::hasGRID(deck))
-            scanSection(GRIDSection(deck), eclipseGrid);
+            scanSection(GRIDSection(deck), eclipseGrid, false);
 
         if (Section::hasREGIONS(deck))
-            scanSection(REGIONSSection(deck), eclipseGrid);
+            scanSection(REGIONSSection(deck), eclipseGrid, false);
 
         if (Section::hasEDIT(deck))
-            scanSection(EDITSection(deck), eclipseGrid);
+            scanSection(EDITSection(deck), eclipseGrid, true);
 
         if (Section::hasPROPS(deck))
-            scanSection(PROPSSection(deck), eclipseGrid);
+            scanSection(PROPSSection(deck), eclipseGrid, false);
 
         if (Section::hasSOLUTION(deck))
-            scanSection(SOLUTIONSection(deck), eclipseGrid);
+            scanSection(SOLUTIONSection(deck), eclipseGrid, false);
     }
 
 
 
     void Eclipse3DProperties::scanSection(const Section& section,
-                                          const EclipseGrid& eclipseGrid) {
+                                          const EclipseGrid& eclipseGrid,
+                                          bool edit_section) {
         BoxManager boxManager(eclipseGrid);
         for( const auto& deckKeyword : section ) {
 
             if (supportsGridProperty(deckKeyword.name()) )
                 loadGridPropertyFromDeckKeyword( boxManager.getActiveBox(),
-                                                 deckKeyword);
+                                                 deckKeyword,
+                                                 edit_section);
             else {
                 if (deckKeyword.name() == "BOX")
                     handleBOXKeyword(deckKeyword, boxManager);

--- a/tests/parser/GridPropertyTests.cpp
+++ b/tests/parser/GridPropertyTests.cpp
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_notData_Throws) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
     SupportedKeywordInfo keywordInfo("TABDIMS" , 100, "1");
     Opm::GridProperty<int> gridProperty( 6 ,1,1 , keywordInfo);
-    BOOST_CHECK_THROW( gridProperty.loadFromDeckKeyword( tabdimsKw ) , std::invalid_argument );
+    BOOST_CHECK_THROW( gridProperty.loadFromDeckKeyword( tabdimsKw, false ) , std::invalid_argument );
 }
 
 
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_wrong_size_throws) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
     SupportedKeywordInfo keywordInfo("SATNUM" , 66, "1");
     Opm::GridProperty<int> gridProperty( 15 ,1,1, keywordInfo);
-    BOOST_CHECK_THROW( gridProperty.loadFromDeckKeyword( satnumKw ) , std::invalid_argument );
+    BOOST_CHECK_THROW( gridProperty.loadFromDeckKeyword( satnumKw, false ) , std::invalid_argument );
 }
 
 
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
     SupportedKeywordInfo keywordInfo("SATNUM" , 99, "1");
     Opm::GridProperty<int> gridProperty( 4 , 4 , 2 , keywordInfo);
-    gridProperty.loadFromDeckKeyword( satnumKw );
+    gridProperty.loadFromDeckKeyword( satnumKw, false );
     const std::vector<int>& data = gridProperty.getData();
     for (size_t k=0; k < 2; k++) {
         for (size_t j=0; j < 4; j++) {


### PR DESCRIPTION
New comment in code:
```C++      
/*  
  The opm input handling is not really section aware, some keywords
  should be handeled differently in the EDIT section and the GRID
  section. In particular this applies top the transmissibility
  multipliers MULT(XYZ) where they should be assigned and reassigned in
  the GRID section, and applied multiplicatively in the EDIT section.

  Here we have special cased hack for the MULT(XYZ) keywords, there are
  probably other keywords as well which also should be handeled
  differently in the GRID and EDIT sections, but this is handeled on a
  bug by bug basis.
*/
```

It should be noted that a more significant refactoring of the 3D properties is under way: https://github.com/OPM/opm-common/pull/1056

