### PR TITLE
Fixed: do not update insert_index when linking segment -> connection

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -136,7 +136,6 @@ namespace Opm {
         void scaleWellPi(double wellPi);
         void updateSegment(int segment_number_arg,
                            double center_depth_arg,
-                           std::size_t seqIndex,
                            std::size_t compseg_insert_index,
                            double start,
                            double end);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
@@ -275,7 +275,6 @@ namespace Opm {
                 connection.updateSegment(compseg.segment_number,
                                          compseg.center_depth,
                                          compseg.m_seqIndex,
-                                         compseg.m_seqIndex,
                                          compseg.m_distance_start,
                                          compseg.m_distance_end);
             }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -206,13 +206,11 @@ namespace Opm {
 
     void Connection::updateSegment(int segment_number_arg,
                                    double center_depth_arg,
-                                   std::size_t seqIndex,
                                    std::size_t compseg_insert_index,
                                    double start,
                                    double end) {
         this->segment_number = segment_number_arg;
         this->center_depth = center_depth_arg;
-        this->m_seqIndex = seqIndex;
         this->m_compSeg_seqIndex = compseg_insert_index;
         this->m_segDistStart = start;
         this->m_segDistEnd = end;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -347,19 +347,14 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                                     direction, ctf_kind,
                                     noConn, 0., 0., defaultSatTable);
             } else {
-                std::size_t noConn = prev->getSeqIndex();
-                // The complnum value carries over; the rest of the state is fully specified by
-                // the current COMPDAT keyword.
-                int complnum = prev->complnum();
                 std::size_t css_ind = prev->getCompSegSeqIndex();
                 int conSegNo = prev->segment();
-                std::size_t con_SIndex = prev->getSeqIndex();
-                double conCDepth = prev->depth();
                 double conSDStart = prev->getSegDistStart();
                 double conSDEnd = prev->getSegDistEnd();
+                double depth = grid.getCellDepth(I,J,k);
                 *prev = Connection(I,J,k,
-                                   complnum,
-                                   grid.getCellDepth(I,J,k),
+                                   prev->complnum(),
+                                   depth,
                                    state,
                                    CF,
                                    Kh,
@@ -368,10 +363,10 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                                    skin_factor,
                                    satTableId,
                                    direction, ctf_kind,
-                                   noConn, conSDStart, conSDEnd, defaultSatTable);
+                                   prev->getSeqIndex(), conSDStart, conSDEnd, defaultSatTable);
+
                 prev->updateSegment(conSegNo,
-                                    conCDepth,
-                                    con_SIndex,
+                                    depth,
                                     css_ind,
                                     conSDStart,
                                     conSDEnd);


### PR DESCRIPTION
When attaching a segment to a connection the connections `insert_index`was updated. This gave complications when restarting.

Part of #1396