### PR TITLE
Silence some warnings.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -253,10 +253,9 @@ namespace Opm {
             const auto& keyword = deck.getKeyword("PVTWSALT");
             size_t numEntries = keyword.size();
             size_t regionIdx = 0;
-            for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
+            for (unsigned lineIdx = 0; lineIdx < numEntries; lineIdx += 2) {
                 pvtwtables[regionIdx].init(keyword.getRecord(lineIdx), keyword.getRecord(lineIdx+1));
                 ++regionIdx;
-                ++lineIdx;
             }
             assert(regionIdx == numTables);
         }

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -525,7 +525,6 @@ const std::vector<Dimension>& DeckItem::defaultDimensions() const {
 template int DeckItem::get< int >( size_t ) const;
 template double DeckItem::get< double >( size_t ) const;
 template std::string DeckItem::get< std::string >( size_t ) const;
-template UDAValue DeckItem::get< UDAValue >( size_t ) const;
 
 template void DeckItem::push_backDummyDefault<int>();
 template void DeckItem::push_backDummyDefault<double>();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2952,8 +2952,7 @@ void Schedule::handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep, c
                               state2.data().begin(), comparePtr);
         };
 
-        auto&& compareMap = [comparePtr,
-                             compareDynState](const auto& map1, const auto& map2) {
+        auto&& compareMap = [compareDynState](const auto& map1, const auto& map2) {
             if (map1.size() != map2.size())
                 return false;
             auto it2 = map2.begin();

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -742,7 +742,6 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
             }
         } else {
             const auto& parserKeyword = parser.getParserKeywordFromDeckName(rawKeyword->getKeywordName());
-            const auto& parserRecord = parserKeyword.getRecord( rawKeyword->size() );
 
             if (rawKeyword->getSizeType() == Raw::CODE) {
                 auto end_pos = line.find(parserKeyword.codeEnd());

--- a/tests/test_ArrayDimChecker.cpp
+++ b/tests/test_ArrayDimChecker.cpp
@@ -341,8 +341,8 @@ struct CaseObjects
     CaseObjects(const CaseObjects& rhs) = default;
     CaseObjects(CaseObjects&& rhs) = default;
 
-    CaseObjects& operator=(const CaseObjects& rhs) = default;
-    CaseObjects& operator=(CaseObjects&& rhs) = default;
+    CaseObjects& operator=(const CaseObjects& rhs) = delete;
+    CaseObjects& operator=(CaseObjects&& rhs) = delete;
 
     Opm::ErrorGuard   guard;
     Opm::EclipseState es;


### PR DESCRIPTION
There are a few more, but some at least are related to the field property refactoring so not worth touching. The DeckItem.cpp change might require a small explanation: the template in question is specialized in the code above, so the explicit instantiation does not do anything.