### PR TITLE
Handle RPTSCHED keywords in a time-sensitive manner

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -329,6 +329,7 @@ if(ENABLE_ECL_INPUT)
     tests/parser/ParseDATAWithDefault.cpp
     tests/parser/PYACTION.cpp
     tests/parser/RawKeywordTests.cpp
+    tests/parser/test_ReportConfig.cpp
     tests/parser/ResinsightTest.cpp
     tests/parser/RestartConfigTests.cpp
     tests/parser/RFTConfigTests.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -116,6 +116,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -669,6 +670,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp
        opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
        opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
+       opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
        opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
        opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp
@@ -22,11 +22,20 @@
 #include <string>
 #include <unordered_map>
 
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
 namespace Opm {
 
 class RPTConfig: public std::unordered_map<std::string,unsigned> {
+#if __cplusplus <= 201703L
 public:
     bool contains(const std::string&) const;
+#endif
+
+public:
+    using std::unordered_map<std::string,unsigned>::unordered_map;
+
+    RPTConfig(const DeckKeyword&);
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp
@@ -1,0 +1,34 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef RPT_CONFIG_HPP
+#define RPT_CONFIG_HPP
+
+#include <string>
+#include <unordered_map>
+
+namespace Opm {
+
+class RPTConfig: public std::unordered_map<std::string,unsigned> {
+public:
+    bool contains(const std::string&) const;
+};
+
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -38,6 +38,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
@@ -221,6 +222,8 @@ namespace Opm
         const Action::Actions& actions(std::size_t timeStep) const;
         void evalAction(const SummaryState& summary_state, size_t timeStep);
 
+        const RPTConfig& report_config(std::size_t timeStep) const;
+
         GTNode groupTree(std::size_t report_step) const;
         GTNode groupTree(const std::string& root_node, std::size_t report_step) const;
         size_t numGroups() const;
@@ -355,6 +358,8 @@ namespace Opm
                      size_t timeStep,
                      Connection::Order wellConnectionOrder,
                      const UnitSystem& unit_system);
+
+        DynamicState<std::shared_ptr<RPTConfig>> rpt_config;
 
         GTNode groupTree(const std::string& root_node, std::size_t report_step, const GTNode * parent) const;
         void updateGroup(std::shared_ptr<Group> group, size_t reportStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -38,7 +38,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
@@ -101,6 +100,7 @@ namespace Opm
     class FieldPropsManager;
     class Python;
     class Runspec;
+    class RPTConfig;
     class SCHEDULESection;
     class SummaryState;
     class TimeMap;
@@ -428,6 +428,7 @@ namespace Opm
         void handleWECON( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleWHISTCTL(const DeckKeyword& keyword, std::size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleMESSAGES(const DeckKeyword& keyword, size_t currentStep);
+        void handleRPTSCHED(const DeckKeyword& keyword, size_t currentStep);
         void handleVFPPROD(const DeckKeyword& vfpprodKeyword, const UnitSystem& unit_system, size_t currentStep);
         void handleVFPINJ(const DeckKeyword& vfpprodKeyword, const UnitSystem& unit_system, size_t currentStep);
         void checkUnhandledKeywords( const SCHEDULESection& ) const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.cpp
@@ -1,0 +1,28 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
+
+namespace {
+
+}
+
+bool Opm::RPTConfig::contains(const std::string& key) const {
+    return find(key) != end();
+}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -145,7 +145,8 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
         m_actions(this->m_timeMap, std::make_shared<Action::Actions>()),
         rft_config(this->m_timeMap),
         m_nupcol(this->m_timeMap, ParserKeywords::NUPCOL::NUM_ITER::defaultValue),
-        restart_config(m_timeMap, deck, parseContext, errors)
+        restart_config(m_timeMap, deck, parseContext, errors),
+        rpt_config(this->m_timeMap, std::make_shared<RPTConfig>())
     {
         addGroup( "FIELD", 0, deck.getActiveUnitSystem());
         if (rst)
@@ -2826,6 +2827,11 @@ void Schedule::invalidNamePattern( const std::string& namePattern,  std::size_t 
         return *ptr;
     }
 
+    const RPTConfig& Schedule::report_config(size_t timeStep) const {
+        const auto& ptr = this->rpt_config.get(timeStep);
+        return *ptr;
+    }
+
 
     size_t Schedule::size() const {
         return this->m_timeMap.size();
@@ -2930,6 +2936,7 @@ void Schedule::invalidNamePattern( const std::string& namePattern,  std::size_t 
                compareDynState(this->gconsump, data.gconsump) &&
                this->global_whistctl_mode == data.global_whistctl_mode &&
                compareDynState(this->m_actions, data.m_actions) &&
+               compareDynState(this->rpt_config, data.rpt_config) &&
                rft_config  == data.rft_config &&
                this->m_nupcol == data.m_nupcol &&
                this->restart_config == data.restart_config &&

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -57,6 +57,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
@@ -452,6 +453,9 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext&
 
         else if (keyword.name() == "MESSAGES")
             handleMESSAGES(keyword, currentStep);
+
+        else if (keyword.name() == "RPTSCHED")
+            handleRPTSCHED(keyword, currentStep);
 
         else if (keyword.name() == "WEFAC")
             handleWEFAC(keyword, currentStep, parseContext, errors);
@@ -1946,6 +1950,10 @@ void Schedule::iterateScheduleSection(const std::string& input_path, const Parse
                 fptr( this->m_messageLimits , currentStep , value );
             }
         }
+    }
+
+    void Schedule::handleRPTSCHED( const DeckKeyword& keyword, size_t currentStep) {
+        this->rpt_config.update(currentStep, std::make_shared<RPTConfig>(keyword));
     }
 
     void Schedule::handleCOMPDAT( const DeckKeyword& keyword, size_t currentStep, const EclipseGrid& grid, const FieldPropsManager& fp, const ParseContext& parseContext, ErrorGuard& errors) {

--- a/tests/parser/test_ReportConfig.cpp
+++ b/tests/parser/test_ReportConfig.cpp
@@ -127,8 +127,8 @@ RPTSCHED
         auto report_config = sched.report_config(0);
         BOOST_CHECK_EQUAL(report_config.size(), 0);
 
-        BOOST_CHECK(!report_config.has("FIPFOAM"));
-        BOOST_CHECK_THROW( report_config.get("FIPFOAM"), std::out_of_range);
+        BOOST_CHECK(!report_config.contains("FIPFOAM"));
+        BOOST_CHECK_THROW( report_config.at("FIPFOAM"), std::out_of_range);
     }
 
     // Configuration at step 1
@@ -144,10 +144,10 @@ RPTSCHED
                 BOOST_CHECK_EQUAL(p.second, 3);
         }
 
-        BOOST_CHECK(!report_config.has("FIPFOAM"));
-        BOOST_CHECK(report_config.has("FIP"));
-        BOOST_CHECK_EQUAL(report_config.get("FIP"), 3);
-        BOOST_CHECK_EQUAL(report_config.get("FIPSOL"), 1);
+        BOOST_CHECK(!report_config.contains("FIPFOAM"));
+        BOOST_CHECK(report_config.contains("FIP"));
+        BOOST_CHECK_EQUAL(report_config.at("FIP"), 3);
+        BOOST_CHECK_EQUAL(report_config.at("FIPSOL"), 1);
     }
 
     // Configuration at step 2 - the special 'NOTHING' has cleared everything
@@ -155,7 +155,7 @@ RPTSCHED
         auto report_config = sched.report_config(2);
         BOOST_CHECK_EQUAL(report_config.size(), 0);
 
-        BOOST_CHECK(!report_config.has("FIPFOAM"));
-        BOOST_CHECK_THROW( report_config.get("FIPFOAM"), std::out_of_range);
+        BOOST_CHECK(!report_config.contains("FIPFOAM"));
+        BOOST_CHECK_THROW( report_config.at("FIPFOAM"), std::out_of_range);
     }
 }

--- a/tests/parser/test_ReportConfig.cpp
+++ b/tests/parser/test_ReportConfig.cpp
@@ -24,6 +24,7 @@
 #define BOOST_TEST_MODULE ReportConfigTest
 #include <boost/test/unit_test.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/parser/test_ReportConfig.cpp
+++ b/tests/parser/test_ReportConfig.cpp
@@ -1,0 +1,161 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdexcept>
+#include <iostream>
+
+
+#define BOOST_TEST_MODULE ReportConfigTest
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/Python/Python.hpp>
+
+
+
+Opm::Schedule make_schedule(const std::string& sched_string) {
+    std::string deck_string = R"(
+RUNSPEC
+DIMENS
+5 5 5 /
+OIL
+WATER
+TABDIMS
+/
+WELLDIMS
+2  10  3  2 /
+GRID
+DXV
+5*100 /
+DYV
+5*100 /
+DZV
+5*5 /
+TOPS
+25*2500 /
+PORO
+125*0.15 /
+PERMX
+125*500 /
+COPY
+'PERMX' 'PERMY' /
+'PERMX' 'PERMZ' /
+/
+MULTIPLY
+'PERMZ' 0.1 /
+/
+PROPS
+SWOF
+0 0 1 0
+1 1 0 0 /
+
+SCHEDULE
+)";
+    Opm::Parser parser;
+    auto deck = parser.parseString(deck_string + sched_string);
+    Opm::EclipseState ecl_state(deck);
+    auto python = std::make_shared<Opm::Python>();
+    return Opm::Schedule(deck, ecl_state, python);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(ReportConfig_INVALID) {
+    const std::string sched_string1 = R"(
+RPTSCHED
+  FIPSOL=X
+)";
+
+    const std::string sched_string2 = R"(
+RPTSCHED
+  FIPSOL=-1
+)";
+
+    const std::string sched_string3 = R"(
+RPTSCHED
+  FIPSOL=2.50
+)";
+
+    BOOST_CHECK_THROW(make_schedule(sched_string1), std::invalid_argument);
+    BOOST_CHECK_THROW(make_schedule(sched_string2), std::invalid_argument);
+    BOOST_CHECK_THROW(make_schedule(sched_string3), std::invalid_argument);
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(ReportConfig) {
+    const std::string sched_string = R"(
+DATES
+   1 'JAN' 2000 /
+/
+
+RPTSCHED
+  FIPSOL FIP=3 /
+
+DATES
+   1  'FEB' 2000 /
+/
+
+RPTSCHED
+  FIPSOL FIP=3 NOTHING /
+
+)";
+    auto sched = make_schedule(sched_string);
+
+    // Empty initial report configuration
+    {
+        auto report_config = sched.report_config(0);
+        BOOST_CHECK_EQUAL(report_config.size(), 0);
+
+        BOOST_CHECK(!report_config.has("FIPFOAM"));
+        BOOST_CHECK_THROW( report_config.get("FIPFOAM"), std::out_of_range);
+    }
+
+    // Configuration at step 1
+    {
+        auto report_config = sched.report_config(1);
+        BOOST_CHECK_EQUAL( report_config.size() , 2);
+
+        for (const auto& p : report_config) {
+            if (p.first == "FIPSOL")
+                BOOST_CHECK_EQUAL(p.second, 1);
+
+            if (p.first == "FIP")
+                BOOST_CHECK_EQUAL(p.second, 3);
+        }
+
+        BOOST_CHECK(!report_config.has("FIPFOAM"));
+        BOOST_CHECK(report_config.has("FIP"));
+        BOOST_CHECK_EQUAL(report_config.get("FIP"), 3);
+        BOOST_CHECK_EQUAL(report_config.get("FIPSOL"), 1);
+    }
+
+    // Configuration at step 2 - the special 'NOTHING' has cleared everything
+    {
+        auto report_config = sched.report_config(2);
+        BOOST_CHECK_EQUAL(report_config.size(), 0);
+
+        BOOST_CHECK(!report_config.has("FIPFOAM"));
+        BOOST_CHECK_THROW( report_config.get("FIPFOAM"), std::out_of_range);
+    }
+}


### PR DESCRIPTION
This feature adds the handling of `RPTSCHED` keywords in a time-sensitive (i.e. `DynamicState<T>`-based) manner. It expands the interface of `Opm::Schedule` as follows:

1. Adds `report_config(std::size_t timeStep)`: Gets the report configuration at `timeStep`.

It also adds `Opm::RPTConfig: public std::unordered_map<std::string,unsigned>`, a container for report settings, with the following interface (in addition to its normal `unsigned_map` interface):

1. `RPTConfig::RPTConfig(const DeckKeyword&)`: Creates a new config entry based on the passed keyword and its arguments.