### PR TITLE
remove unused member parser_keyword from DeckKeyword

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -42,7 +42,7 @@ namespace Opm {
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
 
         explicit DeckKeyword(const ParserKeyword& parserKeyword);
-        DeckKeyword(const ParserKeyword& parserKeyword, const Location& location, const std::string& keywordName);
+        DeckKeyword(const Location& location, const std::string& keywordName);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<std::vector<DeckValue>>& record_list, UnitSystem& system_active, UnitSystem& system_default);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, UnitSystem& system_active, UnitSystem& system_default);
@@ -65,7 +65,6 @@ namespace Opm {
         const std::vector<double>& getSIDoubleData() const;
         const std::vector<std::string>& getStringData() const;
         const std::vector<value::status>& getValueStatus() const;
-        const ParserKeyword& parserKeyword() const;
         size_t getDataSize() const;
         void write( DeckOutput& output ) const;
         void write_data( DeckOutput& output ) const;
@@ -94,7 +93,6 @@ namespace Opm {
         std::vector< DeckRecord > m_recordList;
         bool m_isDataKeyword;
         bool m_slashTerminated;
-        ParserKeyword parser_keyword;
     };
 }
 

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -34,17 +34,15 @@ namespace Opm {
     DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword) :
         m_keywordName(parserKeyword.getName()),
         m_isDataKeyword(false),
-        m_slashTerminated(true),
-        parser_keyword(parserKeyword)
+        m_slashTerminated(true)
     {
     }
 
-    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const Location& location, const std::string& keywordName) :
+    DeckKeyword::DeckKeyword(const Location& location, const std::string& keywordName) :
         m_keywordName(keywordName),
         m_location(location),
         m_isDataKeyword(false),
-        m_slashTerminated(true),
-        parser_keyword(parserKeyword)
+        m_slashTerminated(true)
     {
     }
 
@@ -193,10 +191,6 @@ namespace Opm {
 
     bool DeckKeyword::isDataKeyword() const {
         return m_isDataKeyword;
-    }
-
-    const ParserKeyword& DeckKeyword::parserKeyword() const {
-        return this->parser_keyword;
     }
 
     const std::string& DeckKeyword::name() const {

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -526,7 +526,7 @@ void set_dimensions( ParserItem& item,
         if( !rawKeyword.isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword.getKeywordName());
 
-        DeckKeyword keyword( *this, rawKeyword.location(), rawKeyword.getKeywordName() );
+        DeckKeyword keyword( rawKeyword.location(), rawKeyword.getKeywordName() );
         keyword.setDataKeyword( isDataKeyword() );
 
         size_t record_nr = 0;


### PR DESCRIPTION
This seems unused. Less entangled (and helps serialization).