### PR TITLE
Rework RFT Config to Handle More Cases

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -324,6 +324,7 @@ if(ENABLE_ECL_INPUT)
     tests/parser/RawKeywordTests.cpp
     tests/parser/ResinsightTest.cpp
     tests/parser/RestartConfigTests.cpp
+    tests/parser/RFTConfigTests.cpp
     tests/parser/RockTableTests.cpp
     tests/parser/RunspecTests.cpp
     tests/parser/SaltTableTests.cpp

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
@@ -19,19 +19,27 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp>
 
+#include <algorithm>
+#include <cassert>
+#include <utility>
+
 namespace Opm {
 
 RFTConfig::RFTConfig()
-    : well_open_rft_time{false, 0}
+    : tm{}
+    , first_rft_event(tm.size())
+    , well_open_rft_time{false, 0}
 {
 }
 
 RFTConfig::RFTConfig(const TimeMap& tmap,
+                     const std::size_t first_rft,
                      const std::pair<bool, std::size_t>& rftTime,
-                     const std::unordered_set<std::string>& rftName,
-                     const std::unordered_map<std::string, std::size_t>& wellOpen,
+                     const WellOpenTimeMap& rftName,
+                     const WellOpenTimeMap& wellOpen,
                      const RFTMap& rconfig, const PLTMap& pconfig)
     : tm(tmap)
+    , first_rft_event(first_rft)
     , well_open_rft_time(rftTime)
     , well_open_rft_name(rftName)
     , well_open(wellOpen)
@@ -41,35 +49,24 @@ RFTConfig::RFTConfig(const TimeMap& tmap,
 }
 
 RFTConfig::RFTConfig(const TimeMap& time_map) :
-    tm(time_map)
+    tm(time_map),
+    first_rft_event(tm.size()),
+    well_open_rft_time{false, 0}
 {
 }
 
 bool RFTConfig::rft(const std::string& well_name, std::size_t report_step) const {
     if (report_step >= this->tm.size())
-        throw std::invalid_argument("Invalid ");
+        throw std::invalid_argument("Invalid report step " + std::to_string(report_step));
 
-    const auto well_iter = this->well_open.find(well_name);
-    if (well_iter != this->well_open.end()) {
+    if (this->outputRftAtWellopen(this->well_open.find(well_name), report_step))
+        return true;
 
-        // A general "Output RFT when the well is opened" has been configured with WRFT
-        if (this->well_open_rft_time.first && this->well_open_rft_time.second <= report_step) {
-            if (well_iter->second == report_step)
-                return true;
-        }
-
-
-        // A FOPN setting has been configured with the WRFTPLT keyword
-        if (this->well_open_rft_name.count(well_name) > 0) {
-            if (well_iter->second == report_step)
-                return true;
-        }
-    }
-
-    if (this->rft_config.count(well_name) == 0)
+    auto cfg = this->rft_config.find(well_name);
+    if (cfg == this->rft_config.end())
         return false;
 
-    auto rft_pair = this->rft_config.at(well_name)[report_step];
+    const auto& rft_pair = cfg->second[report_step];
     if (rft_pair.first == RFT::YES)
         return (rft_pair.second == report_step);
 
@@ -89,10 +86,11 @@ bool RFTConfig::plt(const std::string& well_name, std::size_t report_step) const
     if (report_step >= this->tm.size())
         throw std::invalid_argument("Invalid ");
 
-    if (this->plt_config.count(well_name) == 0)
+    auto cfg = this->plt_config.find(well_name);
+    if (cfg == this->plt_config.end())
         return false;
 
-    auto plt_pair = this->plt_config.at(well_name)[report_step];
+    const auto& plt_pair = cfg->second[report_step];
     if (plt_pair.first == PLT::YES)
         return (plt_pair.second == report_step);
 
@@ -108,24 +106,52 @@ bool RFTConfig::plt(const std::string& well_name, std::size_t report_step) const
     return false;
 }
 
+template <typename Value>
+void RFTConfig::updateConfig(const std::string& well_name,
+                             const std::size_t  report_step,
+                             const Value        value,
+                             ConfigMap<Value>&  cfgmap)
+{
+    auto cfg = cfgmap.find(well_name);
+    if (cfg == cfgmap.end()) {
+        auto state = DynamicState<std::pair<Value, std::size_t>> {
+            this->tm, std::make_pair(Value::NO, 0)
+        };
+
+        auto stat = cfgmap.emplace(well_name, std::move(state));
+        if (! stat.second)
+            return;
+
+        cfg = stat.first;
+    }
+
+    cfg->second.update(report_step, std::make_pair(value, report_step));
+}
+
 void RFTConfig::updateRFT(const std::string& well_name, std::size_t report_step, RFT value) {
-    if (value == RFT::FOPN)
-        this->setWellOpenRFT(well_name);
-    else {
-        if (this->rft_config.count(well_name) == 0) {
-            auto state = DynamicState<std::pair<RFT, std::size_t>>(this->tm, std::make_pair(RFT::NO, 0));
-            this->rft_config.emplace( well_name, state );
-        }
-        this->rft_config.at(well_name).update(report_step, std::make_pair(value, report_step));
+    if (value == RFT::FOPN) {
+        this->setWellOpenRFT(well_name, report_step);
+
+        auto wo = this->well_open.find(well_name);
+        if (wo != this->well_open.end())
+            // New candidate first RFT event time is 'report_step' if
+            // well is already open, well's open event time otherwise.
+            this->updateFirst(std::max(report_step, wo->second));
+    } else {
+        this->updateConfig(well_name, report_step, value, this->rft_config);
+
+        if (value != RFT::NO)
+            // YES, REPT, or TIMESTEP.
+            this->updateFirstIfNotShut(well_name, report_step);
     }
 }
 
 void RFTConfig::updatePLT(const std::string& well_name, std::size_t report_step, PLT value) {
-    if (this->plt_config.count(well_name) == 0) {
-        auto state = DynamicState<std::pair<PLT, std::size_t>>(this->tm, std::make_pair(PLT::NO, 0));
-        this->plt_config.emplace( well_name, state );
-    }
-    this->plt_config.at(well_name).update(report_step, std::make_pair(value, report_step));
+    this->updateConfig(well_name, report_step, value, this->plt_config);
+
+    if (value != PLT::NO)
+        // YES, REPT, or TIMESTEP.
+        this->updateFirstIfNotShut(well_name, report_step);
 }
 
 
@@ -138,67 +164,31 @@ bool RFTConfig::getWellOpenRFT(const std::string& well_name, std::size_t report_
 
 
 void RFTConfig::setWellOpenRFT(std::size_t report_step) {
-    this->well_open_rft_time = std::make_pair(true, report_step);
+    this->well_open_rft_time.second = this->well_open_rft_time.first
+        ? std::min(this->well_open_rft_time.second, report_step)
+        : report_step;
+
+    this->well_open_rft_time.first = true;
+
+    this->updateFirst(this->firstWellopenStepNotBefore(report_step));
 }
 
 void RFTConfig::setWellOpenRFT(const std::string& well_name) {
-    this->well_open_rft_name.insert( well_name );
+    this->setWellOpenRFT(well_name, std::size_t(0));
 }
 
 
 void RFTConfig::addWellOpen(const std::string& well_name, std::size_t report_step) {
-    if (this->well_open.count(well_name) == 0)
-        this->well_open[well_name] = report_step;
-}
-
-std::size_t RFTConfig::firstRFTOutput() const {
-    std::size_t first_rft = this->tm.size();
-    if (this->well_open_rft_time.first) {
-        // The WRFT keyword has been used to request RFT output at well open for all wells.
-        std::size_t rft_time = this->well_open_rft_time.second;
-        for (const auto& rft_pair : this->well_open) {
-            if (rft_pair.second >= rft_time)
-                first_rft = std::min(first_rft, rft_pair.second);
-        }
-    } else {
-        // Go through the individual wells and look for first open settings
-        for (const auto& rft_pair : this->well_open)
-            first_rft = std::min(first_rft, rft_pair.second);
-    }
-
-    for (const auto& plt_pair : this->plt_config) {
-        const auto& dynamic_state = plt_pair.second;
-        /*
-          We do not really output PLT, so this predictae will unconditionally
-          return false.
-        */
-        auto pred = [] (const std::pair<PLT, std::size_t>& ) { return false; };
-        int this_first_rft = dynamic_state.find_if(pred);
-        if (this_first_rft >= 0)
-            first_rft = std::min(first_rft, static_cast<std::size_t>(this_first_rft));
-    }
-
-    for (const auto& rft_pair : this->rft_config) {
-      const auto& dynamic_state = rft_pair.second;
-
-      auto pred = [] (const std::pair<RFT, std::size_t>& pred_arg) {
-                    if (pred_arg.first == RFT::YES)
-                        return true;
-                    if (pred_arg.first == RFT::REPT)
-                        return true;
-                    if (pred_arg.first == RFT::TIMESTEP)
-                        return true;
-                    return false;
-                  };
-
-      int this_first_rft = dynamic_state.find_if(pred);
-      if (this_first_rft >= 0)
-        first_rft = std::min(first_rft, static_cast<std::size_t>(this_first_rft));
-    }
-    return first_rft;
+    // Implicitly handles 'well_name' already being in the map.
+    this->well_open.emplace(well_name, report_step);
 }
 
 bool RFTConfig::active(std::size_t report_step) const {
+    for (auto well = this->well_open.begin(), end = this->well_open.end(); well != end; ++well) {
+        if (this->outputRftAtWellopen(well, report_step))
+            return true;
+    }
+
     for (const auto& rft_pair : this->rft_config) {
         if (this->rft(rft_pair.first, report_step))
             return true;
@@ -280,11 +270,11 @@ const std::pair<bool, std::size_t>& RFTConfig::wellOpenRftTime() const {
     return well_open_rft_time;
 }
 
-const std::unordered_set<std::string>& RFTConfig::wellOpenRftName() const {
+const RFTConfig::WellOpenTimeMap& RFTConfig::wellOpenRftName() const {
     return well_open_rft_name;
 }
 
-const std::unordered_map<std::string, std::size_t>& RFTConfig::wellOpen() const {
+const RFTConfig::WellOpenTimeMap& RFTConfig::wellOpen() const {
     return well_open;
 }
 
@@ -298,6 +288,7 @@ const RFTConfig::PLTMap& RFTConfig::pltConfig() const {
 
 bool RFTConfig::operator==(const RFTConfig& data) const {
     return this->timeMap() == data.timeMap() &&
+           this->firstRFTOutput() == data.firstRFTOutput() &&
            this->wellOpenRftTime() == data.wellOpenRftTime() &&
            this->wellOpenRftName() == data.wellOpenRftName() &&
            this->wellOpen() == data.wellOpen() &&
@@ -305,4 +296,83 @@ bool RFTConfig::operator==(const RFTConfig& data) const {
            this->pltConfig() == data.pltConfig();
 }
 
+bool RFTConfig::outputRftAtWellopen(WellOpenTimeMap::const_iterator well_iter, const std::size_t report_step) const {
+    assert ((report_step < this->tm.size()) && "Internal logic error for report step");
+
+    if (well_iter == this->well_open.end())
+        return false;
+
+    if (report_step < this->first_rft_event)
+        return false;
+
+    if (this->well_open_rft_time.first && this->well_open_rft_time.second <= report_step) {
+        // A general "Output RFT when the well is opened" has been
+        // configured with WRFT.  Output RFT data if the well opens
+        // at this report step.
+        if (well_iter->second == report_step)
+            return true;
+    }
+
+    auto rft_open = this->well_open_rft_name.find(well_iter->first);
+    if (rft_open == this->well_open_rft_name.end())
+        // No FOPN event configured for this well (i.e., well_iter->first).
+        return false;
+
+    // An FOPN setting has been configured with the WRFTPLT keyword.
+    // Output RFT data if we're at the FOPN event time and the well is
+    // already open or if we're after FOPN event time and the well
+    // opens at this step.
+    return ((report_step == rft_open->second) && (well_iter->second <= report_step))
+        || ((report_step >  rft_open->second) && (well_iter->second == report_step));
+}
+
+std::size_t RFTConfig::firstWellopenStepNotBefore(const std::size_t report_step) const {
+    if (well_open.empty())
+        // No well-open events at all (unexpected).
+        return this->tm.size();
+
+    using VT = WellOpenTimeMap::value_type;
+
+    auto event = std::min_element(this->well_open.begin(), this->well_open.end(),
+        [report_step](const VT& elem, const VT& low) -> bool
+    {
+        if (elem.second < report_step)
+            return false;
+
+        return elem.second < low.second;
+    });
+
+    if (event->second < report_step)
+        // All well-open events happen *before* 'report_step'.
+        return this->tm.size();
+
+    return event->second;
+}
+
+void RFTConfig::updateFirstIfNotShut(const std::string& well_name, const std::size_t report_step) {
+    auto wo = this->well_open.find(well_name);
+
+    if ((wo != this->well_open.end()) && (wo->second <= report_step))
+        // Well opens no later than 'report_step'.  New candidate
+        // first RFT output event is 'report_step'.
+        this->updateFirst(report_step);
+}
+
+void RFTConfig::updateFirst(const std::size_t report_step) {
+    this->first_rft_event = std::min(this->first_rft_event, report_step);
+}
+
+void RFTConfig::setWellOpenRFT(const std::string& well_name, const std::size_t report_step)
+{
+    auto pos = this->well_open_rft_name.find(well_name);
+    if (pos == this->well_open_rft_name.end()) {
+        auto stat = this->well_open_rft_name.emplace(well_name, this->tm.size());
+        if (! stat.second)
+            return;
+
+        pos = stat.first;
+    }
+
+    pos->second = std::min(pos->second, report_step);
+}
 }

--- a/tests/parser/RFTConfigTests.cpp
+++ b/tests/parser/RFTConfigTests.cpp
@@ -1,0 +1,874 @@
+/*
+  Copyright 2020 Equnor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE RFTConfigTests
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
+#include <string>
+
+namespace {
+    struct Setup
+    {
+        Setup(const ::Opm::Deck& deck);
+
+        ::Opm::EclipseState es;
+        ::Opm::Schedule     sched;
+    };
+
+    Setup::Setup(const ::Opm::Deck& deck)
+        : es   (deck)
+        , sched(deck, es)
+    {}
+
+    Setup parseDeckString(const std::string& input)
+    {
+        return { ::Opm::Parser{}.parseString(input) };
+    }
+
+    std::string basesetup_5x5x5()
+    {
+        return R"(RUNSPEC
+DIMENS
+  5 5 5 /
+
+WELLDIMS
+ 2 5 2 2 /
+
+TABDIMS
+/
+
+OIL
+WATER
+GAS
+DISGAS
+METRIC
+
+GRID
+INIT
+
+DXV
+  5*100.0 /
+DYV
+  5*100.0 /
+DZV
+  5*1.0 /
+DEPTHZ
+  36*2000.0 /
+
+PORO
+  125*0.3 /
+
+PERMX
+  125*100.0 /
+COPY
+  'PERMX' 'PERMY' /
+  'PERMX' 'PERMZ' /
+/
+MULTIPLY
+  'PERMZ' 0.1 /
+/
+
+PROPS
+DENSITY
+  812.3  1024.5  1.0 /
+
+SCHEDULE
+WELSPECS
+ 'I' 'I' 1 1 2000.0 WATER /
+ 'P' 'P' 5 5 2005.0 OIL /
+/
+
+COMPDAT
+ 'I' 0 0 1 5 'OPEN' 2* 0.5 /
+ 'P' 0 0 1 5 'OPEN' 2* 0.5 /
+/
+)";
+    }
+} // Anonymous
+
+BOOST_AUTO_TEST_SUITE(No_RFT_Keywords)
+
+namespace {
+
+    std::string simple_tstep_all_open()
+    {
+        return R"(
+WCONINJE
+  'I' 'WATER' 'OPEN' 'RATE'  1000.0  1*  500.0 /
+/
+
+WCONPROD
+  'P' 'OPEN' 'ORAT'  750.0  750.0  10.0E+3  1250.0  1*  75.0 /
+/
+
+TSTEP
+-- 1   2   3   4   5   6  7 8  9  10..19
+  0.1 0.2 0.3 0.4 0.5 1.5 5 10 20 10*30 /
+
+)";
+    }
+
+    std::string simple_tstep_deferred_open()
+    {
+        return R"(
+WCONINJE
+  'I' 'WATER' 'SHUT' 'RATE'  1000.0  1*  500.0 /
+/
+
+WCONPROD
+  'P' 'OPEN' 'ORAT'  750.0  750.0  10.0E+3  1250.0  1*  75.0 /
+/
+
+TSTEP
+-- 1   2   3   4   5   6  7 8  9
+  0.1 0.2 0.3 0.4 0.5 1.5 5 10 20 /
+
+WELOPEN
+  'I' 'OPEN' /
+/
+
+TSTEP
+-- 10..19
+   10*30 /
+
+)";
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Simple)
+{
+    const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_all_open());
+    const auto& rftcfg = cse.sched.rftConfig();
+
+    BOOST_CHECK_EQUAL(rftcfg.timeMap().size(), std::size_t(20));
+    BOOST_CHECK_EQUAL(rftcfg.firstRFTOutput(), std::size_t(20));
+
+    for (auto nstep = std::size_t(20), step = 0*nstep; step < nstep; ++step) {
+        BOOST_CHECK_MESSAGE(!rftcfg.active(step), "RFT Config must be Inactive");
+
+        BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", step),
+                            R"(Well "I" must not have a Well Open RFT request")");
+
+        BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", step),
+                            R"(Well "P" must not have a Well Open RFT request")");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Simple_Deferred_Open)
+{
+    const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_deferred_open());
+    const auto& rftcfg = cse.sched.rftConfig();
+
+    BOOST_CHECK_EQUAL(rftcfg.timeMap().size(), std::size_t(20));
+    BOOST_CHECK_EQUAL(rftcfg.firstRFTOutput(), std::size_t(20));
+
+    for (auto nstep = std::size_t(20), step = 0*nstep; step < nstep; ++step) {
+        BOOST_CHECK_MESSAGE(!rftcfg.active(step), "RFT Config must be Inactive");
+
+        // WELOPEN does not imply RFT output
+        BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", step),
+                            R"(Well "I" must not have a Well Open RFT request")");
+
+        BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", step),
+                            R"(Well "P" must not have a Well Open RFT request")");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // No_RFT_Keywords
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE(WRFT)
+
+namespace {
+
+    std::string simple_tstep_all_open()
+    {
+        return R"(
+WCONINJE
+  'I' 'WATER' 'OPEN' 'RATE'  1000.0  1*  500.0 /
+/
+
+WCONPROD
+  'P' 'OPEN' 'ORAT'  750.0  750.0  10.0E+3  1250.0  1*  75.0 /
+/
+
+TSTEP
+-- 1   2   3   4  (sim step = 0..3)
+  0.1 0.2 0.3 0.4 /
+
+WRFT
+-- Request RFT output for all wells SUBSEQUENTLY opened.
+/
+
+TSTEP
+-- 5..7 (sim step = 4..6)
+   3*30 /
+
+WRFT
+-- Request RFT output for 'P' and all wells subsequently opened
+  'P' /
+/
+
+TSTEP
+-- 8..10 (sim step = 7..9)
+   3*30 /
+)";
+    }
+
+    std::string simple_tstep_deferred_open()
+    {
+        return R"(
+WCONINJE
+  'I' 'WATER' 'SHUT' 'RATE'  1000.0  1*  500.0 /
+/
+
+WCONPROD
+  'P' 'OPEN' 'ORAT'  750.0  750.0  10.0E+3  1250.0  1*  75.0 /
+/
+
+TSTEP
+-- 1   2   3   4  (sim step = 0..3)
+  0.1 0.2 0.3 0.4 /
+
+WRFT
+-- Request RFT output for all wells SUBSEQUENTLY opened.
+/
+
+TSTEP
+-- 5..7 (sim step = 4..6)
+   3*30 /
+
+WELOPEN
+  'I' 'OPEN' /
+/
+
+TSTEP
+-- 8..10 (sim step = 7..9)
+   3*30 /
+
+WRFT
+-- Request RFT output for 'P' and all wells subsequently opened
+  'P' /
+/
+
+TSTEP
+-- 11..13 (sim step = 10..12)
+   3*30 /
+
+)";
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Simple)
+{
+    const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_all_open());
+    const auto& rftcfg = cse.sched.rftConfig();
+
+    BOOST_CHECK_EQUAL(rftcfg.timeMap().size(), std::size_t(11));
+    BOOST_CHECK_EQUAL(rftcfg.firstRFTOutput(), std::size_t( 7));
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 0), R"(Should NOT Output RFT Data for "P" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 1), R"(Should NOT Output RFT Data for "P" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 2), R"(Should NOT Output RFT Data for "P" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 3), R"(Should NOT Output RFT Data for "P" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 4), R"(Should NOT Output RFT Data for "P" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 5), R"(Should NOT Output RFT Data for "P" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 6), R"(Should NOT Output RFT Data for "P" at Step 6)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 7), R"(Should Output RFT Data for "P" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 8), R"(Should NOT Output RFT Data for "P" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 9), R"(Should NOT Output RFT Data for "P" at Step 9)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 0), R"(Should NOT Output RFT Data for "I" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 1), R"(Should NOT Output RFT Data for "I" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 2), R"(Should NOT Output RFT Data for "I" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 3), R"(Should NOT Output RFT Data for "I" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 4), R"(Should NOT Output RFT Data for "I" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 5), R"(Should NOT Output RFT Data for "I" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 6), R"(Should NOT Output RFT Data for "I" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 7), R"(Should NOT Output RFT Data for "I" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 8), R"(Should NOT Output RFT Data for "I" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 9), R"(Should NOT Output RFT Data for "I" at Step 9)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.active(0), "RFT Config must be Inactive at Step 0");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(1), "RFT Config must be Inactive at Step 1");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(2), "RFT Config must be Inactive at Step 2");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(3), "RFT Config must be Inactive at Step 3");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(4), "RFT Config must be Inactive at Step 4");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(5), "RFT Config must be Inactive at Step 5");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(6), "RFT Config must be Inactive at Step 6");
+    BOOST_CHECK_MESSAGE( rftcfg.active(7), "RFT Config must be ACTIVE at Step 7");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(8), "RFT Config must be Inactive at Step 8");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(9), "RFT Config must be Inactive at Step 9");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", 0),
+                        R"(Well "I" must not have a Well Open RFT request at step 0")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", 1),
+                        R"(Well "I" must not have a Well Open RFT request at step 1")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", 2),
+                        R"(Well "I" must not have a Well Open RFT request at step 2")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", 3),
+                        R"(Well "I" must not have a Well Open RFT request at step 3")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 4),
+                        R"(Well "I" must have a Well Open RFT request at step 4")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 5),
+                        R"(Well "I" must have a Well Open RFT request at step 5")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 6),
+                        R"(Well "I" must have a Well Open RFT request at step 6")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 7),
+                        R"(Well "I" must have a Well Open RFT request at step 7")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 8),
+                        R"(Well "I" must have a Well Open RFT request at step 8")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 9),
+                        R"(Well "I" must have a Well Open RFT request at step 9")");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", 0),
+                        R"(Well "P" must not have a Well Open RFT request at step 0")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", 1),
+                        R"(Well "P" must not have a Well Open RFT request at step 1")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", 2),
+                        R"(Well "P" must not have a Well Open RFT request at step 2")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", 3),
+                        R"(Well "P" must not have a Well Open RFT request at step 3")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 4),
+                        R"(Well "P" must have a Well Open RFT request at step 4")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 5),
+                        R"(Well "P" must have a Well Open RFT request at step 5")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 6),
+                        R"(Well "P" must have a Well Open RFT request at step 6")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 7),
+                        R"(Well "P" must have a Well Open RFT request at step 7")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 8),
+                        R"(Well "P" must have a Well Open RFT request at step 8")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 9),
+                        R"(Well "P" must have a Well Open RFT request at step 9")");
+}
+
+BOOST_AUTO_TEST_CASE(Deferred_Open)
+{
+    const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_deferred_open());
+    const auto& rftcfg = cse.sched.rftConfig();
+
+    BOOST_CHECK_EQUAL(rftcfg.timeMap().size(), std::size_t(14));
+    BOOST_CHECK_EQUAL(rftcfg.firstRFTOutput(), std::size_t( 7));
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  0), R"(Should NOT Output RFT Data for "P" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  1), R"(Should NOT Output RFT Data for "P" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  2), R"(Should NOT Output RFT Data for "P" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  3), R"(Should NOT Output RFT Data for "P" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  4), R"(Should NOT Output RFT Data for "P" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  5), R"(Should NOT Output RFT Data for "P" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  6), R"(Should NOT Output RFT Data for "P" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  7), R"(Should NOT Output RFT Data for "P" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  8), R"(Should NOT Output RFT Data for "P" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  9), R"(Should NOT Output RFT Data for "P" at Step 9)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 10), R"(Should Output RFT Data for "P" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 11), R"(Should NOT Output RFT Data for "P" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 12), R"(Should NOT Output RFT Data for "P" at Step 12)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  0), R"(Should NOT Output RFT Data for "I" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  1), R"(Should NOT Output RFT Data for "I" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  2), R"(Should NOT Output RFT Data for "I" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  3), R"(Should NOT Output RFT Data for "I" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  4), R"(Should NOT Output RFT Data for "I" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  5), R"(Should NOT Output RFT Data for "I" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  6), R"(Should NOT Output RFT Data for "I" at Step 6)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I",  7), R"(Should Output RFT Data for "I" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  8), R"(Should NOT Output RFT Data for "I" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  9), R"(Should NOT Output RFT Data for "I" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 10), R"(Should NOT Output RFT Data for "I" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 11), R"(Should NOT Output RFT Data for "I" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 12), R"(Should NOT Output RFT Data for "I" at Step 9)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 0), "RFT Config must be Inactive at Step 0");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 1), "RFT Config must be Inactive at Step 1");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 2), "RFT Config must be Inactive at Step 2");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 3), "RFT Config must be Inactive at Step 3");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 4), "RFT Config must be Inactive at Step 4");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 5), "RFT Config must be Inactive at Step 5");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 6), "RFT Config must be Inactive at Step 6");
+    BOOST_CHECK_MESSAGE( rftcfg.active( 7), "RFT Config must be ACTIVE at Step 7");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 8), "RFT Config must be Inactive at Step 8");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 9), "RFT Config must be Inactive at Step 9");
+    BOOST_CHECK_MESSAGE( rftcfg.active(10), "RFT Config must be ACTIVE at Step 10");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(11), "RFT Config must be Inactive at Step 11");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(12), "RFT Config must be Inactive at Step 12");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", 0),
+                        R"(Well "I" must not have a Well Open RFT request at step 0")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", 1),
+                        R"(Well "I" must not have a Well Open RFT request at step 1")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", 2),
+                        R"(Well "I" must not have a Well Open RFT request at step 2")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("I", 3),
+                        R"(Well "I" must not have a Well Open RFT request at step 3")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 4),
+                        R"(Well "I" must have a Well Open RFT request at step 4")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 5),
+                        R"(Well "I" must have a Well Open RFT request at step 5")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 6),
+                        R"(Well "I" must have a Well Open RFT request at step 6")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 7),
+                        R"(Well "I" must have a Well Open RFT request at step 7")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 8),
+                        R"(Well "I" must have a Well Open RFT request at step 8")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 9),
+                        R"(Well "I" must have a Well Open RFT request at step 9")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 10),
+                        R"(Well "I" must have a Well Open RFT request at step 10")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 11),
+                        R"(Well "I" must have a Well Open RFT request at step 11")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("I", 12),
+                        R"(Well "I" must have a Well Open RFT request at step 12")");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", 0),
+                        R"(Well "P" must not have a Well Open RFT request at step 0")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", 1),
+                        R"(Well "P" must not have a Well Open RFT request at step 1")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", 2),
+                        R"(Well "P" must not have a Well Open RFT request at step 2")");
+    BOOST_CHECK_MESSAGE(!rftcfg.getWellOpenRFT("P", 3),
+                        R"(Well "P" must not have a Well Open RFT request at step 3")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 4),
+                        R"(Well "P" must have a Well Open RFT request at step 4")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 5),
+                        R"(Well "P" must have a Well Open RFT request at step 5")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 6),
+                        R"(Well "P" must have a Well Open RFT request at step 6")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 7),
+                        R"(Well "P" must have a Well Open RFT request at step 7")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 8),
+                        R"(Well "P" must have a Well Open RFT request at step 8")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 9),
+                        R"(Well "P" must have a Well Open RFT request at step 9")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 10),
+                        R"(Well "P" must have a Well Open RFT request at step 10")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 11),
+                        R"(Well "P" must have a Well Open RFT request at step 11")");
+    BOOST_CHECK_MESSAGE(rftcfg.getWellOpenRFT("P", 12),
+                        R"(Well "P" must have a Well Open RFT request at step 12")");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WRFT
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE(WRFTPLT)
+
+namespace {
+
+    std::string simple_tstep_all_open()
+    {
+        return R"(
+WCONINJE
+  'I' 'WATER' 'OPEN' 'RATE'  1000.0  1*  500.0 /
+/
+
+WCONPROD
+  'P' 'OPEN' 'ORAT'  750.0  750.0  10.0E+3  1250.0  1*  75.0 /
+/
+
+TSTEP
+-- 1   2   3   4  (sim step = 0..3)
+  0.1 0.2 0.3 0.4 /
+
+WRFTPLT
+  'P' FOPN /
+/
+
+TSTEP
+-- 5..7 (sim step = 4..6)
+   3*30 /
+
+WRFTPLT
+  'P' 1* YES /
+  'I' REPT /
+/
+
+TSTEP
+-- 8..10 (sim step = 7..9)
+   3*30 /
+
+WRFTPLT
+  'P' YES /
+  'I' NO YES /
+/
+
+TSTEP
+-- 11..13 (sim step = 10..12)
+   3*30 /
+
+WRFTPLT
+  '*' TIMESTEP /
+/
+
+TSTEP
+-- 14..15 (sim step = 13..14)
+   30 30 /
+)";
+    }
+
+    std::string simple_tstep_deferred_open()
+    {
+        return R"(
+WCONINJE
+  'I' 'WATER' 'SHUT' 'RATE'  1000.0  1*  500.0 /
+/
+
+WCONPROD
+  'P' 'OPEN' 'ORAT'  500.0  500.0  10.0E+3  1250.0  1*  75.0 /
+/
+
+TSTEP
+-- 1   2   3   4  (sim step = 0..3)
+  0.1 0.2 0.3 0.4 /
+
+WRFTPLT
+  '*' FOPN /
+/
+
+TSTEP
+-- 5..7 (sim step = 4..6)
+   3*30 /
+
+WELOPEN
+  'I' 'OPEN' /
+/
+
+TSTEP
+-- 8..10 (sim step = 7..9)
+   3*30 /
+
+WRFTPLT
+  'P' 1* YES /
+  'I' REPT /
+/
+
+WELSPECS
+ 'P2' 'P' 1 5 2005.0 OIL /
+/
+
+COMPDAT
+ 'P2' 0 0 1 5 'OPEN' 2* 0.5 /
+/
+
+TSTEP
+-- 11..13 (sim step = 10..12)
+   3*30 /
+
+WRFTPLT
+  'P' YES /
+  'I' NO YES /
+/
+
+TSTEP
+-- 14..16 (sim step = 13..15)
+   3*30 /
+
+WCONPROD
+  'P2' 'OPEN' 'ORAT'  250.0  250.0  10.0E+3  1250.0  1*  75.0 /
+/
+
+TSTEP
+-- 17..18 (sim step = 16..17)
+  30 30 /
+
+WRFTPLT
+  '*' TIMESTEP /
+/
+
+TSTEP
+-- 19..20 (sim step = 18..19)
+   30 30 /
+)";
+    }
+}
+
+BOOST_AUTO_TEST_CASE(All_Open)
+{
+    const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_all_open());
+    const auto& rftcfg = cse.sched.rftConfig();
+
+    BOOST_CHECK_EQUAL(rftcfg.timeMap().size(), std::size_t(16));
+    BOOST_CHECK_EQUAL(rftcfg.firstRFTOutput(), std::size_t( 4));
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  0), R"(Should NOT Output RFT Data for "P" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  1), R"(Should NOT Output RFT Data for "P" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  2), R"(Should NOT Output RFT Data for "P" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  3), R"(Should NOT Output RFT Data for "P" at Step 3)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P",  4), R"(Should Output RFT Data for "P" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  5), R"(Should NOT Output RFT Data for "P" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  6), R"(Should NOT Output RFT Data for "P" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  7), R"(Should NOT Output RFT Data for "P" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  8), R"(Should NOT Output RFT Data for "P" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  9), R"(Should NOT Output RFT Data for "P" at Step 9)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 10), R"(Should Output RFT Data for "P" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 11), R"(Should NOT Output RFT Data for "P" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 12), R"(Should NOT Output RFT Data for "P" at Step 12)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 13), R"(Should Output RFT Data for "P" at Step 13)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 14), R"(Should Output RFT Data for "P" at Step 14)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 15), R"(Should Output RFT Data for "P" at Step 15)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  0), R"(Should NOT Output PLT Data for "P" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  1), R"(Should NOT Output PLT Data for "P" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  2), R"(Should NOT Output PLT Data for "P" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  3), R"(Should NOT Output PLT Data for "P" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  4), R"(Should NOT Output PLT Data for "P" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  5), R"(Should NOT Output PLT Data for "P" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  6), R"(Should NOT Output PLT Data for "P" at Step 6)");
+    BOOST_CHECK_MESSAGE( rftcfg.plt("P",  7), R"(Should Output PLT Data for "P" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  8), R"(Should NOT Output PLT Data for "P" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  9), R"(Should NOT Output PLT Data for "P" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 10), R"(Should NOT Output PLT Data for "P" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 11), R"(Should NOT Output PLT Data for "P" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 12), R"(Should NOT Output PLT Data for "P" at Step 12)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 13), R"(Should NOT Output PLT Data for "P" at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 14), R"(Should NOT Output PLT Data for "P" at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 15), R"(Should NOT Output PLT Data for "P" at Step 15)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  0), R"(Should NOT Output RFT Data for "I" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  1), R"(Should NOT Output RFT Data for "I" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  2), R"(Should NOT Output RFT Data for "I" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  3), R"(Should NOT Output RFT Data for "I" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  4), R"(Should NOT Output RFT Data for "I" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  5), R"(Should NOT Output RFT Data for "I" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  6), R"(Should NOT Output RFT Data for "I" at Step 6)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I",  7), R"(Should Output RFT Data for "I" at Step 7)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I",  8), R"(Should Output RFT Data for "I" at Step 8)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I",  9), R"(Should Output RFT Data for "I" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 10), R"(Should NOT Output RFT Data for "I" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 11), R"(Should NOT Output RFT Data for "I" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 12), R"(Should NOT Output RFT Data for "I" at Step 12)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 13), R"(Should Output RFT Data for "I" at Step 13)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 14), R"(Should Output RFT Data for "I" at Step 14)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 15), R"(Should Output RFT Data for "I" at Step 15)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  0), R"(Should NOT Output PLT Data for "I" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  1), R"(Should NOT Output PLT Data for "I" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  2), R"(Should NOT Output PLT Data for "I" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  3), R"(Should NOT Output PLT Data for "I" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  4), R"(Should NOT Output PLT Data for "I" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  5), R"(Should NOT Output PLT Data for "I" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  6), R"(Should NOT Output PLT Data for "I" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  7), R"(Should NOT Output PLT Data for "I" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  8), R"(Should NOT Output PLT Data for "I" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  9), R"(Should NOT Output PLT Data for "I" at Step 9)");
+    BOOST_CHECK_MESSAGE( rftcfg.plt("I", 10), R"(Should Output PLT Data for "I" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 11), R"(Should NOT Output PLT Data for "I" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 12), R"(Should NOT Output PLT Data for "I" at Step 12)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 13), R"(Should NOT Output PLT Data for "I" at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 14), R"(Should NOT Output PLT Data for "I" at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 15), R"(Should NOT Output PLT Data for "I" at Step 15)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 0), R"(RFT Config must be Inactive at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 1), R"(RFT Config must be Inactive at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 2), R"(RFT Config must be Inactive at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 3), R"(RFT Config must be Inactive at Step 3)");
+    BOOST_CHECK_MESSAGE( rftcfg.active( 4), R"(RFT Config must be Active at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 5), R"(RFT Config must be Inactive at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 6), R"(RFT Config must be Inactive at Step 6)");
+    BOOST_CHECK_MESSAGE( rftcfg.active( 7), R"(RFT Config must be Active at Step 7)");
+    BOOST_CHECK_MESSAGE( rftcfg.active( 8), R"(RFT Config must be Active at Step 8)");
+    BOOST_CHECK_MESSAGE( rftcfg.active( 9), R"(RFT Config must be Active at Step 9)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(10), R"(RFT Config must be Active at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(11), R"(RFT Config must be Inactive at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(12), R"(RFT Config must be Inactive at Step 12)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(13), R"(RFT Config must be Active at Step 13)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(14), R"(RFT Config must be Active at Step 14)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(15), R"(RFT Config must be Active at Step 15)");
+}
+
+BOOST_AUTO_TEST_CASE(Deferred_Open)
+{
+    const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_deferred_open());
+    const auto& rftcfg = cse.sched.rftConfig();
+
+    BOOST_CHECK_EQUAL(rftcfg.timeMap().size(), std::size_t(21));
+    BOOST_CHECK_EQUAL(rftcfg.firstRFTOutput(), std::size_t( 4));
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  0), R"(Should NOT Output RFT Data for "P" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  1), R"(Should NOT Output RFT Data for "P" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  2), R"(Should NOT Output RFT Data for "P" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  3), R"(Should NOT Output RFT Data for "P" at Step 3)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P",  4), R"(Should Output RFT Data for "P" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  5), R"(Should NOT Output RFT Data for "P" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  6), R"(Should NOT Output RFT Data for "P" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  7), R"(Should NOT Output RFT Data for "P" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  8), R"(Should NOT Output RFT Data for "P" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P",  9), R"(Should NOT Output RFT Data for "P" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 10), R"(Should NOT Output RFT Data for "P" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 11), R"(Should NOT Output RFT Data for "P" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 12), R"(Should NOT Output RFT Data for "P" at Step 12)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 13), R"(Should Output RFT Data for "P" at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 14), R"(Should NOT Output RFT Data for "P" at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 15), R"(Should NOT Output RFT Data for "P" at Step 15)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 16), R"(Should NOT Output RFT Data for "P" at Step 16)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P", 17), R"(Should NOT Output RFT Data for "P" at Step 17)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 18), R"(Should Output RFT Data for "P" at Step 18)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 19), R"(Should Output RFT Data for "P" at Step 19)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P", 20), R"(Should Output RFT Data for "P" at Step 20)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  0), R"(Should NOT Output PLT Data for "P" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  1), R"(Should NOT Output PLT Data for "P" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  2), R"(Should NOT Output PLT Data for "P" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  3), R"(Should NOT Output PLT Data for "P" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  4), R"(Should NOT Output PLT Data for "P" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  5), R"(Should NOT Output PLT Data for "P" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  6), R"(Should NOT Output PLT Data for "P" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  7), R"(Should NOT Output PLT Data for "P" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  8), R"(Should NOT Output PLT Data for "P" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P",  9), R"(Should NOT Output PLT Data for "P" at Step 9)");
+    BOOST_CHECK_MESSAGE( rftcfg.plt("P", 10), R"(Should Output PLT Data for "P" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 11), R"(Should NOT Output PLT Data for "P" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 12), R"(Should NOT Output PLT Data for "P" at Step 12)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 13), R"(Should NOT Output PLT Data for "P" at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 14), R"(Should NOT Output PLT Data for "P" at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 15), R"(Should NOT Output PLT Data for "P" at Step 15)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 16), R"(Should NOT Output PLT Data for "P" at Step 16)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 17), R"(Should NOT Output PLT Data for "P" at Step 17)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 18), R"(Should NOT Output PLT Data for "P" at Step 18)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 19), R"(Should NOT Output PLT Data for "P" at Step 19)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P", 20), R"(Should NOT Output PLT Data for "P" at Step 20)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  0), R"(Should NOT Output RFT Data for "I" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  1), R"(Should NOT Output RFT Data for "I" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  2), R"(Should NOT Output RFT Data for "I" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  3), R"(Should NOT Output RFT Data for "I" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  4), R"(Should NOT Output RFT Data for "I" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  5), R"(Should NOT Output RFT Data for "I" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  6), R"(Should NOT Output RFT Data for "I" at Step 6)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I",  7), R"(Should Output RFT Data for "I" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  8), R"(Should NOT Output RFT Data for "I" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I",  9), R"(Should NOT Output RFT Data for "I" at Step 9)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 10), R"(Should Output RFT Data for "I" at Step 10)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 11), R"(Should Output RFT Data for "I" at Step 11)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 12), R"(Should Output RFT Data for "I" at Step 12)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 13), R"(Should Output RFT Data for "I" at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 14), R"(Should NOT Output RFT Data for "I" at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 15), R"(Should NOT Output RFT Data for "I" at Step 15)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 16), R"(Should NOT Output RFT Data for "I" at Step 16)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("I", 17), R"(Should NOT Output RFT Data for "I" at Step 17)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 18), R"(Should Output RFT Data for "I" at Step 18)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 19), R"(Should Output RFT Data for "I" at Step 19)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("I", 20), R"(Should Output RFT Data for "I" at Step 20)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  0), R"(Should NOT Output PLT Data for "I" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  1), R"(Should NOT Output PLT Data for "I" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  2), R"(Should NOT Output PLT Data for "I" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  3), R"(Should NOT Output PLT Data for "I" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  4), R"(Should NOT Output PLT Data for "I" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  5), R"(Should NOT Output PLT Data for "I" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  6), R"(Should NOT Output PLT Data for "I" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  7), R"(Should NOT Output PLT Data for "I" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  8), R"(Should NOT Output PLT Data for "I" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I",  9), R"(Should NOT Output PLT Data for "I" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 10), R"(Should NOT Output PLT Data for "I" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 11), R"(Should NOT Output PLT Data for "I" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 12), R"(Should NOT Output PLT Data for "I" at Step 12)");
+    BOOST_CHECK_MESSAGE( rftcfg.plt("I", 13), R"(Should Output PLT Data for "I" at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 14), R"(Should NOT Output PLT Data for "I" at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 15), R"(Should NOT Output PLT Data for "I" at Step 15)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 16), R"(Should NOT Output PLT Data for "I" at Step 16)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 17), R"(Should NOT Output PLT Data for "I" at Step 17)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 18), R"(Should NOT Output PLT Data for "I" at Step 18)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 19), R"(Should NOT Output PLT Data for "I" at Step 19)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("I", 20), R"(Should NOT Output PLT Data for "I" at Step 20)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  0), R"(Should NOT Output RFT Data for "P2" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  1), R"(Should NOT Output RFT Data for "P2" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  2), R"(Should NOT Output RFT Data for "P2" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  3), R"(Should NOT Output RFT Data for "P2" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  4), R"(Should NOT Output RFT Data for "P2" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  5), R"(Should NOT Output RFT Data for "P2" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  6), R"(Should NOT Output RFT Data for "P2" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  7), R"(Should NOT Output RFT Data for "P2" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  8), R"(Should NOT Output RFT Data for "P2" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2",  9), R"(Should NOT Output RFT Data for "P2" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2", 10), R"(Should NOT Output RFT Data for "P2" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2", 11), R"(Should NOT Output RFT Data for "P2" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2", 12), R"(Should NOT Output RFT Data for "P2" at Step 12)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2", 13), R"(Should NOT Output RFT Data for "P2" at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2", 14), R"(Should NOT Output RFT Data for "P2" at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2", 15), R"(Should NOT Output RFT Data for "P2" at Step 15)");
+
+    // NOTE: Not at FOPN because P2 was not declared at WRFTPLT:FOPN time.
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2", 16), R"(Should NOT Output RFT Data for "P2" at Step 16)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.rft("P2", 17), R"(Should NOT Output RFT Data for "P2" at Step 17)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P2", 18), R"(Should Output RFT Data for "P2" at Step 18)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P2", 19), R"(Should Output RFT Data for "P2" at Step 19)");
+    BOOST_CHECK_MESSAGE( rftcfg.rft("P2", 20), R"(Should Output RFT Data for "P2" at Step 20)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  0), R"(Should NOT Output PLT Data for "P2" at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  1), R"(Should NOT Output PLT Data for "P2" at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  2), R"(Should NOT Output PLT Data for "P2" at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  3), R"(Should NOT Output PLT Data for "P2" at Step 3)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  4), R"(Should NOT Output PLT Data for "P2" at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  5), R"(Should NOT Output PLT Data for "P2" at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  6), R"(Should NOT Output PLT Data for "P2" at Step 6)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  7), R"(Should NOT Output PLT Data for "P2" at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  8), R"(Should NOT Output PLT Data for "P2" at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2",  9), R"(Should NOT Output PLT Data for "P2" at Step 9)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 10), R"(Should NOT Output PLT Data for "P2" at Step 10)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 11), R"(Should NOT Output PLT Data for "P2" at Step 11)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 12), R"(Should NOT Output PLT Data for "P2" at Step 12)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 13), R"(Should NOT Output PLT Data for "P2" at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 14), R"(Should NOT Output PLT Data for "P2" at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 15), R"(Should NOT Output PLT Data for "P2" at Step 15)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 16), R"(Should NOT Output PLT Data for "P2" at Step 16)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 17), R"(Should NOT Output PLT Data for "P2" at Step 17)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 18), R"(Should NOT Output PLT Data for "P2" at Step 18)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 19), R"(Should NOT Output PLT Data for "P2" at Step 19)");
+    BOOST_CHECK_MESSAGE(!rftcfg.plt("P2", 20), R"(Should NOT Output PLT Data for "P2" at Step 20)");
+
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 0), R"(RFT Config must be Inactive at Step 0)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 1), R"(RFT Config must be Inactive at Step 1)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 2), R"(RFT Config must be Inactive at Step 2)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 3), R"(RFT Config must be Inactive at Step 3)");
+    BOOST_CHECK_MESSAGE( rftcfg.active( 4), R"(RFT Config must be Active at Step 4)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 5), R"(RFT Config must be Inactive at Step 5)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 6), R"(RFT Config must be Inactive at Step 6)");
+    BOOST_CHECK_MESSAGE( rftcfg.active( 7), R"(RFT Config must be Active at Step 7)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 8), R"(RFT Config must be Inactive at Step 8)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active( 9), R"(RFT Config must be Inactive at Step 9)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(10), R"(RFT Config must be Active at Step 10)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(11), R"(RFT Config must be Active at Step 11)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(12), R"(RFT Config must be Active at Step 12)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(13), R"(RFT Config must be Active at Step 13)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(14), R"(RFT Config must be Inactive at Step 14)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(15), R"(RFT Config must be Inactive at Step 15)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(16), R"(RFT Config must be Inactive at Step 15)");
+    BOOST_CHECK_MESSAGE(!rftcfg.active(17), R"(RFT Config must be Inactive at Step 15)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(18), R"(RFT Config must be Active at Step 15)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(19), R"(RFT Config must be Active at Step 15)");
+    BOOST_CHECK_MESSAGE( rftcfg.active(20), R"(RFT Config must be Active at Step 15)");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WRFTPLT

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -315,46 +315,47 @@ static Deck createDeckWithWellsAndCompletionData() {
 }
 
 static Deck createDeckRFTConfig() {
-    Opm::Parser parser;
-    std::string input =
-      "START             -- 0 \n"
-      "1 NOV 1979 / \n"
-      "SCHEDULE\n"
-      "DATES             -- 1\n"
-      " 1 DES 1979/ \n"
-      "/\n"
-      "WELSPECS\n"
-      "    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
-      "    'OP_2'       'OP'   8   8 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
-      "    'OP_3'       'OP'   7   7 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
-      "/\n"
-      "COMPDAT\n"
-      " 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
-      " 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
-      " 'OP_2'  8  8   1   3 'OPEN' 1*    1.168   0.311   107.872 1*  1*  'Y'  21.925 / \n"
-      " 'OP_2'  8  7   3   3 'OPEN' 1*   15.071   0.311  1391.859 1*  1*  'Y'  21.920 / \n"
-      " 'OP_2'  8  7   3   6 'OPEN' 1*    6.242   0.311   576.458 1*  1*  'Y'  21.915 / \n"
-      " 'OP_3'  7  7   1   1 'OPEN' 1*   27.412   0.311  2445.337 1*  1*  'Y'  18.521 / \n"
-      " 'OP_3'  7  7   2   2 'OPEN' 1*   55.195   0.311  4923.842 1*  1*  'Y'  18.524 / \n"
-      "/\n"
-      "WELOPEN\n"
-      " 'OP_2' 'OPEN' /\n"
-      "/\n"
-      "DATES\n"
-      " 10  JUL 2007 / \n"
-      "/\n"
-      "WRFTPLT"
-      "  'OP_2'       'YES'        'NO'        'NO' / \n"
-      "/\n"
-      "DATES \n"
-      " 10  AUG 2007 / \n"
-      "/\n"
-      "COMPDAT\n" // with defaulted I and J
-      " 'OP_1'  0  *   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
-      "/\n";
-
-    return parser.parseString(input);
+    return ::Opm::Parser{}.parseString(R"(RUNSPEC
+START             -- 0
+  1 NOV 1979 /
+SCHEDULE
+DATES             -- 1  (sim step = 0)
+ 1 DES 1979/
+/
+WELSPECS
+    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+    'OP_2'       'OP'   8   8 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+    'OP_3'       'OP'   7   7 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+/
+COMPDAT
+ 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+ 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 /
+ 'OP_2'  8  8   1   3 'OPEN' 1*    1.168   0.311   107.872 1*  1*  'Y'  21.925 /
+ 'OP_2'  8  7   3   3 'OPEN' 1*   15.071   0.311  1391.859 1*  1*  'Y'  21.920 /
+ 'OP_2'  8  7   3   6 'OPEN' 1*    6.242   0.311   576.458 1*  1*  'Y'  21.915 /
+ 'OP_3'  7  7   1   1 'OPEN' 1*   27.412   0.311  2445.337 1*  1*  'Y'  18.521 /
+ 'OP_3'  7  7   2   2 'OPEN' 1*   55.195   0.311  4923.842 1*  1*  'Y'  18.524 /
+/
+WELOPEN
+ 'OP_2' 'OPEN' /
+/
+DATES             -- 2  (sim step = 1)
+ 10  JUL 2007 /
+/
+WRFTPLT
+  'OP_2'       'YES'        'NO'        'NO' /
+/
+DATES             -- 3  (sim step = 2)
+ 10  AUG 2007 /
+/
+COMPDAT
+-- with defaulted I and J
+ 'OP_1'  0  *   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+END
+)");
 }
+
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     Deck deck;
     Parser parser;
@@ -3444,7 +3445,8 @@ BOOST_AUTO_TEST_CASE(RFT_CONFIG2) {
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
     const auto& rft_config = schedule.rftConfig();
-    BOOST_CHECK_EQUAL(1, rft_config.firstRFTOutput());
+
+    BOOST_CHECK_EQUAL(2, rft_config.firstRFTOutput());
 }
 
 
@@ -3602,5 +3604,3 @@ DATES             -- 4
 
     gr.compute("XYZ",1, 1.0, oil_pot, gas_pot, wat_pot);
 }
-
-


### PR DESCRIPTION
Generally, this commit captures more of the surrounding context of calls to the `updateRFT()` and `updatePLT()` member functions.  We need this additional context in order to handle the conflicting semantics of output requests `WRFT` and `WRFTPLT:FOPN`.  The former generates RFT output when the well opens if this event does not happen earlier in the simulation schedule than the output request.  Otherwise no RFT data is emitted.  The latter outputs RFT data at request time if well opens no later than the request; otherwise at well-open time.

To this end, switch the `well_open_rft_name` data member from an `unordered_set` of well names into an `unordered_map` from well names to RFT output request times.  With this additional information we can use `well_open_rft_time` to infer the appropriate response to whether or not to activate RFT output at well open time.  Moreover, we now guarantee that no RFT output is ever activated before the first RFT output request.

Switching the type of the `well_open_rft_name` data member also begets an API update to the serialization related `RFTConfig` constructor and to the return type of `RFTConfig::wellOpenRftName()`.

We furthermore switch to caching the first RFT output event in a new scalar data member, `first_rft_event`.  This caching, coupled with the additional calling context mentioned earlier, means we are now able to report a high-fidelity, constant time answer to the
```
RFTConfig::firstRFTOutput()
```
request.  This, in turn, is very useful for the RFT output code. Finally, we also add a couple of new, private member functions to simplify updating `first_rft_event` depending on context.

As part of this update, member function
```
RFTConfig::setWellOpenRFT(report_step)
```
will now use the minimum of all 'report_step' values to support the `WRFT` keyword being specified more than once.

Finally, add a set of unit tests to exercise the various RFT output request combinations.

While here, also switch to using `unordered_map<>::find()` and `emplace()` where possible to limit repeated look-up of the same keys.