### PR TITLE
correction to ISEG[0] in AggregateMSWData.cpp

### DIFF
--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -120,7 +120,6 @@ namespace {
     }
     std::vector<std::size_t> segmentOrder(const Opm::WellSegments& segSet, const std::size_t segIndex) {
         std::vector<std::size_t> ordSegNumber;
-        std::vector<std::size_t> tempOrdVect;
         std::vector<std::size_t> segIndCB;
         // Store "heel" segment since that will not always be at the end of the list
         segIndCB.push_back(segIndex);

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -169,17 +169,7 @@ namespace {
                 newSInd = segSet.size();
             }
         }
-
-        if (origBranchNo == 1) {
-            // make the vector of ordered segments - by segment index (zero-based)
-            tempOrdVect.resize(ordSegNumber.size());
-            for (std::size_t ov_ind = 0; ov_ind < ordSegNumber.size(); ov_ind++) {
-                tempOrdVect[ordSegNumber[ov_ind]] = ov_ind;
-            }
-            return tempOrdVect;
-        } else {
-            return ordSegNumber;
-        }
+        return ordSegNumber;
     }
 
 


### PR DESCRIPTION
This pull request contains a fix for the ISEG[0] parameter in the Eclipse compatible Restart file. 
The fix will trigger changes in the reference data for ISEG[0], in the case: 
opm-tests/msw_3d_hfa 3D_MSW.DATA case. This has been checked vs. E100 results.

