### PR TITLE
changed rootfinders to return also when absolute tolerance is less th…

### DIFF
--- a/opm/common/utility/numeric/RootFinders.hpp
+++ b/opm/common/utility/numeric/RootFinders.hpp
@@ -124,7 +124,7 @@ namespace Opm
             iterations_used = 0;
             // In every iteraton, x1 is the last point computed,
             // and x0 is the last point computed that makes it a bracket.
-            while (fabs(x1 - x0) >= 1e-9*eps) {
+            while (fabs(x1 - x0) >= eps) {
                 double xnew = regulaFalsiStep(x0, x1, f0, f1);
                 double fnew = f(xnew);
 // 		cout << "xnew = " << xnew << "    fnew = " << fnew << endl;
@@ -221,7 +221,7 @@ namespace Opm
             iterations_used = 0;
             // In every iteraton, x1 is the last point computed,
             // and x0 is the last point computed that makes it a bracket.
-            while (fabs(x1 - x0) >= 1e-9*eps) {
+            while (fabs(x1 - x0) >= eps) {
                 double xnew = regulaFalsiStep(x0, x1, f0, f1);
                 double fnew = f(xnew);
 // 		cout << "xnew = " << xnew << "    fnew = " << fnew << endl;

--- a/opm/common/utility/numeric/RootFinders.hpp
+++ b/opm/common/utility/numeric/RootFinders.hpp
@@ -43,7 +43,7 @@ namespace Opm
         {
             OPM_THROW(std::runtime_error, "Maximum number of iterations exceeded: " << maxiter << "\n"
                   << "Current interval is [" << std::min(x0, x1) << ", "
-                  << std::max(x0, x1) << "]");
+                  << std::max(x0, x1) << "] abs(x0-x1) " << std::abs(x0-x1));
             return -1e100; // Never reached.
         }
     };
@@ -64,7 +64,7 @@ namespace Opm
             OPM_REPORT;
             std::cerr << "Maximum number of iterations exceeded: " << maxiter
                       << ", current interval is [" << std::min(x0, x1) << ", "
-                      << std::max(x0, x1) << "]";
+                      << std::max(x0, x1) << "]  abs(x0-x1) " << std::abs(x0-x1);
             return 0.5*(x0 + x1);
         }
     };
@@ -327,7 +327,7 @@ namespace Opm
             // and x0 is the last point computed that makes it a bracket.
             double width = fabs(x1 - x0);
             double contraction = 1.0;
-            while (width >= 1e-9 * eps) {
+            while (width >= eps) {
                 // If we are contracting sufficiently to at least halve
                 // the interval width in two iterations we use regula
                 // falsi. Otherwise, we take a bisection step to avoid


### PR DESCRIPTION
changed rootfinders to return when also when abs tol is less than tol.
In some cases the solver would not report convergence even if interval was 1e-17 when it was
solved for saturations.