### PR TITLE
Internalize the existence of SKIPREST in the TimeMap

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -53,6 +53,7 @@ namespace Opm {
         /// Return the date and time where a given time step starts.
         std::time_t getStartTime(size_t tStepIdx) const;
         std::time_t getEndTime() const;
+        bool skiprest() const;
         /// Return the period of time in seconds which passed between the start of the simulation and a given point in time.
         double getTimePassedUntil(size_t tLevelIdx) const;
         /// Return the length of a given time step in seconds.
@@ -95,6 +96,7 @@ namespace Opm {
         std::vector<std::time_t> m_timeList;
         std::vector<StepData> m_first_timestep_years;   // A list of the first timestep of every year
         std::vector<StepData> m_first_timestep_months;  // A list of the first timestep of every month
+        bool m_skiprest = false;
         std::size_t m_restart_offset = 0;
     };
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -159,6 +159,7 @@ namespace {
                     TimeStampUTC ts(restart_time);
                     throw std::invalid_argument("Could not find restart date " + std::to_string(ts.year()) + "-" + std::to_string(ts.month()) + "-" + std::to_string(ts.day()));
                 }
+                this->m_skiprest = true;
             }
         }
     }
@@ -426,6 +427,10 @@ namespace {
 
     std::size_t TimeMap::restart_offset() const {
         return this->m_restart_offset;
+    }
+
+    bool TimeMap::skiprest() const {
+        return this->m_skiprest;
     }
 }
 

--- a/tests/parser/TimeMapTest.cpp
+++ b/tests/parser/TimeMapTest.cpp
@@ -223,6 +223,7 @@ BOOST_AUTO_TEST_CASE(TimeStepsCorrect) {
 
     BOOST_CHECK_EQUAL(tmap.getTimeStepLength(8), 6*24*60*60);
     BOOST_CHECK_EQUAL(tmap.getTimeStepLength(9), 7*24*60*60);
+    BOOST_CHECK(!tmap.skiprest());
 }
 
 
@@ -694,6 +695,7 @@ TSTEP
     auto start = tm1[0];
     BOOST_CHECK_EQUAL(start , Opm::asTimeT(Opm::TimeStampUTC({2000,1,1})));
     BOOST_CHECK_EQUAL(tm1[5] , Opm::asTimeT(Opm::TimeStampUTC({2005,1,1})));
+    BOOST_CHECK(tm1.skiprest());
 
     Opm::TimeMap tm2(deck2, valid_restart);
     BOOST_CHECK_EQUAL(tm2[5], Opm::asTimeT(Opm::TimeStampUTC({2005,1,1})));


### PR DESCRIPTION
Small step in #1396