### PR TITLE
Rename SpiralICD -> SICD

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -113,7 +113,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.cpp
-    src/opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Network/Branch.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.cpp
@@ -717,7 +717,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
        opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
        opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.hpp
-       opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp
+       opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
        opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
@@ -33,12 +33,12 @@ namespace Opm {
     class DeckRecord;
     class DeckKeyword;
 
-    class SpiralICD {
+    class SICD {
     public:
 
-        SpiralICD();
-        explicit SpiralICD(const DeckRecord& record);
-        SpiralICD(double strength,
+        SICD();
+        explicit SICD(const DeckRecord& record);
+        SICD(double strength,
                   double length,
                   double densityCalibration,
                   double viscosityCalibration,
@@ -50,13 +50,13 @@ namespace Opm {
                   ICDStatus status,
                   double scalingFactor);
 
-        static SpiralICD serializeObject();
+        static SICD serializeObject();
 
         // the function will return a map
         // [
         //     "WELL1" : [<seg1, sicd1>, <seg2, sicd2> ...]
         //     ....
-        static std::map<std::string, std::vector<std::pair<int, SpiralICD> > >
+        static std::map<std::string, std::vector<std::pair<int, SICD> > >
         fromWSEGSICD(const DeckKeyword& wsegsicd);
 
         double maxAbsoluteRate() const;
@@ -73,7 +73,7 @@ namespace Opm {
         void updateScalingFactor(const double segment_length, const double completion_length);
         double scalingFactor() const;
         int ecl_status() const;
-        bool operator==(const SpiralICD& data) const;
+        bool operator==(const SICD& data) const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -24,7 +24,7 @@
 #include <vector>
 
 namespace Opm {
-    class SpiralICD;
+    class SICD;
     class Valve;
 
     namespace RestartIO {
@@ -78,10 +78,10 @@ namespace Opm {
         bool operator==( const Segment& ) const;
         bool operator!=( const Segment& ) const;
 
-        const std::shared_ptr<SpiralICD>& spiralICD() const;
+        const std::shared_ptr<SICD>& spiralICD() const;
         const Valve* valve() const;
 
-        void updateSpiralICD(const SpiralICD& spiral_icd);
+        void updateSpiralICD(const SICD& spiral_icd);
         void updateValve(const Valve& valve, const double segment_length);
         void addInletSegment(const int segment_number);
 
@@ -156,7 +156,7 @@ namespace Opm {
 
         // information related to SpiralICD. It is nullptr for segments are not
         // spiral ICD type
-        std::shared_ptr<SpiralICD> m_spiral_icd;
+        std::shared_ptr<SICD> m_spiral_icd;
 
         // information related to sub-critical valve. It is nullptr for segments are not
         // of type of Valve

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp
@@ -27,7 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp>
 
 namespace Opm {
-    class SpiralICD;
+    class SICD;
     class Valve;
 }
 
@@ -95,7 +95,7 @@ namespace Opm {
         std::set<int> branches() const;
 
         // it returns true if there is no error encountered during the update
-        bool updateWSEGSICD(const std::vector<std::pair<int, SpiralICD> >& sicd_pairs);
+        bool updateWSEGSICD(const std::vector<std::pair<int, SICD> >& sicd_pairs);
 
         bool updateWSEGVALV(const std::vector<std::pair<int, Valve> >& valve_pairs);
         const std::vector<Segment>::const_iterator begin() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -49,6 +49,7 @@ struct WellInjectionProperties;
 class WellProductionProperties;
 class UDQActive;
 class UDQConfig;
+class SICD;
 
 namespace RestartIO {
 struct RstWell;
@@ -538,7 +539,7 @@ public:
     bool updateEconLimits(std::shared_ptr<WellEconProductionLimits> econ_limits);
     bool updateProduction(std::shared_ptr<WellProductionProperties> production);
     bool updateInjection(std::shared_ptr<WellInjectionProperties> injection);
-    bool updateWSEGSICD(const std::vector<std::pair<int, SpiralICD> >& sicd_pairs);
+    bool updateWSEGSICD(const std::vector<std::pair<int, SICD> >& sicd_pairs);
     bool updateWSEGVALV(const std::vector<std::pair<int, Valve> >& valve_pairs);
 
     bool handleWELSEGS(const DeckKeyword& keyword);

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -24,7 +24,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.cpp
@@ -19,7 +19,7 @@
 */
 
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/icd.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
@@ -29,12 +29,12 @@
 
 namespace Opm {
 
-    SpiralICD::SpiralICD()
-        : SpiralICD(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0.0, ICDStatus::SHUT, 1.0)
+    SICD::SICD()
+        : SICD(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0.0, ICDStatus::SHUT, 1.0)
     {
     }
 
-    SpiralICD::SpiralICD(double strength,
+    SICD::SICD(double strength,
                          double length,
                          double densityCalibration,
                          double viscosityCalibration,
@@ -60,7 +60,7 @@ namespace Opm {
     }
 
 
-    SpiralICD::SpiralICD(const DeckRecord& record)
+    SICD::SICD(const DeckRecord& record)
             : m_strength(record.getItem("STRENGTH").getSIDouble(0)),
               m_length(record.getItem("LENGTH").getSIDouble(0)),
               m_density_calibration(record.getItem("DENSITY_CALI").getSIDouble(0)),
@@ -81,9 +81,9 @@ namespace Opm {
     }
 
 
-    SpiralICD SpiralICD::serializeObject()
+    SICD SICD::serializeObject()
     {
-        SpiralICD result;
+        SICD result;
         result.m_strength = 1.0;
         result.m_length = 2.0;
         result.m_density_calibration = 3.0;
@@ -99,10 +99,10 @@ namespace Opm {
         return result;
     }
 
-    std::map<std::string, std::vector<std::pair<int, SpiralICD> > >
-    SpiralICD::fromWSEGSICD(const DeckKeyword& wsegsicd)
+    std::map<std::string, std::vector<std::pair<int, SICD> > >
+    SICD::fromWSEGSICD(const DeckKeyword& wsegsicd)
     {
-        std::map<std::string, std::vector<std::pair<int, SpiralICD> > > res;
+        std::map<std::string, std::vector<std::pair<int, SICD> > > res;
 
         for (const DeckRecord &record : wsegsicd) {
             const std::string well_name = record.getItem("WELL").getTrimmedString(0);
@@ -118,7 +118,7 @@ namespace Opm {
                 throw std::invalid_argument(message);
             }
 
-            const SpiralICD spiral_icd(record);
+            const SICD spiral_icd(record);
             for (int seg = start_segment; seg <= end_segment; seg++) {
                 res[well_name].push_back(std::make_pair(seg, spiral_icd));
             }
@@ -127,51 +127,51 @@ namespace Opm {
         return res;
     }
 
-    double SpiralICD::maxAbsoluteRate() const {
+    double SICD::maxAbsoluteRate() const {
         return m_max_absolute_rate;
     }
 
-    ICDStatus SpiralICD::status() const {
+    ICDStatus SICD::status() const {
         return m_status;
     }
 
-    double SpiralICD::strength() const {
+    double SICD::strength() const {
         return m_strength;
     }
 
-    double SpiralICD::length() const {
+    double SICD::length() const {
         return m_length;
     }
 
-    double SpiralICD::densityCalibration() const {
+    double SICD::densityCalibration() const {
         return m_density_calibration;
     }
 
-    double SpiralICD::viscosityCalibration() const
+    double SICD::viscosityCalibration() const
     {
         return m_viscosity_calibration;
     }
 
-    double SpiralICD::criticalValue() const {
+    double SICD::criticalValue() const {
         return m_critical_value;
     }
 
-    double SpiralICD::widthTransitionRegion() const
+    double SICD::widthTransitionRegion() const
     {
         return m_width_transition_region;
     }
 
-    double SpiralICD::maxViscosityRatio() const
+    double SICD::maxViscosityRatio() const
     {
         return m_max_viscosity_ratio;
     }
 
-    int SpiralICD::methodFlowScaling() const
+    int SICD::methodFlowScaling() const
     {
         return m_method_flow_scaling;
     }
 
-    double SpiralICD::scalingFactor() const
+    double SICD::scalingFactor() const
     {
         if (m_scaling_factor <= 0.)
             throw std::runtime_error("the scaling factor has invalid value " + std::to_string(m_scaling_factor));
@@ -179,7 +179,7 @@ namespace Opm {
         return m_scaling_factor;
     }
 
-    void SpiralICD::updateScalingFactor(const double outlet_segment_length, const double completion_length)
+    void SICD::updateScalingFactor(const double outlet_segment_length, const double completion_length)
     {
         if (m_method_flow_scaling < 0) {
             if (m_length > 0.) { // icd length / outlet segment length
@@ -207,7 +207,7 @@ namespace Opm {
     }
 
 
-    bool SpiralICD::operator==(const SpiralICD& data) const {
+    bool SICD::operator==(const SICD& data) const {
         return this->strength() == data.strength() &&
                this->length() == data.length() &&
                this->densityCalibration() == data.densityCalibration() &&
@@ -221,7 +221,7 @@ namespace Opm {
                this->scalingFactor() == data.scalingFactor();
     }
 
-int SpiralICD::ecl_status() const {
+int SICD::ecl_status() const {
     return to_int(this->m_status);
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
@@ -19,7 +19,7 @@
 
 #include <opm/io/eclipse/rst/segment.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 
 #include <cassert>
@@ -77,17 +77,17 @@ namespace {
         if (this->m_segment_type == SegmentType::SICD) {
             double scalingFactor = -1;  // The scaling factor will be and updated from the simulator.
 
-            SpiralICD icd(rst_segment.base_strength,
-                          rst_segment.icd_length,
-                          rst_segment.fluid_density,
-                          rst_segment.fluid_viscosity,
-                          rst_segment.critical_water_fraction,
-                          rst_segment.transition_region_width,
-                          rst_segment.max_emulsion_ratio,
-                          rst_segment.icd_scaling_mode,
-                          rst_segment.max_valid_flow_rate,
-                          rst_segment.icd_status,
-                          scalingFactor);
+            SICD icd(rst_segment.base_strength,
+                    rst_segment.icd_length,
+                    rst_segment.fluid_density,
+                    rst_segment.fluid_viscosity,
+                    rst_segment.critical_water_fraction,
+                    rst_segment.transition_region_width,
+                    rst_segment.max_emulsion_ratio,
+                    rst_segment.icd_scaling_mode,
+                    rst_segment.max_valid_flow_rate,
+                    rst_segment.icd_status,
+                    scalingFactor);
 
             this->updateSpiralICD(icd);
         }
@@ -179,7 +179,7 @@ namespace {
       result.m_volume = 11.0;
       result.m_data_ready = true;
       result.m_segment_type = SegmentType::SICD;
-      result.m_spiral_icd = std::make_shared<SpiralICD>(SpiralICD::serializeObject());
+      result.m_spiral_icd = std::make_shared<SICD>(SICD::serializeObject());
       result.m_valve = std::make_shared<Valve>(Valve::serializeObject());
 
       return result;
@@ -265,12 +265,12 @@ namespace {
         return !this->operator==(rhs);
     }
 
-    void Segment::updateSpiralICD(const SpiralICD& spiral_icd) {
+    void Segment::updateSpiralICD(const SICD& spiral_icd) {
         m_segment_type = SegmentType::SICD;
-        m_spiral_icd = std::make_shared<SpiralICD>(spiral_icd);
+        m_spiral_icd = std::make_shared<SICD>(spiral_icd);
     }
 
-    const std::shared_ptr<SpiralICD>& Segment::spiralICD() const {
+    const std::shared_ptr<SICD>& Segment::spiralICD() const {
         return m_spiral_icd;
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
@@ -32,7 +32,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
 
@@ -507,7 +507,7 @@ namespace Opm {
         return segments;
     }
 
-    bool WellSegments::updateWSEGSICD(const std::vector<std::pair<int, SpiralICD> >& sicd_pairs) {
+    bool WellSegments::updateWSEGSICD(const std::vector<std::pair<int, SICD> >& sicd_pairs) {
         if (m_comp_pressure_drop == CompPressureDrop::H__) {
             const std::string msg = "to use spiral ICD segment you have to activate the frictional pressure drop calculation";
             throw std::runtime_error(msg);
@@ -515,7 +515,7 @@ namespace Opm {
 
         for (const auto& pair_elem : sicd_pairs) {
             const int segment_number = pair_elem.first;
-            const SpiralICD& spiral_icd = pair_elem.second;
+            const SICD& spiral_icd = pair_elem.second;
             Segment segment = this->getFromSegmentNumber(segment_number);
             segment.updateSpiralICD(spiral_icd);
             this->addSegment(segment);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -51,7 +51,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/updatingConnectionsWithSegments.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
@@ -2105,13 +2105,12 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext&
 
     void Schedule::handleWSEGSICD( const DeckKeyword& keyword, size_t currentStep) {
 
-        const std::map<std::string, std::vector<std::pair<int, SpiralICD> > > spiral_icds =
-                                SpiralICD::fromWSEGSICD(keyword);
+        const std::map<std::string, std::vector<std::pair<int, SICD> > > spiral_icds = SICD::fromWSEGSICD(keyword);
 
         for (const auto& map_elem : spiral_icds) {
             const std::string& well_name_pattern = map_elem.first;
             const auto well_names = this->wellNames(well_name_pattern, currentStep);
-            const std::vector<std::pair<int, SpiralICD> >& sicd_pairs = map_elem.second;
+            const std::vector<std::pair<int, SICD> >& sicd_pairs = map_elem.second;
 
             for (const auto& well_name : well_names) {
                 auto& dynamic_state = this->wells_static.at(well_name);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -960,7 +960,7 @@ bool Well::updatePVTTable(int pvt_table_) {
 }
 
 
-bool Well::updateWSEGSICD(const std::vector<std::pair<int, SpiralICD> >& sicd_pairs) {
+bool Well::updateWSEGSICD(const std::vector<std::pair<int, SICD> >& sicd_pairs) {
     auto new_segments = std::make_shared<WellSegments>(*this->segments);
     if (new_segments->updateWSEGSICD(sicd_pairs)) {
         this->segments = new_segments;

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -35,7 +35,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     BOOST_CHECK_EQUAL(8, start_segment);
     BOOST_CHECK_EQUAL(8, end_segment);
 
-    const auto sicd_map = Opm::SpiralICD::fromWSEGSICD(wsegsicd);
+    const auto sicd_map = Opm::SICD::fromWSEGSICD(wsegsicd);
 
     BOOST_CHECK_EQUAL(1U, sicd_map.size());
 
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     const auto& sicd_vector = it->second;
     BOOST_CHECK_EQUAL(1U, sicd_vector.size());
     const int segment_number = sicd_vector[0].first;
-    const Opm::SpiralICD& sicd = sicd_vector[0].second;
+    const Opm::SICD& sicd = sicd_vector[0].second;
 
     BOOST_CHECK_EQUAL(8, segment_number);
 
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
 
     BOOST_CHECK(Opm::Segment::SegmentType::SICD==segment.segmentType());
 
-    const std::shared_ptr<Opm::SpiralICD> sicd_ptr = segment.spiralICD();
+    const std::shared_ptr<Opm::SICD> sicd_ptr = segment.spiralICD();
     BOOST_CHECK_GT(sicd_ptr->maxAbsoluteRate(), 1.e99);
     BOOST_CHECK(sicd_ptr->status()==Opm::ICDStatus::SHUT);
     // 0.002 bars*day*day/Volume^2


### PR DESCRIPTION
This PR is a preparation for implementing AICD support in opm-common. Turns out that AICD is a perfect superset of SICD  - the plan is therefor to have one `ICD` with some extra optional `AICD`settings. The very first step - which is this PR - is to rename the `SpiralICD` class to the more generic `ICD`. 