### PR TITLE
Can parse keywords of type double-record. 

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -58,7 +58,9 @@ namespace Opm {
         DeckRecord& getRecord(size_t index);
         const DeckRecord& getDataRecord() const;
         void setDataKeyword(bool isDataKeyword = true);
+        void setDoubleRecordKeyword(bool isDoubleRecordKeyword = true);
         bool isDataKeyword() const;
+        bool isDoubleRecordKeyword() const;
 
         const std::vector<int>& getIntData() const;
         const std::vector<double>& getRawDoubleData() const;
@@ -93,6 +95,7 @@ namespace Opm {
         std::vector< DeckRecord > m_recordList;
         bool m_isDataKeyword;
         bool m_slashTerminated;
+        bool m_isDoubleRecordKeyword = false;
     };
 }
 

--- a/opm/parser/eclipse/Parser/ParserEnums.hpp
+++ b/opm/parser/eclipse/Parser/ParserEnums.hpp
@@ -29,7 +29,8 @@ namespace Opm {
         FIXED = 1,
         OTHER_KEYWORD_IN_DECK = 2,
         UNKNOWN = 3,
-        FIXED_CODE = 4
+        FIXED_CODE = 4,
+        DOUBLE_SLASH_TERMINATED = 5
     };
 
 

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -131,7 +131,9 @@ namespace Opm {
         bool rawStringKeyword() const;
         bool isCodeKeyword() const;
         bool isAlternatingKeyword() const;
+        bool isDoubleRecordKeyword() const;
         void setAlternatingKeyword(bool alternating);
+        void setDoubleRecordsKeyword(bool double_rec);
 
         std::string createDeclaration(const std::string& indent) const;
         std::string createDecl() const;
@@ -154,6 +156,7 @@ namespace Opm {
         std::string m_Description;
         bool raw_string_keyword = false;
         bool alternating_keyword = false;
+        bool double_records = false;
         std::string code_end;
 
         static bool validNameStart(const string_view& name);

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -189,8 +189,16 @@ namespace Opm {
         m_isDataKeyword = isDataKeyword_;
     }
 
+   void DeckKeyword::setDoubleRecordKeyword(bool isDoubleRecordKeyword) {
+        m_isDoubleRecordKeyword = isDoubleRecordKeyword;
+   }
+
     bool DeckKeyword::isDataKeyword() const {
         return m_isDataKeyword;
+    }
+
+    bool DeckKeyword::isDoubleRecordKeyword() const {
+        return m_isDoubleRecordKeyword;
     }
 
     const std::string& DeckKeyword::name() const {

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -560,11 +560,16 @@ void ParserState::addPathAlias( const std::string& alias, const std::string& pat
 RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string& keywordString, ParserState& parserState, const Parser& parser) {
     bool raw_string_keyword = parserKeyword.rawStringKeyword();
 
-    if( parserKeyword.getSizeType() == SLASH_TERMINATED || parserKeyword.getSizeType() == UNKNOWN) {
+    if( parserKeyword.getSizeType() == SLASH_TERMINATED || parserKeyword.getSizeType() == UNKNOWN || parserKeyword.getSizeType() == DOUBLE_SLASH_TERMINATED) {
 
-        const auto rawSizeType = parserKeyword.getSizeType() == SLASH_TERMINATED
-            ? Raw::SLASH_TERMINATED
-            : Raw::UNKNOWN;
+        const auto size_type = parserKeyword.getSizeType();
+        Raw::KeywordSizeEnum rawSizeType;
+
+        switch(size_type) {
+            case SLASH_TERMINATED:        rawSizeType = Raw::SLASH_TERMINATED; break;
+            case UNKNOWN:                 rawSizeType = Raw::UNKNOWN; break;
+            case DOUBLE_SLASH_TERMINATED: rawSizeType = Raw::DOUBLE_SLASH_TERMINATED; break;
+        }
 
         return new RawKeyword( keywordString,
                                parserState.current_path().string(),

--- a/src/opm/parser/eclipse/Parser/ParserEnums.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserEnums.cpp
@@ -42,6 +42,9 @@ namespace Opm {
         case FIXED_CODE:
             return "FIXED_CODE";
             break;
+        case DOUBLE_SLASH_TERMINATED:
+            return "DOUBLE_SLASH_TERMINATED";
+            break;
         default:
             throw std::invalid_argument("Implementation error - should NOT be here");
         }

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -553,8 +553,10 @@ void set_dimensions( ParserItem& item,
                std::vector< std::vector<DeckRecord >> m_recordList; */
             size_t record_nr = 0;
             for (auto& rawRecord : rawKeyword) {
-                if (rawRecord.size() == 0)
+                if (rawRecord.size() == 0) {
+                     keyword.addRecord( DeckRecord() );
                      record_nr = 0;
+                }
                 else {
                      keyword.addRecord( this->getRecord( record_nr ).parse( parseContext, errors, rawRecord, active_unitsystem, default_unitsystem, rawKeyword.getKeywordName(), filename ) );
                      record_nr++;

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -548,9 +548,8 @@ void set_dimensions( ParserItem& item,
 
         if (double_records) {
             /* Note: this merely dumps all records sequentially into m_recordList.
-               In order to actually use double-record keywords, DeckKeyword needs to have a 
-               2-dimensional DeckRecord structure, e.g.
-               std::vector< std::vector<DeckRecord >> m_recordList; */
+               Each block of records is separated by an empty DeckRecord.
+            */
             size_t record_nr = 0;
             for (auto& rawRecord : rawKeyword) {
                 if (rawRecord.size() == 0) {

--- a/src/opm/parser/eclipse/Parser/raw/RawEnums.hpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawEnums.hpp
@@ -30,6 +30,7 @@ namespace Opm {
             UNKNOWN = 3,
             TABLE_COLLECTION = 4,
             CODE = 5,
+            DOUBLE_SLASH_TERMINATED = 6
         };
     }
 }

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
@@ -96,6 +96,13 @@ namespace {
         if (this->m_sizeType == Raw::SLASH_TERMINATED)
             this->m_isFinished = true;
 
+        if (this->m_sizeType == Raw::DOUBLE_SLASH_TERMINATED) {
+            if (m_isTempFinished)
+                this->m_isFinished = true;
+            else
+                this->m_isTempFinished = true; 
+        }
+
         if (m_sizeType == Raw::TABLE_COLLECTION) {
             m_currentNumTables += 1;
             if (m_currentNumTables == m_numTables)
@@ -110,12 +117,15 @@ namespace {
 
 
     bool RawKeyword::addRecord(RawRecord record) {
+
+        if (record.size() > 0)
+            m_isTempFinished = false;
+
         this->m_records.push_back(std::move(record));
         if (m_records.size() == this->m_fixedSize) {
             if( this->m_sizeType == Raw::FIXED || this->m_sizeType == Raw::CODE)
                 this->m_isFinished = true;
         }
-
         return this->m_isFinished;
     }
 

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp
@@ -71,6 +71,7 @@ namespace Opm {
         size_t m_fixedSize = 0;
         size_t m_numTables = 0;
         size_t m_currentNumTables = 0;
+        bool m_isTempFinished = false;
         bool m_isFinished = false;
 
         std::vector< RawRecord > m_records;

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/CECONT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/C/CECONT
@@ -1,0 +1,22 @@
+{
+    "name" : "CECONT", "sections" : ["SCHEDULE"], "records_set" : [
+    [
+        {"name" : "WELL", "value_type" : "STRING"},
+        {"name" : "I", "value_type" : "INT", "default" : 0},
+        {"name" : "J", "value_type" : "INT", "default" : 0},
+        {"name" : "K_UPPER", "value_type" : "INT", "default" : 0},
+        {"name" : "K_LOWER", "value_type" : "INT", "default" : 0},
+        {"name" : "PROCEDURE", "value_type" : "STRING", "default" : "CON"},
+        {"name" : "CHECK_STOPPED_WELLS", "value_type" : "STRING", "default" : "NO"}
+    ],
+    [
+        {"name" : "TRACER", "value_type" : "STRING"},
+        {"name" : "MAX_TOTAL_TRACER_RATE", "value_type" : "DOUBLE", "default" : 1e200},
+        {"name" : "MAX_TOTAL_TRACER_CONC", "value_type" : "DOUBLE", "default" : 1e200},
+        {"name" : "MAX_FREE_TRACER_RATE", "value_type" : "DOUBLE", "default" : 1e200},
+        {"name" : "MAX_FREE_TRACER_CONC", "value_type" : "DOUBLE", "default" : 1e200},
+        {"name" : "MAX_SOL_TRACER_RATE", "value_type" : "DOUBLE", "default" : 1e200},
+        {"name" : "MAX_SOL_TRACER_CONC", "value_type" : "DOUBLE", "default" : 1e200}
+    ]
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GCUTBACT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GCUTBACT
@@ -1,0 +1,16 @@
+{
+    "name" : "GCUTBACT", "sections" : ["SCHEDULE"], "records_set" : [
+    [
+        {"name" : "GROUP", "value_type" : "STRING"},
+        {"name" : "RATE_CUTBACK", "value_type" : "DOUBLE", "dimension" : "1"},
+        {"name" : "CONTROL_PHASE", "value_type" : "STRING"}
+    ],
+    [
+        {"name" : "TRACER", "value_type" : "STRING"},
+        {"name" : "UPPER_RATE_LIM", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200},
+        {"name" : "LOWER_RATE_LIM", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200},
+        {"name" : "UPPER_CONC_LIM", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200},
+        {"name" : "LOWER_CONC_LIM", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200}
+    ]
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GECONT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GECONT
@@ -1,0 +1,19 @@
+{
+    "name" : "GECONT", "sections" : ["SCHEDULE"], "records_set" : [
+    [
+        {"name" : "GROUP", "value_type" : "STRING"},
+        {"name" : "PROCEDURE", "value_type" : "STRING", "default" : "NONE"},
+        {"name" : "END_RUN", "value_type" : "STRING", "default" : "NO"},
+        {"name" : "MAX_OPEN_WELLS", "value_type" : "INT", "default" : 0}
+    ],
+    [
+        {"name" : "TRACER", "value_type" : "STRING"},
+        {"name" : "MAX_TOTAL_TRACER_RATE", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200},
+        {"name" : "MAX_TOTAL_TRACER_CONC", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200},
+        {"name" : "MAX_FREE_TRACER_RATE", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200},
+        {"name" : "MAX_FREE_TRACER_CONC", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200},
+        {"name" : "MAX_SOL_TRACER_RATE", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200},
+        {"name" : "MAX_SOL_TRACER_CONC", "value_type" : "DOUBLE", "dimension" : "1", "default" : 1e200}
+    ]
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MPFNNC
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MPFNNC
@@ -1,0 +1,19 @@
+{
+    "name" : "MPFNNC", "sections" : ["GRID"], "records_set" : [
+    [
+        {"name" : "IX", "value_type" : "INT"},
+        {"name" : "IY", "value_type" : "INT"},
+        {"name" : "IZ", "value_type" : "INT"},
+        {"name" : "JX", "value_type" : "INT"},
+        {"name" : "JY", "value_type" : "INT"},
+        {"name" : "JZ", "value_type" : "INT"},
+        {"name" : "TRANP", "value_type" : "DOUBLE", "dimension" : "Transmissibility"}
+    ],
+    [
+        {"name" : "KX", "value_type" : "INT"},
+        {"name" : "KY", "value_type" : "INT"},
+        {"name" : "KZ", "value_type" : "INT"},
+        {"name" : "TRANS", "value_type" : "DOUBLE", "dimension" : "Transmissibility"}
+    ]
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -79,6 +79,7 @@ set( keywords
      000_Eclipse100/C/CART
      000_Eclipse100/C/CBMOPTS
      000_Eclipse100/C/CECON
+     000_Eclipse100/C/CECONT
      000_Eclipse100/C/COAL
      000_Eclipse100/C/COALADS
      000_Eclipse100/C/COALNUM

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -10,13 +10,8 @@
 # the file: opm/autodiff/MissingFeatures.cpp
 
 #Some keywords are found to be of 'special' structure:
-#These are grouped as:
+#These are :
 #
-#    Double records:
-#       CECONT: note that this also has two types of records
-#       DYNAMICS: note that this also has two types of records
-#       GCUTBACT: note that this also has two types of records
-#       GECONT: note that this also has two types of records
 #       MPFNNC: note that this also has two types of records
 #       UDT: user defined table
 #
@@ -272,6 +267,7 @@ set( keywords
      000_Eclipse100/G/GCONSUMP
      000_Eclipse100/G/GCONTOL
      000_Eclipse100/G/GCUTBACK
+     000_Eclipse100/G/GCUTBACT
      000_Eclipse100/G/GCVD
      000_Eclipse100/G/GDCQ
      000_Eclipse100/G/GDCQECON
@@ -280,6 +276,7 @@ set( keywords
      000_Eclipse100/G/GDORIENT
      000_Eclipse100/G/GDRILPOT
      000_Eclipse100/G/GECON
+     000_Eclipse100/G/GECONT
      000_Eclipse100/G/GEFAC
      000_Eclipse100/G/GETGLOB
      000_Eclipse100/G/GI
@@ -476,6 +473,7 @@ set( keywords
      000_Eclipse100/M/MLANGSLV
      000_Eclipse100/M/MONITOR
      000_Eclipse100/M/MPFANUM
+     000_Eclipse100/M/MPFNNC
      000_Eclipse100/M/MSFN
      000_Eclipse100/M/MSGFILE
      000_Eclipse100/M/MULSGGD

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -2227,13 +2227,15 @@ PLAT-B 15 /
     BOOST_CHECK(record01.getItem(1).getType() == type_tag::fdouble);
     BOOST_CHECK_EQUAL(record01.getItem(1).get<double>(0), 1000);
 
-    auto record04 = kw.getRecord(4);
+    BOOST_CHECK_EQUAL( kw.getRecord(4).size(), 0 );
+
+    auto record04 = kw.getRecord(5);
     BOOST_CHECK_EQUAL(record04.getItem(0).name(), "WELL");
     BOOST_CHECK_EQUAL(record04.getItem(0).get<std::string>(0), "PROD2");
     BOOST_CHECK(record04.getItem(1).getType() == type_tag::integer);
     BOOST_CHECK_EQUAL(record04.getItem(1).get<int>(0), 5);
 
-    auto record08 = kw.getRecord(8);
+    auto record08 = kw.getRecord(10);
     BOOST_CHECK_EQUAL(record08.getItem(0).name(), "TRACER");
     BOOST_CHECK_EQUAL(record08.getItem(0).get<std::string>(0), "PLY");
     BOOST_CHECK(record08.getItem(2).getType() == type_tag::fdouble);


### PR DESCRIPTION
This PR makes it possible to parse keywords with a nested record structure, referred to as double-record keywords. Such keywords are `CECONT`, `GCUTBACT`, `GECONT` and `MPFNNC`.
Example:
```
CECONT
PROD1 4* CON NO /
TR1 1000.0 0.5 /
TR2 2* 1* 0.8 2* /
TR3 1500.0 0.1 /
/
PROD2 5 6 3 3 CON+ NO /
TR3 100.0 0.05 /
/
PROD3 6* /
TR4 200 5* /
PLY 1* 0.7 /
/
/
```
For this PR, `DeckKeyword` has been added a bool signifying a "double-record" structure. However, no structural change has been med to the `m_recordList` structure. The records are dumped into the m_recordList structure, with a empty record signifying the end of a set of records. 

Also for this PR: keywords `CECONT`, `GCUTBACT`, `GECONT` and `MPFNNC` are added. 
