### PR TITLE
Add GuideRate::has() method.

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -70,6 +70,7 @@ namespace Opm {
 
         EclipseState() = default;
         EclipseState(const Deck& deck);
+        virtual ~EclipseState() = default;
 
         const IOConfig& getIOConfig() const;
         IOConfig& getIOConfig();

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -81,6 +81,7 @@ public:
     double get(const std::string& well, Well::GuideRateTarget target) const;
     double get(const std::string& group, Group::GuideRateTarget target) const;
     double get(const std::string& name, GuideRateModel::Target model_target) const;
+    bool has(const std::string& name) const;
 
 private:
     void well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -105,6 +105,11 @@ double GuideRate::get(const std::string& name, GuideRateModel::Target model_targ
     }
 }
 
+bool GuideRate::has(const std::string& name) const
+{
+    return this->values.count(name) > 0;
+}
+
 
 
 void GuideRate::compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot) {


### PR DESCRIPTION
Add a has() method to the GuideRate class, for use downstream.

Also silence a warning due to missing virtual destructor for EclipseState. Although the missing destructor so far did not lead to bugs as far as I can tell (the derived class is used through shared_ptr<EclipseState>, but constructed through the templated constructor which embeds a type-erased proper destruction mechanism), it is better to do it as it would be expected (for example, naked pointer deletes will then work correctly instead of slicing).