### PR TITLE
fix bug in guiderate model

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
@@ -138,8 +138,8 @@ double GuideRateModel::eval(double oil_pot, double gas_pot, double wat_pot) cons
         break;
 
     case Target::LIQ:
-        R1 = oil_pot / (oil_pot + wat_pot);
-        R2 = wat_pot / (oil_pot + wat_pot);
+        R1 = wat_pot / (oil_pot + wat_pot);
+        R2 = gas_pot / (oil_pot + wat_pot);
         break;
 
     case Target::GAS:


### PR DESCRIPTION
R1 is supposed to be water-liquid ratio and R2 is gas-liquid ratio for target LIQ. 