### PR TITLE
Update regexp to allow for digits in UDQ name

### DIFF
--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -120,7 +120,7 @@ bool Opm::EclIO::SummaryNode::is_user_defined() const {
         "SURFWNUM",
     } ;
 
-    static const std::regex user_defined_regex { "[ABCFGRSW]U[A-Z]+" } ;
+    static const std::regex user_defined_regex { "[ABCFGRSW]U[A-Z0-9]+" } ;
 
     const bool matched     { std::regex_match(keyword, user_defined_regex) } ;
     const bool blacklisted { udq_blacklist.find(keyword) != udq_blacklist.end() } ;


### PR DESCRIPTION
Should fix: https://github.com/OPM/opm-simulators/issues/2581