### PR TITLE
Move RestartConfig to Schedule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,9 @@ if (OPM_ENABLE_PYTHON)
     install( CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/python/install.py ${PROJECT_BINARY_DIR}/python/python/opm ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX} 1)")
   endif()
 
+  # Observe that if the opmcommon library has been built as a shared library the
+  # python library opmcommon_python will in general not find it runtime while
+  # testing.
   add_test(NAME python_tests
            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/python
            COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext --dry-run --build-lib ${PROJECT_BINARY_DIR}/python/python/opm test

--- a/examples/msim.cpp
+++ b/examples/msim.cpp
@@ -37,7 +37,7 @@ int main(int /* argc */, char** argv) {
     Opm::ErrorGuard error_guard;
 
     Opm::Deck deck = parser.parseFile(deck_file, parse_context, error_guard);
-    Opm::EclipseState state(deck, parse_context, error_guard);
+    Opm::EclipseState state(deck);
     Opm::Schedule schedule(deck, state, parse_context, error_guard);
     Opm::SummaryConfig summary_config(deck, schedule, state.getTableManager(), parse_context, error_guard);
 

--- a/examples/opmi.cpp
+++ b/examples/opmi.cpp
@@ -56,7 +56,7 @@ inline void loadDeck( const char * deck_file) {
     std::cout << "parse complete - creating EclipseState .... ";  std::cout.flush();
 
     start = std::chrono::system_clock::now();
-    Opm::EclipseState state( deck, parseContext, errors );
+    Opm::EclipseState state( deck );
     auto state_time = std::chrono::system_clock::now() - start;
 
     std::cout << "creating Schedule .... ";  std::cout.flush();

--- a/examples/opmpack.cpp
+++ b/examples/opmpack.cpp
@@ -19,6 +19,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <fstream>
 #include <getopt.h>
 
 #include <opm/common/utility/FileSystem.hpp>

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -24,34 +24,28 @@
 
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
 
 namespace Opm {
 
     class Deck;
-    class ParseContext;
-    class ErrorGuard;
 
     class EclipseConfig
     {
     public:
         EclipseConfig() = default;
-        EclipseConfig(const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors);
-        EclipseConfig(const InitConfig& initConfig,
-                      const RestartConfig& restartConfig);
+        EclipseConfig(const Deck& deck);
+        EclipseConfig(const InitConfig& initConfig, const IOConfig& io_conf);
 
         const InitConfig& init() const;
         IOConfig& io();
         const IOConfig& io() const;
-        const RestartConfig& restart() const;
         const InitConfig& getInitConfig() const;
-        const RestartConfig& getRestartConfig() const;
 
         bool operator==(const EclipseConfig& data) const;
 
     private:
         InitConfig m_initConfig;
-        RestartConfig m_restartConfig;
+        IOConfig io_config;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -23,7 +23,6 @@
 #include <memory>
 #include <vector>
 
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp>
@@ -52,7 +51,6 @@ namespace Opm {
     class EclipseGrid;
     class InitConfig;
     class IOConfig;
-    class ParseContext;
     class RestartConfig;
     class DeckSection;
     class SimulationConfig;
@@ -68,9 +66,6 @@ namespace Opm {
             AllProperties = IntProperties | DoubleProperties
         };
 
-        template<typename T>
-        EclipseState(const Deck& deck , const ParseContext& parseContext, T&& errors);
-        EclipseState(const Deck& deck , const ParseContext& parseContext, ErrorGuard& errors);
         EclipseState(const Deck& deck);
 
         const IOConfig& getIOConfig() const;
@@ -78,9 +73,6 @@ namespace Opm {
 
         const InitConfig& getInitConfig() const;
         const SimulationConfig& getSimulationConfig() const;
-        const RestartConfig& getRestartConfig() const;
-        RestartConfig& getRestartConfig();
-
         const EclipseGrid& getInputGrid() const;
 
         const FaultCollection& getFaults() const;

--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <set>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 
 /*
@@ -198,7 +199,6 @@ namespace Opm {
     class RUNSPECSection;
     class SCHEDULESection;
     class SOLUTIONSection;
-    class TimeMap;
     class Schedule;
     class ParseContext;
     class ErrorGuard;
@@ -319,13 +319,10 @@ namespace Opm {
         RestartConfig() = default;
 
         template<typename T>
-        RestartConfig( const Deck&, const ParseContext& parseContext, T&& errors );
-
-        RestartConfig( const Deck&, const ParseContext& parseContext, ErrorGuard& errors );
-        RestartConfig( const Deck& );
-
-        RestartConfig(const IOConfig& io_config,
-                      const TimeMap& timeMap,
+        RestartConfig( const TimeMap& time_map, const Deck&, const ParseContext& parseContext, T&& errors );
+        RestartConfig( const TimeMap& time_map, const Deck&, const ParseContext& parseContext, ErrorGuard& errors );
+        RestartConfig( const TimeMap& time_map, const Deck& );
+        RestartConfig(const TimeMap& timeMap,
                       int firstRestartStep,
                       bool writeInitial,
                       const DynamicState<RestartSchedule>& restart_sched,
@@ -336,8 +333,6 @@ namespace Opm {
         bool getWriteRestartFile(size_t timestep, bool log=true) const;
         const std::map< std::string, int >& getRestartKeywords( size_t timestep ) const;
         int getKeyword( const std::string& keyword, size_t timeStep) const;
-        const IOConfig& ioConfig() const;
-        IOConfig& ioConfig();
 
         void overrideRestartWriteInterval(size_t interval);
         void handleSolutionSection(const SOLUTIONSection& solutionSection, const ParseContext& parseContext, ErrorGuard& errors);
@@ -374,7 +369,6 @@ namespace Opm {
         void update( size_t step, const RestartSchedule& rs);
         static RestartSchedule rptsched( const DeckKeyword& );
 
-        IOConfig io_config;
         TimeMap m_timemap;
         int     m_first_restart_step = 1;
         bool    m_write_initial_RST_file = false;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
@@ -177,6 +178,7 @@ namespace Opm
                  const DynamicState<std::shared_ptr<Action::Actions>>& actions,
                  const RFTConfig& rftconfig,
                  const DynamicState<int>& nupCol,
+                 const RestartConfig& rst_config,
                  const std::map<std::string,Events>& wellGroupEvents);
 
         /*
@@ -260,6 +262,8 @@ namespace Opm
         */
         void filterConnections(const ActiveGridCells& grid);
         size_t size() const;
+        const RestartConfig& restart() const;
+        RestartConfig& restart();
 
         void applyAction(size_t reportStep, const Action::ActionX& action, const Action::Result& result);
         int getNupcol(size_t reportStep) const;
@@ -308,7 +312,7 @@ namespace Opm
         DynamicState<std::shared_ptr<Action::Actions>> m_actions;
         RFTConfig rft_config;
         DynamicState<int> m_nupcol;
-
+        RestartConfig restart_config;
 
         std::map<std::string,Events> wellgroup_events;
         void load_rst(const RestartIO::RstState& rst, const UnitSystem& unit_system);

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -103,7 +103,7 @@ namespace Opm {
             addParserKeyword( T() );
         }
 
-        static EclipseState parse(const Deck& deck,            const ParseContext& context, ErrorGuard& errors);
+        static EclipseState parse(const Deck& deck,            const ParseContext& context);
         static EclipseState parse(const std::string &filename, const ParseContext& context, ErrorGuard& errors);
         static EclipseState parseData(const std::string &data, const ParseContext& context, ErrorGuard& errors);
 
@@ -118,8 +118,7 @@ namespace Opm {
         /// we construct only a lean grid, otherwise, we construct a full EclipseState and return the
         /// fully constructed InputGrid
         static EclipseGrid parseGrid(const Deck& deck,
-                                     const ParseContext& context,
-                                     ErrorGuard& errors);
+                                     const ParseContext& context);
 
         /// Parses the provided deck string.  If context contains ParseContext::PARSE_PARTIAL_DECK,
         /// we construct only a lean grid, otherwise, we construct a full EclipseState and return the

--- a/python/cxx/eclipse_config.cpp
+++ b/python/cxx/eclipse_config.cpp
@@ -1,6 +1,5 @@
-#include <vector>  // workaround for missing import in opm-parser/Equil.hpp
+#include <vector>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
@@ -15,8 +14,7 @@
 void python::common::export_EclipseConfig(py::module& module)
 {
     py::class_< EclipseConfig >( module, "EclipseConfig" )
-      .def( "init",            &EclipseConfig::init, ref_internal)
-      .def( "restart",         &EclipseConfig::restart, ref_internal);
+        .def( "init",            &EclipseConfig::init, ref_internal);
 
     py::class_< SummaryConfig >( module, "SummaryConfig")
         .def(py::init([](const Deck& deck, const EclipseState& state, const Schedule& schedule) {
@@ -30,10 +28,7 @@ void python::common::export_EclipseConfig(py::module& module)
         .def( "restartRequested",   &InitConfig::restartRequested )
         .def( "getRestartStep"  ,   &InitConfig::getRestartStep );
 
-    py::class_< RestartConfig >( module, "RestartConfig")
-        .def( "getKeyword",          &RestartConfig::getKeyword )
-        .def( "getFirstRestartStep", &RestartConfig::getFirstRestartStep )
-        .def( "getWriteRestartFile", &RestartConfig::getWriteRestartFile, py::arg("reportStep"), py::arg("log") = true);
+    py::class_< IOConfig >( module, "IOConfig");
 
     py::class_< SimulationConfig >( module, "SimulationConfig")
         .def("hasThresholdPressure", &SimulationConfig::useThresholdPressure )
@@ -41,3 +36,4 @@ void python::common::export_EclipseConfig(py::module& module)
         .def("hasDISGAS",            &SimulationConfig::hasDISGAS )
         .def("hasVAPOIL",            &SimulationConfig::hasVAPOIL );
 }
+

--- a/python/cxx/parser.cpp
+++ b/python/cxx/parser.cpp
@@ -6,6 +6,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <pybind11/stl.h>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 #include "export.hpp"
 

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -85,7 +85,9 @@ namespace {
         return sch.hasWell( wellName );
     }
 
-
+    const RestartConfig& restart(const Schedule& sch) {
+        return sch.restart();
+    }
 }
 
 void python::common::export_Schedule(py::module& module) {
@@ -96,6 +98,7 @@ void python::common::export_Schedule(py::module& module) {
     .def_property_readonly( "start",  &get_start_time )
     .def_property_readonly( "end",    &get_end_time )
     .def_property_readonly( "timesteps", &get_timesteps )
+    .def_property_readonly("restart", &restart)
     .def( "shut_well", &Schedule::shut_well)
     .def( "open_well", &Schedule::open_well)
     .def( "stop_well", &Schedule::stop_well)
@@ -103,5 +106,10 @@ void python::common::export_Schedule(py::module& module) {
     .def( "get_well", &get_well)
     .def( "__contains__", &has_well )
     .def( "group", &Schedule::getGroup, ref_internal);
+
+    py::class_< RestartConfig >( module, "RestartConfig")
+        .def( "getKeyword",          &RestartConfig::getKeyword )
+        .def( "getFirstRestartStep", &RestartConfig::getFirstRestartStep )
+        .def( "getWriteRestartFile", &RestartConfig::getWriteRestartFile, py::arg("reportStep"), py::arg("log") = true);
 
 }

--- a/python/tests/test_schedule.py
+++ b/python/tests/test_schedule.py
@@ -68,6 +68,12 @@ class TestSchedule(unittest.TestCase):
         prod = sch.get_well("PROD", 10)
         self.assertEqual(prod.status(), "SHUT")
 
+    def test_restart(self):
+        deck  = Parser().parse(test_path('spe3/SPE3CASE1.DATA'))
+        state = EclipseState(deck)
+        sch = Schedule( deck, state )
+        rst = sch.restart
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_state.py
+++ b/python/tests/test_state.py
@@ -78,10 +78,6 @@ SATNUM
         self.assertFalse(init.restartRequested())
         self.assertEqual(0, init.getRestartStep())
 
-        rst = cfg.restart()
-        self.assertFalse(rst.getWriteRestartFile(0))
-        self.assertEqual(7, rst.getFirstRestartStep())
-
     def test_repr_title(self):
         self.assertEqual('SPE 3 - CASE 1', self.state.title)
 

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -213,7 +213,7 @@ void EclipseIO::writeTimeStep(const SummaryState& st,
       but there is an unsupported option to the RPTSCHED keyword which
       will request restart output from every timestep.
     */
-    if(!isSubstep && es.cfg().restart().getWriteRestartFile(report_step))
+    if(!isSubstep && schedule.restart().getWriteRestartFile(report_step))
     {
         EclIO::OutputStream::Restart rstFile {
             EclIO::OutputStream::ResultSet { this->impl->outputDir,

--- a/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -28,17 +28,16 @@
 
 namespace Opm {
 
-    EclipseConfig::EclipseConfig(const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors) :
-            m_initConfig(      deck),
-            m_restartConfig(   deck, parseContext, errors )
+    EclipseConfig::EclipseConfig(const Deck& deck) :
+        m_initConfig(deck),
+        io_config(deck)
     {
     }
 
 
-    EclipseConfig::EclipseConfig(const InitConfig& initConfig,
-                                 const RestartConfig& restartConfig) :
+    EclipseConfig::EclipseConfig(const InitConfig& initConfig, const IOConfig& io_conf):
         m_initConfig(initConfig),
-        m_restartConfig(restartConfig)
+        io_config(io_conf)
     {
     }
 
@@ -47,31 +46,20 @@ namespace Opm {
         return m_initConfig;
     }
 
-    const IOConfig& EclipseConfig::io() const {
-        return this->m_restartConfig.ioConfig();
-    }
-
-    IOConfig& EclipseConfig::io() {
-        return this->m_restartConfig.ioConfig();
-    }
-
-    const RestartConfig& EclipseConfig::restart() const {
-        return this->m_restartConfig;
-    }
-
-    // [[deprecated]] --- use restart()
-    const RestartConfig& EclipseConfig::getRestartConfig() const {
-        return this->restart();
-    }
-
     // [[deprecated]] --- use init()
     const InitConfig& EclipseConfig::getInitConfig() const {
         return init();
     }
 
     bool EclipseConfig::operator==(const EclipseConfig& data) const {
-        return this->init() == data.init() &&
-               this->restart() == data.restart();
+        return this->init() == data.init();
     }
 
+    IOConfig& EclipseConfig::io() {
+        return const_cast<IOConfig &>(this->io_config);
+    }
+
+    const IOConfig& EclipseConfig::io() const {
+        return this->io_config;
+    }
 }

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -45,21 +45,6 @@
 
 namespace Opm {
 
-/*
-This Function is used in Python to check if the
-ENABBLE_3DPROPS_TESTING macro has been set.
-*/
-#ifdef ENABLE_3DPROPS_TESTING
-bool enable3DPropsTesting() {
-    return true;
-}
-#else
-bool enable3DPropsTesting() {
-    return false;
-}
-#endif
-
-
 
 
 

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -37,7 +37,6 @@
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
@@ -48,10 +47,10 @@ namespace Opm {
 
 
 
-    EclipseState::EclipseState(const Deck& deck , const ParseContext& parseContext, ErrorGuard& errors) :
+    EclipseState::EclipseState(const Deck& deck) :
         m_tables(            deck ),
         m_runspec(           deck ),
-        m_eclipseConfig(     deck, parseContext, errors ),
+        m_eclipseConfig(     deck ),
         m_deckUnitSystem(    deck.getActiveUnitSystem() ),
         m_inputNnc(          deck ),
         m_inputEditNnc(      deck ),
@@ -80,17 +79,6 @@ namespace Opm {
     }
 
 
-    template<typename T>
-    EclipseState::EclipseState(const Deck& deck, const ParseContext& parseContext, T&& errors) :
-        EclipseState(deck, parseContext, errors)
-    {}
-
-
-    EclipseState::EclipseState(const Deck& deck) :
-        EclipseState(deck, ParseContext(), ErrorGuard())
-    {}
-
-
     const UnitSystem& EclipseState::getDeckUnitSystem() const {
         return m_deckUnitSystem;
     }
@@ -104,16 +92,8 @@ namespace Opm {
     }
 
 
-    const RestartConfig& EclipseState::getRestartConfig() const {
-        return m_eclipseConfig.getRestartConfig();
-    }
-
     const SimulationConfig& EclipseState::getSimulationConfig() const {
         return m_simulationConfig;
-    }
-
-    RestartConfig& EclipseState::getRestartConfig() {
-        return const_cast< RestartConfig& >( m_eclipseConfig.getRestartConfig() );
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -515,18 +515,17 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
     }
 
     template<typename T>
-    RestartConfig::RestartConfig( const Deck& deck, const ParseContext& parseContext, T&& errors ) :
-        RestartConfig(deck, parseContext, errors)
+    RestartConfig::RestartConfig( const TimeMap& time_map, const Deck& deck, const ParseContext& parseContext, T&& errors ) :
+        RestartConfig(time_map, deck, parseContext, errors)
     {}
 
-    RestartConfig::RestartConfig( const Deck& deck) :
-        RestartConfig(deck, ParseContext(), ErrorGuard())
+    RestartConfig::RestartConfig( const TimeMap& time_map, const Deck& deck) :
+        RestartConfig(time_map, deck, ParseContext(), ErrorGuard())
     {}
 
 
-    RestartConfig::RestartConfig( const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors ) :
-        io_config( deck ),
-        m_timemap( deck ),
+    RestartConfig::RestartConfig( const TimeMap& time_map, const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors ) :
+        m_timemap( time_map ),
         m_first_restart_step( -1 ),
         restart_schedule( m_timemap, {0,0,1}),
         restart_keywords( m_timemap, {} ),
@@ -538,14 +537,12 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
     }
 
 
-    RestartConfig::RestartConfig(const IOConfig& io_config_arg,
-                                 const TimeMap& timeMap,
+    RestartConfig::RestartConfig(const TimeMap& timeMap,
                                  int firstRestartStep,
                                  bool writeInitial,
                                  const DynamicState<RestartSchedule>& restart_sched,
                                  const DynamicState<std::map<std::string,int>>& restart_keyw,
                                  const std::vector<bool>& save_keyw) :
-        io_config(io_config_arg),
         m_timemap(timeMap),
         m_first_restart_step(firstRestartStep),
         m_write_initial_RST_file(writeInitial),
@@ -582,14 +579,6 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
 
     const std::map< std::string, int >& RestartConfig::getRestartKeywords( size_t timestep ) const {
         return restart_keywords.at( timestep );
-    }
-
-    IOConfig& RestartConfig::ioConfig() {
-        return this->io_config;
-    }
-
-    const IOConfig& RestartConfig::ioConfig() const {
-        return this->io_config;
     }
 
     int RestartConfig::getKeyword( const std::string& keyword, size_t timeStep) const {
@@ -778,7 +767,6 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
                this->writeInitialRst() == data.writeInitialRst() &&
                this->restartSchedule() == data.restartSchedule() &&
                this->restartKeywords() == data.restartKeywords() &&
-               this->saveKeywords() == data.saveKeywords() &&
-               this->ioConfig() == data.ioConfig();
+               this->saveKeywords() == data.saveKeywords();
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -22,6 +22,7 @@
 #include <stdexcept>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -21,6 +21,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
 
+#include <opm/parser/eclipse/Utility/String.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
@@ -52,11 +53,9 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
         deckValid = deckValid && DeckSection::checkSectionTopology(deck, parser, ensureKeywordSection);
     }
 
-    std::string deckUnitSystem = deck.getActiveUnitSystem().getName();
-    uppercase(deckUnitSystem);
+    const std::string& deckUnitSystem = uppercase(deck.getActiveUnitSystem().getName());
     for (const auto& keyword : deck.getKeywordList("FILEUNIT")) {
-        std::string fileUnitSystem = keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0);
-        uppercase(fileUnitSystem);
+        const std::string& fileUnitSystem = uppercase(keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0));
         if (fileUnitSystem != deckUnitSystem) {
             const auto& location = keyword->location();
             std::string msg =

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -942,32 +942,32 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
 
     EclipseState Parser::parse(const std::string &filename, const ParseContext& context, ErrorGuard& errors) {
         assertFullDeck(context);
-        return EclipseState( Parser{}.parseFile( filename, context, errors ), context, errors );
+        return EclipseState( Parser{}.parseFile( filename, context, errors ));
     }
 
-    EclipseState Parser::parse(const Deck& deck, const ParseContext& context, ErrorGuard& errors) {
+    EclipseState Parser::parse(const Deck& deck, const ParseContext& context) {
         assertFullDeck(context);
-        return EclipseState(deck, context, errors);
+        return EclipseState(deck);
     }
 
     EclipseState Parser::parseData(const std::string &data, const ParseContext& context, ErrorGuard& errors) {
         assertFullDeck(context);
         Parser p;
         auto deck = p.parseString(data, context, errors);
-        return parse(deck, context, errors);
+        return parse(deck, context);
     }
 
-    EclipseGrid Parser::parseGrid(const std::string &filename, const ParseContext& context, ErrorGuard& errors) {
+    EclipseGrid Parser::parseGrid(const std::string &filename, const ParseContext& context , ErrorGuard& errors) {
         if (context.hasKey(ParseContext::PARSE_MISSING_SECTIONS))
             return EclipseGrid{ filename };
         return parse(filename, context, errors).getInputGrid();
     }
 
-    EclipseGrid Parser::parseGrid(const Deck& deck, const ParseContext& context, ErrorGuard& errors)
+    EclipseGrid Parser::parseGrid(const Deck& deck, const ParseContext& context)
     {
         if (context.hasKey(ParseContext::PARSE_MISSING_SECTIONS))
             return EclipseGrid{ deck };
-        return parse(deck, context, errors).getInputGrid();
+        return parse(deck, context).getInputGrid();
     }
 
     EclipseGrid Parser::parseGridData(const std::string &data, const ParseContext& context, ErrorGuard& errors) {
@@ -976,7 +976,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
         if (context.hasKey(ParseContext::PARSE_MISSING_SECTIONS)) {
             return EclipseGrid{ deck };
         }
-        return parse(deck, context, errors).getInputGrid();
+        return parse(deck, context).getInputGrid();
     }
 
     Deck Parser::parseFile(const std::string &dataFileName, const ParseContext& parseContext, ErrorGuard& errors) const {

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -496,9 +496,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
 
     Parser parser{};
     auto deck = parser.parseString(deckData) ;
-    EclipseState state(deck );
-
-    const RestartConfig& rstConfig = state.cfg().restart();
+    RestartConfig rstConfig(TimeMap(deck), deck);
 
     BOOST_CHECK_EQUAL(false, rstConfig.getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false, rstConfig.getWriteRestartFile(1));
@@ -549,9 +547,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
 
     Parser parser;
     auto deck = parser.parseString(deckData) ;
-    EclipseState state(deck);
-
-    const RestartConfig& rstConfig = state.cfg().restart();
+    RestartConfig rstConfig(TimeMap(deck), deck);
 
     BOOST_CHECK_EQUAL(true  ,  rstConfig.getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false ,  rstConfig.getWriteRestartFile(1));
@@ -643,18 +639,14 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
 
     {   //mnemnonics
         auto deck = parser.parseString(deckData) ;
-        EclipseState state(deck);
-
-        const RestartConfig& rstConfig = state.cfg().restart();
+        RestartConfig rstConfig(TimeMap(deck), deck);
 
         BOOST_CHECK_EQUAL(true, rstConfig.getWriteRestartFile(0));
     }
 
     {   //old fashion integer mnemonics
         auto deck = parser.parseString(deckData2) ;
-        EclipseState state(deck);
-
-        const RestartConfig& rstConfig = state.cfg().restart();
+        RestartConfig rstConfig(TimeMap(deck), deck);
 
         BOOST_CHECK_EQUAL(true, rstConfig.getWriteRestartFile(0));
     }

--- a/tests/parser/IOConfigTests.cpp
+++ b/tests/parser/IOConfigTests.cpp
@@ -27,6 +27,8 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
 
 using namespace Opm;
 
@@ -190,7 +192,7 @@ BOOST_AUTO_TEST_CASE(DefaultProperties) {
 
     auto deck = Parser().parseString( data);
     IOConfig ioConfig( deck );
-    RestartConfig rstConfig( deck);
+    RestartConfig rstConfig( TimeMap(deck), deck);
 
     /*If no GRIDFILE nor NOGGF keywords are specified, default output an EGRID file*/
     BOOST_CHECK( ioConfig.getWriteEGRIDFile() );

--- a/tests/parser/InitConfigTest.cpp
+++ b/tests/parser/InitConfigTest.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <fstream>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -39,6 +39,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.hpp>
 

--- a/tests/parser/ParseContext_EXIT1.cpp
+++ b/tests/parser/ParseContext_EXIT1.cpp
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/tests/parser/ParserIncludeTests.cpp
+++ b/tests/parser/ParserIncludeTests.cpp
@@ -21,11 +21,13 @@
 #define BOOST_TEST_MODULE ParserTests
 #include <boost/test/unit_test.hpp>
 
+#include <iostream>
 #include <opm/common/utility/FileSystem.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 #include <iostream>
 

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -21,12 +21,14 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/json/JsonObject.hpp>
+#include <iostream>
 
 #include <opm/common/utility/FileSystem.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>

--- a/tests/parser/RestartConfigTests.cpp
+++ b/tests/parser/RestartConfigTests.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED_INTEGER) {
     Parser parser;
 
     auto deck1 = parser.parseString( deckData1);
-    RestartConfig rstConfig1( deck1);
+    RestartConfig rstConfig1( TimeMap(deck1), deck1);
 
     BOOST_CHECK(  rstConfig1.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 1 ) );
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(RPTRST_mixed_mnemonics_int_list) {
     ErrorGuard errors;
     auto deck = Parser().parseString( data, parseContext, errors );
     parseContext.update(ParseContext::RPT_MIXED_STYLE, InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW( RestartConfig( deck, parseContext, errors ), std::invalid_argument);
+    BOOST_CHECK_THROW( RestartConfig( TimeMap(deck), deck, parseContext, errors ), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(RPTRST) {
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     Opm::Parser parser;
 
     auto deck1 = parser.parseString( deckData1);
-    RestartConfig rstConfig1( deck1 );
+    RestartConfig rstConfig1( TimeMap(deck1), deck1 );
 
     // Observe that this is true due to some undocumented guessing that
     // the initial restart file should be written if a RPTRST keyword is
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     BOOST_CHECK_EQUAL( rstConfig1.getKeyword( "ALLPROPS" , 2 ) , 0);
 
     auto deck2 = parser.parseString( deckData2 );
-    RestartConfig rstConfig2( deck2 );
+    RestartConfig rstConfig2( TimeMap(deck2), deck2 );
 
     const auto expected2 = { "BASIC", "FLOWS", "FREQ" };
     const auto kw_list2 = fun::map( fst, rstConfig2.getRestartKeywords( 2 ) );
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 3 ) );
 
     auto deck3 = parser.parseString( deckData3 );
-    RestartConfig rstConfig3( deck3 );
+    RestartConfig rstConfig3( TimeMap(deck3), deck3 );
 
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 1 ) );
@@ -466,15 +466,15 @@ BOOST_AUTO_TEST_CASE(RPTRST_FORMAT_ERROR) {
     auto deck1 = parser.parseString( deckData1, ctx, errors );
     ctx.update(ParseContext::RPT_UNKNOWN_MNEMONIC, InputError::IGNORE);
     ctx.update(ParseContext::RPT_MIXED_STYLE, InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW(RestartConfig(deck1, ctx, errors), std::invalid_argument);
+    BOOST_CHECK_THROW(RestartConfig(TimeMap(deck1), deck1, ctx, errors), std::invalid_argument);
 
     ctx.update(ParseContext::RPT_MIXED_STYLE, InputError::IGNORE);
-    RestartConfig rstConfig1( deck1, ctx, errors );
+    RestartConfig rstConfig1( TimeMap(deck1), deck1, ctx, errors );
 
 
     // The case "BASIC 1" - i.e. without '=' can not be salvaged; this should
     // give an exception whatever is the value of ParseContext::RPT_MIXED_STYLE:
-    BOOST_CHECK_THROW(RestartConfig(deck0, ctx, errors), std::invalid_argument);
+    BOOST_CHECK_THROW(RestartConfig(TimeMap(deck0), deck0, ctx, errors), std::invalid_argument);
 
 
     // Observe that this is true due to some undocumented guessing that
@@ -497,10 +497,10 @@ BOOST_AUTO_TEST_CASE(RPTRST_FORMAT_ERROR) {
     auto deck2 = parser.parseString( deckData2, ctx, errors );
 
     ctx.update(ParseContext::RPT_UNKNOWN_MNEMONIC, InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW(RestartConfig(deck2, ctx, errors), std::invalid_argument);
+    BOOST_CHECK_THROW(RestartConfig(TimeMap(deck2), deck2, ctx, errors), std::invalid_argument);
     ctx.update(ParseContext::RPT_UNKNOWN_MNEMONIC, InputError::IGNORE);
 
-    RestartConfig rstConfig2( deck2, ctx, errors );
+    RestartConfig rstConfig2( TimeMap(deck2), deck2, ctx, errors );
 
     const auto expected2 = { "BASIC", "FLOWS", "FREQ" };
     const auto kw_list2 = fun::map( fst, rstConfig2.getRestartKeywords( 2 ) );
@@ -513,7 +513,7 @@ BOOST_AUTO_TEST_CASE(RPTRST_FORMAT_ERROR) {
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 3 ) );
 
     auto deck3 = parser.parseString( deckData3, ctx, errors );
-    RestartConfig rstConfig3( deck3, ctx, errors );
+    RestartConfig rstConfig3( TimeMap(deck3), deck3, ctx, errors );
 
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 1 ) );
@@ -607,7 +607,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
     Parser parser;
 
     auto deck1 = parser.parseString( deckData1 );
-    RestartConfig rstConfig1( deck1 );
+    RestartConfig rstConfig1( TimeMap(deck1), deck1 );
 
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 1 ) );
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
 
 
     auto deck2 = parser.parseString( deckData2 );
-    RestartConfig rstConfig2( deck2 );
+    RestartConfig rstConfig2( TimeMap(deck2), deck2 );
 
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 1 ) );
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
 
 
     auto deck3 = parser.parseString( deckData3 );
-    RestartConfig rstConfig3( deck3 );
+    RestartConfig rstConfig3( TimeMap(deck3), deck3 );
     //Older ECLIPSE 100 data set may use integer controls instead of mnemonics
     BOOST_CHECK(  rstConfig3.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 1 ) );
@@ -672,7 +672,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED_and_RPTRST) {
     Opm::Parser parser;
 
     auto deck = parser.parseString( deckData );
-    RestartConfig rstConfig( deck );
+    RestartConfig rstConfig( TimeMap(deck), deck );
 
     BOOST_CHECK( !rstConfig.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig.getWriteRestartFile( 1 ) );
@@ -702,7 +702,7 @@ BOOST_AUTO_TEST_CASE(NO_BASIC) {
                        "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck);
+    RestartConfig ioConfig( TimeMap(deck), deck);
 
     for( size_t ts = 0; ts < 4; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -733,7 +733,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_1) {
                        "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck);
+    RestartConfig ioConfig( TimeMap(deck), deck);
 
     for( size_t ts = 0; ts < 3; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -768,7 +768,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_3) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck);
+    RestartConfig ioConfig( TimeMap(deck), deck);
 
     const size_t freq = 3;
 
@@ -805,7 +805,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_4) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck);
+    RestartConfig ioConfig( TimeMap(deck), deck);
 
     /* BASIC=4, restart file is written at the first report step of each year.
      */
@@ -843,7 +843,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_4_FREQ_2) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck);
+    RestartConfig ioConfig( TimeMap(deck), deck);
 
     /* BASIC=4, restart file is written at the first report step of each year.
      * Optionally, if the mnemonic FREQ is set >1 the restart is written only
@@ -885,7 +885,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_5) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck);
+    RestartConfig ioConfig( TimeMap(deck), deck);
 
     /* BASIC=5, restart file is written at the first report step of each month.
      */
@@ -923,7 +923,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_0) {
                         "/\n";
 
     auto deck = Parser().parseString( data ) ;
-    RestartConfig ioConfig( deck );
+    RestartConfig ioConfig( TimeMap(deck), deck );
 
     /* RESTART=0, no restart file is written
      */
@@ -959,7 +959,7 @@ BOOST_AUTO_TEST_CASE(RESTART_EQ_0) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck);
+    RestartConfig ioConfig( TimeMap(deck), deck);
 
     /* RESTART=0, no restart file is written
      */
@@ -999,7 +999,7 @@ BOOST_AUTO_TEST_CASE(RESTART_BASIC_GT_2) {
                        "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck);
+    RestartConfig ioConfig( TimeMap(deck), deck);
 
     for( size_t ts : { 1, 2, 3, 4, 5, 7, 8, 10, 11  } )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -1040,7 +1040,7 @@ BOOST_AUTO_TEST_CASE(RESTART_BASIC_LEQ_2) {
                        "/\n";
 
     auto deck = Parser().parseString( data );
-    RestartConfig ioConfig( deck );
+    RestartConfig ioConfig( TimeMap(deck), deck );
 
     BOOST_CHECK( ioConfig.getWriteRestartFile( 1 ) );
     for( size_t ts = 2; ts < 11; ++ts )
@@ -1075,7 +1075,7 @@ BOOST_AUTO_TEST_CASE(RESTART_SAVE) {
                         "TSTEP \n"
                         " 1 /\n";
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck );
+    RestartConfig ioConfig( TimeMap(deck), deck );
 
     for( size_t ts = 1; ts < 11; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -45,6 +45,8 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 

--- a/tests/parser/SectionTests.cpp
+++ b/tests/parser/SectionTests.cpp
@@ -28,6 +28,7 @@
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -26,6 +26,7 @@
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 #include <algorithm>
@@ -147,7 +148,7 @@ static std::vector< std::string > sorted_key_names( const SummaryConfig& summary
 static SummaryConfig createSummary( std::string input , const ParseContext& parseContext = ParseContext()) {
     ErrorGuard errors;
     auto deck = createDeck( input );
-    EclipseState state( deck, parseContext, errors );
+    EclipseState state( deck );
     Schedule schedule(deck, state, parseContext, errors);
     return SummaryConfig( deck, schedule, state.getTableManager( ), parseContext, errors );
 }
@@ -178,7 +179,7 @@ BOOST_AUTO_TEST_CASE(wells_missingI) {
     const auto input = "WWCT\n/\n";
     auto deck = createDeck_no_wells( input );
     parseContext.update(ParseContext::SUMMARY_UNKNOWN_WELL, InputError::THROW_EXCEPTION);
-    EclipseState state( deck, parseContext, errors );
+    EclipseState state( deck );
     Schedule schedule(deck, state, parseContext, errors );
     BOOST_CHECK_NO_THROW( SummaryConfig( deck, schedule, state.getTableManager( ), parseContext, errors ));
 }

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -33,6 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 
 
 using namespace Opm;

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -741,11 +741,6 @@ BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(BAD_CAST) {
-    UDQFunctionTable udqft;
-    auto x = udqft.get("==");
-    BOOST_CHECK_EQUAL(dynamic_cast<const UDQUnaryElementalFunction*>(&x), nullptr);
-}
 
 
 BOOST_AUTO_TEST_CASE(ELEMENTAL_UNARY_FUNCTIONS) {

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -16,6 +16,8 @@ Copyright 2018 Statoil ASA.
 #define BOOST_TEST_MODULE UDQTests
 #include <boost/test/unit_test.hpp>
 
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -41,6 +41,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>

--- a/tests/parser/integration/CheckDeckValidity.cpp
+++ b/tests/parser/integration/CheckDeckValidity.cpp
@@ -25,6 +25,9 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+
 
 BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
     Opm::Parser parser;

--- a/tests/parser/integration/IOConfigIntegrationTest.cpp
+++ b/tests/parser/integration/IOConfigIntegrationTest.cpp
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE( NorneRestartConfig ) {
     EclipseState state(deck);
     Schedule schedule(deck, state);
 
-    verifyRestartConfig(schedule.getTimeMap(), state.cfg().restart(), rptConfig);
+    verifyRestartConfig(schedule.getTimeMap(), schedule.restart(), rptConfig);
 }
 
 
@@ -353,8 +353,8 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     auto deck = parser.parseFile(path_prefix() + "IOConfig/RPT_TEST2.DATA");
     EclipseState state( deck);
     Schedule schedule(deck, state);
-    const auto& rstConfig = state.cfg().restart();
-    verifyRestartConfig(schedule.getTimeMap(), state.cfg().restart(), rptConfig);
+    const auto& rstConfig = schedule.restart();
+    verifyRestartConfig(schedule.getTimeMap(), rstConfig, rptConfig);
 
     BOOST_CHECK_EQUAL( rstConfig.getFirstRestartStep() , 0 );
 }

--- a/tests/parser/integration/IncludeTest.cpp
+++ b/tests/parser/integration/IncludeTest.cpp
@@ -21,6 +21,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 #include <opm/common/utility/FileSystem.hpp>
+#include <iostream>
 #include <ostream>
 #include <fstream>
 #include <iostream>

--- a/tests/test_ArrayDimChecker.cpp
+++ b/tests/test_ArrayDimChecker.cpp
@@ -351,7 +351,7 @@ struct CaseObjects
 
 CaseObjects::CaseObjects(const Opm::Deck& deck, const Opm::ParseContext& ctxt)
     : guard{}
-    , es   (deck,     ctxt, guard)
+    , es   (deck)
     , sched(deck, es, ctxt, guard)
 {
 }


### PR DESCRIPTION
The restartconfiguration is very much time dependent, this therefore belongs in the Schedule object. Has not made much difference before, but now it simplifies things to move it there. 

Downstream: https://github.com/OPM/opm-simulators/pull/2343
~~https://github.com/OPM/opm-upscaling/pull/305~~
Part of #1396