### PR TITLE
WPIMULT: directly multiply the connection transmissibility factor

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -119,7 +119,6 @@ namespace RestartIO {
         double rw() const;
         double r0() const;
         double skinFactor() const;
-        double wellPi() const;
         CTFKind kind() const;
 
         void setState(State state);
@@ -167,7 +166,6 @@ namespace RestartIO {
             serializer(m_segDistEnd);
             serializer(m_defaultSatTabId);
             serializer(segment_number);
-            serializer(wPi);
         }
 
     private:
@@ -245,7 +243,6 @@ namespace RestartIO {
         // related segment number
         // 0 means the completion is not related to segment
         int segment_number = 0;
-        double wPi = 1.0;
 
         static std::string CTFKindToString(const CTFKind);
     };

--- a/python/cxx/connection.cpp
+++ b/python/cxx/connection.cpp
@@ -36,6 +36,5 @@ void python::common::export_Connection(py::module& module) {
     .def_property_readonly( "sat_table_id",        &Connection::satTableId)
     .def_property_readonly( "segment_number",      &Connection::segment)
     .def_property_readonly( "cf",                  &Connection::CF)
-    .def_property_readonly( "kh",                  &Connection::Kh)
-    .def_property_readonly( "well_pi",             &Connection::wellPi );
+    .def_property_readonly( "kh",                  &Connection::Kh);
 }

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -556,7 +556,7 @@ inline quantity trans_factors ( const fn_args& args ) {
 
     if( connection == connections.end() ) return zero;
 
-    const auto& v = connection->CF() * connection->wellPi();
+    const auto& v = connection->CF();
     return { v, measure::transmissibility };
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -3131,7 +3131,6 @@ bool Schedule::cmp(const Schedule& sched1, const Schedule& sched2, std::size_t r
 
                 //well_count += not_equal( conn1.r0(), conn2.r0(), well_connection_msg(well1.name(), conn1, "r0"));
                 well_count += not_equal( conn1.skinFactor(), conn2.skinFactor(), well_connection_msg(well1.name(), conn1, "skinFactor"));
-                well_count += not_equal( conn1.wellPi(), conn2.wellPi(), well_connection_msg(well1.name(), conn1, "PI"));
 
             }
         }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -79,7 +79,6 @@ namespace Opm {
 
 namespace {
 constexpr bool defaultSatTabId = true;
-constexpr double def_wellPi = 1.0;
 }
 
 Connection::Connection(const RestartIO::RstConnection& rst_connection, const EclipseGrid& grid, const FieldPropsManager& fp) :
@@ -100,8 +99,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         m_segDistStart(rst_connection.segdist_start),
         m_segDistEnd(rst_connection.segdist_end),
         m_defaultSatTabId(defaultSatTabId),
-        segment_number(rst_connection.segment),
-        wPi(def_wellPi)
+        segment_number(rst_connection.segment)
     {
         if (this->m_defaultSatTabId) {
             const auto& satnum = fp.get_int("SATNUM");
@@ -136,7 +134,6 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         result.m_segDistEnd = 15.0;
         result.m_defaultSatTabId = true;
         result.segment_number = 16;
-        result.wPi = 17.0;
 
         return result;
     }
@@ -261,11 +258,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
     }
 
     void Connection::scaleWellPi(double wellPi) {
-        this->wPi *= wellPi;
-    }
-
-    double Connection::wellPi() const {
-        return this->wPi;
+        this->m_CF *= wellPi;
     }
 
 
@@ -278,7 +271,6 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         ss << "RW " << this->m_rw << std::endl;
         ss << "R0 " << this->m_r0 << std::endl;
         ss << "skinf " << this->m_skin_factor << std::endl;
-        ss << "wPi " << this->wPi << std::endl;
         ss << "kh " << this->m_Kh << std::endl;
         ss << "sat_tableId " << this->sat_tableId << std::endl;
         ss << "open_state " << Connection::State2String(this->open_state) << std::endl;
@@ -299,7 +291,6 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
             && this->m_rw == rhs.m_rw
             && this->m_r0 == rhs.m_r0
             && this->m_skin_factor == rhs.m_skin_factor
-            && this->wPi == rhs.wPi
             && this->m_Kh == rhs.m_Kh
             && this->sat_tableId == rhs.sat_tableId
             && this->open_state == rhs.open_state

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1191,20 +1191,18 @@ BOOST_AUTO_TEST_CASE(createDeckWithWPIMULT) {
     Runspec runspec (deck);
     Schedule schedule(deck, grid , fp, runspec, python);
 
+    const auto& cs1 = schedule.getWell("OP_1", 1).getConnections();
     const auto& cs2 = schedule.getWell("OP_1", 2).getConnections();
     const auto& cs3 = schedule.getWell("OP_1", 3).getConnections();
     const auto& cs4 = schedule.getWell("OP_1", 4).getConnections();
     for(size_t i = 0; i < cs2.size(); i++)
-        BOOST_CHECK_EQUAL(cs2.get( i ).wellPi(), 1.3);
+        BOOST_CHECK_EQUAL(cs2.get( i ).CF() / cs1.get(i).CF(), 1.3);
 
     for(size_t i = 0; i < cs3.size(); i++ )
-        BOOST_CHECK_EQUAL(cs3.get( i ).wellPi(), (1.3*1.3));
+        BOOST_CHECK_EQUAL(cs3.get( i ).CF() / cs1.get(i).CF(), (1.3*1.3));
 
     for(size_t i = 0; i < cs4.size(); i++ )
-        BOOST_CHECK_EQUAL(cs4.get( i ).wellPi(), 1.0);
-
-    for(size_t i = 0; i < cs4.size(); i++ )
-        BOOST_CHECK_EQUAL(cs4.get( i ).wellPi(), 1.0);
+        BOOST_CHECK_EQUAL(cs4.get( i ).CF(), cs1.get(i).CF());
 
     BOOST_CHECK_THROW(schedule.simTime(10000), std::invalid_argument);
     auto sim_time1 = TimeStampUTC{ schedule.simTime(1) };


### PR DESCRIPTION
Do not handle WellPI as a separate entity in the Connection class - just multiply with the transmissibility factor right away.