### PR TITLE
Add GuideRate properties to GroupProduction::operator==

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -134,6 +134,8 @@ bool Group::GroupProductionProperties::operator==(const GroupProductionPropertie
         this->water_target        == other.oil_target &&
         this->gas_target          == other.gas_target &&
         this->liquid_target       == other.liquid_target &&
+        this->guide_rate          == other.guide_rate &&
+        this->guide_rate_def      == other.guide_rate_def &&
         this->production_controls == other.production_controls &&
         this->resv_target         == other.resv_target;
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1557,11 +1557,12 @@ namespace {
                         std::string guide_rate_str = record.getItem("GUIDE_RATE_DEF").getTrimmedString(0);
                         guide_rate_def = Group::GuideRateTargetFromString( guide_rate_str );
 
-                        if ((guide_rate_str == "INJ" || guide_rate_str == "POTN" || guide_rate_str == "FORM")) {
+                        if ((guide_rate_def == Group::GuideRateTarget::INJV ||
+                             guide_rate_def == Group::GuideRateTarget::POTN ||
+                             guide_rate_def == Group::GuideRateTarget::FORM)) {
                             std::string msg = "The supplied guide_rate value will be ignored";
                             parseContext.handleError(ParseContext::SCHEDULE_IGNORED_GUIDE_RATE, msg, errors);
-                        }
-                        else {
+                        } else {
                             guide_rate = record.getItem("GUIDE_RATE").get<double>(0);
                             if (guide_rate == 0)
                                 guide_rate_def = Group::GuideRateTarget::POTN;


### PR DESCRIPTION
The guide rate properties was not included in the GroupProducrtionProperties== - this was masked by another bug, but lead to false positive here: https://github.com/OPM/opm-common/pull/1329/files