### PR TITLE
Resolve Address Sanitizer Issues

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -903,7 +903,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         }
 
         return coord;
-    };
+    }
 
     std::vector<double> EclipseGrid::makeZcornDzTops(const std::array<int, 3>& dims, const std::vector<double>& dz, const std::vector<double>& tops) const {
 
@@ -947,7 +947,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         }
 
         return zcorn;
-    };
+    }
 
     double EclipseGrid::sumIdir(int i1, int j, int k, const std::array<int, 3>& dims, const std::vector<double>& dx) const {
 
@@ -1156,7 +1156,10 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
                 const auto& actnumKeyword = deck.getKeyword<ParserKeywords::ACTNUM>();
                 actnumVector = actnumKeyword.getIntData();
 
-                actnum=actnumVector.data();
+                const auto nGlobCells = dims[0] * dims[1] * dims[2];
+                if (actnumVector.size() == static_cast<decltype(actnumVector.size())>(nGlobCells)) {
+                    actnum=actnumVector.data();
+                }
              }
 
             initCornerPointGrid( dims, coord , zcorn, actnum, nullptr );

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.cpp
@@ -22,6 +22,7 @@
 
 #include "Compsegs.hpp"
 
+#include <memory>
 
 namespace Opm {
     WellConnections * newConnectionsWithSegments(const DeckKeyword& compsegs,
@@ -31,10 +32,10 @@ namespace Opm {
                                                  const ParseContext& parseContext,
                                                  ErrorGuard& errors)
     {
-        WellConnections * new_connection_set = new WellConnections(input_connections);
+        std::unique_ptr<WellConnections> new_connection_set(new WellConnections(input_connections));
         std::vector<Compsegs> compsegs_vector = Compsegs::compsegsFromCOMPSEGSKeyword( compsegs, grid, parseContext, errors);
         Compsegs::processCOMPSEGS(compsegs_vector, segment_set);
         Compsegs::updateConnectionsWithSegment(compsegs_vector, grid, *new_connection_set);
-        return new_connection_set;
+        return new_connection_set.release();
     }
 }

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -17,14 +17,16 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdexcept>
-#include <iostream>
-#include <boost/filesystem.hpp>
 #include <cstdio>
-#include <numeric>
-#include <math.h>
-#include <unistd.h>
 #include <ctime>
+#include <iostream>
+#include <math.h>
+#include <memory>
+#include <numeric>
+#include <stdexcept>
+#include <unistd.h>
+
+#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE EclipseGridTests
 #include <boost/test/unit_test.hpp>
@@ -1029,7 +1031,7 @@ BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
 BOOST_AUTO_TEST_CASE(GridActnumViaState) {
     auto deck = createActnumDeck();
 
-    BOOST_CHECK_NO_THROW( new Opm::EclipseState( deck));
+    BOOST_CHECK_NO_THROW( std::unique_ptr<Opm::EclipseState>(new Opm::EclipseState( deck)));
     Opm::EclipseState es( deck);
     BOOST_CHECK_EQUAL(es.getInputGrid().getNumActive(), 2 * 2 * 2 - 1);
 }

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
                           "/\n";
 
 
-    Parser parser(new Parser());
+    Parser parser{};
     auto deck = parser.parseString(deckData) ;
     EclipseState state(deck );
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -17,8 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdexcept>
 #include <iostream>
+#include <memory>
+#include <stdexcept>
+
 #include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE WellConnectionsTests
@@ -91,8 +93,8 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     Opm::ParseContext parseContext;
     parseContext.update(Opm::ParseContext::SCHEDULE_COMPSEGS_INVALID, Opm::InputError::THROW_EXCEPTION);
     parseContext.update(Opm::ParseContext::SCHEDULE_COMPSEGS_NOT_SUPPORTED, Opm::InputError::THROW_EXCEPTION);
-    Opm::WellConnections* new_connection_set = nullptr;
-    BOOST_CHECK_NO_THROW(new_connection_set = Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard));
+    std::unique_ptr<Opm::WellConnections> new_connection_set{nullptr};
+    BOOST_CHECK_NO_THROW(new_connection_set.reset(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard)));
 
     BOOST_CHECK_EQUAL(7U, new_connection_set->size());
 
@@ -178,10 +180,10 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS) {
     Opm::ErrorGuard   errorGuard;
     Opm::ParseContext parseContext;
     parseContext.update(Opm::ParseContext::SCHEDULE_COMPSEGS_INVALID, Opm::InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard), std::invalid_argument);
+    BOOST_CHECK_THROW(std::unique_ptr<Opm::WellConnections>(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard)), std::invalid_argument);
 
     parseContext.update(Opm::ParseContext::SCHEDULE_COMPSEGS_INVALID, Opm::InputError::IGNORE);
-    BOOST_CHECK_NO_THROW(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard));
+    BOOST_CHECK_NO_THROW(std::unique_ptr<Opm::WellConnections>(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard)));
 }
 
 BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS) {
@@ -234,9 +236,10 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS) {
 
     Opm::ErrorGuard   errorGuard;
     Opm::ParseContext parseContext;
+    std::unique_ptr<Opm::WellConnections> wconns{nullptr};
     parseContext.update(Opm::ParseContext::SCHEDULE_COMPSEGS_NOT_SUPPORTED, Opm::InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard), std::invalid_argument);
+    BOOST_CHECK_THROW(wconns.reset(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard)), std::invalid_argument);
 
     parseContext.update(Opm::ParseContext::SCHEDULE_COMPSEGS_NOT_SUPPORTED, Opm::InputError::IGNORE);
-    BOOST_CHECK_NO_THROW(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard));
+    BOOST_CHECK_NO_THROW(wconns.reset(Opm::newConnectionsWithSegments(compsegs, connection_set, segment_set, grid, parseContext, errorGuard)));
 }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1403,7 +1403,8 @@ WCONPROD
     }
     {
         const auto& udq_config = schedule.getUDQConfig(2);
-        const auto& def1 = udq_config.definitions()[0];
+        const auto& def = udq_config.definitions();
+        const auto& def1 = def[0];
         const auto& tokens = def1.func_tokens();
         BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::number ), 1);
         BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::ecl_expr), 1);


### PR DESCRIPTION
This PR addresses a few minor issues that I discovered when running opm-common's unit tests with [Address Sanitizer](https://en.wikipedia.org/wiki/AddressSanitizer).

Specifically

1. Do not use a deck's `ACTNUM` vector ~even~ if incorrectly sized.  This broke the [ACTNUM_BEST_EFFORT](https://github.com/OPM/opm-common/blob/390a29d425ecd5c57026a7e6731180f55a00785e/tests/parser/EclipseGridTests.cpp#L799-L801) unit test (index out of bounds).  With the new changes coming in the property systems this will be less needed for full decks, but we may need it for unit tests.

2. Leaking memory if `newConnectionsWithSegments` throws an exception.  Fixed by using a `unique_ptr<>` internally and returning the `.release()` of that `unique_ptr`.  Arguably, the function should return a `unique_ptr` itself since it acts as a factory function.

3. Leaking memory in various unit tests because `new` was not matched with a corresponding `delete`.  Replaced with smart pointers where applicable.

4. Fix a dangling reference in a UDQ unit test.