### PR TITLE
added: comparison operators for various output structures

### DIFF
--- a/opm/output/data/Cells.hpp
+++ b/opm/output/data/Cells.hpp
@@ -69,6 +69,13 @@ namespace data {
         UnitSystem::measure dim;   //< Dimension of the data to write
         std::vector<double> data;  //< The actual data itself
         TargetType target;
+
+        bool operator==(const CellData& cell2) const
+        {
+            return dim == cell2.dim &&
+                   data == cell2.data &&
+                   target == cell2.target;
+        }
     };
 
 }

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -90,6 +90,8 @@ namespace Opm {
             template <class MessageBufferType>
             void read(MessageBufferType& buffer);
 
+            bool operator==(const Rates& rat2) const;
+
         private:
             double& get_ref( opt );
             const double& get_ref( opt ) const;
@@ -128,6 +130,18 @@ namespace Opm {
         double cell_saturation_gas;
         double effective_Kh;
 
+        bool operator==(const Connection& conn2) const
+        {
+            return index == conn2.index &&
+                   rates == conn2.rates &&
+                   pressure == conn2.pressure &&
+                   reservoir_rate == conn2.reservoir_rate &&
+                   cell_pressure == conn2.cell_pressure &&
+                   cell_saturation_water == conn2.cell_saturation_water &&
+                   cell_saturation_gas == conn2.cell_saturation_gas &&
+                   effective_Kh == conn2.effective_Kh;
+        }
+
         template <class MessageBufferType>
         void write(MessageBufferType& buffer) const;
         template <class MessageBufferType>
@@ -138,6 +152,13 @@ namespace Opm {
         Rates rates;
         double pressure;
         std::size_t segNumber;
+
+        bool operator==(const Segment& seg2) const
+        {
+          return rates == seg2.rates &&
+                 pressure == seg2.pressure &&
+                 segNumber == seg2.segNumber;
+        }
 
         template <class MessageBufferType>
         void write(MessageBufferType& buffer) const;
@@ -159,6 +180,17 @@ namespace Opm {
         void write(MessageBufferType& buffer) const;
         template <class MessageBufferType>
         void read(MessageBufferType& buffer);
+
+        bool operator==(const Well& well2) const
+        {
+          return rates == well2.rates &&
+                 bhp == well2.bhp &&
+                 thp == well2.thp &&
+                 temperature == well2.temperature &&
+                 control == well2.control &&
+                 connections == well2.connections &&
+                 segments == well2.segments;
+        }
     };
 
 
@@ -213,10 +245,9 @@ namespace Opm {
                 this->emplace(name, well);
             }
         }
-
     };
 
-    using Wells = WellRates;    
+    using Wells = WellRates;
 
 
     /* IMPLEMENTATIONS */
@@ -250,6 +281,28 @@ namespace Opm {
                     );
 
         return *this;
+    }
+
+    inline bool Rates::operator==(const Rates& rate) const
+    {
+      return mask == rate.mask &&
+             wat == rate.wat &&
+             oil == rate.oil &&
+             gas == rate.gas &&
+             polymer == rate.polymer &&
+             solvent == rate.solvent &&
+             energy == rate.energy &&
+             dissolved_gas == rate.dissolved_gas &&
+             vaporized_oil == rate.vaporized_oil &&
+             reservoir_water == rate.reservoir_water &&
+             reservoir_oil == rate.reservoir_oil &&
+             reservoir_gas == rate.reservoir_gas &&
+             productivity_index_water == rate.productivity_index_water &&
+             productivity_index_gas == rate.productivity_index_gas &&
+             productivity_index_oil == rate.productivity_index_oil &&
+             well_potential_water == rate.well_potential_water &&
+             well_potential_oil == rate.well_potential_oil &&
+             well_potential_gas == rate.well_potential_gas;
     }
 
 

--- a/opm/output/eclipse/RestartValue.hpp
+++ b/opm/output/eclipse/RestartValue.hpp
@@ -51,6 +51,12 @@ namespace Opm {
               required(_required)
         {}
 
+        bool operator==(const RestartKey& key2) const
+        {
+            return key == key2.key &&
+                   dim == key2.dim &&
+                   required == key2.required;
+        }
     };
 
 
@@ -69,6 +75,8 @@ namespace Opm {
 
         RestartValue(data::Solution sol, data::Wells wells_arg);
 
+        RestartValue() {}
+
         bool hasExtra(const std::string& key) const;
         void addExtra(const std::string& key, UnitSystem::measure dimension, std::vector<double> data);
         void addExtra(const std::string& key, std::vector<double> data);
@@ -76,6 +84,13 @@ namespace Opm {
 
         void convertFromSI(const UnitSystem& units);
         void convertToSI(const UnitSystem& units);
+
+        bool operator==(const RestartValue& val2) const
+        {
+          return solution == val2.solution &&
+                 wells == val2.wells &&
+                 extra == val2.extra;
+        }
     };
 
 }

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -258,47 +258,6 @@ std::ostream& operator<<( std::ostream& stream,
     return stream;
 }
 
-bool operator==( const Rates& lhs, const Rates& rhs ) {
-    using rt = Rates::opt;
-
-    BOOST_CHECK_EQUAL( lhs.has( rt::wat ), rhs.has( rt::wat ) );
-    BOOST_CHECK_EQUAL( lhs.has( rt::oil ), rhs.has( rt::oil ) );
-    BOOST_CHECK_EQUAL( lhs.has( rt::gas ), rhs.has( rt::gas ) );
-    BOOST_CHECK_EQUAL( lhs.has( rt::polymer ), rhs.has( rt::polymer ) );
-    BOOST_CHECK_EQUAL( lhs.get( rt::wat, 0.0 ), rhs.get( rt::wat, 0.0 ) );
-    BOOST_CHECK_EQUAL( lhs.get( rt::oil, 0.0 ), rhs.get( rt::oil, 0.0 ) );
-    BOOST_CHECK_EQUAL( lhs.get( rt::gas, 0.0 ), rhs.get( rt::gas, 0.0 ) );
-    BOOST_CHECK_EQUAL( lhs.get( rt::polymer, 0.0 ), rhs.get( rt::polymer, 0.0 ) );
-
-    return true;
-}
-
-bool operator==( const Connection& lhs, const Connection& rhs ) {
-    BOOST_CHECK_EQUAL( lhs.index, rhs.index );
-    BOOST_CHECK_EQUAL( lhs.rates, rhs.rates );
-    BOOST_CHECK_EQUAL( lhs.pressure, rhs.pressure );
-    BOOST_CHECK_EQUAL( lhs.reservoir_rate, rhs.reservoir_rate );
-
-    return true;
-}
-
-bool operator!=( const Connection& lhs, const Connection& rhs ) {
-    return !( lhs == rhs );
-}
-
-bool operator==( const Well& lhs, const Well& rhs ) {
-    BOOST_CHECK_EQUAL( lhs.rates, rhs.rates );
-    BOOST_CHECK_EQUAL( lhs.bhp, rhs.bhp );
-    BOOST_CHECK_EQUAL( lhs.temperature, rhs.temperature );
-    BOOST_CHECK_EQUAL( lhs.control, rhs.control );
-
-    BOOST_CHECK_EQUAL_COLLECTIONS(
-            lhs.connections.begin(), lhs.connections.end(),
-            rhs.connections.begin(), rhs.connections.end() );
-
-    return true;
-}
-
 }
 
 


### PR DESCRIPTION
This will be used for some tests in opm-simulators. I open this early to help explain why https://github.com/OPM/opm-common/pull/1266 is required.