### PR TITLE
Write RSM File

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -240,6 +240,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/io/eclipse/ERft.cpp
           src/opm/io/eclipse/ERst.cpp
           src/opm/io/eclipse/ESmry.cpp
+          src/opm/io/eclipse/ESmry_write_rsm_file.cpp
           src/opm/io/eclipse/OutputStream.cpp
           src/opm/io/eclipse/SummaryNode.cpp
           src/opm/io/eclipse/rst/connection.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -240,7 +240,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/io/eclipse/ERft.cpp
           src/opm/io/eclipse/ERst.cpp
           src/opm/io/eclipse/ESmry.cpp
-          src/opm/io/eclipse/ESmry_write_rsm_file.cpp
+          src/opm/io/eclipse/ESmry_write_rsm.cpp
           src/opm/io/eclipse/OutputStream.cpp
           src/opm/io/eclipse/SummaryNode.cpp
           src/opm/io/eclipse/rst/connection.cpp

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -59,7 +59,7 @@ public:
     const std::string& get_unit(const SummaryNode& node) const;
 
     void write_rsm(std::ostream&) const;
-    void write_rsm_file() const;
+    void write_rsm_file(std::optional<Opm::filesystem::path> = std::nullopt) const;
 
 private:
     Opm::filesystem::path inputFileName;

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -61,6 +61,7 @@ public:
     void write_rsm(std::ostream&) const;
 
 private:
+    Opm::filesystem::path inputFileName;
     int nVect, nI, nJ, nK;
 
     void ijk_from_global_index(int glob, int &i, int &j, int &k) const;
@@ -87,6 +88,8 @@ private:
 
     std::string unpackNumber(const SummaryNode&) const;
     std::string lookupKey(const SummaryNode&) const;
+
+    void write_block(std::ostream &, const std::vector<SummaryNode>&) const;
 };
 
 }} // namespace Opm::EclIO

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -19,6 +19,7 @@
 #ifndef OPM_IO_ESMRY_HPP
 #define OPM_IO_ESMRY_HPP
 
+#include <ostream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -56,6 +57,14 @@ public:
 
     const std::string& get_unit(const std::string& name) const;
     const std::string& get_unit(const SummaryNode& node) const;
+
+    void write_rsm_file(std::ostream&) const;
+
+    std::ostream& operator<<(std::ostream& os) const {
+        write_rsm_file(os);
+
+        return os;
+    }
 
 private:
     int nVect, nI, nJ, nK;

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -59,6 +59,7 @@ public:
     const std::string& get_unit(const SummaryNode& node) const;
 
     void write_rsm(std::ostream&) const;
+    void write_rsm_file() const;
 
 private:
     Opm::filesystem::path inputFileName;

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -58,7 +58,7 @@ public:
     const std::string& get_unit(const std::string& name) const;
     const std::string& get_unit(const SummaryNode& node) const;
 
-    void write_rsm_file(std::ostream&) const;
+    void write_rsm(std::ostream&) const;
 
 private:
     int nVect, nI, nJ, nK;
@@ -92,7 +92,7 @@ private:
 }} // namespace Opm::EclIO
 
 inline std::ostream& operator<<(std::ostream& os, const Opm::EclIO::ESmry& smry) {
-    smry.write_rsm_file(os);
+    smry.write_rsm(os);
 
     return os;
 }

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -60,12 +60,6 @@ public:
 
     void write_rsm_file(std::ostream&) const;
 
-    std::ostream& operator<<(std::ostream& os) const {
-        write_rsm_file(os);
-
-        return os;
-    }
-
 private:
     int nVect, nI, nJ, nK;
 
@@ -96,5 +90,11 @@ private:
 };
 
 }} // namespace Opm::EclIO
+
+inline std::ostream& operator<<(std::ostream& os, const Opm::EclIO::ESmry& smry) {
+    smry.write_rsm_file(os);
+
+    return os;
+}
 
 #endif // OPM_IO_ESMRY_HPP

--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -21,6 +21,7 @@
 #define OPM_IO_SUMMARYNODE_HPP
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <unordered_set>
 
@@ -65,6 +66,10 @@ struct SummaryNode {
     bool is_user_defined() const;
 
     static Category category_from_keyword(const std::string&, const std::unordered_set<std::string> &miscellaneous_keywords = {});
+
+    std::optional<std::string> display_name() const;
+    std::optional<std::string> display_number() const;
+    std::optional<std::string> display_number(number_renderer) const;
 };
 
 } // namespace Opm::EclIO

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -52,10 +52,10 @@
 namespace Opm { namespace EclIO {
 
 ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
+    inputFileName { filename },
     summaryNodes { }
 {
 
-    Opm::filesystem::path inputFileName(filename);
     Opm::filesystem::path rootName = inputFileName.parent_path() / inputFileName.stem();
 
     // if root name (without any extension) given as first argument in constructor, binary will then be assumed

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -70,13 +70,13 @@ void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vector
 
     os << ' ';
     for (const auto& vector : vectors) {
-        os << std::setw(8) << std::left << vector.wgname << std::setw(5) << "";
+        os << std::setw(8) << std::left << vector.display_name().value_or("") << std::setw(5) << "";
     }
     os << '\n';
 
     os << ' ';
     for (const auto& vector : vectors) {
-        os << std::setw(8) << std::left << vector.number << std::setw(5) << "";
+        os << std::setw(8) << std::left << vector.display_number().value_or("") << std::setw(5) << "";
     }
     os << '\n';
 

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -18,6 +18,8 @@
 
 #include <opm/io/eclipse/ESmry.hpp>
 
+#include <iomanip>
+#include <ostream>
 #include <string>
 
 namespace {
@@ -30,16 +32,33 @@ constexpr size_t column_count { 10 } ;
 constexpr size_t total_column { column_width + column_space } ;
 constexpr size_t total_width  { total_column * column_count } ;
 
-const std::string version_line { "1" + std::string(total_width,     ' ') + "\n" } ;
+const std::string version_line { } ;
 // the fact that the dashed header line has 127 rather than 130 dashes has no provenance
-const std::string divider_line { " " + std::string(total_width - 3, '-') + "\n" } ;
+const std::string divider_line { std::string(total_width - 3, '-') } ;
+
+const std::string block_header_line(const std::string& run_name, const std::string& comment) {
+    return "SUMMARY OF RUN " + run_name + " OPM FLOW VERSION 1910 " + comment;
+}
+
+void write_line(std::ostream& os, const std::string& line, char prefix = ' ') {
+    os << prefix << std::setw(total_width) << std::left << line << '\n';
+}
 
 }
 
 namespace Opm::EclIO {
 
 void ESmry::write_rsm(std::ostream& os) const {
-    os << version_line << divider_line;
+    write_line(os, version_line, '1');
+    write_line(os, divider_line);
+    write_line(os, block_header_line("nor01-temp01-rsm-date", "ANYTHING CAN GO HERE: USER, MACHINE ETC."));
+    write_line(os, divider_line);
+
+    // write headers
+
+    write_line(os, divider_line);
+
+    // write data
 }
 
 } // namespace Opm::EclIO

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -26,13 +26,13 @@
 
 namespace {
 
-constexpr size_t column_width { 8 } ;
-constexpr size_t column_space { 5 } ;
+constexpr std::size_t column_width { 8 } ;
+constexpr std::size_t column_space { 5 } ;
 
-constexpr size_t column_count { 10 } ;
+constexpr std::size_t column_count { 10 } ;
 
-constexpr size_t total_column { column_width + column_space } ;
-constexpr size_t total_width  { total_column * column_count } ;
+constexpr std::size_t total_column { column_width + column_space } ;
+constexpr std::size_t total_width  { total_column * column_count } ;
 
 const std::string version_line { } ;
 // the fact that the dashed header line has 127 rather than 130 dashes has no provenance
@@ -80,11 +80,25 @@ void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vector
     }
     os << '\n';
 
-    // write headers
-
     write_line(os, divider_line);
 
-    // write data
+    std::vector<std::vector<float>> data;
+
+    for (const auto& vector : vectors) {
+        data.push_back(get(vector));
+    }
+
+    std::size_t rows { data[0].size() };
+
+    for (std::size_t i { 0 } ; i < rows; i++) {
+        os << ' ';
+        for (const auto& data_vector : data) {
+            os << std::setw(8) << std::right << data_vector[i] << std::setw(5) << "";
+        }
+        os << '\n';
+    }
+
+    os << std::flush;
 }
 
 void ESmry::write_rsm(std::ostream& os) const {
@@ -103,8 +117,8 @@ void ESmry::write_rsm(std::ostream& os) const {
 
     std::vector<std::list<SummaryNode>> data_vector_blocks;
 
-    constexpr size_t data_column_count { column_count - 1 } ;
-    for (size_t i { 0 } ; i < data_vectors.size(); i += data_column_count) {
+    constexpr std::size_t data_column_count { column_count - 1 } ;
+    for (std::size_t i { 0 } ; i < data_vectors.size(); i += data_column_count) {
         auto last = std::min(data_vectors.size(), i + data_column_count);
         data_vector_blocks.emplace_back(data_vectors.begin() + i, data_vectors.begin() + last);
         data_vector_blocks.back().push_front(date_vector);

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -48,17 +48,28 @@ void write_line(std::ostream& os, const std::string& line, char prefix = ' ') {
 
 namespace Opm::EclIO {
 
-void ESmry::write_rsm(std::ostream& os) const {
+void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vectors) const {
     write_line(os, version_line, '1');
     write_line(os, divider_line);
-    write_line(os, block_header_line("nor01-temp01-rsm-date", "ANYTHING CAN GO HERE: USER, MACHINE ETC."));
+    write_line(os, block_header_line(inputFileName.stem(), "ANYTHING CAN GO HERE: USER, MACHINE ETC."));
     write_line(os, divider_line);
+
+    os << ' ';
+    for (const auto& vector : vectors) {
+        os << std::setw(8) << std::left << vector.keyword << std::setw(5) << "";
+    }
+    os << '\n';
 
     // write headers
 
     write_line(os, divider_line);
 
     // write data
+}
+
+void ESmry::write_rsm(std::ostream& os) const {
+    os << "Writing for " << summaryNodes.size() << " vectors." << std::endl;
+    write_block(os, { summaryNodes[0], summaryNodes[1], summaryNodes[2] });
 }
 
 } // namespace Opm::EclIO

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -68,6 +68,16 @@ namespace {
         os << '\n';
     }
 
+    void write_data_row(std::ostream& os, const std::vector<std::vector<float>>& data, std::size_t index, char prefix = ' ') {
+        os << prefix;
+
+        for (const auto& vector: data) {
+            print_float_element(os, vector[index]);
+        }
+
+        os << '\n';
+    }
+
 }
 
 namespace Opm::EclIO {
@@ -94,11 +104,7 @@ void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vector
     std::size_t rows { data[0].size() };
 
     for (std::size_t i { 0 } ; i < rows; i++) {
-        os << ' ';
-        for (const auto& data_vector : data) {
-            os << std::setw(8) << std::right << data_vector[i] << std::setw(5) << "";
-        }
-        os << '\n';
+        write_data_row(os, data, i);
     }
 
     os << std::flush;

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -38,7 +38,7 @@ const std::string divider_line { " " + std::string(total_width - 3, '-') + "\n" 
 
 namespace Opm::EclIO {
 
-void ESmry::write_rsm_file(std::ostream& os) const {
+void ESmry::write_rsm(std::ostream& os) const {
     os << version_line << divider_line;
 }
 

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -107,6 +107,7 @@ void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vector
 
     std::vector<std::pair<std::vector<float>, int>> data;
 
+    bool has_scale_factors { false } ;
     for (const auto& vector : vectors) {
         int scale_factor { 0 } ;
         const auto& vector_data { get(vector) } ;
@@ -115,8 +116,10 @@ void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vector
 
         if (max >= 10'000'000'000) {
             scale_factor = 6;
+            has_scale_factors = true;
         } else if (max >= 10'000'000) {
             scale_factor = 3;
+            has_scale_factors = true;
         }
 
         data.emplace_back(vector_data, scale_factor);
@@ -126,7 +129,9 @@ void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vector
 
     write_header_columns(os, vectors, [](std::ostream& os, const SummaryNode& node) { print_text_element(os, node.keyword); });
     write_header_columns(os, vectors, [this](std::ostream& os, const SummaryNode& node) { print_text_element(os, this->get_unit(node)); });
-    write_scale_columns(os, data);
+    if (has_scale_factors) {
+        write_scale_columns(os, data);
+    }
     write_header_columns(os, vectors, [](std::ostream& os, const SummaryNode& node) { print_text_element(os, node.display_name().value_or("")); });
     write_header_columns(os, vectors, [](std::ostream& os, const SummaryNode& node) { print_text_element(os, node.display_number().value_or("")); });
 

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -155,8 +155,6 @@ void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vector
 }
 
 void ESmry::write_rsm(std::ostream& os) const {
-    os << "Writing for " << summaryNodes.size() << " vectors." << std::endl;
-
     SummaryNode date_vector;
     std::vector<SummaryNode> data_vectors;
     std::remove_copy_if(summaryNodes.begin(), summaryNodes.end(), std::back_inserter(data_vectors), [&date_vector](const SummaryNode& node){

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -19,10 +19,13 @@
 #include <opm/io/eclipse/ESmry.hpp>
 
 #include <algorithm>
+#include <fstream>
 #include <iomanip>
 #include <list>
 #include <ostream>
 #include <string>
+
+#include <opm/common/ErrorMacros.hpp>
 
 namespace {
 
@@ -127,6 +130,21 @@ void ESmry::write_rsm(std::ostream& os) const {
     for (const auto& data_vector_block : data_vector_blocks) {
         write_block(os, { data_vector_block.begin(), data_vector_block.end() });
     }
+}
+
+void ESmry::write_rsm_file() const {
+    Opm::filesystem::path summary_file_name { inputFileName } ;
+    summary_file_name.replace_extension("RSM");
+
+    std::ofstream rsm_file { summary_file_name } ;
+
+    if (!rsm_file.is_open()) {
+        OPM_THROW(std::runtime_error, "Could not open file " + std::string(summary_file_name));
+    }
+
+    write_rsm(rsm_file);
+
+    rsm_file.close();
 }
 
 } // namespace Opm::EclIO

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include <list>
 #include <ostream>
+#include <regex>
 #include <string>
 
 #include <opm/common/ErrorMacros.hpp>
@@ -57,7 +58,16 @@ namespace {
     }
 
     void print_float_element(std::ostream& os, float element) {
-        os << std::setw(8) << std::right << element << std::setw(5) << "";
+        static const std::regex integer_regex { "\\.0*$" };
+
+        auto element_string = std::to_string(element);
+        element_string = std::regex_replace(element_string, integer_regex, "");
+
+        if (element_string.size() > 8) {
+            element_string = element_string.substr(0, 8);
+        }
+
+        os << std::setw(8) << std::right << element_string << std::setw(5) << "";
     }
 
     void write_header_columns(std::ostream& os, const std::vector<Opm::EclIO::SummaryNode>& vectors, std::function<void(std::ostream&, const Opm::EclIO::SummaryNode&)> print_element, char prefix = ' ') {

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -132,8 +132,8 @@ void ESmry::write_rsm(std::ostream& os) const {
     }
 }
 
-void ESmry::write_rsm_file() const {
-    Opm::filesystem::path summary_file_name { inputFileName } ;
+void ESmry::write_rsm_file(std::optional<Opm::filesystem::path> filename) const {
+    Opm::filesystem::path summary_file_name { filename.value_or(inputFileName) } ;
     summary_file_name.replace_extension("RSM");
 
     std::ofstream rsm_file { summary_file_name } ;

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -62,6 +62,24 @@ void ESmry::write_block(std::ostream& os, const std::vector<SummaryNode>& vector
     }
     os << '\n';
 
+    os << ' ';
+    for (const auto& vector : vectors) {
+        os << std::setw(8) << std::left << get_unit(vector) << std::setw(5) << "";
+    }
+    os << '\n';
+
+    os << ' ';
+    for (const auto& vector : vectors) {
+        os << std::setw(8) << std::left << vector.wgname << std::setw(5) << "";
+    }
+    os << '\n';
+
+    os << ' ';
+    for (const auto& vector : vectors) {
+        os << std::setw(8) << std::left << vector.number << std::setw(5) << "";
+    }
+    os << '\n';
+
     // write headers
 
     write_line(os, divider_line);

--- a/src/opm/io/eclipse/ESmry_write_rsm_file.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm_file.cpp
@@ -1,0 +1,45 @@
+/*
+   Copyright 2020 Equinor ASA.
+
+   This file is part of the Open Porous Media project (OPM).
+
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OPM is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+   */
+
+#include <opm/io/eclipse/ESmry.hpp>
+
+#include <string>
+
+namespace {
+
+constexpr size_t column_width { 8 } ;
+constexpr size_t column_space { 5 } ;
+
+constexpr size_t column_count { 10 } ;
+
+constexpr size_t total_column { column_width + column_space } ;
+constexpr size_t total_width  { total_column * column_count } ;
+
+const std::string version_line { "1" + std::string(total_width,     ' ') + "\n" } ;
+// the fact that the dashed header line has 127 rather than 130 dashes has no provenance
+const std::string divider_line { " " + std::string(total_width - 3, '-') + "\n" } ;
+
+}
+
+namespace Opm::EclIO {
+
+void ESmry::write_rsm_file(std::ostream& os) const {
+    os << version_line << divider_line;
+}
+
+} // namespace Opm::EclIO

--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -74,11 +74,11 @@ std::string default_number_renderer(const Opm::EclIO::SummaryNode& node) {
 std::string Opm::EclIO::SummaryNode::unique_key(number_renderer render_number) const {
     std::vector<std::string> key_parts { keyword } ;
 
-    if (use_name(category))
-        key_parts.emplace_back(wgname);
+    if (auto opt = display_name())
+        key_parts.emplace_back(opt.value());
 
-    if (use_number(category))
-        key_parts.emplace_back(render_number(*this));
+    if (auto opt = display_number(render_number))
+        key_parts.emplace_back(opt.value());
 
     auto compose_key = [](std::string& key, const std::string& key_part) -> std::string {
         constexpr auto delimiter { ':' } ;
@@ -150,5 +150,25 @@ Opm::EclIO::SummaryNode::Category Opm::EclIO::SummaryNode::category_from_keyword
     case 'S': return Category::Segment;
     case 'W': return Category::Well;
     default:  return Category::Miscellaneous;
+    }
+}
+
+std::optional<std::string> Opm::EclIO::SummaryNode::display_name() const {
+    if (use_name(category)) {
+        return wgname;
+    } else {
+        return std::nullopt;
+    }
+}
+
+std::optional<std::string> Opm::EclIO::SummaryNode::display_number() const {
+    return display_number(default_number_renderer);
+}
+
+std::optional<std::string> Opm::EclIO::SummaryNode::display_number(number_renderer render_number) const {
+    if (use_number(category)) {
+        return render_number(*this);
+    } else {
+        return std::nullopt;
     }
 }

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -211,9 +211,7 @@ void EclipseIO::writeTimeStep(const SummaryState& st,
         this->impl->summary.write();
     }
 
-    auto length { this->impl->schedule.posixEndTime() - this->impl->schedule.posixStartTime() } ;
-    auto timeStep { this->impl->schedule.stepLength(report_step) } ;
-    bool final_step { secs_elapsed >= length - timeStep } ;
+    bool final_step { report_step == static_cast<int>(this->impl->schedule.size()) - 1 };
 
     if (final_step && this->impl->summaryConfig.createRunSummary()) {
         Opm::filesystem::path outputDir { this->impl->outputDir } ;

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -42,6 +42,7 @@
 #include <opm/output/eclipse/WriteInit.hpp>
 #include <opm/output/eclipse/WriteRFT.hpp>
 
+#include <opm/io/eclipse/ESmry.hpp>
 #include <opm/io/eclipse/OutputStream.hpp>
 
 #include <algorithm>
@@ -105,6 +106,7 @@ class EclipseIO::Impl {
         const Schedule& schedule;
         std::string outputDir;
         std::string baseName;
+        SummaryConfig summaryConfig;
         out::Summary summary;
         bool output_enabled;
 };
@@ -118,7 +120,8 @@ EclipseIO::Impl::Impl( const EclipseState& eclipseState,
     , schedule( schedule_ )
     , outputDir( eclipseState.getIOConfig().getOutputDir() )
     , baseName( uppercase( eclipseState.getIOConfig().getBaseName() ) )
-    , summary( eclipseState, summary_config, grid , schedule )
+    , summaryConfig( summary_config )
+    , summary( eclipseState, summaryConfig, grid , schedule )
     , output_enabled( eclipseState.getIOConfig().getOutputEnabled() )
 {}
 
@@ -206,6 +209,16 @@ void EclipseIO::writeTimeStep(const SummaryState& st,
         this->impl->summary.add_timestep( st,
                                           report_step);
         this->impl->summary.write();
+    }
+
+    auto length { this->impl->schedule.posixEndTime() - this->impl->schedule.posixStartTime() } ;
+    auto timeStep { this->impl->schedule.stepLength(report_step) } ;
+    bool final_step { secs_elapsed >= length - timeStep } ;
+
+    if (final_step && this->impl->summaryConfig.createRunSummary()) {
+        Opm::filesystem::path outputDir { this->impl->outputDir } ;
+        Opm::filesystem::path outputFile { outputDir / this->impl->baseName } ;
+        EclIO::ESmry(outputFile).write_rsm_file();
     }
 
     /*

--- a/tests/SPE1CASE1.DATA
+++ b/tests/SPE1CASE1.DATA
@@ -281,6 +281,8 @@ RSVD
 SUMMARY
 -- -------------------------------------------------------------------------	 
 
+RUNSUM
+
 -- 1a) Oil rate vs time
 FOPR
 -- Field Oil Production Rate

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
 
         msim.run(schedule, io, false);
 
-        for (const auto& fname : {"SPE1CASE1.INIT", "SPE1CASE1.UNRST", "SPE1CASE1.EGRID", "SPE1CASE1.SMSPEC", "SPE1CASE1.UNSMRY"})
+        for (const auto& fname : {"SPE1CASE1.INIT", "SPE1CASE1.UNRST", "SPE1CASE1.EGRID", "SPE1CASE1.SMSPEC", "SPE1CASE1.UNSMRY", "SPE1CASE1.RSM"})
             BOOST_CHECK( is_file( fname ));
 
         {

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -360,3 +360,9 @@ BOOST_AUTO_TEST_CASE(TestUnits) {
     BOOST_CHECK_EQUAL( smry.get_unit("TIME"), "DAYS");
     BOOST_CHECK_EQUAL( smry.get_unit("WOPR:PROD"), "STB/DAY");
 }
+
+BOOST_AUTO_TEST_CASE(WriteRSM) {
+    ESmry smry("SPE1CASE1.SMSPEC");
+
+    std::cout << smry;
+}

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -19,6 +19,7 @@
 #include "config.h"
 
 #include <opm/io/eclipse/ESmry.hpp>
+#include <opm/common/utility/FileSystem.hpp>
 
 #define BOOST_TEST_MODULE Test EclIO
 #include <boost/test/unit_test.hpp>
@@ -352,6 +353,16 @@ BOOST_AUTO_TEST_CASE(TestESmry_4) {
 }
 
 
+namespace fs = Opm::filesystem;
+BOOST_AUTO_TEST_CASE(TestCreateRSM) {
+    ESmry smry1("SPE1CASE1.SMSPEC");
+
+    smry1.write_rsm();
+    BOOST_CHECK(fs::exists("SPE1CASE1.RSM"));
+
+    smry1.write_rsm("TEST.RSM");
+    BOOST_CHECK(fs::exists("TEST.RSM"));
+}
 
 BOOST_AUTO_TEST_CASE(TestUnits) {
     ESmry smry("SPE1CASE1.SMSPEC");

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -357,10 +357,10 @@ namespace fs = Opm::filesystem;
 BOOST_AUTO_TEST_CASE(TestCreateRSM) {
     ESmry smry1("SPE1CASE1.SMSPEC");
 
-    smry1.write_rsm();
+    smry1.write_rsm_file();
     BOOST_CHECK(fs::exists("SPE1CASE1.RSM"));
 
-    smry1.write_rsm("TEST.RSM");
+    smry1.write_rsm_file("TEST.RSM");
     BOOST_CHECK(fs::exists("TEST.RSM"));
 }
 
@@ -370,10 +370,4 @@ BOOST_AUTO_TEST_CASE(TestUnits) {
     BOOST_CHECK_THROW( smry.get_unit("NO_SUCH_KEY"), std::out_of_range);
     BOOST_CHECK_EQUAL( smry.get_unit("TIME"), "DAYS");
     BOOST_CHECK_EQUAL( smry.get_unit("WOPR:PROD"), "STB/DAY");
-}
-
-BOOST_AUTO_TEST_CASE(WriteRSM) {
-    ESmry smry("SPE1CASE1.SMSPEC");
-
-    smry.write_rsm_file();
 }

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -364,5 +364,5 @@ BOOST_AUTO_TEST_CASE(TestUnits) {
 BOOST_AUTO_TEST_CASE(WriteRSM) {
     ESmry smry("SPE1CASE1.SMSPEC");
 
-    std::cout << smry;
+    smry.write_rsm_file();
 }


### PR DESCRIPTION
This feature adds writing an RSM file from an `Opm::EclIO::ESmry` object, with the following interfaces:

1. `Opm::EclIO::ESmry::write_rsm(std::ostream& os) const`: Writes the summary to `os`
2. `std::ostream& ::operator<<(std::ostream& os, const ESmry& smry)`: Wraps `write_rsm()`
2. `ESmry::write_rsm_file() const`: Writes to a file with the same name as the runspec, in the same directory, with the extension `.RSM` (e.g. `ESmry("SPE1CASE1.SMSPEC").write_rsm_file() => SPE1CASE1.RSM`)