### PR TITLE
Remove Connection::compsegSeqIndex - sort output on segment number

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -113,7 +113,6 @@ namespace RestartIO {
                    double segDistStart,
                    double segDistEnd,
                    bool defaultSatTabId,
-                   std::size_t compSegSeqIndex,
                    int segment,
                    double wellPi);
 
@@ -143,12 +142,10 @@ namespace RestartIO {
         void scaleWellPi(double wellPi);
         void updateSegment(int segment_number_arg,
                            double center_depth_arg,
-                           std::size_t compseg_insert_index,
                            double start,
                            double end);
         const std::size_t& getSeqIndex() const;
         const bool& getDefaultSatTabId() const;
-        const std::size_t& getCompSegSeqIndex() const;
         void setDefaultSatTabId(bool id);
         const double& getSegDistStart() const;
         const double& getSegDistEnd() const;
@@ -178,7 +175,6 @@ namespace RestartIO {
         double m_segDistStart;
         double m_segDistEnd;
         bool m_defaultSatTabId;
-        std::size_t m_compSeg_seqIndex=0;
 
         // related segment number
         // 0 means the completion is not related to segment

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -74,7 +74,7 @@ namespace {
                 //sort connections according to input sequence in COMPSEGS
                 std::sort(connSI.begin(), connSI.end(), [](const Opm::Connection* conn1, const Opm::Connection* conn2)
                                                             {
-                                                                return conn1->getCompSegSeqIndex() < conn2->getCompSegSeqIndex();
+                                                                return conn1->segment() < conn2->segment();
                                                             });
             } else {
                 std::sort(connSI.begin(), connSI.end(), [](const Opm::Connection* conn1, const Opm::Connection* conn2)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
@@ -274,7 +274,6 @@ namespace Opm {
                 Connection& connection = connection_set.getFromIJK(i, j, k);
                 connection.updateSegment(compseg.segment_number,
                                          compseg.center_depth,
-                                         compseg.m_seqIndex,
                                          compseg.m_distance_start,
                                          compseg.m_distance_end);
             }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2939,13 +2939,11 @@ void Schedule::load_rst(const RestartIO::RstState& rst_state, const EclipseGrid&
         for (auto& connection : connections) {
             int segment_id = connection.segment();
             if (segment_id > 0) {
-                std::size_t compsegs_insert_index = 0;
                 double segment_start = 0;
                 double segment_end = 0;
                 const auto& segment = segments.at(segment_id);
                 connection.updateSegment(segment.segmentNumber(),
                                          segment.depth(),
-                                         compsegs_insert_index,
                                          segment_start,
                                          segment_end);
             }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -77,7 +77,6 @@ namespace Opm {
 
 namespace {
 constexpr bool defaultSatTabId = true;
-constexpr int compseg_seqIndex = 1;
 constexpr double def_wellPi = 1.0;
 }
 
@@ -98,7 +97,6 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
         m_segDistStart(rst_connection.segdist_start),
         m_segDistEnd(rst_connection.segdist_end),
         m_defaultSatTabId(defaultSatTabId),
-        m_compSeg_seqIndex(compseg_seqIndex),
         segment_number(rst_connection.segment),
         wPi(def_wellPi)
     {
@@ -117,7 +115,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
                            const std::array<int,3>& IJK,
                            CTFKind kind, std::size_t seqIndex,
                            double segDistStart, double segDistEnd,
-                           bool defaultSatTabId, std::size_t compSegSeqIndex,
+                           bool defaultSatTabId,
                            int segment, double wellPi)
         : direction(dir)
         , center_depth(depth)
@@ -135,7 +133,6 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
         , m_segDistStart(segDistStart)
         , m_segDistEnd(segDistEnd)
         , m_defaultSatTabId(defaultSatTabId)
-        , m_compSeg_seqIndex(compSegSeqIndex)
         , segment_number(segment)
         , wPi(wellPi)
     {}
@@ -143,7 +140,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
     Connection::Connection()
           : Connection(Direction::X, 1.0, State::SHUT,
                        0, 0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                       {0,0,0}, CTFKind::Defaulted, 0, 0.0, 0.0, false, 0, 0, 0.0)
+                       {0,0,0}, CTFKind::Defaulted, 0, 0.0, 0.0, false, 0, 0.0)
     {}
 
     bool Connection::sameCoordinate(const int i, const int j, const int k) const {
@@ -176,10 +173,6 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
 
     const bool& Connection::getDefaultSatTabId() const {
         return m_defaultSatTabId;
-    }
-
-    const std::size_t& Connection::getCompSegSeqIndex() const {
-        return m_compSeg_seqIndex;
     }
 
     Connection::Direction Connection::dir() const {
@@ -245,12 +238,10 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
 
     void Connection::updateSegment(int segment_number_arg,
                                    double center_depth_arg,
-                                   std::size_t compseg_insert_index,
                                    double start,
                                    double end) {
         this->segment_number = segment_number_arg;
         this->center_depth = center_depth_arg;
-        this->m_compSeg_seqIndex = compseg_insert_index;
         this->m_segDistStart = start;
         this->m_segDistEnd = end;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -351,7 +351,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                                     direction, ctf_kind,
                                     noConn, 0., 0., defaultSatTable);
             } else {
-                std::size_t css_ind = prev->getCompSegSeqIndex();
                 int conSegNo = prev->segment();
                 double conSDStart = prev->getSegDistStart();
                 double conSDEnd = prev->getSegDistEnd();
@@ -371,7 +370,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
 
                 prev->updateSegment(conSegNo,
                                     depth,
-                                    css_ind,
                                     conSDStart,
                                     conSDEnd);
             }


### PR DESCRIPTION
This is a suggestion/idea - so please be gentle if you think it is completely wrong.

Downstream: https://github.com/OPM/opm-simulators/pull/2480

This is minor suggestion tangential to this: https://github.com/OPM/opm-common/issues/1601