### PR TITLE
WIP: matplot.pyplot interference

### DIFF
--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -3,6 +3,7 @@ import os.path
 import sys
 
 import numpy as np
+import matplotlib.pyplot
 
 from opm.io.parser import Parser
 from opm.io.parser import ParseContext


### PR DESCRIPTION
There is an interference between matplotlib.pyplot and the reading of strings in libopmcommon_python.
