### PR TITLE
Use std::shared_ptr<Python> for Python argument in Schedule

### DIFF
--- a/examples/msim.cpp
+++ b/examples/msim.cpp
@@ -36,7 +36,7 @@ int main(int /* argc */, char** argv) {
     Opm::Parser parser;
     Opm::ParseContext parse_context;
     Opm::ErrorGuard error_guard;
-    Opm::Python python;
+    auto python = std::make_shared<Opm::Python>();
 
     Opm::Deck deck = parser.parseFile(deck_file, parse_context, error_guard);
     Opm::EclipseState state(deck);

--- a/examples/opmi.cpp
+++ b/examples/opmi.cpp
@@ -45,7 +45,7 @@ inline void loadDeck( const char * deck_file) {
     Opm::ParseContext parseContext;
     Opm::ErrorGuard errors;
     Opm::Parser parser;
-    Opm::Python python;
+    auto python = std::make_shared<Opm::Python>();
 
     std::cout << "Loading deck: " << deck_file << " ..... "; std::cout.flush();
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -123,7 +123,7 @@ namespace Opm
                  const Runspec &runspec,
                  const ParseContext& parseContext,
                  ErrorGuard& errors,
-                 const Python& python,
+                 std::shared_ptr<const Python> python,
                  const RestartIO::RstState* rst = nullptr);
 
         template<typename T>
@@ -133,21 +133,21 @@ namespace Opm
                  const Runspec &runspec,
                  const ParseContext& parseContext,
                  T&& errors,
-                 const Python& python,
+                 std::shared_ptr<const Python> python,
                  const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
                  const EclipseGrid& grid,
                  const FieldPropsManager& fp,
                  const Runspec &runspec,
-                 const Python& python,
+                 std::shared_ptr<const Python> python,
                  const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
                  const EclipseState& es,
                  const ParseContext& parseContext,
                  ErrorGuard& errors,
-                 const Python& python,
+                 std::shared_ptr<const Python> python,
                  const RestartIO::RstState* rst = nullptr);
 
         template <typename T>
@@ -155,12 +155,12 @@ namespace Opm
                  const EclipseState& es,
                  const ParseContext& parseContext,
                  T&& errors,
-                 const Python& python,
+                 std::shared_ptr<const Python> python,
                  const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
                  const EclipseState& es,
-                 const Python& python,
+                 std::shared_ptr<const Python> python,
                  const RestartIO::RstState* rst = nullptr);
 
         // The constructor *without* the Python arg should really only be used from Python itself

--- a/opm/parser/eclipse/Python/Python.hpp
+++ b/opm/parser/eclipse/Python/Python.hpp
@@ -45,7 +45,7 @@ class EclipseState;
   this Python manager indeed has a valid Python runtime:
 
 
-     Python python;
+     auto python = std::make_shared<Python>();
 
      if (python)
          python.exec("print('Hello world')")

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -124,7 +124,7 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
                         const Runspec &runspec,
                         const ParseContext& parseContext,
                         ErrorGuard& errors,
-                        [[maybe_unused]] const Python& python,
+                        [[maybe_unused]] std::shared_ptr<const Python> python,
                         const RestartIO::RstState * rst) :
         m_timeMap( deck , restart_info( rst )),
         m_oilvaporizationproperties( this->m_timeMap, OilVaporizationProperties(runspec.tabdims().getNumPVTTables()) ),
@@ -176,7 +176,7 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
                         const Runspec &runspec,
                         const ParseContext& parseContext,
                         T&& errors,
-                        const Python& python,
+                        std::shared_ptr<const Python> python,
                         const RestartIO::RstState * rst) :
         Schedule(deck, grid, fp, runspec, parseContext, errors, python, rst)
     {}
@@ -186,13 +186,13 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
                         const EclipseGrid& grid,
                         const FieldPropsManager& fp,
                         const Runspec &runspec,
-                        const Python& python,
+                        std::shared_ptr<const Python> python,
                         const RestartIO::RstState * rst) :
         Schedule(deck, grid, fp, runspec, ParseContext(), ErrorGuard(), python, rst)
     {}
 
 
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, ErrorGuard& errors, const Python& python, const RestartIO::RstState * rst) :
+Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, ErrorGuard& errors, std::shared_ptr<const Python> python, const RestartIO::RstState * rst) :
         Schedule(deck,
                  es.getInputGrid(),
                  es.fieldProps(),
@@ -206,7 +206,7 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
 
 
     template <typename T>
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, T&& errors, const Python& python, const RestartIO::RstState * rst) :
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, T&& errors, std::shared_ptr<const Python> python, const RestartIO::RstState * rst) :
         Schedule(deck,
                  es.getInputGrid(),
                  es.fieldProps(),
@@ -218,13 +218,13 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
     {}
 
 
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const Python& python, const RestartIO::RstState * rst) :
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, std::shared_ptr<const Python> python, const RestartIO::RstState * rst) :
         Schedule(deck, es, ParseContext(), ErrorGuard(), python, rst)
     {}
 
 
     Schedule::Schedule(const Deck& deck, const EclipseState& es, const RestartIO::RstState * rst) :
-        Schedule(deck, es, ParseContext(), ErrorGuard(), Python(), rst)
+        Schedule(deck, es, ParseContext(), ErrorGuard(), std::make_shared<const Python>(), rst)
     {}
 
     Schedule Schedule::serializeObject()

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -70,7 +70,7 @@ bool is_file(const Opm::filesystem::path& name)
 
 BOOST_AUTO_TEST_CASE(RUN) {
     Parser parser;
-    Python python;
+    auto python = std::make_shared<Python>();
     Deck deck = parser.parseFile("SPE1CASE1.DATA");
     EclipseState state(deck);
     Schedule schedule(deck, state, python);

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -25,6 +25,7 @@
 
 #include <stdexcept>
 #include <iostream>
+#include <memory>
 
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
@@ -54,12 +55,12 @@ struct test_data {
     EclipseState state;
     Schedule schedule;
     SummaryConfig summary_config;
-    Python python;
+    std::shared_ptr<Python> python = std::make_shared<Python>();
 
     test_data(const std::string& deck_string) :
         deck( Parser().parseString(deck_string)),
         state( this->deck ),
-        schedule( this->deck, this->state, python),
+        schedule( this->deck, this->state, this->python),
         summary_config( this->deck, this->schedule, this->state.getTableManager())
     {
         auto& ioconfig = this->state.getIOConfig();

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -124,7 +124,7 @@ ENDACTIO
 TSTEP
    10 /
 )"};
-    Opm::Python python;
+    auto python = std::make_shared<Python>();
     Opm::Parser parser;
     auto deck1 = parser.parseString(MISSING_END);
     auto deck2 = parser.parseString(WITH_WELSPECS);
@@ -233,7 +233,7 @@ TSTEP
     std::string deck_string = start + action_string + end;
     Opm::Parser parser;
     auto deck = parser.parseString(deck_string);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
@@ -707,7 +707,7 @@ TSTEP
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
-    Python python;
+    auto python = std::make_shared<Python>();
 
     Runspec runspec (deck);
     Schedule sched(deck, grid1, fp, runspec, python);

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(loadCOMPDATTESTSPE1) {
     Opm::Parser parser;
 
     const auto deck = parser.parseFile("SPE1CASE1.DATA");
-    Opm::Python python;
+    auto python = std::make_shared<Opm::Python>();
     Opm::EclipseState state(deck);
     Opm::Schedule sched(deck, state, python);
     const auto& units = deck.getActiveUnitSystem();
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(loadCOMPDATTESTSPE9) {
     Opm::Parser parser;
 
     const auto deck = parser.parseFile("SPE9_CP_PACKED.DATA");
-    Opm::Python python;
+    auto python = std::make_shared<Opm::Python>();
     Opm::EclipseState state(deck);
     Opm::Schedule sched(deck, state, python);
     const auto& units = deck.getActiveUnitSystem();

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -200,7 +200,7 @@ const char *deckData =
 
 BOOST_AUTO_TEST_CASE(CreateSchedule) {
     auto deck = createDeck();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseState state(deck);
     Schedule schedule(deck, state, python);
     BOOST_CHECK_EQUAL(schedule.getStartTime(), TimeMap::mkdate( 1998 , 3 , 8));

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -37,7 +37,7 @@ using namespace Opm;
 #ifndef EMBEDDED_PYTHON
 
 BOOST_AUTO_TEST_CASE(INSTANTIATE) {
-    Python python;
+    auto python = std::make_shared<Python>();
     BOOST_CHECK(!python.enabled());
     BOOST_CHECK_THROW(python.exec("print('Hello world')"), std::logic_error);
     BOOST_CHECK(! Python::supported() );
@@ -53,10 +53,10 @@ BOOST_AUTO_TEST_CASE(INSTANTIATE) {
 #else
 
 BOOST_AUTO_TEST_CASE(INSTANTIATE) {
-    Python python;
+    auto python = std::make_shared<Python>();
     BOOST_CHECK(Python::supported());
-    BOOST_CHECK(python.enabled());
-    BOOST_CHECK_NO_THROW(python.exec("print('Hello world')"));
+    BOOST_CHECK(python->enabled());
+    BOOST_CHECK_NO_THROW(python->exec("print('Hello world')"));
 
     Parser parser;
     Deck deck;
@@ -66,7 +66,7 @@ print('Deck: {}'.format(context.deck))
 kw = context.DeckKeyword( context.parser['FIELD'] )
 context.deck.add(kw)
 )";
-    BOOST_CHECK_NO_THROW( python.exec(python_code, parser, deck));
+    BOOST_CHECK_NO_THROW( python->exec(python_code, parser, deck));
     BOOST_CHECK( deck.hasKeyword("FIELD") );
 }
 
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(PYINPUT_BASIC) {
 
 BOOST_AUTO_TEST_CASE(PYACTION) {
     Parser parser;
-    Python python;
+    auto python = std::make_shared<Python>();
     auto deck = parser.parseFile("EMBEDDED_PYTHON.DATA");
     auto ecl_state = EclipseState(deck);
     auto schedule = Schedule(deck, ecl_state, python);
@@ -120,14 +120,14 @@ BOOST_AUTO_TEST_CASE(PYACTION) {
     const std::string& fname = pyaction_kw.getRecord(1).getItem(0).get<std::string>(0);
     Action::PyAction py_action("WCLOSE", Action::PyAction::RunCount::unlimited, Action::PyAction::load(deck.getInputPath(), fname));
     st.update_well_var("PROD1", "WWCT", 0);
-    python.exec(py_action, ecl_state, schedule, 10, st);
+    python->exec(py_action, ecl_state, schedule, 10, st);
 
     st.update("FOPR", 0);
-    python.exec(py_action, ecl_state, schedule, 10, st);
+    python->exec(py_action, ecl_state, schedule, 10, st);
 
     st.update("FOPR", 100);
     st.update_well_var("PROD1", "WWCT", 0.90);
-    python.exec(py_action, ecl_state, schedule, 10, st);
+    python->exec(py_action, ecl_state, schedule, 10, st);
     const auto& well1 = schedule.getWell("PROD1", 10);
     const auto& well2 = schedule.getWell("PROD2", 10);
     BOOST_CHECK( well1.getStatus() == Well::Status::SHUT );

--- a/tests/parser/GeomodifierTests.cpp
+++ b/tests/parser/GeomodifierTests.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE( CheckUnsoppertedInSCHEDULE ) {
         "   10 10/\n"
         "\n";
 
-    Python python;
+    auto python = std::make_shared<Python>();
     Parser parser(true);
     ParseContext parseContext;
     ErrorGuard errors;

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGEFAC) {
             "/\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     Runspec runspec (deck );
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWGRUPCONandWCONPROD) {
 
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGRUPNET) {
         "/\n";
 
         auto deck = parser.parseString(input);
-        Python python;
+        auto python = std::make_shared<Python>();
         EclipseGrid grid(10,10,10);
         TableManager table ( deck );
         FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGCONPROD) {
         /)";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(TESTGuideRateLINCOM) {
         )";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -363,7 +363,7 @@ BOOST_AUTO_TEST_CASE(TESTGuideRate) {
         )";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(TESTGCONSALE) {
         )";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -467,7 +467,7 @@ BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
         )";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck , Phases{true, true, true}, grid, table);

--- a/tests/parser/MessageLimitTests.cpp
+++ b/tests/parser/MessageLimitTests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(MESSAGES) {
         ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE( CheckUnsupportedInSCHEDULE ) {
     TableManager table ( deckSupported );
     FieldPropsManager fp(deckSupported, Phases{true, true, true}, grid, table);
     Runspec runspec(deckSupported);
-    Python python;
+    auto python = std::make_shared<Python>();
 
     parseContext.update( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , InputError::IGNORE );
     BOOST_CHECK_NO_THROW( Schedule( deckSupported  , grid , fp, runspec, parseContext, errors, python  ));
@@ -415,7 +415,7 @@ BOOST_AUTO_TEST_CASE(TestCOMPORD) {
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
-    Python python;
+    auto python = std::make_shared<Python>();
 
     parseContext.update( ParseContext::UNSUPPORTED_COMPORD_TYPE , InputError::IGNORE);
     BOOST_CHECK_NO_THROW( Schedule( deck , grid , fp, runspec, parseContext, errors, python ));
@@ -761,7 +761,7 @@ BOOST_AUTO_TEST_CASE( test_invalid_wtemplate_config ) {
         deckinput = defDeckString + sample;
         auto deckUnSupported = parser.parseString( deckinput , parseContext, errors );
 
-        Python python;
+        auto python = std::make_shared<Python>();
         EclipseGrid grid( deckUnSupported );
         TableManager table ( deckUnSupported );
         FieldPropsManager fp( deckUnSupported, Phases{true, true, true}, grid, table);

--- a/tests/parser/RFTConfigTests.cpp
+++ b/tests/parser/RFTConfigTests.cpp
@@ -40,13 +40,14 @@ namespace {
     {
         Setup(const ::Opm::Deck& deck);
 
-        ::Opm::Python       python;
         ::Opm::EclipseState es;
+        std::shared_ptr<::Opm::Python> python;
         ::Opm::Schedule     sched;
     };
 
     Setup::Setup(const ::Opm::Deck& deck)
         : es   (deck)
+        , python(std::make_shared<::Opm::Python>() )
         , sched(deck, es, python)
     {}
 

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(LoadRST) {
     EclIO::ERst rst_file("SPE1CASE2.X0060");
     auto rst_state = RestartIO::RstState::load(rst_file, 60);
     BOOST_REQUIRE_THROW( rst_state.get_well("NO_SUCH_WELL"), std::out_of_range);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseState ecl_state(deck);
     Schedule sched(deck, ecl_state, python);
     const auto& well_names = sched.wellNames(60);
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(LoadRST) {
 }
 
 BOOST_AUTO_TEST_CASE(LoadRestartSim) {
-    Python python;
+    auto python = std::make_shared<Python>();
     Parser parser;
     auto deck = parser.parseFile("SPE1CASE2.DATA");
     EclipseState ecl_state(deck);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -364,7 +364,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     Deck deck;
     Parser parser;
     deck.addKeyword( DeckKeyword( parser.getKeyword("SCHEDULE" )));
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -375,7 +375,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     auto deck = createDeckWithWellsOrdered();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(100,100,100);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -405,7 +405,7 @@ bool has_well( const std::vector<Well>& wells, const std::string& well_name) {
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
     auto deck = createDeckWithWellsOrderedGRUPTREE();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(100,100,100);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -457,7 +457,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrderedGRUPTREE) {
 
 BOOST_AUTO_TEST_CASE(GroupTree2TEST) {
     auto deck = createDeckWithWellsOrderedGRUPTREE();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(100,100,100);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(GroupTree2TEST) {
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
     auto deck = createDeck();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     Parser parser;
     Deck deck;
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
 }
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = createDeck();
     TableManager table ( deck );
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
 
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = createDeck();
     TableManager table ( deck );
@@ -599,7 +599,7 @@ END
 )"
     };
 
-    ::Opm::Python python;
+    auto python = std::make_shared<::Opm::Python>();
     const auto deck = ::Opm::Parser{}.parseString(input);
     const auto es = ::Opm::EclipseState{deck};
     const auto sched = ::Opm::Schedule{ deck, es, python };
@@ -624,7 +624,7 @@ END
 }
 
 BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = createDeck();
     TableManager table ( deck );
@@ -643,7 +643,7 @@ BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
 }
 
 BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = createDeckWithWells();
     TableManager table ( deck );
@@ -663,7 +663,7 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
 
 
 BOOST_AUTO_TEST_CASE(ReturnNumWellsTimestep) {
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = createDeckWithWells();
     TableManager table ( deck );
@@ -678,7 +678,7 @@ BOOST_AUTO_TEST_CASE(ReturnNumWellsTimestep) {
 }
 
 BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = createDeckForTestingCrossFlow();
     TableManager table ( deck );
@@ -752,7 +752,7 @@ static Deck createDeckWithWellsAndConnectionDataWithWELOPEN() {
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndConnectionDataWithWELOPEN) {
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = createDeckWithWellsAndConnectionDataWithWELOPEN();
     TableManager table ( deck );
@@ -837,7 +837,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
         " 'OP_1' OPEN / \n "
         "/\n";
 
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = parser.parseString(input);
     TableManager table ( deck );
@@ -898,7 +898,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_CombineShutCompletionsAndAddN
                   " 12  NOV 2008 / \n"
                   "/\n";
 
-  Python python;
+  auto python = std::make_shared<Python>();
   EclipseGrid grid(10,10,10);
   auto deck = parser.parseString(input);
   TableManager table ( deck );
@@ -957,7 +957,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
                     "/\n";
 
 
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = parser.parseString(input);
     TableManager table ( deck );
@@ -1016,7 +1016,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
                     "DATES             -- 5\n"
                     " 10  NOV 2008 / \n"
                     "/\n";
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     auto deck = parser.parseString(input);
     TableManager table ( deck );
@@ -1068,7 +1068,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
             "/\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1117,7 +1117,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException) {
             "/\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1137,7 +1137,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException2) {
             "/\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1184,7 +1184,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWPIMULT) {
                     "/\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1256,7 +1256,7 @@ BOOST_AUTO_TEST_CASE(WELSPECS_WGNAME_SPACE) {
         )";
 
         auto deck = parser.parseString(input);
-        Python python;
+        auto python = std::make_shared<Python>();
         EclipseGrid grid( deck );
         TableManager table ( deck );
         FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1309,7 +1309,7 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
         )";
 
         auto deck = parser.parseString(input);
-        Python python;
+        auto python = std::make_shared<Python>();
         EclipseGrid grid( deck );
         TableManager table ( deck );
         FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1359,7 +1359,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDT) {
             "/\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1394,7 +1394,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDTR) {
             "2 /\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
@@ -1442,7 +1442,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDTthenDRVDT) {
             "/\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1484,7 +1484,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithVAPPARS) {
             "/\n";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1516,7 +1516,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithOutOilVaporizationProperties) {
 
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1578,7 +1578,7 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
             ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1676,7 +1676,7 @@ BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {
             ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1783,7 +1783,7 @@ BOOST_AUTO_TEST_CASE(fromWCONHISTtoWCONPROD) {
             ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1872,7 +1872,7 @@ BOOST_AUTO_TEST_CASE(WHISTCTL_NEW_WELL) {
             ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1949,7 +1949,7 @@ BOOST_AUTO_TEST_CASE(unsupportedOptionWHISTCTL) {
             ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -1979,7 +1979,7 @@ BOOST_AUTO_TEST_CASE(move_HEAD_I_location) {
     )";
 
     auto deck = Parser().parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2011,7 +2011,7 @@ BOOST_AUTO_TEST_CASE(change_ref_depth) {
     )";
 
     auto deck = Parser().parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2051,7 +2051,7 @@ BOOST_AUTO_TEST_CASE(WTEMP_well_template) {
     )";
 
     auto deck = Parser().parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2098,7 +2098,7 @@ BOOST_AUTO_TEST_CASE(WTEMPINJ_well_template) {
     )";
 
         auto deck = Parser().parseString(input);
-        Python python;
+        auto python = std::make_shared<Python>();
         EclipseGrid grid(10,10,10);
         TableManager table ( deck );
         FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2151,7 +2151,7 @@ BOOST_AUTO_TEST_CASE( COMPDAT_sets_automatic_complnum ) {
     )";
 
     auto deck = Parser().parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2202,7 +2202,7 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_wells ) {
     )";
 
     auto deck = Parser().parseString( input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid( 10, 10, 10 );
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2272,7 +2272,7 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_records_same_completion ) {
     )";
 
     auto deck = Parser().parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2313,7 +2313,7 @@ BOOST_AUTO_TEST_CASE( complump_less_than_1 ) {
     )";
 
     auto deck = Parser().parseString( input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid( 10, 10, 10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2366,7 +2366,7 @@ BOOST_AUTO_TEST_CASE( complump ) {
     constexpr auto shut = Connection::State::SHUT;
 
     auto deck = Parser().parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2457,7 +2457,7 @@ BOOST_AUTO_TEST_CASE( COMPLUMP_specific_coordinates ) {
     constexpr auto shut = Connection::State::SHUT;
 
     auto deck = Parser().parseString( input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid( 10, 10, 10 );
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2928,7 +2928,7 @@ BOOST_AUTO_TEST_CASE(handleWEFAC) {
             ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -2974,7 +2974,7 @@ BOOST_AUTO_TEST_CASE(historic_BHP_and_THP) {
         ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -3009,7 +3009,7 @@ BOOST_AUTO_TEST_CASE(FilterCompletions2) {
     EclipseGrid grid1(10,10,10);
     std::vector<int> actnum(1000,1);
     auto deck = createDeckWithWellsAndCompletionData();
-    Python python;
+    auto python = std::make_shared<Python>();
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
     Runspec runspec (deck);
@@ -3099,7 +3099,7 @@ VFPINJ \n                                       \
 
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
@@ -3226,7 +3226,7 @@ BOOST_AUTO_TEST_CASE(POLYINJ_TEST) {
 
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
@@ -3287,7 +3287,7 @@ BOOST_AUTO_TEST_CASE(WFOAM_TEST) {
 
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
@@ -3306,7 +3306,7 @@ BOOST_AUTO_TEST_CASE(WFOAM_TEST) {
 
 BOOST_AUTO_TEST_CASE(WTEST_CONFIG) {
     auto deck = createDeckWTEST();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
@@ -3336,7 +3336,7 @@ bool has(const std::vector<std::string>& l, const std::string& s) {
 
 BOOST_AUTO_TEST_CASE(WELL_STATIC) {
     auto deck = createDeckWithWells();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
@@ -3386,7 +3386,7 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
 
 BOOST_AUTO_TEST_CASE(WellNames) {
     auto deck = createDeckWTEST();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
@@ -3504,7 +3504,7 @@ BOOST_AUTO_TEST_CASE(RFT_CONFIG) {
 
 BOOST_AUTO_TEST_CASE(RFT_CONFIG2) {
     auto deck = createDeckRFTConfig();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid1(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
@@ -3539,7 +3539,7 @@ BOOST_AUTO_TEST_CASE(nupcol) {
         ;
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -3632,7 +3632,7 @@ DATES             -- 4
      )";
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -3731,7 +3731,7 @@ TSTEP
 END
 )");
 
-    ::Opm::Python python;
+    auto python = std::make_shared<::Opm::Python>();
     const auto st = ::Opm::SummaryState{ std::chrono::system_clock::now() };
     const auto es = ::Opm::EclipseState{ deck };
     const auto sched = ::Opm::Schedule{ deck, es, python };
@@ -3805,7 +3805,7 @@ TSTEP
 END
 )");
 
-    ::Opm::Python python;
+    auto python = std::make_shared<::Opm::Python>();
     const auto st = ::Opm::SummaryState{ std::chrono::system_clock::now() };
     const auto es = ::Opm::EclipseState{ deck };
     const auto sched = ::Opm::Schedule{ deck, es, python };

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -149,7 +149,7 @@ static std::vector< std::string > sorted_key_names( const SummaryConfig& summary
 static SummaryConfig createSummary( std::string input , const ParseContext& parseContext = ParseContext()) {
     ErrorGuard errors;
     auto deck = createDeck( input );
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseState state( deck );
     Schedule schedule(deck, state, parseContext, errors, python);
     return SummaryConfig( deck, schedule, state.getTableManager( ), parseContext, errors );
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(wells_all) {
 
 BOOST_AUTO_TEST_CASE(EMPTY) {
     auto deck = createDeck_no_wells( "" );
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseState state( deck );
     Schedule schedule(deck, state, python);
     SummaryConfig conf(deck, schedule, state.getTableManager());
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(EMPTY) {
 }
 
 BOOST_AUTO_TEST_CASE(wells_missingI) {
-    Python python;
+    auto python = std::make_shared<Python>();
     ParseContext parseContext;
     ErrorGuard errors;
     const auto input = "WWCT\n/\n";
@@ -719,7 +719,7 @@ BOOST_AUTO_TEST_CASE( SUMMARY_MISC) {
 
 BOOST_AUTO_TEST_CASE(Summary_Segment)
 {
-    Python python;
+    auto python = std::make_shared<Python>();
     const auto input = std::string { "SOFR_TEST.DATA" };
     const auto deck  = Parser{}.parseFile(input);
     const auto state = EclipseState { deck };

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -71,7 +71,7 @@ static Deck createDeck(const std::string& input) {
 BOOST_AUTO_TEST_CASE(TuningTest) {
 
   auto deck = createDeck(deckStr);
-  Python python;
+  auto python = std::make_shared<Python>();
   EclipseGrid grid(10,10,10);
   TableManager table ( deck );
   FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(TEST)
 
 Schedule make_schedule(const std::string& input) {
     Parser parser;
-    Python python;
+    auto python = std::make_shared<Python>();
 
     auto deck = parser.parseString(input);
     if (deck.hasKeyword("DIMENS")) {

--- a/tests/parser/WLIST.cpp
+++ b/tests/parser/WLIST.cpp
@@ -146,7 +146,7 @@ static Opm::Schedule createSchedule(const std::string& schedule) {
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     return Schedule(deck, grid , fp, runspec, python );
 }
 

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -176,7 +176,7 @@ static Deck createDeckWithWaterInjector() {
 }
 BOOST_AUTO_TEST_CASE(TestNoSolvent) {
     auto deck = createDeckWithOutSolvent();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(TestNoSolvent) {
 
 BOOST_AUTO_TEST_CASE(TestGasInjector) {
     auto deck = createDeckWithGasInjector();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(TestGasInjector) {
 
 BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
     auto deck = createDeckWithDynamicWSOLVENT();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
 
 BOOST_AUTO_TEST_CASE(TestOilInjector) {
     auto deck = createDeckWithOilInjector();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(TestOilInjector) {
 
 BOOST_AUTO_TEST_CASE(TestWaterInjector) {
     auto deck = createDeckWithWaterInjector();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
 
 
     auto deck = parser.parseString(input);
-    Opm::Python python;
+    auto python = std::make_shared<Python>();
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestDefaultTRACK) {
 
 
     auto deck = parser.parseString(input);
-    Opm::Python python;
+    auto python = std::make_shared<Python>();
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestINPUT) {
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Opm::Runspec runspec (deck);
-    Opm::Python python;
+    auto python = std::make_shared<Python>();
     Opm::Schedule schedule(deck, grid , fp, runspec, Opm::ParseContext(), errors, python);
     const auto& op_1 = schedule.getWell("OP_1", 2);
 
@@ -856,7 +856,7 @@ BOOST_AUTO_TEST_CASE(WELOPEN) {
 
 
     auto deck = parser.parseString(input);
-    Python python;
+    auto python = std::make_shared<Python>();
     Opm::EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(TestNoTracer) {
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Python python;
+    auto python = std::make_shared<Python>();
     Runspec runspec ( deck );
     Schedule schedule(deck, grid , fp, runspec, python);
     BOOST_CHECK(!deck.hasKeyword("WTRACER"));
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(TestNoTracer) {
 
 BOOST_AUTO_TEST_CASE(TestDynamicWTRACER) {
     auto deck = createDeckWithDynamicWTRACER();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER) {
 
 BOOST_AUTO_TEST_CASE(TestTracerInProducerTHROW) {
     auto deck = createDeckWithTracerInProducer();
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);

--- a/tests/parser/integration/IOConfigIntegrationTest.cpp
+++ b/tests/parser/integration/IOConfigIntegrationTest.cpp
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE( NorneRestartConfig ) {
     rptConfig.push_back( std::make_tuple(240 , true , boost::gregorian::date( 2006,10,1)) );
     rptConfig.push_back( std::make_tuple(241 , true , boost::gregorian::date( 2006,10,10)) );
 
-    Python python;
+    auto python = std::make_shared<Python>();
     Parser parser;
     auto deck = parser.parseFile( path_prefix() + "IOConfig/RPTRST_DECK.DATA");
     EclipseState state(deck);
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     }
 
 
-    Python python;
+    auto python = std::make_shared<Python>();
     Parser parser;
     auto deck = parser.parseFile(path_prefix() + "IOConfig/RPT_TEST2.DATA");
     EclipseState state( deck);

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -595,7 +595,7 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
     const EclipseState state(deck);
     const TableManager table ( deck );
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     const Schedule sched(deck, state, python);
 
     // checking the relation between segments and completions
@@ -1370,7 +1370,7 @@ BOOST_AUTO_TEST_CASE( WCONPROD ) {
     TableManager table ( deck );
     FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck, grid, fp, runspec, python);
 
     BOOST_CHECK_EQUAL(5U, sched.numWells());
@@ -1413,7 +1413,7 @@ BOOST_AUTO_TEST_CASE( WCONINJE ) {
     Parser parser;
     std::string wconprodFile(pathprefix() + "WellWithWildcards/WCONINJE1");
     auto deck = parser.parseFile(wconprodFile);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(30,30,30);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -47,7 +47,7 @@ inline std::string pathprefix() {
 
 BOOST_AUTO_TEST_CASE(CreateSchedule) {
     Parser parser;
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE1");
     auto deck1 =  parser.parseFile(scheduleFile);
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
     const auto& timeMap = sched.getTimeMap();
     BOOST_CHECK_EQUAL(TimeMap::mkdate(2007, 5 , 10) , sched.getStartTime());
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_MissingCmode) {
     EclipseGrid grid(10,10,3);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
-    Python python;
+    auto python = std::make_shared<Python>();
     Runspec runspec (deck);
     BOOST_CHECK_NO_THROW( Schedule(deck, grid , fp, runspec, python) );
 }
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_Missing_DATA) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     BOOST_CHECK_THROW( Schedule(deck, grid , fp, runspec, python) , std::invalid_argument );
 }
 
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(WellTestRefDepth) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck , grid , fp, runspec, python);
 
     const auto& well1 = sched.getWellatEnd("W_1");
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT_DEFAULTED_ITEMS) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
 }
 
@@ -299,7 +299,7 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
 
     BOOST_CHECK_EQUAL(4U, sched.numWells());
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_correct) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule schedule(deck,  grid , fp, runspec, python);
 
     BOOST_CHECK( schedule.hasGroup( "FIELD" ));
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
 
     const auto& field_group = sched.getGroup("FIELD", 1);
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
     SummaryState st(std::chrono::system_clock::now());
 
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
 
     {
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE(WellTestWGRUPCONWellPropertiesSet) {
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_WGRUPCON");
     auto deck =  parser.parseFile(scheduleFile);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
@@ -542,7 +542,7 @@ COMPDAT \n\
      'W1'   2*    1    1      'OPEN'  1*     32.948      0.311   3047.839  2*         'X'     22.100 /\n\
 /\n";
     auto deck =  parser.parseString(deckString);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(30,30,10);
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
@@ -562,7 +562,7 @@ BOOST_AUTO_TEST_CASE(OpmCode) {
     Parser parser;
     std::string scheduleFile(pathprefix() + "SCHEDULE/wells_group.data");
     auto deck =  parser.parseFile(scheduleFile);
-    Python python;
+    auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,5);
     TableManager table ( deck );
     Runspec runspec (deck);
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(OpmCode) {
 
 BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
     Parser parser;
-    Python python;
+    auto python = std::make_shared<Python>();
     std::string scheduleFile(pathprefix() + "SCHEDULE/SCHEDULE_SHUT_WELL");
     auto deck =  parser.parseFile(scheduleFile);
     EclipseGrid grid(20,40,1);
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
 
 
@@ -679,7 +679,7 @@ BOOST_AUTO_TEST_CASE(WellTestWFOAM) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
 
 
@@ -747,7 +747,7 @@ BOOST_AUTO_TEST_CASE(WellTestWECON) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
 
     BOOST_CHECK_EQUAL(3U, sched.numWells());
@@ -858,7 +858,7 @@ BOOST_AUTO_TEST_CASE(TestEvents) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck , grid , fp, runspec, python);
     const Events& events = sched.getEvents();
 
@@ -893,7 +893,7 @@ BOOST_AUTO_TEST_CASE(TestWellEvents) {
     TableManager table ( deck );
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec(deck);
-    Python python;
+    auto python = std::make_shared<Python>();
     Schedule sched(deck , grid , fp, runspec, python);
 
     BOOST_CHECK(  sched.hasWellGroupEvent( "W_1", ScheduleEvents::NEW_WELL , 0 ));

--- a/tests/parser/integration/TransMultIntegrationTests.cpp
+++ b/tests/parser/integration/TransMultIntegrationTests.cpp
@@ -34,7 +34,7 @@ inline std::string pathprefix() {
 
 BOOST_AUTO_TEST_CASE(MULTFLT_IN_SCHEDULE) {
     Parser parser;
-    Python python;
+    auto python = std::make_shared<Python>();
     std::string scheduleFile(pathprefix() + "TRANS/Deck1");
     ParseContext parseContext;
     auto deck = parser.parseFile(scheduleFile);

--- a/tests/parser/integration/parse_write.cpp
+++ b/tests/parser/integration/parse_write.cpp
@@ -29,7 +29,7 @@
 
 inline void loadDeck( const char * deck_file) {
     Opm::Parser parser;
-    Opm::Python python;
+    auto python = std::make_shared<Opm::Python>();
 
     auto deck = parser.parseFile(deck_file);
     Opm::EclipseState state( deck);

--- a/tests/rst_test.cpp
+++ b/tests/rst_test.cpp
@@ -66,7 +66,7 @@ void initLogging() {
 */
 
 
-Opm::Schedule load_schedule(const Opm::Python& python, const std::string& fname, int& report_step) {
+Opm::Schedule load_schedule(std::shared_ptr<const Opm::Python> python, const std::string& fname, int& report_step) {
     Opm::Parser parser;
     auto deck = parser.parseFile(fname);
     Opm::EclipseState state(deck);
@@ -83,7 +83,7 @@ Opm::Schedule load_schedule(const Opm::Python& python, const std::string& fname,
         return Opm::Schedule(deck, state, python);
 }
 
-Opm::Schedule load_schedule(const Opm::Python& python, const std::string& fname) {
+Opm::Schedule load_schedule(std::shared_ptr<const Opm::Python> python, const std::string& fname) {
     int report_step;
     return load_schedule(python, fname, report_step);
 }
@@ -91,7 +91,7 @@ Opm::Schedule load_schedule(const Opm::Python& python, const std::string& fname)
 
 
 int main(int argc, char ** argv) {
-    Opm::Python python;
+    auto python = std::make_shared<Opm::Python>();
     initLogging();
     if (argc == 2)
         load_schedule(python, argv[1]);

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -79,14 +79,15 @@ struct SimulationCase
 {
     explicit SimulationCase(const Opm::Deck& deck)
         : es   { deck }
-	, grid { deck }
+        , grid { deck }
+        , python{ std::make_shared<Opm::Python>() }
         , sched{ deck, es, python }
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
-    Opm::Python       python;
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
+    std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
 
 };

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -529,7 +529,7 @@ END
     struct SimulationCase {
         explicit SimulationCase(const Opm::Deck& deck)
             : es(deck)
-            , python()
+            , python(std::make_shared<Opm::Python>())
             , grid(deck)
             , sched(deck, es, python)
         {
@@ -537,7 +537,7 @@ END
 
         // Order requirement: 'es' must be declared/initialised before 'sched'.
         Opm::EclipseState es;
-        Opm::Python python;
+        std::shared_ptr<Opm::Python> python;
         Opm::EclipseGrid grid;
         Opm::Schedule sched;
     };

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -458,12 +458,13 @@ struct SimulationCase
 {
     explicit SimulationCase(const Opm::Deck& deck)
         : es   ( deck )
+        , python( std::make_shared<Opm::Python>() )
         , sched (deck, es, python )
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
-    Opm::Python       python;
     Opm::EclipseState es;
+    std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
 };
 

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -587,13 +587,14 @@ struct SimulationCase
     explicit SimulationCase(const Opm::Deck& deck)
         : es   ( deck )
         , grid ( deck )
+        , python( std::make_shared<Opm::Python>() )
         , sched( deck, es, python )
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
-    Opm::Python       python;
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
+    std::shared_ptr<Opm::Python>  python;
     Opm::Schedule     sched;
 };
 

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -110,13 +110,14 @@ struct SimulationCase
     explicit SimulationCase(const Opm::Deck& deck)
         : es   { deck }
         , grid { deck }
+        , python { std::make_shared<Opm::Python>()}
         , sched{ deck, es, python }
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
-    Opm::Python       python;
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
+    std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
 
 };

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -357,13 +357,14 @@ struct SimulationCase
     explicit SimulationCase(const Opm::Deck& deck)
         : es   { deck }
         , grid { deck }
+        , python{ std::make_shared<Opm::Python>()}
         , sched{ deck, es, python }
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
-    Opm::Python       python;
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
+    std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
 };
 

--- a/tests/test_ArrayDimChecker.cpp
+++ b/tests/test_ArrayDimChecker.cpp
@@ -345,15 +345,16 @@ struct CaseObjects
     CaseObjects& operator=(const CaseObjects& rhs) = delete;
     CaseObjects& operator=(CaseObjects&& rhs) = delete;
 
-    Opm::Python       python;
     Opm::ErrorGuard   guard;
     Opm::EclipseState es;
+    std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
 };
 
 CaseObjects::CaseObjects(const Opm::Deck& deck, const Opm::ParseContext& ctxt)
     : guard{}
     , es   (deck)
+    , python( std::make_shared<Opm::Python>())
     , sched(deck, es, ctxt, guard, python)
 {
 }

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         auto deck = Parser().parseString( deckString);
         auto es = EclipseState( deck );
         auto& eclGrid = es.getInputGrid();
-        Python python;
+        auto python = std::make_shared<Python>();
         Schedule schedule(deck, es, python);
         SummaryConfig summary_config( deck, schedule, es.getTableManager( ));
         SummaryState st(std::chrono::system_clock::now());

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_SUITE(Using_EclipseIO)
 
 BOOST_AUTO_TEST_CASE(test_RFT)
 {
-    Python python;
+    auto python = std::make_shared<Python>();
     const auto rset = RSet{ "TESTRFT" };
 
     const auto eclipse_data_filename = std::string{ "testrft.DATA" };
@@ -367,7 +367,7 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(test_RFT2)
 {
-    Python python;
+    auto python = std::make_shared<Python>();
     const auto rset = RSet{ "TESTRFT" };
 
     const auto eclipse_data_filename = std::string{ "testrft.DATA" };
@@ -457,13 +457,13 @@ namespace {
 
         explicit Setup(const ::Opm::Deck& deck)
             : es    { deck }
-            , python{ }
+            , python{ std::make_shared<::Opm::Python>() }
             , sched { deck, es , python }
         {
         }
 
         ::Opm::EclipseState es;
-        ::Opm::Python       python;
+        std::shared_ptr<::Opm::Python> python;
         ::Opm::Schedule     sched;
     };
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -342,14 +342,15 @@ struct Setup {
     Deck deck;
     EclipseState es;
     const EclipseGrid& grid;
+    std::shared_ptr<Python> python;
     Schedule schedule;
     SummaryConfig summary_config;
-    Python python;
 
     Setup( const char* path) :
         deck( Parser().parseFile( path) ),
         es( deck),
         grid( es.getInputGrid( ) ),
+        python( std::make_shared<Python>() ),
         schedule( deck, es, python ),
         summary_config( deck, schedule, es.getTableManager( ))
     {

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -369,10 +369,10 @@ double ecl_sum_get_well_completion_var( const EclIO::ESmry* smry,
 }
 
 struct setup {
-    Python python;
     Deck deck;
     EclipseState es;
     const EclipseGrid& grid;
+    std::shared_ptr<Python> python;
     Schedule schedule;
     SummaryConfig config;
     data::Wells wells;
@@ -386,6 +386,7 @@ struct setup {
         deck( Parser().parseFile( path) ),
         es( deck ),
         grid( es.getInputGrid() ),
+        python( std::make_shared<Python>() ),
         schedule( deck, es, python),
         config( deck, schedule, es.getTableManager()),
         wells( result_wells() ),

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -205,10 +205,10 @@ static data::Group result_groups() {
 
 
 struct setup {
-    Python python;
     Deck deck;
     EclipseState es;
     const EclipseGrid& grid;
+    std::shared_ptr<Python> python;
     Schedule schedule;
     SummaryConfig config;
     data::Wells wells;
@@ -222,6 +222,7 @@ struct setup {
         deck( Parser().parseFile( path) ),
         es( deck ),
         grid( es.getInputGrid() ),
+        python( std::make_shared<Python>() ),
         schedule( deck, es, python),
         config( deck, schedule, es.getTableManager()),
         wells( result_wells() ),

--- a/tests/test_regionCache.cpp
+++ b/tests/test_regionCache.cpp
@@ -40,7 +40,7 @@ const char* path = "summary_deck.DATA";
 
 
 BOOST_AUTO_TEST_CASE(create) {
-    Python python;
+    auto python = std::make_shared<Python>();
     Parser parser;
     Deck deck( parser.parseFile( path ));
     EclipseState es(deck);

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
 
     std::string eclipse_data_filename    = "testblackoilstate3.DATA";
 
-    Opm::Python python;
+    auto python = std::make_shared<Opm::Python>();
     Opm::Parser parser;
     Opm::Deck deck( parser.parseFile( eclipse_data_filename ));
     Opm::EclipseState es(deck);

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -188,16 +188,16 @@ TSTEP            -- 8
 struct SimulationCase
 {
     explicit SimulationCase(const Opm::Deck& deck)
-        : python{ }
-        , es    { deck }
+        : es    { deck }
         , grid  { deck }
+        , python{ std::make_shared<Opm::Python>() }
         , sched { deck, es, python}
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
-    Opm::Python       python;
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
+    std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
 };
 


### PR DESCRIPTION
Sorry about the noise. To hold on to one shared Python instance it had to be a pointer.

Downstream: 
https://github.com/OPM/opm-material/pull/415
https://github.com/OPM/opm-simulators/pull/2507