### PR TITLE
Store complnum value directly without taking std::abs()

### DIFF
--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -135,7 +135,7 @@ namespace {
             iConn[Ix::Imbibition] = iConn[Ix::Drainage];
 
             //complnum is(1 too large): 1 - based while icon is 0 - based?
-            iConn[Ix::ComplNum] = std::abs(conn.complnum());
+            iConn[Ix::ComplNum] = conn.complnum();
             //iConn[Ix::ComplNum] = iConn[Ix::SeqIndex];
 
             iConn[Ix::ConnDir] = static_cast<int>(conn.dir());


### PR DESCRIPTION
I *think* the background for this `std::abs` was that we used to have a home made scheme where connections were assigned negative completion numbers internally. This scheme has now ended - and the use `std::abs( )` in the output code just looks misleading.  