### PR TITLE
replacing long int and unsigned long int

### DIFF
--- a/opm/io/eclipse/EclFile.hpp
+++ b/opm/io/eclipse/EclFile.hpp
@@ -52,7 +52,7 @@ public:
       char_array.clear();
     }
 
-    using EclEntry = std::tuple<std::string, eclArrType, long int>;
+    using EclEntry = std::tuple<std::string, eclArrType, int64_t>;
     std::vector<EclEntry> getList() const;
 
     template <typename T>
@@ -79,9 +79,9 @@ protected:
 
     std::vector<std::string> array_name;
     std::vector<eclArrType> array_type;
-    std::vector<long int> array_size;
+    std::vector<int64_t> array_size;
 
-    std::vector<unsigned long int> ifStreamPos;
+    std::vector<uint64_t> ifStreamPos;
 
     std::map<std::string, int> array_index;
 
@@ -109,7 +109,7 @@ private:
     std::vector<bool> arrayLoaded;
 
     void loadBinaryArray(std::fstream& fileH, std::size_t arrIndex);
-    void loadFormattedArray(const std::string& fileStr, std::size_t arrIndex, long int fromPos);
+    void loadFormattedArray(const std::string& fileStr, std::size_t arrIndex, int64_t fromPos);
     
 };
 

--- a/opm/io/eclipse/EclOutput.hpp
+++ b/opm/io/eclipse/EclOutput.hpp
@@ -79,7 +79,7 @@ public:
     friend class OutputStream::SummarySpecification;
 
 private:
-    void writeBinaryHeader(const std::string& arrName, long int size, eclArrType arrType);
+    void writeBinaryHeader(const std::string& arrName, int64_t size, eclArrType arrType);
 
     template <typename T>
     void writeBinaryArray(const std::vector<T>& data);

--- a/opm/io/eclipse/EclUtil.hpp
+++ b/opm/io/eclipse/EclUtil.hpp
@@ -27,7 +27,7 @@
 namespace Opm { namespace EclIO {
 
     int flipEndianInt(int num);
-    long int flipEndianLongInt(long int num);
+    int64_t flipEndianLongInt(int64_t num);
     float flipEndianFloat(float num);
     double flipEndianDouble(double num);
 

--- a/python/cxx/eclipse_io.cpp
+++ b/python/cxx/eclipse_io.cpp
@@ -21,7 +21,7 @@ namespace py = pybind11;
 namespace {
 
 using npArray = std::tuple<py::array, Opm::EclIO::eclArrType>;
-using EclEntry = std::tuple<std::string, Opm::EclIO::eclArrType, long int>;
+using EclEntry = std::tuple<std::string, Opm::EclIO::eclArrType, int64_t>;
 
 class EclOutputBind {
 
@@ -337,10 +337,10 @@ void python::common::export_IO(py::module& m) {
         .def(py::init<const std::string &>())
         .def("__get_list_of_rfts", &Opm::EclIO::ERft::listOfRftReports)
 
-        .def("__get_list_of_arrays", (std::vector< std::tuple<std::string, Opm::EclIO::eclArrType, long int> >
+        .def("__get_list_of_arrays", (std::vector< std::tuple<std::string, Opm::EclIO::eclArrType, int64_t> >
                                      (Opm::EclIO::ERft::*)(int) const) &Opm::EclIO::ERft::listOfRftArrays)
 
-        .def("__get_list_of_arrays", (std::vector< std::tuple<std::string, Opm::EclIO::eclArrType, long int> >
+        .def("__get_list_of_arrays", (std::vector< std::tuple<std::string, Opm::EclIO::eclArrType, int64_t> >
                                      (Opm::EclIO::ERft::*)(const std::string&, int, int, int) const)
                                       &Opm::EclIO::ERft::listOfRftArrays)
 

--- a/src/opm/io/eclipse/EclFile.cpp
+++ b/src/opm/io/eclipse/EclFile.cpp
@@ -57,7 +57,7 @@ bool isFormatted(const std::string& filename)
 bool isEOF(std::fstream* fileH)
 {
     int num;
-    long int pos = fileH->tellg();
+    int64_t pos = fileH->tellg();
     fileH->read(reinterpret_cast<char*>(&num), sizeof(num));
 
     if (fileH->eof()) {
@@ -99,7 +99,7 @@ void readBinaryHeader(std::fstream& fileH, std::string& tmpStrName,
 }
 
 void readBinaryHeader(std::fstream& fileH, std::string& arrName,
-                      long int& size, Opm::EclIO::eclArrType &arrType)
+                      int64_t& size, Opm::EclIO::eclArrType &arrType)
 {
     std::string tmpStrName(8,' ');
     std::string tmpStrType(4,' ');
@@ -119,9 +119,9 @@ void readBinaryHeader(std::fstream& fileH, std::string& arrName,
         if (x231exp < 0)
             OPM_THROW(std::runtime_error, "Invalied X231 header, size of array should be negative'");
         
-        size = static_cast<long int>(tmpSize) + static_cast<long int>(x231exp) * pow(2,31); 
+        size = static_cast<int64_t>(tmpSize) + static_cast<int64_t>(x231exp) * pow(2,31);
     } else {
-        size = static_cast<long int>(tmpSize);
+        size = static_cast<int64_t>(tmpSize);
     }
 
     arrName = tmpStrName;
@@ -141,9 +141,9 @@ void readBinaryHeader(std::fstream& fileH, std::string& arrName,
         OPM_THROW(std::runtime_error, "Error, unknown array type '" + tmpStrType +"'");
 }
 
-unsigned long int sizeOnDiskBinary(long int num, Opm::EclIO::eclArrType arrType)
+uint64_t sizeOnDiskBinary(int64_t num, Opm::EclIO::eclArrType arrType)
 {
-    unsigned long int size = 0;
+    uint64_t size = 0;
 
     if (arrType == Opm::EclIO::MESS) {
         if (num > 0) {
@@ -158,16 +158,16 @@ unsigned long int sizeOnDiskBinary(long int num, Opm::EclIO::eclArrType arrType)
             int maxBlockSize = std::get<1>(sizeData);
             int maxNumberOfElements = maxBlockSize / sizeOfElement;
 
-            long unsigned int numBlocks = static_cast<unsigned long int>(num)/static_cast<unsigned long int>(maxNumberOfElements);
-            long unsigned int rest = static_cast<unsigned long int>(num) - numBlocks*static_cast<unsigned long int>(maxNumberOfElements);
+            auto numBlocks = static_cast<uint64_t>(num)/static_cast<uint64_t>(maxNumberOfElements);
+            auto rest = static_cast<uint64_t>(num) - numBlocks*static_cast<uint64_t>(maxNumberOfElements);
 
-            long unsigned int size2Inte = static_cast<long unsigned int>(Opm::EclIO::sizeOfInte) * 2;
-            long unsigned int sizeFullBlocks = numBlocks * (static_cast<long unsigned int>(maxBlockSize) + size2Inte);
+            auto size2Inte = static_cast<uint64_t>(Opm::EclIO::sizeOfInte) * 2;
+            auto sizeFullBlocks = numBlocks * (static_cast<uint64_t>(maxBlockSize) + size2Inte);
 
-            long unsigned int sizeLastBlock = 0;
+            uint64_t sizeLastBlock = 0;
 
             if (rest > 0)
-                sizeLastBlock = rest * static_cast<long unsigned int>(sizeOfElement) + size2Inte;
+                sizeLastBlock = rest * static_cast<uint64_t>(sizeOfElement) + size2Inte;
 
             size = sizeFullBlocks + sizeLastBlock;
         }
@@ -176,9 +176,9 @@ unsigned long int sizeOnDiskBinary(long int num, Opm::EclIO::eclArrType arrType)
     return size;
 }
 
-unsigned long int sizeOnDiskFormatted(const long int num, Opm::EclIO::eclArrType arrType)
+uint64_t sizeOnDiskFormatted(const int64_t num, Opm::EclIO::eclArrType arrType)
 {
-    unsigned long int size = 0;
+    uint64_t size = 0;
 
     if (arrType == Opm::EclIO::MESS) {
         if (num > 0) {
@@ -204,7 +204,7 @@ unsigned long int sizeOnDiskFormatted(const long int num, Opm::EclIO::eclArrType
                 nLinesBlock++;
             }
 
-            long int blockSize = maxBlockSize * columnWidth + nLinesBlock;
+            int64_t blockSize = maxBlockSize * columnWidth + nLinesBlock;
             size = nBlocks * blockSize;
         }
 
@@ -223,7 +223,7 @@ unsigned long int sizeOnDiskFormatted(const long int num, Opm::EclIO::eclArrType
 
 
 template<typename T, typename T2>
-std::vector<T> readBinaryArray(std::fstream& fileH, const long int size, Opm::EclIO::eclArrType type,
+std::vector<T> readBinaryArray(std::fstream& fileH, const int64_t size, Opm::EclIO::eclArrType type,
                                std::function<T(T2)>& flip)
 {
     std::vector<T> arr;
@@ -235,7 +235,7 @@ std::vector<T> readBinaryArray(std::fstream& fileH, const long int size, Opm::Ec
 
     arr.reserve(size);
 
-    long int rest = size;
+    int64_t rest = size;
     while (rest > 0) {
         int dhead;
         fileH.read(reinterpret_cast<char*>(&dhead), sizeof(dhead));
@@ -274,27 +274,27 @@ std::vector<T> readBinaryArray(std::fstream& fileH, const long int size, Opm::Ec
 }
 
 
-std::vector<int> readBinaryInteArray(std::fstream &fileH, const long int size)
+std::vector<int> readBinaryInteArray(std::fstream &fileH, const int64_t size)
 {
     std::function<int(int)> f = Opm::EclIO::flipEndianInt;
     return readBinaryArray<int,int>(fileH, size, Opm::EclIO::INTE, f);
 }
 
 
-std::vector<float> readBinaryRealArray(std::fstream& fileH, const long int size)
+std::vector<float> readBinaryRealArray(std::fstream& fileH, const int64_t size)
 {
     std::function<float(float)> f = Opm::EclIO::flipEndianFloat;
     return readBinaryArray<float,float>(fileH, size, Opm::EclIO::REAL, f);
 }
 
 
-std::vector<double> readBinaryDoubArray(std::fstream& fileH, const long int size)
+std::vector<double> readBinaryDoubArray(std::fstream& fileH, const int64_t size)
 {
     std::function<double(double)> f = Opm::EclIO::flipEndianDouble;
     return readBinaryArray<double,double>(fileH, size, Opm::EclIO::DOUB, f);
 }
 
-std::vector<bool> readBinaryLogiArray(std::fstream &fileH, const long int size)
+std::vector<bool> readBinaryLogiArray(std::fstream &fileH, const int64_t size)
 {
     std::function<bool(unsigned int)> f = [](unsigned int intVal)
                                           {
@@ -313,7 +313,7 @@ std::vector<bool> readBinaryLogiArray(std::fstream &fileH, const long int size)
 }
 
 
-std::vector<std::string> readBinaryCharArray(std::fstream& fileH, const long int size)
+std::vector<std::string> readBinaryCharArray(std::fstream& fileH, const int64_t size)
 {
     using Char8 = std::array<char, 8>;
     std::function<std::string(Char8)> f = [](const Char8& val)
@@ -326,7 +326,7 @@ std::vector<std::string> readBinaryCharArray(std::fstream& fileH, const long int
 
 
 void readFormattedHeader(std::fstream& fileH, std::string& arrName,
-                         long int &num, Opm::EclIO::eclArrType &arrType)
+                         int64_t &num, Opm::EclIO::eclArrType &arrType)
 {
     std::string line;
     std::getline(fileH,line);
@@ -368,18 +368,18 @@ void readFormattedHeader(std::fstream& fileH, std::string& arrName,
 
 
 template<typename T>
-std::vector<T> readFormattedArray(const std::string& file_str, const int size, long int fromPos,
+std::vector<T> readFormattedArray(const std::string& file_str, const int size, int64_t fromPos,
                                  std::function<T(const std::string&)>& process)
 {
     std::vector<T> arr;
 
     arr.reserve(size);
 
-    long int p1=fromPos;
+    int64_t p1=fromPos;
 
     for (int i=0; i< size; i++) {
         p1 = file_str.find_first_not_of(' ',p1);
-        long int p2 = file_str.find_first_of(' ', p1);
+        int64_t p2 = file_str.find_first_of(' ', p1);
 
         arr.push_back(process(file_str.substr(p1, p2-p1)));
 
@@ -391,7 +391,7 @@ std::vector<T> readFormattedArray(const std::string& file_str, const int size, l
 }
 
 
-std::vector<int> readFormattedInteArray(const std::string& file_str, const long int size, long int fromPos)
+std::vector<int> readFormattedInteArray(const std::string& file_str, const int64_t size, int64_t fromPos)
 {
 
     std::function<int(const std::string&)> f = [](const std::string& val)
@@ -403,12 +403,12 @@ std::vector<int> readFormattedInteArray(const std::string& file_str, const long 
 }
 
 
-std::vector<std::string> readFormattedCharArray(const std::string& file_str, const long int size, long int fromPos)
+std::vector<std::string> readFormattedCharArray(const std::string& file_str, const int64_t size, int64_t fromPos)
 {
     std::vector<std::string> arr;
     arr.reserve(size);
 
-    long int p1=fromPos;
+    int64_t p1=fromPos;
 
     for (int i=0; i< size; i++) {
         p1 = file_str.find_first_of('\'',p1);
@@ -427,7 +427,7 @@ std::vector<std::string> readFormattedCharArray(const std::string& file_str, con
 }
 
 
-std::vector<float> readFormattedRealArray(const std::string& file_str, const long int size, long int fromPos)
+std::vector<float> readFormattedRealArray(const std::string& file_str, const int64_t size, int64_t fromPos)
 {
 
     std::function<float(const std::string&)> f = [](const std::string& val)
@@ -442,7 +442,7 @@ std::vector<float> readFormattedRealArray(const std::string& file_str, const lon
 }
 
 
-std::vector<bool> readFormattedLogiArray(const std::string& file_str, const long int size, long int fromPos)
+std::vector<bool> readFormattedLogiArray(const std::string& file_str, const int64_t size, int64_t fromPos)
 {
 
     std::function<bool(const std::string&)> f = [](const std::string& val)
@@ -460,7 +460,7 @@ std::vector<bool> readFormattedLogiArray(const std::string& file_str, const long
     return readFormattedArray<bool>(file_str, size, fromPos, f);
 }
 
-std::vector<double> readFormattedDoubArray(const std::string& file_str, const long int size, long int fromPos)
+std::vector<double> readFormattedDoubArray(const std::string& file_str, const int64_t size, int64_t fromPos)
 {
 
     std::function<double(const std::string&)> f = [](std::string val)
@@ -514,7 +514,7 @@ EclFile::EclFile(const std::string& filename, bool preload) : inputFilename(file
     while (!isEOF(&fileH)) {
         std::string arrName(8,' ');
         eclArrType arrType;
-        long int num;
+        int64_t num;
         
         if (formatted) {
             readFormattedHeader(fileH,arrName,num,arrType);
@@ -528,17 +528,17 @@ EclFile::EclFile(const std::string& filename, bool preload) : inputFilename(file
         array_name.push_back(trimr(arrName));
         array_index[array_name[n]] = n;
 
-        unsigned long int pos = fileH.tellg();
+        uint64_t pos = fileH.tellg();
         ifStreamPos.push_back(pos);
 
         arrayLoaded.push_back(false);
 
         if (num > 0){ 
             if (formatted) {
-                unsigned long int sizeOfNextArray = sizeOnDiskFormatted(num, arrType);
+                uint64_t sizeOfNextArray = sizeOnDiskFormatted(num, arrType);
                 fileH.seekg(static_cast<std::streamoff>(sizeOfNextArray), std::ios_base::cur);
             } else {
-                unsigned long int sizeOfNextArray = sizeOnDiskBinary(num, arrType);
+                uint64_t sizeOfNextArray = sizeOnDiskBinary(num, arrType);
                 fileH.seekg(static_cast<std::streamoff>(sizeOfNextArray), std::ios_base::cur);
             }
         }
@@ -548,7 +548,7 @@ EclFile::EclFile(const std::string& filename, bool preload) : inputFilename(file
     };
 
     fileH.seekg(0, std::ios_base::end);
-    this->ifStreamPos.push_back(static_cast<unsigned long>(fileH.tellg()));
+    this->ifStreamPos.push_back(static_cast<uint64_t>(fileH.tellg()));
     fileH.close();
 
     if (preload)
@@ -586,7 +586,7 @@ void EclFile::loadBinaryArray(std::fstream& fileH, std::size_t arrIndex)
     arrayLoaded[arrIndex] = true;
 }
 
-void EclFile::loadFormattedArray(const std::string& fileStr, std::size_t arrIndex, long int fromPos)
+void EclFile::loadFormattedArray(const std::string& fileStr, std::size_t arrIndex, int64_t fromPos)
 {
 
     switch (array_type[arrIndex]) {

--- a/src/opm/io/eclipse/EclOutput.cpp
+++ b/src/opm/io/eclipse/EclOutput.cpp
@@ -91,15 +91,15 @@ void EclOutput::flushStream()
     this->ofileH.flush();
 }
 
-void EclOutput::writeBinaryHeader(const std::string&arrName, long int size, eclArrType arrType)
+void EclOutput::writeBinaryHeader(const std::string&arrName, int64_t size, eclArrType arrType)
 {
     int bhead = flipEndianInt(16);
     std::string name = arrName + std::string(8 - arrName.size(),' ');
 
     // write X231 header if size larger that limits for 4 byte integers
     if (size > std::numeric_limits<int>::max()) {
-        long int val231 = std::pow(2,31);
-        long int x231 = size / val231;
+        int64_t val231 = std::pow(2,31);
+        int64_t x231 = size / val231;
 
         int flippedx231 = flipEndianInt(static_cast<int>( (-1)*x231 ));
         
@@ -147,14 +147,14 @@ template <typename T>
 void EclOutput::writeBinaryArray(const std::vector<T>& data)
 {
     int num, rval;
-    long int rest;
+    int64_t rest;
     int dhead;
     float value_f;
     double value_d;
     int intVal;
 
-    long int n = 0;
-    long int size = data.size();
+    int64_t n = 0;
+    int64_t size = data.size();
 
     eclArrType arrType = MESS;
 
@@ -178,7 +178,7 @@ void EclOutput::writeBinaryArray(const std::vector<T>& data)
         OPM_THROW(std::runtime_error, "fstream fileH not open for writing");
     }
 
-    rest = size * static_cast<long int>(sizeOfElement);
+    rest = size * static_cast<int64_t>(sizeOfElement);
     while (rest > 0) {
         if (rest > maxBlockSize) {
             rest -= maxBlockSize;

--- a/src/opm/io/eclipse/EclUtil.cpp
+++ b/src/opm/io/eclipse/EclUtil.cpp
@@ -30,10 +30,10 @@ int Opm::EclIO::flipEndianInt(int num)
     return static_cast<int>(tmp);
 }
 
-long int Opm::EclIO::flipEndianLongInt(long int num)
+int64_t Opm::EclIO::flipEndianLongInt(int64_t num)
 {
-    unsigned long int tmp = __builtin_bswap64(num);
-    return static_cast<long int>(tmp);
+    uint64_t tmp = __builtin_bswap64(num);
+    return static_cast<int64_t>(tmp);
 }
 
 float Opm::EclIO::flipEndianFloat(float num)

--- a/tests/test_ERst.cpp
+++ b/tests/test_ERst.cpp
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(TestERst_1) {
 
 
     // try to get a list of vectors from non-existing report step, should throw exception
-    std::vector<std::tuple<std::string, eclArrType, long int>> rstArrays; // = rst1.listOfRstArrays(4);
+    std::vector<std::tuple<std::string, eclArrType, int64_t>> rstArrays; // = rst1.listOfRstArrays(4);
     BOOST_CHECK_THROW(rstArrays = rst1.listOfRstArrays(4), std::invalid_argument);
 
     // non exising report step number, should throw exception


### PR DESCRIPTION
All EclIO classes and associated tests has been checked and updated. This includes cpp file for python bindings

  - long int -> int64_t
  - unsigned long int -> uint64_t


