### PR TITLE
Disable checking of DOUBHEAD[1] with compareECL

### DIFF
--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -817,6 +817,12 @@ void ECLRegressionTest::results_rst()
                         } else if (arrayType1[i] == DOUB) {
                             auto vect1 = rst1.getRst<double>(keywords1[i], seqn, 0);
                             auto vect2 = rst2.getRst<double>(keywords2[ind2], seqn, 0);
+
+                            // hack in order to not test doubhead[1], dependent on simulation results
+                            // All ohter items in DOUBHEAD are tested with strict tolerances
+                            if (keywords1[i]=="DOUBHEAD"){
+                                vect2[1] = vect1[1];
+                            }
                             compareFloatingPointVectors(vect1, vect2, keywords1[i], reference);
                         } else if (arrayType1[i] == LOGI) {
                             auto vect1 = rst1.getRst<bool>(keywords1[i], seqn, 0);


### PR DESCRIPTION
DOUBHEAD array is set to be using strict tolerances in compareECL since this array holds data which is not dependent on simulation results. 

This is not 100% true since item number 2 (DOUBHEAD[1]) is related to size of next simulation step (used by flow when restarting). This property is highly dependent on simulation results. 
 
Suggesting to skip this item when testing DOUBHEAD. The alternative would be to stop using strict tolerances on DOUBHEAD array. 
