### PR TITLE
Prepare serialization for PlyshlogTable and RocktabTable

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -32,7 +32,16 @@ namespace Opm {
     public:
         friend class TableManager;
 
+        PlyshlogTable() = default;
         PlyshlogTable(const DeckRecord& indexRecord, const DeckRecord& dataRecord);
+        PlyshlogTable(const TableSchema& schema,
+                      const OrderedMap<std::string, TableColumn>& columns,
+                      bool jfunc,
+                      double refPolymerConcentration,
+                      double refSalinity,
+                      double refTemperature,
+                      bool hasRefSalinity,
+                      bool hasRefTemperature);
 
         double getRefPolymerConcentration() const;
         double getRefSalinity() const;
@@ -47,13 +56,15 @@ namespace Opm {
         const TableColumn& getWaterVelocityColumn() const;
         const TableColumn& getShearMultiplierColumn() const;
 
-    private:
-        double m_refPolymerConcentration;
-        double m_refSalinity;
-        double m_refTemperature;
+        bool operator==(const PlyshlogTable& data) const;
 
-        bool m_hasRefSalinity;
-        bool m_hasRefTemperature;
+    private:
+        double m_refPolymerConcentration = 1.0;
+        double m_refSalinity = 0.0;
+        double m_refTemperature = 0.0;
+
+        bool m_hasRefSalinity = false;
+        bool m_hasRefTemperature = false;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -27,9 +27,13 @@ namespace Opm {
 
     class RocktabTable : public  SimpleTable {
     public:
+        RocktabTable() = default;
         RocktabTable(const DeckItem& item,
                      bool isDirectional,
                      bool hasStressOption);
+        RocktabTable(const TableSchema& schema,
+                     const OrderedMap<std::string, TableColumn>& columns,
+                     bool jfunc, bool isDirectional);
 
         const TableColumn& getPressureColumn() const;
         const TableColumn& getPoreVolumeMultiplierColumn() const;
@@ -38,8 +42,12 @@ namespace Opm {
         const TableColumn& getTransmissibilityMultiplierYColumn() const;
         const TableColumn& getTransmissibilityMultiplierZColumn() const;
 
+        bool isDirectional() const;
+
+        bool operator==(const RocktabTable& data) const;
+
     private:
-        bool m_isDirectional;
+        bool m_isDirectional = false;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
@@ -59,7 +59,7 @@ namespace Opm {
             container.gteTable(10 ) ==> exception
         */
     public:
-        using TableMap = std::map<size_t, std::shared_ptr<const SimpleTable>>;
+        using TableMap = std::map<size_t, std::shared_ptr<SimpleTable>>;
 
         TableContainer();
         explicit TableContainer( size_t maxTables );
@@ -72,7 +72,7 @@ namespace Opm {
 
         size_t max() const;
         const TableMap& tables() const;
-        void addTable(size_t tableNumber , std::shared_ptr<const SimpleTable> table);
+        void addTable(size_t tableNumber , std::shared_ptr<SimpleTable> table);
 
 
         /*

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -83,7 +83,7 @@ namespace Opm {
         return getTable(tableNumber);
     }
 
-    void TableContainer::addTable(size_t tableNumber , std::shared_ptr<const SimpleTable> table) {
+    void TableContainer::addTable(size_t tableNumber , std::shared_ptr<SimpleTable> table) {
         if (tableNumber >= m_maxTables)
             throw std::invalid_argument("TableContainer has max: " + std::to_string( m_maxTables ) + " tables. Table number: " + std::to_string( tableNumber ) + " illegal.");
 

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -644,6 +644,23 @@ PlyshlogTable::PlyshlogTable(
     SimpleTable::init( dataRecord.getItem<ParserKeywords::PLYSHLOG::DATA>() );
 }
 
+PlyshlogTable::PlyshlogTable(const TableSchema& schema,
+                             const OrderedMap<std::string, TableColumn>& columns,
+                             bool jfunc,
+                             double refPolymerConcentration,
+                             double refSalinity,
+                             double refTemperature,
+                             bool hasRefSalinity,
+                             bool hasRefTemperature)
+    : SimpleTable(schema, columns, jfunc)
+    , m_refPolymerConcentration(refPolymerConcentration)
+    , m_refSalinity(refSalinity)
+    , m_refTemperature(refTemperature)
+    , m_hasRefSalinity(hasRefSalinity)
+    , m_hasRefTemperature(hasRefTemperature)
+{
+}
+
 double PlyshlogTable::getRefPolymerConcentration() const {
     return m_refPolymerConcentration;
 }
@@ -689,6 +706,15 @@ const TableColumn& PlyshlogTable::getWaterVelocityColumn() const {
 
 const TableColumn& PlyshlogTable::getShearMultiplierColumn() const {
     return getColumn(1);
+}
+
+bool PlyshlogTable::operator==(const PlyshlogTable& data) const {
+    return this->SimpleTable::operator==(data) &&
+           m_refPolymerConcentration == data.m_refPolymerConcentration &&
+           m_refSalinity == data.m_refSalinity &&
+           m_refTemperature == data.m_refTemperature &&
+           m_hasRefSalinity == data.m_hasRefSalinity &&
+           m_hasRefTemperature == data.m_hasRefTemperature;
 }
 
 OilvisctTable::OilvisctTable( const DeckItem& item ) {

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -839,6 +839,13 @@ RocktabTable::RocktabTable(
     SimpleTable::init(item);
 }
 
+RocktabTable::RocktabTable(const TableSchema& schema,
+                           const OrderedMap<std::string, TableColumn>& columns,
+                           bool jfunc, bool isDirectional)
+    : SimpleTable(schema, columns, jfunc)
+    , m_isDirectional(isDirectional)
+{
+}
 
 const TableColumn& RocktabTable::getPressureColumn() const {
     return SimpleTable::getColumn(0);
@@ -866,6 +873,15 @@ const TableColumn& RocktabTable::getTransmissibilityMultiplierZColumn() const {
     if (!m_isDirectional)
         return SimpleTable::getColumn(2);
     return SimpleTable::getColumn(4);
+}
+
+bool RocktabTable::isDirectional() const {
+    return m_isDirectional;
+}
+
+bool RocktabTable::operator==(const RocktabTable& data) const {
+    return this->SimpleTable::operator==(data) &&
+           m_isDirectional == data.m_isDirectional;
 }
 
 RsvdTable::RsvdTable( const DeckItem& item ) {


### PR DESCRIPTION
These extend the SimpleTable class and thus needs to be serialized as the actual types.