### PR TITLE
Code to write UDQ and ACTIONX data to the Eclipse compatible restart file

### DIFF
--- a/opm/output/eclipse/AggregateGroupData.hpp
+++ b/opm/output/eclipse/AggregateGroupData.hpp
@@ -23,7 +23,7 @@
 #include <opm/output/eclipse/WindowedArray.hpp>
 
 #include <opm/io/eclipse/PaddedOutputString.hpp>
-
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <cstddef>
 #include <string>
 #include <vector>
@@ -32,7 +32,8 @@
 namespace Opm {
 class Schedule;
 class SummaryState;
-class Group;
+//class Group;
+class UnitSystem;
 } // Opm
 
 namespace Opm { namespace RestartIO { namespace Helpers {
@@ -42,10 +43,11 @@ class AggregateGroupData
 public:
     explicit AggregateGroupData(const std::vector<int>& inteHead);
 
-    void captureDeclaredGroupData(const Opm::Schedule&                 sched,
-                                  const std::size_t                    simStep,
-                                  const Opm::SummaryState&             sumState,
-                                  const std::vector<int>&              inteHead);
+    void captureDeclaredGroupData(const Opm::Schedule&        sched,
+                         const Opm::UnitSystem&               units,
+                         const std::size_t                    simStep,
+                         const Opm::SummaryState&             sumState,
+                         const std::vector<int>&              inteHead);
 
     const std::vector<int>& getIGroup() const
     {
@@ -103,6 +105,19 @@ public:
                                                            {"GWITH", 140},
                                                            {"GGPTH", 143},
                                                            {"GGITH", 144},
+    };
+    
+    
+    using inj_cmode_enum = Opm::Group::InjectionCMode;
+    const std::map<inj_cmode_enum, int> cmodeToNum = {
+        
+        {inj_cmode_enum::NONE, 0},
+        {inj_cmode_enum::RATE, 1},
+        {inj_cmode_enum::RESV, 2},
+        {inj_cmode_enum::REIN, 3},
+        {inj_cmode_enum::VREP, 4},
+        {inj_cmode_enum::FLD,  0},
+        {inj_cmode_enum::SALE, 0},
     };
 
     const std::map<std::string, size_t> fieldKeyToIndex = {

--- a/opm/output/eclipse/AggregateWellData.hpp
+++ b/opm/output/eclipse/AggregateWellData.hpp
@@ -23,6 +23,7 @@
 #include <opm/output/eclipse/WindowedArray.hpp>
 
 #include <opm/io/eclipse/PaddedOutputString.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp>
 
 #include <cstddef>
 #include <string>
@@ -39,6 +40,11 @@ namespace Opm { namespace data {
 }} // Opm::data
 
 namespace Opm { namespace RestartIO { namespace Helpers {
+    
+    struct ActionResStatus {
+        std::vector<Opm::Action::Result> result;
+        std::vector<std::string> name;
+    };
 
     class AggregateWellData
     {

--- a/opm/output/eclipse/DoubHEAD.hpp
+++ b/opm/output/eclipse/DoubHEAD.hpp
@@ -40,6 +40,17 @@ namespace Opm { namespace RestartIO {
             std::chrono::duration<double, std::chrono::seconds::period> elapsed;
         };
         
+        struct guideRate {
+            double A;
+            double B;
+            double C;
+            double D;
+            double E;
+            double F;
+            double delay;
+            double damping_fact;
+        };
+        
         DoubHEAD();
 
         ~DoubHEAD() = default;
@@ -61,6 +72,7 @@ namespace Opm { namespace RestartIO {
                         const double      cnvT);
 	
         DoubHEAD& udq_param(const UDQParams& udqPar);
+        DoubHEAD& guide_rate_param(const guideRate& guide_rp);
 
         const std::vector<double>& data() const
         {

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -143,6 +143,7 @@ namespace Opm { namespace RestartIO {
         InteHEAD& actionParam(const ActionParam& act_par);
         InteHEAD& variousUDQ_ACTIONXParam();
         InteHEAD& nominatedPhaseGuideRate(GuideRateNominatedPhase nphase);
+        InteHEAD& whistControlMode(int mode);
 
         const std::vector<int>& data() const
         {

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -93,7 +93,11 @@ namespace Opm { namespace RestartIO {
 	
 	struct UdqParam {
 	  int    udqParam_1;
-      int    no_udqs;
+      int    no_wudqs;
+      int    no_gudqs;
+      int    no_fudqs;
+      int    no_iuads;
+      int    no_iuaps;
 	};
 
     struct ActionParam {
@@ -102,6 +106,11 @@ namespace Opm { namespace RestartIO {
       int   max_no_conditions_per_action;
       int   max_no_characters_per_line;
      };
+     
+     struct GuideRateNominatedPhase {
+      int   nominated_phase;
+     };
+     
         InteHEAD();
         ~InteHEAD() = default;
 
@@ -122,6 +131,7 @@ namespace Opm { namespace RestartIO {
         InteHEAD& params_NWELZ(const int niwelz, const int nswelz, const int nxwelz, const int nzwelz);
         InteHEAD& params_NCON(const int niconz, const int nsconz, const int nxconz);
         InteHEAD& params_GRPZ(const std::array<int, 4>& grpz);
+        InteHEAD& params_NGCTRL(const int gct);
         InteHEAD& params_NAAQZ(const int ncamax, const int niaaqz, const int nsaaqz, const int nxaaqz, const int nicaqz, const int nscaqz, const int nacaqz);
         InteHEAD& stepParam(const int tstep, const int report_step);
         InteHEAD& tuningParam(const TuningPar& tunpar);
@@ -131,6 +141,8 @@ namespace Opm { namespace RestartIO {
         InteHEAD& ngroups(const Group& gr);
         InteHEAD& udqParam_1(const UdqParam& udqpar);
         InteHEAD& actionParam(const ActionParam& act_par);
+        InteHEAD& variousUDQ_ACTIONXParam();
+        InteHEAD& nominatedPhaseGuideRate(GuideRateNominatedPhase nphase);
 
         const std::vector<int>& data() const
         {

--- a/opm/output/eclipse/VectorItems/connection.hpp
+++ b/opm/output/eclipse/VectorItems/connection.hpp
@@ -57,6 +57,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
             item30       = 29, // Unknown
             item31       = 30, // Unknown
+            item41       = 40, // = 0 for connection factor not defined, = 1 for connection factor defined
         };
     } // SConn
 

--- a/opm/output/eclipse/VectorItems/doubhead.hpp
+++ b/opm/output/eclipse/VectorItems/doubhead.hpp
@@ -27,12 +27,20 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
     // This is a subset of the items in src/opm/output/eclipse/DoubHEAD.cpp .
     // Promote items from that list to this in order to make them public.
     enum doubhead : std::vector<double>::size_type {
-        TsInit = 1,             // Maximum Length of Next Timestep
-        TsMaxz = 2,             // Maximum Length of Timestep After Next
-        TsMinz = 3,             // Minumum Length of All Timesteps
-	UdqPar_2 = 212,		// UDQPARAM item number 2 (Permitted range (+/-) of user-defined quantities)
-	UdqPar_3 = 213,		// UDQPARAM item number 3 (Value given to undefined elements when outputting data)
-	UdqPar_4 = 214,		// UDQPARAM item number 4 (fractional equality tolerance used in ==, <= etc. functions)
+        TsInit  = 1,             // Maximum Length of Next Timestep
+        TsMaxz  = 2,             // Maximum Length of Timestep After Next
+        TsMinz  = 3,             // Minumum Length of All Timesteps
+        GRpar_a = 87,     // Guiderate parameter A
+        GRpar_b = 88,     // Guiderate parameter B
+        GRpar_c = 89,     // Guiderate parameter C
+        GRpar_d = 90,     // Guiderate parameter D
+        GRpar_e = 91,     // Guiderate parameter E
+        GRpar_f = 92,     // Guiderate parameter F
+        GRpar_int = 97,     // Guiderate parameter delay interval
+        GRpar_damp = 144,     // Guiderate parameter damping factor
+        UdqPar_2 = 212,		// UDQPARAM item number 2 (Permitted range (+/-) of user-defined quantities)
+        UdqPar_3 = 213,		// UDQPARAM item number 3 (Value given to undefined elements when outputting data)
+        UdqPar_4 = 214,		// UDQPARAM item number 4 (fractional equality tolerance used in ==, <= etc. functions)
     };
 
 }}}} // Opm::RestartIO::Helpers::VectorItems

--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -24,6 +24,30 @@
 
 namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
 
+    
+        namespace SGroup {
+        enum prod_index : std::vector<float>::size_type {
+            OilRateLimit  =  6, // Group's oil production target/limit
+            WatRateLimit  =  7, // Group's water production target/limit
+            GasRateLimit  =  8, // Group's gas production target/limit
+            LiqRateLimit  =  9, // Group's liquid production target/limit
+        };
+        
+        enum inj_index : std::vector<float>::size_type {
+            waterSurfRateLimit      =  15, // Group's water surface volume injection rate target/limit
+            waterResRateLimit       =  16, // Group's water reservoir volume injection rate target/limit
+            waterReinjectionLimit   =  17, // Group's water reinjection fraction target/limit
+            waterVoidageLimit       =  18, // Group's water voidage injection fraction target/limit
+            gasSurfRateLimit        =  20, // Group's gas surface volume injection rate target/limit
+            gasResRateLimit         =  21, // Group's gas reservoir volume injection rate target/limit
+            gasReinjectionLimit     =  22, // Group's gas reinjection fraction target/limit
+            gasVoidageLimit         =  23, // Group's gas voidage injection fraction target/limit
+
+        };
+    } // SGroup
+
+    
+    
     namespace XGroup {
         enum index : std::vector<double>::size_type {
             OilPrRate  =  0, // Group's oil production rate

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -75,6 +75,10 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NICAQZ  =  45,      //  Number of data elements per aquifer connection in ICAQ array
         NSCAQZ  =  46,      //  Number of data elements per aquifer connection in SCAQ array
         NACAQZ  =  47,      //  Number of data elements per aquifer connection in ACAQ array
+        
+        NGCTRL   =  51,      //  Index indicating if group control is used or not (1 - if group control, 0 if not)
+        
+        NGRNPH   =  58,      //  Index indicating if group control is used or not (1 - if group control, 0 if not)
 
         DAY     =  64,      //  Calendar day of report step (1..31)
         MONTH   =  65,      //  Calendar month of report step (1..12)
@@ -96,11 +100,14 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NILBRZ  = 180,      //  Number of entries per segment in ILBR array
 
         MAX_ACT_COND = 245,      //  Maximum number of conditions pr action
-
         MAX_AN_AQUIFERS = 252, // Maximum number of analytic aquifers
 
-        NO_UDQS = 266,      //  No of UDQ data (parameters)
-        UDQPAR_1 = 267,      //  Integer seed value for the RAND
+        NO_FIELD_UDQS = 262, //  No of Field UDQ data (parameters) /  
+        NO_GROUP_UDQS = 263, //  No of Group UDQ data (parameters) /  
+        NO_WELL_UDQS = 266,  //  No of Well UDQ data (parameters) /  
+        UDQPAR_1 = 267,      //  Integer seed value for the RAND /  
+        NO_IUADS = 290,      //  No IUADs 
+        NO_IUAPS = 291,      //  No IUAPs
         RSEED    = 296,
     };
 }}}} // Opm::RestartIO::Helpers::VectorItems

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -83,6 +83,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         DAY     =  64,      //  Calendar day of report step (1..31)
         MONTH   =  65,      //  Calendar month of report step (1..12)
         YEAR    =  66,      //  Calendar year of report step
+        
+        WHISTC   =  71,      //  Calendar year of report step
 
         NOOFACTIONS = 156,  //  The number of actions in the dataset
         MAXNOLINES = 157,   //  Maximum number of lines of schedule data for ACTION keyword - including ENDACTIO

--- a/opm/output/eclipse/VectorItems/msw.hpp
+++ b/opm/output/eclipse/VectorItems/msw.hpp
@@ -39,6 +39,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
         namespace Value {
             enum SegmentType : int {
+                REGULAR = -1,
                 AICD  = -8,
                 SICD  = -7,
                 Valve = -5,

--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -180,6 +180,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
     namespace ZWell {
         enum index : std::vector<const char*>::size_type {
             WellName = 0, // Well name
+            ActionX  = 2, // ActionX name
         };
     } // ZWell
 }}}} // Opm::RestartIO::Helpers::VectorItems

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp
@@ -95,11 +95,15 @@ public:
 
     explicit operator bool() const;
     std::vector<std::string> wells() const;
-    bool has_well(const std::string& well);
+
+    bool has_well(const std::string& well) const;
+
     void add_well(const std::string& well);
 
     Result& operator|=(const Result& other);
+    Result& operator=(const Result& src); 
     Result& operator&=(const Result& other);
+    
 private:
     void assign(bool value);
     bool result;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -197,6 +197,7 @@ struct ProductionControls {
     InjectionControls injectionControls(const SummaryState& st) const;
     const GroupProductionProperties& productionProperties() const;
     const GroupInjectionProperties& injectionProperties() const;
+    const GroupType& getGroupType() const;
     ProductionCMode production_cmode() const;
     InjectionCMode injection_cmode() const;
     Phase injection_phase() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
@@ -62,7 +62,13 @@ public:
     bool operator==(const GuideRateModel& other) const;
     bool operator!=(const GuideRateModel& other) const;
     Target target() const;
-
+    double getA() const;
+    double getB() const;
+    double getC() const;
+    double getD() const; 
+    double getE() const;
+    double getF() const;
+    
     static Target convert_target(Group::GuideRateTarget group_target);
     static Target convert_target(Well::GuideRateTarget well_target);
     static double pot(Target target, double oil_pot, double gas_pot, double wat_pot);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -184,6 +184,7 @@ namespace Opm
         std::vector<const Group*> getChildGroups2(const std::string& group_name, size_t timeStep) const;
         std::vector<Well> getChildWells2(const std::string& group_name, size_t timeStep) const;
         const OilVaporizationProperties& getOilVaporizationProperties(size_t timestep) const;
+        const Well::ProducerCMode& getGlobalWhistctlMmode(size_t timestep) const;
 
         const UDQActive& udqActive(size_t timeStep) const;
         const WellTestConfig& wtestConfig(size_t timestep) const;

--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -19,6 +19,7 @@
 
 #include <opm/output/eclipse/AggregateActionxData.hpp>
 #include <opm/output/eclipse/AggregateGroupData.hpp>
+#include <opm/output/eclipse/AggregateWellData.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -30,6 +31,9 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionContext.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp>
@@ -42,7 +46,7 @@
 #include <iostream>
 
 // #####################################################################
-// Class Opm::RestartIO::Helpers::AggregateGroupData
+// Class Opm::RestartIO::Helpers
 // ---------------------------------------------------------------------
 
 
@@ -55,6 +59,25 @@ namespace {
                                                            {"M",  11},
                                                            {"Y",  12},
     }; 
+    
+    /*const std::map<std::string, int> lhsQuantityToItem_12 = {
+                                                           {"F",   0},
+                                                           {"W",   0},
+                                                           {"G",   0},
+                                                           {"D",   0},
+                                                           {"M",   1},
+                                                           {"Y",   0},
+    };*/ 
+    
+    using cmp_enum = Opm::Action::Condition::Comparator;
+    const std::map<cmp_enum, int> cmpToIacn_12 = {
+                                                    {cmp_enum::GREATER,       0},
+                                                    {cmp_enum::LESS,          1},
+                                                    {cmp_enum::GREATER_EQUAL, 0},
+                                                    {cmp_enum::LESS_EQUAL,    1},
+                                                    {cmp_enum::EQUAL,         1},
+                                                    {cmp_enum::INVALID,       0},
+    };
 
     const std::map<std::string, double> monthToNo = {
                                                            {"JAN",   1.},
@@ -72,35 +95,35 @@ namespace {
     }; 
 
     
-            const std::map<std::string, int> rhsQuantityToIndex = {
-                                                           {"F",   1},
-                                                           {"W",   2},
-                                                           {"G",   3},
-        }; 
+const std::map<std::string, int> rhsQuantityToIndex = {
+                                                {"F",   1},
+                                                {"W",   2},
+                                                {"G",   3},
+}; 
         
-        using logic_enum = Opm::Action::Condition::Logical;
-        const std::map<logic_enum, int> logicalToIndex_13 = {
-                                                          {logic_enum::AND,   1},
-                                                          {logic_enum::OR,    2},
-                                                          {logic_enum::END,   0},
-        };
-        
-        const std::map<logic_enum, int> logicalToIndex_17 = {
-                                                          {logic_enum::AND,   1},
-                                                          {logic_enum::OR,    0},
-                                                          {logic_enum::END,   0},
-        }; 
-        
+using logic_enum = Opm::Action::Condition::Logical;
+const std::map<logic_enum, int> logicalToIndex_13 = {
+                                                    {logic_enum::AND,   1},
+                                                    {logic_enum::OR,    2},
+                                                    {logic_enum::END,   0},
+};
 
-        using cmp_enum = Opm::Action::Condition::Comparator;
-        const std::map<cmp_enum, int> cmpToIndex = {
-                                                          {cmp_enum::GREATER,       1},
-                                                          {cmp_enum::LESS,          2},
-                                                          {cmp_enum::GREATER_EQUAL, 3},
-                                                          {cmp_enum::LESS_EQUAL,    4},
-                                                          {cmp_enum::EQUAL,         5},
-                                                          {cmp_enum::INVALID,       0},
-        };
+const std::map<logic_enum, int> logicalToIndex_17 = {
+                                                    {logic_enum::AND,   1},
+                                                    {logic_enum::OR,    0},
+                                                    {logic_enum::END,   0},
+}; 
+
+
+using cmp_enum = Opm::Action::Condition::Comparator;
+const std::map<cmp_enum, int> cmpToIndex = {
+                                                    {cmp_enum::GREATER,       1},
+                                                    {cmp_enum::LESS,          2},
+                                                    {cmp_enum::GREATER_EQUAL, 3},
+                                                    {cmp_enum::LESS_EQUAL,    4},
+                                                    {cmp_enum::EQUAL,         5},
+                                                    {cmp_enum::INVALID,       0},
+};
 
 
     namespace iACT {
@@ -109,9 +132,12 @@ namespace {
         allocate(const std::vector<int>& actDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
+
+            int nwin = std::max(actDims[0], 1);
+            int nitPrWin = std::max(actDims[1], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(actDims[0]) },
-                WV::WindowSize{ static_cast<std::size_t>(actDims[1]) }
+                WV::NumWindows{ static_cast<std::size_t>(nwin) },
+                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
             };
         }
 
@@ -122,8 +148,18 @@ namespace {
             iAct[0] = 0;
             //item [1]: The number of lines of schedule data including ENDACTIO
             iAct[1] = actx.keyword_strings().size();
-            //item [2]: is unknown, (=1)
-            iAct[2] = 1;
+            //item [2]: is = 1 for condition and previous condition = AND, and combinations OR/AND
+            //          is = 2 for all conditions and previous conditions = OR  
+            //          This is not implemented yet - only use 1 for all cases
+            const auto& actx_cond = actx.conditions();
+            int i_temp = 2;
+            for (auto cond_it = actx_cond.begin(); cond_it < actx_cond.end(); cond_it++) {
+                const auto it_logic_17 = logicalToIndex_17.find(cond_it->logic);
+                if (it_logic_17 != logicalToIndex_17.end()) {
+                    if (it_logic_17->first == logic_enum::AND) i_temp = 1;
+                }
+            }
+            iAct[2] = i_temp;
             //item [3]: is unknown, (=7)
             iAct[3] = 7;
             //item [4]: is unknown, (=0)
@@ -146,9 +182,12 @@ namespace {
         allocate(const std::vector<int>& actDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<float>;
+
+            int nwin = std::max(actDims[0], 1);
+            int nitPrWin = std::max(actDims[2], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(actDims[0]) },
-                WV::WindowSize{ static_cast<std::size_t>(actDims[2]) }
+                WV::NumWindows{ static_cast<std::size_t>(nwin) },
+                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
             };
         }
 
@@ -173,10 +212,12 @@ namespace {
             using WV = Opm::RestartIO::Helpers::WindowedArray<
                 Opm::EclIO::PaddedOutputString<8>
             >;
-
+            
+            int nwin = std::max(actDims[0], 1);
+            int nitPrWin = std::max(actDims[3], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(actDims[0]) },
-                WV::WindowSize{ static_cast<std::size_t>(actDims[3]) }
+                WV::NumWindows{ static_cast<std::size_t>(nwin) },
+                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
             };
         }
 
@@ -198,10 +239,11 @@ namespace {
             using WV = Opm::RestartIO::Helpers::WindowedArray<
                 Opm::EclIO::PaddedOutputString<8>
             >;
-
+            int nwin = std::max(actDims[0], 1);
+            int nitPrWin = std::max(actDims[4], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(actDims[0]) },
-                WV::WindowSize{ static_cast<std::size_t>(actDims[4]) }
+                WV::NumWindows{ static_cast<std::size_t>(nwin) },
+                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
             };
         }
         
@@ -243,9 +285,11 @@ namespace {
                 Opm::EclIO::PaddedOutputString<8>
             >;
 
+            int nwin = std::max(actDims[0], 1);
+            int nitPrWin = std::max(actDims[5], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(actDims[0]) },
-                WV::WindowSize{ static_cast<std::size_t>(actDims[5]) }
+                WV::NumWindows{ static_cast<std::size_t>(nwin) },
+                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
             };
         }
   
@@ -291,8 +335,6 @@ namespace {
             }
         }      
     } // zAcn
- 
-}
 
     namespace iACN {
 
@@ -300,9 +342,12 @@ namespace {
         allocate(const std::vector<int>& actDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
+
+            int nwin = std::max(actDims[0], 1);
+            int nitPrWin = std::max(actDims[6], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(actDims[0]) },
-                WV::WindowSize{ static_cast<std::size_t>(actDims[6]) }
+                WV::NumWindows{ static_cast<std::size_t>(nwin) },
+                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
             };
         }
 
@@ -352,13 +397,13 @@ namespace {
                     iAcn[ind + 11] = it_rhsq->second;
                 }
                 
-                 /*item[12] - index for lhs type
-                    1 - for MNTH
-                    0 - for all other types
+                 /*item[12] - index for relational operator (<, =, > )
+                 0 - for LHS quantity greater RHS quantity
+                 1 - for LHS quantity less than or equal to RHS quantity
                 */
-                std::string lhsQ = z_data.lhs.quantity;
-                if ( lhsQ == "MNTH") {
-                    iAcn[ind + 12] = 1;
+                const auto it_lhs_it = cmpToIacn_12.find(z_data.cmp);
+                if (it_lhs_it != cmpToIacn_12.end()) {
+                    iAcn[ind + 12] = it_lhs_it->second;
                 }
                 
                 /*item [13] - relates to operator
@@ -424,42 +469,62 @@ namespace {
         allocate(const std::vector<int>& actDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<double>;
+            
+            int nwin = std::max(actDims[0], 1);
+            int nitPrWin = std::max(actDims[7], 1);
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(actDims[0]) },
-                WV::WindowSize{ static_cast<std::size_t>(actDims[7]) }
+                WV::NumWindows{ static_cast<std::size_t>(nwin) },
+                WV::WindowSize{ static_cast<std::size_t>(nitPrWin) }
             };
+        }
+        
+        Opm::Action::Result
+        act_res(const Opm::Schedule& sched, const Opm::SummaryState&  smry, const std::size_t sim_step, std::vector<Opm::Action::ActionX>::const_iterator act_x) {
+            Opm::Action::Result ar(false);
+            Opm::Action::Context context(smry);
+            auto sim_time = sched.simTime(sim_step);
+            if (act_x->ready(sim_time)) {
+                    ar = act_x->eval(sim_time, context);
+            }
+            return {ar};
         }
 
         template <class SACNArray>
-        void staticContrib(const Opm::Action::ActionX& actx, 
-                           const Opm::SummaryState& st,
-                           SACNArray& sAcn)
+        void staticContrib(std::vector<Opm::Action::ActionX>::const_iterator    actx_it, 
+                           const Opm::SummaryState&                             st,
+                           const Opm::Schedule&                                 sched,
+                           const std::size_t                                    simStep,
+                           SACNArray&                                           sAcn)
         {
             std::size_t ind = 0;
             int noEPZacn = 16;
             double undef_high_val = 1.0E+20;
+            const auto& wells = sched.getWells(simStep);
+            const auto ar = sACN::act_res(sched, st, simStep, actx_it); 
             // write out the schedule Actionx conditions
-            const auto& actx_cond = actx.conditions();
+            const auto& actx_cond = actx_it->conditions();
             for (const auto&  z_data : actx_cond) {
                 
                 // item [0 - 1] = 0 (unknown)
                 sAcn[ind + 0] = 0.;
                 sAcn[ind + 1] = 0.;
                 
-                //item  [2, 5, 7, 9]: value of condition 1 (zero if well, group or field variable
+                const std::string& lhsQtype = z_data.lhs.quantity.substr(0,1);
                 const std::string& rhsQtype = z_data.rhs.quantity.substr(0,1);
+                
+                //item  [2, 5, 7, 9]: value of condition 1 (zero if well, group or field variable
                 const auto& it_rhsq = rhsQuantityToIndex.find(rhsQtype);
                 if (it_rhsq == rhsQuantityToIndex.end()) {
                     //come here if constant value condition
                     double t_val = 0.;
-                    if (rhsQtype == "M") {
+                    if (lhsQtype == "M") {
                        const auto& it_mnth = monthToNo.find(z_data.rhs.quantity); 
                        if (it_mnth != monthToNo.end()) {
                            t_val = it_mnth->second;
                        }
                        else {
                             std::cout << "Unknown Month: " << z_data.rhs.quantity << std::endl;
-                            throw std::invalid_argument("Actionx: " + actx.name() + "  Condition: " + z_data.lhs.quantity );
+                            throw std::invalid_argument("Actionx: " + actx_it->name() + "  Condition: " + z_data.lhs.quantity );
                         }
                     }
                     else {
@@ -470,39 +535,33 @@ namespace {
                     sAcn[ind + 7] = sAcn[ind + 2];
                     sAcn[ind + 9] = sAcn[ind + 2];
                 }
-                //Treat well, group and field right hand side conditions
+
+                
+                                //Treat well, group and field right hand side conditions
                 if (it_rhsq != rhsQuantityToIndex.end()) {
                     //Well variable
-                    if (it_rhsq->first == "W") {
-                        sAcn[ind + 4] = st.get_well_var(z_data.rhs.args[0], z_data.rhs.quantity);
+                    if ((it_rhsq->first == "W") && (st.has_well_var(z_data.rhs.args[0], z_data.rhs.quantity))) {
                         sAcn[ind + 5] = st.get_well_var(z_data.rhs.args[0], z_data.rhs.quantity);
-                        sAcn[ind + 6] = st.get_well_var(z_data.rhs.args[0], z_data.rhs.quantity);
                         sAcn[ind + 7] = st.get_well_var(z_data.rhs.args[0], z_data.rhs.quantity);
-                        sAcn[ind + 8] = st.get_well_var(z_data.rhs.args[0], z_data.rhs.quantity);
                         sAcn[ind + 9] = st.get_well_var(z_data.rhs.args[0], z_data.rhs.quantity);
                     }
                     //group variable
-                    if (it_rhsq->first == "G") {
-                        sAcn[ind + 4] = st.get_group_var(z_data.rhs.args[0], z_data.rhs.quantity);
+                    if ((it_rhsq->first == "G") && (st.has_group_var(z_data.rhs.args[0], z_data.rhs.quantity))) {;
                         sAcn[ind + 5] = st.get_group_var(z_data.rhs.args[0], z_data.rhs.quantity);
-                        sAcn[ind + 6] = st.get_group_var(z_data.rhs.args[0], z_data.rhs.quantity);
                         sAcn[ind + 7] = st.get_group_var(z_data.rhs.args[0], z_data.rhs.quantity);
-                        sAcn[ind + 8] = st.get_group_var(z_data.rhs.args[0], z_data.rhs.quantity);
                         sAcn[ind + 9] = st.get_group_var(z_data.rhs.args[0], z_data.rhs.quantity);
                     }
                     //field variable
-                    if (it_rhsq->first == "F") {
-                        sAcn[ind + 4] = st.get(z_data.rhs.quantity);
+                    if ((it_rhsq->first == "F") && (st.has(z_data.rhs.quantity))) {
                         sAcn[ind + 5] = st.get(z_data.rhs.quantity);
-                        sAcn[ind + 6] = st.get(z_data.rhs.quantity);
                         sAcn[ind + 7] = st.get(z_data.rhs.quantity);
-                        sAcn[ind + 8] = st.get(z_data.rhs.quantity);
                         sAcn[ind + 9] = st.get(z_data.rhs.quantity);
                     }
                 }
+
+                
                 
                 //treat cases with left hand side condition being: DAY, MNTH og YEAR variable
-                const std::string& lhsQtype = z_data.lhs.quantity.substr(0,1);
                 const auto& it_lhsq = lhsQuantityToIndex.find(lhsQtype);
                 if ((it_lhsq->first == "D") || (it_lhsq->first == "M") || (it_lhsq->first == "Y")) {
                     sAcn[ind + 4] = undef_high_val;
@@ -513,6 +572,41 @@ namespace {
                     sAcn[ind + 9] = undef_high_val;
                 }
                 
+                //Treat well, group and field left hand side conditions
+                if (it_lhsq != lhsQuantityToIndex.end()) {
+                    std::string wn = "";
+                    //Well variable
+                    if (it_lhsq->first == "W") {                        
+                        //find the well that violates action if relevant
+                        for (const auto& well : wells) 
+                        {
+                            if (ar.has_well(well.name())) {                    
+                                //set well name
+                                wn = well.name();
+                                break;
+                            }
+                        }
+
+                        if ((it_lhsq->first == "W") && (st.has_well_var(wn, z_data.lhs.quantity)) ) {    
+                            sAcn[ind + 4] = st.get_well_var(wn, z_data.lhs.quantity);
+                            sAcn[ind + 6] = st.get_well_var(wn, z_data.lhs.quantity);
+                            sAcn[ind + 8] = st.get_well_var(wn, z_data.lhs.quantity);
+                        }
+                    }
+                    //group variable
+                    if ((it_lhsq->first == "G") && (st.has_group_var(z_data.lhs.args[0], z_data.lhs.quantity))) {
+                        sAcn[ind + 4] = st.get_group_var(z_data.lhs.args[0], z_data.lhs.quantity);
+                        sAcn[ind + 6] = st.get_group_var(z_data.lhs.args[0], z_data.lhs.quantity);
+                        sAcn[ind + 8] = st.get_group_var(z_data.lhs.args[0], z_data.lhs.quantity);
+                    }
+                    //field variable
+                    if ((it_lhsq->first == "F") && (st.has(z_data.lhs.quantity))) {
+                        sAcn[ind + 4] = st.get(z_data.lhs.quantity);
+                        sAcn[ind + 6] = st.get(z_data.lhs.quantity);
+                        sAcn[ind + 8] = st.get(z_data.lhs.quantity);
+                    }
+                }
+                
                 //increment index according to no of items pr condition                    
                 ind += static_cast<std::size_t>(noEPZacn);
             }
@@ -520,7 +614,7 @@ namespace {
 
     } // sAcn
 
-    
+}
 // =====================================================================
 
 Opm::RestartIO::Helpers::AggregateActionxData::
@@ -543,7 +637,7 @@ captureDeclaredActionxData( const Opm::Schedule&    sched,
                             const std::vector<int>& actDims,
                             const std::size_t       simStep)
 {
-    auto acts = sched.actions(simStep);
+    const auto acts = sched.actions(simStep);
     std::size_t act_ind = 0;
     for (auto actx_it = acts.begin(); actx_it < acts.end(); actx_it++) {
         {
@@ -578,7 +672,7 @@ captureDeclaredActionxData( const Opm::Schedule&    sched,
 
         {
             auto s_acn = this->sACN_[act_ind];
-            sACN::staticContrib(*actx_it, st, s_acn);
+            sACN::staticContrib(actx_it, st, sched, simStep, s_acn);
         }
 
         act_ind +=1;

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -191,7 +191,7 @@ namespace {
 
             sConn[Ix::item30] = -1.0e+20f;
             sConn[Ix::item31] = -1.0e+20f;
-            sConn[Ix::item41] = (conn.CF() > 0) ? 1 : 0;
+            sConn[Ix::item41] = (conn.ctfAssignedFromInput()) ? 1 : 0;
         }
     } // SConn
 

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -191,6 +191,7 @@ namespace {
 
             sConn[Ix::item30] = -1.0e+20f;
             sConn[Ix::item31] = -1.0e+20f;
+            sConn[Ix::item41] = (conn.CF() > 0) ? 1 : 0;
         }
     } // SConn
 

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -163,7 +163,6 @@ void staticContrib(const Opm::Schedule&     sched,
     
     if ((group.getGroupType() == Opm::Group::GroupType::NONE) || (group.getGroupType() == Opm::Group::GroupType::PRODUCTION) ) {
         const auto& prod_cmode = group.production_cmode();
-        std::cout << "IGRP[nwgmax + 5] group.name()" << group.name() << " prod_cmode " << static_cast<int>(prod_cmode) << std::endl;
         
         if (prod_cmode == Opm::Group::ProductionCMode::FLD) {
             iGrp[nwgmax + 5] = -1;

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -19,6 +19,7 @@
 
 #include <opm/output/eclipse/AggregateGroupData.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
+#include <opm/output/eclipse/VectorItems/group.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
@@ -123,12 +124,14 @@ allocate(const std::vector<int>& inteHead)
 }
 
 template <class IGrpArray>
-void staticContrib(const Opm::Schedule&    sched,
-                   const Opm::Group&      group,
-                   const int               nwgmax,
-                   const int               ngmaxz,
-                   const std::size_t       simStep,
-                   IGrpArray&              iGrp)
+void staticContrib(const Opm::Schedule&     sched,
+                   const Opm::Group&        group,
+                   const int                nwgmax,
+                   const int                ngmaxz,
+                   const std::size_t        simStep,
+                   const Opm::SummaryState& sumState,
+                   const std::map<Opm::Group::InjectionCMode, int> cmodeToNum,
+                   IGrpArray&               iGrp)
 {
     if (group.wellgroup()) {
         int igrpCount = 0;
@@ -151,6 +154,88 @@ void staticContrib(const Opm::Schedule&    sched,
     //assign the number of child wells or child groups to
     // location nwgmax
     iGrp[nwgmax] = groupSize(group);
+    
+    /*IGRP[NWGMAX + 5]  
+        =   -1 group under higher group control
+        =   0    for NONE (no control)
+        =   1  group under rate control
+    */
+    
+    if ((group.getGroupType() == Opm::Group::GroupType::NONE) || (group.getGroupType() == Opm::Group::GroupType::PRODUCTION) ) {
+        const auto& prod_cmode = group.production_cmode();
+        std::cout << "IGRP[nwgmax + 5] group.name()" << group.name() << " prod_cmode " << static_cast<int>(prod_cmode) << std::endl;
+        
+        if (prod_cmode == Opm::Group::ProductionCMode::FLD) {
+            iGrp[nwgmax + 5] = -1;
+        }
+        else if (prod_cmode == Opm::Group::ProductionCMode::NONE) {
+             iGrp[nwgmax + 5] = 0;
+        }
+        else {
+            iGrp[nwgmax + 5] = 1;
+        }
+
+        // Set iGrp for [nwgmax + 7]
+        /*
+        = 0 for group with  "FLD" or "NONE"
+        = 4 for "GRAT" FIELD
+        = -40000 for production group with "ORAT"
+        = -4000  for production group with "WRAT"
+        = -400    for production group with "GRAT"
+        = -40     for production group with "LRAT"
+         */
+
+        if ((prod_cmode == Opm::Group::ProductionCMode::NONE) || prod_cmode == Opm::Group::ProductionCMode::FLD) {
+            iGrp[nwgmax + 7] = 0;
+        }
+        else if ((prod_cmode == Opm::Group::ProductionCMode::ORAT)) {
+            iGrp[nwgmax + 7] = -40000;
+        }
+        else if ((prod_cmode == Opm::Group::ProductionCMode::WRAT)) {
+            iGrp[nwgmax + 7] = -4000;
+        }
+        else if ((prod_cmode == Opm::Group::ProductionCMode::GRAT)) {
+            iGrp[nwgmax + 7] = -400;
+            if (group.name() == "FIELD") {
+                iGrp[nwgmax + 7] = 4;
+            }
+        }
+        else if ((prod_cmode == Opm::Group::ProductionCMode::LRAT)) {
+            iGrp[nwgmax + 7] = -40;
+        }
+    }
+    //Set injection group status
+    //item[nwgmax + 16] - mode for operation for injection group
+    // 1 - RATE 
+    // 2 - RESV
+    // 3 - REIN
+    // 4 - VREP
+    // 0 - ellers
+    
+    if (group.isInjectionGroup()) {
+        const auto& inj_cntl = group.injectionControls(sumState);
+        const auto& inj_mode = inj_cntl.cmode;
+        const auto& phs = inj_cntl.phase;
+        //Gas injection control
+        if (phs == Opm::Phase::WATER) {
+            const auto it = cmodeToNum.find(inj_mode);
+            if (it != cmodeToNum.end()) {
+                iGrp[nwgmax + 16] = it->second;
+                iGrp[nwgmax + 18] = iGrp[nwgmax + 16];
+                iGrp[nwgmax + 19] = iGrp[nwgmax + 16];
+            }
+        }
+        //Water injection control
+        else if (phs == Opm::Phase::GAS) {
+            const auto it = cmodeToNum.find(inj_mode);
+            if (it != cmodeToNum.end()) {
+                iGrp[nwgmax + 21] = it->second;
+                iGrp[nwgmax + 23] = iGrp[nwgmax + 21];
+                iGrp[nwgmax + 24] = iGrp[nwgmax + 21];
+            }
+        }
+    }
+    
     iGrp[nwgmax + 26] = groupType(group);
 
     //find group level ("FIELD" is level 0) and store the level in
@@ -161,7 +246,7 @@ void staticContrib(const Opm::Schedule&    sched,
     //
     if (group.name() != "FIELD")
     {
-        iGrp[nwgmax+ 5] = -1;
+        //iGrp[nwgmax+ 5] = -1;
         iGrp[nwgmax+12] = -1;
         iGrp[nwgmax+17] = -1;
         iGrp[nwgmax+22] = -1;
@@ -192,6 +277,7 @@ void staticContrib(const Opm::Schedule&    sched,
         else
             iGrp[nwgmax+28] = parent_group.insert_index();
     }
+
 }
 } // Igrp
 
@@ -214,8 +300,15 @@ allocate(const std::vector<int>& inteHead)
 }
 
 template <class SGrpArray>
-void staticContrib(SGrpArray& sGrp)
+void staticContrib(const Opm::Group&        group,
+                   const Opm::SummaryState& sumState,
+                   const Opm::UnitSystem& units,
+                   SGrpArray&               sGrp)
 {
+    using Isp = ::Opm::RestartIO::Helpers::VectorItems::SGroup::prod_index;
+    using Isi = ::Opm::RestartIO::Helpers::VectorItems::SGroup::inj_index;
+    using M = ::Opm::UnitSystem::measure;
+    
     const auto dflt   = -1.0e+20f;
     const auto dflt_2 = -2.0e+20f;
     const auto infty  =  1.0e+20f;
@@ -256,6 +349,67 @@ void staticContrib(SGrpArray& sGrp)
     auto e = b + std::min(init.size(), sz);
 
     std::copy(b, e, std::begin(sGrp));
+    
+    auto sgprop = [&units](const M u, const double x) -> float
+    {
+        return static_cast<float>(units.from_si(u, x));
+    };
+    
+    if (group.isProductionGroup()) {
+        const auto& prod_cntl = group.productionControls(sumState);
+        
+        if (prod_cntl.oil_target > 0.) {
+            sGrp[Isp::OilRateLimit] = sgprop(M::liquid_surface_rate, prod_cntl.oil_target);
+            sGrp[37] = sGrp[Isp::OilRateLimit];
+            sGrp[52] = sGrp[Isp::OilRateLimit];  // "ORAT" control
+        }
+        if (prod_cntl.water_target > 0.) {
+            sGrp[Isp::WatRateLimit > 0.] = sgprop(M::liquid_surface_rate, prod_cntl.water_target);
+            sGrp[38] = sGrp[Isp::WatRateLimit];
+            sGrp[53] = sGrp[Isp::WatRateLimit];  //"WRAT" control
+        }
+        if (prod_cntl.gas_target > 0.) {
+            sGrp[Isp::GasRateLimit] = sgprop(M::gas_surface_rate, prod_cntl.gas_target);
+            sGrp[39] = sGrp[Isp::GasRateLimit];
+        }
+        if (prod_cntl.liquid_target > 0.) {
+            sGrp[Isp::LiqRateLimit] = sgprop(M::liquid_surface_rate, prod_cntl.liquid_target);
+            sGrp[40] = sGrp[Isp::LiqRateLimit];
+        }
+    }
+    
+    if (group.isInjectionGroup()) {
+        const auto& inj_cntl = group.injectionControls(sumState);
+        const auto& phs = inj_cntl.phase;
+        if (phs == Opm::Phase::GAS) {
+            if (inj_cntl.surface_max_rate > 0.) {
+                sGrp[Isi::gasSurfRateLimit] = sgprop(M::gas_surface_rate, inj_cntl.surface_max_rate);
+            }
+            if (inj_cntl.resv_max_rate > 0.) {
+                sGrp[Isi::gasResRateLimit > 0.] = sgprop(M::rate, inj_cntl.resv_max_rate);
+            }
+            if (inj_cntl.target_reinj_fraction > 0.) {
+                sGrp[Isi::gasReinjectionLimit] = inj_cntl.target_reinj_fraction;
+            }
+            if (inj_cntl.target_void_fraction > 0.) {
+                sGrp[Isi::gasVoidageLimit] = inj_cntl.target_void_fraction;
+            }
+        }
+        if (phs == Opm::Phase::WATER) {
+            if (inj_cntl.surface_max_rate > 0.) {
+                sGrp[Isi::waterSurfRateLimit] = sgprop(M::liquid_surface_rate, inj_cntl.surface_max_rate);
+            }
+            if (inj_cntl.resv_max_rate > 0.) {
+                sGrp[Isi::waterResRateLimit > 0.] = sgprop(M::rate, inj_cntl.resv_max_rate);
+            }
+            if (inj_cntl.target_reinj_fraction > 0.) {
+                sGrp[Isi::waterReinjectionLimit] = inj_cntl.target_reinj_fraction;
+            }
+            if (inj_cntl.target_void_fraction > 0.) {
+                sGrp[Isi::waterVoidageLimit] = inj_cntl.target_void_fraction;
+            }
+        }
+    }
 }
 } // SGrp
 
@@ -355,6 +509,7 @@ AggregateGroupData(const std::vector<int>& inteHead)
 void
 Opm::RestartIO::Helpers::AggregateGroupData::
 captureDeclaredGroupData(const Opm::Schedule&                 sched,
+                         const Opm::UnitSystem&               units,
                          const std::size_t                    simStep,
                          const Opm::SummaryState&             sumState,
                          const std::vector<int>&              inteHead)
@@ -367,21 +522,21 @@ captureDeclaredGroupData(const Opm::Schedule&                 sched,
         curGroups[ind] = std::addressof(group);
     }
 
-    groupLoop(curGroups, [&sched, simStep, this]
+    groupLoop(curGroups, [&sched, simStep, sumState, this]
               (const Group& group, const std::size_t groupID) -> void
                          {
                              auto ig = this->iGroup_[groupID];
 
                              IGrp::staticContrib(sched, group, this->nWGMax_, this->nGMaxz_,
-                                                 simStep, ig);
+                                                 simStep, sumState, this->cmodeToNum, ig);
                          });
 
     // Define Static Contributions to SGrp Array.
     groupLoop(curGroups,
-              [this](const Group& /* group */, const std::size_t groupID) -> void
+              [&sumState, &units, this](const Group& group , const std::size_t groupID) -> void
               {
                   auto sw = this->sGroup_[groupID];
-                  SGrp::staticContrib(sw);
+                  SGrp::staticContrib(group, sumState, units, sw);
               });
 
     // Define Dynamic Contributions to XGrp Array.

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -418,24 +418,21 @@ namespace {
                                             const std::size_t   baseIndex,
                                             ISegArray&          iSeg)
         {
-                
-            using IsTyp = ::Opm::RestartIO::Helpers::
-                VectorItems::ISeg::Value::SegmentType;
-            using IsStatus = ::Opm::RestartIO::Helpers::
-                VectorItems::ISeg::Value::SICDStatus;
+             namespace ISegValue = ::Opm::RestartIO::Helpers::
+                VectorItems::ISeg::Value;
 
             using Ix = ::Opm::RestartIO::Helpers::
                 VectorItems::ISeg::index;
 
             const auto& sicd = segment.spiralICD();
 
-            iSeg[baseIndex + Ix::SegmentType]    = IsTyp::SICD;
+            iSeg[baseIndex + Ix::SegmentType]    = ISegValue::SegmentType::SICD;
             iSeg[baseIndex + Ix::ICDScalingMode] = sicd->methodFlowScaling();
 
             iSeg[baseIndex + Ix::ICDOpenShutFlag] =
                 (sicd->status() == Opm::SpiralICD::Status::OPEN)
-                ? IsStatus::Open
-                : IsStatus::Shut;
+                ? ISegValue::SICDStatus::Open
+                : ISegValue::SICDStatus::Shut;
         }
 
         template <class ISegArray>
@@ -472,6 +469,7 @@ namespace {
         {
             using IsTyp = ::Opm::RestartIO::Helpers::
                 VectorItems::ISeg::Value::SegmentType;
+                
             using Ix = ::Opm::RestartIO::Helpers::
                 VectorItems::ISeg::index;
                 
@@ -506,7 +504,7 @@ namespace {
                     if (! isRegular(segment)) {
                         assignSegmentTypeCharacteristics(segment, iS, iSeg);
                     }
-                    else if (segment.segmentType() == Opm::Segment::SegmentType::REGULAR) {
+                    if (segment.segmentType() == Opm::Segment::SegmentType::REGULAR) {
                        iSeg[iS + Ix::SegmentType] =  IsTyp::REGULAR;
                     }
                 }

--- a/src/opm/output/eclipse/AggregateUDQData.cpp
+++ b/src/opm/output/eclipse/AggregateUDQData.cpp
@@ -17,9 +17,12 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/output/eclipse/AggregateUDQData.hpp>
 #include <opm/output/eclipse/AggregateGroupData.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
+#include <opm/output/eclipse/InteHEAD.hpp>
+#include <opm/output/eclipse/VectorItems/intehead.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
@@ -46,7 +49,7 @@
 // Class Opm::RestartIO::Helpers::AggregateGroupData
 // ---------------------------------------------------------------------
 
-
+namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 namespace {
 
     // maximum number of groups
@@ -56,12 +59,36 @@ namespace {
     }
 
     // maximum number of wells
-    /*std::size_t nwmaxz(const std::vector<int>& inteHead)
+    std::size_t nwmaxz(const std::vector<int>& inteHead)
     {
         return inteHead[163];
-    }*/
+    }
 
 
+    // Categorize function in terms of which token-types are used in formula
+    int define_type(const std::set<Opm::UDQTokenType> tokens) {
+        int type = -4;
+        std::vector <Opm::UDQTokenType> type_1 = { 
+        Opm::UDQTokenType::elemental_func_sorta,
+        Opm::UDQTokenType::elemental_func_sortd,
+        Opm::UDQTokenType::elemental_func_undef,
+        Opm::UDQTokenType::scalar_func_sum,
+        Opm::UDQTokenType::scalar_func_avea,
+        Opm::UDQTokenType::scalar_func_aveg,
+        Opm::UDQTokenType::scalar_func_aveh,
+        Opm::UDQTokenType::scalar_func_max,
+        Opm::UDQTokenType::scalar_func_min, 
+        Opm::UDQTokenType::binary_op_div
+        };
+        
+        int num_type_1 = 0;
+        for (const auto& tok_type : type_1) {
+            num_type_1 += tokens.count(tok_type);
+        }   
+        type = (num_type_1 > 0) ? -1 : -4;
+        return type;
+    }
+    
 
     namespace iUdq {
 
@@ -80,8 +107,10 @@ namespace {
         void staticContrib(const Opm::UDQInput& udq_input, IUDQArray& iUdq)
         {
             if (udq_input.is<Opm::UDQDefine>()) {
+                const auto& udq_define = udq_input.get<Opm::UDQDefine>();
+                const auto& tokens = udq_define.func_tokens();
                 iUdq[0] = 2;
-                iUdq[1] = -4;
+                iUdq[1] = define_type(tokens);
             } else {
                 iUdq[0] = 0;
                 iUdq[1] = -4;
@@ -442,6 +471,8 @@ captureDeclaredUDQData(const Opm::Schedule&                 sched,
                        const std::vector<int>&              inteHead)
 {
     const auto& udqCfg = sched.getUDQConfig(simStep);
+    const auto nudq = inteHead[VI::intehead::NO_WELL_UDQS] + inteHead[VI::intehead::NO_GROUP_UDQS] + inteHead[VI::intehead::NO_FIELD_UDQS];
+    int cnt_udq = 0;
     for (const auto& udq_input : udqCfg.input()) {
         auto udq_index = udq_input.index.insert_index;
         {
@@ -456,66 +487,119 @@ captureDeclaredUDQData(const Opm::Schedule&                 sched,
             auto z_udl = this->zUDL_[udq_index];
             zUdl::staticContrib(udq_input, z_udl);
         }
+        cnt_udq += 1;
     }
-
+    if (cnt_udq != nudq) {
+        std::stringstream str;
+        str << "Inconsistent total number of udqs: " << cnt_udq << " and sum of well, group and field udqs: " << nudq;
+        OpmLog::error(str.str());
+    }
+    
+    
     auto udq_active = sched.udqActive(simStep);
     if (udq_active) {
         const auto& udq_records = udq_active.get_iuad();
+        int cnt_iuad = 0;
         for (std::size_t index = 0; index < udq_records.size(); index++) {
             const auto& record = udq_records[index];
             auto i_uad = this->iUAD_[index];
             iUad::staticContrib(record, i_uad);
+            cnt_iuad += 1;
+        }
+        if (cnt_iuad != inteHead[VI::intehead::NO_IUADS]) {
+            std::stringstream str;
+            str << "Inconsistent number of iuad's: " << cnt_iuad << " number of iuad's from intehead " << inteHead[VI::intehead::NO_IUADS];
+            OpmLog::error(str.str());
         }
         
         const auto& iuap_records = udq_active.get_iuap();
+        int cnt_iuap = 0;
         const auto iuap_vect = iuap_data(sched, simStep,iuap_records);
         for (std::size_t index = 0; index < iuap_vect.size(); index++) {
             const auto& wg_no = iuap_vect[index];
             auto i_uap = this->iUAP_[index];
             iUap::staticContrib(wg_no, i_uap);
+            cnt_iuap += 1;
+        }
+        if (cnt_iuap != inteHead[VI::intehead::NO_IUAPS]) {
+            std::stringstream str;
+            str << "Inconsistent number of iuap's: " << cnt_iuap << " number of iuap's from intehead " << inteHead[VI::intehead::NO_IUAPS];
+            OpmLog::error(str.str());
         }
 
+
     }
-    Opm::RestartIO::Helpers::igphData igph_dat;
-    auto igph = igph_dat.ig_phase(sched, simStep, inteHead);
-    for (std::size_t index = 0; index < igph.size(); index++) {
-            auto i_igph = this->iGPH_[index];
-            iGph::staticContrib(igph[index], i_igph);
+    if (inteHead[VI::intehead::NO_GROUP_UDQS] > 0) {
+        Opm::RestartIO::Helpers::igphData igph_dat;
+        int cnt_igph = 0;
+        auto igph = igph_dat.ig_phase(sched, simStep, inteHead);
+        for (std::size_t index = 0; index < igph.size(); index++) {
+                auto i_igph = this->iGPH_[index];
+                iGph::staticContrib(igph[index], i_igph);
+                cnt_igph += 1;
         }
-#if 0        
+        if (cnt_igph != inteHead[VI::intehead::NGMAXZ]) {
+            std::stringstream str;
+            str << "Inconsistent number of igph's: " << cnt_igph << " number of igph's from intehead " << inteHead[VI::intehead::NGMAXZ];
+            OpmLog::error(str.str());
+        }
+    }
+        
     std::size_t i_wudq = 0;
     const auto& wnames = sched.wellNames(simStep);
     const auto nwmax = nwmaxz(inteHead);
+    int cnt_dudw = 0;
     for (const auto& udq_input : udqCfg.input()) {
         if (udq_input.var_type() ==  UDQVarType::WELL_VAR) {
             const std::string& udq = udq_input.keyword();
             auto i_dudw = this->dUDW_[i_wudq];
             dUdw::staticContrib(st, wnames, udq, nwmax, i_dudw);
             i_wudq++;
+            cnt_dudw += 1;
         }
     }
-#endif 
+    if (cnt_dudw != inteHead[VI::intehead::NO_WELL_UDQS]) {
+        std::stringstream str;
+        str << "Inconsistent number of dudw's: " << cnt_dudw << " number of dudw's from intehead " << inteHead[VI::intehead::NO_WELL_UDQS];
+        OpmLog::error(str.str());
+    }
+    
     std::size_t i_gudq = 0;
     const auto curGroups = currentGroups(sched, simStep, inteHead);
     const auto ngmax = ngmaxz(inteHead);
+    int cnt_dudg = 0;
     for (const auto& udq_input : udqCfg.input()) {
         if (udq_input.var_type() ==  UDQVarType::GROUP_VAR) {
             const std::string& udq = udq_input.keyword();
             auto i_dudg = this->dUDG_[i_gudq];
             dUdg::staticContrib(st, curGroups, udq, ngmax, i_dudg);
             i_gudq++;
+            cnt_dudg += 1;
         }
+    }
+    if (cnt_dudg != inteHead[VI::intehead::NO_GROUP_UDQS]) {
+        std::stringstream str;
+        str << "Inconsistent number of dudg's: " << cnt_dudg << " number of dudg's from intehead " << inteHead[VI::intehead::NO_GROUP_UDQS];
+        OpmLog::error(str.str());
     }
    
     std::size_t i_fudq = 0;
+    int cnt_dudf = 0;
     for (const auto& udq_input : udqCfg.input()) {
         if (udq_input.var_type() ==  UDQVarType::FIELD_VAR) {
             const std::string& udq = udq_input.keyword();
             auto i_dudf = this->dUDF_[i_fudq];
             dUdf::staticContrib(st, udq, i_dudf);
             i_fudq++;
+            cnt_dudf += 1;
         }
     }
+    if (cnt_dudf != inteHead[VI::intehead::NO_FIELD_UDQS]) {
+        std::stringstream str;
+        str << "Inconsistent number of dudf's: " << cnt_dudf << " number of dudf's from intehead " << inteHead[VI::intehead::NO_FIELD_UDQS];
+        OpmLog::error(str.str());
+    }
+
    
 }
 

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -31,6 +31,11 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionContext.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -72,6 +77,9 @@ namespace {
         // Remove leading/trailing blanks.
         return s.substr(b, e - b + 1);
     }
+    
+     
+
 
     template <typename WellOp>
     void wellLoop(const std::vector<Opm::Well>& wells,
@@ -407,11 +415,11 @@ namespace {
                 zero , zero , infty, infty, zero , dflt ,    //  12.. 17  ( 2)
                 infty, infty, infty, infty, infty, zero ,    //  18.. 23  ( 3)
                 one  , zero , zero , zero , zero , zero ,    //  24.. 29  ( 4)
-                zero , one  , zero , zero,  zero , zero ,    //  30.. 35  ( 5)
+                zero , one  , zero , infty,  zero , zero ,    //  30.. 35  ( 5)
                 zero , zero , zero , zero , zero , zero ,    //  36.. 41  ( 6)
                 zero , zero , zero , zero , zero , zero ,    //  42.. 47  ( 7)
                 zero , zero , zero , zero , zero , zero ,    //  48.. 53  ( 8)
-                zero,  zero , zero , zero , zero , zero ,    //  54.. 59  ( 9)
+                infty,  zero , zero , zero , zero , zero ,    //  54.. 59  ( 9)
                 zero , zero , zero , zero , zero , zero ,    //  60.. 65  (10)
                 zero , zero , zero , zero , zero , zero ,    //  66.. 71  (11)
                 zero , zero , zero , zero , zero , zero ,    //  72.. 77  (12)
@@ -460,28 +468,28 @@ namespace {
                 const auto& pc = well.productionControls(smry);
                 const auto& predMode = well.predictionMode();
 
-                if ((pc.oil_rate != 0.0) || (!predMode)) {
+                if (pc.oil_rate != 0.0) {
                     sWell[Ix::OilRateTarget] =
                         swprop(M::liquid_surface_rate, pc.oil_rate);
                 }
 
-                if ((pc.water_rate != 0.0) || (!predMode)) {
+                if (pc.water_rate != 0.0) {
                     sWell[Ix::WatRateTarget] =
                         swprop(M::liquid_surface_rate, pc.water_rate);
                 }
 
-                if ((pc.gas_rate != 0.0) || (!predMode)) {
+                if (pc.gas_rate != 0.0) {
                     sWell[Ix::GasRateTarget] =
                         swprop(M::gas_surface_rate, pc.gas_rate);
                     sWell[Ix::HistGasRateTarget] = sWell[Ix::GasRateTarget];
                 }
 
-                if (pc.liquid_rate != 0.0 || (!predMode)) {
+                if (pc.liquid_rate != 0.0) {    // check if this works - may need to be rewritten
                     sWell[Ix::LiqRateTarget] =
                         swprop(M::liquid_surface_rate, pc.liquid_rate);
                     sWell[Ix::HistLiqRateTarget] = sWell[Ix::LiqRateTarget];
                 }
-                else  {
+                else if (!predMode)  {
                     sWell[Ix::LiqRateTarget] =
                         swprop(M::liquid_surface_rate, pc.oil_rate + pc.water_rate);
                 }
@@ -761,12 +769,31 @@ namespace {
             };
         }
 
+        Opm::RestartIO::Helpers::ActionResStatus 
+        act_res_stat(const Opm::Schedule& sched, const Opm::SummaryState&  smry, const std::size_t sim_step) {
+            std::vector<Opm::Action::Result> act_res;
+            std::vector<std::string> act_name;
+            const auto acts = sched.actions(sim_step);
+            Opm::Action::Context context(smry);
+            auto sim_time = sched.simTime(sim_step);
+            for (const auto& action : acts.pending(sim_time)) {
+                act_res.push_back(action->eval(sim_time, context));
+                act_name.push_back(action->name());
+            }
+            return {act_res, act_name};
+        }
+        
         template <class ZWellArray>
-        void staticContrib(const Opm::Well& well, ZWellArray& zWell)
+        void staticContrib(const Opm::Well& well, const Opm::RestartIO::Helpers::ActionResStatus& actResStat, ZWellArray& zWell)
         {
             using Ix = ::Opm::RestartIO::Helpers::VectorItems::ZWell::index;
-
             zWell[Ix::WellName] = well.name();
+            //loop over actions to assign action name for relevant wells
+            for (std::size_t ind = 0; ind < actResStat.result.size(); ind++) {
+                if (actResStat.result[ind].has_well(well.name())) {
+                    zWell[Ix::ActionX] = actResStat.name[ind];
+                }                
+            }
         }
     } // ZWell
 } // Anonymous
@@ -828,14 +855,16 @@ captureDeclaredWellData(const Schedule&   sched,
         XWell::staticContrib(well, smry, units, xw);
     });
 
-    // Static contributions to ZWEL array.
-    wellLoop(wells,
-        [this](const Well& well, const std::size_t wellID) -> void
     {
-        auto zw = this->zWell_[wellID];
-
-        ZWell::staticContrib(well, zw);
-    });
+        const auto actResStat = ZWell::act_res_stat(sched, smry, sim_step); 
+        // Static contributions to ZWEL array.
+        wellLoop(wells,
+            [&actResStat, this](const Well& well, const std::size_t wellID) -> void
+        {
+            auto zw = this->zWell_[wellID];
+            ZWell::staticContrib(well, actResStat, zw);
+        });
+    }
 }
 
 // ---------------------------------------------------------------------

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -103,11 +103,9 @@ namespace {
         for (const auto& group_name : sched.groupNames(lookup_step)) {
             const auto& group = sched.getGroup(group_name, lookup_step);
             if (group.isProductionGroup()) { 
-                std::cout << "CrIH group.name()" << group.name() << " group.production_cmode() " << static_cast<int>(group.production_cmode()) << std::endl;
                 gctrl = 1;
             }
             if (group.isInjectionGroup()) { 
-                std::cout << "CrIH group.name()" << group.name() << " group.injection_cmode() " << static_cast<int>(group.injection_cmode()) << std::endl;
                 gctrl = 2;
             }
         }

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -55,6 +55,17 @@ namespace {
         {nph_enum::COMB, 9},
     };
     
+    using prod_cmode = Opm::Well::ProducerCMode;
+    const std::map<prod_cmode, int> prod_cmodeToECL = {
+        {prod_cmode::NONE,  0},
+        {prod_cmode::ORAT,  1},
+        {prod_cmode::WRAT,  2},
+        {prod_cmode::GRAT,  3},
+        {prod_cmode::LRAT,  4},
+        {prod_cmode::RESV,  5},
+        {prod_cmode::BHP,   7},
+    };
+    
     int maxConnPerWell(const Opm::Schedule& sched,
                        const std::size_t    lookup_step)
     {
@@ -365,6 +376,20 @@ namespace {
 
             return {nom_phase};
     }
+    
+    int getWhistctlMode(const ::Opm::Schedule& sched,
+                     const std::size_t    lookup_step)
+    {
+            int mode = 0;            
+            const auto& w_hist_ctl_mode = sched.getGlobalWhistctlMmode(lookup_step);
+            const auto it_ctl = prod_cmodeToECL.find(w_hist_ctl_mode);
+                if (it_ctl != prod_cmodeToECL.end()) {
+                    mode = it_ctl->second;
+                }
+
+            return mode;
+    }
+
 } // Anonymous
 
 // #####################################################################
@@ -416,6 +441,7 @@ createInteHead(const EclipseState& es,
         .actionParam        (getActionParam(rspec, acts))
         .variousUDQ_ACTIONXParam()
         .nominatedPhaseGuideRate(setGuideRateNominatedPhase(sched,lookup_step))
+        .whistControlMode(getWhistctlMode(sched,lookup_step))
         ;
 
     return ih.data();

--- a/src/opm/output/eclipse/CreateUdqDims.cpp
+++ b/src/opm/output/eclipse/CreateUdqDims.cpp
@@ -20,6 +20,7 @@
 
 #include <opm/output/eclipse/AggregateUDQData.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
+#include <opm/output/eclipse/VectorItems/intehead.hpp>
 
 #include <opm/output/eclipse/InteHEAD.hpp>
 #include <opm/output/eclipse/DoubHEAD.hpp>
@@ -38,6 +39,8 @@
 #include <chrono>
 #include <cstddef>
 #include <vector>
+
+namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 
 namespace {
 
@@ -68,56 +71,10 @@ std::size_t entriesPerZUDL()
 
 std::size_t noIGphs(const std::vector<int>& inteHead)
 {
-    std::size_t no_entries = inteHead[20];
+    std::size_t no_entries = (inteHead[VI::intehead::NO_GROUP_UDQS] > 0) ? inteHead[20] : 0;
     return no_entries;
 }
 
-// maximum number of wells
-std::size_t nwmaxz(const std::vector<int>& inteHead)
-{
-        return inteHead[163];
-}
-
-// maximum number of groups
-std::size_t ngmaxz(const std::vector<int>& inteHead)
-{
-    return inteHead[20];
-}
-
-int noWellUdqs(const Opm::Schedule& sched,
-               const std::size_t    simStep)
-{
-    const auto& udqCfg = sched.getUDQConfig(simStep);
-    std::size_t i_wudq = 0;
-    for (const auto& udq_input : udqCfg.input()) {
-        if (udq_input.var_type() ==  Opm::UDQVarType::WELL_VAR) {
-            i_wudq++;
-        }
-    }   
-    return i_wudq;
-}
-
-int noGroupUdqs(const Opm::Schedule& sched,
-               const std::size_t    simStep)
-{
-    const auto& udqCfg = sched.getUDQConfig(simStep);
-    const auto& input = udqCfg.input();
-    return std::count_if(input.begin(), input.end(), [](const Opm::UDQInput inp) { return (inp.var_type() == Opm::UDQVarType::GROUP_VAR); });
-
-}
-
-int noFieldUdqs(const Opm::Schedule& sched,
-               const std::size_t    simStep)
-{
-    const auto& udqCfg = sched.getUDQConfig(simStep);
-    std::size_t i_fudq = 0;
-    for (const auto& udq_input : udqCfg.input()) {
-        if (udq_input.var_type() ==  Opm::UDQVarType::FIELD_VAR) {
-            i_fudq++;
-        }
-    }
-    return i_fudq;
-}
 
 } // Anonymous
 
@@ -132,23 +89,22 @@ createUdqDims(const Schedule&     		sched,
               const std::vector<int>&   inteHead) 
 {
     const auto& udqCfg = sched.getUDQConfig(lookup_step);
-    const auto& udqActive = sched.udqActive(lookup_step);
     std::vector<int> udqDims; 
     udqDims.resize(13,0);
     
     udqDims[ 0] = udqCfg.size();
     udqDims[ 1] = entriesPerIUDQ();
-    udqDims[ 2] = udqActive.IUAD_size();
+    udqDims[ 2] = inteHead[VI::intehead::NO_IUADS];
     udqDims[ 3] = entriesPerIUAD();
     udqDims[ 4] = entriesPerZUDN();
     udqDims[ 5] = entriesPerZUDL();
     udqDims[ 6] = noIGphs(inteHead);
-    udqDims[ 7] = udqActive.IUAP_size();
-    udqDims[ 8] = nwmaxz(inteHead);
-    udqDims[ 9] = noWellUdqs(sched, lookup_step);
-    udqDims[10] = ngmaxz(inteHead);
-    udqDims[11] = noGroupUdqs(sched, lookup_step);
-    udqDims[12] = noFieldUdqs(sched, lookup_step);
+    udqDims[ 7] = inteHead[VI::intehead::NO_IUAPS];
+    udqDims[ 8] = inteHead[VI::intehead::NWMAXZ];
+    udqDims[ 9] = inteHead[VI::intehead::NO_WELL_UDQS];
+    udqDims[10] = inteHead[VI::intehead::NGMAXZ];
+    udqDims[11] = inteHead[VI::intehead::NO_GROUP_UDQS];
+    udqDims[12] = inteHead[VI::intehead::NO_FIELD_UDQS];
 
     return udqDims;
 }

--- a/src/opm/output/eclipse/DoubHEAD.cpp
+++ b/src/opm/output/eclipse/DoubHEAD.cpp
@@ -146,19 +146,19 @@ enum Index : std::vector<double>::size_type {
     DdpLim  =  84,
     DdsLim  =  85,
     dh_086  =  86,
-    dh_087  =  87,
-    dh_088  =  88,
-    dh_089  =  89,
+    grpar_a =  VI::doubhead::GRpar_a,
+    grpar_b =  VI::doubhead::GRpar_b,
+    grpar_c =  VI::doubhead::GRpar_c,
 
     // 90..99
-    dh_090  =  90,
-    dh_091  =  91,
-    dh_092  =  92,
+    grpar_d =  VI::doubhead::GRpar_d,
+    grpar_e =  VI::doubhead::GRpar_e,
+    grpar_f =  VI::doubhead::GRpar_f,
     dh_093  =  93,
     dh_094  =  94,
     dh_095  =  95,
     dh_096  =  96,
-    dh_097  =  97,
+    grpar_int =  VI::doubhead::GRpar_int,
     dh_098  =  98,
     ThrUPT  =  99,
 
@@ -215,7 +215,7 @@ enum Index : std::vector<double>::size_type {
     dh_141  = 141,
     dh_142  = 142,
     dh_143  = 143,
-    dh_144  = 144,
+    grpar_dmp = VI::doubhead::GRpar_damp,
     dh_145  = 145,
     dh_146  = 146,
     dh_147  = 147,
@@ -396,8 +396,8 @@ Opm::RestartIO::DoubHEAD::DoubHEAD()
     this->data_[Index::dh_069] = -1.0;
     this->data_[Index::dh_080] = 1.0e+20;
     this->data_[Index::dh_081] = 1.0e+20;
-    this->data_[Index::dh_091] = 0.0;
-    this->data_[Index::dh_092] = 0.0;
+    this->data_[grpar_e] = 0.0;
+    this->data_[grpar_f] = 0.0;
     this->data_[Index::dh_093] = 0.0;
     this->data_[Index::dh_096] = 0.0;
     this->data_[Index::dh_105] = 1.0;
@@ -624,6 +624,21 @@ Opm::RestartIO::DoubHEAD::udq_param(const UDQParams& udqPar)
     this->data_[UdqPar_2] = udqPar.range();
     this->data_[UdqPar_3] = udqPar.undefinedValue();
     this->data_[UdqPar_4] = udqPar.cmpEpsilon();
+
+    return *this;
+}
+
+Opm::RestartIO::DoubHEAD&
+Opm::RestartIO::DoubHEAD::guide_rate_param(const guideRate& guide_rp)
+{
+    this->data_[grpar_a] = guide_rp.A;
+    this->data_[grpar_b] = guide_rp.B;
+    this->data_[grpar_c] = guide_rp.C;
+    this->data_[grpar_d] = guide_rp.D;
+    this->data_[grpar_e] = guide_rp.E;
+    this->data_[grpar_f] = guide_rp.F;
+    this->data_[grpar_int] = guide_rp.delay;
+    this->data_[grpar_dmp] = guide_rp.damping_fact;
 
     return *this;
 }

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -90,7 +90,7 @@ enum index : std::vector<int>::size_type {
   REPORT_STEP       =  68       ,              // The sequence/report number for for this restart file.
   ih_069       =       69       ,              //       0       0
   ih_070       =       70       ,              //       0       0
-  ih_071       =       71       ,              //       0       0
+  NWHISTCTL    =       VI::intehead::WHISTC,   //       index for WHISTCTL keyword
   ih_072       =       72       ,              //       0       0
   ih_073       =       73       ,              //       0       0
   ih_074       =       74       ,              //       0       0
@@ -736,6 +736,15 @@ Opm::RestartIO::InteHEAD::
 nominatedPhaseGuideRate(GuideRateNominatedPhase nphase)
 {
     this -> data_[NGRNPHASE]  =  nphase.nominated_phase;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::
+whistControlMode(int mode)
+{
+    this -> data_[NWHISTCTL]  =  mode;
 
     return *this;
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <vector>
+#include <algorithm>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp>
 
@@ -43,10 +44,9 @@ Result::Result(bool result_arg, const WellSet& wells) :
 Result::Result(const Result& src)
 {
     this->result = src.result;
-    if (src.matching_wells)
+    if (src.matching_wells) 
         this->matching_wells.reset( new WellSet(*src.matching_wells) );
 }
-
 
 Result::operator bool() const {
     return this->result;
@@ -58,7 +58,6 @@ std::vector<std::string> Result::wells() const {
     else
         return {};
 }
-
 
 Result& Result::operator|=(const Result& other) {
     this->result = this->result || other.result;
@@ -84,6 +83,14 @@ Result& Result::operator&=(const Result& other) {
     return *this;
 }
 
+Result& Result::operator=(const Result& src) 
+{
+    this->result = src.result;
+    if (src.matching_wells) this->matching_wells.reset( new WellSet(*src.matching_wells) );
+    
+    return *this;
+}
+
 void Result::assign(bool value) {
     this->result = value;
 }
@@ -94,7 +101,7 @@ void Result::add_well(const std::string& well) {
     this->matching_wells->add(well);
 }
 
-bool Result::has_well(const std::string& well) {
+bool Result::has_well(const std::string& well) const {
     if (!this->matching_wells)
         return false;
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -309,6 +309,9 @@ Phase Group::injection_phase() const {
     return this->injection_properties.phase;
 }
 
+const Group::GroupType& Group::getGroupType() const {
+    return this-> group_type;
+}
 
 bool Group::ProductionControls::has_control(Group::ProductionCMode control) const {
     return (this->production_controls & static_cast<int>(control)) != 0;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
@@ -175,6 +175,30 @@ double GuideRateModel::damping_factor() const {
     return this->damping_factor_;
 }
 
+double GuideRateModel::getA() const {
+    return this->A;
+}
+
+double GuideRateModel::getB() const {
+    return this->B;
+}
+
+double GuideRateModel::getC() const {
+    return this->C;
+}
+
+double GuideRateModel::getD() const {
+    return this->D;
+}
+
+double GuideRateModel::getE() const {
+    return this->E;
+}
+
+double GuideRateModel::getF() const {
+    return this->F;
+}
+
 bool GuideRateModel::allow_increase() const {
     return this->allow_increase_;
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2601,6 +2601,11 @@ void Schedule::handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep, c
     const OilVaporizationProperties& Schedule::getOilVaporizationProperties(size_t timestep) const {
         return m_oilvaporizationproperties.get(timestep);
     }
+    
+    const Well::ProducerCMode& Schedule::getGlobalWhistctlMmode(size_t timestep) const {
+        return global_whistctl_mode.get(timestep);
+    }
+
 
     bool Schedule::hasOilVaporizationProperties() const {
         for( size_t i = 0; i < this->m_timeMap.size(); ++i )

--- a/tests/UDQ_ACTIONX_TEST1.DATA
+++ b/tests/UDQ_ACTIONX_TEST1.DATA
@@ -415,7 +415,7 @@ ACTIONX
 ACT02 11 /
 FMWPR > 25 AND /
 WGPR 'OPL02' > GGPR 'LOWER' AND /
-MNTH > MAY / 
+MNTH > NOV / 
 /
 WELOPEN
 '?' 'SHUT' 0 0 0 2* /
@@ -441,19 +441,12 @@ WELOPEN
 /
 ENDACTIO
 
-WELOPEN
- 'OPL01' 'OPEN' 5* / 
-/
-DATES
- 1 'OCT' 2018 / 
-/
-
 --start files/actionxprod.tmpl
 ACTIONX
 ACT01 10 /
 FMWPR > 45 AND /
 WUPR3 'OP*' > 46 OR /
-MNTH > JUN  /
+MNTH > OCT  /
 /
 WELOPEN
 '?' SHUT 0 0 0 2* /
@@ -465,6 +458,14 @@ WELOPEN
  'OPL02' 'OPEN' 5* / 
 /
 ENDACTIO
+
+WELOPEN
+ 'OPL01' 'OPEN' 5* / 
+/
+
+DATES
+ 1 'OCT' 2018 / 
+/
 
 
 WELOPEN

--- a/tests/msim/actionx1.include
+++ b/tests/msim/actionx1.include
@@ -56,7 +56,7 @@ WELLDIMS
 -- 	   - we are dealing with only one 'group'
 -- Item 4: maximum number of wells in any one group
 -- 	   - there must be two wells in a group as there are two wells in total
-   2 1 1 2 /
+   5 1 1 2 /
 
 UNIFOUT
 

--- a/tests/msim/actionx2.include
+++ b/tests/msim/actionx2.include
@@ -56,7 +56,7 @@ WELLDIMS
 -- 	   - we are dealing with only one 'group'
 -- Item 4: maximum number of wells in any one group
 -- 	   - there must be two wells in a group as there are two wells in total
-   2 1 1 2 /
+   5 1 1 2 /
 
 UNIFOUT
 

--- a/tests/msim/uda.include
+++ b/tests/msim/uda.include
@@ -40,7 +40,7 @@ START
    1 'DEC' 2014 /
 
 WELLDIMS
-   2 1 1 2 /
+   5 1 1 2 /
 
 UNIFOUT
 

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -40,21 +40,7 @@ namespace {
         return Opm::Parser{}.parseFile(fname);        
     } 
 }
-/*
-Opm::SummaryState sum_state_TEST1_FLOW()
-    {
-        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
-        state.update_well_var("OPU01", "WUPR3", 4);
-        state.update_well_var("OPU02", "WUPR3", 3);
-        state.update_well_var("OPL01", "WUPR3", 1);
-        state.update_well_var("OPL02", "WUPR3", 2);
-        
-        state.update("FMWPR", 4);
-                
 
-        return state;
-}
-*/
 Opm::SummaryState sum_state_TEST1()
     {
         auto state = Opm::SummaryState{std::chrono::system_clock::now()};
@@ -143,26 +129,10 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
     const auto udqDims = Opm::RestartIO::Helpers::createUdqDims(sched, rptStep, ih);
     auto  udqData = Opm::RestartIO::Helpers::AggregateUDQData(udqDims);
     udqData.captureDeclaredUDQData(sched, rptStep, st, ih);
-       
+    
     const auto actDims = Opm::RestartIO::Helpers::createActionxDims(rspec, sched, rptStep);
     auto  actionxData = Opm::RestartIO::Helpers::AggregateActionxData(actDims);
     actionxData.captureDeclaredActionxData(sched, st, actDims, rptStep);
-
-    /*rstFile.write("INTEHEAD", ih);
-    rstFile.write("IUDQ", udqData.getIUDQ());
-    rstFile.write("IUAD", udqData.getIUAD());
-    rstFile.write("IGPH", udqData.getIGPH());
-    rstFile.write("IUAP", udqData.getIUAP());
-    rstFile.write("ZUDN", udqData.getZUDN());
-    rstFile.write("ZUDL", udqData.getZUDL());
-    
-    rstFile.write("IACT", actionxData.getIACT());
-    rstFile.write("SACT", actionxData.getSACT());
-    rstFile.write("ZACT", actionxData.getZACT());
-    rstFile.write("ZLACT", actionxData.getZLACT());
-    rstFile.write("ZACN", actionxData.getZACN());
-    rstFile.write("IACN", actionxData.getIACN());
-    rstFile.write("SACN", actionxData.getSACN());  */
     
     {
         /*
@@ -188,7 +158,7 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         const auto ih_2 = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
                                                 secs_elapsed, rptStep, rptStep_2);        
         BOOST_CHECK_EQUAL(ih_2[156] ,       3); 
-        BOOST_CHECK_EQUAL(ih_2[157] ,       7); 
+        BOOST_CHECK_EQUAL(ih_2[157] ,      10); 
 
         const auto rptStep_3 = std::size_t{2};
         const auto ih_3 = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
@@ -219,7 +189,7 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         
         auto start = 0*actDims[1];
         BOOST_CHECK_EQUAL(iAct[start + 0] ,  0); 
-        BOOST_CHECK_EQUAL(iAct[start + 1] ,  4); 
+        BOOST_CHECK_EQUAL(iAct[start + 1] , 10); 
         BOOST_CHECK_EQUAL(iAct[start + 2] ,  1); 
         BOOST_CHECK_EQUAL(iAct[start + 3] ,  7);
         BOOST_CHECK_EQUAL(iAct[start + 4] ,  0);
@@ -298,7 +268,7 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "/       "); 
 
         start = start_a +  3*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "ENDACTIO"); 
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN "); 
 
         //Second action
         start_a = 1*actDims[4];
@@ -343,18 +313,18 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         //First action
         auto start_a = 0*actDims[5];
         auto start = start_a + 0*13;
-        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "WWPR    ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "FMWPR   ");  
         BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");  
         BOOST_CHECK_EQUAL(zAcn[start + 2].c_str() ,   ">       ");
-        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "OP*     "); 
+        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        "); 
 
         start = start_a + 1*13;
-        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "GMWPR   ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "WUPR3   ");  
         BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");  
         BOOST_CHECK_EQUAL(zAcn[start + 2].c_str() ,   ">       ");
-        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "OP*     ");  
         BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 5].c_str() ,   "T*      "); 
+        BOOST_CHECK_EQUAL(zAcn[start + 5].c_str() ,   "        "); 
 
         start = start_a + 2*13;
         BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "        ");  
@@ -412,10 +382,10 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(iAcn[start +  7] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  8] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  9] ,  0);
-        BOOST_CHECK_EQUAL(iAcn[start + 10] ,  2);
+        BOOST_CHECK_EQUAL(iAcn[start + 10] ,  1);
         BOOST_CHECK_EQUAL(iAcn[start + 11] ,  8);
         BOOST_CHECK_EQUAL(iAcn[start + 12] ,  0);
-        BOOST_CHECK_EQUAL(iAcn[start + 13] ,  2);
+        BOOST_CHECK_EQUAL(iAcn[start + 13] ,  1);
         BOOST_CHECK_EQUAL(iAcn[start + 14] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 15] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 16] ,  1);
@@ -432,10 +402,10 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(iAcn[start +  7] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  8] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  9] ,  0);
-        BOOST_CHECK_EQUAL(iAcn[start + 10] ,  3);
+        BOOST_CHECK_EQUAL(iAcn[start + 10] ,  2);
         BOOST_CHECK_EQUAL(iAcn[start + 11] ,  8);
         BOOST_CHECK_EQUAL(iAcn[start + 12] ,  0);
-        BOOST_CHECK_EQUAL(iAcn[start + 13] ,  1);
+        BOOST_CHECK_EQUAL(iAcn[start + 13] ,  2);
         BOOST_CHECK_EQUAL(iAcn[start + 14] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 15] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 16] ,  1);
@@ -495,7 +465,7 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(iAcn[start +  9] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 10] , 11);
         BOOST_CHECK_EQUAL(iAcn[start + 11] ,  8);
-        BOOST_CHECK_EQUAL(iAcn[start + 12] ,  1);
+        BOOST_CHECK_EQUAL(iAcn[start + 12] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 13] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 14] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 15] ,  0);
@@ -520,14 +490,14 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         auto start = start_a + 0*16;
         BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0); 
         BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  2] , 17); 
+        BOOST_CHECK_EQUAL(sAcn[start +  2] , 45); 
         BOOST_CHECK_EQUAL(sAcn[start +  3] ,  0);
-        BOOST_CHECK_EQUAL(sAcn[start +  4] , 24);
-        BOOST_CHECK_EQUAL(sAcn[start +  5] , 17);
-        BOOST_CHECK_EQUAL(sAcn[start +  6] , 24);
-        BOOST_CHECK_EQUAL(sAcn[start +  7] , 17);
-        BOOST_CHECK_EQUAL(sAcn[start +  8] , 24);
-        BOOST_CHECK_EQUAL(sAcn[start +  9] , 17);
+        BOOST_CHECK_EQUAL(sAcn[start +  4] ,  4);
+        BOOST_CHECK_EQUAL(sAcn[start +  5] , 45);
+        BOOST_CHECK_EQUAL(sAcn[start +  6] ,  4);
+        BOOST_CHECK_EQUAL(sAcn[start +  7] , 45);
+        BOOST_CHECK_EQUAL(sAcn[start +  8] ,  4);
+        BOOST_CHECK_EQUAL(sAcn[start +  9] , 45);
         BOOST_CHECK_EQUAL(sAcn[start + 10] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start + 11] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start + 12] ,  0);
@@ -538,14 +508,14 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         start = start_a + 1*16;
         BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0); 
         BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  2] , 14); 
+        BOOST_CHECK_EQUAL(sAcn[start +  2] , 46); 
         BOOST_CHECK_EQUAL(sAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start +  4] ,  0);
-        BOOST_CHECK_EQUAL(sAcn[start +  5] , 14);
+        BOOST_CHECK_EQUAL(sAcn[start +  5] , 46);
         BOOST_CHECK_EQUAL(sAcn[start +  6] ,  0);
-        BOOST_CHECK_EQUAL(sAcn[start +  7] , 14);
+        BOOST_CHECK_EQUAL(sAcn[start +  7] , 46);
         BOOST_CHECK_EQUAL(sAcn[start +  8] ,  0);
-        BOOST_CHECK_EQUAL(sAcn[start +  9] , 14);
+        BOOST_CHECK_EQUAL(sAcn[start +  9] , 46);
         BOOST_CHECK_EQUAL(sAcn[start + 10] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start + 11] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start + 12] ,  0);
@@ -556,7 +526,7 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         start = start_a + 2*16;
         BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0); 
         BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  2] ,  3); 
+        BOOST_CHECK_EQUAL(sAcn[start +  2] , 10); 
         BOOST_CHECK_EQUAL(sAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start +  4] ,  1.E+20);
         BOOST_CHECK_EQUAL(sAcn[start +  5] ,  1.E+20);

--- a/tests/test_AggregateActionxData_2.cpp
+++ b/tests/test_AggregateActionxData_2.cpp
@@ -4,7 +4,7 @@
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well2.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
@@ -40,21 +40,7 @@ namespace {
         return Opm::Parser{}.parseFile(fname);        
     } 
 }
-/*
-Opm::SummaryState sum_state_TEST1_FLOW()
-    {
-        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
-        state.update_well_var("OPU01", "WUPR3", 4);
-        state.update_well_var("OPU02", "WUPR3", 3);
-        state.update_well_var("OPL01", "WUPR3", 1);
-        state.update_well_var("OPL02", "WUPR3", 2);
-        
-        state.update("FMWPR", 4);
-                
 
-        return state;
-}
-*/
 Opm::SummaryState sum_state_TEST1()
     {
         auto state = Opm::SummaryState{std::chrono::system_clock::now()};

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -51,7 +51,7 @@ struct MockIH
 	   const int nsegWell 	  =  1,  // E100
 	   const int ncwMax       = 20,
 	   const int iConnPerConn =  25,  // NICONZ
-	   const int sConnPerConn =  40,  // NSCONZ
+	   const int sConnPerConn =  41,  // NSCONZ
 	   const int xConnPerConn =  58);  // NXCONZ
 
 

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -498,10 +498,10 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data)
     BOOST_CHECK_EQUAL(ih.nwells, MockIH::Sz{4});
 
     const auto smry = sim_state();
+    const auto& units    = simCase.es.getUnits();
     auto agrpd = Opm::RestartIO::Helpers::AggregateGroupData{ih.value};
-    agrpd.captureDeclaredGroupData(simCase.sched,
-				   rptStep, smry,
-				   ih.value);
+    agrpd.captureDeclaredGroupData(simCase.sched, units, rptStep, smry,
+            ih.value);
 
     // IGRP (PROD)
     {

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -187,10 +187,10 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
         */
         
-        /*BOOST_CHECK_EQUAL(ih[267] ,       -1); 
+        BOOST_CHECK_EQUAL(ih[267] ,       -1); 
         BOOST_CHECK_EQUAL(dh[212] ,  1.0E+20); 
         BOOST_CHECK_EQUAL(dh[213] ,      0.0); 
-        BOOST_CHECK_EQUAL(dh[214] ,   1.0E-4); */
+        BOOST_CHECK_EQUAL(dh[214] ,   1.0E-4); 
 
     }
 

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data)
         BOOST_CHECK_CLOSE(swell[i0 + Ix::GasRateTarget], 1.0e20f, 1.0e-7f);
 
         // LRAT limit derived from ORAT + WRAT (= ORAT + 0.0)
-        BOOST_CHECK_CLOSE(swell[i0 + Ix::LiqRateTarget], 20.0e3f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i0 + Ix::LiqRateTarget], 1.0e20f, 1.0e-7f);
 
         // No direct limit, extract value from 'smry' (WVPR:OP_1)
         BOOST_CHECK_CLOSE(swell[i0 + Ix::ResVRateTarget], 1.0e20f, 1.0e-7f);


### PR DESCRIPTION
This pullrequest contains code to activate the writing of UDQ and ACTIONX related data to the Eclipse compatible restart file. There are also changes to the content of the various vectors that are written out. 

I would like to acknowledge collabration with and contributions to this pullrequest from Joakim Hove and Bård Skaflestad. 