### PR TITLE
move data serialization objects close to the class code

### DIFF
--- a/opm/common/OpmLog/Location.hpp
+++ b/opm/common/OpmLog/Location.hpp
@@ -33,6 +33,15 @@ public:
         lineno(lno)
     {}
 
+    static Location serializeObject()
+    {
+        Location result;
+        result.filename = "test";
+        result.lineno = 1;
+
+        return result;
+    }
+
     bool operator==(const Location& data) const {
         return filename == data.filename &&
                lineno == data.lineno;

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -126,14 +126,9 @@ namespace Opm {
             using iterator = std::vector< DeckKeyword >::iterator;
 
             Deck();
-
             Deck( const Deck& );
-            Deck(const std::vector<DeckKeyword>& keywords,
-                 const UnitSystem& defUnits,
-                 const UnitSystem* activeUnits,
-                 const std::string& dataFile,
-                 const std::string& inputPath,
-                 size_t accessCount);
+
+            static Deck serializeObject();
 
             Deck& operator=(const Deck& rhs);
             bool operator==(const Deck& data) const;

--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -44,16 +44,8 @@ namespace Opm {
         DeckItem( const std::string&, UDAValue) = delete;
         DeckItem( const std::string&, UDAValue, const std::vector<Dimension>& active_dim, const std::vector<Dimension>& default_dim);
         DeckItem( const std::string&, double, const std::vector<Dimension>& active_dim, const std::vector<Dimension>& default_dim);
-        DeckItem(const std::vector<double>& dVec,
-                 const std::vector<int>& iVec,
-                 const std::vector<std::string>& sVec,
-                 const std::vector<UDAValue>& uVec,
-                 type_tag type,
-                 const std::string& itemName,
-                 const std::vector<value::status>& valueStat,
-                 bool rawdata,
-                 const std::vector<Dimension>& activeDim,
-                 const std::vector<Dimension>& defDim);
+
+        static DeckItem serializeObject();
 
         const std::string& name() const;
 

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -47,12 +47,8 @@ namespace Opm {
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<std::vector<DeckValue>>& record_list, UnitSystem& system_active, UnitSystem& system_default);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, UnitSystem& system_active, UnitSystem& system_default);
-        DeckKeyword(const std::string& kwName,
-                    const Location& loc,
-                    const std::vector<DeckRecord>& record,
-                    bool dataKw,
-                    bool slashTerminated);
 
+        static DeckKeyword serializeObject();
 
         const std::string& name() const;
         void setFixedSize();

--- a/opm/parser/eclipse/Deck/DeckRecord.hpp
+++ b/opm/parser/eclipse/Deck/DeckRecord.hpp
@@ -36,6 +36,8 @@ namespace Opm {
         DeckRecord() = default;
         DeckRecord( std::vector< DeckItem >&& );
 
+        static DeckRecord serializeObject();
+
         size_t size() const;
         void addItem( DeckItem deckItem );
 

--- a/opm/parser/eclipse/Deck/UDAValue.hpp
+++ b/opm/parser/eclipse/Deck/UDAValue.hpp
@@ -38,6 +38,8 @@ public:
     UDAValue(double data, const Dimension& dim);
     UDAValue(const std::string& data, const Dimension& dim);
 
+    static UDAValue serializeObject();
+
     /*
       The get<double>() and get<std::string>() methods will throw an
       exception if the internal type and the template parameter disagree.

--- a/opm/parser/eclipse/EclipseState/Aquancon.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquancon.hpp
@@ -82,6 +82,8 @@ namespace Opm {
             Aquancon(const EclipseGrid& grid, const Deck& deck);
             Aquancon(const std::unordered_map<int, std::vector<Aquancon::AquancCell>>& data);
 
+            static Aquancon serializeObject();
+
             const std::unordered_map<int, std::vector<Aquancon::AquancCell>>& data() const;
             bool operator==(const Aquancon& other) const;
             bool active() const;

--- a/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -110,6 +110,8 @@ namespace Opm {
         AquiferCT(const TableManager& tables, const Deck& deck);
         AquiferCT(const std::vector<AquiferCT::AQUCT_data>& data);
 
+        static AquiferCT serializeObject();
+
         std::size_t size() const;
         std::vector<AquiferCT::AQUCT_data>::const_iterator begin() const;
         std::vector<AquiferCT::AQUCT_data>::const_iterator end() const;

--- a/opm/parser/eclipse/EclipseState/AquiferConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/AquiferConfig.hpp
@@ -36,6 +36,8 @@ public:
     AquiferConfig(const TableManager& tables, const EclipseGrid& grid, const Deck& deck);
     AquiferConfig(const Aquifetp& fetp, const AquiferCT& ct, const Aquancon& conn);
 
+    static AquiferConfig serializeObject();
+
     bool active() const;
     const AquiferCT& ct() const;
     const Aquifetp& fetp() const;

--- a/opm/parser/eclipse/EclipseState/Aquifetp.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifetp.hpp
@@ -66,6 +66,9 @@ class Aquifetp {
     Aquifetp() = default;
     Aquifetp(const Deck& deck);
     Aquifetp(const std::vector<Aquifetp::AQUFETP_data>& data);
+
+    static Aquifetp serializeObject();
+
     const std::vector<Aquifetp::AQUFETP_data>& data() const;
 
     std::size_t size() const;

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -36,6 +36,8 @@ namespace Opm {
         EclipseConfig(const Deck& deck);
         EclipseConfig(const InitConfig& initConfig, const IOConfig& io_conf);
 
+        static EclipseConfig serializeObject();
+
         const InitConfig& init() const;
         IOConfig& io();
         const IOConfig& io() const;

--- a/opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp
+++ b/opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp
@@ -32,7 +32,8 @@ public:
     /// Construct from input deck
     explicit EDITNNC(const Deck& deck);
 
-    explicit EDITNNC(const std::vector<NNCdata>& data);
+    /// Returns an instance used for serialization test
+    static EDITNNC serializeObject();
 
     /// \brief Get an ordered set of EDITNNC
     const std::vector<NNCdata>& data() const

--- a/opm/parser/eclipse/EclipseState/EndpointScaling.hpp
+++ b/opm/parser/eclipse/EclipseState/EndpointScaling.hpp
@@ -29,7 +29,8 @@ class EndpointScaling {
     public:
         EndpointScaling() noexcept = default;
         explicit EndpointScaling( const Deck& );
-        EndpointScaling(const std::bitset<4>& opts);
+
+        static EndpointScaling serializeObject();
 
         /* true if endpoint scaling is enabled, otherwise false */
         operator bool() const noexcept;

--- a/opm/parser/eclipse/EclipseState/Grid/Fault.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Fault.hpp
@@ -34,9 +34,8 @@ class Fault {
 public:
     Fault() = default;
     explicit Fault(const std::string& faultName);
-    Fault(const std::string& name,
-           double transMult,
-           const std::vector<FaultFace>& faceList);
+
+    static Fault serializeObject();
 
     const  std::string& getName() const;
     void   setTransMult(double transMult);

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
@@ -36,7 +36,8 @@ class FaultCollection {
 public:
     FaultCollection();
     FaultCollection(const GRIDSection& gridSection, const GridDims& grid);
-    FaultCollection(const OrderedMap<std::string, Fault>& faults);
+
+    static FaultCollection serializeObject();
 
     size_t size() const;
     bool hasFault(const std::string& faultName) const;

--- a/opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp
@@ -35,7 +35,8 @@ public:
               size_t J1 , size_t J2,
               size_t K1 , size_t K2,
               FaceDir::DirEnum faceDir);
-    FaultFace(const std::vector<size_t>& indices, FaceDir::DirEnum faceDir);
+
+    static FaultFace serializeObject();
 
     std::vector<size_t>::const_iterator begin() const;
     std::vector<size_t>::const_iterator end() const;

--- a/opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
@@ -34,8 +34,9 @@ namespace Opm {
 
         GridDims();
         explicit GridDims(std::array<int, 3> xyz);
-
         GridDims(size_t nx, size_t ny, size_t nz);
+
+        static GridDims serializeObject();
 
         explicit GridDims(const Deck& deck);
 

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -94,11 +94,8 @@ namespace Opm {
         MULTREGTScanner(const GridDims& grid,
                         const FieldPropsManager* fp_arg,
                         const std::vector< const DeckKeyword* >& keywords);
-        MULTREGTScanner(const std::array<size_t,3>& size,
-                        const std::vector<MULTREGTRecord>& records,
-                        const ExternalSearchMap& searchMap,
-                        const std::map<std::string, std::vector<int>>& region,
-                        const std::string& defaultRegion);
+
+        static MULTREGTScanner serializeObject();
 
         double getRegionMultiplier(size_t globalCellIdx1, size_t globalCellIdx2, FaceDir::DirEnum faceDir) const;
 

--- a/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
@@ -64,7 +64,9 @@ public:
 
     /// Construct from input deck.
     explicit NNC(const Deck& deck);
-    explicit NNC(const std::vector<NNCdata>& nncdata) : m_nnc(nncdata) {}
+
+    static NNC serializeObject();
+
     void addNNC(const size_t cell1, const size_t cell2, const double trans);
     const std::vector<NNCdata>& data() const { return m_nnc; }
     size_t numNNC() const;

--- a/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
@@ -49,10 +49,8 @@ namespace Opm {
     public:
         TransMult() = default;
         TransMult(const GridDims& dims, const Deck& deck, const FieldPropsManager& fp);
-        TransMult(const std::array<size_t,3>& size,
-                  const std::map<FaceDir::DirEnum, std::vector<double>>& trans,
-                  const std::map<FaceDir::DirEnum, std::string>& names,
-                  const MULTREGTScanner& scanner);
+
+        static TransMult serializeObject();
 
         double getMultiplier(size_t globalIndex, FaceDir::DirEnum faceDir) const;
         double getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const;

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -151,15 +151,8 @@ namespace Opm {
         IOConfig() = default;
         explicit IOConfig( const Deck& );
         explicit IOConfig( const std::string& input_path );
-        IOConfig(bool write_init, bool write_egrid,
-                 bool unifin, bool unifout,
-                 bool fmtin, bool fmtout,
-                 const std::string& deck_name,
-                 bool output_enabled,
-                 const std::string& output_dir,
-                 bool no_sim,
-                 const std::string& base_name,
-                 bool ecl_compatible_rst);
+
+        static IOConfig serializeObject();
 
         void setEclCompatibleRST(bool ecl_rst);
         bool getEclCompatibleRST() const;

--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -298,6 +298,9 @@ namespace Opm {
             RestartSchedule() = default;
             explicit RestartSchedule( size_t sched_restart);
             RestartSchedule( size_t step, size_t b, size_t freq);
+
+            static RestartSchedule serializeObject();
+
             bool writeRestartFile( size_t timestep , const TimeMap& timemap) const;
             bool operator!=(const RestartSchedule& rhs) const;
             bool operator==( const RestartSchedule& rhs ) const;
@@ -330,12 +333,8 @@ namespace Opm {
         RestartConfig( const TimeMap& time_map, const Deck&, const ParseContext& parseContext, T&& errors );
         RestartConfig( const TimeMap& time_map, const Deck&, const ParseContext& parseContext, ErrorGuard& errors );
         RestartConfig( const TimeMap& time_map, const Deck& );
-        RestartConfig(const TimeMap& timeMap,
-                      int firstRestartStep,
-                      bool writeInitial,
-                      const DynamicState<RestartSchedule>& restart_sched,
-                      const DynamicState<std::map<std::string,int>>& restart_keyw,
-                      const std::vector<bool>& save_keyw);
+
+        static RestartConfig serializeObject();
 
         int  getFirstRestartStep() const;
         bool getWriteRestartFile(size_t timestep, bool log=true) const;

--- a/opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp
@@ -58,7 +58,8 @@ namespace Opm {
 
             Equil() = default;
             explicit Equil( const DeckKeyword& );
-            Equil(const std::vector<EquilRecord>& records);
+
+            static Equil serializeObject();
 
             const EquilRecord& getRecord( size_t id ) const;
 

--- a/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp
@@ -38,11 +38,8 @@ public:
     FoamData();
     FoamData(const DeckRecord& FOAMFSC_record, const DeckRecord& FOAMROCK_record);
     explicit FoamData(const DeckRecord& FOAMROCK_record);
-    FoamData(double reference_surfactant_concentration,
-             double exponent,
-             double minimum_surfactant_concentration,
-             bool allow_desorption,
-             double rock_density);
+
+    static FoamData serializeObject();
 
     double referenceSurfactantConcentration() const;
     double exponent() const;
@@ -82,9 +79,8 @@ public:
 
     FoamConfig() = default;
     explicit FoamConfig(const Deck&);
-    FoamConfig(const std::vector<FoamData>& data,
-               Phase transport_phase,
-               MobilityModel mobility_model);
+
+    static FoamConfig serializeObject();
 
     const FoamData& getRecord(std::size_t index) const;
 

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -34,9 +34,8 @@ namespace Opm {
     public:
         InitConfig();
         explicit InitConfig(const Deck& deck);
-        InitConfig(const Equil& equil, const FoamConfig& foam,
-                   bool filleps, bool gravity, bool restartReq, int restartStep,
-                   const std::string& restartRootName);
+
+        static InitConfig serializeObject();
 
         void setRestart( const std::string& root, int step);
         bool restartRequested() const;

--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -54,7 +54,8 @@ class Phases {
         Phases() noexcept = default;
         Phases( bool oil, bool gas, bool wat, bool solvent = false, bool polymer = false, bool energy = false,
                 bool polymw = false, bool foam = false, bool brine = false ) noexcept;
-        Phases(const std::bitset<NUM_PHASES_IN_ENUM>& bbits);
+
+        static Phases serializeObject();
 
         bool active( Phase ) const noexcept;
         size_t size() const noexcept;
@@ -82,8 +83,8 @@ class Welldims {
 public:
     Welldims() = default;
     explicit Welldims(const Deck& deck);
-    Welldims(int WMax, int CWMax, int WGMax, int GMax) :
-      nWMax(WMax), nCWMax(CWMax), nWGMax(WGMax), nGMax(GMax) {}
+
+    static Welldims serializeObject();
 
     int maxConnPerWell() const
     {
@@ -132,7 +133,8 @@ class WellSegmentDims {
 public:
     WellSegmentDims();
     explicit WellSegmentDims(const Deck& deck);
-    WellSegmentDims(int segWellMax, int segMax, int latBranchMax);
+
+    static WellSegmentDims serializeObject();
 
 
     int maxSegmentedWells() const
@@ -171,8 +173,8 @@ class EclHysterConfig
 public:
     EclHysterConfig() = default;
     explicit EclHysterConfig(const Deck& deck);
-    EclHysterConfig(bool active, int pcMod, int krMod);
 
+    static EclHysterConfig serializeObject();
 
     /*!
      * \brief Specify whether hysteresis is enabled or not.
@@ -232,6 +234,9 @@ public:
     SatFuncControls(const double tolcritArg,
                     ThreePhaseOilKrModel model);
 
+
+    static SatFuncControls serializeObject();
+
     double minimumRelpermMobilityThreshold() const
     {
         return this->tolcrit;
@@ -260,15 +265,8 @@ class Runspec {
 public:
     Runspec() = default;
     explicit Runspec( const Deck& );
-    Runspec(const Phases& act_phases,
-            const Tabdims& tabdims,
-            const EndpointScaling& endScale,
-            const Welldims& wellDims,
-            const WellSegmentDims& wsegDims,
-            const UDQParams& udqparams,
-            const EclHysterConfig& hystPar,
-            const Actdims& actDims,
-            const SatFuncControls& sfuncctrl);
+
+    static Runspec serializeObject();
 
     const UDQParams& udqParams() const noexcept;
     const Phases& phases() const noexcept;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.hpp
@@ -17,9 +17,8 @@ public:
     ASTNode(TokenType type_arg);
     ASTNode(double value);
     ASTNode(TokenType type_arg, FuncType func_type_arg, const std::string& func_arg, const std::vector<std::string>& arg_list_arg);
-    ASTNode(TokenType type_arg, FuncType ftype, const std::string& func_arg,
-            const std::vector<std::string>& args, double number,
-            const std::vector<ASTNode>& childs);
+
+    static ASTNode serializeObject();
 
     Action::Result eval(const Action::Context& context) const;
     Action::Value value(const Action::Context& context) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.hpp
@@ -28,8 +28,8 @@ class Actdims {
 public:
     Actdims();
     explicit Actdims(const Deck& deck);
-    Actdims(std::size_t keyw, std::size_t line_cnt,
-            std::size_t chars, std::size_t conds);
+
+    static Actdims serializeObject();
 
     std::size_t max_keywords() const;
     std::size_t max_line_count() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.hpp
@@ -44,7 +44,9 @@ class AST{
 public:
     AST() = default;
     explicit AST(const std::vector<std::string>& tokens);
-    AST(const std::shared_ptr<ASTNode>& cond);
+
+    static AST serializeObject();
+
     Result eval(const Context& context) const;
 
     bool operator==(const AST& data) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp
@@ -67,15 +67,8 @@ public:
     ActionX(const std::string& name, size_t max_run, double max_wait, std::time_t start_time);
     ActionX(const DeckKeyword& kw, std::time_t start_time);
     ActionX(const DeckRecord& record, std::time_t start_time);
-    ActionX(const std::string& nam,
-            size_t maxRun,
-            double minWait,
-            std::time_t startTime,
-            const std::vector<DeckKeyword>& keyword,
-            const AST& cond,
-            const std::vector<Condition>& conditions,
-            size_t runCount,
-            std::time_t lastRun);
+
+    static ActionX serializeObject();
 
     void addKeyword(const DeckKeyword& kw);
     bool ready(std::time_t sim_time) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp
@@ -40,6 +40,9 @@ class Actions {
 public:
     Actions() = default;
     Actions(const std::vector<ActionX>& action, const std::vector<PyAction>& pyactions);
+
+    static Actions serializeObject();
+
     size_t size() const;
     int max_input_lines() const;
     bool empty() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/PyAction.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/PyAction.hpp
@@ -41,6 +41,9 @@ public:
 
     PyAction() = default;
     PyAction(const std::string& name, RunCount run_count, const std::string& code);
+
+    static PyAction serializeObject();
+
     const std::string& code() const;
     const std::string& name() const;
     bool operator==(const PyAction& other) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
@@ -123,7 +123,9 @@ namespace Opm
     public:
         Events() = default;
         explicit Events(const TimeMap& timeMap);
-        explicit Events(const DynamicVector<uint64_t>& events);
+
+        static Events serializeObject();
+
         void addEvent(ScheduleEvents::Events event, size_t reportStep);
         bool hasEvent(uint64_t eventMask, size_t reportStep) const;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GConSale.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GConSale.hpp
@@ -72,8 +72,7 @@ namespace Opm {
             MaxProcedure max_proc;
         };
 
-        GConSale() = default;
-        GConSale(const std::map<std::string, GCONSALEGroup>& group);
+        static GConSale serializeObject();
         
         bool has(const std::string& name) const;
         const GCONSALEGroup& get(const std::string& name) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GConSump.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GConSump.hpp
@@ -63,8 +63,7 @@ namespace Opm {
             std::string network_node;
         };
 
-        GConSump() = default;
-        GConSump(const std::map<std::string, GCONSUMPGroup>& group);
+        static GConSump serializeObject();
 
         bool has(const std::string& name) const;
         const GCONSUMPGroup& get(const std::string& name) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -114,6 +114,8 @@ struct GroupInjectionProperties {
     std::string reinj_group;
     std::string voidage_group;
 
+    static GroupInjectionProperties serializeObject();
+
     int injection_controls = 0;
     bool operator==(const GroupInjectionProperties& other) const;
     bool operator!=(const GroupInjectionProperties& other) const;
@@ -157,6 +159,8 @@ struct GroupProductionProperties {
     GuideRateTarget guide_rate_def;
     double resv_target = 0;
 
+    static GroupProductionProperties serializeObject();
+
     int production_controls = 0;
     bool operator==(const GroupProductionProperties& other) const;
     bool operator!=(const GroupProductionProperties& other) const;
@@ -194,22 +198,8 @@ struct ProductionControls {
 
     Group();
     Group(const std::string& group_name, std::size_t insert_index_arg, std::size_t init_step_arg, double udq_undefined_arg, const UnitSystem& unit_system);
-    Group(const std::string& gname,
-          std::size_t insert_idx,
-          std::size_t initstep,
-          double udqUndef,
-          const UnitSystem& units,
-          GroupType gtype,
-          double groupEF,
-          bool transferGroupEF,
-          bool availableForGroupControl,
-          int vfp,
-          const std::string& parent,
-          const IOrderSet<std::string>& well,
-          const IOrderSet<std::string>& group,
-          const std::map<Phase, GroupInjectionProperties> &injProps,
-          const GroupProductionProperties& prodProps);
 
+    static Group serializeObject();
 
     bool defined(std::size_t timeStep) const;
     std::size_t insert_index() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp
@@ -71,10 +71,7 @@ struct GroupTarget {
     }
 };
 
-    GuideRateConfig() = default;
-    GuideRateConfig(std::shared_ptr<GuideRateModel> model,
-                    const std::unordered_map<std::string,WellTarget>& well,
-                    const std::unordered_map<std::string,GroupTarget>& group);
+    static GuideRateConfig serializeObject();
 
     const GuideRateModel& model() const;
     bool has_model() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
@@ -52,17 +52,10 @@ public:
                    bool allow_increase_arg,
                    double damping_factor_arg,
                    bool use_free_gas_arg);
-
-    GuideRateModel(double time_interval_arg,
-                   Target target_arg,
-                   const std::array<double,6>& coefs_arg,
-                   bool allow_increase_arg,
-                   double damping_factor_arg,
-                   bool use_free_gas_arg,
-                   bool use_default_model_arg,
-                   const std::array<UDAValue,3>& udaCoefs_arg);
-
     GuideRateModel() = default;
+
+    static GuideRateModel serializeObject();
+
     bool updateLINCOM(const UDAValue& alpha, const UDAValue& beta, const UDAValue& gamma);
     double eval(double oil_pot, double gas_pot, double wat_pot) const;
     double update_delay() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -51,24 +51,9 @@ namespace Opm {
         Segment(const Segment& src, double new_volume);
         Segment(int segment_number_in, int branch_in, int outlet_segment_in, double length_in, double depth_in,
                 double internal_diameter_in, double roughness_in, double cross_area_in, double volume_in, bool data_ready_in, SegmentType segment_type_in);
-
-
-        Segment(int segmentNumber,
-                int branchNumber,
-                int outlegSegment,
-                const std::vector<int>& inletSegments,
-                double totalLength,
-                double depth,
-                double internalDiameter,
-                double roughness,
-                double crossArea,
-                double volume,
-                bool dataReady,
-                SegmentType segmentType,
-                std::shared_ptr<SpiralICD> spiralICD,
-                std::shared_ptr<Valve> valv);
-
         Segment(const RestartIO::RstSegment& rst_segment);
+
+        static Segment serializeObject();
 
         int segmentNumber() const;
         int branchNumber() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp
@@ -49,6 +49,8 @@ namespace Opm {
                   ICDStatus status,
                   double scalingFactor);
 
+        static SpiralICD serializeObject();
+
         // the function will return a map
         // [
         //     "WELL1" : [<seg1, sicd1>, <seg2, sicd2> ...]

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp
@@ -47,6 +47,8 @@ namespace Opm {
               double pipeCrossA,
               ICDStatus stat);
 
+        static Valve serializeObject();
+
         // the function will return a map
         // [
         //     "WELL1" : [<seg1, valv1>, <seg2, valv2> ...]

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
@@ -66,6 +66,8 @@ namespace Opm {
                      const std::vector<Segment>& segments);
         explicit WellSegments(const DeckKeyword& keyword);
 
+        static WellSegments serializeObject();
+
         std::size_t size() const;
         double depthTopSegment() const;
         double lengthTopSegment() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
@@ -41,6 +41,24 @@ namespace Opm {
         int error_stop_limit    = ParserKeywords::MESSAGES::ERROR_STOP_LIMIT::defaultValue;
         int bug_stop_limit      = ParserKeywords::MESSAGES::BUG_STOP_LIMIT::defaultValue;
 
+        static MLimits serializeObject()
+        {
+            MLimits result;
+            result.message_print_limit = 1;
+            result.comment_print_limit = 2;
+            result.warning_print_limit = 3;
+            result.problem_print_limit = 4;
+            result.error_print_limit = 5;
+            result.bug_print_limit = 6;
+            result.message_stop_limit = 7;
+            result.comment_stop_limit = 8;
+            result.warning_stop_limit = 9;
+            result.problem_stop_limit = 10;
+            result.error_stop_limit = 11;
+            result.bug_stop_limit = 12;
+
+            return result;
+        }
 
         bool operator==(const MLimits& other) const {
             return  ((this->message_print_limit == other.message_print_limit) &&
@@ -92,7 +110,8 @@ namespace Opm {
         */
 
         explicit MessageLimits( const TimeMap& );
-        explicit MessageLimits( const DynamicState<MLimits>& );
+
+        static MessageLimits serializeObject();
 
         ///Get all the value from MESSAGES keyword.
         int getMessagePrintLimit(size_t timestep) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
@@ -42,12 +42,9 @@ namespace Opm
 
         OilVaporizationProperties();
         explicit OilVaporizationProperties(const size_t numPvtReginIdx);
-        OilVaporizationProperties(OilVaporization type,
-                                  double vap1,
-                                  double vap2,
-                                  const std::vector<double>& maxDRSDT,
-                                  const std::vector<bool>& maxDRSDT_allCells,
-                                  const std::vector<double>& maxDRVDT);
+
+        static OilVaporizationProperties serializeObject();
+
         static void updateDRSDT(Opm::OilVaporizationProperties& ovp, const std::vector<double>& maxDRSDT, const std::vector<std::string>& option);
         static void updateDRVDT(Opm::OilVaporizationProperties& ovp, const std::vector<double>& maxDRVDT);
         static void updateVAPPARS(Opm::OilVaporizationProperties& ovp, double vap1, double vap2);

--- a/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
@@ -59,15 +59,10 @@ public:
     using WellOpenTimeMap = std::unordered_map<std::string, std::size_t>;
 
     RFTConfig();
-    RFTConfig(const TimeMap& tm,
-              const std::size_t first_rft,
-              const std::pair<bool, std::size_t>& rftTime,
-              const WellOpenTimeMap& rftName,
-              const WellOpenTimeMap& wellOpen,
-              const ConfigMap<RFT>& rconfig,
-              const ConfigMap<PLT>& pconfig);
-
     explicit RFTConfig(const TimeMap& time_map);
+
+    static RFTConfig serializeObject();
+
     bool rft(const std::string& well, std::size_t report_step) const;
     bool plt(const std::string& well, std::size_t report_step) const;
     bool getWellOpenRFT(const std::string& well_name, std::size_t report_step) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -156,30 +156,7 @@ namespace Opm
                  const EclipseState& es,
                  const RestartIO::RstState* rst = nullptr);
 
-        Schedule(const TimeMap& timeMap,
-                 const WellMap& wellsStatic,
-                 const GroupMap& group,
-                 const DynamicState<OilVaporizationProperties>& oilVapProps,
-                 const Events& events,
-                 const DynamicVector<Deck>& modifierDeck,
-                 const DynamicState<Tuning>& tuning,
-                 const MessageLimits& messageLimits,
-                 const Runspec& runspec,
-                 const VFPProdMap& vfpProdTables,
-                 const VFPInjMap& vfpInjTables,
-                 const DynamicState<std::shared_ptr<WellTestConfig>>& wtestConfig,
-                 const DynamicState<std::shared_ptr<WListManager>>& wListManager,
-                 const DynamicState<std::shared_ptr<UDQConfig>>& udqConfig,
-                 const DynamicState<std::shared_ptr<UDQActive>>& udqActive,
-                 const DynamicState<std::shared_ptr<GuideRateConfig>>& guideRateConfig,
-                 const DynamicState<std::shared_ptr<GConSale>>& gconSale,
-                 const DynamicState<std::shared_ptr<GConSump>>& gconSump,
-                 const DynamicState<Well::ProducerCMode>& globalWhistCtlMode,
-                 const DynamicState<std::shared_ptr<Action::Actions>>& actions,
-                 const RFTConfig& rftconfig,
-                 const DynamicState<int>& nupCol,
-                 const RestartConfig& rst_config,
-                 const std::map<std::string,Events>& wellGroupEvents);
+        static Schedule serializeObject();
 
         /*
          * If the input deck does not specify a start time, Eclipse's 1. Jan

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
@@ -42,6 +42,8 @@ public:
     explicit WellType(Phase welspecs_phase);
     WellType() = default;
 
+    static WellType serializeObject();
+
     bool injector() const;
     bool producer() const;
     bool update(InjectorType injector_type);

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -43,6 +43,8 @@ namespace Opm {
         explicit TimeMap(const Deck& deck, const std::pair<std::time_t, std::size_t>& restart = std::make_pair(std::time_t{0}, std::size_t{0}));
         explicit TimeMap(const std::vector<std::time_t>& time_points);
 
+        static TimeMap serializeObject();
+
         size_t size() const;
         size_t last() const;
         size_t numTimesteps() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
@@ -27,6 +27,51 @@ namespace Opm {
     struct Tuning {
         using TuningKw = ParserKeywords::TUNING;
 
+        static Tuning serializeObject()
+        {
+            Tuning result;
+            result.TSINIT = 1.0;
+            result.TSMAXZ = 2.0;
+            result.TSMINZ = 3.0;
+            result.TSMCHP = 4.0;
+            result.TSFMAX = 5.0;
+            result.TSFMIN = 6.0;
+            result.TFDIFF = 7.0;
+            result.TSFCNV = 8.0;
+            result.THRUPT = 9.0;
+            result.TMAXWC = 10.0;
+            result.TMAXWC_has_value = true;
+
+            result.TRGTTE = 11.0;
+            result.TRGCNV = 12.0;
+            result.TRGMBE = 13.0;
+            result.TRGLCV = 14.0;
+            result.XXXTTE = 15.0;
+            result.XXXCNV = 16.0;
+            result.XXXMBE = 17.0;
+            result.XXXLCV = 18.0;
+            result.XXXWFL = 19.0;
+            result.TRGFIP = 20.0;
+            result.TRGSFT = 21.0;
+            result.TRGSFT_has_value = true;
+            result.THIONX = 22.0;
+            result.TRWGHT = 23.0;
+
+            result.NEWTMX = 24;
+            result.NEWTMN = 25;
+            result.LITMAX = 26;
+            result.LITMIN = 27;
+            result.MXWSIT = 28;
+            result.MXWPIT = 29;
+            result.DDPLIM = 30.0;
+            result.DDSLIM = 31.0;
+            result.TRGDPR = 32.0;
+            result.XXXDPR = 33.0;
+            result.XXXDPR_has_value = true;
+
+            return result;
+        }
+
         // Record1
         double TSINIT = TuningKw::TSINIT::defaultValue * Metric::Time;
         double TSMAXZ = TuningKw::TSMAXZ::defaultValue * Metric::Time;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
@@ -42,12 +42,8 @@ public:
     UDQASTNode(UDQTokenType type_arg, const std::string& func_name, const UDQASTNode& left, const UDQASTNode& right);
     UDQASTNode(UDQTokenType type_arg, const std::string& func_name);
     UDQASTNode(UDQTokenType type_arg, const std::string& string_value, const std::vector<std::string>& selector);
-    UDQASTNode(UDQVarType varType, UDQTokenType typ,
-               const std::string& stringVal,
-               double scalarVal,
-               const std::vector<std::string>& selectors,
-               const std::shared_ptr<UDQASTNode>& left_arg,
-               const std::shared_ptr<UDQASTNode>& right_arg);
+
+    static UDQASTNode serializeObject();
 
     UDQSet eval(UDQVarType eval_target, const UDQContext& context) const;
 
@@ -65,6 +61,7 @@ public:
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
+        serializer(var_type);
         serializer(type);
         serializer(string_value);
         serializer(selector);

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp
@@ -127,11 +127,8 @@ public:
         UDAControl control;
     };
 
-    UDQActive() = default;
-    UDQActive(const std::vector<InputRecord>& inputRecs,
-              const std::vector<Record>& outputRecs,
-              const std::unordered_map<std::string,std::size_t>& udqkeys,
-              const std::unordered_map<std::string,std::size_t>& wgkeys);
+    static UDQActive serializeObject();
+
     int update(const UDQConfig& udq_config, const UDAValue& uda, const std::string& wgname, UDAControl control);
     std::size_t IUAD_size() const;
     std::size_t IUAP_size() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
@@ -58,9 +58,8 @@ public:
 
     UDQAssign();
     UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value);
-    UDQAssign(const std::string& keyword,
-              UDQVarType varType,
-              const std::vector<AssignRecord>& records);
+
+    static UDQAssign serializeObject();
 
     const std::string& keyword() const;
     UDQVarType var_type() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -43,14 +43,8 @@ namespace Opm {
         UDQConfig() = default;
         explicit UDQConfig(const Deck& deck);
         explicit UDQConfig(const UDQParams& params);
-        UDQConfig(const UDQParams& params,
-                  const UDQFunctionTable& funcTable,
-                  const std::unordered_map<std::string, UDQDefine>& definition,
-                  const std::unordered_map<std::string, UDQAssign>& assignment,
-                  const std::unordered_map<std::string, std::string>& unit,
-                  const OrderedMap<std::string, UDQIndex>& inputIdx,
-                  const std::map<UDQVarType, std::size_t>& tCount);
 
+        static UDQConfig serializeObject();
 
         const std::string& unit(const std::string& key) const;
         bool has_unit(const std::string& keyword) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
@@ -62,6 +62,8 @@ public:
               UDQVarType type,
               const std::string& string_data);
 
+    static UDQDefine serializeObject();
+
     UDQSet eval(const UDQContext& context) const;
     const std::string& keyword() const;
     const std::string& input_string() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
@@ -42,6 +42,17 @@ public:
     {
     }
 
+    static UDQIndex serializeObject()
+    {
+        UDQIndex result;
+        result.insert_index = 1;
+        result.typed_insert_index = 2;
+        result.action = UDQAction::ASSIGN;
+        result.var_type = UDQVarType::WELL_VAR;
+
+        return result;
+    }
+
     bool operator==(const UDQIndex& data) const {
         return insert_index == data.insert_index &&
                typed_insert_index == data.typed_insert_index &&

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp
@@ -32,9 +32,8 @@ namespace Opm {
     public:
         explicit UDQParams(const Deck& deck);
         UDQParams();
-        UDQParams(bool reseed, int seed,
-                  double range, double undefined,
-                  double cmp);
+
+        static UDQParams serializeObject();
 
         bool reseed() const;
         int rand_seed() const noexcept;

--- a/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp
@@ -43,14 +43,9 @@ public:
 
 
     VFPInjTable();
-    VFPInjTable(int table_num,
-                double datum_depth,
-                FLO_TYPE flo_type,
-                const std::vector<double>& flo_data,
-                const std::vector<double>& thp_data,
-                const array_type& data);
-
     VFPInjTable(const DeckKeyword& table, const UnitSystem& deck_unit_system);
+
+    static VFPInjTable serializeObject();
 
     inline int getTableNum() const {
         return m_table_num;

--- a/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp
@@ -70,6 +70,7 @@ public:
     };
 
     VFPProdTable();
+    VFPProdTable( const DeckKeyword& table, const UnitSystem& deck_unit_system);
     VFPProdTable(int table_num,
                  double datum_depth,
                  FLO_TYPE flo_type,
@@ -83,7 +84,7 @@ public:
                  const std::vector<double>& alq_data,
                  const array_type& data);
 
-    VFPProdTable( const DeckKeyword& table, const UnitSystem& deck_unit_system);
+    static VFPProdTable serializeObject();
 
     inline int getTableNum() const {
         return m_table_num;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -98,28 +98,9 @@ namespace RestartIO {
                    const double segDistEnd,
                    const bool defaultSatTabId);
 
-        Connection(Direction dir,
-                   double depth,
-                   State state,
-                   int satTableId,
-                   int complnum,
-                   double CF,
-                   double Kh,
-                   double rw,
-                   double r0,
-                   double skinFactor,
-                   const std::array<int,3>& IJK,
-                   std::size_t global_index,
-                   CTFKind kind,
-                   std::size_t seqIndex,
-                   double segDistStart,
-                   double segDistEnd,
-                   bool defaultSatTabId,
-                   std::size_t compSegSeqIndex,
-                   int segment,
-                   double wellPi);
-
         Connection(const RestartIO::RstConnection& rst_connection, std::size_t insert_index, const EclipseGrid& grid, const FieldPropsManager& fp);
+
+        static Connection serializeObject();
 
         bool attachedToSegment() const;
         bool sameCoordinate(const int i, const int j, const int k) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp
@@ -28,7 +28,9 @@ class WList;
 class WListManager {
 public:
     WListManager() = default;
-    WListManager(const std::map<std::string,WList>& list);
+
+    static WListManager serializeObject();
+
     bool hasList(const std::string&) const;
     WList& getList(const std::string& name);
     const WList& getList(const std::string& name) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -155,6 +155,17 @@ public:
         GuideRateTarget guide_phase;
         double scale_factor;
 
+        static WellGuideRate serializeObject()
+        {
+            WellGuideRate result;
+            result.available = true;
+            result.guide_rate = 1.0;
+            result.guide_phase = GuideRateTarget::COMB;
+            result.scale_factor = 2.0;
+
+            return result;
+        }
+
         bool operator==(const WellGuideRate& data) const {
             return available == data.available &&
                    guide_rate == data.guide_rate &&
@@ -225,21 +236,8 @@ public:
 
         WellInjectionProperties();
         WellInjectionProperties(const UnitSystem& units, const std::string& wname);
-        WellInjectionProperties(const std::string& wname,
-                                const UDAValue& surfaceInjRate,
-                                const UDAValue& reservoirInjRate,
-                                const UDAValue& BHP,
-                                const UDAValue& THP,
-                                double bhp_hist,
-                                double thp_hist,
-                                double temp,
-                                double bhph,
-                                double thph,
-                                int vfpTableNum,
-                                bool predMode,
-                                int injControls,
-                                InjectorType injType,
-                                InjectorCMode ctrlMode);
+
+        static WellInjectionProperties serializeObject();
 
         void handleWELTARG(WELTARGCMode cmode, double newValue, double SIFactorP);
         void handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name);
@@ -351,24 +349,8 @@ public:
 
         WellProductionProperties();
         WellProductionProperties(const UnitSystem& units, const std::string& name_arg);
-        WellProductionProperties(const std::string& wname,
-                                 const UDAValue& oilRate,
-                                 const UDAValue& waterRate,
-                                 const UDAValue& gasRate,
-                                 const UDAValue& liquidRate,
-                                 const UDAValue& resvRate,
-                                 const UDAValue& BHP,
-                                 const UDAValue& THP,
-                                 double bhp_hist,
-                                 double thp_hist,
-                                 double bhph,
-                                 double thph,
-                                 int vfpTableNum,
-                                 double alqValue,
-                                 bool predMode,
-                                 ProducerCMode ctrlMode,
-                                 ProducerCMode whistctlMode,
-                                 int prodCtrls);
+
+        static WellProductionProperties serializeObject();
 
         bool hasProductionControl(ProducerCMode controlModeArg) const {
             return (m_productionControls & static_cast<int>(controlModeArg)) != 0;
@@ -454,33 +436,7 @@ public:
          const UnitSystem& unit_system,
          double udq_undefined);
 
-    Well(const std::string& wname,
-         const std::string& gname,
-         std::size_t init_step,
-         std::size_t insert_index,
-         int headI,
-         int headJ,
-         double ref_depth,
-         const WellType& wtype_arg,
-         const UnitSystem& unit_system,
-         double udq_undefined,
-         Status status,
-         double drainageRadius,
-         bool allowCrossFlow,
-         bool automaticShutIn,
-         const WellGuideRate& guideRate,
-         double efficiencyFactor,
-         double solventFraction,
-         bool prediction_mode,
-         std::shared_ptr<WellEconProductionLimits> econLimits,
-         std::shared_ptr<WellFoamProperties> foamProperties,
-         std::shared_ptr<WellPolymerProperties> polymerProperties,
-         std::shared_ptr<WellBrineProperties> brineProperties,
-         std::shared_ptr<WellTracerProperties> tracerProperties,
-         std::shared_ptr<WellConnections> connections,
-         std::shared_ptr<WellProductionProperties> production,
-         std::shared_ptr<WellInjectionProperties> injection,
-         std::shared_ptr<WellSegments> segments);
+    static Well serializeObject();
 
     bool isMultiSegment() const;
     bool isAvailableForGroupControl() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellBrineProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellBrineProperties.hpp
@@ -28,9 +28,12 @@ class DeckRecord;
 struct WellBrineProperties
 {
     double m_saltConcentration = 0.0;
+
     void handleWSALT(const DeckRecord& rec);
     bool operator!=(const WellBrineProperties& other) const;
     bool operator==(const WellBrineProperties& other) const;
+
+    static WellBrineProperties serializeObject();
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -37,6 +37,8 @@ namespace Opm {
         WellConnections(Connection::Order ordering, int headI, int headJ,
                         const std::vector<Connection>& connections);
 
+        static WellConnections serializeObject();
+
         // cppcheck-suppress noExplicitConstructor
         WellConnections(const WellConnections& src, const EclipseGrid& grid);
         void addConnection(int i, int j , int k ,

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.hpp
@@ -55,17 +55,8 @@ namespace Opm {
 
         explicit WellEconProductionLimits(const DeckRecord& record);
         WellEconProductionLimits();
-        WellEconProductionLimits(double minOilRate, double minGasRate,
-                                 double maxWaterCut, double maxGasOilRatio,
-                                 double maxWaterGasRatio,
-                                 EconWorkover workover, bool endRun,
-                                 const std::string& followonWell,
-                                 QuantityLimit quantityLimit,
-                                 double secondaryMaxWaterCut,
-                                 EconWorkover workoverSecondary,
-                                 double maxGasLiquidRatio,
-                                 double minLiquidRate, double maxTemperature,
-                                 double minReservoirFluidRate);
+
+        static WellEconProductionLimits serializeObject();
 
         // TODO: not handling things related to m_secondary_max_water_cut
         // for the moment.

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellFoamProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellFoamProperties.hpp
@@ -27,6 +27,8 @@ class DeckRecord;
 
 struct WellFoamProperties
 {
+    static WellFoamProperties serializeObject();
+
     double m_foamConcentration = 0.0;
     void handleWFOAM(const DeckRecord& rec);
     bool operator==(const WellFoamProperties& other) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.hpp
@@ -26,21 +26,16 @@ namespace Opm {
     class DeckRecord;
 
     struct WellPolymerProperties {
-        double m_polymerConcentration;
-        double m_saltConcentration;
-        int m_plymwinjtable;
-        int m_skprwattable;
-        int m_skprpolytable;
+        double m_polymerConcentration = 0.0;
+        double m_saltConcentration = 0.0;
+        int m_plymwinjtable = -1;
+        int m_skprwattable = -1;
+        int m_skprpolytable = -1;
 
-        WellPolymerProperties(double polymerConcentration,
-                              double saltConcentration,
-                              int plymwinjtable,
-                              int skprwattable,
-                              int skprpolytable);
+        static WellPolymerProperties serializeObject();
 
         bool operator==(const WellPolymerProperties& other) const;
         bool operator!=(const WellPolymerProperties& other) const;
-        WellPolymerProperties();
         void handleWPOLYMER(const DeckRecord& record);
         void handleWPMITAB(const DeckRecord& record);
         void handleWSKPTAB(const DeckRecord& record);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp
@@ -68,7 +68,8 @@ public:
     };
 
     WellTestConfig();
-    WellTestConfig(const std::vector<WTESTWell>& well);
+
+    static WellTestConfig serializeObject();
 
     void add_well(const std::string& well, Reason reason, double test_interval, int num_test, double startup_time, int current_step);
     void add_well(const std::string& well, const std::string& reasons, double test_interval,

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTracerProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTracerProperties.hpp
@@ -28,9 +28,7 @@ namespace Opm {
     class WellTracerProperties {
 
     public:
-        using ConcentrationMap = std::map<std::string,double>;
-        WellTracerProperties();
-        WellTracerProperties(const std::map<std::string,double>& concentrations);
+        static WellTracerProperties serializeObject();
 
         void setConcentration(const std::string& name, const double& concentration);
         double getConcentration(const std::string& name) const;
@@ -45,7 +43,7 @@ namespace Opm {
         }
 
     private:
-        ConcentrationMap m_tracerConcentrations;
+        std::map<std::string,double> m_tracerConcentrations;
     };
 
 }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
@@ -58,16 +58,11 @@ public:
         BCComponent component;
         double rate;
 
-
         BCFace() = default;
         BCFace(const DeckRecord& record);
-        BCFace(std::size_t i1_arg, std::size_t i2_arg,
-               std::size_t j1_arg, std::size_t j2_arg,
-               std::size_t k1_arg, std::size_t k2_arg,
-               BCType type_arg,
-               FaceDir::DirEnum dir_arg,
-               BCComponent comp_arg,
-               double rate_arg);
+
+        static BCFace serializeObject();
+
         bool operator==(const BCFace& other) const;
 
         template<class Serializer>
@@ -88,9 +83,10 @@ public:
 
 
     BCConfig() = default;
-    explicit BCConfig(const std::vector<BCFace>& input_faces);
     explicit BCConfig(const Deck& deck);
-    const std::vector<BCConfig::BCFace>& faces() const;
+
+    static BCConfig serializeObject();
+
     std::size_t size() const;
     std::vector<BCFace>::const_iterator begin() const;
     std::vector<BCFace>::const_iterator end() const;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
@@ -61,7 +61,8 @@ struct RockComp {
 
     RockConfig() = default;
     RockConfig(const Deck& deck, const FieldPropsManager& fp);
-    RockConfig(bool active, const std::vector<RockComp>& comp, const std::string& num_prop, std::size_t num_rock_tables, bool water_compaction, Hysteresis hyst);
+
+    static RockConfig serializeObject();
 
     bool active() const;
     const std::vector<RockConfig::RockComp>& comp() const;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -37,10 +37,8 @@ namespace Opm {
         SimulationConfig(bool restart,
                          const Deck& deck,
                          const FieldPropsManager& fp);
-        SimulationConfig(const ThresholdPressure& thresholdPressure,
-                         const BCConfig& bc,
-                         const RockConfig& rock_config,
-                         bool useCPR, bool DISGAS, bool VAPOIL, bool isThermal);
+
+        static SimulationConfig serializeObject();
 
         const RockConfig& rock_config() const;
         const ThresholdPressure& getThresholdPressure() const;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -39,11 +39,10 @@ namespace Opm {
                           const Deck& deck,
                           const FieldPropsManager& fp);
 
-        ThresholdPressure(bool active, bool restart,
-                          const ThresholdPressureTable& thpTable,
-                          const PressureTable& pTable);
-
         ThresholdPressure() { m_active = m_restart = false; }
+
+        //! \brief Returns an instance for serialization tests.
+        static ThresholdPressure serializeObject();
 
         /*
           The hasRegionBarrier() method checks if a threshold pressure

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -53,6 +53,8 @@ namespace Opm {
         SummaryConfigNode() = default;
         explicit SummaryConfigNode(std::string keyword, const Category cat, Location loc_arg);
 
+        static SummaryConfigNode serializeObject();
+
         SummaryConfigNode& parameterType(const Type type);
         SummaryConfigNode& namedEntity(std::string name);
         SummaryConfigNode& number(const int num);
@@ -150,6 +152,7 @@ namespace Opm {
                           const std::set<std::string>& shortKwds,
                           const std::set<std::string>& smryKwds);
 
+            static SummaryConfig serializeObject();
 
             const_iterator begin() const;
             const_iterator end() const;

--- a/opm/parser/eclipse/EclipseState/Tables/Aqudims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Aqudims.hpp
@@ -46,19 +46,6 @@ namespace Opm {
             
         { }
 
-        Aqudims(size_t mxnaqn, size_t mxnaqc, size_t niftbl, size_t nriftb,
-                size_t nanaqu, size_t ncamax, size_t mxnali, size_t mxaaql) :
-            m_mxnaqn(mxnaqn),
-            m_mxnaqc(mxnaqc),
-            m_niftbl(niftbl),
-            m_nriftb(nriftb),
-            m_nanaqu(nanaqu),
-            m_ncamax(ncamax),
-            m_mxnali(mxnali),
-            m_mxaaql(mxaaql)
-
-        { }
-
         explicit Aqudims(const Deck& deck) :
             Aqudims()
         {
@@ -73,6 +60,21 @@ namespace Opm {
                 m_mxnali  = record.getItem("MXNALI").get<int>(0);
                 m_mxaaql  = record.getItem("MXAAQL").get<int>(0);
             }
+        }
+
+        static Aqudims serializeObject()
+        {
+            Aqudims result;
+            result.m_mxnaqn = 1;
+            result.m_mxnaqc = 2;
+            result.m_niftbl = 3;
+            result.m_nriftb = 4;
+            result.m_nanaqu = 5;
+            result.m_ncamax = 6;
+            result.m_mxnali = 7;
+            result.m_mxaaql = 8;
+
+            return result;
         }
 
         size_t getNumAqunum() const

--- a/opm/parser/eclipse/EclipseState/Tables/BrineDensityTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/BrineDensityTable.hpp
@@ -26,8 +26,7 @@ namespace Opm {
 
     class BrineDensityTable {
     public:
-        BrineDensityTable();
-        BrineDensityTable(const std::vector<double>& tableValues);
+        static BrineDensityTable serializeObject();
 
         void init(const Opm::DeckRecord& record);
         const std::vector<double>& getBrineDensityColumn() const;

--- a/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp
@@ -33,6 +33,9 @@ namespace Opm {
         ColumnSchema();
         ColumnSchema(const std::string& name , Table::ColumnOrderEnum order, Table::DefaultAction defaultAction);
         ColumnSchema(const std::string& name , Table::ColumnOrderEnum order, double defaultValue);
+
+        static ColumnSchema serializeObject();
+
         const std::string& name() const;
         bool validOrder( double value1 , double value2) const;
         bool lookupValid( ) const;

--- a/opm/parser/eclipse/EclipseState/Tables/DenT.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/DenT.hpp
@@ -51,9 +51,9 @@ namespace Opm {
 
         DenT() = default;
         explicit DenT(const DeckKeyword& keyword);
-        explicit DenT(const std::vector<DenT::entry>& records_arg);
 
-        const std::vector<DenT::entry>& records() const;
+        static DenT serializeObject();
+
         const entry& operator[](const std::size_t index) const;
         bool operator==(const DenT& other) const;
         std::size_t size() const;

--- a/opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp
@@ -48,6 +48,11 @@ namespace Opm {
             m_nstrvd( nstrvd )
         { }
 
+        static Eqldims serializeObject()
+        {
+            return Eqldims(1, 2, 3, 4, 5);
+        }
+
         size_t getNumEquilRegions() const
         {
             return m_ntequl;

--- a/opm/parser/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -44,6 +44,11 @@ struct DENSITYRecord {
 
 struct DensityTable : public FlatTable< DENSITYRecord > {
     using FlatTable< DENSITYRecord >::FlatTable;
+
+    static DensityTable serializeObject()
+    {
+        return DensityTable({{1.0, 2.0, 3.0}});
+    }
 };
 
 struct PVTWRecord {
@@ -76,6 +81,11 @@ struct PVTWRecord {
 
 struct PvtwTable : public FlatTable< PVTWRecord > {
     using FlatTable< PVTWRecord >::FlatTable;
+
+    static PvtwTable serializeObject()
+    {
+        return PvtwTable({{1.0, 2.0, 3.0, 4.0, 5.0}});
+    }
 };
 
 struct ROCKRecord {
@@ -99,6 +109,11 @@ struct ROCKRecord {
 
 struct RockTable : public FlatTable< ROCKRecord > {
     using FlatTable< ROCKRecord >::FlatTable;
+
+    static RockTable serializeObject()
+    {
+        return RockTable({{1.0, 2.0}});
+    }
 };
 
 struct PVCDORecord {
@@ -131,6 +146,11 @@ struct PVCDORecord {
 
 struct PvcdoTable : public FlatTable< PVCDORecord > {
     using FlatTable< PVCDORecord >::FlatTable;
+
+    static PvcdoTable serializeObject()
+    {
+        return PvcdoTable({{1.0, 2.0, 3.0, 4.0, 5.0}});
+    }
 };
 
 struct PlmixparRecord {
@@ -151,6 +171,11 @@ struct PlmixparRecord {
 
 struct PlmixparTable : public FlatTable< PlmixparRecord> {
     using FlatTable< PlmixparRecord >::FlatTable;
+
+    static PlmixparTable serializeObject()
+    {
+        return PlmixparTable({PlmixparRecord{1.0}});
+    }
 };
 
 struct PlyvmhRecord {
@@ -180,6 +205,11 @@ struct PlyvmhRecord {
 
 struct PlyvmhTable : public FlatTable<PlyvmhRecord> {
     using FlatTable< PlyvmhRecord >::FlatTable;
+
+    static PlyvmhTable serializeObject()
+    {
+        return PlyvmhTable({{1.0, 2.0, 3.0, 4.0}});
+    }
 };
 
 struct ShrateRecord {
@@ -200,6 +230,11 @@ struct ShrateRecord {
 
 struct ShrateTable : public FlatTable<ShrateRecord> {
     using FlatTable< ShrateRecord >::FlatTable;
+
+    static ShrateTable serializeObject()
+    {
+        return ShrateTable({ShrateRecord{1.0}});
+    }
 };
 
 struct Stone1exRecord {
@@ -220,6 +255,11 @@ struct Stone1exRecord {
 
 struct Stone1exTable : public FlatTable<Stone1exRecord> {
     using FlatTable< Stone1exRecord >::FlatTable;
+
+    static Stone1exTable serializeObject()
+    {
+        return Stone1exTable({Stone1exRecord{1.0}});
+    }
 };
 
 struct TlmixparRecord {
@@ -243,6 +283,11 @@ struct TlmixparRecord {
 
 struct TlmixparTable : public FlatTable< TlmixparRecord> {
     using FlatTable< TlmixparRecord >::FlatTable;
+
+    static TlmixparTable serializeObject()
+    {
+        return TlmixparTable({{1.0, 2.0}});
+    }
 };
 
 struct VISCREFRecord {
@@ -266,6 +311,11 @@ struct VISCREFRecord {
 
 struct ViscrefTable : public FlatTable< VISCREFRecord > {
     using FlatTable< VISCREFRecord >::FlatTable;
+
+    static ViscrefTable serializeObject()
+    {
+        return ViscrefTable({{1.0, 2.0}});
+    }
 };
 
 struct WATDENTRecord {
@@ -292,6 +342,11 @@ struct WATDENTRecord {
 
 struct WatdentTable : public FlatTable< WATDENTRecord > {
     using FlatTable< WATDENTRecord >::FlatTable;
+
+    static WatdentTable serializeObject()
+    {
+        return WatdentTable({{1.0, 2.0, 3.0}});
+    }
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Tables/JFunc.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/JFunc.hpp
@@ -34,8 +34,8 @@ public:
 
     JFunc();
     explicit JFunc(const Deck& deck);
-    JFunc(Flag flag, double ow, double go,
-          double alpha, double beta, Direction dir);
+
+    static JFunc serializeObject();
 
     double alphaFactor() const;
     double betaFactor() const;

--- a/opm/parser/eclipse/EclipseState/Tables/PlymwinjTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlymwinjTable.hpp
@@ -27,13 +27,10 @@ namespace Opm {
 
     class PlymwinjTable : public PolyInjTable {
     public:
-
         PlymwinjTable() = default;
-        PlymwinjTable(const std::vector<double>& throughputs,
-                      const std::vector<double>& velocities,
-                      int tableNumber,
-                      const std::vector<std::vector<double>>& data);
         explicit PlymwinjTable(const DeckKeyword& table);
+
+        static PlymwinjTable serializeObject();
 
         const std::vector<std::vector<double>>& getMoleWeights() const;
         bool operator==(const PlymwinjTable& data) const;

--- a/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -34,14 +34,8 @@ namespace Opm {
 
         PlyshlogTable() = default;
         PlyshlogTable(const DeckRecord& indexRecord, const DeckRecord& dataRecord);
-        PlyshlogTable(const TableSchema& schema,
-                      const OrderedMap<std::string, TableColumn>& columns,
-                      bool jfunc,
-                      double refPolymerConcentration,
-                      double refSalinity,
-                      double refTemperature,
-                      bool hasRefSalinity,
-                      bool hasRefTemperature);
+
+        static PlyshlogTable serializeObject();
 
         double getRefPolymerConcentration() const;
         double getRefSalinity() const;

--- a/opm/parser/eclipse/EclipseState/Tables/PolyInjTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PolyInjTable.hpp
@@ -43,12 +43,7 @@ namespace Opm {
 
     class PolyInjTable {
     public:
-
-        PolyInjTable() = default;
-        PolyInjTable(const std::vector<double>& throughputs,
-                     const std::vector<double>& velocities,
-                     int tableNumber,
-                     const std::vector<std::vector<double>>& data);
+        static PolyInjTable serializeObject();
 
         int getTableNumber() const;
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp
@@ -29,12 +29,8 @@ namespace Opm {
     public:
         PvtgTable() = default;
         PvtgTable( const DeckKeyword& keyword, size_t tableIdx);
-        PvtgTable(const ColumnSchema& outer_schema,
-                  const TableColumn& outer_column,
-                  const TableSchema& undersat_schema,
-                  const TableSchema& sat_schema,
-                  const std::vector<SimpleTable>& undersat_tables,
-                  const SimpleTable& sat_table);
+
+        static PvtgTable serializeObject();
 
         bool operator==(const PvtgTable& data) const;
     };

--- a/opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp
@@ -29,12 +29,8 @@ namespace Opm {
     public:
         PvtoTable() = default;
         PvtoTable(const DeckKeyword& keyword, size_t tableIdx);
-        PvtoTable(const ColumnSchema& outer_schema,
-                  const TableColumn& outer_column,
-                  const TableSchema& undersat_schema,
-                  const TableSchema& sat_schema,
-                  const std::vector<SimpleTable>& undersat_tables,
-                  const SimpleTable& sat_table);
+
+        static PvtoTable serializeObject();
 
         bool operator==(const PvtoTable& data) const;
     };

--- a/opm/parser/eclipse/EclipseState/Tables/PvtwsaltTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtwsaltTable.hpp
@@ -28,9 +28,8 @@ namespace Opm {
     class PvtwsaltTable {
     public:
         PvtwsaltTable();
-        PvtwsaltTable(double refPressValue,
-                      double refSaltConValue,
-                      const std::vector<double>& tableValues);
+
+        static PvtwsaltTable serializeObject();
 
         void init(const Opm::DeckRecord& record0, const Opm::DeckRecord& record1);
         size_t size() const;

--- a/opm/parser/eclipse/EclipseState/Tables/PvtxTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtxTable.hpp
@@ -113,14 +113,10 @@ The first row actually corresponds to saturated values.
         static std::vector<std::pair<size_t , size_t> > recordRanges( const DeckKeyword& keyword);
 
         PvtxTable() = default;
-        PvtxTable(const ColumnSchema& outer_schema,
-                  const TableColumn& outer_column,
-                  const TableSchema& undersat_schema,
-                  const TableSchema& sat_schema,
-                  const std::vector<SimpleTable>& undersat_tables,
-                  const SimpleTable& sat_table);
-
         explicit PvtxTable(const std::string& columnName);
+
+        static PvtxTable serializeObject();
+
         const SimpleTable& getUnderSaturatedTable(size_t tableNumber) const;
         void init(const DeckKeyword& keyword, size_t tableIdx);
         size_t size() const;

--- a/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
@@ -47,6 +47,12 @@ namespace Opm {
             m_NPLMIX( nplmix )
         {}
 
+        static Regdims serializeObject()
+        {
+            return Regdims(1, 2, 3, 4, 5);
+        }
+
+
         size_t getNTFIP() const {
             return m_NTFIP;
         }

--- a/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.hpp
@@ -28,8 +28,9 @@ namespace Opm {
     class Rock2dTable {
     public:
         Rock2dTable();
-        Rock2dTable(const std::vector<std::vector<double>>& pvmultValues,
-                    const std::vector<double>& pressureValues);
+
+        static Rock2dTable serializeObject();
+
         void init(const Opm::DeckRecord& record, size_t tableIdx);
         size_t size() const;
         size_t sizeMultValues() const;

--- a/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.hpp
@@ -28,8 +28,9 @@ namespace Opm {
     class Rock2dtrTable {
     public:
         Rock2dtrTable();
-        Rock2dtrTable(const std::vector<std::vector<double>>& transMultValues,
-                      const std::vector<double>& pressureValues);
+
+        static Rock2dtrTable serializeObject();
+
         void init(const Opm::DeckRecord& record, size_t tableIdx);
         size_t size() const;
         size_t sizeMultValues() const;

--- a/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -31,9 +31,8 @@ namespace Opm {
         RocktabTable(const DeckItem& item,
                      bool isDirectional,
                      bool hasStressOption);
-        RocktabTable(const TableSchema& schema,
-                     const OrderedMap<std::string, TableColumn>& columns,
-                     bool jfunc, bool isDirectional);
+
+        static RocktabTable serializeObject();
 
         const TableColumn& getPressureColumn() const;
         const TableColumn& getPoreVolumeMultiplierColumn() const;

--- a/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
@@ -37,10 +37,9 @@ namespace Opm {
     public:
         SimpleTable() = default;
         SimpleTable(TableSchema, const DeckItem& deckItem);
-        SimpleTable(const TableSchema& schema,
-                    const OrderedMap<std::string, TableColumn>& columns,
-                    bool jfunc);
         explicit SimpleTable( TableSchema );
+
+        static SimpleTable serializeObject();
 
         void addColumns();
         void init(const DeckItem& deckItem );

--- a/opm/parser/eclipse/EclipseState/Tables/SkprpolyTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SkprpolyTable.hpp
@@ -27,14 +27,10 @@ namespace Opm {
 
     class SkprpolyTable : public PolyInjTable {
     public:
-
         SkprpolyTable() = default;
-        SkprpolyTable(const std::vector<double>& throughputs,
-                     const std::vector<double>& velocities,
-                     int tableNumber,
-                     const std::vector<std::vector<double>>& data,
-                     double ref_polymer_concentration);
         explicit SkprpolyTable(const DeckKeyword& table);
+
+        static SkprpolyTable serializeObject();
 
         double referenceConcentration() const;
 

--- a/opm/parser/eclipse/EclipseState/Tables/SkprwatTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SkprwatTable.hpp
@@ -27,14 +27,10 @@ namespace Opm {
 
     class SkprwatTable : public PolyInjTable {
     public:
-
         SkprwatTable() = default;
-        SkprwatTable(const std::vector<double>& throughputs,
-                     const std::vector<double>& velocities,
-                     int tableNumber,
-                     const std::vector<std::vector<double>>& data);
-
         explicit SkprwatTable(const DeckKeyword& table);
+
+        static SkprwatTable serializeObject();
 
         const std::vector<std::vector<double>>& getSkinPressures() const;
 

--- a/opm/parser/eclipse/EclipseState/Tables/SolventDensityTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SolventDensityTable.hpp
@@ -25,8 +25,7 @@ namespace Opm {
 
     class SolventDensityTable {
     public:
-        SolventDensityTable();
-        SolventDensityTable(const std::vector<double>& tableValues);
+        static SolventDensityTable serializeObject();
 
         void init(const Opm::DeckRecord& record);
         const std::vector<double>& getSolventDensityColumn() const;

--- a/opm/parser/eclipse/EclipseState/Tables/StandardCond.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/StandardCond.hpp
@@ -23,10 +23,8 @@ namespace Opm {
 
     struct StandardCond {
         StandardCond();
-        StandardCond(double temp, double press)
-            : temperature(temp)
-            , pressure(press)
-        {}
+
+        static StandardCond serializeObject();
 
         bool operator==(const StandardCond& data) const {
             return temperature == data.temperature &&

--- a/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
@@ -63,12 +63,18 @@ namespace Opm {
             }
         }
 
-        Tabdims(size_t ntsfun, size_t ntpvt, size_t nssfun, size_t nppvt,
-                size_t ntfip, size_t nrpvt) :
-            m_ntsfun(ntsfun), m_ntpvt(ntpvt), m_nssfun(nssfun),
-            m_nppvt(nppvt), m_ntfip(ntfip), m_nrpvt(nrpvt)
-        { }
+        static Tabdims serializeObject()
+        {
+            Tabdims result;
+            result.m_ntsfun = 1;
+            result.m_ntpvt = 2;
+            result.m_nssfun = 3;
+            result.m_nppvt = 4;
+            result.m_ntfip = 5;
+            result.m_nrpvt = 6;
 
+            return result;
+        }
 
         size_t getNumSatTables() const {
             return m_ntsfun;

--- a/opm/parser/eclipse/EclipseState/Tables/TableColumn.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableColumn.hpp
@@ -33,11 +33,9 @@ namespace Opm {
     public:
         TableColumn();
         explicit TableColumn( const ColumnSchema& schema );
-        TableColumn(const ColumnSchema& schema,
-                    const std::string& name,
-                    const std::vector<double>& values,
-                    const std::vector<bool>& defaults,
-                    size_t defaultCount);
+
+        static TableColumn serializeObject();
+
         size_t size( ) const;
         const std::string& name() const;
         void assertOrder(double value1 , double value2) const;

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
@@ -63,6 +63,9 @@ namespace Opm {
 
         TableContainer();
         explicit TableContainer( size_t maxTables );
+
+        static TableContainer serializeObject();
+
         bool empty() const;
 
         /*

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -64,43 +64,8 @@ namespace Opm {
     public:
         explicit TableManager( const Deck& deck );
         TableManager() = default;
-        TableManager(const std::map<std::string, TableContainer>& simpleTables,
-                     const std::vector<PvtgTable>& pvtgTables,
-                     const std::vector<PvtoTable>& pvtoTables,
-                     const std::vector<Rock2dTable>& rock2dTables,
-                     const std::vector<Rock2dtrTable>& rock2dtrTables,
-                     const PvtwTable& pvtwTable,
-                     const PvcdoTable& pvcdoTable,
-                     const DensityTable& densityTable,
-                     const PlyvmhTable& plyvmhTable,
-                     const RockTable& rockTable,
-                     const PlmixparTable& plmixparTable,
-                     const ShrateTable& shrateTable,
-                     const Stone1exTable& stone1exTable,
-                     const TlmixparTable& tlmixparTable,
-                     const ViscrefTable& viscrefTable,
-                     const WatdentTable& watdentTable,
-                     const std::vector<PvtwsaltTable>& pvtwsaltTables,
-                     const std::vector<BrineDensityTable>& bdensityTables,
-                     const std::vector<SolventDensityTable>& sdensityTables,
-                     const std::map<int, PlymwinjTable>& plymwinjTables,
-                     const std::map<int, SkprwatTable>& skprwatTables,
-                     const std::map<int, SkprpolyTable>& skprpolyTables,
-                     const Tabdims& tabdims,
-                     const Regdims& regdims,
-                     const Eqldims& eqldims,
-                     const Aqudims& aqudims,
-                     bool useImptvd,
-                     bool useEnptvd,
-                     bool useEqlnum,
-                     bool useShrate,
-                     std::shared_ptr<JFunc> jfunc_param,
-                     const DenT& oilDenT,
-                     const DenT& gasDenT,
-                     const DenT& watDenT,
-                     const StandardCond& stcond,
-                     std::size_t gas_comp_index,
-                     double rtemp);
+
+        static TableManager serializeObject();
 
         TableManager& operator=(const TableManager& data);
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableSchema.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableSchema.hpp
@@ -30,8 +30,8 @@ namespace Opm {
 
     class TableSchema {
     public:
-        TableSchema() = default;
-        TableSchema(const OrderedMap<std::string, ColumnSchema>& columns);
+        static TableSchema serializeObject();
+
         void addColumn( ColumnSchema );
         const ColumnSchema& getColumn( const std::string& name ) const;
         const ColumnSchema& getColumn( size_t columnIndex ) const;

--- a/opm/parser/eclipse/Units/Dimension.hpp
+++ b/opm/parser/eclipse/Units/Dimension.hpp
@@ -30,6 +30,8 @@ namespace Opm {
         Dimension(double SIfactor,
                   double SIoffset = 0.0);
 
+        static Dimension serializeObject();
+
         double getSIScaling() const;
         double getSIOffset() const;
 

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -79,9 +79,8 @@ namespace Opm {
         explicit UnitSystem(int ecl_id);
         explicit UnitSystem(UnitType unit = UnitType::UNIT_TYPE_METRIC);
         explicit UnitSystem(const std::string& deck_name);
-        UnitSystem(const std::string& name, UnitType unit,
-                   const std::map<std::string,Dimension>& dimensions,
-                   size_t use_count);
+
+        static UnitSystem serializeObject();
 
         const std::string& getName() const;
         UnitType getType() const;

--- a/src/opm/parser/eclipse/Deck/Deck.cpp
+++ b/src/opm/parser/eclipse/Deck/Deck.cpp
@@ -132,25 +132,6 @@ namespace Opm {
         Deck( std::vector<DeckKeyword>() )
     {}
 
-    Deck::Deck(const std::vector<DeckKeyword>& keywords,
-               const UnitSystem& defUnits,
-               const UnitSystem* activeUnit,
-               const std::string& dataFile,
-               const std::string& inputPath,
-               size_t accessCount) :
-        keywordList(keywords),
-        defaultUnits(defUnits),
-        m_dataFile(dataFile),
-        input_path(inputPath),
-        unit_system_access_count(accessCount)
-    {
-        if (activeUnit)
-            activeUnits.reset(new UnitSystem(*activeUnit));
-        this->init(keywordList.begin(), keywordList.end());
-    }
-
-
-
     /*
       This constructor should be ssen as a technical implemtation detail of the
       default constructor, and not something which should be invoked directly.
@@ -178,6 +159,18 @@ namespace Opm {
         unit_system_access_count = d.unit_system_access_count;
     }
 
+    Deck Deck::serializeObject()
+    {
+        Deck result;
+        result.keywordList = {DeckKeyword::serializeObject()};
+        result.defaultUnits = UnitSystem::serializeObject();
+        result.activeUnits = std::make_unique<UnitSystem>(UnitSystem::serializeObject());
+        result.m_dataFile = "test1";
+        result.input_path = "test2";
+        result.unit_system_access_count = 1;
+
+        return result;
+    }
 
     void Deck::addKeyword( DeckKeyword&& keyword ) {
         if (keyword.name() == "FIELD")

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -30,28 +30,6 @@
 
 namespace Opm {
 
-DeckItem::DeckItem(const std::vector<double>& dVec,
-                   const std::vector<int>& iVec,
-                   const std::vector<std::string>& sVec,
-                   const std::vector<UDAValue>& uVec,
-                   type_tag typ,
-                   const std::string& itemName,
-                   const std::vector<value::status>& valueStat,
-                   bool rawdata,
-                   const std::vector<Dimension>& activeDim,
-                   const std::vector<Dimension>& defDim)
-    : dval(dVec)
-    , ival(iVec)
-    , sval(sVec)
-    , uval(uVec)
-    , type(typ)
-    , item_name(itemName)
-    , value_status(valueStat)
-    , raw_data(rawdata)
-    , active_dimensions(activeDim)
-    , default_dimensions(defDim)
-{}
-
 template< typename T >
 std::vector< T >& DeckItem::value_ref() {
     return const_cast< std::vector< T >& >(
@@ -120,6 +98,22 @@ DeckItem::DeckItem( const std::string& nm, UDAValue, const std::vector<Dimension
 {
 }
 
+DeckItem DeckItem::serializeObject()
+{
+    DeckItem result;
+    result.dval = {1.0};
+    result.ival = {2};
+    result.sval = {"test1"};
+    result.uval = {UDAValue(3.0)};
+    result.type = type_tag::string;
+    result.item_name = "test2";
+    result.value_status = {value::status::deck_value};
+    result.raw_data = false;
+    result.active_dimensions = {Dimension::serializeObject()};
+    result.default_dimensions = {Dimension::serializeObject()};
+
+    return result;
+}
 
 const std::string& DeckItem::name() const {
     return this->item_name;

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -38,18 +38,31 @@ namespace Opm {
     {
     }
 
-    DeckKeyword::DeckKeyword() :
-        m_isDataKeyword(false),
-        m_slashTerminated(false)
-    {
-    }
-
     DeckKeyword::DeckKeyword(const Location& location, const std::string& keywordName) :
         m_keywordName(keywordName),
         m_location(location),
         m_isDataKeyword(false),
         m_slashTerminated(true)
     {
+    }
+
+    DeckKeyword::DeckKeyword() :
+        m_isDataKeyword(false),
+        m_slashTerminated(false)
+    {
+    }
+
+    DeckKeyword DeckKeyword::serializeObject()
+    {
+        DeckKeyword result;
+        result.m_keywordName = "test";
+        result.m_location = Location::serializeObject();
+        result.m_recordList = {DeckRecord::serializeObject()};
+        result.m_isDataKeyword = true;
+        result.m_slashTerminated = true;
+        result.m_isDoubleRecordKeyword = true;
+
+        return result;
     }
 
     namespace {
@@ -179,20 +192,6 @@ namespace Opm {
         deck_record.addItem( std::move(item) );
         addRecord( std::move(deck_record) );
     }
-
-    DeckKeyword::DeckKeyword(const std::string& kwName,
-                             const Location& loc,
-                             const std::vector<DeckRecord>& record,
-                             bool dataKw,
-                             bool slashTerminated) :
-       m_keywordName(kwName),
-       m_location(loc),
-       m_recordList(record),
-       m_isDataKeyword(dataKw),
-       m_slashTerminated(slashTerminated)
-    {
-    }
-
 
 
     void DeckKeyword::setFixedSize() {

--- a/src/opm/parser/eclipse/Deck/DeckRecord.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckRecord.cpp
@@ -53,6 +53,14 @@ namespace Opm {
         throw std::invalid_argument( msg );
     }
 
+    DeckRecord DeckRecord::serializeObject()
+    {
+        DeckRecord result;
+        result.m_items = {DeckItem::serializeObject()};
+
+        return result;
+    }
+
     size_t DeckRecord::size() const {
         return m_items.size();
     }

--- a/src/opm/parser/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/parser/eclipse/Deck/UDAValue.cpp
@@ -58,6 +58,17 @@ UDAValue::UDAValue(const std::string& value, const Dimension& dim_):
 {
 }
 
+UDAValue UDAValue::serializeObject()
+{
+    UDAValue result;
+    result.numeric_value = true;
+    result.double_value = 1.0;
+    result.string_value = "test";
+    result.dim = Dimension::serializeObject();
+
+    return result;
+}
+
 
 void UDAValue::assert_numeric() const {
     std::string msg = "Internal error: The support for use of UDQ/UDA is not complete in opm/flow. The string: '" + this->string_value + "' must be numeric";

--- a/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquancon.cpp
@@ -106,6 +106,15 @@ namespace Opm {
     }
 
 
+    Aquancon Aquancon::serializeObject()
+    {
+        Aquancon result;
+        result.cells = {{1, {{2, 3, {true, 4.0}, 5.0, FaceDir::XPlus}}}};
+
+        return result;
+    }
+
+
     const std::vector<Aquancon::AquancCell> Aquancon::operator[](int aquiferID) const {
         return this->cells.at( aquiferID );
     }
@@ -145,7 +154,6 @@ namespace Opm {
             throw std::runtime_error("Unknown FaceDir enum " + std::to_string(faceDir));
         }
     }
-
 
     Aquancon::Aquancon(const std::unordered_map<int, std::vector<Aquancon::AquancCell>>& data) :
         cells(data)

--- a/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferCT.cpp
@@ -146,6 +146,14 @@ AquiferCT::AquiferCT(const std::vector<AquiferCT::AQUCT_data>& data) :
     m_aquct(data)
 {}
 
+AquiferCT AquiferCT::serializeObject()
+{
+    AquiferCT result;
+    result.m_aquct = {{1, 2, 3, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+                       11.0, 12.0, {true, 13.0}, {14.0}, {15.0}, {16}}};
+
+    return result;
+}
 
 std::size_t AquiferCT::size() const {
     return this->m_aquct.size();

--- a/src/opm/parser/eclipse/EclipseState/AquiferConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/AquiferConfig.cpp
@@ -32,13 +32,21 @@ AquiferConfig::AquiferConfig(const TableManager& tables, const EclipseGrid& grid
     aqconn(grid,deck)
 {}
 
-
 AquiferConfig::AquiferConfig(const Aquifetp& fetp, const AquiferCT& ct, const Aquancon& conn) :
     aquifetp(fetp),
     aquiferct(ct),
     aqconn(conn)
 {}
 
+AquiferConfig AquiferConfig::serializeObject()
+{
+    AquiferConfig result;
+    result.aquifetp = Aquifetp::serializeObject();
+    result.aquiferct = AquiferCT::serializeObject();
+    result.aqconn = Aquancon::serializeObject();
+
+    return result;
+}
 
 bool AquiferConfig::active() const {
     return this->aqconn.active();

--- a/src/opm/parser/eclipse/EclipseState/Aquifetp.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifetp.cpp
@@ -64,10 +64,6 @@ Aquifetp::AQUFETP_data::AQUFETP_data(int aquiferID_, int pvttableID_, double J_,
 {}
 
 
-Aquifetp::Aquifetp(const std::vector<Aquifetp::AQUFETP_data>& data) :
-    m_aqufetp(data)
-{}
-
 
 Aquifetp::Aquifetp(const Deck& deck)
 {
@@ -77,6 +73,20 @@ Aquifetp::Aquifetp(const Deck& deck)
     const auto& aqufetpKeyword = deck.getKeyword<AQUFETP>();
     for (auto& record : aqufetpKeyword)
         this->m_aqufetp.emplace_back(record);
+}
+
+
+Aquifetp::Aquifetp(const std::vector<Aquifetp::AQUFETP_data>& data) :
+    m_aqufetp(data)
+{}
+
+
+Aquifetp Aquifetp::serializeObject()
+{
+    Aquifetp result;
+    result.m_aqufetp = {{1, 2, 3.0, 4.0, 5.0, 6.0, {true, 7.0}}};
+
+    return result;
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -42,6 +42,16 @@ namespace Opm {
     }
 
 
+    EclipseConfig EclipseConfig::serializeObject()
+    {
+        EclipseConfig result;
+        result.m_initConfig = InitConfig::serializeObject();
+        result.io_config = IOConfig::serializeObject();
+
+        return result;
+    }
+
+
     const InitConfig& EclipseConfig::init() const {
         return m_initConfig;
     }

--- a/src/opm/parser/eclipse/EclipseState/Edit/EDITNNC.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Edit/EDITNNC.cpp
@@ -78,9 +78,12 @@ EDITNNC::EDITNNC(const Deck& deck)
     std::sort(m_editnnc.begin(), m_editnnc.end(), compare);
 }
 
-EDITNNC::EDITNNC(const std::vector<NNCdata>& data)
-    : m_editnnc(data)
+EDITNNC EDITNNC::serializeObject()
 {
+    EDITNNC result;
+    result.m_editnnc = {{1,2,1.0},{2,3,2.0}};
+
+    return result;
 }
 
 size_t EDITNNC::size() const {

--- a/src/opm/parser/eclipse/EclipseState/EndpointScaling.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EndpointScaling.cpp
@@ -4,6 +4,14 @@
 
 namespace Opm {
 
+EndpointScaling EndpointScaling::serializeObject()
+{
+    EndpointScaling result;
+    result.options = std::bitset<4>{13};
+
+    return result;
+}
+
 EndpointScaling::operator bool() const noexcept {
     return this->options[ static_cast< ue >( option::any ) ];
 }
@@ -120,10 +128,4 @@ EndpointScaling::EndpointScaling( const Deck& deck ) {
     }
 }
 
-EndpointScaling::EndpointScaling(const std::bitset<4>& opts) :
-    options(opts)
-{
 }
-
-}
-

--- a/src/opm/parser/eclipse/EclipseState/Grid/Fault.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/Fault.cpp
@@ -27,13 +27,14 @@ namespace Opm {
     {
     }
 
-    Fault::Fault(const std::string& name,
-                 double transMult,
-                 const std::vector<FaultFace>& faceList) :
-        m_name(name),
-        m_transMult(transMult),
-        m_faceList(faceList)
+    Fault Fault::serializeObject()
     {
+        Fault result;
+        result.m_name = "test";
+        result.m_transMult = 1.0;
+        result.m_faceList = {FaultFace::serializeObject()};
+
+        return result;
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -56,11 +56,13 @@ namespace Opm {
         }
     }
 
-    FaultCollection::FaultCollection(const OrderedMap<std::string, Fault>& faults) :
-        m_faults(faults)
+    FaultCollection FaultCollection::serializeObject()
     {
-    }
+        FaultCollection result;
+        result.m_faults.insert({"test", Fault::serializeObject()});
 
+        return result;
+    }
 
     void FaultCollection::addFaultFaces(const GridDims& grid,
                                         const DeckRecord& faultRecord,

--- a/src/opm/parser/eclipse/EclipseState/Grid/FaultFace.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FaultFace.cpp
@@ -55,12 +55,14 @@ namespace Opm {
                 }
     }
 
-    FaultFace::FaultFace(const std::vector<size_t>& indices, FaceDir::DirEnum faceDir)
-        : m_faceDir(faceDir)
-        , m_indexList(indices)
+    FaultFace FaultFace::serializeObject()
     {
-    }
+        FaultFace result;
+        result.m_faceDir = FaceDir::YPlus;
+        result.m_indexList = {1,2,3,4,5,6};
 
+        return result;
+    }
 
     void FaultFace::checkCoord(size_t dim , size_t l1 , size_t l2) {
         if (l1 > l2)

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
@@ -43,6 +43,16 @@ namespace Opm {
     {
     }
 
+    GridDims GridDims::serializeObject()
+    {
+        GridDims result;
+        result.m_nx = 1;
+        result.m_ny = 2;
+        result.m_nz = 3;
+
+        return result;
+    }
+
     GridDims::GridDims(const Deck& deck) {
         if (deck.hasKeyword("SPECGRID"))
             init(deck.getKeyword("SPECGRID"));

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -154,22 +154,19 @@ std::vector<int> unique(const std::vector<int> data) {
         }
     }
 
-
-    MULTREGTScanner::MULTREGTScanner(const std::array<size_t,3>& size,
-                                     const std::vector<MULTREGTRecord>& records,
-                                     const ExternalSearchMap& searchMap,
-                                     const std::map<std::string, std::vector<int>>& region,
-                                     const std::string& defaultRegion) :
-        nx(size[0]),
-        ny(size[1]),
-        nz(size[2]),
-        m_records(records),
-        regions(region),
-        default_region(defaultRegion)
+    MULTREGTScanner MULTREGTScanner::serializeObject()
     {
-        constructSearchMap(searchMap);
-    }
+        MULTREGTScanner result;
+        result.nx = 1;
+        result.ny = 2;
+        result.nz = 3;
+        result.m_records = {{4, 5, 6.0, 7, MULTREGT::ALL, "test1"}};
+        result.constructSearchMap({{"test2", {{{8, 9}, 10}}}});
+        result.regions = {{"test3", {11}}};
+        result.default_region = "test4";
 
+        return result;
+    }
 
     MULTREGTScanner::MULTREGTScanner(const MULTREGTScanner& data) {
         *this = data;

--- a/src/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
@@ -54,6 +54,15 @@ namespace Opm
             }
         }
     }
+
+    NNC NNC::serializeObject()
+    {
+        NNC result;
+        result.m_nnc = {{1,2,1.0},{2,3,2.0}};
+
+        return result;
+    }
+
     void NNC::addNNC(const size_t cell1, const size_t cell2, const double trans) {
         NNCdata tmp;
         tmp.cell1 = cell1;

--- a/src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
@@ -56,18 +56,17 @@ R"(This deck has the MULTREGT keyword located in the EDIT section. Note that:
         }
     }
 
-
-    TransMult::TransMult(const std::array<size_t,3>& size,
-                         const std::map<FaceDir::DirEnum, std::vector<double>>& trans,
-                         const std::map<FaceDir::DirEnum, std::string>& names,
-                         const MULTREGTScanner& scanner) :
-        m_nx(size[0]),
-        m_ny(size[1]),
-        m_nz(size[2]),
-        m_trans(trans),
-        m_names(names),
-        m_multregtScanner(scanner)
+    TransMult TransMult::serializeObject()
     {
+        TransMult result;
+        result.m_nx = 1;
+        result.m_ny = 2;
+        result.m_nz = 3;
+        result.m_trans = {{FaceDir::YPlus, {4.0, 5.0}}};
+        result.m_names = {{FaceDir::ZPlus, "test1"}};
+        result.m_multregtScanner = MULTREGTScanner::serializeObject();
+
+        return result;
     }
 
     void TransMult::assertIJK(size_t i , size_t j , size_t k) const {

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -87,31 +87,24 @@ namespace Opm {
         this->setBaseName(basename(input_path));
     }
 
-    IOConfig::IOConfig(bool write_init, bool write_egrid,
-                       bool unifin, bool unifout,
-                       bool fmtin, bool fmtout,
-                       const std::string& deck_name,
-                       bool output_enabled,
-                       const std::string& output_dir,
-                       bool no_sim,
-                       const std::string& base_name,
-                       bool ecl_compatible_r) :
-        m_write_INIT_file(write_init),
-        m_write_EGRID_file(write_egrid),
-        m_UNIFIN(unifin),
-        m_UNIFOUT(unifout),
-        m_FMTIN(fmtin),
-        m_FMTOUT(fmtout),
-        m_deck_filename(deck_name),
-        m_output_enabled(output_enabled),
-        m_output_dir(output_dir),
-        m_nosim(no_sim),
-        m_base_name(base_name),
-        ecl_compatible_rst(ecl_compatible_r)
+    IOConfig IOConfig::serializeObject()
     {
+        IOConfig result;
+        result.m_write_INIT_file = true;
+        result.m_write_EGRID_file = false;
+        result.m_UNIFIN = true;
+        result.m_UNIFOUT = true;
+        result.m_FMTIN = true;
+        result.m_FMTOUT = true;
+        result.m_deck_filename = "test1";
+        result.m_output_enabled = false;
+        result.m_output_dir = "test2";
+        result.m_nosim = true;
+        result.m_base_name = "test3";
+        result.ecl_compatible_rst = false;
+
+        return result;
     }
-
-
 
     static inline bool write_egrid_file( const GRIDSection& grid ) {
         if( grid.hasKeyword( "NOGGF" ) ) return false;

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -236,6 +236,15 @@ bool is_RPTSCHED_mnemonic( const std::string& kw ) {
          */
     }
 
+    RestartSchedule RestartSchedule::serializeObject()
+    {
+        RestartSchedule result(1, 2, 3);
+        result.rptsched_restart_set = true;
+        result.rptsched_restart = 4;
+
+        return result;
+    }
+
     bool RestartSchedule::operator!=(const RestartSchedule & rhs) const {
         return !( *this == rhs );
     }
@@ -536,22 +545,18 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
         initFirstOutput( );
     }
 
-
-    RestartConfig::RestartConfig(const TimeMap& timeMap,
-                                 int firstRestartStep,
-                                 bool writeInitial,
-                                 const DynamicState<RestartSchedule>& restart_sched,
-                                 const DynamicState<std::map<std::string,int>>& restart_keyw,
-                                 const std::vector<bool>& save_keyw) :
-        m_timemap(timeMap),
-        m_first_restart_step(firstRestartStep),
-        m_write_initial_RST_file(writeInitial),
-        restart_schedule(restart_sched),
-        restart_keywords(restart_keyw),
-        save_keywords(save_keyw)
+    RestartConfig RestartConfig::serializeObject()
     {
-    }
+        RestartConfig result;
+        result.m_timemap = TimeMap::serializeObject();
+        result.m_first_restart_step = 2;
+        result.m_write_initial_RST_file = true;
+        result.restart_schedule = {{RestartSchedule::serializeObject()}, 2};
+        result.restart_keywords = {{{{"test",3}}}, 3};
+        result.save_keywords = {false, true};
 
+        return result;
+    }
 
     RestartSchedule RestartConfig::getNode( size_t timestep ) const{
         return restart_schedule.get(timestep);

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/Equil.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/Equil.cpp
@@ -89,9 +89,12 @@ namespace Opm {
         }
     }
 
-    Equil::Equil(const std::vector<EquilRecord>& records) :
-        m_records(records)
+    Equil Equil::serializeObject()
     {
+        Equil result;
+        result.m_records = {{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, true, false, 1}};
+
+        return result;
     }
 
     const EquilRecord& Equil::getRecord( size_t id ) const {

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
@@ -30,10 +30,11 @@ namespace Opm
 // FoamData member functions.
 
 FoamData::FoamData()
-    : FoamData(0.0,
-               ParserKeywords::FOAMFSC::EXPONENT::defaultValue,
-               ParserKeywords::FOAMFSC::MIN_SURF_CONC::defaultValue,
-               false, 1.0)
+    : reference_surfactant_concentration_(0.0)
+    , exponent_(ParserKeywords::FOAMFSC::EXPONENT::defaultValue)
+    , minimum_surfactant_concentration_(ParserKeywords::FOAMFSC::MIN_SURF_CONC::defaultValue)
+    , allow_desorption_(false)
+    , rock_density_(1.0)
 {
 }
 
@@ -67,17 +68,17 @@ FoamData::FoamData(const DeckRecord& FOAMROCK_record)
     allow_desorption_ = (ads_ind == 1);
 }
 
-FoamData::FoamData(double reference_surfactant_concentration,
-                   double exponent,
-                   double minimum_surfactant_concentration,
-                   bool allow_desorption,
-                   double rock_density)
-    : reference_surfactant_concentration_(reference_surfactant_concentration)
-    , exponent_(exponent)
-    , minimum_surfactant_concentration_(minimum_surfactant_concentration)
-    , allow_desorption_(allow_desorption)
-    , rock_density_(rock_density)
+FoamData
+FoamData::serializeObject()
 {
+    FoamData result;
+    result.reference_surfactant_concentration_ = 1.0;
+    result.exponent_ = 2.0;
+    result.minimum_surfactant_concentration_ = 3.0;
+    result.allow_desorption_ = true;
+    result.rock_density_ = 4.0;
+
+    return result;
 }
 
 double
@@ -168,13 +169,15 @@ FoamConfig::FoamConfig(const Deck& deck)
     }
 }
 
-FoamConfig::FoamConfig(const std::vector<FoamData>& data,
-                       Phase transport_phase,
-                       MobilityModel mobility_model)
-    : data_(data)
-    , transport_phase_(transport_phase)
-    , mobility_model_(mobility_model)
+FoamConfig
+FoamConfig::serializeObject()
 {
+    FoamConfig result;
+    result.data_ = {Opm::FoamData::serializeObject()};
+    result.transport_phase_ = Phase::GAS;
+    result.mobility_model_ = MobilityModel::TAB;
+
+    return result;
 }
 
 const FoamData&

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -78,17 +78,18 @@ namespace Opm {
             this->setRestart( input_path + "/" + root, step );
     }
 
-    InitConfig::InitConfig(const Equil& equils, const FoamConfig& foam,
-                           bool filleps, bool gravity, bool restartReq, int restartStep,
-                           const std::string& restartRootName)
-        : equil(equils)
-        , foamconfig(foam)
-        , m_filleps(filleps)
-        , m_gravity(gravity)
-        , m_restartRequested(restartReq)
-        , m_restartStep(restartStep)
-        , m_restartRootName(restartRootName)
+    InitConfig InitConfig::serializeObject()
     {
+        InitConfig result;
+        result.equil = Equil::serializeObject();
+        result.foamconfig = FoamConfig::serializeObject();
+        result.m_filleps = true;
+        result.m_gravity = false;
+        result.m_restartRequested = true;
+        result.m_restartStep = 20;
+        result.m_restartRootName = "test1";
+
+        return result;
     }
 
     void InitConfig::setRestart( const std::string& root, int step) {

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -74,9 +74,9 @@ Phases::Phases( bool oil, bool gas, bool wat, bool sol, bool pol, bool energy, b
 
 {}
 
-Phases::Phases(const std::bitset<NUM_PHASES_IN_ENUM>& bset) :
-    bits(bset)
+Phases Phases::serializeObject()
 {
+    return Phases(true, true, true, false, true, false, true, false);
 }
 
 bool Phases::active( Phase p ) const noexcept {
@@ -105,8 +105,19 @@ Welldims::Welldims(const Deck& deck)
         //
         // i.e., the maximum of item 1 and item 4 here.
         this->nGMax = wd.getItem("MAXGROUPS").get<int>(0);
-	this->nWMax = wd.getItem("MAXWELLS").get<int>(0);
+	      this->nWMax = wd.getItem("MAXWELLS").get<int>(0);
     }
+}
+
+Welldims Welldims::serializeObject()
+{
+    Welldims result;
+    result.nWMax = 1;
+    result.nCWMax = 2;
+    result.nWGMax = 3;
+    result.nGMax = 4;
+
+    return result;
 }
 
 WellSegmentDims::WellSegmentDims() :
@@ -126,11 +137,14 @@ WellSegmentDims::WellSegmentDims(const Deck& deck) : WellSegmentDims()
     }
 }
 
-WellSegmentDims::WellSegmentDims(int segWellMax, int segMax, int latBranchMax) :
-    nSegWellMax(segWellMax),
-    nSegmentMax(segMax),
-    nLatBranchMax(latBranchMax)
+WellSegmentDims WellSegmentDims::serializeObject()
 {
+    WellSegmentDims result;
+    result.nSegWellMax = 1;
+    result.nSegmentMax = 2;
+    result.nLatBranchMax = 3;
+
+    return result;
 }
 
 bool WellSegmentDims::operator==(const WellSegmentDims& data) const
@@ -211,11 +225,15 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
         }
     }
 
-EclHysterConfig::EclHysterConfig(bool active, int pcMod, int krMod) :
-    activeHyst(active), pcHystMod(pcMod), krHystMod(krMod)
-    {
-    }
-    
+EclHysterConfig EclHysterConfig::serializeObject()
+{
+    EclHysterConfig result;
+    result.activeHyst = true;
+    result.pcHystMod = 1;
+    result.krHystMod = 2;
+
+    return result;
+}
 
 bool EclHysterConfig::active() const 
     { return activeHyst; }
@@ -261,6 +279,15 @@ SatFuncControls::SatFuncControls(const double tolcritArg,
     , krmodel(model)
 {}
 
+SatFuncControls SatFuncControls::serializeObject()
+{
+    SatFuncControls result;
+    result.tolcrit = 1.0;
+    result.krmodel = ThreePhaseOilKrModel::Stone2;
+
+    return result;
+}
+
 bool SatFuncControls::operator==(const SatFuncControls& rhs) const
 {
     return this->minimumRelpermMobilityThreshold() == rhs.minimumRelpermMobilityThreshold() &&
@@ -287,25 +314,21 @@ Runspec::Runspec( const Deck& deck ) :
     m_sfuncctrl( deck )
 {}
 
-Runspec::Runspec(const Phases& act_phases,
-                 const Tabdims& tabdims,
-                 const EndpointScaling& endScale,
-                 const Welldims& wellDims,
-                 const WellSegmentDims& wsegDims,
-                 const UDQParams& udqparams,
-                 const EclHysterConfig& hystPar,
-                 const Actdims& actDims,
-                 const SatFuncControls& sfuncctrl) :
-    active_phases(act_phases),
-    m_tabdims(tabdims),
-    endscale(endScale),
-    welldims(wellDims),
-    wsegdims(wsegDims),
-    udq_params(udqparams),
-    hystpar(hystPar),
-    m_actdims(actDims),
-    m_sfuncctrl(sfuncctrl)
-{}
+Runspec Runspec::serializeObject()
+{
+    Runspec result;
+    result.active_phases = Phases::serializeObject();
+    result.m_tabdims = Tabdims::serializeObject();
+    result.endscale = EndpointScaling::serializeObject();
+    result.welldims = Welldims::serializeObject();
+    result.wsegdims = WellSegmentDims::serializeObject();
+    result.udq_params = UDQParams::serializeObject();
+    result.hystpar = EclHysterConfig::serializeObject();
+    result.m_actdims = Actdims::serializeObject();
+    result.m_sfuncctrl = SatFuncControls::serializeObject();
+
+    return result;
+}
 
 const Phases& Runspec::phases() const noexcept {
     return this->active_phases;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
@@ -67,16 +67,19 @@ ASTNode::ASTNode(TokenType type_arg, FuncType func_type_arg, const std::string& 
     arg_list(strip_quotes(arg_list_arg))
 {}
 
-ASTNode::ASTNode(TokenType type_arg, FuncType ftype, const std::string& func_arg,
-                 const std::vector<std::string>& args, double num,
-                 const std::vector<ASTNode>& childs):
-    type(type_arg),
-    func_type(ftype),
-    func(func_arg),
-    arg_list(args),
-    number(num),
-    children(childs)
-{}
+ASTNode ASTNode::serializeObject()
+{
+    ASTNode result;
+    result.type = ::number;
+    result.func_type = FuncType::field;
+    result.func = "test1";
+    result.arg_list = {"test2"};
+    result.number = 1.0;
+    ASTNode child = result;
+    result.children = {child};
+
+    return result;
+}
 
 size_t ASTNode::size() const {
     return this->children.size();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.cpp
@@ -44,13 +44,16 @@ Actdims::Actdims(const Deck& deck)
     }
 }
 
-Actdims::Actdims(std::size_t keyw, std::size_t line_cnt,
-                 std::size_t chars, std::size_t conds) :
-    keywords(keyw),
-    line_count(line_cnt),
-    characters(chars),
-    conditions(conds)
-{}
+Actdims Actdims::serializeObject()
+{
+    Actdims result;
+    result.keywords = 1;
+    result.line_count = 2;
+    result.characters = 3;
+    result.conditions = 4;
+
+    return result;
+}
 
 std::size_t Actdims::max_keywords() const {
     return this->keywords;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.cpp
@@ -38,10 +38,13 @@ AST::AST(const std::vector<std::string>& tokens) {
     this->condition.reset( new Action::ASTNode(condition_node) );
 }
 
-AST::AST(const std::shared_ptr<ASTNode>& cond)
-    : condition(cond)
-{}
+AST AST::serializeObject()
+{
+    AST result;
+    result.condition = std::make_shared<ASTNode>(ASTNode::serializeObject());
 
+    return result;
+}
 
 Action::Result AST::eval(const Action::Context& context) const {
     if (this->condition)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
@@ -76,27 +76,30 @@ ActionX::ActionX(const DeckKeyword& kw, std::time_t start_time) :
 }
 
 
-ActionX::ActionX(const std::string& nam,
-                 size_t maxRun,
-                 double minWait,
-                 std::time_t startTime,
-                 const std::vector<DeckKeyword>& keyword,
-                 const AST& cond,
-                 const std::vector<Condition>& conditions,
-                 size_t runCount,
-                 std::time_t lastRun) :
-    m_name(nam),
-    m_max_run(maxRun),
-    m_min_wait(minWait),
-    m_start_time(startTime),
-    keywords(keyword),
-    condition(cond),
-    m_conditions(conditions),
-    run_count(runCount),
-    last_run(lastRun)
+ActionX ActionX::serializeObject()
 {
-}
+    ActionX result;
+    result.m_name = "test";
+    result.m_max_run = 1;
+    result.m_min_wait = 2;
+    result.m_start_time = 3;
+    result.keywords = {DeckKeyword::serializeObject()};
+    result.condition = Action::AST::serializeObject();
+    Quantity quant;
+    quant.quantity = "test1";
+    quant.args = {"test2"};
+    Condition cond;
+    cond.lhs = quant;
+    cond.rhs = quant;
+    cond.logic = Condition::Logical::AND;
+    cond.cmp = Condition::Comparator::GREATER_EQUAL;
+    cond.cmp_string = "test3";
+    result.m_conditions = {cond};
+    result.run_count = 4;
+    result.last_run = 5;
 
+    return result;
+}
 
 
 void ActionX::addKeyword(const DeckKeyword& kw) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
@@ -25,10 +25,20 @@ namespace Opm {
 namespace Action {
 
 
-Actions::Actions(const std::vector<ActionX>& action, const std::vector<PyAction>& pyactions)
+Actions::Actions(const std::vector<ActionX>& action, const std::vector<PyAction>& pyaction)
     : actions(action),
-      pyactions(pyactions)
+      pyactions(pyaction)
 {}
+
+
+Actions Actions::serializeObject()
+{
+    Actions result;
+    result.actions = {ActionX::serializeObject()};
+    result.pyactions = {PyAction::serializeObject()};
+
+    return result;
+}
 
 
 size_t Actions::size() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/PyAction.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/PyAction.cpp
@@ -51,6 +51,15 @@ PyAction::RunCount PyAction::from_string(std::string run_count) {
     throw std::invalid_argument("RunCount string: " + run_count + " not recognized ");
 }
 
+PyAction PyAction::serializeObject()
+{
+    PyAction result;
+    result.m_name = "name";
+    result.m_run_count = RunCount::unlimited;
+    result.input_code = "import opm";
+
+    return result;
+}
 
 std::string PyAction::load(const std::string& input_path, const std::string& fname) {
     namespace fs = Opm::filesystem;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Events.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Events.cpp
@@ -26,9 +26,14 @@ namespace Opm {
         m_events( DynamicVector<uint64_t>( timeMap , 0 ) )
     { }
 
-    Events::Events(const DynamicVector<uint64_t>& events) :
-        m_events(events)
-    { }
+
+    Events Events::serializeObject()
+    {
+        Events result;
+        result.m_events = DynamicVector<uint64_t>({1,2,3,4,5});
+
+        return result;
+    }
 
 
     bool Events::hasEvent(uint64_t eventMask , size_t reportStep) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GConSale.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GConSale.cpp
@@ -25,9 +25,14 @@
 
 namespace Opm {
 
-GConSale::GConSale(const std::map<std::string,GCONSALEGroup>& group)
-    : groups(group)
-{}
+GConSale GConSale::serializeObject()
+{
+    GConSale result;
+    result.groups = {{"test1", {UDAValue(1.0), UDAValue(2.0), UDAValue(3.0),
+                                MaxProcedure::PLUG, 4.0, UnitSystem::serializeObject()}}};
+
+    return result;
+}
 
 bool GConSale::has(const std::string& name) const {
     return (groups.find(name) != groups.end());

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GConSump.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GConSump.cpp
@@ -23,9 +23,14 @@
 
 namespace Opm {
 
-GConSump::GConSump(const std::map<std::string,GCONSUMPGroup>& group)
-    : groups(group)
-{}
+GConSump GConSump::serializeObject()
+{
+    GConSump result;
+    result.groups = {{"test1", {UDAValue(1.0), UDAValue(2.0), "test2", 3.0,
+                                UnitSystem::serializeObject()}}};
+
+    return result;
+}
 
 bool GConSump::has(const std::string& name) const {
     return (groups.find(name) != groups.end());

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -47,39 +47,28 @@ Group::Group(const std::string& name, std::size_t insert_index_arg, std::size_t 
         this->parent_group = "FIELD";
 }
 
-Group::Group(const std::string& gname,
-             std::size_t insert_idx,
-             std::size_t initstep,
-             double udqUndef,
-             const UnitSystem& units,
-             GroupType gtype,
-             double groupEF,
-             bool transferGroupEF,
-             bool availableForGroupControl,
-             int vfp,
-             const std::string& parentName,
-             const IOrderSet<std::string>& well,
-             const IOrderSet<std::string>& group,
-             const std::map<Phase, GroupInjectionProperties>& injProps,
-             const GroupProductionProperties& prodProps) :
-    m_name(gname),
-    m_insert_index(insert_idx),
-    init_step(initstep),
-    udq_undefined(udqUndef),
-    unit_system(units),
-    group_type(gtype),
-    gefac(groupEF),
-    transfer_gefac(transferGroupEF),
-    available_for_group_control(availableForGroupControl),
-    vfp_table(vfp),
-    parent_group(parentName),
-    m_wells(well),
-    m_groups(group),
-    injection_properties(injProps),
-    production_properties(prodProps)
+Group Group::serializeObject()
 {
-}
+    Group result;
+    result.m_name = "test1";
+    result.m_insert_index = 1;
+    result.init_step = 2;
+    result.udq_undefined = 3.0;
+    result.unit_system = UnitSystem::serializeObject();
+    result.group_type = GroupType::PRODUCTION;
+    result.gefac = 4.0;
+    result.transfer_gefac = true;
+    result.available_for_group_control = false;
+    result.vfp_table = 5;
+    result.parent_group = "test2";
+    result.m_wells = {{"test3", "test4"}, {"test5", "test6"}};
+    result.m_groups = {{"test7", "test8"}, {"test9", "test10"}};
+    result.injection_properties = {{Opm::Phase::OIL, GroupInjectionProperties::serializeObject()}};
+    result.production_properties = GroupProductionProperties::serializeObject();
+    result.m_topup_phase = {Phase::OIL, true};
 
+    return result;
+}
 
 std::size_t Group::insert_index() const {
     return this->m_insert_index;
@@ -178,6 +167,23 @@ bool Group::updateProduction(const GroupProductionProperties& production) {
 }
 
 
+Group::GroupInjectionProperties Group::GroupInjectionProperties::serializeObject()
+{
+    Group::GroupInjectionProperties result;
+    result.phase = Phase::OIL;
+    result.cmode = InjectionCMode::REIN;
+    result.surface_max_rate = UDAValue(1.0);
+    result.resv_max_rate = UDAValue(2.0);
+    result.target_reinj_fraction = UDAValue(3.0);
+    result.target_void_fraction = UDAValue(4.0);
+    result.reinj_group = "test1";
+    result.voidage_group = "test2";
+    result.injection_controls = 5;
+
+    return result;
+}
+
+
 bool Group::GroupInjectionProperties::operator==(const GroupInjectionProperties& other) const {
     return
         this->phase                 == other.phase &&
@@ -194,6 +200,24 @@ bool Group::GroupInjectionProperties::operator==(const GroupInjectionProperties&
 
 bool Group::GroupInjectionProperties::operator!=(const GroupInjectionProperties& other) const {
     return !(*this == other);
+}
+
+
+Group::GroupProductionProperties Group::GroupProductionProperties::serializeObject()
+{
+    Group::GroupProductionProperties result;
+    result.cmode = ProductionCMode::PRBL;
+    result.exceed_action = ExceedAction::WELL;
+    result.oil_target = UDAValue(1.0);
+    result.water_target = UDAValue(2.0);
+    result.gas_target = UDAValue(3.0);
+    result.liquid_target = UDAValue(4.0);
+    result.guide_rate = 5.0;
+    result.guide_rate_def = GuideRateTarget::COMB;
+    result.resv_target = 6.0;
+    result.production_controls = 7;
+
+    return result;
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.cpp
@@ -23,13 +23,15 @@
 
 namespace Opm {
 
-GuideRateConfig::GuideRateConfig(std::shared_ptr<GuideRateModel> model,
-                                 const std::unordered_map<std::string,WellTarget>& well,
-                                 const std::unordered_map<std::string,GroupTarget>& group)
-    : m_model(model)
-    , wells(well)
-    , groups(group)
-{}
+GuideRateConfig GuideRateConfig::serializeObject()
+{
+    GuideRateConfig result;
+    result.m_model = std::make_shared<GuideRateModel>(GuideRateModel::serializeObject());
+    result.wells = {{"test1", WellTarget{1.0, Well::GuideRateTarget::COMB, 2.0}}};
+    result.groups = {{"test2", GroupTarget{1.0, Group::GuideRateTarget::COMB}}};
+
+    return result;
+}
 
 
 const GuideRateModel& GuideRateConfig::model() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
@@ -68,32 +68,27 @@ GuideRateModel::GuideRateModel(double time_interval_arg,
         throw std::logic_error("Sorry - the 'COMB' mode is not supported");
 }
 
-GuideRateModel::GuideRateModel(double time_interval_arg,
-                               Target target_arg,
-                               const std::array<double, 6>& coefs_arg,
-                               bool allow_increase_arg,
-                               double damping_factor_arg,
-                               bool use_free_gas_arg,
-                               bool use_default_model_arg,
-                               const std::array<UDAValue,3>& udaCoefs_arg) :
-    time_interval(time_interval_arg),
-    m_target(target_arg),
-    A(coefs_arg[0]),
-    B(coefs_arg[1]),
-    C(coefs_arg[2]),
-    D(coefs_arg[3]),
-    E(coefs_arg[4]),
-    F(coefs_arg[5]),
-    allow_increase_(allow_increase_arg),
-    damping_factor_(damping_factor_arg),
-    use_free_gas(use_free_gas_arg),
-    default_model(use_default_model_arg),
-    alpha(udaCoefs_arg[0]),
-    beta(udaCoefs_arg[1]),
-    gamma(udaCoefs_arg[2])
+GuideRateModel GuideRateModel::serializeObject()
 {
-}
+    GuideRateModel result;
+    result.time_interval = 1.0;
+    result.m_target = Target::WAT;
+    result.A = 2.0;
+    result.B = 3.0;
+    result.C = 4.0;
+    result.D = 5.0;
+    result.E = 6.0;
+    result.F = 7.0;
+    result.allow_increase_ = false;
+    result.damping_factor_ = 8.0;
+    result.use_free_gas = true;
+    result.default_model = false;
+    result.alpha = UDAValue(9.0);
+    result.beta = UDAValue(10.0);
+    result.gamma = UDAValue(11.0);
 
+    return result;
+}
 
 double GuideRateModel::pot(double oil_pot, double gas_pot, double wat_pot) const {
     return pot(this->target(), oil_pot, gas_pot, wat_pot);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
@@ -131,30 +131,6 @@ static constexpr double invalid_value = -1.e100;
     {
     }
 
-    Segment::Segment(int segmentNum, int branchNum, int outletSeg,
-                     const std::vector<int>& inletSegs,
-                     double totalLen, double dept, double internalDiam,
-                     double rough, double crossA, double vol,
-                     bool dr, SegmentType segment,
-                     std::shared_ptr<SpiralICD> spiralIcd,
-                     std::shared_ptr<Valve> valv)
-    : m_segment_number(segmentNum),
-      m_branch(branchNum),
-      m_outlet_segment(outletSeg),
-      m_inlet_segments(inletSegs),
-      m_total_length(totalLen),
-      m_depth(dept),
-      m_internal_diameter(internalDiam),
-      m_roughness(rough),
-      m_cross_area(crossA),
-      m_volume(vol),
-      m_data_ready(dr),
-      m_segment_type(segment),
-      m_spiral_icd(spiralIcd),
-      m_valve(valv)
-  {
-  }
-
   Segment::Segment(const Segment& src, double new_depth, double new_length):
       Segment(src)
   {
@@ -169,12 +145,31 @@ static constexpr double invalid_value = -1.e100;
        this->m_volume = new_volume;
    }
 
-
-
   Segment::Segment(const Segment& src, double new_volume):
       Segment(src)
   {
       this->m_volume = new_volume;
+  }
+
+  Segment Segment::serializeObject()
+  {
+      Segment result;
+      result.m_segment_number = 1;
+      result.m_branch = 2;
+      result.m_outlet_segment = 3;
+      result.m_inlet_segments = {4, 5};
+      result.m_total_length = 6.0;
+      result.m_depth = 7.0;
+      result.m_internal_diameter = 8.0;
+      result.m_roughness = 9.0;
+      result.m_cross_area = 10.0;
+      result.m_volume = 11.0;
+      result.m_data_ready = true;
+      result.m_segment_type = SegmentType::SICD;
+      result.m_spiral_icd = std::make_shared<SpiralICD>(SpiralICD::serializeObject());
+      result.m_valve = std::make_shared<Valve>(Valve::serializeObject());
+
+      return result;
   }
 
     int Segment::segmentNumber() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.cpp
@@ -80,6 +80,25 @@ namespace Opm {
         }
     }
 
+
+    SpiralICD SpiralICD::serializeObject()
+    {
+        SpiralICD result;
+        result.m_strength = 1.0;
+        result.m_length = 2.0;
+        result.m_density_calibration = 3.0;
+        result.m_viscosity_calibration = 4.0;
+        result.m_critical_value = 5.0;
+        result.m_width_transition_region = 6.0;
+        result.m_max_viscosity_ratio = 7.0;
+        result.m_method_flow_scaling = 8;
+        result.m_max_absolute_rate = 9.0;
+        result.m_status = ICDStatus::OPEN;
+        result.m_scaling_factor = 10.0;
+
+        return result;
+    }
+
     std::map<std::string, std::vector<std::pair<int, SpiralICD> > >
     SpiralICD::fromWSEGSICD(const DeckKeyword& wsegsicd)
     {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.cpp
@@ -96,6 +96,21 @@ namespace Opm {
         }
     }
 
+    Valve Valve::serializeObject()
+    {
+        Valve result;
+        result.m_con_flow_coeff = 1.0;
+        result.m_con_cross_area = 2.0;
+        result.m_con_max_cross_area = 3.0;
+        result.m_pipe_additional_length = 4.0;
+        result.m_pipe_diameter = 5.0;
+        result.m_pipe_roughness = 6.0;
+        result.m_pipe_cross_area = 7.0;
+        result.m_status = ICDStatus::OPEN;
+
+        return result;
+    }
+
     std::map<std::string, std::vector<std::pair<int, Valve> > >
     Valve::fromWSEGVALV(const DeckKeyword& keyword)
     {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
@@ -50,6 +50,17 @@ namespace Opm {
     }
 
 
+    WellSegments WellSegments::serializeObject()
+    {
+        WellSegments result;
+        result.m_comp_pressure_drop = CompPressureDrop::HF_;
+        result.m_segments = {Opm::Segment::serializeObject()};
+        result.segment_number_to_index = {{1, 2}};
+
+        return result;
+    }
+
+
     std::size_t WellSegments::size() const {
         return m_segments.size();
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.cpp
@@ -32,9 +32,14 @@ namespace Opm {
         limits( timemap , MLimits())
     { }
 
-    MessageLimits::MessageLimits(const DynamicState<MLimits>& limits_) :
-        limits(limits_)
-    { }
+
+    MessageLimits MessageLimits::serializeObject()
+    {
+       MessageLimits result;
+       result.limits = {{MLimits::serializeObject()}, 2};
+
+        return result;
+    }
 
 
     int MessageLimits::getMessagePrintLimit(size_t timestep) const

--- a/src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
@@ -34,19 +34,18 @@ namespace Opm {
          m_maxDRVDT(numPvtRegionIdx, -1.0)
     {  }
 
-    OilVaporizationProperties::OilVaporizationProperties(OilVaporization type,
-                                                         double vap1,
-                                                         double vap2,
-                                                         const std::vector<double>& maxDRSDT,
-                                                         const std::vector<bool>& maxDRSDT_allCells,
-                                                         const std::vector<double>& maxDRVDT):
-        m_type(type),
-        m_vap1(vap1),
-        m_vap2(vap2),
-        m_maxDRSDT(maxDRSDT),
-        m_maxDRSDT_allCells(maxDRSDT_allCells),
-        m_maxDRVDT(maxDRVDT)
-    {  }
+    OilVaporizationProperties OilVaporizationProperties::serializeObject()
+    {
+        OilVaporizationProperties result;
+        result.m_type = OilVaporization::VAPPARS;
+        result.m_vap1 = 1.0;
+        result.m_vap2 = 2.0;
+        result.m_maxDRSDT = {3.0};
+        result.m_maxDRSDT_allCells = {4.0};
+        result.m_maxDRVDT = {5.0};
+
+        return result;
+    }
 
     double OilVaporizationProperties::getMaxDRVDT(const size_t pvtRegionIdx) const{
         if (drvdtActive()){

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
@@ -32,27 +32,25 @@ RFTConfig::RFTConfig()
 {
 }
 
-RFTConfig::RFTConfig(const TimeMap& tmap,
-                     const std::size_t first_rft,
-                     const std::pair<bool, std::size_t>& rftTime,
-                     const WellOpenTimeMap& rftName,
-                     const WellOpenTimeMap& wellOpen,
-                     const ConfigMap<RFT>& rconfig, const ConfigMap<PLT>& pconfig)
-    : tm(tmap)
-    , first_rft_event(first_rft)
-    , well_open_rft_time(rftTime)
-    , well_open_rft_name(rftName)
-    , well_open(wellOpen)
-    , rft_config(rconfig)
-    , plt_config(pconfig)
-{
-}
-
 RFTConfig::RFTConfig(const TimeMap& time_map) :
     tm(time_map),
     first_rft_event(tm.size()),
     well_open_rft_time{false, 0}
 {
+}
+
+RFTConfig RFTConfig::serializeObject()
+{
+    RFTConfig result;
+    result.tm = TimeMap::serializeObject();
+    result.first_rft_event = 1;
+    result.well_open_rft_time = {true, 2};
+    result.well_open_rft_name = {{"test1", 3}};
+    result.well_open = {{"test2", 4}};
+    result.rft_config = {{"test3", {{{RFT::TIMESTEP, 5}}, 6}}};
+    result.plt_config = {{"test3", {{{PLT::REPT, 7}}, 8}}};
+
+    return result;
 }
 
 bool RFTConfig::rft(const std::string& well_name, std::size_t report_step) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -218,57 +218,36 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
     {}
 
 
+    Schedule Schedule::serializeObject()
+    {
+        Schedule result;
+        result.m_timeMap = TimeMap::serializeObject();
+        result.wells_static.insert({"test1", {{std::make_shared<Opm::Well>(Opm::Well::serializeObject())},1}});
+        result.groups.insert({"test2", {{std::make_shared<Opm::Group>(Opm::Group::serializeObject())},1}});
+        result.m_oilvaporizationproperties = {{Opm::OilVaporizationProperties::serializeObject()},1};
+        result.m_events = Events::serializeObject();
+        result.m_modifierDeck = DynamicVector<Deck>({Deck::serializeObject()});
+        result.m_tuning = {{Tuning::serializeObject()}, 1};
+        result.m_messageLimits = MessageLimits::serializeObject();
+        result.m_runspec = Runspec::serializeObject();
+        result.vfpprod_tables = {{1, {{std::make_shared<VFPProdTable>(VFPProdTable::serializeObject())}, 1}}};
+        result.vfpinj_tables = {{2, {{std::make_shared<VFPInjTable>(VFPInjTable::serializeObject())}, 1}}};
+        result.wtest_config = {{std::make_shared<WellTestConfig>(WellTestConfig::serializeObject())}, 1};
+        result.wlist_manager = {{std::make_shared<WListManager>(WListManager::serializeObject())}, 1};
+        result.udq_config = {{std::make_shared<UDQConfig>(UDQConfig::serializeObject())}, 1};
+        result.udq_active = {{std::make_shared<UDQActive>(UDQActive::serializeObject())}, 1};
+        result.guide_rate_config = {{std::make_shared<GuideRateConfig>(GuideRateConfig::serializeObject())}, 1};
+        result.gconsale = {{std::make_shared<GConSale>(GConSale::serializeObject())}, 1};
+        result.gconsump = {{std::make_shared<GConSump>(GConSump::serializeObject())}, 1};
+        result.global_whistctl_mode = {{Well::ProducerCMode::CRAT}, 1};
+        result.m_actions = {{std::make_shared<Action::Actions>(Action::Actions::serializeObject())}, 1};
+        result.rft_config = RFTConfig::serializeObject();
+        result.m_nupcol = {{1}, 1};
+        result.restart_config = RestartConfig::serializeObject();
+        result.wellgroup_events = {{"test", Events::serializeObject()}};
 
-    Schedule::Schedule(const TimeMap& timeMap,
-                       const WellMap& wellsStatic,
-                       const GroupMap& group,
-                       const DynamicState<OilVaporizationProperties>& oilVapProps,
-                       const Events& events,
-                       const DynamicVector<Deck>& modifierDeck,
-                       const DynamicState<Tuning>& tuning,
-                       const MessageLimits& messageLimits,
-                       const Runspec& runspec,
-                       const VFPProdMap& vfpProdTables,
-                       const VFPInjMap& vfpInjTables,
-                       const DynamicState<std::shared_ptr<WellTestConfig>>& wtestConfig,
-                       const DynamicState<std::shared_ptr<WListManager>>& wListManager,
-                       const DynamicState<std::shared_ptr<UDQConfig>>& udqConfig,
-                       const DynamicState<std::shared_ptr<UDQActive>>& udqActive,
-                       const DynamicState<std::shared_ptr<GuideRateConfig>>& guideRateConfig,
-                       const DynamicState<std::shared_ptr<GConSale>>& gconSale,
-                       const DynamicState<std::shared_ptr<GConSump>>& gconSump,
-                       const DynamicState<Well::ProducerCMode>& globalWhistCtlMode,
-                       const DynamicState<std::shared_ptr<Action::Actions>>& actions,
-                       const RFTConfig& rftconfig,
-                       const DynamicState<int>& nupCol,
-                       const RestartConfig& rst_config,
-                       const std::map<std::string,Events>& wellGroupEvents) :
-        m_timeMap(timeMap),
-        wells_static(wellsStatic),
-        groups(group),
-        m_oilvaporizationproperties(oilVapProps),
-        m_events(events),
-        m_modifierDeck(modifierDeck),
-        m_tuning(tuning),
-        m_messageLimits(messageLimits),
-        m_runspec(runspec),
-        vfpprod_tables(vfpProdTables),
-        vfpinj_tables(vfpInjTables),
-        wtest_config(wtestConfig),
-        wlist_manager(wListManager),
-        udq_config(udqConfig),
-        udq_active(udqActive),
-        guide_rate_config(guideRateConfig),
-        gconsale(gconSale),
-        gconsump(gconSump),
-        global_whistctl_mode(globalWhistCtlMode),
-        m_actions(actions),
-        rft_config(rftconfig),
-        m_nupcol(nupCol),
-        restart_config(rst_config),
-        wellgroup_events(wellGroupEvents)
-    {}
-
+        return result;
+    }
 
 
     std::time_t Schedule::getStartTime() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
@@ -122,6 +122,16 @@ WellType::WellType(Phase phase) :
     WellType(true, phase)
 {}
 
+WellType WellType::serializeObject()
+{
+    WellType result;
+    result.m_producer = true;
+    result.injection_phase = Phase::OIL;
+    result.m_welspecs_phase = Phase::WATER;
+
+    return result;
+}
+
 bool WellType::update(bool producer_arg) {
     if (this->m_producer != producer_arg) {
         this->m_producer = producer_arg;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -166,6 +166,15 @@ namespace {
         }
     }
 
+    TimeMap TimeMap::serializeObject()
+    {
+        TimeMap result({123});
+        result.m_skiprest = true;
+        result.m_restart_offset = 4;
+
+        return result;
+    }
+
 
     size_t TimeMap::numTimesteps() const {
         return m_timeList.size() - 1;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.cpp
@@ -104,21 +104,19 @@ UDQASTNode::UDQASTNode(UDQTokenType type_arg,
 }
 
 
-UDQASTNode::UDQASTNode(UDQVarType varType, UDQTokenType typ,
-                       const std::string& stringVal,
-                       double scalarVal,
-                       const std::vector<std::string>& selectors,
-                       const std::shared_ptr<UDQASTNode>& left_arg,
-                       const std::shared_ptr<UDQASTNode>& right_arg) :
-    var_type(varType),
-    type(typ),
-    string_value(stringVal),
-    selector(selectors),
-    scalar_value(scalarVal),
-    left(left_arg),
-    right(right_arg)
-{}
+UDQASTNode UDQASTNode::serializeObject()
+{
+    UDQASTNode result;
+    result.var_type = UDQVarType::REGION_VAR;
+    result.type = UDQTokenType::error;
+    result.string_value = "test1";
+    result.selector = {"test2"};
+    result.scalar_value = 1.0;
+    UDQASTNode left = result;
+    result.left = std::make_shared<UDQASTNode>(left);
 
+    return result;
+}
 
 UDQASTNode::UDQASTNode(UDQTokenType type_arg,
                        const std::string& string_value_arg,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.cpp
@@ -25,15 +25,16 @@
 
 namespace Opm {
 
-UDQActive::UDQActive(const std::vector<InputRecord>& inputRecs,
-                     const std::vector<Record>& outputRecs,
-                     const std::unordered_map<std::string,std::size_t>& udqkeys,
-                     const std::unordered_map<std::string,std::size_t>& wgkeys)
-    : input_data(inputRecs)
-    , output_data(outputRecs)
-    , udq_keys(udqkeys)
-    , wg_keys(wgkeys)
-{}
+UDQActive UDQActive::serializeObject()
+{
+    UDQActive result;
+    result.input_data = {{1, "test1", "test2", UDAControl::WCONPROD_ORAT}};
+    result.output_data = {{"test1", 1, 2, "test2", UDAControl::WCONPROD_ORAT}};
+    result.udq_keys = {{"test1", 1}};
+    result.wg_keys = {{"test2", 2}};
+
+    return result;
+}
 
 std::size_t UDQActive::IUAD_size() const {
     const auto& output = this->get_iuad();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
@@ -34,13 +34,14 @@ UDQAssign::UDQAssign(const std::string& keyword, const std::vector<std::string>&
     this->add_record(selector, value);
 }
 
-UDQAssign::UDQAssign(const std::string& keyword,
-                     UDQVarType varType,
-                     const std::vector<AssignRecord>& record) :
-    m_keyword(keyword),
-    m_var_type(varType),
-    records(record)
+UDQAssign UDQAssign::serializeObject()
 {
+    UDQAssign result;
+    result.m_keyword = "test";
+    result.m_var_type = UDQVarType::CONNECTION_VAR;
+    result.records = {{{"test1"}, 1.0}};
+
+    return result;
 }
 
 void UDQAssign::add_record(const std::vector<std::string>& selector, double value) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -45,23 +45,19 @@ namespace Opm {
         udqft(this->udq_params)
     {}
 
+    UDQConfig UDQConfig::serializeObject()
+    {
+        UDQConfig result;
+        result.udq_params = UDQParams::serializeObject();
+        result.udqft = UDQFunctionTable(result.udq_params);
+        result.m_definitions = {{"test1", UDQDefine::serializeObject()}};
+        result.m_assignments = {{"test2", UDQAssign::serializeObject()}};
+        result.units = {{"test3", "test4"}};
+        result.input_index.insert({"test5", UDQIndex::serializeObject()});
+        result.type_count = {{UDQVarType::SCALAR, 5}};
 
-    UDQConfig::UDQConfig(const UDQParams& params,
-                         const UDQFunctionTable& funcTable,
-                         const std::unordered_map<std::string, UDQDefine>& definition,
-                         const std::unordered_map<std::string, UDQAssign>& assignment,
-                         const std::unordered_map<std::string, std::string>& unit,
-                         const OrderedMap<std::string, UDQIndex>& inputIdx,
-                         const std::map<UDQVarType, std::size_t>& tCount) :
-        udq_params(params),
-        udqft(funcTable),
-        m_definitions(definition),
-        m_assignments(assignment),
-        units(unit),
-        input_index(inputIdx),
-        type_count(tCount)
-    {}
-
+        return result;
+    }
 
     const UDQParams& UDQConfig::params() const {
         return this->udq_params;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -146,6 +146,18 @@ UDQDefine::UDQDefine(const std::string& keyword,
 {}
 
 
+UDQDefine UDQDefine::serializeObject()
+{
+    UDQDefine result;
+    result.m_keyword = "test1";
+    result.ast = std::make_shared<UDQASTNode>(UDQASTNode::serializeObject());
+    result.m_var_type = UDQVarType::SEGMENT_VAR;
+    result.string_data = "test2";
+
+    return result;
+}
+
+
 namespace {
 
 /*

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
@@ -76,22 +76,17 @@ namespace Opm {
         this->m_sim_rng.seed( this->random_seed );
     }
 
-
-    UDQParams::UDQParams(bool reseed, int seed,
-                         double range, double undefined,
-                         double cmp) :
-        reseed_rng(reseed),
-        random_seed(seed),
-        value_range(range),
-        undefined_value(undefined),
-        cmp_eps(cmp)
+    UDQParams UDQParams::serializeObject()
     {
-        auto now = std::chrono::high_resolution_clock::now();
-        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
-        this->m_true_rng.seed( ns.count() );
-        this->m_sim_rng.seed( this->random_seed );
-    }
+        UDQParams result;
+        result.reseed_rng = true;
+        result.random_seed = 1;
+        result.value_range = 2.0;
+        result.undefined_value = 3.0;
+        result.cmp_eps = 4.0;
 
+        return result;
+    }
 
     /*
       If the internal flag reseed_rng is set to true, this method will reset the

--- a/src/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.cpp
@@ -59,24 +59,6 @@ VFPInjTable::VFPInjTable()
     m_flo_type = FLO_INVALID;
 }
 
-VFPInjTable::VFPInjTable(int table_num,
-                         double datum_depth,
-                         FLO_TYPE flo_type,
-                         const std::vector<double>& flo_data,
-                         const std::vector<double>& thp_data,
-                         const array_type& data) {
-    m_table_num = table_num;
-    m_datum_depth = datum_depth;
-    m_flo_type = flo_type;
-    m_flo_data = flo_data;
-    m_thp_data = thp_data;
-
-    m_data = data;
-
-    check();
-}
-
-
 
 VFPInjTable::VFPInjTable( const DeckKeyword& table, const UnitSystem& deck_unit_system) {
     using ParserKeywords::VFPINJ;
@@ -193,7 +175,18 @@ VFPInjTable::VFPInjTable( const DeckKeyword& table, const UnitSystem& deck_unit_
 }
 
 
+VFPInjTable VFPInjTable::serializeObject()
+{
+    VFPInjTable result;
+    result.m_table_num = 1;
+    result.m_datum_depth = 2.0;
+    result.m_flo_type = FLO_WAT;
+    result.m_flo_data = {3.0, 4.0};
+    result.m_thp_data = {5.0, 6.0};
+    result.m_data = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
 
+    return result;
+}
 
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
@@ -126,6 +126,7 @@ VFPProdTable::ALQ_TYPE getALQType( const DeckItem& item) {
 
 }
 
+
 VFPProdTable::VFPProdTable()
 {
     m_table_num = -1;
@@ -136,6 +137,7 @@ VFPProdTable::VFPProdTable()
     m_alq_type = ALQ_INVALID;
 
 }
+
 
 VFPProdTable::VFPProdTable(int table_num,
                            double datum_depth,
@@ -164,6 +166,26 @@ VFPProdTable::VFPProdTable(int table_num,
     m_data = data;
 
     //check();
+}
+
+
+VFPProdTable VFPProdTable::serializeObject()
+{
+    VFPProdTable result;
+    result.m_table_num = 1;
+    result.m_datum_depth = 2;
+    result.m_flo_type = FLO_OIL;
+    result.m_wfr_type = WFR_WOR;
+    result.m_gfr_type = GFR_GLR;
+    result.m_alq_type = ALQ_TGLR;
+    result.m_flo_data = {1.0, 2.0, 3.0, 4.0, 5.0};
+    result.m_thp_data = {6.0};
+    result.m_wfr_data = {7.0};
+    result.m_gfr_data = {8.0};
+    result.m_alq_data = {9.0, 10.0, 11.0};
+    result.m_data = {12.0, 13.0, 14.0, 15.0, 16.0};
+
+    return result;
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -112,43 +112,37 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, std::size
 
     }
 
-
-    Connection::Connection(Direction dir, double depth, State state,
-                           int satTableId, int complnum, double CF,
-                           double Kh, double rw, double r0, double skinFactor,
-                           const std::array<int,3>& IJK,
-                           std::size_t global_index,
-                           CTFKind kind, std::size_t seqIndex,
-                           double segDistStart, double segDistEnd,
-                           bool defaultSatTabId, std::size_t compSegSeqIndex,
-                           int segment, double wellPi)
-        : direction(dir)
-        , center_depth(depth)
-        , open_state(state)
-        , sat_tableId(satTableId)
-        , m_complnum(complnum)
-        , m_CF(CF)
-        , m_Kh(Kh)
-        , m_rw(rw)
-        , m_r0(r0)
-        , m_skin_factor(skinFactor)
-        , ijk(IJK)
-        , m_global_index(global_index)
-        , m_ctfkind(kind)
-        , m_seqIndex(seqIndex)
-        , m_segDistStart(segDistStart)
-        , m_segDistEnd(segDistEnd)
-        , m_defaultSatTabId(defaultSatTabId)
-        , m_compSeg_seqIndex(compSegSeqIndex)
-        , segment_number(segment)
-        , wPi(wellPi)
-    {}
-
     Connection::Connection()
-          : Connection(Direction::X, 1.0, State::SHUT,
-                       0, 0, 0.0, 0.0, 0.0, 0.0, 0.0,
-                      {0,0,0},0, CTFKind::Defaulted, 0, 0.0, 0.0, false, 0, 0, 0.0)
+          : Connection(0, 0, 0, 0, 0, 0.0, State::SHUT, 0.0, 0.0, 0.0, 0.0, 0.0,
+                       0, Direction::X, CTFKind::DeckValue, 0, 0.0, 0.0, false)
     {}
+
+    Connection Connection::serializeObject()
+    {
+        Connection result;
+        result.direction = Direction::Y;
+        result.center_depth = 1.0;
+        result.open_state = State::OPEN;
+        result.sat_tableId = 2;
+        result.m_complnum = 3;
+        result.m_CF = 4.0;
+        result.m_Kh = 5.0;
+        result.m_rw = 6.0;
+        result.m_r0 = 7.0;
+        result.m_skin_factor = 8.0;
+        result.ijk = {9, 10, 11};
+        result.m_ctfkind = CTFKind::Defaulted;
+        result.m_global_index = 12;
+        result.m_seqIndex = 13;
+        result.m_segDistStart = 14.0;
+        result.m_segDistEnd = 15.0;
+        result.m_defaultSatTabId = true;
+        result.m_compSeg_seqIndex = 15;
+        result.segment_number = 16;
+        result.wPi = 17.0;
+
+        return result;
+    }
 
     bool Connection::sameCoordinate(const int i, const int j, const int k) const {
         if ((ijk[0] == i) && (ijk[1] == j) && (ijk[2] == k)) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.cpp
@@ -22,9 +22,12 @@
 
 namespace Opm {
 
-    WListManager::WListManager(const std::map<std::string,WList>& list)
-        : wlists(list)
+    WListManager WListManager::serializeObject()
     {
+        WListManager result;
+        result.wlists = {{"test1", WList({"test2", "test3"})}};
+
+        return result;
     }
 
     bool WListManager::hasList(const std::string& name) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -311,61 +311,38 @@ Well::Well(const std::string& wname_arg,
     this->updateProduction(p);
 }
 
-Well::Well(const std::string& wname_arg,
-          const std::string& gname,
-          std::size_t init_step_arg,
-          std::size_t insert_index_arg,
-          int headI_arg,
-          int headJ_arg,
-          double ref_depth_arg,
-          const WellType& wtype_arg,
-          const UnitSystem& units,
-          double udq_undefined_arg,
-          Status status_arg,
-          double drainageRadius,
-          bool allowCrossFlow,
-          bool automaticShutIn,
-          const WellGuideRate& guideRate,
-          double efficiencyFactor,
-          double solventFraction,
-          bool predictionMode,
-          std::shared_ptr<WellEconProductionLimits> econLimits,
-          std::shared_ptr<WellFoamProperties> foamProperties,
-          std::shared_ptr<WellPolymerProperties> polymerProperties,
-          std::shared_ptr<WellBrineProperties> brineProperties,
-          std::shared_ptr<WellTracerProperties> tracerProperties,
-          std::shared_ptr<WellConnections> connections_arg,
-          std::shared_ptr<WellProductionProperties> production_arg,
-          std::shared_ptr<WellInjectionProperties> injection_arg,
-          std::shared_ptr<WellSegments> segments_arg) :
-    wname(wname_arg),
-    group_name(gname),
-    init_step(init_step_arg),
-    insert_index(insert_index_arg),
-    headI(headI_arg),
-    headJ(headJ_arg),
-    ref_depth(ref_depth_arg),
-    unit_system(units),
-    udq_undefined(udq_undefined_arg),
-    status(status_arg),
-    drainage_radius(drainageRadius),
-    allow_cross_flow(allowCrossFlow),
-    automatic_shutin(automaticShutIn),
-    wtype(wtype_arg),
-    guide_rate(guideRate),
-    efficiency_factor(efficiencyFactor),
-    solvent_fraction(solventFraction),
-    prediction_mode(predictionMode),
-    econ_limits(econLimits),
-    foam_properties(foamProperties),
-    polymer_properties(polymerProperties),
-    brine_properties(brineProperties),
-    tracer_properties(tracerProperties),
-    connections(connections_arg),
-    production(production_arg),
-    injection(injection_arg),
-    segments(segments_arg)
+Well Well::serializeObject()
 {
+    Well result;
+    result.wname = "test1";
+    result.group_name = "test2";
+    result.init_step = 1;
+    result.insert_index = 2;
+    result.headI = 3;
+    result.headJ = 4;
+    result.ref_depth = 5;
+    result.unit_system = UnitSystem::serializeObject();
+    result.udq_undefined = 6.0;
+    result.status = Status::SHUT;
+    result.drainage_radius = 7.0;
+    result.allow_cross_flow = true;
+    result.automatic_shutin = false;
+    result.wtype = WellType(Phase::WATER);
+    result.guide_rate = WellGuideRate::serializeObject();
+    result.efficiency_factor = 8.0;
+    result.solvent_fraction = 9.0;
+    result.prediction_mode = false;
+    result.econ_limits = std::make_shared<Opm::WellEconProductionLimits>(Opm::WellEconProductionLimits::serializeObject());
+    result.foam_properties = std::make_shared<WellFoamProperties>(WellFoamProperties::serializeObject());
+    result.polymer_properties =  std::make_shared<WellPolymerProperties>(WellPolymerProperties::serializeObject());
+    result.brine_properties = std::make_shared<WellBrineProperties>(WellBrineProperties::serializeObject());
+    result.tracer_properties = std::make_shared<WellTracerProperties>(WellTracerProperties::serializeObject());
+    result.connections = std::make_shared<WellConnections>(WellConnections::serializeObject());
+    result.production = std::make_shared<Well::WellProductionProperties>(Well::WellProductionProperties::serializeObject());
+    result.injection = std::make_shared<Well::WellInjectionProperties>(Well::WellInjectionProperties::serializeObject());
+    result.segments = std::make_shared<WellSegments>(WellSegments::serializeObject());
+
+    return result;
 }
 
 bool Well::updateEfficiencyFactor(double efficiency_factor_arg) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellBrineProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellBrineProperties.cpp
@@ -22,6 +22,14 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
 
+Opm::WellBrineProperties Opm::WellBrineProperties::serializeObject()
+{
+    Opm::WellBrineProperties result;
+    result.m_saltConcentration = 1.0;
+
+    return result;
+}
+
 void Opm::WellBrineProperties::handleWSALT(const DeckRecord& rec)
 {
     this->m_saltConcentration = rec.getItem("CONCENTRATION").get<UDAValue>(0).get<double>();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -140,6 +140,17 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
     }
 
 
+    WellConnections WellConnections::serializeObject()
+    {
+        WellConnections result;
+        result.m_ordering = Connection::Order::DEPTH;
+        result.headI = 1;
+        result.headJ = 2;
+        result.m_connections = {Connection::serializeObject()};
+
+        return result;
+    }
+
 
     WellConnections::WellConnections(const WellConnections& src, const EclipseGrid& grid) :
         m_ordering(src.ordering()),

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.cpp
@@ -47,40 +47,6 @@ namespace Opm {
     {
     }
 
-    WellEconProductionLimits::WellEconProductionLimits(double minOilRate,
-                                                       double minGasRate,
-                                                       double maxWaterCut,
-                                                       double maxGasOilRatio,
-                                                       double maxWaterGasRatio,
-                                                       EconWorkover workover,
-                                                       bool endRun,
-                                                       const std::string& followonWell,
-                                                       QuantityLimit quantityLimit,
-                                                       double secondaryMaxWaterCut,
-                                                       EconWorkover workoverSecondary,
-                                                       double maxGasLiquidRatio,
-                                                       double minLiquidRate,
-                                                       double maxTemperature,
-                                                       double minReservoirFluidRate)
-        : m_min_oil_rate(minOilRate)
-        , m_min_gas_rate(minGasRate)
-        , m_max_water_cut(maxWaterCut)
-        , m_max_gas_oil_ratio(maxGasOilRatio)
-        , m_max_water_gas_ratio(maxWaterGasRatio)
-        , m_workover(workover)
-        , m_end_run(endRun)
-        , m_followon_well(followonWell)
-        , m_quantity_limit(quantityLimit)
-        , m_secondary_max_water_cut(secondaryMaxWaterCut)
-        , m_workover_secondary(workoverSecondary)
-        , m_max_gas_liquid_ratio(maxGasLiquidRatio)
-        , m_min_liquid_rate(minLiquidRate)
-        , m_max_temperature(maxTemperature)
-        , m_min_reservoir_fluid_rate(minReservoirFluidRate)
-    {
-    }
-
-
 
     WellEconProductionLimits::WellEconProductionLimits(const DeckRecord& record)
         : m_min_oil_rate(record.getItem("MIN_OIL_PRODUCTION").get<UDAValue>(0).getSI())
@@ -122,6 +88,28 @@ namespace Opm {
                 throw std::invalid_argument("Unknown input: " + string_endrun + " for END_RUN_FLAG in WECON");
             }
         }
+    }
+
+    WellEconProductionLimits WellEconProductionLimits::serializeObject()
+    {
+        WellEconProductionLimits result;
+        result.m_min_oil_rate = 1.0;
+        result.m_min_gas_rate = 2.0;
+        result.m_max_water_cut = 3.0;
+        result.m_max_gas_oil_ratio = 4.0;
+        result.m_max_water_gas_ratio = 5.0;
+        result.m_workover = EconWorkover::CONP;
+        result.m_end_run = true;
+        result.m_followon_well = "test";
+        result.m_quantity_limit = QuantityLimit::POTN;
+        result.m_secondary_max_water_cut = 6.0;
+        result.m_workover_secondary = EconWorkover::WELL;
+        result.m_max_gas_liquid_ratio = 7.0;
+        result.m_min_liquid_rate = 8.0;
+        result.m_max_temperature = 9.0;
+        result.m_min_reservoir_fluid_rate = 10.0;
+
+        return result;
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellFoamProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellFoamProperties.cpp
@@ -22,6 +22,14 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
 
+Opm::WellFoamProperties Opm::WellFoamProperties::serializeObject()
+{
+    Opm::WellFoamProperties result;
+    result.m_foamConcentration = 1.0;
+
+    return result;
+}
+
 void Opm::WellFoamProperties::handleWFOAM(const DeckRecord& rec)
 {
     this->m_foamConcentration = rec.getItem("FOAM_CONCENTRATION").get<UDAValue>(0).getSI();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.cpp
@@ -59,39 +59,27 @@ namespace Opm {
     {
     }
 
-    Well::WellInjectionProperties::WellInjectionProperties(const std::string& wname,
-                                                           const UDAValue& surfaceInjRate,
-                                                           const UDAValue& reservoirInjRate,
-                                                           const UDAValue& BHP,
-                                                           const UDAValue& THP,
-                                                           double bhp_hist,
-                                                           double thp_hist,
-                                                           double temp,
-                                                           double bhph,
-                                                           double thph,
-                                                           int vfpTableNum,
-                                                           bool predMode,
-                                                           int injControls,
-                                                           InjectorType injType,
-                                                           InjectorCMode ctrlMode)
-        : name(wname),
-          surfaceInjectionRate(surfaceInjRate),
-          reservoirInjectionRate(reservoirInjRate),
-          BHPTarget(BHP),
-          THPTarget(THP),
-          bhp_hist_limit(bhp_hist),
-          thp_hist_limit(thp_hist),
-          temperature(temp),
-          BHPH(bhph),
-          THPH(thph),
-          VFPTableNumber(vfpTableNum),
-          predictionMode(predMode),
-          injectionControls(injControls),
-          injectorType(injType),
-          controlMode(ctrlMode)
+    Well::WellInjectionProperties Well::WellInjectionProperties::serializeObject()
     {
-    }
+        Well::WellInjectionProperties result;
+        result.name = "test";
+        result.surfaceInjectionRate = UDAValue(1.0);
+        result.reservoirInjectionRate = UDAValue("test");
+        result.BHPTarget = UDAValue(2.0);
+        result.THPTarget = UDAValue(3.0);
+        result.bhp_hist_limit = 4.0;
+        result.thp_hist_limit = 5.0;
+        result.temperature = 6.0;
+        result.BHPH = 7.0;
+        result.THPH = 8.0;
+        result.VFPTableNumber = 9;
+        result.predictionMode = true;
+        result.injectionControls = 10;
+        result.injectorType = InjectorType::OIL;
+        result.controlMode = InjectorCMode::BHP;
 
+        return result;
+    }
 
     void Well::WellInjectionProperties::handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name) {
         this->injectorType = InjectorTypeFromString( record.getItem("TYPE").getTrimmedString(0) );

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellPolymerProperties.cpp
@@ -26,25 +26,17 @@
 
 namespace Opm {
 
-    WellPolymerProperties::WellPolymerProperties() {
-        m_polymerConcentration = 0.0;
-        m_saltConcentration = 0.0;
-        m_plymwinjtable = -1; // unusable table number
-        m_skprwattable = -1;
-        m_skprpolytable = -1;
-    }
+    WellPolymerProperties WellPolymerProperties::serializeObject()
+    {
+        WellPolymerProperties result;
+        result.m_polymerConcentration = 1.0;
+        result.m_saltConcentration = 2.0;
+        result.m_plymwinjtable = 3;
+        result.m_skprwattable = 4;
+        result.m_skprpolytable = 5;
 
-    WellPolymerProperties::WellPolymerProperties(double polymerConcentration,
-                                                 double saltConcentration,
-                                                 int plymwinjtable,
-                                                 int skprwattable,
-                                                 int skprpolytable)
-        : m_polymerConcentration(polymerConcentration)
-        , m_saltConcentration(saltConcentration)
-        , m_plymwinjtable(plymwinjtable)
-        , m_skprwattable(skprwattable)
-        , m_skprpolytable(skprpolytable)
-    { }
+        return result;
+    }
 
     bool WellPolymerProperties::operator==(const WellPolymerProperties& other) const {
         if ((m_polymerConcentration == other.m_polymerConcentration) &&

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -57,47 +57,30 @@ namespace Opm {
     {}
 
 
-    Well::WellProductionProperties::WellProductionProperties(const std::string& wname,
-                                                             const UDAValue& oilRate,
-                                                             const UDAValue& waterRate,
-                                                             const UDAValue& gasRate,
-                                                             const UDAValue& liquidRate,
-                                                             const UDAValue& resvRate,
-                                                             const UDAValue& BHP,
-                                                             const UDAValue& THP,
-                                                             double bhp_hist,
-                                                             double thp_hist,
-                                                             double bhph,
-                                                             double thph,
-                                                             int vfpTableNum,
-                                                             double alqValue,
-                                                             bool predMode,
-                                                             ProducerCMode ctrlMode,
-                                                             ProducerCMode whistctlMode,
-                                                             int prodCtrls)
-        : name(wname),
-          OilRate(oilRate),
-          WaterRate(waterRate),
-          GasRate(gasRate),
-          LiquidRate(liquidRate),
-          ResVRate(resvRate),
-          BHPTarget(BHP),
-          THPTarget(THP),
-          bhp_hist_limit(bhp_hist),
-          thp_hist_limit(thp_hist),
-          BHPH(bhph),
-          THPH(thph),
-          VFPTableNumber(vfpTableNum),
-          ALQValue(alqValue),
-          predictionMode(predMode),
-          controlMode(ctrlMode),
-          whistctl_cmode(whistctlMode),
-          m_productionControls(prodCtrls)
+    Well::WellProductionProperties Well::WellProductionProperties::serializeObject()
     {
+        Well::WellProductionProperties result;
+        result.name = "test";
+        result.OilRate = UDAValue(1.0);
+        result.WaterRate = UDAValue("test");
+        result.GasRate = UDAValue(2.0);
+        result.LiquidRate = UDAValue(3.0);
+        result.ResVRate = UDAValue(4.0);
+        result.BHPTarget = UDAValue(5.0);
+        result.THPTarget = UDAValue(6.0);
+        result.bhp_hist_limit = 7.0;
+        result.thp_hist_limit = 8.0;
+        result.BHPH = 9.0;
+        result.THPH = 10.0;
+        result.VFPTableNumber = 11;
+        result.ALQValue = 12.0;
+        result.predictionMode = true;
+        result.controlMode = ProducerCMode::CRAT;
+        result.whistctl_cmode = ProducerCMode::BHP;
+        result.m_productionControls = 13;
+
+        return result;
     }
-
-
-
 
     void Well::WellProductionProperties::init_rates( const DeckRecord& record ) {
         this->OilRate    = record.getItem("ORAT").get<UDAValue>(0);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.cpp
@@ -28,9 +28,13 @@ WellTestConfig::WellTestConfig() {
 
 }
 
-WellTestConfig::WellTestConfig(const std::vector<WTESTWell>& well)
-    : wells(well)
+
+WellTestConfig WellTestConfig::serializeObject()
 {
+    WellTestConfig result;
+    result.wells = {{"test", ECONOMIC, 1.0, 2, 3.0, 4}};
+
+    return result;
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTracerProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTracerProperties.cpp
@@ -24,13 +24,13 @@
 
 namespace Opm {
 
-    WellTracerProperties::WellTracerProperties() {
+    WellTracerProperties WellTracerProperties::serializeObject()
+    {
+        WellTracerProperties result;
+        result.m_tracerConcentrations = {{"test", 1.0}, {"test2", 2.0}};
+
+        return result;
     }
-
-    WellTracerProperties::WellTracerProperties(const ConcentrationMap& concentrations)
-        : m_tracerConcentrations(concentrations)
-    { }
-
 
     bool WellTracerProperties::operator==(const WellTracerProperties& other) const {
         if (m_tracerConcentrations == other.m_tracerConcentrations)

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
@@ -78,26 +78,22 @@ BCConfig::BCFace::BCFace(const DeckRecord& record) :
 {
 }
 
+BCConfig::BCFace BCConfig::BCFace::serializeObject()
+{
+    BCFace result;
+    result.i1 = 10;
+    result.i2 = 11;
+    result.j1 = 12;
+    result.j2 = 13;
+    result.k1 = 14;
+    result.k2 = 15;
+    result.bctype = BCType::RATE;
+    result.dir = FaceDir::XPlus;
+    result.component = BCComponent::GAS;
+    result.rate = 100.0;
 
-BCConfig::BCFace::BCFace(std::size_t i1_arg, std::size_t i2_arg,
-                         std::size_t j1_arg, std::size_t j2_arg,
-                         std::size_t k1_arg, std::size_t k2_arg,
-                         BCType type_arg,
-                         FaceDir::DirEnum dir_arg,
-                         BCComponent comp_arg,
-                         double rate_arg) :
-    i1(i1_arg),
-    i2(i2_arg),
-    j1(j1_arg),
-    j2(j2_arg),
-    k1(k1_arg),
-    k2(k2_arg),
-    bctype(type_arg),
-    dir(dir_arg),
-    component(comp_arg),
-    rate(rate_arg)
-{}
-
+    return result;
+}
 
 
 bool BCConfig::BCFace::operator==(const BCConfig::BCFace& other) const {
@@ -123,14 +119,12 @@ BCConfig::BCConfig(const Deck& deck) {
 }
 
 
-BCConfig::BCConfig(const std::vector<BCFace>& input_faces):
-    m_faces(input_faces)
-{}
+BCConfig BCConfig::serializeObject()
+{
+    BCConfig result;
+    result.m_faces = {BCFace::serializeObject()};
 
-
-
-const std::vector<BCConfig::BCFace>& BCConfig::faces() const {
-    return this->m_faces;
+    return result;
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
@@ -77,15 +77,18 @@ RockConfig::RockComp::RockComp(double pref_arg, double comp_arg) :
     compressibility(comp_arg)
 {}
 
+RockConfig RockConfig::serializeObject()
+{
+    RockConfig result;
+    result.m_active = true;
+    result.m_comp = {{100, 0.25}, {200, 0.30}};
+    result.num_property = "ROCKNUM";
+    result.num_tables = 10;
+    result.m_water_compaction = false;
+    result.hyst_mode = Hysteresis::HYSTER;
 
-RockConfig::RockConfig(bool active_arg, const std::vector<RockComp>& comp, const std::string& num_prop, std::size_t num_rock_tables, bool water_compaction, RockConfig::Hysteresis hyst):
-    m_active(active_arg),
-    m_comp(comp),
-    num_property(num_prop),
-    num_tables(num_rock_tables),
-    m_water_compaction(water_compaction),
-    hyst_mode(hyst)
-{}
+    return result;
+}
 
 bool RockConfig::water_compaction() const {
     return this->m_water_compaction;

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -48,7 +48,10 @@
 namespace Opm {
 
     SimulationConfig::SimulationConfig() :
-        SimulationConfig(ThresholdPressure(), BCConfig(), RockConfig(), false, false, false, false)
+        m_useCPR(false),
+        m_DISGAS(false),
+        m_VAPOIL(false),
+        m_isThermal(false)
     {
     }
 
@@ -84,19 +87,18 @@ namespace Opm {
         }
     }
 
-    SimulationConfig::SimulationConfig(const ThresholdPressure& thresholdPressure,
-                                       const BCConfig& bcconfig,
-                                       const RockConfig& rock_config,
-                                       bool useCPR, bool DISGAS,
-                                       bool VAPOIL, bool isThermal) :
-        m_ThresholdPressure(thresholdPressure),
-        m_bcconfig(bcconfig),
-        m_rock_config(rock_config),
-        m_useCPR(useCPR),
-        m_DISGAS(DISGAS),
-        m_VAPOIL(VAPOIL),
-        m_isThermal(isThermal)
+    SimulationConfig SimulationConfig::serializeObject()
     {
+        SimulationConfig result;
+        result.m_ThresholdPressure = ThresholdPressure::serializeObject();
+        result.m_bcconfig = BCConfig::serializeObject();
+        result.m_rock_config = RockConfig::serializeObject();
+        result.m_useCPR = false;
+        result.m_DISGAS = true;
+        result.m_VAPOIL = false;
+        result.m_isThermal = true;
+
+        return result;
     }
 
     const ThresholdPressure& SimulationConfig::getThresholdPressure() const {

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -127,14 +127,14 @@ namespace Opm {
         }
     }
 
-    ThresholdPressure::ThresholdPressure(bool active, bool restart,
-                                         const ThresholdPressureTable& thpTable,
-                                         const PressureTable& pTable)
-      : m_active(active)
-      , m_restart(restart)
-      , m_thresholdPressureTable(thpTable)
-      , m_pressureTable(pTable)
+    ThresholdPressure ThresholdPressure::serializeObject()
     {
+        ThresholdPressure result;
+        result.m_active = false;
+        result.m_restart = true;
+        result.m_thresholdPressureTable = {{true, 1.0}, {false, 2.0}};
+        result.m_pressureTable = {{{1,2},{false,3.0}},{{2,3},{true,4.0}}};
+        return result;
     }
 
     bool ThresholdPressure::hasRegionBarrier(int r1 , int r2) const {

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -848,6 +848,20 @@ SummaryConfigNode::SummaryConfigNode(std::string keyword, const Category cat, Lo
     loc(std::move(loc_arg))
 {}
 
+SummaryConfigNode SummaryConfigNode::serializeObject()
+{
+    SummaryConfigNode result;
+    result.keyword_ = "test1";
+    result.category_ = Category::Region;
+    result.loc = Location::serializeObject();
+    result.type_ = Type::Pressure;
+    result.name_ = "test2";
+    result.number_ = 2;
+    result.userDefined_ = true;
+
+    return result;
+}
+
 SummaryConfigNode& SummaryConfigNode::parameterType(const Type type)
 {
     this->type_ = type;
@@ -1045,6 +1059,15 @@ SummaryConfig::SummaryConfig(const keyword_list& kwds,
     keywords(kwds), short_keywords(shortKwds), summary_keywords(smryKwds)
 {}
 
+SummaryConfig SummaryConfig::serializeObject()
+{
+    SummaryConfig result;
+    result.keywords = {SummaryConfigNode::serializeObject()};
+    result.short_keywords = {"test1"};
+    result.summary_keywords = {"test2"};
+
+    return result;
+}
 
 SummaryConfig::const_iterator SummaryConfig::begin() const {
     return this->keywords.cbegin();

--- a/src/opm/parser/eclipse/EclipseState/Tables/BrineDensityTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/BrineDensityTable.cpp
@@ -24,14 +24,12 @@
 #include <opm/parser/eclipse/EclipseState/Tables/BrineDensityTable.hpp>
 
 namespace Opm {
-
-        BrineDensityTable::BrineDensityTable()
+        BrineDensityTable BrineDensityTable::serializeObject()
         {
-        }
+            BrineDensityTable result;
+            result.m_tableValues = {1.0, 2.0, 3.0};
 
-        BrineDensityTable::BrineDensityTable(const std::vector<double>& tableValues)
-            : m_tableValues(tableValues)
-        {
+            return result;
         }
 
         void BrineDensityTable::init(const Opm::DeckRecord& record )

--- a/src/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.cpp
@@ -48,6 +48,17 @@ namespace Opm {
     {
     }
 
+    ColumnSchema ColumnSchema::serializeObject()
+    {
+        ColumnSchema result;
+        result.m_name = "test1";
+        result.m_order = Table::INCREASING;
+        result.m_defaultAction = Table::DEFAULT_LINEAR;
+        result.m_defaultValue = 1.0;
+
+        return result;
+    }
+
     const std::string& ColumnSchema::name() const {
         return m_name;
     }

--- a/src/opm/parser/eclipse/EclipseState/Tables/DenT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/DenT.cpp
@@ -34,9 +34,13 @@ DenT::entry::entry(const DeckRecord& record) :
 {
 }
 
-DenT::DenT(const std::vector<DenT::entry>& records) :
-    m_records(records)
-{}
+DenT DenT::serializeObject()
+{
+    DenT result;
+    result.m_records = {{1,2,3}, {4,5,6}};
+
+    return result;
+}
 
 std::size_t DenT::size() const {
     return this->m_records.size();
@@ -63,10 +67,5 @@ bool DenT::operator==(const DenT& other) const {
 const DenT::entry& DenT::operator[](const std::size_t index) const {
     return this->m_records.at(index);
 }
-
-const std::vector<DenT::entry>& DenT::records() const {
-    return this->m_records;
-}
-
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Tables/JFunc.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/JFunc.cpp
@@ -24,7 +24,12 @@
 namespace Opm {
 
     JFunc::JFunc()
-        : JFunc(Flag::BOTH, 0.0, 0.0, 0.0, 0.0, Direction::XY)
+        : m_flag(Flag::BOTH)
+        , m_owSurfaceTension(0.0)
+        , m_goSurfaceTension(0.0)
+        , m_alphaFactor(0.5)
+        , m_betaFactor(0.5)
+        , m_direction(Direction::XY)
     {
     }
 
@@ -64,15 +69,17 @@ namespace Opm {
             throw std::invalid_argument("Illegal JFUNC DIRECTION, must be XY, X, Y, or Z.  Was \"" + kw_dir + "\".");
     }
 
-    JFunc::JFunc(Flag flag, double ow, double go,
-                 double alpha, double beta, Direction dir)
-        : m_flag(flag)
-        , m_owSurfaceTension(ow)
-        , m_goSurfaceTension(go)
-        , m_alphaFactor(alpha)
-        , m_betaFactor(beta)
-        , m_direction(dir)
+    JFunc JFunc::serializeObject()
     {
+        JFunc result;
+        result.m_flag = Flag::BOTH;
+        result.m_owSurfaceTension = 1.0;
+        result.m_goSurfaceTension = 2.0;
+        result.m_alphaFactor = 3.0;
+        result.m_betaFactor = 4.0;
+        result.m_direction = Direction::X;
+
+        return result;
     }
 
     double JFunc::alphaFactor() const {

--- a/src/opm/parser/eclipse/EclipseState/Tables/PolyInjTables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/PolyInjTables.cpp
@@ -37,16 +37,15 @@
 namespace Opm{
 
     // PolyInjTable
-
-    PolyInjTable::PolyInjTable(const std::vector<double>& throughputs,
-                               const std::vector<double>& velocities,
-                               int tableNumber,
-                               const std::vector<std::vector<double>>& data)
-        : m_throughputs(throughputs)
-        , m_velocities(velocities)
-        , m_table_number(tableNumber)
-        , m_data(data)
+    PolyInjTable PolyInjTable::serializeObject()
     {
+        PolyInjTable result;
+        result.m_throughputs = {1.0};
+        result.m_velocities = {2.0};
+        result.m_table_number = 1;
+        result.m_data = {{1.0}, {2.0}};
+
+        return result;
     }
 
     int PolyInjTable::getTableNumber() const
@@ -80,13 +79,12 @@ namespace Opm{
 
 
     // PlymwinjTable
-
-    PlymwinjTable::PlymwinjTable(const std::vector<double>& throughputs,
-                                 const std::vector<double>& velocities,
-                                 int tableNumber,
-                                 const std::vector<std::vector<double>>& data)
-        : PolyInjTable(throughputs, velocities, tableNumber, data)
+    PlymwinjTable PlymwinjTable::serializeObject()
     {
+        PlymwinjTable result;
+        static_cast<PolyInjTable&>(result) = PolyInjTable::serializeObject();
+
+        return result;
     }
 
     PlymwinjTable::PlymwinjTable(const Opm::DeckKeyword& table)
@@ -139,13 +137,12 @@ namespace Opm{
 
 
     // SkprwatTable
-
-    SkprwatTable::SkprwatTable(const std::vector<double>& throughputs,
-                               const std::vector<double>& velocities,
-                               int tableNumber,
-                               const std::vector<std::vector<double>>& data)
-        : PolyInjTable(throughputs, velocities, tableNumber, data)
+    SkprwatTable SkprwatTable::serializeObject()
     {
+        SkprwatTable result;
+        static_cast<PolyInjTable&>(result) = PolyInjTable::serializeObject();
+
+        return result;
     }
 
     SkprwatTable::SkprwatTable(const Opm::DeckKeyword &table)
@@ -197,17 +194,14 @@ namespace Opm{
     }
 
     // SkprpolyTable
-
-    SkprpolyTable::SkprpolyTable(const std::vector<double>& throughputs,
-                                 const std::vector<double>& velocities,
-                                 int tableNumber,
-                                 const std::vector<std::vector<double>>& data,
-                                 double referenceConcentration)
-        : PolyInjTable(throughputs, velocities, tableNumber, data)
-        , m_ref_polymer_concentration(referenceConcentration)
+    SkprpolyTable SkprpolyTable::serializeObject()
     {
-    }
+        SkprpolyTable result;
+        static_cast<PolyInjTable&>(result) = PolyInjTable::serializeObject();
+        result.m_ref_polymer_concentration = 3.0;
 
+        return result;
+    }
 
     SkprpolyTable::SkprpolyTable(const Opm::DeckKeyword &table)
     {

--- a/src/opm/parser/eclipse/EclipseState/Tables/PvtwsaltTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/PvtwsaltTable.cpp
@@ -30,13 +30,14 @@ namespace Opm {
         {
         }
 
-        PvtwsaltTable::PvtwsaltTable(double refPressValue,
-                                     double refSaltConValue,
-                                     const std::vector<double>& tableValues)
-            : m_pRefValues(refPressValue)
-            , m_saltConsRefValues(refSaltConValue)
-            , m_tableValues(tableValues)
+        PvtwsaltTable PvtwsaltTable::serializeObject()
         {
+            PvtwsaltTable result;
+            result.m_pRefValues = 1.0;
+            result.m_saltConsRefValues = 2.0;
+            result.m_tableValues = {3.0, 4.0, 5.0};
+
+            return result;
         }
 
         void PvtwsaltTable::init(const Opm::DeckRecord& record0, const Opm::DeckRecord& record1)

--- a/src/opm/parser/eclipse/EclipseState/Tables/PvtxTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/PvtxTable.cpp
@@ -34,22 +34,18 @@ namespace Opm {
 
     }
 
-
-    PvtxTable::PvtxTable(const ColumnSchema& outer_schema,
-                         const TableColumn& outer_column,
-                         const TableSchema& undersat_schema,
-                         const TableSchema& sat_schema,
-                         const std::vector<SimpleTable>& undersat_tables,
-                         const SimpleTable& sat_table) :
-        m_outerColumnSchema(outer_schema),
-        m_outerColumn(outer_column),
-        m_underSaturatedSchema(undersat_schema),
-        m_saturatedSchema(sat_schema),
-        m_underSaturatedTables(undersat_tables),
-        m_saturatedTable(sat_table)
+    PvtxTable PvtxTable::serializeObject()
     {
-    }
+        PvtxTable result;
+        result.m_outerColumnSchema = ColumnSchema::serializeObject();
+        result.m_outerColumn = TableColumn::serializeObject();
+        result.m_underSaturatedSchema = TableSchema::serializeObject();
+        result.m_saturatedSchema = TableSchema::serializeObject();
+        result.m_underSaturatedTables = {SimpleTable::serializeObject()};
+        result.m_saturatedTable = SimpleTable::serializeObject();
 
+        return result;
+    }
 
     /*
       The Schema pointers m_saturatedSchema and m_underSaturatedSchema must

--- a/src/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Rock2dTable.cpp
@@ -29,11 +29,13 @@ namespace Opm {
         {
         }
 
-        Rock2dTable::Rock2dTable(const std::vector<std::vector<double>>& pvmultValues,
-                                 const std::vector<double>& pressureValues)
-            : m_pvmultValues(pvmultValues)
-            , m_pressureValues(pressureValues)
+        Rock2dTable Rock2dTable::serializeObject()
         {
+            Rock2dTable result;
+            result.m_pvmultValues = {{1.0,2.0},{3.0,4.0}};
+            result.m_pressureValues = {1.0, 2.0, 3.0};
+
+            return result;
         }
 
         void Rock2dTable::init(const DeckRecord& record, size_t /* tableIdx */)

--- a/src/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
@@ -29,11 +29,14 @@ namespace Opm {
         {
         }
 
-        Rock2dtrTable::Rock2dtrTable(const std::vector<std::vector<double>>& transMultValues,
-                                     const std::vector<double>& pressureValues)
-            : m_transMultValues(transMultValues)
-            , m_pressureValues(pressureValues)
+        Rock2dtrTable  Rock2dtrTable::serializeObject()
         {
+            Rock2dtrTable result;
+
+            result.m_transMultValues = {{1.0,2.0},{3.0,4.0}};
+            result.m_pressureValues = {1.0, 2.0, 3.0};
+
+            return result;
         }
 
         void Rock2dtrTable::init(const DeckRecord& record, size_t /* tableIdx */)

--- a/src/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -41,15 +41,15 @@ namespace Opm {
     }
 
 
-    SimpleTable::SimpleTable(const TableSchema& schema,
-                             const OrderedMap<std::string, TableColumn>& columns,
-                             bool jf) :
-        m_schema(schema),
-        m_columns(columns),
-        m_jfunc(jf)
+    SimpleTable SimpleTable::serializeObject()
     {
-    }
+        SimpleTable result;
+        result.m_schema = Opm::TableSchema::serializeObject();
+        result.m_columns.insert({"test3", Opm::TableColumn::serializeObject()});
+        result.m_jfunc = true;
 
+        return result;
+    }
 
     void SimpleTable::addRow( const std::vector<double>& row) {
         if (row.size() == numColumns()) {

--- a/src/opm/parser/eclipse/EclipseState/Tables/SolventDensityTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/SolventDensityTable.cpp
@@ -24,14 +24,12 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SolventDensityTable.hpp>
 
 namespace Opm {
-
-        SolventDensityTable::SolventDensityTable()
+        SolventDensityTable SolventDensityTable::serializeObject()
         {
-        }
+            SolventDensityTable result;
+            result.m_tableValues = {1.0, 2.0, 3.0};
 
-        SolventDensityTable::SolventDensityTable(const std::vector<double>& tableValues)
-            : m_tableValues(tableValues)
-        {
+            return result;
         }
 
         void SolventDensityTable::init(const Opm::DeckRecord& record )

--- a/src/opm/parser/eclipse/EclipseState/Tables/StandardCond.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/StandardCond.cpp
@@ -34,4 +34,14 @@ StandardCond::StandardCond() {
 }
 
 
+StandardCond StandardCond::serializeObject()
+{
+    StandardCond result;
+    result.temperature = 1.0;
+    result.pressure = 2.0;
+
+    return result;
+}
+
+
 }

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableColumn.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableColumn.cpp
@@ -38,17 +38,16 @@ namespace Opm {
     }
 
 
-    TableColumn::TableColumn(const ColumnSchema& schema,
-                             const std::string& name,
-                             const std::vector<double>& values,
-                             const std::vector<bool>& defaults,
-                             size_t defaultCount) :
-        m_schema(schema),
-        m_name(name),
-        m_values(values),
-        m_default(defaults),
-        m_defaultCount(defaultCount)
+    TableColumn TableColumn::serializeObject()
     {
+        TableColumn result;
+        result.m_schema = Opm::ColumnSchema::serializeObject();
+        result.m_name = "test2";
+        result.m_values = {1.0, 2.0};
+        result.m_default = {false, true};
+        result.m_defaultCount = 2;
+
+        return result;
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -35,6 +35,15 @@ namespace Opm {
     {
     }
 
+    TableContainer TableContainer::serializeObject()
+    {
+        TableContainer result;
+        result.m_maxTables = 2;
+        result.addTable(0, std::make_shared<Opm::SimpleTable>(Opm::SimpleTable::serializeObject()));
+        result.addTable(1, std::make_shared<Opm::SimpleTable>(Opm::SimpleTable::serializeObject()));
+
+        return result;
+    }
 
     bool TableContainer::empty() const {
         return m_tables.empty();

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -95,85 +95,6 @@
 
 namespace Opm {
 
-    TableManager::TableManager(const std::map<std::string, TableContainer>& simpleTables,
-                               const std::vector<PvtgTable>& pvtgTables,
-                               const std::vector<PvtoTable>& pvtoTables,
-                               const std::vector<Rock2dTable>& rock2dTables,
-                               const std::vector<Rock2dtrTable>& rock2dtrTables,
-                               const PvtwTable& pvtwTable,
-                               const PvcdoTable& pvcdoTable,
-                               const DensityTable& densityTable,
-                               const PlyvmhTable& plyvmhTable,
-                               const RockTable& rockTable,
-                               const PlmixparTable& plmixparTable,
-                               const ShrateTable& shrateTable,
-                               const Stone1exTable& stone1exTable,
-                               const TlmixparTable& tlmixparTable,
-                               const ViscrefTable& viscrefTable,
-                               const WatdentTable& watdentTable,
-                               const std::vector<PvtwsaltTable>& pvtwsaltTables,
-                               const std::vector<BrineDensityTable>& bdensityTables,
-                               const std::vector<SolventDensityTable>& sdensityTables,
-                               const std::map<int, PlymwinjTable>& plymwinjTables,
-                               const std::map<int, SkprwatTable>& skprwatTables,
-                               const std::map<int, SkprpolyTable>& skprpolyTables,
-                               const Tabdims& tabdims,
-                               const Regdims& regdims,
-                               const Eqldims& eqldims,
-                               const Aqudims& aqudims,
-                               bool useImptvd,
-                               bool useEnptvd,
-                               bool useEqlnum,
-                               bool useShrate,
-                               std::shared_ptr<JFunc> jfunc_param,
-                               const DenT& oilDenT_,
-                               const DenT& gasDenT_,
-                               const DenT& watDenT_,
-                               const StandardCond& stcond_,
-                               std::size_t gas_comp_index,
-                               double rtemp)
-        :
-        m_simpleTables(simpleTables),
-        m_pvtgTables(pvtgTables),
-        m_pvtoTables(pvtoTables),
-        m_rock2dTables(rock2dTables),
-        m_rock2dtrTables(rock2dtrTables),
-        m_pvtwTable(pvtwTable),
-        m_pvcdoTable(pvcdoTable),
-        m_densityTable(densityTable),
-        m_plyvmhTable(plyvmhTable),
-        m_rockTable(rockTable),
-        m_plmixparTable(plmixparTable),
-        m_shrateTable(shrateTable),
-        m_stone1exTable(stone1exTable),
-        m_tlmixparTable(tlmixparTable),
-        m_viscrefTable(viscrefTable),
-        m_watdentTable(watdentTable),
-        m_pvtwsaltTables(pvtwsaltTables),
-        m_bdensityTables(bdensityTables),
-        m_sdensityTables(sdensityTables),
-        m_plymwinjTables(plymwinjTables),
-        m_skprwatTables(skprwatTables),
-        m_skprpolyTables(skprpolyTables),
-        m_tabdims(tabdims),
-        m_regdims(regdims),
-        m_eqldims(eqldims),
-        m_aqudims(aqudims),
-        hasImptvd(useImptvd),
-        hasEnptvd(useEnptvd),
-        hasEqlnum(useEqlnum),
-        hasShrate(useShrate),
-        jfunc(std::move(jfunc_param)),
-        oilDenT(oilDenT_),
-        gasDenT(gasDenT_),
-        watDenT(watDenT_),
-        stcond(stcond_),
-        m_gas_comp_index(gas_comp_index),
-        m_rtemp(rtemp)
-    {
-    }
-
-
     TableManager::TableManager( const Deck& deck )
         :
         m_tabdims( Tabdims(deck)),
@@ -314,6 +235,49 @@ namespace Opm {
         m_gas_comp_index = data.m_gas_comp_index;
 
         return *this;
+    }
+
+    TableManager TableManager::serializeObject()
+    {
+        TableManager result;
+        result.m_simpleTables = {{"test", TableContainer::serializeObject()}};
+        result.m_pvtgTables = {PvtgTable::serializeObject()};
+        result.m_pvtoTables = {PvtoTable::serializeObject()};
+        result.m_rock2dTables = {Rock2dTable::serializeObject()};
+        result.m_rock2dtrTables = {Rock2dtrTable::serializeObject()};
+        result.m_pvtwTable = PvtwTable::serializeObject();
+        result.m_pvcdoTable = PvcdoTable::serializeObject();
+        result.m_densityTable = DensityTable::serializeObject();
+        result.m_plyvmhTable = PlyvmhTable::serializeObject();
+        result.m_rockTable = RockTable::serializeObject();
+        result.m_plmixparTable = PlmixparTable::serializeObject();
+        result.m_shrateTable = ShrateTable::serializeObject();
+        result.m_stone1exTable = Stone1exTable::serializeObject();
+        result.m_tlmixparTable = TlmixparTable::serializeObject();
+        result.m_viscrefTable = ViscrefTable::serializeObject();
+        result.m_watdentTable = WatdentTable::serializeObject();
+        result.m_pvtwsaltTables = {PvtwsaltTable::serializeObject()};
+        result.m_bdensityTables = {BrineDensityTable::serializeObject()};
+        result.m_sdensityTables = {SolventDensityTable::serializeObject()};
+        result.m_plymwinjTables = {{1, Opm::PlymwinjTable::serializeObject()}};
+        result.m_skprwatTables =  {{2, Opm::SkprwatTable::serializeObject()}};
+        result.m_skprpolyTables = {{3, Opm::SkprpolyTable::serializeObject()}};
+        result.m_tabdims = Tabdims::serializeObject();
+        result.m_regdims = Regdims::serializeObject();
+        result.m_eqldims = Eqldims::serializeObject();
+        result.hasImptvd = true;
+        result.hasEnptvd = true;
+        result.hasEqlnum = true;
+        result.hasShrate = true;
+        result.jfunc = std::make_shared<Opm::JFunc>(Opm::JFunc::serializeObject());
+        result.oilDenT = DenT::serializeObject();
+        result.gasDenT = DenT::serializeObject();
+        result.watDenT = DenT::serializeObject();
+        result.stcond = StandardCond::serializeObject();
+        result.m_gas_comp_index = 77;
+        result.m_rtemp = 1.0;
+
+        return result;
     }
 
     void TableManager::initDims(const Deck& deck) {

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableSchema.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableSchema.cpp
@@ -22,9 +22,12 @@
 
 namespace Opm {
 
-    TableSchema::TableSchema(const OrderedMap<std::string, ColumnSchema>& columns) :
-        m_columns(columns)
+    TableSchema TableSchema::serializeObject()
     {
+        TableSchema result;
+        result.m_columns.insert({"test1", ColumnSchema::serializeObject()});
+
+        return result;
     }
 
     void TableSchema::addColumn( ColumnSchema column ) {

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -96,15 +96,11 @@ PvtgTable::PvtgTable( const DeckKeyword& keyword, size_t tableIdx ) :
         PvtxTable::init(keyword, tableIdx);
     }
 
-PvtgTable::PvtgTable(const ColumnSchema& outer_schema,
-                     const TableColumn& outer_column,
-                     const TableSchema& undersat_schema,
-                     const TableSchema& sat_schema,
-                     const std::vector<SimpleTable>& undersat_tables,
-                     const SimpleTable& sat_table) :
-      PvtxTable(outer_schema, outer_column, undersat_schema, sat_schema,
-                undersat_tables, sat_table)
-{
+PvtgTable PvtgTable::serializeObject() {
+    PvtgTable result;
+    static_cast<PvtxTable&>(result) = PvtxTable::serializeObject();
+
+    return result;
 }
 
 bool PvtgTable::operator==(const PvtgTable& data) const {
@@ -125,17 +121,12 @@ PvtoTable::PvtoTable( const DeckKeyword& keyword, size_t tableIdx) :
         PvtxTable::init(keyword , tableIdx);
     }
 
-PvtoTable::PvtoTable(const ColumnSchema& outer_schema,
-                     const TableColumn& outer_column,
-                     const TableSchema& undersat_schema,
-                     const TableSchema& sat_schema,
-                     const std::vector<SimpleTable>& undersat_tables,
-                     const SimpleTable& sat_table) :
-      PvtxTable(outer_schema, outer_column, undersat_schema, sat_schema,
-                undersat_tables, sat_table)
-{
-}
+PvtoTable PvtoTable::serializeObject() {
+    PvtoTable result;
+    static_cast<PvtxTable&>(result) = PvtxTable::serializeObject();
 
+    return result;
+}
 
 bool PvtoTable::operator==(const PvtoTable& data) const {
     return static_cast<const PvtxTable&>(*this) == static_cast<const PvtxTable&>(data);
@@ -644,21 +635,17 @@ PlyshlogTable::PlyshlogTable(
     SimpleTable::init( dataRecord.getItem<ParserKeywords::PLYSHLOG::DATA>() );
 }
 
-PlyshlogTable::PlyshlogTable(const TableSchema& schema,
-                             const OrderedMap<std::string, TableColumn>& columns,
-                             bool jfunc,
-                             double refPolymerConcentration,
-                             double refSalinity,
-                             double refTemperature,
-                             bool hasRefSalinity,
-                             bool hasRefTemperature)
-    : SimpleTable(schema, columns, jfunc)
-    , m_refPolymerConcentration(refPolymerConcentration)
-    , m_refSalinity(refSalinity)
-    , m_refTemperature(refTemperature)
-    , m_hasRefSalinity(hasRefSalinity)
-    , m_hasRefTemperature(hasRefTemperature)
+PlyshlogTable PlyshlogTable::serializeObject()
 {
+    PlyshlogTable result;
+    static_cast<SimpleTable&>(result) = SimpleTable::serializeObject();
+    result.m_refPolymerConcentration = 1.0;
+    result.m_refSalinity = 2.0;
+    result.m_refTemperature = 3.0;
+    result.m_hasRefSalinity = true;
+    result.m_hasRefTemperature = true;
+
+    return result;
 }
 
 double PlyshlogTable::getRefPolymerConcentration() const {
@@ -839,12 +826,13 @@ RocktabTable::RocktabTable(
     SimpleTable::init(item);
 }
 
-RocktabTable::RocktabTable(const TableSchema& schema,
-                           const OrderedMap<std::string, TableColumn>& columns,
-                           bool jfunc, bool isDirectional)
-    : SimpleTable(schema, columns, jfunc)
-    , m_isDirectional(isDirectional)
+RocktabTable RocktabTable::serializeObject()
 {
+    RocktabTable result;
+    static_cast<SimpleTable&>(result) = Opm::SimpleTable::serializeObject();
+    result.m_isDirectional = true;
+
+    return result;
 }
 
 const TableColumn& RocktabTable::getPressureColumn() const {

--- a/src/opm/parser/eclipse/Units/Dimension.cpp
+++ b/src/opm/parser/eclipse/Units/Dimension.cpp
@@ -39,6 +39,11 @@ namespace Opm {
         m_SIoffset = SIoffset;
     }
 
+    Dimension Dimension::serializeObject()
+    {
+        return Dimension(1.0, 2.0);
+    }
+
     double Dimension::getSIScaling() const {
         if (!std::isfinite(m_SIfactor))
             throw std::logic_error("The DeckItem contains a field with a context dependent unit. "

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -802,15 +802,9 @@ namespace {
         init();
     }
 
-    UnitSystem::UnitSystem(const std::string& name, UnitType unit,
-                           const std::map<std::string,Dimension>& dimensions,
-                           size_t use_count)
-        : m_name(name)
-        , m_unittype(unit)
-        , m_dimensions(dimensions)
-        , m_use_count(use_count)
+    UnitSystem UnitSystem::serializeObject()
     {
-        init();
+        return UnitSystem(UnitType::UNIT_TYPE_METRIC);
     }
 
     void UnitSystem::initINPUT() {


### PR DESCRIPTION
add static method to return a test object for serialization. this allows killing the constructors taking member values.

@joakim-hove as discussed. this is pretty unreviewable but you said yes to the idea.