### PR TITLE
Transmult regions

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -83,6 +83,7 @@ namespace Opm {
         std::vector< MULTREGTRecord > m_records;
         std::map<std::string , MULTREGTSearchMap> m_searchMap;
         std::map<std::string, std::vector<int>> regions;
+        std::string default_region;
     };
 
 }

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -82,6 +82,7 @@ namespace Opm {
         const Eclipse3DProperties& m_e3DProps;
         std::vector< MULTREGTRecord > m_records;
         std::map<std::string , MULTREGTSearchMap> m_searchMap;
+        std::map<std::string, std::vector<int>> regions;
     };
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -122,7 +122,11 @@ std::vector<int> unique(const std::vector<int> data) {
         MULTREGTSearchMap searchPairs;
         for (std::vector<MULTREGTRecord>::const_iterator record = m_records.begin(); record != m_records.end(); ++record) {
             const std::string& region_name = record->region_name;
+#ifdef ENABLE_3DPROPS_TESTING
+            if (fp_arg.has<int>( region_name)) {
+#else
             if (e3DProps.hasDeckIntGridProperty( region_name)) {
+#endif
                 int srcRegion    = record->src_value;
                 int targetRegion = record->target_value;
 
@@ -146,7 +150,7 @@ std::vector<int> unique(const std::vector<int> data) {
                 this->regions[region_name] = this->fp.get_global<int>(region_name);
 #else
             if (this->regions.count(region_name) == 0)
-                this->regions[region_name] = this->m_3DProps.getIntGridProperty(region_name).getData();
+                this->regions[region_name] = this->m_e3DProps.getIntGridProperty(region_name).getData();
 #endif
         }
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -116,16 +116,22 @@ std::vector<int> unique(const std::vector<int> data) {
          fp(fp_arg),
          m_e3DProps(e3DProps) {
 
+#ifdef ENABLE_3DPROPS_TESTING
+         this->default_region = this->fp.default_region();
+#else
+         this->default_region = this->m_e3DProps.getDefaultRegionKeyword();
+#endif
+
         for (size_t idx = 0; idx < keywords.size(); idx++)
-            this->addKeyword(*keywords[idx] , this->fp.default_region());
+            this->addKeyword(*keywords[idx] , this->default_region);
 
         MULTREGTSearchMap searchPairs;
         for (std::vector<MULTREGTRecord>::const_iterator record = m_records.begin(); record != m_records.end(); ++record) {
             const std::string& region_name = record->region_name;
 #ifdef ENABLE_3DPROPS_TESTING
-            if (fp_arg.has<int>( region_name)) {
+            if (this->fp.has<int>( region_name)) {
 #else
-            if (e3DProps.hasDeckIntGridProperty( region_name)) {
+            if (this->m_e3DProps.hasDeckIntGridProperty( region_name)) {
 #endif
                 int srcRegion    = record->src_value;
                 int targetRegion = record->target_value;


### PR DESCRIPTION
Cache the region properties for the transmissibility multipliers - to enable testing of the new 3D implementation.

Replace #1284 as fix for performance regression in #1240.