### PR TITLE
added some 'special' keywords. Reorganized list of 'special' keywords.

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/COALNUM
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/COALNUM
@@ -1,0 +1,1 @@
+{"name" : "COALNUM" , "sections" : ["GRID"], "data" : {"value_type" : "INT"}}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFCN
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/F/FOAMFCN
@@ -1,7 +1,7 @@
 {"name" : "FOAMFCN" ,
  "sections" : ["PROPS"],
  "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
-"items" : [{"name" : "DATA" ,
-            "value_type" : "DOUBLE" ,
-            "size_type" : "ALL",
-            "dimension" : ["1", "1"]}]}
+ "items" : [
+                {"name" : "CAPILLARY_NUMBER", "value_type" : "INT"},
+                {"name" : "EXP", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1.0}
+]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GCONPRI
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GCONPRI
@@ -1,0 +1,19 @@
+{"name" : "GCONPRI" , "sections" : ["SCHEDULE"], "items" : [
+        {"name" : "GROUP" , "value_type" : "STRING" },
+        {"name" : "OIL_PROD_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "LiquidSurfaceVolume/Time", "default" : 1e200},
+        {"name" : "PROCEDURE_OIL_LIMIT" , "value_type" : "STRING", "default" : "NONE"},
+        {"name" : "WAT_PROD_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "LiquidSurfaceVolume/Time", "default" : 1e200},
+        {"name" : "PROCEDURE_WAT_LIMIT" , "value_type" : "STRING", "default" : "NONE"},
+        {"name" : "GAS_PROD_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "GasSurfaceVolume/Time", "default" : 1e200},
+        {"name" : "PROCEDURE_GAS_LIMIT" , "value_type" : "STRING", "default" : "NONE"},
+        {"name" : "LIQ_PROD_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "LiquidSurfaceVolume/Time", "default" : 1e200},
+        {"name" : "PROCEDURE_LIQ_LIMIT" , "value_type" : "STRING", "default" : "NONE"},
+        {"name" : "RES_FLUID_PROD_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "ReservoirVolume/Time", "default" : 1e200},
+        {"name" : "RES_VOL_BALANCING_FRAC_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "1", "default" : 1e200},
+        {"name" : "WET_GAS_PROD_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "GasSurfaceVolume/Time", "default" : 1e200},
+        {"name" : "PROCEDURE_WET_GAS_LIMIT" , "value_type" : "STRING", "default" : "NONE"},
+        {"name" : "SURF_GAS_BALANCING_FRAC_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "1", "default" : 1e200},
+        {"name" : "SURF_WAT_BALANCING_FRAC_UPPER_LIMIT" , "value_type" : "UDA", "dimension" : "1", "default" : 1e200},
+        {"name" : "UPPER_LIMIT" , "value_type" : "UDA", "default" : 1e200},
+        {"name" : "PROCEDURE_LIMIT" , "value_type" : "STRING", "default" : "NONE"}    
+]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GIALL
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GIALL
@@ -1,0 +1,8 @@
+{"name" : "GIALL" ,
+ "sections" : ["PROPS"],
+ "size" : {"keyword" : "TABDIMS" , "item" : "NTPVT"},
+"items" : [
+                {"name" : "PRESSURE", "value_type" : "DOUBLE", "dimension" : "Pressure"},
+                {"name" : "TABLE" ,  "value_type" : "DOUBLE" , "size_type" : "ALL", "dimension" : ["1", "1", "1", "1"]}
+          ]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MASSFLOW
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MASSFLOW
@@ -1,0 +1,3 @@
+{"name" : "MASSFLOW" , "sections" : ["PROPS"], "items" : [
+        {"name" : "WORD" , "value_type" : "STRING", "size_type" : "ALL"}
+]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MESSAGE
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MESSAGE
@@ -1,0 +1,2 @@
+{"name" : "MESSAGE" , "sections" : ["RUNSPEC", "GRID", "EDIT", "PROPS", "REGIONS", "SOLUTION", "SUMMARY", "SCHEDULE"], "size" : 1 , "items" : [
+    {"name" : "MessageText"   , "value_type" : "STRING", "size_type" : "ALL"}]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PARAOPTS
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PARAOPTS
@@ -1,0 +1,11 @@
+{"name" : "PARAOPTS" , "sections" : ["GRID"], "size" : 1, "items" : [
+        {"name" : "METHOD" , "value_type" : "STRING", "default" : "TREE" },
+        {"name" : "SET_PRINT" , "value_type" : "INT", "default" : 0 },
+        {"name" : "SIZE" , "value_type" : "INT", "default" : 0 },
+        {"name" : "NUM_BUFFERS" , "value_type" : "INT", "default" : 2 },
+        {"name" : "VALUE_MEM" , "value_type" : "INT", "default" : 0 },
+        {"name" : "VALUE_COARSE" , "value_type" : "INT", "default" : 0 },
+        {"name" : "VALUE_NNC" , "value_type" : "INT", "default" : 0 },
+        {"name" : "VALUE_PRT_FILE" , "value_type" : "INT", "default" : 1 },
+        {"name" : "RESERVED" , "value_type" : "STRING"}
+]}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PCG32D
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PCG32D
@@ -1,0 +1,5 @@
+{"name" : "PCG32D" , "sections" : ["PROPS"], "num_tables" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
+        "items" : [
+            {"name":"SOME_DATA", "value_type":"DOUBLE", "size_type" : "ALL"}
+         ]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PCW32D
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PCW32D
@@ -1,0 +1,5 @@
+{"name" : "PCW32D" , "sections" : ["PROPS"], "num_tables" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
+        "items" : [
+            {"name":"SOME_DATA", "value_type":"DOUBLE", "size_type" : "ALL"}
+         ]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RPTRST
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RPTRST
@@ -1,2 +1,2 @@
-{"name" : "RPTRST", "sections" : ["SOLUTION", "SCHEDULE"], "size" : 1, "items" : [
+{"name" : "RPTRST", "sections" : ["SOLUTION", "SCHEDULE"], "deck_name" : ["OUTSOL"], "size" : 1, "items" : [
     {"name" : "MNEMONIC_LIST" , "size_type" : "ALL" , "value_type" : "STRING"}]}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -10,28 +10,20 @@
 # the file: opm/autodiff/MissingFeatures.cpp
 
 #Some keywords are found to be of 'special' structure:
-#W             WHAT
-#ECONT         Terminates with two /
-#COALNUM       matrix structure
-#DYNAMICR      records of records
-#FIP           prefix to a possible user-defined longer keyword.
-#              e.g. FIPXAREA or FIPYAREA
-#FOAMFCN       records of records
-#GCONPRI       Eclipse300 specific items
-#GCUTBACT      records of records
-#GECONT        records of records
-#GIALL         records of tables
-#MASSFLOW      tables w/ int, double, str
-#MESSAGE       record without slash
-#MPFNNC        records of records
-#OUTSOL        old kw without explanation
-#PARAOPTS      typeless item (reserved)
-#PCG32D        2 types of tables/records, first size fixed but not always 1
-#PCW32D        2 types of tables/records, first size fixed but not always 1
-#PVZG          2 types of tables/records
-#PVTWSALT      2 types of tables/records
-#UDT
-#STOG, STOW, STWG    records of records
+#These are grouped as:
+#
+#    Double records:
+#       CECONT: note that this also has two types of records
+#       DYNAMICS: note that this also has two types of records
+#       GCUTBACT: note that this also has two types of records
+#       GECONT: note that this also has two types of records
+#       MPFNNC: note that this also has two types of records
+#       UDT: user defined table
+#
+#    Alternating record types
+#       PVZG
+#       PVTSALT
+#       STOG, STOW, STWG
 
 set( keywords
      000_Eclipse100/A/ACTDIMS
@@ -93,6 +85,7 @@ set( keywords
      000_Eclipse100/C/CECON
      000_Eclipse100/C/COAL
      000_Eclipse100/C/COALADS
+     000_Eclipse100/C/COALNUM
      000_Eclipse100/C/COALPP
      000_Eclipse100/C/COARSEN
      000_Eclipse100/C/COLLAPSE
@@ -276,6 +269,7 @@ set( keywords
      000_Eclipse100/G/GCONCAL
      000_Eclipse100/G/GCONENG
      000_Eclipse100/G/GCONINJE
+     000_Eclipse100/G/GCONPRI
      000_Eclipse100/G/GCONPROD
      000_Eclipse100/G/GCONSALE
      000_Eclipse100/G/GCONSUMP
@@ -292,6 +286,7 @@ set( keywords
      000_Eclipse100/G/GEFAC
      000_Eclipse100/G/GETGLOB
      000_Eclipse100/G/GI
+     000_Eclipse100/G/GIALL
      000_Eclipse100/G/GIMODEL
      000_Eclipse100/G/GINODE
      000_Eclipse100/G/GLIFTLIM
@@ -463,9 +458,11 @@ set( keywords
      000_Eclipse100/L/LZ
      000_Eclipse100/M/MAPAXES
      000_Eclipse100/M/MAPUNITS
+     000_Eclipse100/M/MASSFLOW
      000_Eclipse100/M/MATCORR
      000_Eclipse100/M/MAXVALUE
      000_Eclipse100/M/MEMORY
+     000_Eclipse100/M/MESSAGE
      000_Eclipse100/M/MESSAGES
      000_Eclipse100/M/MESSOPTS
      000_Eclipse100/M/MESSSRVC
@@ -555,12 +552,15 @@ set( keywords
      000_Eclipse100/O/OUTRAD
      000_Eclipse100/O/OVERBURD
      000_Eclipse100/P/PARALLEL
+     000_Eclipse100/P/PARAOPTS
      000_Eclipse100/P/PARTTRAC
      000_Eclipse100/P/PATHS
      000_Eclipse100/P/PBUB
      000_Eclipse100/P/PBVD
      000_Eclipse100/P/PCG
+     000_Eclipse100/P/PCG32D
      000_Eclipse100/P/PCW
+     000_Eclipse100/P/PCW32D
      000_Eclipse100/P/PDEW
      000_Eclipse100/P/PDVD
      000_Eclipse100/P/PEBI


### PR DESCRIPTION
added keywords GCONPRI, GIALL, MASSFLOW, MESSAGE, OUTSOL, PARAOPTS,  PVG32D, PCW32D.

The list of 'special' keywords that are not readable by the opm-parser system has been updated. 