### PR TITLE
Schedule: add std::shared_ptr<Python> arg to "default" constructor

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -118,6 +118,7 @@ namespace Opm
         using VFPInjMap = std::map<int, DynamicState<std::shared_ptr<VFPInjTable>>>;
 
         Schedule() = default;
+        Schedule(std::shared_ptr<const Python>) {}
         Schedule(const Deck& deck,
                  const EclipseGrid& grid,
                  const FieldPropsManager& fp,


### PR DESCRIPTION
This is to ensure that also the `rank != 0` processes have access to a Python object. There will be further changes - but this should be the API change. 