### PR TITLE
Add missing <string> include.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
@@ -20,6 +20,8 @@
 #ifndef OPM_SCHEDULE_TYPES_HPP
 #define OPM_SCHEDULE_TYPES_HPP
 
+#include <string>
+
 namespace Opm {
 
 enum class InjectorType {


### PR DESCRIPTION
Critical for clang systems (compile error without it).