### PR TITLE
Parse PYINPUT

### DIFF
--- a/opm/parser/eclipse/Python/Python.hpp
+++ b/opm/parser/eclipse/Python/Python.hpp
@@ -60,7 +60,11 @@ public:
 private:
     std::shared_ptr<PythonInterp> interp;
 };
+
+std::unique_ptr<Python> PythonInstance();
+
 }
+
 
 
 #endif

--- a/src/opm/parser/eclipse/Parser/raw/RawConsts.hpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawConsts.hpp
@@ -32,6 +32,7 @@ namespace Opm {
         const std::string end = "END";
         const std::string endinclude = "ENDINC";
         const std::string paths = "PATHS";
+        const std::string pyinput = "PYINPUT";
         const unsigned int maxKeywordLength = 8;
 
         /* The lookup uses some bit-tricks to achieve branchless lookup in the

--- a/src/opm/parser/eclipse/Python/EmbedModule.hpp
+++ b/src/opm/parser/eclipse/Python/EmbedModule.hpp
@@ -1,0 +1,58 @@
+/*
+This Code is a copy paste of part of the contents of pybind11/embed.h
+It allows for slightly changing the python embedding without changing the pybind11 sourcecode.
+*/
+
+#ifndef OPM_EMBED_MODULE
+#define OPM_EMBED_MODULE
+
+#ifdef EMBEDDED_PYTHON
+#include <pybind11/embed.h>
+
+#define OPM_EMBEDDED_MODULE(name, variable)                              \
+    static void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &);    \
+    static PyObject PYBIND11_CONCAT(*pybind11_init_wrapper_, name)() {        \
+        auto m = pybind11::module(PYBIND11_TOSTRING(name));                   \
+        try {                                                                 \
+            PYBIND11_CONCAT(pybind11_init_, name)(m);                         \
+            return m.ptr();                                                   \
+        } catch (pybind11::error_already_set &e) {                            \
+            PyErr_SetString(PyExc_ImportError, e.what());                     \
+            return nullptr;                                                   \
+        } catch (const std::exception &e) {                                   \
+            PyErr_SetString(PyExc_ImportError, e.what());                     \
+            return nullptr;                                                   \
+        }                                                                     \
+    }                                                                         \
+    PYBIND11_EMBEDDED_MODULE_IMPL(name)                                       \
+    Opm::embed::python_module name(PYBIND11_TOSTRING(name),           \
+                               PYBIND11_CONCAT(pybind11_init_impl_, name));   \
+    void PYBIND11_CONCAT(pybind11_init_, name)(pybind11::module &variable)
+
+namespace Opm {
+namespace embed {
+
+/// Python 2.7/3.x compatible version of `PyImport_AppendInittab` and error checks.
+struct python_module {
+#if PY_MAJOR_VERSION >= 3
+    using init_t = PyObject *(*)();
+#else
+    using init_t = void (*)();
+#endif
+    python_module(const char *name, init_t init) {
+
+        auto result = PyImport_AppendInittab(name, init);
+        if (result == -1)
+            pybind11::pybind11_fail("Insufficient memory to add a new module");
+    }
+};  
+
+}
+}
+
+
+
+
+#endif
+
+#endif

--- a/src/opm/parser/eclipse/Python/Python.cpp
+++ b/src/opm/parser/eclipse/Python/Python.cpp
@@ -50,8 +50,10 @@ Python::operator bool() const {
 }
 
 std::unique_ptr<Python> PythonInstance() {
+    #ifdef EMBEDDED_PYTHON
     if (Py_IsInitialized())
         return NULL;
+    #endif
     
     return std::make_unique<Python>();
 }

--- a/src/opm/parser/eclipse/Python/Python.cpp
+++ b/src/opm/parser/eclipse/Python/Python.cpp
@@ -23,11 +23,10 @@
 
 namespace Opm {
 
-Python::Python():
-    interp(std::make_shared<PythonInterp>())
+Python::Python() :
+    interp(std::make_shared<PythonInterp>())    
 {
 }
-
 
 bool Python::exec(const std::string& python_code) const {
     this->interp->exec(python_code);
@@ -48,6 +47,13 @@ Python::operator bool() const {
         return bool( *this->interp );
     else
         return false;
+}
+
+std::unique_ptr<Python> PythonInstance() {
+    if (Py_IsInitialized())
+        return NULL;
+    
+    return std::make_unique<Python>();
 }
 
 

--- a/src/opm/parser/eclipse/Python/PythonInterp.cpp
+++ b/src/opm/parser/eclipse/Python/PythonInterp.cpp
@@ -27,11 +27,12 @@
 
 #include "python/cxx/export.hpp"
 #include "PythonInterp.hpp"
+#include "EmbedModule.hpp"
 
 namespace py = pybind11;
 namespace Opm {
 
-PYBIND11_EMBEDDED_MODULE(context, module) {
+OPM_EMBEDDED_MODULE(context, module) {
     python::common::export_all(module);
 }
 

--- a/src/opm/parser/eclipse/Python/PythonInterp.hpp
+++ b/src/opm/parser/eclipse/Python/PythonInterp.hpp
@@ -18,8 +18,8 @@
 */
 
 
-#ifndef EMBEDDED_PYTHON_INTERP
-#define EMBEDDED_PYTHON_INTERP
+#ifndef PYTHON_INTERP
+#define PYTHON_INTERP
 
 #include <string>
 #include <stdexcept>

--- a/src/opm/parser/eclipse/share/keywords/900_OPM/P/PYINPUT
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/P/PYINPUT
@@ -1,3 +1,3 @@
-{"name" : "PYACTION",
+{"name" : "PYINPUT",
  "sections" : ["RUNSPEC", "GRID", "EDIT", "PROPS", "REGIONS", "SOLUTION", "SUMMARY", "SCHEDULE"],
  "code" : {"end" : "<<<"}}


### PR DESCRIPTION
This allows python code to be written in eclipse .DATA files. 
Note: it is not yet possible to embed Python while still running python (e.g. the below example is not possible for the python Parser.).

The syntax is:
```
PYINPUT
import numpy as np
dx = np.array([0.25, 0.25, 0.25, 0.25])
active_unit_system = context.deck.active_unit_system()
default_unit_system = context.deck.default_unit_system()        
kw = context.DeckKeyword( context.parser['DX'], dx, active_unit_system, default_unit_system )
context.deck.add(kw)
<<<
```

Some reading:  https://stackoverflow.com/questions/24656088/static-member-variable-for-class-that-is-dynamically-loaded