### PR TITLE
updates of ERst API, supports multiple occurrence of array names

### DIFF
--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -42,10 +42,18 @@ public:
     void loadReportStepNumber(int number);
 
     template <typename T>
-    const std::vector<T>& getRst(const std::string& name, int reportStepNumber);
+    const std::vector<T>& getRst(const std::string& name, int reportStepNumber, int occurrence);
+
+    template <typename T>
+    const std::vector<T>& getRst(int index, int reportStepNumber){
+        auto indRange = this->getIndexRange(reportStepNumber);
+        return  this->get<T>(index + std::get<0>(indRange));
+    }
+
+    int count(const std::string& name, int reportStepNumber) const; 
 
     const std::vector<int>& listOfReportStepNumbers() const { return seqnum; }
-
+    
     std::vector<EclEntry> listOfRstArrays(int reportStepNumber);
 
     friend class OutputStream::Restart;
@@ -59,10 +67,12 @@ private:
     void initUnified();
     void initSeparate(const int number);
 
-    int getArrayIndex(const std::string& name, int seqnum) const;
+    int getArrayIndex(const std::string& name, int seqnum, int occurrence) const;
+    std::tuple<int,int> getIndexRange(int reportStepNumber) const; 
 
     std::streampos
     restartStepWritePosition(const int seqnumValue) const;
+    
 };
 
 }} // namespace Opm::EclIO

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -126,7 +126,7 @@ public:
     const std::vector<ElmType>&
     getKeyword(const std::string& vector)
     {
-        return this->rst_file_->getRst<ElmType>(vector, this->report_step_);
+        return this->rst_file_->getRst<ElmType>(vector, this->report_step_, 0);
     }
 
     const std::vector<int>& intehead()

--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -776,24 +776,24 @@ void ECLRegressionTest::results_rst()
                         std::cout << "Comparing " << keywords1[i] << " ... ";
 
                         if (arrayType1[i] == INTE) {
-                            auto vect1 = rst1.getRst<int>(keywords1[i], seqn);
-                            auto vect2 = rst2.getRst<int>(keywords2[ind2], seqn);
+                            auto vect1 = rst1.getRst<int>(keywords1[i], seqn, 0);
+                            auto vect2 = rst2.getRst<int>(keywords2[ind2], seqn, 0);
                             compareVectors(vect1, vect2, keywords1[i], reference);
                         } else if (arrayType1[i] == REAL) {
-                            auto vect1 = rst1.getRst<float>(keywords1[i], seqn);
-                            auto vect2 = rst2.getRst<float>(keywords2[ind2], seqn);
+                            auto vect1 = rst1.getRst<float>(keywords1[i], seqn, 0);
+                            auto vect2 = rst2.getRst<float>(keywords2[ind2], seqn, 0);
                             compareFloatingPointVectors(vect1, vect2, keywords1[i], reference);
                         } else if (arrayType1[i] == DOUB) {
-                            auto vect1 = rst1.getRst<double>(keywords1[i], seqn);
-                            auto vect2 = rst2.getRst<double>(keywords2[ind2], seqn);
+                            auto vect1 = rst1.getRst<double>(keywords1[i], seqn, 0);
+                            auto vect2 = rst2.getRst<double>(keywords2[ind2], seqn, 0);
                             compareFloatingPointVectors(vect1, vect2, keywords1[i], reference);
                         } else if (arrayType1[i] == LOGI) {
-                            auto vect1 = rst1.getRst<bool>(keywords1[i], seqn);
-                            auto vect2 = rst2.getRst<bool>(keywords2[ind2], seqn);
+                            auto vect1 = rst1.getRst<bool>(keywords1[i], seqn, 0);
+                            auto vect2 = rst2.getRst<bool>(keywords2[ind2], seqn, 0);
                             compareVectors(vect1, vect2, keywords1[i], reference);
                         } else if (arrayType1[i] == CHAR) {
-                            auto vect1 = rst1.getRst<std::string>(keywords1[i], seqn);
-                            auto vect2 = rst2.getRst<std::string>(keywords2[ind2], seqn);
+                            auto vect1 = rst1.getRst<std::string>(keywords1[i], seqn, 0);
+                            auto vect2 = rst2.getRst<std::string>(keywords2[ind2], seqn, 0);
                             compareVectors(vect1, vect2, keywords1[i], reference);
                         } else if (arrayType1[i] == MESS) {
                             // shold not be any associated data

--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -22,12 +22,20 @@ void write(EclOutput& outFile, EclFile& file1,
 
 template<typename T>
 void write(EclOutput& outFile, ERst& file1,
-           const std::string& name, int reportStepNumber)
+           const std::string& name, int index, int reportStepNumber)
 {
-
-    auto vect = file1.getRst<T>(name, reportStepNumber);
+    auto vect = file1.getRst<T>(index, reportStepNumber);
     outFile.write(name, vect);
 }
+
+template<typename T>
+void write(EclOutput& outFile, ERst& file1,
+           const std::string& name, int index)
+{
+    auto vect = file1.get<T>(index);
+    outFile.write(name, vect);
+}
+
 
 template <typename T>
 void writeArray(std::string name, eclArrType arrType, T& file1, int index, EclOutput& outFile) {
@@ -50,24 +58,42 @@ void writeArray(std::string name, eclArrType arrType, T& file1, int index, EclOu
     }
 }
 
+template <typename T>
+void writeArray(std::string name, eclArrType arrType, T& file1, int index, int reportStepNumber, EclOutput& outFile) {
+
+    if (arrType == INTE) {
+        write<int>(outFile, file1, name, index, reportStepNumber);
+    } else if (arrType == REAL) {
+        write<float>(outFile, file1, name, index, reportStepNumber);
+    } else if (arrType == DOUB) {
+        write<double>(outFile, file1, name, index, reportStepNumber);
+    } else if (arrType == LOGI) {
+        write<bool>(outFile, file1, name, index, reportStepNumber);
+    } else if (arrType == CHAR) {
+        write<std::string>(outFile, file1, name, index, reportStepNumber);
+    } else if (arrType == MESS) {
+        outFile.message(name);
+    } else {
+        std::cout << "unknown array type " << std::endl;
+        exit(1);
+    }
+}
+
 void writeArrayList(std::vector<EclEntry>& arrayList, EclFile file1, EclOutput& outFile) {
 
     for (size_t index = 0; index < arrayList.size(); index++) {
         std::string name = std::get<0>(arrayList[index]);
         eclArrType arrType = std::get<1>(arrayList[index]);
-
         writeArray(name, arrType, file1, index, outFile);
     }
 }
-
 
 void writeArrayList(std::vector<EclEntry>& arrayList, ERst file1, int reportStepNumber, EclOutput& outFile) {
 
     for (size_t index = 0; index < arrayList.size(); index++) {
         std::string name = std::get<0>(arrayList[index]);
         eclArrType arrType = std::get<1>(arrayList[index]);
-
-        writeArray(name, arrType, file1, reportStepNumber, outFile);
+        writeArray(name, arrType, file1, index , reportStepNumber, outFile);
     }
 }
 
@@ -131,7 +157,7 @@ int main(int argc, char **argv) {
 
             for (auto seqn : reportStepList) {
 
-                std::vector<int> inteh = rst1.getRst<int>("INTEHEAD", seqn);
+                std::vector<int> inteh = rst1.getRst<int>("INTEHEAD", seqn, 0);
 
                 std::cout << "Report step number: "
                           << std::setfill(' ') << std::setw(4) << seqn << "   Date: " << inteh[66] << "/"

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -101,8 +101,8 @@ BOOST_AUTO_TEST_CASE(RUN) {
             auto rst = EclIO::ERst("SPE1CASE1.UNRST");
 
             for (const auto& step : rst.listOfReportStepNumbers()) {
-                const auto& dh    = rst.getRst<double>("DOUBHEAD", step);
-                const auto& press = rst.getRst<float>("PRESSURE", step);
+                const auto& dh    = rst.getRst<double>("DOUBHEAD", step, 0);
+                const auto& press = rst.getRst<float>("PRESSURE", step, 0);
 
                 // DOUBHEAD[0] is elapsed time in days since start of simulation.
                 BOOST_CHECK_CLOSE( press[0], dh[0] * 86400, 1e-3 );

--- a/tests/test_ERst.cpp
+++ b/tests/test_ERst.cpp
@@ -127,28 +127,28 @@ BOOST_AUTO_TEST_CASE(TestERst_1) {
 
     // non exising report step number, should throw exception 
     
-    BOOST_CHECK_THROW(std::vector<int> vect1=rst1.getRst<int>("ICON",0) , std::invalid_argument );
-    BOOST_CHECK_THROW(std::vector<float> vect2=rst1.getRst<float>("PRESSURE",0) , std::invalid_argument );
-    BOOST_CHECK_THROW(std::vector<double> vect3=rst1.getRst<double>("XGRP",0) , std::invalid_argument );
-    BOOST_CHECK_THROW(std::vector<bool> vect4=rst1.getRst<bool>("LOGIHEAD",0) , std::invalid_argument );
-    BOOST_CHECK_THROW(std::vector<std::string> vect4=rst1.getRst<std::string>("ZWEL",0) , std::invalid_argument );
+    BOOST_CHECK_THROW(std::vector<int> vect1=rst1.getRst<int>("ICON",0, 0) , std::invalid_argument );
+    BOOST_CHECK_THROW(std::vector<float> vect2=rst1.getRst<float>("PRESSURE",0, 0) , std::invalid_argument );
+    BOOST_CHECK_THROW(std::vector<double> vect3=rst1.getRst<double>("XGRP",0, 0) , std::invalid_argument );
+    BOOST_CHECK_THROW(std::vector<bool> vect4=rst1.getRst<bool>("LOGIHEAD",0, 0) , std::invalid_argument );
+    BOOST_CHECK_THROW(std::vector<std::string> vect4=rst1.getRst<std::string>("ZWEL",0, 0) , std::invalid_argument );
 
     // calling getRst<T> member function with wrong type, should throw exception
 
-    BOOST_CHECK_THROW(std::vector<float> vect1=rst1.getRst<float>("ICON",5) , std::runtime_error );
-    BOOST_CHECK_THROW(std::vector<int> vect2=rst1.getRst<int>("PRESSURE",5), std::runtime_error );
-    BOOST_CHECK_THROW(std::vector<float> vect3=rst1.getRst<float>("XGRP",5), std::runtime_error );
-    BOOST_CHECK_THROW(std::vector<double> vect4=rst1.getRst<double>("LOGIHEAD",5), std::runtime_error );
-    BOOST_CHECK_THROW(std::vector<bool> vect5=rst1.getRst<bool>("ZWEL",5), std::runtime_error );
+    BOOST_CHECK_THROW(std::vector<float> vect1=rst1.getRst<float>("ICON",5, 0) , std::runtime_error );
+    BOOST_CHECK_THROW(std::vector<int> vect2=rst1.getRst<int>("PRESSURE",5, 0), std::runtime_error );
+    BOOST_CHECK_THROW(std::vector<float> vect3=rst1.getRst<float>("XGRP",5, 0), std::runtime_error );
+    BOOST_CHECK_THROW(std::vector<double> vect4=rst1.getRst<double>("LOGIHEAD",5, 0), std::runtime_error );
+    BOOST_CHECK_THROW(std::vector<bool> vect5=rst1.getRst<bool>("ZWEL",5, 0), std::runtime_error );
 
     // report step number exists, but data is not loaded. Vector should in this case
     // be loaded on demand. Hence not throwing an exception
 
-    std::vector<int> vect1=rst1.getRst<int>("ICON",10);
-    std::vector<float> vect2=rst1.getRst<float>("PRESSURE",10);
-    std::vector<double> vect3=rst1.getRst<double>("XGRP",10);
-    std::vector<bool> vect4=rst1.getRst<bool>("LOGIHEAD",10);
-    std::vector<std::string> vect5=rst1.getRst<std::string>("ZWEL",10);
+    std::vector<int> vect1=rst1.getRst<int>("ICON",10, 0);
+    std::vector<float> vect2=rst1.getRst<float>("PRESSURE",10, 0);
+    std::vector<double> vect3=rst1.getRst<double>("XGRP",10, 0);
+    std::vector<bool> vect4=rst1.getRst<bool>("LOGIHEAD",10, 0);
+    std::vector<std::string> vect5=rst1.getRst<std::string>("ZWEL",10, 0);
 
     BOOST_CHECK_EQUAL(ref_icon_10==vect1, true);
 
@@ -163,11 +163,11 @@ BOOST_AUTO_TEST_CASE(TestERst_1) {
 
     rst1.loadReportStepNumber(25);
 
-    vect1 = rst1.getRst<int>("ICON",25);
-    vect2 = rst1.getRst<float>("PRESSURE",25);
-    vect3 = rst1.getRst<double>("XGRP",25);
-    vect4 = rst1.getRst<bool>("LOGIHEAD",25);
-    vect5 = rst1.getRst<std::string>("ZWEL",25);
+    vect1 = rst1.getRst<int>("ICON",25, 0);
+    vect2 = rst1.getRst<float>("PRESSURE",25, 0);
+    vect3 = rst1.getRst<double>("XGRP",25, 0);
+    vect4 = rst1.getRst<bool>("LOGIHEAD",25, 0);
+    vect5 = rst1.getRst<std::string>("ZWEL",25, 0);
 
     BOOST_CHECK_EQUAL(ref_icon_25==vect1, true);
 
@@ -187,19 +187,19 @@ static void readAndWrite(EclOutput& eclTest, ERst& rst1,
                          eclArrType arrType)
 {
     if (arrType == INTE) {
-        std::vector<int> vect = rst1.getRst<int>(name, seqnum);
+        std::vector<int> vect = rst1.getRst<int>(name, seqnum, 0);
         eclTest.write(name, vect);
     } else if (arrType == REAL) {
-        std::vector<float> vect = rst1.getRst<float>(name, seqnum);
+        std::vector<float> vect = rst1.getRst<float>(name, seqnum, 0);
         eclTest.write(name, vect);
     } else if (arrType == DOUB) {
-        std::vector<double> vect = rst1.getRst<double>(name, seqnum);
+        std::vector<double> vect = rst1.getRst<double>(name, seqnum, 0);
         eclTest.write(name, vect);
     } else if (arrType == LOGI) {
-        std::vector<bool> vect = rst1.getRst<bool>(name, seqnum);
+        std::vector<bool> vect = rst1.getRst<bool>(name, seqnum, 0);
         eclTest.write(name, vect);
     } else if (arrType == CHAR) {
-        std::vector<std::string> vect = rst1.getRst<std::string>(name, seqnum);
+        std::vector<std::string> vect = rst1.getRst<std::string>(name, seqnum, 0);
         eclTest.write(name, vect);
     } else if (arrType == MESS) {
         eclTest.write(name, std::vector<char>());
@@ -301,9 +301,9 @@ BOOST_AUTO_TEST_CASE(TestERst_4) {
     BOOST_CHECK_EQUAL(rst3.hasReportStepNumber(4), false);
     BOOST_CHECK_EQUAL(rst3.hasReportStepNumber(25), true);
 
-    std::vector<float> pres1 = rst1.getRst<float>("PRESSURE",25);
-    std::vector<float> pres2 = rst2.getRst<float>("PRESSURE",25);
-    std::vector<float> pres3 = rst3.getRst<float>("PRESSURE",25);
+    std::vector<float> pres1 = rst1.getRst<float>("PRESSURE",25, 0);
+    std::vector<float> pres2 = rst2.getRst<float>("PRESSURE",25, 0);
+    std::vector<float> pres3 = rst3.getRst<float>("PRESSURE",25, 0);
     
     BOOST_CHECK_EQUAL(pres1==pres2, true);
     BOOST_CHECK_EQUAL(pres1==pres3, true);
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         rst.loadReportStepNumber(1);
 
         {
-            const auto& I = rst.getRst<int>("I", 1);
+            const auto& I = rst.getRst<int>("I", 1, 0);
             const auto  expect_I = std::vector<int>{ 1, 7, 2, 9 };
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -451,7 +451,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& L = rst.getRst<bool>("L", 1);
+            const auto& L = rst.getRst<bool>("L", 1, 0);
             const auto  expect_L = std::vector<bool> {
                 true, false, false, true,
             };
@@ -462,7 +462,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 1);
+            const auto& S = rst.getRst<float>("S", 1, 0);
             const auto  expect_S = std::vector<float>{
                 3.1f, 4.1f, 59.265f,
             };
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 1);
+            const auto& D = rst.getRst<double>("D", 1, 0);
             const auto  expect_D = std::vector<double>{
                 2.71, 8.21,
             };
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 1);
+            const auto& Z = rst.getRst<std::string>("Z", 1, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "W1", "W2",  // ERst trims trailing blanks
             };
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         rst.loadReportStepNumber(5);
 
         {
-            const auto& I = rst.getRst<int>("I", 5);
+            const auto& I = rst.getRst<int>("I", 5, 0);
             const auto  expect_I = std::vector<int>{ 1, 2, 3, 4 };
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& L = rst.getRst<bool>("L", 5);
+            const auto& L = rst.getRst<bool>("L", 5, 0);
             const auto  expect_L = std::vector<bool> {
                 false, false, false, true,
             };
@@ -560,7 +560,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 5);
+            const auto& S = rst.getRst<float>("S", 5, 0);
             const auto  expect_S = std::vector<float>{
                 1.23e-04f, 1.234e5f, -5.4321e-9f,
             };
@@ -569,7 +569,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 5);
+            const auto& D = rst.getRst<double>("D", 5, 0);
             const auto  expect_D = std::vector<double>{
                 0.6931, 1.6180,
             };
@@ -578,7 +578,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 5);
+            const auto& Z = rst.getRst<std::string>("Z", 5, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "HELLO", ",", "WORLD",  // ERst trims trailing blanks
             };
@@ -639,7 +639,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         rst.loadReportStepNumber(13);
 
         {
-            const auto& I = rst.getRst<int>("I", 13);
+            const auto& I = rst.getRst<int>("I", 13, 0);
             const auto  expect_I = std::vector<int>{ 35, 51, 13};
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -647,7 +647,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& L = rst.getRst<bool>("L", 13);
+            const auto& L = rst.getRst<bool>("L", 13, 0);
             const auto  expect_L = std::vector<bool> {
                 true, true, true, false,
             };
@@ -658,7 +658,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 13);
+            const auto& S = rst.getRst<float>("S", 13, 0);
             const auto  expect_S = std::vector<float>{
                 17.29e-02f, 1.4142f,
             };
@@ -667,7 +667,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 13);
+            const auto& D = rst.getRst<double>("D", 13, 0);
             const auto  expect_D = std::vector<double>{
                 0.6931, 1.6180, 123.45e6,
             };
@@ -676,7 +676,7 @@ BOOST_AUTO_TEST_CASE(Unformatted)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 13);
+            const auto& Z = rst.getRst<std::string>("Z", 13, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "G1", "FIELD",  // ERst trims trailing blanks
             };
@@ -747,7 +747,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         rst.loadReportStepNumber(13);
 
         {
-            const auto& I = rst.getRst<int>("I", 13);
+            const auto& I = rst.getRst<int>("I", 13, 0);
             const auto  expect_I = std::vector<int>{ 35, 51, 13 };
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -755,7 +755,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& L = rst.getRst<bool>("L", 13);
+            const auto& L = rst.getRst<bool>("L", 13, 0);
             const auto  expect_L = std::vector<bool> {
                 true, true, true, false,
             };
@@ -766,7 +766,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 13);
+            const auto& S = rst.getRst<float>("S", 13, 0);
             const auto  expect_S = std::vector<float>{
                 17.29e-02f, 1.4142f,
             };
@@ -775,7 +775,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 13);
+            const auto& D = rst.getRst<double>("D", 13, 0);
             const auto  expect_D = std::vector<double>{
                 0.6931, 1.6180, 123.45e6,
             };
@@ -784,7 +784,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 13);
+            const auto& Z = rst.getRst<std::string>("Z", 13, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "G1", "FIELD",  // ERst trims trailing blanks
             };
@@ -836,7 +836,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         rst.loadReportStepNumber(5);
 
         {
-            const auto& I = rst.getRst<int>("I", 5);
+            const auto& I = rst.getRst<int>("I", 5, 0);
             const auto  expect_I = std::vector<int>{ 1, 2, 3, 4 };
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -855,7 +855,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 5);
+            const auto& S = rst.getRst<float>("S", 5, 0);
             const auto  expect_S = std::vector<float>{
                 1.23e-04f, 1.234e5f, -5.4321e-9f,
             };
@@ -864,7 +864,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 5);
+            const auto& D = rst.getRst<double>("D", 5, 0);
             const auto  expect_D = std::vector<double>{
                 0.6931, 1.6180,
             };
@@ -873,7 +873,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 5);
+            const auto& Z = rst.getRst<std::string>("Z", 5, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "HELLO", ",", "WORLD",  // ERst trims trailing blanks
             };
@@ -917,7 +917,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         rst.loadReportStepNumber(13);
 
         {
-            const auto& I = rst.getRst<int>("I", 13);
+            const auto& I = rst.getRst<int>("I", 13, 0);
             const auto  expect_I = std::vector<int>{ 35, 51, 13 };
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -925,7 +925,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& L = rst.getRst<bool>("L", 13);
+            const auto& L = rst.getRst<bool>("L", 13, 0);
             const auto  expect_L = std::vector<bool> {
                 true, true, true, false,
             };
@@ -936,7 +936,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 13);
+            const auto& S = rst.getRst<float>("S", 13, 0);
             const auto  expect_S = std::vector<float>{
                 17.29e-02f, 1.4142f,
             };
@@ -945,7 +945,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 13);
+            const auto& D = rst.getRst<double>("D", 13, 0);
             const auto  expect_D = std::vector<double>{
                 0.6931, 1.6180, 123.45e6,
             };
@@ -954,7 +954,7 @@ BOOST_AUTO_TEST_CASE(Formatted)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 13);
+            const auto& Z = rst.getRst<std::string>("Z", 13, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "G1", "FIELD",  // ERst trims trailing blanks
             };

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -195,7 +195,7 @@ void checkRestartFile( int timeStepIdx ) {
         const auto& knownVec = rstFile.listOfRstArrays(i);
 
         if (keywordExists(knownVec, "PRESSURE")) {
-            const auto& press = rstFile.getRst<float>("PRESSURE", i);
+            const auto& press = rstFile.getRst<float>("PRESSURE", i, 0);
             for( auto& x : sol.data("PRESSURE") )
                 x /= Metric::Pressure;
 
@@ -203,22 +203,22 @@ void checkRestartFile( int timeStepIdx ) {
         }
 
         if (keywordExists(knownVec, "SWAT")) {
-            const auto& swat = rstFile.getRst<float>("SWAT", i);
+            const auto& swat = rstFile.getRst<float>("SWAT", i, 0);
             compareErtData( sol.data("SWAT"), swat, 1e-4 );
         }
 
         if (keywordExists(knownVec, "SGAS")) {
-            const auto& sgas = rstFile.getRst<float>("SGAS", i);
+            const auto& sgas = rstFile.getRst<float>("SGAS", i, 0);
             compareErtData( sol.data("SGAS"), sgas, 1e-4 );
         }
 
         if (keywordExists(knownVec, "KRO")) {
-            const auto& kro = rstFile.getRst<float>("KRO", i);
+            const auto& kro = rstFile.getRst<float>("KRO", i, 0);
             BOOST_CHECK_CLOSE(1.0 * i * kro.size(), sum(kro), 1.0e-8);
         }
 
         if (keywordExists(knownVec, "KRG")) {
-            const auto& krg = rstFile.getRst<float>("KRG", i);
+            const auto& krg = rstFile.getRst<float>("KRG", i, 0);
             BOOST_CHECK_CLOSE(10.0 * i * krg.size(), sum(krg), 1.0e-8);
         }
     }

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -564,7 +564,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         rst.loadReportStepNumber(13);
 
         {
-            const auto& I = rst.getRst<int>("I", 13);
+            const auto& I = rst.getRst<int>("I", 13, 0);
             const auto  expect_I = std::vector<int>{ 35, 51, 13};
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -572,7 +572,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& L = rst.getRst<bool>("L", 13);
+            const auto& L = rst.getRst<bool>("L", 13, 0);
             const auto  expect_L = std::vector<bool> {
                 true, true, true, false,
             };
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 13);
+            const auto& S = rst.getRst<float>("S", 13, 0);
             const auto  expect_S = std::vector<float>{
                 17.29e-02f, 1.4142f,
             };
@@ -592,7 +592,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 13);
+            const auto& D = rst.getRst<double>("D", 13, 0);
             const auto  expect_D = std::vector<double>{
                 0.6931, 1.6180, 123.45e6,
             };
@@ -601,7 +601,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 13);
+            const auto& Z = rst.getRst<std::string>("Z", 13, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "G1", "FIELD",  // ERst trims trailing blanks
             };
@@ -663,7 +663,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         rst.loadReportStepNumber(5);
 
         {
-            const auto& I = rst.getRst<int>("I", 5);
+            const auto& I = rst.getRst<int>("I", 5, 0);
             const auto  expect_I = std::vector<int>{ 1, 2, 3, 4 };
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -671,7 +671,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& L = rst.getRst<bool>("L", 5);
+            const auto& L = rst.getRst<bool>("L", 5, 0);
             const auto  expect_L = std::vector<bool> {
                 false, false, false, true,
             };
@@ -682,7 +682,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 5);
+            const auto& S = rst.getRst<float>("S", 5, 0);
             const auto  expect_S = std::vector<float>{
                 1.23e-04f, 1.234e5f, -5.4321e-9f,
             };
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 5);
+            const auto& D = rst.getRst<double>("D", 5, 0);
             const auto  expect_D = std::vector<double>{
                 0.6931, 1.6180,
             };
@@ -700,7 +700,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 5);
+            const auto& Z = rst.getRst<std::string>("Z", 5, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "HELLO", ",", "WORLD",  // ERst trims trailing blanks
             };
@@ -762,7 +762,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         rst.loadReportStepNumber(13);
 
         {
-            const auto& I = rst.getRst<int>("I", 13);
+            const auto& I = rst.getRst<int>("I", 13, 0);
             const auto  expect_I = std::vector<int>{ 35, 51, 13};
             BOOST_CHECK_EQUAL_COLLECTIONS(I.begin(), I.end(),
                                           expect_I.begin(),
@@ -770,7 +770,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& L = rst.getRst<bool>("L", 13);
+            const auto& L = rst.getRst<bool>("L", 13, 0);
             const auto  expect_L = std::vector<bool> {
                 true, true, true, false,
             };
@@ -781,7 +781,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& S = rst.getRst<float>("S", 13);
+            const auto& S = rst.getRst<float>("S", 13, 0);
             const auto  expect_S = std::vector<float>{
                 17.29e-02f, 1.4142f,
             };
@@ -790,7 +790,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& D = rst.getRst<double>("D", 13);
+            const auto& D = rst.getRst<double>("D", 13, 0);
             const auto  expect_D = std::vector<double>{
                 0.6931, 1.6180, 123.45e6,
             };
@@ -799,7 +799,7 @@ BOOST_AUTO_TEST_CASE(Unformatted_Unified)
         }
 
         {
-            const auto& Z = rst.getRst<std::string>("Z", 13);
+            const auto& Z = rst.getRst<std::string>("Z", 13, 0);
             const auto  expect_Z = std::vector<std::string>{
                 "G1", "FIELD",  // ERst trims trailing blanks
             };

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -806,7 +806,7 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
                 EclIO::ERst rst{ rstFile };
                 BOOST_CHECK_MESSAGE( rst.hasKey("EXTRA"), "Restart file is expexted to have EXTRA vector");
 
-                const auto& ex = rst.getRst<double>("EXTRA", 1);
+                const auto& ex = rst.getRst<double>("EXTRA", 1, 0);
                 BOOST_CHECK_CLOSE( 10 , units.to_si( UnitSystem::measure::pressure, ex[0] ), 0.00001);
                 BOOST_CHECK_CLOSE( units.from_si( UnitSystem::measure::pressure, 3), ex[3], 0.00001);
             }


### PR DESCRIPTION
Aquifer related array names in the restart output file (Eclipse format) can occur more that once for a given report step number. This will be the case if a model contains more that one analytic aquifer connected to the grid. Multiple instances of array names will also occur for models with local grid refinements (LGR). 

The API for the ERst class has been extended with more member functions in order to handle multiple instances of array names within a given report step.

This PR also include updates for program convertECL. The current version of the program have a bug with option -r if multiple instances of a array name occur. This has been fixed with this PR.

Notice that the program compareECL will also need an update, but this is not included in this PR.
  