### PR TITLE
fix faulty fix in 811d2e2a643e75feb8573f90f6246a47627eb7b8

### DIFF
--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -457,14 +457,14 @@ namespace {
 
         explicit Setup(const ::Opm::Deck& deck)
             : es    { deck }
-            , sched { deck, es , python }
             , python{ }
+            , sched { deck, es , python }
         {
         }
 
         ::Opm::EclipseState es;
-        ::Opm::Schedule     sched;
         ::Opm::Python       python;
+        ::Opm::Schedule     sched;
     };
 
     std::vector<Opm::data::Connection>


### PR DESCRIPTION
sched uses python, so we have to reorder the members instead