### PR TITLE
Add FieldPropsManager::get_copy() which does not add to container

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -79,13 +79,10 @@ public:
     const std::vector<T>& get(const std::string& keyword) const;
 
     template <typename T>
+    std::vector<T> get_copy(const std::string& keyword, bool global=false) const;
+
+    template <typename T>
     const std::vector<T>* try_get(const std::string& keyword) const;
-
-    template <typename T>
-    bool has(const std::string& keyword) const;
-
-    template <typename T>
-    std::vector<std::string> keys() const;
 
     template <typename T>
     std::vector<T> get_global(const std::string& keyword) const;
@@ -95,6 +92,12 @@ public:
 
     template <typename T>
     static bool supported(const std::string& keyword);
+
+    template <typename T>
+    bool has(const std::string& keyword) const;
+
+    template <typename T>
+    std::vector<std::string> keys() const;
 
 private:
     std::shared_ptr<FieldProps> fp;

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -596,6 +596,25 @@ void FieldProps::erase<double>(const std::string& keyword) {
     this->double_data.erase(keyword);
 }
 
+template <>
+std::vector<int> FieldProps::extract<int>(const std::string& keyword) {
+    auto field_iter = this->int_data.find(keyword);
+    auto field = std::move(field_iter->second);
+    std::vector<int> data = std::move( field.data );
+    this->int_data.erase( field_iter );
+    return data;
+}
+
+template <>
+std::vector<double> FieldProps::extract<double>(const std::string& keyword) {
+    auto field_iter = this->double_data.find(keyword);
+    auto field = std::move(field_iter->second);
+    std::vector<double> data = std::move( field.data );
+    this->double_data.erase( field_iter );
+    return data;
+}
+
+
 
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -195,6 +195,28 @@ public:
 
 
     template <typename T>
+    std::vector<T> get_copy(const std::string& keyword, bool global) {
+        if (this->has<T>(keyword)) {
+            const auto& data = this->get_valid_data<T>(keyword);
+
+            if (global)
+                return this->global_copy(data);
+            else
+                return data;
+        } else {
+            const auto& field_ptr = this->try_get<T>(keyword);
+            if (!field_ptr)
+                throw std::invalid_argument("No such valid keyword: " + keyword);
+
+            if (global)
+                return this->global_copy(this->extract<T>(keyword));
+            else
+                return this->extract<T>(keyword);
+        }
+    }
+
+
+    template <typename T>
     std::vector<bool> defaulted(const std::string& keyword) {
         const auto& field = this->get<T>(keyword);
         std::vector<bool> def(field.size());
@@ -217,6 +239,8 @@ private:
     template <typename T>
     void erase(const std::string& keyword);
 
+    template <typename T>
+    std::vector<T> extract(const std::string& keyword);
 
     template <typename T>
     static void apply(ScalarOperation op, FieldData<T>& data, T scalar_value, const std::vector<Box::cell_index>& index_list);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -67,6 +67,11 @@ std::vector<T> FieldPropsManager::get_global(const std::string& keyword) const {
 }
 
 template <typename T>
+std::vector<T> FieldPropsManager::get_copy(const std::string& keyword, bool global) const {
+    return this->fp->get_copy<T>(keyword, global);
+}
+
+template <typename T>
 bool FieldPropsManager::supported(const std::string& keyword) {
     return FieldProps::supported<T>(keyword);
 }
@@ -120,6 +125,9 @@ template std::vector<double> FieldPropsManager::get_global(const std::string& ke
 
 template const std::vector<int>& FieldPropsManager::get(const std::string& keyword) const;
 template const std::vector<double>& FieldPropsManager::get(const std::string& keyword) const;
+
+template std::vector<int> FieldPropsManager::get_copy(const std::string& keyword, bool global) const;
+template std::vector<double> FieldPropsManager::get_copy(const std::string& keyword, bool global) const;
 
 template const std::vector<int>* FieldPropsManager::try_get(const std::string& keyword) const;
 template const std::vector<double>* FieldPropsManager::try_get(const std::string& keyword) const;

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -276,7 +276,7 @@ MULTPV
 ENDBOX
 )";
 
-    EclipseGrid grid(EclipseGrid(10,10, 4));
+    EclipseGrid grid(10,10, 4);
     Deck deck = Parser{}.parseString(deck_string);
     FieldPropsManager fpm(deck, grid, TableManager());
     const auto& poro = fpm.get<double>("PORO");
@@ -463,3 +463,36 @@ BOOST_AUTO_TEST_CASE(LATE_GET_SATFUNC) {
 
 }
 
+BOOST_AUTO_TEST_CASE(GET_TEMP) {
+    std::string deck_string = R"(
+GRID
+
+PORO
+   200*0.15 /
+
+)";
+
+    EclipseGrid grid(10,10, 2);
+    Deck deck = Parser{}.parseString(deck_string);
+    std::vector<int> actnum(200, 1); actnum[0] = 0;
+    grid.resetACTNUM(actnum);
+    FieldPropsManager fpm(deck, grid, TableManager());
+
+    BOOST_CHECK(!fpm.has<double>("NTG"));
+    const auto& ntg = fpm.get_copy<double>("NTG");
+    BOOST_CHECK(!fpm.has<double>("NTG"));
+    BOOST_CHECK(ntg.size() == grid.getNumActive());
+
+
+    BOOST_CHECK(fpm.has<double>("PORO"));
+    const auto& poro = fpm.get_copy<double>("PORO");
+    BOOST_CHECK(fpm.has<double>("PORO"));
+
+    BOOST_CHECK(!fpm.has<int>("SATNUM"));
+    const auto& satnum = fpm.get_copy<int>("SATNUM", true);
+    BOOST_CHECK(!fpm.has<int>("SATNUM"));
+    BOOST_CHECK(satnum.size() == grid.getCartesianSize());
+
+    //The PERMY keyword can not be default initialized
+    BOOST_CHECK_THROW(fpm.get_copy<double>("PERMY"), std::invalid_argument);
+}


### PR DESCRIPTION
There are many callsites where we get a properyty from the container - and then forget about it.Do not let the container grow in this case.