### PR TITLE
Add size to SOLVDIRS json

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOLVDIRS
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOLVDIRS
@@ -3,6 +3,7 @@
   "sections": [
     "GRID"
   ],
+  "size": 1,
   "items": [
     {
       "name": "DIRECTION",


### PR DESCRIPTION
Parsing a DATA deck with 
```
SOLVDIRS
   '-Y'  /
```
gives the error 
```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  
Failed to parse keyword: SOLVDIRS
In file /home/berland/xxxx.DATA, line 119

Error message: PARSE_EXTRA_DATA: The RawRecord for keyword "SOLVDIRS" in file"/home/bxxxxx.DATA" contained 2 too many items according to the spec. RawRecord was: PROPS
```

This is due to a missing `size` section in the corresponding  json, which is added in this PR.