### PR TITLE
Allow for mixing of SOF2 from familiy 2 and family 1 for 3p + solvent 

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
@@ -81,16 +81,19 @@ namespace {
         const auto wat    = ph.active(::Opm::Phase::WATER);
         const auto oil    = ph.active(::Opm::Phase::OIL);
         const auto gas    = ph.active(::Opm::Phase::GAS);
+
         const auto threeP = gas && oil && wat;
+        const auto twoP = (!gas && oil && wat) || (gas && oil && !wat) ;
 
         const auto family1 =       // SGOF/SLGOF and/or SWOF
             (gas && (tm.hasTables("SGOF") || tm.hasTables("SLGOF"))) ||
             (wat && tm.hasTables("SWOF"));
+        // note: we allow for SOF2 to be part of family1 for threeP + solvent simulations.
 
         const auto family2 =      // SGFN, SOF{2,3}, SWFN
             (gas && tm.hasTables("SGFN")) ||
             (oil && ((threeP && tm.hasTables("SOF3")) ||
-                     tm.hasTables("SOF2"))) ||
+                     (twoP && tm.hasTables("SOF2")))) ||
             (wat && tm.hasTables("SWFN"));
 
         if (gas && tm.hasTables("SGOF") && tm.hasTables("SLGOF")) {


### PR DESCRIPTION
The solvent model in Eclipse (annoyingly) enforce family 2 input for solvent models. I haven't found any reasons why. This will allow Flow to use family 1 input in kombinasjon with SOF2 for solvent models again. This used to work so I have many cases where SOF2 and family 1 is combined and don't want to convert all those to family 2. 