### PR TITLE
Add Dedicated Units of Measurement for SICD Strength Parameter

### DIFF
--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -52,9 +52,11 @@ namespace Opm {
             liquid_surface_volume,
             gas_surface_volume,
             volume,
+            geometric_volume,
             liquid_surface_rate,
             gas_surface_rate,
             rate,
+            geometric_volume_rate,
             transmissibility,
             effective_Kh,
             mass,
@@ -70,7 +72,8 @@ namespace Opm {
             water_inverse_formation_volume_factor,
             liquid_productivity_index,
             gas_productivity_index,
-            energy
+            energy,
+            icd_strength,
         };
 
         explicit UnitSystem(UnitType unit = UnitType::UNIT_TYPE_METRIC);

--- a/opm/parser/eclipse/Units/Units.hpp
+++ b/opm/parser/eclipse/Units/Units.hpp
@@ -265,6 +265,7 @@ namespace Opm {
         constexpr const double LiquidSurfaceVolume  = cubic(meter);
         constexpr const double GasSurfaceVolume     = cubic(meter);
         constexpr const double ReservoirVolume      = cubic(meter);
+        constexpr const double GeomVolume           = cubic(meter);
         constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
         constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
         constexpr const double Density              = kilogram/cubic(meter);
@@ -294,6 +295,7 @@ namespace Opm {
         constexpr const double LiquidSurfaceVolume  = stb;
         constexpr const double GasSurfaceVolume     = 1000*cubic(feet);
         constexpr const double ReservoirVolume      = stb;
+        constexpr const double GeomVolume           = cubic(feet);
         constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
         constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
         constexpr const double Density              = pound/cubic(feet);
@@ -323,6 +325,7 @@ namespace Opm {
         constexpr const double LiquidSurfaceVolume  = cubic(centi*meter);
         constexpr const double GasSurfaceVolume     = cubic(centi*meter);
         constexpr const double ReservoirVolume      = cubic(centi*meter);
+        constexpr const double GeomVolume           = cubic(centi*meter);
         constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
         constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
         constexpr const double Density              = gram/cubic(centi*meter);
@@ -352,6 +355,7 @@ namespace Opm {
         constexpr const double LiquidSurfaceVolume  = cubic(meter);
         constexpr const double GasSurfaceVolume     = cubic(meter);
         constexpr const double ReservoirVolume      = cubic(meter);
+        constexpr const double GeomVolume           = cubic(meter);
         constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
         constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
         constexpr const double Density              = kilogram/cubic(meter);

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -1035,7 +1035,8 @@ namespace {
 
 
     void UnitSystem::addDimension( Dimension dimension ) {
-        this->m_dimensions[ dimension.getName() ] = std::move( dimension );
+        const auto dimname = dimension.getName();
+        this->m_dimensions[ dimname ] = std::move( dimension );
     }
 
     void UnitSystem::addDimension(const std::string& dimension , double SIfactor, double SIoffset) {

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -73,7 +73,10 @@ namespace {
         0.0,
         0.0,
         0.0,
-        0.0
+        0.0,
+        0.0,
+        0.0,
+        0.0,
     };
 
     static const double to_metric[] = {
@@ -89,9 +92,11 @@ namespace {
         1 / Metric::LiquidSurfaceVolume,
         1 / Metric::GasSurfaceVolume,
         1 / Metric::ReservoirVolume,
+        1 / Metric::GeomVolume,
         1 / ( Metric::LiquidSurfaceVolume / Metric::Time ),
         1 / ( Metric::GasSurfaceVolume / Metric::Time ),
         1 / ( Metric::ReservoirVolume / Metric::Time ),
+        1 / ( Metric::GeomVolume / Metric::Time ),
         1 / Metric::Transmissibility,
         1 / (Metric::Permeability * Metric::Length),
         1 / Metric::Mass,
@@ -107,9 +112,8 @@ namespace {
         1, /* water inverse formation volume factor */
         1 / (Metric::LiquidSurfaceVolume / Metric::Time / Metric::Pressure),
         1 / (Metric::GasSurfaceVolume / Metric::Time / Metric::Pressure),
-        1 / Metric::Energy
-
-
+        1 / Metric::Energy,
+        1 / (Metric::Pressure / Opm::unit::square(Metric::GeomVolume / Metric::Time)),
     };
 
     static const double from_metric[] = {
@@ -125,9 +129,11 @@ namespace {
         Metric::LiquidSurfaceVolume,
         Metric::GasSurfaceVolume,
         Metric::ReservoirVolume,
+        Metric::GeomVolume,
         Metric::LiquidSurfaceVolume / Metric::Time,
         Metric::GasSurfaceVolume / Metric::Time,
         Metric::ReservoirVolume / Metric::Time,
+        Metric::GeomVolume / Metric::Time,
         Metric::Transmissibility,
         Metric::Permeability * Metric::Length,
         Metric::Mass,
@@ -143,8 +149,8 @@ namespace {
         1, /* water inverse formation volume factor */
         Metric::LiquidSurfaceVolume / Metric::Time / Metric::Pressure,
         Metric::GasSurfaceVolume / Metric::Time / Metric::Pressure,
-        Metric::Energy
-
+        Metric::Energy,
+        Metric::Pressure / Opm::unit::square(Metric::GeomVolume / Metric::Time),
     };
 
     static constexpr const char* metric_names[] = {
@@ -160,9 +166,11 @@ namespace {
         "SM3",
         "SM3",
         "RM3",
+        "SM3",  // Should possibly be RM3
         "SM3/DAY",
         "SM3/DAY",
         "RM3/DAY",
+        "SM3/DAY",  // Should possibly be RM3/DAY
         "CPR3/DAY/BARS",
         "MDM",
         "KG",
@@ -179,7 +187,7 @@ namespace {
         "SM3/DAY/BARS",
         "SM3/DAY/BARS",
         "KJ", /* energy */
-
+        "BARS/(RM3/DAY)2", /* ICD strength parameter */
     };
 
     // =================================================================
@@ -216,7 +224,10 @@ namespace {
         0.0,
         0.0,
         0.0,
-        0.0
+        0.0,
+        0.0,
+        0.0,
+        0.0,
     };
 
     static const double to_field[] = {
@@ -232,9 +243,11 @@ namespace {
         1 / Field::LiquidSurfaceVolume,
         1 / Field::GasSurfaceVolume,
         1 / Field::ReservoirVolume,
+        1 / Field::GeomVolume,
         1 / ( Field::LiquidSurfaceVolume / Field::Time ),
         1 / ( Field::GasSurfaceVolume / Field::Time ),
         1 / ( Field::ReservoirVolume / Field::Time ),
+        1 / ( Field::GeomVolume / Field::Time ),
         1 / Field::Transmissibility,
         1 / (Field::Permeability * Field::Length),
         1 / Field::Mass,
@@ -250,8 +263,8 @@ namespace {
         1, /* water inverse formation volume factor */
         1 / (Field::LiquidSurfaceVolume / Field::Time / Field::Pressure),
         1 / (Field::GasSurfaceVolume / Field::Time / Field::Pressure),
-        1 / Field::Energy
-
+        1 / Field::Energy,
+        1 / (Field::Pressure / Opm::unit::square(Field::GeomVolume / Field::Time)),
     };
 
     static const double from_field[] = {
@@ -267,9 +280,11 @@ namespace {
          Field::LiquidSurfaceVolume,
          Field::GasSurfaceVolume,
          Field::ReservoirVolume,
+         Field::GeomVolume,
          Field::LiquidSurfaceVolume / Field::Time,
          Field::GasSurfaceVolume / Field::Time,
          Field::ReservoirVolume / Field::Time,
+         Field::GeomVolume / Field::Time,
          Field::Transmissibility,
          Field::Permeability * Field::Length,
          Field::Mass,
@@ -285,8 +300,8 @@ namespace {
          1, /* water inverse formation volume factor */
          Field::LiquidSurfaceVolume / Field::Time / Field::Pressure,
          Field::GasSurfaceVolume / Field::Time / Field::Pressure,
-         Field::Energy
-
+         Field::Energy,
+         Field::Pressure / Opm::unit::square(Field::GeomVolume / Field::Time),
     };
 
     static constexpr const char* field_names[] = {
@@ -302,9 +317,11 @@ namespace {
         "STB",
         "MSCF",
         "RB",
+        "FT3",       // Should possibly be RFT3
         "STB/DAY",
         "MSCF/DAY",
         "RB/DAY",
+        "FT3/DAY",   // Should possibly be RFT3/DAY
         "CPRB/DAY/PSI",
         "MDFT",
         "LB",
@@ -321,7 +338,7 @@ namespace {
         "STB/DAY/PSIA",
         "MSCF/DAY/PSIA",
         "BTU", /* energy */
-
+        "PSI/(RFT3/DAY)2", /* ICD strength parameter */
     };
 
     // =================================================================
@@ -358,7 +375,10 @@ namespace {
         0.0,
         0.0,
         0.0,
-        0.0
+        0.0,
+        0.0,
+        0.0,
+        0.0,
     };
 
     static const double to_lab[] = {
@@ -374,9 +394,11 @@ namespace {
         1 / Lab::LiquidSurfaceVolume,
         1 / Lab::GasSurfaceVolume,
         1 / Lab::ReservoirVolume,
+        1 / Lab::GeomVolume,
         1 / ( Lab::LiquidSurfaceVolume / Lab::Time ),
         1 / ( Lab::GasSurfaceVolume / Lab::Time ),
         1 / ( Lab::ReservoirVolume / Lab::Time ),
+        1 / ( Lab::GeomVolume / Lab::Time ),
         1 / Lab::Transmissibility,
         1 / (Lab::Permeability * Lab::Length),
         1 / Lab::Mass,
@@ -392,8 +414,8 @@ namespace {
         1, /* water inverse formation volume factor */
         1 / (Lab::LiquidSurfaceVolume / Lab::Time / Lab::Pressure),
         1 / (Lab::GasSurfaceVolume / Lab::Time / Lab::Pressure),
-        1 / Lab::Energy
-
+        1 / Lab::Energy,
+        1 / (Lab::Pressure / Opm::unit::square(Lab::GeomVolume / Lab::Time)),
     };
 
     static const double from_lab[] = {
@@ -409,9 +431,11 @@ namespace {
         Lab::LiquidSurfaceVolume,
         Lab::GasSurfaceVolume,
         Lab::ReservoirVolume,
+        Lab::GeomVolume,
         Lab::LiquidSurfaceVolume / Lab::Time,
         Lab::GasSurfaceVolume / Lab::Time,
         Lab::ReservoirVolume / Lab::Time,
+        Lab::GeomVolume / Lab::Time,
         Lab::Transmissibility,
         Lab::Permeability * Lab::Length,
         Lab::Mass,
@@ -427,8 +451,8 @@ namespace {
         1, /* water inverse formation volume factor */
         Lab::LiquidSurfaceVolume / Lab::Time / Lab::Pressure,
         Lab::GasSurfaceVolume / Lab::Time / Lab::Pressure,
-        Lab::Energy
-
+        Lab::Energy,
+        Lab::Pressure / Opm::unit::square(Lab::GeomVolume / Lab::Time),
     };
 
     static constexpr const char* lab_names[] = {
@@ -444,9 +468,11 @@ namespace {
         "SCC",
         "SCC",
         "RCC",
+        "SCC",      // Should possibly be RCC
         "SCC/HR",
         "SCC/HR",
         "RCC/HR",
+        "SCC/HR",   // Should possibly be RCC/HR
         "CPRCC/HR/ATM",
         "MDCC",
         "G",
@@ -463,7 +489,7 @@ namespace {
         "SCC/HR/ATM",
         "SCC/HR/ATM",
         "J", /* energy */
-
+        "ATM/(RCC/H)2", /* ICD strength parameter */
     };
 
     // =================================================================
@@ -500,7 +526,10 @@ namespace {
         0.0,
         0.0,
         0.0,
-        0.0
+        0.0,
+        0.0,
+        0.0,
+        0.0,
     };
 
     static const double to_pvt_m[] = {
@@ -516,9 +545,11 @@ namespace {
         1 / PVT_M::LiquidSurfaceVolume,
         1 / PVT_M::GasSurfaceVolume,
         1 / PVT_M::ReservoirVolume,
+        1 / PVT_M::GeomVolume,
         1 / ( PVT_M::LiquidSurfaceVolume / PVT_M::Time ),
         1 / ( PVT_M::GasSurfaceVolume / PVT_M::Time ),
         1 / ( PVT_M::ReservoirVolume / PVT_M::Time ),
+        1 / ( PVT_M::GeomVolume / PVT_M::Time ),
         1 / PVT_M::Transmissibility,
         1 / (PVT_M::Permeability * PVT_M::Length),
         1 / PVT_M::Mass,
@@ -534,8 +565,8 @@ namespace {
         1 / (PVT_M::LiquidSurfaceVolume / PVT_M::ReservoirVolume), /* 1/Bw */
         1 / (PVT_M::LiquidSurfaceVolume / PVT_M::Time / PVT_M::Pressure),
         1 / (PVT_M::GasSurfaceVolume / PVT_M::Time / PVT_M::Pressure),
-        1 / PVT_M::Energy
-
+        1 / PVT_M::Energy,
+        1 / (PVT_M::Pressure / Opm::unit::square(PVT_M::GeomVolume / PVT_M::Time)),
     };
 
     static const double from_pvt_m[] = {
@@ -551,9 +582,11 @@ namespace {
         PVT_M::LiquidSurfaceVolume,
         PVT_M::GasSurfaceVolume,
         PVT_M::ReservoirVolume,
+        PVT_M::GeomVolume,
         PVT_M::LiquidSurfaceVolume / PVT_M::Time,
         PVT_M::GasSurfaceVolume / PVT_M::Time,
         PVT_M::ReservoirVolume / PVT_M::Time,
+        PVT_M::GeomVolume / PVT_M::Time,
         PVT_M::Transmissibility,
         PVT_M::Permeability * PVT_M::Length,
         PVT_M::Mass,
@@ -569,8 +602,8 @@ namespace {
         PVT_M::LiquidSurfaceVolume / PVT_M::ReservoirVolume, /* 1/Bw */
         PVT_M::LiquidSurfaceVolume / PVT_M::Time / PVT_M::Pressure,
         PVT_M::GasSurfaceVolume / PVT_M::Time / PVT_M::Pressure,
-        PVT_M::Energy
-
+        PVT_M::Energy,
+        PVT_M::Pressure / Opm::unit::square(PVT_M::GeomVolume / PVT_M::Time),
     };
 
     static constexpr const char* pvt_m_names[] = {
@@ -586,9 +619,11 @@ namespace {
         "SM3",
         "SM3",
         "RM3",
+        "SM3",         // Should possibly be RM3
         "SM3/DAY",
         "SM3/DAY",
         "RM3/DAY",
+        "SM3/DAY",     // Should possibly be SM3/DAY
         "CPR3/DAY/ATM",
         "MDM",
         "KG",
@@ -605,7 +640,7 @@ namespace {
         "SM3/DAY/ATM",
         "SM3/DAY/ATM",
         "KJ" /* energy */,
-
+        "ATM/(RM3/DAY)2" /* ICD strength parameter */,
     };
 
     // =================================================================
@@ -642,7 +677,10 @@ namespace {
         0.0,
         0.0,
         0.0,
-        0.0
+        0.0,
+        0.0,
+        0.0,
+        0.0,
     };
 
     static const double to_input[] = {
@@ -676,7 +714,10 @@ namespace {
         1,
         1,
         1,
-        1
+        1,
+        1,
+        1,
+        1,
     };
 
     static const double from_input[] = {
@@ -710,7 +751,10 @@ namespace {
         1,
         1,
         1,
-        1
+        1,
+        1,
+        1,
+        1,
     };
 
     static constexpr const char* input_names[] = {
@@ -726,9 +770,11 @@ namespace {
         "SM3",
         "SM3",
         "RM3",
+        "SM3",
         "SM3/DAY",
         "SM3/DAY",
         "RM3/DAY",
+        "SM3/DAY",
         "CPR3/DAY/BARS",
         "MDM",
         "KG",
@@ -745,7 +791,7 @@ namespace {
         "SM3/DAY/BARS",
         "SM3/DAY/BARS",
         "KJ", /* energy */
-
+        "BARS/(RM3/DAY)2", /* ICD strength parameter */
     };
 
 } // namespace Anonymous
@@ -802,6 +848,7 @@ namespace {
         this->addDimension("LiquidSurfaceVolume", 1.0);
         this->addDimension("GasSurfaceVolume" , 1.0);
         this->addDimension("ReservoirVolume", 1.0);
+        this->addDimension("GeometricVolume", 1.0 );
         this->addDimension("Density"   , 1.0);
         this->addDimension("PolymerDensity", 1.0);
         this->addDimension("FoamDensity", 1.0);
@@ -837,6 +884,7 @@ namespace {
         this->addDimension("LiquidSurfaceVolume", PVT_M::LiquidSurfaceVolume );
         this->addDimension("GasSurfaceVolume" , PVT_M::GasSurfaceVolume );
         this->addDimension("ReservoirVolume", PVT_M::ReservoirVolume );
+        this->addDimension("GeometricVolume", PVT_M::GeomVolume );
         this->addDimension("Density"   , PVT_M::Density );
         this->addDimension("PolymerDensity", PVT_M::PolymerDensity);
         this->addDimension("FoamDensity", PVT_M::FoamDensity);
@@ -872,6 +920,7 @@ namespace {
         this->addDimension("LiquidSurfaceVolume", Lab::LiquidSurfaceVolume );
         this->addDimension("GasSurfaceVolume", Lab::GasSurfaceVolume );
         this->addDimension("ReservoirVolume", Lab::ReservoirVolume );
+        this->addDimension("GeometricVolume", Lab::GeomVolume );
         this->addDimension("Density", Lab::Density );
         this->addDimension("PolymerDensity", Lab::PolymerDensity);
         this->addDimension("FoamDensity", Lab::FoamDensity);
@@ -908,6 +957,7 @@ namespace {
         this->addDimension("LiquidSurfaceVolume", Metric::LiquidSurfaceVolume );
         this->addDimension("GasSurfaceVolume" , Metric::GasSurfaceVolume );
         this->addDimension("ReservoirVolume", Metric::ReservoirVolume );
+        this->addDimension("GeometricVolume", Metric::GeomVolume );
         this->addDimension("Density"   , Metric::Density );
         this->addDimension("PolymerDensity", Metric::PolymerDensity);
         this->addDimension("FoamDensity", Metric::FoamDensity);
@@ -942,6 +992,7 @@ namespace {
         this->addDimension("LiquidSurfaceVolume", Field::LiquidSurfaceVolume );
         this->addDimension("GasSurfaceVolume", Field::GasSurfaceVolume );
         this->addDimension("ReservoirVolume", Field::ReservoirVolume );
+        this->addDimension("GeometricVolume", Field::GeomVolume );
         this->addDimension("Density", Field::Density );
         this->addDimension("PolymerDensity", Field::PolymerDensity);
         this->addDimension("FoamDensity", Field::FoamDensity);

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WSEGSICD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WSEGSICD
@@ -2,7 +2,7 @@
    {"name" : "WELL" , "value_type" : "STRING"},
    {"name" : "SEG1", "value_type" : "INT"},
    {"name" : "SEG2", "value_type" : "INT"},
-   {"name" : "STRENGTH", "value_type" : "DOUBLE", "dimension" : "Pressure*Time*Time/Length*Length*Length*Length*Length*Length"},
+   {"name" : "STRENGTH", "value_type" : "DOUBLE", "dimension" : "Pressure*Time*Time/GeometricVolume*GeometricVolume"},
    {"name" : "LENGTH", "value_type" : "DOUBLE", "dimension" : "Length", "default" : 12.0},
    {"name" : "DENSITY_CALI", "value_type" : "DOUBLE", "dimension" : "Density", "default" : 1000.25},
    {"name" : "VISCOSITY_CALI", "value_type" : "DOUBLE", "dimension" : "Viscosity", "default" : 1.45},
@@ -10,6 +10,5 @@
    {"name" : "WIDTH_TRANS", "value_type" : "DOUBLE", "dimension" : "1", "default" : 0.05},
    {"name" : "MAX_VISC_RATIO", "value_type" : "DOUBLE", "dimension" : "1", "default" : 5.0},
    {"name" : "METHOD_SCALING_FACTOR", "value_type" : "INT", "default" : -1},
-   {"name" : "MAX_ABS_RATE", "value_type" : "DOUBLE", "dimension" : "Length*Length*Length/Time"},
+   {"name" : "MAX_ABS_RATE", "value_type" : "DOUBLE", "dimension" : "GeometricVolume/Time"},
    {"name" : "STATUS", "value_type" : "STRING", "default" : "OPEN"}]}
-

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -302,12 +302,15 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.to_si( Meas::liquid_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::geometric_volume, 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::liquid_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::geometric_volume_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::transmissibility , 1.0 ) , 1.157407407407407e-13 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::mass_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
@@ -320,6 +323,7 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.to_si( Meas::liquid_productivity_index , 1.0 ) , 1.1574074074074073e-10 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_productivity_index , 1.0 ) , 1.1574074074074073e-10 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::energy, 1.0), 1000, 1e-10);
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::icd_strength, 1.0), 7.46496e+14, 1e-10);
 
     // ----------------------------------------------------------------
     // SI -> METRIC
@@ -335,12 +339,15 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.from_si( Meas::liquid_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::geometric_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::liquid_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::rate , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::geometric_volume_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::transmissibility , 1.0 ) , 8.64e+12 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::mass_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
@@ -353,6 +360,7 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.from_si( Meas::liquid_productivity_index , 1.0 ) , 86.400e8 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_productivity_index , 1.0 ) , 86.400e8 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::energy, 1000.0), 1, 1e-10);
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::icd_strength, 7.46496e+14), 1.0, 1e-10);
 }
 
 BOOST_AUTO_TEST_CASE(FIELD_UNITS)
@@ -377,12 +385,15 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.to_si( Meas::liquid_surface_volume , 1.0 ) , 0.1589872949280001 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::gas_surface_volume , 1.0 ) , 28.31684659200000 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::volume , 1.0 ) , 0.1589872949280001 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::geometric_volume, 1.0 ) , 2.8316846592e-02 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::liquid_surface_rate , 1.0 ) , 1.840130728333334e-06 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::gas_surface_rate , 1.0 ) , 3.277412800000001e-04 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::rate , 1.0 ) , 1.840130728333334e-06 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::geometric_volume_rate, 1.0 ) , 3.2774128e-07 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::transmissibility , 1.0 ) , 2.668883979653090e-13 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::effective_Kh , 1.0 ) , 3.008142116950407e-16 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::mass , 1.0 ) , 0.45359237 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::mass_rate , 1.0 ) , 5.249911689814815e-06 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::gas_oil_ratio , 1.0 ) , 178.1076066790352 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::oil_gas_ratio , 1.0 ) , 5.614583333333335e-03 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
@@ -394,6 +405,8 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.to_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::liquid_productivity_index , 1.0 ) , 1.840130728333334e-06 / 6.894757293168360e+03  , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::gas_productivity_index , 1.0 ) , 3.277412800000001e-04 / 6.894757293168360e+03 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::energy , 1.0 ) , 1054.3503 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::icd_strength , 1.0 ) , 6.418842091749854e+16 , 1.0e-10 );
 
     // ----------------------------------------------------------------
     // SI -> FIELD
@@ -409,9 +422,11 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.from_si( Meas::liquid_surface_volume , 1.0 ) , 6.289810770432102e+00 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::gas_surface_volume , 1.0 ) , 3.531466672148859e-02 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::volume , 1.0 ) , 6.289810770432102e+00 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::geometric_volume, 2.8316846592e-02 ), 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::liquid_surface_rate , 1.0 ) , 5.434396505653337e+05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::gas_surface_rate , 1.0 ) , 3.051187204736614e+03 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::rate , 1.0 ) , 5.434396505653337e+05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::geometric_volume_rate, 3.2774128e-07 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::transmissibility , 1.0 ) , 3.746884494132199e+12 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::effective_Kh , 1.0 ) , 3.324311023622047e+15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::mass , 1.0 ) , 2.204622621848776e+00 , 1.0e-10 );
@@ -426,6 +441,8 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.from_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::liquid_productivity_index , 1.0 ) , 5.434396505653337e+05 * 6.894757293168360e+03 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::gas_productivity_index , 1.0 ) , 3.051187204736614e+03 * 6.894757293168360e+03, 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::energy , 1054.3503 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::icd_strength , 6.418842091749854e+16 ) , 1.0 , 1.0e-10 );
 }
 
 BOOST_AUTO_TEST_CASE(LAB_UNITS)
@@ -450,12 +467,15 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.to_si( Meas::liquid_surface_volume , 1.0 ) , 1.0e-6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_surface_volume , 1.0 ) , 1.0e-6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::volume , 1.0 ) , 1.0e-6 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::geometric_volume, 1.0 ) , 1.0e-6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::liquid_surface_rate , 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_surface_rate , 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::rate , 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::geometric_volume_rate, 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::transmissibility , 1.0 ) , 2.741453518655592e-18 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160130e-18 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::mass , 1.0 ) , 1.0e-3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::mass_rate , 1.0 ) , 2.777777777777778e-07 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
@@ -467,6 +487,8 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.to_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::liquid_productivity_index , 1.0 ) , 2.777777777777778e-10 / 101325.0  , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_productivity_index , 1.0 ) , 2.777777777777778e-10 / 101325.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::energy , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::icd_strength , 1.0 ) , 1.313172e+24 , 1.0e-10 );
 
     // ----------------------------------------------------------------
     // SI -> LAB
@@ -482,12 +504,15 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.from_si( Meas::liquid_surface_volume , 1.0 ) , 1.0e6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_surface_volume , 1.0 ) , 1.0e6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::volume , 1.0 ) , 1.0e6 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::geometric_volume , 1.0 ) , 1.0e6 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::liquid_surface_rate , 1.0 ) , 3.6e9 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_surface_rate , 1.0 ) , 3.6e9 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::rate , 1.0 ) , 3.6e9 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::geometric_volume_rate, 1.0 ) , 3.6e9 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::transmissibility , 1.0 ) , 3.647699999999999e+17 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+17 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::mass , 1.0 ) , 1.0e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::mass_rate , 1.0 ) , 3.6e+06 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
@@ -499,6 +524,8 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.from_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::liquid_productivity_index , 1.0 ) , 3.6e9 * 101325.0, 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_productivity_index , 1.0 ) , 3.6e9 * 101325.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::energy , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::icd_strength , 1.0 ) , 7.615148662932201e-25 , 1.0e-10 );
 }
 
 BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
@@ -523,12 +550,15 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::liquid_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::geometric_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::liquid_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::geometric_volume_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::transmissibility , 1.0 ) , 1.142272299439830e-13 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::mass_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
@@ -540,6 +570,8 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::liquid_productivity_index , 1.0 ) , 1.1574074074074073e-05 /101325.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_productivity_index , 1.0 ) , 1.1574074074074073e-05 /101325.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::energy , 1.0 ) , 1.0e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::icd_strength , 1.0 ) , 7.56387072e+14 , 1.0e-10 );
 
     // ----------------------------------------------------------------
     // SI -> PVT-M
@@ -555,12 +587,15 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::liquid_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::volume , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::geometric_volume , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::liquid_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::rate , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::geometric_volume_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::transmissibility , 1.0 ) , 8.75448e+12 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::mass_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_oil_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::oil_gas_ratio , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::water_cut , 1.0 ) , 1.0 , 1.0e-10 );
@@ -572,6 +607,8 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::liquid_productivity_index , 1.0 ) , 86.400e3 * 101325.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_productivity_index , 1.0 ) , 86.400e3 * 101325.0, 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::energy , 1.0 ) , 1.0e-3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::icd_strength , 1.0 ) , 1.322074420647951e-15 , 1.0e-10 );
 }
 
 BOOST_AUTO_TEST_CASE(TemperatureConversions)


### PR DESCRIPTION
This PR introduces a couple of new units of measure for ICD-related quantities, especially AICD and SICD strength parameters.  Add base unit "GeomVolume" ([Length]**3) and 'measure' entities
```
geometric_volume      (= GeomVolume)
geometric_volume_rate (= GeomVolume / Time)
icd_strength          (= Pressure / (GeomVolume / Time)**2)
```
Add conversion factor unit tests for these, and also complete the set of unit tests for FIELD, LAB, and PVT_M to cover measures that were not already there.

Also add a parser Dimension ("GeometricVolume") to play the role of [Length]**3 in .json files.