### PR TITLE
add a default to quell unhandled value in switch warning

### DIFF
--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -538,6 +538,9 @@ namespace {
 
                 case UType::UNIT_TYPE_PVT_M:
                     return 1.322e-15f;
+
+                default:
+                    break;
             }
 
             throw std::invalid_argument {


### PR DESCRIPTION
not sure if this is actually the desired outcome, but i'm not changing anything except killing the warning.