### PR TITLE
[FIX] Resolves a build error on macOS/AppleClang 11.0.3

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
@@ -24,6 +24,8 @@
 
 #include <cassert>
 
+#include <string>
+
 namespace Opm {
 namespace {
 


### PR DESCRIPTION
This feature resolves a build issue caused by different standard library headers pulling in different other standard library headers on different compilers/platforms; in this case `<string>` was not pulled in on AppleClang from other headers.