### PR TITLE
Summary: Recognise Aliases for Potential Phase Injection Rates

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1212,8 +1212,10 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "WOPP", potential_rate< rt::well_potential_oil , true, false>},
     { "WGPP", potential_rate< rt::well_potential_gas , true, false>},
     { "WWPI", potential_rate< rt::well_potential_water , false, true>},
+    { "WWIP", potential_rate< rt::well_potential_water , false, true>}, // Alias for 'WWPI'
     { "WOPI", potential_rate< rt::well_potential_oil , false, true>},
     { "WGPI", potential_rate< rt::well_potential_gas , false, true>},
+    { "WGIP", potential_rate< rt::well_potential_gas , false, true>}, // Alias for 'WGPI'
 };
 
 


### PR DESCRIPTION
This commit adds the aliases `WGIP` and `WWIP` for the existing summary vector names 'WGPI' (potential gas injection rate at well level), and 'WWPI' (potental water injection rate at well level), respectively.

Some [datasets](https://github.com/OPM/opm-tests/blob/e8a6cba3acf8ad4a0da821f02af6d4e73cda0ca8/model2/include/summary.inc#L147-L151) in 'opm-tests' use these alias names.