### PR TITLE
New Solution Vector Tag for Restart File Output

### DIFF
--- a/opm/output/data/Cells.hpp
+++ b/opm/output/data/Cells.hpp
@@ -36,10 +36,10 @@ namespace data {
       from the TargetType enum which indicates why they they have been
       added to the container - and where they are headed.
 
-      RESTART_SOLUTION : Fields which represent primary variables, and
-       are reqired for restart. Typically pressure and
-       suturation. WIll end up in the SOLUTION section of the restart
-       file.
+     RESTART_SOLUTION : Cell-based quantities that are output to the
+       SOLUTION section of the restart file.  ECLIPSE-compatible names.
+       Many, but not necessarily all, of these quantities are required
+       for restarting the simulator.
 
      RESTART_AUXILIARY : Fields with extra information, not required
        for restart. Examples of this include fluid in place values or
@@ -52,6 +52,10 @@ namespace data {
        will not be output anywhere else.
 
      INIT : Fields which should go to the INIT file.
+
+     RESTART_OPM_EXTENDED: Cell-based quantities that are specific to
+       OPM-Flow.  Output only to extended OPM restart files.  Specifically
+       not output to ECLIPSE-compatible restart files.
     */
 
 
@@ -60,6 +64,7 @@ namespace data {
         RESTART_AUXILIARY,
         SUMMARY,
         INIT,
+        RESTART_OPM_EXTENDED,
     };
 
     /**

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -479,7 +479,8 @@ namespace {
         vectors.reserve(value.solution.size());
 
         for (const auto& [name, vector] : value.solution) {
-            if (vector.target == data::TargetType::RESTART_AUXILIARY)
+            if ((vector.target == data::TargetType::RESTART_AUXILIARY) ||
+                (vector.target == data::TargetType::RESTART_OPM_EXTENDED))
             {
                 vectors.push_back(name);
             }

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -59,6 +59,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace Opm { namespace RestartIO {
@@ -456,6 +457,80 @@ namespace {
         return smax;
     }
 
+    std::vector<std::string>
+    solutionVectorNames(const RestartValue& value)
+    {
+        auto vectors = std::vector<std::string>{};
+        vectors.reserve(value.solution.size());
+
+        for (const auto& [name, vector] : value.solution) {
+            if (vector.target == data::TargetType::RESTART_SOLUTION) {
+                vectors.push_back(name);
+            }
+        }
+
+        return vectors;
+    }
+
+    std::vector<std::string>
+    extendedSolutionVectorNames(const RestartValue& value)
+    {
+        auto vectors = std::vector<std::string>{};
+        vectors.reserve(value.solution.size());
+
+        for (const auto& [name, vector] : value.solution) {
+            if (vector.target == data::TargetType::RESTART_AUXILIARY)
+            {
+                vectors.push_back(name);
+            }
+        }
+
+        return vectors;
+    }
+
+    template <class OutputVector>
+    void writeSolutionVectors(const RestartValue&             value,
+                              const std::vector<std::string>& vectors,
+                              const bool                      write_double,
+                              OutputVector&&                  writeVector)
+    {
+        for (const auto& vector : vectors) {
+            writeVector(vector, value.solution.data(vector), write_double);
+        }
+    }
+
+    template <class OutputVector>
+    void writeRegularSolutionVectors(const RestartValue& value,
+                                     const bool          write_double,
+                                     OutputVector&&      writeVector)
+    {
+        writeSolutionVectors(value, solutionVectorNames(value), write_double,
+                             std::forward<OutputVector>(writeVector));
+    }
+
+    template <class OutputVector>
+    void writeExtendedSolutionVectors(const RestartValue& value,
+                                      const bool          write_double,
+                                      OutputVector&&      writeVector)
+    {
+        writeSolutionVectors(value, extendedSolutionVectorNames(value), write_double,
+                             std::forward<OutputVector>(writeVector));
+    }
+
+    template <class OutputVector>
+    void writeExtraVectors(const RestartValue& value,
+                           OutputVector&&      writeVector)
+    {
+        for (const auto& elm : value.extra) {
+            const std::string& key = elm.first.key;
+            if (extraInSolution(key)) {
+                // Observe that the extra data is unconditionally
+                // output as double precision.
+                writeVector(key, elm.second, true);
+            }
+        }
+    }
+
     template <class OutputVector>
     void writeEclipseCompatHysteresis(const RestartValue& value,
                                       const bool          write_double,
@@ -496,8 +571,6 @@ namespace {
                        const std::vector<int>&       inteHD,
                        EclIO::OutputStream::Restart& rstFile)
     {
-        rstFile.message("STARTSOL");
-
         auto write = [&rstFile]
             (const std::string&         key,
              const std::vector<double>& data,
@@ -513,39 +586,23 @@ namespace {
             }
         };
 
-        for (const auto& elm : value.solution) {
-            if (elm.second.target == data::TargetType::RESTART_SOLUTION)
-            {
-                write(elm.first, elm.second.data, write_double_arg);
-            }
-        }
+        rstFile.message("STARTSOL");
+
+        writeRegularSolutionVectors(value, write_double_arg, write);
 
         writeUDQ(report_step, sim_step, schedule, sum_state, inteHD, rstFile);
-        
-        for (const auto& elm : value.extra) {
-            const std::string& key = elm.first.key;
-            if (extraInSolution(key)) {
-                // Observe that the extra data is unconditionally
-                // output as double precision.
-                write(key, elm.second, true);
-            }
-        }
+
+        writeExtraVectors(value, write);
 
         if (ecl_compatible_rst && haveHysteresis(value)) {
             writeEclipseCompatHysteresis(value, write_double_arg, write);
         }
 
+        if (! ecl_compatible_rst) {
+            writeExtendedSolutionVectors(value, write_double_arg, write);
+        }
+
         rstFile.message("ENDSOL");
-
-        if (ecl_compatible_rst) {
-            return;
-        }
-
-        for (const auto& elm : value.solution) {
-            if (elm.second.target == data::TargetType::RESTART_AUXILIARY) {
-                write(elm.first, elm.second.data, write_double_arg);
-            }
-        }
     }
 
     void writeExtraData(const RestartValue::ExtraVector& extra_data,


### PR DESCRIPTION
This PR introduces a new tag, `RESTART_OPM_EXTENDED`, for cell-based quantities that don't have ECLIPSE-compatible names/contents.  The ResInsight post-processor will visualize such variables, but we must not output these variables to an ECLIPSE-compatible restart file.

At present `RESTART_OPM_EXTENDED` is recognized at the output layer (function `RestartIO::save()`) and behaves as an alias of `RESTART_AUXILIARY`.  My goal, however, is to deprecate the latter&mdash;tentatively in OPM 2020.04 with a `[[deprecated]]` annotation and to convert all current uses in the OPM codebase to either `RESTART_SOLUTION` or `RESTART_OPM_EXTENDED` as appropriate.  Then I would like to retire the `RESTART_ AUXILIARY` tag entirely&mdash;tentatively in OPM 2020.10&mdash;since the tag does not serve a practical purpose anymore.  Distinguishing vectors by whether or not they are required for restart is no longer a good fit for the restart file writing (or reading) code.  The vectors will end up in the restart file regardless.

Note that while this is a PR that is ready for merging right now, I'm leaving it as a draft to allow other interested parties to discuss the new tag (naming, functionality &c)