### PR TITLE
Add class to internalize BC keyword - and add to SimulationConfig

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -130,6 +130,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
+    src/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
     src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
     src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
     src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -655,6 +656,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.hpp
        opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+       opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp
        opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
@@ -1,0 +1,91 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_BCCONFIG_HPP
+#define OPM_BCCONFIG_HPP
+
+#include <vector>
+#include <cstddef>
+
+#include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
+
+
+namespace Opm {
+
+class Deck;
+class DeckRecord;
+
+enum class BCType {
+     RATE,
+     FREE
+};
+
+enum class BCComponent {
+     OIL,
+     GAS,
+     WATER,
+     SOLVENT,
+     POLYMER,
+     NONE
+};
+
+
+class BCConfig {
+public:
+
+    struct BCFace {
+        int i1,i2;
+        int j1,j2;
+        int k1,k2;
+        BCType bctype;
+        FaceDir::DirEnum dir;
+        BCComponent component;
+        double rate;
+
+
+        BCFace() = default;
+        BCFace(const DeckRecord& record);
+        BCFace(std::size_t i1_arg, std::size_t i2_arg,
+               std::size_t j1_arg, std::size_t j2_arg,
+               std::size_t k1_arg, std::size_t k2_arg,
+               BCType type_arg,
+               FaceDir::DirEnum dir_arg,
+               BCComponent comp_arg,
+               double rate_arg);
+        bool operator==(const BCFace& other) const;
+    };
+
+
+    BCConfig() = default;
+    explicit BCConfig(const std::vector<BCFace>& input_faces);
+    explicit BCConfig(const Deck& deck);
+    const std::vector<BCConfig::BCFace>& faces() const;
+    std::size_t size() const;
+    std::vector<BCFace>::const_iterator begin() const;
+    std::vector<BCFace>::const_iterator end() const;
+    bool operator==(const BCConfig& other) const;
+private:
+    std::vector<BCFace> m_faces;
+};
+
+} //namespace Opm
+
+
+
+#endif

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -21,6 +21,7 @@
 #define OPM_SIMULATION_CONFIG_HPP
 
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
 
 namespace Opm {
 
@@ -36,9 +37,11 @@ namespace Opm {
                          const Deck& deck,
                          const FieldPropsManager& fp);
         SimulationConfig(const ThresholdPressure& thresholdPressure,
+                         const BCConfig& bc,
                          bool useCPR, bool DISGAS, bool VAPOIL, bool isThermal);
 
         const ThresholdPressure& getThresholdPressure() const;
+        const BCConfig& bcconfig() const;
         bool useThresholdPressure() const;
         bool useCPR() const;
         bool hasDISGAS() const;
@@ -49,6 +52,7 @@ namespace Opm {
 
     private:
         ThresholdPressure m_ThresholdPressure;
+        BCConfig m_bcconfig;
         bool m_useCPR;
         bool m_DISGAS;
         bool m_VAPOIL;

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
@@ -1,0 +1,155 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.
+*/
+
+#include <string>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/B.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
+
+namespace Opm {
+namespace {
+
+namespace fromstring {
+
+BCType bctype(const std::string& s) {
+    if (s == "RATE")
+        return BCType::RATE;
+
+    if (s == "FREE")
+        return BCType::FREE;
+
+    throw std::invalid_argument("Not recognized boundary condition type: " + s);
+}
+
+
+BCComponent component(const std::string& s) {
+    if (s == "OIL")
+        return BCComponent::OIL;
+
+    if (s == "GAS")
+        return BCComponent::GAS;
+
+    if (s == "WATER")
+        return BCComponent::WATER;
+
+    if (s == "SOLVENT")
+        return BCComponent::SOLVENT;
+
+    if (s == "POLYMER")
+        return BCComponent::POLYMER;
+
+    if (s == "NONE")
+        return BCComponent::NONE;
+
+    throw std::invalid_argument("Not recognized boundary condition compononet: " + s);
+}
+
+}
+}
+
+BCConfig::BCFace::BCFace(const DeckRecord& record) :
+    i1(record.getItem("I1").get<int>(0) - 1),
+    i2(record.getItem("I2").get<int>(0) - 1),
+    j1(record.getItem("J1").get<int>(0) - 1),
+    j2(record.getItem("J2").get<int>(0) - 1),
+    k1(record.getItem("K1").get<int>(0) - 1),
+    k2(record.getItem("K2").get<int>(0) - 1),
+    bctype(fromstring::bctype(record.getItem("TYPE").get<std::string>(0))),
+    dir(FaceDir::FromString(record.getItem("DIRECTION").get<std::string>(0))),
+    component(fromstring::component(record.getItem("COMPONENT").get<std::string>(0))),
+    rate(record.getItem("RATE").getSIDouble(0))
+{
+}
+
+
+BCConfig::BCFace::BCFace(std::size_t i1_arg, std::size_t i2_arg,
+                         std::size_t j1_arg, std::size_t j2_arg,
+                         std::size_t k1_arg, std::size_t k2_arg,
+                         BCType type_arg,
+                         FaceDir::DirEnum dir_arg,
+                         BCComponent comp_arg,
+                         double rate_arg) :
+    i1(i1_arg),
+    i2(i2_arg),
+    j1(j1_arg),
+    j2(j2_arg),
+    k1(k1_arg),
+    k2(k2_arg),
+    bctype(type_arg),
+    dir(dir_arg),
+    component(comp_arg),
+    rate(rate_arg)
+{}
+
+
+
+bool BCConfig::BCFace::operator==(const BCConfig::BCFace& other) const {
+    return this->i1 == other.i1 &&
+           this->i2 == other.i2 &&
+           this->j1 == other.j1 &&
+           this->j2 == other.j2 &&
+           this->k1 == other.k1 &&
+           this->k2 == other.k2 &&
+           this->bctype == other.bctype &&
+           this->dir == other.dir &&
+           this->component == other.component &&
+           this->rate == other.rate;
+}
+
+
+
+BCConfig::BCConfig(const Deck& deck) {
+    for (const auto& kw: deck.getKeywordList<ParserKeywords::BC>()) {
+        for (const auto& record : *kw)
+            this->m_faces.emplace_back( record );
+    }
+}
+
+
+BCConfig::BCConfig(const std::vector<BCFace>& input_faces):
+    m_faces(input_faces)
+{}
+
+
+
+const std::vector<BCConfig::BCFace>& BCConfig::faces() const {
+    return this->m_faces;
+}
+
+
+std::size_t BCConfig::size() const {
+    return this->m_faces.size();
+}
+
+std::vector<BCConfig::BCFace>::const_iterator BCConfig::begin() const {
+    return this->m_faces.begin();
+}
+
+std::vector<BCConfig::BCFace>::const_iterator BCConfig::end() const {
+    return this->m_faces.end();
+}
+
+bool BCConfig::operator==(const BCConfig& other) const {
+    return this->m_faces == other.m_faces;
+}
+
+
+} //namespace Opm
+

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -48,7 +48,7 @@
 namespace Opm {
 
     SimulationConfig::SimulationConfig() :
-        SimulationConfig(ThresholdPressure(), false, false, false, false)
+        SimulationConfig(ThresholdPressure(), BCConfig(), false, false, false, false)
     {
     }
 
@@ -56,6 +56,7 @@ namespace Opm {
                                        const Deck& deck,
                                        const FieldPropsManager& fp) :
         m_ThresholdPressure( restart, deck, fp),
+        m_bcconfig(deck),
         m_useCPR(false),
         m_DISGAS(false),
         m_VAPOIL(false),
@@ -83,9 +84,11 @@ namespace Opm {
     }
 
     SimulationConfig::SimulationConfig(const ThresholdPressure& thresholdPressure,
+                                       const BCConfig& bcconfig,
                                        bool useCPR, bool DISGAS,
                                        bool VAPOIL, bool isThermal) :
         m_ThresholdPressure(thresholdPressure),
+        m_bcconfig(bcconfig),
         m_useCPR(useCPR),
         m_DISGAS(DISGAS),
         m_VAPOIL(VAPOIL),
@@ -95,6 +98,10 @@ namespace Opm {
 
     const ThresholdPressure& SimulationConfig::getThresholdPressure() const {
         return m_ThresholdPressure;
+    }
+
+    const BCConfig& SimulationConfig::bcconfig() const {
+        return m_bcconfig;
     }
 
     bool SimulationConfig::useThresholdPressure() const {
@@ -119,6 +126,7 @@ namespace Opm {
 
     bool SimulationConfig::operator==(const SimulationConfig& data) const {
         return this->getThresholdPressure() == data.getThresholdPressure() &&
+               this->bcconfig() == data.bcconfig() &&
                this->useCPR() == data.useCPR() &&
                this->hasDISGAS() == data.hasDISGAS() &&
                this->hasVAPOIL() == data.hasVAPOIL() &&


### PR DESCRIPTION
Simple class to internalize Boundary Conditions in EclipseState - and reduce Deck usage downstream.