### PR TITLE
Fix abs() ambiguity, add copyright headers.

### DIFF
--- a/test_util/summary.cpp
+++ b/test_util/summary.cpp
@@ -1,10 +1,29 @@
-//#include <chrono>
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <tuple>
 #include <getopt.h>
 #include <sstream>
-  
+
 #include <opm/io/eclipse/ESmry.hpp>
 
 
@@ -32,7 +51,7 @@ std::string formatString(float data){
 
     std::stringstream stream;
     
-    if (abs(data)<1e6){
+    if (std::fabs(data) < 1e6){
        stream << std::fixed << std::setw(16) << std::setprecision(6) << data;
     } else {
        stream << std::scientific << std::setw(16) << std::setprecision(6)  << data;


### PR DESCRIPTION
The abs() call is ambiguous, and that is good: otherwise the abs(int) overload from C would be the one called on at least my (clang-using) system. Including `<cmath>` and explicitly using `std::fabs` is the clearest way to fix this.

Note that if you really need a generic abs() for a template context where you need to handle both integer and floating-point numbers, you can use the std::abs() template from `<cmath>` (since C++17, used to be only in `<cstdlib>` together with the C-inherited abs(int) overload).

I also took the liberty of updating the copyright header the way I assumed it should be. @tskille please check!