### PR TITLE
Add WellTypes class

### DIFF
--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -62,12 +62,6 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         };
 
         namespace Value {
-            enum WellType : int {
-                Producer = 1,  // Well is producer
-                OilInj   = 2,  // Well is oil injector
-                WatInj   = 3,  // Well is water injector
-                GasInj   = 4,  // Well is gas injector
-            };
 
             enum WellCtrlMode : int {
                 WMCtlUnk = -10,  // Unknown well control mode (OPM only)

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
@@ -21,6 +21,7 @@
 #define OPM_SCHEDULE_TYPES_HPP
 
 #include <string>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 namespace Opm {
 
@@ -32,6 +33,48 @@ enum class InjectorType {
 };
 const std::string InjectorType2String( InjectorType enumValue );
 InjectorType InjectorTypeFromString( const std::string& stringValue );
+
+
+class WellType {
+public:
+    WellType(int ecl_wtype, int welspecs_phase);
+    WellType(bool producer, Phase welspecs_phase);
+    explicit WellType(Phase welspecs_phase);
+    WellType() = default;
+
+    bool injector() const;
+    bool producer() const;
+    bool update(InjectorType injector_type);
+    bool update(bool producer);
+
+    static bool oil_injector(int ecl_wtype);
+    static bool gas_injector(int ecl_wtype);
+    static bool water_injector(int ecl_wtype);
+    static bool producer(int ecl_wtype);
+
+    int   ecl_wtype() const;
+    int   ecl_phase() const;
+    Phase preferred_phase() const;
+    InjectorType injector_type() const;
+    bool operator==(const WellType& other) const;
+private:
+    bool  m_producer;
+    /*
+      The injection_phase member is updated during the course of the simulation;
+      following each WCONINJE keyword the injection phase is updated. If an
+      producer is specified in the constructor the injection_phase is
+      initialzied to the welspecs phase. This is not wildly random - but the
+      injection_phase will not be meaningfull before an update(Phase) call has been
+      issued.
+
+      The welspecs_phase is the preferred phase specified when the well is
+      defined with the WELSPECS keyword. This member is immutable, and it is only
+      used when initializing the well equations for a producer.
+    */
+
+    Phase injection_phase;
+    Phase m_welspecs_phase;
+};
 
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -384,7 +384,7 @@ public:
          int headI,
          int headJ,
          double ref_depth,
-         Phase phase,
+         const WellType& wtype_arg,
          ProducerCMode whistctl_cmode,
          Connection::Order ordering,
          const UnitSystem& unit_system,
@@ -400,7 +400,7 @@ public:
          int headI,
          int headJ,
          double ref_depth,
-         const Phase& phase_arg,
+         const WellType& wtype_arg,
          Connection::Order ordering,
          const UnitSystem& unit_system,
          double udq_undefined,
@@ -408,7 +408,6 @@ public:
          double drainageRadius,
          bool allowCrossFlow,
          bool automaticShutIn,
-         bool isProducer,
          const WellGuideRate& guideRate,
          double efficiencyFactor,
          double solventFraction,
@@ -431,6 +430,7 @@ public:
 
     bool hasBeenDefined(size_t timeStep) const;
     std::size_t firstTimeStep() const;
+    const WellType& wellType() const;
     bool predictionMode() const;
     bool canOpen() const;
     bool isProducer() const;
@@ -495,7 +495,6 @@ public:
     bool updateConnections(const std::shared_ptr<WellConnections> connections);
     bool updateStatus(Status status, bool update_connections);
     bool updateGroup(const std::string& group);
-    bool updateProducer(bool is_producer);
     bool updateWellGuideRate(bool available, double guide_rate, GuideRateTarget guide_phase, double scale_factor);
     bool updateWellGuideRate(double guide_rate);
     bool updateEfficiencyFactor(double efficiency_factor);
@@ -517,8 +516,6 @@ public:
     bool handleWPIMULT(const DeckRecord& record);
 
     void filterConnections(const ActiveGridCells& grid);
-    void switchToInjector();
-    void switchToProducer();
     ProductionControls productionControls(const SummaryState& st) const;
     InjectionControls injectionControls(const SummaryState& st) const;
     int vfp_table_number() const;
@@ -532,6 +529,9 @@ public:
     bool operator==(const Well& data) const;
     void setInsertIndex(std::size_t index);
 private:
+    void switchToInjector();
+    void switchToProducer();
+
     std::string wname;
     std::string group_name;
     std::size_t init_step;
@@ -539,7 +539,6 @@ private:
     int headI;
     int headJ;
     double ref_depth;
-    Phase phase;
     Connection::Order ordering;
     UnitSystem unit_system;
     double udq_undefined;
@@ -548,7 +547,7 @@ private:
     double drainage_radius;
     bool allow_cross_flow;
     bool automatic_shutin;
-    bool producer;
+    WellType wtype;
     WellGuideRate guide_rate;
     double efficiency_factor;
     double solvent_fraction;

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -136,29 +136,6 @@ namespace {
             return ind;
         }
 
-        int wellType(const Opm::Well& well, const Opm::SummaryState& st)
-        {
-            using WTypeVal = VI::IWell::Value::WellType;
-
-            if (well.isProducer()) {
-                return WTypeVal::Producer;
-            }
-
-            using IType = ::Opm::InjectorType;
-
-            const auto itype = well.injectionControls(st).injector_type;
-
-            switch (itype) {
-            case IType::OIL:   return WTypeVal::OilInj;
-            case IType::WATER: return WTypeVal::WatInj;
-            case IType::GAS:   return WTypeVal::GasInj;
-            case IType::MULTI:
-                throw std::invalid_argument("Do not know how to serialize injectortype MULTI - fatal error for well " + well.name());
-                break;
-            default:
-                throw std::invalid_argument("SHould not be here - unhandled enum value in wellType");
-            }
-        }
 
         int wellVFPTab(const Opm::Well& well, const Opm::SummaryState& st)
         {
@@ -382,7 +359,7 @@ namespace {
             iWell[Ix::Group] =
                 groupIndex(trim(well.groupName()), GroupMapNameInd);
 
-            iWell[Ix::WType]  = wellType  (well, st);
+            iWell[Ix::WType]  = well.wellType().ecl_wtype();
             iWell[Ix::VFPTab] = wellVFPTab(well, st);
             iWell[Ix::XFlow]  = well.getAllowCrossFlow() ? 1 : 0;
 

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -45,6 +45,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
@@ -1053,20 +1054,19 @@ namespace {
     injectorControlMode(const int curr, const int itype)
     {
         using IMode = ::Opm::Well::InjectorCMode;
-        using WType = VI::IWell::Value::WellType;
         using Ctrl  = VI::IWell::Value::WellCtrlMode;
 
         switch (curr) {
             case Ctrl::OilRate:
-                return (itype == WType::OilInj)
+                return Opm::WellType::oil_injector(itype)
                     ? IMode::RATE : IMode::CMODE_UNDEFINED;
 
             case Ctrl::WatRate:
-                return (itype == WType::WatInj)
+                return Opm::WellType::water_injector(itype)
                     ? IMode::RATE : IMode::CMODE_UNDEFINED;
 
             case Ctrl::GasRate:
-                return (itype == WType::GasInj)
+                return Opm::WellType::gas_injector(itype)
                     ? IMode::RATE : IMode::CMODE_UNDEFINED;
 
             case Ctrl::ResVRate: return IMode::RESV;
@@ -1088,7 +1088,7 @@ namespace {
 
         auto& curr = xw.current_control;
 
-        curr.isProducer = wtyp == VI::IWell::Value::WellType::Producer;
+        curr.isProducer = Opm::WellType::producer(wtyp);
         if (curr.isProducer) {
             curr.prod = producerControlMode(act);
         }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -838,15 +838,12 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
 
                     if (switching_from_injector) {
                         properties->resetDefaultBHPLimit();
-                        well2->updateProducer(true);
 
                         auto inj_props = std::make_shared<Well::WellInjectionProperties>(well2->getInjectionProperties());
                         inj_props->resetBHPLimit();
                         well2->updateInjection(inj_props);
-                    }
-
-                    if (well2->updateProducer(true))
                         update_well = true;
+                    }
 
                     if (well2->updateProduction(properties))
                         update_well = true;
@@ -906,9 +903,6 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
 
                     if (switching_from_injector)
                         properties->resetDefaultBHPLimit();
-
-                    if (well2->updateProducer(true))
-                        update_well = true;
 
                     if (well2->updateProduction(properties))
                         update_well = true;
@@ -1005,9 +999,6 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
                     auto injection = std::make_shared<Well::WellInjectionProperties>(well2->getInjectionProperties());
                     injection->handleWCONINJE(record, well2->isAvailableForGroupControl(), well_name);
 
-                    if (well2->updateProducer(false))
-                        update_well = true;
-
                     if (well2->updateInjection(injection))
                         update_well = true;
 
@@ -1067,9 +1058,6 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
                     auto well2 = std::make_shared<Well>(*dynamic_state[currentStep]);
                     auto injection = std::make_shared<Well::WellInjectionProperties>(well2->getInjectionProperties());
                     injection->handleWCONINJH(record, well2->isProducer(), well_name);
-
-                    if (well2->updateProducer(false))
-                        update_well = true;
 
                     if (well2->updateInjection(injection))
                         update_well = true;
@@ -2269,7 +2257,7 @@ void Schedule::invalidNamePattern( const std::string& namePattern,  std::size_t 
                   0,
                   headI, headJ,
                   refDepth,
-                  preferredPhase,
+                  WellType(preferredPhase),
                   this->global_whistctl_mode[timeStep],
                   wellConnectionOrder,
                   unit_system,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
@@ -22,6 +22,204 @@
 
 namespace Opm {
 
+namespace ecl {
+
+static constexpr int producer       = 1;
+static constexpr int oil_injector   = 2;
+static constexpr int water_injector = 3;
+static constexpr int gas_injector   = 4;
+
+
+static constexpr int oil_phase      = 1;
+static constexpr int water_phase    = 2;
+static constexpr int gas_phase      = 3;
+static constexpr int liquid_phase   = 4;
+
+
+Phase from_ecl_phase(int ecl_phase) {
+    switch(ecl_phase) {
+    case ecl::oil_phase:
+        return Phase::OIL;
+    case ecl::water_phase:
+        return Phase::WATER;
+    case ecl::gas_phase:
+        return Phase::GAS;
+    case ecl::liquid_phase:
+        throw std::logic_error("Sorry wells with preferred phase:LIQUID is not supported");
+    default:
+        throw std::invalid_argument("Invalid integer well phase");
+    }
+}
+}
+
+
+namespace {
+
+Phase from_injector_type(InjectorType injector_type) {
+    switch (injector_type) {
+    case InjectorType::WATER:
+        return Phase::WATER;
+    case InjectorType::GAS:
+        return Phase::GAS;
+    case InjectorType::OIL:
+        return Phase::OIL;
+    default:
+        throw std::logic_error("Unhandled injector type");
+    }
+}
+
+}
+
+
+bool WellType::producer(int ecl_wtype) {
+    return ecl_wtype == ecl::producer;
+}
+
+bool WellType::oil_injector(int ecl_wtype) {
+    return ecl_wtype == ecl::oil_injector;
+}
+
+bool WellType::water_injector(int ecl_wtype) {
+    return ecl_wtype == ecl::water_injector;
+}
+
+bool WellType::gas_injector(int ecl_wtype) {
+    return ecl_wtype == ecl::gas_injector;
+}
+
+
+WellType::WellType(int ecl_wtype, int ecl_phase) :
+    injection_phase(ecl::from_ecl_phase(ecl_phase)),
+    m_welspecs_phase(ecl::from_ecl_phase(ecl_phase))
+{
+    this->m_producer = false;
+    switch (ecl_wtype) {
+    case ecl::producer:
+        this->m_producer = true;
+        break;
+    case ecl::oil_injector:
+        this->injection_phase = Phase::OIL;
+        break;
+    case ecl::water_injector:
+        this->injection_phase = Phase::WATER;
+        break;
+    case ecl::gas_injector:
+        this->injection_phase = Phase::GAS;
+        break;
+    default:
+        throw std::invalid_argument("Invalid integer well type ID");
+    }
+
+}
+
+WellType::WellType(bool producer, Phase phase) :
+    m_producer(producer),
+    injection_phase(phase),
+    m_welspecs_phase(phase)
+{}
+
+WellType::WellType(Phase phase) :
+    WellType(true, phase)
+{}
+
+bool WellType::update(bool producer_arg) {
+    if (this->m_producer != producer_arg) {
+        this->m_producer = producer_arg;
+        return true;
+    } else
+        return false;
+}
+
+bool WellType::update(InjectorType injector_type) {
+    bool ret_value = false;
+    if (this->m_producer) {
+        this->m_producer = false;
+        ret_value = true;
+    }
+
+    auto inj_phase = from_injector_type(injector_type);
+    if (this->injection_phase != inj_phase) {
+        this->injection_phase = inj_phase;
+        ret_value = true;
+    }
+
+    return ret_value;
+}
+
+bool WellType::producer() const {
+    return this->m_producer;
+}
+
+bool WellType::injector() const {
+    return !this->m_producer;
+}
+
+int WellType::ecl_wtype() const {
+    if (this->m_producer)
+        return ecl::producer;
+
+    switch (this->injection_phase) {
+    case Phase::OIL:
+        return ecl::oil_injector;
+    case Phase::WATER:
+        return ecl::water_injector;
+    case Phase::GAS:
+        return ecl::gas_injector;
+    default:
+        throw std::logic_error("Internal error - should not be here");
+    }
+}
+
+/*
+  The enum Runspec::Phase is maybe not very well suited; it has lots of 'extra'
+  phases like ENERGY and BRINE, and at the same time it is missing the phase
+  LIQUID which should map to ecl value 4.
+*/
+
+int WellType::ecl_phase() const {
+    switch (this->m_welspecs_phase) {
+    case Phase::OIL:
+        return ecl::oil_phase;
+    case Phase::WATER:
+        return ecl::water_phase;
+    case Phase::GAS:
+        return ecl::gas_phase;
+    default:
+        throw std::logic_error("Member has invalid phase");
+    }
+}
+
+
+Phase WellType::preferred_phase() const {
+    return this->m_welspecs_phase;
+}
+
+
+bool WellType::operator==(const WellType& other) const {
+    return this->m_welspecs_phase == other.m_welspecs_phase &&
+           this->injection_phase == other.injection_phase &&
+           this->m_producer == other.m_producer;
+}
+
+
+InjectorType WellType::injector_type() const {
+    if (this->producer())
+        throw std::invalid_argument("Asked for injector type for a well which is a producer");
+
+    switch (this->injection_phase) {
+    case Phase::OIL:
+        return InjectorType::OIL;
+    case Phase::WATER:
+        return InjectorType::WATER;
+    case Phase::GAS:
+        return InjectorType::GAS;
+    default:
+        throw std::logic_error("Member has invalid phase");
+    }
+
+}
+
+
 const std::string InjectorType2String( InjectorType enumValue ) {
     switch( enumValue ) {
     case InjectorType::OIL:

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -27,6 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
@@ -76,7 +77,7 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE2) {
 
     const UnitSystem us{};
     std::vector<Well> wells;
-    wells.emplace_back("WELL_NAME", "A", 0, 0, 1, 1, 200., Phase::OIL, Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
+    wells.emplace_back("WELL_NAME", "A", 0, 0, 1, 1, 200., WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
     {
         wells[0].updateStatus(Well::Status::SHUT, false);
         auto shut_wells = st.updateWells(wc, wells, 5000);
@@ -110,8 +111,8 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
 
     const UnitSystem us{};
     std::vector<Well> wells;
-    wells.emplace_back("WELL_NAME", "A", 0, 0, 1, 1, 200., Phase::OIL, Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
-    wells.emplace_back("WELLX", "A", 0, 0, 2, 2, 200., Phase::OIL, Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
+    wells.emplace_back("WELL_NAME", "A", 0, 0, 1, 1, 200., WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
+    wells.emplace_back("WELLX", "A", 0, 0, 2, 2, 200.,     WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
 
     WellTestConfig wc;
     {
@@ -181,9 +182,9 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
 
     const UnitSystem us{};
     std::vector<Well> wells;
-    wells.emplace_back("WELL_NAME", "A", 0, 0, 1, 1, 200., Phase::OIL, Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
+    wells.emplace_back("WELL_NAME", "A", 0, 0, 1, 1, 200., WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
     wells[0].updateStatus(Well::Status::OPEN, false);
-    wells.emplace_back("WELLX", "A", 0, 0, 2, 2, 200., Phase::OIL, Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
+    wells.emplace_back("WELLX", "A", 0, 0, 2, 2, 200., WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true);
     wells[1].updateStatus(Well::Status::OPEN, false);
 
     auto closed_completions = st.updateWells(wc, wells, 5000);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -61,6 +61,7 @@ inline std::ostream& operator<<( std::ostream& stream, const Well& well ) {
 }
 
 
+
 BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
     Opm::Parser parser;
     std::string input =
@@ -193,7 +194,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestINPUT) {
 }
 
 BOOST_AUTO_TEST_CASE(NewWellZeroCompletions) {
-    Opm::Well well("WELL1", "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED,  Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1", "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED,  Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
     BOOST_CHECK_EQUAL( 0U , well.getConnections( ).size() );
 }
 
@@ -202,7 +203,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
     // HACK: This test checks correctly setting of isProducer/isInjector. This property depends on which of
     //       WellProductionProperties/WellInjectionProperties is set last, independent of actual values.
     {
-        Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+        Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
 
         /* 1: Well is created as producer */
@@ -220,7 +221,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
 
 
     {
-        Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+        Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
         /* Set a reservoir injection rate => Well becomes an Injector */
         auto injectionProps2 = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
@@ -231,7 +232,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
     }
 
     {
-        Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+        Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
         /* Set rates => Well becomes a producer; injection rate should be set to 0. */
         auto injectionProps3 = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
@@ -254,7 +255,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
 }
 
 BOOST_AUTO_TEST_CASE(GroupnameCorretlySet) {
-    Opm::Well well("WELL1" , "G1", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1" , "G1", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
     BOOST_CHECK_EQUAL("G1" , well.groupName());
     well.updateGroup( "GROUP2");
@@ -263,7 +264,7 @@ BOOST_AUTO_TEST_CASE(GroupnameCorretlySet) {
 
 
 BOOST_AUTO_TEST_CASE(addWELSPECS_setData_dataSet) {
-    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::Phase::WATER, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::WellType(Opm::Phase::WATER), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
     BOOST_CHECK_EQUAL(23, well.getHeadI());
     BOOST_CHECK_EQUAL(42, well.getHeadJ());
@@ -273,7 +274,7 @@ BOOST_AUTO_TEST_CASE(addWELSPECS_setData_dataSet) {
 
 
 BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
-    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::Phase::WATER, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::WellType(Opm::Phase::WATER), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
 
     auto productionProps = std::make_shared<Opm::Well::WellProductionProperties>(well.getProductionProperties());
@@ -293,7 +294,7 @@ BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
 
 
 BOOST_AUTO_TEST_CASE(ScheduleTypesInjectorType) {
-    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::Phase::WATER, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::WellType(Opm::Phase::WATER), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
 
     auto injectionProps = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
@@ -311,7 +312,7 @@ BOOST_AUTO_TEST_CASE(ScheduleTypesInjectorType) {
 
 
 BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
-    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::Phase::WATER, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::WellType(Opm::Phase::WATER), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
 
     BOOST_CHECK( !well.getProductionProperties().hasProductionControl( Opm::Well::ProducerCMode::ORAT ));
@@ -358,7 +359,7 @@ BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
 
 
 BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
-    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::Phase::WATER, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::WellType(Opm::Phase::WATER), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
     BOOST_CHECK( !well.getInjectionProperties().hasInjectionControl( Opm::Well::InjectorCMode::RATE ));
     BOOST_CHECK( !well.getInjectionProperties().hasInjectionControl( Opm::Well::InjectorCMode::RESV ));
@@ -400,7 +401,7 @@ BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
 /*********************************************************************/
 
 BOOST_AUTO_TEST_CASE(WellGuideRatePhase_GuideRatePhaseSet) {
-    Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
     BOOST_CHECK(Opm::Well::GuideRateTarget::UNDEFINED == well.getGuideRatePhase());
 
@@ -411,7 +412,7 @@ BOOST_AUTO_TEST_CASE(WellGuideRatePhase_GuideRatePhaseSet) {
 }
 
 BOOST_AUTO_TEST_CASE(WellEfficiencyFactorSet) {
-    Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well well("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
     BOOST_CHECK_EQUAL(1.0, well.getEfficiencyFactor());
     BOOST_CHECK( well.updateEfficiencyFactor(0.9));
@@ -780,7 +781,7 @@ BOOST_AUTO_TEST_CASE(CMODE_DEFAULT) {
 
 BOOST_AUTO_TEST_CASE(WELL_CONTROLS) {
     auto unit_system = UnitSystem::newMETRIC();
-    Opm::Well well("WELL", "GROUP", 0, 0, 0, 0, 1000, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Opm::Connection::Order::DEPTH, unit_system, 0, 1.0, false, false);
+    Opm::Well well("WELL", "GROUP", 0, 0, 0, 0, 1000, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Opm::Connection::Order::DEPTH, unit_system, 0, 1.0, false, false);
     Opm::Well::WellProductionProperties prod(unit_system, "OP1");
     Opm::SummaryState st(std::chrono::system_clock::now());
     well.productionControls(st);
@@ -801,8 +802,8 @@ BOOST_AUTO_TEST_CASE(WELL_CONTROLS) {
 
 
 BOOST_AUTO_TEST_CASE(ExtraAccessors) {
-    Opm::Well inj("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
-    Opm::Well prod("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well inj("WELL1" , "GROUP", 0, 1, 0, 0, 0.0,  Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
+    Opm::Well prod("WELL1" , "GROUP", 0, 1, 0, 0, 0.0, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
     auto inj_props= std::make_shared<Opm::Well::WellInjectionProperties>(inj.getInjectionProperties());
     inj_props->VFPTableNumber = 100;

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -863,3 +863,47 @@ BOOST_AUTO_TEST_CASE(WELOPEN) {
 }
 
 
+BOOST_AUTO_TEST_CASE(WellTypeTest) {
+    BOOST_CHECK_THROW(Opm::WellType(0, 3), std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::WellType(5, 3), std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::WellType(3, 0), std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::WellType(3, 5), std::invalid_argument);
+
+    Opm::WellType wt1(1,1);
+    BOOST_CHECK(wt1.producer());
+    BOOST_CHECK(!wt1.injector());
+    BOOST_CHECK_EQUAL(wt1.ecl_wtype(), 1);
+    BOOST_CHECK_EQUAL(wt1.ecl_phase(), 1);
+    BOOST_CHECK(wt1.preferred_phase() == Phase::OIL);
+    BOOST_CHECK_THROW(wt1.injector_type(), std::invalid_argument);
+
+    Opm::WellType wt4(4,3);
+    BOOST_CHECK(!wt4.producer());
+    BOOST_CHECK(wt4.injector());
+    BOOST_CHECK_EQUAL(wt4.ecl_wtype(), 4);
+    BOOST_CHECK_EQUAL(wt4.ecl_phase(), 3);
+    BOOST_CHECK(wt4.preferred_phase() == Phase::GAS);
+    BOOST_CHECK(wt4.injector_type() == InjectorType::GAS);
+
+    BOOST_CHECK(wt4.update(true));
+    BOOST_CHECK(!wt4.update(true));
+    BOOST_CHECK(wt4.producer());
+    BOOST_CHECK(!wt4.injector());
+    BOOST_CHECK_EQUAL(wt4.ecl_wtype(), 1);
+    BOOST_CHECK_EQUAL(wt4.ecl_phase(), 3);
+    BOOST_CHECK(wt4.preferred_phase() == Phase::GAS);
+
+    Opm::WellType wtp(false, Phase::WATER);
+    BOOST_CHECK(!wtp.producer());
+    BOOST_CHECK(wtp.injector());
+    BOOST_CHECK_EQUAL(wtp.ecl_wtype(), 3);
+    BOOST_CHECK_EQUAL(wtp.ecl_phase(), 2);
+    BOOST_CHECK(wtp.preferred_phase() == Phase::WATER);
+    BOOST_CHECK(wtp.injector_type() == InjectorType::WATER);
+
+    wtp.update( InjectorType::GAS );
+    BOOST_CHECK_EQUAL(wtp.ecl_wtype(), 4);
+    BOOST_CHECK_EQUAL(wtp.ecl_phase(), 2);
+    BOOST_CHECK(wtp.preferred_phase() == Phase::WATER);
+    BOOST_CHECK(wtp.injector_type() == InjectorType::GAS);
+}


### PR DESCRIPTION
The type of a well - i.e. injector/producer and the phase is a surprsingly flickety small piece of code; implemented as a class here. ~~Depends on: #1527 and https://github.com/OPM/opm-simulators/pull/2389 which must be merged first.~~

This is not very elegant - and might not be the final solution; but it works for now.

Downstream: https://github.com/OPM/opm-simulators/pull/2392

Part of #1396