### PR TITLE
Use braces to force correct parsing.

### DIFF
--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(INSTANTIATE) {
     */
     BOOST_CHECK(! Python::enabled() );
 
-    BOOST_CHECK_THROW( Python(Python::Enable::ON), std::logic_error );
+    BOOST_CHECK_THROW( Python{Python::Enable::ON}, std::logic_error );
     Python python_cond(Python::Enable::COND);
     BOOST_CHECK(!python_cond);
 


### PR DESCRIPTION
Without this, clang thinks it is a declaration, not a function call. Not sure why gcc accepts it, maybe it was not checked?

See https://en.wikipedia.org/wiki/Most_vexing_parse for explanation.