### PR TITLE
Add json file for OPTIONS3, E300.

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/001_Eclipse300/O/OPTIONS3
+++ b/src/opm/parser/eclipse/share/keywords/001_Eclipse300/O/OPTIONS3
@@ -1,0 +1,1450 @@
+{
+  "name": "OPTIONS3",
+  "sections": [
+    "RUNSPEC",
+    "SCHEDULE"
+  ],
+  "size": 1,
+  "items": [
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM1"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM2"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM3"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM4"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM5"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM6"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM7"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM8"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM9"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM10"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM11"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM12"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM13"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM14"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM15"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM16"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM17"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM18"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM19"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM20"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM21"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM22"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM23"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM24"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM25"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM26"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM27"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM28"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM29"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM30"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM31"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM32"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM33"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM34"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM35"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM36"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM37"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM38"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM39"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM40"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM41"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM42"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM43"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM44"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM45"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM46"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM47"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM48"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM49"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM50"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM51"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM52"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM53"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM54"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM55"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM56"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM57"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM58"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM59"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM60"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM61"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM62"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM63"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM64"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM65"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM66"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM67"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM68"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM69"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM70"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM71"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM72"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM73"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM74"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM75"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM76"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM77"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM78"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM79"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM80"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM81"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM82"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM83"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM84"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM85"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM86"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM87"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM88"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM89"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM90"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM91"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM92"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM93"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM94"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM95"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM96"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM97"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM98"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM99"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM100"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM101"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM102"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM103"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM104"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM105"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM106"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM107"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM108"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM109"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM110"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM111"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM112"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM113"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM114"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM115"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM116"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM117"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM118"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM119"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM120"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM121"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM122"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM123"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM124"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM125"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM126"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM127"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM128"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM129"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM130"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM131"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM132"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM133"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM134"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM135"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM136"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM137"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM138"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM139"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM140"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM141"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM142"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM143"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM144"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM145"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM146"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM147"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM148"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM149"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM150"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM151"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM152"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM153"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM154"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM155"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM156"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM157"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM158"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM159"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM160"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM161"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM162"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM163"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM164"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM165"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM166"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM167"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM168"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM169"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM170"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM171"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM172"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM173"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM174"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM175"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM176"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM177"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM178"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM179"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM180"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM181"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM182"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM183"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM184"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM185"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM186"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM187"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM188"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM189"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM190"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM191"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM192"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM193"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM194"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM195"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM196"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM197"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM198"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM199"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM200"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM201"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM202"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM203"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM204"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM205"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM206"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM207"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM208"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM209"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM210"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM211"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM212"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM213"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM214"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM215"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM216"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM217"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM218"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM219"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM220"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM221"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM222"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM223"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM224"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM225"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM226"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM227"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM228"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM229"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM230"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM231"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM232"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM233"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM234"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM235"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM236"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM237"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM238"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM239"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM240"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM241"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM242"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM243"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM244"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM245"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM246"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM247"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM248"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM249"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM250"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM251"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM252"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM253"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM254"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM255"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM256"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM257"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM258"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM259"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM260"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM261"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM262"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM263"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM264"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM265"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM266"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM267"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM268"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM269"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM270"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM271"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM272"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM273"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM274"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM275"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM276"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM277"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM278"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM279"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM280"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM281"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM282"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM283"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM284"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM285"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM286"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM287"
+    },
+    {
+      "default": 0,
+      "value_type": "INT",
+      "name": "ITEM288"
+    }
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -1061,6 +1061,7 @@ set( keywords
      001_Eclipse300/O/OILCOMPR
      001_Eclipse300/O/OILMW
      001_Eclipse300/O/OILVTIM
+     001_Eclipse300/O/OPTIONS3
      001_Eclipse300/P/PREF
      001_Eclipse300/P/PREFS
      001_Eclipse300/S/STCOND


### PR DESCRIPTION
Need to be able to have the schedule section manipulation  code support the E300 keyword OPTIONS3. Maybe adding this file is sufficient?

```python
import json
from collections import OrderedDict
keyw =  OrderedDict()
keyw["name"] = "OPTIONS3"
keyw["sections"] = ["RUNSPEC", "SCHEDULE"]
keyw["size"] = 1
keyw["items"] = []
for a in range(288):
    keyw["items"].append(OrderedDict(name="ITEM"+str(a+1), value_type="INT", default=0))
open('OPTIONS3.dirty', 'w').write(json.dumps(keyw))
```

```bash
jq . < OPTIONS3.dirty > OPTIONS3
```