### PR TITLE
Make sure the action name is only added to ZWEL when it is true

### DIFF
--- a/opm/output/eclipse/AggregateWellData.hpp
+++ b/opm/output/eclipse/AggregateWellData.hpp
@@ -41,11 +41,6 @@ namespace Opm { namespace data {
 
 namespace Opm { namespace RestartIO { namespace Helpers {
     
-    struct ActionResStatus {
-        std::vector<Opm::Action::Result> result;
-        std::vector<std::string> name;
-    };
-
     class AggregateWellData
     {
     public:

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp
@@ -101,9 +101,9 @@ public:
     void add_well(const std::string& well);
 
     Result& operator|=(const Result& other);
-    Result& operator=(const Result& src); 
+    Result& operator=(const Result& src);
     Result& operator&=(const Result& other);
-    
+
 private:
     void assign(bool value);
     bool result;

--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -575,23 +575,16 @@ const std::map<cmp_enum, int> cmpToIndex = {
                 //Treat well, group and field left hand side conditions
                 if (it_lhsq != lhsQuantityToIndex.end()) {
                     //Well variable
-                    if (it_lhsq->first == "W") {
+                    if (it_lhsq->first == "W" && ar) {
                         //find the well that violates action if relevant
-                        if (ar) {
-                            std::optional<std::string> wn;
-                            for (const auto& well : wells)
-                            {
-                                if (ar.has_well(well.name())) {
-                                    //set well name
-                                    wn = well.name();
-                                    break;
-                                }
-                            }
+                        auto well_iter = std::find_if(wells.begin(), wells.end(), [&ar](const Opm::Well& well) { return ar.has_well(well.name()); });
+                        if (well_iter != wells.end()) {
+                            const auto& wn = well_iter->name();
 
-                            if (wn.has_value() && st.has_well_var(*wn, z_data.lhs.quantity)) {
-                                sAcn[ind + 4] = st.get_well_var(*wn, z_data.lhs.quantity);
-                                sAcn[ind + 6] = st.get_well_var(*wn, z_data.lhs.quantity);
-                                sAcn[ind + 8] = st.get_well_var(*wn, z_data.lhs.quantity);
+                            if (st.has_well_var(wn, z_data.lhs.quantity)) {
+                                sAcn[ind + 4] = st.get_well_var(wn, z_data.lhs.quantity);
+                                sAcn[ind + 6] = st.get_well_var(wn, z_data.lhs.quantity);
+                                sAcn[ind + 8] = st.get_well_var(wn, z_data.lhs.quantity);
                             }
                         }
                     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.cpp
@@ -53,6 +53,9 @@ Result::operator bool() const {
 }
 
 std::vector<std::string> Result::wells() const {
+    if (!this->result)
+        throw std::logic_error("Programming error: trying to check wells in ActionResult which is false");
+
     if (this->matching_wells)
         return this->matching_wells->wells();
     else
@@ -102,6 +105,9 @@ void Result::add_well(const std::string& well) {
 }
 
 bool Result::has_well(const std::string& well) const {
+    if (!this->result)
+        throw std::logic_error("Programming error: trying to check wells in ActionResult which is false");
+
     if (!this->matching_wells)
         return false;
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.cpp
@@ -44,7 +44,7 @@ Result::Result(bool result_arg, const WellSet& wells) :
 Result::Result(const Result& src)
 {
     this->result = src.result;
-    if (src.matching_wells) 
+    if (src.matching_wells)
         this->matching_wells.reset( new WellSet(*src.matching_wells) );
 }
 
@@ -83,11 +83,11 @@ Result& Result::operator&=(const Result& other) {
     return *this;
 }
 
-Result& Result::operator=(const Result& src) 
+Result& Result::operator=(const Result& src)
 {
     this->result = src.result;
     if (src.matching_wells) this->matching_wells.reset( new WellSet(*src.matching_wells) );
-    
+
     return *this;
 }
 

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -608,8 +608,9 @@ BOOST_AUTO_TEST_CASE(TestFieldAND) {
     st.update("FMWPR", 1);
     {
         auto res = ast.eval(context);
-        auto wells = res.wells();
         BOOST_CHECK(!res);
+        BOOST_CHECK_THROW(res.wells(), std::logic_error);
+        BOOST_CHECK_THROW(res.has_well("ABC"), std::logic_error);
     }
 
     st.update("FMWPR", 4);
@@ -782,19 +783,6 @@ TSTEP
 }
 
 
-
-BOOST_AUTO_TEST_CASE(ACTIONRESULT_COPY_EMPTY) {
-    Action::Result res1(false);
-    auto res2 = res1;
-
-    BOOST_CHECK(!res1);
-    BOOST_CHECK(!res2);
-    BOOST_CHECK(res1.wells() == std::vector<std::string>());
-    BOOST_CHECK(res2.wells() == std::vector<std::string>());
-
-    BOOST_CHECK(!res1.has_well("NO"));
-    BOOST_CHECK(!res2.has_well("NO"));
-}
 
 BOOST_AUTO_TEST_CASE(ACTIONRESULT_COPY_WELLS) {
     Action::Result res1(true, {"W1", "W2", "W3"});


### PR DESCRIPTION
This is a preparatory step on the way to merge #1772.

This PR does not change logic in any way, but it does change the `ZWEL` vector in the restart files and a data update will be required. 

With this PR the action name is added to the `ZWEL` array exactly at the report step when it evaluates to true; previously it was added to `ZWEL` also in situations where the action did not evaluate to true. Consider the action:
 ```
ACTIONX
    FALSE AND /
    WUPR '*' = 1 /
/ 
```
In this case the result object will evaluate to `false`, but the internal list of wells will still contain the name of all wells where the second condition applies[1] - and in current master those wells will be added to `ZWEL`. For this PR that is changed and the action name is only added to `ZWEL` for exactly the timestep where the action is true.

To me this seems Right&trade; but unfortunately it is not 100% identical to Eclipse. The situation is as follows:

**master:** Add to ZWEL for steps up to and including the "correct" step.

**eclipse:** Add to ZWEL for steps from the "correct" step and onwards (and maybe before as well)?

**this PR:** Add to ZWEL right at the "correct" step.


**Update:** Have added a second commit which very similar in spirit - in this case we need to check the overall action result before updating the `SACN` vector.

**Update 2:** Have added a third commit which will throw `std::logic_error()` if the internal wellset is accessed for a `ActionResult`which is overall `false`.

[1]: That is really an implementation detail - it does not make sense to peek into the well list for a result object which is overall `false`.