### PR TITLE
Use std::vector<double> instead of GridProperty<double> in TransMult

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
@@ -52,7 +52,7 @@ namespace Opm {
         double getMultiplier(size_t globalIndex, FaceDir::DirEnum faceDir) const;
         double getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const;
         double getRegionMultiplier( size_t globalCellIndex1, size_t globalCellIndex2, FaceDir::DirEnum faceDir) const;
-        void applyMULT(const GridProperty<double>& srcMultProp, FaceDir::DirEnum faceDir);
+        void applyMULT(const std::vector<double>& srcMultProp, FaceDir::DirEnum faceDir);
         void applyMULTFLT(const FaultCollection& faults);
         void applyMULTFLT(const Fault& fault);
 
@@ -60,12 +60,11 @@ namespace Opm {
         size_t getGlobalIndex(size_t i , size_t j , size_t k) const;
         void assertIJK(size_t i , size_t j , size_t k) const;
         double getMultiplier__(size_t globalIndex , FaceDir::DirEnum faceDir) const;
-        void insertNewProperty(FaceDir::DirEnum faceDir);
         bool hasDirectionProperty(FaceDir::DirEnum faceDir) const;
-        GridProperty<double>& getDirectionProperty(FaceDir::DirEnum faceDir);
+        std::vector<double>& getDirectionProperty(FaceDir::DirEnum faceDir);
 
         size_t m_nx , m_ny , m_nz;
-        std::map<FaceDir::DirEnum , GridProperty<double> > m_trans;
+        std::map<FaceDir::DirEnum , std::vector<double> > m_trans;
         std::map<FaceDir::DirEnum , std::string> m_names;
         MULTREGTScanner m_multregtScanner;
     };

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -279,19 +279,19 @@ void assert_field_properties(const EclipseGrid& grid, const FieldPropsManager& f
     void EclipseState::initTransMult() {
         const auto& p = m_eclipseProperties;
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTX"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTX"), FaceDir::XPlus);
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTX").getData(), FaceDir::XPlus);
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTX-"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTX-"), FaceDir::XMinus);
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTX-").getData(), FaceDir::XMinus);
 
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTY"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTY"), FaceDir::YPlus);
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTY").getData(), FaceDir::YPlus);
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTY-"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTY-"), FaceDir::YMinus);
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTY-").getData(), FaceDir::YMinus);
 
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTZ"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ"), FaceDir::ZPlus);
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ").getData(), FaceDir::ZPlus);
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTZ-"))
-            m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ-"), FaceDir::ZMinus);
+            m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ-").getData(), FaceDir::ZMinus);
     }
 
     void EclipseState::initFaults(const Deck& deck) {

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -277,6 +277,17 @@ void assert_field_properties(const EclipseGrid& grid, const FieldPropsManager& f
     }
 
     void EclipseState::initTransMult() {
+#ifdef ENABLE_3DPROPS_TESTING
+        const auto& fp = this->field_props;
+        if (fp.has<double>("MULTX"))  this->m_transMult.applyMULT(fp.get_global<double>("MULTX") , FaceDir::XPlus);
+        if (fp.has<double>("MULTX-")) this->m_transMult.applyMULT(fp.get_global<double>("MULTX-"), FaceDir::XMinus);
+
+        if (fp.has<double>("MULTY"))  this->m_transMult.applyMULT(fp.get_global<double>("MULTY") , FaceDir::YPlus);
+        if (fp.has<double>("MULTY-")) this->m_transMult.applyMULT(fp.get_global<double>("MULTY-"), FaceDir::YMinus);
+
+        if (fp.has<double>("MULTZ"))  this->m_transMult.applyMULT(fp.get_global<double>("MULTZ") , FaceDir::ZPlus);
+        if (fp.has<double>("MULTZ-")) this->m_transMult.applyMULT(fp.get_global<double>("MULTZ-"), FaceDir::ZMinus);
+#else
         const auto& p = m_eclipseProperties;
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTX"))
             m_transMult.applyMULT(p.getDoubleGridProperty("MULTX").getData(), FaceDir::XPlus);
@@ -292,6 +303,7 @@ void assert_field_properties(const EclipseGrid& grid, const FieldPropsManager& f
             m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ").getData(), FaceDir::ZPlus);
         if (m_eclipseProperties.hasDeckDoubleGridProperty("MULTZ-"))
             m_transMult.applyMULT(p.getDoubleGridProperty("MULTZ-").getData(), FaceDir::ZMinus);
+#endif
     }
 
     void EclipseState::initFaults(const Deck& deck) {

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -45,13 +45,28 @@ static const std::map<std::string, std::string> unit_string = {{"PORO", "1"},
                                                                {"PERMZ", "Permeability"},
                                                                {"PORV", "ReservoirVolume"},
                                                                {"NTG", "1"},
-                                                               {"SWATINIT", "1"}};
+                                                               {"SWATINIT", "1"},
+                                                               {"MULTPV", "1"},
+                                                               {"MULTX", "1"},
+                                                               {"MULTX-", "1"},
+                                                               {"MULTY", "1"},
+                                                               {"MULTY-", "1"},
+                                                               {"MULTZ", "1"},
+                                                               {"MULTZ-", "1"}};
+
+
 
 static const std::set<std::string> oper_keywords = {"ADD", "EQUALS", "MAXVALUE", "MINVALUE", "MULTIPLY"};
 static const std::set<std::string> region_oper_keywords = {"ADDREG", "EQUALREG"};
 static const std::set<std::string> box_keywords = {"BOX", "ENDBOX"};
 static const std::map<std::string, double> double_scalar_init = {{"NTG", 1},
-                                                                 {"MULTPV", 1}};
+                                                                 {"MULTPV", 1},
+                                                                 {"MULTX", 1},
+                                                                 {"MULTX-", 1},
+                                                                 {"MULTY", 1},
+                                                                 {"MULTY-", 1},
+                                                                 {"MULTZ", 1},
+                                                                 {"MULTZ-", 1}};
 
 static const std::map<std::string, int> int_scalar_init = {{"SATNUM", 1},
                                                            {"FIPNUM", 1},   // All FIPxxx keywords should (probably) be added with init==1 
@@ -69,13 +84,13 @@ bool isFipxxx< int >(const std::string& keyword) {
 */
 
 namespace GRID {
-static const std::set<std::string> double_keywords = {"MULTPV", "NTG", "PORO", "PERMX", "PERMY", "PERMZ", "THCONR"};
+static const std::set<std::string> double_keywords = {"MULTPV", "NTG", "PORO", "PERMX", "PERMY", "PERMZ", "THCONR", "MULTX", "MULTX-", "MULTY-", "MULTY", "MULTZ", "MULTZ-"};
 static const std::set<std::string> int_keywords    = {"ACTNUM", "FLUXNUM", "MULTNUM", "OPERNUM", "ROCKNUM"};
 static const std::set<std::string> top_keywords    = {"PORO", "PERMX", "PERMY", "PERMZ"};
 }
 
 namespace EDIT {
-static const std::set<std::string> double_keywords = {"MULTPV", "PORV"};
+static const std::set<std::string> double_keywords = {"MULTPV", "PORV","MULTX", "MULTX-", "MULTY-", "MULTY", "MULTZ", "MULTZ-"};
 static const std::set<std::string> int_keywords = {};
 }
 

--- a/tests/parser/TransMultTests.cpp
+++ b/tests/parser/TransMultTests.cpp
@@ -76,6 +76,6 @@ MULTZ
     Opm::FieldPropsManager fp(deck, grid, tables);
     Opm::TransMult transMult(grid, deck, fp, props);
 
-    transMult.applyMULT(props.getDoubleGridProperty("MULTZ"), Opm::FaceDir::ZPlus);
+    transMult.applyMULT(props.getDoubleGridProperty("MULTZ").getData(), Opm::FaceDir::ZPlus);
     BOOST_CHECK_EQUAL( transMult.getMultiplier(0,0,0 , Opm::FaceDir::ZPlus) , 4.0 );
 }


### PR DESCRIPTION
YAPR in the endless stream of small refactorings to prepare for new 3D implementation.