### PR TITLE
Add missing include statement.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Network/Branch.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Network/Branch.hpp
@@ -22,6 +22,7 @@
 #define NETWORK_BRANCH_HPP
 
 #include <optional>
+#include <string>
 
 namespace Opm {
 namespace Network {


### PR DESCRIPTION
Compile fix for clang. Does not need to be backported, since #1746 was not. (Unless I misunderstood something serious).