### PR TITLE
Parser will skip keyword UDT.

### DIFF
--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -658,6 +658,31 @@ RawKeyword * newRawKeyword( const std::string& deck_name, ParserState& parserSta
     return nullptr;
 }
 
+// This code is made to skip part of the eclipse file containing the contents of UDT
+// UDT is currently not a asupported keyword. 
+// The first record of UDT contains a line, that MAY (although unlikely) contain a keyword.
+// Skipping this first line, and the next, skipUDT then searches for the next
+// keyword, which marks the end of UDT. 
+void skipUDT( ParserState& parserState, const Parser& parser) {
+  //Skipping first two records of UDT:
+  size_t record_count = 0;
+  size_t count_max = 2;
+
+  while( !parserState.done() ) {
+      auto line = parserState.getline();
+      if( line.empty() ) continue;
+
+      if (record_count < count_max)
+          record_count++;
+      else {
+           std::string deck_name = str::make_deck_name( line );        
+           if (parser.hasKeyword(deck_name)) {
+               parserState.ungetline(line);
+               return;
+           }
+      }
+  }
+}
 
 
 std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Parser& parser) {
@@ -694,6 +719,10 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
                 if (ptr) {
                     rawKeyword.reset( ptr );
                     const auto& parserKeyword = parser.getParserKeywordFromDeckName(rawKeyword->getKeywordName());
+                    if (deck_name == "UDT") {
+                        skipUDT(parserState, parser);
+                        return NULL;  
+                    }
                     parserState.lastSizeType = parserKeyword.getSizeType();
                     parserState.lastKeyWord = deck_name;
                     if (rawKeyword->isFinished())

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/U/UDT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/U/UDT
@@ -1,0 +1,4 @@
+{"name": "UDT", "sections": ["SCHEDULE"], 
+  "comment0" : "This is a keyword that is not in use.",
+  "comment1" : "If this keyword is in the eclipse file, the parser will parse the file, but the deck will not contain any UDT keyword."
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -9,12 +9,6 @@
 # you are therefore encouraged to go to the opm-simulators repository and update
 # the file: opm/autodiff/MissingFeatures.cpp
 
-#Some keywords are found to be of 'special' structure:
-#These are :
-#
-#       UDT: user defined table
-#
-
 set( keywords
      000_Eclipse100/A/ACTDIMS
      000_Eclipse100/A/ACTION
@@ -882,6 +876,7 @@ set( keywords
      000_Eclipse100/U/UDQ
      000_Eclipse100/U/UDQDIMS
      000_Eclipse100/U/UDQPARAM
+     000_Eclipse100/U/UDT
      000_Eclipse100/U/UDTDIMS
      000_Eclipse100/U/UNCODHMD
      000_Eclipse100/U/UNIFIN

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -2270,7 +2270,6 @@ PLAT-B 15 /
     BOOST_CHECK_EQUAL(record08.getItem(2).get<double>(0), 0.7);
 }
 
-
 BOOST_AUTO_TEST_CASE(ParseSpecialKeywords) {
     const auto deck_string = std::string { R"(RUNSPEC
 FIELD
@@ -2289,16 +2288,34 @@ ROCK
 3000 0 /
 
 SCHEDULE
+UDT
+-- here comes a comment
+-- and another comment
+-- comment
+
+
+FIELD 1/
+-- and anothther comment
+NV 4.0E+06 5.0E+06 6.0E+06 7.0E+06 /
+40 50 60 70 /
+/
+/
 GCUTBACK
 G1 0.6 3* 0.9 LIQ /
+G2 1* 3.0 2* 0.9 RESV /
 /
+UDT
+LANGMUIR 4 /
+LC 2 /
+This keyword will not be finished
 )"};
 
 Parser parser;
 auto deck = parser.parseString(deck_string);
 BOOST_CHECK( deck.hasKeyword("GCUTBACK") );
 auto kw = deck.getKeyword("GCUTBACK");
-BOOST_CHECK_EQUAL( kw.size(), 1 );
+BOOST_CHECK_EQUAL( kw.size(), 2 );
+auto record = kw.getRecord(1);
+BOOST_CHECK_EQUAL( record.getItem(5).get<double>(0), 0.9 );
+BOOST_CHECK( !deck.hasKeyword("LANGMUIR") );
 }
-
-


### PR DESCRIPTION
UDT is the last known keyword. 
It has been postponed for a while due to its complicated structure. 
This PR modifies the parser code so that the Parser will handle UDT keywords (skip them), but will not add them to deck. 