### PR TITLE
Add UnitSystem functionality to handle eclipse integer id

### DIFF
--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -25,15 +25,16 @@
 #include <memory>
 #include <vector>
 
-namespace Opm { namespace RestartIO {
+
+namespace Opm {
+
+class UnitSystem;
+
+namespace RestartIO {
 
     class InteHEAD
     {
     public:
-        enum class UnitSystem {
-            Metric, Field, Lab, PVT_M
-        };
-
         struct WellTableDim {
             int numWells;
             int maxPerf;

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -76,6 +76,7 @@ namespace Opm {
             icd_strength,
         };
 
+        explicit UnitSystem(int ecl_id);
         explicit UnitSystem(UnitType unit = UnitType::UNIT_TYPE_METRIC);
         explicit UnitSystem(const std::string& deck_name);
         UnitSystem(const std::string& name, UnitType unit,
@@ -84,6 +85,7 @@ namespace Opm {
 
         const std::string& getName() const;
         UnitType getType() const;
+        int ecl_id() const;
 
         void addDimension(const std::string& dimension, double SIfactor, double SIoffset = 0.0);
         void addDimension( Dimension );

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -35,8 +35,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Regdims.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
-#include <opm/parser/eclipse/Units/UnitSystem.hpp>
-
 #include <algorithm>
 #include <cstddef>
 #include <exception>
@@ -207,32 +205,6 @@ namespace {
         }};
     }
 
-    Opm::RestartIO::InteHEAD::UnitSystem
-    getUnitConvention(const ::Opm::UnitSystem& us)
-    {
-        using US = ::Opm::RestartIO::InteHEAD::UnitSystem;
-
-        switch (us.getType()) {
-        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC:
-            return US::Metric;
-
-        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD:
-            return US::Field;
-
-        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_LAB:
-            return US::Lab;
-
-        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_PVT_M:
-            return US::PVT_M;
-
-        case ::Opm::UnitSystem::UnitType::UNIT_TYPE_INPUT:
-            throw std::invalid_argument {
-                "Cannot Run Simulation With Non-Standard Units"
-            };
-        }
-
-        return US::Metric;
-    }
 
     Opm::RestartIO::InteHEAD::Phases
     getActivePhases(const ::Opm::Runspec& rspec)
@@ -413,7 +385,7 @@ createInteHead(const EclipseState& es,
     const auto ih = InteHEAD{}
         .dimensions         (grid.getNXYZ())
         .numActive          (static_cast<int>(grid.getNumActive()))
-        .unitConventions    (getUnitConvention(es.getDeckUnitSystem()))
+        .unitConventions    (es.getDeckUnitSystem())
         .wellTableDimensions(getWellTableDims(nwgmax, ngmax, rspec,
                                               sched, lookup_step))
         .calendarDate       (getSimulationTimePoint(sched.posixStartTime(), simTime))

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -1,6 +1,7 @@
 #include <opm/output/eclipse/InteHEAD.hpp>
 
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -473,20 +474,7 @@ Opm::RestartIO::InteHEAD::numActive(const int nactive)
 Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::unitConventions(const UnitSystem& usys)
 {
-    const auto unit = [&usys]()
-    {
-        switch (usys) {
-        case UnitSystem::Metric: return 1;
-        case UnitSystem::Field:  return 2;
-        case UnitSystem::Lab:    return 3;
-        case UnitSystem::PVT_M:  return 4;
-        }
-
-        return 1;
-    }();
-
-    this->data_[UNIT] = unit;
-
+    this->data_[UNIT] = usys.ecl_id();
     return *this;
 }
 

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -1043,37 +1043,70 @@ namespace {
 
     namespace {
 
-        UnitSystem::UnitType fromDeckName(const std::string& deck_name) {
-            if (deck_name == "FIELD")
-                return UnitSystem::UnitType::UNIT_TYPE_FIELD;
+    int to_ecl_id(UnitSystem::UnitType unit_type) {
+        if (unit_type == UnitSystem::UnitType::UNIT_TYPE_METRIC)
+            return 1;
 
-            if (deck_name == "METRIC")
-                return UnitSystem::UnitType::UNIT_TYPE_METRIC;
+        if (unit_type == UnitSystem::UnitType::UNIT_TYPE_FIELD)
+            return 2;
 
-            if (deck_name == "LAB")
-                return UnitSystem::UnitType::UNIT_TYPE_LAB;
+        if (unit_type == UnitSystem::UnitType::UNIT_TYPE_LAB)
+            return 3;
 
-            if (deck_name == "PVT-M")
-                return UnitSystem::UnitType::UNIT_TYPE_PVT_M;
+        if (unit_type == UnitSystem::UnitType::UNIT_TYPE_PVT_M)
+            return 4;
 
-            throw std::invalid_argument("Unit string: " + deck_name + " not recognized ");
-        }
+        throw std::invalid_argument("The nonstandard unit system does not have a corresponding ecl id");
     }
 
-    bool UnitSystem::valid_name(const std::string& deck_name) {
-        if (deck_name == "FIELD")
-            return true;
+    UnitSystem::UnitType from_ecl_id(int ecl_id) {
+        if (ecl_id == 1)
+            return UnitSystem::UnitType::UNIT_TYPE_METRIC;
 
-        if (deck_name == "METRIC")
-            return true;
+        if (ecl_id == 2)
+            return UnitSystem::UnitType::UNIT_TYPE_FIELD;
 
-        if (deck_name == "LAB")
-            return true;
+        if (ecl_id == 3)
+            return UnitSystem::UnitType::UNIT_TYPE_LAB;
 
-        if (deck_name == "PVT-M")
-            return true;
+        if (ecl_id == 4)
+            return UnitSystem::UnitType::UNIT_TYPE_PVT_M;
 
-        return false;
+        throw std::invalid_argument("The integer value: " + std::to_string(ecl_id) + " is not recogmized as a valid Eclipse unit ID");
+    }
+
+    UnitSystem::UnitType fromDeckName(const std::string &deck_name) {
+      if (deck_name == "FIELD")
+        return UnitSystem::UnitType::UNIT_TYPE_FIELD;
+
+      if (deck_name == "METRIC")
+        return UnitSystem::UnitType::UNIT_TYPE_METRIC;
+
+      if (deck_name == "LAB")
+        return UnitSystem::UnitType::UNIT_TYPE_LAB;
+
+      if (deck_name == "PVT-M")
+        return UnitSystem::UnitType::UNIT_TYPE_PVT_M;
+
+      throw std::invalid_argument("Unit string: " + deck_name +
+                                  " not recognized ");
+    }
+    }
+
+    bool UnitSystem::valid_name(const std::string &deck_name) {
+      if (deck_name == "FIELD")
+        return true;
+
+      if (deck_name == "METRIC")
+        return true;
+
+      if (deck_name == "LAB")
+        return true;
+
+      if (deck_name == "PVT-M")
+        return true;
+
+      return false;
     }
 
     std::string UnitSystem::deck_name() const {
@@ -1092,6 +1125,17 @@ namespace {
         UnitSystem( fromDeckName(deck_name) )
     {
     }
+
+
+    UnitSystem::UnitSystem(int ecl_id) :
+        UnitSystem(from_ecl_id(ecl_id))
+    {}
+
+
+    int UnitSystem::ecl_id() const {
+        return to_ecl_id( this->m_unittype );
+    }
+
 
     bool UnitSystem::hasDimension(const std::string& dimension) const {
         return (m_dimensions.find( dimension ) != m_dimensions.end());

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -644,6 +644,20 @@ BOOST_AUTO_TEST_CASE(TemperatureConversions)
 
 
 
+BOOST_AUTO_TEST_CASE(EclipseID) {
+    BOOST_CHECK_THROW(UnitSystem(0), std::invalid_argument);
+    BOOST_CHECK_THROW(UnitSystem(5), std::invalid_argument);
+
+    UnitSystem metric1(UnitSystem::UnitType::UNIT_TYPE_METRIC);
+    UnitSystem metric2(metric1.ecl_id());
+    BOOST_CHECK( metric1 == metric2 );
+
+    UnitSystem field1(UnitSystem::UnitType::UNIT_TYPE_FIELD);
+    UnitSystem field2(field1.ecl_id());
+    BOOST_CHECK( field1 == field2 );
+}
+
+
 BOOST_AUTO_TEST_CASE(DECK_NAMES) {
     BOOST_CHECK( !UnitSystem::valid_name("INVALID"));
     BOOST_CHECK( UnitSystem::valid_name("FIELD"));

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -29,6 +29,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/io/eclipse/rst/header.hpp>
 
@@ -114,13 +115,11 @@ BOOST_AUTO_TEST_CASE(NumActive)
 
 BOOST_AUTO_TEST_CASE(UnitConventions)
 {
-    using USys = Opm::RestartIO::InteHEAD::UnitSystem;
-
     auto ih = Opm::RestartIO::InteHEAD{};
 
     // Metric
     {
-        ih.unitConventions(USys::Metric);
+        ih.unitConventions(Opm::UnitSystem::newMETRIC());
 
         const auto& v = ih.data();
 
@@ -129,7 +128,7 @@ BOOST_AUTO_TEST_CASE(UnitConventions)
 
     // Field
     {
-        ih.unitConventions(USys::Field);
+        ih.unitConventions(Opm::UnitSystem::newFIELD());
 
         const auto& v = ih.data();
 
@@ -138,7 +137,7 @@ BOOST_AUTO_TEST_CASE(UnitConventions)
 
     // Lab
     {
-        ih.unitConventions(USys::Lab);
+        ih.unitConventions(Opm::UnitSystem::newLAB());
 
         const auto& v = ih.data();
 
@@ -147,7 +146,7 @@ BOOST_AUTO_TEST_CASE(UnitConventions)
 
     // PVT-M
     {
-        ih.unitConventions(USys::PVT_M);
+        ih.unitConventions(Opm::UnitSystem::newPVT_M());
 
         const auto& v = ih.data();
 
@@ -492,7 +491,6 @@ TSTEP
 
 
 BOOST_AUTO_TEST_CASE(TestHeader) {
-    using USys = Opm::RestartIO::InteHEAD::UnitSystem;
     using Ph = Opm::RestartIO::InteHEAD::Phases;
 
     const auto nx = 10;
@@ -556,7 +554,7 @@ BOOST_AUTO_TEST_CASE(TestHeader) {
     auto ih = Opm::RestartIO::InteHEAD{}
          .dimensions(nx, ny, nz)
          .numActive(nactive)
-         .unitConventions(USys::Metric)
+         .unitConventions(Opm::UnitSystem::newMETRIC())
          .wellTableDimensions({ numWells, maxPerf, maxWellsInGroup, maxGroupInField, maxWellsInField})
          .calendarDate({year, month, mday, hour, minute, seconds, mseconds})
          .activePhases(Ph{1,1,1})


### PR DESCRIPTION
To enable instantiating the unit system from a restart/init file. Writing of INTEHEAD keyword uses `UnitSystem` class instead of intermediate enum `RestartIO::UnitSystem` which has been removed.