### PR TITLE
Add missing <array> include.

### DIFF
--- a/src/opm/io/eclipse/EclUtil.cpp
+++ b/src/opm/io/eclipse/EclUtil.cpp
@@ -21,6 +21,7 @@
 #include <opm/common/ErrorMacros.hpp>
 
 #include <algorithm>
+#include <array>
 #include <stdexcept>
 #include <cmath>
 #include <fstream>


### PR DESCRIPTION
Compile fix for clang. Will self-merge when green, unless beat to it.