### PR TITLE
Get connection rates from well rates object

### DIFF
--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -55,8 +55,9 @@ namespace {
 
     template <class ConnOp>
     void connectionLoop(const std::vector<Opm::Well>& wells,
-                        const Opm::EclipseGrid&        grid,
-                        ConnOp&&                       connOp)
+                        const Opm::EclipseGrid&       grid,
+                        const Opm::data::WellRates&   xw,
+                        ConnOp&&                      connOp)
     {
         for (auto nWell = wells.size(), wellID = 0*nWell;
              wellID < nWell; ++wellID)
@@ -83,11 +84,15 @@ namespace {
                                                         });
             }
 
-
-            for (auto nConn = connSI.size(), connID = 0*nConn;
-                 connID < nConn; ++connID)
+            const auto well_iter = xw.find(well.name());
+            const Opm::data::Well * well_rates = (well_iter == xw.end()) ? nullptr : &well_iter->second;
+            for (auto nConn = connSI.size(), connID = 0*nConn; connID < nConn; ++connID)
             {
-                connOp(well, wellID, *(connSI[connID]), connID);
+                const auto& conn = *(connSI[connID]);
+                if (well_rates)
+                    connOp(wellID, conn, connID, well_rates->find_connection(conn.global_index()));
+                else
+                    connOp(wellID, conn, connID, nullptr);
             }
         }
     }
@@ -281,61 +286,20 @@ captureDeclaredConnData(const Schedule&        sched,
                         const data::WellRates& xw,
                         const std::size_t      sim_step)
 {
-    using ConnectionRates = std::vector<const Opm::data::Connection*>;
     const auto& wells = sched.getWells(sim_step);
-    //
-    // construct a composite vector of connection objects  holding
-    // rates for all open connectons
-    //
-    std::map<std::string, ConnectionRates> allRates;
-    for (const auto& wl : wells) {
-        const auto conns = WellConnections(wl.getConnections(), grid);
-
-        allRates[wl.name()] = ConnectionRates{conns.size(), nullptr};
-        const auto rates_iter = xw.find(wl.name());
-        size_t rCInd = 0;
-        if (rates_iter != xw.end()) {
-            auto& well_rates = allRates[wl.name()];
-            for (auto nConn = conns.size(), connID = 0*nConn; connID < nConn; connID++) {
-                const auto& conn = conns[connID];
-
-                // WellRates connections are only defined for OPEN connections
-                if (conn.state() != Opm::Connection::State::OPEN)
-                    continue;
-
-                const auto& connection_rates = rates_iter->second.connections;
-
-                if (rCInd < connection_rates.size()) {
-                    well_rates[connID] = &(connection_rates[rCInd]);
-                    rCInd += 1;
-                } else
-                    throw std::invalid_argument {
-                        "Inconsistent number of open connections I in vector<Opm::data::Connection*> (" +
-                            std::to_string(connection_rates.size()) + ") in Well " + wl.name()
-                    };
-            }
-        }
-    }
-
-    connectionLoop(wells, grid, [&units, &allRates, this]
-        (const Well&      well, const std::size_t wellID,
-         const Connection& conn, const std::size_t connID) -> void
+    connectionLoop(wells, grid, xw, [&units, this]
+        (const std::size_t wellID,
+         const Connection& conn, const std::size_t connID,
+         const Opm::data::Connection* conn_rates) -> void
     {
         auto ic = this->iConn_(wellID, connID);
         auto sc = this->sConn_(wellID, connID);
 
         IConn::staticContrib(conn, connID, ic);
         SConn::staticContrib(conn, units, sc);
-
-        auto xi = allRates.find(well.name());
-        if ((xi != allRates.end()) &&
-            (connID < xi->second.size()))
-            //(connID < xi->second.connections.size()))
-        {
+        if (conn_rates) {
             auto xc = this->xConn_(wellID, connID);
-
-            //XConn::dynamicContrib(xi->second.connections[connID],
-            if (xi->second[connID]) XConn::dynamicContrib(*(xi->second[connID]), units, xc);
+            XConn::dynamicContrib(*conn_rates, units, xc);
         }
     });
 }

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -793,15 +793,15 @@ BOOST_AUTO_TEST_CASE(InactiveCell) {
         }
     }
 
-    // The XCON data consults the open/shut status of the connection. That
-    // should already be correct, i.e. shut, for an inactive cell. Hence no
-    // change in the XCON vector.
     {
         const auto xconn0 = conn0.getXConn();
         const auto xconn1 = conn1.getXConn();
         for (std::size_t conn_index = 0; conn_index < num_test_connections; conn_index++) {
             std::size_t offset1 = conn_index * ih.nxconz;
             std::size_t offset0 = offset1;
+
+            if (conn_index >= 2)
+                offset0 += ih.nxconz;
 
             for (std::size_t elm_index = 0; elm_index < ih.nxconz; elm_index++)
                 BOOST_CHECK_EQUAL(xconn1[offset1 + elm_index], xconn0[offset0 + elm_index]);


### PR DESCRIPTION
This is in top of #1615 

As part of #1396 - and specifically the MSW support the connections are shuffled around in different orders. With this PR the connection rates supplied from the simulator - and eventually output to the XCON vector - are assembled based on the global index of connection - thereby allowing different storage order in `WellConnections` and `data::Well::Connection` (and the restart file ....).

The (second to ...) last commit in this series changes a test (which I had written ....). Grateful if someone takes a look at that.

This PR also changes the XCON vector in the MSW test and will require an update_data before it can be merged. I argue that there is a bug in master for how the XCON data is distributed , and that this PR fixes the bug - but please double check my arguments (from current master):

1. Before actually writing the data to disk the connection rates are assembled into a temporary structure [here](https://github.com/OPM/opm-common/blob/master/src/opm/output/eclipse/AggregateConnectionData.cpp#L290). In this loop the connection rates are assembled with a `connID` integer index which applies to the connection ordering in `WellConnections`.

2. Before the connection data is actually written out to disk the connections are reordered [here](https://github.com/OPM/opm-common/blob/master/src/opm/output/eclipse/AggregateConnectionData.cpp#L73), and in [the loop](https://github.com/OPM/opm-common/blob/master/src/opm/output/eclipse/AggregateConnectionData.cpp#L87) the `connID` refers to elements in the reordered set of connections.

3. When the `XCON` data is eventually written out [here](https://github.com/OPM/opm-common/blob/master/src/opm/output/eclipse/AggregateConnectionData.cpp#L330) the `connID` index is used to look up both connection rates (original ordering) and actual connection objects and storage in the `XCON` vector (new ordering).

Update: the same problem applies to other tests as well, in that case due to `COMPORD` reordering.



