### PR TITLE
More serialization effort

### DIFF
--- a/opm/common/utility/TimeService.hpp
+++ b/opm/common/utility/TimeService.hpp
@@ -45,6 +45,11 @@ namespace Opm {
 
         explicit TimeStampUTC(const std::time_t tp);
         explicit TimeStampUTC(const YMD& ymd);
+        TimeStampUTC(const YMD& ymd,
+                     int hour,
+                     int minutes,
+                     int seconds,
+                     int usec);
 
         TimeStampUTC& operator=(const std::time_t tp);
         bool operator==(const TimeStampUTC& data) const;
@@ -54,6 +59,7 @@ namespace Opm {
         TimeStampUTC& seconds(const int s);
         TimeStampUTC& microseconds(const int us);
 
+        const YMD& ymd() const { return ymd_; }
         int year()         const { return this->ymd_.year;  }
         int month()        const { return this->ymd_.month; }
         int day()          const { return this->ymd_.day;   }

--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -35,6 +35,8 @@ public:
     explicit UDAValue(double);
     explicit UDAValue(const std::string&);
     UDAValue(const UDAValue& src, const Dimension& dim);
+    UDAValue(double data, const Dimension& dim);
+    UDAValue(const std::string& data, const Dimension& dim);
 
     /*
       The get<double>() and get<std::string>() methods will throw an

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -102,6 +102,7 @@ namespace Opm {
                    double r0,
                    double skinFactor,
                    const std::array<int,3>& IJK,
+                   CTFKind kind,
                    std::size_t seqIndex,
                    double segDistStart,
                    double segDistEnd,
@@ -128,6 +129,7 @@ namespace Opm {
         double r0() const;
         double skinFactor() const;
         double wellPi() const;
+        CTFKind kind() const;
 
         void setState(State state);
         void setComplnum(int compnum);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -202,8 +202,8 @@ public:
         UDAValue  BHPTarget;
         UDAValue  THPTarget;
 
-        double  bhp_hist_limit;
-        double  thp_hist_limit = 0;
+        double  bhp_hist_limit = 0.0;
+        double  thp_hist_limit = 0.0;
 
         double  temperature;
         double  BHPH;
@@ -308,8 +308,8 @@ public:
         UDAValue  THPTarget;
 
         // BHP and THP limit
-        double  bhp_hist_limit;
-        double  thp_hist_limit = 0;
+        double  bhp_hist_limit = 0.0;
+        double  thp_hist_limit = 0.0;
 
         // historical BHP and THP under historical mode
         double  BHPH        = 0.0;

--- a/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
@@ -50,9 +50,9 @@ public:
     {
     }
 
-    const index_type getIndex() const { return m_map; }
+    const index_type& getIndex() const { return m_map; }
 
-    const storage_type getStorage() const { return m_vector; }
+    const storage_type& getStorage() const { return m_vector; }
 
     std::size_t count(const K& key) const {
         return this->m_map.count(key);

--- a/opm/parser/eclipse/Units/Dimension.hpp
+++ b/opm/parser/eclipse/Units/Dimension.hpp
@@ -27,7 +27,8 @@ namespace Opm {
     class Dimension {
     public:
         Dimension();
-        Dimension(const std::string& name, double SIfactor, double SIoffset = 0.0);
+        Dimension(const std::string& name, double SIfactor,
+                  double SIoffset = 0.0, bool sanityCheck = true);
 
         double getSIScaling() const;
         double getSIScalingRaw() const;

--- a/src/opm/common/utility/TimeService.cpp
+++ b/src/opm/common/utility/TimeService.cpp
@@ -63,6 +63,15 @@ Opm::TimeStampUTC::TimeStampUTC(const std::time_t tp)
     this->hour(tm.tm_hour).minutes(tm.tm_min).seconds(tm.tm_sec);
 }
 
+Opm::TimeStampUTC::TimeStampUTC(const Opm::TimeStampUTC::YMD& ymd,
+                                int hour, int minutes, int seconds, int usec)
+    : ymd_(ymd)
+    , hour_(hour)
+    , minutes_(minutes)
+    , seconds_(seconds)
+    , usec_(usec)
+{}
+
 Opm::TimeStampUTC& Opm::TimeStampUTC::operator=(const std::time_t tp)
 {
     auto t = tp;

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -29,6 +29,13 @@ UDAValue::UDAValue(double value):
 {
 }
 
+UDAValue::UDAValue(double value, const Dimension& dim_):
+    numeric_value(true),
+    double_value(value),
+    dim(dim_)
+{
+}
+
 
 UDAValue::UDAValue() :
     UDAValue(0)
@@ -37,6 +44,13 @@ UDAValue::UDAValue() :
 UDAValue::UDAValue(const std::string& value):
     numeric_value(false),
     string_value(value)
+{
+}
+
+UDAValue::UDAValue(const std::string& value, const Dimension& dim_):
+    numeric_value(false),
+    string_value(value),
+    dim(dim_)
 {
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -75,7 +75,8 @@ namespace Opm {
     Connection::Connection(Direction dir, double depth, State state,
                            int satTableId, int complnum, double CF,
                            double Kh, double rw, double r0, double skinFactor,
-                           const std::array<int,3>& IJK, std::size_t seqIndex,
+                           const std::array<int,3>& IJK,
+                           CTFKind kind, std::size_t seqIndex,
                            double segDistStart, double segDistEnd,
                            bool defaultSatTabId, std::size_t compSegSeqIndex,
                            int segment, double wellPi)
@@ -90,6 +91,7 @@ namespace Opm {
         , m_r0(r0)
         , m_skin_factor(skinFactor)
         , ijk(IJK)
+        , m_ctfkind(kind)
         , m_seqIndex(seqIndex)
         , m_segDistStart(segDistStart)
         , m_segDistEnd(segDistEnd)
@@ -102,7 +104,7 @@ namespace Opm {
     Connection::Connection()
           : Connection(Direction::X, 1.0, State::SHUT,
                        0, 0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                       {0,0,0}, 0, 0.0, 0.0, false, 0, 0, 0.0)
+                       {0,0,0}, CTFKind::Defaulted, 0, 0.0, 0.0, false, 0, 0, 0.0)
     {}
 
     bool Connection::sameCoordinate(const int i, const int j, const int k) const {
@@ -387,6 +389,10 @@ std::string Connection::CTFKindToString(const CTFKind ctf_kind)
         "Unhandled CTF Kind Value: " +
         std::to_string(static_cast<int>(ctf_kind))
     };
+}
+
+Connection::CTFKind Connection::kind() const {
+    return m_ctfkind;
 }
 
 }

--- a/src/opm/parser/eclipse/Units/Dimension.cpp
+++ b/src/opm/parser/eclipse/Units/Dimension.cpp
@@ -33,9 +33,10 @@ namespace Opm {
 
     }
 
-    Dimension::Dimension(const std::string& name, double SIfactor, double SIoffset)
+    Dimension::Dimension(const std::string& name, double SIfactor,
+                         double SIoffset, bool sanityCheck)
     {
-        for (auto iter = name.begin(); iter != name.end(); ++iter) {
+        for (auto iter = name.begin(); iter != name.end() && sanityCheck; ++iter) {
             if (!isalpha(*iter) && (*iter) != '1')
                 throw std::invalid_argument("Invalid dimension name");
         }


### PR DESCRIPTION
This contains various fixes for the schedule serialization.

However, I cannot make this work properly without the use of mutable accessors. I do not understand why it makes a difference, but it does; if i serialize into a temporary and pass the well and group maps through the constructor, everything goes tits up in the SPE9_CP_GROUP test and I cannot figure out why (the rest of the tests pass fine). If I however deserialize directly into the member, everything appears to be working fine.

I have separated out the mutable accessor addition and marked the commit as temporary. I hope that some more eyes can help me crack this problem.

Likewise, there are separate commits marked as temporary in the downstream.