### PR TITLE
Remove / rename DeckItem::size()

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -661,6 +661,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/Deck/DeckKeyword.hpp
        opm/parser/eclipse/Deck/DeckRecord.hpp
        opm/parser/eclipse/Deck/UDAValue.hpp
+       opm/parser/eclipse/Deck/value_status.hpp
        opm/parser/eclipse/Python/Python.hpp)
 endif()
 if(ENABLE_ECL_OUTPUT)

--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -28,12 +28,15 @@
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 #include <opm/parser/eclipse/Utility/Typetools.hpp>
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
+#include <opm/parser/eclipse/Deck/value_status.hpp>
+
 
 namespace Opm {
     class DeckOutput;
 
     class DeckItem {
     public:
+
         DeckItem() = default;
         DeckItem( const std::string&, int);
         DeckItem( const std::string&, std::string);
@@ -59,7 +62,6 @@ namespace Opm {
         // keyword, though...
 
         size_t data_size() const;
-        size_t out_size() const;
 
         template<typename T>
         T get( size_t index ) const;
@@ -84,6 +86,8 @@ namespace Opm {
         void push_backDefault( double );
         void push_backDefault( std::string );
         // trying to access the data of a "dummy default item" will raise an exception
+
+        template <typename T>
         void push_backDummyDefault();
 
         type_tag getType() const;
@@ -120,7 +124,7 @@ namespace Opm {
         type_tag type = type_tag::unknown;
 
         std::string item_name;
-        std::vector< bool > defaulted;
+        std::vector<value::status> value_status;
         /*
           To save space we mutate the dval object in place when asking for SI
           data; the current state of of the dval member is tracked with the

--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -57,7 +57,8 @@ namespace Opm {
         // keywords like e.g. SGL), then the remaining values are defaulted. The deck
         // creates the defaulted items if all their sizes are fully specified by the
         // keyword, though...
-        size_t size() const;
+
+        size_t data_size() const;
         size_t out_size() const;
 
         template<typename T>

--- a/opm/parser/eclipse/Deck/value_status.hpp
+++ b/opm/parser/eclipse/Deck/value_status.hpp
@@ -1,0 +1,56 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef VALUE_STATUS
+#define VALUE_STATUS
+
+namespace Opm {
+
+namespace value {
+
+enum class status : unsigned char { unitialized = 0,
+                                    deck_value = 1,
+                                    empty_default = 2,
+                                    valid_default = 3 };
+
+
+inline bool defaulted(status st) {
+    if (st == status::empty_default)
+        return true;
+
+    if (st == status::valid_default)
+        return true;
+
+    return false;
+}
+
+
+inline bool has_value(status st) {
+    if (st == status::deck_value)
+        return true;
+
+    if (st == status::valid_default)
+        return true;
+
+    return false;
+}
+}
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -195,7 +195,7 @@ namespace Opm {
             size_t regionIdx = 0;
             size_t tableIdx = 0;
             for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
-                if (keyword.getRecord(lineIdx).getItem("PRESSURE").size() > 0) {
+                if (keyword.getRecord(lineIdx).getItem("PRESSURE").hasValue(0)) {
                     rocktable[regionIdx].init(keyword.getRecord(lineIdx), tableIdx);
                     tableIdx++;
                 } else { // next region
@@ -227,8 +227,8 @@ namespace Opm {
 
             const auto& tableKeyword = deck.getKeyword(keywordName);
             for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
-                const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem( 0 );
-                if (dataItem.size() > 0) {
+                const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
+                if (dataItem.data_size() > 0) {
                     std::shared_ptr<TableType> table = std::make_shared<TableType>( dataItem, useJFunc() );
                     container.addTable( tableIdx , table );
                 }
@@ -254,8 +254,8 @@ namespace Opm {
 
             const auto& tableKeyword = deck.getKeyword(keywordName);
             for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
-                const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem( 0 );
-                if (dataItem.size() > 0) {
+                const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
+                if (dataItem.data_size() > 0) {
                     std::shared_ptr<TableType> table = std::make_shared<TableType>( dataItem );
                     container.addTable( tableIdx , table );
                 }
@@ -293,8 +293,8 @@ namespace Opm {
 
             const auto& tableKeyword = deck.getKeyword(keywordName);
             for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
-                const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem( 0 );
-                if (dataItem.size() == 0) {
+                const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
+                if (dataItem.data_size() == 0) {
                     // for simple tables, an empty record indicates that the previous table
                     // should be copied...
                     if (tableIdx == 0) {

--- a/python/cxx/deck_keyword.cpp
+++ b/python/cxx/deck_keyword.cpp
@@ -185,7 +185,7 @@ void python::common::export_DeckKeyword(py::module& module) {
 
 
     py::class_< DeckItem >(module, "DeckItem")
-        .def( "__len__", &DeckItem::size )
+        .def( "__len__", &DeckItem::data_size )
         .def("get_str", &DeckItem::get<std::string>)
         .def("get_int", &DeckItem::get<int>)
         .def("get_raw", &DeckItem::get<double>)

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -105,39 +105,30 @@ const std::string& DeckItem::name() const {
 }
 
 bool DeckItem::defaultApplied( size_t index ) const {
-    return this->defaulted.at( index );
+    return value::defaulted( this->value_status.at(index));
 }
 
 bool DeckItem::hasValue( size_t index ) const {
-    switch( this->type ) {
-        case type_tag::integer: return this->ival.size() > index;
-        case type_tag::fdouble: return this->dval.size() > index;
-        case type_tag::string:  return this->sval.size() > index;
-        case type_tag::uda:     return this->uval.size() > index;
-        default: throw std::logic_error( "DeckItem::hasValue: Type not set." );
-    }
+    if (index >= this->value_status.size())
+        return false;
+
+    return value::has_value( this->value_status[index] );
 }
 
 size_t DeckItem::data_size() const {
-    switch( this->type ) {
-        case type_tag::integer: return this->ival.size();
-        case type_tag::fdouble: return this->dval.size();
-        case type_tag::string:  return this->sval.size();
-        case type_tag::uda:     return this->uval.size();
-        default: throw std::logic_error( "DeckItem::size: Type not set." );
-    }
-}
-
-
-size_t DeckItem::out_size() const {
-    size_t data_size = this->data_size();
-    return std::max( data_size , this->defaulted.size() );
+    return this->value_status.size();
 }
 
 
 template< typename T >
 T DeckItem::get( size_t index ) const {
-    return this->value_ref< T >().at( index );
+    if (index >= this->value_status.size())
+        throw std::out_of_range("Invalid index");
+
+    if (!value::has_value(this->value_status[index]))
+        throw std::invalid_argument("Invalid arguemnt");
+
+    return this->value_ref< T >()[index];
 }
 
 template<>
@@ -147,7 +138,7 @@ UDAValue DeckItem::get( size_t index ) const {
         return value;
 
     std::size_t dim_index = index % this->active_dimensions.size();
-    if (this->defaulted[index])
+    if (value::defaulted(this->value_status[index]))
         return UDAValue( value, this->default_dimensions[dim_index]);
     else
         return UDAValue( value, this->active_dimensions[dim_index]);
@@ -165,7 +156,7 @@ void DeckItem::push( T x ) {
     auto& val = this->value_ref< T >();
 
     val.push_back( std::move( x ) );
-    this->defaulted.push_back( false );
+    this->value_status.push_back( value::status::deck_value );
 }
 
 void DeckItem::push_back( int x ) {
@@ -189,7 +180,7 @@ void DeckItem::push( T x, size_t n ) {
     auto& val = this->value_ref< T >();
 
     val.insert( val.end(), n, x );
-    this->defaulted.insert( this->defaulted.end(), n, false );
+    this->value_status.insert( this->value_status.end(), n, value::status::deck_value );
 }
 
 void DeckItem::push_back( int x, size_t n ) {
@@ -211,12 +202,12 @@ void DeckItem::push_back( UDAValue x, size_t n ) {
 template< typename T >
 void DeckItem::push_default( T x ) {
     auto& val = this->value_ref< T >();
-    if( this->defaulted.size() != val.size() )
+    if( this->value_status.size() != val.size() )
         throw std::logic_error("To add a value to an item, "
                 "no 'pseudo defaults' can be added before");
 
     val.push_back( std::move( x ) );
-    this->defaulted.push_back( true );
+    this->value_status.push_back( value::status::valid_default );
 }
 
 void DeckItem::push_backDefault( int x ) {
@@ -236,11 +227,11 @@ void DeckItem::push_backDefault( UDAValue x ) {
 }
 
 
+template<typename T>
 void DeckItem::push_backDummyDefault() {
-    if( !this->defaulted.empty() )
-        throw std::logic_error("Pseudo defaults can only be specified for empty items");
-
-    this->defaulted.push_back( true );
+    auto& val = this->value_ref< T >();
+    val.push_back( T() );
+    this->value_status.push_back( value::status::empty_default );
 }
 
 std::string DeckItem::getTrimmedString( size_t index ) const {
@@ -262,8 +253,13 @@ const std::vector<double>& DeckItem::getData() const {
     const auto dim_size = this->active_dimensions.size();
     for( size_t index = 0; index < data.size(); index++ ) {
         const auto dimIndex = index % dim_size;
-        const auto& dim = this->defaulted[index] ? this->default_dimensions[dimIndex] : this->active_dimensions[dimIndex];
-        data[ index ] = dim.convertSiToRaw( data[ index ] );
+        if (value::defaulted(this->value_status[index])) {
+            const auto& dim = this->default_dimensions[dimIndex];
+            data[ index ] = dim.convertSiToRaw( data[ index ] );
+        } else {
+            const auto& dim = this->active_dimensions[dimIndex];
+            data[ index ] = dim.convertSiToRaw( data[ index ] );
+        }
     }
     this->raw_data = true;
     return data;
@@ -289,8 +285,13 @@ const std::vector< double >& DeckItem::getSIDoubleData() const {
     const auto sz = data.size();
     for( size_t index = 0; index < sz; index++ ) {
         const auto dimIndex = index % dim_size;
-        const auto& dim = this->defaulted[index] ? this->default_dimensions[dimIndex] : this->active_dimensions[dimIndex];
-        data[ index ] = dim.convertRawToSi( data[ index ] );
+        if (value::defaulted(this->value_status[index])) {
+            const auto& dim = this->default_dimensions[dimIndex];
+            data[ index ] = dim.convertRawToSi( data[ index ] );
+        } else {
+            const auto& dim = this->active_dimensions[dimIndex];
+            data[ index ] = dim.convertRawToSi( data[ index ] );
+        }
     }
     this->raw_data = false;
     return data;
@@ -305,7 +306,7 @@ type_tag DeckItem::getType() const {
 
 template< typename T >
 void DeckItem::write_vector(DeckOutput& stream, const std::vector<T>& data) const {
-    for (size_t index = 0; index < this->out_size(); index++) {
+    for (size_t index = 0; index < this->data_size(); index++) {
         if (this->defaultApplied(index))
             stream.stash_default( );
         else
@@ -373,7 +374,7 @@ bool DeckItem::equal(const DeckItem& other, bool cmp_default, bool cmp_numeric) 
         return false;
 
     if (cmp_default)
-        if (this->defaulted != other.defaulted)
+        if (this->value_status != other.value_status)
             return false;
 
     switch( this->type ) {
@@ -468,6 +469,11 @@ template int DeckItem::get< int >( size_t ) const;
 template double DeckItem::get< double >( size_t ) const;
 template std::string DeckItem::get< std::string >( size_t ) const;
 template UDAValue DeckItem::get< UDAValue >( size_t ) const;
+
+template void DeckItem::push_backDummyDefault<int>();
+template void DeckItem::push_backDummyDefault<double>();
+template void DeckItem::push_backDummyDefault<std::string>();
+template void DeckItem::push_backDummyDefault<UDAValue>();
 
 template const std::vector< int >& DeckItem::getData< int >() const;
 template const std::vector< UDAValue >& DeckItem::getData< UDAValue >() const;

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -118,7 +118,7 @@ bool DeckItem::hasValue( size_t index ) const {
     }
 }
 
-size_t DeckItem::size() const {
+size_t DeckItem::data_size() const {
     switch( this->type ) {
         case type_tag::integer: return this->ival.size();
         case type_tag::fdouble: return this->dval.size();
@@ -128,8 +128,9 @@ size_t DeckItem::size() const {
     }
 }
 
+
 size_t DeckItem::out_size() const {
-    size_t data_size = this->size();
+    size_t data_size = this->data_size();
     return std::max( data_size , this->defaulted.size() );
 }
 
@@ -365,7 +366,7 @@ bool DeckItem::equal(const DeckItem& other, bool cmp_default, bool cmp_numeric) 
     if (this->type != other.type)
         return false;
 
-    if (this->size() != other.size())
+    if (this->data_size() != other.data_size())
         return false;
 
     if (this->item_name != other.item_name)

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -55,7 +55,7 @@ namespace Opm {
               if (parser_item.hasDefault())
                   deck_item.push_back( parser_item.getDefault<T>() );
               else
-                  deck_item.push_backDummyDefault();
+                  deck_item.push_backDummyDefault<T>();
          }
          else if (input_record[j].is_compatible<T>())
              deck_item.push_back( input_record[j].get<T>() );

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -237,7 +237,7 @@ namespace Opm {
 
 
     size_t DeckKeyword::getDataSize() const {
-        return this->getDataRecord().getDataItem().size();
+        return this->getDataRecord().getDataItem().data_size();
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -246,7 +246,7 @@ namespace Opm {
     template< typename T >
     void GridProperty< T >::loadFromDeckKeyword( const DeckKeyword& deckKeyword, bool multiply ) {
         const auto& deckItem = getDeckItem(deckKeyword);
-        const auto size = deckItem.size();
+        const auto size = deckItem.data_size();
         for (size_t dataPointIdx = 0; dataPointIdx < size; ++dataPointIdx) {
             if (!deckItem.defaultApplied(dataPointIdx)) {
                 if (multiply)
@@ -266,10 +266,10 @@ namespace Opm {
         else {
             const auto& deckItem = getDeckItem(deckKeyword);
             const std::vector<size_t>& indexList = inputBox.getIndexList();
-            if (indexList.size() == deckItem.size()) {
+            if (indexList.size() == deckItem.data_size()) {
                 for (size_t sourceIdx = 0; sourceIdx < indexList.size(); sourceIdx++) {
                     size_t targetIdx = indexList[sourceIdx];
-                    if (sourceIdx < deckItem.size()
+                    if (sourceIdx < deckItem.data_size()
                         && !deckItem.defaultApplied(sourceIdx))
                         {
                             if (multiply)
@@ -280,7 +280,7 @@ namespace Opm {
                 }
             } else {
                 std::string boxSize = std::to_string(static_cast<long long>(indexList.size()));
-                std::string keywordSize = std::to_string(static_cast<long long>(deckItem.size()));
+                std::string keywordSize = std::to_string(static_cast<long long>(deckItem.data_size()));
 
                 throw std::invalid_argument("Size mismatch: Box:" + boxSize + "  DeckKeyword:" + keywordSize);
             }
@@ -397,9 +397,9 @@ namespace Opm {
 
         const auto& deckItem = deckKeyword.getRecord(0).getItem(0);
 
-        if (deckItem.size() > m_data.size())
+        if (deckItem.data_size() > m_data.size())
             throw std::invalid_argument("Size mismatch when setting data for:" + getKeywordName()
-                                        + " keyword size: " + std::to_string( deckItem.size() )
+                                        + " keyword size: " + std::to_string( deckItem.data_size() )
                                         + " input size: " + std::to_string( m_data.size()) );
 
         return deckItem;

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -439,8 +439,9 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
             continue;
         }
 
-        if( name == "TSTEP" ) {
-            current_step += keyword.getRecord( 0 ).getItem( 0 ).size();
+
+       if( name == "TSTEP" ) {
+            current_step += keyword.getRecord( 0 ).getItem( 0 ).data_size();
             continue;
         }
 
@@ -668,7 +669,7 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
 
         const auto& item = record.getItem(0);
 
-        for (size_t index = 0; index < item.size(); ++index) {
+        for (size_t index = 0; index < item.data_size(); ++index) {
             const std::string& mnemonic = item.get< std::string >(index);
 
             found_mnemonic_RESTART = mnemonic.find("RESTART=");
@@ -685,7 +686,7 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
            Restart integer switch is integer control nr 7 */
 
         if (found_mnemonic_RESTART == std::string::npos) {
-            if (item.size() >= 7)  {
+            if (item.data_size() >= 7)  {
                 const std::string& integer_control = item.get< std::string >(6);
                 try {
                     restart = boost::lexical_cast<size_t>(integer_control);

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -112,14 +112,14 @@ WellSegmentDims::WellSegmentDims(const Deck& deck) : WellSegmentDims()
     }
 }
 
-EclHysterConfig::EclHysterConfig(const Opm::Deck& deck) 
+EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
     {
 
         if (!deck.hasKeyword("SATOPTS"))
             return;
 
         const auto& satoptsItem = deck.getKeyword("SATOPTS").getRecord(0).getItem(0);
-        for (unsigned i = 0; i < satoptsItem.size(); ++i) {
+        for (unsigned i = 0; i < satoptsItem.data_size(); ++i) {
             std::string satoptsValue = satoptsItem.get< std::string >(0);
             std::transform(satoptsValue.begin(),
                            satoptsValue.end(),

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -253,7 +253,7 @@ namespace {
 
         else if (keyword.name() == "TSTEP") {
             checkIfAllConnectionsIsShut(currentStep);
-            currentStep += keyword.getRecord(0).getItem(0).size(); // This is a bit weird API.
+            currentStep += keyword.getRecord(0).getItem(0).data_size(); // This is a bit weird API.
         }
 
         else if (keyword.name() == "UDQ")

--- a/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -198,7 +198,7 @@ namespace {
         {
             const auto &item = TSTEPKeyword.getRecord(0).getItem(0);
 
-            for (size_t itemIndex = 0; itemIndex < item.size(); itemIndex++) {
+            for (size_t itemIndex = 0; itemIndex < item.data_size(); itemIndex++) {
                 const int64_t seconds = static_cast<int64_t>(item.getSIDouble(itemIndex));
                 addTStep(seconds);
             }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.cpp
@@ -37,8 +37,8 @@ namespace {
 template <typename T>
 inline const Opm::DeckItem& getNonEmptyItem( const Opm::DeckRecord& record) {
     const auto& retval = record.getItem<T>();
-    if (retval.size() == 0) {
-        throw std::invalid_argument("Zero-sized record found where non-empty record expected");
+    if (!retval.hasValue(0)) {
+        throw std::invalid_argument("Missing data");
     }
     return retval;
 }

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -440,7 +440,7 @@ inline void keywordR2R( SummaryConfig::keyword_list& /* list */,
     const auto& item = keyword.getDataRecord().getDataItem();
     std::vector<int> regions;
 
-    if (item.size() > 0)
+    if (item.data_size() > 0)
         regions = item.getData< int >();
     else {
         for (size_t region=1; region <= numfip; region++)

--- a/src/opm/parser/eclipse/EclipseState/Tables/PvtxTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/PvtxTable.cpp
@@ -131,7 +131,7 @@ namespace Opm {
         size_t recordIndex = 0;
         while (recordIndex < keyword.size()) {
             const auto& item = keyword.getRecord(recordIndex).getItem(0);
-            if (item.size( ) == 0) {
+            if (!item.hasValue(0)) {
                 ranges.push_back( std::make_pair( startRecord , recordIndex ) );
                 startRecord = recordIndex + 1;
             }

--- a/src/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -75,11 +75,11 @@ namespace Opm {
     void SimpleTable::init( const DeckItem& deckItem ) {
         this->addColumns();
 
-        if ( (deckItem.size() % numColumns()) != 0)
+        if ( (deckItem.data_size() % numColumns()) != 0)
             throw std::runtime_error("Number of columns in the data file is"
                     "inconsistent with the ones specified");
 
-        size_t rows = deckItem.size() / numColumns();
+        size_t rows = deckItem.data_size() / numColumns();
         for (size_t colIdx = 0; colIdx < numColumns(); ++colIdx) {
             auto& column = getColumn( colIdx );
             for (size_t rowIdx = 0; rowIdx < rows; rowIdx++) {

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -412,7 +412,7 @@ namespace Opm {
         for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& tableRecord = tableKeyword.getRecord( tableIdx );
             const auto& dataItem = tableRecord.getItem( 0 );
-            if (dataItem.size() > 0) {
+            if (dataItem.data_size() > 0) {
                 std::shared_ptr<GasvisctTable> table = std::make_shared<GasvisctTable>( deck , dataItem );
                 container.addTable( tableIdx , table );
             }
@@ -444,7 +444,7 @@ namespace Opm {
             const auto& indexRecord = tableKeyword.getRecord( tableIdx );
             const auto& dataRecord = tableKeyword.getRecord( tableIdx + 1);
             const auto& dataItem = dataRecord.getItem( 0 );
-            if (dataItem.size() > 0) {
+            if (dataItem.data_size() > 0) {
                 std::shared_ptr<PlyshlogTable> table = std::make_shared<PlyshlogTable>(indexRecord , dataRecord);
                 container.addTable( tableIdx , table );
             }
@@ -600,7 +600,7 @@ namespace Opm {
         for (size_t tableIdx = 0; tableIdx < rocktabKeyword.size(); ++tableIdx) {
             const auto& tableRecord = rocktabKeyword.getRecord( tableIdx );
             const auto& dataItem = tableRecord.getItem( 0 );
-            if (dataItem.size() > 0) {
+            if (dataItem.data_size() > 0) {
                 std::shared_ptr<RocktabTable> table = std::make_shared<RocktabTable>( dataItem , isDirectional, useStressOption );
                 container.addTable( tableIdx , table );
             }

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -702,11 +702,11 @@ GasvisctTable::GasvisctTable( const Deck& deck, const DeckItem& deckItem ) {
 
     SimpleTable::addColumns();
 
-    if ( deckItem.size() % numColumns() != 0)
+    if ( deckItem.data_size() % numColumns() != 0)
         throw std::runtime_error("Number of columns in the data file is inconsistent "
                                  "with the expected number for keyword GASVISCT");
 
-    size_t rows = deckItem.size() / m_schema.size();
+    size_t rows = deckItem.data_size() / m_schema.size();
     for (size_t columnIndex=0; columnIndex < m_schema.size(); columnIndex++) {
         auto& column = getColumn( columnIndex );
         for (size_t rowIdx = 0; rowIdx < rows; rowIdx++) {

--- a/src/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -513,7 +513,7 @@ void scan_item( DeckItem& deck_item, const ParserItem& parser_item, RawRecord& r
         } else {
             // ... otherwise indicate that the deck item should throw once the
             // item's data is accessed.
-            deck_item.push_backDummyDefault();
+            deck_item.push_backDummyDefault<T>();
         }
 
         return;
@@ -541,7 +541,7 @@ void scan_item( DeckItem& deck_item, const ParserItem& parser_item, RawRecord& r
     else if( parser_item.hasDefault() )
         deck_item.push_backDefault( parser_item.getDefault< T >() );
     else
-        deck_item.push_backDummyDefault();
+        deck_item.push_backDummyDefault<T>();
 
     const auto value_start = token.size() - valueString.size();
     // replace the first occurence of "N*FOO" by a sequence of N-1 times

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/ALKADS
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/ALKADS
@@ -1,7 +1,7 @@
 {"name" : "ALKADS" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Density" , "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/ALPOLADS
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/ALPOLADS
@@ -1,7 +1,7 @@
 {"name" : "ALPOLADS" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Density" , "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/ALSURFAD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/ALSURFAD
@@ -1,7 +1,7 @@
 {"name" : "ALSURFAD" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Density" , "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/ALSURFST
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/ALSURFST
@@ -1,7 +1,7 @@
 {"name" : "ALSURFST" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Density" , "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUTAB
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUTAB
@@ -1,7 +1,7 @@
 {"name" : "AQUTAB" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "AQUDIMS" , "item" : "NIFTBL", "shift" : -1},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1" , "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/COALADS
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/COALADS
@@ -1,7 +1,7 @@
 {"name" : "COALADS" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "REGDIMS" , "item" : "NTCREG"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1", "1", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/COALPP
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/COALPP
@@ -1,7 +1,7 @@
 {"name" : "COALPP" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "REGDIMS" , "item" : "NTCREG"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1", "1", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/E/ESSNODE
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/E/ESSNODE
@@ -1,7 +1,7 @@
 {"name" : "ESSNODE" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Density"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FHERCHBL
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FHERCHBL
@@ -1,7 +1,7 @@
 {"name" : "FHERCHBL" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "NNEWTF" , "item" : "NTHRBL"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Density" , "1", "1", "Pressure"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMDCYO
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMDCYO
@@ -1,7 +1,7 @@
 {"name" : "FOAMDCYO" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1", "Time"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMDCYW
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMDCYW
@@ -1,7 +1,7 @@
 {"name" : "FOAMDCYW" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1", "Time"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFCN
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFCN
@@ -1,7 +1,7 @@
 {"name" : "FOAMFCN" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFRM
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFRM
@@ -1,7 +1,7 @@
 {"name" : "FOAMFRM" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFSO
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFSO
@@ -1,7 +1,7 @@
 {"name" : "FOAMFSO" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFST
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFST
@@ -1,7 +1,7 @@
 {"name" : "FOAMFST" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["FoamDensity", "SurfaceTension"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFSW
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFSW
@@ -1,7 +1,7 @@
 {"name" : "FOAMFSW" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMMOBP
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMMOBP
@@ -1,7 +1,7 @@
 {"name" : "FOAMMOBP" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Pressure", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMMOBS
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMMOBS
@@ -1,7 +1,7 @@
 {"name" : "FOAMMOBS" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Length/Time", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GCVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GCVD
@@ -1,7 +1,7 @@
 {"name" : "GCVD" ,
  "sections" : ["SOLUTION"],
  "size" : {"keyword" : "EQLDIMS" , "item" : "NTEQUL"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Length" , "GasSurfaceVolume/Length*Length*Length"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GINODE
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GINODE
@@ -1,7 +1,7 @@
 {"name" : "GINODE" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/H/HDISP
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/H/HDISP
@@ -1,7 +1,7 @@
 {"name" : "HDISP" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Length" , "Length"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/IMPCVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/IMPCVD
@@ -1,7 +1,7 @@
 {"name" : "IMPCVD" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "ENDSCALE" , "item" : "NTENDP"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Length" , "Pressure", "Pressure"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/IMSPCVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/IMSPCVD
@@ -1,7 +1,7 @@
 {"name" : "IMSPCVD" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "ENDSCALE" , "item" : "NTENDP"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Length" , "1", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/L/LANGMUIR
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/L/LANGMUIR
@@ -1,7 +1,7 @@
 {"name" : "LANGMUIR" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "REGDIMS" , "item" : "NTCREG"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Pressure", "GasSurfaceVolume/Length*Length*Length", "GasSurfaceVolume/Length*Length*Length"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/L/LANGSOLV
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/L/LANGSOLV
@@ -1,7 +1,7 @@
 {"name" : "LANGSOLV" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "REGDIMS" , "item" : "NTCREG"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Pressure", "GasSurfaceVolume/Length*Length*Length"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/L/LSALTFNC
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/L/LSALTFNC
@@ -1,7 +1,7 @@
 {"name" : "LSALTFNC" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Pressure", "1", "1"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MSFN
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MSFN
@@ -1,5 +1,5 @@
 {"name" : "MSFN" , "sections" : ["PROPS"], "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
         "items" : [
-            {"name":"table", "value_type":"DOUBLE", "size_type" : "ALL", "dimension" : ["1","1","1"]}
+            {"name":"DATA", "value_type":"DOUBLE", "size_type" : "ALL", "dimension" : ["1","1","1"]}
          ]
 }

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/O/OVERBURD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/O/OVERBURD
@@ -1,5 +1,5 @@
 {"name" : "OVERBURD" , "sections" : ["PROPS"], "size" : {"keyword" : "ROCKCOMP" , "item" : "NTROCC"},
-        "items" : [{"name" : "table" ,
+        "items" : [{"name" : "DATA" ,
                    "value_type" : "DOUBLE" ,
                    "size_type" : "ALL",
                    "dimension" : ["Length" , "Pressure"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PBVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PBVD
@@ -1,5 +1,5 @@
 {"name" : "PBVD" , "sections" : ["SOLUTION"], "size" : {"keyword" : "EQLDIMS" , "item" : "NTEQUL"},
-        "items" : [{"name" : "table" ,
+        "items" : [{"name" : "DATA" ,
                    "value_type" : "DOUBLE" ,
                    "size_type" : "ALL",
                    "dimension" : ["Length" , "Pressure"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PDVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PDVD
@@ -1,5 +1,5 @@
 {"name" : "PDVD" , "sections" : ["SOLUTION"], "size" : {"keyword" : "EQLDIMS" , "item" : "NTEQUL"},
-        "items" : [{"name" : "table" ,
+        "items" : [{"name" : "DATA" ,
                    "value_type" : "DOUBLE" ,
                    "size_type" : "ALL",
                    "dimension" : ["Length" , "Pressure"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PEGTABX
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PEGTABX
@@ -12,7 +12,7 @@
                 "PEGTAB7"
         ],
  "size" : {"keyword" : "PEDIMS" , "item" : "NUM_REGIONS"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Pressure" , "Pressure"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PEKTABX
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PEKTABX
@@ -12,7 +12,7 @@
                 "PEKTAB7"
         ],
  "size" : {"keyword" : "PEDIMS" , "item" : "NUM_REGIONS"},
-"items" : [{"name" : "table" ,
+"items" : [{"name" : "DATA" ,
             "value_type" : "DOUBLE" ,
             "size_type" : "ALL",
             "dimension" : ["Pressure" , "Pressure"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PVDG
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PVDG
@@ -1,4 +1,4 @@
 {"name" : "PVDG" , "sections" : ["PROPS"], "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"} , "items" : [
-        {"name" : "data" , "size_type" : "ALL" , "value_type" : "DOUBLE"  , "dimension" : ["Pressure","OilDissolutionFactor","Viscosity"]}]}
+        {"name" : "DATA" , "size_type" : "ALL" , "value_type" : "DOUBLE"  , "dimension" : ["Pressure","OilDissolutionFactor","Viscosity"]}]}
 
 

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PVDO
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PVDO
@@ -1,2 +1,2 @@
 {"name" : "PVDO" , "sections" : ["PROPS"], "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"} , "items" : [
-        {"name" : "data" , "size_type" : "ALL" , "value_type" : "DOUBLE"  , "dimension" : ["Pressure","1","Viscosity"]}]}
+        {"name" : "DATA" , "size_type" : "ALL" , "value_type" : "DOUBLE"  , "dimension" : ["Pressure","1","Viscosity"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PVDS
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PVDS
@@ -1,4 +1,4 @@
 {"name" : "PVDS" , "sections" : ["PROPS"], "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"} , "items" : [
-        {"name" : "data" , "size_type" : "ALL" , "value_type" : "DOUBLE"  , "dimension" : ["Pressure","OilDissolutionFactor","Viscosity"]}]}
+        {"name" : "DATA" , "size_type" : "ALL" , "value_type" : "DOUBLE"  , "dimension" : ["Pressure","OilDissolutionFactor","Viscosity"]}]}
 
 

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/ROCKWNOD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/ROCKWNOD
@@ -1,5 +1,5 @@
 {"name" : "ROCKWNOD" , "sections" : ["PROPS"], "size" : {"keyword" : "ROCKCOMP" , "item" : "NTROCC"},
         "items" : [
-            {"name":"SATURATION", "value_type" : "DOUBLE", "size_type" : "ALL", "dimension":"1" }
+            {"name":"DATA", "value_type" : "DOUBLE", "size_type" : "ALL", "dimension":"1" }
          ]
 }

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RSVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RSVD
@@ -1,5 +1,5 @@
 {"name" : "RSVD" , "sections" : ["SOLUTION"], "size" : {"keyword" : "EQLDIMS" , "item" : "NTEQUL"},
-        "items" : [{"name" : "table" ,
+        "items" : [{"name" : "DATA" ,
                    "value_type" : "DOUBLE" ,
                    "size_type" : "ALL",
                    "dimension" : ["Length" , "GasDissolutionFactor"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RVVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RVVD
@@ -1,5 +1,5 @@
 {"name" : "RVVD" , "sections" : ["SOLUTION"], "size" : {"keyword" : "EQLDIMS" , "item" : "NTEQUL"},
-        "items" : [{"name" : "table" ,
+        "items" : [{"name" : "DATA" ,
                    "value_type" : "DOUBLE" ,
                    "size_type" : "ALL",
                    "dimension" : ["Length" , "OilDissolutionFactor"]}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGOF
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGOF
@@ -1,5 +1,5 @@
 {"name" : "SGOF" , "sections" : ["PROPS"], "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
         "items" : [
-            {"name":"table", "value_type":"DOUBLE", "size_type" : "ALL", "dimension" : ["1","1","1","Pressure"]}
+            {"name":"DATA", "value_type":"DOUBLE", "size_type" : "ALL", "dimension" : ["1","1","1","Pressure"]}
          ]
 }

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/T/TVDP
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/T/TVDP
@@ -6,7 +6,7 @@
   "keyword":"EQLDIMS" , "item":"NTTRVD"
  },
  "items" : [{
-  "name" : "table",
+  "name" : "DATA",
   "value_type" : "DOUBLE",
   "size_type" : "ALL",
   "dimension" : ["Length" , "1"]

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -166,10 +166,10 @@ BOOST_AUTO_TEST_CASE(DummyDefaultsString) {
     DeckItem deckStringItem("TEST", std::string() );
     BOOST_CHECK_EQUAL(deckStringItem.data_size(), 0);
 
-    deckStringItem.push_backDummyDefault();
-    BOOST_CHECK_EQUAL(deckStringItem.data_size(), 0);
+    deckStringItem.push_backDummyDefault<std::string>();
+    BOOST_CHECK_EQUAL(deckStringItem.data_size(), 1);
     BOOST_CHECK_EQUAL(true, deckStringItem.defaultApplied(0));
-    BOOST_CHECK_THROW(deckStringItem.get< std::string >(0), std::out_of_range);
+    BOOST_CHECK_THROW(deckStringItem.get< std::string >(0), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(GetStringAtIndex_NoData_ExceptionThrown) {
@@ -270,10 +270,10 @@ BOOST_AUTO_TEST_CASE(DummyDefaultsDouble) {
     DeckItem deckDoubleItem( "TEST", double(), dims.first, dims.second);
     BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 0);
 
-    deckDoubleItem.push_backDummyDefault();
-    BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 0);
+    deckDoubleItem.push_backDummyDefault<double>();
+    BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 1);
     BOOST_CHECK_EQUAL(true, deckDoubleItem.defaultApplied(0));
-    BOOST_CHECK_THROW(deckDoubleItem.get< double >(0), std::out_of_range);
+    BOOST_CHECK_THROW(deckDoubleItem.get< double >(0), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(PushBackMultipleDouble) {
@@ -344,12 +344,12 @@ BOOST_AUTO_TEST_CASE(DummyDefaultsInt) {
     DeckItem deckIntItem( "TEST", int() );
     BOOST_CHECK_EQUAL(deckIntItem.data_size(), 0);
 
-    deckIntItem.push_backDummyDefault();
-    BOOST_CHECK_EQUAL(deckIntItem.data_size(), 0);
+    deckIntItem.push_backDummyDefault<int>();
+    BOOST_CHECK_EQUAL(deckIntItem.data_size(), 1);
     BOOST_CHECK_EQUAL(true, deckIntItem.defaultApplied(0));
     BOOST_CHECK_EQUAL( false , deckIntItem.hasValue(0));
     BOOST_CHECK_EQUAL( false , deckIntItem.hasValue(1));
-    BOOST_CHECK_THROW(deckIntItem.get< int >(0), std::out_of_range);
+    BOOST_CHECK_THROW(deckIntItem.get< int >(0), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(GetIntAtIndex_NoData_ExceptionThrown) {

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -164,10 +164,10 @@ BOOST_AUTO_TEST_CASE(set_and_get_data_file) {
 
 BOOST_AUTO_TEST_CASE(DummyDefaultsString) {
     DeckItem deckStringItem("TEST", std::string() );
-    BOOST_CHECK_EQUAL(deckStringItem.size(), 0);
+    BOOST_CHECK_EQUAL(deckStringItem.data_size(), 0);
 
     deckStringItem.push_backDummyDefault();
-    BOOST_CHECK_EQUAL(deckStringItem.size(), 0);
+    BOOST_CHECK_EQUAL(deckStringItem.data_size(), 0);
     BOOST_CHECK_EQUAL(true, deckStringItem.defaultApplied(0));
     BOOST_CHECK_THROW(deckStringItem.get< std::string >(0), std::out_of_range);
 }
@@ -182,31 +182,31 @@ BOOST_AUTO_TEST_CASE(GetStringAtIndex_NoData_ExceptionThrown) {
 BOOST_AUTO_TEST_CASE(size_variouspushes_sizecorrect) {
     DeckItem deckStringItem( "TEST", std::string() );
 
-    BOOST_CHECK_EQUAL(0U, deckStringItem.size());
+    BOOST_CHECK_EQUAL(0U, deckStringItem.data_size());
     deckStringItem.push_back("WELL-3");
-    BOOST_CHECK_EQUAL(1U, deckStringItem.size());
+    BOOST_CHECK_EQUAL(1U, deckStringItem.data_size());
 
     deckStringItem.push_back("WELL-4");
     deckStringItem.push_back("WELL-5");
-    BOOST_CHECK_EQUAL(3U, deckStringItem.size());
+    BOOST_CHECK_EQUAL(3U, deckStringItem.data_size());
 }
 
 BOOST_AUTO_TEST_CASE(DefaultNotAppliedString) {
     DeckItem deckStringItem( "TEST", std::string() );
-    BOOST_CHECK( deckStringItem.size() == 0 );
+    BOOST_CHECK( deckStringItem.data_size() == 0 );
 
     deckStringItem.push_back( "FOO") ;
-    BOOST_CHECK( deckStringItem.size() == 1 );
+    BOOST_CHECK( deckStringItem.data_size() == 1 );
     BOOST_CHECK( deckStringItem.get< std::string >(0) == "FOO" );
     BOOST_CHECK( !deckStringItem.defaultApplied(0) );
 }
 
 BOOST_AUTO_TEST_CASE(DefaultAppliedString) {
     DeckItem deckStringItem( "TEST", std::string() );
-    BOOST_CHECK( deckStringItem.size() == 0 );
+    BOOST_CHECK( deckStringItem.data_size() == 0 );
 
     deckStringItem.push_backDefault( "FOO" );
-    BOOST_CHECK( deckStringItem.size() == 1 );
+    BOOST_CHECK( deckStringItem.data_size() == 1 );
     BOOST_CHECK( deckStringItem.get< std::string >(0) == "FOO" );
     BOOST_CHECK( deckStringItem.defaultApplied(0) );
 }
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(DefaultAppliedString) {
 BOOST_AUTO_TEST_CASE(PushBackMultipleString) {
     DeckItem stringItem( "TEST", std::string() );
     stringItem.push_back("Heisann ", 100U );
-    BOOST_CHECK_EQUAL( 100U , stringItem.size() );
+    BOOST_CHECK_EQUAL( 100U , stringItem.data_size() );
     for (size_t i=0; i < 100; i++)
         BOOST_CHECK_EQUAL("Heisann " , stringItem.get< std::string >(i));
 }
@@ -236,13 +236,13 @@ BOOST_AUTO_TEST_CASE(sizeDouble_correct) {
     auto dims = make_dims();
     DeckItem deckDoubleItem( "TEST", double(), dims.first, dims.second);
 
-    BOOST_CHECK_EQUAL( 0U , deckDoubleItem.size());
+    BOOST_CHECK_EQUAL( 0U , deckDoubleItem.data_size());
     deckDoubleItem.push_back( 100.0 );
-    BOOST_CHECK_EQUAL( 1U , deckDoubleItem.size());
+    BOOST_CHECK_EQUAL( 1U , deckDoubleItem.data_size());
 
     deckDoubleItem.push_back( 100.0 );
     deckDoubleItem.push_back( 100.0 );
-    BOOST_CHECK_EQUAL( 3U , deckDoubleItem.size());
+    BOOST_CHECK_EQUAL( 3U , deckDoubleItem.data_size());
 }
 
 
@@ -250,28 +250,28 @@ BOOST_AUTO_TEST_CASE(sizeDouble_correct) {
 BOOST_AUTO_TEST_CASE(SetInDeck) {
     auto dims = make_dims();
     DeckItem deckDoubleItem( "TEST", double(), dims.first, dims.second);
-    BOOST_CHECK( deckDoubleItem.size() == 0 );
+    BOOST_CHECK( deckDoubleItem.data_size() == 0 );
 
     deckDoubleItem.push_backDefault( 1.0 );
-    BOOST_CHECK( deckDoubleItem.size() == 1 );
+    BOOST_CHECK( deckDoubleItem.data_size() == 1 );
     BOOST_CHECK_EQUAL( true , deckDoubleItem.defaultApplied(0) );
 
     deckDoubleItem.push_back( 10.0 );
-    BOOST_CHECK( deckDoubleItem.size() == 2 );
+    BOOST_CHECK( deckDoubleItem.data_size() == 2 );
     BOOST_CHECK_EQUAL( false , deckDoubleItem.defaultApplied(1) );
 
     deckDoubleItem.push_backDefault( 1.0 );
-    BOOST_CHECK( deckDoubleItem.size() == 3 );
+    BOOST_CHECK( deckDoubleItem.data_size() == 3 );
     BOOST_CHECK_EQUAL( true , deckDoubleItem.defaultApplied(2) );
 }
 
 BOOST_AUTO_TEST_CASE(DummyDefaultsDouble) {
     auto dims = make_dims();
     DeckItem deckDoubleItem( "TEST", double(), dims.first, dims.second);
-    BOOST_CHECK_EQUAL(deckDoubleItem.size(), 0);
+    BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 0);
 
     deckDoubleItem.push_backDummyDefault();
-    BOOST_CHECK_EQUAL(deckDoubleItem.size(), 0);
+    BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 0);
     BOOST_CHECK_EQUAL(true, deckDoubleItem.defaultApplied(0));
     BOOST_CHECK_THROW(deckDoubleItem.get< double >(0), std::out_of_range);
 }
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(PushBackMultipleDouble) {
     auto dims = make_dims();
     DeckItem item( "HEI", double() , dims.first, dims.second);
     item.push_back(10.22 , 100 );
-    BOOST_CHECK_EQUAL( 100U , item.size() );
+    BOOST_CHECK_EQUAL( 100U , item.data_size() );
     for (size_t i=0; i < 100; i++)
         BOOST_CHECK_EQUAL(10.22 , item.get< double >(i));
 }
@@ -342,10 +342,10 @@ BOOST_AUTO_TEST_CASE(HasValue) {
 
 BOOST_AUTO_TEST_CASE(DummyDefaultsInt) {
     DeckItem deckIntItem( "TEST", int() );
-    BOOST_CHECK_EQUAL(deckIntItem.size(), 0);
+    BOOST_CHECK_EQUAL(deckIntItem.data_size(), 0);
 
     deckIntItem.push_backDummyDefault();
-    BOOST_CHECK_EQUAL(deckIntItem.size(), 0);
+    BOOST_CHECK_EQUAL(deckIntItem.data_size(), 0);
     BOOST_CHECK_EQUAL(true, deckIntItem.defaultApplied(0));
     BOOST_CHECK_EQUAL( false , deckIntItem.hasValue(0));
     BOOST_CHECK_EQUAL( false , deckIntItem.hasValue(1));
@@ -361,27 +361,27 @@ BOOST_AUTO_TEST_CASE(GetIntAtIndex_NoData_ExceptionThrown) {
 
 BOOST_AUTO_TEST_CASE(InitializeDefaultApplied) {
     DeckItem deckIntItem( "TEST", int() );
-    BOOST_CHECK( deckIntItem.size() == 0 );
+    BOOST_CHECK( deckIntItem.data_size() == 0 );
 }
 
 BOOST_AUTO_TEST_CASE(size_correct) {
     DeckItem deckIntItem( "TEST", int() );
 
-    BOOST_CHECK_EQUAL( 0U , deckIntItem.size());
+    BOOST_CHECK_EQUAL( 0U , deckIntItem.data_size());
     deckIntItem.push_back( 100 );
-    BOOST_CHECK_EQUAL( 1U , deckIntItem.size());
+    BOOST_CHECK_EQUAL( 1U , deckIntItem.data_size());
 
     deckIntItem.push_back( 100 );
     deckIntItem.push_back( 100 );
-    BOOST_CHECK_EQUAL( 3U , deckIntItem.size());
+    BOOST_CHECK_EQUAL( 3U , deckIntItem.data_size());
 }
 
 BOOST_AUTO_TEST_CASE(DefaultNotAppliedInt) {
     DeckItem deckIntItem( "TEST", int() );
-    BOOST_CHECK( deckIntItem.size() == 0 );
+    BOOST_CHECK( deckIntItem.data_size() == 0 );
 
     deckIntItem.push_back( 100 );
-    BOOST_CHECK( deckIntItem.size() == 1 );
+    BOOST_CHECK( deckIntItem.data_size() == 1 );
     BOOST_CHECK( deckIntItem.get< int >(0) == 100 );
     BOOST_CHECK( !deckIntItem.defaultApplied(0) );
 
@@ -403,24 +403,24 @@ BOOST_AUTO_TEST_CASE(UseDefault) {
 
 BOOST_AUTO_TEST_CASE(DefaultAppliedInt) {
     DeckItem deckIntItem( "TEST", int() );
-    BOOST_CHECK( deckIntItem.size() == 0 );
+    BOOST_CHECK( deckIntItem.data_size() == 0 );
 
     deckIntItem.push_backDefault( 100 );
-    BOOST_CHECK( deckIntItem.size() == 1 );
+    BOOST_CHECK( deckIntItem.data_size() == 1 );
     BOOST_CHECK( deckIntItem.get< int >(0) == 100 );
     BOOST_CHECK( deckIntItem.defaultApplied(0) );
     deckIntItem.push_back( 10 );
     BOOST_CHECK_EQUAL( false, deckIntItem.defaultApplied(1) );
     deckIntItem.push_backDefault( 1 );
     BOOST_CHECK_EQUAL( true , deckIntItem.defaultApplied(2) );
-    BOOST_CHECK_EQUAL( 3 , deckIntItem.size() );
+    BOOST_CHECK_EQUAL( 3 , deckIntItem.data_size() );
 }
 
 
 BOOST_AUTO_TEST_CASE(PushBackMultipleInt) {
     DeckItem item( "HEI", int() );
     item.push_back(10 , 100U );
-    BOOST_CHECK_EQUAL( 100U , item.size() );
+    BOOST_CHECK_EQUAL( 100U , item.data_size() );
     for (size_t i=0; i < 100; i++)
         BOOST_CHECK_EQUAL(10 , item.get< int >(i));
 }

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1247,7 +1247,7 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooFewItems) {
     BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord, unit_system, unit_system, "KEWYORD", "filename"));
     auto record = parserRecord.parse(parseContext, errors , rawRecord, unit_system, unit_system, "KEYWORD", "filename");
     BOOST_CHECK_NO_THROW(record.getItem(2));
-    BOOST_CHECK_THROW(record.getItem(2).get< int >(0), std::out_of_range);
+    BOOST_CHECK_THROW(record.getItem(2).get< int >(0), std::invalid_argument);
 }
 
 

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE(Scan_All_CorrectIntSetInDeckItem) {
     RawRecord rawRecord( "100 443 10*77 10*1 25" );
     UnitSystem unit_system;
     const auto deckIntItem = itemInt.scan(rawRecord, unit_system, unit_system);
-    BOOST_CHECK_EQUAL(23U, deckIntItem.size());
+    BOOST_CHECK_EQUAL(23U, deckIntItem.data_size());
     BOOST_CHECK_EQUAL(77,  deckIntItem.get< int >(3));
     BOOST_CHECK_EQUAL(1,   deckIntItem.get< int >(21));
     BOOST_CHECK_EQUAL(25,  deckIntItem.get< int >(22));
@@ -662,7 +662,7 @@ BOOST_AUTO_TEST_CASE(Scan_All_WithDefaults) {
     RawRecord rawRecord( "100 10* 10*1 25" );
     UnitSystem unit_system;
     const auto deckIntItem = itemInt.scan(rawRecord, unit_system, unit_system);
-    BOOST_CHECK_EQUAL(22U, deckIntItem.size());
+    BOOST_CHECK_EQUAL(22U, deckIntItem.data_size());
     BOOST_CHECK(!deckIntItem.defaultApplied(0));
     BOOST_CHECK( deckIntItem.defaultApplied(1));
     BOOST_CHECK(!deckIntItem.defaultApplied(11));
@@ -848,7 +848,7 @@ BOOST_AUTO_TEST_CASE(scan_all_valuesCorrect) {
     UnitSystem unit_system;
     itemString.setSizeType( ParserItem::item_size::ALL );
     const auto deckItem = itemString.scan(rawRecord, unit_system, unit_system);
-    BOOST_CHECK_EQUAL(8U, deckItem.size());
+    BOOST_CHECK_EQUAL(8U, deckItem.data_size());
 
     BOOST_CHECK_EQUAL("WELL1", deckItem.get< std::string >(0));
     BOOST_CHECK_EQUAL("FISK", deckItem.get< std::string >(1));
@@ -868,7 +868,7 @@ BOOST_AUTO_TEST_CASE(scan_all_withdefaults) {
     itemString.setSizeType( ParserItem::item_size::ALL );
     const auto deckItem = itemString.scan(rawRecord, unit_system, unit_system);
 
-    BOOST_CHECK_EQUAL(30U, deckItem.size());
+    BOOST_CHECK_EQUAL(30U, deckItem.data_size());
 
     BOOST_CHECK( !deckItem.defaultApplied(0) );
     BOOST_CHECK( !deckItem.defaultApplied(9) );
@@ -891,7 +891,6 @@ BOOST_AUTO_TEST_CASE(scan_single_dataCorrect) {
     RawRecord rawRecord( "'WELL1' 'WELL2'" );
     UnitSystem unit_system;
     const auto deckItem = itemString.scan(rawRecord, unit_system, unit_system);
-    BOOST_CHECK_EQUAL(1U, deckItem.size());
     BOOST_CHECK_EQUAL("WELL1", deckItem.get< std::string >(0));
 }
 
@@ -1144,10 +1143,6 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
         const auto& deckIntItem = itemInt.scan(rawRecord, unit_system, unit_system);
         const auto& deckDoubleItem = itemDouble.scan(rawRecord, unit_system, unit_system);
 
-        BOOST_CHECK(deckStringItem.size() == 1);
-        BOOST_CHECK(deckIntItem.size() == 1);
-        BOOST_CHECK(deckDoubleItem.size() == 1);
-
         BOOST_CHECK(deckStringItem.defaultApplied(0));
         BOOST_CHECK(deckIntItem.defaultApplied(0));
         BOOST_CHECK(deckDoubleItem.defaultApplied(0));
@@ -1159,10 +1154,6 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
         const auto deckStringItem = itemString.scan(rawRecord, unit_system, unit_system);
         const auto deckIntItem = itemInt.scan(rawRecord, unit_system, unit_system);
         const auto deckDoubleItem = itemDouble.scan(rawRecord, unit_system, unit_system);
-
-        BOOST_CHECK_EQUAL(deckStringItem.size(), 1);
-        BOOST_CHECK_EQUAL(deckIntItem.size(), 1);
-        BOOST_CHECK_EQUAL(deckDoubleItem.size(), 1);
 
         BOOST_CHECK(deckStringItem.defaultApplied(0));
         BOOST_CHECK(deckIntItem.defaultApplied(0));
@@ -1180,10 +1171,6 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
         const auto& deckIntItem = itemInt.scan(rawRecord, unit_system, unit_system);
         const auto& deckDoubleItem = itemDouble.scan(rawRecord, unit_system, unit_system);
 
-        BOOST_CHECK_EQUAL(deckStringItem.size(), 1);
-        BOOST_CHECK_EQUAL(deckIntItem.size(), 1);
-        BOOST_CHECK_EQUAL(deckDoubleItem.size(), 1);
-
         BOOST_CHECK(!deckStringItem.defaultApplied(0));
         BOOST_CHECK(!deckIntItem.defaultApplied(0));
         BOOST_CHECK(!deckDoubleItem.defaultApplied(0));
@@ -1197,10 +1184,6 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
         const auto deckIntItem = itemInt.scan(rawRecord, unit_system, unit_system);
         const auto deckDoubleItem = itemDouble.scan(rawRecord, unit_system, unit_system);
 
-        BOOST_CHECK_EQUAL(deckStringItem.size(), 1);
-        BOOST_CHECK_EQUAL(deckIntItem.size(), 1);
-        BOOST_CHECK_EQUAL(deckDoubleItem.size(), 1);
-
         BOOST_CHECK(deckStringItem.defaultApplied(0));
         BOOST_CHECK(deckIntItem.defaultApplied(0));
         BOOST_CHECK(deckDoubleItem.defaultApplied(0));
@@ -1212,10 +1195,6 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
         const auto deckStringItem = itemString.scan(rawRecord, unit_system, unit_system);
         const auto deckIntItem = itemInt.scan(rawRecord, unit_system, unit_system);
         const auto deckDoubleItem = itemDouble.scan(rawRecord, unit_system, unit_system);
-
-        BOOST_CHECK_EQUAL(deckStringItem.size(), 1);
-        BOOST_CHECK_EQUAL(deckIntItem.size(), 1);
-        BOOST_CHECK_EQUAL(deckDoubleItem.size(), 1);
 
         BOOST_CHECK(deckStringItem.defaultApplied(0));
         BOOST_CHECK(deckIntItem.defaultApplied(0));
@@ -1653,8 +1632,6 @@ BOOST_AUTO_TEST_CASE(ParseEmptyRecord) {
 
     const auto& deckRecord = deckKeyword.getRecord(0);
     BOOST_REQUIRE_EQUAL( 1U , deckRecord.size());
-
-    BOOST_CHECK_EQUAL(0U , deckRecord.getItem( 0 ).size());
 }
 
 
@@ -1945,9 +1922,6 @@ DENSITY
     BOOST_CHECK_EQUAL( rs.name( ), "RS" );
     BOOST_CHECK_EQUAL( pbub.name( ), "PB" );
 
-    BOOST_CHECK_EQUAL( rs.size( ), 1 );
-    BOOST_CHECK_EQUAL( pbub.size( ), 1 );
-
     BOOST_CHECK( ! rs.defaultApplied( 0 ) );
     BOOST_CHECK( ! pbub.defaultApplied( 0 ) );
 
@@ -1994,9 +1968,6 @@ DENSITY
 
     BOOST_CHECK_EQUAL( rs.name( ), "RS" );
     BOOST_CHECK_EQUAL( pbub.name( ), "PB" );
-
-    BOOST_CHECK_EQUAL( rs.size( ), 0 );
-    BOOST_CHECK_EQUAL( pbub.size( ), 0 );
 
     BOOST_CHECK( rs.defaultApplied( 0 ) );
     BOOST_CHECK( pbub.defaultApplied( 0 ) );
@@ -2082,9 +2053,6 @@ DENSITY
         BOOST_CHECK_EQUAL( rs.name( ), "RS_CONSTT" );
         BOOST_CHECK_EQUAL( pbub.name( ), "PB_CONSTT" );
 
-        BOOST_CHECK_EQUAL( rs.size( ), 1 );
-        BOOST_CHECK_EQUAL( pbub.size( ), 1 );
-
         BOOST_CHECK( ! rs.defaultApplied( 0 ) );
         BOOST_CHECK( ! pbub.defaultApplied( 0 ) );
 
@@ -2105,9 +2073,6 @@ DENSITY
 
         BOOST_CHECK_EQUAL( rs.name( ), "RS_CONSTT" );
         BOOST_CHECK_EQUAL( pbub.name( ), "PB_CONSTT" );
-
-        BOOST_CHECK_EQUAL( rs.size( ), 1 );
-        BOOST_CHECK_EQUAL( pbub.size( ), 1 );
 
         BOOST_CHECK( ! rs.defaultApplied( 0 ) );
         BOOST_CHECK( ! pbub.defaultApplied( 0 ) );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1099,7 +1099,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException2) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Runspec runspec (deck);
-    BOOST_CHECK_THROW(Schedule(deck, grid , eclipseProperties, runspec), std::out_of_range);
+    BOOST_CHECK_THROW(Schedule(deck, grid , eclipseProperties, runspec), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(createDeckWithWPIMULT) {

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -1012,7 +1012,7 @@ VFPPROD \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::out_of_range);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
     }
 
 

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -731,10 +731,10 @@ BOOST_AUTO_TEST_CASE( RSVD ) {
     const auto& rec1 = kw1.getRecord(0);
     const auto& rec3 = kw1.getRecord(2);
 
-    const auto& item1       = rec1.getItem("table");
+    const auto& item1       = rec1.getItem("DATA");
     BOOST_CHECK( fabs(item1.getSIDouble(0) - 2382) < 0.001);
 
-    const auto& item3       = rec3.getItem("table");
+    const auto& item3       = rec3.getItem("DATA");
     BOOST_CHECK( fabs(item3.getSIDouble(7) - 106.77) < 0.001);
 }
 
@@ -775,21 +775,18 @@ PVTG
 
     const auto& item0_0 = record0.getItem("GAS_PRESSURE");
     const auto& item0_1 = record0.getItem("DATA");
-    BOOST_CHECK_EQUAL(1U , item0_0.size());
-    BOOST_CHECK_EQUAL(9U , item0_1.size());
-    BOOST_CHECK_EQUAL(2U , record0.size());
+    BOOST_CHECK(item0_0.hasValue(0));
+    BOOST_CHECK_EQUAL(9U , item0_1.data_size());
 
     const auto& item1_0 = record1.getItem("GAS_PRESSURE");
     const auto& item1_1 = record1.getItem("DATA");
-    BOOST_CHECK_EQUAL(1U , item1_0.size());
-    BOOST_CHECK_EQUAL(9U , item1_1.size());
-    BOOST_CHECK_EQUAL(2U , record1.size());
+    BOOST_CHECK(item1_0.hasValue(0));
+    BOOST_CHECK_EQUAL(9U , item1_1.data_size());
 
     const auto& item2_0 = record2.getItem("GAS_PRESSURE");
     const auto& item2_1 = record2.getItem("DATA");
     BOOST_CHECK( item2_0.defaultApplied(0));
-    BOOST_CHECK_EQUAL(0U , item2_1.size());
-    BOOST_CHECK_EQUAL(2U , record2.size());
+    BOOST_CHECK_EQUAL(0U , item2_1.data_size());
 
 
     const auto& item3_0 = record3.getItem("GAS_PRESSURE");
@@ -800,16 +797,14 @@ PVTG
     BOOST_CHECK( !item3_1.defaultApplied(3));
     BOOST_CHECK( item3_1.defaultApplied(4));
     BOOST_CHECK( !item3_1.defaultApplied(5));
-    BOOST_CHECK_EQUAL(1U , item3_0.size());
-    BOOST_CHECK_EQUAL(9U , item3_1.size());
-    BOOST_CHECK_EQUAL(2U , record3.size());
+    BOOST_CHECK(item3_0.hasValue(0));
+    BOOST_CHECK_EQUAL(9U , item3_1.data_size());
 
 
     const auto& item4_0 = record4.getItem("GAS_PRESSURE");
     const auto& item4_1 = record4.getItem("DATA");
-    BOOST_CHECK_EQUAL(1U , item4_0.size());
-    BOOST_CHECK_EQUAL(9U , item4_1.size());
-    BOOST_CHECK_EQUAL(2U , record4.size());
+    BOOST_CHECK(item4_0.hasValue(0));
+    BOOST_CHECK_EQUAL(9U , item4_1.data_size());
 
     /*
     {
@@ -872,32 +867,32 @@ PVTO
 
     const auto& item0_0 = record0.getItem("RS");
     const auto& item0_1 = record0.getItem("DATA");
-    BOOST_CHECK_EQUAL(1U , item0_0.size());
-    BOOST_CHECK_EQUAL(9U , item0_1.size());
+    BOOST_CHECK(item0_0.hasValue(0));
+    BOOST_CHECK_EQUAL(9U , item0_1.data_size());
     BOOST_CHECK_EQUAL(2U , record0.size());
 
     const auto& item1_0 = record1.getItem("RS");
     const auto& item1_1 = record1.getItem("DATA");
-    BOOST_CHECK_EQUAL(1U , item1_0.size());
-    BOOST_CHECK_EQUAL(9U , item1_1.size());
+    BOOST_CHECK(item1_0.hasValue(0));
+    BOOST_CHECK_EQUAL(9U , item1_1.data_size());
     BOOST_CHECK_EQUAL(2U , record1.size());
 
     const auto& item2_0 = record2.getItem("RS");
     const auto& item2_1 = record2.getItem("DATA");
     BOOST_CHECK(item2_0.defaultApplied(0));
-    BOOST_CHECK_EQUAL(0U , item2_1.size());
+    BOOST_CHECK_EQUAL(0U , item2_1.data_size());
     BOOST_CHECK_EQUAL(2U , record2.size());
 
     const auto& item3_0 = record3.getItem("RS");
     const auto& item3_1 = record3.getItem("DATA");
-    BOOST_CHECK_EQUAL(1U , item3_0.size());
-    BOOST_CHECK_EQUAL(9U , item3_1.size());
+    BOOST_CHECK(item3_0.hasValue(0));
+    BOOST_CHECK_EQUAL(9U , item3_1.data_size());
     BOOST_CHECK_EQUAL(2U , record3.size());
 
     const auto& item4_0 = record4.getItem("RS");
     const auto& item4_1 = record4.getItem("DATA");
-    BOOST_CHECK_EQUAL(1U , item4_0.size());
-    BOOST_CHECK_EQUAL(9U , item4_1.size());
+    BOOST_CHECK(item4_0.hasValue(0));
+    BOOST_CHECK_EQUAL(9U , item4_1.data_size());
     BOOST_CHECK_EQUAL(2U , record4.size());
 
 
@@ -945,7 +940,7 @@ SGOF
     const auto& record0 = kw1.getRecord(0);
     BOOST_CHECK_EQUAL(1U , record0.size());
     const auto& item0 = record0.getItem(0);
-    BOOST_CHECK_EQUAL(10U * 4, item0.size());
+    BOOST_CHECK_EQUAL(10U * 4, item0.data_size());
 
     Opm::SgofTable sgofTable(deck.getKeyword("SGOF").getRecord(0).getItem(0), false);
     BOOST_CHECK_EQUAL(10U, sgofTable.getSgColumn().size());
@@ -983,7 +978,7 @@ SWOF
     const auto& item0 = record0.getItem(0);
     BOOST_CHECK_EQUAL(1U , kw1.size());
     BOOST_CHECK_EQUAL(1U , record0.size());
-    BOOST_CHECK_EQUAL(10U * 4, item0.size());
+    BOOST_CHECK_EQUAL(10U * 4, item0.data_size());
 
     Opm::SwofTable swofTable(deck.getKeyword("SWOF").getRecord(0).getItem(0), false);
     BOOST_CHECK_EQUAL(10U, swofTable.getSwColumn().size());
@@ -1039,7 +1034,7 @@ SLGOF
     const auto& item0 = record0.getItem(0);
     BOOST_CHECK_EQUAL(1U , kw1.size());
     BOOST_CHECK_EQUAL(1U , record0.size());
-    BOOST_CHECK_EQUAL(10U * 4, item0.size());
+    BOOST_CHECK_EQUAL(10U * 4, item0.data_size());
 
     Opm::SlgofTable slgofTable( deck.getKeyword("SLGOF").getRecord(0).getItem(0), false );
     BOOST_CHECK_EQUAL(10U, slgofTable.getSlColumn().size());
@@ -1169,7 +1164,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
         const auto& record = VFPPROD1.getRecord(1);
         const auto& item = record.getItem("FLOW_VALUES");
 
-        BOOST_CHECK_EQUAL( item.size() , 12 );
+        BOOST_CHECK_EQUAL( item.data_size() , 12 );
         BOOST_CHECK_EQUAL( item.get< double >(0)  ,   100 );
         BOOST_CHECK_EQUAL( item.get< double >(11) , 20000 );
     }
@@ -1178,7 +1173,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
         const auto& record = VFPPROD1.getRecord(2);
         const auto& item = record.getItem("THP_VALUES");
 
-        BOOST_CHECK_EQUAL( item.size() , 7 );
+        BOOST_CHECK_EQUAL( item.data_size() , 7 );
         BOOST_CHECK_CLOSE( item.get< double >(0)  , 16.01 , 0.0001 );
         BOOST_CHECK_CLOSE( item.get< double >(6) ,  61.01 , 0.0001 );
     }
@@ -1187,7 +1182,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
         const auto& record = VFPPROD1.getRecord(3);
         const auto& item = record.getItem("WFR_VALUES");
 
-        BOOST_CHECK_EQUAL( item.size() , 9 );
+        BOOST_CHECK_EQUAL( item.data_size() , 9 );
         BOOST_CHECK_CLOSE( item.get< double >(1)  , 0.1 , 0.0001 );
         BOOST_CHECK_CLOSE( item.get< double >(7) ,  0.9 , 0.0001 );
     }
@@ -1196,7 +1191,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
         const auto& record = VFPPROD1.getRecord(4);
         const auto& item = record.getItem("GFR_VALUES");
 
-        BOOST_CHECK_EQUAL( item.size() , 9 );
+        BOOST_CHECK_EQUAL( item.data_size() , 9 );
         BOOST_CHECK_EQUAL( item.get< double >(0)  ,   90 );
         BOOST_CHECK_EQUAL( item.get< double >(8) , 10000 );
     }
@@ -1205,7 +1200,7 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
         const auto& record = VFPPROD1.getRecord(5);
         const auto& item = record.getItem("ALQ_VALUES");
 
-        BOOST_CHECK_EQUAL( item.size() , 1 );
+        BOOST_CHECK_EQUAL( item.data_size() , 1 );
         BOOST_CHECK_EQUAL( item.get< double >(0)  ,   0 );
     }
 
@@ -1214,28 +1209,28 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
 
         {
             const auto& item = record.getItem("THP_INDEX");
-            BOOST_CHECK_EQUAL( item.size() , 1 );
+            BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
 
         {
             const auto& item = record.getItem("WFR_INDEX");
-            BOOST_CHECK_EQUAL( item.size() , 1 );
+            BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
         {
             const auto& item = record.getItem("GFR_INDEX");
-            BOOST_CHECK_EQUAL( item.size() , 1 );
+            BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
         {
             const auto& item = record.getItem("ALQ_INDEX");
-            BOOST_CHECK_EQUAL( item.size() , 1 );
+            BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
         {
             const auto& item = record.getItem("VALUES");
-            BOOST_CHECK_EQUAL( item.size() , 12 );
+            BOOST_CHECK_EQUAL( item.data_size() , 12 );
             BOOST_CHECK_EQUAL( item.get< double >(0) , 44.85 );
             BOOST_CHECK_EQUAL( item.get< double >(11) , 115.14 );
         }
@@ -1245,27 +1240,27 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
         const auto& record = VFPPROD1.getRecord(572);
         {
             const auto& item = record.getItem("THP_INDEX");
-            BOOST_CHECK_EQUAL( item.size() , 1 );
+            BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 7 );
         }
         {
             const auto& item = record.getItem("WFR_INDEX");
-            BOOST_CHECK_EQUAL( item.size() , 1 );
+            BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 9 );
         }
         {
             const auto& item = record.getItem("GFR_INDEX");
-            BOOST_CHECK_EQUAL( item.size() , 1 );
+            BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 9 );
         }
         {
             const auto& item = record.getItem("ALQ_INDEX");
-            BOOST_CHECK_EQUAL( item.size() , 1 );
+            BOOST_CHECK( item.hasValue(0));
             BOOST_CHECK_EQUAL( item.get< int >(0) , 1 );
         }
         {
             const auto& item = record.getItem("VALUES");
-            BOOST_CHECK_EQUAL( item.size() , 12 );
+            BOOST_CHECK_EQUAL( item.data_size() , 12 );
             BOOST_CHECK_EQUAL( item.get< double >(0) , 100.80 );
             BOOST_CHECK_EQUAL( item.get< double >(11) , 147.79 );
         }


### PR DESCRIPTION
The deck datastructures are organized in a hierarchy: `Deck, DeckKeyword, DeckRecord, DeckItem` where the actual data is in the `DeckItem` type. When originally implemented the intention was that the `DeckItem` type could contain a configurable / variable number of items and all actual data storage was organized around a `std::vector<T>` type.

As things have turned out the `DeckItem`either contain exactly one item - which might be defaulted, or it can contain all the elements found in the - i.e. for the `PORO` keyword and the various tables[1]. In current master the `DeckItem::size()` method is used in two different ways:

**Single element:** Check if the item has been set with a valid in the the deck:
```C++
if (item.size() > 0) {
    // Have a value
}  else {
   // Don't have a value
}
```

**Data container:** Check how many elements are in the deck (fictous example):
```C++
if (poro_item.size() != nx*ny*nz)
    throw std::invalid_argument("PORO keyword must have exactly: nx*ny*nz elements");
```
These two ways of using the `::size()`method are semantically quite different. In this PR the first type of calls is replaced with `item.hasValue(0)` - and for the latter callsites the renamed `data( )` &rightarrow; `data_size( )` is used.

The motivation for this is default handling of 3D keywords, which again is part of 3D refactoring.

Downstream: https://github.com/OPM/opm-material/pull/360

[1]: Some future PR might utilize this - and use a scalar storage type for the common case of scalar data - so we do not have to pass argument '0' to all the `DeckItem::getXXX(0)` methods - but that is for another day.