### PR TITLE
Make sure the ACTNUM field is not output to the INIT file

### DIFF
--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -476,8 +476,10 @@ namespace {
         properties.assertKeyword("FIPNUM");
 
         for (const auto& property : properties) {
-            auto ecl_data = property.compressedCopy(grid);
+            if (property.getKeywordName() == "ACTNUM")
+                continue;
 
+            auto ecl_data = property.compressedCopy(grid);
             initFile.write(property.getKeywordName(), ecl_data);
         }
     }


### PR DESCRIPTION
The code to write INIT files has a loop over all int properties; this typically includes the "ACTNUM" keyword - which should not be output to the INIT file (I think ....?). This PR - with the necessary update_data is again a preparation for the 3D refactor.

In the `FieldProps`based implementation the `ACTNUM`field is treated differently, and it will not be necessary to special case at the output level.