### PR TITLE
changed: remove test

### DIFF
--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -741,12 +741,6 @@ BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(BAD_CAST) {
-    UDQFunctionTable udqft;
-    auto x = udqft.get("==");
-    BOOST_CHECK_EQUAL(dynamic_cast<const UDQUnaryElementalFunction*>(&x), nullptr);
-}
-
 
 BOOST_AUTO_TEST_CASE(ELEMENTAL_UNARY_FUNCTIONS) {
     UDQFunctionTable udqft;


### PR DESCRIPTION
testing that dyncast does its deed seems useless. furthermore
this causes problems on certain toolchains.

i realize it wants to make sure that the == function is not
a unary function, but the cost seems higher than the gains