### PR TITLE
Py code records

### DIFF
--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -55,11 +55,13 @@ namespace Opm {
         bool operator==( const ParserRecord& ) const;
         bool operator!=( const ParserRecord& ) const;
         bool rawStringRecord() const;
+        const std::string& end_string() const;
 
     private:
         bool m_dataRecord;
         std::vector< ParserItem > m_items;
         bool raw_string_record = false;
+        std::string record_end = "/";
     };
 
 std::ostream& operator<<( std::ostream&, const ParserRecord& );

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -814,19 +814,8 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
         if (rawKeyword->getSizeType() == Raw::UNKNOWN)
             rawKeyword->terminateKeyword();
 
-        if (!rawKeyword->isFinished()) {
-            /*
-              It is not necessary to explicitly terminate code keywords, in that
-              case they will load all the content until EOF is reached.
-            */
-            if (rawKeyword->getSizeType() == Raw::CODE) {
-                RawRecord record(string_view{ record_buffer.begin(), record_buffer.end() + 1}, true);
-                rawKeyword->addRecord(record);
-                return rawKeyword;
-            }
-
+        if (!rawKeyword->isFinished())
             throw std::invalid_argument("Keyword " + rawKeyword->getKeywordName() + " is not properly terminated");
-        }
     }
 
     return rawKeyword;

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -741,8 +741,10 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
                     parserState.handleRandomText( line );
             }
         } else {
+            const auto& parserKeyword = parser.getParserKeywordFromDeckName(rawKeyword->getKeywordName());
+            const auto& parserRecord = parserKeyword.getRecord( rawKeyword->size() );
+
             if (rawKeyword->getSizeType() == Raw::CODE) {
-                const auto& parserKeyword = parser.getParserKeywordFromDeckName(rawKeyword->getKeywordName());
                 auto end_pos = line.find(parserKeyword.codeEnd());
                 if (end_pos != std::string::npos) {
                     string_view line_content = { line.begin(), line.begin() + end_pos};

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -207,4 +207,9 @@ namespace {
         return stream << "    }";
     }
 
+
+    const std::string& ParserRecord::end_string() const {
+        return this->record_end;
+    }
+
 }

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
@@ -169,5 +169,9 @@ namespace {
         return this->raw_string_keyword;
     }
 
+    std::size_t RawKeyword::size() const {
+        return this->m_records.size();
+    }
+
 }
 

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp
@@ -62,6 +62,7 @@ namespace Opm {
         iterator end();
         const_iterator begin() const;
         const_iterator end() const;
+        std::size_t size() const;
     private:
         std::string m_name;
         Location m_location;

--- a/src/opm/parser/eclipse/share/keywords/900_OPM/P/PYACTION
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/P/PYACTION
@@ -1,1 +1,1 @@
-{"name" : "PYACTION", "sections" : ["SCHEDULE"], "code" : {"end" : "<<<"}}
+{"name" : "PYACTION", "sections" : ["SCHEDULE"], "code" : {"end" : "PYEND"}}

--- a/src/opm/parser/eclipse/share/keywords/900_OPM/P/PYINPUT
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/P/PYINPUT
@@ -1,3 +1,3 @@
 {"name" : "PYINPUT",
  "sections" : ["RUNSPEC", "GRID", "EDIT", "PROPS", "REGIONS", "SOLUTION", "SUMMARY", "SCHEDULE"],
- "code" : {"end" : "<<<"}}
+ "code" : {"end" : "PYEND"}}

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -68,17 +68,17 @@ BOOST_AUTO_TEST_CASE(PYINPUT_BASIC) {
         PYINPUT
         kw = context.DeckKeyword( context.parser['FIELD'] )
         context.deck.add(kw)
-        <<<
+        PYEND
         DIMENS
         2 2 1 /
         PYINPUT
         import numpy as np
         dx = np.array([0.25, 0.25, 0.25, 0.25])
         active_unit_system = context.deck.active_unit_system()
-        default_unit_system = context.deck.default_unit_system()        
+        default_unit_system = context.deck.default_unit_system()
         kw = context.DeckKeyword( context.parser['DX'], dx, active_unit_system, default_unit_system )
         context.deck.add(kw)
-        <<<
+        PYEND
         DY
         4*0.25 /
         )";

--- a/tests/parser/PYACTION.cpp
+++ b/tests/parser/PYACTION.cpp
@@ -44,7 +44,7 @@ C = B * 20
 SCHEDULE
 
 PYACTION Her comes an ignored comment
-)" + input_code + "<<<";
+)" + input_code + "PYEND";
 
     const std::string deck_string2 = R"(
 SCHEDULE
@@ -57,7 +57,7 @@ PYACTION
 SCHEDULE
 
 PYACTION -- Comment
-)" + input_code + "<<<" + "\nGRID";
+)" + input_code + "PYEND" + "\nGRID";
 
 
     Parser parser;

--- a/tests/parser/PYACTION.cpp
+++ b/tests/parser/PYACTION.cpp
@@ -49,13 +49,6 @@ PYACTION Her comes an ignored comment
     const std::string deck_string2 = R"(
 SCHEDULE
 
-PYACTION
-)" + input_code;
-
-
-    const std::string deck_string3 = R"(
-SCHEDULE
-
 PYACTION -- Comment
 )" + input_code + "PYEND" + "\nGRID";
 
@@ -68,11 +61,6 @@ PYACTION -- Comment
     }
     {
         auto deck = parser.parseString(deck_string2);
-        const auto& parsed_code = deck.getKeyword("PYACTION").getRecord(0).getItem("code").get<std::string>(0);
-        BOOST_CHECK_EQUAL(parsed_code, input_code);
-    }
-    {
-        auto deck = parser.parseString(deck_string3);
         const auto& parsed_code = deck.getKeyword("PYACTION").getRecord(0).getItem("code").get<std::string>(0);
         BOOST_CHECK_EQUAL(parsed_code, input_code);
         BOOST_CHECK( deck.hasKeyword("GRID"));


### PR DESCRIPTION
Small baby refactorings to enable multi record Python keywords:
```
PYACTION
    WWCT /

if context.well_var("OP1", "WWCT") > 0.80:
     context.schedule.shut_well("OP1")

PYEND
```

the important point is the normal first record "WWCT /". 

There will be more steps. 
