### PR TITLE
Time map rm cons

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -37,24 +37,9 @@ namespace Opm {
 
     class TimeMap {
     public:
-        struct StepData
-        {
-            size_t stepnumber;
-            TimeStampUTC timestamp;
-
-            bool operator==(const StepData& data) const
-            {
-                return stepnumber == data.stepnumber &&
-                       timestamp == data.timestamp;
-            }
-        };
-
         TimeMap() = default;
         explicit TimeMap(const Deck& deck);
         explicit TimeMap(const std::vector<std::time_t>& time_points);
-        TimeMap(const std::vector<std::time_t>& timeList,
-                const std::vector<StepData>& firstStepMonths,
-                const std::vector<StepData>& firstStepYears);
 
         size_t size() const;
         size_t last() const;
@@ -72,9 +57,6 @@ namespace Opm {
         double getTimeStepLength(size_t tStepIdx) const;
 
         const std::vector<std::time_t>& timeList() const;
-        const std::vector<StepData>& firstTimeStepMonths() const;
-        const std::vector<StepData>& firstTimeStepYears() const;
-
         bool operator==(const TimeMap& data) const;
 
         /// Return true if the given timestep is the first one of a new month or year, or if frequency > 1,
@@ -89,6 +71,17 @@ namespace Opm {
         static std::time_t mkdatetime(int year, int month, int day, int hour, int minute, int second);
         static const std::map<std::string, int>& eclipseMonthIndices();
     private:
+        struct StepData
+        {
+            size_t stepnumber;
+            TimeStampUTC timestamp;
+
+            bool operator==(const StepData& data) const
+            {
+                return stepnumber == data.stepnumber &&
+                       timestamp == data.timestamp;
+            }
+        };
 
         std::vector<std::time_t> m_timeList;
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -96,15 +96,6 @@ namespace {
         }
     }
 
-    TimeMap::TimeMap(const std::vector<std::time_t>& timeList,
-                     const std::vector<StepData>& firstStepMonths,
-                     const std::vector<StepData>& firstStepYears)
-        : m_timeList(timeList)
-        , m_first_timestep_years(firstStepYears)
-        , m_first_timestep_months(firstStepMonths)
-    {
-    }
-
 
     size_t TimeMap::numTimesteps() const {
         return m_timeList.size() - 1;
@@ -241,21 +232,12 @@ namespace {
         return m_timeList;
     }
 
-    const std::vector<TimeMap::StepData>& TimeMap::firstTimeStepMonths() const
-    {
-        return m_first_timestep_months;
-    }
-
-    const std::vector<TimeMap::StepData>& TimeMap::firstTimeStepYears() const
-    {
-        return m_first_timestep_years;
-    }
 
     bool TimeMap::operator==(const TimeMap& data) const
     {
-        return this->timeList() == data.timeList() &&
-               this->firstTimeStepMonths() == data.firstTimeStepMonths() &&
-               this->firstTimeStepYears() == data.firstTimeStepYears();
+        return this->m_timeList == data.m_timeList &&
+               this->m_first_timestep_months == data.m_first_timestep_months &&
+               this->m_first_timestep_years == data.m_first_timestep_years;
     }
 
     bool TimeMap::isTimestepInFirstOfMonthsYearsSequence(size_t timestep, bool years, size_t start_timestep, size_t frequency) const {


### PR DESCRIPTION
With the new constructor added in #1425 it should be possible to serialize using the normal (new) constructor; have therefor removed the code specially added for serialization. 

PR in opm-simulators coming.