### PR TITLE
changed: hide the templated 'has' and 'get' interfaces in FieldPropsManager

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -113,26 +113,6 @@ public:
 
 
     /*
-      Return the keyword values as a std::vector<>. All elements in the return
-      value are guaranteed to be assigned a valid value. If the keyword is not
-      in the container, or not all elements have a valid value - an exception
-      will be raised:
-
-       - keyword which is not supported at all -> std::logic_error
-       - keyword which is not in the deck at all -> std::out_of_range
-       - keyword which has not been fully initialized -> std::runtime_error
-
-      Many of the keywords in the container can be automatically created, in
-      that case the get() method will silently create a new keyword and default
-      initialize if it is not already in the container. The different exceptions
-      raised for the different error conditions are the same for get(),
-      get_copy() and get_global().
-    */
-    template <typename T>
-    const std::vector<T>& get(const std::string& keyword) const;
-
-
-    /*
       The get_copy() has exactly the same behaviour as get(), but the important
       difference is that said keyword is not already in the container it is not
       installed in the container; if we look at SATNUM which is a keywor which
@@ -155,14 +135,6 @@ public:
     std::vector<T> get_copy(const std::string& keyword, bool global=false) const;
 
     /*
-      This is exactly like the get() method, but the returned vector will have
-      global cartesian size, where all inactive cells have been filled with
-      zeros.
-    */
-    template <typename T>
-    std::vector<T> get_global(const std::string& keyword) const;
-
-    /*
       Will return a pointer to the keyword data, or nullptr if the container
       does not have suce a keyword. Observe that container will hold on to an
       manage the underlying keyword data.
@@ -173,14 +145,6 @@ public:
     */
     template <typename T> const std::vector<T>* try_get(const
     std::string& keyword) const;
-
-    /*
-      Will check if the container has the keyword loaded; in a fully initialized
-      state. If you ask for a keyword which is not supported at all you will
-      just get false back.
-    */
-    template <typename T>
-    bool has(const std::string& keyword) const;
 
     /*
       You can ask whether the elements in the keyword have a default value -
@@ -213,9 +177,6 @@ public:
     template <typename T>
     std::vector<std::string> keys() const;
 
-    /*
-      Don't understand why - but these are needed to work with opm-simulators heavily templated code?!
-     */
     const std::vector<int>& get_int(const std::string& keyword) const { return this->get<int>(keyword); }
     std::vector<int> get_global_int(const std::string& keyword) const { return this->get_global<int>(keyword); }
 
@@ -226,6 +187,42 @@ public:
     bool has_double(const std::string& keyword) const { return this->has<double>(keyword); }
 
 private:
+    /*
+      Return the keyword values as a std::vector<>. All elements in the return
+      value are guaranteed to be assigned a valid value. If the keyword is not
+      in the container, or not all elements have a valid value - an exception
+      will be raised:
+
+       - keyword which is not supported at all -> std::logic_error
+       - keyword which is not in the deck at all -> std::out_of_range
+       - keyword which has not been fully initialized -> std::runtime_error
+
+      Many of the keywords in the container can be automatically created, in
+      that case the get() method will silently create a new keyword and default
+      initialize if it is not already in the container. The different exceptions
+      raised for the different error conditions are the same for get(),
+      get_copy() and get_global().
+    */
+    template <typename T>
+    const std::vector<T>& get(const std::string& keyword) const;
+
+    /*
+      Will check if the container has the keyword loaded; in a fully initialized
+      state. If you ask for a keyword which is not supported at all you will
+      just get false back.
+    */
+    template <typename T>
+    bool has(const std::string& keyword) const;
+
+    /*
+      This is exactly like the get() method, but the returned vector will have
+      global cartesian size, where all inactive cells have been filled with
+      zeros.
+    */
+    template <typename T>
+    std::vector<T> get_global(const std::string& keyword) const;
+
+
     std::shared_ptr<FieldProps> fp;
 };
 

--- a/python/cxx/field_props.cpp
+++ b/python/cxx/field_props.cpp
@@ -10,35 +10,35 @@
 namespace {
 
     bool contains( const FieldPropsManager& manager, const std::string& kw) {
-        if (manager.has<int>(kw))
+        if (manager.has_int(kw))
             return true;
-        if (manager.has<double>(kw))
+        if (manager.has_double(kw))
             return true;
 
         return false;
     }
 
     py::array_t<double> get_double_array(const FieldPropsManager& m, const std::string& kw) {
-        if (m.has<double>(kw))
-            return convert::numpy_array( m.get<double>(kw) );
+        if (m.has_double(kw))
+            return convert::numpy_array( m.get_double(kw) );
         else
             throw std::invalid_argument("Keyword '" + kw + "'is not of type double.");
     }
 
     py::array_t<int> get_int_array(const FieldPropsManager& m, const std::string& kw) {
-        if (m.has<int>(kw))
-            return convert::numpy_array( m.get<int>(kw) );
+        if (m.has_int(kw))
+            return convert::numpy_array( m.get_int(kw) );
         else
             throw std::invalid_argument("Keyword '" + kw + "'is not of type int.");
     }
 
 
     py::array get_array(const FieldPropsManager& m, const std::string& kw) {
-        if (m.has<double>(kw))
-            return convert::numpy_array(m.get<double>(kw));
+        if (m.has_double(kw))
+            return convert::numpy_array(m.get_double(kw));
 
-        if (m.has<int>(kw))
-            return convert::numpy_array(m.get<int>(kw));
+        if (m.has_int(kw))
+            return convert::numpy_array(m.get_int(kw));
 
         throw std::invalid_argument("No such keyword: " + kw);
     }

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2088,7 +2088,7 @@ SummaryImplementation(const EclipseState&  es,
                       const Schedule&      sched,
                       const std::string&   basename)
     : grid_          (std::cref(grid))
-    , regCache_      (es.fieldProps().get<int>("FIPNUM"), grid, sched)
+    , regCache_      (es.fieldProps().get_int("FIPNUM"), grid, sched)
     , deferredSMSpec_(makeDeferredSMSpecCreation(es, grid, sched))
     , rset_          (makeResultSet(es.cfg().io(), basename))
     , fmt_           { es.cfg().io().getFMTOUT() }

--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -330,13 +330,13 @@ namespace {
         // invoke the autocreation property, and ensure that the keywords
         // exist in the properties container.
         const auto& fp = es.fieldProps();
-        fp.get<int>("PVTNUM");
-        fp.get<int>("SATNUM");
-        fp.get<int>("EQLNUM");
-        fp.get<int>("FIPNUM");
+        fp.get_int("PVTNUM");
+        fp.get_int("SATNUM");
+        fp.get_int("EQLNUM");
+        fp.get_int("FIPNUM");
 
         for (const auto& keyword : fp.keys<int>())
-            initFile.write(keyword, fp.get<int>(keyword));
+            initFile.write(keyword, fp.get_int(keyword));
 
     }
 
@@ -370,17 +370,17 @@ namespace {
         initFile.write("DZ"   , dz);
     }
 
-    template <typename T, class WriteVector>
-    void writeCellPropertiesWithDefaultFlag(const Properties& propList,
-                                            const ::Opm::FieldPropsManager& fp,
-                                            WriteVector&&  write)
+    template <class WriteVector>
+    void writeCellDoublePropertiesWithDefaultFlag(const Properties& propList,
+                                                  const ::Opm::FieldPropsManager& fp,
+                                                  WriteVector&&  write)
     {
         for (const auto& prop : propList) {
-            if (! fp.has<T>(prop.name))
+            if (! fp.has_double(prop.name))
                 continue;
 
-            auto data = fp.get<T>(prop.name);
-            auto defaulted = fp.defaulted<T>(prop.name);
+            auto data = fp.get_double(prop.name);
+            auto defaulted = fp.defaulted<double>(prop.name);
             write(prop, std::move(defaulted), std::move(data));
         }
     }
@@ -392,9 +392,9 @@ namespace {
     {
         for (const auto& prop : propList) {
 
-            if (!fp.has<double>(prop.name))
+            if (!fp.has_double(prop.name))
                 continue;
-            auto data = fp.get<double>(prop.name);
+            auto data = fp.get_double(prop.name);
             write(prop, std::move(data));
         }
     }
@@ -406,7 +406,7 @@ namespace {
                                    ::Opm::EclIO::OutputStream::Init&    initFile)
     {
         if (needDflt) {
-            writeCellPropertiesWithDefaultFlag<double>(propList, fp,
+            writeCellDoublePropertiesWithDefaultFlag(propList, fp,
                 [&units, &initFile](const CellProperty&   prop,
                                     std::vector<bool>&&   dflt,
                                     std::vector<double>&& value)
@@ -454,7 +454,7 @@ namespace {
         // therefore invoke the auto create functionality to ensure
         // that "NTG" is included in the properties container.
         const auto& fp = es.fieldProps();
-        es.fieldProps().get<double>("NTG");
+        es.fieldProps().get_double("NTG");
         writeDoubleCellProperties(doubleKeywords, fp,
                                   units, false, initFile);
     }
@@ -506,7 +506,7 @@ namespace {
                                    ::Opm::EclIO::OutputStream::Init& initFile)
     {
         for (const auto& prop : propList)
-            fp.get<double>(prop.name);
+            fp.get_double(prop.name);
 
         // Don't write sentinel value if input defaulted.
         writeDoubleCellProperties(propList, fp,

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -199,14 +199,14 @@ bool enable3DPropsTesting() {
 
     void EclipseState::initTransMult() {
         const auto& fp = this->field_props;
-        if (fp.has<double>("MULTX"))  this->m_transMult.applyMULT(fp.get_global<double>("MULTX") , FaceDir::XPlus);
-        if (fp.has<double>("MULTX-")) this->m_transMult.applyMULT(fp.get_global<double>("MULTX-"), FaceDir::XMinus);
+        if (fp.has_double("MULTX"))  this->m_transMult.applyMULT(fp.get_global_double("MULTX") , FaceDir::XPlus);
+        if (fp.has_double("MULTX-")) this->m_transMult.applyMULT(fp.get_global_double("MULTX-"), FaceDir::XMinus);
 
-        if (fp.has<double>("MULTY"))  this->m_transMult.applyMULT(fp.get_global<double>("MULTY") , FaceDir::YPlus);
-        if (fp.has<double>("MULTY-")) this->m_transMult.applyMULT(fp.get_global<double>("MULTY-"), FaceDir::YMinus);
+        if (fp.has_double("MULTY"))  this->m_transMult.applyMULT(fp.get_global_double("MULTY") , FaceDir::YPlus);
+        if (fp.has_double("MULTY-")) this->m_transMult.applyMULT(fp.get_global_double("MULTY-"), FaceDir::YMinus);
 
-        if (fp.has<double>("MULTZ"))  this->m_transMult.applyMULT(fp.get_global<double>("MULTZ") , FaceDir::ZPlus);
-        if (fp.has<double>("MULTZ-")) this->m_transMult.applyMULT(fp.get_global<double>("MULTZ-"), FaceDir::ZMinus);
+        if (fp.has_double("MULTZ"))  this->m_transMult.applyMULT(fp.get_global_double("MULTZ") , FaceDir::ZPlus);
+        if (fp.has_double("MULTZ-")) this->m_transMult.applyMULT(fp.get_global_double("MULTZ-"), FaceDir::ZMinus);
     }
 
     void EclipseState::initFaults(const Deck& deck) {

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -120,7 +120,7 @@ std::vector<int> unique(const std::vector<int> data) {
         MULTREGTSearchMap searchPairs;
         for (std::vector<MULTREGTRecord>::const_iterator record = m_records.begin(); record != m_records.end(); ++record) {
             const std::string& region_name = record->region_name;
-            if (this->fp->has<int>( region_name)) {
+            if (this->fp->has_int( region_name)) {
                 int srcRegion    = record->src_value;
                 int targetRegion = record->target_value;
 
@@ -140,7 +140,7 @@ std::vector<int> unique(const std::vector<int> data) {
                                 + " which is not in the deck");
 
             if (this->regions.count(region_name) == 0)
-                this->regions[region_name] = this->fp->get_global<int>(region_name);
+                this->regions[region_name] = this->fp->get_global_int(region_name);
         }
 
         for (auto iter = searchPairs.begin(); iter != searchPairs.end(); ++iter) {
@@ -216,12 +216,12 @@ std::vector<int> unique(const std::vector<int> data) {
                 region_name = MULTREGT::RegionNameFromDeckValue( regionItem.get<std::string>(0) );
 
             if (srcItem.defaultApplied(0) || srcItem.get<int>(0) < 0)
-                src_regions = unique(this->fp->get<int>(region_name));
+                src_regions = unique(this->fp->get_int(region_name));
             else
                 src_regions.push_back(srcItem.get<int>(0));
 
             if (targetItem.defaultApplied(0) || targetItem.get<int>(0) < 0)
-                target_regions = unique(fp->get<int>(region_name));
+                target_regions = unique(fp->get_int(region_name));
             else
                 target_regions.push_back(targetItem.get<int>(0));
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -216,8 +216,8 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         const auto permx        = field_properties.try_get<double>("PERMX");
         const auto permy        = field_properties.try_get<double>("PERMY");
         const auto permz        = field_properties.try_get<double>("PERMZ");
-        const auto& ntg         = field_properties.get<double>("NTG");
-        const auto& satnum_data = field_properties.get<int>("SATNUM");
+        const auto& ntg         = field_properties.get_double("NTG");
+        const auto& satnum_data = field_properties.get_int("SATNUM");
 
         this->loadCOMPDAT(record, grid, satnum_data, permx, permy, permz, ntg);
     }

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -88,10 +88,10 @@ namespace Opm {
 
         //Option is set and keyword is found
         if( m_active && thpresKeyword ) {
-            if (!fp.has<int>("EQLNUM"))
+            if (!fp.has_int("EQLNUM"))
                 throw std::runtime_error("Error when internalizing THPRES: EQLNUM keyword not found in deck");
 
-            const auto& eqlnum = fp.get<int>("EQLNUM");
+            const auto& eqlnum = fp.get_int("EQLNUM");
 
             //Find max of eqlnum
             int maxEqlnum = *std::max_element(eqlnum.begin(), eqlnum.end());

--- a/src/opm/parser/eclipse/Python/PythonInterp.hpp
+++ b/src/opm/parser/eclipse/Python/PythonInterp.hpp
@@ -69,7 +69,7 @@ public:
         return this->fail();
     }
 
-    bool exec(const PyAction&, EclipseState& ecl_state, Schedule&, std::size_t, SummaryState& ) {
+    bool exec(const PyAction&, EclipseState&, Schedule&, std::size_t, SummaryState& ) {
         return this->fail();
     }
 

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -969,7 +969,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
     const auto& fp = es.fieldProps();
     const auto& grid = es.getInputGrid();
 
-    BOOST_CHECK_NO_THROW(fp.get<int>("ACTNUM"));
+    BOOST_CHECK_NO_THROW(fp.get_int("ACTNUM"));
 
     size_t active = 10 * 10 * 10     // 1000
                     - (10 * 10 * 1)  // - top layer
@@ -1024,7 +1024,7 @@ BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
     std::vector<int> actnum = {1, 1, 0, 1, 1, 0, 1, 1};
     Opm::EclipseGrid grid3( grid , actnum);
 
-    BOOST_CHECK_NO_THROW(fp.get<int>("ACTNUM"));
+    BOOST_CHECK_NO_THROW(fp.get_int("ACTNUM"));
     BOOST_CHECK_NO_THROW(grid.getNumActive());
     BOOST_CHECK_EQUAL(grid.getNumActive(), 2 * 2 * 2 - 1);
 

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -99,8 +99,8 @@ BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
     EclipseState state(deck );
     const auto& fp = state.fieldProps();
 
-    const auto& poro  = fp.get<double>( "PORO" );
-    const auto& permx = fp.get<double>( "PERMX" );
+    const auto& poro  = fp.get_double( "PORO" );
+    const auto& permx = fp.get_double( "PERMX" );
 
     for (size_t i=0; i < poro.size(); i++) {
         BOOST_CHECK_EQUAL( 0.10 , poro[i]);
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(IntProperties) {
 
     BOOST_CHECK_EQUAL( false, state.fieldProps().supported<int>( "NONO" ) );
     BOOST_CHECK_EQUAL( true,  state.fieldProps().supported<int>( "SATNUM" ) );
-    BOOST_CHECK_EQUAL( true,  state.fieldProps().has<int>( "SATNUM" ) );
+    BOOST_CHECK_EQUAL( true,  state.fieldProps().has_int( "SATNUM" ) );
 }
 
 
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
     auto deck = createDeck();
     EclipseState state(deck);
 
-    const auto& satnum = state.fieldProps().get_global<int>("SATNUM");
+    const auto& satnum = state.fieldProps().get_global_int("SATNUM");
     BOOST_CHECK_EQUAL(1000U , satnum.size() );
     for (size_t i=0; i < satnum.size(); i++)
         BOOST_CHECK_EQUAL( 2 , satnum[i]);
@@ -420,10 +420,10 @@ BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
     auto deck = createDeckNoGridOpts();
     EclipseState state(deck);
     const auto& fp = state.fieldProps();
-    const auto& multnum = fp.get<int>("MULTNUM");
-    const auto& fluxnum = fp.get<int>("FLUXNUM");
+    const auto& multnum = fp.get_int("MULTNUM");
+    const auto& fluxnum = fp.get_int("FLUXNUM");
     const auto  default_kw = fp.default_region();
-    const auto& def_pro = fp.get<int>(default_kw);
+    const auto& def_pro = fp.get_int(default_kw);
 
     BOOST_CHECK_EQUAL( &fluxnum  , &def_pro );
     BOOST_CHECK_NE( &fluxnum  , &multnum );
@@ -434,10 +434,10 @@ BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
     auto deck = createDeckWithGridOpts();
     EclipseState state(deck);
     const auto& fp = state.fieldProps();
-    const auto& multnum = fp.get<int>("MULTNUM");
-    const auto& fluxnum = fp.get<int>("FLUXNUM");
+    const auto& multnum = fp.get_int("MULTNUM");
+    const auto& fluxnum = fp.get_int("FLUXNUM");
     const auto  default_kw = fp.default_region();
-    const auto& def_pro = fp.get<int>(default_kw);
+    const auto& def_pro = fp.get_int(default_kw);
 
     BOOST_CHECK_EQUAL( &multnum , &def_pro );
     BOOST_CHECK_NE( &fluxnum  , &multnum );

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -52,14 +52,14 @@ BOOST_AUTO_TEST_CASE(CreateFieldProps) {
     BOOST_CHECK(!fpm.try_get<double>("NO_SUCH_KEYWOWRD"));
     BOOST_CHECK(!fpm.try_get<int>("NO_SUCH_KEYWOWRD"));
 
-    BOOST_CHECK_THROW(fpm.get<double>("PORO"), std::out_of_range);
-    BOOST_CHECK_THROW(fpm.get_global<double>("PERMX"), std::out_of_range);
+    BOOST_CHECK_THROW(fpm.get_double("PORO"), std::out_of_range);
+    BOOST_CHECK_THROW(fpm.get_global_double("PERMX"), std::out_of_range);
     BOOST_CHECK_THROW(fpm.get_copy<double>("PERMX"), std::out_of_range);
-    BOOST_CHECK_THROW(fpm.get<int>("NOT_SUPPORTED"), std::logic_error);
-    BOOST_CHECK_THROW(fpm.get<double>("NOT_SUPPORTED"), std::logic_error);
+    BOOST_CHECK_THROW(fpm.get_int("NOT_SUPPORTED"), std::logic_error);
+    BOOST_CHECK_THROW(fpm.get_double("NOT_SUPPORTED"), std::logic_error);
 
-    BOOST_CHECK_THROW(fpm.get_global<double>("NO1"), std::logic_error);
-    BOOST_CHECK_THROW(fpm.get_global<int>("NO2"), std::logic_error);
+    BOOST_CHECK_THROW(fpm.get_global_double("NO1"), std::logic_error);
+    BOOST_CHECK_THROW(fpm.get_global_int("NO2"), std::logic_error);
 }
 
 
@@ -92,20 +92,20 @@ PERMX
     Deck deck = Parser{}.parseString(deck_string);
     FieldPropsManager fpm(deck, grid, TableManager());
 
-    BOOST_CHECK(!fpm.has<double>("NO-PORO"));
-    BOOST_CHECK(fpm.has<double>("PORO"));
-    const auto& poro1 = fpm.get<double>("PORO");
+    BOOST_CHECK(!fpm.has_double("NO-PORO"));
+    BOOST_CHECK(fpm.has_double("PORO"));
+    const auto& poro1 = fpm.get_double("PORO");
     BOOST_CHECK_EQUAL(poro1.size(), grid.getNumActive());
 
     const auto& poro2 = fpm.try_get<double>("PORO");
     BOOST_CHECK(poro1 == *poro2);
 
-    BOOST_CHECK(!fpm.has<double>("NO-PORO"));
+    BOOST_CHECK(!fpm.has_double("NO-PORO"));
 
     // PERMX keyword is not fully initialized
     BOOST_CHECK(!fpm.try_get<double>("PERMX"));
-    BOOST_CHECK(!fpm.has<double>("PERMX"));
-    BOOST_CHECK_THROW(fpm.get<double>("PERMX"), std::runtime_error);
+    BOOST_CHECK(!fpm.has_double("PERMX"));
+    BOOST_CHECK_THROW(fpm.get_double("PERMX"), std::runtime_error);
     {
         const auto& keys = fpm.keys<double>();
         BOOST_CHECK_EQUAL(keys.size(), 1);
@@ -151,7 +151,7 @@ SATNUM
     EclipseGrid grid(3,1,3); grid.resetACTNUM(actnum1);
     Deck deck = Parser{}.parseString(deck_string);
     FieldPropsManager fpm(deck, grid, TableManager());
-    const auto& s1 = fpm.get<int>("SATNUM");
+    const auto& s1 = fpm.get_int("SATNUM");
     BOOST_CHECK_EQUAL(s1.size(), 6);
     BOOST_CHECK_EQUAL(s1[0], 0);
     BOOST_CHECK_EQUAL(s1[1], 1);
@@ -193,7 +193,7 @@ ADDREG
     EclipseGrid grid(3,2,1); grid.resetACTNUM(actnum1);
     Deck deck = Parser{}.parseString(deck_string);
     FieldPropsManager fpm(deck, grid, TableManager());
-    const auto& poro = fpm.get<double>("PORO");
+    const auto& poro = fpm.get_double("PORO");
     BOOST_CHECK_EQUAL(poro.size(), 4);
     BOOST_CHECK_EQUAL(poro[0], 0.10);
     BOOST_CHECK_EQUAL(poro[3], 1.10);
@@ -231,7 +231,7 @@ NTG
     EclipseGrid grid(EclipseGrid(10,10, 2));
     Deck deck = Parser{}.parseString(deck_string);
     FieldPropsManager fpm(deck, grid, TableManager());
-    const auto& ntg = fpm.get<double>("NTG");
+    const auto& ntg = fpm.get_double("NTG");
     const auto& defaulted = fpm.defaulted<double>("NTG");
 
     for (std::size_t g=0; g < 100; g++) {
@@ -301,9 +301,9 @@ ENDBOX
     EclipseGrid grid(10,10, 5);
     Deck deck = Parser{}.parseString(deck_string);
     FieldPropsManager fpm(deck, grid, TableManager());
-    const auto& poro = fpm.get<double>("PORO");
-    const auto& ntg = fpm.get<double>("NTG");
-    const auto& multpv = fpm.get<double>("MULTPV");
+    const auto& poro = fpm.get_double("PORO");
+    const auto& ntg = fpm.get_double("NTG");
+    const auto& multpv = fpm.get_double("MULTPV");
     const auto& defaulted = fpm.defaulted<double>("PORV");
     const auto& porv = fpm.porv();
 
@@ -479,12 +479,12 @@ BOOST_AUTO_TEST_CASE(LATE_GET_SATFUNC) {
     Opm::EclipseGrid eg(deck);
     Opm::FieldPropsManager fp(deck, eg, tm);
 
-    const auto& fp_swu = fp.get_global<double>("SWU");
+    const auto& fp_swu = fp.get_global_double("SWU");
     BOOST_CHECK_EQUAL(fp_swu[1 + 0 * 3*3], 0.93);
     BOOST_CHECK_EQUAL(fp_swu[1 + 1 * 3*3], 0.852);
     BOOST_CHECK_EQUAL(fp_swu[1 + 2 * 3*3], 0.801);
 
-    const auto& fp_sgu = fp.get_global<double>("ISGU");
+    const auto& fp_sgu = fp.get_global_double("ISGU");
     BOOST_CHECK_EQUAL(fp_sgu[1 + 0 * 3*3], 0.9);
     BOOST_CHECK_EQUAL(fp_sgu[1 + 1 * 3*3], 0.85);
     BOOST_CHECK_EQUAL(fp_sgu[1 + 2 * 3*3], 0.80);
@@ -506,24 +506,24 @@ PORO
     grid.resetACTNUM(actnum);
     FieldPropsManager fpm(deck, grid, TableManager());
 
-    BOOST_CHECK(!fpm.has<double>("NTG"));
+    BOOST_CHECK(!fpm.has_double("NTG"));
     const auto& ntg = fpm.get_copy<double>("NTG");
-    BOOST_CHECK(!fpm.has<double>("NTG"));
+    BOOST_CHECK(!fpm.has_double("NTG"));
     BOOST_CHECK(ntg.size() == grid.getNumActive());
 
 
-    BOOST_CHECK(fpm.has<double>("PORO"));
+    BOOST_CHECK(fpm.has_double("PORO"));
     const auto& poro1 = fpm.get_copy<double>("PORO");
-    BOOST_CHECK(fpm.has<double>("PORO"));
+    BOOST_CHECK(fpm.has_double("PORO"));
     const auto& poro2 = fpm.get_copy<double>("PORO");
-    BOOST_CHECK(fpm.has<double>("PORO"));
+    BOOST_CHECK(fpm.has_double("PORO"));
     BOOST_CHECK( poro1 == poro2 );
     BOOST_CHECK( &poro1 != &poro2 );
     BOOST_CHECK( poro1.size() == grid.getNumActive());
 
-    BOOST_CHECK(!fpm.has<int>("SATNUM"));
+    BOOST_CHECK(!fpm.has_int("SATNUM"));
     const auto& satnum = fpm.get_copy<int>("SATNUM", true);
-    BOOST_CHECK(!fpm.has<int>("SATNUM"));
+    BOOST_CHECK(!fpm.has_int("SATNUM"));
     BOOST_CHECK(satnum.size() == grid.getCartesianSize());
 
     //The PERMY keyword can not be default initialized
@@ -550,7 +550,7 @@ RTEMPVD
     Opm::TableManager tm(deck);
     FieldPropsManager fpm(deck, grid, tm);
 
-    const auto& tempi = fpm.get<double>("TEMPI");
+    const auto& tempi = fpm.get_double("TEMPI");
     double celcius_offset = 273.15;
     BOOST_CHECK_CLOSE( tempi[0], 0 + celcius_offset , 1e-6);
     BOOST_CHECK_CLOSE( tempi[1], 100 + celcius_offset , 1e-6);
@@ -580,8 +580,8 @@ MULTZ
     Opm::TableManager tm(deck);
     FieldPropsManager fpm(deck, grid, tm);
 
-    const auto& multz = fpm.get<double>("MULTZ");
-    const auto& multx = fpm.get<double>("MULTX");
+    const auto& multz = fpm.get_double("MULTZ");
+    const auto& multx = fpm.get_double("MULTX");
     BOOST_CHECK_EQUAL( multz[0], 4 );
     BOOST_CHECK_EQUAL( multx[0], 2 );
 }

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -296,10 +296,10 @@ BOOST_AUTO_TEST_CASE(MULTREGT_COPY_MULTNUM) {
     Opm::EclipseGrid eg(deck);
     Opm::FieldPropsManager fp(deck, eg, tm);
 
-    BOOST_CHECK_NO_THROW(fp.has<int>("FLUXNUM"));
-    BOOST_CHECK_NO_THROW(fp.has<int>("MULTNUM"));
-    const auto& fdata = fp.get_global<int>("FLUXNUM");
-    const auto& mdata = fp.get_global<int>("MULTNUM");
+    BOOST_CHECK_NO_THROW(fp.has_int("FLUXNUM"));
+    BOOST_CHECK_NO_THROW(fp.has_int("MULTNUM"));
+    const auto& fdata = fp.get_global_int("FLUXNUM");
+    const auto& mdata = fp.get_global_int("MULTNUM");
     std::vector<int> data = { 1, 2, 1, 2, 3, 4, 3, 4 };
 
     for (auto i = 0; i < 2 * 2 * 2; i++) {

--- a/tests/parser/MultiRegTests.cpp
+++ b/tests/parser/MultiRegTests.cpp
@@ -234,8 +234,8 @@ BOOST_AUTO_TEST_CASE(Test_OPERATER) {
     Opm::FieldPropsManager fp(deck, eg, tm);
 
     const auto& porv  = fp.porv(true);
-    const auto& permx = fp.get_global<double>("PERMX");
-    const auto& permy = fp.get_global<double>("PERMY");
+    const auto& permx = fp.get_global_double("PERMX");
+    const auto& permy = fp.get_global_double("PERMY");
 
     BOOST_CHECK_EQUAL( porv[0], 0.50 );
     BOOST_CHECK_EQUAL( porv[1], 1.00 );

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -235,7 +235,7 @@ struct Setup
 BOOST_AUTO_TEST_CASE(ThresholdPressureDeckHasEqlnum) {
     Setup s(inputStrWithEqlNum);
 
-    BOOST_CHECK(s.fp.has<int>("EQLNUM"));
+    BOOST_CHECK(s.fp.has_int("EQLNUM"));
 }
 
 BOOST_AUTO_TEST_CASE(ThresholdPressureTest) {

--- a/tests/parser/TransMultTests.cpp
+++ b/tests/parser/TransMultTests.cpp
@@ -72,6 +72,6 @@ MULTZ
     Opm::FieldPropsManager fp(deck, grid, tables);
     Opm::TransMult transMult(grid, deck, fp);
 
-    transMult.applyMULT(fp.get_global<double>("MULTZ"), Opm::FaceDir::ZPlus);
+    transMult.applyMULT(fp.get_global_double("MULTZ"), Opm::FaceDir::ZPlus);
     BOOST_CHECK_EQUAL( transMult.getMultiplier(0,0,0 , Opm::FaceDir::ZPlus) , 4.0 );
 }

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -49,9 +49,9 @@ inline EclipseState makeState(const std::string& fileName) {
 
 BOOST_AUTO_TEST_CASE( PERMX ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& permx = state.fieldProps().get_global<double>( "PERMX" );
-    const auto& permy = state.fieldProps().get_global<double>( "PERMY" );
-    const auto& permz = state.fieldProps().get_global<double>( "PERMZ" );
+    const auto& permx = state.fieldProps().get_global_double( "PERMX" );
+    const auto& permy = state.fieldProps().get_global_double( "PERMY" );
+    const auto& permz = state.fieldProps().get_global_double( "PERMZ" );
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE( PERMX ) {
 
 BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& satnum = state.fieldProps().get_global<int>( "SATNUM" );
+    const auto& satnum = state.fieldProps().get_global_int( "SATNUM" );
     {
         size_t i, j, k;
         const EclipseGrid& grid = state.getInputGrid();
@@ -94,8 +94,8 @@ BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
 
 BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& satnum = state.fieldProps().get_global<int>( "SATNUM" );
-    const auto& fipnum = state.fieldProps().get_global<int>( "FIPNUM" );
+    const auto& satnum = state.fieldProps().get_global_int( "SATNUM" );
+    const auto& fipnum = state.fieldProps().get_global_int( "FIPNUM" );
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
@@ -119,9 +119,9 @@ BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
 
 BOOST_AUTO_TEST_CASE( EQUALS ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
-    const auto& pvtnum = state.fieldProps().get_global<int>( "PVTNUM" );
-    const auto& eqlnum = state.fieldProps().get_global<int>( "EQLNUM" );
-    const auto& poro   = state.fieldProps().get_global<double>( "PORO" );
+    const auto& pvtnum = state.fieldProps().get_global_int( "PVTNUM" );
+    const auto& eqlnum = state.fieldProps().get_global_int( "EQLNUM" );
+    const auto& poro   = state.fieldProps().get_global_double( "PORO" );
     size_t i, j, k;
     const EclipseGrid& grid = state.getInputGrid();
 
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE( EQUALS ) {
 BOOST_AUTO_TEST_CASE( OPERATE ) {
     EclipseState state = makeState( prefix() + "BOX/BOXTEST1" );
     const EclipseGrid& grid = state.getInputGrid();
-    const auto& ntg = state.fieldProps().get_global<double>("NTG");
+    const auto& ntg = state.fieldProps().get_global_double("NTG");
     BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,0)], 8.50 );  // MULTA
     BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,5,0)], 5.00 );  // POLY
     BOOST_CHECK_EQUAL( ntg[grid.getGlobalIndex(0,0,1)], 4.0 );   // COPY

--- a/tests/test_regionCache.cpp
+++ b/tests/test_regionCache.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(create) {
     EclipseState es(deck);
     const EclipseGrid& grid = es.getInputGrid();
     Schedule schedule( deck, es);
-    out::RegionCache rc(es.fieldProps().get<int>("FIPNUM"), grid, schedule);
+    out::RegionCache rc(es.fieldProps().get_int("FIPNUM"), grid, schedule);
     {
         const auto& empty = rc.connections( 4 );
         BOOST_CHECK_EQUAL( empty.size() , 0 );


### PR DESCRIPTION
motivation: an upcoming parallel frontend to the field props manager.
templated functions cannot be virtualized, and thus having these exposed
would give a great chance of confusing the users in the downstream
code, where properties would be caught from the (potentially) empty
backend instead of from the frontend.

i realize this isn't necessarily the most popular change, but i cannot get around it without complicating matters a lot in the downstreams. this is the smallest cost in my opinion.