### PR TITLE
quell deprecation warnings with boost 1.71

### DIFF
--- a/tests/test_calculateCellVol.cpp
+++ b/tests/test_calculateCellVol.cpp
@@ -22,7 +22,12 @@
 
 #define BOOST_TEST_MODULE CubicTest
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 /* --- our own headers --- */
 #include <opm/common/utility/numeric/calculateCellVol.hpp>

--- a/tests/test_cubic.cpp
+++ b/tests/test_cubic.cpp
@@ -40,7 +40,12 @@
 
 #define BOOST_TEST_MODULE CubicTest
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 /* --- our own headers --- */
 #include <opm/common/utility/numeric/MonotCubicInterpolator.hpp>


### PR DESCRIPTION
header was relocated.