### PR TITLE
[WIP] Write .RSM file

### DIFF
--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -34,7 +34,7 @@ public:
     // input is smspec (or fsmspec file)
     explicit ESmry(const std::string& filename, bool loadBaseRunData=false);
 
-    bool write_rsm(const std::optional<std::string>& = std::nullopt) const;
+    void write_rsm(const std::optional<std::string>& filename = std::nullopt) const;
 
     int numberOfVectors() const { return nVect; }
 

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -19,6 +19,7 @@
 #ifndef OPM_IO_ESMRY_HPP
 #define OPM_IO_ESMRY_HPP
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -32,6 +33,8 @@ public:
 
     // input is smspec (or fsmspec file)
     explicit ESmry(const std::string& filename, bool loadBaseRunData=false);
+
+    bool write_rsm(const std::optional<std::string>& = std::nullopt) const;
 
     int numberOfVectors() const { return nVect; }
 
@@ -48,6 +51,7 @@ public:
     const std::string& get_unit(const std::string& name) const;
 
 private:
+    Opm::filesystem::path rootName;
     int nVect, nI, nJ, nK;
 
     void ijk_from_global_index(int glob, int &i, int &j, int &k) const;

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -51,7 +51,7 @@ public:
     const std::string& get_unit(const std::string& name) const;
 
 private:
-    Opm::filesystem::path rootName;
+    Opm::filesystem::path inputFileName;
     int nVect, nI, nJ, nK;
 
     void ijk_from_global_index(int glob, int &i, int &j, int &k) const;

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -419,10 +419,10 @@ void ESmry::updatePathAndRootName(Opm::filesystem::path& dir, Opm::filesystem::p
     rootN = rootN.stem();
 }
 
-bool ESmry::write_rsm(const std::optional<std::string>& o_filename) const {
+void ESmry::write_rsm(const std::optional<std::string>& o_filename) const {
     const std::string filename = o_filename.value_or(std::string(rootName) + ".RSM");
 
-    return false;
+    OPM_THROW(std::runtime_error, "Could not write file " + filename);
 }
 
 bool ESmry::hasKey(const std::string &key) const

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -52,10 +52,9 @@
 namespace Opm { namespace EclIO {
 
 ESmry::ESmry(const std::string &filename, bool loadBaseRunData)
+    : inputFileName { filename }
 {
-
-    Opm::filesystem::path inputFileName(filename);
-    rootName = inputFileName.parent_path() / inputFileName.stem();
+    Opm::filesystem::path rootName { inputFileName.parent_path() / inputFileName.stem() } ;
 
     // if root name (without any extension) given as first argument in constructor, binary will then be assumed
     if (inputFileName.extension()==""){
@@ -420,9 +419,9 @@ void ESmry::updatePathAndRootName(Opm::filesystem::path& dir, Opm::filesystem::p
 }
 
 void ESmry::write_rsm(const std::optional<std::string>& o_filename) const {
-    const std::string filename = o_filename.value_or(std::string(rootName) + ".RSM");
+    const Opm::filesystem::path rsm_file { o_filename.value_or(Opm::filesystem::path(inputFileName).replace_extension("RSM")) } ;
 
-    OPM_THROW(std::runtime_error, "Could not write file " + filename);
+    OPM_THROW(std::runtime_error, "Could not write file " + rsm_file.string());
 }
 
 bool ESmry::hasKey(const std::string &key) const

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -55,7 +55,7 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData)
 {
 
     Opm::filesystem::path inputFileName(filename);
-    Opm::filesystem::path rootName = inputFileName.parent_path() / inputFileName.stem();
+    rootName = inputFileName.parent_path() / inputFileName.stem();
 
     // if root name (without any extension) given as first argument in constructor, binary will then be assumed
     if (inputFileName.extension()==""){
@@ -417,6 +417,12 @@ void ESmry::updatePathAndRootName(Opm::filesystem::path& dir, Opm::filesystem::p
     }
 
     rootN = rootN.stem();
+}
+
+bool ESmry::write_rsm(const std::optional<std::string>& o_filename) const {
+    const std::string filename = o_filename.value_or(std::string(rootName) + ".RSM");
+
+    return false;
 }
 
 bool ESmry::hasKey(const std::string &key) const

--- a/tests/SPE1CASE1.DATA
+++ b/tests/SPE1CASE1.DATA
@@ -281,6 +281,8 @@ RSVD
 SUMMARY
 -- -------------------------------------------------------------------------	 
 
+RUNSUM
+
 -- 1a) Oil rate vs time
 FOPR
 -- Field Oil Production Rate

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
 
         msim.run(schedule, io, false);
 
-        for (const auto& fname : {"SPE1CASE1.INIT", "SPE1CASE1.UNRST", "SPE1CASE1.EGRID", "SPE1CASE1.SMSPEC", "SPE1CASE1.UNSMRY"})
+        for (const auto& fname : {"SPE1CASE1.INIT", "SPE1CASE1.UNRST", "SPE1CASE1.EGRID", "SPE1CASE1.SMSPEC", "SPE1CASE1.UNSMRY", "SPE1CASE1.RSM"})
             BOOST_CHECK( is_file( fname ));
 
         {

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -19,6 +19,7 @@
 #include "config.h"
 
 #include <opm/io/eclipse/ESmry.hpp>
+#include <opm/common/utility/FileSystem.hpp>
 
 #define BOOST_TEST_MODULE Test EclIO
 #include <boost/test/unit_test.hpp>
@@ -352,6 +353,16 @@ BOOST_AUTO_TEST_CASE(TestESmry_4) {
 }
 
 
+namespace fs = Opm::filesystem;
+BOOST_AUTO_TEST_CASE(TestCreateRSM) {
+    ESmry smry1("SPE1CASE1.SMSPEC");
+
+    smry1.write_rsm();
+    BOOST_CHECK(fs::exists("SPE1CASE1.RSM"));
+
+    smry1.write_rsm("TEST.RSM");
+    BOOST_CHECK(fs::exists("TEST.RSM"));
+}
 
 BOOST_AUTO_TEST_CASE(TestUnits) {
     ESmry smry("SPE1CASE1.SMSPEC");


### PR DESCRIPTION
This feature adds support for writing an .RSM file. This is done by extending the API of `Opm::EclIO::ESmry` as follows:

1. Adds `void Opm::EclIO::ESmry::write_rsm(const std::optional<std::string>&) const`, which writes the RSM file to disk or throws an exception.