### PR TITLE
WIP/BUG: Getting UDA values from DeckKeywords

### DIFF
--- a/python/cxx/deck_keyword.cpp
+++ b/python/cxx/deck_keyword.cpp
@@ -8,6 +8,7 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
 #include <opm/parser/eclipse/Utility/Typetools.hpp>
 
 #include "export.hpp"
@@ -190,6 +191,7 @@ void python::common::export_DeckKeyword(py::module& module) {
         .def("get_int", &DeckItem::get<int>)
         .def("get_raw", &DeckItem::get<double>)
         .def("get_SI", &DeckItem::getSIDouble)
+        .def("get_UDA", &DeckItem::get<UDAValue>)
         .def("get_data_list", &item_to_pylist)
         .def("get_raw_data_list", &raw_data_to_pylist)
         .def("get_SI_data_list", &SI_data_to_pylist)

--- a/python/tests/test_parser.py
+++ b/python/tests/test_parser.py
@@ -59,6 +59,22 @@ FIPNUM
         deck = parser.parse_string(string)
         deck = parser.parse_string(string, context)
 
+    def test_spe_records(self):
+        parser = Parser()
+        deck = parser.parse(self.spe3fn)
+        assert(deck["START"][0][0].get_int(0) == 1)
+        assert(deck["START"][0][1].get_str(0) == "JAN")
+        assert(deck["START"][0][2].get_int(0) == 2015)
+
+        assert(deck["WCONPROD"][0][0].get_str(0) == "PROD")
+        assert(not deck["WCONPROD"][0][0].defaulted(0))
+        assert(deck["WCONPROD"][0][1].get_str(0) == "OPEN")
+        assert(deck["WCONPROD"][0][2].get_str(0) == "GRAT")
+        assert(deck["WCONPROD"][0][3].defaulted(0))
+        assert(deck["WCONPROD"][0][4].defaulted(0))
+        assert(deck["WCONPROD"][0][5].get_UDA(0) == 6200)
+
+
     def test_deck_kw_records(self):
         parser = Parser()
         deck = parser.parse_string(self.REGIONDATA)
@@ -155,8 +171,8 @@ FIPNUM
         assert( not( "ZCORN" in deck ) )
         deck.add( zcorn_kw )
         assert( "ZCORN" in deck )
-        
-    
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -132,7 +132,7 @@ namespace Opm {
         DeckKeyword(parserKeyword)
     {
         if (!parserKeyword.isDataKeyword())
-            throw std::invalid_argument("Deckkeyword '" + name() + "' is not a data keyword.");
+            throw std::invalid_argument("DeckKeyword '" + name() + "' is not a data keyword.");
 
         const ParserRecord& parser_record = parserKeyword.getRecord(0);
         const ParserItem& parser_item = parser_record.get(0);
@@ -140,7 +140,7 @@ namespace Opm {
         setDataKeyword();
         if (parser_item.dataType() != type_tag::integer)
             throw std::invalid_argument("Input to DeckKeyword '" + name() + "': cannot be std::vector<int>.");
-      
+
         DeckItem item(parser_item.name(), int() );
         for (int val : data)
             item.push_back(val);


### PR DESCRIPTION
I can't find a working Python function to obtain the values for DeckItem defined as UDA, exemplified by the added test function in this PR (the last line of `get_spe_records()` is failing. (the other code edits in the cxx code is most likely not the way to do it)