### PR TITLE
Silence a few warnings, remove some end-of-line whitespace.

### DIFF
--- a/opm/common/utility/platform_dependent/disable_warnings.h
+++ b/opm/common/utility/platform_dependent/disable_warnings.h
@@ -69,13 +69,11 @@
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wunneeded-internal-declaration"
 #pragma GCC diagnostic ignored "-Wunused-private-field"
-#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #pragma GCC diagnostic ignored "-Wcast-align"
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #pragma GCC diagnostic ignored "-Wignored-attributes"
-#pragma GCC diagnostic ignored "-Wmisleading-indentation"
 #endif // COMPATIBLE_COMPILER
 
 #endif // SILENCE_EXTERNAL_WARNINGS

--- a/opm/io/eclipse/rst/group.hpp
+++ b/opm/io/eclipse/rst/group.hpp
@@ -26,7 +26,7 @@
 namespace Opm {
 namespace RestartIO {
 
-class RstHeader;
+struct RstHeader;
 
 struct RstGroup {
     RstGroup(const std::string* zwel,

--- a/opm/io/eclipse/rst/well.hpp
+++ b/opm/io/eclipse/rst/well.hpp
@@ -31,7 +31,7 @@
 namespace Opm {
 namespace RestartIO {
 
-class RstHeader;
+struct RstHeader;
 
 struct RstWell {
     RstWell(const RstHeader& header,

--- a/opm/output/eclipse/DoubHEAD.hpp
+++ b/opm/output/eclipse/DoubHEAD.hpp
@@ -25,7 +25,7 @@
 #include <vector>
 
 namespace Opm {
-    class Tuning;
+    struct Tuning;
     class Schedule;
     class UDQParams;
 }
@@ -39,7 +39,7 @@ namespace Opm { namespace RestartIO {
             std::chrono::time_point<std::chrono::system_clock>          start;
             std::chrono::duration<double, std::chrono::seconds::period> elapsed;
         };
-        
+
         struct guideRate {
             double A;
             double B;
@@ -50,7 +50,7 @@ namespace Opm { namespace RestartIO {
             double delay;
             double damping_fact;
         };
-        
+
         DoubHEAD();
 
         ~DoubHEAD() = default;
@@ -69,7 +69,7 @@ namespace Opm { namespace RestartIO {
         DoubHEAD& drsdt(const Schedule&   sched,
                         const std::size_t lookup_step,
                         const double      cnvT);
-	
+
         DoubHEAD& udq_param(const UDQParams& udqPar);
         DoubHEAD& guide_rate_param(const guideRate& guide_rp);
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
@@ -286,7 +286,7 @@ bool static_type_check(UDQVarType lhs, UDQVarType rhs) {
 
 UDQASTNode UDQParser::parse(const UDQParams& udq_params, UDQVarType target_type, const std::string& target_var, const std::vector<std::string>& tokens, const ParseContext& parseContext, ErrorGuard& errors)
 {
-    UDQParser parser(udq_params, target_type, tokens);
+    UDQParser parser(udq_params, tokens);
     parser.next();
     auto tree = parser.parse_cmp();
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
@@ -65,10 +65,9 @@ public:
   static UDQASTNode parse(const UDQParams& udq_params, UDQVarType target_type, const std::string& target_var, const std::vector<std::string>& tokens, const ParseContext& parseContext, ErrorGuard& errors);
 
 private:
-    UDQParser(const UDQParams& udq_params1, UDQVarType ttype, const std::vector<std::string>& tokens1) :
+    UDQParser(const UDQParams& udq_params1, const std::vector<std::string>& tokens1) :
         udq_params(udq_params1),
         udqft(UDQFunctionTable(udq_params)),
-        target_type(ttype),
         tokens(tokens1)
     {}
 
@@ -86,7 +85,6 @@ private:
 
     const UDQParams& udq_params;
     UDQFunctionTable udqft;
-    UDQVarType target_type;
     std::vector<std::string> tokens;
     ssize_t current_pos = -1;
 };

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -305,7 +305,6 @@ ENDBOX
     const auto& poro = fpm.get_double("PORO");
     const auto& ntg = fpm.get_double("NTG");
     const auto& multpv = fpm.get_double("MULTPV");
-    const auto& defaulted = fpm.defaulted<double>("PORV");
     const auto& porv = fpm.porv();
 
     // All cells should be active for this grid

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -743,8 +743,8 @@ BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
 
 BOOST_AUTO_TEST_CASE(BAD_CAST) {
     UDQFunctionTable udqft;
-
-    BOOST_CHECK_THROW( dynamic_cast<const UDQUnaryElementalFunction&>(udqft.get("==")), std::bad_cast);
+    auto x = udqft.get("==");
+    BOOST_CHECK_EQUAL(dynamic_cast<const UDQUnaryElementalFunction*>(&x), nullptr);
 }
 
 

--- a/tests/rst_load.cpp
+++ b/tests/rst_load.cpp
@@ -27,8 +27,10 @@ int main(int argc, char ** argv) {
     for (int iarg = 1; iarg < argc; iarg++) {
         Opm::EclIO::ERst rst_file(argv[iarg]);
         for (int report_step : rst_file.listOfReportStepNumbers()) {
-            if (report_step > 0)
+            if (report_step > 0) {
                 const auto& state = Opm::RestartIO::RstState::load(rst_file, report_step);
+                static_cast<void>(state); // Suppress unused variable warning.
+            }
         }
     }
 }


### PR DESCRIPTION
With this, opm-common compiles warning-free with clang for me.