### PR TITLE
Add Restart File Support for Spiral Inflow-Control Devices

### DIFF
--- a/opm/output/eclipse/VectorItems/msw.hpp
+++ b/opm/output/eclipse/VectorItems/msw.hpp
@@ -43,6 +43,11 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
                 SICD  = -7,
                 Valve = -5,
             };
+
+            enum SICDStatus : int {
+                Open = 0, // Yes, Open = 0 is correct
+                Shut = 1,
+            };
         } // Value
     } // ISeg
 

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -52,6 +52,11 @@ namespace Opm {
 
         SegmentType segmentType() const;
 
+        bool isSpiralICD() const
+        {
+            return this->segmentType() == SegmentType::SICD;
+        }
+
         void setVolume(const double volume_in);
         void setDepthAndLength(const double depth_in, const double length_in);
 


### PR DESCRIPTION
This commit identifies well segments that correspond to SICDs (input keyword `WSEGSICD`) and captures those in the ISEG vector.  Furthermore, we output characteristic properties of such SICD segments (e.g, the length, the base strength, calibration fluid properties) in the RSEG vector.

Thanks to @tskille and @jalvestad for invaluable assistance in identifying these items.

---

Note that this PR depends on both PRs #1269 and #1251 and must not be merged before those are installed in master. On top of those PRs, we change only the `AggregateMSWData.cpp` file. This PR can be used separately for testing purposes.