### PR TITLE
Special case ACTNUM and PORV in the FieldProps keys() method

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -449,11 +449,19 @@ bool FieldProps::has<int>(const std::string& keyword) const {
     return (this->int_data.count(keyword) != 0);
 }
 
+
+/*
+  The ACTNUM and PORV keywords are special cased with quite extensive
+  postprocessing, and should be access through the special ::porv() and
+  ::actnum() methods instead of the general ::get<T>( ) method. These two
+  keywords are also hidden from the keys<T>() vectors.
+*/
+
 template <>
 std::vector<std::string> FieldProps::keys<double>() const {
     std::vector<std::string> klist;
     for (const auto& data_pair : this->double_data) {
-        if (data_pair.second.valid())
+        if (data_pair.second.valid() && data_pair.first != "PORV")
             klist.push_back(data_pair.first);
     }
     return klist;
@@ -462,8 +470,10 @@ std::vector<std::string> FieldProps::keys<double>() const {
 template <>
 std::vector<std::string> FieldProps::keys<int>() const {
     std::vector<std::string> klist;
-    for (const auto& data_pair : this->int_data)
-        klist.push_back(data_pair.first);
+    for (const auto& data_pair : this->int_data) {
+        if (data_pair.second.valid() && data_pair.first != "ACTNUM")
+            klist.push_back(data_pair.first);
+    }
     return klist;
 }
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -72,6 +72,12 @@ PORO
 BOX
   1 3 1 3 1 3 /
 
+PORV
+  27*100 /
+
+ACTNUM
+   27*1 /
+
 PERMX
   27*0.6/
 
@@ -103,10 +109,16 @@ PERMX
         BOOST_CHECK_EQUAL(keys.size(), 1);
         BOOST_CHECK(std::find(keys.begin(), keys.end(), "PORO")  != keys.end());
         BOOST_CHECK(std::find(keys.begin(), keys.end(), "PERMX") == keys.end());
+
+        // The PORV property should be extracted with the special function
+        // fp.porv() and not the general get<double>() functionality.
+        BOOST_CHECK(std::find(keys.begin(), keys.end(), "PORV") == keys.end());
     }
     {
         const auto& keys = fpm.keys<int>();
         BOOST_CHECK_EQUAL(keys.size(), 0);
+
+        BOOST_CHECK(std::find(keys.begin(), keys.end(), "ACTNUM") == keys.end());
     }
 }
 


### PR DESCRIPTION
Comment in code:

```c++
/*
  The ACTNUM and PORV keywords are special cased with quite extensive
  postprocessing, and should be access through the special ::porv() and
  ::actnum() methods instead of the general ::get<T>( ) method. These two
  keywords are also hidden from the keys<T>() vectors.
*/
```
