### PR TITLE
BOX keyword: using defaultApplied.

### DIFF
--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -4,35 +4,10 @@ import sys
 
 from opm.io.parser import Parser
 from opm.io.parser import ParseContext
-
 from opm.io.deck import DeckKeyword
 
 
 class TestParser(unittest.TestCase):
-
-    REGIONDATA = """
-START             -- 0
-10 MAI 2007 /
-RUNSPEC
-
-DIMENS
-2 2 1 /
-GRID
-DX
-4*0.25 /
-DY
-4*0.25 /
-DZ
-4*0.25 /
-TOPS
-4*0.25 /
-REGIONS
-OPERNUM
-3 3 1 2 /
-FIPNUM
-1 1 2 3 /
-"""
-
 
     def setUp(self):
         self.spe3fn = 'tests/spe3/SPE3CASE1.DATA'

--- a/python/tests/test_state.py
+++ b/python/tests/test_state.py
@@ -8,6 +8,7 @@ from opm.io.summary import SummaryConfig
 
 
 class TestState2(unittest.TestCase):
+
     FAULTS_DECK = """
 RUNSPEC
 

--- a/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -847,13 +847,22 @@ namespace Opm {
 
 
     void Eclipse3DProperties::handleBOXKeyword( const DeckKeyword& deckKeyword,  BoxManager& boxManager) {
-        const auto& record = deckKeyword.getRecord(0);
-        int I1 = record.getItem("I1").get< int >(0) - 1;
-        int I2 = record.getItem("I2").get< int >(0) - 1;
-        int J1 = record.getItem("J1").get< int >(0) - 1;
-        int J2 = record.getItem("J2").get< int >(0) - 1;
-        int K1 = record.getItem("K1").get< int >(0) - 1;
-        int K2 = record.getItem("K2").get< int >(0) - 1;
+        const auto& deckRecord = deckKeyword.getRecord(0);
+        const auto& I1Item = deckRecord.getItem("I1");
+        const auto& I2Item = deckRecord.getItem("I2");
+        const auto& J1Item = deckRecord.getItem("J1");
+        const auto& J2Item = deckRecord.getItem("J2");
+        const auto& K1Item = deckRecord.getItem("K1");
+        const auto& K2Item = deckRecord.getItem("K2");
+
+        const auto& active_box = boxManager.getActiveBox();
+
+        const int I1 = I1Item.defaultApplied(0) ? active_box.I1() : I1Item.get<int>(0) - 1;
+        const int I2 = I2Item.defaultApplied(0) ? active_box.I2() : I2Item.get<int>(0) - 1;
+        const int J1 = J1Item.defaultApplied(0) ? active_box.J1() : J1Item.get<int>(0) - 1;
+        const int J2 = J2Item.defaultApplied(0) ? active_box.J2() : J2Item.get<int>(0) - 1;
+        const int K1 = K1Item.defaultApplied(0) ? active_box.K1() : K1Item.get<int>(0) - 1;
+        const int K2 = K2Item.defaultApplied(0) ? active_box.K2() : K2Item.get<int>(0) - 1;
 
         boxManager.setInputBox( I1 , I2 , J1 , J2 , K1 , K2 );
     }

--- a/src/opm/parser/eclipse/EclipseState/Grid/setKeywordBox.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/setKeywordBox.cpp
@@ -31,12 +31,12 @@ namespace Opm {
 
         const auto& active_box = boxManager.getActiveBox();
 
-        const int i1 = I1Item.hasValue(0) ? I1Item.get<int>(0) - 1 : active_box.I1();
-        const int i2 = I2Item.hasValue(0) ? I2Item.get<int>(0) - 1 : active_box.I2();
-        const int j1 = J1Item.hasValue(0) ? J1Item.get<int>(0) - 1 : active_box.J1();
-        const int j2 = J2Item.hasValue(0) ? J2Item.get<int>(0) - 1 : active_box.J2();
-        const int k1 = K1Item.hasValue(0) ? K1Item.get<int>(0) - 1 : active_box.K1();
-        const int k2 = K2Item.hasValue(0) ? K2Item.get<int>(0) - 1 : active_box.K2();
+        const int i1 = I1Item.defaultApplied(0) ? active_box.I1() : I1Item.get<int>(0) - 1;
+        const int i2 = I2Item.defaultApplied(0) ? active_box.I2() : I2Item.get<int>(0) - 1;
+        const int j1 = J1Item.defaultApplied(0) ? active_box.J1() : J1Item.get<int>(0) - 1;
+        const int j2 = J2Item.defaultApplied(0) ? active_box.J2() : J2Item.get<int>(0) - 1;
+        const int k1 = K1Item.defaultApplied(0) ? active_box.K1() : K1Item.get<int>(0) - 1;
+        const int k2 = K2Item.defaultApplied(0) ? active_box.K2() : K2Item.get<int>(0) - 1;
 
         boxManager.setKeywordBox( i1,i2,j1,j2,k1,k2 );
     }

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -649,3 +649,33 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
     }
 }
 
+
+BOOST_AUTO_TEST_CASE(TestBox) {
+    const char * regionData =
+                "START             --\n"
+                "10 MAI 2007 /\n"
+                "RUNSPEC\n"
+                "DIMENS\n"
+                "2 2 1 /\n"
+                "GRID\n"
+                "DX\n"
+                "4*0.25 /\n"
+                "BOX\n"
+                "1* 1 1 1 1 1 /\n"
+                "DY\n"
+                "4*0.25 /\n"
+                "DZ\n"
+                "4*0.25 /\n"
+                "TOPS\n"
+                "4*0.25 /\n"
+                "REGIONS\n"
+                "OPERNUM\n"
+                "3 3 1 2 /\n"
+                "FIPNUM\n"
+                "1 1 2 3 /\n";
+    Parser parser;
+    auto deck = parser.parseString(regionData);
+    EclipseState state(deck);    
+
+}
+


### PR DESCRIPTION
This relates to opm-simulators: issue https://github.com/OPM/opm-simulators/issues/2097.

When using BOX:
```
BOX
1* 1 1 1 3 3 /
```
This causes an exception. 

This PR remedies the situation. 