### PR TITLE
Use seekg() rather than ignore() to skip ahead.

### DIFF
--- a/src/opm/io/eclipse/EclFile.cpp
+++ b/src/opm/io/eclipse/EclFile.cpp
@@ -501,10 +501,10 @@ EclFile::EclFile(const std::string& filename, bool preload) : inputFilename(file
 
         if (formatted) {
             unsigned long int sizeOfNextArray = sizeOnDiskFormatted(num, arrType);
-            fileH.ignore(sizeOfNextArray);
+            fileH.seekg(static_cast<std::streamoff>(sizeOfNextArray), std::ios_base::cur);
         } else {
             unsigned long int sizeOfNextArray = sizeOnDiskBinary(num, arrType);
-            fileH.ignore(sizeOfNextArray);
+            fileH.seekg(static_cast<std::streamoff>(sizeOfNextArray), std::ios_base::cur);
         }
 
         n++;


### PR DESCRIPTION
I noticed while profiling something else that restart file writing was taking much more time than it used to. And 99% of that time was spent in the ignore() call modified here. Replacing it with seekg() seems to give far better performance.