### PR TITLE
Schedule: Record RFT Well Open Events on Status Changes

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -933,6 +933,8 @@ namespace {
                 this->addWellGroupEvent( well2->name(), ScheduleEvents::WELL_STATUS_CHANGE, reportStep);
                 this->updateWell(well2, reportStep);
                 update = true;
+                if (status == Well::Status::OPEN)
+                    this->rft_config.addWellOpen(well_name, reportStep);
             }
         }
         return update;


### PR DESCRIPTION
This commit ensures that we record a "well open" event whenever
```
Schedule::updateWellStatus
```
switches a well's status to OPEN.  We need this information in order to correctly output RFT data configured with WRFT or the FOPN option of keyword WRFTPLT.  Previously, we recorded such events only in the context of the WELOPEN keyword.