### PR TITLE
Connection - Segment interaction implemented with optional pair

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <optional>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/Value.hpp>
@@ -94,8 +95,6 @@ namespace RestartIO {
                    const Direction direction,
                    const CTFKind ctf_kind,
                    const std::size_t sort_value,
-                   const double segDistStart,
-                   const double segDistEnd,
                    const bool defaultSatTabId);
 
         Connection(const RestartIO::RstConnection& rst_connection, const EclipseGrid& grid, const FieldPropsManager& fp);
@@ -129,13 +128,11 @@ namespace RestartIO {
         void updateSegment(int segment_number_arg,
                            double center_depth_arg,
                            std::size_t compseg_insert_index,
-                           double start,
-                           double end);
+                           const std::pair<double,double>& perf_range);
         std::size_t sort_value() const;
         const bool& getDefaultSatTabId() const;
         void setDefaultSatTabId(bool id);
-        const double& getSegDistStart() const;
-        const double& getSegDistEnd() const;
+        const std::optional<std::pair<double, double>>& perf_range() const;
         std::string str() const;
         bool ctfAssignedFromInput() const
         {
@@ -162,8 +159,7 @@ namespace RestartIO {
             serializer(m_global_index);
             serializer(m_ctfkind);
             serializer(m_sort_value);
-            serializer(m_segDistStart);
-            serializer(m_segDistEnd);
+            serializer(m_perf_range);
             serializer(m_defaultSatTabId);
             serializer(segment_number);
         }
@@ -236,8 +232,7 @@ namespace RestartIO {
         */
 
         std::size_t m_sort_value;
-        double m_segDistStart;
-        double m_segDistEnd;
+        std::optional<std::pair<double,double>> m_perf_range;
         bool m_defaultSatTabId;
 
         // related segment number

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -54,8 +54,6 @@ namespace Opm {
                            const Connection::Direction direction = Connection::Direction::Z,
                            const Connection::CTFKind ctf_kind = Connection::CTFKind::DeckValue,
                            const std::size_t seqIndex = 0,
-                           const double segDistStart= 0.0,
-                           const double segDistEnd= 0.0,
                            const bool defaultSatTabId = true);
         void loadCOMPDAT(const DeckRecord& record, const EclipseGrid& grid, const FieldPropsManager& field_properties);
 
@@ -117,8 +115,6 @@ namespace Opm {
                            const Connection::Direction direction = Connection::Direction::Z,
                            const Connection::CTFKind ctf_kind = Connection::CTFKind::DeckValue,
                            const std::size_t seqIndex = 0,
-                           const double segDistStart= 0.0,
-                           const double segDistEnd= 0.0,
                            const bool defaultSatTabId = true);
 
         void loadCOMPDAT(const DeckRecord& record,

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -169,12 +169,16 @@ namespace {
             sConn[Ix::EffectiveKH] =
                 scprop(M::effective_Kh, conn.Kh());
 
-            sConn[Ix::SkinFactor] = conn.skinFactor(); 
+            sConn[Ix::SkinFactor] = conn.skinFactor();
 
             sConn[Ix::item12] = sConn[Ix::ConnTrans];
 
-            sConn[Ix::SegDistEnd]   = scprop(M::length, conn.getSegDistEnd());
-            sConn[Ix::SegDistStart] = scprop(M::length, conn.getSegDistStart());
+
+            if (conn.attachedToSegment()) {
+                const auto& [start, end] = *conn.perf_range();
+                sConn[Ix::SegDistStart] = scprop(M::length, start);
+                sConn[Ix::SegDistEnd]   = scprop(M::length, end);
+            }
 
             sConn[Ix::item30] = -1.0e+20f;
             sConn[Ix::item31] = -1.0e+20f;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
@@ -275,8 +275,7 @@ namespace Opm {
                 connection.updateSegment(compseg.segment_number,
                                          compseg.center_depth,
                                          compseg.m_seqIndex,
-                                         compseg.m_distance_start,
-                                         compseg.m_distance_end);
+                                         { compseg.m_distance_start, compseg.m_distance_end });
             }
         }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -53,10 +53,8 @@ namespace Opm {
                            const int satTableId,
                            const Direction directionArg,
                            const CTFKind ctf_kind,
-			   const std::size_t sort_value,
-			   const double segDistStart,
-			   const double segDistEnd,
-			   const bool defaultSatTabId)
+                           const std::size_t sort_value,
+                           const bool defaultSatTabId)
         : direction(directionArg),
           center_depth(depth),
           open_state(stateArg),
@@ -71,8 +69,6 @@ namespace Opm {
           m_ctfkind(ctf_kind),
           m_global_index(global_index),
           m_sort_value(sort_value),
-          m_segDistStart(segDistStart),
-          m_segDistEnd(segDistEnd),
           m_defaultSatTabId(defaultSatTabId)
     {
     }
@@ -96,8 +92,6 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         m_ctfkind(rst_connection.cf_kind),
         m_global_index(grid.getGlobalIndex(this->ijk[0], this->ijk[1], this->ijk[2])),
         m_sort_value(rst_connection.rst_index),
-        m_segDistStart(rst_connection.segdist_start),
-        m_segDistEnd(rst_connection.segdist_end),
         m_defaultSatTabId(defaultSatTabId),
         segment_number(rst_connection.segment)
     {
@@ -106,12 +100,13 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
             auto active_index = grid.activeIndex(this->ijk[0], this->ijk[1], this->ijk[2]);
             this->sat_tableId = satnum[active_index];
         }
-
+        if (this->segment_number > 0)
+            this->m_perf_range = std::make_pair(rst_connection.segdist_start, rst_connection.segdist_end);
     }
 
     Connection::Connection()
           : Connection(0, 0, 0, 0, 0, 0.0, State::SHUT, 0.0, 0.0, 0.0, 0.0, 0.0,
-                       0, Direction::X, CTFKind::DeckValue, 0, 0.0, 0.0, false)
+                       0, Direction::X, CTFKind::DeckValue, 0, false)
     {}
 
     Connection Connection::serializeObject()
@@ -130,8 +125,8 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         result.ijk = {9, 10, 11};
         result.m_ctfkind = CTFKind::Defaulted;
         result.m_global_index = 12;
+        result.m_perf_range = std::make_pair(14,15);
         result.m_sort_value = 14;
-        result.m_segDistEnd = 15.0;
         result.m_defaultSatTabId = true;
         result.segment_number = 16;
 
@@ -178,14 +173,9 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         return this->direction;
     }
 
-    const double& Connection::getSegDistStart() const {
-        return m_segDistStart;
+const std::optional<std::pair<double, double>>& Connection::perf_range() const {
+        return this->m_perf_range;
     }
-
-    const double& Connection::getSegDistEnd() const {
-        return m_segDistEnd;
-    }
-
 
     void Connection::setDefaultSatTabId(bool id) {
         m_defaultSatTabId = id;
@@ -238,13 +228,11 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
     void Connection::updateSegment(int segment_number_arg,
                                    double center_depth_arg,
                                    std::size_t compseg_insert_index,
-                                   double start,
-                                   double end) {
+                                   const std::pair<double, double>& perf_range) {
         this->segment_number = segment_number_arg;
         this->center_depth = center_depth_arg;
         this->m_sort_value = compseg_insert_index;
-        this->m_segDistStart = start;
-        this->m_segDistEnd = end;
+        this->m_perf_range = perf_range;
     }
 
     void Connection::updateSegmentRST(int segment_number_arg,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -196,15 +196,13 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                                         const Connection::Direction direction,
                                         const Connection::CTFKind ctf_kind,
                                         const std::size_t seqIndex,
-                                        const double segDistStart,
-                                        const double segDistEnd,
                                         const bool defaultSatTabId)
     {
         int conn_i = (i < 0) ? this->headI : i;
         int conn_j = (j < 0) ? this->headJ : j;
         Connection conn(conn_i, conn_j, k, global_index, complnum, depth, state, CF, Kh, rw, r0,
                         skin_factor, satTableId, direction, ctf_kind,
-                        seqIndex, segDistStart, segDistEnd, defaultSatTabId);
+                        seqIndex, defaultSatTabId);
         this->add(conn);
     }
 
@@ -223,8 +221,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                                         const Connection::Direction direction,
                                         const Connection::CTFKind ctf_kind,
                                         const std::size_t seqIndex,
-                                        const double segDistStart,
-                                        const double segDistEnd,
                                         const bool defaultSatTabId)
     {
         int complnum = (this->m_connections.size() + 1);
@@ -244,8 +240,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                             direction,
                             ctf_kind,
                             seqIndex,
-                            segDistStart,
-                            segDistEnd,
                             defaultSatTabId);
     }
 
@@ -385,13 +379,14 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                                     r0,
                                     skin_factor,
                                     satTableId,
-                                    direction, ctf_kind,
-                                    noConn, 0., 0., defaultSatTable);
+                                    direction,
+                                    ctf_kind,
+                                    noConn,
+                                    defaultSatTable);
             } else {
                 std::size_t css_ind = prev->sort_value();
                 int conSegNo = prev->segment();
-                double conSDStart = prev->getSegDistStart();
-                double conSDEnd = prev->getSegDistEnd();
+                const auto& perf_range = prev->perf_range();
                 double depth = grid.getCellDepth(I,J,k);
                 *prev = Connection(I,J,k,
                                    grid.getGlobalIndex(I,J,k),
@@ -404,14 +399,15 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                                    r0,
                                    skin_factor,
                                    satTableId,
-                                   direction, ctf_kind,
-                                   prev->sort_value(), conSDStart, conSDEnd, defaultSatTable);
+                                   direction,
+                                   ctf_kind,
+                                   prev->sort_value(),
+                                   defaultSatTable);
 
                 prev->updateSegment(conSegNo,
                                     depth,
                                     css_ind,
-                                    conSDStart,
-                                    conSDEnd);
+                                    *perf_range);
             }
         }
     }

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -71,8 +71,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
-    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true);
-    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -86,8 +86,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
 BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,true);
+    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,true);
     Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
@@ -107,9 +107,9 @@ BOOST_AUTO_TEST_CASE(AddCompletionCopy) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
 
-    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion2( 10,10,11, 101, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion3( 10,10,12, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion2( 10,10,11, 101, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion3( 10,10,12, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
 
     completionSet.add( completion1 );
     completionSet.add( completion2 );
@@ -130,9 +130,9 @@ BOOST_AUTO_TEST_CASE(ActiveCompletions) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::Defaulted;
     Opm::WellConnections completions(Opm::Connection::Order::TRACK, 10,10);
-    Opm::Connection completion1( 0,0,0, grid.getGlobalIndex(0,0,0), 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion2( 0,0,1, grid.getGlobalIndex(0,0,1), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
-    Opm::Connection completion3( 0,0,2, grid.getGlobalIndex(0,0,2), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,0., 0., true);
+    Opm::Connection completion1( 0,0,0, grid.getGlobalIndex(0,0,0), 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion2( 0,0,1, grid.getGlobalIndex(0,0,1), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion3( 0,0,2, grid.getGlobalIndex(0,0,2), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
 
     completions.add( completion1 );
     completions.add( completion2 );

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -52,14 +52,14 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0,grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 1,grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 2,grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 0,grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1,grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2,grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1,grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 17, 0, 1,grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 16, 0, 1,grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 15, 0, 1,grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 18, 0, 1,grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1,grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1,grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1,grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -155,7 +155,8 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     const double outlet_segment_length = segment_set.segmentLength(outlet_segment_number);
     // only one connection attached to the outlet segment in this case
     const Opm::Connection& connection = new_connection_set->getFromIJK(15, 0, 1);
-    const double connection_length = connection.getSegDistEnd() - connection.getSegDistStart();
+    const auto& perf_range = connection.perf_range();
+    const auto connection_length = perf_range->second - perf_range->first;
     sicd_ptr->updateScalingFactor(outlet_segment_length, connection_length);
 
     // updated, so it should not throw
@@ -201,14 +202,14 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -258,14 +259,14 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -316,14 +317,14 @@ BOOST_AUTO_TEST_CASE(testwsegvalv) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, 0., 0., true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 


### PR DESCRIPTION
Slight refactor of the segment information embedded in a connection object, instead of two doubles this PR uses:
```
std::optional<std::pair<double, double>> perf_range;
```
where the optional is empty for a normal well. Purpose is to simplify WELSPECS report for MSW well.