### PR TITLE
Fp reset actnum

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -34,7 +34,7 @@ public:
     // The default constructed fieldProps object is **NOT** usable
     FieldPropsManager() = default;
     FieldPropsManager(const Deck& deck, const EclipseGrid& grid, const TableManager& tables);
-    void reset_grid(const EclipseGrid& grid);
+    void reset_actnum(const std::vector<int>& actnum);
     const std::string& default_region() const;
     std::vector<int> actnum() const;
     std::vector<double> porv(bool global = false) const;

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -164,7 +164,7 @@ void assert_field_properties(const EclipseGrid& grid, const FieldPropsManager& f
         initTransMult();
         initFaults(deck);
 #ifdef ENABLE_3DPROPS_TESTING
-        this->field_props.reset_grid( this->m_inputGrid );
+        this->field_props.reset_actnum( this->m_inputGrid.getACTNUM() );
         assert_field_properties(this->m_inputGrid, this->field_props, this->m_eclipseProperties);
 #endif
     }

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -385,20 +385,23 @@ FieldProps::FieldProps(const Deck& deck, const EclipseGrid& grid, const TableMan
 
 
 
-void FieldProps::reset_grid(const EclipseGrid& grid) {
-    if (this->global_size != grid.getCartesianSize())
-        throw std::logic_error("reset_grid() must be called with the same number of global cells");
+void FieldProps::reset_actnum(const std::vector<int>& new_actnum) {
+    if (this->global_size != new_actnum.size())
+        throw std::logic_error("reset_actnum() must be called with the same number of global cells");
 
-    const auto& new_actnum = grid.getACTNUM();
     if (new_actnum == this->m_actnum)
         return;
 
     std::vector<bool> active_map(this->active_size, true);
     std::size_t active_index = 0;
+    std::size_t new_active_size = 0;
     for (std::size_t g = 0; g < this->m_actnum.size(); g++) {
         if (this->m_actnum[g] != 0) {
             if (new_actnum[g] == 0)
                 active_map[active_index] = false;
+            else
+                new_active_size += 1;
+
             active_index += 1;
         } else {
             if (new_actnum[g] != 0)
@@ -412,14 +415,13 @@ void FieldProps::reset_grid(const EclipseGrid& grid) {
     for (auto& data : this->int_data)
         data.second.compress(active_map);
 
-    this->m_actnum = std::move(new_actnum);
-    this->active_size = grid.getNumActive();
-    this->cell_volume = extract_cell_volume(grid);
-    this->cell_depth = extract_cell_depth(grid);
+    FieldProps::compress(this->cell_volume, active_map);
+    FieldProps::compress(this->cell_depth, active_map);
     if (this->porv_ptr)
         this->porv_ptr.reset( nullptr );
 
-    this->grid_ptr = &grid;
+    this->m_actnum = std::move(new_actnum);
+    this->active_size = new_active_size;
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -44,6 +44,21 @@ public:
          MAX = 5
     };
 
+    template<typename T>
+    static void compress(std::vector<T>& data, const std::vector<bool>& active_map) {
+        std::size_t shift = 0;
+        for (std::size_t g = 0; g < active_map.size(); g++) {
+            if (active_map[g] && shift > 0) {
+                data[g - shift] = data[g];
+                continue;
+            }
+
+            if (!active_map[g])
+                shift += 1;
+        }
+
+        data.resize(data.size() - shift);
+    }
 
     template<typename T>
     struct FieldData {
@@ -73,22 +88,9 @@ public:
             return false;
         }
 
-
         void compress(const std::vector<bool>& active_map) {
-            std::size_t shift = 0;
-            for (std::size_t g = 0; g < active_map.size(); g++) {
-                if (active_map[g] && shift > 0) {
-                    this->data[g - shift] = this->data[g];
-                    this->value_status[g - shift] = this->value_status[g];
-                    continue;
-                }
-
-                if (!active_map[g])
-                    shift += 1;
-            }
-
-            this->data.resize(this->data.size() - shift);
-            this->value_status.resize(this->value_status.size() - shift);
+            FieldProps::compress(this->data, active_map);
+            FieldProps::compress(this->value_status, active_map);
         }
 
         void copy(const FieldData<T>& src, const std::vector<Box::cell_index>& index_list) {
@@ -132,7 +134,7 @@ public:
 
 
     FieldProps(const Deck& deck, const EclipseGrid& grid, const TableManager& table_arg);
-    void reset_grid(const EclipseGrid& grid);
+    void reset_actnum(const std::vector<int>& actnum);
 
     const std::string& default_region() const;
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -30,8 +30,8 @@ FieldPropsManager::FieldPropsManager(const Deck& deck, const EclipseGrid& grid_a
     fp(std::make_shared<FieldProps>(deck, grid_arg, tables))
 {}
 
-void FieldPropsManager::reset_grid(const EclipseGrid& grid) {
-    this->fp->reset_grid(grid);
+void FieldPropsManager::reset_actnum(const std::vector<int>& actnum) {
+    this->fp->reset_actnum(actnum);
 }
 
 template <typename T>

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -159,8 +159,7 @@ SATNUM
     BOOST_CHECK_EQUAL(s1[5], 8);
 
     std::vector<int> actnum2 = {1,0,1,0,0,0,1,0,1};
-    grid.resetACTNUM(actnum2);
-    fpm.reset_grid(grid);
+    fpm.reset_actnum(actnum2);
 
     BOOST_CHECK_EQUAL(s1.size(), 4);
     BOOST_CHECK_EQUAL(s1[0], 0);
@@ -168,8 +167,7 @@ SATNUM
     BOOST_CHECK_EQUAL(s1[2], 6);
     BOOST_CHECK_EQUAL(s1[3], 8);
 
-    grid.resetACTNUM(actnum1);
-    BOOST_CHECK_THROW(fpm.reset_grid(grid), std::logic_error);
+    BOOST_CHECK_THROW(fpm.reset_actnum(actnum1), std::logic_error);
 }
 
 BOOST_AUTO_TEST_CASE(ADDREG) {
@@ -329,7 +327,7 @@ ENDBOX
     actnum[0] = 0;
     grid.resetACTNUM(actnum);
 
-    fpm.reset_grid(grid);
+    fpm.reset_actnum(actnum);
     auto porv_global = fpm.porv(true);
     auto porv_active = fpm.porv(false);
     BOOST_CHECK_EQUAL( porv_active.size(), grid.getNumActive());


### PR DESCRIPTION
When postprocessing has deactivated some cells the active cells in the `FieldProps` must be updated. This was previously done with a `reset_grid()` call - now it is instead `reset_actnum()`. We work on a strict need to know basis!