### PR TITLE
Move Connection::Order member from Well to WellConnections

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -411,7 +411,6 @@ public:
          int headJ,
          double ref_depth,
          const WellType& wtype_arg,
-         Connection::Order ordering,
          const UnitSystem& unit_system,
          double udq_undefined,
          Status status,
@@ -455,7 +454,6 @@ public:
     double getRefDepth() const;
     double getDrainageRadius() const;
     double getEfficiencyFactor() const;
-    Connection::Order getWellConnectionOrdering() const;
     double getSolventFraction() const;
     Status getStatus() const;
     const std::string& groupName() const;
@@ -551,7 +549,6 @@ private:
     int headI;
     int headJ;
     double ref_depth;
-    Connection::Order ordering;
     UnitSystem unit_system;
     double udq_undefined;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -33,8 +33,8 @@ namespace Opm {
 
 
         WellConnections();
-        WellConnections(int headI, int headJ);
-        WellConnections(int headI, int headJ,
+        WellConnections(Connection::Order ordering, int headI, int headJ);
+        WellConnections(Connection::Order ordering, int headI, int headJ,
                         size_t numRemoved,
                         const std::vector<Connection>& connections);
 
@@ -83,7 +83,7 @@ namespace Opm {
         /// \param[in] well_i  logical cartesian i-coordinate of well head
         /// \param[in] well_j  logical cartesian j-coordinate of well head
         /// \param[in] grid    EclipseGrid object, used for cell depths
-        void orderTRACK(size_t well_i, size_t well_j);
+        void order(size_t well_i, size_t well_j);
 
         bool operator==( const WellConnections& ) const;
         bool operator!=( const WellConnections& ) const;
@@ -92,7 +92,7 @@ namespace Opm {
         int getHeadJ() const;
         size_t getNumRemoved() const;
         const std::vector<Connection>& getConnections() const;
-
+        Connection::Order ordering() const { return this->m_ordering; }
     private:
         void addConnection(int i, int j , int k ,
                            int complnum,
@@ -121,6 +121,7 @@ namespace Opm {
 
         size_t findClosestConnection(int oi, int oj, double oz, size_t start_pos);
 
+        Connection::Order m_ordering = Connection::Order::TRACK;
         int headI, headJ;
         size_t num_removed = 0;
         std::vector< Connection > m_connections;

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -291,7 +291,7 @@ namespace {
             using COVal = ::Opm::RestartIO::Helpers::
                 VectorItems::IWell::Value::CompOrder;
 
-            switch (well.getWellConnectionOrdering()) {
+            switch (well.getConnections().ordering()) {
             case WCO::TRACK: return COVal::Track;
             case WCO::DEPTH: return COVal::Depth;
             case WCO::INPUT: return COVal::Input;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -116,20 +116,25 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
 } // anonymous namespace
 
     WellConnections::WellConnections() :
-      headI(0), headJ(0), num_removed(0)
+        headI(0),
+        headJ(0),
+        num_removed(0)
     {
     }
 
-    WellConnections::WellConnections(int headIArg, int headJArg) :
+    WellConnections::WellConnections(Connection::Order order,int headIArg, int headJArg) :
+        m_ordering(order),
         headI(headIArg),
         headJ(headJArg)
     {
     }
 
 
-    WellConnections::WellConnections(int headIArg, int headJArg,
+    WellConnections::WellConnections(Connection::Order order,
+                                     int headIArg, int headJArg,
                                      size_t numRemoved,
                                      const std::vector<Connection>& connections) :
+        m_ordering(order),
         headI(headIArg),
         headJ(headJArg),
         num_removed(numRemoved),
@@ -140,6 +145,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
 
 
     WellConnections::WellConnections(const WellConnections& src, const EclipseGrid& grid) :
+        m_ordering(src.ordering()),
         headI(src.headI),
         headJ(src.headJ)
     {
@@ -437,11 +443,13 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
 
 
 
-    void WellConnections::orderTRACK(size_t well_i, size_t well_j)
+    void WellConnections::order(size_t well_i, size_t well_j)
     {
-        if (m_connections.empty()) {
+        if (m_connections.empty())
             return;
-        }
+
+        if (this->m_ordering != Connection::Order::TRACK)
+            return;
 
         // Find the first connection and swap it into the 0-position.
         const double surface_z = 0.0;
@@ -498,6 +506,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
     bool WellConnections::operator==( const WellConnections& rhs ) const {
         return this->size() == rhs.size() &&
             this->num_removed == rhs.num_removed &&
+            this->m_ordering == rhs.m_ordering &&
             std::equal( this->begin(), this->end(), rhs.begin() );
     }
 

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -60,7 +60,7 @@ inline std::ostream& operator<<( std::ostream& stream, const WellConnections& cs
 
 
 BOOST_AUTO_TEST_CASE(CreateWellConnectionsOK) {
-    Opm::WellConnections completionSet(1,1);
+    Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
     BOOST_CHECK_EQUAL( 0U , completionSet.size() );
     BOOST_CHECK(!completionSet.allConnectionsShut());
 }
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(CreateWellConnectionsOK) {
 BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    Opm::WellConnections completionSet(1,1);
+    Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
     Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true);
     Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true);
     completionSet.add( completion1 );
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
     Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::WellConnections completionSet(1,1);
+    Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
 
 
 BOOST_AUTO_TEST_CASE(AddCompletionCopy) {
-    Opm::WellConnections completionSet(10,10);
+    Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 10,10);
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
 
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(ActiveCompletions) {
     Opm::EclipseGrid grid(10,20,20);
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::Defaulted;
-    Opm::WellConnections completions(10,10);
+    Opm::WellConnections completions(Opm::Connection::Order::TRACK, 10,10);
     Opm::Connection completion1( 0,0,0, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
     Opm::Connection completion2( 0,0,1, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
     Opm::Connection completion3( 0,0,2, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
@@ -155,7 +155,7 @@ Opm::WellConnections loadCOMPDAT(const std::string& compdat_keyword) {
     const auto deck = parser.parseString(compdat_keyword);
     Opm::FieldPropsManager field_props(deck, Opm::Phases{true, true, true}, grid, Opm::TableManager());
     const auto& keyword = deck.getKeyword("COMPDAT", 0);
-    Opm::WellConnections connections(10,10);
+    Opm::WellConnections connections(Opm::Connection::Order::TRACK, 10,10);
     for (const auto& rec : keyword)
         connections.loadCOMPDAT(rec, grid, field_props);
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
 
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    Opm::WellConnections connection_set(10,10);
+    Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
     connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
     connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
 BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    Opm::WellConnections connection_set(10,10);
+    Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
     connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
     connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS) {
 BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    Opm::WellConnections connection_set(10,10);
+    Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
     connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
     connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS) {
 BOOST_AUTO_TEST_CASE(testwsegvalv) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    Opm::WellConnections connection_set(10,10);
+    Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
     connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
     connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3317,7 +3317,7 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
 
     const auto& connections = ws.getConnections();
     BOOST_CHECK_EQUAL(connections.size(), 0);
-    auto c2 = std::make_shared<WellConnections>(1,1);
+    auto c2 = std::make_shared<WellConnections>(Connection::Order::TRACK, 1,1);
     c2->addConnection(1,1,1,
                       100,
                       Connection::State::OPEN,


### PR DESCRIPTION
A small trivial refactor to support #1601

Dwonstream: https://github.com/OPM/opm-simulators/pull/2481