### PR TITLE
Minifix: Fixes forward declaration compiler warnings

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -34,7 +34,7 @@
 namespace Opm {
 
 namespace RestartIO {
-    class RstConnection;
+    struct RstConnection;
 }
 
     class DeckKeyword;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -50,7 +50,7 @@ class UDQActive;
 class UDQConfig;
 
 namespace RestartIO {
-class RstWell;
+struct RstWell;
 }
 
 


### PR DESCRIPTION
This minifix resolves an issue where two structs were forward declared as classes, resulting in a number of compiler warnings:

1. `Opm::RestartIO::RstConnection`
2. `Opm::RestartIO::RstWell`
