### PR TITLE
Fix TimeMap::isTimestepInFirstOfMonthsYearsSequence() method.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -21,6 +21,8 @@
 #ifndef TIMEMAP_HPP_
 #define TIMEMAP_HPP_
 
+#include <opm/common/utility/TimeService.hpp>
+
 #include <vector>
 #include <ctime>
 #include <map>
@@ -58,8 +60,7 @@ namespace Opm {
         double getTimeStepLength(size_t tStepIdx) const;
 
         /// Return true if the given timestep is the first one of a new month or year, or if frequency > 1,
-        /// return true for every n'th timestep of every first new month or first new year timesteps,
-        /// starting from start_timestep-1.
+        /// return true if the step is the first of each n-month or n-month period, starting from start_timestep - 1.
         bool isTimestepInFirstOfMonthsYearsSequence(size_t timestep, bool years = true, size_t start_timestep = 1, size_t frequency = 1) const;
 
         static std::time_t timeFromEclipse(const DeckRecord &dateRecord);
@@ -73,13 +74,16 @@ namespace Opm {
 
         std::vector<std::time_t> m_timeList;
 
-        const std::vector<size_t>& getFirstTimestepMonths() const;
-        const std::vector<size_t>& getFirstTimestepYears() const;
         bool isTimestepInFreqSequence (size_t timestep, size_t start_timestep, size_t frequency, bool years) const;
         size_t closest(const std::vector<size_t> & vec, size_t value) const;
 
-        std::vector<size_t> m_first_timestep_years;   // A list of the first timestep of every year
-        std::vector<size_t> m_first_timestep_months;  // A list of the first timestep of every month
+        struct StepData
+        {
+            size_t stepnumber;
+            TimeStampUTC timestamp;
+        };
+        std::vector<StepData> m_first_timestep_years;   // A list of the first timestep of every year
+        std::vector<StepData> m_first_timestep_months;  // A list of the first timestep of every month
     };
 }
 

--- a/tests/parser/RestartConfigTests.cpp
+++ b/tests/parser/RestartConfigTests.cpp
@@ -876,12 +876,12 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_5) {
                         " 24 MAY 1981 /\n"
                         "  1 JUN 1981 /\n"
                         "  1 JUL 1981 /\n" // write
-                        "  1 JAN 1982 /\n"
+                        "  1 JAN 1982 /\n" // write
                         "  2 JAN 1982 /\n"
-                        "  1 FEB 1982 /\n" // write
-                        "  1 MAR 1982 /\n"
-                        "  1 APR 1983 /\n" //write
-                        "  2 JUN 1983 /\n"
+                        "  1 FEB 1982 /\n"
+                        "  1 MAR 1982 /\n" // write
+                        "  1 APR 1983 /\n" // write
+                        "  2 JUN 1983 /\n" // write
                         "/\n";
 
     auto deck = Parser().parseString( data);
@@ -889,10 +889,10 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_5) {
 
     /* BASIC=5, restart file is written at the first report step of each month.
      */
-    for( size_t ts : { 1, 2, 3, 4, 6, 7, 9, 11  } )
+    for( size_t ts : { 1, 2, 3, 4, 7, 8 } )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
 
-    for( size_t ts : { 5, 8, 10 } )
+    for( size_t ts : { 5, 6, 9, 10, 11 } )
         BOOST_CHECK( ioConfig.getWriteRestartFile( ts ) );
 }
 


### PR DESCRIPTION
This is intended to address problems with restart files not getting written at timesteps when they really should, based on the RPTRST keyword.

This logic happens in the TimeMap class. My interpretation of the "restart frequency logic" is (paraphrasing from code comment): return true (i.e. write a restart file) if the step is the first of each n-month or n-month period, starting from start_timestep - 1. Note that I did not change that API-quirk (subtracting 1) in order to avoid having to change too much other code.

Developed using test-driven development, so any bugs will have to be demonstrated by an added failing test (or pointing out that a test is wrong). :-) The changes to RestartConfigTests.cpp have been considered carefully by me to be correct, i.e. the existing test was wrong. Please verify.

I have not had the time yet to test with a full-size deck, so no guarantee this is sufficient to fix the original problem of not getting all the restart steps expected!