### PR TITLE
changed: disable building of test suite if Boost::test is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,8 @@ if (ENABLE_MOCKSIM)
   foreach( test test_msim test_msim_ACTIONX )
     opm_add_test(${test} SOURCES tests/msim/${test}.cpp
                          LIBRARIES ${_libs}
-                         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
+                         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests
+                         CONDITION HAVE_ECL_INPUT AND Boost_UNIT_TEST_FRAMEWORK_FOUND)
   endforeach()
 endif()
 
@@ -205,7 +206,7 @@ if(ENABLE_ECL_INPUT)
 
   opm_add_test(test_EclFilesComparator
     CONDITION
-      ENABLE_ECL_INPUT
+      ENABLE_ECL_INPUT AND Boost_UNIT_TEST_FRAMEWORK_FOUND
     SOURCES
       tests/test_EclFilesComparator.cpp
       test_util/EclFilesComparator.cpp
@@ -217,7 +218,7 @@ if(ENABLE_ECL_INPUT)
 
   opm_add_test(test_EclRegressionTest
     CONDITION
-      ENABLE_ECL_INPUT
+      ENABLE_ECL_INPUT AND Boost_UNIT_TEST_FRAMEWORK_FOUND
     SOURCES
       tests/test_EclRegressionTest.cpp
       test_util/EclFilesComparator.cpp
@@ -229,7 +230,7 @@ if(ENABLE_ECL_INPUT)
     )
 
   foreach(test test_EclIO test_EGrid test_ERft test_ERst test_ESmry)
-    opm_add_test(${test} CONDITION ENABLE_ECL_INPUT
+    opm_add_test(${test} CONDITION ENABLE_ECL_INPUT AND Boost_UNIT_TEST_FRAMEWORK_FOUND
                          LIBRARIES ${_libs}
                          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
   endforeach()

--- a/ExtraTests.cmake
+++ b/ExtraTests.cmake
@@ -2,6 +2,8 @@
 set(TEST_LIBS opmcommon Boost::unit_test_framework)
 set(EXTRA_TESTS)
 
+if (Boost_UNIT_TEST_FRAMEWORK_FOUND)
+
 # Generated source, needs to be here
 opm_add_test(InlineKeywordTest
              EXE_NAME TestKeywords
@@ -113,3 +115,5 @@ opm_add_test(jsonTests
              LIBRARIES ${TEST_LIBS}
              TEST_ARGS ${PROJECT_SOURCE_DIR}/tests/json/example1.json)
 list(APPEND EXTRA_TESTS jsonTests)
+
+endif()

--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -56,6 +56,9 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
 
   # compile each of these separately
   foreach (_sat_FILE IN LISTS ${satellite}_SOURCES)
+    if (NOT "${test_regexp}" STREQUAL "" AND NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
+        continue()
+    endif()
     get_filename_component (_sat_NAME "${_sat_FILE}" NAME_WE)
     add_executable (${_sat_NAME} ${excl_all} ${_sat_FILE})
     add_dependencies (${satellite} ${_sat_NAME})


### PR DESCRIPTION
Motivation: Being able to build without boost libraries (of course there is more to that which will come later).