### PR TITLE
WELTARG keyword can have UDA-data in E100

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WELTARG
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WELTARG
@@ -14,7 +14,7 @@
     },
     {
       "name": "NEW_VALUE",
-      "value_type": "DOUBLE"
+      "value_type": "UDA"
     }
   ]
 }


### PR DESCRIPTION
The third argument of WELTARG can be an UDA in E100. 

https://github.com/OPM/opm-common/blob/0a9a0285dc948b8e3da011e5b77b602cc56d684f/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp#L223  
indicates that this is not supported in OPM, and may explain the current json file.

Will it create problems to still declare as UDA in json as in this PR (needed for using opm-common to parse decks, not for running flow).