### PR TITLE
Support multiple phases in group injection

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -177,7 +177,7 @@ struct ProductionControls {
           const std::string& parent,
           const IOrderSet<std::string>& well,
           const IOrderSet<std::string>& group,
-          const GroupInjectionProperties& injProps,
+          const std::map<Phase, GroupInjectionProperties> &injProps,
           const GroupProductionProperties& prodProps);
 
 
@@ -221,7 +221,7 @@ struct ProductionControls {
     InjectionControls injectionControls(Phase phase, const SummaryState& st) const;
     bool hasInjectionControl(Phase phase) const;
     const GroupProductionProperties& productionProperties() const;
-    const GroupInjectionProperties& injectionProperties() const;
+    const std::map<Phase , GroupInjectionProperties>& injectionProperties() const;
     const GroupType& getGroupType() const;
     ProductionCMode production_cmode() const;
     InjectionCMode injection_cmode() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -22,6 +22,7 @@
 
 
 #include <string>
+#include <map>
 
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp>
@@ -217,7 +218,8 @@ struct ProductionControls {
     const std::vector<std::string>& groups() const;
     bool wellgroup() const;
     ProductionControls productionControls(const SummaryState& st) const;
-    InjectionControls injectionControls(const SummaryState& st) const;
+    InjectionControls injectionControls(Phase phase, const SummaryState& st) const;
+    bool hasInjectionControl(Phase phase) const;
     const GroupProductionProperties& productionProperties() const;
     const GroupInjectionProperties& injectionProperties() const;
     const GroupType& getGroupType() const;
@@ -228,6 +230,8 @@ struct ProductionControls {
     bool has_control(InjectionCMode control) const;
 
     bool operator==(const Group& data) const;
+    const Phase& topup_phase() const;
+    bool has_topup_phase() const;
 
 private:
     bool hasType(GroupType gtype) const;
@@ -247,8 +251,9 @@ private:
     IOrderSet<std::string> m_wells;
     IOrderSet<std::string> m_groups;
 
-    GroupInjectionProperties injection_properties{};
+    std::map<Phase, GroupInjectionProperties> injection_properties;
     GroupProductionProperties production_properties{};
+    std::pair<Phase, bool> m_topup_phase{Phase::WATER, false};
 };
 
 Group::GroupType operator |(Group::GroupType lhs, Group::GroupType rhs);

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -212,11 +212,9 @@ void staticContrib(const Opm::Schedule&     sched,
     // 0 - ellers
     
     if (group.isInjectionGroup()) {
-        const auto& inj_cntl = group.injectionControls(sumState);
-        const auto& inj_mode = inj_cntl.cmode;
-        const auto& phs = inj_cntl.phase;
-        //Gas injection control
-        if (phs == Opm::Phase::WATER) {
+        if (group.hasInjectionControl(Opm::Phase::WATER)) {
+            const auto& inj_cntl = group.injectionControls(Opm::Phase::WATER, sumState);
+            const auto& inj_mode = inj_cntl.cmode;
             const auto it = cmodeToNum.find(inj_mode);
             if (it != cmodeToNum.end()) {
                 iGrp[nwgmax + 16] = it->second;
@@ -224,8 +222,10 @@ void staticContrib(const Opm::Schedule&     sched,
                 iGrp[nwgmax + 19] = iGrp[nwgmax + 16];
             }
         }
-        //Water injection control
-        else if (phs == Opm::Phase::GAS) {
+
+        if (group.hasInjectionControl(Opm::Phase::GAS)) {
+            const auto& inj_cntl = group.injectionControls(Opm::Phase::GAS, sumState);
+            const auto& inj_mode = inj_cntl.cmode;
             const auto it = cmodeToNum.find(inj_mode);
             if (it != cmodeToNum.end()) {
                 iGrp[nwgmax + 21] = it->second;
@@ -378,9 +378,8 @@ void staticContrib(const Opm::Group&        group,
     }
     
     if (group.isInjectionGroup()) {
-        const auto& inj_cntl = group.injectionControls(sumState);
-        const auto& phs = inj_cntl.phase;
-        if (phs == Opm::Phase::GAS) {
+        if (group.hasInjectionControl(Opm::Phase::GAS)) {
+            const auto& inj_cntl = group.injectionControls(Opm::Phase::GAS, sumState);
             if (inj_cntl.surface_max_rate > 0.) {
                 sGrp[Isi::gasSurfRateLimit] = sgprop(M::gas_surface_rate, inj_cntl.surface_max_rate);
             }
@@ -394,7 +393,9 @@ void staticContrib(const Opm::Group&        group,
                 sGrp[Isi::gasVoidageLimit] = inj_cntl.target_void_fraction;
             }
         }
-        if (phs == Opm::Phase::WATER) {
+
+        if (group.hasInjectionControl(Opm::Phase::WATER)) {
+            const auto& inj_cntl = group.injectionControls(Opm::Phase::WATER, sumState);
             if (inj_cntl.surface_max_rate > 0.) {
                 sGrp[Isi::waterSurfRateLimit] = sgprop(M::liquid_surface_rate, inj_cntl.surface_max_rate);
             }

--- a/src/opm/output/eclipse/AggregateUDQData.cpp
+++ b/src/opm/output/eclipse/AggregateUDQData.cpp
@@ -409,10 +409,19 @@ const std::vector<int> Opm::RestartIO::Helpers::igphData::ig_phase(const Opm::Sc
         if (curGroups[ind] != nullptr) {
             const auto& group = *curGroups[ind];
             if (group.isInjectionGroup()) {
-                const auto& phase = group.injection_phase();
-                if ( phase == Opm::Phase::OIL   ) inj_phase[group.insert_index()] = 1;
-                if ( phase == Opm::Phase::WATER ) inj_phase[group.insert_index()] = 2;
-                if ( phase == Opm::Phase::GAS   ) inj_phase[group.insert_index()] = 3;
+                /*
+                  Initial code could only inject one phase for each group, then
+                  numerical value '3' was used for the gas phase, that can not
+                  be right?
+                */
+                int phase_sum = 0;
+                if (group.hasInjectionControl(Opm::Phase::OIL))
+                    phase_sum += 1;
+                if (group.hasInjectionControl(Opm::Phase::WATER))
+                    phase_sum += 2;
+                if (group.hasInjectionControl(Opm::Phase::GAS))
+                    phase_sum += 4;
+                inj_phase[group.insert_index()] = phase_sum;
             }
         }
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -45,7 +45,7 @@ Group::Group(const std::string& name, std::size_t insert_index_arg, std::size_t 
     if (name != "FIELD")
         this->parent_group = "FIELD";
 }
-/*
+
 Group::Group(const std::string& gname,
              std::size_t insert_idx,
              std::size_t initstep,
@@ -58,7 +58,7 @@ Group::Group(const std::string& gname,
              const std::string& parentName,
              const IOrderSet<std::string>& well,
              const IOrderSet<std::string>& group,
-             const GroupInjectionProperties& injProps,
+             const std::map<Phase, GroupInjectionProperties>& injProps,
              const GroupProductionProperties& prodProps) :
     m_name(gname),
     m_insert_index(insert_idx),
@@ -76,7 +76,7 @@ Group::Group(const std::string& gname,
     production_properties(prodProps)
 {
 }
-*/
+
 
 std::size_t Group::insert_index() const {
     return this->m_insert_index;
@@ -110,6 +110,9 @@ const Group::GroupProductionProperties& Group::productionProperties() const {
     return this->production_properties;
 }
 
+const std::map<Phase, Group::GroupInjectionProperties>& Group::injectionProperties() const {
+    return this->injection_properties;
+}
 
 int Group::getGroupNetVFPTable() const {
     return this->vfp_table;
@@ -390,6 +393,7 @@ Group::InjectionControls Group::injectionControls(Phase phase, const SummaryStat
 
     ic.phase = inj.phase;
     ic.cmode = inj.cmode;
+    ic.injection_controls = inj.injection_controls;
     ic.surface_max_rate = UDA::eval_group_uda_rate(inj.surface_max_rate, this->m_name, st, this->udq_undefined, ic.phase, this->unit_system);
     ic.resv_max_rate = UDA::eval_group_uda(inj.resv_max_rate, this->m_name, st, this->udq_undefined);
     ic.target_reinj_fraction = UDA::eval_group_uda(inj.target_reinj_fraction, this->m_name, st, this->udq_undefined);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -45,7 +45,7 @@ Group::Group(const std::string& name, std::size_t insert_index_arg, std::size_t 
     if (name != "FIELD")
         this->parent_group = "FIELD";
 }
-
+/*
 Group::Group(const std::string& gname,
              std::size_t insert_idx,
              std::size_t initstep,
@@ -76,6 +76,7 @@ Group::Group(const std::string& gname,
     production_properties(prodProps)
 {
 }
+*/
 
 std::size_t Group::insert_index() const {
     return this->m_insert_index;
@@ -109,9 +110,6 @@ const Group::GroupProductionProperties& Group::productionProperties() const {
     return this->production_properties;
 }
 
-const Group::GroupInjectionProperties& Group::injectionProperties() const {
-    return this->injection_properties;
-}
 
 int Group::getGroupNetVFPTable() const {
     return this->vfp_table;
@@ -133,19 +131,50 @@ bool Group::updateNetVFPTable(int vfp_arg) {
         return false;
 }
 
+namespace {
+namespace detail {
+
+bool has_control(int controls, Group::InjectionCMode cmode) {
+    return ((controls & static_cast<int>(cmode)) != 0);
+}
+
+bool has_control(int controls, Group::ProductionCMode cmode) {
+    return ((controls & static_cast<int>(cmode)) != 0);
+}
+}
+}
+
 bool Group::updateInjection(const GroupInjectionProperties& injection) {
     bool update = false;
-
-    if (this->injection_properties != injection) {
-        this->injection_properties = injection;
-        update = true;
-    }
 
     if (!this->hasType(GroupType::INJECTION)) {
         this->addType(GroupType::INJECTION);
         update = true;
     }
 
+    auto iter = this->injection_properties.find(injection.phase);
+    if (iter == this->injection_properties.end()) {
+        this->injection_properties.insert(std::make_pair(injection.phase, injection));
+        update = true;
+    } else {
+        if (iter->second != injection) {
+            iter->second = injection;
+            update = true;
+        }
+    }
+
+    if (detail::has_control(injection.injection_controls, Group::InjectionCMode::RESV) ||
+        detail::has_control(injection.injection_controls, Group::InjectionCMode::REIN) ||
+        detail::has_control(injection.injection_controls, Group::InjectionCMode::VREP)) {
+        auto topup_phase = std::make_pair(injection.phase, true);
+        if (topup_phase != this->m_topup_phase) {
+            this->m_topup_phase = topup_phase;
+            update = true;
+        }
+    } else {
+        if (this->m_topup_phase == std::make_pair(injection.phase, true))
+            this->m_topup_phase = std::make_pair(injection.phase, false);
+    }
     return update;
 }
 
@@ -317,6 +346,18 @@ const std::string& Group::parent() const {
     return this->parent_group;
 }
 
+const Phase& Group::topup_phase() const {
+    if (this->m_topup_phase.second)
+        return this->m_topup_phase.first;
+    else
+        throw std::logic_error("Asked for topup phase in well without topup phase defined");
+}
+
+
+bool Group::has_topup_phase() const {
+    return this->m_topup_phase.second;
+}
+
 
 bool Group::updateParent(const std::string& parent) {
     if (this->parent_group != parent) {
@@ -343,30 +384,31 @@ Group::ProductionControls Group::productionControls(const SummaryState& st) cons
     return pc;
 }
 
-Group::InjectionControls Group::injectionControls(const SummaryState& st) const {
+Group::InjectionControls Group::injectionControls(Phase phase, const SummaryState& st) const {
     Group::InjectionControls ic;
+    const auto& inj = this->injection_properties.at(phase);
 
-    ic.phase = this->injection_properties.phase;
-    ic.cmode = this->injection_properties.cmode;
-    ic.surface_max_rate = UDA::eval_group_uda_rate(this->injection_properties.surface_max_rate, this->m_name, st, this->udq_undefined, ic.phase, this->unit_system);
-    ic.resv_max_rate = UDA::eval_group_uda(this->injection_properties.resv_max_rate, this->m_name, st, this->udq_undefined);
-    ic.target_reinj_fraction = UDA::eval_group_uda(this->injection_properties.target_reinj_fraction, this->m_name, st, this->udq_undefined);
-    ic.target_void_fraction = UDA::eval_group_uda(this->injection_properties.target_void_fraction, this->m_name, st, this->udq_undefined);
-    ic.reinj_group = this->injection_properties.reinj_group;
-    ic.voidage_group = this->injection_properties.voidage_group;
+    ic.phase = inj.phase;
+    ic.cmode = inj.cmode;
+    ic.surface_max_rate = UDA::eval_group_uda_rate(inj.surface_max_rate, this->m_name, st, this->udq_undefined, ic.phase, this->unit_system);
+    ic.resv_max_rate = UDA::eval_group_uda(inj.resv_max_rate, this->m_name, st, this->udq_undefined);
+    ic.target_reinj_fraction = UDA::eval_group_uda(inj.target_reinj_fraction, this->m_name, st, this->udq_undefined);
+    ic.target_void_fraction = UDA::eval_group_uda(inj.target_void_fraction, this->m_name, st, this->udq_undefined);
+    ic.reinj_group = inj.reinj_group;
+    ic.voidage_group = inj.voidage_group;
+
     return ic;
 }
 
+bool Group::hasInjectionControl(Phase phase) const {
+    return (this->injection_properties.count(phase) > 0);
+}
+
+
+
+
 Group::ProductionCMode Group::production_cmode() const {
     return this->production_properties.cmode;
-}
-
-Group::InjectionCMode Group::injection_cmode() const {
-    return this->injection_properties.cmode;
-}
-
-Phase Group::injection_phase() const {
-    return this->injection_properties.phase;
 }
 
 const Group::GroupType& Group::getGroupType() const {
@@ -374,20 +416,15 @@ const Group::GroupType& Group::getGroupType() const {
 }
 
 bool Group::ProductionControls::has_control(Group::ProductionCMode control) const {
-    return (this->production_controls & static_cast<int>(control)) != 0;
+    return detail::has_control(this->production_controls, control);
 }
 
-
 bool Group::InjectionControls::has_control(InjectionCMode cmode_arg) const {
-    return (this->injection_controls & static_cast<int>(cmode_arg)) != 0;
+    return detail::has_control(this->injection_controls, cmode_arg);
 }
 
 bool Group::has_control(Group::ProductionCMode control) const {
-    return (this->production_properties.production_controls & static_cast<int>(control)) != 0;
-}
-
-bool Group::has_control(InjectionCMode control) const {
-    return (this->injection_properties.injection_controls & static_cast<int>(control)) != 0;
+    return detail::has_control(production_properties.production_controls, control);
 }
 
 
@@ -567,7 +604,8 @@ bool Group::operator==(const Group& data) const
            this->parent() == data.parent() &&
            this->iwells() == data.iwells() &&
            this->igroups() == data.igroups() &&
-           this->injectionProperties() == data.injectionProperties() &&
+           this->m_topup_phase == data.m_topup_phase &&
+           this->injection_properties == data.injection_properties &&
            this->productionProperties() == data.productionProperties();
 }
 

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -75,21 +75,6 @@ BOOST_AUTO_TEST_CASE(CreateGroup_SetInjectorProducer_CorrectStatusSet) {
 
 
 
-BOOST_AUTO_TEST_CASE(ControlModeOK) {
-    Opm::Group group("G1" , 1, 0, 0, UnitSystem::newMETRIC());
-    Opm::SummaryState st(std::chrono::system_clock::now());
-    const auto& inj = group.injectionControls(st);
-    BOOST_CHECK( Opm::Group::InjectionCMode::NONE == inj.cmode);
-}
-
-
-
-BOOST_AUTO_TEST_CASE(GroupChangePhaseSameTimeThrows) {
-    Opm::Group group("G1" , 1, 0, 0, UnitSystem::newMETRIC());
-    Opm::SummaryState st(std::chrono::system_clock::now());
-    const auto& inj = group.injectionControls(st);
-    BOOST_CHECK_EQUAL( Opm::Phase::WATER , inj.phase); // Default phase - assumed WATER
-}
 
 
 
@@ -442,4 +427,80 @@ BOOST_AUTO_TEST_CASE(TESTGCONSALE) {
 
 
 
+}
+
+BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
+    Parser parser;
+    std::string input = R"(
+        START             -- 0
+        31 AUG 1993 /
+        SCHEDULE
+
+        GRUPTREE
+           'G1'  'FIELD' /
+           'G2'  'FIELD' /
+        /
+
+        GCONINJE
+           'G1'   'WATER'   1*  1000      /
+           'G1'   'GAS'     1*  1*   2000 /
+           'G2'   'WATER'   1*  1000      /
+        /
+
+        TSTEP
+           10 /
+
+        GCONINJE
+           'G2'   'WATER'   1*  1000      /
+           'G2'   'GAS'     1*  1*   2000 /
+           'G1'   'GAS'     1*  1000      /
+        /
+
+        )";
+
+    auto deck = parser.parseString(input);
+    EclipseGrid grid(10,10,10);
+    TableManager table ( deck );
+    FieldPropsManager fp( deck , Phases{true, true, true}, grid, table);
+    Runspec runspec (deck );
+    Schedule schedule(deck, grid, fp, runspec);
+    SummaryState st(std::chrono::system_clock::now());
+    // Step 0
+    {
+        const auto& g1 = schedule.getGroup("G1", 0);
+        BOOST_CHECK(  g1.hasInjectionControl(Phase::WATER));
+        BOOST_CHECK(  g1.hasInjectionControl(Phase::GAS));
+        BOOST_CHECK( !g1.hasInjectionControl(Phase::OIL));
+
+        const auto& wc = g1.injectionControls(Phase::WATER, st);
+        const auto& gc = g1.injectionControls(Phase::GAS, st);
+        BOOST_CHECK_THROW(g1.injectionControls(Phase::OIL, st), std::out_of_range);
+
+        BOOST_CHECK(g1.has_topup_phase());
+        BOOST_CHECK(Phase::GAS == g1.topup_phase());
+    }
+    {
+        const auto& g2 = schedule.getGroup("G2", 0);
+        BOOST_CHECK(!g2.has_topup_phase());
+        BOOST_CHECK_THROW(g2.topup_phase(), std::logic_error);
+    }
+    // Step 1
+    {
+        const auto& g2 = schedule.getGroup("G2", 1);
+        BOOST_CHECK(  g2.hasInjectionControl(Phase::WATER));
+        BOOST_CHECK(  g2.hasInjectionControl(Phase::GAS));
+        BOOST_CHECK( !g2.hasInjectionControl(Phase::OIL));
+
+        const auto& wc = g2.injectionControls(Phase::WATER, st);
+        const auto& gc = g2.injectionControls(Phase::GAS, st);
+        BOOST_CHECK_THROW(g2.injectionControls(Phase::OIL, st), std::out_of_range);
+
+        BOOST_CHECK(g2.has_topup_phase());
+        BOOST_CHECK(Phase::GAS == g2.topup_phase());
+    }
+    {
+        const auto& g1 = schedule.getGroup("G1", 1);
+        BOOST_CHECK(!g1.has_topup_phase());
+        BOOST_CHECK_THROW(g1.topup_phase(), std::logic_error);
+    }
 }

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
 
     {
         auto& group = sched.getGroup("INJ", 3);
-        const auto& injection = group.injectionControls(st);
+        const auto& injection = group.injectionControls(Phase::WATER, st);
         BOOST_CHECK_EQUAL( Phase::WATER , injection.phase);
         BOOST_CHECK( Group::InjectionCMode::VREP == injection.cmode);
         BOOST_CHECK_CLOSE( 10/Metric::Time , injection.surface_max_rate, 0.001);
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     }
     {
         auto& group = sched.getGroup("INJ", 6);
-        const auto& injection = group.injectionControls(st);
+        const auto& injection = group.injectionControls(Phase::OIL, st);
         BOOST_CHECK_EQUAL( Phase::OIL , injection.phase);
         BOOST_CHECK( Group::InjectionCMode::RATE == injection.cmode);
         BOOST_CHECK_CLOSE( 1000/Metric::Time , injection.surface_max_rate, 0.0001);


### PR DESCRIPTION
The GCONINJE keyword can be used to specify multiple phases. This PR implements support for that.

Observe the second commit where the original code use integer value '3' for the gas phase in the restart file; this can not possibly carry over to the multiple phases situation. I guessed the value 4 which is used elsewhere when creating a phase sum; alternatively this should be quite different?

Good if some of the restart experts could take a look.

Apart from the [Temp] commit I consider this complete now. Will let it linger until someone find the time to implement the necessary changes downstream. 
