### PR TITLE
Time map restart

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -26,6 +26,7 @@
 #include <vector>
 #include <ctime>
 #include <map>
+#include <utility>
 
 #include <stddef.h>
 
@@ -38,7 +39,7 @@ namespace Opm {
     class TimeMap {
     public:
         TimeMap() = default;
-        explicit TimeMap(const Deck& deck);
+        explicit TimeMap(const Deck& deck, const std::pair<std::time_t, std::size_t>& restart = std::make_pair(std::time_t{0}, std::size_t{0}));
         explicit TimeMap(const std::vector<std::time_t>& time_points);
 
         size_t size() const;
@@ -83,17 +84,17 @@ namespace Opm {
             }
         };
 
-        std::vector<std::time_t> m_timeList;
-
         bool isTimestepInFreqSequence (size_t timestep, size_t start_timestep, size_t frequency, bool years) const;
         size_t closest(const std::vector<size_t> & vec, size_t value) const;
         void addTStep(int64_t step);
         void addTime(std::time_t newTime);
-        void addFromDATESKeyword( const DeckKeyword& DATESKeyword );
         void addFromTSTEPKeyword( const DeckKeyword& TSTEPKeyword );
+        void init_start(std::time_t start_time);
 
+        std::vector<std::time_t> m_timeList;
         std::vector<StepData> m_first_timestep_years;   // A list of the first timestep of every year
         std::vector<StepData> m_first_timestep_months;  // A list of the first timestep of every month
+        std::size_t restart_offset = 0;
     };
 }
 


### PR DESCRIPTION
Add optional restart information to a a time_map. If the restart information is provided in the time map constructor the time points before the restart date are blanked out with an invalid value.

Another step on this journey: https://github.com/OPM/opm-common/issues/1396