### PR TITLE
[bugfix][cmake] Fix FindParMETIS check

### DIFF
--- a/cmake/Modules/FindParMETIS.cmake
+++ b/cmake/Modules/FindParMETIS.cmake
@@ -58,6 +58,7 @@ if(PARMETIS_INCLUDE_DIR)
 endif()
 set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${MPI_C_COMPILE_FLAGS}")
 
+include(CheckIncludeFile)
 check_include_file(parmetis.h PARMETIS_FOUND)
 _search_parmetis_lib(PARMETIS_LIBRARY parmetis "The main ParMETIS library.")
 


### PR DESCRIPTION
This fixes a cmake issue by adding the missing include(CheckIncludeFile).