### PR TITLE
Continue replacing boost usage

### DIFF
--- a/examples/opmpack.cpp
+++ b/examples/opmpack.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <fstream>
 #include <iostream>
 #include <getopt.h>
 

--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -24,7 +24,6 @@
 #include <set>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
-#include <boost/date_time.hpp>
 
 /*
   The RestartConfig class internalizes information of when (at which

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -22,8 +22,6 @@
 #include <map>
 #include <memory>
 
-#include <boost/date_time/posix_time/posix_time_types.hpp>
-
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>

--- a/opm/parser/eclipse/Units/Units.hpp
+++ b/opm/parser/eclipse/Units/Units.hpp
@@ -236,7 +236,7 @@ namespace Opm {
              * \code
              *    using namespace Opm::unit;
              *    std::transform(p.begin(), p.end(), p.begin(),
-             *                   boost::bind(convert::to, _1, psia));
+             *                   std::bind(convert::to, std::placeholders::_1, psia));
              * \endcode
              *
              * @param[in] q    Physical quantity, measured in SI units.

--- a/opm/parser/eclipse/Utility/String.hpp
+++ b/opm/parser/eclipse/Utility/String.hpp
@@ -3,7 +3,9 @@
 
 #include <algorithm>
 #include <cctype>
+#include <sstream>
 #include <string>
+#include <vector>
 
 namespace Opm {
 
@@ -66,6 +68,39 @@ void replaceAll(T& data, const T& toSearch, const T& replace)
         // Get the next occurrence from the current position
         pos = data.find(toSearch, pos + replace.size());
     }
+}
+
+
+inline std::vector<std::string> split_string(const std::string& input,
+                                             char delimiter)
+{
+    std::vector<std::string> result;
+    std::string token;
+    std::istringstream tokenStream(input);
+    while (std::getline(tokenStream, token, delimiter))
+        result.push_back(token);
+
+    return result;
+}
+
+
+inline std::vector<std::string> split_string(const std::string& input,
+                                             const std::string& delimiters)
+{
+    std::vector<std::string> result;
+    std::string::size_type start = 0;
+    while (start < input.size()) {
+        auto end = input.find_first_of(delimiters, start);
+        if (end == std::string::npos) {
+            result.push_back(input.substr(start));
+            end = input.size() - 1;
+        } else if (end != start)
+            result.push_back(input.substr(start, end-start));
+
+        start = end + 1;
+    }
+
+    return result;
 }
 
 }

--- a/opm/parser/eclipse/Utility/String.hpp
+++ b/opm/parser/eclipse/Utility/String.hpp
@@ -50,5 +50,24 @@ std::string trim_copy(const T& s)
 {
     return ltrim_copy( rtrim_copy(s) );
 }
+
+
+template<typename T>
+void replaceAll(T& data, const T& toSearch, const T& replace)
+{
+    // Get the first occurrence
+    size_t pos = data.find(toSearch);
+
+    // Repeat till end is reached
+    while (pos != std::string::npos)
+    {
+        // Replace this occurrence of Sub String
+        data.replace(pos, toSearch.size(), replace);
+        // Get the next occurrence from the current position
+        pos = data.find(toSearch, pos + replace.size());
+    }
 }
+
+}
+
 #endif //OPM_UTILITY_STRING_HPP

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -44,6 +44,7 @@
 #include <cstring>
 #include <exception>
 #include <iterator>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -20,8 +20,7 @@
 #include <opm/parser/eclipse/Deck/DeckOutput.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
-
-#include <boost/algorithm/string.hpp>
+#include <opm/parser/eclipse/Utility/String.hpp>
 
 #include <algorithm>
 #include <string>
@@ -261,9 +260,7 @@ void DeckItem::push_backDummyDefault() {
 }
 
 std::string DeckItem::getTrimmedString( size_t index ) const {
-    return boost::algorithm::trim_copy(
-               this->value_ref< std::string >().at( index )
-           );
+    return trim_copy(this->value_ref< std::string >().at(index));
 }
 
 double DeckItem::getSIDouble( size_t index ) const {

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -19,8 +19,6 @@
 
 #include <set>
 
-#include <boost/algorithm/string/join.hpp>
-
 #include <opm/common/OpmLog/LogUtil.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>
@@ -86,7 +84,9 @@ bool enable3DPropsTesting() {
             const auto& titleKeyword = deck.getKeyword( "TITLE" );
             const auto& item = titleKeyword.getRecord( 0 ).getItem( 0 );
             std::vector<std::string> itemValue = item.getData<std::string>();
-            m_title = boost::algorithm::join( itemValue, " " );
+            for (const auto& entry : itemValue)
+                m_title += entry + ' ';
+            m_title.pop_back();
         }
 
         initTransMult();

--- a/src/opm/parser/eclipse/EclipseState/Grid/PinchMode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/PinchMode.cpp
@@ -17,8 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <boost/algorithm/string.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/PinchMode.hpp>
+#include <opm/parser/eclipse/Utility/String.hpp>
+
+#include <stdexcept>
 
 namespace Opm {
 
@@ -44,8 +46,7 @@ namespace Opm {
         }
 
         ModeEnum PinchModeFromString(const std::string& stringValue) {
-            std::string s(stringValue);
-            boost::algorithm::trim(s);
+            std::string s = trim_copy(stringValue);
 
             ModeEnum mode;
             if      (s == "ALL")    { mode = ModeEnum::ALL;    }

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <algorithm>
+#include <climits>
 #include <iostream>
 #include <iterator>
 #include <iomanip>

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -24,8 +24,6 @@
 #include <iomanip>
 #include <sstream>
 
-#include <boost/lexical_cast.hpp>
-
 #include <opm/parser/eclipse/Utility/Functional.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
@@ -687,7 +685,7 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
             found_mnemonic_RESTART = mnemonic.find("RESTART=");
             if (found_mnemonic_RESTART != std::string::npos) {
                 std::string restart_no = mnemonic.substr(found_mnemonic_RESTART+8, mnemonic.size());
-                restart = boost::lexical_cast<size_t>(restart_no);
+                restart = std::strtoul(restart_no.c_str(), nullptr, 10);
                 handle_RPTSOL_RESTART = true;
             }
         }
@@ -700,12 +698,9 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
         if (found_mnemonic_RESTART == std::string::npos) {
             if (item.data_size() >= 7)  {
                 const std::string& integer_control = item.get< std::string >(6);
-                try {
-                    restart = boost::lexical_cast<size_t>(integer_control);
+                restart = std::strtoul(integer_control.c_str(), nullptr, 10);
+                if (restart != ULONG_MAX)
                     handle_RPTSOL_RESTART = true;
-                } catch (boost::bad_lexical_cast &) {
-                    //do nothing
-                }
             }
         }
 

--- a/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -26,6 +26,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/parser/eclipse/Utility/String.hpp>
 
 namespace Opm {
 bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& parseContext, ErrorGuard& errorGuard, size_t enabledChecks) {
@@ -51,10 +52,11 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
         deckValid = deckValid && DeckSection::checkSectionTopology(deck, parser, ensureKeywordSection);
     }
 
-    const std::string& deckUnitSystem = boost::to_upper_copy(deck.getActiveUnitSystem().getName());
+    std::string deckUnitSystem = deck.getActiveUnitSystem().getName();
+    uppercase(deckUnitSystem);
     for (const auto& keyword : deck.getKeywordList("FILEUNIT")) {
-        const std::string& fileUnitSystem =
-            boost::to_upper_copy(keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0));
+        std::string fileUnitSystem = keyword->getRecord(0).getItem("FILE_UNIT_SYSTEM").getTrimmedString(0);
+        uppercase(fileUnitSystem);
         if (fileUnitSystem != deckUnitSystem) {
             const auto& location = keyword->location();
             std::string msg =

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -20,13 +20,12 @@
 #include <cstdlib>
 #include <iostream>
 
-#include <boost/algorithm/string.hpp>
-
 #include <fnmatch.h>
 
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Utility/String.hpp>
 
 namespace Opm {
 
@@ -294,8 +293,7 @@ namespace Opm {
     */
 
     void ParseContext::update(const std::string& keyString , InputError::Action action) {
-        std::vector<std::string> keys;
-        boost::split( keys , keyString , boost::is_any_of(":|"));
+        std::vector<std::string> keys = split_string(keyString, ":|");
         for (const auto& input_key : keys) {
             std::vector<std::string> matching_keys;
             size_t wildcard_pos = input_key.find("*");

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -20,8 +20,9 @@
 #include <cctype>
 #include <fstream>
 #include <iterator>
+#include <iomanip>
+#include <iostream>
 
-#include <boost/algorithm/string.hpp>
 #include <opm/common/utility/FileSystem.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -535,7 +535,7 @@ Opm::filesystem::path ParserState::getIncludeFilePath( std::string path ) const 
         size_t cutOffPosition = stringStartingAtPathName.find_first_not_of(validPathNameCharacters);
         std::string stringToFind = stringStartingAtPathName.substr(0, cutOffPosition);
         std::string stringToReplace = this->pathMap.at( stringToFind );
-        boost::replace_all(path, pathKeywordPrefix + stringToFind, stringToReplace);
+        replaceAll(path, pathKeywordPrefix + stringToFind, stringToReplace);
     }
 
     // Check if there are any backslashes in the path...

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
@@ -17,7 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdexcept>
-#include <boost/algorithm/string.hpp>
 
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Utility/String.hpp>
@@ -31,7 +30,7 @@ namespace Opm {
 namespace {
 
      std::string keyword_name(const std::string& input_name) {
-         std::string name = boost::algorithm::trim_right_copy(input_name);
+         std::string name = rtrim_copy(input_name);
          if (!ParserKeyword::validDeckName(name))
             throw std::invalid_argument("Not a valid keyword:" + name);
 

--- a/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -17,7 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <stdexcept>
-#include <boost/algorithm/string.hpp>
 
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/RawDeck/RawConsts.hpp>
@@ -153,12 +152,12 @@ namespace Opm {
     }
 
     void RawKeyword::setKeywordName(const std::string& name) {
-        m_name = boost::algorithm::trim_right_copy(name);
+        m_name = rtrim_copy(name);
         if (!isValidKeyword(m_name)) {
             throw std::invalid_argument("Not a valid keyword:" + name);
         } else if (m_name.size() > Opm::RawConsts::maxKeywordLength) {
             throw std::invalid_argument("Too long keyword:" + name);
-        } else if (boost::algorithm::trim_left_copy(m_name) != m_name) {
+        } else if (ltrim_copy(m_name) != m_name) {
             throw std::invalid_argument("Illegal whitespace start of keyword:" + name);
         }
     }

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -20,8 +20,8 @@
 
 #include <iostream>
 #include <stdexcept>
-#include <boost/algorithm/string.hpp>
 
+#include <opm/parser/eclipse/Utility/String.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
@@ -1183,8 +1183,7 @@ namespace {
 
 
     Dimension UnitSystem::parseFactor(const std::string& dimension) const {
-        std::vector<std::string> dimensionList;
-        boost::split(dimensionList , dimension , boost::is_any_of("*"));
+        std::vector<std::string> dimensionList = split_string(dimension, '*');
 
         double SIfactor = 1.0;
         for( const auto& x : dimensionList ) {
@@ -1210,8 +1209,7 @@ namespace {
         const bool haveDivisor = divCount == 1;
         if( !haveDivisor ) return this->parseFactor( dimension );
 
-        std::vector<std::string> parts;
-        boost::split(parts , dimension , boost::is_any_of("/"));
+        std::vector<std::string> parts = split_string(dimension, '/');
         Dimension dividend = this->parseFactor( parts[0] );
         Dimension divisor = this->parseFactor( parts[1] );
 

--- a/tests/parser/InitConfigTest.cpp
+++ b/tests/parser/InitConfigTest.cpp
@@ -29,6 +29,8 @@
 
 #include <tests/WorkArea.cpp>
 
+#include <fstream>
+
 using namespace Opm;
 
 const std::string& deckStr =

--- a/tests/parser/ParseContext_EXIT1.cpp
+++ b/tests/parser/ParseContext_EXIT1.cpp
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/parser/ParserIncludeTests.cpp
+++ b/tests/parser/ParserIncludeTests.cpp
@@ -27,6 +27,8 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
+#include <iostream>
+
 inline std::string prefix() {
     return boost::unit_test::framework::master_test_suite().argv[1];
 }

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -35,6 +35,8 @@
 #include "src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp"
 #include "src/opm/parser/eclipse/Parser/raw/RawRecord.hpp"
 
+#include <iostream>
+
 using namespace Opm;
 
 namespace {

--- a/tests/parser/StringTests.cpp
+++ b/tests/parser/StringTests.cpp
@@ -213,3 +213,11 @@ BOOST_AUTO_TEST_CASE(trim) {
     BOOST_CHECK_EQUAL(rtrim_copy(s5) , s5);
     BOOST_CHECK_EQUAL(rtrim_copy(s6) , s5);
 }
+
+
+BOOST_AUTO_TEST_CASE(replace_all) {
+    std::string s1 = "lorem ipsum";
+
+    replaceAll<std::string>(s1, "m", "foo");
+    BOOST_CHECK_EQUAL(s1, "lorefoo ipsufoo");
+}

--- a/tests/parser/StringTests.cpp
+++ b/tests/parser/StringTests.cpp
@@ -221,3 +221,24 @@ BOOST_AUTO_TEST_CASE(replace_all) {
     replaceAll<std::string>(s1, "m", "foo");
     BOOST_CHECK_EQUAL(s1, "lorefoo ipsufoo");
 }
+
+
+BOOST_AUTO_TEST_CASE(split) {
+    std::string s1 = "lorem ipsum";
+
+    auto split1 = split_string(s1, ' ');
+    BOOST_CHECK_EQUAL(split1.size(), 2);
+    BOOST_CHECK_EQUAL(split1[0], "lorem");
+    BOOST_CHECK_EQUAL(split1[1], "ipsum");
+
+    auto split2 = split_string(s1, "r ");
+    BOOST_CHECK_EQUAL(split2.size(), 3);
+    BOOST_CHECK_EQUAL(split2[0], "lo");
+    BOOST_CHECK_EQUAL(split2[1], "em");
+    BOOST_CHECK_EQUAL(split2[2], "ipsum");
+
+    auto split3 = split_string(s1, "m ");
+    BOOST_CHECK_EQUAL(split3.size(), 2);
+    BOOST_CHECK_EQUAL(split3[0], "lore");
+    BOOST_CHECK_EQUAL(split3[1], "ipsu");
+}

--- a/tests/parser/integration/IncludeTest.cpp
+++ b/tests/parser/integration/IncludeTest.cpp
@@ -23,6 +23,7 @@
 #include <opm/common/utility/FileSystem.hpp>
 #include <ostream>
 #include <fstream>
+#include <iostream>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 

--- a/tests/parser/integration/parse_write.cpp
+++ b/tests/parser/integration/parse_write.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <iostream>
 #include <sstream>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>


### PR DESCRIPTION
- use already introduced trim functions more
- use already introduced uppercase functions
- use strtoul instead of lexical_cast
- add replace_all replacement
- add split_string replacement
- avoid use of join