### PR TITLE
Load Restart: Support Basic Quantities from Analytic Aquifers

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -676,9 +676,11 @@ if(ENABLE_ECL_OUTPUT)
         opm/io/eclipse/ESmry.hpp
         opm/io/eclipse/PaddedOutputString.hpp
         opm/io/eclipse/OutputStream.hpp
+        opm/output/data/Aquifer.hpp
         opm/output/data/Cells.hpp
         opm/output/data/Solution.hpp
         opm/output/data/Wells.hpp
+        opm/output/eclipse/VectorItems/aquifer.hpp
         opm/output/eclipse/VectorItems/connection.hpp
         opm/output/eclipse/VectorItems/group.hpp
         opm/output/eclipse/VectorItems/intehead.hpp

--- a/opm/output/data/Aquifer.hpp
+++ b/opm/output/data/Aquifer.hpp
@@ -21,6 +21,7 @@
 #define OPM_OUTPUT_AQUIFER_HPP
 
 #include <map>
+#include <memory>
 #include <vector>
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
@@ -31,10 +32,26 @@ namespace Opm { namespace data {
      * Small struct that keeps track of data for output to restart/summary
      * files.
      */
+    enum class AquiferType
+    {
+        Fetkovich, CarterTracey,
+    };
+
+    struct FetkovichData {
+        double initVolume;
+        double prodIndex;
+        double timeConstant;
+    };
+
     struct AquiferData {
         int aquiferID;    //< One-based ID, range 1..NANAQ
         double pressure;  //< Aquifer pressure
         double volume;    //< Produced liquid volume
+        double initPressure;    //< Aquifer's initial pressure
+        double datumDepth;      //< Aquifer's pressure reference depth
+
+        AquiferType type;
+        std::shared_ptr<FetkovichData> aquFet;
     };
 
 }} // Opm::data

--- a/opm/output/data/Aquifer.hpp
+++ b/opm/output/data/Aquifer.hpp
@@ -1,0 +1,42 @@
+/*
+  Copyright 2019 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_OUTPUT_AQUIFER_HPP
+#define OPM_OUTPUT_AQUIFER_HPP
+
+#include <map>
+#include <vector>
+
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+namespace Opm { namespace data {
+
+    /**
+     * Small struct that keeps track of data for output to restart/summary
+     * files.
+     */
+    struct AquiferData {
+        int aquiferID;    //< One-based ID, range 1..NANAQ
+        double pressure;  //< Aquifer pressure
+        double volume;    //< Produced liquid volume
+    };
+
+}} // Opm::data
+
+#endif // OPM_OUTPUT_AQUIFER_HPP

--- a/opm/output/eclipse/RestartValue.hpp
+++ b/opm/output/eclipse/RestartValue.hpp
@@ -18,16 +18,18 @@
 #ifndef RESTART_VALUE_HPP
 #define RESTART_VALUE_HPP
 
-#include <string>
 #include <map>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/output/data/Aquifer.hpp>
 #include <opm/output/data/Solution.hpp>
 #include <opm/output/data/Wells.hpp>
 
 namespace Opm {
-
 
     class RestartKey {
     public:
@@ -59,19 +61,17 @@ namespace Opm {
         }
     };
 
-
     /*
-      A simple class used to communicate values between the simulator and the
-      RestartIO function.
+      A simple class used to communicate values between the simulator and
+      the RestartIO functions.
     */
-
-
     class RestartValue {
     public:
         using ExtraVector = std::vector<std::pair<RestartKey, std::vector<double>>>;
         data::Solution solution;
         data::Wells wells;
         ExtraVector extra;
+        std::vector<data::AquiferData> aquifer;
 
         RestartValue(data::Solution sol, data::Wells wells_arg);
 
@@ -95,5 +95,4 @@ namespace Opm {
 
 }
 
-
-#endif
+#endif // RESTART_VALUE_HPP

--- a/opm/output/eclipse/VectorItems/aquifer.hpp
+++ b/opm/output/eclipse/VectorItems/aquifer.hpp
@@ -1,0 +1,36 @@
+/*
+  Copyright (c) 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_OUTPUT_ECLIPSE_VECTOR_AQUIFER_HPP
+#define OPM_OUTPUT_ECLIPSE_VECTOR_AQUIFER_HPP
+
+#include <vector>
+
+namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+
+    namespace XAnalyticAquifer {
+        enum index : std::vector<double>::size_type {
+            Pressure   = 1,  // Dynamic aquifer pressure
+            ProdVolume = 2,  // Liquid volume produced from aquifer (into reservoir)
+        };
+    } // XAnalyticAquifer
+
+}}}} // Opm::RestartIO::Helpers::VectorItems
+
+#endif // OPM_OUTPUT_ECLIPSE_VECTOR_AQUIFER_HPP

--- a/opm/output/eclipse/VectorItems/aquifer.hpp
+++ b/opm/output/eclipse/VectorItems/aquifer.hpp
@@ -24,10 +24,44 @@
 
 namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
 
+    namespace IAnalyticAquifer {
+        enum index : std::vector<int>::size_type {
+            NumAquiferConn = 0,
+            WatPropTable = 1,
+
+            TypeRelated1 =  9,
+            TypeRelated2 = 10,
+        };
+    } // IAnalyticAquifer
+
+    namespace SAnalyticAquifer {
+        enum index : std::vector<float>::size_type {
+            Compressibility = 0,
+
+            FetInitVol = 1,
+            FetProdIndex = 2,
+            FetTimeConstant = 3,
+
+            CTRadius = 1,
+            CTPermeability = 2,
+            CTPorosity = 3,
+
+            InitPressure = 4,
+            DatumDepth = 5,
+
+            CTThickness = 6,
+            CTAngle = 7,
+            CTWatMassDensity = 8,
+            CTWatViscosity = 9,
+        };
+    } // SAnalyticAquifer
+
     namespace XAnalyticAquifer {
         enum index : std::vector<double>::size_type {
+            FlowRate   = 0,
             Pressure   = 1,  // Dynamic aquifer pressure
             ProdVolume = 2,  // Liquid volume produced from aquifer (into reservoir)
+            TotalArea  = 3,
         };
     } // XAnalyticAquifer
 

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -85,7 +85,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         MAXNOSTRPRLINE = 158,   //  Maximum number of 8-chars strings pr input line of Action data (rounded up from input)
 
         NWMAXZ  = 163,      //  Maximum number of wells in the model
-        
+
         NSEGWL  = 174,      //  Number of multisegment wells defined with WELSEG
         NSWLMX  = 175,      //  Maximum number of segmented wells (item 1 ofWSEGDIMS)
         NSEGMX  = 176,      //  Maximum number of segments per well (item 2 of WSEGDIMS)
@@ -94,10 +94,13 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NISEGZ  = 178,      //  Number of entries per segment in ISEG array
         NRSEGZ  = 179,      //  Number of entries per segment in RSEG array
         NILBRZ  = 180,      //  Number of entries per segment in ILBR array
-	
-        MAX_ACT_COND = 245,      //  Maximum number of conditions pr action /  
-        NO_UDQS = 266,      //  No of UDQ data (parameters) /  
-        UDQPAR_1 = 267,      //  Integer seed value for the RAND /  
+
+        MAX_ACT_COND = 245,      //  Maximum number of conditions pr action
+
+        MAX_AN_AQUIFERS = 252, // Maximum number of analytic aquifers
+
+        NO_UDQS = 266,      //  No of UDQ data (parameters)
+        UDQPAR_1 = 267,      //  Integer seed value for the RAND
         RSEED    = 296,
     };
 }}}} // Opm::RestartIO::Helpers::VectorItems

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -271,7 +271,7 @@ enum index : std::vector<int>::size_type {
   ih_249       =      249       ,              //       0
   ih_250       =      250       ,              //       0
   ih_251       =      251       ,              //       0
-  MAAQID       =      252       ,              //       0                     MAAQID = maximum number of analytic aquifers
+  MAAQID       =      VI::intehead::MAX_AN_AQUIFERS,              //       0                     MAAQID = maximum number of analytic aquifers
   ih_253       =      253       ,              //       0
   ih_254       =      254       ,              //       0
   ih_255       =      255       ,              //       0

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -57,6 +57,7 @@
 #include <functional>
 #include <initializer_list>
 #include <map>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -500,25 +501,59 @@ public:
 
     bool hasDefinedValues() const;
 
+    Window<int>    iaaq(const std::size_t aquiferID) const;
+    Window<float>  saaq(const std::size_t aquiferID) const;
     Window<double> xaaq(const std::size_t aquiferID) const;
 
 private:
     std::size_t maxAnalyticAquifer_;
-    std::size_t numXAnalyticAquiferElm_;
+    std::size_t numIntAnalyticAquiferElm_;
+    std::size_t numFloatAnalyticAquiferElm_;
+    std::size_t numDoubleAnalyticAquiferElm_;
 
     std::shared_ptr<RestartFileView> rstView_;
 };
 
 AquiferVectors::AquiferVectors(const std::vector<int>&          intehead,
                                std::shared_ptr<RestartFileView> rst_view)
-    : maxAnalyticAquifer_    (intehead[VI::intehead::MAX_AN_AQUIFERS])
-    , numXAnalyticAquiferElm_(intehead[VI::intehead::NXAAQZ])
-    , rstView_               (std::move(rst_view))
+    : maxAnalyticAquifer_         (intehead[VI::intehead::MAX_AN_AQUIFERS])
+    , numIntAnalyticAquiferElm_   (intehead[VI::intehead::NIAAQZ])
+    , numFloatAnalyticAquiferElm_ (intehead[VI::intehead::NSAAQZ])
+    , numDoubleAnalyticAquiferElm_(intehead[VI::intehead::NXAAQZ])
+    , rstView_                    (std::move(rst_view))
 {}
 
 bool AquiferVectors::hasDefinedValues() const
 {
-    return this->rstView_->hasKeyword<double>("XAAQ");
+    return this->rstView_->hasKeyword<int>   ("IAAQ")
+        && this->rstView_->hasKeyword<float> ("SAAQ")
+        && this->rstView_->hasKeyword<double>("XAAQ");
+}
+
+AquiferVectors::Window<int>
+AquiferVectors::iaaq(const std::size_t aquiferID) const
+{
+    if (! this->hasDefinedValues()) {
+        throw std::logic_error {
+            "Cannot Request IAAQ Values Unless Defined"
+        };
+    }
+
+    return getDataWindow(this->rstView_->getKeyword<int>("IAAQ"),
+                         this->numIntAnalyticAquiferElm_, aquiferID);
+}
+
+AquiferVectors::Window<float>
+AquiferVectors::saaq(const std::size_t aquiferID) const
+{
+    if (! this->hasDefinedValues()) {
+        throw std::logic_error {
+            "Cannot Request SAAQ Values Unless Defined"
+        };
+    }
+
+    return getDataWindow(this->rstView_->getKeyword<float>("SAAQ"),
+                         this->numFloatAnalyticAquiferElm_, aquiferID);
 }
 
 AquiferVectors::Window<double>
@@ -531,7 +566,7 @@ AquiferVectors::xaaq(const std::size_t aquiferID) const
     }
 
     return getDataWindow(this->rstView_->getKeyword<double>("XAAQ"),
-                         this->numXAnalyticAquiferElm_, aquiferID);
+                         this->numDoubleAnalyticAquiferElm_, aquiferID);
 }
 
 // ---------------------------------------------------------------------
@@ -1152,6 +1187,49 @@ namespace {
         return soln;
     }
 
+    Opm::data::AquiferType
+    determineAquiferType(const AquiferVectors::Window<int>& iaaq)
+    {
+        const auto t1 = iaaq[VI::IAnalyticAquifer::TypeRelated1];
+        const auto t2 = iaaq[VI::IAnalyticAquifer::TypeRelated2];
+
+        if ((t1 == 1) && (t2 == 1)) {
+            return Opm::data::AquiferType::CarterTracey;
+        }
+
+        if ((t1 == 0) && (t2 == 0)) {
+            return Opm::data::AquiferType::Fetkovich;
+        }
+
+        throw std::runtime_error {
+            "Unknown Aquifer Type:"
+                  " T1 = "  + std::to_string(t1)
+                + ", T2 = " + std::to_string(t2)
+        };
+    }
+
+    std::shared_ptr<Opm::data::FetkovichData>
+    extractFetkcovichData(const Opm::UnitSystem&               usys,
+                          const AquiferVectors::Window<float>& saaq)
+    {
+        using M = ::Opm::UnitSystem::measure;
+
+        auto data = std::make_shared<Opm::data::FetkovichData>();
+
+        data->initVolume =
+            usys.to_si(M::liquid_surface_volume,
+                       saaq[VI::SAnalyticAquifer::FetInitVol]);
+
+        data->prodIndex =
+            usys.to_si(M::liquid_surface_rate,
+            usys.from_si(M::pressure,
+                         saaq[VI::SAnalyticAquifer::FetProdIndex]));
+
+        data->timeConstant = saaq[VI::SAnalyticAquifer::FetTimeConstant];
+
+        return data;
+    }
+
     void restore_aquifers(const ::Opm::EclipseState&       es,
                           std::shared_ptr<RestartFileView> rst_view,
                           Opm::RestartValue&               rst_value)
@@ -1166,6 +1244,7 @@ namespace {
         const auto& units = es.getUnits();
 
         for (auto aquiferID = 0*numAq; aquiferID < numAq; ++aquiferID) {
+            const auto& saaq = aquiferData.saaq(aquiferID);
             const auto& xaaq = aquiferData.xaaq(aquiferID);
 
             rst_value.aquifer.emplace_back();
@@ -1176,6 +1255,18 @@ namespace {
             aqData.pressure  = units.to_si(M::pressure, xaaq[Ix::Pressure]);
             aqData.volume    = units.to_si(M::liquid_surface_volume,
                                            xaaq[Ix::ProdVolume]);
+
+            aqData.initPressure =
+                units.to_si(M::pressure, saaq[VI::SAnalyticAquifer::InitPressure]);
+
+            aqData.datumDepth =
+                units.to_si(M::length, saaq[VI::SAnalyticAquifer::DatumDepth]);
+
+            aqData.type = determineAquiferType(aquiferData.iaaq(aquiferID));
+
+            if (aqData.type == Opm::data::AquiferType::Fetkovich) {
+                aqData.aquFet = extractFetkcovichData(units, saaq);
+            }
         }
     }
 


### PR DESCRIPTION
This adds a basic protocol for retrieving simple scalar data for each analytic aquifer, specifically from `XAAQ`.  At the moment we only support retrieving the aquifer pressure and the total produced liquid volume from the aquifer and into the reservoir model.