### PR TITLE
Determine that wells are flowing from nonzero rates

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -82,8 +82,8 @@ namespace Opm {
             /// chaining.
             inline Rates& set( opt m, double value );
 
-            /// true if any option is set; false otherwise
-            inline bool any() const noexcept;
+            /// Returns true if any of the rates oil, gas, water is nonzero
+            inline bool flowing() const;
 
             template <class MessageBufferType>
             void write(MessageBufferType& buffer) const;
@@ -349,12 +349,15 @@ namespace Opm {
                 );
     }
 
-    inline bool Rates::any() const noexcept {
-        return static_cast< enum_size >( this->mask ) != 0;
+
+    bool inline Rates::flowing() const {
+        return ((this->wat != 0) ||
+                (this->oil != 0) ||
+                (this->gas != 0));
     }
 
     inline bool Well::flowing() const noexcept {
-        return this->rates.any();
+        return this->rates.flowing();
     }
 
     template <class MessageBufferType>

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -348,7 +348,7 @@ namespace {
                             std::end  (xw.connections),
                     [](const Opm::data::Connection& c)
                 {
-                    return c.rates.any();
+                    return c.rates.flowing();
                 });
 
             iWell[Ix::item9] = any_flowing_conn


### PR DESCRIPTION
The summary keywords `FMWPR` and `FMWIN`count the number of flowing producers and injectors. In current code a well is set to flowing if one of the [Rates](https://github.com/OPM/opm-common/blob/master/opm/output/data/Wells.hpp#L37) is set; however it does not check the numeric value - i.e. if a rate is set to `0.0` the well will counted as flowing.

In this PR the numerical values is checked.