### PR TITLE
Use minimal information when filtering connections

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -257,6 +257,7 @@ if(ENABLE_ECL_OUTPUT)
 endif()
 
 list (APPEND TEST_SOURCE_FILES
+      tests/test_ActiveGridCells.cpp
       tests/test_calculateCellVol.cpp
       tests/test_cmp.cpp
       tests/test_cubic.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -30,6 +30,7 @@ list (APPEND MAIN_SOURCE_FILES
       src/opm/common/OpmLog/OpmLog.cpp
       src/opm/common/OpmLog/StreamLog.cpp
       src/opm/common/OpmLog/TimerLog.cpp
+      src/opm/common/utility/ActiveGridCells.cpp
       src/opm/common/utility/numeric/MonotCubicInterpolator.cpp
       src/opm/common/utility/parameters/Parameter.cpp
       src/opm/common/utility/parameters/ParameterGroup.cpp
@@ -451,6 +452,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/OpmLog/OpmLog.hpp
       opm/common/OpmLog/StreamLog.hpp
       opm/common/OpmLog/TimerLog.hpp
+      opm/common/utility/ActiveGridCells.hpp
       opm/common/utility/numeric/cmp.hpp
       opm/common/utility/platform_dependent/disable_warnings.h
       opm/common/utility/platform_dependent/reenable_warnings.h

--- a/opm/common/utility/ActiveGridCells.hpp
+++ b/opm/common/utility/ActiveGridCells.hpp
@@ -1,0 +1,79 @@
+/*
+  Copyright 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef ACTIVEGRIDCELLS_HPP
+#define ACTIVEGRIDCELLS_HPP
+
+#include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
+
+#include <array>
+
+namespace Opm
+{
+
+/**
+ * \brief Simple class capturing active cells of a grid
+ *
+ */
+class ActiveGridCells
+    : public GridDims
+{
+public:
+    /// \brief Constructs mapping of active cells.
+    /// \param xyz The cartesian dimensions of the grid
+    /// \param globalCell Pointer to first entry of contiguous
+    ///        array mapping local index to cartesian one.
+    /// \param nc The number of cells of a grid.
+    ActiveGridCells(std::array<int, 3> xyz,
+                    const int* globalCell, std::size_t nc);
+
+    /// \brief Constructs mapping of active cells.
+    /// \param nx Number of cells in x
+    /// \param ny Number of cells in y
+    /// \param nz Number of cells in z
+    /// \param globalCell Pointer to first entry of contiguous
+    ///        array mapping local index to cartesian one.
+    /// \param nc The number of cells of a grid.
+    ActiveGridCells(std::size_t nx, std::size_t ny, std::size_t nz,
+                    const int* globalCell, std::size_t nc);
+
+    bool cellActive(std::size_t i, std::size_t j, std::size_t k) const;
+
+    bool cellActive(std::size_t cartesianIndex) const;
+
+    std::vector<int> actNum() const;
+
+    /// \brief Get the local index of a cell
+    /// \param cartesianIndex The cartesian index of the cell
+    /// \return The local index or -1 if the cell is inactive
+    int localCell(std::size_t cartesianIndex) const;
+    
+    /// \brief Get the local index of a cell
+    /// \param i The index in the i direction
+    /// \param j The index in the j direction
+    /// \param k The index in the k direction
+    /// \return The local index or -1 if the cell is inactive
+    int localCell(std::size_t i, std::size_t j, std::size_t k) const;
+protected:
+    /// \brief Maps the cartesian index to a compressed local index.
+    ///
+    /// nonactive cells are marked with -1.
+    std::vector<int> localCell_;
+};
+} // end namespace Opm
+#endif //  ACTIVEGRIDCELLS_HPP

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -45,6 +45,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
 
+#include <opm/common/utility/ActiveGridCells.hpp>
 
 /*
   The DynamicState<std::shared_ptr<T>> pattern: The quantities in the Schedule
@@ -220,7 +221,7 @@ namespace Opm
           Will remove all completions which are connected to cell which is not
           active. Will scan through all wells and all timesteps.
         */
-        void filterConnections(const EclipseGrid& grid);
+        void filterConnections(const ActiveGridCells& grid);
         size_t size() const;
 
         void applyAction(size_t reportStep, const Action::ActionX& action, const Action::Result& result);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -35,6 +35,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 
+#include <opm/common/utility/ActiveGridCells.hpp>
 
 namespace Opm {
 
@@ -430,7 +431,7 @@ public:
     bool handleCOMPLUMP(const DeckRecord& record);
     bool handleWPIMULT(const DeckRecord& record);
 
-    void filterConnections(const EclipseGrid& grid);
+    void filterConnections(const ActiveGridCells& grid);
     void switchToInjector();
     void switchToProducer();
     ProductionControls productionControls(const SummaryState& st) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -23,6 +23,8 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
 
+#include <opm/common/utility/ActiveGridCells.hpp>
+
 namespace Opm {
     class EclipseGrid;
     class Eclipse3DProperties;
@@ -63,7 +65,7 @@ namespace Opm {
 
         const_iterator begin() const { return this->m_connections.begin(); }
         const_iterator end() const { return this->m_connections.end(); }
-        void filter(const EclipseGrid& grid);
+        void filter(const ActiveGridCells& grid);
         bool allConnectionsShut() const;
         /// Order connections irrespective of input order.
         /// The algorithm used is the following:

--- a/src/opm/common/utility/ActiveGridCells.cpp
+++ b/src/opm/common/utility/ActiveGridCells.cpp
@@ -1,0 +1,70 @@
+/*
+  Copyright 2019 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/common/utility/ActiveGridCells.hpp>
+
+#include <iterator>
+#include <algorithm>
+
+namespace Opm
+{
+ActiveGridCells::ActiveGridCells(std::array<int, 3> xyz,
+                                 const int* globalCell, std::size_t nc)
+    : ActiveGridCells(xyz[0], xyz[1], xyz[2], globalCell, nc)
+{}
+
+ActiveGridCells::ActiveGridCells(std::size_t nx, std::size_t ny, std::size_t nz,
+                                 const int* globalCell, std::size_t nc)
+    : GridDims(nx, ny, nz), localCell_(nx*ny*nz, -1)
+{
+    for (auto cell = globalCell, cellEnd = globalCell + nc; cell != cellEnd; ++cell)
+    {
+        localCell_[*cell] = cell-globalCell;
+    }
+}
+
+bool ActiveGridCells::cellActive(std::size_t i, std::size_t j, std::size_t k) const
+{
+    return cellActive(this->getGlobalIndex(i,j,k));
+}
+
+bool ActiveGridCells::cellActive(std::size_t cartesianIndex) const
+{
+    return localCell_[cartesianIndex]>=0;
+}
+
+int ActiveGridCells::localCell(std::size_t cartesianIndex) const
+{
+    return localCell_[cartesianIndex];
+}
+
+int ActiveGridCells::localCell(std::size_t i, std::size_t j, std::size_t k) const
+{
+    return localCell(this->getGlobalIndex(i,j,k));
+}
+
+std::vector<int> ActiveGridCells::actNum() const
+{
+    std::vector<int> actnum;
+    actnum.reserve(localCell_.size());
+    std::transform(localCell_.begin(), localCell_.end(),
+                   std::back_inserter(actnum), [](int i){ return i>=0;});
+    return actnum;
+}
+}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2600,7 +2600,7 @@ void Schedule::handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep, c
     }
 
 
-    void Schedule::filterConnections(const EclipseGrid& grid) {
+    void Schedule::filterConnections(const ActiveGridCells& grid) {
         for (auto& dynamic_pair : this->wells_static) {
             auto& dynamic_state = dynamic_pair.second;
             for (auto& well_pair : dynamic_state.unique()) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -25,7 +25,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
-
 #include <fnmatch.h>
 
 namespace Opm {
@@ -651,7 +650,7 @@ bool Well::updateWSEGSICD(const std::vector<std::pair<int, SpiralICD> >& sicd_pa
         return false;
 }
 
-void Well::filterConnections(const EclipseGrid& grid) {
+void Well::filterConnections(const ActiveGridCells& grid) {
     this->connections->filter(grid);
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -491,7 +491,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
     }
 
 
-    void WellConnections::filter(const EclipseGrid& grid) {
+    void WellConnections::filter(const ActiveGridCells& grid) {
         auto new_end = std::remove_if(m_connections.begin(),
                                       m_connections.end(),
                                       [&grid](const Connection& c) { return !grid.cellActive(c.getI(), c.getJ(), c.getK()); });

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2992,8 +2992,13 @@ BOOST_AUTO_TEST_CASE(FilterCompletions2) {
     }
     actnum[grid1.getGlobalIndex(8,8,1)] = 0;
     {
-        EclipseGrid grid2(grid1, actnum);
-        schedule.filterConnections(grid2);
+        std::vector<int> globalCell(grid1.getNumActive());
+        for(std::size_t i = 0; i < grid1.getNumActive(); ++i)
+            if (actnum[grid1.getGlobalIndex(i)])
+                globalCell[i] = grid1.getGlobalIndex(i);
+        ActiveGridCells active(grid1.getNXYZ(), globalCell.data(),
+                               grid1.getNumActive());
+        schedule.filterConnections(active);
 
         const auto& c1_1 = schedule.getWell("OP_1", 1).getConnections();
         const auto& c1_3 = schedule.getWell("OP_1", 3).getConnections();

--- a/tests/test_ActiveGridCells.cpp
+++ b/tests/test_ActiveGridCells.cpp
@@ -1,0 +1,88 @@
+/*
+  Copyright 2019 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#define BOOST_TEST_MODULE ActiveGridCells
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/utility/ActiveGridCells.hpp>
+#include <opm/output/eclipse/Summary.hpp>
+
+BOOST_AUTO_TEST_SUITE(Default)
+
+BOOST_AUTO_TEST_CASE(testLocal) {
+    std::size_t nx=2, ny = 3, nz=2;
+    Opm::GridDims dims(nx, ny, nz);
+    std::vector<int> cells(9);
+    std::set<std::array<std::size_t,3> > inactive;
+    inactive.insert({{0,0,0}});
+    inactive.insert({{1,1,0}});
+    inactive.insert({{1,0,1}});
+
+    for(std::size_t k = 0, index = 0; k < nz; ++k)
+    {
+        for(std::size_t j = 0; j < ny; ++j)
+        {
+            for(std::size_t i = 0; i < nx; ++i)
+            {
+                if ( inactive.find({{i,j,k}})==inactive.end())
+                {
+                    cells[index++] = dims.getGlobalIndex(i,j,k);
+                }
+            }
+        }
+    }
+
+    Opm::ActiveGridCells active(nx, ny, nz, cells.data(), cells.size());
+
+    const auto& actnum = active.actNum();
+
+    for(std::size_t k = 0, index = 0; k < nz; ++k)
+    {
+        for(std::size_t j = 0; j < ny; ++j)
+        {
+            for(std::size_t i = 0; i < nx; ++i)
+            {
+                auto cartIndex = dims.getGlobalIndex(i,j,k);
+
+                if ( inactive.find({{i,j,k}})!=inactive.end())
+                {
+                    BOOST_CHECK(actnum[cartIndex] == 0);
+                    BOOST_CHECK(active.localCell(cartIndex) == -1);
+                    BOOST_CHECK(active.localCell(i,j,k) == -1);
+                    BOOST_CHECK(!active.cellActive(cartIndex));
+                    BOOST_CHECK(!active.cellActive(i, j, k));
+                }
+                else
+                {
+                    BOOST_CHECK(actnum[cartIndex] == 1);
+                    BOOST_CHECK(active.localCell(cartIndex) == (int)index);
+                    BOOST_CHECK(active.localCell(i,j,k) == (int)index);
+                    BOOST_CHECK(active.cellActive(cartIndex));
+                    BOOST_CHECK(active.cellActive(i, j, k));
+                    ++index;
+                }
+            }
+        }
+    }
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
To do this we only need to query whether a cell is active or not by its cartesian index. Constructing an EclipseGrid just for that seem overkill and will in the future not be possible anymore on all ranks of a parallel run. Hence we construct a simple utility class the only uses the information of the globalCell arrays.

This will need a downstream PR in opm-simulators.