### PR TITLE
Uda value dim constructor

### DIFF
--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -72,8 +72,6 @@ private:
     double double_value;
     std::string string_value;
 
-    /* This 'mutable' modifier is a hack to avoid tampering with the overall
-       const-ness of the data in a deck item. */
     Dimension dim;
 };
 

--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -34,6 +34,7 @@ public:
     UDAValue();
     explicit UDAValue(double);
     explicit UDAValue(const std::string&);
+    explicit UDAValue(const Dimension& dim);
     UDAValue(const UDAValue& src, const Dimension& dim);
     UDAValue(double data, const Dimension& dim);
     UDAValue(const std::string& data, const Dimension& dim);

--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -55,15 +55,14 @@ public:
     template<typename T>
     bool is() const;
 
-    void reset(double value);
-    void reset(const std::string& value);
-
     void assert_numeric() const;
     void assert_numeric(const std::string& error_msg) const;
     const Dimension& get_dim() const;
 
     bool operator==(const UDAValue& other) const;
     bool operator!=(const UDAValue& other) const;
+    UDAValue& operator=(double value);
+    UDAValue& operator=(const std::string& value);
 
     bool is_numeric() { return numeric_value; }
 

--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -35,7 +35,6 @@ public:
     explicit UDAValue(double);
     explicit UDAValue(const std::string&);
     explicit UDAValue(const Dimension& dim);
-    UDAValue(const UDAValue& src, const Dimension& dim);
     UDAValue(double data, const Dimension& dim);
     UDAValue(const std::string& data, const Dimension& dim);
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -317,7 +317,7 @@ public:
         bool operator!=(const WellProductionProperties& other) const;
 
         WellProductionProperties();
-        WellProductionProperties(const std::string& name_arg);
+        WellProductionProperties(const UnitSystem& units, const std::string& name_arg);
         WellProductionProperties(const std::string& wname,
                                  const UDAValue& oilRate,
                                  const UDAValue& waterRate,

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -211,7 +211,7 @@ public:
         bool operator!=(const WellInjectionProperties& other) const;
 
         WellInjectionProperties();
-        WellInjectionProperties(const std::string& wname);
+        WellInjectionProperties(const UnitSystem& units, const std::string& wname);
         WellInjectionProperties(const std::string& wname,
                                 const UDAValue& surfaceInjRate,
                                 const UDAValue& reservoirInjRate,

--- a/opm/parser/eclipse/Units/Dimension.hpp
+++ b/opm/parser/eclipse/Units/Dimension.hpp
@@ -39,7 +39,6 @@ namespace Opm {
 
         bool equal(const Dimension& other) const;
         bool isCompositable() const;
-        static Dimension newComposite(const std::string& dim, double SIfactor, double SIoffset = 0.0);
 
         bool operator==( const Dimension& ) const;
         bool operator!=( const Dimension& ) const;

--- a/opm/parser/eclipse/Units/Dimension.hpp
+++ b/opm/parser/eclipse/Units/Dimension.hpp
@@ -27,8 +27,8 @@ namespace Opm {
     class Dimension {
     public:
         Dimension();
-        Dimension(const std::string& name, double SIfactor,
-                  double SIoffset = 0.0, bool sanityCheck = true);
+        Dimension(double SIfactor,
+                  double SIoffset = 0.0);
 
         double getSIScaling() const;
         double getSIScalingRaw() const;
@@ -38,7 +38,6 @@ namespace Opm {
         double convertSiToRaw(double siValue) const;
 
         bool equal(const Dimension& other) const;
-        const std::string& getName() const;
         bool isCompositable() const;
         static Dimension newComposite(const std::string& dim, double SIfactor, double SIoffset = 0.0);
 
@@ -46,7 +45,6 @@ namespace Opm {
         bool operator!=( const Dimension& ) const;
 
     private:
-        std::string m_name;
         double m_SIfactor;
         double m_SIoffset;
     };

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -87,8 +87,8 @@ namespace Opm {
         UnitType getType() const;
         int ecl_id() const;
 
+        void addDimension(const std::string& dimension , const Dimension& dim);
         void addDimension(const std::string& dimension, double SIfactor, double SIoffset = 0.0);
-        void addDimension( Dimension );
         const Dimension& getNewDimension(const std::string& dimension);
         const Dimension& getDimension(const std::string& dimension) const;
         bool hasDimension(const std::string& dimension) const;

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -91,6 +91,9 @@ namespace Opm {
         void addDimension(const std::string& dimension, double SIfactor, double SIoffset = 0.0);
         const Dimension& getNewDimension(const std::string& dimension);
         const Dimension& getDimension(const std::string& dimension) const;
+        Dimension getDimension(measure m) const;
+
+
         bool hasDimension(const std::string& dimension) const;
         bool equal(const UnitSystem& other) const;
         const std::map<std::string,Dimension>& getDimensions() const;

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -162,11 +162,21 @@ UDAValue DeckItem::get( size_t index ) const {
     if (this->active_dimensions.empty())
         return value;
 
+    // The UDA value held internally by the DeckItem does not have dimension set
+    // correctly we therefor need to create a new one with the correct dimension
+    // attached before returning.
     std::size_t dim_index = index % this->active_dimensions.size();
-    if (value::defaulted(this->value_status[index]))
-        return UDAValue( value, this->default_dimensions[dim_index]);
-    else
-        return UDAValue( value, this->active_dimensions[dim_index]);
+    if (value::defaulted(this->value_status[index])) {
+        if (value.is<std::string>())
+            return UDAValue(value.get<std::string>(), this->default_dimensions[dim_index]);
+        else
+            return UDAValue(value.get<double>(), this->default_dimensions[dim_index]);
+    } else {
+        if (value.is<std::string>())
+            return UDAValue(value.get<std::string>(), this->active_dimensions[dim_index]);
+        else
+            return UDAValue(value.get<double>(), this->active_dimensions[dim_index]);
+    }
 }
 
 

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -36,6 +36,10 @@ UDAValue::UDAValue(double value, const Dimension& dim_):
 {
 }
 
+UDAValue::UDAValue(const Dimension& dim_):
+    UDAValue(0, dim_)
+{
+}
 
 UDAValue::UDAValue() :
     UDAValue(0)

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -58,12 +58,6 @@ UDAValue::UDAValue(const std::string& value, const Dimension& dim_):
 {
 }
 
-UDAValue::UDAValue(const UDAValue& src, const Dimension& new_dim):
-    UDAValue(src)
-{
-    this->dim = new_dim;
-}
-
 
 void UDAValue::assert_numeric() const {
     std::string msg = "Internal error: The support for use of UDQ/UDA is not complete in opm/flow. The string: '" + this->string_value + "' must be numeric";

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -96,14 +96,17 @@ double UDAValue::getSI() const {
     return this->dim.convertRawToSi(this->double_value);
 }
 
-void UDAValue::reset(double value) {
+
+UDAValue& UDAValue::operator=(double value) {
     this->double_value = value;
     this->numeric_value = true;
+    return *this;
 }
 
-void UDAValue::reset(const std::string& value) {
+UDAValue& UDAValue::operator=(const std::string& value) {
     this->string_value = value;
     this->numeric_value = false;
+    return *this;
 }
 
 template<>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -133,7 +133,7 @@ Well::Well(const std::string& wname_arg,
     tracer_properties(std::make_shared<WellTracerProperties>()),
     connections(std::make_shared<WellConnections>(headI, headJ)),
     production(std::make_shared<WellProductionProperties>(unit_system, wname)),
-    injection(std::make_shared<WellInjectionProperties>(wname))
+    injection(std::make_shared<WellInjectionProperties>(unit_system, wname))
 {
     auto p = std::make_shared<WellProductionProperties>(this->unit_system, this->wname);
     p->whistctl_cmode = whistctl_cmode;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -273,7 +273,7 @@ bool Well::updateEconLimits(std::shared_ptr<WellEconProductionLimits> econ_limit
 void Well::switchToProducer() {
     auto p = std::make_shared<WellInjectionProperties>(this->getInjectionProperties());
 
-    p->BHPTarget.reset(0);
+    p->BHPTarget = 0;
     p->dropInjectionControl( Opm::Well::InjectorCMode::BHP );
     this->updateInjection( p );
     this->updateProducer(true);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -132,10 +132,10 @@ Well::Well(const std::string& wname_arg,
     brine_properties(std::make_shared<WellBrineProperties>()),
     tracer_properties(std::make_shared<WellTracerProperties>()),
     connections(std::make_shared<WellConnections>(headI, headJ)),
-    production(std::make_shared<WellProductionProperties>(wname)),
+    production(std::make_shared<WellProductionProperties>(unit_system, wname)),
     injection(std::make_shared<WellInjectionProperties>(wname))
 {
-    auto p = std::make_shared<WellProductionProperties>(wname);
+    auto p = std::make_shared<WellProductionProperties>(this->unit_system, this->wname);
     p->whistctl_cmode = whistctl_cmode;
     this->updateProduction(p);
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
@@ -150,14 +150,14 @@ namespace Opm {
         if (cmode == Well::WELTARGCMode::BHP){
             if (this->predictionMode) {
                 this->BHPTarget.assert_numeric("Can not combine UDA and WELTARG");
-                this->BHPTarget.reset( newValue );
+                this->BHPTarget = newValue;
             } else
                 this->bhp_hist_limit = newValue * SiFactorP;
         }
         else if (cmode == WELTARGCMode::ORAT){
             if(this->injectorType == InjectorType::OIL){
                 this->surfaceInjectionRate.assert_numeric("Can not combine UDA and WELTARG");
-                this->surfaceInjectionRate.reset( newValue );
+                this->surfaceInjectionRate = newValue;
             }else{
                 std::invalid_argument("Well type must be OIL to set the oil rate");
             }
@@ -165,7 +165,7 @@ namespace Opm {
         else if (cmode == WELTARGCMode::WRAT){
             if (this->injectorType == InjectorType::WATER) {
                 this->surfaceInjectionRate.assert_numeric("Can not combine UDA and WELTARG");
-                this->surfaceInjectionRate.reset( newValue );
+                this->surfaceInjectionRate = newValue;
             }
             else
                 std::invalid_argument("Well type must be WATER to set the water rate");
@@ -173,21 +173,21 @@ namespace Opm {
         else if (cmode == WELTARGCMode::GRAT){
             if(this->injectorType == InjectorType::GAS){
                 this->surfaceInjectionRate.assert_numeric("Can not combine UDA and WELTARG");
-                this->surfaceInjectionRate.reset( newValue );
+                this->surfaceInjectionRate = newValue;
             }else{
                 std::invalid_argument("Well type must be GAS to set the gas rate");
             }
         }
         else if (cmode == WELTARGCMode::THP){
             this->THPTarget.assert_numeric("Can not combine UDA and WELTARG");
-            this->THPTarget.reset( newValue );
+            this->THPTarget = newValue;
         }
         else if (cmode == WELTARGCMode::VFP){
             this->VFPTableNumber = static_cast<int> (newValue);
         }
         else if (cmode == WELTARGCMode::RESV){
             this->surfaceInjectionRate.assert_numeric("Can not combine UDA and WELTARG");
-            this->reservoirInjectionRate.reset( newValue );
+            this->reservoirInjectionRate = newValue;
         }
         else if (cmode != WELTARGCMode::GUID){
             throw std::invalid_argument("Invalid keyword (MODE) supplied");
@@ -206,7 +206,7 @@ namespace Opm {
 
         if (!record.getItem("RATE").defaultApplied(0)) {
             double injectionRate = record.getItem("RATE").get<double>(0);
-            this->surfaceInjectionRate.reset( injectionRate );
+            this->surfaceInjectionRate = injectionRate;
         }
         if ( record.getItem( "BHP" ).hasValue(0) )
             this->BHPH = record.getItem("BHP").getSIDouble(0);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
@@ -37,26 +37,26 @@ namespace Opm {
 
 
     Well::WellInjectionProperties::WellInjectionProperties()
-        : temperature(0.0), BHPH(0.0), THPH(0.0), VFPTableNumber(0),
-          predictionMode(false), injectionControls(0),
-          injectorType(InjectorType::WATER),
-          controlMode(InjectorCMode::CMODE_UNDEFINED)
+        : WellInjectionProperties(UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC), "")
     {
     }
 
-    Well::WellInjectionProperties::WellInjectionProperties(const std::string& wname)
+
+    Well::WellInjectionProperties::WellInjectionProperties(const UnitSystem& units, const std::string& wname)
         : name(wname),
+          surfaceInjectionRate(units.getDimension(UnitSystem::measure::identity)),
+          reservoirInjectionRate(units.getDimension(UnitSystem::measure::rate)),
+          BHPTarget(units.getDimension(UnitSystem::measure::pressure)),
+          THPTarget(units.getDimension(UnitSystem::measure::pressure)),
+          temperature(Metric::TemperatureOffset + ParserKeywords::STCOND::TEMPERATURE::defaultValue),
+          BHPH(0),
+          THPH(0),
+          VFPTableNumber(0),
+          predictionMode(true),
+          injectionControls(0),
           injectorType(InjectorType::WATER),
           controlMode(InjectorCMode::CMODE_UNDEFINED)
     {
-        temperature=
-            Metric::TemperatureOffset
-            + ParserKeywords::STCOND::TEMPERATURE::defaultValue;
-        BHPH=0.0;
-        THPH=0.0;
-        VFPTableNumber=0;
-        predictionMode=true;
-        injectionControls=0;
     }
 
     Well::WellInjectionProperties::WellInjectionProperties(const std::string& wname,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -101,8 +101,7 @@ namespace Opm {
         this->predictionMode = false;
         // update LiquidRate. The funnny constrction with explicitly making a new
         // UDAValue is to ensure that the UDAValue has the correct dimension.
-        this->LiquidRate = UDAValue(this->LiquidRate, this->OilRate.get_dim());
-        this->LiquidRate.reset(this->WaterRate.get<double>() + this->OilRate.get<double>());
+        this->LiquidRate = UDAValue(this->WaterRate.get<double>() + this->OilRate.get<double>(), this->OilRate.get_dim());
 
         if ( record.getItem( "BHP" ).hasValue(0) )
             this->BHPH = record.getItem("BHP").get<UDAValue>(0).getSI();
@@ -208,8 +207,8 @@ namespace Opm {
     void Well::WellProductionProperties::handleWCONHIST(const DeckRecord& record)
     {
         this->init_rates(record);
-        this->LiquidRate.reset(0);
-        this->ResVRate.reset(0);
+        this->LiquidRate = 0;
+        this->ResVRate = 0;
 
         // when the well is switching to history matching producer from prediction mode
         // or switching from injector to producer
@@ -229,40 +228,40 @@ namespace Opm {
     void Well::WellProductionProperties::handleWELTARG(Well::WELTARGCMode cmode, double newValue, double SiFactorP) {
         if (cmode == WELTARGCMode::ORAT){
             this->OilRate.assert_numeric("Can not combine UDA and WELTARG");
-            this->OilRate.reset( newValue );
+            this->OilRate = newValue;
             this->addProductionControl( ProducerCMode::ORAT );
         }
         else if (cmode == WELTARGCMode::WRAT){
             this->WaterRate.assert_numeric("Can not combine UDA and WELTARG");
-            this->WaterRate.reset( newValue );
+            this->WaterRate = newValue;
             this->addProductionControl( ProducerCMode::WRAT );
         }
         else if (cmode == WELTARGCMode::GRAT){
             this->GasRate.assert_numeric("Can not combine UDA and WELTARG");
-            this->GasRate.reset( newValue );
+            this->GasRate = newValue;
             this->addProductionControl( ProducerCMode::GRAT );
         }
         else if (cmode == WELTARGCMode::LRAT){
             this->LiquidRate.assert_numeric("Can not combine UDA and WELTARG");
-            this->LiquidRate.reset( newValue );
+            this->LiquidRate = newValue;
             this->addProductionControl( ProducerCMode::LRAT );
         }
         else if (cmode == WELTARGCMode::RESV){
             this->ResVRate.assert_numeric("Can not combine UDA and WELTARG");
-            this->ResVRate.reset( newValue );
+            this->ResVRate = newValue;
             this->addProductionControl( ProducerCMode::RESV );
         }
         else if (cmode == WELTARGCMode::BHP){
             if (this->predictionMode) {
                 this->BHPTarget.assert_numeric("Can not combine UDA and WELTARG");
-                this->BHPTarget.reset( newValue );
+                this->BHPTarget = newValue;
             } else
                 this->bhp_hist_limit = newValue * SiFactorP;
             this->addProductionControl( ProducerCMode::BHP );
         }
         else if (cmode == WELTARGCMode::THP){
             this->THPTarget.assert_numeric("Can not combine UDA and WELTARG");
-            this->THPTarget.reset(newValue );
+            this->THPTarget = newValue;
             this->addProductionControl( ProducerCMode::THP );
         }
         else if (cmode == WELTARGCMode::VFP)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -33,17 +33,27 @@
 
 namespace Opm {
 
-    Well::WellProductionProperties::WellProductionProperties()
-        : BHPH(0.0), THPH(0.0), VFPTableNumber(0),
-          ALQValue(0.0), predictionMode(false),
-          controlMode(ProducerCMode::NONE),
-          whistctl_cmode(ProducerCMode::NONE),
-          m_productionControls(0)
+    Well::WellProductionProperties::WellProductionProperties() :
+        WellProductionProperties(UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC), "")
     {}
 
-    Well::WellProductionProperties::WellProductionProperties(const std::string& name_arg) :
+    Well::WellProductionProperties::WellProductionProperties(const UnitSystem& units, const std::string& name_arg) :
         name(name_arg),
-        predictionMode( true )
+        OilRate(units.getDimension(UnitSystem::measure::liquid_surface_rate)),
+        WaterRate(units.getDimension(UnitSystem::measure::liquid_surface_rate)),
+        GasRate(units.getDimension(UnitSystem::measure::gas_surface_rate)),
+        LiquidRate(units.getDimension(UnitSystem::measure::liquid_surface_rate)),
+        ResVRate(units.getDimension(UnitSystem::measure::rate)),
+        BHPTarget(units.getDimension(UnitSystem::measure::pressure)),
+        THPTarget(units.getDimension(UnitSystem::measure::pressure)),
+        BHPH(0.0),
+        THPH(0.0),
+        VFPTableNumber(0),
+        ALQValue(0.0),
+        predictionMode(true),
+        controlMode(ProducerCMode::CMODE_UNDEFINED),
+        whistctl_cmode(ProducerCMode::CMODE_UNDEFINED),
+        m_productionControls(0)
     {}
 
 

--- a/src/opm/parser/eclipse/Units/Dimension.cpp
+++ b/src/opm/parser/eclipse/Units/Dimension.cpp
@@ -25,22 +25,16 @@
 
 namespace Opm {
 
-    Dimension::Dimension() :
-        m_name("Dimensionless")
+    Dimension::Dimension()
     {
         this->m_SIfactor = 1.0;
         this->m_SIoffset = 0.0;
 
     }
 
-    Dimension::Dimension(const std::string& name, double SIfactor,
-                         double SIoffset, bool sanityCheck)
+    Dimension::Dimension(double SIfactor,
+                         double SIoffset)
     {
-        for (auto iter = name.begin(); iter != name.end() && sanityCheck; ++iter) {
-            if (!isalpha(*iter) && (*iter) != '1')
-                throw std::invalid_argument("Invalid dimension name");
-        }
-        m_name = name;
         m_SIfactor = SIfactor;
         m_SIoffset = SIoffset;
     }
@@ -76,9 +70,6 @@ namespace Opm {
         return (siValue - m_SIoffset)/m_SIfactor;
     }
 
-    const std::string& Dimension::getName() const {
-        return m_name;
-    }
 
     // only dimensions with zero offset are compositable...
     bool Dimension::isCompositable() const
@@ -86,7 +77,6 @@ namespace Opm {
 
     Dimension Dimension::newComposite(const std::string& dim , double SIfactor, double SIoffset) {
         Dimension dimension;
-        dimension.m_name = dim;
         dimension.m_SIfactor = SIfactor;
         dimension.m_SIoffset = SIoffset;
         return dimension;
@@ -98,7 +88,6 @@ namespace Opm {
     }
 
     bool Dimension::operator==( const Dimension& rhs ) const {
-        if( this->m_name != rhs.m_name ) return false;
         if( this->m_SIfactor == rhs.m_SIfactor
          && this->m_SIoffset == rhs.m_SIoffset ) return true;
 

--- a/src/opm/parser/eclipse/Units/Dimension.cpp
+++ b/src/opm/parser/eclipse/Units/Dimension.cpp
@@ -75,13 +75,6 @@ namespace Opm {
     bool Dimension::isCompositable() const
     { return m_SIoffset == 0.0; }
 
-    Dimension Dimension::newComposite(const std::string& dim , double SIfactor, double SIoffset) {
-        Dimension dimension;
-        dimension.m_SIfactor = SIfactor;
-        dimension.m_SIoffset = SIoffset;
-        return dimension;
-    }
-
 
     bool Dimension::equal(const Dimension& other) const {
         return *this == other;

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -1144,7 +1144,7 @@ namespace {
 
     const Dimension& UnitSystem::getNewDimension(const std::string& dimension) {
         if( !hasDimension( dimension ) )
-            this->addDimension( this->parse( dimension ) );
+            this->addDimension( dimension, this->parse( dimension ) );
 
         return getDimension( dimension );
     }
@@ -1163,14 +1163,12 @@ namespace {
         return this->m_use_count;
     }
 
-
-    void UnitSystem::addDimension( Dimension dimension ) {
-        const auto dimname = dimension.getName();
-        this->m_dimensions[ dimname ] = std::move( dimension );
+    void UnitSystem::addDimension(const std::string& dimension , const Dimension& dim) {
+        this->m_dimensions[ dimension ] = std::move(dim);
     }
 
     void UnitSystem::addDimension(const std::string& dimension , double SIfactor, double SIoffset) {
-        this->addDimension( Dimension { dimension, SIfactor, SIoffset } );
+        this->addDimension(dimension, Dimension(SIfactor, SIoffset));
     }
 
     const std::string& UnitSystem::getName() const {

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -1195,7 +1195,7 @@ namespace {
 
             SIfactor *= dim.getSIScaling();
         }
-        return Dimension::newComposite( dimension , SIfactor );
+        return Dimension( SIfactor );
     }
 
     Dimension UnitSystem::parse(const std::string& dimension) const {
@@ -1214,7 +1214,7 @@ namespace {
         if (dividend.getSIOffset() != 0.0 || divisor.getSIOffset() != 0.0)
             throw std::invalid_argument("Composite dimensions cannot currently require a conversion offset");
 
-        return Dimension::newComposite( dimension, dividend.getSIScaling() / divisor.getSIScaling() );
+        return Dimension( dividend.getSIScaling() / divisor.getSIScaling() );
     }
 
 

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -1158,6 +1158,12 @@ namespace {
         return iter->second;
     }
 
+    Dimension UnitSystem::getDimension(measure m) const {
+        double si_factor = this->measure_table_to_si[ static_cast< int >( m ) ];
+        double si_offset = this->measure_table_to_si_offset[ static_cast<int>( m ) ];
+        return Dimension(si_factor, si_offset);
+    }
+
 
     std::size_t UnitSystem::use_count() const {
         return this->m_use_count;

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(GetSIWithoutDimensionThrows) {
 }
 
 BOOST_AUTO_TEST_CASE(GetSISingleDimensionCorrect) {
-    Dimension dim{ "Length" , 100 };
+    Dimension dim{ 100 };
     DeckItem item( "HEI", double(), { dim }, { dim } );
 
     item.push_back(1.0 , 100 );
@@ -305,8 +305,8 @@ BOOST_AUTO_TEST_CASE(GetSISingleDimensionCorrect) {
 }
 
 BOOST_AUTO_TEST_CASE(GetSISingleDefault) {
-    Dimension dim{ "Length" , 1 };
-    Dimension defaultDim{ "Length" , 100 };
+    Dimension dim{ 1 };
+    Dimension defaultDim{  100 };
     DeckItem item( "HEI", double() , {dim}, {defaultDim});
 
     item.push_backDefault( 1.0 );
@@ -315,11 +315,11 @@ BOOST_AUTO_TEST_CASE(GetSISingleDefault) {
 }
 
 BOOST_AUTO_TEST_CASE(GetSIMultipleDim) {
-    Dimension dim1{ "Length" , 2 };
-    Dimension dim2{ "Length" , 4 };
-    Dimension dim3{ "Length" , 8 };
-    Dimension dim4{ "Length" ,16 };
-    Dimension defaultDim{ "Length" , 100 };
+    Dimension dim1{  2 };
+    Dimension dim2{  4 };
+    Dimension dim3{  8 };
+    Dimension dim4{ 16 };
+    Dimension defaultDim{  100 };
     DeckItem item( "HEI", double(), {dim1, dim2, dim3, dim4}, {defaultDim, defaultDim, defaultDim, defaultDim} );
 
     item.push_back( 1.0, 16 );

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1217,10 +1217,10 @@ BOOST_AUTO_TEST_CASE(UDA_VALUE) {
     BOOST_CHECK(!value0.is<std::string>());
     BOOST_CHECK_EQUAL( value0.get<double>(), 0);
     BOOST_CHECK_THROW( value0.get<std::string>(), std::invalid_argument);
-    value0.reset( 10 );
+    value0 = 10;
     BOOST_CHECK_EQUAL( value0.get<double>(), 10);
     BOOST_CHECK_THROW( value0.get<std::string>(), std::invalid_argument);
-    value0.reset( "STRING" );
+    value0 = "STRING";
     BOOST_CHECK_EQUAL( value0.get<std::string>(), std::string("STRING"));
     BOOST_CHECK_THROW( value0.get<double>(), std::invalid_argument);
 

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1248,7 +1248,7 @@ BOOST_AUTO_TEST_CASE(UDA_VALUE) {
 
 BOOST_AUTO_TEST_CASE(UDA_VALUE_DIM) {
     UDAValue value0(1);
-    Dimension dim("DUMMY", 10);
+    Dimension dim(10);
     UDAValue value1(1, dim);
 
     BOOST_CHECK_EQUAL( value0.get<double>(), 1);

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1249,7 +1249,7 @@ BOOST_AUTO_TEST_CASE(UDA_VALUE) {
 BOOST_AUTO_TEST_CASE(UDA_VALUE_DIM) {
     UDAValue value0(1);
     Dimension dim("DUMMY", 10);
-    UDAValue value1(value0, dim);
+    UDAValue value1(1, dim);
 
     BOOST_CHECK_EQUAL( value0.get<double>(), 1);
     BOOST_CHECK_EQUAL( value0.getSI(), 1);

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -37,25 +37,13 @@ BOOST_AUTO_TEST_CASE(DefDim) {
 }
 
 BOOST_AUTO_TEST_CASE(CreateDimension) {
-    Dimension length("Length" , 1);
-    BOOST_CHECK_EQUAL("Length" , length.getName());
+    Dimension length(1);
     BOOST_CHECK_EQUAL(1 , length.getSIScaling());
 }
 
 BOOST_AUTO_TEST_CASE(makeComposite) {
     auto composite = Dimension::newComposite("Length*Length*Length/Time" , 100);
-    BOOST_CHECK_EQUAL("Length*Length*Length/Time" , composite.getName());
     BOOST_CHECK_EQUAL(100 , composite.getSIScaling());
-}
-
-
-BOOST_AUTO_TEST_CASE(CreateDimensionInvalidNameThrows) {
-    BOOST_CHECK_THROW(Dimension(" " , 1) , std::invalid_argument);
-    BOOST_CHECK_THROW(Dimension(".LX" , 1) , std::invalid_argument);
-    BOOST_CHECK_THROW(Dimension("*" , 1) , std::invalid_argument);
-    BOOST_CHECK_THROW(Dimension("/" , 1) , std::invalid_argument);
-    BOOST_CHECK_THROW(Dimension("2" , 1) , std::invalid_argument);
-    BOOST_CHECK_NO_THROW(Dimension("1" , 1));
 }
 
 
@@ -112,7 +100,6 @@ BOOST_AUTO_TEST_CASE(UnitSystemParseInvalidThrows) {
     system.addDimension("Time" , 9.0 );
 
     auto volumePerTime = system.parse( "Length*Length*Length/Time" );
-    BOOST_CHECK_EQUAL("Length*Length*Length/Time" , volumePerTime.getName() );
     BOOST_CHECK_EQUAL(3.0 , volumePerTime.getSIScaling());
 }
 
@@ -123,6 +110,7 @@ static void checkSystemHasRequiredDimensions( const UnitSystem& system) {
     BOOST_CHECK( system.hasDimension("Length"));
     BOOST_CHECK( system.hasDimension("Mass"));
     BOOST_CHECK( system.hasDimension("Time"));
+
     BOOST_CHECK( system.hasDimension("Permeability"));
     BOOST_CHECK( system.hasDimension("Pressure"));
     BOOST_CHECK( system.hasDimension("Temperature"));
@@ -174,14 +162,12 @@ BOOST_AUTO_TEST_CASE(CreateInputSystem) {
 
 
 BOOST_AUTO_TEST_CASE(DimensionEqual) {
-    Dimension d1("Length" , 1);
-    Dimension d2("Length" , 1);
-    Dimension d3("Time" , 1);
-    Dimension d4("Length" , 2);
+    Dimension d1(1);
+    Dimension d2(1);
+    Dimension d4(2);
 
     BOOST_CHECK_EQUAL( true  , d1.equal(d1) );
     BOOST_CHECK_EQUAL( true  , d1.equal(d2) );
-    BOOST_CHECK_EQUAL( false , d1.equal(d3) );
     BOOST_CHECK_EQUAL( false , d1.equal(d4) );
 }
 

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -41,11 +41,6 @@ BOOST_AUTO_TEST_CASE(CreateDimension) {
     BOOST_CHECK_EQUAL(1 , length.getSIScaling());
 }
 
-BOOST_AUTO_TEST_CASE(makeComposite) {
-    auto composite = Dimension::newComposite("Length*Length*Length/Time" , 100);
-    BOOST_CHECK_EQUAL(100 , composite.getSIScaling());
-}
-
 
 BOOST_AUTO_TEST_CASE(CreateUnitSystem) {
     UnitSystem system(UnitSystem::UnitType::UNIT_TYPE_METRIC);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -493,10 +493,10 @@ namespace {
 
         Opm::Well::WellProductionProperties properties(const std::string& input) {
             Opm::Parser parser;
-
+            Opm::UnitSystem unit_system(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
             auto deck = parser.parseString(input);
             const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
-            Opm::Well::WellProductionProperties hist("W");
+            Opm::Well::WellProductionProperties hist(unit_system, "W");
             hist.handleWCONHIST(record);
 
 
@@ -542,14 +542,14 @@ namespace {
             return input;
         }
 
-
+        Opm::UnitSystem unit_system(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
         Opm::Well::WellProductionProperties properties(const std::string& input)
         {
             Opm::Parser parser;
             auto deck = parser.parseString(input);
             const auto& kwd     = deck.getKeyword("WCONPROD");
             const auto&  record = kwd.getRecord(0);
-            Opm::Well::WellProductionProperties pred("W");
+            Opm::Well::WellProductionProperties pred(unit_system, "W");
             pred.handleWCONPROD("WELL", record);
 
             return pred;
@@ -767,7 +767,8 @@ BOOST_AUTO_TEST_CASE(BHP_CMODE)
 
 
 BOOST_AUTO_TEST_CASE(CMODE_DEFAULT) {
-    const Opm::Well::WellProductionProperties Pproperties("W");
+    auto unit_system = UnitSystem::newMETRIC();
+    const Opm::Well::WellProductionProperties Pproperties(unit_system, "W");
     const Opm::Well::WellInjectionProperties Iproperties("W");
 
     BOOST_CHECK( Pproperties.controlMode == Opm::Well::ProducerCMode::CMODE_UNDEFINED );
@@ -778,8 +779,9 @@ BOOST_AUTO_TEST_CASE(CMODE_DEFAULT) {
 
 
 BOOST_AUTO_TEST_CASE(WELL_CONTROLS) {
-    Opm::Well well("WELL", "GROUP", 0, 0, 0, 0, 1000, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Opm::Connection::Order::DEPTH, UnitSystem::newMETRIC(), 0, 1.0, false, false);
-    Opm::Well::WellProductionProperties prod("OP1");
+    auto unit_system = UnitSystem::newMETRIC();
+    Opm::Well well("WELL", "GROUP", 0, 0, 0, 0, 1000, Opm::Phase::OIL, Opm::Well::ProducerCMode::CMODE_UNDEFINED, Opm::Connection::Order::DEPTH, unit_system, 0, 1.0, false, false);
+    Opm::Well::WellProductionProperties prod(unit_system, "OP1");
     Opm::SummaryState st(std::chrono::system_clock::now());
     well.productionControls(st);
 

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
 
         /* Set a surface injection rate => Well becomes an Injector */
         auto injectionProps1 = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
-        injectionProps1->surfaceInjectionRate.reset(100);
+        injectionProps1->surfaceInjectionRate = 100;
         well.updateInjection(injectionProps1);
         BOOST_CHECK_EQUAL( true  , well.isInjector());
         BOOST_CHECK_EQUAL( false , well.isProducer());
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
 
         /* Set a reservoir injection rate => Well becomes an Injector */
         auto injectionProps2 = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
-        injectionProps2->reservoirInjectionRate.reset(200);
+        injectionProps2->reservoirInjectionRate = 200;
         well.updateInjection(injectionProps2);
         BOOST_CHECK_EQUAL( false , well.isProducer());
         BOOST_CHECK_EQUAL( 200 , well.getInjectionProperties().reservoirInjectionRate.get<double>());
@@ -238,9 +238,9 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
         well.updateInjection(injectionProps3);
 
         auto properties = std::make_shared<Opm::Well::WellProductionProperties>( well.getProductionProperties() );
-        properties->OilRate.reset(100);
-        properties->GasRate.reset(200);
-        properties->WaterRate.reset(300);
+        properties->OilRate = 100;
+        properties->GasRate = 200;
+        properties->WaterRate = 300;
         well.updateProduction(properties);
 
         BOOST_CHECK_EQUAL( false , well.isInjector());
@@ -277,14 +277,14 @@ BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
 
 
     auto productionProps = std::make_shared<Opm::Well::WellProductionProperties>(well.getProductionProperties());
-    productionProps->BHPTarget.reset(100);
+    productionProps->BHPTarget = 100;
     productionProps->addProductionControl(Opm::Well::ProducerCMode::BHP);
     well.updateProduction(productionProps);
     BOOST_CHECK_EQUAL( 100 , well.getProductionProperties().BHPTarget.get<double>());
     BOOST_CHECK_EQUAL( true, well.getProductionProperties().hasProductionControl( Opm::Well::ProducerCMode::BHP ));
 
     auto injProps = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
-    injProps->THPTarget.reset(200);
+    injProps->THPTarget = 200;
     well.updateInjection(injProps);
     BOOST_CHECK_EQUAL( 200 , well.getInjectionProperties().THPTarget.get<double>());
     BOOST_CHECK( !well.getInjectionProperties().hasInjectionControl( Opm::Well::InjectorCMode::THP ));
@@ -318,26 +318,26 @@ BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
     BOOST_CHECK( !well.getProductionProperties().hasProductionControl( Opm::Well::ProducerCMode::RESV ));
 
     auto properties1 = std::make_shared<Opm::Well::WellProductionProperties>(well.getProductionProperties());
-    properties1->OilRate.reset(100);
+    properties1->OilRate = 100;
     properties1->addProductionControl(Opm::Well::ProducerCMode::ORAT);
     well.updateProduction(properties1);
     BOOST_CHECK(  well.getProductionProperties().hasProductionControl( Opm::Well::ProducerCMode::ORAT ));
     BOOST_CHECK( !well.getProductionProperties().hasProductionControl( Opm::Well::ProducerCMode::RESV ));
 
     auto properties2 = std::make_shared<Opm::Well::WellProductionProperties>(well.getProductionProperties());
-    properties2->ResVRate.reset( 100 );
+    properties2->ResVRate = 100;
     properties2->addProductionControl(Opm::Well::ProducerCMode::RESV);
     well.updateProduction(properties2);
     BOOST_CHECK( well.getProductionProperties().hasProductionControl( Opm::Well::ProducerCMode::RESV ));
 
     auto properties3 = std::make_shared<Opm::Well::WellProductionProperties>(well.getProductionProperties());
-    properties3->OilRate.reset(100);
-    properties3->WaterRate.reset(100);
-    properties3->GasRate.reset(100);
-    properties3->LiquidRate.reset(100);
-    properties3->ResVRate.reset(100);
-    properties3->BHPTarget.reset(100);
-    properties3->THPTarget.reset(100);
+    properties3->OilRate = 100;
+    properties3->WaterRate = 100;
+    properties3->GasRate = 100;
+    properties3->LiquidRate = 100;
+    properties3->ResVRate = 100;
+    properties3->BHPTarget = 100;
+    properties3->THPTarget = 100;
     properties3->addProductionControl(Opm::Well::ProducerCMode::ORAT);
     properties3->addProductionControl(Opm::Well::ProducerCMode::LRAT);
     properties3->addProductionControl(Opm::Well::ProducerCMode::BHP);
@@ -364,22 +364,22 @@ BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
     BOOST_CHECK( !well.getInjectionProperties().hasInjectionControl( Opm::Well::InjectorCMode::RESV ));
 
     auto injProps1 = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
-    injProps1->surfaceInjectionRate.reset(100);
+    injProps1->surfaceInjectionRate = 100;
     injProps1->addInjectionControl(Opm::Well::InjectorCMode::RATE);
     well.updateInjection(injProps1);
     BOOST_CHECK(  well.getInjectionProperties().hasInjectionControl( Opm::Well::InjectorCMode::RATE ));
     BOOST_CHECK( !well.getInjectionProperties().hasInjectionControl( Opm::Well::InjectorCMode::RESV ));
 
     auto injProps2 = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
-    injProps2->reservoirInjectionRate.reset(100);
+    injProps2->reservoirInjectionRate = 100;
     injProps2->addInjectionControl(Opm::Well::InjectorCMode::RESV);
     well.updateInjection(injProps2);
     BOOST_CHECK( well.getInjectionProperties().hasInjectionControl( Opm::Well::InjectorCMode::RESV ));
 
     auto injProps3 = std::make_shared<Opm::Well::WellInjectionProperties>(well.getInjectionProperties());
-    injProps3->BHPTarget.reset(100);
+    injProps3->BHPTarget = 100;
     injProps3->addInjectionControl(Opm::Well::InjectorCMode::BHP);
-    injProps3->THPTarget.reset(100);
+    injProps3->THPTarget = 100;
     injProps3->addInjectionControl(Opm::Well::InjectorCMode::THP);
     well.updateInjection(injProps3);
 

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE(BHP_CMODE)
 BOOST_AUTO_TEST_CASE(CMODE_DEFAULT) {
     auto unit_system = UnitSystem::newMETRIC();
     const Opm::Well::WellProductionProperties Pproperties(unit_system, "W");
-    const Opm::Well::WellInjectionProperties Iproperties("W");
+    const Opm::Well::WellInjectionProperties Iproperties(unit_system, "W");
 
     BOOST_CHECK( Pproperties.controlMode == Opm::Well::ProducerCMode::CMODE_UNDEFINED );
     BOOST_CHECK( Iproperties.controlMode == Opm::Well::InjectorCMode::CMODE_UNDEFINED );


### PR DESCRIPTION
UDA values and dimensions have been a long source of frustration. The main point about this PR is to ensure that UDAValues (i.e. rates in this case) have the correct unit irrespective of whether the come from the `Schedule` / `Deck` or the restart file.

In addition there are several small drive-by improvements/simplifications in the `Dimension` and `UDAValue` classes.

Downstream: https://github.com/OPM/opm-simulators/pull/2414

Part of #1396