### PR TITLE
Warn about downstream deck usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(ENABLE_MOCKSIM "Build the mock simulator for io testing" ON)
 option(OPM_ENABLE_PYTHON "Enable python bindings?" OFF)
 option(OPM_INSTALL_PYTHON "Enable python bindings?" OFF)
 option(OPM_ENABLE_EMBEDDED_PYTHON "Enable python bindings?" OFF)
+add_definitions(-DOPM_PARSER_DECK_API)
 
 # Output implies input
 if(ENABLE_ECL_OUTPUT)

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -29,7 +29,6 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
-#ifdef OPM_PARSER_DECK_API_WARNING
 #ifndef OPM_PARSER_DECK_API
 #pragma message "\n\n" \
 "   ----------------------------------------------------------------------------------\n" \
@@ -39,7 +38,6 @@
 "   #define OPM_PARSER_DECK_API before including the Deck.hpp header.                 \n" \
 "   ----------------------------------------------------------------------------------\n" \
 ""
-#endif
 #endif
 
 


### PR DESCRIPTION
This is a system I devised a long time ago to avoid `Deck` usage downstream; at the time it was unrealistic to enforce it - but maybe now it can be enforced?

Downstream modules must 
```C++
#define OPM_PARSER_DECK_API
```
before `Deck.hpp` is included - otherwise they get a big fat warning; could be an error. What do you think?

Opinonons on this: @bska, @atgeirr, @totto82, @akva2, ...