### PR TITLE
Address performance issue for DX/DY/DZ/TOPS grids.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -247,10 +247,6 @@ namespace Opm {
         std::vector<double> makeZcornDzvDepthz(const std::vector<double>& dzv, const std::vector<double>& depthz) const;
         std::vector<double> makeCoordDxvDyvDzvDepthz(const std::vector<double>& dxv, const std::vector<double>& dyv, const std::vector<double>& dzv, const std::vector<double>& depthz) const;
 
-        double sumIdir(int j, int k, int i1, const std::vector<double>& dx) const;
-        double sumJdir(int i, int k, int j1, const std::vector<double>& dy) const;
-        double sumKdir(int i, int j, const std::vector<double>& dz) const;
-
         void getCellCorners(const std::array<int, 3>& ijk, const std::array<int, 3>& dims, std::array<double,8>& X, std::array<double,8>& Y, std::array<double,8>& Z) const;
         void getCellCorners(const std::size_t globalIndex,
                             std::array<double,8>& X,


### PR DESCRIPTION
The sumIdir() and sumJdir() methods were called inside loop nests over i and j. Since the methods themselves were linear in nx and ny, respectively, this was a quadratic algorithm. Performance only becomes an issue for large (> 10k) values of NX or NY, which was thought not to ever happen. This assumption was wrong.

This can occur for example when the grid is "abused" by using NNCs (and no "normal" cartesian connections) to make the simulator run on an arbitrary unstructured grid.