### PR TITLE
Udq token types

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+#include <set>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
@@ -59,6 +60,7 @@ public:
     const std::string& keyword() const;
     const std::string& input_string() const;
     UDQVarType  var_type() const;
+    std::set<UDQTokenType> func_tokens() const;
 private:
     const UDQParams& udq_params;  // Beacuse of the shared RNG stream this must be a reference.
     std::string m_keyword;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.cpp
@@ -201,5 +201,17 @@ UDQSet UDQASTNode::eval(UDQVarType target_type, const UDQContext& context) const
     throw std::invalid_argument("Should not be here ...");
 }
 
+void UDQASTNode::func_tokens(std::set<UDQTokenType>& tokens) const {
+    tokens.insert( this->type );
+    for (const auto& arg : this->arglist)
+        arg.func_tokens(tokens);
+}
+
+std::set<UDQTokenType> UDQASTNode::func_tokens() const {
+    std::set<UDQTokenType> tokens;
+    this->func_tokens(tokens);
+    return tokens;
+}
+
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
@@ -21,6 +21,7 @@
 #define UDQASTNODE_HPP
 
 #include <string>
+#include <set>
 #include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
@@ -43,7 +44,9 @@ public:
 
     UDQTokenType type;
     UDQVarType var_type = UDQVarType::NONE;
+    std::set<UDQTokenType> func_tokens() const;
 private:
+    void func_tokens(std::set<UDQTokenType>& tokens) const;
 
     std::string string_value;
     double scalar_value;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -195,4 +195,8 @@ const std::string& UDQDefine::input_string() const {
     return this->string_data;
 }
 
+std::set<UDQTokenType> UDQDefine::func_tokens() const {
+    return this->ast->func_tokens();
+}
+
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -268,6 +268,7 @@ std::string typeName(UDQVarType var_type) {
     }
 }
 
+
 UDAKeyword keyword(UDAControl control) {
     const std::map<UDAControl, UDAKeyword> c2k = {{UDAControl::WCONPROD_ORAT, UDAKeyword::WCONPROD},
                                                   {UDAControl::WCONPROD_GRAT, UDAKeyword::WCONPROD},
@@ -315,6 +316,6 @@ int uadCode(UDAControl control) {
       return it->second;
 
     throw std::logic_error("Unrecognized enum type - internal error");
-}  
+}
 }
 }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1401,4 +1401,14 @@ WCONPROD
         BOOST_CHECK_EQUAL( record1.use_count, 1);
         BOOST_CHECK_EQUAL( record1.use_index, 1);
     }
+    {
+        const auto& udq_config = schedule.getUDQConfig(2);
+        const auto& def1 = udq_config.definitions()[0];
+        const auto& tokens = def1.func_tokens();
+        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::number ), 1);
+        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::ecl_expr), 1);
+        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::binary_op_sub), 1);
+        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::binary_op_mul), 1);
+    }
 }
+


### PR DESCRIPTION
This function will return a `std::set<UDQTokenType>` for all the the tokens which are in use for a `UDQDefine`statement. It is weird functionality - but hopefully useful for restart.

