### PR TITLE
Schedule add rst argument

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -46,6 +46,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
+#include <opm/io/eclipse/rst/state.hpp>
+
 
 /*
   The DynamicState<std::shared_ptr<T>> pattern: The quantities in the Schedule
@@ -120,7 +122,8 @@ namespace Opm
                  const FieldPropsManager& fp,
                  const Runspec &runspec,
                  const ParseContext& parseContext,
-                 ErrorGuard& errors);
+                 ErrorGuard& errors,
+                 const RestartIO::RstState* rst = nullptr);
 
         template<typename T>
         Schedule(const Deck& deck,
@@ -128,26 +131,31 @@ namespace Opm
                  const FieldPropsManager& fp,
                  const Runspec &runspec,
                  const ParseContext& parseContext,
-                 T&& errors);
+                 T&& errors,
+                 const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
                  const EclipseGrid& grid,
                  const FieldPropsManager& fp,
-                 const Runspec &runspec);
+                 const Runspec &runspec,
+                 const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
                  const EclipseState& es,
                  const ParseContext& parseContext,
-                 ErrorGuard& errors);
+                 ErrorGuard& errors,
+                 const RestartIO::RstState* rst = nullptr);
 
         template <typename T>
         Schedule(const Deck& deck,
                  const EclipseState& es,
                  const ParseContext& parseContext,
-                 T&& errors);
+                 T&& errors,
+                 const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
-                 const EclipseState& es);
+                 const EclipseState& es,
+                 const RestartIO::RstState* rst = nullptr);
 
         Schedule(const TimeMap& timeMap,
                  const WellMap& wellsStatic,

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -313,6 +313,7 @@ namespace Opm
 
 
         std::map<std::string,Events> wellgroup_events;
+        void load_rst(const RestartIO::RstState& rst, const UnitSystem& unit_system);
         void addWell(const std::string& wellName,
                      const std::string& group,
                      int headI,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -112,7 +112,8 @@ namespace {
                         const FieldPropsManager& fp,
                         const Runspec &runspec,
                         const ParseContext& parseContext,
-                        ErrorGuard& errors) :
+                        ErrorGuard& errors,
+                        const RestartIO::RstState * rst) :
         m_timeMap( deck ),
         m_oilvaporizationproperties( this->m_timeMap, OilVaporizationProperties(runspec.tabdims().getNumPVTTables()) ),
         m_events( this->m_timeMap ),
@@ -159,43 +160,47 @@ namespace {
                         const FieldPropsManager& fp,
                         const Runspec &runspec,
                         const ParseContext& parseContext,
-                        T&& errors) :
-        Schedule(deck, grid, fp, runspec, parseContext, errors)
+                        T&& errors,
+                        const RestartIO::RstState * rst) :
+        Schedule(deck, grid, fp, runspec, parseContext, errors, rst)
     {}
 
 
     Schedule::Schedule( const Deck& deck,
                         const EclipseGrid& grid,
                         const FieldPropsManager& fp,
-                        const Runspec &runspec) :
-        Schedule(deck, grid, fp, runspec, ParseContext(), ErrorGuard())
+                        const Runspec &runspec,
+                        const RestartIO::RstState * rst) :
+        Schedule(deck, grid, fp, runspec, ParseContext(), ErrorGuard(), rst)
     {}
 
 
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, ErrorGuard& errors) :
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, ErrorGuard& errors, const RestartIO::RstState * rst) :
         Schedule(deck,
                  es.getInputGrid(),
                  es.fieldProps(),
                  es.runspec(),
                  parse_context,
-                 errors)
+                 errors,
+                 rst)
     {}
 
 
 
     template <typename T>
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, T&& errors) :
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, T&& errors, const RestartIO::RstState * rst) :
         Schedule(deck,
                  es.getInputGrid(),
                  es.fieldProps(),
                  es.runspec(),
                  parse_context,
-                 errors)
+                 errors,
+                 rst)
     {}
 
 
-    Schedule::Schedule(const Deck& deck, const EclipseState& es) :
-        Schedule(deck, es, ParseContext(), ErrorGuard())
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, const RestartIO::RstState * rst) :
+        Schedule(deck, es, ParseContext(), ErrorGuard(), rst)
     {}
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -133,6 +133,9 @@ namespace {
         rft_config(this->m_timeMap),
         m_nupcol(this->m_timeMap, ParserKeywords::NUPCOL::NUM_ITER::defaultValue)
     {
+        if (rst)
+            this->load_rst(*rst, deck.getActiveUnitSystem());
+
         addGroup( "FIELD", 0, deck.getActiveUnitSystem());
 
         /*
@@ -2953,5 +2956,10 @@ void Schedule::handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep, c
                this->getNupCol() == data.getNupCol() &&
                this->getWellGroupEvents() == data.getWellGroupEvents();
      }
+
+void Schedule::load_rst(const RestartIO::RstState&, const UnitSystem&)
+{
+}
+
 
 }

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -89,11 +89,14 @@ BOOST_AUTO_TEST_CASE(LoadRST) {
 BOOST_AUTO_TEST_CASE(LoadRestartSim) {
     Parser parser;
     auto deck = parser.parseFile("SPE1CASE2.DATA");
+    EclipseState ecl_state(deck);
+    Schedule sched(deck, ecl_state);
+
     auto restart_deck = parser.parseFile("SPE1CASE2_RESTART.DATA");
     EclIO::ERst rst_file("SPE1CASE2.X0060");
     auto rst_state = RestartIO::RstState::load(rst_file, 60);
+    EclipseState ecl_state_restart(restart_deck);
+    Schedule restart_sched(restart_deck, ecl_state_restart, &rst_state);
 
-    EclipseState ecl_state(deck);
-    Schedule sched(deck, ecl_state);
-    //Schedule restart_sched(deck, ecl_state, &rst_state);
+    // Verify that sched and restart_sched are identical from report_step 60 and onwords.
 }


### PR DESCRIPTION
This PR adds an optional `const RstState *` to the `Schedule`constructor - to facilitate loading/initializing the `Schedule` object from restart information. The PR only has an api change - actually "doing something" is still on my machine.


Part of #1396 