### PR TITLE
Add global_index to Connections

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -81,6 +81,7 @@ namespace RestartIO {
 
         Connection();
         Connection(int i, int j , int k ,
+                   std::size_t global_index,
                    int complnum,
                    double depth,
                    State state,
@@ -108,6 +109,7 @@ namespace RestartIO {
                    double r0,
                    double skinFactor,
                    const std::array<int,3>& IJK,
+                   std::size_t global_index,
                    CTFKind kind,
                    std::size_t seqIndex,
                    double segDistStart,
@@ -124,6 +126,7 @@ namespace RestartIO {
         int getI() const;
         int getJ() const;
         int getK() const;
+        std::size_t global_index() const;
         State state() const;
         Direction dir() const;
         double depth() const;
@@ -175,6 +178,7 @@ namespace RestartIO {
             serializer(m_r0);
             serializer(m_skin_factor);
             serializer(ijk);
+            serializer(m_global_index);
             serializer(m_ctfkind);
             serializer(m_seqIndex);
             serializer(m_segDistStart);
@@ -199,6 +203,7 @@ namespace RestartIO {
 
         std::array<int,3> ijk;
         CTFKind m_ctfkind;
+        std::size_t m_global_index;
         std::size_t m_seqIndex;
         double m_segDistStart;
         double m_segDistEnd;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -40,6 +40,7 @@ namespace Opm {
         // cppcheck-suppress noExplicitConstructor
         WellConnections(const WellConnections& src, const EclipseGrid& grid);
         void addConnection(int i, int j , int k ,
+                           std::size_t global_index,
                            double depth,
                            Connection::State state ,
                            double CF,
@@ -99,6 +100,7 @@ namespace Opm {
 
     private:
         void addConnection(int i, int j , int k ,
+                           std::size_t global_index,
                            int complnum,
                            double depth,
                            Connection::State state ,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -41,6 +41,7 @@ namespace Opm {
 
 
     Connection::Connection(int i, int j , int k ,
+                           std::size_t global_index,
                            int compnum,
                            double depth,
                            State stateArg ,
@@ -68,6 +69,7 @@ namespace Opm {
           m_skin_factor(skin_factor),
           ijk({i,j,k}),
           m_ctfkind(ctf_kind),
+          m_global_index(global_index),
           m_seqIndex(seqIndex),
           m_segDistStart(segDistStart),
           m_segDistEnd(segDistEnd),
@@ -115,6 +117,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
                            int satTableId, int complnum, double CF,
                            double Kh, double rw, double r0, double skinFactor,
                            const std::array<int,3>& IJK,
+                           std::size_t global_index,
                            CTFKind kind, std::size_t seqIndex,
                            double segDistStart, double segDistEnd,
                            bool defaultSatTabId, std::size_t compSegSeqIndex,
@@ -130,6 +133,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
         , m_r0(r0)
         , m_skin_factor(skinFactor)
         , ijk(IJK)
+        , m_global_index(global_index)
         , m_ctfkind(kind)
         , m_seqIndex(seqIndex)
         , m_segDistStart(segDistStart)
@@ -143,7 +147,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
     Connection::Connection()
           : Connection(Direction::X, 1.0, State::SHUT,
                        0, 0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                       {0,0,0}, CTFKind::Defaulted, 0, 0.0, 0.0, false, 0, 0, 0.0)
+                      {0,0,0},0, CTFKind::Defaulted, 0, 0.0, 0.0, false, 0, 0, 0.0)
     {}
 
     bool Connection::sameCoordinate(const int i, const int j, const int k) const {
@@ -164,6 +168,10 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
 
     int Connection::getK() const {
         return ijk[2];
+    }
+
+    std::size_t Connection::global_index() const {
+        return this->m_global_index;
     }
 
     bool Connection::attachedToSegment() const {
@@ -291,7 +299,8 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
 }
 
     bool Connection::operator==( const Connection& rhs ) const {
-        bool eq = this->ijk == rhs.ijk
+        return this->ijk == rhs.ijk
+            && this->m_global_index == rhs.m_global_index
             && this->m_complnum == rhs.m_complnum
             && this->m_CF == rhs.m_CF
             && this->m_rw == rhs.m_rw
@@ -305,10 +314,6 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
             && this->segment_number == rhs.segment_number
             && this->center_depth == rhs.center_depth
             && this->m_seqIndex == rhs.m_seqIndex;
-        if (!eq) {
-            //std::cout << this->str() << rhs.str() << std::endl;
-        }
-        return eq;
     }
 
     bool Connection::operator!=( const Connection& rhs ) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -153,6 +153,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
     }
 
     void WellConnections::addConnection(int i, int j , int k ,
+                                        std::size_t global_index,
                                         int complnum,
                                         double depth,
                                         Connection::State state,
@@ -171,7 +172,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
     {
         int conn_i = (i < 0) ? this->headI : i;
         int conn_j = (j < 0) ? this->headJ : j;
-        Connection conn(conn_i, conn_j, k, complnum, depth, state, CF, Kh, rw, r0,
+        Connection conn(conn_i, conn_j, k, global_index, complnum, depth, state, CF, Kh, rw, r0,
                         skin_factor, satTableId, direction, ctf_kind,
                         seqIndex, segDistStart, segDistEnd, defaultSatTabId);
         this->add(conn);
@@ -180,6 +181,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
 
 
     void WellConnections::addConnection(int i, int j , int k ,
+                                        std::size_t global_index,
                                         double depth,
                                         Connection::State state ,
                                         double CF,
@@ -199,6 +201,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         this->addConnection(i,
                             j,
                             k,
+                            global_index,
                             complnum,
                             depth,
                             state,
@@ -343,6 +346,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
             if (prev == this->m_connections.end()) {
                 std::size_t noConn = this->m_connections.size();
                 this->addConnection(I,J,k,
+                                    grid.getGlobalIndex(I,J,k),
                                     grid.getCellDepth( I,J,k ),
                                     state,
                                     CF,
@@ -360,6 +364,7 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                 double conSDEnd = prev->getSegDistEnd();
                 double depth = grid.getCellDepth(I,J,k);
                 *prev = Connection(I,J,k,
+                                   grid.getGlobalIndex(I,J,k),
                                    prev->complnum(),
                                    depth,
                                    state,

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -71,8 +71,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
-    Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true);
-    Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true);
+    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -86,8 +86,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
 BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
     Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
@@ -107,9 +107,9 @@ BOOST_AUTO_TEST_CASE(AddCompletionCopy) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
 
-    Opm::Connection completion1( 10,10,10, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion2( 10,10,11, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion3( 10,10,12, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion2( 10,10,11, 101, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion3( 10,10,12, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
 
     completionSet.add( completion1 );
     completionSet.add( completion2 );
@@ -130,9 +130,9 @@ BOOST_AUTO_TEST_CASE(ActiveCompletions) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::Defaulted;
     Opm::WellConnections completions(Opm::Connection::Order::TRACK, 10,10);
-    Opm::Connection completion1( 0,0,0, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion2( 0,0,1, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion3( 0,0,2, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion1( 0,0,0, grid.getGlobalIndex(0,0,0), 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion2( 0,0,1, grid.getGlobalIndex(0,0,1), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion3( 0,0,2, grid.getGlobalIndex(0,0,2), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
 
     completions.add( completion1 );
     completions.add( completion2 );

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -50,14 +50,14 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 0,grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 1,grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 2,grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 18, 0, 1,grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 17, 0, 1,grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 16, 0, 1,grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 15, 0, 1,grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -199,14 +199,14 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -256,14 +256,14 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -314,14 +314,14 @@ BOOST_AUTO_TEST_CASE(testwsegvalv) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3316,6 +3316,7 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
     BOOST_CHECK_EQUAL(connections.size(), 0);
     auto c2 = std::make_shared<WellConnections>(Connection::Order::TRACK, 1,1);
     c2->addConnection(1,1,1,
+                      grid1.getGlobalIndex(1,1,1),
                       100,
                       Connection::State::OPEN,
                       10,


### PR DESCRIPTION
To provide some safety for matching up simulated connection data and declared connection data when writing restart file.