### PR TITLE
fixed: guess -std=c++17 flag if cmake version is too old

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -65,9 +65,14 @@ enable_language (C)
 enable_language (CXX)
 
 # Languages and global compiler settings
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+if(CMAKE_VERSION VERSION_LESS 3.8)
+  message(WARNING "CMake version does not support c++17, guessing -std=c++17")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+else()
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
 
 # Various compiler extension checks
 include(OpmCompilerChecks)


### PR DESCRIPTION
to aid compilation on rhel6