### PR TITLE
Write diameter, roughness and area also for first segment

### DIFF
--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -668,6 +668,9 @@ namespace {
                 // Treat the top segment individually
                 rSeg[iS + Ix::DistOutlet]      = units.from_si(M::length, welSegSet.lengthTopSegment());
                 rSeg[iS + Ix::OutletDepthDiff] = units.from_si(M::length, welSegSet.depthTopSegment());
+                rSeg[iS + Ix::SegDiam]         = units.from_si(M::length, (segment0.internalDiameter()));
+                rSeg[iS + Ix::SegRough]        = units.from_si(M::length, (segment0.roughness()));
+                rSeg[iS + Ix::SegArea]         = areaFromLengthUnitConv *  segment0.crossArea();
                 rSeg[iS + Ix::SegVolume]       = volFromLengthUnitConv*welSegSet.volumeTopSegment();
                 rSeg[iS + Ix::DistBHPRef]      = rSeg[iS + Ix::DistOutlet];
                 rSeg[iS + Ix::DepthBHPRef]     = rSeg[iS + Ix::OutletDepthDiff];


### PR DESCRIPTION
The code writing restart information for MSW wells does not write information about segment diameter, roughness and surface area for the first segment. 

This PR writes that information also for the first segment. This will trigger a data update because the RSEG keyword will change. 