### PR TITLE
introducing keywords using alternating records.

### DIFF
--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -166,7 +166,7 @@ namespace Opm {
         void initSizeKeyword(const Json::JsonObject& sizeObject);
         void commonInit(const std::string& name, ParserKeywordSizeEnum sizeType);
         void addItems( const Json::JsonObject& jsonConfig);
-        void parseRecords( const Json::JsonObject recordsConfig, size_t num_records );
+        void parseRecords( const Json::JsonObject& recordsConfig, size_t num_records );
     };
 
 std::ostream& operator<<( std::ostream&, const ParserKeyword& );

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -130,6 +130,8 @@ namespace Opm {
         bool isDataKeyword() const;
         bool rawStringKeyword() const;
         bool isCodeKeyword() const;
+        bool isAlternatingKeyword() const;
+        void setAlternatingKeyword(bool alternating);
 
         std::string createDeclaration(const std::string& indent) const;
         std::string createDecl() const;
@@ -151,6 +153,7 @@ namespace Opm {
         bool m_isTableCollection;
         std::string m_Description;
         bool raw_string_keyword = false;
+        bool alternating_keyword = false;
         std::string code_end;
 
         static bool validNameStart(const string_view& name);
@@ -163,6 +166,7 @@ namespace Opm {
         void initSizeKeyword(const Json::JsonObject& sizeObject);
         void commonInit(const std::string& name, ParserKeywordSizeEnum sizeType);
         void addItems( const Json::JsonObject& jsonConfig);
+        void parseRecords( const Json::JsonObject recordsConfig, size_t num_records );
     };
 
 std::ostream& operator<<( std::ostream&, const ParserKeyword& );

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -153,7 +153,7 @@ namespace Opm {
     }
 
 
-    void ParserKeyword::parseRecords( const Json::JsonObject recordsConfig , size_t num_records) {
+    void ParserKeyword::parseRecords( const Json::JsonObject& recordsConfig , size_t num_records) {
          if (recordsConfig.is_array()) {
              size_t num_records = recordsConfig.size();
              for (size_t i = 0; i < num_records; i++) {
@@ -443,7 +443,7 @@ void set_dimensions( ParserItem& item,
 
         if( recordIndex >= this->m_records.size() ) {
             if (alternating_keyword) {
-                return this->m_records[ recordIndex % 2 ];
+                return this->m_records[ recordIndex % this->m_records.size() ];
             }
             else
                 return this->m_records.back();

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -203,8 +203,6 @@ namespace Opm {
                 throw std::invalid_argument("alternating_records must have num_tables.");
             const Json::JsonObject recordsConfig = jsonConfig.get_item("alternating_records");
             size_t num_records = recordsConfig.size();
-            if (num_records != 2)
-                throw std::invalid_argument("alternating records has only 2 records.");
             parseRecords( recordsConfig, num_records );
         }
 

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -153,6 +153,18 @@ namespace Opm {
     }
 
 
+    void ParserKeyword::parseRecords( const Json::JsonObject recordsConfig , size_t num_records) {
+         if (recordsConfig.is_array()) {
+             size_t num_records = recordsConfig.size();
+             for (size_t i = 0; i < num_records; i++) {
+                  const Json::JsonObject itemsConfig = recordsConfig.get_array_item(i);
+                  addItems(itemsConfig);
+             }
+         } else
+             throw std::invalid_argument("The records item must point to an array item");
+    }
+
+
     ParserKeyword::ParserKeyword(const Json::JsonObject& jsonConfig) {
 
       if (jsonConfig.has_item("name")) {
@@ -172,7 +184,7 @@ namespace Opm {
         initSectionNames(jsonConfig);
         initMatchRegex(jsonConfig);
 
-        if (jsonConfig.has_item("items") && jsonConfig.has_item("records"))
+        if (jsonConfig.has_item("items") && (jsonConfig.has_item("records") || jsonConfig.has_item("alternating_records")))
             throw std::invalid_argument("Fatal error in " + getName() + " configuration. Can NOT have both records: and items:");
 
         if (jsonConfig.has_item("items")) {
@@ -182,14 +194,18 @@ namespace Opm {
 
         if (jsonConfig.has_item("records")) {
             const Json::JsonObject recordsConfig = jsonConfig.get_item("records");
-            if (recordsConfig.is_array()) {
-                size_t num_records = recordsConfig.size();
-                for (size_t i = 0; i < num_records; i++) {
-                    const Json::JsonObject itemsConfig = recordsConfig.get_array_item(i);
-                    addItems(itemsConfig);
-                }
-            } else
-                throw std::invalid_argument("The records item must point to an array item");
+            parseRecords( recordsConfig, recordsConfig.size() );
+        }
+
+        if (jsonConfig.has_item("alternating_records")) {
+            alternating_keyword = true;
+            if (!jsonConfig.has_item("num_tables") || jsonConfig.has_item("size"))
+                throw std::invalid_argument("alternating_records must have num_tables.");
+            const Json::JsonObject recordsConfig = jsonConfig.get_item("alternating_records");
+            size_t num_records = recordsConfig.size();
+            if (num_records != 2)
+                throw std::invalid_argument("alternating records has only 2 records.");
+            parseRecords( recordsConfig, num_records );
         }
 
         if (jsonConfig.has_item("data"))
@@ -425,8 +441,13 @@ void set_dimensions( ParserItem& item,
         if( this->m_records.empty() )
             throw std::invalid_argument( "Trying to get record from empty keyword" );
 
-        if( recordIndex >= this->m_records.size() )
-            return this->m_records.back();
+        if( recordIndex >= this->m_records.size() ) {
+            if (alternating_keyword) {
+                return this->m_records[ recordIndex % 2 ];
+            }
+            else
+                return this->m_records.back();
+        }
 
         return this->m_records[ recordIndex ];
     }
@@ -566,6 +587,14 @@ void set_dimensions( ParserItem& item,
         return (this->m_keywordSizeType == FIXED_CODE);
     }
 
+    bool ParserKeyword::isAlternatingKeyword() const {
+        return alternating_keyword;
+    }
+
+    void ParserKeyword::setAlternatingKeyword(bool alternating) {
+        alternating_keyword = alternating;
+    }
+
     bool ParserKeyword::hasMatchRegex() const {
         return !m_matchRegexString.empty();
     }
@@ -667,6 +696,10 @@ void set_dimensions( ParserItem& item,
         {
             ss << indent << "addDeckName(\"" << *deckNameIt << "\");" << '\n';
         }
+
+        // set AlternatingRecords
+        if (alternating_keyword)
+            ss << indent << "setAlternatingKeyword(true);" << '\n';
 
         // set the deck name match regex
         if (hasMatchRegex())

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/STOG
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/STOG
@@ -1,0 +1,9 @@
+{
+    "name" : "STOG", "sections" : ["PROPS"], "num_tables" : {"keyword" : "TABDIMS" , "item" : "NTPVT"}, "alternating_records" : [
+    [
+        {"name" : "REF_OIL_PHASE_PRESSURE", "value_type" : "DOUBLE", "dimension" : "Pressure"}
+    ],
+    [ 
+        {"name" : "table", "value_type" : "DOUBLE", "size_type" : "ALL", "dimension" : ["Pressure" , "SurfaceTension"]}
+    ]]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -789,6 +789,7 @@ set( keywords
      000_Eclipse100/S/SSWL
      000_Eclipse100/S/SSWU
      000_Eclipse100/S/START
+     000_Eclipse100/S/STOG
      000_Eclipse100/S/STONE
      000_Eclipse100/S/STONE1
      000_Eclipse100/S/STONE1EX

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1723,6 +1723,69 @@ BOOST_AUTO_TEST_CASE(ConstructFromJson_withRecords_and_items_throws) {
     BOOST_CHECK_THROW( ParserKeyword kw( jsonObject ) , std::invalid_argument);
 }
 
+BOOST_AUTO_TEST_CASE(ConstructFromJson_withAlternatingRecords) {
+    const std::string json_string = R"(
+    {"name" : "STOG", "sections" : ["PROPS"] , "num_tables" : {"keyword" : "TABDIMS" , "item" : "NTPVT"}, "alternating_records" : [[
+      {"name" : "ref_oil_pressure", "value_type" : "DOUBLE"}], [
+      {"name" : "oil_phase_pressure" , "value_type" : "DOUBLE"},
+      {"name" : "surface_rension", "value_type" : "DOUBLE"}]]}
+    )";
+    Json::JsonObject jsonObject( json_string );
+    ParserKeyword kw( jsonObject );
+    BOOST_CHECK( kw.isAlternatingKeyword() );
+    BOOST_CHECK_EQUAL(kw.getRecord(0).size(), 1);
+    BOOST_CHECK_EQUAL(kw.getRecord(1).size(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(ConstructFromJson_withAlternatingRecordswithItems) {
+    const std::string json_string = R"(
+    {"name" : "STOG", "sections" : ["PROPS"] , "num_tables" : {"keyword" : "TABDIMS" , "item" : "NTPVT"}, "alternating_records" : [[
+      {"name" : "ref_oil_pressure", "value_type" : "DOUBLE"}], [
+      {"name" : "oil_phase_pressure" , "value_type" : "DOUBLE"},
+      {"name" : "surface_rension", "value_type" : "DOUBLE"}]], "items" : [{"name" : "w", "value_type" : "STRING"}]}
+    )";
+    Json::JsonObject jsonObject( json_string );
+    BOOST_CHECK_THROW( ParserKeyword kw( jsonObject ), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(ConstructFromJson_withAlternatingRecordsSizeWithoutBrackets) {
+    const std::string json_string = R"(
+    {"name" : "STOG", "sections" : ["PROPS"] , "size" : 6, "alternating_records" : [[
+      {"name" : "ref_oil_pressure", "value_type" : "DOUBLE"}], [
+      {"name" : "oil_phase_pressure" , "value_type" : "DOUBLE"},
+      {"name" : "surface_rension", "value_type" : "DOUBLE"}]]}
+    )";
+    Json::JsonObject jsonObject( json_string );
+    BOOST_CHECK_THROW( ParserKeyword kw( jsonObject ), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(ConstructFromJson_withAlternatingRecordsWrongSize) {
+    const std::string json_string = R"(
+    {"name" : "STOG", "sections" : ["PROPS"] , "num_tables" : {"keyword" : "TABDIMS" , "item" : "NTPVT"}, "alternating_records" : [[
+      {"name" : "ref_oil_pressure", "value_type" : "DOUBLE"}], [
+      {"name" : "oil_phase_pressure" , "value_type" : "DOUBLE"},
+      {"name" : "surface_rension", "value_type" : "DOUBLE"}], [
+      {"name" : "Name", "value_type" : "STRING"}]]}
+    )";
+    Json::JsonObject jsonObject( json_string );
+    BOOST_CHECK_THROW( ParserKeyword kw( jsonObject ), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(GetAlternatingKeywordFromParser) {
+    Parser parser;
+    BOOST_CHECK(parser.hasKeyword("STOG"));
+    ParserKeyword kw = parser.getKeyword("STOG");
+    BOOST_CHECK(kw.isAlternatingKeyword());
+    auto record0 = kw.getRecord(0);
+    auto record1 = kw.getRecord(1);
+    BOOST_CHECK_EQUAL(record0.get(0).name(), "REF_OIL_PHASE_PRESSURE");
+    BOOST_CHECK_EQUAL(record1.get(0).name(), "table");
+    BOOST_CHECK(kw.getRecord(2) == record0);
+    BOOST_CHECK(kw.getRecord(3) == record1);
+    BOOST_CHECK(kw.getRecord(12) == record0);
+    BOOST_CHECK(kw.getRecord(13) == record1);
+}
+
 
 BOOST_AUTO_TEST_CASE(Create1Arg) {
     ParserKeyword kw("GRID");

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1759,18 +1759,6 @@ BOOST_AUTO_TEST_CASE(ConstructFromJson_withAlternatingRecordsSizeWithoutBrackets
     BOOST_CHECK_THROW( ParserKeyword kw( jsonObject ), std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE(ConstructFromJson_withAlternatingRecordsWrongSize) {
-    const std::string json_string = R"(
-    {"name" : "STOG", "sections" : ["PROPS"] , "num_tables" : {"keyword" : "TABDIMS" , "item" : "NTPVT"}, "alternating_records" : [[
-      {"name" : "ref_oil_pressure", "value_type" : "DOUBLE"}], [
-      {"name" : "oil_phase_pressure" , "value_type" : "DOUBLE"},
-      {"name" : "surface_rension", "value_type" : "DOUBLE"}], [
-      {"name" : "Name", "value_type" : "STRING"}]]}
-    )";
-    Json::JsonObject jsonObject( json_string );
-    BOOST_CHECK_THROW( ParserKeyword kw( jsonObject ), std::invalid_argument);
-}
-
 BOOST_AUTO_TEST_CASE(GetAlternatingKeywordFromParser) {
     Parser parser;
     BOOST_CHECK(parser.hasKeyword("STOG"));


### PR DESCRIPTION
Keywords such as STOG, STOW, STWG has the following structure:
record1 : a value
record2: a table
This structure may repeat itself. There is no support for this in opm-common and the keywords are on the 'special' keyword list. 

This PR makes it possible to create support for these keywords. 
also keyword STOG has been added. 


