### PR TITLE
Record Output of Restart File Data

### DIFF
--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -75,7 +75,11 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NICAQZ  =  45,      //  Number of data elements per aquifer connection in ICAQ array
         NSCAQZ  =  46,      //  Number of data elements per aquifer connection in SCAQ array
         NACAQZ  =  47,      //  Number of data elements per aquifer connection in ACAQ array
-        
+
+        DAY     =  64,      //  Calendar day of report step (1..31)
+        MONTH   =  65,      //  Calendar month of report step (1..12)
+        YEAR    =  66,      //  Calendar year of report step
+
         NOOFACTIONS = 156,  //  The number of actions in the dataset
         MAXNOLINES = 157,   //  Maximum number of lines of schedule data for ACTION keyword - including ENDACTIO
         MAXNOSTRPRLINE = 158,   //  Maximum number of 8-chars strings pr input line of Action data (rounded up from input)

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -83,9 +83,9 @@ enum index : std::vector<int>::size_type {
   ih_061       =       61       ,              //       0       0
   ih_062       =       62       ,              //       0       0
   ih_063       =       63       ,              //       0       0
-  DAY          =       64       ,              //       IDAY       2              IDAY = calendar day at this report time
-  MONTH        =       65       ,              //       IMON       6              IMON = calendar month at this report time
-  YEAR         =       66       ,              //       IYEAR       2016              IYEAR = calendar year at this report time
+  DAY          =       VI::intehead::DAY,      //       IDAY          2     IDAY = calendar day at this report time
+  MONTH        =       VI::intehead::MONTH,    //       IMON          6     IMON = calendar month at this report time
+  YEAR         =       VI::intehead::YEAR,     //       IYEAR      2016     IYEAR = calendar year at this report time
   NUM_SOLVER_STEPS  =  67       ,              //  The number of solver steps the simulator has performed so far.
   REPORT_STEP       =  68       ,              // The sequence/report number for for this restart file.
   ih_069       =       69       ,              //       0       0


### PR DESCRIPTION
This changeset adds a simple one-line record to the screen and, typically, the .PRT file, each time a set of restart values are output to the (or a) restart file.  Format of the output is along the lines of
```
Restart file written for report step: 169/247.  Date: 2003/09/13
```
This is intended as simple information for human readers.  Machine readable data is already output to the actual restart files.

---

As an example, with this you can use a command like
```sh
$ grep '^Restart file' ./NORNE_ATW2013.PRT
```
to get output like
```
Restart file written for report step:   0/247.  Date: 1997/11/06
Restart file written for report step:   1/247.  Date: 1997/11/14
Restart file written for report step:   2/247.  Date: 1997/12/01
Restart file written for report step:   3/247.  Date: 1997/12/17
Restart file written for report step:   4/247.  Date: 1998/01/01
Restart file written for report step:   5/247.  Date: 1998/02/01
Restart file written for report step:  10/247.  Date: 1998/04/23
[...]
Restart file written for report step: 148/247.  Date: 2003/01/02
Restart file written for report step: 157/247.  Date: 2003/05/01
Restart file written for report step: 161/247.  Date: 2003/07/10
Restart file written for report step: 164/247.  Date: 2003/08/12
Restart file written for report step: 165/247.  Date: 2003/09/01
Restart file written for report step: 166/247.  Date: 2003/09/02
Restart file written for report step: 167/247.  Date: 2003/09/10
[...]
Restart file written for report step: 238/247.  Date: 2006/09/01
Restart file written for report step: 239/247.  Date: 2006/09/14
Restart file written for report step: 240/247.  Date: 2006/10/01
Restart file written for report step: 241/247.  Date: 2006/10/10
```