### PR TITLE
Don't Output Dynamic Data to Restart File for SEQNUM=0

### DIFF
--- a/opm/output/eclipse/WriteRestartHelpers.hpp
+++ b/opm/output/eclipse/WriteRestartHelpers.hpp
@@ -22,11 +22,6 @@
 
 #include <vector>
 
-// Missing definitions (really belong in ert/ecl_well/well_const.h, but not
-// defined there)
-#define SCON_KH_INDEX 3
-
-
 // Forward declarations
 
 namespace Opm {
@@ -43,8 +38,6 @@ namespace Opm {
 
 namespace Opm { namespace RestartIO { namespace Helpers {
 
-    const double UNIMPLEMENTED_VALUE = 1e-100; // placeholder for values not yet available 
-
     std::vector<double>
     createDoubHead(const EclipseState& es,
                    const Schedule&     sched,
@@ -52,15 +45,14 @@ namespace Opm { namespace RestartIO { namespace Helpers {
                    const double        simTime,
                    const double        nextTimeStep);
 
-
-
     std::vector<int>
     createInteHead(const EclipseState& es,
                    const EclipseGrid&  grid,
                    const Schedule&     sched,
                    const double        simTime,
                    const int           num_solver_steps,
-                   const int           lookup_step);   // The integer index used to look up dynamic properties, e.g. the number of well.
+                   const int           report_step,
+                   const int           lookup_step);
 
     std::vector<bool>
     createLogiHead(const EclipseState& es);

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -38,11 +38,12 @@
 #include <algorithm>
 #include <cstddef>
 #include <exception>
+#include <iterator>
 #include <stdexcept>
 #include <vector>
 
 namespace {
-    
+
     using nph_enum = Opm::GuideRateModel::Target;
     const std::map<nph_enum, int> nph_enumToECL = {
         {nph_enum::NONE, 0},
@@ -52,7 +53,7 @@ namespace {
         {nph_enum::RES,  6},
         {nph_enum::COMB, 9},
     };
-    
+
     using prod_cmode = Opm::Well::ProducerCMode;
     const std::map<prod_cmode, int> prod_cmodeToECL = {
         {prod_cmode::NONE,  0},
@@ -63,12 +64,16 @@ namespace {
         {prod_cmode::RESV,  5},
         {prod_cmode::BHP,   7},
     };
-    
+
     int maxConnPerWell(const Opm::Schedule& sched,
+                       const std::size_t    report_step,
                        const std::size_t    lookup_step)
     {
-        auto ncwmax = 0;
+        if (report_step == std::size_t{0}) {
+            return 0;
+        }
 
+        auto ncwmax = 0;
         for (const auto& well : sched.getWells(lookup_step)) {
             const auto ncw = well.getConnections().size();
 
@@ -92,12 +97,16 @@ namespace {
         // Number of non-FIELD groups.
         return ngmax - 1;
     }
-    
+
     int GroupControl(const Opm::Schedule& sched,
-                         const std::size_t    lookup_step)
+                     const std::size_t    report_step,
+                     const std::size_t    lookup_step)
     {
         int gctrl = 0;
-        
+        if (report_step == std::size_t{0}) {
+            return gctrl;
+        }
+
         for (const auto& group_name : sched.groupNames(lookup_step)) {
             const auto& group = sched.getGroup(group_name, lookup_step);
             if (group.isProductionGroup()) { 
@@ -111,34 +120,48 @@ namespace {
         // Index for group control
         return gctrl;
     }
-    
-    
+
     int noWellUdqs(const Opm::Schedule& sched,
-               const std::size_t    simStep)
+                   const std::size_t    rptStep,
+                   const std::size_t    simStep)
     {
+        if (rptStep == std::size_t{0}) {
+            return 0;
+        }
+
         const auto& udqCfg = sched.getUDQConfig(simStep);
         std::size_t i_wudq = 0;
         for (const auto& udq_input : udqCfg.input()) {
             if (udq_input.var_type() ==  Opm::UDQVarType::WELL_VAR) {
                 i_wudq++;
             }
-        }   
+        }
+
         return i_wudq;
     }
-    
-    
+
     int noGroupUdqs(const Opm::Schedule& sched,
-                const std::size_t    simStep)
+                    const std::size_t    rptStep,
+                    const std::size_t    simStep)
     {
+        if (rptStep == std::size_t{0}) {
+            return 0;
+        }
+
         const auto& udqCfg = sched.getUDQConfig(simStep);
         const auto& input = udqCfg.input();
-        return std::count_if(input.begin(), input.end(), [](const Opm::UDQInput inp) { return (inp.var_type() == Opm::UDQVarType::GROUP_VAR); });
 
+        return std::count_if(input.begin(), input.end(), [](const Opm::UDQInput inp) { return (inp.var_type() == Opm::UDQVarType::GROUP_VAR); });
     }
 
     int noFieldUdqs(const Opm::Schedule& sched,
-                const std::size_t    simStep)
+                    const std::size_t    rptStep,
+                    const std::size_t    simStep)
     {
+        if (rptStep == std::size_t{0}) {
+            return 0;
+        }
+
         const auto& udqCfg = sched.getUDQConfig(simStep);
         std::size_t i_fudq = 0;
         for (const auto& udq_input : udqCfg.input()) {
@@ -146,15 +169,31 @@ namespace {
                 i_fudq++;
             }
         }
-        return i_fudq;
-}
 
+        return i_fudq;
+    }
+
+    int numMultiSegWells(const ::Opm::Schedule& sched,
+                         const std::size_t      report_step,
+                         const std::size_t      lookup_step)
+    {
+        if (report_step == 0) { return 0; }
+
+        const auto& wnames = sched.wellNames(lookup_step);
+
+        return std::count_if(std::begin(wnames), std::end(wnames),
+            [&sched, lookup_step](const std::string& wname) -> bool
+        {
+            return sched.getWell(wname, lookup_step).isMultiSegment();
+        });
+    }
 
     Opm::RestartIO::InteHEAD::WellTableDim
     getWellTableDims(const int              nwgmax,
                      const int              ngmax,
                      const ::Opm::Runspec&  rspec,
                      const ::Opm::Schedule& sched,
+                     const std::size_t      report_step,
                      const std::size_t      lookup_step)
     {
         const auto& wd = rspec.wellDimensions();
@@ -163,22 +202,22 @@ namespace {
 
         const auto maxPerf =
             std::max(wd.maxConnPerWell(),
-                     maxConnPerWell(sched, lookup_step));
+                     maxConnPerWell(sched, report_step, lookup_step));
 
         const auto maxWellInGroup =
             std::max(wd.maxWellsPerGroup(), nwgmax);
 
         const auto maxGroupInField =
             std::max(wd.maxGroupsInField(), ngmax);
-            
+
         const auto nWMaxz = wd.maxWellsInField();
 
         return {
-            numWells,
+            (report_step > 0) ? numWells : 0,
             maxPerf,
             maxWellInGroup,
             maxGroupInField,
-            nWMaxz
+            (report_step > 0) ? std::max(nWMaxz, numWells) : nWMaxz
         };
     }
 
@@ -223,83 +262,83 @@ namespace {
     Opm::RestartIO::InteHEAD::TuningPar
     getTuningPars(const ::Opm::Tuning& tuning)
     {
-        const auto& newtmx = tuning.NEWTMX;
-        const auto& newtmn = tuning.NEWTMN;
-        const auto& litmax = tuning.LITMAX;
-        const auto& litmin = tuning.LITMIN;
-        const auto& mxwsit = tuning.MXWSIT;
-        const auto& mxwpit = tuning.MXWPIT;
-
         return {
-            newtmx,
-            newtmn,
-            litmax,
-            litmin,
-            mxwsit,
-            mxwpit,
+            tuning.NEWTMX,
+            tuning.NEWTMN,
+            tuning.LITMAX,
+            tuning.LITMIN,
+            tuning.MXWSIT,
+            tuning.MXWPIT,
         };
     }
-    
-    
+
     Opm::RestartIO::InteHEAD::UdqParam
-    getUdqParam(const ::Opm::Runspec& rspec, const Opm::Schedule& sched,
-               const std::size_t simStep )
-    { 
+    getUdqParam(const ::Opm::Runspec& rspec,
+                const Opm::Schedule&  sched,
+                const std::size_t     rptStep,
+                const std::size_t     simStep)
+    {
+        if (rptStep == std::size_t{0}) {
+            return { 0, 0, 0, 0, 0, 0 };
+        }
+
         const auto& udq_par = rspec.udqParams();
         const auto& udqActive = sched.udqActive(simStep);
         const auto r_seed   = udq_par.rand_seed();
-        const auto no_wudq  = noWellUdqs(sched, simStep);
-        const auto no_gudq  = noGroupUdqs(sched, simStep);
-        const auto no_fudq  = noFieldUdqs(sched, simStep);
+        const auto no_wudq  = noWellUdqs(sched, rptStep, simStep);
+        const auto no_gudq  = noGroupUdqs(sched, rptStep, simStep);
+        const auto no_fudq  = noFieldUdqs(sched, rptStep, simStep);
         const auto no_iuads = udqActive.IUAD_size();
         const auto no_iuaps = udqActive.IUAP_size();
-               
-        return { r_seed, static_cast<int>(no_wudq), static_cast<int>(no_gudq), static_cast<int>(no_fudq), 
-            static_cast<int>(no_iuads), static_cast<int>(no_iuaps)};
+
+        return {
+            r_seed,
+            static_cast<int>(no_wudq),
+            static_cast<int>(no_gudq),
+            static_cast<int>(no_fudq),
+            static_cast<int>(no_iuads),
+            static_cast<int>(no_iuaps)
+        };
     }
-    
+
     Opm::RestartIO::InteHEAD::ActionParam
-    getActionParam(const ::Opm::Runspec& rspec, const ::Opm::Action::Actions& acts )
-    { 
+    getActionParam(const ::Opm::Runspec&         rspec,
+                   const ::Opm::Action::Actions& acts,
+                   const std::size_t             rptStep)
+    {
+        if (rptStep == std::size_t{0}) {
+            return { 0, 0, 0, 0 };
+        }
+
         const auto& no_act = acts.size();
         const auto max_lines_pr_action = acts.max_input_lines();
         const auto max_cond_per_action = rspec.actdims().max_conditions();
         const auto max_characters_per_line = rspec.actdims().max_characters();
         
-        return { static_cast<int>(no_act), max_lines_pr_action, static_cast<int>(max_cond_per_action), static_cast<int>(max_characters_per_line)};
+        return {
+            static_cast<int>(no_act),
+            max_lines_pr_action,
+            static_cast<int>(max_cond_per_action),
+            static_cast<int>(max_characters_per_line)
+        };
     }
-    
+
     Opm::RestartIO::InteHEAD::WellSegDims
     getWellSegDims(const ::Opm::Runspec&  rspec,
                    const ::Opm::Schedule& sched,
+                   const std::size_t      report_step,
                    const std::size_t      lookup_step)
     {
-	const auto& wsd = rspec.wellSegmentDimensions();
-
-        const auto& sched_wells = sched.getWells(lookup_step);
-
-        const auto nsegwl =
-            std::count_if(std::begin(sched_wells), std::end(sched_wells),
-                          [](const Opm::Well& well)
-            {
-                return well.isMultiSegment();
-            });
-
-        const auto nswlmx = wsd.maxSegmentedWells();
-        const auto nsegmx = wsd.maxSegmentsPerWell();
-        const auto nlbrmx = wsd.maxLateralBranchesPerWell();
-        const auto nisegz = 22;  // Number of entries per segment in ISEG.
-        const auto nrsegz = 146; // Number of entries per segment in RSEG array.  (Eclipse v.2017)
-        const auto nilbrz = 10;  // Number of entries per segment in ILBR array.
+        const auto& wsd = rspec.wellSegmentDimensions();
 
         return {
-            static_cast<int>(nsegwl),
-            nswlmx,
-            nsegmx,
-            nlbrmx,
-            nisegz,
-            nrsegz,
-            nilbrz
+            numMultiSegWells(sched, report_step, lookup_step),
+            wsd.maxSegmentedWells(),
+            wsd.maxSegmentsPerWell(),
+            wsd.maxLateralBranchesPerWell(),
+             22,   // Number of entries per segment in ISEG (2017.2)
+            146,   // Number of entries per segment in RSEG (2017.2)
+             10    // Number of entries per segment in ILBR (2017.2)
         };
     }
 
@@ -321,42 +360,52 @@ namespace {
             static_cast<int>(nplmix),
         };
     }
-    
+
     Opm::RestartIO::InteHEAD::GuideRateNominatedPhase
     setGuideRateNominatedPhase(const ::Opm::Schedule& sched,
-                     const std::size_t    lookup_step)
+                               const std::size_t      report_step,
+                               const std::size_t      lookup_step)
     {
-            int nom_phase = 0;
+        int nom_phase = 0;
+        if (report_step == std::size_t{0}) {
+            return { nom_phase };
+        }
+
+        const auto& guideCFG = sched.guideRateConfig(lookup_step);
+        if (guideCFG.has_model()) {
+            const auto& guideRateModel = guideCFG.model();
             
-            const auto& guideCFG = sched.guideRateConfig(lookup_step);
-            if (guideCFG.has_model()) {
-                const auto& guideRateModel = guideCFG.model();
-                
-                const auto& targPhase = guideRateModel.target();
-                const auto& allow_incr = guideRateModel.allow_increase();
-                
-                const auto it_nph = nph_enumToECL.find(targPhase);
-                    if (it_nph != nph_enumToECL.end()) {
-                    nom_phase = it_nph->second;
-                    }
-                //nominated phase has negative sign for allow increment set to 'NO'
-                if (!allow_incr) nom_phase *= -1;
+            const auto& targPhase = guideRateModel.target();
+            const auto& allow_incr = guideRateModel.allow_increase();
+            
+            const auto it_nph = nph_enumToECL.find(targPhase);
+            if (it_nph != nph_enumToECL.end()) {
+                nom_phase = it_nph->second;
             }
 
-            return {nom_phase};
-    }
-    
-    int getWhistctlMode(const ::Opm::Schedule& sched,
-                     const std::size_t    lookup_step)
-    {
-            int mode = 0;            
-            const auto& w_hist_ctl_mode = sched.getGlobalWhistctlMmode(lookup_step);
-            const auto it_ctl = prod_cmodeToECL.find(w_hist_ctl_mode);
-                if (it_ctl != prod_cmodeToECL.end()) {
-                    mode = it_ctl->second;
-                }
+            //nominated phase has negative sign for allow increment set to 'NO'
+            if (!allow_incr) nom_phase *= -1;
+        }
 
+        return {nom_phase};
+    }
+
+    int getWhistctlMode(const ::Opm::Schedule& sched,
+                        const std::size_t      report_step,
+                        const std::size_t      lookup_step)
+    {
+        int mode = 0;
+        if (report_step == std::size_t{0}) {
             return mode;
+        }
+
+        const auto& w_hist_ctl_mode = sched.getGlobalWhistctlMmode(lookup_step);
+        const auto it_ctl = prod_cmodeToECL.find(w_hist_ctl_mode);
+        if (it_ctl != prod_cmodeToECL.end()) {
+            mode = it_ctl->second;
+        }
+
+        return mode;
     }
 
 } // Anonymous
@@ -372,21 +421,26 @@ createInteHead(const EclipseState& es,
                const Schedule&     sched,
                const double        simTime,
                const int           num_solver_steps,
+               const int           report_step,
                const int           lookup_step)
 {
-    const auto  nwgmax = maxGroupSize(sched, lookup_step);
-    const auto  ngmax  = numGroupsInField(sched, lookup_step);
-    const auto& acts   = sched.actions(lookup_step);
-    const auto& rspec  = es.runspec();
-    const auto& tdim   = es.getTableManager();
-    const auto& rdim   = tdim.getRegdims();
+    const auto nwgmax = (report_step == 0)
+        ? 0 : maxGroupSize(sched, lookup_step);
+
+    const auto ngmax  = (report_step == 0)
+        ? 0 : numGroupsInField(sched, lookup_step);
+
+    const auto& acts  = sched.actions(lookup_step);
+    const auto& rspec = es.runspec();
+    const auto& tdim  = es.getTableManager();
+    const auto& rdim  = tdim.getRegdims();
 
     const auto ih = InteHEAD{}
         .dimensions         (grid.getNXYZ())
         .numActive          (static_cast<int>(grid.getNumActive()))
         .unitConventions    (es.getDeckUnitSystem())
-        .wellTableDimensions(getWellTableDims(nwgmax, ngmax, rspec,
-                                              sched, lookup_step))
+        .wellTableDimensions(getWellTableDims(nwgmax, ngmax, rspec, sched,
+                                              report_step, lookup_step))
         .calendarDate       (getSimulationTimePoint(sched.posixStartTime(), simTime))
         .activePhases       (getActivePhases(rspec))
              // The numbers below have been determined experimentally to work
@@ -399,18 +453,18 @@ createInteHead(const EclipseState& es,
              // n{isx}aaqz: number of data elements per aquifer in {ISX}AAQ
              // n{isa}caqz: number of data elements per aquifer connection in {ISA}CAQ
         .params_NAAQZ       (1, 18, 24, 10, 7, 2, 4)
-        .stepParam          (num_solver_steps, lookup_step)
+        .stepParam          (num_solver_steps, report_step)
         .tuningParam        (getTuningPars(sched.getTuning(lookup_step)))
-        .wellSegDimensions  (getWellSegDims(rspec, sched, lookup_step))
+        .wellSegDimensions  (getWellSegDims(rspec, sched, report_step, lookup_step))
         .regionDimensions   (getRegDims(tdim, rdim))
         .ngroups            ({ ngmax })
-        .params_NGCTRL      (GroupControl(sched,lookup_step))
+        .params_NGCTRL      (GroupControl(sched, report_step, lookup_step))
         .variousParam       (201802, 100)  // Output should be compatible with Eclipse 100, 2017.02 version.
-        .udqParam_1         (getUdqParam(rspec, sched, lookup_step ))
-        .actionParam        (getActionParam(rspec, acts))
+        .udqParam_1         (getUdqParam(rspec, sched, report_step, lookup_step))
+        .actionParam        (getActionParam(rspec, acts, report_step))
         .variousUDQ_ACTIONXParam()
-        .nominatedPhaseGuideRate(setGuideRateNominatedPhase(sched,lookup_step))
-        .whistControlMode(getWhistctlMode(sched,lookup_step))
+        .nominatedPhaseGuideRate(setGuideRateNominatedPhase(sched, report_step, lookup_step))
+        .whistControlMode   (getWhistctlMode(sched, report_step, lookup_step))
         ;
 
     return ih.data();

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -591,10 +591,10 @@ params_NAAQZ(const int ncamax,
 
 Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::
-stepParam(const int num_solver_steps, const int sim_step)
+stepParam(const int num_solver_steps, const int report_step)
 {
     this -> data_[NUM_SOLVER_STEPS] = num_solver_steps;
-    this -> data_[REPORT_STEP]      = sim_step + 1;
+    this -> data_[REPORT_STEP]      = report_step;
 
     return *this;
 }

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -93,24 +93,26 @@ namespace {
 
     std::vector<int>
     serialize_OPM_IWEL(const data::Wells&              wells,
-                       const std::vector<std::string>& sched_wells)
+                       const std::vector<std::string>& well_names)
     {
       const auto getctrl = [&]( const std::string& wname ) {
             const auto itr = wells.find( wname );
             return itr == wells.end() ? 0 : itr->second.control;
         };
 
-        std::vector<int> iwel(sched_wells.size(), 0.0);
-        std::transform(sched_wells.begin(), sched_wells.end(), iwel.begin(), getctrl);
+        std::vector<int> iwel(well_names.size(), 0.0);
+        std::transform(well_names.begin(), well_names.end(), iwel.begin(), getctrl);
 
         return iwel;
     }
 
     std::vector<double>
-    serialize_OPM_XWEL(const data::Wells&             wells,
-                       const std::vector<Opm::Well>& sched_wells,
-                       const Phases&                  phase_spec,
-                       const EclipseGrid&             grid)
+    serialize_OPM_XWEL(const data::Wells&              wells,
+                       const Schedule&                 schedule,
+                       const std::vector<std::string>& well_names,
+                       const int                       sim_step,
+                       const Phases&                   phase_spec,
+                       const EclipseGrid&              grid)
     {
         using rt = data::Rates::opt;
 
@@ -120,8 +122,9 @@ namespace {
         if (phase_spec.active(Phase::GAS))   phases.push_back(rt::gas);
 
         std::vector< double > xwel;
-        for (const auto& sched_well : sched_wells) {
-            if (wells.count(sched_well.name()) == 0 ||
+        for (const auto& wellname : well_names) {
+            const auto& sched_well = schedule.getWell(wellname, sim_step);
+            if (wells.count(wellname) == 0 ||
                 sched_well.getStatus() == Opm::Well::Status::SHUT)
             {
                 const auto elems = (sched_well.getConnections().size()
@@ -134,7 +137,7 @@ namespace {
                 continue;
             }
 
-            const auto& well = wells.at( sched_well.name() );
+            const auto& well = wells.at( wellname );
 
             xwel.push_back( well.bhp );
             xwel.push_back( well.thp );
@@ -341,16 +344,17 @@ namespace {
         }
     }
 
-    void writeWell(int                           sim_step,
-                   const bool                    ecl_compatible_rst,
-                   const Phases&                 phases,
-                   const UnitSystem&             units,
-                   const EclipseGrid&            grid,
-                   const Schedule&               schedule,
-                   const data::Wells&            wells,
-                   const Opm::SummaryState&      sumState,
-                   const std::vector<int>&       ih,
-                   EclIO::OutputStream::Restart& rstFile)
+    void writeWell(int                             sim_step,
+                   const bool                      ecl_compatible_rst,
+                   const Phases&                   phases,
+                   const UnitSystem&               units,
+                   const EclipseGrid&              grid,
+                   const Schedule&                 schedule,
+                   const std::vector<std::string>& well_names,
+                   const data::Wells&              wells,
+                   const Opm::SummaryState&        sumState,
+                   const std::vector<int>&         ih,
+                   EclIO::OutputStream::Restart&   rstFile)
     {
         auto wellData = Helpers::AggregateWellData(ih);
         wellData.captureDeclaredWellData(schedule, units, sim_step, sumState, ih);
@@ -365,13 +369,11 @@ namespace {
         // Extended set of OPM well vectors
         if (!ecl_compatible_rst)
         {
-            const auto sched_wells = schedule.getWells(sim_step);
-            const auto sched_well_names = schedule.wellNames(sim_step);
-
             const auto opm_xwel =
-                serialize_OPM_XWEL(wells, sched_wells, phases, grid);
+                serialize_OPM_XWEL(wells, schedule, well_names,
+                                   sim_step, phases, grid);
 
-            const auto opm_iwel = serialize_OPM_IWEL(wells, sched_well_names);
+            const auto opm_iwel = serialize_OPM_IWEL(wells, well_names);
 
             rstFile.write("OPM_IWEL", opm_iwel);
             rstFile.write("OPM_XWEL", opm_xwel);
@@ -400,15 +402,15 @@ namespace {
         writeGroup(sim_step, units, schedule, sumState, inteHD, rstFile);
 
         // Write well and MSW data only when applicable (i.e., when present)
-        const auto& wells = schedule.getWells(sim_step);
+        const auto& wells = schedule.wellNames(sim_step);
 
         if (! wells.empty()) {
             const auto haveMSW =
                 std::any_of(std::begin(wells), std::end(wells),
-                    [](const Well& well)
-            {
-                return well.isMultiSegment();
-            });
+                    [&schedule, sim_step](const std::string& well)
+                {
+                    return schedule.getWell(well, sim_step).isMultiSegment();
+                });
 
             if (haveMSW) {
                 writeMSWData(sim_step, units, schedule, grid, sumState,
@@ -416,7 +418,7 @@ namespace {
             }
 
             writeWell(sim_step, ecl_compatible_rst,
-                      phases, units, grid, schedule,
+                      phases, units, grid, schedule, wells,
                       wellSol, sumState, inteHD, rstFile);
         }
     }

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -218,7 +218,7 @@ namespace {
                 EclIO::OutputStream::Restart& rstFile)
     {
         // write INTEHEAD to restart file
-        const auto ih = Helpers::
+        auto ih = Helpers::
             createInteHead(es, grid, schedule, simTime,
                            report_step, // Should really be number of timesteps
                            report_step, sim_step);

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2570,10 +2570,15 @@ void Summary::eval(SummaryState&                  st,
 
     const double duration = secs_elapsed - st.get_elapsed();
 
-    /* report_step is the number of the file we are about to write - i.e. for instance CASE.S$report_step
-     * for the data in a non-unified summary file.
-     * sim_step is the timestep which has been effective in the simulator, and as such is the value
-     * necessary to use when consulting the Schedule object. */
+    /* Report_step is the one-based sequence number of the containing report.
+     * Report_step = 0 for the initial condition, before simulation starts.
+     * We typically don't get reports_step = 0 here.  When outputting
+     * separate summary files 'report_step' is the number that gets
+     * incorporated into the filename extension.
+     *
+     * Sim_step is the timestep which has been effective in the simulator,
+     * and as such is the value necessary to use when looking up active
+     * wells, groups, connections &c in the Schedule object. */
     const auto sim_step = std::max( 0, report_step - 1 );
 
     this->pImpl_->eval(es, schedule, sim_step, duration,

--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -290,7 +290,7 @@ namespace {
     {
         {
             const auto ih = ::Opm::RestartIO::Helpers::
-                createInteHead(es, grid, sched, 0.0, 0, 0);
+                createInteHead(es, grid, sched, 0.0, 0, 0, 0);
 
             initFile.write("INTEHEAD", ih);
         }

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -121,8 +121,10 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         };
 
     double secs_elapsed = 3.1536E07;
-    const auto ih = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
-                                                secs_elapsed, rptStep, rptStep);
+    const auto ih = Opm::RestartIO::Helpers::
+        createInteHead(es, grid, sched, secs_elapsed,
+                       rptStep, rptStep, rptStep);
+
     //set dummy value for next_step_size 
     const double next_step_size= 0.1;
     const auto dh = Opm::RestartIO::Helpers::createDoubHead(es, sched, rptStep, 
@@ -150,7 +152,7 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         */
         const auto rptStep_1 = std::size_t{0};
         const auto ih_1 = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
-                                                secs_elapsed, rptStep, rptStep_1);   
+                                                secs_elapsed, rptStep, rptStep_1 + 1, rptStep_1);
         
         BOOST_CHECK_EQUAL(ih_1[156] ,       2); 
         BOOST_CHECK_EQUAL(ih_1[157] ,       7); 
@@ -158,13 +160,13 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         
         const auto rptStep_2 = std::size_t{1};
         const auto ih_2 = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
-                                                secs_elapsed, rptStep, rptStep_2);        
+                                                secs_elapsed, rptStep, rptStep_2 + 1, rptStep_2);
         BOOST_CHECK_EQUAL(ih_2[156] ,       3); 
         BOOST_CHECK_EQUAL(ih_2[157] ,      10); 
 
         const auto rptStep_3 = std::size_t{2};
         const auto ih_3 = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
-                                                secs_elapsed, rptStep, rptStep_3);
+                                                secs_elapsed, rptStep, rptStep_3 + 1, rptStep_3);
         
         BOOST_CHECK_EQUAL(ih_3[156] ,       3); 
         BOOST_CHECK_EQUAL(ih_3[157] ,      10); 

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -150,8 +150,10 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
         };
     
     double secs_elapsed = 3.1536E07;
-    const auto ih = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
-                                                secs_elapsed, rptStep, rptStep);
+    const auto ih = Opm::RestartIO::Helpers::
+        createInteHead(es, grid, sched, secs_elapsed,
+                       rptStep, rptStep, rptStep);
+
     //set dummy value for next_step_size 
     const double next_step_size= 0.1;
     const auto dh = Opm::RestartIO::Helpers::createDoubHead(es, sched, rptStep, 

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -801,6 +801,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD) {
                                                             simCase.sched,
                                                             0,
                                                             sim_step,
+                                                            sim_step,
                                                             sim_step);
 
     auto wellData = Opm::RestartIO::Helpers::AggregateWellData(ih);
@@ -846,6 +847,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD) {
                            xcon.data() + xcon_offset);
 
     }
+
     // Well OP2
     const auto& well2 = wells[1];
     BOOST_CHECK_EQUAL(well2.k1k2.first, 1);

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -331,8 +331,8 @@ BOOST_AUTO_TEST_CASE(Time_and_report_step)
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[VI::intehead::NUM_SOLVER_STEPS], 12);    // TSTEP
-    BOOST_CHECK_EQUAL(v[VI::intehead::REPORT_STEP], 2 + 1); // REP_STEP (= sim_step + 1)
+    BOOST_CHECK_EQUAL(v[VI::intehead::NUM_SOLVER_STEPS], 12); // TSTEP (1st argument to stepParam)
+    BOOST_CHECK_EQUAL(v[VI::intehead::REPORT_STEP],       2); // REP_STEP (2nd argument to stepParam)
 }
 
 BOOST_AUTO_TEST_CASE(Tuning_param)
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE(ngroups)
 
     const auto ih = Opm::RestartIO::InteHEAD{}
         .ngroups({ ngroup });
-	
+
     const auto& v = ih.data();
 
     BOOST_CHECK_EQUAL(v[VI::intehead::NGRP], ngroup);
@@ -489,6 +489,11 @@ TSTEP
     checkDate(11, { 2010, 12, 30 }); // RStep 11 == 2009-12-30 -> 2010-12-30
 }
 
+BOOST_AUTO_TEST_SUITE_END() // Member_Functions
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE(Transfer_Protocol)
 
 BOOST_AUTO_TEST_CASE(TestHeader) {
     using Ph = Opm::RestartIO::InteHEAD::Phases;
@@ -530,8 +535,7 @@ BOOST_AUTO_TEST_CASE(TestHeader) {
     const auto nscaqz = 1111111;
     const auto nacaqz = 11111111;
     const auto tstep  = 78;
-    const auto sim_step = 12;
-    const auto report_step = sim_step + 1;
+    const auto report_step = 12;
     const auto newtmx	= 17;
     const auto newtmn	=  5;
     const auto litmax	= 102;
@@ -562,7 +566,7 @@ BOOST_AUTO_TEST_CASE(TestHeader) {
          .params_NCON(niconz, nsconz, nxconz)
          .params_GRPZ({nigrpz, nsgrpz, nxgrpz, nzgrpz})
          .params_NAAQZ(ncamax, niaaqz, nsaaqz, nxaaqz, nicaqz, nscaqz, nacaqz)
-         .stepParam(tstep, sim_step)
+         .stepParam(tstep, report_step)
          .tuningParam({newtmx, newtmn, litmax, litmin, mxwsit, mxwpit})
          .variousParam(version, iprog)
          .wellSegDimensions({nsegwl, nswlmx, nsegmx, nlbrmx, nisegz, nrsegz, nilbrz})
@@ -624,6 +628,4 @@ BOOST_AUTO_TEST_CASE(TestHeader) {
     BOOST_CHECK_EQUAL(header.ngroup, ngroup);
 }
 
-
-BOOST_AUTO_TEST_SUITE_END()
-
+BOOST_AUTO_TEST_SUITE_END() // Transfer_Protocol

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -183,9 +183,6 @@ TSTEP            -- 8
 
         return Opm::Parser{}.parseString(input);
     }
-
-
-
 } // namespace
 
 struct SimulationCase
@@ -217,6 +214,7 @@ BOOST_AUTO_TEST_CASE(group_test) {
                                                             simCase.grid,
                                                             simCase.sched,
                                                             0,
+                                                            sim_step,
                                                             sim_step,
                                                             sim_step);
 
@@ -267,6 +265,7 @@ BOOST_AUTO_TEST_CASE(State_test) {
                                                             simCase.grid,
                                                             simCase.sched,
                                                             0,
+                                                            sim_step,
                                                             sim_step,
                                                             sim_step);
 


### PR DESCRIPTION
This PR introduces a special case for the restart file writing code.  In particular we no longer write dynamic data vectors (e.g., `*WEL`, `*GRP`, `*CON`) to the restart file if we're being asked to output
the initial condition (i.e., report step/sequence number 0).

Add the report step as a new explicit parameter to `createInteHEAD()` instead of inferring this value from the "sim_step" and output dynamic sizes as zero for report_step=0.  While here, also correct an omission from earlier commit 7986e99 (PR #640).  We must ensure that the maximum number of wells in the field (`intehead[163]`) is at least as large as the current number of active wells (`intehead[16]`).

As a small carry-on piece of luggage, this PR also reduces the number of times we copy the Schedule object's complete wells.  We rather switch to using a name/step lookup where easy to do so.