### PR TITLE
Adding support for larger EclFile arrays

### DIFF
--- a/opm/io/eclipse/EclFile.hpp
+++ b/opm/io/eclipse/EclFile.hpp
@@ -52,7 +52,7 @@ public:
       char_array.clear();
     }
 
-    using EclEntry = std::tuple<std::string, eclArrType, int>;
+    using EclEntry = std::tuple<std::string, eclArrType, long int>;
     std::vector<EclEntry> getList() const;
 
     template <typename T>
@@ -78,7 +78,7 @@ protected:
 
     std::vector<std::string> array_name;
     std::vector<eclArrType> array_type;
-    std::vector<int> array_size;
+    std::vector<long int> array_size;
 
     std::vector<unsigned long int> ifStreamPos;
 

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -26,6 +26,7 @@
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 #include <opm/io/eclipse/PaddedOutputString.hpp>
+#include <iostream>
 
 namespace Opm { namespace EclIO { namespace OutputStream {
     class Restart;
@@ -78,7 +79,7 @@ public:
     friend class OutputStream::SummarySpecification;
 
 private:
-    void writeBinaryHeader(const std::string& arrName, int size, eclArrType arrType);
+    void writeBinaryHeader(const std::string& arrName, long int size, eclArrType arrType);
 
     template <typename T>
     void writeBinaryArray(const std::vector<T>& data);
@@ -94,6 +95,7 @@ private:
     void writeFormattedCharArray(const std::vector<std::string>& data);
     void writeFormattedCharArray(const std::vector<PaddedOutputString<8>>& data);
 
+    void writeArrayType(const eclArrType arrType);
     std::string make_real_string(float value) const;
     std::string make_doub_string(double value) const;
 

--- a/opm/io/eclipse/EclUtil.hpp
+++ b/opm/io/eclipse/EclUtil.hpp
@@ -27,6 +27,7 @@
 namespace Opm { namespace EclIO {
 
     int flipEndianInt(int num);
+    long int flipEndianLongInt(long int num);
     float flipEndianFloat(float num);
     double flipEndianDouble(double num);
 

--- a/src/opm/io/eclipse/EclUtil.cpp
+++ b/src/opm/io/eclipse/EclUtil.cpp
@@ -30,6 +30,11 @@ int Opm::EclIO::flipEndianInt(int num)
     return static_cast<int>(tmp);
 }
 
+long int Opm::EclIO::flipEndianLongInt(long int num)
+{
+    unsigned long int tmp = __builtin_bswap64(num);
+    return static_cast<long int>(tmp);
+}
 
 float Opm::EclIO::flipEndianFloat(float num)
 {

--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -9,7 +9,7 @@
 #include <opm/io/eclipse/EclOutput.hpp>
 
 using namespace Opm::EclIO;
-using EclEntry = std::tuple<std::string, eclArrType, int>;
+using EclEntry = std::tuple<std::string, eclArrType, long int>;
 
 template <typename T>
 void write(EclOutput& outFile, EclFile& file1,

--- a/tests/test_ERst.cpp
+++ b/tests/test_ERst.cpp
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(TestERst_1) {
 
 
     // try to get a list of vectors from non-existing report step, should throw exception
-    std::vector<std::tuple<std::string, eclArrType, int>> rstArrays; // = rst1.listOfRstArrays(4);
+    std::vector<std::tuple<std::string, eclArrType, long int>> rstArrays; // = rst1.listOfRstArrays(4);
     BOOST_CHECK_THROW(rstArrays = rst1.listOfRstArrays(4), std::invalid_argument);
 
     // non exising report step number, should throw exception


### PR DESCRIPTION
- EclIO classes have been updated to support arrays with size beyond numeric limits for integers
- int data type changed to data type long int in EclEntry tuple in EclFile.hpp
- the standard 16 byte header used when size of array are within range for int data type
- an alternative 20 byte binary header used when size of an array is beyon numeric limits for int

### More details related to changes in this PR below

The EclFile binary array header contains 24 bytes, where 8 bytes is used to specify that the header contains 16 bytes of header data. Example below of a standard binary header

```
size on disk   4 |    8   |     4 |   4 |  4     
example       16 |  ZCORN | 79200 | REAL| 16
```

This header will be used whenever the size of the array is within limits for 4 byte integers. This ensures that we are supporting existing post processing tools in the industry.

The alternative header will be used only for arrays with size beyond limits for 4 bytes integers. These arrays will not be supported by other than our own IO classes. Example 

```
size on disk   4 |    8   |      8     |   4 |  4     
example       20 |  ZCORN | 6400000000 | REAL| 20
```

I have not added any additional tests for testing the 20 byte binary header. Reason for this is that I have not found a good way to do this. The code below is what I have used locally when working on this PR. 
```C++
BOOST_AUTO_TEST_CASE(TestEclFile_HUGE_BINARY) {
    long int vectSize= static_cast<long int>(std::numeric_limits<int>::max()) + 1;
    std::vector<float> hugeRealVector;
    hugeRealVector.resize(vectSize, 1.2345);
    std::string testFile="TEST.DAT";
    {    
        EclOutput eclTest(testFile, false);
        eclTest.write("ZCORN", hugeRealVector);
    }
    EclFile test1(testFile);
    auto zcorn = test1.get<float>("ZCORN");
}
```
The challenge with the above is that it creates a file with size 8.1GByte and run time for this test alone is 98 seconds.  
  
Yes, we have already seen models in our company with ZCORN (Egrid file) larger than the limits for integers. The industry standard simulator produced an invalid header which even Petrel was not able to load.

Update: I have changed the on-disk size of the 'REAL' string to 4 bytes - it was 6 bytes in the original PR description (@joakim-hove)