### PR TITLE
Change section for WPOTCALC keyword to RUNSPEC

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WPOTCALC
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WPOTCALC
@@ -1,7 +1,7 @@
 {
     "name" : "WPOTCALC",
     "size" : 1,
-    "sections" : ["SCHEDULE" ],
+    "sections" : ["RUNSPEC" ],
     "items" :
     [{"name" : "FORCE_CALC",           "value_type" : "STRING", "default": "YES"},
      {"name" : "USE_SEGMENT_VOLUMES" , "value_type" : "STRING" , "default" : "NO"}]}


### PR DESCRIPTION
This keyword belongs in RUNSPEC at least in the documentation for Eclipse 100 2017.1.