### PR TITLE
avoid designated initializer error

### DIFF
--- a/tests/test_ActiveGridCells.cpp
+++ b/tests/test_ActiveGridCells.cpp
@@ -32,9 +32,9 @@ BOOST_AUTO_TEST_CASE(testLocal) {
     Opm::GridDims dims(nx, ny, nz);
     std::vector<int> cells(9);
     std::set<std::array<std::size_t,3> > inactive;
-    inactive.insert({{0,0,0}});
-    inactive.insert({{1,1,0}});
-    inactive.insert({{1,0,1}});
+    inactive.insert({0,0,0});
+    inactive.insert({1,1,0});
+    inactive.insert({1,0,1});
 
     for(std::size_t k = 0, index = 0; k < nz; ++k)
     {


### PR DESCRIPTION
With the double braces, I get
```
/home/bernd/Dumux/opm-common/tests/test_ActiveGridCells.cpp: In member function ‘void Default::testLocal::test_method()’:
/home/bernd/Dumux/opm-common/tests/test_ActiveGridCells.cpp:36:30: error: ‘[0] =’ used in a GNU-style designated initializer for class ‘std::array<long unsigned int, 3>’
   36 |     inactive.insert({{1,1,0}});
      |                              ^
```
