### PR TITLE
WriteInit.cpp fix

### DIFF
--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -350,8 +350,9 @@ namespace {
                           const ::Opm::EclipseGrid&         grid,
                           const ::Opm::UnitSystem&          units,
                           ::Opm::EclIO::OutputStream::Init& initFile)
-         auto porv = es.get3DProperties()
-            .getDoubleGridProperty("PORV").getData();
+     {
+        auto porv = es.get3DProperties()
+           .getDoubleGridProperty("PORV").getData();
         for (auto nGlob    = porv.size(),
                   globCell = 0*nGlob; globCell < nGlob; ++globCell)
         {
@@ -361,7 +362,7 @@ namespace {
         }
         units.from_si(::Opm::UnitSystem::measure::volume, porv);
         initFile.write("PORV", singlePrecision(porv));
-    }
+     }
 
 
     void writeIntegerCellProperties(const ::Opm::EclipseState&        es,


### PR DESCRIPTION
There is a tiny bug in WriteInit.cpp: lack of bracket for function 'writePoreVolume'.