### PR TITLE
Preparation for serialization support

### DIFF
--- a/opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp
+++ b/opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp
@@ -31,6 +31,9 @@ public:
 
     /// Construct from input deck
     explicit EDITNNC(const Deck& deck);
+
+    explicit EDITNNC(const std::vector<NNCdata>& data);
+
     /// \brief Get an ordered set of EDITNNC
     const std::vector<NNCdata>& data() const
     {
@@ -40,6 +43,8 @@ public:
     size_t size() const;
     /// \brief Whether EDITNNC was empty.
     bool empty() const;
+
+    bool operator==(const EDITNNC& data) const;
 
 private:
     std::vector<NNCdata> m_editnnc;

--- a/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
@@ -32,6 +32,14 @@ struct NNCdata {
         : cell1(c1), cell2(c2), trans(t)
     {}
     NNCdata() = default;
+
+    bool operator==(const NNCdata& data) const
+    {
+        return cell1 == data.cell1 &&
+               cell2 == data.cell2 &&
+               trans == data.trans;
+    }
+
     size_t cell1;
     size_t cell2;
     double trans;
@@ -48,10 +56,13 @@ public:
 
     /// Construct from input deck.
     explicit NNC(const Deck& deck);
+    explicit NNC(const std::vector<NNCdata>& nncdata) : m_nnc(nncdata) {}
     void addNNC(const size_t cell1, const size_t cell2, const double trans);
     const std::vector<NNCdata>& data() const { return m_nnc; }
     size_t numNNC() const;
     bool hasNNC() const;
+
+    bool operator==(const NNC& data) const;
 
 private:
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -33,11 +33,19 @@ namespace Opm {
     class ThresholdPressure {
 
     public:
+        using ThresholdPressureTable = std::vector<std::pair<bool,double>>;
+        using PressureTable = std::map<std::pair<int,int>,std::pair<bool,double>>;
+
         ThresholdPressure(bool restart,
                           const Deck& deck,
                           const FieldPropsManager& fp,
                           const Eclipse3DProperties& eclipseProperties);
 
+        ThresholdPressure(bool active, bool restart,
+                          const ThresholdPressureTable& thpTable,
+                          const PressureTable& pTable);
+
+        ThresholdPressure() { m_active = m_restart = false; }
 
         /*
           The hasRegionBarrier() method checks if a threshold pressure
@@ -67,6 +75,14 @@ namespace Opm {
         size_t size() const;
         bool active() const;
         bool restart() const;
+
+        const ThresholdPressureTable& thresholdPressureTable() const
+        { return m_thresholdPressureTable; }
+
+        const PressureTable& pressureTable() const
+        { return m_pressureTable; }
+
+        bool operator==(const ThresholdPressure& data) const;
     private:
         bool m_active;
         bool m_restart;

--- a/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp
@@ -30,9 +30,11 @@ namespace Opm {
 
     class ColumnSchema {
     public:
+        ColumnSchema();
         ColumnSchema(const std::string& name , Table::ColumnOrderEnum order, Table::DefaultAction defaultAction);
         ColumnSchema(const std::string& name , Table::ColumnOrderEnum order, double defaultValue);
         const std::string& name() const;
+        Table::ColumnOrderEnum order() const;
         bool validOrder( double value1 , double value2) const;
         bool lookupValid( ) const;
         bool acceptsDefault( ) const;
@@ -40,6 +42,9 @@ namespace Opm {
         bool isDecreasing( ) const;
         Table::DefaultAction getDefaultMode( ) const;
         double getDefaultValue( ) const;
+
+        bool operator==(const ColumnSchema& data) const;
+
     private:
         std::string m_name;
         Table::ColumnOrderEnum m_order;

--- a/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.hpp
@@ -28,12 +28,21 @@ namespace Opm {
     class Rock2dTable {
     public:
         Rock2dTable();
+        Rock2dTable(const std::vector<std::vector<double>>& pvmultValues,
+                    const std::vector<double>& pressureValues);
         void init(const Opm::DeckRecord& record, size_t tableIdx);
         size_t size() const;
         size_t sizeMultValues() const;
         double getPressureValue(size_t index) const;
         double getPvmultValue(size_t pressureIndex, size_t saturationIndex ) const;
 
+        const std::vector<std::vector<double>>& pvmultValues() const
+        { return m_pvmultValues; }
+
+        const std::vector<double>& pressureValues() const
+        { return m_pressureValues; }
+
+        bool operator==(const Rock2dTable& data) const;
 
     protected:
         std::vector< std::vector <double> > m_pvmultValues;

--- a/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.hpp
@@ -28,11 +28,21 @@ namespace Opm {
     class Rock2dtrTable {
     public:
         Rock2dtrTable();
+        Rock2dtrTable(const std::vector<std::vector<double>>& transMultValues,
+                      const std::vector<double>& pressureValues);
         void init(const Opm::DeckRecord& record, size_t tableIdx);
         size_t size() const;
         size_t sizeMultValues() const;
         double getPressureValue(size_t index) const;
         double getTransMultValue(size_t pressureIndex, size_t saturationIndex ) const;
+
+        const std::vector<std::vector<double>>& transMultValues() const
+        { return m_transMultValues; }
+
+        const std::vector<double>& pressureValues() const
+        { return m_pressureValues; }
+
+        bool operator==(const Rock2dtrTable& data) const;
 
     protected:
         std::vector< std::vector <double> > m_transMultValues;

--- a/opm/parser/eclipse/EclipseState/Tables/TableSchema.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableSchema.hpp
@@ -30,13 +30,19 @@ namespace Opm {
 
     class TableSchema {
     public:
+        TableSchema() = default;
+        TableSchema(const OrderedMap<std::string, ColumnSchema>& columns);
         void addColumn( ColumnSchema );
         const ColumnSchema& getColumn( const std::string& name ) const;
         const ColumnSchema& getColumn( size_t columnIndex ) const;
         bool hasColumn(const std::string&) const;
 
+        const OrderedMap<std::string, ColumnSchema>& getColumns() const;
+
         /* Number of columns */
         size_t size() const;
+
+        bool operator==(const TableSchema& data) const;
     private:
         OrderedMap<std::string, ColumnSchema> m_columns;
     };

--- a/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
@@ -30,17 +30,29 @@ namespace Opm {
 
 template <typename K, typename T>
 class OrderedMap {
-
-using storage_type = typename std::vector<std::pair<K,T>>;
-using index_type = typename std::unordered_map<K,std::size_t>;
-using iter_type = typename storage_type::iterator;
-using const_iter_type = typename storage_type::const_iterator;
+public:
+    using storage_type = typename std::vector<std::pair<K,T>>;
+    using index_type = typename std::unordered_map<K,std::size_t>;
+    using iter_type = typename storage_type::iterator;
+    using const_iter_type = typename storage_type::const_iterator;
 
 private:
     index_type m_map;
     storage_type m_vector;
 
 public:
+
+    OrderedMap() = default;
+
+    OrderedMap(const index_type& index, const storage_type& storage)
+        : m_map(index)
+        , m_vector(storage)
+    {
+    }
+
+    const index_type getIndex() const { return m_map; }
+
+    const storage_type getStorage() const { return m_vector; }
 
     std::size_t count(const K& key) const {
         return this->m_map.count(key);
@@ -174,6 +186,11 @@ public:
             return this->m_vector.end();
 
         return std::next(this->m_vector.begin(), map_iter->second);
+    }
+
+    bool operator==(const OrderedMap<K,T>& data) const {
+        return this->getIndex() == data.getIndex() &&
+               this->getStorage() == data.getStorage();
     }
 };
 }

--- a/src/opm/parser/eclipse/EclipseState/Edit/EDITNNC.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Edit/EDITNNC.cpp
@@ -78,6 +78,11 @@ EDITNNC::EDITNNC(const Deck& deck)
     std::sort(m_editnnc.begin(), m_editnnc.end(), compare);
 }
 
+EDITNNC::EDITNNC(const std::vector<NNCdata>& data)
+    : m_editnnc(data)
+{
+}
+
 size_t EDITNNC::size() const {
     return(m_editnnc.size());
 }
@@ -85,4 +90,9 @@ size_t EDITNNC::size() const {
 bool EDITNNC::empty() const {
     return m_editnnc.empty();
 }
+
+bool EDITNNC::operator==(const EDITNNC& data) const {
+    return m_editnnc == data.m_editnnc;
+}
+
 } // namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
@@ -70,5 +70,9 @@ namespace Opm
         return m_nnc.size()>0;
     }
 
+    bool NNC::operator==(const NNC& data) const {
+        return m_nnc == data.m_nnc;
+    }
+
 } // namespace Opm
 

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -143,6 +143,16 @@ namespace Opm {
         }
     }
 
+    ThresholdPressure::ThresholdPressure(bool active, bool restart,
+                                         const ThresholdPressureTable& thpTable,
+                                         const PressureTable& pTable)
+      : m_active(active)
+      , m_restart(restart)
+      , m_thresholdPressureTable(thpTable)
+      , m_pressureTable(pTable)
+    {
+    }
+
     bool ThresholdPressure::hasRegionBarrier(int r1 , int r2) const {
         std::pair<int,int> indexPair = makeIndex(r1,r2);
         if (m_pressureTable.find( indexPair ) == m_pressureTable.end())
@@ -219,6 +229,13 @@ namespace Opm {
             auto value_pair = pair_pair.second;
             return value_pair.first;
         }
+    }
+
+    bool ThresholdPressure::operator==(const ThresholdPressure& data) const {
+        return this->active() == data.active() &&
+               this->restart() == data.restart() &&
+               this->thresholdPressureTable() == data.thresholdPressureTable() &&
+               this->pressureTable() == data.pressureTable();
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.cpp
@@ -23,6 +23,13 @@
 
 namespace Opm {
 
+    ColumnSchema::ColumnSchema() :
+        m_order(Table::INCREASING),
+        m_defaultAction(Table::DEFAULT_NONE),
+        m_defaultValue(0.0)
+    {
+    }
+
     ColumnSchema::ColumnSchema(const std::string& nm, Table::ColumnOrderEnum order, Table::DefaultAction defaultAction) :
         m_name( nm ),
         m_order( order ),
@@ -45,6 +52,9 @@ namespace Opm {
         return m_name;
     }
 
+    Table::ColumnOrderEnum ColumnSchema::order() const {
+        return m_order;
+    }
 
     bool ColumnSchema::validOrder( double value1 , double value2) const {
         switch (m_order) {
@@ -109,6 +119,14 @@ namespace Opm {
             return m_defaultValue;
         else
             throw std::invalid_argument("Column must be configured with constant default when using this method");
+    }
+
+
+    bool ColumnSchema::operator==(const ColumnSchema& data) const {
+        return this->name() == data.name() &&
+               this->order() == data.order() &&
+               this->getDefaultMode() == data.getDefaultMode() &&
+               m_defaultValue == data.m_defaultValue;
     }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.cpp
@@ -29,6 +29,13 @@ namespace Opm {
         {
         }
 
+        Rock2dTable::Rock2dTable(const std::vector<std::vector<double>>& pvmultValues,
+                                 const std::vector<double>& pressureValues)
+            : m_pvmultValues(pvmultValues)
+            , m_pressureValues(pressureValues)
+        {
+        }
+
         void Rock2dTable::init(const DeckRecord& record, size_t /* tableIdx */)
         {
             m_pressureValues.push_back(record.getItem("PRESSURE").getSIDoubleData()[0]);
@@ -53,6 +60,12 @@ namespace Opm {
         double Rock2dTable::getPvmultValue(size_t pressureIndex, size_t saturationIndex) const
         {
             return m_pvmultValues[pressureIndex][saturationIndex];
+        }
+
+        bool Rock2dTable::operator==(const Rock2dTable& data) const
+        {
+            return this->pvmultValues() == data.pvmultValues() &&
+                   this->pressureValues() == data.pressureValues();
         }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
@@ -29,6 +29,13 @@ namespace Opm {
         {
         }
 
+        Rock2dtrTable::Rock2dtrTable(const std::vector<std::vector<double>>& transMultValues,
+                                     const std::vector<double>& pressureValues)
+            : m_transMultValues(transMultValues)
+            , m_pressureValues(pressureValues)
+        {
+        }
+
         void Rock2dtrTable::init(const DeckRecord& record, size_t /* tableIdx */)
         {
             m_pressureValues.push_back(record.getItem("PRESSURE").getSIDoubleData()[0]);
@@ -53,6 +60,12 @@ namespace Opm {
         double Rock2dtrTable::getTransMultValue(size_t pressureIndex, size_t saturationIndex) const
         {
             return m_transMultValues[pressureIndex][saturationIndex];
+        }
+
+        bool Rock2dtrTable::operator==(const Rock2dtrTable& data) const
+        {
+              return this->transMultValues() == data.transMultValues() &&
+                     this->pressureValues() == data.pressureValues();
         }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableSchema.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableSchema.cpp
@@ -22,6 +22,11 @@
 
 namespace Opm {
 
+    TableSchema::TableSchema(const OrderedMap<std::string, ColumnSchema>& columns) :
+        m_columns(columns)
+    {
+    }
+
     void TableSchema::addColumn( ColumnSchema column ) {
         m_columns.insert( std::make_pair( column.name(), column ));
     }
@@ -42,4 +47,11 @@ namespace Opm {
         return m_columns.count( name ) > 0;
     }
 
+    const OrderedMap<std::string, ColumnSchema>& TableSchema::getColumns() const {
+        return m_columns;
+    }
+
+    bool TableSchema::operator==(const TableSchema& data) const {
+        return this->getColumns() == data.getColumns();
+    }
 }


### PR DESCRIPTION
I am working towards enabling parsing the input file only on the root process in parallel. This means the all the data types that come out of this needs to be serialized for mpi broadcast.

Since we are doing the serialization external to the classes, this means we need accessors for all private data, and the ability to recreate the classes from separately stored data. Since I, and I know others, are not particular found of mutable class state accessors, this means a constructor taking the data as parameters. Finally, to enable testing, equality operators must be available.

This is the first flush of class modifications required. More to come, but bite size is of value here.