### PR TITLE
Eclstate aquifer

### DIFF
--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -44,55 +44,35 @@ namespace Opm {
     class AquiferCT {
         public:
 
-            struct AQUCT_data{
+        struct AQUCT_data{
 
-                    // Aquifer ID
-                    int aquiferID;
-                    // Table IDs
-                    int inftableID, pvttableID;
-                    std::vector<int> cell_id;
-                    // Variables constants
-                    double  phi_aq , //aquifer porosity
-                            d0,   //aquifer datum depth
-                            C_t , //total compressibility
-                            r_o , //aquifer inner radius
-                            k_a , //aquifer permeability
-                            c1, // 0.008527 (METRIC, PVT-M); 0.006328 (FIELD); 3.6 (LAB)
-                            h , //aquifer thickness
-                            theta , //angle subtended by the aquifer boundary
-                            c2 ; //6.283 (METRIC, PVT-M); 1.1191 (FIELD); 6.283 (LAB).
+            AQUCT_data(const DeckRecord& record, const TableManager& tables);
 
-                    std::shared_ptr<double> p0; //Initial aquifer pressure at datum depth, d0
-                    std::vector<double> td, pi;
-            };
+            int aquiferID;
+            int inftableID, pvttableID;
 
-            AquiferCT(const TableManager& tables, const Deck& deck);
+            double  phi_aq , // aquifer porosity
+                    d0,      // aquifer datum depth
+                    C_t ,    // total compressibility
+                    r_o ,    // aquifer inner radius
+                    k_a ,    // aquifer permeability
+                    c1,      // 0.008527 (METRIC, PVT-M); 0.006328 (FIELD); 3.6 (LAB)
+                    h ,      // aquifer thickness
+                    theta ,  // angle subtended by the aquifer boundary
+                    c2 ;     // 6.283 (METRIC, PVT-M); 1.1191 (FIELD); 6.283 (LAB).
 
-            std::size_t size() const;
-            std::vector<AquiferCT::AQUCT_data>::const_iterator begin() const;
-            std::vector<AquiferCT::AQUCT_data>::const_iterator end() const;
-        private:
+            std::shared_ptr<double> p0; //Initial aquifer pressure at datum depth, d0
+            std::vector<double> td, pi;
+            std::vector<int> cell_id;
+        };
 
-            std::vector<AquiferCT::AQUCT_data> m_aquct;
+        AquiferCT(const TableManager& tables, const Deck& deck);
 
-            //Set the default Pd v/s Td tables (constant terminal rate case for an infinite aquifer) as described in
-            //Van Everdingen, A. & Hurst, W., December, 1949.The Application of the Laplace Transformation to Flow Problems in Reservoirs.
-            //Petroleum Transactions, AIME.
-            inline void set_default_tables(std::vector<double>& td, std::vector<double>& pi)
-            {
-                std::vector<double> default_pressure_ = { 0.112, 0.229, 0.315, 0.376, 0.424, 0.469, 0.503, 0.564, 0.616, 0.659, 0.702, 0.735,
-                                                          0.772, 0.802, 0.927, 1.02, 1.101, 1.169, 1.275, 1.362, 1.436, 1.5, 1.556, 1.604,
-                                                          1.651, 1.829, 1.96, 2.067, 2.147, 2.282, 2.388, 2.476, 2.55, 2.615, 2.672, 2.723,
-                                                          2.921, 3.064, 3.173, 3.263, 3.406, 3.516, 3.608, 3.684, 3.75, 3.809, 3.86 };
-
-                std::vector<double> default_time_ = { 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1,
-                                                        1.5, 2, 2.5, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60, 70,
-                                                        80, 90, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000 };
-
-                td = default_time_;
-                pi = default_pressure_;
-            }
-
+        std::size_t size() const;
+        std::vector<AquiferCT::AQUCT_data>::const_iterator begin() const;
+        std::vector<AquiferCT::AQUCT_data>::const_iterator end() const;
+    private:
+        std::vector<AquiferCT::AQUCT_data> m_aquct;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -68,10 +68,9 @@ namespace Opm {
 
             AquiferCT(const TableManager& tables, const Deck& deck);
 
-            const std::vector<AquiferCT::AQUCT_data>& getAquifers() const;
-            int getAqInflTabID(size_t aquiferIndex);
-            int getAqPvtTabID(size_t aquiferIndex);
-
+            std::size_t size() const;
+            std::vector<AquiferCT::AQUCT_data>::const_iterator begin() const;
+            std::vector<AquiferCT::AQUCT_data>::const_iterator end() const;
         private:
 
             std::vector<AquiferCT::AQUCT_data> m_aquct;

--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -69,10 +69,12 @@ namespace Opm {
         };
 
         AquiferCT(const TableManager& tables, const Deck& deck);
+        AquiferCT(const std::vector<AquiferCT::AQUCT_data>& data);
 
         std::size_t size() const;
         std::vector<AquiferCT::AQUCT_data>::const_iterator begin() const;
         std::vector<AquiferCT::AQUCT_data>::const_iterator end() const;
+        const std::vector<AquiferCT::AQUCT_data>& data() const;
         bool operator==(const AquiferCT& other) const;
     private:
         std::vector<AquiferCT::AQUCT_data> m_aquct;

--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -61,9 +61,11 @@ namespace Opm {
                     theta ,  // angle subtended by the aquifer boundary
                     c2 ;     // 6.283 (METRIC, PVT-M); 1.1191 (FIELD); 6.283 (LAB).
 
-            std::shared_ptr<double> p0; //Initial aquifer pressure at datum depth, d0
+            std::pair<bool, double> p0; //Initial aquifer pressure at datum depth, d0
             std::vector<double> td, pi;
             std::vector<int> cell_id;
+
+            bool operator==(const AQUCT_data& other) const;
         };
 
         AquiferCT(const TableManager& tables, const Deck& deck);
@@ -71,6 +73,7 @@ namespace Opm {
         std::size_t size() const;
         std::vector<AquiferCT::AQUCT_data>::const_iterator begin() const;
         std::vector<AquiferCT::AQUCT_data>::const_iterator end() const;
+        bool operator==(const AquiferCT& other) const;
     private:
         std::vector<AquiferCT::AQUCT_data> m_aquct;
     };

--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -39,7 +39,7 @@
 
 namespace Opm {
 
-    class EclipseState;
+    class TableManager;
 
     class AquiferCT {
         public:
@@ -66,7 +66,7 @@ namespace Opm {
                     std::vector<double> td, pi;
             };
 
-            AquiferCT(const EclipseState& eclState, const Deck& deck);
+            AquiferCT(const TableManager& tables, const Deck& deck);
 
             const std::vector<AquiferCT::AQUCT_data>& getAquifers() const;
             int getAqInflTabID(size_t aquiferIndex);

--- a/opm/parser/eclipse/EclipseState/Aquifetp.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifetp.hpp
@@ -25,36 +25,38 @@
   This includes the logic for parsing as well as the associated tables. It is meant to be used by opm-grid and opm-simulators in order to
   implement the Fetkovich analytical aquifer model in OPM Flow.
 */
-#include <memory>
+#include <vector>
 
-#include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 
 namespace Opm {
+
+class Deck;
+class DeckRecord;
 
 class Aquifetp {
     public:
 
     struct AQUFETP_data{
+        AQUFETP_data(const DeckRecord& record);
+        bool operator==(const AQUFETP_data& other) const;
 
-        // Aquifer ID
         int aquiferID;
-        // Table IDs
-        int inftableID, pvttableID;
-        std::vector<int> cell_id;
-        // Variables constants
+        int pvttableID;
         double  J, // Specified Productivity Index
-            rho, // water density in the aquifer
-            C_t, // total rock compressibility
-            V0, // initial volume of water in aquifer
-            d0; // aquifer datum depth
-		    std::shared_ptr<double> p0; //Initial aquifer pressure at datum depth d0 - nullptr if the pressure has been defaulted.
+                C_t, // total rock compressibility
+                V0, // initial volume of water in aquifer
+                d0; // aquifer datum depth
+        std::pair<bool, double> p0;
     };
 
     Aquifetp(const Deck& deck);
-    const std::vector<Aquifetp::AQUFETP_data>& getAquifers() const;
-    int getAqPvtTabID(size_t aquiferIndex);
+    Aquifetp(const std::vector<Aquifetp::AQUFETP_data>& data);
+    const std::vector<Aquifetp::AQUFETP_data>& data() const;
 
+    std::size_t size() const;
+    std::vector<Aquifetp::AQUFETP_data>::const_iterator begin() const;
+    std::vector<Aquifetp::AQUFETP_data>::const_iterator end() const;
+    bool operator==(const Aquifetp& other) const;
 private:
     std::vector<Aquifetp::AQUFETP_data> m_aqufetp;
 };

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -22,60 +22,84 @@
 
 namespace Opm {
 
-    AquiferCT::AquiferCT(const TableManager& tables, const Deck& deck)
-    {
-        if (!deck.hasKeyword("AQUCT"))
-            return;
+namespace {
 
-        const auto& aquctKeyword = deck.getKeyword("AQUCT");
-        for (auto& aquctRecord : aquctKeyword){
+// The default Pd v/s Td tables (constant terminal rate case for an infinite
+// aquifer) as described in Van Everdingen, A. & Hurst, W., December, 1949.The
+// Application of the Laplace Transformation to Flow Problems in Reservoirs.
+// Petroleum Transactions, AIME.
 
-            AquiferCT::AQUCT_data data;
+static const std::vector<double> default_pressure = { 0.112, 0.229, 0.315, 0.376, 0.424, 0.469, 0.503, 0.564,
+                                                      0.616, 0.659, 0.702, 0.735, 0.772, 0.802, 0.927, 1.020,
+                                                      1.101, 1.169, 1.275, 1.362, 1.436, 1.500, 1.556, 1.604,
+                                                      1.651, 1.829, 1.960, 2.067, 2.147, 2.282, 2.388, 2.476,
+                                                      2.550, 2.615, 2.672, 2.723, 2.921, 3.064, 3.173, 3.263,
+                                                      3.406, 3.516, 3.608, 3.684, 3.750, 3.809, 3.86 };
 
-            data.c1 = 1.0;
-            data.c2 = 6.283;        // Value of C2 used by E100 (for METRIC, PVT-M and LAB unit systems)
-            data.aquiferID = aquctRecord.getItem("AQUIFER_ID").template get<int>(0);
-            data.h = aquctRecord.getItem("THICKNESS_AQ").getSIDouble(0);
-            data.phi_aq = aquctRecord.getItem("PORO_AQ").getSIDouble(0);
-            data.d0 = aquctRecord.getItem("DAT_DEPTH").getSIDouble(0);
-            data.C_t = aquctRecord.getItem("C_T").getSIDouble(0);
-            data.r_o = aquctRecord.getItem("RAD").getSIDouble(0);
-            data.k_a = aquctRecord.getItem("PERM_AQ").getSIDouble(0);
-            data.theta = aquctRecord.getItem("INFLUENCE_ANGLE").getSIDouble(0)/360.0;
-            data.inftableID = aquctRecord.getItem("TABLE_NUM_INFLUENCE_FN").template get<int>(0);
-            data.pvttableID = aquctRecord.getItem("TABLE_NUM_WATER_PRESS").template get<int>(0);
+static const std::vector<double> default_time =     { 0.010, 0.050, 0.100, 0.150, 0.200, 0.250, 0.300, 0.400,
+                                                      0.500, 0.600, 0.700, 0.800, 0.900, 1.000, 1.500, 2.000,
+                                                      2.500, 3.000, 4.000, 5.000, 6.000, 7.000, 8.000, 9.000,
+                                                      10.00, 15.00, 20.00, 25.00, 30.00, 40.00, 50.00, 60.00,
+                                                      70.00, 80.00, 90.00, 100.0, 150.0, 200.0, 250.0, 300.0,
+                                                      400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000 };
 
-            if (aquctRecord.getItem("P_INI").hasValue(0)) {
-                double * raw_ptr = new double( aquctRecord.getItem("P_INI").getSIDouble(0) );
-                data.p0.reset( raw_ptr );
-            }
+}
 
-            // Get the correct influence table values
-            if (data.inftableID > 1){
-                const auto& aqutabTable = tables.getAqutabTables().getTable(data.inftableID - 2);
-                const auto& aqutab_tdColumn = aqutabTable.getColumn(0);
-                const auto& aqutab_piColumn = aqutabTable.getColumn(1);
-                data.td = aqutab_tdColumn.vectorCopy();
-                data.pi = aqutab_piColumn.vectorCopy();
-                }
-            else
-                {
-                    set_default_tables(data.td,data.pi);
-                }
-                m_aquct.push_back( std::move(data) );
-            }
+
+AquiferCT::AQUCT_data::AQUCT_data(const DeckRecord& record, const TableManager& tables) :
+    aquiferID(record.getItem("AQUIFER_ID").get<int>(0)),
+    inftableID(record.getItem("TABLE_NUM_INFLUENCE_FN").get<int>(0)),
+    pvttableID(record.getItem("TABLE_NUM_WATER_PRESS").get<int>(0)),
+    phi_aq(record.getItem("PORO_AQ").getSIDouble(0)),
+    d0(record.getItem("DAT_DEPTH").getSIDouble(0)),
+    C_t(record.getItem("C_T").getSIDouble(0)),
+    r_o(record.getItem("RAD").getSIDouble(0)),
+    k_a(record.getItem("PERM_AQ").getSIDouble(0)),
+    c1(1.0),
+    h(record.getItem("THICKNESS_AQ").getSIDouble(0)),
+    theta( record.getItem("INFLUENCE_ANGLE").getSIDouble(0)/360.0),
+    c2(6.283)        // Value of C2 used by E100 (for METRIC, PVT-M and LAB unit systems)
+{
+    if (record.getItem("P_INI").hasValue(0)) {
+        double * raw_ptr = new double( record.getItem("P_INI").getSIDouble(0) );
+        this->p0.reset( raw_ptr );
     }
 
-
-    std::size_t AquiferCT::size() const {
-        return this->m_aquct.size();
+    // Get the correct influence table values
+    if (this->inftableID > 1) {
+        const auto& aqutabTable = tables.getAqutabTables().getTable(this->inftableID - 2);
+        const auto& aqutab_tdColumn = aqutabTable.getColumn(0);
+        const auto& aqutab_piColumn = aqutabTable.getColumn(1);
+        this->td = aqutab_tdColumn.vectorCopy();
+        this->pi = aqutab_piColumn.vectorCopy();
+    } else {
+        this->td = default_time;
+        this->pi = default_pressure;
     }
+}
 
-    std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::begin() const {
-        return this->m_aquct.begin();
-    }
 
-    std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::end() const {
-        return this->m_aquct.end();
-    }
+AquiferCT::AquiferCT(const TableManager& tables, const Deck& deck)
+{
+    using AQUCT = ParserKeywords::AQUCT;
+    if (!deck.hasKeyword<AQUCT>())
+        return;
+
+    const auto& aquctKeyword = deck.getKeyword<AQUCT>();
+    for (auto& record : aquctKeyword)
+        this->m_aquct.emplace_back(record, tables);
+}
+
+
+std::size_t AquiferCT::size() const {
+    return this->m_aquct.size();
+}
+
+std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::begin() const {
+    return this->m_aquct.begin();
+}
+
+std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::end() const {
+    return this->m_aquct.end();
+}
 }

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -66,19 +66,16 @@ namespace Opm {
             }
     }
 
-    const std::vector<AquiferCT::AQUCT_data>& AquiferCT::getAquifers() const
-    {
-        return m_aquct;
+
+    std::size_t AquiferCT::size() const {
+        return this->m_aquct.size();
     }
 
-    int AquiferCT::getAqInflTabID(size_t aquiferIndex)
-    {
-        return m_aquct.at(aquiferIndex).inftableID;
+    std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::begin() const {
+        return this->m_aquct.begin();
     }
 
-    int AquiferCT::getAqPvtTabID(size_t aquiferIndex)
-    {
-        return m_aquct.at(aquiferIndex).pvttableID;
+    std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::end() const {
+        return this->m_aquct.end();
     }
-
 }

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -58,12 +58,11 @@ AquiferCT::AQUCT_data::AQUCT_data(const DeckRecord& record, const TableManager& 
     c1(1.0),
     h(record.getItem("THICKNESS_AQ").getSIDouble(0)),
     theta( record.getItem("INFLUENCE_ANGLE").getSIDouble(0)/360.0),
-    c2(6.283)        // Value of C2 used by E100 (for METRIC, PVT-M and LAB unit systems)
+    c2(6.283),         // Value of C2 used by E100 (for METRIC, PVT-M and LAB unit systems)
+    p0(std::make_pair(false, 0))
 {
-    if (record.getItem("P_INI").hasValue(0)) {
-        double * raw_ptr = new double( record.getItem("P_INI").getSIDouble(0) );
-        this->p0.reset( raw_ptr );
-    }
+    if (record.getItem("P_INI").hasValue(0))
+        this->p0 = std::make_pair(true, record.getItem("P_INI").getSIDouble(0));
 
     // Get the correct influence table values
     if (this->inftableID > 1) {
@@ -78,6 +77,24 @@ AquiferCT::AQUCT_data::AQUCT_data(const DeckRecord& record, const TableManager& 
     }
 }
 
+
+bool AquiferCT::AQUCT_data::operator==(const AquiferCT::AQUCT_data& other) const {
+    return this->aquiferID == other.aquiferID &&
+           this->inftableID == other.inftableID &&
+           this->pvttableID == other.pvttableID &&
+           this->phi_aq == other.phi_aq &&
+           this->C_t == other.C_t &&
+           this->r_o == other.r_o &&
+           this->k_a == other.k_a &&
+           this->c1  == other.c1  &&
+           this->h   == other.h   &&
+           this->theta == other.theta &&
+           this->c2 == other.c2 &&
+           this->p0 == other.p0 &&
+           this->td == other.td &&
+           this->pi == other.pi &&
+           this->cell_id == other.cell_id;
+}
 
 AquiferCT::AquiferCT(const TableManager& tables, const Deck& deck)
 {
@@ -101,5 +118,9 @@ std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::begin() const {
 
 std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::end() const {
     return this->m_aquct.end();
+}
+
+bool AquiferCT::operator==(const AquiferCT& other) const {
+    return this->m_aquct == other.m_aquct;
 }
 }

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -107,6 +107,10 @@ AquiferCT::AquiferCT(const TableManager& tables, const Deck& deck)
         this->m_aquct.emplace_back(record, tables);
 }
 
+AquiferCT::AquiferCT(const std::vector<AquiferCT::AQUCT_data>& data) :
+    m_aquct(data)
+{}
+
 
 std::size_t AquiferCT::size() const {
     return this->m_aquct.size();
@@ -123,4 +127,9 @@ std::vector<AquiferCT::AQUCT_data>::const_iterator AquiferCT::end() const {
 bool AquiferCT::operator==(const AquiferCT& other) const {
     return this->m_aquct == other.m_aquct;
 }
+
+const std::vector<AquiferCT::AQUCT_data>& AquiferCT::data() const {
+    return this->m_aquct;
+}
+
 }

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -22,13 +22,12 @@
 
 namespace Opm {
 
-    AquiferCT::AquiferCT(const EclipseState& eclState, const Deck& deck)
+    AquiferCT::AquiferCT(const TableManager& tables, const Deck& deck)
     {
         if (!deck.hasKeyword("AQUCT"))
             return;
 
         const auto& aquctKeyword = deck.getKeyword("AQUCT");
-
         for (auto& aquctRecord : aquctKeyword){
 
             AquiferCT::AQUCT_data data;
@@ -53,7 +52,7 @@ namespace Opm {
 
             // Get the correct influence table values
             if (data.inftableID > 1){
-                const auto& aqutabTable = eclState.getTableManager().getAqutabTables().getTable(data.inftableID - 2);
+                const auto& aqutabTable = tables.getAqutabTables().getTable(data.inftableID - 2);
                 const auto& aqutab_tdColumn = aqutabTable.getColumn(0);
                 const auto& aqutab_piColumn = aqutabTable.getColumn(1);
                 data.td = aqutab_tdColumn.vectorCopy();

--- a/tests/parser/AquiferCTTests.cpp
+++ b/tests/parser/AquiferCTTests.cpp
@@ -99,30 +99,32 @@ inline Deck createAquiferCTDeckDefaultP0() {
     return parser.parseString(deckData);
 }
 
-inline std::vector<AquiferCT::AQUCT_data> init_aquiferct(Deck& deck){
+AquiferCT init_aquiferct(const Deck& deck){
     EclipseState eclState( deck );
-    AquiferCT aquct( eclState.getTableManager(), deck);
-    std::vector<AquiferCT::AQUCT_data> aquiferct = aquct.getAquifers();
-
-    return aquiferct;
+    return AquiferCT(eclState.getTableManager(), deck);
 }
 
 BOOST_AUTO_TEST_CASE(AquiferCTTest){
     auto deck = createAquiferCTDeck();
-    std::vector< AquiferCT::AQUCT_data > aquiferct = init_aquiferct(deck);
-    for (const auto& it : aquiferct){
-        BOOST_CHECK_EQUAL(it.aquiferID , 1);
-        BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
-        BOOST_CHECK_EQUAL(it.inftableID , 2);
-        BOOST_CHECK_CLOSE(*(it.p0), 1.5e5, 1e-6);
+    {
+        auto aquiferct = init_aquiferct(deck);
+        for (const auto& it : aquiferct){
+            BOOST_CHECK_EQUAL(it.aquiferID , 1);
+            BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
+            BOOST_CHECK_EQUAL(it.inftableID , 2);
+            BOOST_CHECK_CLOSE(*(it.p0), 1.5e5, 1e-6);
+        }
+        BOOST_CHECK_EQUAL(aquiferct.size(), 1);
     }
 
     auto deck_default_p0 = createAquiferCTDeckDefaultP0();
-    aquiferct = init_aquiferct(deck_default_p0);
-    for (const auto& it : aquiferct){
-        BOOST_CHECK_EQUAL(it.aquiferID , 1);
-        BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
-        BOOST_CHECK_EQUAL(it.inftableID , 2);
-        BOOST_CHECK(it.p0 == nullptr);
+    {
+        auto aquiferct = init_aquiferct(deck_default_p0);
+        for (const auto& it : aquiferct){
+            BOOST_CHECK_EQUAL(it.aquiferID , 1);
+            BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
+            BOOST_CHECK_EQUAL(it.inftableID , 2);
+            BOOST_CHECK(it.p0 == nullptr);
+        }
     }
 }

--- a/tests/parser/AquiferCTTests.cpp
+++ b/tests/parser/AquiferCTTests.cpp
@@ -127,5 +127,8 @@ BOOST_AUTO_TEST_CASE(AquiferCTTest){
             BOOST_CHECK_EQUAL(it.inftableID , 2);
             BOOST_CHECK(it.p0.first == false);
         }
+        auto data = aquiferct.data();
+        AquiferCT aq2(data);
+        BOOST_CHECK( aq2 == aquiferct );
     }
 }

--- a/tests/parser/AquiferCTTests.cpp
+++ b/tests/parser/AquiferCTTests.cpp
@@ -112,7 +112,8 @@ BOOST_AUTO_TEST_CASE(AquiferCTTest){
             BOOST_CHECK_EQUAL(it.aquiferID , 1);
             BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
             BOOST_CHECK_EQUAL(it.inftableID , 2);
-            BOOST_CHECK_CLOSE(*(it.p0), 1.5e5, 1e-6);
+            BOOST_CHECK(it.p0.first == true);
+            BOOST_CHECK_CLOSE(it.p0.second, 1.5e5, 1e-6);
         }
         BOOST_CHECK_EQUAL(aquiferct.size(), 1);
     }
@@ -124,7 +125,7 @@ BOOST_AUTO_TEST_CASE(AquiferCTTest){
             BOOST_CHECK_EQUAL(it.aquiferID , 1);
             BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
             BOOST_CHECK_EQUAL(it.inftableID , 2);
-            BOOST_CHECK(it.p0 == nullptr);
+            BOOST_CHECK(it.p0.first == false);
         }
     }
 }

--- a/tests/parser/AquiferCTTests.cpp
+++ b/tests/parser/AquiferCTTests.cpp
@@ -101,7 +101,7 @@ inline Deck createAquiferCTDeckDefaultP0() {
 
 inline std::vector<AquiferCT::AQUCT_data> init_aquiferct(Deck& deck){
     EclipseState eclState( deck );
-    AquiferCT aquct( eclState, deck);
+    AquiferCT aquct( eclState.getTableManager(), deck);
     std::vector<AquiferCT::AQUCT_data> aquiferct = aquct.getAquifers();
 
     return aquiferct;

--- a/tests/parser/AquifetpTests.cpp
+++ b/tests/parser/AquifetpTests.cpp
@@ -129,33 +129,35 @@ inline Deck createAquifetpDeck_defaultPressure(){
   return parser.parseString(deckData);
 }
 
-inline std::vector<Aquifetp::AQUFETP_data> init_aquifetp(Deck& deck){
+inline Aquifetp init_aquifetp(Deck& deck){
   Aquifetp aqufetp(deck);
-  std::vector<Aquifetp::AQUFETP_data> aquifetp = aqufetp.getAquifers();
-
-  return aquifetp;
+  return aqufetp;
 }
 
 BOOST_AUTO_TEST_CASE(AquifetpTest){
   auto aqufetp_deck = createAquifetpDeck();
-  std::vector< Aquifetp::AQUFETP_data > aquifetp = init_aquifetp(aqufetp_deck);
+  const auto& aquifetp = init_aquifetp(aqufetp_deck);
   for (const auto& it : aquifetp){
     BOOST_CHECK_EQUAL(it.aquiferID , 1);
     BOOST_CHECK_EQUAL(it.V0, 2.0e9);
     BOOST_CHECK_EQUAL(it.J, 500/86400e5);
+    BOOST_CHECK( it.p0.first );
   }
+  const auto& data = aquifetp.data();
+  Aquifetp aq2(data);
+  BOOST_CHECK(aq2 == aquifetp);
 
   auto aqufetp_deck_null = createNullAquifetpDeck();
-  std::vector< Aquifetp::AQUFETP_data > aquifetp_null = init_aquifetp(aqufetp_deck_null);
+  const auto& aquifetp_null = init_aquifetp(aqufetp_deck_null);
   BOOST_CHECK_EQUAL(aquifetp_null.size(), 0);
 
   auto aqufetp_deck_default = createAquifetpDeck_defaultPressure();
-  std::vector< Aquifetp::AQUFETP_data > aquifetp_default = init_aquifetp(aqufetp_deck_default);
+  const auto& aquifetp_default = init_aquifetp(aqufetp_deck_default);
   for (const auto& it : aquifetp_default){
     BOOST_CHECK_EQUAL(it.aquiferID , 1);
     BOOST_CHECK_EQUAL(it.V0, 2.0e9);
     BOOST_CHECK_EQUAL(it.J, 500/86400e5);
-    BOOST_CHECK( !it.p0 );
+    BOOST_CHECK( !it.p0.first );
   }
 
 }


### PR DESCRIPTION
The purpose of this PR is to internalize the Aquifer configuration in the EclipseState and thereby reduce deck usage downstream. This PR just contains initial refactoring, and not the final step moving the Aquifer code in under the EclipseState umbrella.

Downstream: https://github.com/OPM/opm-simulators/pull/2319