### PR TITLE
Internalise TOLCRIT Keyword

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -183,7 +183,22 @@ private:
     int krHystMod { 0 };
 };
 
+class SatFuncControls {
+public:
+    SatFuncControls();
+    explicit SatFuncControls(const Deck& deck);
+    explicit SatFuncControls(const double tolcritArg);
 
+    double minimumRelpermMobilityThreshold() const
+    {
+        return this->tolcrit;
+    }
+
+    bool operator==(const SatFuncControls& rhs) const;
+
+private:
+    double tolcrit;
+};
 
 class Runspec {
 public:
@@ -196,7 +211,8 @@ public:
             const WellSegmentDims& wsegDims,
             const UDQParams& udqparams,
             const EclHysterConfig& hystPar,
-            const Actdims& actDims);
+            const Actdims& actDims,
+            const SatFuncControls& sfuncctrl);
 
     const UDQParams& udqParams() const noexcept;
     const Phases& phases() const noexcept;
@@ -207,6 +223,7 @@ public:
     int eclPhaseMask( ) const noexcept;
     const EclHysterConfig& hysterPar() const noexcept;
     const Actdims& actdims() const noexcept;
+    const SatFuncControls& saturationFunctionControls() const noexcept;
 
     bool operator==(const Runspec& data) const;
 
@@ -219,10 +236,10 @@ private:
     UDQParams udq_params;
     EclHysterConfig hystpar;
     Actdims m_actdims;
+    SatFuncControls m_sfuncctrl;
 };
 
 
 }
 
 #endif // OPM_RUNSPEC_HPP
-

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -477,6 +477,54 @@ BOOST_AUTO_TEST_CASE( SWATINIT ) {
 
 }
 
+BOOST_AUTO_TEST_CASE(TolCrit)
+{
+    {
+        const auto sfctrl = ::Opm::SatFuncControls{};
+        BOOST_CHECK_CLOSE(sfctrl.minimumRelpermMobilityThreshold(), 1.0e-6, 1.0e-10);
+        BOOST_CHECK_MESSAGE(sfctrl == ::Opm::SatFuncControls{},
+                            "Default-constructed SatFuncControl must equal itself");
+    }
+
+    {
+        const auto sfctrl = ::Opm::SatFuncControls{ 5.0e-7 };
+        BOOST_CHECK_CLOSE(sfctrl.minimumRelpermMobilityThreshold(), 5.0e-7, 1.0e-10);
+        BOOST_CHECK_MESSAGE(!(sfctrl == ::Opm::SatFuncControls{}),
+                            "Default-constructed SatFuncControl must NOT equal non-default");
+
+        const auto deck = ::Opm::Parser{}.parseString(R"(
+TOLCRIT
+  5.0E-7 /
+)");
+        BOOST_CHECK_CLOSE(sfctrl.minimumRelpermMobilityThreshold(),
+                          ::Opm::SatFuncControls{deck}.minimumRelpermMobilityThreshold(),
+                          1.0e-10);
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(
+RUNSPEC
+END
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_CLOSE(sfctrl.minimumRelpermMobilityThreshold(), 1.0e-6, 1.0e-10);
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(
+TOLCRIT
+  5.0E-7 /
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_CLOSE(sfctrl.minimumRelpermMobilityThreshold(), 5.0e-7, 1.0e-10);
+    }
+}
 
 BOOST_AUTO_TEST_CASE(Solvent) {
     const std::string input = R"(


### PR DESCRIPTION
This commit internalises the TOLCRIT keyword into the `EclipseState` for subsequent use in determining critical saturations when processing saturation function keywords such as SGOF and SOF3. Specifically, we add a new type
```
Opm::SatFuncControls
```
that, at present, stores only the TOLCRIT data item (defaulted to the keyword's default value).  Client code can then retrieve the value by calling the
```C++
SatFuncControls::minimumRelpermMobilityThreshold()
```
member function.

Add a new data member of this type to the `Opm::Runspec` class so that we complete the chain from `EclipseState`, and a few simple unit tests to exercise the expected functionality.