### PR TITLE
fixed: initialize iterators after deserialization

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -163,6 +163,8 @@ namespace Opm {
                 serializer(m_dataFile);
                 serializer(input_path);
                 serializer(unit_system_access_count);
+                if (!serializer.isSerializing())
+                  this->init(this->keywordList.begin(), this->keywordList.end());
             }
 
         private:


### PR DESCRIPTION
If not, no modifications are applied in parallel.