### PR TITLE
fixed: serialize thp to OPM_XWEL

### DIFF
--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -705,7 +705,7 @@ namespace {
                 -> std::size_t
             {
                 return acc
-                    + 2 + phases.size()
+                    + 3 + phases.size()
                     + (w.getConnections().size()
                         * (phases.size() + Opm::data::Connection::restart_size));
             });
@@ -764,6 +764,7 @@ namespace {
             auto& well = wells[ sched_well.name() ];
 
             well.bhp         = *opm_xwel_data;  ++opm_xwel_data;
+            well.thp         = *opm_xwel_data;  ++opm_xwel_data;
             well.temperature = *opm_xwel_data;  ++opm_xwel_data;
             well.control     = *opm_iwel_data;  ++opm_iwel_data;
 

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -124,7 +124,7 @@ namespace {
             {
                 const auto elems = (sched_well.getConnections().size()
                                     * (phases.size() + data::Connection::restart_size))
-                    + 2 /* bhp, temperature */
+                    + 3 /* bhp, thp, temperature */
                     + phases.size();
 
                 // write zeros if no well data is provided
@@ -135,6 +135,7 @@ namespace {
             const auto& well = wells.at( sched_well.name() );
 
             xwel.push_back( well.bhp );
+            xwel.push_back( well.thp );
             xwel.push_back( well.temperature );
 
             for (auto phase : phases)

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -285,6 +285,7 @@ data::Wells mkWells() {
 
     data::Well w1, w2;
     w1.rates = r1;
+    w1.thp = 1.0;
     w1.bhp = 1.23;
     w1.temperature = 3.45;
     w1.control = 1;
@@ -297,6 +298,7 @@ data::Wells mkWells() {
     w1.connections.push_back( { 288, rc2, 33.19, 123.4, 432.1, 0.26, 0.45, 2.56 } );
 
     w2.rates = r2;
+    w2.thp = 2.0;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
     w2.control = 2;


### PR DESCRIPTION
This fixes test_Restart.

I am sorry for the breakage. Due to several screwups I was falsely under the impression that the test passed.

1) I had accidentially squashed an initializer for the thp variable in an unrelated commit in the branch where I tested.
2) I thought I had tested on jenkins, but I ran the downstream builder and the tests here were not executed.

I have here opted to rather fix the serialization than adding the initializer. Since all data in these structs are uninitialized, I don't want to just initialize the one entry. I rather leave it up to those two know this code better to decide whether proper initialization is too costly to have or not. Since this again only affects the XWEL code and that is slated for removal, I chose the "local" fix.