### PR TITLE
fixed: update FoamConfig defaults

### DIFF
--- a/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
@@ -66,8 +66,8 @@ class FoamConfig
 {
 public:
     enum class MobilityModel {
-      INVALID,
-      TAB
+      TAB,
+      FUNC
     };
 
     FoamConfig() = default;
@@ -94,7 +94,7 @@ public:
 private:
     std::vector<FoamData> data_;
     Phase transport_phase_ = Phase::GAS;
-    MobilityModel mobility_model_ = MobilityModel::INVALID;
+    MobilityModel mobility_model_ = MobilityModel::TAB;
 };
 
 } // end namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
@@ -132,8 +132,17 @@ FoamConfig::FoamConfig(const Deck& deck)
         // do not store any data related to it.
         const auto& kw_foamopts = deck.getKeyword<ParserKeywords::FOAMOPTS>();
         transport_phase_ = get_phase(kw_foamopts.getRecord(0).getItem(0).get<std::string>(0));
-        if (kw_foamopts.getRecord(0).getItem(1).get<std::string>(0) == "TAB") {
+        std::string mobModel = kw_foamopts.getRecord(0).getItem(1).get<std::string>(0);
+        if (mobModel.empty()) {
+            if (transport_phase_ == Phase::GAS) {
+                mobility_model_ = MobilityModel::TAB;
+            } else if (transport_phase_ == Phase::WATER) {
+                mobility_model_ = MobilityModel::FUNC;
+            }
+        } else if (mobModel == "TAB") {
             mobility_model_ = MobilityModel::TAB;
+        } else if (mobModel == "FUNC") {
+            mobility_model_ = MobilityModel::FUNC;
         }
     }
     if (deck.hasKeyword<ParserKeywords::FOAMFSC>()) {


### PR DESCRIPTION
Foam cases should run without FOAMOPTS available. That means
we need to default the mobility model to a valid value.

This also adds enum value 'FUNC' and handles setting the default model
if only transport phase is unspecified.