### PR TITLE
changed: rename accessor to data()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
@@ -49,7 +49,7 @@ public:
     /// Construct from input deck.
     explicit NNC(const Deck& deck);
     void addNNC(const size_t cell1, const size_t cell2, const double trans);
-    const std::vector<NNCdata>& nncdata() const { return m_nnc; }
+    const std::vector<NNCdata>& data() const { return m_nnc; }
     size_t numNNC() const;
     bool hasNNC() const;
 

--- a/python/cxx/eclipse_state.cpp
+++ b/python/cxx/eclipse_state.cpp
@@ -10,7 +10,7 @@ namespace {
 
     py::list getNNC( const EclipseState& state ) {
         py::list l;
-        for( const auto& x : state.getInputNNC().nncdata() )
+        for( const auto& x : state.getInputNNC().data() )
             l.append( py::make_tuple( x.cell1, x.cell2, x.trans )  );
         return l;
     }

--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -596,7 +596,7 @@ namespace {
         auto tran = std::vector<double>{};
         tran.reserve(nnc.numNNC());
 
-        for (const auto& nd : nnc.nncdata()) {
+        for (const auto& nd : nnc.data()) {
             tran.push_back(nd.trans);
         }
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -1614,7 +1614,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         std::vector<int> nnc1;
         std::vector<int> nnc2;
 
-        for (const NNCdata& n : nnc.nncdata() ) {
+        for (const NNCdata& n : nnc.data() ) {
             nnc1.push_back(n.cell1 + 1);
             nnc2.push_back(n.cell2 + 1);
         }

--- a/tests/parser/integration/NNCTests.cpp
+++ b/tests/parser/integration/NNCTests.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(readDeck)
     EclipseState eclipseState(deck);
     const auto& nnc = eclipseState.getInputNNC();
     BOOST_CHECK(nnc.hasNNC());
-    const std::vector<NNCdata>& nncdata = nnc.nncdata();
+    const std::vector<NNCdata>& nncdata = nnc.data();
 
     // test the NNCs in nnc.DATA
     BOOST_CHECK_EQUAL(nnc.numNNC(), 4);
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(addNNCfromDeck)
     EclipseState eclipseState(deck);
     auto nnc = eclipseState.getInputNNC();
     BOOST_CHECK(nnc.hasNNC());
-    const std::vector<NNCdata>& nncdata = nnc.nncdata();
+    const std::vector<NNCdata>& nncdata = nnc.data();
 
     BOOST_CHECK_EQUAL(nnc.numNNC(), 4);
     // test add NNC
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(addNNC)
     Opm::NNC nnc;
     // add NNC
     nnc.addNNC(2,2,2.0);
-    const std::vector<NNCdata>& nncdata = nnc.nncdata();
+    const std::vector<NNCdata>& nncdata = nnc.data();
     BOOST_CHECK_EQUAL(nnc.numNNC(), 1);
     BOOST_CHECK_EQUAL(nncdata[0].cell1, 2);
     BOOST_CHECK_EQUAL(nncdata[0].cell1, 2);


### PR DESCRIPTION
the two classes EDITNNC and NNC are very similar, which makes templating
useful. this small difference makes it hard to do. unify them.