### PR TITLE
Write report to stringstream and not stdout

### DIFF
--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -259,8 +259,12 @@ void EclipseIO::writeTimeStep(const SummaryState& st,
                      grid, schedule, value.wells, rftFile);
     }
 
-    for (const auto& report : schedule.report_config(report_step)) {
-        RptIO::write_report(std::cout, report.first, report.second, schedule, report_step);
+
+    if (!isSubstep) {
+        for (const auto& report : schedule.report_config(report_step)) {
+            std::stringstream ss;
+            RptIO::write_report(ss, report.first, report.second, schedule, report_step);
+        }
     }
  }
 


### PR DESCRIPTION
This is a fixup to #1672 and specifically [this comment.](https://github.com/OPM/opm-common/pull/1672#issuecomment-612478962)

The report should eventually end up in the PRT file; for the moment it should just go to `/dev/null` - which is implemented with this PR; `std::cout` output clobbering up the terminal was a mismerge of debug code. 

> I'm also not too impressed by the fact that we output this information—which is mostly unchanging—on every timestep rather than limited to report-steps only.

With this PR it is only created for every report step; but there is more in this direction. It is not yet clear (to me at least) how much information should be output when there is a change - specifically should the `WELSPECS` information for *all* wells be output when *one* well has changed? That is work in progress.