### PR TITLE
Add Restart File Support for WSEGVALV Devices

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -33,7 +33,7 @@ namespace Opm {
         enum class SegmentType {
             REGULAR,
             SICD,
-            VALVE
+            VALVE,
         };
 
         Segment();
@@ -54,9 +54,19 @@ namespace Opm {
 
         SegmentType segmentType() const;
 
+        bool isRegular() const
+        {
+            return this->segmentType() == SegmentType::REGULAR;
+        }
+
         bool isSpiralICD() const
         {
             return this->segmentType() == SegmentType::SICD;
+        }
+
+        bool isValve() const
+        {
+            return this->segmentType() == SegmentType::VALVE;
         }
 
         void setVolume(const double volume_in);

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -22,8 +22,11 @@
 
 #include <memory>
 #include <vector>
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
+
+namespace Opm {
+    class SpiralICD;
+    class Valve;
+}
 
 namespace Opm {
 
@@ -53,21 +56,6 @@ namespace Opm {
         bool dataReady() const;
 
         SegmentType segmentType() const;
-
-        bool isRegular() const
-        {
-            return this->segmentType() == SegmentType::REGULAR;
-        }
-
-        bool isSpiralICD() const
-        {
-            return this->segmentType() == SegmentType::SICD;
-        }
-
-        bool isValve() const
-        {
-            return this->segmentType() == SegmentType::VALVE;
-        }
 
         void setVolume(const double volume_in);
         void setDepthAndLength(const double depth_in, const double length_in);
@@ -135,7 +123,7 @@ namespace Opm {
         bool m_data_ready;
 
         // indicate the type of the segment
-        // regular or spiral ICD
+        // regular, spiral ICD, or Valve.
         SegmentType m_segment_type = SegmentType::REGULAR;
 
         // information related to SpiralICD. It is nullptr for segments are not
@@ -151,8 +139,22 @@ namespace Opm {
         // They are not used in the simulations and we are not supporting the plotting.
         // There are other three properties for segment related to thermal conduction,
         // while they are not supported by the keyword at the moment.
-
     };
+
+    inline bool isRegular(const Segment& segment)
+    {
+        return segment.segmentType() == Segment::SegmentType::REGULAR;
+    }
+
+    inline bool isSpiralICD(const Segment& segment)
+    {
+        return segment.segmentType() == Segment::SegmentType::SICD;
+    }
+
+    inline bool isValve(const Segment& segment)
+    {
+        return segment.segmentType() == Segment::SegmentType::VALVE;
+    }
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
@@ -26,6 +26,11 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp>
 
 namespace Opm {
+    class SpiralICD;
+    class Valve;
+}
+
+namespace Opm {
 
     class DeckKeyword;
 

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -22,8 +22,9 @@
 #include <opm/output/eclipse/VectorItems/msw.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
@@ -452,11 +453,11 @@ namespace {
                                               const std::size_t   baseIndex,
                                               ISegArray&          iSeg)
         {
-            if (segment.isSpiralICD()) {
+            if (isSpiralICD(segment)) {
                 assignSpiralICDCharacteristics(segment, baseIndex, iSeg);
             }
 
-            if (segment.isValve()) {
+            if (isValve(segment)) {
                 assignValveCharacteristics(baseIndex, iSeg);
             }
         }
@@ -488,7 +489,7 @@ namespace {
                     iSeg[iS + 7] = sumConnectionsSegment(completionSet, welSegSet, ind);
                     iSeg[iS + 8] = iSeg[iS+0];
 
-                    if (! segment.isRegular()) {
+                    if (! isRegular(segment)) {
                         assignSegmentTypeCharacteristics(segment, iS, iSeg);
                     }
                 }
@@ -617,11 +618,11 @@ namespace {
                                               const int                baseIndex,
                                               RSegArray&               rSeg)
         {
-            if (segment.isSpiralICD()) {
+            if (isSpiralICD(segment)) {
                 assignSpiralICDCharacteristics(segment, usys, baseIndex, rSeg);
             }
 
-            if (segment.isValve()) {
+            if (isValve(segment)) {
                 assignValveCharacteristics(segment, usys, baseIndex, rSeg);
             }
         }
@@ -773,7 +774,7 @@ namespace {
                     rSeg[iS + 109] = 1.0;
                     rSeg[iS + 110] = 1.0;
 
-                    if (! segment.isRegular()) {
+                    if (! isRegular(segment)) {
                         assignSegmentTypeCharacteristics(segment, units, iS, rSeg);
                     }
                 }

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -24,10 +24,12 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
+
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <algorithm>
@@ -433,6 +435,33 @@ namespace {
         }
 
         template <class ISegArray>
+        void assignValveCharacteristics(const std::size_t baseIndex,
+                                        ISegArray&        iSeg)
+        {
+            namespace ISegValue = ::Opm::RestartIO::Helpers::
+                VectorItems::ISeg::Value;
+
+            using Ix = ::Opm::RestartIO::Helpers::
+                VectorItems::ISeg::index;
+
+            iSeg[baseIndex + Ix::SegmentType] = ISegValue::SegmentType::Valve;
+        }
+
+        template <class ISegArray>
+        void assignSegmentTypeCharacteristics(const Opm::Segment& segment,
+                                              const std::size_t   baseIndex,
+                                              ISegArray&          iSeg)
+        {
+            if (segment.isSpiralICD()) {
+                assignSpiralICDCharacteristics(segment, baseIndex, iSeg);
+            }
+
+            if (segment.isValve()) {
+                assignValveCharacteristics(baseIndex, iSeg);
+            }
+        }
+
+        template <class ISegArray>
         void staticContrib(const Opm::Well&       well,
                            const std::vector<int>& inteHead,
                            ISegArray&              iSeg)
@@ -459,8 +488,8 @@ namespace {
                     iSeg[iS + 7] = sumConnectionsSegment(completionSet, welSegSet, ind);
                     iSeg[iS + 8] = iSeg[iS+0];
 
-                    if (segment.isSpiralICD()) {
-                        assignSpiralICDCharacteristics(segment, iS, iSeg);
+                    if (! segment.isRegular()) {
+                        assignSegmentTypeCharacteristics(segment, iS, iSeg);
                     }
                 }
             }
@@ -487,6 +516,64 @@ namespace {
                 WV::NumWindows{ nswlmx(inteHead) },
                 WV::WindowSize{ entriesPerMSW(inteHead) }
             };
+        }
+
+        float valveFlowUnitCoefficient(const Opm::UnitSystem::UnitType uType)
+        {
+            using UType = Opm::UnitSystem::UnitType;
+
+            // Numerical values taken from written sources.  Nothing known
+            // about their origins, other than the fact that they depend on
+            // the active unit conventions.
+            switch (uType) {
+                case UType::UNIT_TYPE_METRIC:
+                    return 1.340e-15f;
+
+                case UType::UNIT_TYPE_FIELD:
+                    return 2.892e-14f;
+
+                case UType::UNIT_TYPE_LAB:
+                    return 7.615e-14f;
+
+                case UType::UNIT_TYPE_PVT_M:
+                    return 1.322e-15f;
+            }
+
+            throw std::invalid_argument {
+                "Unsupported Unit Convention: '" +
+                std::to_string(static_cast<int>(uType)) + '\''
+            };
+        }
+
+        template <class RSegArray>
+        void assignValveCharacteristics(const ::Opm::Segment&    segment,
+                                        const ::Opm::UnitSystem& usys,
+                                        const int                baseIndex,
+                                        RSegArray&               rSeg)
+        {
+            using Ix = ::Opm::RestartIO::Helpers::VectorItems::RSeg::index;
+            using M  = ::Opm::UnitSystem::measure;
+
+            const auto* valve = segment.valve();
+
+            rSeg[baseIndex + Ix::ValveLength] =
+                usys.from_si(M::length, valve->pipeAdditionalLength());
+
+            rSeg[baseIndex + Ix::ValveArea] =
+                usys.from_si(M::length, usys.from_si(M::length, valve->conCrossArea()));
+
+            rSeg[baseIndex + Ix::ValveFlowCoeff] = valve->conFlowCoefficient();
+            rSeg[baseIndex + Ix::ValveMaxArea]   =
+                usys.from_si(M::length, usys.from_si(M::length, valve->conMaxCrossArea()));
+
+            const auto Cu   = valveFlowUnitCoefficient(usys.getType());
+            const auto CvAc = rSeg[baseIndex + Ix::ValveFlowCoeff]
+                *             rSeg[baseIndex + Ix::ValveArea];
+
+            rSeg[baseIndex + Ix::DeviceBaseStrength] = Cu / (2.0f * CvAc * CvAc);
+            rSeg[baseIndex + Ix::ValveAreaFraction] =
+                  rSeg[baseIndex + Ix::ValveArea]
+                / rSeg[baseIndex + Ix::ValveMaxArea];
         }
 
         template <class RSegArray>
@@ -522,6 +609,21 @@ namespace {
 
             rSeg[baseIndex + Ix::ICDLength] =
                 usys.from_si(M::length, sicd->length());
+        }
+
+        template <class RSegArray>
+        void assignSegmentTypeCharacteristics(const ::Opm::Segment&    segment,
+                                              const ::Opm::UnitSystem& usys,
+                                              const int                baseIndex,
+                                              RSegArray&               rSeg)
+        {
+            if (segment.isSpiralICD()) {
+                assignSpiralICDCharacteristics(segment, usys, baseIndex, rSeg);
+            }
+
+            if (segment.isValve()) {
+                assignValveCharacteristics(segment, usys, baseIndex, rSeg);
+            }
         }
 
         template <class RSegArray>
@@ -671,8 +773,8 @@ namespace {
                     rSeg[iS + 109] = 1.0;
                     rSeg[iS + 110] = 1.0;
 
-                    if (segment.isSpiralICD()) {
-                        assignSpiralICDCharacteristics(segment, units, iS, rSeg);
+                    if (! segment.isRegular()) {
+                        assignSegmentTypeCharacteristics(segment, units, iS, rSeg);
                     }
                 }
             }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
@@ -18,6 +18,9 @@
 */
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
+
 #include <cassert>
 
 namespace Opm {
@@ -194,4 +197,3 @@ namespace Opm {
     }
 
 }
-

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
@@ -30,8 +30,9 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
-
 
 namespace Opm {
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -46,8 +46,10 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -29,11 +29,12 @@
 
 #include <string>
 
-
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 


### PR DESCRIPTION
This PR adds support for identifying well segments that correspond to valves (input keyword `WSEGVALV`) and captures those in the ISEG vector.  Furthermore, we output characteristic properties of such valve segments (e.g, the valve length, the base strength, and cross-sectional area) in the RSEG vector.

Thanks to @tskille and @jalvestad for invaluable assistance in identifying these items.

---

Note that this PR depends on both PRs #1269 and #1257 and must not be merged before those are installed in master.  On top of those PRs, we change only the `AggregateMSWData.cpp` file.  This PR can be used separately for testing purposes.