### PR TITLE
Cache cell volume

### DIFF
--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -3,7 +3,8 @@
 
 # defines that must be present in config.h for our headers
 set (opm-common_CONFIG_VAR
-	"HAS_ATTRIBUTE_UNUSED")
+	HAVE_OPENMP
+	)
 
 # dependencies
 set (opm-common_DEPS

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -154,6 +154,7 @@ namespace Opm {
         std::array<double, 3> getCellCenter(size_t i,size_t j, size_t k) const;
         std::array<double, 3> getCellCenter(size_t globalIndex) const;
         std::array<double, 3> getCornerPos(size_t i,size_t j, size_t k, size_t corner_index) const;
+        std::vector<double> activeVolume() const;
         double getCellVolume(size_t globalIndex) const;
         double getCellVolume(size_t i , size_t j , size_t k) const;
         double getCellThickness(size_t globalIndex) const;

--- a/python/setup.py
+++ b/python/setup.py
@@ -66,7 +66,8 @@ ext_modules = [
         language='c++',
         undef_macros=["NDEBUG"],
         include_dirs=["pybind11/include"],
-        extra_compile_args=['-std=c++17']
+        extra_compile_args=['-std=c++17', '-fopenmp'],
+        extra_link_args=['-fopenmp']
     )
 ]
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -388,10 +388,7 @@ void handle_box_keyword(const DeckKeyword& deckKeyword,  Box& box) {
 
 
 std::vector<double> extract_cell_volume(const EclipseGrid& grid) {
-    std::vector<double> cell_volume(grid.getNumActive());
-    for (std::size_t active_index = 0; active_index < grid.getNumActive(); active_index++)
-        cell_volume[active_index] = grid.getCellVolume( grid.getGlobalIndex(active_index));
-    return cell_volume;
+    return grid.activeVolume();
 }
 
 std::vector<double> extract_cell_depth(const EclipseGrid& grid) {


### PR DESCRIPTION
The purpose of this PR is to calculate the volume for all the active cells in one go, the purpose of that again is to get an openmp based speedup for the volume calculations.

For this PR it is essential that all `ACTNUM` manipulations go through the `resetACTNUM` function. Facilitating that ended up in refactoring which got a little out of hand. This #1687 should be merged first. 

Update: the change here was simplified and #1687 is no longer required; I still think #1687 is an improvement though - and intend to merge it.

**OpenMP:** The core of this PR is to add a small function with an `omp` pragma. It seems to work - but I have to questions:

1. Should the use of OpenMP be protected by some build switch; and possibly some flags should be updated? Now I have just added the `omp`pragma and everything seems to work - but I feels a bit to simple?

2. For the python modules I had to add openmp flags to `setup.py` - I would have thought that the openmp dependency came transitively through opm-common? 