### PR TITLE
Add Aquifer Category

### DIFF
--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -23,6 +23,7 @@ namespace Opm::EclIO {
 
 struct SummaryNode {
     enum class Category {
+        Aquifer,
         Well,
         Group,
         Field,

--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -29,6 +29,7 @@ namespace {
 
 constexpr bool use_number(Opm::EclIO::SummaryNode::Category category) {
     switch (category) {
+    case Opm::EclIO::SummaryNode::Category::Aquifer:       [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Block:         [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Connection:    [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Region:        [[fallthrough]];
@@ -49,6 +50,7 @@ constexpr bool use_name(Opm::EclIO::SummaryNode::Category category) {
     case Opm::EclIO::SummaryNode::Category::Segment:       [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Well:
         return true;
+    case Opm::EclIO::SummaryNode::Category::Aquifer:       [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Block:         [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Field:         [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Miscellaneous: [[fallthrough]];

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1328,7 +1328,8 @@ inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,
         return wells;
     }
 
-    case Opm::EclIO::SummaryNode::Category::Block:
+    case Opm::EclIO::SummaryNode::Category::Aquifer:       [[fallthrough]];
+    case Opm::EclIO::SummaryNode::Category::Block:         [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Miscellaneous:
         return {};
     }
@@ -1346,6 +1347,7 @@ bool need_wells(const Opm::EclIO::SummaryNode& node) {
        return true;
     case Opm::EclIO::SummaryNode::Category::Region:
         return std::regex_match(node.keyword, region_keyword_regex);
+    case Opm::EclIO::SummaryNode::Category::Aquifer:       [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Miscellaneous: [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Block:
         return false;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
@@ -93,6 +93,7 @@ FuncType Parser::get_func(const std::string& arg) {
     using Cat = SummaryConfigNode::Category;
     SummaryConfigNode::Category cat = parseKeywordCategory(arg);
     switch (cat) {
+        case Cat::Aquifer:    return FuncType::aquifer;
         case Cat::Well:       return FuncType::well;
         case Cat::Group:      return FuncType::group;
         case Cat::Connection: return FuncType::well_connection;

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -712,6 +712,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
 
     std::string to_string(const SummaryConfigNode::Category cat) {
         switch( cat ) {
+            case SummaryConfigNode::Category::Aquifer: return "Aquifer";
             case SummaryConfigNode::Category::Well: return "Well";
             case SummaryConfigNode::Category::Group: return "Group";
             case SummaryConfigNode::Category::Field: return "Field";
@@ -828,6 +829,7 @@ SummaryConfigNode::Category parseKeywordCategory(const std::string& keyword) {
     if (is_special(keyword)) { return Cat::Miscellaneous; }
 
     switch (keyword[0]) {
+        case 'A': return Cat::Aquifer;
         case 'W': return Cat::Well;
         case 'G': return Cat::Group;
         case 'F': return Cat::Field;
@@ -897,6 +899,7 @@ std::string SummaryConfigNode::uniqueNodeKey() const
     case SummaryConfigNode::Category::Miscellaneous:
         return this->keyword();
 
+    case SummaryConfigNode::Category::Aquifer: [[fallthrough]];
     case SummaryConfigNode::Category::Region: [[fallthrough]];
     case SummaryConfigNode::Category::Block:
         return this->keyword() + ':' + std::to_string(this->number());
@@ -929,6 +932,7 @@ bool operator==(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
             // Equal if associated to same named entity
             return lhs.namedEntity() == rhs.namedEntity();
 
+        case SummaryConfigNode::Category::Aquifer: [[fallthrough]];
         case SummaryConfigNode::Category::Region: [[fallthrough]];
         case SummaryConfigNode::Category::Block:
             // Equal if associated to same numeric entity
@@ -964,6 +968,7 @@ bool operator<(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
             // Ordering determined by namedEntityd entity
             return lhs.namedEntity() < rhs.namedEntity();
 
+        case SummaryConfigNode::Category::Aquifer: [[fallthrough]];
         case SummaryConfigNode::Category::Region: [[fallthrough]];
         case SummaryConfigNode::Category::Block:
             // Ordering determined by numeric entity


### PR DESCRIPTION
This feature adds `::Aquifer` to `Opm::EclIO::SummaryNode::Category` (and, by extension, to `Opm::SummaryConfigNode::Category`.

This PR requires the resolution of #1609.