### PR TITLE
Fix start-time of ACTIONX actions.

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -529,7 +529,7 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext&
         while (true) {
             const auto& keyword = section.getKeyword(keywordIdx);
             if (keyword.name() == "ACTIONX") {
-                Action::ActionX action(keyword, this->m_timeMap.getStartTime(currentStep + 1));
+                Action::ActionX action(keyword, this->m_timeMap.getStartTime(currentStep));
                 while (true) {
                     keywordIdx++;
                     if (keywordIdx == section.size())


### PR DESCRIPTION
This also exposed a bug: we do not handle lists of groups. Addressed by removing such list (replace with the single group matching pattern) in test case. The action expression involving the group list was never actually evaluated, since the start-time of the action was too high, making the action not `ready()` and therefore evaluate to false without evaluating any subexpressions.