### PR TITLE
Mark OpenMP as prerequisite for opm-common

### DIFF
--- a/cmake/Modules/OpmDefaults.cmake
+++ b/cmake/Modules/OpmDefaults.cmake
@@ -5,6 +5,8 @@ is_compiler_gcc_compatible ()
 include(TestCXXAcceptsFlag)
 
 macro (opm_defaults opm)
+
+  message("Processing opm_defaults ${opm}")
   # if we are installing a development version (default when checking out of
   # VCS), then remember which directories were used when configuring. package
   # distribution should disable this option.

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -15,7 +15,7 @@ set (opm-common_DEPS
 list(APPEND opm-common_DEPS
       # various runtime library enhancements
       "Boost 1.44.0 COMPONENTS system unit_test_framework REQUIRED"
-      "OpenMP"
+      "OpenMP QUIET"
 )
 
 find_package_deps(opm-common)

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -15,6 +15,7 @@ set (opm-common_DEPS
 list(APPEND opm-common_DEPS
       # various runtime library enhancements
       "Boost 1.44.0 COMPONENTS system unit_test_framework REQUIRED"
+      "OpenMP"
 )
 
 find_package_deps(opm-common)


### PR DESCRIPTION
to automatically trigger find_package(OpenMP) in downstream modules (e.g. Dumux).

Tested on my system with cornerpoint example in Dumux.

Hopefully closes #1751