### PR TITLE
Integrate SummaryNode in ESmry

### DIFF
--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -40,6 +40,7 @@ public:
     bool hasKey(const std::string& key) const;
 
     const std::vector<float>& get(const std::string& name) const;
+    const std::vector<float>& get(const SummaryNode& node) const;
 
     std::vector<float> get_at_rstep(const std::string& name) const;
 

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -79,6 +79,8 @@ private:
     void updatePathAndRootName(Opm::filesystem::path& dir, Opm::filesystem::path& rootN) const;
 
     std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num) const;
+
+    std::string unpackNumber(const SummaryNode&) const;
 };
 
 }} // namespace Opm::EclIO

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -45,7 +45,8 @@ public:
 
     const std::vector<int>& get_startdat() const { return startdat; }
 
-    const std::vector<std::string>& keywordList() const { return keyword; }
+    const std::vector<std::string>& keywordList() const;
+    const std::vector<SummaryNode>& summaryNodeList() const;
 
     int timestepIdxAtReportstepStart(const int reportStep) const;
 

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -43,6 +43,7 @@ public:
     const std::vector<float>& get(const SummaryNode& node) const;
 
     std::vector<float> get_at_rstep(const std::string& name) const;
+    std::vector<float> get_at_rstep(const SummaryNode& node) const;
 
     const std::vector<int>& get_startdat() const { return startdat; }
 
@@ -54,6 +55,7 @@ public:
     size_t numberOfTimeSteps() const { return param[0].size(); }
 
     const std::string& get_unit(const std::string& name) const;
+    const std::string& get_unit(const SummaryNode& node) const;
 
 private:
     int nVect, nI, nJ, nK;
@@ -81,6 +83,7 @@ private:
     std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num) const;
 
     std::string unpackNumber(const SummaryNode&) const;
+    std::string lookupKey(const SummaryNode&) const;
 };
 
 }} // namespace Opm::EclIO

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -22,7 +22,9 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include <opm/common/utility/FileSystem.hpp>
+#include <opm/io/eclipse/SummaryNode.hpp>
 
 namespace Opm { namespace EclIO {
 
@@ -57,6 +59,7 @@ private:
     void ijk_from_global_index(int glob, int &i, int &j, int &k) const;
     std::vector<std::vector<float>> param;
     std::vector<std::string> keyword;
+    std::vector<SummaryNode> summaryNodes;
     std::unordered_map<std::string, std::string> kwunits;
 
     std::vector<int> seqIndex;

--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -57,7 +57,9 @@ struct SummaryNode {
     constexpr static int default_number { std::numeric_limits<int>::min() };
 
     std::string unique_key() const;
-    std::string unique_key(int nI, int nJ, int nK) const;
+
+    using number_renderer = std::function<std::string(const SummaryNode&)>;
+    std::string unique_key(number_renderer) const;
 
     bool is_user_defined() const;
 

--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -17,6 +17,9 @@
    along with OPM.  If not, see <http://www.gnu.org/licenses/>.
    */
 
+#ifndef OPM_IO_SUMMARYNODE_HPP
+#define OPM_IO_SUMMARYNODE_HPP
+
 #include <string>
 
 namespace Opm::EclIO {
@@ -57,3 +60,5 @@ struct SummaryNode {
 };
 
 } // namespace Opm::EclIO
+
+#endif // OPM_IO_SUMMARYNODE_HPP

--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -57,6 +57,8 @@ struct SummaryNode {
     constexpr static int default_number { std::numeric_limits<int>::min() };
 
     std::string unique_key() const;
+    std::string unique_key(int nI, int nJ, int nK) const;
+
     bool is_user_defined() const;
 
     static Category category_from_keyword(const std::string&, const std::unordered_set<std::string> &miscellaneous_keywords = {});

--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_IO_SUMMARYNODE_HPP
 #define OPM_IO_SUMMARYNODE_HPP
 
+#include <functional>
 #include <string>
 #include <unordered_set>
 

--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -21,6 +21,7 @@
 #define OPM_IO_SUMMARYNODE_HPP
 
 #include <string>
+#include <unordered_set>
 
 namespace Opm::EclIO {
 
@@ -57,6 +58,8 @@ struct SummaryNode {
 
     std::string unique_key() const;
     bool is_user_defined() const;
+
+    static Category category_from_keyword(const std::string&, const std::unordered_set<std::string> &miscellaneous_keywords = {});
 };
 
 } // namespace Opm::EclIO

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -546,8 +546,20 @@ std::string ESmry::unpackNumber(const SummaryNode& node) const {
     }
 }
 
+std::string ESmry::lookupKey(const SummaryNode& node) const {
+    return node.unique_key(std::bind( &ESmry::unpackNumber, this, std::placeholders::_1 ));
+}
+
 const std::vector<float>& ESmry::get(const SummaryNode& node) const {
-    return get(node.unique_key(std::bind( &ESmry::unpackNumber, this, std::placeholders::_1 )));
+    return get(lookupKey(node));
+}
+
+std::vector<float> ESmry::get_at_rstep(const SummaryNode& node) const {
+    return get_at_rstep(lookupKey(node));
+}
+
+const std::string& ESmry::get_unit(const SummaryNode& node) const {
+    return get_unit(lookupKey(node));
 }
 
 const std::vector<float>& ESmry::get(const std::string& name) const

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -527,18 +527,8 @@ std::string ESmry::unpackNumber(const SummaryNode& node) const {
 
         return std::to_string(_i) + "," + std::to_string(_j) + "," + std::to_string(_k);
     } else if (node.category == SummaryNode::Category::Region && node.keyword[2] == 'F') {
-        // NUMS = R1 + 32768*(R2 + 10)
-        int r2 = 0;
-        int y = 32768 * (r2 + 10) - node.number;
-
-        while (y < 0) {
-            r2++;
-            y = 32768 * (r2 + 10) - node.number;
-        }
-
-        r2--;
-
-        const int r1 = node.number - 32768 * (r2 + 10);
+        const auto r1 =  node.number % (1 << 15);
+        const auto r2 = (node.number / (1 << 15)) - 10;
 
         return std::to_string(r1) + "-" + std::to_string(r2);
     } else {

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -566,4 +566,12 @@ const std::string& ESmry::get_unit(const std::string& name) const {
     return kwunits.at(name);
 }
 
+const std::vector<std::string>& ESmry::keywordList() const {
+    return keyword;
+}
+
+const std::vector<SummaryNode>& ESmry::summaryNodeList() const {
+    return summaryNodes;
+}
+
 }} // namespace Opm::ecl

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -51,7 +51,8 @@
 
 namespace Opm { namespace EclIO {
 
-ESmry::ESmry(const std::string &filename, bool loadBaseRunData)
+ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
+    summaryNodes { }
 {
 
     Opm::filesystem::path inputFileName(filename);
@@ -108,6 +109,13 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData)
             const std::string keyString = makeKeyString(keywords[i], wgnames[i], nums[i]);
             if (keyString.length() > 0) {
                 keywList.insert(keyString);
+                summaryNodes.push_back({
+                    keywords[i],
+                    SummaryNode::Category::Miscellaneous,
+                    SummaryNode::Type::Undefined,
+                    wgnames[i],
+                    nums[i]
+                });
                 kwunits[keyString] = units[i];
             }
         }
@@ -151,6 +159,13 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData)
             const std::string keyString = makeKeyString(keywords[i], wgnames[i], nums[i]);
             if (keyString.length() > 0) {
                 keywList.insert(keyString);
+                summaryNodes.push_back({
+                    keywords[i],
+                    SummaryNode::Category::Miscellaneous,
+                    SummaryNode::Type::Undefined,
+                    wgnames[i],
+                    nums[i]
+                });
                 kwunits[keyString] = units[i];
             }
         }

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -85,6 +85,12 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
     std::set<std::string> keywList;
     std::vector<std::pair<std::string,int>> smryArray;
 
+    const std::unordered_set<std::string> segmentExceptions {
+        "SEPARATE",
+        "STEPTYPE",
+        "SUMTHIN",
+    } ;
+
     // Read data from the summary into local data members.
     {
         EclFile smspec(smspec_file.string());
@@ -109,14 +115,15 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
             const std::string keyString = makeKeyString(keywords[i], wgnames[i], nums[i]);
             if (keyString.length() > 0) {
                 keywList.insert(keyString);
+                kwunits[keyString] = units[i];
+
                 summaryNodes.push_back({
                     keywords[i],
-                    SummaryNode::Category::Miscellaneous,
+                    SummaryNode::category_from_keyword(keywords[i], segmentExceptions),
                     SummaryNode::Type::Undefined,
                     wgnames[i],
                     nums[i]
                 });
-                kwunits[keyString] = units[i];
             }
         }
 
@@ -159,14 +166,15 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
             const std::string keyString = makeKeyString(keywords[i], wgnames[i], nums[i]);
             if (keyString.length() > 0) {
                 keywList.insert(keyString);
+                kwunits[keyString] = units[i];
+
                 summaryNodes.push_back({
                     keywords[i],
-                    SummaryNode::Category::Miscellaneous,
+                    SummaryNode::category_from_keyword(keywords[i], segmentExceptions),
                     SummaryNode::Type::Undefined,
                     wgnames[i],
                     nums[i]
                 });
-                kwunits[keyString] = units[i];
             }
         }
 

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -519,8 +519,35 @@ std::string ESmry::makeKeyString(const std::string& keywordArg, const std::strin
     return keyStr;
 }
 
+std::string ESmry::unpackNumber(const SummaryNode& node) const {
+    if (node.category == SummaryNode::Category::Block ||
+        node.category == SummaryNode::Category::Connection) {
+        int _i,_j,_k;
+        ijk_from_global_index(node.number, _i, _j, _k);
+
+        return std::to_string(_i) + "," + std::to_string(_j) + "," + std::to_string(_k);
+    } else if (node.category == SummaryNode::Category::Region && node.keyword[2] == 'F') {
+        // NUMS = R1 + 32768*(R2 + 10)
+        int r2 = 0;
+        int y = 32768 * (r2 + 10) - node.number;
+
+        while (y < 0) {
+            r2++;
+            y = 32768 * (r2 + 10) - node.number;
+        }
+
+        r2--;
+
+        const int r1 = node.number - 32768 * (r2 + 10);
+
+        return std::to_string(r1) + "-" + std::to_string(r2);
+    } else {
+        return std::to_string(node.number);
+    }
+}
+
 const std::vector<float>& ESmry::get(const SummaryNode& node) const {
-    return get(node.unique_key(nI, nJ, nK));
+    return get(node.unique_key(std::bind( &ESmry::unpackNumber, this, std::placeholders::_1 )));
 }
 
 const std::vector<float>& ESmry::get(const std::string& name) const

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -114,9 +114,6 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
         for (unsigned int i=0; i<keywords.size(); i++) {
             const std::string keyString = makeKeyString(keywords[i], wgnames[i], nums[i]);
             if (keyString.length() > 0) {
-                keywList.insert(keyString);
-                kwunits[keyString] = units[i];
-
                 summaryNodes.push_back({
                     keywords[i],
                     SummaryNode::category_from_keyword(keywords[i], segmentExceptions),
@@ -124,6 +121,9 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
                     wgnames[i],
                     nums[i]
                 });
+
+                keywList.insert(keyString);
+                kwunits[keyString] = units[i];
             }
         }
 
@@ -165,9 +165,6 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
         for (size_t i = 0; i < keywords.size(); i++) {
             const std::string keyString = makeKeyString(keywords[i], wgnames[i], nums[i]);
             if (keyString.length() > 0) {
-                keywList.insert(keyString);
-                kwunits[keyString] = units[i];
-
                 summaryNodes.push_back({
                     keywords[i],
                     SummaryNode::category_from_keyword(keywords[i], segmentExceptions),
@@ -175,6 +172,9 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
                     wgnames[i],
                     nums[i]
                 });
+
+                keywList.insert(keyString);
+                kwunits[keyString] = units[i];
             }
         }
 

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -519,6 +519,9 @@ std::string ESmry::makeKeyString(const std::string& keywordArg, const std::strin
     return keyStr;
 }
 
+const std::vector<float>& ESmry::get(const SummaryNode& node) const {
+    return get(node.unique_key(nI, nJ, nK));
+}
 
 const std::vector<float>& ESmry::get(const std::string& name) const
 {

--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -66,53 +66,24 @@ std::string compose_key(std::string& key, const std::string& key_part) {
     return key.empty() ? key_part : key + delimiter + key_part;
 }
 
-std::string compose_ijk(std::string& ijk, const int& element) {
-    constexpr auto delimiter { ',' } ;
-
-    return ijk.empty() ? std::to_string(element) : ijk + delimiter + std::to_string(element);
-}
-
-inline std::array<int, 3> unpack_ijk(int num, int nI, int nJ, int /* nK */) {
-    const int index { num - 1 } ;
-    const int nIJ { nI * nJ };
-
-    const int k { 1 + index / nIJ } ;
-
-    const int remainder { index % nIJ } ;
-    const int j { 1 + remainder / nI } ;
-    const int i { 1 + remainder % nI } ;
-
-    return { i, j, k } ;
-}
-
-inline std::string num_as_ijk(int num, int nI, int nJ, int nK) {
-    const auto ijk { unpack_ijk(num, nI, nJ, nK) } ;
-
-    return std::accumulate(std::begin(ijk), std::end(ijk), std::string(), compose_ijk);
+std::string default_number_renderer(const Opm::EclIO::SummaryNode& node) {
+    return std::to_string(node.number);
 }
 
 };
 
 std::string Opm::EclIO::SummaryNode::unique_key() const {
-    std::vector<std::string> key_parts { keyword } ;
-
-    if (use_name(category))
-        key_parts.emplace_back(wgname);
-
-    if (use_number(category))
-        key_parts.emplace_back(std::to_string(number));
-
-    return std::accumulate(std::begin(key_parts), std::end(key_parts), std::string(), compose_key);
+    return unique_key(default_number_renderer);
 }
 
-std::string Opm::EclIO::SummaryNode::unique_key(int nI, int nJ, int nK) const {
+std::string Opm::EclIO::SummaryNode::unique_key(number_renderer render_number) const {
     std::vector<std::string> key_parts { keyword } ;
 
     if (use_name(category))
         key_parts.emplace_back(wgname);
 
     if (use_number(category))
-        key_parts.emplace_back(num_as_ijk(number, nI, nJ, nK));
+        key_parts.emplace_back(render_number(*this));
 
     return std::accumulate(std::begin(key_parts), std::end(key_parts), std::string(), compose_key);
 }

--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -59,21 +59,11 @@ constexpr bool use_name(Opm::EclIO::SummaryNode::Category category) {
     }
 }
 
-std::string compose_key(std::string& key, const std::string& key_part) {
-    constexpr auto delimiter { ':' } ;
-
-    return key.empty() ? key_part : key + delimiter + key_part;
-}
-
 std::string default_number_renderer(const Opm::EclIO::SummaryNode& node) {
     return std::to_string(node.number);
 }
 
 };
-
-std::string Opm::EclIO::SummaryNode::unique_key() const {
-    return unique_key(default_number_renderer);
-}
 
 std::string Opm::EclIO::SummaryNode::unique_key(number_renderer render_number) const {
     std::vector<std::string> key_parts { keyword } ;
@@ -84,7 +74,16 @@ std::string Opm::EclIO::SummaryNode::unique_key(number_renderer render_number) c
     if (use_number(category))
         key_parts.emplace_back(render_number(*this));
 
+    auto compose_key = [](std::string& key, const std::string& key_part) -> std::string {
+        constexpr auto delimiter { ':' } ;
+        return key.empty() ? key_part : key + delimiter + key_part;
+    };
+
     return std::accumulate(std::begin(key_parts), std::end(key_parts), std::string(), compose_key);
+}
+
+std::string Opm::EclIO::SummaryNode::unique_key() const {
+    return unique_key(default_number_renderer);
 }
 
 bool Opm::EclIO::SummaryNode::is_user_defined() const {

--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -17,7 +17,6 @@
    along with OPM.  If not, see <http://www.gnu.org/licenses/>.
    */
 
-#include <array>
 #include <numeric>
 #include <regex>
 #include <string>

--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -113,3 +113,28 @@ bool Opm::EclIO::SummaryNode::is_user_defined() const {
 
     return matched && !blacklisted;
 }
+
+Opm::EclIO::SummaryNode::Category Opm::EclIO::SummaryNode::category_from_keyword(
+    const std::string& keyword,
+    const std::unordered_set<std::string>& miscellaneous_keywords
+) {
+    if (keyword.length() == 0) {
+        return Category::Miscellaneous;
+    }
+
+    if (miscellaneous_keywords.find(keyword) != miscellaneous_keywords.end()) {
+        return Category::Miscellaneous;
+    }
+
+    switch (keyword[0]) {
+    case 'A': return Category::Aquifer;
+    case 'B': return Category::Block;
+    case 'C': return Category::Connection;
+    case 'F': return Category::Field;
+    case 'G': return Category::Group;
+    case 'R': return Category::Region;
+    case 'S': return Category::Segment;
+    case 'W': return Category::Well;
+    default:  return Category::Miscellaneous;
+    }
+}

--- a/tests/test_SummaryNode.cpp
+++ b/tests/test_SummaryNode.cpp
@@ -45,4 +45,32 @@ BOOST_AUTO_TEST_CASE(UniqueKey) {
     expect_key( { "KEYW", Category::Miscellaneous, Type::Rate, "NORA", 8 }, "KEYW" );
 }
 
+BOOST_AUTO_TEST_CASE(InjectedNumberRenderer) {
+    using Category = Opm::EclIO::SummaryNode::Category;
+    using Type = Opm::EclIO::SummaryNode::Type;
+
+    Opm::EclIO::SummaryNode positiveNode {
+      "SIGN",
+      Category::Region,
+      Type::Undefined,
+      "-",
+      2
+    };
+
+    Opm::EclIO::SummaryNode negativeNode {
+      "SIGN",
+      Category::Region,
+      Type::Undefined,
+      "-",
+      -2
+    };
+
+    auto chooseSign = [](const Opm::EclIO::SummaryNode& node) -> std::string {
+        return node.number > 0 ? "+" : "-";
+    };
+
+    BOOST_CHECK_EQUAL(positiveNode.unique_key(chooseSign), "SIGN:+");
+    BOOST_CHECK_EQUAL(negativeNode.unique_key(chooseSign), "SIGN:-");
+}
+
 BOOST_AUTO_TEST_SUITE_END() // UniqueKey


### PR DESCRIPTION
This feature integrates `Opm::EclIO::SummaryNode` in `Opm::EclIO::ESmry`.

Adds the public interface `ESmry::get(const SummaryNode&)`, and `ESmry::summaryNodeList()`, which allow fetching vectors by a `SummaryNode` (from any source).