### PR TITLE
UDQ parse A - B - C

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -59,14 +59,14 @@ namespace Opm {
 enum class UDQVarType {
     NONE = 0,
     SCALAR = 1,
-    WELL_VAR = 2,
-    CONNECTION_VAR= 3,
-    FIELD_VAR = 4,
-    GROUP_VAR = 5,
-    REGION_VAR = 6,
-    SEGMENT_VAR = 7,
-    AQUIFER_VAR = 8,
-    BLOCK_VAR = 9
+    CONNECTION_VAR = 2,
+    FIELD_VAR = 3,
+    REGION_VAR = 4,
+    SEGMENT_VAR = 5,
+    AQUIFER_VAR = 6,
+    BLOCK_VAR = 7,
+    WELL_VAR = 8,
+    GROUP_VAR = 9
 };
 
 
@@ -165,8 +165,10 @@ enum class UDAKeyword {
 
 namespace UDQ {
 
+    UDQVarType targetType(const std::string& keyword, const std::vector<std::string>& selector);
     UDQVarType targetType(const std::string& keyword);
     UDQVarType varType(const std::string& keyword);
+    UDQVarType coerce(UDQVarType t1, UDQVarType t2);
     UDQAction actionType(const std::string& action_string);
     UDQTokenType funcType(const std::string& func_name);
     bool binaryFunc(UDQTokenType token_type);
@@ -177,7 +179,6 @@ namespace UDQ {
     std::string typeName(UDQVarType var_type);
     UDAKeyword keyword(UDAControl control);
     int uadCode(UDAControl control);
-
 }
 }
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1208,25 +1208,47 @@ void eval_udq(const Opm::Schedule& schedule, std::size_t sim_step, Opm::SummaryS
     const UDQConfig& udq = schedule.getUDQConfig(sim_step);
     const auto& func_table = udq.function_table();
     UDQContext context(func_table, st);
-    std::vector<std::string> wells;
-    for (const auto& well_name : schedule.wellNames())
-        wells.push_back(well_name);
+    {
+        const std::vector<std::string> wells = st.wells();
 
-    for (const auto& assign : udq.assignments(UDQVarType::WELL_VAR)) {
-        auto ws = assign.eval(wells);
-        for (const auto& well : wells) {
-            const auto& udq_value = ws[well];
-            if (udq_value)
-                st.update_well_var(well, ws.name(), udq_value.value());
+        for (const auto& assign : udq.assignments(UDQVarType::WELL_VAR)) {
+            auto ws = assign.eval(wells);
+            for (const auto& well : wells) {
+                const auto& udq_value = ws[well];
+                if (udq_value)
+                    st.update_well_var(well, ws.name(), udq_value.value());
+            }
+        }
+
+        for (const auto& def : udq.definitions(UDQVarType::WELL_VAR)) {
+            auto ws = def.eval(context);
+            for (const auto& well : wells) {
+                const auto& udq_value = ws[well];
+                if (udq_value)
+                    st.update_well_var(well, def.keyword(), udq_value.value());
+            }
         }
     }
 
-    for (const auto& def : udq.definitions(UDQVarType::WELL_VAR)) {
-        auto ws = def.eval(context);
-        for (const auto& well : wells) {
-            const auto& udq_value = ws[well];
-            if (udq_value)
-                st.update_well_var(well, def.keyword(), udq_value.value());
+    {
+        const std::vector<std::string> groups = st.groups();
+
+        for (const auto& assign : udq.assignments(UDQVarType::GROUP_VAR)) {
+            auto ws = assign.eval(groups);
+            for (const auto& group : groups) {
+                const auto& udq_value = ws[group];
+                if (udq_value)
+                    st.update_group_var(group, ws.name(), udq_value.value());
+            }
+        }
+
+        for (const auto& def : udq.definitions(UDQVarType::GROUP_VAR)) {
+            auto ws = def.eval(context);
+            for (const auto& group : groups) {
+                const auto& udq_value = ws[group];
+                if (udq_value)
+                    st.update_group_var(group, def.keyword(), udq_value.value());
+            }
         }
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <set>
 #include <vector>
+#include <memory>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp>
@@ -34,24 +35,33 @@ namespace Opm {
 
 class UDQASTNode {
 public:
-    UDQASTNode(UDQTokenType type_arg);
-    UDQASTNode(double scalar_value);
-    UDQASTNode(UDQTokenType type_arg, const std::string& string_value, const std::vector<std::string>& selector);
+    explicit UDQASTNode(UDQTokenType type_arg);
+    explicit UDQASTNode(double scalar_value);
     UDQASTNode(UDQTokenType type_arg, const std::string& func_name, const UDQASTNode& arg);
     UDQASTNode(UDQTokenType type_arg, const std::string& func_name, const UDQASTNode& left, const UDQASTNode& right);
+    UDQASTNode(UDQTokenType type_arg, const std::string& func_name);
+    UDQASTNode(UDQTokenType type_arg, const std::string& string_value, const std::vector<std::string>& selector);
+
 
     UDQSet eval(UDQVarType eval_target, const UDQContext& context) const;
 
-    UDQTokenType type;
+    bool valid() const;
     UDQVarType var_type = UDQVarType::NONE;
     std::set<UDQTokenType> func_tokens() const;
+    void update_type(const UDQASTNode& arg);
+    void set_left(const UDQASTNode& arg);
+    void set_right(const UDQASTNode& arg);
+    UDQASTNode* get_left() const;
+    UDQASTNode* get_right() const;
 private:
+    UDQTokenType type;
     void func_tokens(std::set<UDQTokenType>& tokens) const;
 
     std::string string_value;
     std::vector<std::string> selector;
     double scalar_value;
-    std::vector<UDQASTNode> arglist;
+    std::shared_ptr<UDQASTNode> left;
+    std::shared_ptr<UDQASTNode> right;
 };
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -131,10 +131,6 @@ UDQVarType targetType(const std::string& keyword) {
 
     char first_char =  keyword[0];
     switch(first_char) {
-    case 'W':
-        return UDQVarType::WELL_VAR;
-    case 'G':
-        return UDQVarType::GROUP_VAR;
     case 'C':
         return UDQVarType::CONNECTION_VAR;
     case 'R':
@@ -147,6 +143,10 @@ UDQVarType targetType(const std::string& keyword) {
         return UDQVarType::AQUIFER_VAR;
     case 'B':
         return UDQVarType::BLOCK_VAR;
+    case 'W':
+        return UDQVarType::WELL_VAR;
+    case 'G':
+        return UDQVarType::GROUP_VAR;
     default:
         try {
             std::stod(keyword);
@@ -157,6 +157,23 @@ UDQVarType targetType(const std::string& keyword) {
     }
 
 }
+
+UDQVarType targetType(const std::string& keyword, const std::vector<std::string>& selector) {
+    auto tt = targetType(keyword);
+
+    if (tt == UDQVarType::WELL_VAR || tt == UDQVarType::GROUP_VAR) {
+        if (selector.empty())
+            return tt;
+        else {
+            const auto& wgname = selector[0];
+            if (wgname.find("*") != std::string::npos)
+                return tt;
+        }
+    }
+
+    return UDQVarType::SCALAR;
+}
+
 
 
 UDQVarType varType(const std::string& keyword) {
@@ -234,7 +251,46 @@ UDQTokenType funcType(const std::string& func_name) {
 }
 
 
+UDQVarType coerce(UDQVarType t1, UDQVarType t2) {
+    if (t1 == t2)
+        return t1;
 
+    if (t1 == UDQVarType::WELL_VAR ) {
+        if (t2 == UDQVarType::GROUP_VAR)
+            throw std::logic_error("Can not coerce well variable and group variable");
+
+        return t1;
+    }
+
+    if (t1 == UDQVarType::GROUP_VAR ) {
+        if (t2 == UDQVarType::WELL_VAR)
+            throw std::logic_error("Can not coerce well variable and group variable");
+
+        return t1;
+    }
+
+    if (t2 == UDQVarType::WELL_VAR ) {
+        if (t1 == UDQVarType::GROUP_VAR)
+            throw std::logic_error("Can not coerce well variable and group variable");
+
+        return t2;
+    }
+
+    if (t2 == UDQVarType::GROUP_VAR ) {
+        if (t1 == UDQVarType::WELL_VAR)
+            throw std::logic_error("Can not coerce well variable and group variable");
+
+        return t2;
+    }
+
+    if (t1 == UDQVarType::NONE)
+        return t2;
+
+    if (t2 == UDQVarType::NONE)
+        return t1;
+
+    return t1;
+}
 
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
@@ -41,7 +41,7 @@ struct UDQParseNode {
         selector(selector_arg)
     {
         if (type_arg == UDQTokenType::ecl_expr)
-            this->var_type = UDQ::targetType(value_arg);
+            this->var_type = UDQ::targetType(value_arg, selector_arg);
     }
 
 
@@ -83,6 +83,7 @@ private:
     UDQParseNode next();
     UDQTokenType get_type(const std::string& arg) const;
     std::size_t current_size() const;
+    bool empty() const;
 
     const UDQParams& udq_params;
     UDQFunctionTable udqft;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -291,8 +291,8 @@ const UDQScalar& UDQSet::operator[](std::size_t index) const {
     return this->values[index];
 }
 
-const UDQScalar& UDQSet::operator[](const std::string& well) const {
-    std::size_t index = this->wgname_index.at(well);
+const UDQScalar& UDQSet::operator[](const std::string& wgname) const {
+    std::size_t index = this->wgname_index.at(wgname);
     return this->operator[](index);
 }
 


### PR DESCRIPTION
The initial version of the UDQ parser parsed expressions like:
```
A - B - C
```
incorrectly - what was actually evaluated was: `A - (B - C)`. Fixed now. Current needs some polish before it is in a mergeable state, but I put it put for early testing.