### PR TITLE
Adding support for the RUNSUM keyword in Opm::SummaryConfig

### DIFF
--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -176,6 +176,8 @@ namespace Opm {
                serializer(summary_keywords);
             }
 
+            bool doRunSummary() const;
+
         private:
             SummaryConfig( const Deck& deck,
                            const Schedule& schedule,
@@ -192,6 +194,8 @@ namespace Opm {
             keyword_list keywords;
             std::set<std::string> short_keywords;
             std::set<std::string> summary_keywords;
+
+            bool doRunSummary_ { false };
     };
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -176,7 +176,7 @@ namespace Opm {
                serializer(summary_keywords);
             }
 
-            bool doRunSummary() const;
+            bool createRunSummary() const;
 
         private:
             SummaryConfig( const Deck& deck,

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -176,7 +176,9 @@ namespace Opm {
                serializer(summary_keywords);
             }
 
-            bool createRunSummary() const;
+            bool createRunSummary() const {
+                return m_createRunSummary;
+            }
 
         private:
             SummaryConfig( const Deck& deck,
@@ -194,6 +196,8 @@ namespace Opm {
             keyword_list keywords;
             std::set<std::string> short_keywords;
             std::set<std::string> summary_keywords;
+
+            bool m_createRunSummary;
     };
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -177,7 +177,7 @@ namespace Opm {
             }
 
             bool createRunSummary() const {
-                return m_createRunSummary;
+                return runSummaryConfig.create;
             }
 
         private:
@@ -197,7 +197,13 @@ namespace Opm {
             std::set<std::string> short_keywords;
             std::set<std::string> summary_keywords;
 
-            bool m_createRunSummary;
+            struct {
+                bool create { false };
+                bool narrow { false };
+                bool separate { true };
+            } runSummaryConfig;
+
+            void handleProcessingInstruction(const std::string& keyword);
     };
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -194,8 +194,6 @@ namespace Opm {
             keyword_list keywords;
             std::set<std::string> short_keywords;
             std::set<std::string> summary_keywords;
-
-            bool doRunSummary_ { false };
     };
 
 } //namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1106,4 +1106,8 @@ bool SummaryConfig::operator==(const Opm::SummaryConfig& data) const {
            this->summary_keywords == data.summary_keywords;
 }
 
+bool SummaryConfig::doRunSummary() const {
+    return this->doRunSummary_;
+}
+
 }

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1117,7 +1117,7 @@ bool SummaryConfig::operator==(const Opm::SummaryConfig& data) const {
            this->summary_keywords == data.summary_keywords;
 }
 
-bool SummaryConfig::doRunSummary() const {
+bool SummaryConfig::createRunSummary() const {
     return this->hasKeyword("RUNSUM");
 }
 

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -151,6 +151,7 @@ namespace {
     bool is_processing_instruction(const std::string& keyword) {
         static const keyword_set processing_instructionkw {
             "NARROW",
+            "RPTONLY",
             "RUNSUM",
             "SEPARATE",
             "SUMMARY",
@@ -447,8 +448,6 @@ inline void keywordR2R( SummaryConfig::keyword_list& /* list */,
                         const TableManager& tables,
                         const ParseContext& parseContext,
                         ErrorGuard& errors ) {
-
-    if( keyword.name() == "RPTONLY" ) return;
 
     if( is_region_to_region(keyword.name()) ) {
         keywordR2R( list, parseContext, errors, keyword );

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1118,8 +1118,4 @@ bool SummaryConfig::operator==(const Opm::SummaryConfig& data) const {
            this->summary_keywords == data.summary_keywords;
 }
 
-bool SummaryConfig::createRunSummary() const {
-    return this->hasKeyword("RUNSUM");
-}
-
 }

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -134,8 +134,13 @@ namespace {
         return special_keywords.find(keyword) != special_keywords.end();
     }
 
+    const std::unordered_set<std::string> udq_blacklist {
+        "RUNSUM",
+        "SUMTHIN",
+    };
+
     bool is_udq_blacklist(const std::string& keyword) {
-        return (keyword == "SUMTHIN") || (keyword == "RUNSUM");
+        return udq_blacklist.find(keyword) != udq_blacklist.end();
     }
 
     bool is_udq(const std::string& keyword) {

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -860,19 +860,19 @@ SummaryNode& SummaryNode::isUserDefined(const bool userDefined)
 std::string SummaryNode::uniqueNodeKey() const
 {
     switch (this->category()) {
-    case SummaryNode::Category::Well: // fall-through
+    case SummaryNode::Category::Well: [[fallthrough]];
     case SummaryNode::Category::Group:
         return this->keyword() + ':' + this->namedEntity();
 
-    case SummaryNode::Category::Field: // fall-through
+    case SummaryNode::Category::Field: [[fallthrough]];
     case SummaryNode::Category::Miscellaneous:
         return this->keyword();
 
-    case SummaryNode::Category::Region: // fall-through
+    case SummaryNode::Category::Region: [[fallthrough]];
     case SummaryNode::Category::Block:
         return this->keyword() + ':' + std::to_string(this->number());
 
-    case SummaryNode::Category::Connection: // fall-through
+    case SummaryNode::Category::Connection: [[fallthrough]];
     case SummaryNode::Category::Segment:
         return this->keyword() + ':' + this->namedEntity() + ':' + std::to_string(this->number());
     }
@@ -890,22 +890,22 @@ bool operator==(const SummaryNode& lhs, const SummaryNode& rhs)
     assert (lhs.category() == rhs.category());
 
     switch( lhs.category() ) {
-        case SummaryNode::Category::Field: // fall-through
+        case SummaryNode::Category::Field: [[fallthrough]];
         case SummaryNode::Category::Miscellaneous:
             // Fully identified by keyword
             return true;
 
-        case SummaryNode::Category::Well:  // fall-through
+        case SummaryNode::Category::Well: [[fallthrough]];
         case SummaryNode::Category::Group:
             // Equal if associated to same named entity
             return lhs.namedEntity() == rhs.namedEntity();
 
-        case SummaryNode::Category::Region:  // fall-through
+        case SummaryNode::Category::Region: [[fallthrough]];
         case SummaryNode::Category::Block:
             // Equal if associated to same numeric entity
             return lhs.number() == rhs.number();
 
-        case SummaryNode::Category::Connection:  // fall-through
+        case SummaryNode::Category::Connection: [[fallthrough]];
         case SummaryNode::Category::Segment:
             // Equal if associated to same numeric
             // sub-entity of same named entity
@@ -924,23 +924,23 @@ bool operator<(const SummaryNode& lhs, const SummaryNode& rhs)
     // If we get here, the keyword are equal.
 
     switch( lhs.category() ) {
-        case SummaryNode::Category::Field:  // fall-through
+        case SummaryNode::Category::Field: [[fallthrough]];
         case SummaryNode::Category::Miscellaneous:
             // Fully identified by keyword.
             // Return false for equal keywords.
             return false;
 
-        case SummaryNode::Category::Well:  // fall-through
+        case SummaryNode::Category::Well: [[fallthrough]];
         case SummaryNode::Category::Group:
             // Ordering determined by namedEntityd entity
             return lhs.namedEntity() < rhs.namedEntity();
 
-        case SummaryNode::Category::Region:  // fall-through
+        case SummaryNode::Category::Region: [[fallthrough]];
         case SummaryNode::Category::Block:
             // Ordering determined by numeric entity
             return lhs.number() < rhs.number();
 
-        case SummaryNode::Category::Connection:  // fall-through
+        case SummaryNode::Category::Connection: [[fallthrough]];
         case SummaryNode::Category::Segment:
         {
             // Ordering determined by pair of namedEntity and numeric ID.

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -126,6 +126,7 @@ namespace {
         "NLINEARS",
         "NLINSMAX",
         "NLINSMIN",
+        "RUNSUM",
         "STEPTYPE",
         "WNEWTON",
     };
@@ -135,7 +136,6 @@ namespace {
     }
 
     const std::unordered_set<std::string> udq_blacklist {
-        "RUNSUM",
         "SUMTHIN",
     };
 
@@ -441,7 +441,6 @@ inline void keywordR2R( SummaryConfig::keyword_list& /* list */,
      * print output. Unfortunately its *recognised* as a region keyword
      * because of its structure and position. Hence the special handling of ignoring it.
      */
-    if( keyword.name() == "RUNSUM" ) return;
     if( keyword.name() == "RPTONLY" ) return;
 
     if( is_region_to_region(keyword.name()) ) {
@@ -1119,7 +1118,7 @@ bool SummaryConfig::operator==(const Opm::SummaryConfig& data) const {
 }
 
 bool SummaryConfig::doRunSummary() const {
-    return this->doRunSummary_;
+    return this->hasKeyword("RUNSUM");
 }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -115,7 +115,13 @@ namespace {
          {"SGAS" , {"BSGAS"}}
     };
 
-    const std::unordered_set<std::string> special_keywords {
+    using keyword_set = std::unordered_set<std::string>;
+
+    inline bool is_in_set(const keyword_set& set, const std::string& keyword) {
+        return set.find(keyword) != set.end();
+    }
+
+    const keyword_set special_keywords {
         "ELAPSED",
         "MAXDPR",
         "MAXDSG",
@@ -132,15 +138,15 @@ namespace {
     };
 
     bool is_special(const std::string& keyword) {
-        return special_keywords.find(keyword) != special_keywords.end();
+        return is_in_set(special_keywords, keyword);
     }
 
-    const std::unordered_set<std::string> udq_blacklist {
+    const keyword_set udq_blacklist {
         "SUMTHIN",
     };
 
     bool is_udq_blacklist(const std::string& keyword) {
-        return udq_blacklist.find(keyword) != udq_blacklist.end();
+        return is_in_set(udq_blacklist, keyword);
     }
 
     bool is_udq(const std::string& keyword) {
@@ -154,17 +160,15 @@ namespace {
     }
 
     bool is_pressure(const std::string& keyword) {
-        using set = std::unordered_set<std::string>;
-        static const auto presskw = set {
+        static const keyword_set presskw {
             "BHP", "BHPH", "THP", "THPH", "PR"
         };
 
-        return presskw.find(keyword.substr(1)) != presskw.end();
+        return is_in_set(presskw, keyword.substr(1));
     }
 
     bool is_rate(const std::string& keyword) {
-        using set = std::unordered_set<std::string>;
-        static const auto ratekw = set {
+        static const keyword_set ratekw {
             "OPR", "GPR", "WPR", "LPR", "NPR", "VPR",
             "OPRH", "GPRH", "WPRH", "LPRH",
             "OVPR", "GVPR", "WVPR",
@@ -177,22 +181,20 @@ namespace {
             "OPI", "OPP", "GPI", "GPP", "WPI", "WPP",
         };
 
-        return ratekw.find(keyword.substr(1)) != ratekw.end();
+        return is_in_set(ratekw, keyword.substr(1));
     }
 
     bool is_ratio(const std::string& keyword) {
-        using set = std::unordered_set<std::string>;
-        static const auto ratiokw = set {
+        static const keyword_set ratiokw {
             "GLR", "GOR", "WCT",
             "GLRH", "GORH", "WCTH",
         };
 
-        return ratiokw.find(keyword.substr(1)) != ratiokw.end();
+        return is_in_set(ratiokw, keyword.substr(1));
     }
 
     bool is_total(const std::string& keyword) {
-        using set = std::unordered_set<std::string>;
-        static const auto totalkw = set {
+        static const keyword_set totalkw {
             "OPT", "GPT", "WPT", "LPT", "NPT",
             "VPT", "OVPT", "GVPT", "WVPT",
             "WPTH", "OPTH", "GPTH", "LPTH",
@@ -202,16 +204,15 @@ namespace {
             "WITH", "OITH", "GITH", "WVIT", "OVIT", "GVIT",
         };
 
-        return totalkw.find(keyword.substr(1)) != totalkw.end();
+        return is_in_set(totalkw, keyword.substr(1));
     }
 
     bool is_count(const std::string& keyword) {
-        using set = std::unordered_set<std::string>;
-        static const auto countkw = set {
+        static const keyword_set countkw {
             "MWIN", "MWIT", "MWPR", "MWPT"
         };
 
-        return countkw.find(keyword) != countkw.end();
+        return is_in_set(countkw, keyword);
     }
 
     bool is_region_to_region(const std::string& keyword) {

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -82,7 +82,6 @@ namespace {
         "MSUMLINS","MSUMNEWT","TIMESTEP","TCPUTS","TCPUDAY","STEPTYPE","TELAPLIN"
     };
 
-
     /*
       The variable type 'ECL_SMSPEC_MISC_TYPE' is a catch-all variable
       type, and will by default internalize keywords like 'ALL' and
@@ -116,15 +115,23 @@ namespace {
          {"SGAS" , {"BSGAS"}}
     };
 
-    bool is_special(const std::string& keyword) {
-        using set = std::unordered_set<std::string>;
-        static const auto specialkw = set {
-            "NEWTON", "NAIMFRAC", "NLINEARS", "NLINSMIN", "NLINSMAX",
-            "ELAPSED", "MAXDPR", "MAXDSO", "MAXDSG", "MAXDSW", "STEPTYPE",
-            "WNEWTON",
-        };
+    const std::unordered_set<std::string> special_keywords {
+        "ELAPSED",
+        "MAXDPR",
+        "MAXDSG",
+        "MAXDSO",
+        "MAXDSW",
+        "NAIMFRAC",
+        "NEWTON",
+        "NLINEARS",
+        "NLINSMAX",
+        "NLINSMIN",
+        "STEPTYPE",
+        "WNEWTON",
+    };
 
-        return specialkw.count(keyword) > set::size_type{0};
+    bool is_special(const std::string& keyword) {
+        return special_keywords.find(keyword) != special_keywords.end();
     }
 
     bool is_udq_blacklist(const std::string& keyword) {

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -159,7 +159,7 @@ namespace {
             "BHP", "BHPH", "THP", "THPH", "PR"
         };
 
-        return presskw.count(&keyword[1]) > set::size_type{0};
+        return presskw.find(keyword.substr(1)) != presskw.end();
     }
 
     bool is_rate(const std::string& keyword) {
@@ -177,7 +177,7 @@ namespace {
             "OPI", "OPP", "GPI", "GPP", "WPI", "WPP",
         };
 
-        return ratekw.count(&keyword[1]) > set::size_type{0};
+        return ratekw.find(keyword.substr(1)) != ratekw.end();
     }
 
     bool is_ratio(const std::string& keyword) {
@@ -187,7 +187,7 @@ namespace {
             "GLRH", "GORH", "WCTH",
         };
 
-        return ratiokw.count(&keyword[1]) > set::size_type{0};
+        return ratiokw.find(keyword.substr(1)) != ratiokw.end();
     }
 
     bool is_total(const std::string& keyword) {
@@ -202,7 +202,7 @@ namespace {
             "WITH", "OITH", "GITH", "WVIT", "OVIT", "GVIT",
         };
 
-        return totalkw.count(&keyword[1]) > set::size_type{0};
+        return totalkw.find(keyword.substr(1)) != totalkw.end();
     }
 
     bool is_count(const std::string& keyword) {
@@ -211,7 +211,7 @@ namespace {
             "MWIN", "MWIT", "MWPR", "MWPT"
         };
 
-        return countkw.count(keyword) > set::size_type{0};
+        return countkw.find(keyword) != countkw.end();
     }
 
     bool is_region_to_region(const std::string& keyword) {
@@ -478,7 +478,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
                          const std::string& keyword,
                          Location loc)
 {
-    if (meta_keywords.count(keyword) == 0)
+    if (meta_keywords.find(keyword) == meta_keywords.end())
         list.emplace_back( keyword, SummaryNode::Category::Miscellaneous , std::move(loc));
 }
 
@@ -1062,12 +1062,12 @@ SummaryConfig& SummaryConfig::merge( SummaryConfig&& other ) {
 
 
 bool SummaryConfig::hasKeyword( const std::string& keyword ) const {
-    return (this->short_keywords.count( keyword ) == 1);
+    return short_keywords.find(keyword) != short_keywords.end();
 }
 
 
 bool SummaryConfig::hasSummaryKey(const std::string& keyword ) const {
-    return (this->summary_keywords.count( keyword ) == 1);
+    return summary_keywords.find(keyword) != summary_keywords.end();
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -121,32 +121,32 @@ namespace {
         return set.find(keyword) != set.end();
     }
 
-    const keyword_set special_keywords {
-        "ELAPSED",
-        "MAXDPR",
-        "MAXDSG",
-        "MAXDSO",
-        "MAXDSW",
-        "NAIMFRAC",
-        "NEWTON",
-        "NLINEARS",
-        "NLINSMAX",
-        "NLINSMIN",
-        "RUNSUM",
-        "STEPTYPE",
-        "WNEWTON",
-    };
-
     bool is_special(const std::string& keyword) {
-        return is_in_set(special_keywords, keyword);
+        static const keyword_set specialkw {
+            "ELAPSED",
+            "MAXDPR",
+            "MAXDSG",
+            "MAXDSO",
+            "MAXDSW",
+            "NAIMFRAC",
+            "NEWTON",
+            "NLINEARS",
+            "NLINSMAX",
+            "NLINSMIN",
+            "RUNSUM",
+            "STEPTYPE",
+            "WNEWTON",
+        };
+
+        return is_in_set(specialkw, keyword);
     }
 
-    const keyword_set udq_blacklist {
-        "SUMTHIN",
-    };
-
     bool is_udq_blacklist(const std::string& keyword) {
-        return is_in_set(udq_blacklist, keyword);
+        static const keyword_set udq_blacklistkw {
+            "SUMTHIN",
+        };
+
+        return is_in_set(udq_blacklistkw, keyword);
     }
 
     bool is_udq(const std::string& keyword) {

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -879,5 +879,8 @@ RUNSUM
     const auto& summary_config2 = createSummary(deck_string2);
 
     BOOST_CHECK(!summary_config1.createRunSummary());
-    BOOST_CHECK(summary_config2.createRunSummary());
+    BOOST_CHECK(!summary_config1.hasKeyword("RUNSUM"));
+
+    BOOST_CHECK( summary_config2.createRunSummary());
+    BOOST_CHECK(!summary_config2.hasKeyword("RUNSUM"));
 }

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -873,9 +873,9 @@ BOOST_AUTO_TEST_CASE(Summary_Segment)
 BOOST_AUTO_TEST_CASE(EnableRSM) {
     std::string deck_string1 = "";
     std::string deck_string2 = R"(
-SUMMARY
+RUNSUM
 )";
-    const auto& summary_config1 = createSummary("");
+    const auto& summary_config1 = createSummary(deck_string1);
     const auto& summary_config2 = createSummary(deck_string2);
 
     BOOST_CHECK(!summary_config1.doRunSummary());

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -878,6 +878,6 @@ SUMMARY
     const auto& summary_config1 = createSummary("");
     const auto& summary_config2 = createSummary(deck_string2);
 
-    BOOST_CHECK(!summary_config1.runsum());
-    BOOST_CHECK(summary_config2.runsum());
+    BOOST_CHECK(!summary_config1.doRunSummary());
+    BOOST_CHECK(summary_config2.doRunSummary());
 }

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -867,7 +867,20 @@ BOOST_AUTO_TEST_CASE(Summary_Segment)
     BOOST_CHECK(!summary.hasSummaryKey("SWFR:INJE01:1"));
 }
 
+BOOST_AUTO_TEST_CASE(ProcessingInstructions) {
+    const std::string deck_string = R"(
+RUNSUM
+NARROW
+SEPARATE
+)";
 
+    const auto& summary_config = createSummary(deck_string);
+
+    BOOST_CHECK(!summary_config.hasKeyword("NARROW"));
+    BOOST_CHECK(!summary_config.hasKeyword("RUNSUM"));
+    BOOST_CHECK(!summary_config.hasKeyword("SEPARATE"));
+    BOOST_CHECK(!summary_config.hasKeyword("SUMMARY"));
+}
 
 
 BOOST_AUTO_TEST_CASE(EnableRSM) {

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -869,6 +869,7 @@ BOOST_AUTO_TEST_CASE(Summary_Segment)
 
 BOOST_AUTO_TEST_CASE(ProcessingInstructions) {
     const std::string deck_string = R"(
+RPTONLY
 RUNSUM
 NARROW
 SEPARATE
@@ -877,6 +878,7 @@ SEPARATE
     const auto& summary_config = createSummary(deck_string);
 
     BOOST_CHECK(!summary_config.hasKeyword("NARROW"));
+    BOOST_CHECK(!summary_config.hasKeyword("RPTONLY"));
     BOOST_CHECK(!summary_config.hasKeyword("RUNSUM"));
     BOOST_CHECK(!summary_config.hasKeyword("SEPARATE"));
     BOOST_CHECK(!summary_config.hasKeyword("SUMMARY"));

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -878,6 +878,6 @@ RUNSUM
     const auto& summary_config1 = createSummary(deck_string1);
     const auto& summary_config2 = createSummary(deck_string2);
 
-    BOOST_CHECK(!summary_config1.doRunSummary());
-    BOOST_CHECK(summary_config2.doRunSummary());
+    BOOST_CHECK(!summary_config1.createRunSummary());
+    BOOST_CHECK(summary_config2.createRunSummary());
 }

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -866,3 +866,18 @@ BOOST_AUTO_TEST_CASE(Summary_Segment)
 
     BOOST_CHECK(!summary.hasSummaryKey("SWFR:INJE01:1"));
 }
+
+
+
+
+BOOST_AUTO_TEST_CASE(EnableRSM) {
+    std::string deck_string1 = "";
+    std::string deck_string2 = R"(
+SUMMARY
+)";
+    const auto& summary_config1 = createSummary("");
+    const auto& summary_config2 = createSummary(deck_string2);
+
+    BOOST_CHECK(!summary_config1.runsum());
+    BOOST_CHECK(summary_config2.runsum());
+}


### PR DESCRIPTION
This feature adds API support for the `RUNSUM` keyword in `Opm::SummaryConfig`, through:

1. The `RUNSUM` keyword being read and added as an `Opm::SummaryNode`
2. The method `Opm::SummaryConfig::createRunSummary` being exposed to test for its presence