### PR TITLE
Udq well

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -23,6 +23,11 @@
 
 namespace Opm {
 
+/*
+
+
+*/
+
 enum class UDQVarType {
     NONE = 0,
     SCALAR = 1,
@@ -132,7 +137,6 @@ enum class UDAKeyword {
 
 namespace UDQ {
 
-    bool compatibleTypes(UDQVarType lhs, UDQVarType rhs);
     UDQVarType targetType(const std::string& keyword);
     UDQVarType varType(const std::string& keyword);
     UDQAction actionType(const std::string& action_string);

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -24,8 +24,36 @@
 namespace Opm {
 
 /*
+  The UDQ variables can be of of many different types. In addition they can be
+  either scalars or vector sets. The arch example of a vector set is well
+  variables - in the expressions:
 
+    UDQ
+       DEFINE WUBHP WBHP * 1.15 /
+       DEFINE WUORAT 1000 /
+    /
 
+  we define two UDQ values 'WUBHP' and 'WUORAT'. Both of these UDQ values will
+  apply to all wells; the WUBHP vector will correspond to the normal BHP scaled
+  up 15%, the WUORAT has the scalar value 1000 for all the wells. The well sets
+  can be qualified with a wellname, if the wellname has a wildcard we will get a
+  well set, if the wellname is fully qualified we have a scalar:
+
+  UDQ
+     DEFINE WUWCT   WWCT 'OP*' /
+     DEFINE FUORAT  WOPR 'OPX' * 100 /
+  /
+
+  Here the UDQ WUCWT corresponds to the well WWCT for all wells matching the
+  name 'OP*', and it is undefined for the remaing wells. The UDQ FUORAT is a
+  scalar, given by the WOPR of well 'OPX' - multiplied by 100.
+
+  There are clearly rules for how the different variable types can be combined
+  in expressions, and what will be resulting type from an expression -
+  unfortunately that is not yet very well implemented in the opm codebase. In
+  UDQParser.cpp there is a function static_type_check and in UDQDefine there is
+  a function dynamic_type_check - these functions try to verfiy that the type
+  conversions are legitimate, but currently they are woefully inadequate.
 */
 
 enum class UDQVarType {

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
@@ -83,6 +83,7 @@ public:
     std::vector<UDQScalar>::const_iterator begin() const;
     std::vector<UDQScalar>::const_iterator end() const;
 
+    std::vector<std::string> wgnames() const;
     std::vector<double> defined_values() const;
     std::size_t defined_size() const;
     const std::string& name() const;
@@ -93,7 +94,7 @@ private:
 
 
     std::string m_name;
-    UDQVarType m_var_type;
+    UDQVarType m_var_type = UDQVarType::NONE;
     std::unordered_map<std::string, std::size_t> wgname_index;
     std::vector<UDQScalar> values;
 };

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
@@ -49,8 +49,8 @@ private:
     void func_tokens(std::set<UDQTokenType>& tokens) const;
 
     std::string string_value;
-    double scalar_value;
     std::vector<std::string> selector;
+    double scalar_value;
     std::vector<UDQASTNode> arglist;
 };
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -131,11 +131,29 @@ UDQDefine::UDQDefine(const UDQParams& udq_params_arg,
     }
 }
 
+namespace {
 
+/*
+  This function unconditinally returns true and is of-course quite useless at
+  the moment; it is retained here in the hope that it is possible to actually
+  make it useful in the future. See the comment in UDQEnums.hpp about 'UDQ type
+  system'.
+*/
+bool dynamic_type_check(UDQVarType lhs, UDQVarType rhs) {
+    if (lhs == rhs)
+        return true;
+
+    if (rhs == UDQVarType::SCALAR)
+        return true;
+
+    return true;
+}
+
+}
 
 UDQSet UDQDefine::eval(const UDQContext& context) const {
     UDQSet res = this->ast->eval(this->m_var_type, context);
-    if (!UDQ::compatibleTypes(this->var_type(), res.var_type())) {
+    if (!dynamic_type_check(this->var_type(), res.var_type())) {
         std::string msg = "Invalid runtime type conversion detected when evaluating UDQ";
         throw std::invalid_argument(msg);
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -170,8 +170,9 @@ UDQSet UDQDefine::eval(const UDQContext& context) const {
 
           Both the expressions "SUM(WOPR)" and "WOPR OP1" evaluate to a scalar,
           this should then be copied all wells, so that WUINJ1:$WELL should
-          evaulate to the same numerical value for all wells; the same should
-          also apply for group sets.
+          evaulate to the same numerical value for all wells. We implement the
+          same behavior for group sets - but there is lots of uncertainty
+          regarding the semantics of group sets.
         */
 
         double scalar_value = res[0].value();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -22,6 +22,7 @@
 #include <map>
 #include <set>
 #include <stdexcept>
+#include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 
@@ -122,6 +123,8 @@ namespace {
                                                                      {"NORM2", UDQTokenType::scalar_func_norm2},
                                                                      {"NORMI", UDQTokenType::scalar_func_normi},
                                                                      {"PROD", UDQTokenType::scalar_func_prod}};
+
+
 }
 
 UDQVarType targetType(const std::string& keyword) {
@@ -231,15 +234,10 @@ UDQTokenType funcType(const std::string& func_name) {
 }
 
 
-bool compatibleTypes(UDQVarType lhs, UDQVarType rhs) {
-    if (lhs == rhs)
-        return true;
 
-    if (rhs == UDQVarType::SCALAR)
-        return true;
 
-    return false;
-}
+
+
 
 std::string typeName(UDQVarType var_type) {
     switch (var_type) {
@@ -264,7 +262,7 @@ std::string typeName(UDQVarType var_type) {
     case UDQVarType::BLOCK_VAR:
         return "BLOCK_VAR";
     default:
-        throw std::runtime_error("Should not be here");
+        throw std::runtime_error("Should not be here: " + std::to_string(static_cast<int>(var_type)));
     }
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
@@ -237,9 +237,27 @@ namespace {
             std::cout << token << " ";
         std::cout << std::endl;
     }
+
+/*
+  This function is extremely weak - hopefully it can be improved in the future.
+  See the comment in UDQEnums.hpp about 'UDQ type system'.
+*/
+bool static_type_check(UDQVarType lhs, UDQVarType rhs) {
+    if (lhs == rhs)
+        return true;
+
+    if (rhs == UDQVarType::SCALAR)
+        return true;
+
+    /*
+      This does not check if the rhs evaluates to a scalar.
+    */
+    if (rhs == UDQVarType::WELL_VAR)
+        return (lhs == UDQVarType::WELL_VAR);
+
+    return true;
 }
-
-
+}
 
 
 UDQASTNode UDQParser::parse(const UDQParams& udq_params, UDQVarType target_type, const std::string& target_var, const std::vector<std::string>& tokens, const ParseContext& parseContext, ErrorGuard& errors)
@@ -264,7 +282,7 @@ UDQASTNode UDQParser::parse(const UDQParams& udq_params, UDQVarType target_type,
         return UDQASTNode( udq_params.undefinedValue() );
     }
 
-    if (!UDQ::compatibleTypes(target_type, tree.var_type)) {
+    if (!static_type_check(target_type, tree.var_type)) {
         std::string msg = "Invalid compile-time type conversion detected in UDQ expression target type: " + UDQ::typeName(target_type) + " expr type: " + UDQ::typeName(tree.var_type);
         parseContext.handleError(ParseContext::UDQ_TYPE_ERROR, msg, errors);
         if (parseContext.get(ParseContext::UDQ_TYPE_ERROR) != InputError::IGNORE)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
@@ -262,9 +262,8 @@ bool static_type_check(UDQVarType lhs, UDQVarType rhs) {
 
 UDQASTNode UDQParser::parse(const UDQParams& udq_params, UDQVarType target_type, const std::string& target_var, const std::vector<std::string>& tokens, const ParseContext& parseContext, ErrorGuard& errors)
 {
-    UDQParser parser(udq_params, tokens);
+    UDQParser parser(udq_params, target_type, tokens);
     parser.next();
-
     auto tree = parser.parse_cmp();
     auto current = parser.current();
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
@@ -66,9 +66,10 @@ public:
   static UDQASTNode parse(const UDQParams& udq_params, UDQVarType target_type, const std::string& target_var, const std::vector<std::string>& tokens, const ParseContext& parseContext, ErrorGuard& errors);
 
 private:
-    UDQParser(const UDQParams& udq_params1, const std::vector<std::string>& tokens1) :
+    UDQParser(const UDQParams& udq_params1, UDQVarType ttype, const std::vector<std::string>& tokens1) :
         udq_params(udq_params1),
         udqft(UDQFunctionTable(udq_params)),
+        target_type(ttype),
         tokens(tokens1)
     {}
 
@@ -85,6 +86,7 @@ private:
 
     const UDQParams& udq_params;
     UDQFunctionTable udqft;
+    UDQVarType target_type;
     std::vector<std::string> tokens;
     ssize_t current_pos = -1;
 };

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -207,6 +207,12 @@ UDQVarType UDQSet::var_type() const {
     return this->m_var_type;
 }
 
+std::vector<std::string> UDQSet::wgnames() const {
+    std::vector<std::string> names;
+    for (const auto& index_pair : this->wgname_index)
+        names.push_back(index_pair.first);
+    return names;
+}
 
 /************************************************************************/
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -287,7 +287,7 @@ std::size_t UDQSet::defined_size() const {
 
 const UDQScalar& UDQSet::operator[](std::size_t index) const {
     if (index >= this->size())
-        throw std::invalid_argument("Index out of range");
+        throw std::out_of_range("Index out of range in UDQset::operator[]");
     return this->values[index];
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -381,9 +381,37 @@ UDQScalar operator/(double lhs, const UDQScalar& rhs) {
     return result;
 }
 
+/*-----------------------------------------------------------------*/
+
+namespace {
+
+/*
+  If one result set is scalar and the other represents a set of wells/groups,
+  the scalar result is promoted to a set of the right type.
+*/
+UDQSet udq_cast(const UDQSet& lhs, const UDQSet& rhs)
+{
+    if (lhs.size() != rhs.size()) {
+        if (lhs.var_type() != UDQVarType::SCALAR) {
+            printf("s1: %ld  s2: %ld \n", lhs.size(), rhs.size());
+            throw std::logic_error("Type/size mismatch");
+        }
+
+        if (rhs.var_type() == UDQVarType::WELL_VAR)
+            return UDQSet::wells(lhs.name(), rhs.wgnames(), lhs[0].value());
+
+        if (rhs.var_type() == UDQVarType::GROUP_VAR)
+            return UDQSet::groups(lhs.name(), rhs.wgnames(), lhs[0].value());
+
+        throw std::logic_error("Don't have a clue");
+    } else
+        return lhs;
+}
+
+}
 
 UDQSet operator+(const UDQSet&lhs, const UDQSet& rhs) {
-    UDQSet sum = lhs;
+    UDQSet sum = udq_cast(lhs, rhs);
     sum += rhs;
     return sum;
 }
@@ -401,9 +429,9 @@ UDQSet operator+(double lhs, const UDQSet& rhs) {
 }
 
 UDQSet operator-(const UDQSet&lhs, const UDQSet& rhs) {
-    UDQSet sum = lhs;
-    sum -= rhs;
-    return sum;
+    UDQSet diff = udq_cast(lhs, rhs);
+    diff -= rhs;
+    return diff;
 }
 
 UDQSet operator-(const UDQSet&lhs, double rhs) {
@@ -419,15 +447,15 @@ UDQSet operator-(double lhs, const UDQSet& rhs) {
 }
 
 UDQSet operator*(const UDQSet&lhs, const UDQSet& rhs) {
-    UDQSet sum = lhs;
-    sum *= rhs;
-    return sum;
+    UDQSet prod = udq_cast(lhs, rhs);
+    prod *= rhs;
+    return prod;
 }
 
 UDQSet operator*(const UDQSet&lhs, double rhs) {
-    UDQSet sum = lhs;
-    sum *= rhs;
-    return sum;
+    UDQSet prod = lhs;
+    prod *= rhs;
+    return prod;
 }
 
 UDQSet operator*(double lhs, const UDQSet& rhs) {
@@ -437,15 +465,15 @@ UDQSet operator*(double lhs, const UDQSet& rhs) {
 }
 
 UDQSet operator/(const UDQSet&lhs, const UDQSet& rhs) {
-    UDQSet sum = lhs;
-    sum /= rhs;
-    return sum;
+    UDQSet frac = udq_cast(lhs, rhs);
+    frac /= rhs;
+    return frac;
 }
 
 UDQSet operator/(const UDQSet&lhs, double rhs) {
-    UDQSet sum = lhs;
-    sum /= rhs;
-    return sum;
+    UDQSet frac = lhs;
+    frac /= rhs;
+    return frac;
 }
 
 UDQSet operator/(double lhs, const UDQSet&rhs) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -213,7 +213,7 @@ UDQVarType UDQSet::var_type() const {
 
 void UDQSet::operator+=(const UDQSet& rhs) {
     if (this->size() != rhs.size())
-        throw std::invalid_argument("Incompatible size in UDQSet operator+");
+        throw std::logic_error("Incompatible size in UDQSet operator+");
 
     for (std::size_t index = 0; index < this->size(); index++)
         this->values[index] += rhs[index];
@@ -235,7 +235,7 @@ void UDQSet::operator-=(const UDQSet& rhs) {
 
 void UDQSet::operator*=(const UDQSet& rhs) {
     if (this->size() != rhs.size())
-        throw std::invalid_argument("Incompatible size");
+        throw std::logic_error("Incompatible size  UDQSet operator*");
 
     for (std::size_t index = 0; index < this->size(); index++)
         this->values[index] *= rhs[index];
@@ -248,7 +248,7 @@ void UDQSet::operator*=(double rhs) {
 
 void UDQSet::operator/=(const UDQSet& rhs) {
     if (this->size() != rhs.size())
-        throw std::invalid_argument("Incompatible size");
+        throw std::logic_error("Incompatible size  UDQSet operator/");
 
     for (std::size_t index = 0; index < this->size(); index++)
         this->values[index] /= rhs[index];

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -110,6 +110,8 @@ BOOST_AUTO_TEST_CASE(UDQWellSetTest) {
     BOOST_CHECK_EQUAL(ws["P1"].value(), 1.0);
 
     BOOST_REQUIRE_THROW(ws.assign("NO_SUCH_WELL", 1.0), std::out_of_range);
+    BOOST_REQUIRE_THROW(ws[10], std::out_of_range);
+    BOOST_REQUIRE_THROW(ws["NO_SUCH_WELL"], std::out_of_range);
 
     ws.assign("*", 2.0);
     for (const auto& w : wells)

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -34,6 +34,52 @@ Copyright 2018 Statoil ASA.
 
 using namespace Opm;
 
+BOOST_AUTO_TEST_CASE(TEST)
+{
+    UDQParams udqp;
+    UDQFunctionTable udqft;
+    UDQDefine def1(udqp, "WUWI3", {"GOPR" , "MAU", "*", "2.0", "*", "0.25", "*", "10"});
+    UDQDefine def2(udqp, "WUWI3", {"2.0", "*", "0.25", "*", "3"});
+    UDQDefine def3(udqp, "WUWI3", {"GOPR" , "FIELD", "-", "2.0", "*", "3"});
+    UDQDefine def4(udqp, "WUWI3", {"FOPR" , "/",  "2"});
+
+    SummaryState st(std::chrono::system_clock::now());
+    UDQContext context(udqft, st);
+
+    st.update_group_var("MAU", "GOPR", 4);
+    st.update_group_var("XXX", "GOPR", 5);
+    st.update_group_var("FIELD", "GOPR", 6);
+    st.update_well_var("P1", "WBHP", 0.5);
+    st.update_well_var("P2", "WBHP", 0.5);
+    st.update("FOPR", 2);
+
+    auto res1 = def1.eval(context);
+    BOOST_CHECK_EQUAL( res1["P1"].value(), 20 );
+    BOOST_CHECK_EQUAL( res1["P2"].value(), 20 );
+
+    auto res2 = def2.eval(context);
+    BOOST_CHECK_EQUAL( res2["P1"].value(), 1.50 );
+    BOOST_CHECK_EQUAL( res2["P2"].value(), 1.50 );
+
+    auto res3 = def3.eval(context);
+    BOOST_CHECK_EQUAL( res3["P1"].value(), 0.00 );
+    BOOST_CHECK_EQUAL( res3["P2"].value(), 0.00 );
+
+    auto res4 = def4.eval(context);
+    BOOST_CHECK_EQUAL( res4["P1"].value(), 1.00 );
+    BOOST_CHECK_EQUAL( res4["P2"].value(), 1.00 );
+
+    /*
+      This expression has a well set as target type, and involves group with
+      wildcard that is not supported by flow.
+    */
+    BOOST_CHECK_THROW( UDQDefine(udqp, "WUWI2", {"GOPR", "G*", "*", "2.0"}), std::logic_error);
+
+    /*
+      UDQVarType == BLOCK is not yet supported.
+    */
+    BOOST_CHECK_THROW( UDQDefine(udqp, "WUWI2", {"BPR", "1","1", "1", "*", "2.0"}), std::logic_error);
+}
 
 Schedule make_schedule(const std::string& input) {
     Parser parser;
@@ -453,7 +499,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SET) {
     s1.assign(0,0.0);
     {
         UDQSet s2("NAME", 6);
-        BOOST_REQUIRE_THROW(s1 + s2, std::invalid_argument);
+        BOOST_REQUIRE_THROW(s1 + s2, std::logic_error);
     }
     {
         UDQSet s2("NAME", 5);
@@ -568,9 +614,7 @@ BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
     arg2.assign(2, 2.5);
     arg2.assign(4, 4.0);
 
-    BOOST_CHECK_THROW(UDQBinaryFunction::EQ(0.25, arg1, arg3), std::invalid_argument);
-
-
+    BOOST_CHECK_THROW(UDQBinaryFunction::EQ(0.25, arg1, arg3), std::logic_error);
     {
         auto result = UDQBinaryFunction::EQ(0, arg1, arg2);
 


### PR DESCRIPTION
The UDQ parser failed when mixing well and group sets:
```
UDQ
   DEFINE WUINJ GGIR 'WEST' * 1.25 /
/
```
this now works - but the exact semantics of the UDQ datatypes is still a bit in the fog.