### PR TITLE
Changes in WellConnection ordering

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -84,12 +84,13 @@ namespace Opm {
         /// \param[in] well_i  logical cartesian i-coordinate of well head
         /// \param[in] well_j  logical cartesian j-coordinate of well head
         /// \param[in] grid    EclipseGrid object, used for cell depths
-        void order(size_t well_i, size_t well_j);
+        void order();
 
         bool operator==( const WellConnections& ) const;
         bool operator!=( const WellConnections& ) const;
 
         Connection::Order ordering() const { return this->m_ordering; }
+        std::vector<const Connection *> output(const EclipseGrid& grid) const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -128,6 +129,8 @@ namespace Opm {
                          const std::vector<double>& ntg);
 
         size_t findClosestConnection(int oi, int oj, double oz, size_t start_pos);
+        void orderTRACK();
+        void orderMSW();
 
         Connection::Order m_ordering = Connection::Order::TRACK;
         int headI, headJ;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -598,7 +598,7 @@ bool Well::updateAutoShutin(bool auto_shutin) {
 
 
 bool Well::updateConnections(std::shared_ptr<WellConnections> connections_arg) {
-    connections_arg->order( this->headI, this->headJ );
+    connections_arg->order(  );
     if (*this->connections != *connections_arg) {
         this->connections = connections_arg;
         //if (this->connections->allConnectionsShut()) {}

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -102,6 +102,12 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
     for (size_t k = 0; k < completions.size(); ++k) {
         BOOST_CHECK_EQUAL(completions.get( k ).getK(), k);
     }
+
+    // Output / input ordering
+    const auto& output_connections = completions.output(grid);
+    std::vector<int> expected = {0,2,3,4,5,6,7,8,1};
+    for (size_t k = 0; k < completions.size(); ++k)
+        BOOST_CHECK_EQUAL( expected[k], output_connections[k]->getK());
 }
 
 


### PR DESCRIPTION
1. If the well is MSW the ~~wells~~ connections in the WellConnection class is sorted in output
   order in the ::order() method, and retained that way.

2. Add method WellConnection::output() which return a vector of connection
   pointers sorted in output order.

The purpose of this is to recover the correct connection order when initializing the `WellConnections` from a restart file. Part of #1396