### PR TITLE
Update connections should hanlde empty list

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -628,7 +628,7 @@ bool Well::updateConnections(std::shared_ptr<WellConnections> connections_arg) {
 
 bool Well::updateConnections(std::shared_ptr<WellConnections> connections_arg, const EclipseGrid& grid, const std::vector<int>& pvtnum) {
     bool update = this->updateConnections(connections_arg);
-    if (this->pvt_table == 0) {
+    if (this->pvt_table == 0 && this->connections->size() > 0) {
         const auto& lowest = this->connections->lowest();
         auto active_index = grid.activeIndex(lowest.global_index());
         this->pvt_table = pvtnum[active_index];

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -431,12 +431,16 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
 
 
     const Connection& WellConnections::lowest() const {
+        if (this->m_connections.empty())
+            throw std::logic_error("Tried to get lowest connection from empty set");
+
         const auto max_iter = std::max_element(this->m_connections.begin(),
                                                this->m_connections.end(),
                                                [](const Connection& c1, const Connection& c2)
                                                {
                                                    return c1.depth() < c2.depth();
                                                });
+
         return *max_iter;
     }
 


### PR DESCRIPTION
This should be a fix for bug mentioned here: https://github.com/OPM/opm-common/pull/1703#issuecomment-617824398

