### PR TITLE
Allow and prefer C++-17 standard.

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -41,7 +41,7 @@ if(NOT CMAKE_CXX_STANDARD)
 
 
   if(NOT MSVC)
-    foreach(_flag "14" "11")
+    foreach(_flag "17" "14" "11")
       set(_FLAG "CXX_FLAG_CXX${_flag}")
       string(TOUPPER ${_FLAG} _FLAG)
       # try to use compiler flag -std=c++${_flag}


### PR DESCRIPTION
Since we decided to support g++ version >=7 for 2020.04 we can allow to activate C++17. This will also allow using the current master of DUMUX which requires C++17. Without this commit DUMUX will be compiled with both -std=c++14 and -std=c++17 (as we fiddle around with downstream compiler flags in project-config.cmake) which results in compilation errors.