### PR TITLE
Add Group::isAvailableForGroupControl() method.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -173,6 +173,7 @@ struct ProductionControls {
           GroupType gtype,
           double groupEF,
           bool transferGroupEF,
+          bool availableForGroupControl,
           int vfp,
           const std::string& parent,
           const IOrderSet<std::string>& well,
@@ -205,6 +206,8 @@ struct ProductionControls {
     void setInjectionGroup();
     double getGroupEfficiencyFactor() const;
     bool   getTransferGroupEfficiencyFactor() const;
+    bool isAvailableForGroupControl() const;
+    void setAvailableForGroupControl(const bool available);
 
     std::size_t numWells() const;
     bool addGroup(const std::string& group_name);
@@ -245,6 +248,7 @@ private:
     GroupType group_type;
     double gefac;
     bool transfer_gefac;
+    bool available_for_group_control;
     int vfp_table;
 
     std::string parent_group;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -39,6 +39,7 @@ Group::Group(const std::string& name, std::size_t insert_index_arg, std::size_t 
     group_type(GroupType::NONE),
     gefac(1),
     transfer_gefac(true),
+    available_for_group_control(name == "FIELD" ? false : true),
     vfp_table(0)
 {
     // All groups are initially created as children of the "FIELD" group.
@@ -54,6 +55,7 @@ Group::Group(const std::string& gname,
              GroupType gtype,
              double groupEF,
              bool transferGroupEF,
+             bool availableForGroupControl,
              int vfp,
              const std::string& parentName,
              const IOrderSet<std::string>& well,
@@ -68,6 +70,7 @@ Group::Group(const std::string& gname,
     group_type(gtype),
     gefac(groupEF),
     transfer_gefac(transferGroupEF),
+    available_for_group_control(availableForGroupControl),
     vfp_table(vfp),
     parent_group(parentName),
     m_wells(well),
@@ -343,6 +346,14 @@ double Group::getGroupEfficiencyFactor() const {
 
 bool Group::getTransferGroupEfficiencyFactor() const {
     return this->transfer_gefac;
+}
+
+bool Group::isAvailableForGroupControl() const {
+    return this->available_for_group_control;
+}
+
+void Group::setAvailableForGroupControl(const bool available) {
+    this->available_for_group_control = available;
 }
 
 const std::string& Group::parent() const {

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -451,8 +451,8 @@ BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
            10 /
 
         GCONINJE
-           'G2'   'WATER'   1*  1000      /
-           'G2'   'GAS'     1*  1*   2000 /
+           'G2'   'WATER'   1*  1000  /
+           'G2'   'GAS'     1*  1*   2000  2*   'NO' /
            'G1'   'GAS'     1*  1000      /
         /
 
@@ -471,6 +471,7 @@ BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
         BOOST_CHECK(  g1.hasInjectionControl(Phase::WATER));
         BOOST_CHECK(  g1.hasInjectionControl(Phase::GAS));
         BOOST_CHECK( !g1.hasInjectionControl(Phase::OIL));
+        BOOST_CHECK(  g1.isAvailableForGroupControl() );
 
         g1.injectionControls(Phase::WATER, st);
         g1.injectionControls(Phase::GAS, st);
@@ -483,6 +484,7 @@ BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
         const auto& g2 = schedule.getGroup("G2", 0);
         BOOST_CHECK(!g2.has_topup_phase());
         BOOST_CHECK_THROW(g2.topup_phase(), std::logic_error);
+        BOOST_CHECK(  g2.isAvailableForGroupControl() );
     }
     // Step 1
     {
@@ -490,6 +492,7 @@ BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
         BOOST_CHECK(  g2.hasInjectionControl(Phase::WATER));
         BOOST_CHECK(  g2.hasInjectionControl(Phase::GAS));
         BOOST_CHECK( !g2.hasInjectionControl(Phase::OIL));
+        BOOST_CHECK( !g2.isAvailableForGroupControl() );
 
         g2.injectionControls(Phase::WATER, st);
         g2.injectionControls(Phase::GAS, st);
@@ -502,5 +505,6 @@ BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
         const auto& g1 = schedule.getGroup("G1", 1);
         BOOST_CHECK(!g1.has_topup_phase());
         BOOST_CHECK_THROW(g1.topup_phase(), std::logic_error);
+        BOOST_CHECK(  g1.isAvailableForGroupControl() );
     }
 }


### PR DESCRIPTION
The method has very similar intended usage as the method of the same name in the Well class.

Requires opm-simulator PR for the serialization.