### PR TITLE
Move enum Well:InjectorType to new file ScheduleTypes

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -115,6 +115,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -651,6 +652,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
        opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+       opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
        opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Equinor ASA.
+  Copyright 2020 Equinor ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -17,20 +17,22 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef INJECTION_HPP
-#define INJECTION_HPP
-
-#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
+#ifndef OPM_SCHEDULE_TYPES_HPP
+#define OPM_SCHEDULE_TYPES_HPP
 
 namespace Opm {
-namespace injection {
 
-double rateToSI(double rawRate, InjectorType wellType, const Opm::UnitSystem &unitSystem);
-double rateToSI(double rawRate, Phase wellPhase, const Opm::UnitSystem& unitSystem);
+enum class InjectorType {
+    WATER = 1,
+    GAS = 2,
+    OIL = 3,
+    MULTI = 4
+};
+const std::string InjectorType2String( InjectorType enumValue );
+InjectorType InjectorTypeFromString( const std::string& stringValue );
 
 }
-}
+
+
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -27,6 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/ProductionControls.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/InjectionControls.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellFoamProperties.hpp>
@@ -62,14 +63,6 @@ public:
     static Status StatusFromString(const std::string& stringValue);
 
 
-    enum class InjectorType {
-        WATER = 1,
-        GAS = 2,
-        OIL = 3,
-        MULTI = 4
-    };
-    static const std::string InjectorType2String( InjectorType enumValue );
-    static InjectorType InjectorTypeFromString( const std::string& stringValue );
 
 
     /*
@@ -211,7 +204,7 @@ public:
         int     VFPTableNumber;
         bool    predictionMode;
         int     injectionControls;
-        Well::InjectorType injectorType;
+        InjectorType injectorType;
         InjectorCMode controlMode;
 
         bool operator==(const WellInjectionProperties& other) const;
@@ -232,7 +225,7 @@ public:
                                 int vfpTableNum,
                                 bool predMode,
                                 int injControls,
-                                Well::InjectorType injType,
+                                InjectorType injType,
                                 InjectorCMode ctrlMode);
 
         void handleWELTARG(WELTARGCMode cmode, double newValue, double SIFactorP);

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -144,7 +144,7 @@ namespace {
                 return WTypeVal::Producer;
             }
 
-            using IType = ::Opm::Well::InjectorType;
+            using IType = ::Opm::InjectorType;
 
             const auto itype = well.injectionControls(st).injector_type;
 
@@ -179,7 +179,7 @@ namespace {
                 const auto wtype = controls.injector_type;
 
                 using CMode = ::Opm::Well::InjectorCMode;
-                using WType = ::Opm::Well::InjectorType;
+                using WType = ::Opm::InjectorType;
 
                 switch (wmctl) {
                 case CMode::RATE: {
@@ -281,7 +281,7 @@ namespace {
                 }
             }
             else { // injector
-                using IType = ::Opm::Well::InjectorType;
+                using IType = ::Opm::InjectorType;
 
                 switch (curr.inj) {
                 case IMode::RATE: {
@@ -599,7 +599,7 @@ namespace {
                 const auto& ic = well.injectionControls(smry);
 
                 using IP = ::Opm::Well::InjectorCMode;
-                using IT = ::Opm::Well::InjectorType;
+                using IT = ::Opm::InjectorType;
 
                 if (ic.hasControl(IP::RATE)) {
                     if (ic.injector_type == IT::OIL) {
@@ -799,7 +799,7 @@ namespace {
                 assignProducer(well.name(), smry, xWell);
             }
             else if (well.isInjector()) {
-                using IType = ::Opm::Well::InjectorType;
+                using IType = ::Opm::InjectorType;
                 const auto itype = well.injectionControls(smry).injector_type;
 
                 switch (itype) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1336,7 +1336,7 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
                 {
                     const auto& well = this->getWell(well_name, currentStep);
                     const auto& inj = well.getInjectionProperties();
-                    if (!well.isProducer() && inj.injectorType == Well::InjectorType::GAS) {
+                    if (!well.isProducer() && inj.injectorType == InjectorType::GAS) {
                         if (well.getSolventFraction() != fraction) {
                             auto new_well = std::make_shared<Well>(well);
                             new_well->updateSolventFraction(fraction);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <stdexcept>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
+
+namespace Opm {
+
+const std::string InjectorType2String( InjectorType enumValue ) {
+    switch( enumValue ) {
+    case InjectorType::OIL:
+        return "OIL";
+    case InjectorType::GAS:
+        return "GAS";
+    case InjectorType::WATER:
+        return "WATER";
+    case InjectorType::MULTI:
+        return "MULTI";
+    default:
+        throw std::invalid_argument("unhandled enum value");
+    }
+}
+
+InjectorType InjectorTypeFromString( const std::string& stringValue ) {
+    if (stringValue == "OIL")
+        return InjectorType::OIL;
+    else if (stringValue == "WATER")
+        return InjectorType::WATER;
+    else if (stringValue == "WAT")
+        return InjectorType::WATER;
+    else if (stringValue == "GAS")
+        return InjectorType::GAS;
+    else if (stringValue == "MULTI")
+        return InjectorType::MULTI;
+    else
+        throw std::invalid_argument("Unknown enum state string: " + stringValue );
+}}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -513,7 +513,7 @@ bool Well::isInjector() const {
 }
 
 
-Well::InjectorType Well::injectorType() const {
+InjectorType Well::injectorType() const {
     if (this->producer)
         throw std::runtime_error("Can not access injectorType attribute of a producer");
 
@@ -901,9 +901,9 @@ double Well::injection_rate(const SummaryState& st, Phase phase_arg) const {
 
     const auto type = controls.injector_type;
 
-    if( phase_arg == Phase::WATER && type != Well::InjectorType::WATER ) return 0.0;
-    if( phase_arg == Phase::OIL   && type != Well::InjectorType::OIL   ) return 0.0;
-    if( phase_arg == Phase::GAS   && type != Well::InjectorType::GAS   ) return 0.0;
+    if( phase_arg == Phase::WATER && type != InjectorType::WATER ) return 0.0;
+    if( phase_arg == Phase::OIL   && type != InjectorType::OIL   ) return 0.0;
+    if( phase_arg == Phase::GAS   && type != InjectorType::GAS   ) return 0.0;
 
     return controls.surface_rate;
 }
@@ -997,35 +997,7 @@ Well::Status Well::StatusFromString(const std::string& stringValue) {
 }
 
 
-const std::string Well::InjectorType2String( Well::InjectorType enumValue ) {
-    switch( enumValue ) {
-    case InjectorType::OIL:
-        return "OIL";
-    case InjectorType::GAS:
-        return "GAS";
-    case InjectorType::WATER:
-        return "WATER";
-    case InjectorType::MULTI:
-        return "MULTI";
-    default:
-        throw std::invalid_argument("unhandled enum value");
-    }
-}
 
-Well::InjectorType Well::InjectorTypeFromString( const std::string& stringValue ) {
-    if (stringValue == "OIL")
-        return InjectorType::OIL;
-    else if (stringValue == "WATER")
-        return InjectorType::WATER;
-    else if (stringValue == "WAT")
-        return InjectorType::WATER;
-    else if (stringValue == "GAS")
-        return InjectorType::GAS;
-    else if (stringValue == "MULTI")
-        return InjectorType::MULTI;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue );
-}
 
 const std::string Well::InjectorCMode2String( InjectorCMode enumValue ) {
     switch( enumValue ) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
@@ -25,6 +25,7 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
@@ -38,8 +39,8 @@ namespace Opm {
     Well::WellInjectionProperties::WellInjectionProperties()
         : temperature(0.0), BHPH(0.0), THPH(0.0), VFPTableNumber(0),
           predictionMode(false), injectionControls(0),
-          injectorType(Well::InjectorType::WATER),
-          controlMode(Well::InjectorCMode::CMODE_UNDEFINED)
+          injectorType(InjectorType::WATER),
+          controlMode(InjectorCMode::CMODE_UNDEFINED)
     {
     }
 
@@ -71,7 +72,7 @@ namespace Opm {
                                                            int vfpTableNum,
                                                            bool predMode,
                                                            int injControls,
-                                                           Well::InjectorType injType,
+                                                           InjectorType injType,
                                                            InjectorCMode ctrlMode)
         : name(wname),
           surfaceInjectionRate(surfaceInjRate),
@@ -93,7 +94,7 @@ namespace Opm {
 
 
     void Well::WellInjectionProperties::handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name) {
-        this->injectorType = Well::InjectorTypeFromString( record.getItem("TYPE").getTrimmedString(0) );
+        this->injectorType = InjectorTypeFromString( record.getItem("TYPE").getTrimmedString(0) );
         this->predictionMode = true;
 
         if (!record.getItem("RATE").defaultApplied(0)) {
@@ -154,7 +155,7 @@ namespace Opm {
                 this->bhp_hist_limit = newValue * SiFactorP;
         }
         else if (cmode == WELTARGCMode::ORAT){
-            if(this->injectorType == Well::InjectorType::OIL){
+            if(this->injectorType == InjectorType::OIL){
                 this->surfaceInjectionRate.assert_numeric("Can not combine UDA and WELTARG");
                 this->surfaceInjectionRate.reset( newValue );
             }else{
@@ -162,7 +163,7 @@ namespace Opm {
             }
         }
         else if (cmode == WELTARGCMode::WRAT){
-            if (this->injectorType == Well::InjectorType::WATER) {
+            if (this->injectorType == InjectorType::WATER) {
                 this->surfaceInjectionRate.assert_numeric("Can not combine UDA and WELTARG");
                 this->surfaceInjectionRate.reset( newValue );
             }
@@ -170,7 +171,7 @@ namespace Opm {
                 std::invalid_argument("Well type must be WATER to set the water rate");
         }
         else if (cmode == WELTARGCMode::GRAT){
-            if(this->injectorType == Well::InjectorType::GAS){
+            if(this->injectorType == InjectorType::GAS){
                 this->surfaceInjectionRate.assert_numeric("Can not combine UDA and WELTARG");
                 this->surfaceInjectionRate.reset( newValue );
             }else{
@@ -201,7 +202,7 @@ namespace Opm {
             const std::string msg = "Injection type can not be defaulted for keyword WCONINJH";
             throw std::invalid_argument(msg);
         }
-        this->injectorType = Well::InjectorTypeFromString( typeItem.getTrimmedString(0));
+        this->injectorType = InjectorTypeFromString( typeItem.getTrimmedString(0));
 
         if (!record.getItem("RATE").defaultApplied(0)) {
             double injectionRate = record.getItem("RATE").get<double>(0);
@@ -295,7 +296,7 @@ namespace Opm {
             << "VFP table: "        << wp.VFPTableNumber << ", "
             << "prediction mode: "  << wp.predictionMode << ", "
             << "injection ctrl: "   << wp.injectionControls << ", "
-            << "injector type: "    << Well::InjectorType2String(wp.injectorType) << ", "
+            << "injector type: "    << InjectorType2String(wp.injectorType) << ", "
             << "control mode: "     << Well::InjectorCMode2String(wp.controlMode) << " }";
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/injection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/injection.cpp
@@ -29,20 +29,20 @@
 namespace Opm {
 namespace injection {
 
-    double rateToSI(double rawRate, Well::InjectorType wellType, const Opm::UnitSystem &unitSystem) {
+    double rateToSI(double rawRate, InjectorType wellType, const Opm::UnitSystem &unitSystem) {
         switch (wellType) {
-        case Well::InjectorType::MULTI:
+        case InjectorType::MULTI:
             // multi-phase controlled injectors are a really funny
             // construct in Eclipse: the quantity controlled for is
             // not physically meaningful, i.e. Eclipse adds up
             // MCFT/day and STB/day.
             throw std::logic_error("There is no generic way to handle multi-phase injectors at this level!");
 
-        case Well::InjectorType::OIL:
-        case Well::InjectorType::WATER:
+        case InjectorType::OIL:
+        case InjectorType::WATER:
             return unitSystem.to_si( UnitSystem::measure::liquid_surface_rate, rawRate );
 
-        case Well::InjectorType::GAS:
+        case InjectorType::GAS:
             return unitSystem.to_si( UnitSystem::measure::gas_surface_rate, rawRate );
 
         default:

--- a/src/opm/parser/eclipse/EclipseState/Schedule/eval_uda.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/eval_uda.cpp
@@ -46,7 +46,7 @@ namespace UDA {
 }
 
 
-double eval_well_uda_rate(const UDAValue& value, const std::string& well, const SummaryState& st, double udq_default, Well::InjectorType wellType, const UnitSystem& unitSystem) {
+double eval_well_uda_rate(const UDAValue& value, const std::string& well, const SummaryState& st, double udq_default, InjectorType wellType, const UnitSystem& unitSystem) {
     double raw_rate = eval_well_uda(value, well, st, udq_default);
     return injection::rateToSI(raw_rate, wellType, unitSystem);
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/eval_uda.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/eval_uda.hpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 
 namespace Opm {
 class UDAvalue;
@@ -32,7 +33,7 @@ class UnitSystem;
 namespace UDA {
 
     double eval_well_uda(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined);
-double eval_well_uda_rate(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined, Well::InjectorType wellType, const UnitSystem& unitSystem);
+    double eval_well_uda_rate(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined, InjectorType wellType, const UnitSystem& unitSystem);
 
     double eval_group_uda(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined);
     double eval_group_uda_rate(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined, Phase phase, const UnitSystem& unitSystem);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2630,34 +2630,34 @@ BOOST_AUTO_TEST_CASE(TestGroupProductionExceedLimitActionEnumLoop) {
 /*****************************************************************/
 
 BOOST_AUTO_TEST_CASE(TestInjectorEnum2String) {
-    BOOST_CHECK_EQUAL( "OIL"  ,  Well::InjectorType2String(Well::InjectorType::OIL));
-    BOOST_CHECK_EQUAL( "GAS"  ,  Well::InjectorType2String(Well::InjectorType::GAS));
-    BOOST_CHECK_EQUAL( "WATER" , Well::InjectorType2String(Well::InjectorType::WATER));
-    BOOST_CHECK_EQUAL( "MULTI" , Well::InjectorType2String(Well::InjectorType::MULTI));
+    BOOST_CHECK_EQUAL( "OIL"  ,  InjectorType2String(InjectorType::OIL));
+    BOOST_CHECK_EQUAL( "GAS"  ,  InjectorType2String(InjectorType::GAS));
+    BOOST_CHECK_EQUAL( "WATER" , InjectorType2String(InjectorType::WATER));
+    BOOST_CHECK_EQUAL( "MULTI" , InjectorType2String(InjectorType::MULTI));
 }
 
 
 BOOST_AUTO_TEST_CASE(TestInjectorEnumFromString) {
-    BOOST_CHECK_THROW( Well::InjectorTypeFromString("XXX") , std::invalid_argument );
-    BOOST_CHECK( Well::InjectorType::OIL   == Well::InjectorTypeFromString("OIL"));
-    BOOST_CHECK( Well::InjectorType::WATER == Well::InjectorTypeFromString("WATER"));
-    BOOST_CHECK( Well::InjectorType::WATER == Well::InjectorTypeFromString("WAT"));
-    BOOST_CHECK( Well::InjectorType::GAS   == Well::InjectorTypeFromString("GAS"));
-    BOOST_CHECK( Well::InjectorType::MULTI == Well::InjectorTypeFromString("MULTI"));
+    BOOST_CHECK_THROW( InjectorTypeFromString("XXX") , std::invalid_argument );
+    BOOST_CHECK( InjectorType::OIL   == InjectorTypeFromString("OIL"));
+    BOOST_CHECK( InjectorType::WATER == InjectorTypeFromString("WATER"));
+    BOOST_CHECK( InjectorType::WATER == InjectorTypeFromString("WAT"));
+    BOOST_CHECK( InjectorType::GAS   == InjectorTypeFromString("GAS"));
+    BOOST_CHECK( InjectorType::MULTI == InjectorTypeFromString("MULTI"));
 }
 
 
 
 BOOST_AUTO_TEST_CASE(TestInjectorEnumLoop) {
-    BOOST_CHECK( Well::InjectorType::OIL   == Well::InjectorTypeFromString( Well::InjectorType2String( Well::InjectorType::OIL ) ));
-    BOOST_CHECK( Well::InjectorType::WATER == Well::InjectorTypeFromString( Well::InjectorType2String( Well::InjectorType::WATER ) ));
-    BOOST_CHECK( Well::InjectorType::GAS   == Well::InjectorTypeFromString( Well::InjectorType2String( Well::InjectorType::GAS ) ));
-    BOOST_CHECK( Well::InjectorType::MULTI == Well::InjectorTypeFromString( Well::InjectorType2String( Well::InjectorType::MULTI ) ));
+    BOOST_CHECK( InjectorType::OIL   == InjectorTypeFromString( InjectorType2String( InjectorType::OIL ) ));
+    BOOST_CHECK( InjectorType::WATER == InjectorTypeFromString( InjectorType2String( InjectorType::WATER ) ));
+    BOOST_CHECK( InjectorType::GAS   == InjectorTypeFromString( InjectorType2String( InjectorType::GAS ) ));
+    BOOST_CHECK( InjectorType::MULTI == InjectorTypeFromString( InjectorType2String( InjectorType::MULTI ) ));
 
-    BOOST_CHECK_EQUAL( "MULTI"    , Well::InjectorType2String(Well::InjectorTypeFromString(  "MULTI" ) ));
-    BOOST_CHECK_EQUAL( "OIL"      , Well::InjectorType2String(Well::InjectorTypeFromString(  "OIL" ) ));
-    BOOST_CHECK_EQUAL( "GAS"      , Well::InjectorType2String(Well::InjectorTypeFromString(  "GAS" ) ));
-    BOOST_CHECK_EQUAL( "WATER"    , Well::InjectorType2String(Well::InjectorTypeFromString(  "WATER" ) ));
+    BOOST_CHECK_EQUAL( "MULTI"    , InjectorType2String(InjectorTypeFromString(  "MULTI" ) ));
+    BOOST_CHECK_EQUAL( "OIL"      , InjectorType2String(InjectorTypeFromString(  "OIL" ) ));
+    BOOST_CHECK_EQUAL( "GAS"      , InjectorType2String(InjectorTypeFromString(  "GAS" ) ));
+    BOOST_CHECK_EQUAL( "WATER"    , InjectorType2String(InjectorTypeFromString(  "WATER" ) ));
 }
 
 /*****************************************************************/

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -35,6 +35,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
@@ -291,16 +292,16 @@ BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
 
 
 
-BOOST_AUTO_TEST_CASE(InjectorType) {
+BOOST_AUTO_TEST_CASE(ScheduleTypesInjectorType) {
     Opm::Well well("WELL1", "GROUP", 0, 1, 23, 42, 2334.32, Opm::Phase::WATER, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
 
 
     auto injectionProps = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
-    injectionProps->injectorType = Opm::Well::InjectorType::WATER;
+    injectionProps->injectorType = Opm::InjectorType::WATER;
     well.updateInjection(injectionProps);
     // TODO: Should we test for something other than wate here, as long as
     //       the default value for InjectorType is WellInjector::WATER?
-    BOOST_CHECK( Opm::Well::InjectorType::WATER == well.getInjectionProperties().injectorType);
+    BOOST_CHECK( Opm::InjectorType::WATER == well.getInjectionProperties().injectorType);
 
 }
 
@@ -858,3 +859,5 @@ BOOST_AUTO_TEST_CASE(WELOPEN) {
         BOOST_CHECK(op_1.getStatus() == Well::Status::SHUT);
     }
 }
+
+

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -144,13 +144,13 @@ void verifyWellState(const std::string& rst_filename, const Opm::Schedule& sched
             sched_wtype = 1;
         } else {
             switch( sched_well2.getInjectionProperties(  ).injectorType ) {
-            case Opm::Well::InjectorType::WATER:
+            case Opm::InjectorType::WATER:
                 sched_wtype = 3;
                 break;
-            case Opm::Well::InjectorType::GAS:
+            case Opm::InjectorType::GAS:
                 sched_wtype = 4;
                 break;
-            case Opm::Well::InjectorType::OIL:
+            case Opm::InjectorType::OIL:
                 sched_wtype = 2;
                 break;
             default:


### PR DESCRIPTION
The type of a well - i.e. injector/producer and the phase is a surprsingly flickety small piece of code. As preparation/simplification for #1396 I am in the process of creating a small class for it, and as a preparation for that again - the current `InjectorType` enum is moved out from the `Well` class to a separate compilation unit; that again is a preparation to avoid circular dependencies.

I don't *really* like this change myself, but it gets the job done.

Dwonstream: https://github.com/OPM/opm-simulators/pull/2389

