### PR TITLE
Simplify the BOX implementation - prepare to drop the manager

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/Box.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Box.hpp
@@ -25,7 +25,9 @@
 #include <cstddef>
 
 namespace Opm {
+    class DeckRecord;
     class EclipseGrid;
+
     class Box {
     public:
 
@@ -44,6 +46,9 @@ namespace Opm {
 
         Box(const EclipseGrid& grid);
         Box(const EclipseGrid& grid , int i1 , int i2 , int j1 , int j2 , int k1 , int k2);
+        void update(const DeckRecord& deckRecord);
+        void reset();
+
         size_t size() const;
         bool   isGlobal() const;
         size_t getDim(size_t idim) const;
@@ -60,11 +65,12 @@ namespace Opm {
         int K2() const;
 
     private:
+        void init(int i1, int i2, int j1, int j2, int k1, int k2);
         void initIndexList();
         const EclipseGrid& grid;
+        size_t m_stride[3];
         size_t m_dims[3] = { 0, 0, 0 };
         size_t m_offset[3];
-        size_t m_stride[3];
 
         bool   m_isGlobal;
         std::vector<size_t> global_index_list;

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -38,12 +38,16 @@ inline std::string prefix() {
     return boost::unit_test::framework::master_test_suite().argv[1];
 }
 
-inline EclipseState makeState(const std::string& fileName) {
+inline Deck makeDeck(const std::string& fileName) {
     Parser parser;
     boost::filesystem::path boxFile(fileName);
-    auto deck =  parser.parseFile(boxFile.string());
-    return EclipseState( deck );
+    return parser.parseFile(boxFile.string());
 }
+
+inline EclipseState makeState(const std::string& fileName) {
+    return EclipseState( makeDeck(fileName) );
+}
+
 
 BOOST_AUTO_TEST_CASE( PERMX ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
@@ -155,3 +159,18 @@ BOOST_AUTO_TEST_CASE( OPERATE ) {
     BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,4)], 1.5 );  // MINVALUE
 }
 
+BOOST_AUTO_TEST_CASE( CONSTRUCTOR_AND_UPDATE ) {
+    auto deck = makeDeck( prefix() + "BOX/BOXTEST1" );
+    EclipseGrid grid(deck);
+    const auto& box_keyword = deck.getKeyword("BOX", 0);
+    const auto& operate_keyword = deck.getKeyword("OPERATE");
+    Box box(grid);
+    box.update(box_keyword.getRecord(0));
+    BOOST_CHECK_EQUAL(box.size(), 8);
+
+    box.update( operate_keyword.getRecord(0) );
+    BOOST_CHECK_EQUAL(box.size(), 50);
+
+    box.reset();
+    BOOST_CHECK_EQUAL(box.size(), 1000);
+}


### PR DESCRIPTION
The box implementation was written at a time when I though you could create boxes within boxes; that is not the case. Rather a `BOX` within a `BOX` range will refer to the global box.

This PR is a small step in the 3D properties refactoring, when that is merged everything box related can be simplified further.