### PR TITLE
Differentiate between valid and invalid default values while parsing

### DIFF
--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -72,6 +72,7 @@ namespace Opm {
 
         template< typename T > const std::vector< T >& getData() const;
         const std::vector< double >& getSIDoubleData() const;
+        const std::vector<value::status>& getValueStatus() const;
 
         void push_back( UDAValue );
         void push_back( int );

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -28,6 +28,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckValue.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/value_status.hpp>
 #include <opm/common/OpmLog/Location.hpp>
 
 namespace Opm {
@@ -63,6 +64,7 @@ namespace Opm {
         const std::vector<double>& getRawDoubleData() const;
         const std::vector<double>& getSIDoubleData() const;
         const std::vector<std::string>& getStringData() const;
+        const std::vector<value::status>& getValueStatus() const;
         const ParserKeyword& parserKeyword() const;
         size_t getDataSize() const;
         void write( DeckOutput& output ) const;

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -108,6 +108,10 @@ bool DeckItem::defaultApplied( size_t index ) const {
     return value::defaulted( this->value_status.at(index));
 }
 
+const std::vector<value::status>& DeckItem::getValueStatus() const {
+    return this->value_status;
+}
+
 bool DeckItem::hasValue( size_t index ) const {
     if (index >= this->value_status.size())
         return false;

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -259,6 +259,10 @@ namespace Opm {
         return this->getDataRecord().getDataItem().getSIDoubleData();
     }
 
+    const std::vector<value::status>& DeckKeyword::getValueStatus() const {
+        return this->getDataRecord().getDataItem().getValueStatus();
+   }
+
     void DeckKeyword::write_data( DeckOutput& output ) const {
         for (const auto& record: *this)
             record.write( output );

--- a/src/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -244,9 +244,6 @@ const T& ParserItem::getDefault() const {
     if( get_type< T >() != this->data_type )
         throw std::invalid_argument( "getDefault: Wrong type." );
 
-    if( !this->hasDefault() && this->m_sizeType == item_size::ALL )
-        return default_value< T >();
-
     if( !this->hasDefault() )
         throw std::invalid_argument( "No default value available for item "
                                      + this->name() );
@@ -497,9 +494,14 @@ void scan_item( DeckItem& deck_item, const ParserItem& parser_item, RawRecord& r
                 continue;
             }
 
-            auto value = parser_item.getDefault< T >();
-            for (size_t i=0; i < st.count(); i++)
-                deck_item.push_backDefault( value );
+            if (parser_item.hasDefault()) {
+                auto value = parser_item.getDefault< T >();
+                for (size_t i=0; i < st.count(); i++)
+                    deck_item.push_backDefault( value );
+            } else {
+                for (size_t i=0; i < st.count(); i++)
+                    deck_item.push_backDummyDefault<T>();
+            }
         }
 
         return;

--- a/tests/parser/DeckValueTests.cpp
+++ b/tests/parser/DeckValueTests.cpp
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(DeckKeywordConstructor) {
 
 
 BOOST_AUTO_TEST_CASE(DeckKeywordVectorInt) {
-    
+
    Parser parser;
    Deck deck;
 
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(DeckKeywordVectorInt) {
    DeckKeyword hbnum_kw(hbnum, data);
    BOOST_CHECK(hbnum_kw.isDataKeyword());
    BOOST_CHECK_EQUAL(hbnum_kw.getDataSize(), 9);
-   BOOST_CHECK( hbnum_kw.getIntData() == data );   
+   BOOST_CHECK( hbnum_kw.getIntData() == data );
 
    std::vector<double> data_double = {1.1, 2.2};
    BOOST_CHECK_THROW(DeckKeyword(hbnum, data_double, unit_active, unit_default), std::invalid_argument);
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(DeckKeywordVectorInt) {
 
 
 BOOST_AUTO_TEST_CASE(DeckKeywordVectorDouble) {
-    
+
    Parser parser;
    Deck deck;
 
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(DeckKeywordVectorDouble) {
    const ParserKeyword& box = parser.getKeyword("BOX");
 
    std::vector<double> data = {1.1, 2.2, 3.3};
-   
+
    BOOST_CHECK_THROW(DeckKeyword(box, data, unit_active, unit_default), std::invalid_argument);
    DeckKeyword zcorn_kw(zcorn, data, unit_active, unit_default);
    BOOST_CHECK(zcorn_kw.isDataKeyword());
@@ -191,5 +191,24 @@ BOOST_AUTO_TEST_CASE(DeckKeywordVectorDouble) {
 
 
 
+
+
+
+BOOST_AUTO_TEST_CASE(ValueStatus) {
+    const std::string deck_string = R"(
+PERMX
+  100* /
+)";
+
+    Parser parser;
+    Deck deck = parser.parseString(deck_string);
+    const auto& permx = deck.getKeyword("PERMX");
+    const auto& status = permx.getValueStatus();
+    BOOST_CHECK_EQUAL(status.size(), 100);
+    for (const auto& vs : status) {
+        BOOST_CHECK(!value::has_value(vs));
+        BOOST_CHECK(vs == value::status::empty_default);
+    }
+}
 
 

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -472,7 +472,7 @@ BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject) {
     ParserItem item1( jsonConfig );
     BOOST_CHECK_EQUAL( "ITEM1" , item1.name() );
     BOOST_CHECK_EQUAL( ParserItem::item_size::ALL, item1.sizeType() );
-    BOOST_CHECK(item1.getDefault< int >() < 0);
+    BOOST_CHECK_THROW(item1.getDefault< int >(), std::invalid_argument);
 }
 
 


### PR DESCRIPTION
Default values have been an endless source of small quibbles. With this PR we export the distinction between valid defaults and invalid defaults.