### PR TITLE
The numerical value 0 is used to signify no connection <-> segment

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -175,8 +175,8 @@ namespace Opm {
         std::size_t m_compSeg_seqIndex=0;
 
         // related segment number
-        // -1 means the completion is not related to segment
-        int segment_number = -1;
+        // 0 means the completion is not related to segment
+        int segment_number = 0;
         double wPi = 1.0;
 
         static std::string CTFKindToString(const CTFKind);

--- a/src/opm/io/eclipse/rst/connection.cpp
+++ b/src/opm/io/eclipse/rst/connection.cpp
@@ -66,7 +66,7 @@ RstConnection::RstConnection(const ::Opm::UnitSystem& unit_system, const int* ic
     imb_sat_table(                                           icon[VI::IConn::Imbibition]),
     completion(                                              icon[VI::IConn::ComplNum]),
     dir(                                                     from_int<Connection::Direction>(icon[VI::IConn::ConnDir])),
-    segment(                                                 icon[VI::IConn::Segment] - 1),
+    segment(                                                 icon[VI::IConn::Segment]),
     tran(          unit_system.to_si(M::transmissibility,    scon[VI::SConn::ConnTrans])),
     depth(         unit_system.to_si(M::length,              scon[VI::SConn::Depth])),
     diameter(      unit_system.to_si(M::length,              scon[VI::SConn::Diameter])),


### PR DESCRIPTION
Changed the numerical value used to indicate: "No this connection is not attached to a segment". This is to simplify ecl interop.

Part of #1396