### PR TITLE
THPRES: Warning if region values exceed max(EQLNUM)

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
@@ -130,12 +131,13 @@ namespace Opm {
                 const int r1 = region1Item.get< int >(0);
                 const int r2 = region2Item.get< int >(0);
                 if (r1 > maxEqlnum || r2 > maxEqlnum) {
-                    throw std::runtime_error("Too high region numbers in THPRES keyword");
+                    OpmLog::warning("The THPRES region values: " + std::to_string(r1) + " and " + std::to_string(r2) + " are not compatible with EQLNUM: 1.." + std::to_string(maxEqlnum) + " ignored");
+                    continue;
                 }
 
-                if (thpressItem.hasValue(0)) {
+                if (thpressItem.hasValue(0))
                     addBarrier( r1 , r2 , thpressItem.getSIDouble( 0 ) );
-                } else
+                else
                     addBarrier( r1 , r2 );
             }
         }


### PR DESCRIPTION
Previously there was a hard check that the region values in the THPRES keyword was <= max(EQLNUM); just use a warning and ignore it.