### PR TITLE
Allow negative rates when evaluating UDA values

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/eval_uda.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/eval_uda.cpp
@@ -41,7 +41,7 @@ namespace UDA {
         output_value = st.get(string_var);
 
     // We do not handle negative rates.
-    output_value = std::max(0.0, output_value);
+    // output_value = std::max(0.0, output_value);
     return value.get_dim().convertRawToSi(output_value);
 }
 
@@ -65,7 +65,7 @@ double eval_group_uda(const UDAValue& value, const std::string& group, const Sum
         output_value = st.get(string_var);
 
     // We do not handle negative rates.
-    output_value = std::max(0.0, output_value);
+    // output_value = std::max(0.0, output_value);
     return value.get_dim().convertRawToSi(output_value);
 }
 


### PR DESCRIPTION
When evaluating UDA rates we clamp to zero to avoid negative rates. Now it turns out that for writing valid restart files in prediction mode we need to retain the negative values; however the clamping was for a reason - so now I think we have two conflicting views. 

I have bought popcorn to the duel and look forward to seeing @jalvestad and @GitPaean resolve the issue:

![image](https://user-images.githubusercontent.com/1321665/72200005-4b104780-3444-11ea-9329-b484d5b97e7c.png)
