### PR TITLE
Implements Group Levels Subreport in WELSPECS

### DIFF
--- a/opm/output/eclipse/WriteRPT.hpp
+++ b/opm/output/eclipse/WriteRPT.hpp
@@ -26,6 +26,7 @@ namespace Opm {
 
     class Schedule;
     class EclipseGrid;
+    class UnitSystem;
 
     namespace RptIO {
 
@@ -35,12 +36,13 @@ namespace Opm {
             unsigned value,
             const Schedule& schedule,
             const EclipseGrid& grid,
+            const UnitSystem& unit_system,
             std::size_t time_step
         );
 
         namespace workers {
 
-            void write_WELSPECS(std::ostream&, unsigned, const Schedule&, const EclipseGrid& grid, std::size_t);
+            void write_WELSPECS(std::ostream&, unsigned, const Schedule&, const EclipseGrid& grid, const UnitSystem&, std::size_t);
 
 }   }   }
 #endif // OPM_WRITE_RPT_HPP

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
@@ -39,6 +39,9 @@ public:
     const std::string& name() const;
     const GTNode& parent() const;
     const Group& group() const;
+    std::size_t level() const;
+
+    std::vector<const GTNode*> all_nodes() const;
 private:
     const Group m_group;
     const GTNode * m_parent;

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -263,7 +263,10 @@ void EclipseIO::writeTimeStep(const SummaryState& st,
     if (!isSubstep) {
         for (const auto& report : schedule.report_config(report_step)) {
             std::stringstream ss;
-            RptIO::write_report(ss, report.first, report.second, schedule, grid, report_step);
+            const auto& unit_system = this->impl->es.getUnits();
+
+            RptIO::write_report(ss, report.first, report.second, schedule, grid, unit_system, report_step);
+
             auto log_string = ss.str();
             if (!log_string.empty())
                 OpmLog::note(log_string);

--- a/src/opm/output/eclipse/WriteRPT.cpp
+++ b/src/opm/output/eclipse/WriteRPT.cpp
@@ -24,7 +24,7 @@
 
 namespace Opm::RptIO {
 
-    using report_function = std::function<void(std::ostream&, unsigned, const Schedule&, const EclipseGrid&, std::size_t)>;
+    using report_function = std::function<void(std::ostream&, unsigned, const Schedule&, const EclipseGrid&, const UnitSystem&, std::size_t)>;
 
     static const std::unordered_map<std::string, report_function> report_functions {
         { "WELSPECS", workers::write_WELSPECS },
@@ -36,11 +36,12 @@ namespace Opm::RptIO {
         unsigned value,
         const Opm::Schedule& schedule,
         const Opm::EclipseGrid& grid,
+        const Opm::UnitSystem& unit_system,
         std::size_t report_step
     ) {
         const auto function { report_functions.find(report) } ;
         if (function != report_functions.end()) {
-            function->second(os, value, schedule, grid, report_step);
+            function->second(os, value, schedule, grid, unit_system, report_step);
         }
     }
 }

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 namespace {
 
@@ -80,7 +81,7 @@ namespace {
         return s;
     }
 
-    template<typename T, std::size_t header_height>
+    template<typename T, std::size_t header_height, Opm::UnitSystem::UnitType unit_type>
     struct column {
         using fetch_function = std::function<std::string(const T&, const context&, std::size_t, std::size_t)>;
         using format_function = std::function<void(std::string&, std::size_t, std::size_t)>;
@@ -109,9 +110,9 @@ namespace {
         }
     };
 
-    template<typename T, std::size_t header_height>
-    struct table: std::vector<column<T, header_height>> {
-        using std::vector<column<T, header_height>>::vector;
+    template<typename T, std::size_t header_height, Opm::UnitSystem::UnitType unit_type = Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC>
+    struct table: std::vector<column<T, header_height, unit_type>> {
+        using std::vector<column<T, header_height, unit_type>>::vector;
 
         std::size_t total_width() const {
             std::size_t r { 1 + this->size() } ;
@@ -158,15 +159,15 @@ namespace {
     };
 
 
-    template<typename InputType, typename OutputType, std::size_t header_height>
+    template<typename InputType, typename OutputType, std::size_t header_height, Opm::UnitSystem::UnitType unit_type = Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC>
     struct report {
 
         std::string title;
         std::string decor;
-        table<OutputType, header_height> column_definition;
+        table<OutputType, header_height, unit_type> column_definition;
         const context ctx;
 
-        report(const std::string& _title, const table<OutputType, header_height>& _coldef, const context& _ctx)
+        report(const std::string& _title, const table<OutputType, header_height, unit_type>& _coldef, const context& _ctx)
             : title              { _title           }
             , decor              { underline(title) }
             , column_definition  { _coldef          }

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -104,7 +104,7 @@ namespace {
 
         std::string header_line(std::size_t row, context ctx) const {
             if (row == header_height && dimension) {
-                return "";
+                return ctx.unit_system.name(dimension.value());
             } else {
                 return header[row];
             }
@@ -351,9 +351,9 @@ namespace {
        {  8, { "WELL"       , "NAME"       ,               }, &WellWrapper::well_name        , left_align  },
        {  8, { "GROUP"      , "NAME"       ,               }, &WellWrapper::group_name       , left_align  },
        {  8, { "WELLHEAD"   , "LOCATION"   , "( I, J )"    }, &WellWrapper::wellhead_location, left_align  },
-       {  8, { "B.H.REF"    , "DEPTH"      , "METRES"      }, &WellWrapper::reference_depth  , right_align },
+       {  8, { "B.H.REF"    , "DEPTH"      , "METRES"      }, &WellWrapper::reference_depth  , right_align, Opm::UnitSystem::measure::length },
        {  5, { "PREF-"      , "ERRED"      , "PHASE"       }, &WellWrapper::preferred_phase  ,             },
-       {  8, { "DRAINAGE"   , "RADIUS"     , "METRES"      }, &WellWrapper::drainage_radius  ,             },
+       {  8, { "DRAINAGE"   , "RADIUS"     , "METRES"      }, &WellWrapper::drainage_radius  , right_align, Opm::UnitSystem::measure::length },
        {  4, { "GAS"        , "INFL"       , "EQUN"        }, &WellWrapper::gas_inflow       ,             },
        {  7, { "SHUT-IN"    , "INSTRCT"    ,               }, &WellWrapper::shut_status      ,             },
        {  5, { "CROSS"      , "FLOW"       , "ABLTY"       }, &WellWrapper::cross_flow       ,             },
@@ -454,11 +454,11 @@ namespace {
        {  7, {"WELL"                   ,"NAME"                     ,                         }, &WellConnection::well_name       , left_align  },
        { 12, {"GRID"                   ,"BLOCK"                    ,                         }, &WellConnection::grid_block      ,             },
        {  3, {"CMPL"                   ,"NO#"                      ,                         }, &WellConnection::cmpl_no         , right_align },
-       {  7, {"CENTRE"                 ,"DEPTH"                    ,"METRES"                 }, &WellConnection::centre_depth    , right_align },
+       {  7, {"CENTRE"                 ,"DEPTH"                    ,"METRES"                 }, &WellConnection::centre_depth    , right_align, Opm::UnitSystem::measure::length },
        {  3, {"OPEN"                   ,"SHUT"                     ,                         }, &WellConnection::open_shut       ,             },
        {  3, {"SAT"                    ,"TAB"                      ,                         }, &WellConnection::sat_tab         ,             },
        {  8, {"CONNECTION"             ,"FACTOR*"                  ,"CPM3/D/B"               }, &WellConnection::conn_factor     , right_align },
-       {  6, {"INT"                    ,"DIAM"                     ,"METRES"                 }, &WellConnection::int_diam        , right_align },
+       {  6, {"INT"                    ,"DIAM"                     ,"METRES"                 }, &WellConnection::int_diam        , right_align, Opm::UnitSystem::measure::length },
        {  7, {"K  H"                   ,"VALUE"                    ,"MD.METRE"               }, &WellConnection::kh_value        , right_align },
        {  6, {"SKIN"                   ,"FACTOR"                   ,                         }, &WellConnection::skin_factor     , right_align },
        { 10, {"CONNECTION"             ,"D-FACTOR 1"               ,"DAY/SM3"                }, &WellConnection::dfactor         ,             },
@@ -654,13 +654,13 @@ namespace {
         {  9, {"CONNECTION" , ""           ,              }, &SegmentConnection::connection_grid  ,             },
         {  5, {"SEGMENT"    , "NUMBER"     ,              }, &SegmentConnection::segment_number   , right_align },
         {  8, {"BRANCH"     , "ID"         ,              }, &SegmentConnection::branch_id        ,             },
-        {  9, {"TUB LENGTH" , "START PERFS", "METRES"     }, unimplemented<SegmentConnection>     , right_align },
-        {  9, {"TUB LENGTH" , "END PERFS"  , "METRES"     }, unimplemented<SegmentConnection>     , right_align },
-        {  9, {"TUB LENGTH" , "CENTR PERFS", "METRES"     }, unimplemented<SegmentConnection>     , right_align },
-        {  9, {"TUB LENGTH" , "END SEGMT"  , "METRES"     }, &SegmentConnection::length_end_segmt , right_align },
-        {  8, {"CONNECTION" , "DEPTH"      , "METRES"     }, &SegmentConnection::connection_depth , right_align },
-        {  8, {"SEGMENT"    , "DEPTH"      , "METRES"     }, &SegmentConnection::segment_depth    , right_align },
-        {  9, {"GRID BLOCK" , "DEPTH"      , "METRES"     }, &SegmentConnection::grid_block_depth , right_align },
+        {  9, {"TUB LENGTH" , "START PERFS", "METRES"     }, unimplemented<SegmentConnection>     , right_align, Opm::UnitSystem::measure::length },
+        {  9, {"TUB LENGTH" , "END PERFS"  , "METRES"     }, unimplemented<SegmentConnection>     , right_align, Opm::UnitSystem::measure::length },
+        {  9, {"TUB LENGTH" , "CENTR PERFS", "METRES"     }, unimplemented<SegmentConnection>     , right_align, Opm::UnitSystem::measure::length },
+        {  9, {"TUB LENGTH" , "END SEGMT"  , "METRES"     }, &SegmentConnection::length_end_segmt , right_align, Opm::UnitSystem::measure::length },
+        {  8, {"CONNECTION" , "DEPTH"      , "METRES"     }, &SegmentConnection::connection_depth , right_align, Opm::UnitSystem::measure::length },
+        {  8, {"SEGMENT"    , "DEPTH"      , "METRES"     }, &SegmentConnection::segment_depth    , right_align, Opm::UnitSystem::measure::length },
+        {  9, {"GRID BLOCK" , "DEPTH"      , "METRES"     }, &SegmentConnection::grid_block_depth , right_align, Opm::UnitSystem::measure::length },
     };
 
     const table<WellSegment, 3> msw_well_table = {
@@ -669,14 +669,14 @@ namespace {
         {  3, { "BRN"       , "NO"         , ""           }, &WellSegment::branch_number       , right_align             },
         {  5, { "MAIN"      , "INLET"      , "SEGMENT"    }, &WellSegment::main_inlet          , right_align             },
         {  5, { ""          , "OUTLET"     , "SEGMENT"    }, &WellSegment::outlet              , right_align             },
-        {  7, { "SEGMENT"   , "LENGTH"     , "METRES"     }, &WellSegment::length              , right_align             },
-        {  8, { "TOT LENGTH", "TO END"     , "METRES"     }, &WellSegment::total_length        , right_align             },
-        {  8, { "DEPTH"     , "CHANGE"     , "METRES"     }, &WellSegment::depth_change        , right_align             },
-        {  8, { "T.V. DEPTH", "AT END"     , "METRES"     }, &WellSegment::t_v_depth           , right_align             },
-        {  6, { "DIA OR F"  , "SCALING"    , "METRES"     }, &WellSegment::internal_diameter   , right_align             },
-        {  8, { "VFP TAB OR", "ABS ROUGHN" , "METRES"     }, &WellSegment::roughness           , right_align             },
-        {  7, { "AREA"      , "X-SECTN"    , "M**2"       }, &WellSegment::cross_section       , right_align             },
-        {  7, { "VOLUME"    , ""           , "M3"         }, &WellSegment::volume              , right_align             },
+        {  7, { "SEGMENT"   , "LENGTH"     , "METRES"     }, &WellSegment::length              , right_align            , Opm::UnitSystem::measure::length },
+        {  8, { "TOT LENGTH", "TO END"     , "METRES"     }, &WellSegment::total_length        , right_align            , Opm::UnitSystem::measure::length },
+        {  8, { "DEPTH"     , "CHANGE"     , "METRES"     }, &WellSegment::depth_change        , right_align            , Opm::UnitSystem::measure::length },
+        {  8, { "T.V. DEPTH", "AT END"     , "METRES"     }, &WellSegment::t_v_depth           , right_align            , Opm::UnitSystem::measure::length },
+        {  6, { "DIA OR F"  , "SCALING"    , "METRES"     }, &WellSegment::internal_diameter   , right_align            , Opm::UnitSystem::measure::length },
+        {  8, { "VFP TAB OR", "ABS ROUGHN" , "METRES"     }, &WellSegment::roughness           , right_align            , Opm::UnitSystem::measure::length },
+        {  7, { "AREA"      , "X-SECTN"    , "M**2"       }, &WellSegment::cross_section       , right_align            },
+        {  7, { "VOLUME"    , ""           , "M3"         }, &WellSegment::volume              , right_align            , Opm::UnitSystem::measure::volume },
         {  8, { "P DROP"    , "MULT"       , "FACTOR 1"   }, &WellSegment::pressure_drop_mult  , right_align             },
     };
 }

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -424,8 +424,8 @@ namespace {
             return std::to_string(connection.satTableId());
         }
 
-        std::string conn_factor(const context&, std::size_t, std::size_t) const {
-            return std::to_string(connection.CF()).substr(0, 10);
+        std::string conn_factor(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::transmissibility, connection.CF())).substr(0, 10);
         }
 
         std::string int_diam(const context& ctx, std::size_t, std::size_t) const {
@@ -454,11 +454,11 @@ namespace {
        {  7, {"WELL"                   ,"NAME"                     ,                         }, &WellConnection::well_name       , left_align  },
        { 12, {"GRID"                   ,"BLOCK"                    ,                         }, &WellConnection::grid_block      ,             },
        {  3, {"CMPL"                   ,"NO#"                      ,                         }, &WellConnection::cmpl_no         , right_align },
-       {  7, {"CENTRE"                 ,"DEPTH"                    ,"METRES"                 }, &WellConnection::centre_depth    , right_align, Opm::UnitSystem::measure::length },
+       {  7, {"CENTRE"                 ,"DEPTH"                    ,"METRES"                 }, &WellConnection::centre_depth    , right_align, Opm::UnitSystem::measure::length           },
        {  3, {"OPEN"                   ,"SHUT"                     ,                         }, &WellConnection::open_shut       ,             },
        {  3, {"SAT"                    ,"TAB"                      ,                         }, &WellConnection::sat_tab         ,             },
-       {  8, {"CONNECTION"             ,"FACTOR*"                  ,"CPM3/D/B"               }, &WellConnection::conn_factor     , right_align },
-       {  6, {"INT"                    ,"DIAM"                     ,"METRES"                 }, &WellConnection::int_diam        , right_align, Opm::UnitSystem::measure::length },
+       { 11, {"CONNECTION"             ,"FACTOR*"                  ,"CPM3/D/B"               }, &WellConnection::conn_factor     , right_align, Opm::UnitSystem::measure::transmissibility },
+       {  6, {"INT"                    ,"DIAM"                     ,"METRES"                 }, &WellConnection::int_diam        , right_align, Opm::UnitSystem::measure::length           },
        {  7, {"K  H"                   ,"VALUE"                    ,"MD.METRE"               }, &WellConnection::kh_value        , right_align },
        {  6, {"SKIN"                   ,"FACTOR"                   ,                         }, &WellConnection::skin_factor     , right_align },
        { 10, {"CONNECTION"             ,"D-FACTOR 1"               ,"DAY/SM3"                }, &WellConnection::dfactor         ,             },

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -294,8 +294,8 @@ namespace {
             return i + ", " + j;
         }
 
-        std::string reference_depth(const context&, std::size_t, std::size_t) const {
-            return std::to_string(well.getRefDepth()).substr(0,6);
+        std::string reference_depth(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, well.getRefDepth())).substr(0,6);
         }
 
         std::string preferred_phase(const context&, std::size_t, std::size_t) const {
@@ -336,10 +336,10 @@ namespace {
             return well.getAllowCrossFlow() ? "YES" : "NO";
         }
 
-        std::string drainage_radius(const context&, std::size_t, std::size_t) const {
+        std::string drainage_radius(const context& ctx, std::size_t, std::size_t) const {
             if (well.getDrainageRadius() == 0)
                 return "P.EQUIV.R";
-            return std::to_string(well.getDrainageRadius()).substr(0,6);
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, well.getDrainageRadius())).substr(0,6);
         }
 
         std::string gas_inflow(const context&, std::size_t, std::size_t) const {
@@ -412,8 +412,8 @@ namespace {
             return std::to_string(connection.complnum());
         }
 
-        std::string centre_depth(const context&, std::size_t, std::size_t) const {
-            return std::to_string(connection.depth()).substr(0, 6);
+        std::string centre_depth(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, connection.depth())).substr(0, 6);
         }
 
         std::string open_shut(const context&, std::size_t, std::size_t) const {
@@ -428,8 +428,8 @@ namespace {
             return std::to_string(connection.CF()).substr(0, 10);
         }
 
-        std::string int_diam(const context&, std::size_t, std::size_t) const {
-            return std::to_string(connection.rw() * 2).substr(0, 8);
+        std::string int_diam(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, connection.rw()) * 2).substr(0, 8);
         }
 
         std::string kh_value(const context&, std::size_t, std::size_t) const {
@@ -498,20 +498,20 @@ namespace {
             return std::to_string(segment.branchNumber());
         }
 
-        std::string length_end_segmt(const context&, std::size_t, std::size_t) const {
-            return std::to_string(segment.totalLength()).substr(0, 6);
+        std::string length_end_segmt(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.totalLength())).substr(0, 6);
         }
 
-        std::string connection_depth(const context&, std::size_t, std::size_t) const {
-            return std::to_string(connection.depth()).substr(0, 6);
+        std::string connection_depth(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, connection.depth())).substr(0, 6);
         }
 
-        std::string segment_depth(const context&, std::size_t, std::size_t) const {
-            return std::to_string(segment.depth()).substr(0, 6);
+        std::string segment_depth(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.depth())).substr(0, 6);
         }
 
         std::string grid_block_depth(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string( ctx.grid.getCellDepth( connection.global_index() )).substr(0,6);
+            return std::to_string( ctx.unit_system.from_si(Opm::UnitSystem::measure::length, ctx.grid.getCellDepth( connection.global_index() ) )).substr(0,6);
         }
 
 
@@ -573,8 +573,8 @@ namespace {
             return std::to_string(segment.outletSegment());
         }
 
-        std::string total_length(const context&, std::size_t, std::size_t) const {
-            return std::to_string(segment.totalLength()).substr(0, 6);
+        std::string total_length(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.totalLength())).substr(0, 6);
         }
 
         std::string length(const context& ctx, std::size_t sub_report, std::size_t line_number) const {
@@ -583,11 +583,11 @@ namespace {
 
             const auto& segments { well.getSegments() } ;
             const auto& outlet_segment { segments.getFromSegmentNumber( segment.outletSegment() ) } ;
-            return std::to_string( segment.totalLength() - outlet_segment.totalLength() ).substr(0, 6);
+            return std::to_string( ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.totalLength() - outlet_segment.totalLength()) ).substr(0, 6);
         }
 
-        std::string t_v_depth(const context&, std::size_t, std::size_t) const {
-            return std::to_string(segment.depth()).substr(0, 6);
+        std::string t_v_depth(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.depth())).substr(0, 6);
         }
 
         std::string depth_change(const context& ctx, std::size_t sub_report, std::size_t line_number) const {
@@ -596,24 +596,24 @@ namespace {
 
             const auto& segments { well.getSegments() } ;
             const auto& outlet_segment { segments.getFromSegmentNumber( segment.outletSegment() ) } ;
-            return std::to_string( segment.depth() - outlet_segment.depth() ).substr(0, 6);
+            return std::to_string( ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.depth() - outlet_segment.depth()) ).substr(0, 6);
         }
 
-        std::string internal_diameter(const context&, std::size_t, std::size_t) const {
+        std::string internal_diameter(const context& ctx, std::size_t, std::size_t) const {
             const auto number { segment.internalDiameter() } ;
 
             if (number != Opm::Segment::invalidValue()) {
-                return std::to_string(number).substr(0, 6);
+                return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, number)).substr(0, 6);
             } else {
                 return "0";
             }
         }
 
-        std::string roughness(const context&, std::size_t, std::size_t) const {
+        std::string roughness(const context& ctx, std::size_t, std::size_t) const {
             const auto number { segment.roughness() } ;
 
             if (number != Opm::Segment::invalidValue()) {
-                return std::to_string(number).substr(0, 8);
+                return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, number)).substr(0, 8);
             } else {
                 return "0";
             }
@@ -629,8 +629,8 @@ namespace {
             }
         }
 
-        std::string volume(const context&, std::size_t, std::size_t) const {
-            return std::to_string(segment.volume()).substr(0, 5);
+        std::string volume(const context& ctx, std::size_t, std::size_t) const {
+            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::volume, segment.volume())).substr(0, 5);
         }
 
         std::string pressure_drop_mult(const context&, std::size_t, std::size_t) const {

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -209,9 +209,11 @@ namespace {
         }
 
         void print_footer(std::ostream& os, const std::vector<std::pair<int, std::string>>& footnotes) const {
-            for (const auto& fnote: footnotes)
-                os << fnote.first << ": " << fnote.second << std::endl;
-            os << std::endl << std::endl;
+            for (const auto& fnote: footnotes) {
+                os << fnote.first << ": " << fnote.second << record_separator;
+            }
+
+            os << section_separator;
         }
     };
 }
@@ -323,9 +325,7 @@ namespace {
         }
 
         std::string dens_calc(const context&, std::size_t, std::size_t) const {
-            if (well.segmented_density_calculation())
-                return "SEG";
-            return "AVG";
+            return well.segmented_density_calculation() ? "SEG" : "AVG";
         }
 
         /*

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -73,6 +73,7 @@ namespace {
     struct context {
         const Opm::Schedule& sched;
         const Opm::EclipseGrid& grid;
+        const Opm::UnitSystem& unit_system;
     };
 
     std::string format_number(const Opm::UnitSystem& unit_system, Opm::UnitSystem::measure measure, double number, std::size_t width) {
@@ -706,7 +707,7 @@ void report_well_connection_data(std::ostream& os, const std::vector<Opm::Well>&
 
 }
 
-void Opm::RptIO::workers::write_WELSPECS(std::ostream& os, unsigned, const Opm::Schedule& schedule, const Opm::EclipseGrid& grid, std::size_t report_step) {
+void Opm::RptIO::workers::write_WELSPECS(std::ostream& os, unsigned, const Opm::Schedule& schedule, const Opm::EclipseGrid& grid, const Opm::UnitSystem& unit_system, std::size_t report_step) {
     auto well_names { schedule.changed_wells(report_step) } ;
     if (well_names.empty())
         return;

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -280,10 +280,6 @@ namespace {
     struct WellWrapper {
         const Opm::Well& well;
 
-        WellWrapper(const Opm::Well& well_arg) :
-            well(well_arg)
-        { }
-
         std::string well_name(const context&, std::size_t, std::size_t) const {
             return well.name();
         }
@@ -372,7 +368,7 @@ namespace {
 void report_well_specification_data(std::ostream& os, const std::vector<Opm::Well>& data, const context& ctx) {
     report<Opm::Well, WellWrapper, 3> well_specification { "WELL SPECIFICATION DATA", well_specification_table, ctx};
     std::vector<WellWrapper> wrapper_data;
-    std::transform(data.begin(), data.end(), std::back_inserter(wrapper_data), [](const Opm::Well& well) { return WellWrapper(well); });
+    std::transform(data.begin(), data.end(), std::back_inserter(wrapper_data), [](const Opm::Well& well) { return WellWrapper { well } ; });
 
     well_specification.print_header(os);
     well_specification.print_data(os, wrapper_data, 0);
@@ -387,12 +383,6 @@ namespace {
         const Opm::Well& well;
         const Opm::Connection& connection;
 
-        WellConnection(const Opm::Well& well_arg, const Opm::Connection& connection_arg) :
-            well(well_arg),
-            connection(connection_arg)
-        {}
-
-
         const std::string& well_name(const context&, std::size_t, std::size_t) const {
             return well.name();
         }
@@ -400,7 +390,7 @@ namespace {
         std::string grid_block(const context&, std::size_t, std::size_t) const {
             const std::array<int,3> ijk { connection.getI() + 1, connection.getJ() + 1, connection.getK() + 1 } ;
 
-            auto compose_coordinates = [](std::string& out, int in) -> std::string {
+            auto compose_coordinates { [](std::string& out, int in) -> std::string {
                 constexpr auto delimiter { ',' } ;
                 std::string coordinate_part { std::to_string(in) } ;
                 right_align(coordinate_part, 3);
@@ -408,7 +398,7 @@ namespace {
                 return out.empty()
                     ? coordinate_part
                     : out + delimiter + coordinate_part;
-            };
+            } };
 
             return std::accumulate(std::begin(ijk), std::end(ijk), std::string {}, compose_coordinates);
         }
@@ -480,13 +470,6 @@ namespace {
 
         const std::pair<double,double>& perf_range;
 
-        SegmentConnection(const Opm::Well& well_arg, const Opm::Connection& conn_arg, const Opm::Segment& segment_arg, const std::pair<double,double>& perf_range_arg) :
-            well(well_arg),
-            connection(conn_arg),
-            segment(segment_arg),
-            perf_range(perf_range_arg)
-        {}
-
         const std::string& well_name(const context&, std::size_t, std::size_t) const {
             return well.name();
         }
@@ -549,11 +532,6 @@ namespace {
     struct WellSegment {
         const Opm::Well& well;
         const Opm::Segment& segment;
-
-        WellSegment(const Opm::Well& well_arg, const Opm::Segment& segment_arg) :
-            well(well_arg),
-            segment(segment_arg)
-        {}
 
         std::string well_name_seg(const context&, std::size_t sub_report, std::size_t n) const {
             if (sub_report > 0)
@@ -710,7 +688,7 @@ void report_well_connection_data(std::ostream& os, const std::vector<Opm::Well>&
     for (const auto& well : data) {
         std::vector<WellConnection> wrapper_data;
         const auto& connections { well.getConnections() } ;
-        std::transform(connections.begin(), connections.end(), std::back_inserter(wrapper_data), [&well]( const Opm::Connection& connection) { return WellConnection(well, connection); });
+        std::transform(connections.begin(), connections.end(), std::back_inserter(wrapper_data), [&well](const Opm::Connection& connection) { return WellConnection { well, connection } ; });
 
         well_connection.print_data(os, wrapper_data, sub_report);
         sub_report++;
@@ -744,7 +722,7 @@ void Opm::RptIO::workers::write_WELSPECS(std::ostream& os, unsigned, const Opm::
                 for (const auto& branch : segments.branches()) {
                     std::vector<WellSegment> wrapper_data;
                     const auto& branch_segments { segments.branchSegments(branch) } ;
-                    std::transform(branch_segments.begin(), branch_segments.end(), std::back_inserter(wrapper_data), [&well](const Opm::Segment& segment) { return WellSegment(well, segment); });
+                    std::transform(branch_segments.begin(), branch_segments.end(), std::back_inserter(wrapper_data), [&well](const Opm::Segment& segment) { return WellSegment { well, segment } ; });
 
                     sub_report++;
                     if (sub_report == (segments.branches().size()))
@@ -763,7 +741,7 @@ void Opm::RptIO::workers::write_WELSPECS(std::ostream& os, unsigned, const Opm::
                     const auto& segments { well.getSegments() } ;
                     const std::pair<double,double> perf_range { } ; // TODO: connect with #1759
                     std::transform(connections.begin(), connections.end(), std::back_inserter(wrapper_data),
-                                   [&well, &segments, &perf_range] (const Opm::Connection& connection) { return SegmentConnection(well, connection, segments.getFromSegmentNumber(connection.segment()), perf_range); });
+                                   [&well, &segments, &perf_range] (const Opm::Connection& connection) { return SegmentConnection { well, connection, segments.getFromSegmentNumber(connection.segment()), perf_range } ; });
                     msw_connection.print_data(os, wrapper_data, 0, '=');
                 }
                 msw_connection.print_footer(os, {});

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -75,6 +75,10 @@ namespace {
         const Opm::EclipseGrid& grid;
     };
 
+    std::string format_number(const Opm::UnitSystem& unit_system, Opm::UnitSystem::measure measure, double number, std::size_t width) {
+        return std::to_string(unit_system.from_si(measure, number)).substr(0, width);
+    }
+
     template<typename T>
     const std::string& unimplemented(const T&, const context&, std::size_t, std::size_t) {
         static const std::string s { } ;
@@ -295,7 +299,7 @@ namespace {
         }
 
         std::string reference_depth(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, well.getRefDepth())).substr(0,6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, well.getRefDepth(), 6);
         }
 
         std::string preferred_phase(const context&, std::size_t, std::size_t) const {
@@ -339,7 +343,7 @@ namespace {
         std::string drainage_radius(const context& ctx, std::size_t, std::size_t) const {
             if (well.getDrainageRadius() == 0)
                 return "P.EQUIV.R";
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, well.getDrainageRadius())).substr(0,6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, well.getDrainageRadius(), 6);
         }
 
         std::string gas_inflow(const context&, std::size_t, std::size_t) const {
@@ -413,7 +417,7 @@ namespace {
         }
 
         std::string centre_depth(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, connection.depth())).substr(0, 6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, connection.depth(), 6);
         }
 
         std::string open_shut(const context&, std::size_t, std::size_t) const {
@@ -425,11 +429,11 @@ namespace {
         }
 
         std::string conn_factor(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::transmissibility, connection.CF())).substr(0, 10);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::transmissibility, connection.CF(), 10);
         }
 
         std::string int_diam(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, connection.rw()) * 2).substr(0, 8);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, connection.rw() * 2, 8);
         }
 
         std::string kh_value(const context&, std::size_t, std::size_t) const {
@@ -499,19 +503,19 @@ namespace {
         }
 
         std::string length_end_segmt(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.totalLength())).substr(0, 6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, segment.totalLength(), 6);
         }
 
         std::string connection_depth(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, connection.depth())).substr(0, 6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, connection.depth(), 6);
         }
 
         std::string segment_depth(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.depth())).substr(0, 6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, segment.depth(), 6);
         }
 
         std::string grid_block_depth(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string( ctx.unit_system.from_si(Opm::UnitSystem::measure::length, ctx.grid.getCellDepth( connection.global_index() ) )).substr(0,6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, ctx.grid.getCellDepth( connection.global_index() ), 6);
         }
 
 
@@ -574,7 +578,7 @@ namespace {
         }
 
         std::string total_length(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.totalLength())).substr(0, 6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, segment.totalLength(), 6);
         }
 
         std::string length(const context& ctx, std::size_t sub_report, std::size_t line_number) const {
@@ -583,11 +587,11 @@ namespace {
 
             const auto& segments { well.getSegments() } ;
             const auto& outlet_segment { segments.getFromSegmentNumber( segment.outletSegment() ) } ;
-            return std::to_string( ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.totalLength() - outlet_segment.totalLength()) ).substr(0, 6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, segment.totalLength() - outlet_segment.totalLength(), 6);
         }
 
         std::string t_v_depth(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.depth())).substr(0, 6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, segment.depth(), 6);
         }
 
         std::string depth_change(const context& ctx, std::size_t sub_report, std::size_t line_number) const {
@@ -596,14 +600,14 @@ namespace {
 
             const auto& segments { well.getSegments() } ;
             const auto& outlet_segment { segments.getFromSegmentNumber( segment.outletSegment() ) } ;
-            return std::to_string( ctx.unit_system.from_si(Opm::UnitSystem::measure::length, segment.depth() - outlet_segment.depth()) ).substr(0, 6);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, segment.depth() - outlet_segment.depth(), 6);
         }
 
         std::string internal_diameter(const context& ctx, std::size_t, std::size_t) const {
             const auto number { segment.internalDiameter() } ;
 
             if (number != Opm::Segment::invalidValue()) {
-                return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, number)).substr(0, 6);
+                return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, number, 6);
             } else {
                 return "0";
             }
@@ -613,7 +617,7 @@ namespace {
             const auto number { segment.roughness() } ;
 
             if (number != Opm::Segment::invalidValue()) {
-                return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::length, number)).substr(0, 8);
+                return format_number(ctx.unit_system, Opm::UnitSystem::measure::length, number, 8);
             } else {
                 return "0";
             }
@@ -630,7 +634,7 @@ namespace {
         }
 
         std::string volume(const context& ctx, std::size_t, std::size_t) const {
-            return std::to_string(ctx.unit_system.from_si(Opm::UnitSystem::measure::volume, segment.volume())).substr(0, 5);
+            return format_number(ctx.unit_system, Opm::UnitSystem::measure::volume, segment.volume(), 5);
         }
 
         std::string pressure_drop_mult(const context&, std::size_t, std::size_t) const {

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <optional>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
@@ -81,7 +82,7 @@ namespace {
         return s;
     }
 
-    template<typename T, std::size_t header_height, Opm::UnitSystem::UnitType unit_type>
+    template<typename T, std::size_t header_height>
     struct column {
         using fetch_function = std::function<std::string(const T&, const context&, std::size_t, std::size_t)>;
         using format_function = std::function<void(std::string&, std::size_t, std::size_t)>;
@@ -91,6 +92,8 @@ namespace {
 
         fetch_function fetch = unimplemented<T>;
         format_function format = centre_align;
+
+        std::optional<Opm::UnitSystem::measure> dimension = std::nullopt;
 
         void print(std::ostream& os, const T& data, const context& ctx, std::size_t sub_report, std::size_t line_number) const {
             std::string string_data { fetch(data, ctx, sub_report, line_number) } ;
@@ -110,9 +113,9 @@ namespace {
         }
     };
 
-    template<typename T, std::size_t header_height, Opm::UnitSystem::UnitType unit_type = Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC>
-    struct table: std::vector<column<T, header_height, unit_type>> {
-        using std::vector<column<T, header_height, unit_type>>::vector;
+    template<typename T, std::size_t header_height>
+    struct table: std::vector<column<T, header_height>> {
+        using std::vector<column<T, header_height>>::vector;
 
         std::size_t total_width() const {
             std::size_t r { 1 + this->size() } ;
@@ -159,15 +162,15 @@ namespace {
     };
 
 
-    template<typename InputType, typename OutputType, std::size_t header_height, Opm::UnitSystem::UnitType unit_type = Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC>
+    template<typename InputType, typename OutputType, std::size_t header_height>
     struct report {
 
         std::string title;
         std::string decor;
-        table<OutputType, header_height, unit_type> column_definition;
+        table<OutputType, header_height> column_definition;
         const context ctx;
 
-        report(const std::string& _title, const table<OutputType, header_height, unit_type>& _coldef, const context& _ctx)
+        report(const std::string& _title, const table<OutputType, header_height>& _coldef, const context& _ctx)
             : title              { _title           }
             , decor              { underline(title) }
             , column_definition  { _coldef          }

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -90,10 +90,10 @@ namespace {
         std::size_t internal_width;
         std::array<std::string, header_height> header;
 
-        fetch_function fetch = unimplemented<T>;
-        format_function format = centre_align;
+        fetch_function fetch { unimplemented<T> } ;
+        format_function format { centre_align } ;
 
-        std::optional<Opm::UnitSystem::measure> dimension = std::nullopt;
+        std::optional<Opm::UnitSystem::measure> dimension { std::nullopt } ;
 
         void print(std::ostream& os, const T& data, const context& ctx, std::size_t sub_report, std::size_t line_number) const {
             std::string string_data { fetch(data, ctx, sub_report, line_number) } ;
@@ -154,7 +154,7 @@ namespace {
         }
 
         void print_data(std::ostream& os, const std::vector<T>& lines, const context& ctx, std::size_t sub_report) const {
-            std::size_t line_number = 0;
+            std::size_t line_number { 0 } ;
             for (const auto& line : lines) {
 
                 for (const auto& column : *this) {
@@ -581,8 +581,8 @@ namespace {
             if (segment.segmentNumber() == 1)
                 return total_length(ctx, sub_report, line_number);
 
-            const auto& segments = well.getSegments();
-            const auto& outlet_segment = segments.getFromSegmentNumber( segment.outletSegment() );
+            const auto& segments { well.getSegments() } ;
+            const auto& outlet_segment { segments.getFromSegmentNumber( segment.outletSegment() ) } ;
             return std::to_string( segment.totalLength() - outlet_segment.totalLength() ).substr(0, 6);
         }
 
@@ -594,8 +594,8 @@ namespace {
             if (segment.segmentNumber() == 1)
                 return t_v_depth(ctx, sub_report, line_number);
 
-            const auto& segments = well.getSegments();
-            const auto& outlet_segment = segments.getFromSegmentNumber( segment.outletSegment() );
+            const auto& segments { well.getSegments() } ;
+            const auto& outlet_segment { segments.getFromSegmentNumber( segment.outletSegment() ) } ;
             return std::to_string( segment.depth() - outlet_segment.depth() ).substr(0, 6);
         }
 
@@ -649,7 +649,7 @@ namespace {
     };
 
 
-    const table<SegmentConnection, 3> msw_connection_table = {
+    const table<SegmentConnection, 3> msw_connection_table {
         {  8, {"WELL"       , "NAME"       ,              }, &SegmentConnection::well_name        , left_header },
         {  9, {"CONNECTION" , ""           ,              }, &SegmentConnection::connection_grid  ,             },
         {  5, {"SEGMENT"    , "NUMBER"     ,              }, &SegmentConnection::segment_number   , right_align },
@@ -663,7 +663,7 @@ namespace {
         {  9, {"GRID BLOCK" , "DEPTH"      , "METRES"     }, &SegmentConnection::grid_block_depth , right_align, Opm::UnitSystem::measure::length },
     };
 
-    const table<WellSegment, 3> msw_well_table = {
+    const table<WellSegment, 3> msw_well_table {
         {  6, { "WELLNAME"  , "AND"        , "SEG TYPE"   }, &WellSegment::well_name_seg       , &WellSegment::ws_format },
         {  3, { "SEG"       , "NO"         , ""           }, &WellSegment::segment_number      , right_align             },
         {  3, { "BRN"       , "NO"         , ""           }, &WellSegment::branch_number       , right_align             },
@@ -687,10 +687,10 @@ void report_well_connection_data(std::ostream& os, const std::vector<Opm::Well>&
     const report<Opm::Well, WellConnection, 3> well_connection { "WELL CONNECTION DATA", connection_table, ctx};
     well_connection.print_header(os);
 
-    std::size_t sub_report = 0;
+    std::size_t sub_report { 0 } ;
     for (const auto& well : data) {
         std::vector<WellConnection> wrapper_data;
-        const auto& connections = well.getConnections();
+        const auto& connections { well.getConnections() } ;
         std::transform(connections.begin(), connections.end(), std::back_inserter(wrapper_data), [&well]( const Opm::Connection& connection) { return WellConnection(well, connection); });
 
         well_connection.print_data(os, wrapper_data, sub_report);
@@ -703,11 +703,11 @@ void report_well_connection_data(std::ostream& os, const std::vector<Opm::Well>&
 }
 
 void Opm::RptIO::workers::write_WELSPECS(std::ostream& os, unsigned, const Opm::Schedule& schedule, const Opm::EclipseGrid& grid, std::size_t report_step) {
-    auto well_names = schedule.changed_wells(report_step);
+    auto well_names { schedule.changed_wells(report_step) } ;
     if (well_names.empty())
         return;
 
-    context ctx{schedule, grid};
+    context ctx { schedule, grid, unit_system } ;
     std::vector<Well> changed_wells;
     std::transform(well_names.begin(), well_names.end(), std::back_inserter(changed_wells), [&report_step, &schedule](const std::string& wname) { return schedule.getWell(wname, report_step); });
 
@@ -720,11 +720,11 @@ void Opm::RptIO::workers::write_WELSPECS(std::ostream& os, unsigned, const Opm::
             {
                 const report<Opm::Well, WellSegment, 3> msw_data { "MULTI-SEGMENT WELL: SEGMENT STRUCTURE", msw_well_table, ctx};
                 msw_data.print_header(os);
-                std::size_t sub_report = 0;
-                const auto& segments = well.getSegments();
+                std::size_t sub_report { 0 } ;
+                const auto& segments { well.getSegments() } ;
                 for (const auto& branch : segments.branches()) {
                     std::vector<WellSegment> wrapper_data;
-                    const auto& branch_segments = segments.branchSegments(branch);
+                    const auto& branch_segments { segments.branchSegments(branch) } ;
                     std::transform(branch_segments.begin(), branch_segments.end(), std::back_inserter(wrapper_data), [&well](const Opm::Segment& segment) { return WellSegment(well, segment); });
 
                     sub_report++;
@@ -740,8 +740,8 @@ void Opm::RptIO::workers::write_WELSPECS(std::ostream& os, unsigned, const Opm::
                 msw_connection.print_header(os);
                 {
                     std::vector<SegmentConnection> wrapper_data;
-                    const auto& connections = well.getConnections();
-                    const auto& segments = well.getSegments();
+                    const auto& connections { well.getConnections() } ;
+                    const auto& segments { well.getSegments() } ;
                     std::transform(connections.begin(), connections.end(), std::back_inserter(wrapper_data),
                                    [&well, &segments] (const Opm::Connection& connection) { return SegmentConnection(well, connection, segments.getFromSegmentNumber(connection.segment())); });
                     msw_connection.print_data(os, wrapper_data, 0, '=');

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -102,10 +102,18 @@ namespace {
             os << string_data;
         }
 
-        void print_header(std::ostream& os, std::size_t row) const {
-            std::string header_line { header[row] } ;
-            centre_align(header_line, total_width());
-            os << header_line;
+        std::string header_line(std::size_t row, context ctx) const {
+            if (row == header_height && dimension) {
+                return "";
+            } else {
+                return header[row];
+            }
+        }
+
+        void print_header(std::ostream& os, std::size_t row, context ctx) const {
+            std::string line { header_line(row, ctx) } ;
+            centre_align(line, total_width());
+            os << line;
         }
 
         constexpr std::size_t total_width() const {
@@ -131,13 +139,13 @@ namespace {
             os << std::string(total_width(), padding) << record_separator;
         }
 
-        void print_header(std::ostream& os) const {
+        void print_header(std::ostream& os, context ctx) const {
             print_divider(os);
             for (size_t i { 0 }; i < header_height; ++i) {
                 for (const auto& column : *this) {
                     os << field_separator;
 
-                    column.print_header(os, i);
+                    column.print_header(os, i, ctx);
                 }
 
                 os << field_separator << record_separator;
@@ -188,7 +196,7 @@ namespace {
             os << title << record_separator;
             os << decor << record_separator;
             os << section_separator;
-            column_definition.print_header(os);
+            column_definition.print_header(os, ctx);
         }
 
         void print_data(std::ostream& os, const std::vector<OutputType>& data, std::size_t sub_report, char bottom_border = '-') const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.cpp
@@ -59,10 +59,14 @@ const std::vector<GTNode>& GTNode::groups() const {
 }
 
 std::vector<const GTNode*> GTNode::all_nodes() const {
-    std::vector<const GTNode*> subs { this } ;
-    std::transform(m_child_groups.begin(), m_child_groups.end(), std::back_inserter(subs), [](const GTNode& node) { return &node; });
+    std::vector<const GTNode*> nodes { this };
 
-    return subs;
+    for (const auto& child_group : m_child_groups) {
+        const auto child_nodes { child_group.all_nodes() } ;
+        nodes.insert(nodes.end(), child_nodes.begin(), child_nodes.end());
+    }
+
+    return nodes;
 }
 
 std::size_t GTNode::level() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.cpp
@@ -58,5 +58,19 @@ const std::vector<GTNode>& GTNode::groups() const {
     return this->m_child_groups;
 }
 
+std::vector<const GTNode*> GTNode::all_nodes() const {
+    std::vector<const GTNode*> subs { this } ;
+    std::transform(m_child_groups.begin(), m_child_groups.end(), std::back_inserter(subs), [](const GTNode& node) { return &node; });
+
+    return subs;
+}
+
+std::size_t GTNode::level() const {
+    if (!m_parent) {
+        return 0;
+    } else {
+        return m_parent->level() + 1;
+    }
+}
 
 }


### PR DESCRIPTION
This feature implements the Group Levels subreport in WELSPECS reporting.

It also extends the interface of `Opm::GTNode` with `::all_nodes()`, which returns a vector containing pointers the receiver and all its descendants; and `::level()`, which returns the tree level of the node (where `FIELD` is level 0).