### PR TITLE
Add Restart Infrastructure for Well's Active Control

### DIFF
--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -1,4 +1,5 @@
 /*
+  Copyright 2019-2020 Equinor ASA
   Copyright 2018 Statoil ASA
 
   This file is part of the Open Porous Media project (OPM).
@@ -77,20 +78,14 @@ namespace {
         // Remove leading/trailing blanks.
         return s.substr(b, e - b + 1);
     }
-    
-     
-
 
     template <typename WellOp>
     void wellLoop(const std::vector<Opm::Well>& wells,
-                  WellOp&&                       wellOp)
+                  WellOp&&                      wellOp)
     {
-        for (auto nWell = wells.size(), wellID = 0*nWell;
-             wellID < nWell; ++wellID)
-        {
-            const auto& well = wells[wellID];
-
-            wellOp(well, wellID);
+        auto wellID = 0*wells.size();
+        for (const auto& well : wells) {
+            wellOp(well, wellID++);
         }
     }
 
@@ -142,7 +137,7 @@ namespace {
 
         int wellType(const Opm::Well& well, const Opm::SummaryState& st)
         {
-            using WTypeVal = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellType;
+            using WTypeVal = VI::IWell::Value::WellType;
 
             if (well.isProducer()) {
                 return WTypeVal::Producer;
@@ -170,7 +165,7 @@ namespace {
 
         int ctrlMode(const Opm::Well& well, const Opm::SummaryState& st)
         {
-            using WMCtrlVal = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
+            using WMCtrlVal = VI::IWell::Value::WellCtrlMode;
 
             if (well.isInjector()) {
                 const auto& controls = well.injectionControls(st);
@@ -243,6 +238,71 @@ namespace {
             return WMCtrlVal::WMCtlUnk;
         }
 
+        bool wellControlDefined(const Opm::data::Well& xw)
+        {
+            using PMode = ::Opm::Well::ProducerCMode;
+            using IMode = ::Opm::Well::InjectorCMode;
+
+            const auto& curr = xw.current_control;
+
+            return (curr.isProducer && (curr.prod != PMode::CMODE_UNDEFINED))
+                || (!curr.isProducer && (curr.inj != IMode::CMODE_UNDEFINED));
+        }
+
+        int ctrlMode(const Opm::Well& well, const Opm::data::Well& xw)
+        {
+            using PMode = ::Opm::Well::ProducerCMode;
+            using IMode = ::Opm::Well::InjectorCMode;
+            using Val   = VI::IWell::Value::WellCtrlMode;
+
+            const auto& curr = xw.current_control;
+
+            if (curr.isProducer) {
+                switch (curr.prod) {
+                case PMode::ORAT: return Val::OilRate;
+                case PMode::WRAT: return Val::WatRate;
+                case PMode::GRAT: return Val::GasRate;
+                case PMode::LRAT: return Val::LiqRate;
+                case PMode::RESV: return Val::ResVRate;
+                case PMode::THP:  return Val::THP;
+                case PMode::BHP:  return Val::BHP;
+                case PMode::CRAT: return Val::CombRate;
+                case PMode::GRUP: return Val::Group;
+
+                default:
+                    if (well.getStatus() == ::Opm::Well::Status::SHUT) {
+                        return Val::Shut;
+                    }
+                }
+            }
+            else { // injector
+                using IType = ::Opm::Well::InjectorType;
+
+                switch (curr.inj) {
+                case IMode::RATE: {
+                    switch (well.injectorType()) {
+                    case IType::OIL:   return Val::OilRate;
+                    case IType::WATER: return Val::WatRate;
+                    case IType::GAS:   return Val::GasRate;
+                    case IType::MULTI: return Val::WMCtlUnk;
+                    }}
+                    break;
+
+                case IMode::RESV: return Val::ResVRate;
+                case IMode::THP:  return Val::THP;
+                case IMode::BHP:  return Val::BHP;
+                case IMode::GRUP: return Val::Group;
+
+                default:
+                    if (well.getStatus() == ::Opm::Well::Status::SHUT) {
+                        return Val::Shut;
+                    }
+                }
+            }
+
+            return Val::WMCtlUnk;
+        }
+
         int compOrder(const Opm::Well& well)
         {
             using WCO   = ::Opm::Connection::Order;
@@ -258,14 +318,37 @@ namespace {
             return 0;
         }
 
+        template <typename IWellArray>
+        void setCurrentControl(const Opm::Well& well,
+                               const int        curr,
+                               IWellArray&      iWell)
+        {
+            using Ix = VI::IWell::index;
+
+            iWell[Ix::ActWCtrl] = curr;
+
+            if (well.predictionMode()) {
+                // Well in prediction mode (WCONPROD, WCONINJE).  Assign
+                // requested control mode for prediction.
+                iWell[Ix::PredReqWCtrl] = curr;
+                iWell[Ix::HistReqWCtrl] = 0;
+            }
+            else {
+                // Well controlled by observed rates/BHP (WCONHIST,
+                // WCONINJH).  Assign requested control mode for history.
+                iWell[Ix::PredReqWCtrl] = 0; // Possibly =1 instead.
+                iWell[Ix::HistReqWCtrl] = curr;
+            }
+        }
+
         template <class IWellArray>
-        void staticContrib(const Opm::Well&               well,
+        void staticContrib(const Opm::Well&                well,
                            const Opm::SummaryState&        st,
                            const std::size_t               msWellID,
                            const std::map <const std::string, size_t>&  GroupMapNameInd,
                            IWellArray&                     iWell)
         {
-            using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+            using Ix = VI::IWell::index;
 
             iWell[Ix::IHead] = well.getHeadI() + 1;
             iWell[Ix::JHead] = well.getHeadJ() + 1;
@@ -309,28 +392,14 @@ namespace {
             // the target control mode requested in the simulation deck.
             // This item is supposed to be the well's actual, active target
             // control mode in the simulator.
-            iWell[Ix::ActWCtrl] = ctrlMode(well, st);
-
-            if (well.predictionMode()) {
-                // Well in prediction mode (WCONPROD, WCONINJE).  Assign
-                // requested control mode for prediction.
-                iWell[Ix::PredReqWCtrl] = iWell[Ix::ActWCtrl];
-                iWell[Ix::HistReqWCtrl] = 0;
-            }
-            else {
-                // Well controlled by observed rates/BHP (WCONHIST,
-                // WCONINJH).  Assign requested control mode for history.
-                iWell[Ix::PredReqWCtrl] = 0; // Possibly =1 instead.
-                iWell[Ix::HistReqWCtrl] = iWell[Ix::ActWCtrl];
-            }
+            setCurrentControl(well, ctrlMode(well, st), iWell);
 
             // Multi-segmented well information
             iWell[Ix::MsWID] = 0;  // MS Well ID (0 or 1..#MS wells)
             iWell[Ix::NWseg] = 0;  // Number of well segments
             if (well.isMultiSegment()) {
                 iWell[Ix::MsWID] = static_cast<int>(msWellID);
-                iWell[Ix::NWseg] =
-                    well.getSegments().size();
+                iWell[Ix::NWseg] = well.getSegments().size();
             }
 
             iWell[Ix::CompOrd] = compOrder(well);
@@ -339,17 +408,22 @@ namespace {
         template <class IWellArray>
         void dynamicContribShut(IWellArray& iWell)
         {
-            using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+            using Ix = VI::IWell::index;
 
             iWell[Ix::item9 ] = -1000;
             iWell[Ix::item11] = -1000;
         }
 
         template <class IWellArray>
-        void dynamicContribOpen(const Opm::data::Well& xw,
+        void dynamicContribOpen(const Opm::Well&       well,
+                                const Opm::data::Well& xw,
                                 IWellArray&            iWell)
         {
-            using Ix = ::Opm::RestartIO::Helpers::VectorItems::IWell::index;
+            using Ix = VI::IWell::index;
+
+            if (wellControlDefined(xw)) {
+                setCurrentControl(well, ctrlMode(well, xw), iWell);
+            }
 
             const auto any_flowing_conn =
                 std::any_of(std::begin(xw.connections),
@@ -415,11 +489,11 @@ namespace {
                 zero , zero , infty, infty, zero , dflt ,    //  12.. 17  ( 2)
                 infty, infty, infty, infty, infty, zero ,    //  18.. 23  ( 3)
                 one  , zero , zero , zero , zero , zero ,    //  24.. 29  ( 4)
-                zero , one  , zero , infty,  zero , zero ,    //  30.. 35  ( 5)
+                zero , one  , zero , infty, zero , zero ,    //  30.. 35  ( 5)
                 zero , zero , zero , zero , zero , zero ,    //  36.. 41  ( 6)
                 zero , zero , zero , zero , zero , zero ,    //  42.. 47  ( 7)
                 zero , zero , zero , zero , zero , zero ,    //  48.. 53  ( 8)
-                infty,  zero , zero , zero , zero , zero ,    //  54.. 59  ( 9)
+                infty, zero , zero , zero , zero , zero ,    //  54.. 59  ( 9)
                 zero , zero , zero , zero , zero , zero ,    //  60.. 65  (10)
                 zero , zero , zero , zero , zero , zero ,    //  66.. 71  (11)
                 zero , zero , zero , zero , zero , zero ,    //  72.. 77  (12)
@@ -856,7 +930,7 @@ captureDeclaredWellData(const Schedule&   sched,
     });
 
     {
-        const auto actResStat = ZWell::act_res_stat(sched, smry, sim_step); 
+        const auto actResStat = ZWell::act_res_stat(sched, smry, sim_step);
         // Static contributions to ZWEL array.
         wellLoop(wells,
             [&actResStat, this](const Well& well, const std::size_t wellID) -> void
@@ -889,7 +963,7 @@ captureDynamicWellData(const Schedule&             sched,
             IWell::dynamicContribShut(iWell);
         }
         else {
-            IWell::dynamicContribOpen(i->second, iWell);
+            IWell::dynamicContribOpen(well, i->second, iWell);
         }
     });
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -297,9 +297,10 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         Opm::data::Wells wells;
 
         using SegRes = decltype(wells["w"].segments);
+        using Ctrl = decltype(wells["w"].current_control);
 
-        wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{} };
-        wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{} };
+        wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{}, Ctrl{} };
+        wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{}, Ctrl{} };
 
         RestartValue restart_value(std::move(solution), std::move(wells));
 
@@ -419,9 +420,10 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
                 Opm::data::Solution solution = createBlackoilState(2, numCells);
 
                 using SegRes = decltype(wells["w"].segments);
+                using Ctrl = decltype(wells["w"].current_control);
 
-                wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{} };
-                wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{} };
+                wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{}, Ctrl{} };
+                wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{}, Ctrl{} };
 
                 RestartValue restart_value(std::move(solution), std::move(wells));
 


### PR DESCRIPTION
This PR introduces a new protocol for communicating a well's active constraint (i.e., its current target control mode) between the running simulator and the restart file.  In particular, we add a new type
```
Opm::data::CurrentControl
```
whose data members indicate if the well is a producer or injector and, depending on that state, carries information about the pertinent active control mode.  The `prod` member should be defined for producing wells and the `inj` member should be defined for injectors.  Default-constructed objects of this type are 'invalid' and not output to the restart file.  Add a `CurrentControl` member to the `Opm::data::Well` type to enable communicating this information using existing restart interfaces.

Expand existing unit tests to exercise the new data member.