### PR TITLE
fixed: add begin/end members to BrineDensityTable

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/BrineDensityTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/BrineDensityTable.hpp
@@ -34,6 +34,14 @@ namespace Opm {
 
         bool operator==(const BrineDensityTable& data) const;
 
+        std::vector<double>::const_iterator begin() const {
+            return m_tableValues.begin();
+        }
+
+        std::vector<double>::const_iterator end() const {
+            return m_tableValues.end();
+        }
+
     private:
         std::vector<double> m_tableValues;
     };


### PR DESCRIPTION
This is partially my fault. The build test in https://github.com/OPM/opm-material/pull/392#event-3043667816 was outdated since it sat for a long time without being processed. https://github.com/OPM/opm-material/pull/395 introduced the requirement for begin() / end on the data container passed.