### PR TITLE
added enum class FuncType for ASTNode.

### DIFF
--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -76,6 +76,8 @@ namespace Opm {
         bool        userDefined_{false};
     };
 
+    SummaryNode::Category parseKeywordCategory(const std::string& keyword);
+
     bool operator==(const SummaryNode& lhs, const SummaryNode& rhs);
     bool operator<(const SummaryNode& lhs, const SummaryNode& rhs);
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
@@ -62,8 +62,9 @@ ASTNode::ASTNode(double value) :
 {}
 
 
-ASTNode::ASTNode(TokenType type_arg, const std::string& func_arg, const std::vector<std::string>& arg_list_arg):
+ASTNode::ASTNode(TokenType type_arg, FuncType func_type_arg, const std::string& func_arg, const std::vector<std::string>& arg_list_arg):
     type(type_arg),
+    func_type(func_type_arg),
     func(func_arg),
     arg_list(strip_quotes(arg_list_arg))
 {}
@@ -92,6 +93,9 @@ Action::Value ASTNode::value(const Action::Context& context) const {
           well patterns like 'P*'.
         */
         if ((this->arg_list.size() == 1) && (arg_list[0].find("*") != std::string::npos)) {
+            if (this->func_type != FuncType::well)
+                throw std::logic_error(": attempted to action-evaluate list not of type well.");
+
             Action::Value well_values;
             int fnmatch_flags = 0;
             for (const auto& well : context.wells(this->func)) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.hpp
@@ -16,11 +16,12 @@ public:
     ASTNode();
     ASTNode(TokenType type_arg);
     ASTNode(double value);
-    ASTNode(TokenType type_arg, const std::string& func_arg, const std::vector<std::string>& arg_list_arg);
+    ASTNode(TokenType type_arg, FuncType func_type_arg, const std::string& func_arg, const std::vector<std::string>& arg_list_arg);
 
     Action::Result eval(const Action::Context& context) const;
     Action::Value value(const Action::Context& context) const;
     TokenType type;
+    FuncType func_type;
     void add_child(const ASTNode& child);
     size_t size() const;
     std::string func;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
@@ -89,13 +89,12 @@ FuncType Parser::get_func(const std::string& arg) {
     using Cat = SummaryNode::Category;
     SummaryNode::Category cat = parseKeywordCategory(arg);
     switch (cat) {
-        case Cat::Well:  return FuncType::well;
-        case Cat::Group: return FuncType::group;
-        /*case 'F': return Cat::Field;
-        case 'C': return Cat::Connection;
-        case 'R': return Cat::Region;
-        case 'B': return Cat::Block;
-        case 'S': return Cat::Segment;*/
+        case Cat::Well:       return FuncType::well;
+        case Cat::Group:      return FuncType::group;
+        case Cat::Connection: return FuncType::well_connection;
+        case Cat::Region:     return FuncType::region;
+        case Cat::Block:      return FuncType::block;
+        case Cat::Segment:    return FuncType::well_segment;
     }
     return FuncType::none;
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
@@ -86,6 +86,10 @@ TokenType Parser::get_type(const std::string& arg) {
 
 FuncType Parser::get_func(const std::string& arg) {
 
+    if (arg == "YEAR") return FuncType::time;
+    if (arg == "MNTH") return FuncType::time;
+    if (arg == "DAY")  return FuncType::time;
+
     using Cat = SummaryNode::Category;
     SummaryNode::Category cat = parseKeywordCategory(arg);
     switch (cat) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
@@ -106,7 +106,7 @@ ParseNode Parser::next() {
         return TokenType::end;
 
     std::string arg = this->tokens[this->current_pos];
-    return ParseNode(get_type(arg), get_func(arg), arg);
+    return ParseNode(get_type(arg), arg);
 }
 
 
@@ -115,7 +115,7 @@ ParseNode Parser::current() const {
         return TokenType::end;
 
     std::string arg = this->tokens[this->current_pos];
-    return ParseNode(get_type(arg), get_func(arg), arg);
+    return ParseNode(get_type(arg), arg);
 }
 
 
@@ -125,7 +125,7 @@ Action::ASTNode Parser::parse_left() {
         return TokenType::error;
 
     std::string func = current.value;
-    FuncType func_type = current.func;
+    FuncType func_type = get_func(current.value);
     std::vector<std::string> arg_list;
     current = this->next();
     while (current.type == TokenType::ecl_expr || current.type == TokenType::number) {
@@ -163,7 +163,7 @@ Action::ASTNode Parser::parse_right() {
         return TokenType::error;
 
     std::string func = current.value;
-    FuncType func_type = current.func;
+    FuncType func_type = FuncType::none;
     std::vector<std::string> arg_list;
     current = this->next();
     while (current.type == TokenType::ecl_expr || current.type == TokenType::number) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.hpp
@@ -31,19 +31,17 @@ namespace Opm {
 namespace Action {
 
 struct ParseNode {
-    ParseNode(TokenType type_arg, FuncType func_arg, const std::string& value_arg) :
+    ParseNode(TokenType type_arg, const std::string& value_arg) :
         type(type_arg),
-        func(func_arg),
         value(value_arg)
     {}
 
-    // Implicit converting constructor. Only for non-functions. 
-    ParseNode(TokenType type_arg) : ParseNode(type_arg, FuncType::none, "")
+    // Implicit converting constructor.
+    ParseNode(TokenType type_arg) : ParseNode(type_arg, "")
     {}
 
 
     TokenType type;
-    FuncType func;
     std::string value;
 };
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.hpp
@@ -31,17 +31,19 @@ namespace Opm {
 namespace Action {
 
 struct ParseNode {
-    ParseNode(TokenType type_arg, const std::string& value_arg) :
+    ParseNode(TokenType type_arg, FuncType func_arg, const std::string& value_arg) :
         type(type_arg),
+        func(func_arg),
         value(value_arg)
     {}
 
-    // Implicit converting constructor.
-    ParseNode(TokenType type_arg) : ParseNode(type_arg, "")
+    // Implicit converting constructor. Only for non-functions. 
+    ParseNode(TokenType type_arg) : ParseNode(type_arg, FuncType::none, "")
     {}
 
 
     TokenType type;
+    FuncType func;
     std::string value;
 };
 
@@ -51,6 +53,7 @@ class Parser {
 public:
     static Action::ASTNode parse(const std::vector<std::string>& tokens);
     static TokenType get_type(const std::string& arg);
+    static FuncType get_func(const std::string& arg);
 
 private:
     explicit Parser(const std::vector<std::string>& tokens);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp
@@ -20,6 +20,20 @@ enum TokenType {
   error          // 13
 };
 
+enum class FuncType {
+  none,
+  time,
+  region,
+  field,
+  group,
+  well,
+  well_segment,
+  well_connection,
+  Well_lgr,
+  aquifer,
+  block
+};
+
 
 
 namespace Opm {

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -683,25 +683,6 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
         }
     }
 
-    SummaryNode::Category parseKeywordCategory(const std::string& keyword) {
-        using Cat = SummaryNode::Category;
-
-        if (is_special(keyword)) { return Cat::Miscellaneous; }
-
-        switch (keyword[0]) {
-            case 'W': return Cat::Well;
-            case 'G': return Cat::Group;
-            case 'F': return Cat::Field;
-            case 'C': return Cat::Connection;
-            case 'R': return Cat::Region;
-            case 'B': return Cat::Block;
-            case 'S': return Cat::Segment;
-        }
-
-        // TCPU, MLINEARS, NEWTON, &c
-        return Cat::Miscellaneous;
-    }
-
     std::string to_string(const SummaryNode::Category cat) {
         switch( cat ) {
             case SummaryNode::Category::Well: return "Well";
@@ -813,6 +794,27 @@ inline void handleKW( SummaryConfig::keyword_list& list,
 }
 
 // =====================================================================
+
+
+SummaryNode::Category parseKeywordCategory(const std::string& keyword) {
+    using Cat = SummaryNode::Category;
+
+    if (is_special(keyword)) { return Cat::Miscellaneous; }
+
+    switch (keyword[0]) {
+        case 'W': return Cat::Well;
+        case 'G': return Cat::Group;
+        case 'F': return Cat::Field;
+        case 'C': return Cat::Connection;
+        case 'R': return Cat::Region;
+        case 'B': return Cat::Block;
+        case 'S': return Cat::Segment;
+    }
+
+    // TCPU, MLINEARS, NEWTON, &c
+    return Cat::Miscellaneous;
+}
+
 
 SummaryNode::SummaryNode(std::string keyword, const Category cat, Location loc_arg) :
     keyword_(std::move(keyword)),

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -478,7 +478,15 @@ BOOST_AUTO_TEST_CASE(Action_ContextTest) {
     BOOST_REQUIRE_THROW(context.get("WGOR", "B37"), std::out_of_range);
 }
 
+//Note: that this is only temporary test.
+//Groupnames w/ astirisks wil eventually work with ACTIONX
+BOOST_AUTO_TEST_CASE(TestGroupList) {
+    Action::AST ast({"GWPR", "*", ">", "1.0"});
+    SummaryState st(std::chrono::system_clock::now());
 
+    Action::Context context(st);
+    BOOST_CHECK_THROW( ast.eval(context), std::logic_error );
+}
 
 BOOST_AUTO_TEST_CASE(TestMatchingWells) {
     Action::AST ast({"WOPR", "*", ">", "1.0"});


### PR DESCRIPTION
This is response to issues https://github.com/OPM/opm-common/issues/1243 and https://github.com/OPM/opm-common/issues/1243.

ASTNode will be supplied with a variable determining what type of keyword (function) is used. This is the FuncType func_type variable. 