### PR TITLE
correcting the unit in the AQUFETP definition

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUFETP
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUFETP
@@ -3,9 +3,9 @@
         {"name" : "AQUIFER_ID" ,              	"value_type" : "INT"},
         {"name" : "DAT_DEPTH" ,     		"value_type" : "DOUBLE" ,                        "dimension" : "Length"},
         {"name" : "P0" ,              		"value_type" : "DOUBLE" ,                        "dimension" : "Pressure"},
-        {"name" : "V0" ,              		"value_type" : "DOUBLE" ,                        "dimension" : "Length*Length*Length"},
+        {"name" : "V0" ,              		"value_type" : "DOUBLE" ,                        "dimension" : "LiquidSurfaceVolume"},
         {"name" : "C_T" , 			"value_type" : "DOUBLE" ,                        "dimension" : "1/Pressure"},
-        {"name" : "PI" ,              		"value_type" : "DOUBLE" ,                        "dimension" : "ReservoirVolume/Pressure*Time"},
+        {"name" : "PI" ,              		"value_type" : "DOUBLE" ,                        "dimension" : "LiquidSurfaceVolume/Pressure*Time"},
         {"name" : "TABLE_NUM_WATER_PRESS" ,     "value_type" : "INT"    , "default" : 1},
         {"name" : "SALINITY" ,        		"value_type" : "DOUBLE" , "default" : 0 , "dimension" : "Salinity"},
         {"name" : "TEMP" ,            		"value_type" : "DOUBLE" , "                      dimension" : "Temperature"}]}


### PR DESCRIPTION
It makes difference for `FIELD` unit. 

Just for confirmation, 

the definition of the PI is `sm^3/day/bars`, it should be `LiquidSurfaceVolume/Pressure*Time`, instead of `LiquidSurfaceVolume/Pressure/Time`, right?