### PR TITLE
Regression testing: Detect reordering of keywords in the INIT file

### DIFF
--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -46,6 +46,17 @@
     } \
   }
 
+namespace {
+
+template <typename T>
+std::vector<T> sorted(std::vector<T> v) {
+    std::sort(v.begin(), v.end());
+    return v;
+}
+
+}
+
+
 using namespace Opm::EclIO;
 
 ECLRegressionTest::~ECLRegressionTest()
@@ -566,7 +577,19 @@ void ECLRegressionTest::results_init()
             std::cout << "\nComparing init files \n" << std::endl;
 
             if (spesificKeyword.empty()) {
-                compareKeywords(keywords1, keywords2, reference);
+                if (keywords1.size() == keywords2.size() && keywords1 != keywords2) {
+                    /*
+                      If the keywords come in different order in the two files
+                      we mark that as a test failure, but all comparisons are
+                      still performed, and the keyword reordering can be
+                      identified by the error message.
+                    */
+                    auto kw1 = sorted(keywords1);
+                    auto kw2 = sorted(keywords2);
+                    compareKeywords(kw1,kw2,reference);
+                    HANDLE_ERROR(std::runtime_error, "Keyword reordering detected in INIT file");
+                } else
+                    compareKeywords(keywords1, keywords2, reference);
             } else {
                 checkSpesificKeyword(keywords1, keywords2, arrayType1, arrayType2, reference);
             }

--- a/test_util/compareECL.cpp
+++ b/test_util/compareECL.cpp
@@ -100,6 +100,7 @@ int main(int argc, char** argv) {
         switch (c) {
         case 'a':
             analysis = true;
+            throwOnError = false;
             break;
         case 'h':
             printHelp();


### PR DESCRIPTION
~~This PR adds a new flag `bool allowKeywordReorder` which is passed to the function comparing keywordlist in the `EclRegressionTest` class. For `INIT` files a value of `true` is passed, whereas `false` - corresponding to current behavior is passed to the other files.~~

With this PR the INIT files are special cases somewhat in the regression testing: If it is detected that the keywords have been reordered that is flagged as an error, but the comparison continues, and if at the end of the test run *only* the keyword order has been changed that can be read from the error message.

The motivation for this is #1236 - where the regression tests fail because the `xxxNUM` keywords are reordered in the new implementation. The current orderering is quite random, and it feels a bit weird to add special case coding to retain a random order, could of course do `update_data`- but the new ordering will be equally random - therefor this suggestion.

Observe that this PR also sets the `compareECL` flag `throwOnError` to false when the `compareECL` application is rerun to analyze results. This is essential to ensure that all *other* tests are performed in the case of reordering problem; which again is essential to know if we can safely issue `update_data` if we only have a reordering error. 