### PR TITLE
Parser.cpp: Include Missing Header

### DIFF
--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -21,11 +21,15 @@
 #define OPM_PARSER_HPP
 
 #include <iosfwd>
+#include <list>
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
-#include <list>
+
+#include <stddef.h>
+
 #include <opm/common/utility/FileSystem.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -22,6 +22,10 @@
 #include <iterator>
 #include <iomanip>
 #include <iostream>
+#include <stack>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <opm/common/utility/FileSystem.hpp>
 


### PR DESCRIPTION
The implementation uses `std::stack` and therefore needs a declaration of this type in scope.  This apparently built by accident earlier. While here, also include a few other headers to make `Parser.[hc]pp` more self-contained.