### PR TITLE
changed: add option for using clang with libstdc++

### DIFF
--- a/cmake/Modules/OpmCompilerChecks.cmake
+++ b/cmake/Modules/OpmCompilerChecks.cmake
@@ -97,3 +97,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     list(APPEND ${project}_LIBRARIES stdc++fs)
   endif()
 endif()
+
+option(OPM_CLANG_WITH_STDC++FS "Using libstdc++ with clang and we want to link to stdc++fs" OFF)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND OPM_CLANG_WITH_STDC++FS)
+  list(APPEND ${project}_LIBRARIES stdc++fs)
+endif()


### PR DESCRIPTION
when using clang, whether or not we should link to stdc++fs
cannot easily be detected. it depends on the c++ lib used
(libstdc++ vs libc++), as well as the versions of these.

to avoid messing up in general, this adds an option for forcing
linking to stdc++fs, even when using clang. it defaults to false
to not break existing build setups where it works. is required
for building on jenkins