### PR TITLE
INIT File: Reenable FILLEPS for Two-Phase Systems

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -27,6 +27,7 @@ namespace Opm {
 class EclipseGrid;
 class Deck;
 class FieldProps;
+class Phases;
 class TableManager;
 
 class FieldPropsManager {
@@ -60,7 +61,7 @@ public:
     // The default constructor should be removed when the FieldPropsManager is mandatory
     // The default constructed fieldProps object is **NOT** usable
     FieldPropsManager() = default;
-    FieldPropsManager(const Deck& deck, const EclipseGrid& grid, const TableManager& tables);
+    FieldPropsManager(const Deck& deck, const Phases& ph, const EclipseGrid& grid, const TableManager& tables);
     void reset_actnum(const std::vector<int>& actnum);
     const std::string& default_region() const;
     std::vector<int> actnum() const;

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -19,185 +19,226 @@
 #ifndef ECLIPSE_SATFUNCPROPERTY_INITIALIZERS_HPP
 #define ECLIPSE_SATFUNCPROPERTY_INITIALIZERS_HPP
 
-#include <vector>
 #include <string>
-
+#include <vector>
 
 namespace Opm {
+
+    class Phases;
+    class TableManager;
 
 namespace satfunc {
 
     std::vector<double> SGLEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> ISGLEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> SGUEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> ISGUEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> SWLEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> ISWLEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> SWUEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> ISWUEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> SGCREndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> ISGCREndpoint(const TableManager&,
+                                      const Phases&,
                                       const std::vector<double>&,
                                       const std::vector<int>&,
                                       const std::vector<int>&);
 
     std::vector<double> SOWCREndpoint(const TableManager&,
+                                      const Phases&,
                                       const std::vector<double>&,
                                       const std::vector<int>&,
                                       const std::vector<int>&);
 
     std::vector<double> ISOWCREndpoint(const TableManager&,
+                                       const Phases&,
                                        const std::vector<double>&,
                                        const std::vector<int>&,
                                        const std::vector<int>&);
 
     std::vector<double> SOGCREndpoint(const TableManager&,
+                                      const Phases&,
                                       const std::vector<double>&,
                                       const std::vector<int>&,
                                       const std::vector<int>&);
 
     std::vector<double> ISOGCREndpoint(const TableManager&,
+                                       const Phases&,
                                        const std::vector<double>&,
                                        const std::vector<int>&,
                                        const std::vector<int>&);
 
     std::vector<double> SWCREndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> ISWCREndpoint(const TableManager&,
+                                      const Phases&,
                                       const std::vector<double>&,
                                       const std::vector<int>&,
                                       const std::vector<int>&);
 
     std::vector<double> PCWEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> IPCWEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> PCGEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> IPCGEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> KRWEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> IKRWEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> KRWREndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> IKRWREndpoint(const TableManager&,
+                                      const Phases&,
                                       const std::vector<double>&,
                                       const std::vector<int>&,
                                       const std::vector<int>&);
 
     std::vector<double> KROEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> IKROEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> KRORWEndpoint(const TableManager&,
+                                      const Phases&,
                                       const std::vector<double>&,
                                       const std::vector<int>&,
                                       const std::vector<int>&);
 
     std::vector<double> IKRORWEndpoint(const TableManager&,
+                                       const Phases&,
                                        const std::vector<double>&,
                                        const std::vector<int>&,
                                        const std::vector<int>&);
 
     std::vector<double> KRORGEndpoint(const TableManager&,
+                                      const Phases&,
                                       const std::vector<double>&,
                                       const std::vector<int>&,
                                       const std::vector<int>&);
 
     std::vector<double> IKRORGEndpoint(const TableManager&,
+                                       const Phases&,
                                        const std::vector<double>&,
                                        const std::vector<int>&,
                                        const std::vector<int>&);
 
     std::vector<double> KRGEndpoint(const TableManager&,
+                                    const Phases&,
                                     const std::vector<double>&,
                                     const std::vector<int>&,
                                     const std::vector<int>&);
 
     std::vector<double> IKRGEndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> KRGREndpoint(const TableManager&,
+                                     const Phases&,
                                      const std::vector<double>&,
                                      const std::vector<int>&,
                                      const std::vector<int>&);
 
     std::vector<double> IKRGREndpoint(const TableManager&,
+                                      const Phases&,
                                       const std::vector<double>&,
                                       const std::vector<int>&,
                                       const std::vector<int>&);
 
-    std::vector<double> init(const std::string& kewyord, const TableManager& tables, const std::vector<double>& cell_depth, const std::vector<int>& num, const std::vector<int>& endnum);
+    std::vector<double> init(const std::string& kewyord,
+                             const TableManager& tables,
+                             const Phases& phases,
+                             const std::vector<double>& cell_depth,
+                             const std::vector<int>& num,
+                             const std::vector<int>& endnum);
 }
 }
 

--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -24,8 +24,6 @@
 
 #include <opm/output/eclipse/WriteInit.hpp>
 
-#include <opm/common/OpmLog/OpmLog.hpp>
-
 #include <opm/io/eclipse/OutputStream.hpp>
 
 #include <opm/output/data/Solution.hpp>
@@ -517,28 +515,12 @@ namespace {
                              const ::Opm::UnitSystem&          units,
                              ::Opm::EclIO::OutputStream::Init& initFile)
     {
-        const auto& ph = es.runspec().phases();
-
         const auto epsVectors = ScalingVectors{}
             .withHysteresis(es.runspec().hysterPar().active())
-            .collect       (ph);
-
-        const auto nactph = ph.active(::Opm::Phase::WATER)
-            + ph.active(Opm::Phase::OIL)
-            + ph.active(Opm::Phase::GAS);
+            .collect       (es.runspec().phases());
 
         const auto& fp = es.fieldProps();
-        if (! es.cfg().init().filleps() || (nactph < 3)) {
-            if (nactph < 3) {
-                const auto msg = "OPM-Flow does currently not support "
-                    "FILLEPS for fewer than 3 active phases. "
-                    "Ignoring FILLEPS for "
-                    + std::to_string(nactph)
-                    + " active phases.";
-
-                Opm::OpmLog::warning(msg);
-            }
-
+        if (! es.cfg().init().filleps()) {
             // No FILLEPS in input deck or number of active phases
             // unsupported by Flow's saturation function finalizers.
             //

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -73,7 +73,7 @@ bool enable3DPropsTesting() {
         m_inputNnc(          deck ),
         m_inputEditNnc(      deck ),
         m_inputGrid(         deck, nullptr ),
-        field_props(         deck, m_inputGrid, m_tables),
+        field_props(         deck, m_runspec.phases(), m_inputGrid, m_tables),
         m_simulationConfig(  m_eclipseConfig.getInitConfig().restartRequested(), deck, field_props),
         m_transMult(         GridDims(deck), deck, field_props)
     {

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -32,6 +32,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 #include "FieldProps.hpp"
 #include "Operate.hpp"
@@ -404,13 +405,14 @@ std::vector<double> extract_cell_depth(const EclipseGrid& grid) {
 
 
 
-FieldProps::FieldProps(const Deck& deck, const EclipseGrid& grid, const TableManager& tables_arg) :
+FieldProps::FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid& grid, const TableManager& tables_arg) :
     active_size(grid.getNumActive()),
     global_size(grid.getCartesianSize()),
     unit_system(deck.getActiveUnitSystem()),
     nx(grid.getNX()),
     ny(grid.getNY()),
     nz(grid.getNZ()),
+    m_phases(phases),
     m_actnum(grid.getACTNUM()),
     cell_volume(extract_cell_volume(grid)),
     cell_depth(extract_cell_depth(grid)),
@@ -1053,10 +1055,10 @@ void FieldProps::init_satfunc(const std::string& keyword, FieldData<double>& sat
     const auto& endnum = this->get<int>("ENDNUM");
     if (keyword[0] == 'I') {
         const auto& imbnum = this->get<int>("IMBNUM");
-        satfunc.default_update(satfunc::init(keyword, this->tables, this->cell_depth, imbnum, endnum));
+        satfunc.default_update(satfunc::init(keyword, this->tables, this->m_phases, this->cell_depth, imbnum, endnum));
     } else {
         const auto& satnum = this->get<int>("SATNUM");
-        satfunc.default_update(satfunc::init(keyword, this->tables, this->cell_depth, satnum, endnum));
+        satfunc.default_update(satfunc::init(keyword, this->tables, this->m_phases, this->cell_depth, satnum, endnum));
     }
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -27,6 +27,7 @@
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 namespace Opm {
 
@@ -213,7 +214,7 @@ public:
 
 
 
-    FieldProps(const Deck& deck, const EclipseGrid& grid, const TableManager& table_arg);
+    FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid& grid, const TableManager& table_arg);
     void reset_actnum(const std::vector<int>& actnum);
 
     const std::string& default_region() const;
@@ -354,6 +355,7 @@ private:
 
     const UnitSystem unit_system;
     std::size_t nx,ny,nz;
+    Phases m_phases;
     std::vector<int> m_actnum;
     std::vector<double> cell_volume;
     std::vector<double> cell_depth;
@@ -367,4 +369,3 @@ private:
 
 }
 #endif
-

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -20,14 +20,15 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 #include "FieldProps.hpp"
 
 
 namespace Opm {
 
-FieldPropsManager::FieldPropsManager(const Deck& deck, const EclipseGrid& grid_arg, const TableManager& tables) :
-    fp(std::make_shared<FieldProps>(deck, grid_arg, tables))
+FieldPropsManager::FieldPropsManager(const Deck& deck, const Phases& phases, const EclipseGrid& grid_arg, const TableManager& tables) :
+    fp(std::make_shared<FieldProps>(deck, phases, grid_arg, tables))
 {}
 
 void FieldPropsManager::reset_actnum(const std::vector<int>& actnum) {

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -31,6 +31,7 @@
 #include <opm/common/OpmLog/Location.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.hpp>
@@ -127,7 +128,7 @@ TSTEP
     auto deck3 = parser.parseString(WITH_GRID);
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck1 );
-    FieldPropsManager fp( deck1 , grid1, table);
+    FieldPropsManager fp( deck1, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck1);
 
     // The ACTIONX keyword has no matching 'ENDACTIO' -> exception
@@ -221,7 +222,7 @@ TSTEP
     auto deck = parser.parseString(deck_string);
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec(deck);
 
     return Schedule(deck, grid1, fp, runspec);
@@ -691,7 +692,7 @@ TSTEP
     auto deck = parser.parseString(deck_string);
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
 
     Runspec runspec (deck);
     Schedule sched(deck, grid1, fp, runspec);

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -38,6 +38,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
 namespace Opm {
@@ -152,7 +153,7 @@ Opm::WellConnections loadCOMPDAT(const std::string& compdat_keyword) {
     Opm::TableManager tables;
     Opm::Parser parser;
     const auto deck = parser.parseString(compdat_keyword);
-    Opm::FieldPropsManager field_props(deck, grid, Opm::TableManager());
+    Opm::FieldPropsManager field_props(deck, Opm::Phases{true, true, true}, grid, Opm::TableManager());
     const auto& keyword = deck.getKeyword("COMPDAT", 0);
     Opm::WellConnections connections(10,10);
     for (const auto& rec : keyword)

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 #include "src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp"
 
@@ -46,7 +47,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(CreateFieldProps) {
     EclipseGrid grid(10,10,10);
     Deck deck;
-    FieldPropsManager fpm(deck, grid, TableManager());
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
     BOOST_CHECK(!fpm.try_get<double>("PORO"));
     BOOST_CHECK(!fpm.try_get<double>("PORO"));
     BOOST_CHECK(!fpm.try_get<double>("NO_SUCH_KEYWOWRD"));
@@ -90,7 +91,7 @@ PERMX
         actnum[i] = 0;
     EclipseGrid grid(EclipseGrid(10,10,10), actnum);
     Deck deck = Parser{}.parseString(deck_string);
-    FieldPropsManager fpm(deck, grid, TableManager());
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
 
     BOOST_CHECK(!fpm.has_double("NO-PORO"));
     BOOST_CHECK(fpm.has_double("PORO"));
@@ -136,7 +137,7 @@ COPY
 
     EclipseGrid grid(EclipseGrid(10,10,10));
     Deck deck = Parser{}.parseString(deck_string);
-    BOOST_CHECK_THROW( FieldPropsManager(deck, grid, TableManager()), std::out_of_range);
+    BOOST_CHECK_THROW( FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager()), std::out_of_range);
 }
 
 BOOST_AUTO_TEST_CASE(GRID_RESET) {
@@ -150,7 +151,7 @@ SATNUM
     std::vector<int> actnum1 = {1,1,1,0,0,0,1,1,1};
     EclipseGrid grid(3,1,3); grid.resetACTNUM(actnum1);
     Deck deck = Parser{}.parseString(deck_string);
-    FieldPropsManager fpm(deck, grid, TableManager());
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
     const auto& s1 = fpm.get_int("SATNUM");
     BOOST_CHECK_EQUAL(s1.size(), 6);
     BOOST_CHECK_EQUAL(s1[0], 0);
@@ -192,7 +193,7 @@ ADDREG
     std::vector<int> actnum1 = {1,1,0,0,1,1};
     EclipseGrid grid(3,2,1); grid.resetACTNUM(actnum1);
     Deck deck = Parser{}.parseString(deck_string);
-    FieldPropsManager fpm(deck, grid, TableManager());
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
     const auto& poro = fpm.get_double("PORO");
     BOOST_CHECK_EQUAL(poro.size(), 4);
     BOOST_CHECK_EQUAL(poro[0], 0.10);
@@ -230,7 +231,7 @@ NTG
 
     EclipseGrid grid(EclipseGrid(10,10, 2));
     Deck deck = Parser{}.parseString(deck_string);
-    FieldPropsManager fpm(deck, grid, TableManager());
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
     const auto& ntg = fpm.get_double("NTG");
     const auto& defaulted = fpm.defaulted<double>("NTG");
 
@@ -300,7 +301,7 @@ ENDBOX
 
     EclipseGrid grid(10,10, 5);
     Deck deck = Parser{}.parseString(deck_string);
-    FieldPropsManager fpm(deck, grid, TableManager());
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
     const auto& poro = fpm.get_double("PORO");
     const auto& ntg = fpm.get_double("NTG");
     const auto& multpv = fpm.get_double("MULTPV");
@@ -477,7 +478,7 @@ BOOST_AUTO_TEST_CASE(LATE_GET_SATFUNC) {
     auto deck = parser.parseString(deckString);
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
-    Opm::FieldPropsManager fp(deck, eg, tm);
+    Opm::FieldPropsManager fp(deck, Phases{true, true, true}, eg, tm);
 
     const auto& fp_swu = fp.get_global_double("SWU");
     BOOST_CHECK_EQUAL(fp_swu[1 + 0 * 3*3], 0.93);
@@ -504,7 +505,7 @@ PORO
     Deck deck = Parser{}.parseString(deck_string);
     std::vector<int> actnum(200, 1); actnum[0] = 0;
     grid.resetACTNUM(actnum);
-    FieldPropsManager fpm(deck, grid, TableManager());
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
 
     BOOST_CHECK(!fpm.has_double("NTG"));
     const auto& ntg = fpm.get_copy<double>("NTG");
@@ -548,7 +549,7 @@ RTEMPVD
     EclipseGrid grid(1,1, 2);
     Deck deck = Parser{}.parseString(deck_string);
     Opm::TableManager tm(deck);
-    FieldPropsManager fpm(deck, grid, tm);
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, tm);
 
     const auto& tempi = fpm.get_double("TEMPI");
     double celcius_offset = 273.15;
@@ -578,7 +579,7 @@ MULTZ
     Opm::Deck deck = parser.parseString(deck_string);
     Opm::EclipseGrid grid(5,5,5);
     Opm::TableManager tm(deck);
-    FieldPropsManager fpm(deck, grid, tm);
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, tm);
 
     const auto& multz = fpm.get_double("MULTZ");
     const auto& multx = fpm.get_double("MULTX");

--- a/tests/parser/GeomodifierTests.cpp
+++ b/tests/parser/GeomodifierTests.cpp
@@ -35,6 +35,8 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 
@@ -76,7 +78,7 @@ BOOST_AUTO_TEST_CASE( CheckUnsoppertedInSCHEDULE ) {
     auto deck = parser.parseString( deckString, parseContext, errors);
     EclipseGrid grid( deck );
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
 
     parseContext.update( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , InputError::IGNORE );
     {

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -31,6 +31,7 @@
 #include <opm/parser/eclipse/EclipseState/Util/Value.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp>
@@ -129,7 +130,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGEFAC) {
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Runspec runspec (deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Opm::Schedule schedule(deck,  grid, fp, runspec);
 
     auto group_names = schedule.groupNames("PRODUC");
@@ -181,7 +182,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWGRUPCONandWCONPROD) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck );
     Opm::Schedule schedule(deck,  grid, fp, runspec);
     const auto& currentWell = schedule.getWell("B-37T2", 0);
@@ -225,7 +226,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGRUPNET) {
         auto deck = parser.parseString(input);
         EclipseGrid grid(10,10,10);
         TableManager table ( deck );
-        FieldPropsManager fp( deck , grid, table);
+        FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
         Runspec runspec (deck );
         Opm::Schedule schedule(deck,  grid, fp, runspec);
 
@@ -283,7 +284,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGCONPROD) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck );
     Opm::Schedule schedule(deck,  grid, fp, runspec);
     SummaryState st(std::chrono::system_clock::now());
@@ -336,7 +337,7 @@ BOOST_AUTO_TEST_CASE(TESTGuideRateLINCOM) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck );
 
     /* The 'COMB' target mode is not supported */
@@ -373,7 +374,7 @@ BOOST_AUTO_TEST_CASE(TESTGuideRate) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck );
     Schedule schedule(deck, grid, fp, runspec);
 
@@ -406,7 +407,7 @@ BOOST_AUTO_TEST_CASE(TESTGCONSALE) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck );
     Schedule schedule(deck, grid, fp, runspec);
 

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -35,6 +35,8 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
 
@@ -107,7 +109,7 @@ BOOST_AUTO_TEST_CASE(InvalidInput) {
     Opm::EclipseGrid grid( deck );
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg( deck );
-    Opm::FieldPropsManager fp(deck, eg, tm);
+    Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, eg, tm);
 
     // Invalid direction
     std::vector<const Opm::DeckKeyword*> keywords0;
@@ -173,7 +175,7 @@ BOOST_AUTO_TEST_CASE(NotSupported) {
     Opm::EclipseGrid grid( deck );
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg( deck );
-    Opm::FieldPropsManager fp(deck, eg, tm);
+    Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, eg, tm);
 
 
     // Not support NOAQUNNC behaviour
@@ -234,7 +236,7 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   Opm::EclipseGrid grid( deck );
   Opm::TableManager tm(deck);
   Opm::EclipseGrid eg( deck );
-  Opm::FieldPropsManager fp(deck, eg, tm);
+  Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, eg, tm);
 
 
   std::vector<const Opm::DeckKeyword*> keywords0;
@@ -294,7 +296,7 @@ BOOST_AUTO_TEST_CASE(MULTREGT_COPY_MULTNUM) {
     Opm::Deck deck = createCopyMULTNUMDeck();
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
-    Opm::FieldPropsManager fp(deck, eg, tm);
+    Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, eg, tm);
 
     BOOST_CHECK_NO_THROW(fp.has_int("FLUXNUM"));
     BOOST_CHECK_NO_THROW(fp.has_int("MULTNUM"));

--- a/tests/parser/MessageLimitTests.cpp
+++ b/tests/parser/MessageLimitTests.cpp
@@ -27,6 +27,8 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -78,7 +80,7 @@ BOOST_AUTO_TEST_CASE(MESSAGES) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid, fp, runspec);
     const MessageLimits limits = schedule.getMessageLimits();
@@ -93,4 +95,3 @@ BOOST_AUTO_TEST_CASE(MESSAGES) {
     BOOST_CHECK_EQUAL( limits.getCommentPrintLimit( 2 ) , 2  );
     BOOST_CHECK_EQUAL( limits.getBugPrintLimit( 2 ) , 77 );
 }
-

--- a/tests/parser/MultiRegTests.cpp
+++ b/tests/parser/MultiRegTests.cpp
@@ -32,7 +32,8 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 static Opm::Deck createDeckInvalidArray() {
     const char* deckData =
@@ -231,7 +232,7 @@ BOOST_AUTO_TEST_CASE(Test_OPERATER) {
     Opm::Deck deck = createValidIntDeck();
     Opm::TableManager tm(deck);
     Opm::EclipseGrid eg(deck);
-    Opm::FieldPropsManager fp(deck, eg, tm);
+    Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, eg, tm);
 
     const auto& porv  = fp.porv(true);
     const auto& permx = fp.get_global_double("PERMX");

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -39,6 +39,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
 using namespace Opm;
@@ -332,7 +333,7 @@ BOOST_AUTO_TEST_CASE( CheckUnsupportedInSCHEDULE ) {
     auto deckUnSupported = parser.parseString( deckStringUnSupported , parseContext, errors );
     EclipseGrid grid( deckSupported );
     TableManager table ( deckSupported );
-    FieldPropsManager fp(deckSupported, grid, table);
+    FieldPropsManager fp(deckSupported, Phases{true, true, true}, grid, table);
     Runspec runspec(deckSupported);
 
     parseContext.update( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , InputError::IGNORE );
@@ -410,7 +411,7 @@ BOOST_AUTO_TEST_CASE(TestCOMPORD) {
 
     EclipseGrid grid( deck );
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
 
     parseContext.update( ParseContext::UNSUPPORTED_COMPORD_TYPE , InputError::IGNORE);
@@ -760,7 +761,7 @@ BOOST_AUTO_TEST_CASE( test_invalid_wtemplate_config ) {
 
         EclipseGrid grid( deckUnSupported );
         TableManager table ( deckUnSupported );
-        FieldPropsManager fp( deckUnSupported , grid, table);
+        FieldPropsManager fp( deckUnSupported, Phases{true, true, true}, grid, table);
         Runspec runspec( deckUnSupported);
 
         BOOST_CHECK_THROW( Schedule( deckUnSupported , grid , fp, runspec , parseContext, errors), std::invalid_argument );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -31,6 +31,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp>
@@ -362,7 +363,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     deck.addKeyword( DeckKeyword( parser.getKeyword("SCHEDULE" )));
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec );
     BOOST_CHECK_EQUAL( schedule.getStartTime() , TimeMap::mkdate(1983, 1 , 1));
@@ -372,7 +373,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     auto deck = createDeckWithWellsOrdered();
     EclipseGrid grid(100,100,100);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
     auto well_names = schedule.wellNames();
@@ -401,7 +402,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
     auto deck = createDeckWithWellsOrderedGRUPTREE();
     EclipseGrid grid(100,100,100);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -452,7 +453,7 @@ BOOST_AUTO_TEST_CASE(GroupTree2TEST) {
     auto deck = createDeckWithWellsOrderedGRUPTREE();
     EclipseGrid grid(100,100,100);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -482,7 +483,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
     auto deck = createDeck();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
 
     Schedule schedule(deck, grid , fp, runspec);
@@ -494,7 +495,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     Deck deck;
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     deck.addKeyword( DeckKeyword( parser.getKeyword("SCHEDULE" )));
     Runspec runspec (deck);
 
@@ -505,7 +506,7 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
     EclipseGrid grid(10,10,10);
     auto deck = createDeck();
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);;
     Schedule schedule(deck, grid , fp, runspec);
     BOOST_CHECK_EQUAL( 0U , schedule.numWells() );
@@ -519,7 +520,7 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {
     EclipseGrid grid(10,10,10);
     auto deck = createDeck();
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck , grid , fp, runspec);
 
@@ -614,7 +615,7 @@ BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
     EclipseGrid grid(10,10,10);
     auto deck = createDeck();
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck , grid , fp, runspec);
 
@@ -632,7 +633,7 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
     EclipseGrid grid(10,10,10);
     auto deck = createDeckWithWells();
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck , grid , fp, runspec);
     size_t timeStep = 0;
@@ -651,7 +652,7 @@ BOOST_AUTO_TEST_CASE(ReturnNumWellsTimestep) {
     EclipseGrid grid(10,10,10);
     auto deck = createDeckWithWells();
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -665,7 +666,7 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
     EclipseGrid grid(10,10,10);
     auto deck = createDeckForTestingCrossFlow();
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -738,7 +739,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndConnectionDataWithWELOPEN) {
     EclipseGrid grid(10,10,10);
   auto deck = createDeckWithWellsAndConnectionDataWithWELOPEN();
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck ,grid , fp, runspec);
     {
@@ -822,7 +823,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
     EclipseGrid grid(10,10,10);
     auto deck = parser.parseString(input);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck ,  grid , fp, runspec);
     const auto& well2_3 = schedule.getWell("OP_1",3);
@@ -882,7 +883,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_CombineShutCompletionsAndAddN
   EclipseGrid grid(10,10,10);
   auto deck = parser.parseString(input);
   TableManager table ( deck );
-  FieldPropsManager fp( deck , grid, table);
+  FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
   Runspec runspec (deck);
   Schedule schedule(deck, grid , fp, runspec);
   const auto& well_3 = schedule.getWell("OP_1", 3);
@@ -940,7 +941,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
     EclipseGrid grid(10,10,10);
     auto deck = parser.parseString(input);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
     const auto& rft_config = schedule.rftConfig();
@@ -998,7 +999,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
     EclipseGrid grid(10,10,10);
     auto deck = parser.parseString(input);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
     const auto& well = schedule.getWell("OP_1", 4);
@@ -1048,7 +1049,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck,  grid , fp, runspec);
     Opm::UnitSystem unitSystem = deck.getActiveUnitSystem();
@@ -1088,7 +1089,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
 
     BOOST_CHECK_THROW(Schedule(deck, grid , fp, runspec),
@@ -1107,7 +1108,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException2) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     BOOST_CHECK_THROW(Schedule(deck, grid , fp, runspec), std::invalid_argument);
 }
@@ -1153,7 +1154,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWPIMULT) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -1224,7 +1225,7 @@ BOOST_AUTO_TEST_CASE(WELSPECS_WGNAME_SPACE) {
         auto deck = parser.parseString(input);
         EclipseGrid grid( deck );
         TableManager table ( deck );
-        FieldPropsManager fp( deck , grid, table);
+        FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
         Runspec runspec (deck);
         ParseContext parseContext;
         ErrorGuard errors;
@@ -1276,7 +1277,7 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
         auto deck = parser.parseString(input);
         EclipseGrid grid( deck );
         TableManager table ( deck );
-        FieldPropsManager fp( deck , grid, table);
+        FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
         Runspec runspec (deck);
         Opm::Schedule schedule(deck,  grid, fp, runspec);
         Opm::SummaryState st(std::chrono::system_clock::now());
@@ -1325,7 +1326,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDT) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
     size_t currentStep = 1;
@@ -1359,7 +1360,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDTR) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
     size_t currentStep = 1;
@@ -1406,7 +1407,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDTthenDRVDT) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), true);
@@ -1447,7 +1448,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithVAPPARS) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
     size_t currentStep = 1;
@@ -1478,7 +1479,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithOutOilVaporizationProperties) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -1539,7 +1540,7 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     SummaryState st(std::chrono::system_clock::now());
     const auto& unit_system = deck.getActiveUnitSystem();
@@ -1636,7 +1637,7 @@ BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -1742,7 +1743,7 @@ BOOST_AUTO_TEST_CASE(fromWCONHISTtoWCONPROD) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -1830,7 +1831,7 @@ BOOST_AUTO_TEST_CASE(WHISTCTL_NEW_WELL) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -1906,7 +1907,7 @@ BOOST_AUTO_TEST_CASE(unsupportedOptionWHISTCTL) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     BOOST_CHECK_THROW(Schedule(deck, grid, fp, runspec), std::invalid_argument);
 }
@@ -1935,7 +1936,7 @@ BOOST_AUTO_TEST_CASE(move_HEAD_I_location) {
     auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
     BOOST_CHECK_EQUAL(2, schedule.getWell("W1", 1).getHeadI());
@@ -1966,7 +1967,7 @@ BOOST_AUTO_TEST_CASE(change_ref_depth) {
     auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
     BOOST_CHECK_CLOSE(2873.94, schedule.getWell("W1", 1).getRefDepth(), 1e-5);
@@ -2005,7 +2006,7 @@ BOOST_AUTO_TEST_CASE(WTEMP_well_template) {
     auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
 
@@ -2051,7 +2052,7 @@ BOOST_AUTO_TEST_CASE(WTEMPINJ_well_template) {
         auto deck = Parser().parseString(input);
         EclipseGrid grid(10,10,10);
         TableManager table ( deck );
-        FieldPropsManager fp( deck , grid, table);
+        FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
         Runspec runspec (deck);
         Schedule schedule( deck, grid, fp, runspec);
 
@@ -2103,7 +2104,7 @@ BOOST_AUTO_TEST_CASE( COMPDAT_sets_automatic_complnum ) {
     auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
     const auto& cs1 = schedule.getWell( "W1", 1 ).getConnections(  );
@@ -2153,7 +2154,7 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_wells ) {
     auto deck = Parser().parseString( input);
     EclipseGrid grid( 10, 10, 10 );
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
 
@@ -2222,7 +2223,7 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_records_same_completion ) {
     auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
     const auto& cs = schedule.getWell( "W1", 1 ).getConnections();
@@ -2262,7 +2263,7 @@ BOOST_AUTO_TEST_CASE( complump_less_than_1 ) {
     auto deck = Parser().parseString( input);
     EclipseGrid grid( 10, 10, 10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     BOOST_CHECK_THROW( Schedule( deck , grid, fp, runspec), std::invalid_argument );
 }
@@ -2314,7 +2315,7 @@ BOOST_AUTO_TEST_CASE( complump ) {
     auto deck = Parser().parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
 
@@ -2404,7 +2405,7 @@ BOOST_AUTO_TEST_CASE( COMPLUMP_specific_coordinates ) {
     auto deck = Parser().parseString( input);
     EclipseGrid grid( 10, 10, 10 );
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
 
@@ -2874,7 +2875,7 @@ BOOST_AUTO_TEST_CASE(handleWEFAC) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec);
 
@@ -2919,7 +2920,7 @@ BOOST_AUTO_TEST_CASE(historic_BHP_and_THP) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
 
@@ -2952,7 +2953,7 @@ BOOST_AUTO_TEST_CASE(FilterCompletions2) {
     std::vector<int> actnum(1000,1);
     auto deck = createDeckWithWellsAndCompletionData();
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
     {
@@ -3045,7 +3046,7 @@ VFPINJ \n                                       \
     auto deck = parser.parseString(deckData);
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
 
@@ -3172,7 +3173,7 @@ BOOST_AUTO_TEST_CASE(POLYINJ_TEST) {
     auto deck = parser.parseString(deckData);
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
 
@@ -3232,7 +3233,7 @@ BOOST_AUTO_TEST_CASE(WFOAM_TEST) {
     auto deck = parser.parseString(deckData);
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
 
@@ -3250,7 +3251,7 @@ BOOST_AUTO_TEST_CASE(WTEST_CONFIG) {
     auto deck = createDeckWTEST();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
 
@@ -3279,7 +3280,7 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
     auto deck = createDeckWithWells();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
     BOOST_CHECK_THROW( schedule.getWell("NO_SUCH_WELL", 0), std::invalid_argument);
@@ -3327,7 +3328,7 @@ BOOST_AUTO_TEST_CASE(WellNames) {
     auto deck = createDeckWTEST();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
 
@@ -3444,7 +3445,7 @@ BOOST_AUTO_TEST_CASE(RFT_CONFIG2) {
     auto deck = createDeckRFTConfig();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid1, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
     Schedule schedule(deck, grid1 , fp, runspec);
     const auto& rft_config = schedule.rftConfig();
@@ -3478,7 +3479,7 @@ BOOST_AUTO_TEST_CASE(nupcol) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
 
@@ -3570,7 +3571,7 @@ DATES             -- 4
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec);
 

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -28,6 +28,7 @@
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
@@ -142,7 +143,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
     auto deck = createDeck(inputStr);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    FieldPropsManager fp(deck, eg, tm);
+    FieldPropsManager fp(deck, Phases{true, true, true}, eg, tm);
     BOOST_CHECK_NO_THROW( SimulationConfig(false, deck, fp) );
 }
 
@@ -151,7 +152,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigNOTHPRES) {
     auto deck = createDeck(inputStr_noTHPRES);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    FieldPropsManager fp(deck, eg, tm);
+    FieldPropsManager fp(deck, Phases{true, true, true}, eg, tm);
     SimulationConfig simulationConfig(false, deck, fp);
     BOOST_CHECK( !simulationConfig.useThresholdPressure() );
 }
@@ -160,7 +161,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
     auto deck = createDeck(inputStr_noTHPRES);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    FieldPropsManager fp(deck, eg, tm);
+    FieldPropsManager fp(deck, Phases{true, true, true}, eg, tm);
     SimulationConfig simulationConfig(false, deck, fp);
     BOOST_CHECK( ! simulationConfig.useCPR());
 }
@@ -170,7 +171,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     SUMMARYSection summary(deck);
-    FieldPropsManager fp(deck, eg, tm);
+    FieldPropsManager fp(deck, Phases{true, true, true}, eg, tm);
     SimulationConfig simulationConfig(false, deck, fp);
     BOOST_CHECK(     simulationConfig.useCPR() );
     BOOST_CHECK(  !  summary.hasKeyword("CPR") );
@@ -182,7 +183,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRInSUMMARYSection) {
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     SUMMARYSection summary(deck);
-    FieldPropsManager fp(deck, eg, tm);
+    FieldPropsManager fp(deck, Phases{true, true, true}, eg, tm);
     SimulationConfig simulationConfig(false, deck, fp);
     BOOST_CHECK( ! simulationConfig.useCPR());
     BOOST_CHECK(   summary.hasKeyword("CPR"));
@@ -194,7 +195,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
     SUMMARYSection summary(deck);
-    FieldPropsManager fp(deck, eg, tm);
+    FieldPropsManager fp(deck, Phases{true, true, true}, eg, tm);
     SimulationConfig simulationConfig(false, deck, fp);
     BOOST_CHECK(  simulationConfig.useCPR());
     BOOST_CHECK(  summary.hasKeyword("CPR"));
@@ -218,7 +219,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     auto deck = createDeck(inputStr);
     TableManager tm(deck);
     EclipseGrid eg(10, 3, 4);
-    FieldPropsManager fp(deck, eg, tm);
+    FieldPropsManager fp(deck, Phases{true, true, true}, eg, tm);
     SimulationConfig simulationConfig(false, deck, fp);
     BOOST_CHECK_EQUAL( false , simulationConfig.hasDISGAS());
     BOOST_CHECK_EQUAL( false , simulationConfig.hasVAPOIL());
@@ -226,7 +227,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     auto deck_vd = createDeck(inputStr_vap_dis);
     TableManager tm_vd(deck_vd);
     EclipseGrid eg_vd(10, 3, 4);
-    FieldPropsManager fp_vd(deck_vd, eg, tm);
+    FieldPropsManager fp_vd(deck_vd, Phases{true, true, true}, eg, tm);
     SimulationConfig simulationConfig_vd(false, deck_vd, fp_vd);
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasDISGAS());
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasVAPOIL());
@@ -239,7 +240,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
         const auto deck = createDeck(inputStr);
         const auto tm = TableManager(deck);
         const auto eg = EclipseGrid(10, 3, 4);
-        const auto fp = FieldPropsManager(deck, eg, tm);
+        const auto fp = FieldPropsManager(deck, Phases{true, true, true}, eg, tm);
         const auto simulationConfig = Opm::SimulationConfig(false, deck, fp);
 
         BOOST_CHECK(! simulationConfig.isThermal());
@@ -249,7 +250,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
         const auto deck = createDeck(simDeckStringTEMP());
         const auto tm = TableManager(deck);
         const auto eg = EclipseGrid(10, 3, 4);
-        const auto fp = FieldPropsManager(deck, eg, tm);
+        const auto fp = FieldPropsManager(deck, Phases{true, true, true}, eg, tm);
         const auto simulationConfig = Opm::SimulationConfig(false, deck, fp);
 
         BOOST_CHECK(simulationConfig.isThermal());
@@ -259,7 +260,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
         const auto deck = createDeck(simDeckStringTHERMAL());
         const auto tm = TableManager(deck);
         const auto eg = EclipseGrid(10, 3, 4);
-        const auto fp = FieldPropsManager(deck, eg, tm);
+        const auto fp = FieldPropsManager(deck, Phases{true, true, true}, eg, tm);
         const auto simulationConfig = Opm::SimulationConfig(false, deck, fp);
 
         BOOST_CHECK(simulationConfig.isThermal());
@@ -288,7 +289,7 @@ ROCKOPTS
     Opm::Parser parser;
     const auto deck = parser.parseString(deck_string);
     EclipseGrid grid(10,10,10);
-    FieldPropsManager fp(deck, grid, TableManager());
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, TableManager());
     RockConfig rc(deck, fp);
     BOOST_CHECK_EQUAL(rc.rocknum_property(), "SATNUM");
     const auto& comp = rc.comp();

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -28,6 +28,7 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
@@ -214,7 +215,7 @@ struct Setup
             deck(createDeck(ParseContext(), input)),
             tablemanager(deck),
             grid(10, 3, 4),
-            fp(deck, grid, tablemanager),
+            fp(deck, Opm::Phases{true, true, true}, grid, tablemanager),
             initConfig(deck),
             threshPres(initConfig.restartRequested(), deck, fp)
     {
@@ -224,7 +225,7 @@ struct Setup
             deck(createDeck(parseContextArg, input)),
             tablemanager(deck),
             grid(10, 3, 4),
-            fp(deck, grid, tablemanager),
+            fp(deck, Opm::Phases{true, true, true}, grid, tablemanager),
             initConfig(deck),
             threshPres(initConfig.restartRequested(), deck, fp)
     {

--- a/tests/parser/TransMultTests.cpp
+++ b/tests/parser/TransMultTests.cpp
@@ -32,10 +32,11 @@
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 BOOST_AUTO_TEST_CASE(Empty) {
     Opm::EclipseGrid grid(10,10,10);
-    Opm::FieldPropsManager fp(Opm::Deck(), grid, Opm::TableManager());
+    Opm::FieldPropsManager fp(Opm::Deck(), Opm::Phases{true, true, true}, grid, Opm::TableManager());
     Opm::TransMult transMult(grid ,{} , fp);
 
     BOOST_CHECK_THROW( transMult.getMultiplier(12,10,10 , Opm::FaceDir::XPlus) , std::invalid_argument );
@@ -69,7 +70,7 @@ MULTZ
     Opm::Deck deck = parser.parseString(deck_string);
     Opm::TableManager tables(deck);
     Opm::EclipseGrid grid(5,5,5);
-    Opm::FieldPropsManager fp(deck, grid, tables);
+    Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, grid, tables);
     Opm::TransMult transMult(grid, deck, fp);
 
     transMult.applyMULT(fp.get_global_double("MULTZ"), Opm::FaceDir::ZPlus);

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -25,6 +25,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
@@ -71,7 +72,7 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   auto deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   TableManager table ( deck );
-  FieldPropsManager fp(deck, grid, table);
+  FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
   Runspec runspec (deck);
   Schedule schedule( deck, grid , fp, runspec);
   auto tuning = schedule.getTuning();
@@ -330,7 +331,7 @@ BOOST_AUTO_TEST_CASE(TuningInitTest) {
   auto deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   TableManager table ( deck );
-  FieldPropsManager fp(deck, grid, table);
+  FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
   Runspec runspec (deck);
   Schedule schedule(deck , grid , fp, runspec);
   auto tuning = schedule.getTuning();
@@ -361,7 +362,7 @@ BOOST_AUTO_TEST_CASE(TuningResetTest) {
   auto deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   TableManager table ( deck );
-  FieldPropsManager fp(deck, grid, table);
+  FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
   Runspec runspec (deck);
   Schedule schedule(deck, grid , fp, runspec);
   auto tuning = schedule.getTuning();

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -19,6 +19,7 @@ Copyright 2018 Statoil ASA.
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
@@ -144,7 +145,7 @@ Schedule make_schedule(const std::string& input) {
     } else {
         EclipseGrid grid(10,10,10);
         TableManager table ( deck );
-        FieldPropsManager fp( deck , grid, table);
+        FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
         Runspec runspec (deck);
         return Schedule(deck, grid , fp, runspec);
     }

--- a/tests/parser/WLIST.cpp
+++ b/tests/parser/WLIST.cpp
@@ -143,7 +143,7 @@ static Opm::Schedule createSchedule(const std::string& schedule) {
     auto deck = parser.parseString(input);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     return Schedule(deck, grid , fp, runspec );
 }

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
@@ -176,7 +177,7 @@ BOOST_AUTO_TEST_CASE(TestNoSolvent) {
     auto deck = createDeckWithOutSolvent();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
     Schedule schedule(deck, grid , fp, runspec);
     BOOST_CHECK(!deck.hasKeyword("WSOLVENT"));
@@ -186,18 +187,17 @@ BOOST_AUTO_TEST_CASE(TestGasInjector) {
     auto deck = createDeckWithGasInjector();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
     Schedule schedule(deck, grid , fp, runspec);
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
-
 }
 
 BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
     auto deck = createDeckWithDynamicWSOLVENT();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
     Schedule schedule(deck, grid , fp, runspec);
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(TestOilInjector) {
     auto deck = createDeckWithOilInjector();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
     BOOST_CHECK_THROW (Schedule(deck , grid , fp, runspec), std::invalid_argument);
 }
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(TestWaterInjector) {
     auto deck = createDeckWithWaterInjector();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
     BOOST_CHECK_THROW (Schedule(deck, grid , fp, runspec), std::invalid_argument);
 }

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -33,6 +33,7 @@
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
@@ -86,7 +87,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
     auto deck = parser.parseString(input);
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Opm::Runspec runspec (deck);
     Opm::Schedule schedule(deck, grid , fp, runspec);
     const auto& op_1 = schedule.getWell("OP_1", 2);
@@ -126,7 +127,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestDefaultTRACK) {
     auto deck = parser.parseString(input);
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Opm::Runspec runspec (deck);
     Opm::Schedule schedule(deck, grid , fp, runspec);
     const auto& op_1 = schedule.getWell("OP_1", 2);
@@ -169,7 +170,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestINPUT) {
     Opm::EclipseGrid grid(10,10,10);
     Opm::ErrorGuard errors;
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Opm::Runspec runspec (deck);
     Opm::Schedule schedule(deck, grid , fp, runspec, Opm::ParseContext(), errors);
     const auto& op_1 = schedule.getWell("OP_1", 2);
@@ -844,7 +845,7 @@ BOOST_AUTO_TEST_CASE(WELOPEN) {
     auto deck = parser.parseString(input);
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Opm::Runspec runspec (deck);
     Opm::Schedule schedule(deck, grid , fp, runspec);
     {
@@ -855,5 +856,4 @@ BOOST_AUTO_TEST_CASE(WELOPEN) {
         const auto& op_1 = schedule.getWell("OP_1", 2);
         BOOST_CHECK(op_1.getStatus() == Well::Status::SHUT);
     }
-
 }

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
@@ -133,7 +134,7 @@ BOOST_AUTO_TEST_CASE(TestNoTracer) {
     auto deck = createDeckWithOutTracer();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec ( deck );
     Schedule schedule(deck, grid , fp, runspec);
     BOOST_CHECK(!deck.hasKeyword("WTRACER"));
@@ -144,7 +145,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER) {
     auto deck = createDeckWithDynamicWTRACER();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec ( deck );
     Schedule schedule(deck, grid , fp, runspec);
     BOOST_CHECK(deck.hasKeyword("WTRACER"));
@@ -166,9 +167,8 @@ BOOST_AUTO_TEST_CASE(TestTracerInProducerTHROW) {
     auto deck = createDeckWithTracerInProducer();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec ( deck );
 
     BOOST_CHECK_THROW(Schedule(deck, grid, fp, runspec), std::invalid_argument);
 }
-

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -22,6 +22,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
@@ -1366,7 +1368,7 @@ BOOST_AUTO_TEST_CASE( WCONPROD ) {
     auto deck =  parser.parseFile(wconprodFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
-    FieldPropsManager fp( deck , grid, table);
+    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck, grid, fp, runspec );
 
@@ -1412,7 +1414,7 @@ BOOST_AUTO_TEST_CASE( WCONINJE ) {
     auto deck = parser.parseFile(wconprodFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched( deck, grid, fp, runspec);
     SummaryState st(std::chrono::system_clock::now());

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -27,6 +27,8 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
@@ -53,7 +55,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
     auto deck2 = parser.parseString( ss.str());
     for (const auto& deck : {deck1 , deck2}) {
         TableManager table ( deck );
-        FieldPropsManager fp(deck, grid, table);
+        FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
         Runspec runspec (deck);
         Schedule sched(deck,  grid , fp, runspec);
         const auto& timeMap = sched.getTimeMap();
@@ -70,7 +72,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
     const auto& timeMap = sched.getTimeMap();
@@ -85,7 +87,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_MissingCmode) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     BOOST_CHECK_NO_THROW( Schedule(deck, grid , fp, runspec) );
 }
@@ -97,7 +99,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_Missing_DATA) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     BOOST_CHECK_THROW( Schedule(deck, grid , fp, runspec) , std::invalid_argument );
 }
@@ -109,7 +111,7 @@ BOOST_AUTO_TEST_CASE(WellTestRefDepth) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck , grid , fp, runspec);
 
@@ -131,7 +133,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -276,7 +278,7 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT_DEFAULTED_ITEMS) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 }
@@ -288,7 +290,7 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,60,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -323,7 +325,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_correct) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule schedule(deck,  grid , fp, runspec);
 
@@ -345,7 +347,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -366,7 +368,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
     SummaryState st(std::chrono::system_clock::now());
@@ -417,7 +419,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -479,7 +481,7 @@ BOOST_AUTO_TEST_CASE(WellTestWGRUPCONWellPropertiesSet) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -527,7 +529,7 @@ COMPDAT \n\
     auto deck =  parser.parseString(deckString);
     EclipseGrid grid(30,30,10);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
     const auto& connections = sched.getWell("W1", 0).getConnections();
@@ -546,8 +548,8 @@ BOOST_AUTO_TEST_CASE(OpmCode) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(10,10,5);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
     Runspec runspec (deck);
+    FieldPropsManager fp(deck, runspec.phases(), grid, table);
     BOOST_CHECK_NO_THROW( Schedule(deck , grid , fp, runspec) );
 }
 
@@ -559,7 +561,7 @@ BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(20,40,1);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -589,7 +591,7 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -656,7 +658,7 @@ BOOST_AUTO_TEST_CASE(WellTestWFOAM) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -723,7 +725,7 @@ BOOST_AUTO_TEST_CASE(WellTestWECON) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck,  grid , fp, runspec);
 
@@ -833,7 +835,7 @@ BOOST_AUTO_TEST_CASE(TestEvents) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,40,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched(deck , grid , fp, runspec);
     const Events& events = sched.getEvents();
@@ -867,7 +869,7 @@ BOOST_AUTO_TEST_CASE(TestWellEvents) {
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(40,40,30);
     TableManager table ( deck );
-    FieldPropsManager fp(deck, grid, table);
+    FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
     Schedule sched(deck , grid , fp, runspec);
 


### PR DESCRIPTION
This changeset passes the run's notion of its active phases, an object of type `Opm::Phases`, through to the initialisation layer for the saturation functions' scaling properties.  In particular, this allows us to discriminate between the phases and to not index into tables or properties that would not be appropriate (e.g., maximum gas saturation (SGU) in a simulation run without active gas).

Moreover, we now have enough information to know to look for SOF2 in two-phase run using family II saturation function keywords.  These changes are necessary in order to extend Flow's support for the FILLEPS output request to two-phase runs.

As a result, this allows us to reenable honouring the `FILLEPS` keyword when outputting the INIT file for two-phase systems (O/G and O/W).  This was disabled in commit c736e71 (PR #1087) due to the issue raised in #1078.

This PR closes #1078.