### PR TITLE
Rsm regression test

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -240,6 +240,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/io/eclipse/EGrid.cpp
           src/opm/io/eclipse/ERft.cpp
           src/opm/io/eclipse/ERst.cpp
+          src/opm/io/eclipse/ERsm.cpp
           src/opm/io/eclipse/ESmry.cpp
           src/opm/io/eclipse/ESmry_write_rsm.cpp
           src/opm/io/eclipse/OutputStream.cpp
@@ -296,6 +297,7 @@ list (APPEND TEST_SOURCE_FILES
 if(ENABLE_ECL_INPUT)
   list(APPEND TEST_SOURCE_FILES
     tests/rst_test.cpp
+    tests/test_ERsm.cpp
     tests/parser/ACTIONX.cpp
     tests/parser/ADDREGTests.cpp
     tests/parser/AquiferTests.cpp
@@ -733,6 +735,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/io/eclipse/EGrid.hpp
         opm/io/eclipse/ERft.hpp
         opm/io/eclipse/ERst.hpp
+        opm/io/eclipse/ERsm.hpp
         opm/io/eclipse/ESmry.hpp
         opm/io/eclipse/PaddedOutputString.hpp
         opm/io/eclipse/OutputStream.hpp

--- a/opm/common/utility/TimeService.hpp
+++ b/opm/common/utility/TimeService.hpp
@@ -53,6 +53,7 @@ namespace Opm {
 
         explicit TimeStampUTC(const std::time_t tp);
         explicit TimeStampUTC(const YMD& ymd);
+        TimeStampUTC(int year, int month, int day);
         TimeStampUTC(const YMD& ymd,
                      int hour,
                      int minutes,

--- a/opm/io/eclipse/ERsm.hpp
+++ b/opm/io/eclipse/ERsm.hpp
@@ -1,0 +1,77 @@
+/*
+   Copyright 2020 Equinor ASA.
+
+   This file is part of the Open Porous Media project (OPM).
+
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OPM is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_IO_ERSM_HPP
+#define OPM_IO_ERSM_HPP
+
+#include <deque>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include <opm/io/eclipse/SummaryNode.hpp>
+#include <opm/common/utility/TimeService.hpp>
+
+namespace Opm { namespace EclIO {
+
+/*
+  Small class to load RSM files. The RSM file is a text based version of the
+  information found in the summary file. The format seems quite fragile - with
+  significant whitespace all over the place.The ambition of this ERsm clas is to
+  be able to do regression testing of the RSM files we export from the ESmry
+  class - it is not meant to be a rock-solid-works-in-every-lunar phase RSM
+  loader.
+*/
+class ESmry;
+
+class ERsm
+{
+
+struct Vector{
+    SummaryNode header;
+    std::vector<double> data;
+
+    Vector(SummaryNode header_, std::size_t size_advice) :
+        header(std::move(header_))
+    {
+        this->data.reserve(size_advice);
+    }
+};
+
+
+public:
+    ERsm(const std::string& fname);
+
+    const std::vector<TimeStampUTC>& dates() const;
+    const std::vector<double>& days() const;
+    bool has_dates() const;
+
+    const std::vector<double>& get(const std::string& key) const;
+    bool has(const std::string& key) const;
+private:
+    void load_block(std::deque<std::string>& lines , std::size_t& vector_length);
+
+    std::unordered_map<std::string, Vector> vectors;
+    std::variant<std::vector<double>, std::vector<TimeStampUTC>> time;
+};
+
+}
+}
+
+#endif

--- a/opm/io/eclipse/ERsm.hpp
+++ b/opm/io/eclipse/ERsm.hpp
@@ -71,6 +71,8 @@ private:
     std::variant<std::vector<double>, std::vector<TimeStampUTC>> time;
 };
 
+bool cmp(const ESmry& esmr, const ERsm& ersm);
+
 }
 }
 

--- a/src/opm/common/utility/TimeService.cpp
+++ b/src/opm/common/utility/TimeService.cpp
@@ -113,6 +113,10 @@ Opm::TimeStampUTC::TimeStampUTC(const YMD& ymd)
     : ymd_{ std::move(ymd) }
 {}
 
+Opm::TimeStampUTC::TimeStampUTC(int year, int month, int day)
+    : ymd_{ year, month, day }
+{}
+
 Opm::TimeStampUTC& Opm::TimeStampUTC::hour(const int h)
 {
     this->hour_ = h;

--- a/src/opm/io/eclipse/ERsm.cpp
+++ b/src/opm/io/eclipse/ERsm.cpp
@@ -1,0 +1,251 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <fstream>
+#include <string>
+#include <cmath>
+#include <chrono>
+
+#include <opm/io/eclipse/ERsm.hpp>
+#include <opm/common/utility/FileSystem.hpp>
+#include <opm/common/utility/String.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+
+namespace Opm {
+namespace EclIO {
+
+namespace {
+
+constexpr std::size_t num_columns  = 10;
+constexpr std::size_t column_width = 13;
+
+
+std::deque<std::string> load(const std::string& fname) {
+    std::deque<std::string> lines;
+    std::ifstream is(fname.c_str());
+    if (!is.good())
+        throw std::invalid_argument("Can not open: " + fname + " for reading");
+
+    std::string line;
+    while(std::getline(is, line)) {
+        if (line.back() == '\r')
+            lines.push_back(line.substr(0, line.size() - 1));
+        else
+            lines.push_back(line);
+    }
+
+    return lines;
+}
+
+std::vector<std::string> split_line(const std::string& line) {
+    std::vector<std::string> tokens;
+    for (std::size_t column = 0; column < num_columns; column++) {
+        if (column * column_width >= line.size())
+            break;
+        tokens.push_back( trim_copy(line.substr(column*column_width, column_width) ));
+    }
+    return tokens;
+}
+
+
+bool block_start(const std::string& line) {
+    if (line.empty())
+        return false;
+
+    if (line[0] != '1')
+        return false;
+
+    if (line.find_first_not_of(' ', 1) != std::string::npos)
+        return false;
+
+    return true;
+}
+
+std::string pop_return(std::deque<std::string>& lines) {
+    auto front = lines.front();
+    lines.pop_front();
+    return front;
+}
+
+void pop_separator(std::deque<std::string>& lines) {
+    lines.pop_front();
+}
+
+int make_num(const std::string& nums_string) {
+    if (nums_string.empty())
+        return 0;
+
+    return std::stoi(nums_string);
+}
+
+TimeStampUTC make_timestamp(const std::string& date_string) {
+    const auto& month_index = TimeMap::eclipseMonthIndices();
+    auto dash_pos1 = date_string.find('-');
+    auto dash_pos2 = date_string.rfind('-');
+    auto day = std::stoi( date_string.substr(0, dash_pos1 ) );
+    auto year = std::stoi( date_string.substr(dash_pos2 + 1) );
+    auto month_name = date_string.substr( dash_pos1 + 1, 3);
+
+    return TimeStampUTC(year, month_index.at(month_name), day);
+}
+
+
+/*
+  The multiplier line is optional; so when looking for the multiplier line in
+  the text we must make sure that line we are looking at is not the WGNAMES line
+  - including the possibility of a totally empty WGNAMES line.
+*/
+std::vector<double> make_multiplier(std::deque<std::string>& lines) {
+    std::vector<double> multiplier = {1,1,1,1,1,1,1,1,1,1};
+    if (lines.front().find_first_not_of("-0123456789* ") != std::string::npos)
+        return multiplier;
+
+    if (lines.front().find_first_not_of(" ") == std::string::npos)
+        return multiplier;
+
+    auto mult_list = split_line(pop_return(lines));
+    for (std::size_t index=0; index < mult_list.size(); index++) {
+        const auto& mult_string = mult_list[index];
+        if (mult_string.empty())
+            continue;
+
+        auto power_pos = mult_string.find("**");
+        if (power_pos == std::string::npos)
+            throw std::invalid_argument("Multiplier item wrong format: " + mult_string);
+
+        double power = std::stod(mult_string.c_str() + power_pos + 2);
+        multiplier[index] = std::pow(10, power);
+    }
+
+    return multiplier;
+}
+}
+
+void ERsm::load_block(std::deque<std::string>& lines, std::size_t& vector_length) {
+    if (!block_start(lines.front()))
+        throw std::invalid_argument("Block should start with '1' in first column");
+
+    lines.pop_front();
+    pop_separator(lines);
+    lines.pop_front();
+    pop_separator(lines);
+
+    auto kw_list = split_line(pop_return(lines));
+    auto unit_list = split_line(pop_return(lines));
+    auto mult_list = make_multiplier(lines);
+    auto wgnames = split_line(pop_return(lines));
+    auto nums_list = split_line(pop_return(lines));
+    pop_separator(lines);
+    std::size_t num_rows = std::count_if(kw_list.begin(), kw_list.end(), [](const std::string& kw) { return !kw.empty();}) - 1;
+
+    if (vector_length == 0) {
+        if (kw_list[0] == "DATE")
+            this->time = std::vector<TimeStampUTC>();
+        else if (kw_list[0] == "TIME") {
+            if (unit_list[0] != "DAYS")
+                throw std::invalid_argument("Only days is supported as time unit");
+            this->time = std::vector<double>();
+        }
+        else
+            throw std::invalid_argument("The first column must be DATE or TIME");
+    }
+
+    std::vector<ERsm::Vector> block_data;
+    for (std::size_t kw_index = 1; kw_index < kw_list.size(); kw_index++) {
+        auto node = SummaryNode{ kw_list[kw_index],
+                                 SummaryNode::category_from_keyword(kw_list[kw_index]),
+                                 SummaryNode::Type::Undefined,
+                                 wgnames[kw_index],
+                                 make_num(nums_list[kw_index])};
+        block_data.emplace_back( node, vector_length );
+    }
+
+    std::size_t block_size = 0;
+    while (true) {
+        if (lines.empty())
+            break;
+
+        if (block_start(lines.front()))
+            break;
+
+        auto data_row = split_line(pop_return(lines));
+        for (std::size_t data_index = 0; data_index < num_rows; data_index++) {
+            double value = std::stod(data_row[data_index + 1]) * mult_list[data_index + 1];
+            block_data[data_index].data.push_back(value);
+        }
+
+        if (vector_length == 0) {
+            if (std::holds_alternative<std::vector<double>>(this->time)) {
+                double d = std::stod(data_row[0]) * mult_list[0];
+                std::get<std::vector<double>>( this->time ).push_back( d );
+            } else {
+                TimeStampUTC ts = make_timestamp(data_row[0]);
+                std::get<std::vector<TimeStampUTC>>( this->time ).push_back( ts );
+            }
+        }
+        block_size += 1;
+    }
+    if (vector_length == 0)
+        vector_length = block_size;
+
+    if (vector_length != block_size)
+        throw std::invalid_argument("Block size error");
+
+    for (auto& v : block_data)
+        this->vectors.insert(std::make_pair<std::string, ERsm::Vector>( v.header.unique_key(), std::move(v)));
+}
+
+
+const std::vector<TimeStampUTC>& ERsm::dates() const {
+    if (std::holds_alternative<std::vector<double>>(this->time))
+        throw std::invalid_argument("This ERsm instance has time given as days");
+
+    return std::get<std::vector<TimeStampUTC>>( this->time );
+}
+
+const std::vector<double>& ERsm::days() const {
+    if (!std::holds_alternative<std::vector<double>>(this->time))
+        throw std::invalid_argument("This ERsm instance has time given as dates");
+
+    return std::get<std::vector<double>>( this->time );
+}
+
+const std::vector<double>& ERsm::get(const std::string& key) const {
+    const auto& vector = this->vectors.at(key);
+    return vector.data;
+}
+
+bool ERsm::has_dates() const {
+    return std::holds_alternative<std::vector<TimeStampUTC>>(this->time);
+}
+
+bool ERsm::has(const std::string& key) const {
+    return this->vectors.count(key) == 1;
+}
+
+ERsm::ERsm(const std::string& fname) {
+    auto lines = load(fname);
+    std::size_t vector_length = 0;
+    while (!lines.empty())
+        load_block(lines, vector_length);
+}
+
+
+}
+}

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -57,6 +57,11 @@ namespace {
         os << prefix << std::setw(total_width) << std::left << line << '\n';
     }
 
+    void write_padding(std::ostream& os, std::size_t columns) {
+        for (std::size_t icol = columns + 1; icol < column_count; icol++)
+            os << std::setw(column_width + column_space) << " ";
+    }
+
     void print_text_element(std::ostream& os, const std::string& element) {
         os << std::setw(8) << std::left << element << std::setw(5) << "";
     }
@@ -88,6 +93,7 @@ namespace {
         for (const auto& vector : vectors) {
             print_element(os, vector);
         }
+        write_padding(os, vectors.size());
 
         os << '\n';
     }
@@ -99,6 +105,7 @@ namespace {
         for (const auto& vector : data) {
             print_float_element(os, vector.first[index] * std::pow(10.0, -vector.second));
         }
+        write_padding(os, data.size());
 
         os << '\n';
     }

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -113,6 +113,7 @@ namespace {
     void write_scale_columns(std::ostream& os, const std::vector<std::pair<std::vector<float>, int>> data, char prefix = ' ') {
         os << prefix;
 
+        print_text_element(os, "");
         for (const auto& vector : data) {
             const auto scale_factor { vector.second } ;
             if (scale_factor) {

--- a/src/opm/io/eclipse/rst/header.cpp
+++ b/src/opm/io/eclipse/rst/header.cpp
@@ -115,7 +115,7 @@ RstHeader::RstHeader(const std::vector<int>& intehead, const std::vector<bool>& 
 }
 
 std::pair<std::time_t, std::size_t> RstHeader::restart_info() const {
-    return std::make_pair(asTimeT(TimeStampUTC({this->year, this->month, this->mday})),
+    return std::make_pair(asTimeT(TimeStampUTC(this->year, this->month, this->mday)),
                           std::size_t(this->report_step));
 }
 

--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -22,7 +22,9 @@
 #include <opm/io/eclipse/ERft.hpp>
 #include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/ESmry.hpp>
+#include <opm/io/eclipse/ERsm.hpp>
 
+#include <opm/common/utility/FileSystem.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
 #include <algorithm>
@@ -972,6 +974,15 @@ void ECLRegressionTest::results_smry()
                 printDeviationReport();
             }
         }
+
+        namespace fs = Opm::filesystem;
+        std::string rsm_file = rootName2 + ".RSM";
+        if (fs::is_regular_file(fs::path(rsm_file))) {
+            auto rsm = ERsm(rsm_file);
+            if (!cmp(smry2, rsm))
+                HANDLE_ERROR(std::runtime_error, "The RSM file did not compare equal to the summary file");
+        }
+
     } else {
         std::cout << "\n!Warning, summary files not found, hence not compared. \n" << std::endl;
     }

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/ESmry.hpp>
+#include <opm/io/eclipse/ERsm.hpp>
 
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
@@ -110,6 +111,9 @@ BOOST_AUTO_TEST_CASE(RUN) {
                 BOOST_CHECK_EQUAL( ts.month(), month[time_index]);
                 BOOST_CHECK_EQUAL( ts.year(), year[time_index]);
             }
+
+            const auto rsm = EclIO::ERsm("SPE1CASE1.RSM");
+            BOOST_CHECK( EclIO::cmp( smry, rsm ));
         }
 
         {

--- a/tests/parser/DynamicStateTests.cpp
+++ b/tests/parser/DynamicStateTests.cpp
@@ -33,7 +33,7 @@
 Opm::TimeMap make_timemap(int num) {
     std::vector<std::time_t> tp;
     for (int i = 0; i < num; i++)
-        tp.push_back( Opm::asTimeT(Opm::TimeStampUTC({2010,1,i+1})));
+        tp.push_back( Opm::asTimeT(Opm::TimeStampUTC(2010,1,i+1)));
 
     Opm::TimeMap timeMap{ tp };
     return timeMap;

--- a/tests/parser/DynamicVectorTests.cpp
+++ b/tests/parser/DynamicVectorTests.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(DynamicVectorSet) {
     const std::time_t startDate = Opm::TimeMap::mkdate(2010, 1, 1);
     std::vector<std::time_t> tp = { startDate };
     for (int i = 0; i < 4; i++)
-        tp.push_back( Opm::asTimeT(Opm::TimeStampUTC({2010,1,i+2})));
+        tp.push_back( Opm::asTimeT(Opm::TimeStampUTC(2010,1,i+2)));
 
     Opm::TimeMap timeMap{ tp };
     Opm::DynamicVector<int> state(timeMap , 137);
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(DynamicVectorPtr) {
     const std::time_t startDate = Opm::TimeMap::mkdate(2010, 1, 1);
     std::vector<std::time_t> tp = { startDate };
     for (int i = 0; i < 4; i++)
-        tp.push_back( Opm::asTimeT(Opm::TimeStampUTC({2010,1,i+2})));
+        tp.push_back( Opm::asTimeT(Opm::TimeStampUTC(2010,1,i+2)));
 
     Opm::TimeMap timeMap{ tp };
     Opm::DynamicVector<int> state( timeMap , 137 );

--- a/tests/parser/EventTests.cpp
+++ b/tests/parser/EventTests.cpp
@@ -32,10 +32,10 @@
 
 
 BOOST_AUTO_TEST_CASE(CreateEmpty) {
-    std::vector<std::time_t> tp = { Opm::asTimeT(Opm::TimeStampUTC({2010,1,1})) };
+    std::vector<std::time_t> tp = { Opm::asTimeT(Opm::TimeStampUTC(2010,1,1)) };
 
     for (int i = 0; i < 11; i++)
-        tp.push_back( Opm::asTimeT(Opm::TimeStampUTC({2010,1,i+2})));
+        tp.push_back( Opm::asTimeT(Opm::TimeStampUTC(2010,1,i+2)));
 
     Opm::TimeMap timeMap(tp);
     Opm::Events events( timeMap );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3453,12 +3453,12 @@ BOOST_AUTO_TEST_CASE(WellNames) {
 
 
 BOOST_AUTO_TEST_CASE(RFT_CONFIG) {
-    std::vector<std::time_t> tp = { asTimeT( TimeStampUTC({2010, 1, 1})),
-                                    asTimeT( TimeStampUTC({2010, 1, 2})),
-                                    asTimeT( TimeStampUTC({2010, 1, 3})),
-                                    asTimeT( TimeStampUTC({2010, 1, 4})),
-                                    asTimeT( TimeStampUTC({2010, 1, 5})),
-                                    asTimeT( TimeStampUTC({2010, 1, 6}))};
+    std::vector<std::time_t> tp = { asTimeT( TimeStampUTC(2010, 1, 1)),
+                                    asTimeT( TimeStampUTC(2010, 1, 2)),
+                                    asTimeT( TimeStampUTC(2010, 1, 3)),
+                                    asTimeT( TimeStampUTC(2010, 1, 4)),
+                                    asTimeT( TimeStampUTC(2010, 1, 5)),
+                                    asTimeT( TimeStampUTC(2010, 1, 6))};
 
 
 

--- a/tests/parser/TimeMapTest.cpp
+++ b/tests/parser/TimeMapTest.cpp
@@ -48,15 +48,15 @@ BOOST_AUTO_TEST_CASE(GetStartDate) {
 
 
 BOOST_AUTO_TEST_CASE(AddDateNegativeStepThrows) {
-    std::vector<std::time_t> time_points = { Opm::asTimeT(Opm::TimeStampUTC({2000,1,1})), Opm::asTimeT(Opm::TimeStampUTC({1999,1,1}))};
+    std::vector<std::time_t> time_points = { Opm::asTimeT(Opm::TimeStampUTC(2000,1,1)), Opm::asTimeT(Opm::TimeStampUTC(1999,1,1))};
     BOOST_CHECK_THROW(Opm::TimeMap timeMap(time_points), std::invalid_argument);
 }
 
 
 BOOST_AUTO_TEST_CASE(AddStepSizeCorrect) {
-    std::vector<std::time_t> time_points = { Opm::asTimeT(Opm::TimeStampUTC({2010,1,1})),
-                                             Opm::asTimeT(Opm::TimeStampUTC({2010,1,2})),
-                                             Opm::asTimeT(Opm::TimeStampUTC({2010,1,3}))};
+    std::vector<std::time_t> time_points = { Opm::asTimeT(Opm::TimeStampUTC(2010,1,1)),
+                                             Opm::asTimeT(Opm::TimeStampUTC(2010,1,2)),
+                                             Opm::asTimeT(Opm::TimeStampUTC(2010,1,3))};
     Opm::TimeMap timeMap(time_points);
     BOOST_CHECK_EQUAL(3U, timeMap.size());
 
@@ -696,25 +696,25 @@ TSTEP
     const auto deck3 = parser.parseString(deck_string3);
 
     // The date 2005-01-02 is not present as a DATES in the deck; invalid input.
-    auto invalid_restart = std::make_pair(Opm::asTimeT(Opm::TimeStampUTC({2005, 1, 2})), 5);
-    auto valid_restart = std::make_pair(Opm::asTimeT(Opm::TimeStampUTC({2005, 1, 1})), 5);
+    auto invalid_restart = std::make_pair(Opm::asTimeT(Opm::TimeStampUTC(2005, 1, 2)), 5);
+    auto valid_restart = std::make_pair(Opm::asTimeT(Opm::TimeStampUTC(2005, 1, 1)), 5);
 
     BOOST_CHECK_THROW( Opm::TimeMap(deck1, invalid_restart) , std::invalid_argument);
     Opm::TimeMap tm1(deck1, valid_restart);
     BOOST_CHECK_THROW( tm1[1], std::invalid_argument );
     BOOST_CHECK_THROW( tm1[4], std::invalid_argument );
     auto start = tm1[0];
-    BOOST_CHECK_EQUAL(start , Opm::asTimeT(Opm::TimeStampUTC({2000,1,1})));
-    BOOST_CHECK_EQUAL(tm1[5] , Opm::asTimeT(Opm::TimeStampUTC({2005,1,1})));
+    BOOST_CHECK_EQUAL(start , Opm::asTimeT(Opm::TimeStampUTC(2000,1,1)));
+    BOOST_CHECK_EQUAL(tm1[5] , Opm::asTimeT(Opm::TimeStampUTC(2005,1,1)));
     BOOST_CHECK(tm1.skiprest());
 
     Opm::TimeMap tm2(deck2, valid_restart);
-    BOOST_CHECK_EQUAL(tm2[5], Opm::asTimeT(Opm::TimeStampUTC({2005,1,1})));
-    BOOST_CHECK_EQUAL(tm2[6], Opm::asTimeT(Opm::TimeStampUTC({2005,7,1})));
+    BOOST_CHECK_EQUAL(tm2[5], Opm::asTimeT(Opm::TimeStampUTC(2005,1,1)));
+    BOOST_CHECK_EQUAL(tm2[6], Opm::asTimeT(Opm::TimeStampUTC(2005,7,1)));
 
     Opm::TimeMap tm3(deck3, valid_restart);
-    BOOST_CHECK_EQUAL(tm3[5], Opm::asTimeT(Opm::TimeStampUTC({2005,1,1})));
-    BOOST_CHECK_EQUAL(tm3[6], Opm::asTimeT(Opm::TimeStampUTC({2005,1,2})));
-    BOOST_CHECK_EQUAL(tm3[7], Opm::asTimeT(Opm::TimeStampUTC({2005,1,3})));
-    BOOST_CHECK_EQUAL(tm3[8], Opm::asTimeT(Opm::TimeStampUTC({2005,1,4})));
+    BOOST_CHECK_EQUAL(tm3[5], Opm::asTimeT(Opm::TimeStampUTC(2005,1,1)));
+    BOOST_CHECK_EQUAL(tm3[6], Opm::asTimeT(Opm::TimeStampUTC(2005,1,2)));
+    BOOST_CHECK_EQUAL(tm3[7], Opm::asTimeT(Opm::TimeStampUTC(2005,1,3)));
+    BOOST_CHECK_EQUAL(tm3[8], Opm::asTimeT(Opm::TimeStampUTC(2005,1,4)));
 }

--- a/tests/test_ERsm.cpp
+++ b/tests/test_ERsm.cpp
@@ -1,0 +1,212 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#define BOOST_TEST_MODULE EclipseRSMLoader
+
+#include <boost/test/unit_test.hpp>
+
+#include <fstream>
+#include <opm/io/eclipse/ERsm.hpp>
+#include <tests/WorkArea.cpp>
+#include <opm/common/utility/FileSystem.hpp>
+
+Opm::EclIO::ERsm create(const std::string& rsm_data) {
+    WorkArea work_area("test_ERsm");
+    {
+        std::ofstream os("TEST.RSM");
+        os << rsm_data;
+    }
+    return Opm::EclIO::ERsm("TEST.RSM");
+}
+
+
+// Dont touch the string literals - it is all part of the format; down to the number of whitespace ... :-(
+
+std::string block1_days = R"(1                                                                                                                                  
+ -------------------------------------------------------------------------------------------------------------------------------
+ SUMMARY OF RUN nor01-temp01-rsm-all OPM FLOW VERSION 1910 ANYTHING CAN GO HERE: USER, MACHINE ETC.                                
+ -------------------------------------------------------------------------------------------------------------------------------
+ TIME         YEARS        FOPR         GOPR         GOPR         GOPR         GOPR         GOPR         GOPR         GOPR         
+ DAYS         YEARS        SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      
+                                        MANI-C       B1-DUMMY     MANI-D1      INJE         PROD         MANI-B2      MANI-B1      
+                                                                                                                                   
+ -------------------------------------------------------------------------------------------------------------------------------
+        0            0            0            0            0            0            0            0            0            0     
+ 1.000000     0.002738     4379.802            0            0     4379.802            0     4379.802            0            0     
+ 4.000000     0.010951     4380.562            0            0     4380.562            0     4380.562            0            0     
+ 8.000000     0.021903     4381.301            0            0     4381.301            0     4381.301            0            0     
+)";
+
+std::string block1_hours = R"(1                                                                                                                                  
+ -------------------------------------------------------------------------------------------------------------------------------
+ SUMMARY OF RUN nor01-temp01-rsm-all OPM FLOW VERSION 1910 ANYTHING CAN GO HERE: USER, MACHINE ETC.                                
+ -------------------------------------------------------------------------------------------------------------------------------
+ TIME         YEARS        FOPR         GOPR         GOPR         GOPR         GOPR         GOPR         GOPR         GOPR         
+ HOURS        YEARS        SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      SM3/DAY      
+                                        MANI-C       B1-DUMMY     MANI-D1      INJE         PROD         MANI-B2      MANI-B1      
+                                                                                                                                   
+ -------------------------------------------------------------------------------------------------------------------------------
+        0            0            0            0            0            0            0            0            0            0     
+ 1.000000     0.002738     4379.802            0            0     4379.802            0     4379.802            0            0     
+ 4.000000     0.010951     4380.562            0            0     4380.562            0     4380.562            0            0     
+ 8.000000     0.021903     4381.301            0            0     4381.301            0     4381.301            0            0     
+)";
+
+
+
+std::string block1_date = R"(1                                                                                                                                  
+ -------------------------------------------------------------------------------------------------------------------------------
+ SUMMARY OF RUN nor01-temp01-rsm-date OPM FLOW VERSION 1910 ANYTHING CAN GO HERE: USER, MACHINE ETC.                               
+ -------------------------------------------------------------------------------------------------------------------------------
+ DATE         WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWCT         
+              SM3          SM3          SM3          SM3          SM3          SM3          SM3          SM3                       
+              *10**3                                              *10**3       *10**3       *10**3                                 
+              C-2H         C-3H         C-4H         C-4AH        F-1H         F-2H         F-3H         F-4H         C-4H         
+                                                                                                                                   
+ -------------------------------------------------------------------------------------------------------------------------------
+  1-MAR-1999  227.7381            0     46279.20            0            0            0            0            0            0     
+  3-MAR-1999  238.5447            0     63147.95            0            0            0            0            0            0     
+  4-MAR-1999  243.9480            0     71582.33            0            0            0            0            0            0     
+  5-MAR-1999  249.3513            0     80016.70            0            0            0            0            0            0     
+)";
+
+std::string block2_date = R"(1                                                                                                                                  
+ -------------------------------------------------------------------------------------------------------------------------------
+ SUMMARY OF RUN nor01-temp01-rsm-date OPM FLOW VERSION 1910 ANYTHING CAN GO HERE: USER, MACHINE ETC.                               
+ -------------------------------------------------------------------------------------------------------------------------------
+ DATE         WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWCT         
+              SM3          SM3          SM3          SM3          SM3          SM3          SM3          SM3                       
+              *10**3                                              *10**3       *10**3       *10**3                                 
+              C-2H         C-3H         C-4H         C-4AH        F-1H         F-2H         F-3H         F-4H         C-4H         
+                                                                                                                                   
+ -------------------------------------------------------------------------------------------------------------------------------
+  1-MAR-1999  227.7381            0     46279.20            0            0            0            0            0            0     
+  3-MAR-1999  238.5447            0     63147.95            0            0            0            0            0            0     
+  4-MAR-1999  243.9480            0     71582.33            0            0            0            0            0            0     
+)";
+
+std::string missing_time = R"(1                                                                                                                                  
+ -------------------------------------------------------------------------------------------------------------------------------
+ SUMMARY OF RUN nor01-temp01-rsm-date OPM FLOW VERSION 1910 ANYTHING CAN GO HERE: USER, MACHINE ETC.                               
+ -------------------------------------------------------------------------------------------------------------------------------
+ XDATE        WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWIT         WWCT         
+              SM3          SM3          SM3          SM3          SM3          SM3          SM3          SM3                       
+              *10**3                                              *10**3       *10**3       *10**3                                 
+              C-2H         C-3H         C-4H         C-4AH        F-1H         F-2H         F-3H         F-4H         C-4H         
+                                                                                                                                   
+ -------------------------------------------------------------------------------------------------------------------------------
+  1-MAR-1999  227.7381            0     46279.20            0            0            0            0            0            0     
+)";
+
+
+std::string no_wgnames = R"(1                                                                                                                                  
+ -------------------------------------------------------------------------------------------------------------------------------   
+ SUMMARY OF RUN SPE1CASE1 OPM FLOW VERSION 1910 ANYTHING CAN GO HERE: USER, MACHINE ETC.                                           
+ -------------------------------------------------------------------------------------------------------------------------------   
+ TIME         DAY          MONTH        YEAR         BGSAT        BGSAT        BGSAT        BGSAT        BGSAT        BGSAT        
+ DAYS                                                                                                                              
+                                                                                                                                   
+                                                     1            10           100          101          110          200          
+ -------------------------------------------------------------------------------------------------------------------------------   
+        7            8            1         2015            0            0            0            0            0            0     
+       14           15            1         2015            0            0            0            0            0            0     
+       21           22            1         2015            0            0            0            0            0            0     
+       28           29            1         2015            0            0            0            0            0            0     
+       31            1            2         2015            0            0            0            0            0            0     
+       38            8            2         2015            0            0            0            0            0            0     
+       45           15            2         2015            0            0            0            0            0            0     
+)";
+
+
+std::string multiple_blocks = R"(1                                                                                                                                  
+ -------------------------------------------------------------------------------------------------------------------------------   
+ SUMMARY OF RUN SPE1CASE1 OPM FLOW VERSION 1910 ANYTHING CAN GO HERE: USER, MACHINE ETC.                                           
+ -------------------------------------------------------------------------------------------------------------------------------   
+ DATE         BGSAT        BGSAT        BGSAT        BGSAT        BGSAT        BGSAT        BGSAT        BGSAT        BGSAT        
+                                                                                                                                   
+                                                                                                                                   
+              1            10           100          101          110          200          201          210          300          
+ -------------------------------------------------------------------------------------------------------------------------------   
+  8-JAN-2015         0            0            0            0            0            0            0            0            0     
+ 15-JAN-2015         0            0            0            0            0            0            0            0            0     
+ 22-JAN-2015         0            0            0            0            0            0            0            0            0     
+ 29-JAN-2015         0            0            0            0            0            0            0            0            0     
+  1-FEB-2015         0            0            0            0            0            0            0            0            0     
+1                                                                                                                                  
+ -------------------------------------------------------------------------------------------------------------------------------   
+ SUMMARY OF RUN SPE1CASE1 OPM FLOW VERSION 1910 ANYTHING CAN GO HERE: USER, MACHINE ETC.                                           
+ -------------------------------------------------------------------------------------------------------------------------------   
+ DATE         BPR          BPR          FGOR         FOPR         WBHP         WBHP         WGIR         WGIR         WGIT         
+              PSIA         PSIA         MSCF/STB     STB/DAY      PSIA         PSIA         MSCF/DAY     MSCF/DAY     MSCF         
+                                                      *10**3                                                                       
+                                                                  INJ          PROD         INJ          PROD         INJ          
+              1            300                                                                                                     
+ -------------------------------------------------------------------------------------------------------------------------------   
+  8-JAN-2015         0            0           -0     604.7999            0            0            0            0            0     
+ 15-JAN-2015         0            0           -0     1209.599            0            0            0            0            0     
+ 22-JAN-2015         0            0           -0     1814.400            0            0            0            0            0     
+ 29-JAN-2015         0            0           -0     2419.199            0            0            0            0            0     
+  1-FEB-2015         0            0           -0     2678.399            0            0            0            0            0     
+)";
+
+
+BOOST_AUTO_TEST_CASE(ERsm) {
+    BOOST_CHECK_THROW(Opm::EclIO::ERsm("file/does/not/exist"), std::invalid_argument);
+    BOOST_CHECK_THROW( create("SomeThingInvalid"), std::invalid_argument);
+    BOOST_CHECK_THROW( create( block1_date + block2_date ) , std::invalid_argument );
+    BOOST_CHECK_THROW( create( block1_hours ) , std::invalid_argument );
+    auto rsm1 = create(block1_days);
+    auto rsm2 = create(block1_date);
+
+    BOOST_CHECK_THROW( rsm1.dates(), std::invalid_argument);
+    BOOST_CHECK_THROW( rsm2.days(),  std::invalid_argument);
+    BOOST_CHECK_THROW( rsm1.get("NO_SUCH_KEY"), std::out_of_range);
+
+    const auto& wwit_c_2h = rsm2.get("WWIT:C-2H");
+    BOOST_CHECK_EQUAL( wwit_c_2h.size(), 4 );
+    std::vector<double> expected = {227.7381, 238.5447, 243.9480, 249.3513};
+    for (std::size_t index = 0; index < 4; index++)
+        BOOST_CHECK_CLOSE( expected[index] * 1000 , wwit_c_2h[index], 1e-6);
+
+    const auto& wwit_c_4h = rsm2.get("WWIT:C-4H");
+    BOOST_CHECK_EQUAL( wwit_c_4h.size(), 4 );
+    std::vector<double> expected2 = {46279.20, 63147.95, 71582.33, 80016.70};
+    for (std::size_t index = 0; index < 4; index++)
+        BOOST_CHECK_CLOSE( expected2[index] * 1 , wwit_c_4h[index], 1e-6);
+
+    std::vector<double> expected_days = {0, 1, 4 , 8};
+    BOOST_CHECK( rsm1.days() ==  expected_days);
+
+    std::vector<Opm::TimeStampUTC> expected_dates = {{1999, 3, 1},
+                                                     {1999, 3, 3},
+                                                     {1999, 3, 4},
+                                                     {1999, 3, 5}};
+    BOOST_CHECK( expected_dates == rsm2.dates() );
+    BOOST_CHECK( rsm2.has_dates() );
+    BOOST_CHECK( !rsm1.has_dates() );
+    BOOST_CHECK( rsm2.has("WWIT:C-2H") );
+    BOOST_CHECK( !rsm2.has("NO_SUCH_KEY") );
+
+    auto nums = create( no_wgnames );
+    BOOST_CHECK( nums.has("BGSAT:1"));
+
+    auto fopr_rsm = create( multiple_blocks );
+    const auto& fopr = fopr_rsm.get("FOPR");
+    std::vector<double> expected_fopr = {604799.9, 1209599, 1814400, 2419199, 2678399};
+    BOOST_CHECK(fopr == expected_fopr);
+}


### PR DESCRIPTION
This is on top of #1683. The new content is the last commit, where a test is added in the `compareECL`machinery. If a `CASE.RSM`file is found it is compared with the current summary data - this a comparison of the "same data" - just formatted in different ways. The comparison does therefor not take numerical precision and so on into account.