### PR TITLE
Disable use of FieldPropsManager in MULTREGTScanner

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -245,7 +245,8 @@ std::vector<int> unique(const std::vector<int> data) {
 
         for (auto iter = m_searchMap.begin(); iter != m_searchMap.end(); iter++) {
 #ifdef ENABLE_3DPROPS_TESTING
-            const auto& region_data = this->fp.get_global<int>( iter->first );
+            // const auto& region_data = this->fp.get_global<int>( iter->first );
+            const auto& region_data = m_e3DProps.getIntGridProperty( (*iter).first ).getData();
 #else
             const auto& region_data = m_e3DProps.getIntGridProperty( (*iter).first ).getData();
 #endif


### PR DESCRIPTION
The transmissibility multiplier is used in a loop over all elements, and the copying from only active to global was expenseive. Temp fix.