### PR TITLE
Grid mem

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -150,8 +150,8 @@ namespace Opm {
         /// Will return a vector a length num_active; where the value
         /// of each element is the corresponding global index.
         const std::vector<int>& getActiveMap() const;
-        const std::array<double, 3>& getCellCenter(size_t i,size_t j, size_t k) const;
-        const std::array<double, 3>& getCellCenter(size_t globalIndex) const;
+        std::array<double, 3> getCellCenter(size_t i,size_t j, size_t k) const;
+        std::array<double, 3> getCellCenter(size_t globalIndex) const;
         std::array<double, 3> getCornerPos(size_t i,size_t j, size_t k, size_t corner_index) const;
         double getCellVolume(size_t globalIndex) const;
         double getCellVolume(size_t i , size_t j , size_t k) const;
@@ -212,12 +212,6 @@ namespace Opm {
         std::vector<int> m_active_to_global;
         std::vector<int> m_global_to_active;
 
-        // Geometry data.
-        std::vector<double> m_dx;
-        std::vector<double> m_dy;
-        std::vector<double> m_dz;
-        std::vector<std::array<double, 3>> m_cellCenter;
-
         void initGridFromEGridFile(Opm::EclIO::EclFile& egridfile, std::string fileName);
 
         void initBinaryGrid(const Deck& deck);
@@ -256,8 +250,6 @@ namespace Opm {
         double sumIdir(int j, int k, int i1, const std::array<int, 3>& dims, const std::vector<double>& dx) const;
         double sumJdir(int i, int k, int j1, const std::array<int, 3>& dims, const std::vector<double>& dy) const;
         double sumKdir(int i, int j, const std::array<int, 3>& dims, const std::vector<double>& dz) const;
-
-        void calculateGeometryData();
 
         void getCellCorners(const std::array<int, 3>& ijk, const std::array<int, 3>& dims, std::array<double,8>& X, std::array<double,8>& Y, std::array<double,8>& Z) const;
         void getCellCorners(const std::size_t globalIndex,

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -195,7 +195,6 @@ namespace Opm {
         PinchMode::ModeEnum m_pinchoutMode;
         PinchMode::ModeEnum m_multzMode;
 
-        mutable std::vector< int > activeMap;
         bool m_circle = false;
 
         size_t zcorn_fixed = 0;

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -213,7 +213,6 @@ namespace Opm {
         std::vector<int> m_global_to_active;
 
         // Geometry data.
-        std::vector<double> m_depth;
         std::vector<double> m_dx;
         std::vector<double> m_dy;
         std::vector<double> m_dz;

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -262,6 +262,11 @@ namespace Opm {
         void calculateGeometryData();
 
         void getCellCorners(const std::array<int, 3>& ijk, const std::array<int, 3>& dims, std::array<double,8>& X, std::array<double,8>& Y, std::array<double,8>& Z) const;
+        void getCellCorners(const std::size_t globalIndex,
+                            std::array<double,8>& X,
+                            std::array<double,8>& Y,
+                            std::array<double,8>& Z) const;
+
    };
 
     class CoordMapper {

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -213,7 +213,6 @@ namespace Opm {
         std::vector<int> m_global_to_active;
 
         // Geometry data.
-        std::vector<double> m_volume;
         std::vector<double> m_depth;
         std::vector<double> m_dx;
         std::vector<double> m_dy;

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -1460,8 +1460,15 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
     double EclipseGrid::getCellThickness(size_t globalIndex) const {
         assertGlobalIndex( globalIndex );
+        std::array<double,8> X;
+        std::array<double,8> Y;
+        std::array<double,8> Z;
+        this->getCellCorners(globalIndex, X, Y, Z );
 
-        return m_dz[globalIndex];
+        double z2 = (Z[4]+Z[5]+Z[6]+Z[7])/4.0;
+        double z1 = (Z[0]+Z[1]+Z[2]+Z[3])/4.0;
+        double dz = z2-z1;
+        return dz;
     }
 
     std::array<double, 3> EclipseGrid::getCellDims(size_t globalIndex) const {

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -710,6 +710,18 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         }
     }
 
+
+    void EclipseGrid::getCellCorners(const std::size_t globalIndex,
+                                     std::array<double,8>& X,
+                                     std::array<double,8>& Y,
+                                     std::array<double,8>& Z) const
+    {
+        this->assertGlobalIndex(globalIndex);
+        auto ijk = this->getIJK(globalIndex);
+        this->getCellCorners(ijk, this->getNXYZ(), X, Y, Z);
+    }
+
+
     std::vector<double> EclipseGrid::makeCoordDxvDyvDzvDepthz(const std::array<int, 3>& dims, const std::vector<double>& dxv, const std::vector<double>& dyv, const std::vector<double>& dzv, const std::vector<double>& depthz) const {
 
         std::vector<double> coord;

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -580,13 +580,11 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         m_dx.clear();
         m_dy.clear();
         m_dz.clear();
-        m_depth.clear();
 
         m_cellCenter.resize(nCells);
         m_dx.resize(nCells);
         m_dy.resize(nCells);
         m_dz.resize(nCells);
-        m_depth.resize(nCells);
 
         std::array<int, 3> ijk;
         size_t n = 0;
@@ -639,8 +637,6 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
                     m_dx[n] = dx;
                     m_dy[n] = dy;
                     m_dz[n] = dz;
-
-                    m_depth[n] =  (z2 + z1) / 2.0;
 
                     n++;
                 }
@@ -1539,16 +1535,20 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
     double EclipseGrid::getCellDepth(size_t globalIndex) const {
         assertGlobalIndex( globalIndex );
+        std::array<double,8> X;
+        std::array<double,8> Y;
+        std::array<double,8> Z;
+        this->getCellCorners(globalIndex, X, Y, Z );
 
-        return m_depth[globalIndex];
+        double z2 = (Z[4]+Z[5]+Z[6]+Z[7])/4.0;
+        double z1 = (Z[0]+Z[1]+Z[2]+Z[3])/4.0;
+        return (z1 + z2)/2.0;
     }
 
     double EclipseGrid::getCellDepth(size_t i, size_t j, size_t k) const {
-        assertIJK(i,j,k);
-
-        size_t globalIndex = getGlobalIndex( i,j,k );
-
-        return getCellDepth(globalIndex);
+        this->assertIJK(i,j,k);
+        size_t globalIndex = getGlobalIndex(i,j,k);
+        return this->getCellDepth(globalIndex);
     }
 
     const std::vector<int>& EclipseGrid::getACTNUM( ) const {

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -576,14 +576,12 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         std::array<double,8> Y = {0.0};
         std::array<double,8> Z = {0.0};
 
-        m_volume.clear();
         m_cellCenter.clear();
         m_dx.clear();
         m_dy.clear();
         m_dz.clear();
         m_depth.clear();
 
-        m_volume.resize(nCells);
         m_cellCenter.resize(nCells);
         m_dx.resize(nCells);
         m_dy.resize(nCells);
@@ -602,8 +600,6 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
                     ijk[2] = k;
 
                     getCellCorners(ijk, dims, X, Y, Z );
-
-                    m_volume[n] = calculateCellVol(X, Y, Z);
 
                     std::array<double, 3> center;
 
@@ -1443,19 +1439,18 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
 
     double EclipseGrid::getCellVolume(size_t globalIndex) const {
-
         assertGlobalIndex( globalIndex );
-
-        return m_volume[globalIndex];
+        std::array<double,8> X;
+        std::array<double,8> Y;
+        std::array<double,8> Z;
+        this->getCellCorners(globalIndex, X, Y, Z );
+        return calculateCellVol(X, Y, Z);
     }
 
     double EclipseGrid::getCellVolume(size_t i , size_t j , size_t k) const {
-
-        assertIJK(i,j,k);
-
-        size_t globalIndex = getGlobalIndex( i,j,k );
-
-        return getCellVolume(globalIndex);
+        this->assertIJK(i,j,k);
+        size_t globalIndex = getGlobalIndex(i,j,k);
+        return this->getCellVolume(globalIndex);
     }
 
     double EclipseGrid::getCellThickness(size_t i , size_t j , size_t k) const {


### PR DESCRIPTION
This PR calculates cell geometry on demand instead of doing it up front when constructing the EclipseGrid. The purpose of this is to reduce memory use - this PR removes storage corresponding to 8 global double vectors.

The disadvantage is that the grid class no longer caches these quantities; on the other hand they were originally calculated for all cells - but they are typically only requested for active cells. 