### PR TITLE
added: serialize the whole connection struct to OPM_XWEL

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -117,7 +117,7 @@ namespace Opm {
 
     struct Connection {
         using global_index = size_t;
-        static const constexpr int restart_size = 2;
+        static const constexpr int restart_size = 6;
 
         global_index index;
         Rates rates;

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -784,8 +784,12 @@ namespace {
                 auto& connection = well.connections.back();
 
                 connection.index          = grid.getGlobalIndex(i, j, k);
-                connection.pressure       = *opm_xwel_data;  ++opm_xwel_data;
-                connection.reservoir_rate = *opm_xwel_data;  ++opm_xwel_data;
+                connection.pressure       = *opm_xwel_data++;
+                connection.reservoir_rate = *opm_xwel_data++;
+                connection.cell_pressure = *opm_xwel_data++;
+                connection.cell_saturation_water = *opm_xwel_data++;
+                connection.cell_saturation_gas = *opm_xwel_data++;
+                connection.effective_Kh = *opm_xwel_data++;
 
                 for (const auto& phase : phases) {
                     connection.rates.set(phase, *opm_xwel_data);

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -166,6 +166,10 @@ namespace {
 
                 xwel.push_back(connection->pressure);
                 xwel.push_back(connection->reservoir_rate);
+                xwel.push_back(connection->cell_pressure);
+                xwel.push_back(connection->cell_saturation_water);
+                xwel.push_back(connection->cell_saturation_gas);
+                xwel.push_back(connection->effective_Kh);
 
                 for (auto phase : phases)
                     xwel.push_back(connection->rates.get(phase));


### PR DESCRIPTION
Currently, only parts of the connection members are serialized in the XWEL structure.

while not really a problem, it became a problem for me due to https://github.com/OPM/opm-common/pull/1265

currently the test itself implements comparison operators. but since i add them globally in that PR, I had to remove the ones in the test file, and consequently I need all members serialized/deserialized for the test to still pass.