### PR TITLE
Separates Opm::Group::parent() for the extended network model

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -196,7 +196,11 @@ struct ProductionControls {
     bool updateNetVFPTable(int vfp_arg);
     bool update_gefac(double gefac, bool transfer_gefac);
 
+    // [[deprecated("use Group::control_group() or Group::flow_group()")]]
     const std::string& parent() const;
+    const std::string& control_group() const;
+    const std::string& flow_group() const;
+
     bool updateParent(const std::string& parent);
     bool updateInjection(const GroupInjectionProperties& injection);
     bool updateProduction(const GroupProductionProperties& production);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -360,6 +360,14 @@ const std::string& Group::parent() const {
     return this->parent_group;
 }
 
+const std::string& Group::control_group() const {
+    return this->parent();
+}
+
+const std::string& Group::flow_group() const {
+    return this->parent();
+}
+
 const Phase& Group::topup_phase() const {
     if (this->m_topup_phase.second)
         return this->m_topup_phase.first;

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -357,9 +357,11 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
     BOOST_CHECK_EQUAL(field_group.groups().size(), 2);
     BOOST_CHECK( field_group.hasGroup("GROUP_NEW"));
     BOOST_CHECK( field_group.hasGroup("GROUP_BJARNE"));
-    BOOST_CHECK_EQUAL( new_group.parent(), "FIELD");
+    BOOST_CHECK_EQUAL( new_group.control_group(), "FIELD");
+    BOOST_CHECK_EQUAL( new_group.flow_group(), "FIELD");
     BOOST_CHECK( new_group.hasGroup("GROUP_NILS"));
-    BOOST_CHECK_EQUAL( nils_group.parent(), "GROUP_NEW");
+    BOOST_CHECK_EQUAL( nils_group.control_group(), "GROUP_NEW");
+    BOOST_CHECK_EQUAL( nils_group.flow_group(), "GROUP_NEW");
 }
 
 BOOST_AUTO_TEST_CASE( WellTestGroups ) {


### PR DESCRIPTION
In order to support the extended network model going forwards, the method `Opm::Group::parent()` is split in the API into two new methods, `Opm::Group::control_group()` and `Opm::Group::flow_group()`. These methods give the names of the parent node in the group control hierarchy and network structure, respectively.

While for the standard network model these two values will be the same (and the same as `::parent()`), code that presently calls `::parent()` should be revisited with an eye to the question of which parent group is desired.