### PR TITLE
Send error for required but disabled packages.

### DIFF
--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -106,8 +106,13 @@ macro (find_and_append_package_to prefix name)
 
   # if we're told not to look for the package, pretend it was never found
   if (CMAKE_DISABLE_FIND_PACKAGE_${name})
-	set (${name}_FOUND FALSE)
-	set (${NAME}_FOUND FALSE)
+    # If required send an error
+    cmake_parse_arguments(FIND "REQUIRED" "" "" ${ARGN} )
+    set (${name}_FOUND FALSE)
+    set (${NAME}_FOUND FALSE)
+    if (FIND_REQUIRED)
+        message(SEND_ERROR "package ${name} but disable with CMAKE_DISABLE_FIND_PACKAGE_${name}")
+    endif ()
   else ()
     # List of components might differ for every module. Therefore we will
     # need to research for a library multiple times. _search_components


### PR DESCRIPTION
When using CMAKE_DISABLE_FIND_PACKAGE_<name>=ON for a required package
CMake did not issue an errors since we never trigger the find_package
call. With this commit we now check whether such package is required
and send an error.