### PR TITLE
Rst well shut

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -117,11 +117,11 @@ void msim::run_step(const Schedule& schedule, SummaryState& st, data::Solution& 
 
 
 
-void msim::output(SummaryState& st, size_t report_step, bool /* substep */, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const {
+void msim::output(SummaryState& st, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const {
     RestartValue value(sol, well_data);
     io.writeTimeStep(st,
                      report_step,
-                     false,
+                     substep,
                      seconds_elapsed,
                      value);
 }

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -42,11 +42,11 @@ msim::msim(const EclipseState& state_arg) :
 void msim::run(Schedule& schedule, EclipseIO& io, bool report_only) {
     const double week = 7 * 86400;
     data::Solution sol;
-    data::Wells well_data;
     SummaryState st(std::chrono::system_clock::from_time_t(schedule.getStartTime()));
 
     io.writeInitial();
     for (size_t report_step = 1; report_step < schedule.size(); report_step++) {
+        data::Wells well_data;
         if (report_only)
             run_step(schedule, st, sol, well_data, report_step, io);
         else {

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -135,6 +135,10 @@ void msim::simulate(const Schedule& schedule, const SummaryState& st, data::Solu
 
     for (const auto& well_pair : this->well_rates) {
         const std::string& well_name = well_pair.first;
+        const auto& sched_well = schedule.getWell(well_name, report_step);
+        if (sched_well.getStatus() != Well::Status::OPEN)
+            continue;
+
         data::Well& well = well_data[well_name];
         for (const auto& rate_pair : well_pair.second) {
             auto rate = rate_pair.first;

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -258,6 +258,9 @@ namespace {
             // returns the target control mode requested in the simulation
             // deck.  This item is supposed to be the well's actual, active
             // target control mode in the simulator.
+            //
+            // Observe that the setupCurrentContro() function is called again
+            // for open wells in the dynamicContrib() function.
             setCurrentControl(well, eclipseControlMode(well, st), iWell);
 
             // Multi-segmented well information

--- a/tests/SPE1CASE1.DATA
+++ b/tests/SPE1CASE1.DATA
@@ -385,7 +385,8 @@ DRSDT
 WELSPECS
 -- Item #: 1	 2	3	4	5	 6
 	'PROD'	'G1'	10	10	8400	'OIL' /
-	'INJ'	'G1'	1	1	8335	'GAS' /
+	'INJ'	  'G1'	1	  1	  8335	'GAS' /
+  'RFT'   'G1'  10  10  8400  'OIL' /
 /
 -- Coordinates in item 3-4 are retrieved from Odeh's figure 1 and 2
 -- Note that the depth at the midpoint of the well grid blocks
@@ -394,6 +395,7 @@ WELSPECS
 COMPDAT
 -- Item #: 1	2	3	4	5	6	7	8	9
 	'PROD'	10	10	3	3	'OPEN'	1*	1*	0.5 /
+	'RFT'	  10	10	3	3	'OPEN'	1*	1*	0.5 /
 	'INJ'	1	1	1	1	'OPEN'	1*	1*	0.5 /
 /
 -- Coordinates in item 2-5 are retreived from Odeh's figure 1 and 2 
@@ -420,8 +422,25 @@ WCONINJE
 
 TSTEP
 --Advance the simulater once a month for TEN years:
-31 28 31 30 31 30 31 31 30 31 30 31 
-31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 /
+
+WELOPEN
+   'RFT' OPEN /
+/
+
+WCONHIST
+   'RFT'  'OPEN'  'RESV'  0 /
+/
+
+TSTEP
+   31 /
+
+WELOPEN
+   'RFT' 'SHUT' /
+/
+
+TSTEP
+   28 31 30 31 30 31 31 30 31 30 31 
 31 28 31 30 31 30 31 31 30 31 30 31 
 31 28 31 30 31 30 31 31 30 31 30 31 
 31 28 31 30 31 30 31 31 30 31 30 31 

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -78,6 +78,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
     msim msim(state);
 
     msim.well_rate("PROD", data::Rates::opt::oil, prod_opr);
+    msim.well_rate("RFT", data::Rates::opt::oil, prod_opr);
     msim.solution("PRESSURE", pressure);
     {
         const WorkArea work_area("test_msim");
@@ -109,6 +110,12 @@ BOOST_AUTO_TEST_CASE(RUN) {
                 // DOUBHEAD[0] is elapsed time in days since start of simulation.
                 BOOST_CHECK_CLOSE( press[0], dh[0] * 86400, 1e-3 );
             }
+
+            const int report_step = 50;
+            const auto& rst_state = Opm::RestartIO::RstState::load(rst, report_step);
+            Schedule sched_rst(deck, state, python, &rst_state);
+            const auto& rft_well = sched_rst.getWell("RFT", report_step);
+            BOOST_CHECK(rft_well.getStatus() == Well::Status::SHUT);
         }
     }
 }

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -317,8 +317,9 @@ BOOST_AUTO_TEST_CASE(UDQ_WUWCT) {
                 std::string wuwct_key = std::string("WUWCT:") + well;
                 std::string wopr_key  = std::string("WOPR:") + well;
 
-                BOOST_CHECK_EQUAL( ecl_sum_get_general_var(ecl_sum, step, wwct_key.c_str()),
-                                   ecl_sum_get_general_var(ecl_sum, step, wuwct_key.c_str()));
+                if (ecl_sum_get_general_var(ecl_sum, step, wwct_key.c_str()) != 0)
+                    BOOST_CHECK_EQUAL( ecl_sum_get_general_var(ecl_sum, step, wwct_key.c_str()),
+                                       ecl_sum_get_general_var(ecl_sum, step, wuwct_key.c_str()));
 
                 wopr_sum += ecl_sum_get_general_var(ecl_sum, step , wopr_key.c_str());
             }


### PR DESCRIPTION
As I understand it: The active control of a well is written to an element in the IWEL vector - this is an integer with an encoding like OilRate == 1 and RESVRate == 5; for a well which is closed the value 0 should be used.

In OPM the active control and the open/shut status of a well are encoded in different variables, so that we can get active_control == RESV for a shut well. This creates problems when going back and forth between Eclipse encoding and OPM variables.
