### PR TITLE
Rename SummaryNode to SummaryConfigNode

### DIFF
--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -116,13 +116,11 @@ namespace Opm {
     }
 
     class Deck;
-    class TableManager;
-    class EclipseState;
-    class ParserKeyword;
-    class Schedule;
     class ErrorGuard;
-    class ParseContext;
     class GridDims;
+    class ParseContext;
+    class Schedule;
+    class TableManager;
 
     class SummaryConfig {
         public:

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -36,7 +36,7 @@ namespace Opm {
       value semantics.
     */
 
-    class SummaryNode {
+    class SummaryConfigNode {
     public:
         enum class Category {
             Well, Group, Field,
@@ -50,13 +50,13 @@ namespace Opm {
             Undefined,
         };
 
-        SummaryNode() = default;
-        explicit SummaryNode(std::string keyword, const Category cat, Location loc_arg);
+        SummaryConfigNode() = default;
+        explicit SummaryConfigNode(std::string keyword, const Category cat, Location loc_arg);
 
-        SummaryNode& parameterType(const Type type);
-        SummaryNode& namedEntity(std::string name);
-        SummaryNode& number(const int num);
-        SummaryNode& isUserDefined(const bool userDefined);
+        SummaryConfigNode& parameterType(const Type type);
+        SummaryConfigNode& namedEntity(std::string name);
+        SummaryConfigNode& number(const int num);
+        SummaryConfigNode& isUserDefined(const bool userDefined);
 
         const std::string& keyword() const { return this->keyword_; }
         Category category() const { return this->category_; }
@@ -90,27 +90,27 @@ namespace Opm {
         bool        userDefined_{false};
     };
 
-    SummaryNode::Category parseKeywordCategory(const std::string& keyword);
+    SummaryConfigNode::Category parseKeywordCategory(const std::string& keyword);
 
-    bool operator==(const SummaryNode& lhs, const SummaryNode& rhs);
-    bool operator<(const SummaryNode& lhs, const SummaryNode& rhs);
+    bool operator==(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs);
+    bool operator<(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs);
 
-    inline bool operator!=(const SummaryNode& lhs, const SummaryNode& rhs)
+    inline bool operator!=(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
     {
         return ! (lhs == rhs);
     }
 
-    inline bool operator<=(const SummaryNode& lhs, const SummaryNode& rhs)
+    inline bool operator<=(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
     {
         return ! (rhs < lhs);
     }
 
-    inline bool operator>(const SummaryNode& lhs, const SummaryNode& rhs)
+    inline bool operator>(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
     {
         return rhs < lhs;
     }
 
-    inline bool operator>=(const SummaryNode& lhs, const SummaryNode& rhs)
+    inline bool operator>=(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
     {
         return ! (lhs < rhs);
     }
@@ -126,7 +126,7 @@ namespace Opm {
 
     class SummaryConfig {
         public:
-            typedef SummaryNode keyword_type;
+            typedef SummaryConfigNode keyword_type;
             typedef std::vector< keyword_type > keyword_list;
             typedef keyword_list::const_iterator const_iterator;
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -67,12 +67,12 @@ namespace {
     struct ParamCTorArgs
     {
         std::string kw;
-        Opm::SummaryNode::Type type;
+        Opm::SummaryConfigNode::Type type;
     };
 
     std::vector<ParamCTorArgs> requiredRestartVectors()
     {
-        using Type = ::Opm::SummaryNode::Type;
+        using Type = ::Opm::SummaryConfigNode::Type;
 
         return {
             // Production
@@ -108,12 +108,12 @@ namespace {
         };
     }
 
-    std::vector<Opm::SummaryNode>
+    std::vector<Opm::SummaryConfigNode>
     requiredRestartVectors(const ::Opm::Schedule& sched)
     {
-        auto entities = std::vector<Opm::SummaryNode>{};
+        auto entities = std::vector<Opm::SummaryConfigNode>{};
 
-        using SN = ::Opm::SummaryNode;
+        using SN = ::Opm::SummaryConfigNode;
 
         const auto& vectors = requiredRestartVectors();
 
@@ -156,10 +156,10 @@ namespace {
         return entities;
     }
 
-    std::vector<Opm::SummaryNode>
+    std::vector<Opm::SummaryConfigNode>
     requiredSegmentVectors(const ::Opm::Schedule& sched)
     {
-        using SN = Opm::SummaryNode;
+        using SN = Opm::SummaryConfigNode;
         auto ret = std::vector<SN>{};
 
         auto sofr = SN{ "SOFR", SN::Category::Segment, ::Opm::Location() }
@@ -1113,15 +1113,15 @@ static const std::unordered_map< std::string, Opm::UnitSystem::measure> block_un
 };
 
 inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,
-                                           const Opm::SummaryNode& node,
+                                           const Opm::SummaryConfigNode& node,
                                            const int sim_step,
                                            const Opm::out::RegionCache& regionCache ) {
 
     const auto cat = node.category();
 
-    if ((cat == Opm::SummaryNode::Category::Well) ||
-        (cat == Opm::SummaryNode::Category::Connection) ||
-        (cat == Opm::SummaryNode::Category::Segment))
+    if ((cat == Opm::SummaryConfigNode::Category::Well) ||
+        (cat == Opm::SummaryConfigNode::Category::Connection) ||
+        (cat == Opm::SummaryConfigNode::Category::Segment))
     {
         const auto& name = node.namedEntity();
 
@@ -1132,7 +1132,7 @@ inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,
             return {};
     }
 
-    if( cat == Opm::SummaryNode::Category::Group ) {
+    if( cat == Opm::SummaryConfigNode::Category::Group ) {
         const auto& name = node.namedEntity();
 
         if( !schedule.hasGroup( name ) ) return {};
@@ -1140,10 +1140,10 @@ inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,
         return schedule.getChildWells2( name, sim_step);
     }
 
-    if( cat == Opm::SummaryNode::Category::Field )
+    if( cat == Opm::SummaryConfigNode::Category::Field )
         return schedule.getWells(sim_step);
 
-    if( cat == Opm::SummaryNode::Category::Region ) {
+    if( cat == Opm::SummaryConfigNode::Category::Region ) {
         std::vector<Opm::Well> wells;
 
         const auto region = node.number();
@@ -1168,21 +1168,21 @@ inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,
 }
 
 
-bool need_wells(Opm::SummaryNode::Category cat, const std::string& keyword) {
+bool need_wells(Opm::SummaryConfigNode::Category cat, const std::string& keyword) {
     static const std::set<std::string> region_keywords{"ROIR", "RGIR", "RWIR", "ROPR", "RGPR", "RWPR", "ROIT", "RWIT", "RGIT", "ROPT", "RGPT", "RWPT"};
-    if (cat == Opm::SummaryNode::Category::Well)
+    if (cat == Opm::SummaryConfigNode::Category::Well)
         return true;
 
-    if (cat == Opm::SummaryNode::Category::Group)
+    if (cat == Opm::SummaryConfigNode::Category::Group)
         return true;
 
-    if (cat == Opm::SummaryNode::Category::Field)
+    if (cat == Opm::SummaryConfigNode::Category::Field)
         return true;
 
-    if (cat == Opm::SummaryNode::Category::Connection)
+    if (cat == Opm::SummaryConfigNode::Category::Connection)
         return true;
 
-    if (cat == Opm::SummaryNode::Category::Segment)
+    if (cat == Opm::SummaryConfigNode::Category::Segment)
         return true;
 
     /*
@@ -1191,7 +1191,7 @@ bool need_wells(Opm::SummaryNode::Category cat, const std::string& keyword) {
       region and consequently the list of defined wells is required, other
       region keywords like 'ROIP' do not require well information.
     */
-    if (cat == Opm::SummaryNode::Category::Region) {
+    if (cat == Opm::SummaryConfigNode::Category::Region) {
         if (region_keywords.count(keyword) > 0)
             return true;
     }
@@ -1257,12 +1257,12 @@ void eval_udq(const Opm::Schedule& schedule, std::size_t sim_step, Opm::SummaryS
     }
 }
 
-void updateValue(const Opm::SummaryNode& node, const double value, Opm::SummaryState& st)
+void updateValue(const Opm::SummaryConfigNode& node, const double value, Opm::SummaryState& st)
 {
-    if (node.category() == Opm::SummaryNode::Category::Well)
+    if (node.category() == Opm::SummaryConfigNode::Category::Well)
         st.update_well_var(node.namedEntity(), node.keyword(), value);
 
-    else if (node.category() == Opm::SummaryNode::Category::Group)
+    else if (node.category() == Opm::SummaryConfigNode::Category::Group)
         st.update_group_var(node.namedEntity(), node.keyword(), value);
 
     else
@@ -1292,13 +1292,13 @@ struct EfficiencyFactor
 
     FacColl factors{};
 
-    void setFactors(const Opm::SummaryNode&        node,
+    void setFactors(const Opm::SummaryConfigNode&        node,
                     const Opm::Schedule&           schedule,
                     const std::vector<Opm::Well>& schedule_wells,
                     const int                      sim_step);
 };
 
-void EfficiencyFactor::setFactors(const Opm::SummaryNode&        node,
+void EfficiencyFactor::setFactors(const Opm::SummaryConfigNode&        node,
                                   const Opm::Schedule&           schedule,
                                   const std::vector<Opm::Well>& schedule_wells,
                                   const int                      sim_step)
@@ -1308,14 +1308,14 @@ void EfficiencyFactor::setFactors(const Opm::SummaryNode&        node,
     if (schedule_wells.empty()) { return; }
 
     const auto cat = node.category();
-    if(    cat != Opm::SummaryNode::Category::Group
-        && cat != Opm::SummaryNode::Category::Field
-        && cat != Opm::SummaryNode::Category::Region
-           && (node.type() != Opm::SummaryNode::Type::Total))
+    if(    cat != Opm::SummaryConfigNode::Category::Group
+        && cat != Opm::SummaryConfigNode::Category::Field
+        && cat != Opm::SummaryConfigNode::Category::Region
+           && (node.type() != Opm::SummaryConfigNode::Type::Total))
         return;
 
-    const bool is_group = (cat == Opm::SummaryNode::Category::Group);
-    const bool is_rate = (node.type() != Opm::SummaryNode::Type::Total);
+    const bool is_group = (cat == Opm::SummaryConfigNode::Category::Group);
+    const bool is_rate = (node.type() != Opm::SummaryConfigNode::Type::Total);
 
     for( const auto& well : schedule_wells ) {
         if (!well.hasBeenDefined(sim_step))
@@ -1372,7 +1372,7 @@ namespace Evaluator {
     class FunctionRelation : public Base
     {
     public:
-        explicit FunctionRelation(Opm::SummaryNode node, ofun fcn)
+        explicit FunctionRelation(Opm::SummaryConfigNode node, ofun fcn)
             : node_(std::move(node))
             , fcn_ (std::move(fcn))
         {}
@@ -1413,14 +1413,14 @@ namespace Evaluator {
         }
 
     private:
-        Opm::SummaryNode node_;
+        Opm::SummaryConfigNode node_;
         ofun             fcn_;
     };
 
     class BlockValue : public Base
     {
     public:
-        explicit BlockValue(Opm::SummaryNode               node,
+        explicit BlockValue(Opm::SummaryConfigNode               node,
                             const Opm::UnitSystem::measure m)
             : node_(std::move(node))
             , m_   (m)
@@ -1442,7 +1442,7 @@ namespace Evaluator {
         }
 
     private:
-        Opm::SummaryNode node_;
+        Opm::SummaryConfigNode node_;
         Opm::UnitSystem::measure m_;
 
         Opm::out::Summary::BlockValues::key_type lookupKey() const
@@ -1454,7 +1454,7 @@ namespace Evaluator {
     class RegionValue : public Base
     {
     public:
-        explicit RegionValue(Opm::SummaryNode               node,
+        explicit RegionValue(Opm::SummaryConfigNode               node,
                              const Opm::UnitSystem::measure m)
             : node_(std::move(node))
             , m_   (m)
@@ -1484,7 +1484,7 @@ namespace Evaluator {
         }
 
     private:
-        Opm::SummaryNode node_;
+        Opm::SummaryConfigNode node_;
         Opm::UnitSystem::measure m_;
 
         std::vector<double>::size_type index() const
@@ -1496,7 +1496,7 @@ namespace Evaluator {
     class GlobalProcessValue : public Base
     {
     public:
-        explicit GlobalProcessValue(Opm::SummaryNode               node,
+        explicit GlobalProcessValue(Opm::SummaryConfigNode               node,
                                     const Opm::UnitSystem::measure m)
             : node_(std::move(node))
             , m_   (m)
@@ -1519,7 +1519,7 @@ namespace Evaluator {
         }
 
     private:
-        Opm::SummaryNode node_;
+        Opm::SummaryConfigNode node_;
         Opm::UnitSystem::measure m_;
     };
 
@@ -1609,7 +1609,7 @@ namespace Evaluator {
         Factory& operator=(const Factory&) = delete;
         Factory& operator=(Factory&&) = delete;
 
-        Descriptor create(const Opm::SummaryNode&);
+        Descriptor create(const Opm::SummaryConfigNode&);
 
     private:
         const Opm::EclipseState& es_;
@@ -1617,7 +1617,7 @@ namespace Evaluator {
         const Opm::SummaryState& st_;
         const Opm::UDQConfig&    udq_;
 
-        const Opm::SummaryNode* node_;
+        const Opm::SummaryConfigNode* node_;
 
         Opm::UnitSystem::measure paramUnit_;
         ofun paramFunction_;
@@ -1640,7 +1640,7 @@ namespace Evaluator {
         std::string userDefinedUnit() const;
     };
 
-    Factory::Descriptor Factory::create(const Opm::SummaryNode& node)
+    Factory::Descriptor Factory::create(const Opm::SummaryConfigNode& node)
     {
         this->node_ = &node;
 
@@ -1816,10 +1816,10 @@ namespace Evaluator {
     }
 } // namespace Evaluator
 
-void reportUnsupportedKeywords(std::vector<Opm::SummaryNode> keywords)
+void reportUnsupportedKeywords(std::vector<Opm::SummaryConfigNode> keywords)
 {
     // Sort by location first, then keyword.
-    auto loc_kw_ordering = [](const Opm::SummaryNode& n1, const Opm::SummaryNode& n2) {
+    auto loc_kw_ordering = [](const Opm::SummaryConfigNode& n1, const Opm::SummaryConfigNode& n2) {
         if (n1.location() == n2.location()) {
             return n1.keyword() < n2.keyword();
         }
@@ -1832,7 +1832,7 @@ void reportUnsupportedKeywords(std::vector<Opm::SummaryNode> keywords)
 
     // Reorder to remove duplicate { keyword, location } pairs, since
     // that will give duplicate and therefore useless warnings.
-    auto same_kw_and_loc = [](const Opm::SummaryNode& n1, const Opm::SummaryNode& n2) {
+    auto same_kw_and_loc = [](const Opm::SummaryConfigNode& n1, const Opm::SummaryConfigNode& n2) {
         return (n1.keyword() == n2.keyword()) && (n1.location() == n2.location());
     };
     auto uend = std::unique(keywords.begin(), keywords.end(), same_kw_and_loc);
@@ -2240,7 +2240,7 @@ configureSummaryInput(const EclipseState&  es,
         es, grid, st, sched.getUDQConfig(sched.size() - 1)
     };
 
-    auto unsuppkw = std::vector<SummaryNode>{};
+    auto unsuppkw = std::vector<SummaryConfigNode>{};
     for (const auto& node : sumcfg) {
         auto prmDescr = fact.create(node);
 
@@ -2271,7 +2271,7 @@ Opm::out::Summary::SummaryImplementation::
 configureRequiredRestartParameters(const SummaryConfig& sumcfg,
                                    const Schedule&      sched)
 {
-    auto makeEvaluator = [&sumcfg, this](const SummaryNode& node) -> void
+    auto makeEvaluator = [&sumcfg, this](const SummaryConfigNode& node) -> void
     {
         if (sumcfg.hasSummaryKey(node.uniqueNodeKey()))
             // Handler already exists.  Don't add second evaluation.

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
@@ -90,8 +90,8 @@ FuncType Parser::get_func(const std::string& arg) {
     if (arg == "MNTH") return FuncType::time;
     if (arg == "DAY")  return FuncType::time;
 
-    using Cat = SummaryNode::Category;
-    SummaryNode::Category cat = parseKeywordCategory(arg);
+    using Cat = SummaryConfigNode::Category;
+    SummaryConfigNode::Category cat = parseKeywordCategory(arg);
     switch (cat) {
         case Cat::Well:       return FuncType::well;
         case Cat::Group:      return FuncType::group;

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -16,9 +16,9 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <iostream>
 #include <algorithm>
 #include <array>
+#include <iostream>
 #include <stdexcept>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -240,14 +240,14 @@ namespace {
         return keyword[0] == 'A';
     }
 
-    SummaryNode::Type parseKeywordType(const std::string& keyword) {
-        if (is_rate(keyword)) return SummaryNode::Type::Rate;
-        if (is_total(keyword)) return SummaryNode::Type::Total;
-        if (is_ratio(keyword)) return SummaryNode::Type::Ratio;
-        if (is_pressure(keyword)) return SummaryNode::Type::Pressure;
-        if (is_count(keyword)) return SummaryNode::Type::Count;
+    SummaryConfigNode::Type parseKeywordType(const std::string& keyword) {
+        if (is_rate(keyword)) return SummaryConfigNode::Type::Rate;
+        if (is_total(keyword)) return SummaryConfigNode::Type::Total;
+        if (is_ratio(keyword)) return SummaryConfigNode::Type::Ratio;
+        if (is_pressure(keyword)) return SummaryConfigNode::Type::Pressure;
+        if (is_count(keyword)) return SummaryConfigNode::Type::Count;
 
-        return SummaryNode::Type::Undefined;
+        return SummaryConfigNode::Type::Undefined;
     }
 
 void handleMissingWell( const ParseContext& parseContext, ErrorGuard& errors, const std::string& keyword, const std::string& well) {
@@ -270,7 +270,7 @@ void handleMissingGroup( const ParseContext& parseContext , ErrorGuard& errors, 
 
 inline void keywordW( SummaryConfig::keyword_list& list,
                       const std::vector<std::string>& well_names,
-                      SummaryNode baseWellParam) {
+                      SummaryConfigNode baseWellParam) {
     for (const auto& wname : well_names)
         list.push_back( baseWellParam.namedEntity(wname) );
 }
@@ -279,8 +279,8 @@ inline void keywordW( SummaryConfig::keyword_list& list,
                       const std::string& keyword,
                       Location loc,
                       const Schedule& schedule) {
-    auto param = SummaryNode {
-        keyword, SummaryNode::Category::Well , std::move(loc)
+    auto param = SummaryConfigNode {
+        keyword, SummaryConfigNode::Category::Well , std::move(loc)
     }
     .parameterType( parseKeywordType(keyword) )
     .isUserDefined( is_udq(keyword) );
@@ -314,8 +314,8 @@ inline void keywordW( SummaryConfig::keyword_list& list,
         }
     }
 
-    auto param = SummaryNode {
-        keyword.name(), SummaryNode::Category::Well, keyword.location()
+    auto param = SummaryConfigNode {
+        keyword.name(), SummaryConfigNode::Category::Well, keyword.location()
     }
     .parameterType( parseKeywordType(keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
@@ -337,8 +337,8 @@ inline void keywordG( SummaryConfig::keyword_list& list,
                       const std::string& keyword,
                       Location loc,
                       const Schedule& schedule ) {
-    auto param = SummaryNode {
-        keyword, SummaryNode::Category::Group, std::move(loc)
+    auto param = SummaryConfigNode {
+        keyword, SummaryConfigNode::Category::Group, std::move(loc)
     }
     .parameterType( parseKeywordType(keyword) )
     .isUserDefined( is_udq(keyword) );
@@ -358,8 +358,8 @@ inline void keywordG( SummaryConfig::keyword_list& list,
 
     if( keyword.name() == "GMWSET" ) return;
 
-    auto param = SummaryNode {
-        keyword.name(), SummaryNode::Category::Group, keyword.location()
+    auto param = SummaryConfigNode {
+        keyword.name(), SummaryConfigNode::Category::Group, keyword.location()
     }
     .parameterType( parseKeywordType(keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
@@ -387,8 +387,8 @@ inline void keywordG( SummaryConfig::keyword_list& list,
 inline void keywordF( SummaryConfig::keyword_list& list,
                       const std::string& keyword,
                       Location loc) {
-    auto param = SummaryNode {
-        keyword, SummaryNode::Category::Field, std::move(loc)
+    auto param = SummaryConfigNode {
+        keyword, SummaryConfigNode::Category::Field, std::move(loc)
     }
     .parameterType( parseKeywordType(keyword) )
     .isUserDefined( is_udq(keyword) );
@@ -419,8 +419,8 @@ inline std::array< int, 3 > getijk( const Connection& completion ) {
 inline void keywordB( SummaryConfig::keyword_list& list,
                       const DeckKeyword& keyword,
                       const GridDims& dims) {
-    auto param = SummaryNode {
-        keyword.name(), SummaryNode::Category::Block, keyword.location()
+    auto param = SummaryConfigNode {
+        keyword.name(), SummaryConfigNode::Category::Block, keyword.location()
     }
     .parameterType( parseKeywordType(keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
@@ -466,8 +466,8 @@ inline void keywordR2R( SummaryConfig::keyword_list& /* list */,
     }
 
     // Don't (currently) need parameter type for region keywords
-    auto param = SummaryNode {
-        keyword.name(), SummaryNode::Category::Region, keyword.location()
+    auto param = SummaryConfigNode {
+        keyword.name(), SummaryConfigNode::Category::Region, keyword.location()
     }
     .isUserDefined( is_udq(keyword.name()) );
 
@@ -485,7 +485,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
                          Location loc)
 {
     if (meta_keywords.find(keyword) == meta_keywords.end())
-        list.emplace_back( keyword, SummaryNode::Category::Miscellaneous , std::move(loc));
+        list.emplace_back( keyword, SummaryConfigNode::Category::Miscellaneous , std::move(loc));
 }
 
 inline void keywordMISC( SummaryConfig::keyword_list& list,
@@ -501,8 +501,8 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
                         const Schedule& schedule,
                         const GridDims& dims) {
 
-    auto param = SummaryNode {
-        keyword.name(), SummaryNode::Category::Connection, keyword.location()
+    auto param = SummaryConfigNode {
+        keyword.name(), SummaryConfigNode::Category::Connection, keyword.location()
     }
     .parameterType( parseKeywordType( keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
@@ -576,8 +576,8 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
             // Not an MSW.  Don't create summary vectors for segments.
             return;
 
-        auto param = SummaryNode {
-            keyword.name(), SummaryNode::Category::Segment, keyword.location()
+        auto param = SummaryConfigNode {
+            keyword.name(), SummaryConfigNode::Category::Segment, keyword.location()
         }
         .namedEntity( well.name() )
         .isUserDefined( is_udq(keyword.name()) );
@@ -701,16 +701,16 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
         }
     }
 
-    std::string to_string(const SummaryNode::Category cat) {
+    std::string to_string(const SummaryConfigNode::Category cat) {
         switch( cat ) {
-            case SummaryNode::Category::Well: return "Well";
-            case SummaryNode::Category::Group: return "Group";
-            case SummaryNode::Category::Field: return "Field";
-            case SummaryNode::Category::Region: return "Region";
-            case SummaryNode::Category::Block: return "Block";
-            case SummaryNode::Category::Connection: return "Connection";
-            case SummaryNode::Category::Segment: return "Segment";
-            case SummaryNode::Category::Miscellaneous: return "Miscellaneous";
+            case SummaryConfigNode::Category::Well: return "Well";
+            case SummaryConfigNode::Category::Group: return "Group";
+            case SummaryConfigNode::Category::Field: return "Field";
+            case SummaryConfigNode::Category::Region: return "Region";
+            case SummaryConfigNode::Category::Block: return "Block";
+            case SummaryConfigNode::Category::Connection: return "Connection";
+            case SummaryConfigNode::Category::Segment: return "Segment";
+            case SummaryConfigNode::Category::Miscellaneous: return "Miscellaneous";
         }
 
         throw std::invalid_argument {
@@ -748,7 +748,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
                         const ParseContext& parseContext,
                         ErrorGuard& errors,
                         const GridDims& dims) {
-    using Cat = SummaryNode::Category;
+    using Cat = SummaryConfigNode::Category;
 
     const auto& name = keyword.name();
     check_udq( name, schedule, parseContext, errors );
@@ -789,7 +789,7 @@ inline void handleKW( SummaryConfig::keyword_list& list,
         return;
     }
 
-    using Cat = SummaryNode::Category;
+    using Cat = SummaryConfigNode::Category;
     const auto cat = parseKeywordCategory( keyword );
 
     switch( cat ) {
@@ -813,8 +813,8 @@ inline void handleKW( SummaryConfig::keyword_list& list,
 
 // =====================================================================
 
-SummaryNode::Category parseKeywordCategory(const std::string& keyword) {
-    using Cat = SummaryNode::Category;
+SummaryConfigNode::Category parseKeywordCategory(const std::string& keyword) {
+    using Cat = SummaryConfigNode::Category;
 
     if (is_special(keyword)) { return Cat::Miscellaneous; }
 
@@ -833,53 +833,53 @@ SummaryNode::Category parseKeywordCategory(const std::string& keyword) {
 }
 
 
-SummaryNode::SummaryNode(std::string keyword, const Category cat, Location loc_arg) :
+SummaryConfigNode::SummaryConfigNode(std::string keyword, const Category cat, Location loc_arg) :
     keyword_(std::move(keyword)),
     category_(cat),
     loc(std::move(loc_arg))
 {}
 
-SummaryNode& SummaryNode::parameterType(const Type type)
+SummaryConfigNode& SummaryConfigNode::parameterType(const Type type)
 {
     this->type_ = type;
     return *this;
 }
 
-SummaryNode& SummaryNode::namedEntity(std::string name)
+SummaryConfigNode& SummaryConfigNode::namedEntity(std::string name)
 {
     this->name_ = std::move(name);
     return *this;
 }
 
-SummaryNode& SummaryNode::number(const int num)
+SummaryConfigNode& SummaryConfigNode::number(const int num)
 {
     this->number_ = num;
     return *this;
 }
 
-SummaryNode& SummaryNode::isUserDefined(const bool userDefined)
+SummaryConfigNode& SummaryConfigNode::isUserDefined(const bool userDefined)
 {
     this->userDefined_ = userDefined;
     return *this;
 }
 
-std::string SummaryNode::uniqueNodeKey() const
+std::string SummaryConfigNode::uniqueNodeKey() const
 {
     switch (this->category()) {
-    case SummaryNode::Category::Well: [[fallthrough]];
-    case SummaryNode::Category::Group:
+    case SummaryConfigNode::Category::Well: [[fallthrough]];
+    case SummaryConfigNode::Category::Group:
         return this->keyword() + ':' + this->namedEntity();
 
-    case SummaryNode::Category::Field: [[fallthrough]];
-    case SummaryNode::Category::Miscellaneous:
+    case SummaryConfigNode::Category::Field: [[fallthrough]];
+    case SummaryConfigNode::Category::Miscellaneous:
         return this->keyword();
 
-    case SummaryNode::Category::Region: [[fallthrough]];
-    case SummaryNode::Category::Block:
+    case SummaryConfigNode::Category::Region: [[fallthrough]];
+    case SummaryConfigNode::Category::Block:
         return this->keyword() + ':' + std::to_string(this->number());
 
-    case SummaryNode::Category::Connection: [[fallthrough]];
-    case SummaryNode::Category::Segment:
+    case SummaryConfigNode::Category::Connection: [[fallthrough]];
+    case SummaryConfigNode::Category::Segment:
         return this->keyword() + ':' + this->namedEntity() + ':' + std::to_string(this->number());
     }
 
@@ -889,30 +889,30 @@ std::string SummaryNode::uniqueNodeKey() const
     };
 }
 
-bool operator==(const SummaryNode& lhs, const SummaryNode& rhs)
+bool operator==(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
 {
     if (lhs.keyword() != rhs.keyword()) return false;
 
     assert (lhs.category() == rhs.category());
 
     switch( lhs.category() ) {
-        case SummaryNode::Category::Field: [[fallthrough]];
-        case SummaryNode::Category::Miscellaneous:
+        case SummaryConfigNode::Category::Field: [[fallthrough]];
+        case SummaryConfigNode::Category::Miscellaneous:
             // Fully identified by keyword
             return true;
 
-        case SummaryNode::Category::Well: [[fallthrough]];
-        case SummaryNode::Category::Group:
+        case SummaryConfigNode::Category::Well: [[fallthrough]];
+        case SummaryConfigNode::Category::Group:
             // Equal if associated to same named entity
             return lhs.namedEntity() == rhs.namedEntity();
 
-        case SummaryNode::Category::Region: [[fallthrough]];
-        case SummaryNode::Category::Block:
+        case SummaryConfigNode::Category::Region: [[fallthrough]];
+        case SummaryConfigNode::Category::Block:
             // Equal if associated to same numeric entity
             return lhs.number() == rhs.number();
 
-        case SummaryNode::Category::Connection: [[fallthrough]];
-        case SummaryNode::Category::Segment:
+        case SummaryConfigNode::Category::Connection: [[fallthrough]];
+        case SummaryConfigNode::Category::Segment:
             // Equal if associated to same numeric
             // sub-entity of same named entity
             return (lhs.namedEntity() == rhs.namedEntity())
@@ -922,7 +922,7 @@ bool operator==(const SummaryNode& lhs, const SummaryNode& rhs)
     return false;
 }
 
-bool operator<(const SummaryNode& lhs, const SummaryNode& rhs)
+bool operator<(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
 {
     if (lhs.keyword() < rhs.keyword()) return true;
     if (rhs.keyword() < lhs.keyword()) return false;
@@ -930,24 +930,24 @@ bool operator<(const SummaryNode& lhs, const SummaryNode& rhs)
     // If we get here, the keyword are equal.
 
     switch( lhs.category() ) {
-        case SummaryNode::Category::Field: [[fallthrough]];
-        case SummaryNode::Category::Miscellaneous:
+        case SummaryConfigNode::Category::Field: [[fallthrough]];
+        case SummaryConfigNode::Category::Miscellaneous:
             // Fully identified by keyword.
             // Return false for equal keywords.
             return false;
 
-        case SummaryNode::Category::Well: [[fallthrough]];
-        case SummaryNode::Category::Group:
+        case SummaryConfigNode::Category::Well: [[fallthrough]];
+        case SummaryConfigNode::Category::Group:
             // Ordering determined by namedEntityd entity
             return lhs.namedEntity() < rhs.namedEntity();
 
-        case SummaryNode::Category::Region: [[fallthrough]];
-        case SummaryNode::Category::Block:
+        case SummaryConfigNode::Category::Region: [[fallthrough]];
+        case SummaryConfigNode::Category::Block:
             // Ordering determined by numeric entity
             return lhs.number() < rhs.number();
 
-        case SummaryNode::Category::Connection: [[fallthrough]];
-        case SummaryNode::Category::Segment:
+        case SummaryConfigNode::Category::Connection: [[fallthrough]];
+        case SummaryConfigNode::Category::Segment:
         {
             // Ordering determined by pair of namedEntity and numeric ID.
             //

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -759,14 +759,14 @@ BOOST_AUTO_TEST_CASE(Summary_Segment)
 
     {
         auto sofr = std::find_if(summary.begin(), summary.end(),
-            [](const SummaryNode& node)
+            [](const SummaryConfigNode& node)
         {
             return node.keyword() == "SOFR";
         });
 
         BOOST_REQUIRE(sofr != summary.end());
 
-        BOOST_CHECK_MESSAGE(sofr->category() == SummaryNode::Category::Segment,
+        BOOST_CHECK_MESSAGE(sofr->category() == SummaryConfigNode::Category::Segment,
             R"("SOFR" keyword category must be "Segment")"
         );
         BOOST_CHECK_EQUAL(sofr->namedEntity(), "PROD01");


### PR DESCRIPTION
This feature renames `Opm::SummaryNode` to `Opm::SummaryConfigNode`, in preparation for introducing a different type under the name `Opm::SummaryNode`.