### PR TITLE
Use std::variant<> to hold ICD alternatives

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -105,7 +105,7 @@ namespace Opm {
         bool operator!=( const Segment& ) const;
 
         const SICD& spiralICD() const;
-        const Valve* valve() const;
+        const Valve& valve() const;
 
         void updatePerfLength(double perf_length);
         void updateSpiralICD(const SICD& spiral_icd);

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -21,19 +21,43 @@
 #define SEGMENT_HPP_HEADER_INCLUDED
 
 #include <optional>
-#include <memory>
+#include <variant>
 #include <vector>
 
-namespace Opm {
-    class SICD;
-    class Valve;
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp>
 
+
+namespace Opm {
     namespace RestartIO {
         struct RstSegment;
     }
 }
 
 namespace Opm {
+
+    /*
+      The current serialization of std::variant<> requires that all the types in
+      the variant have serializeOp() method, that is why this RegularSegment
+      type is introduced, ideally the icd variant should just have
+      std::monostate to represent the regular non ICD segment.
+    */
+    struct RegularSegment : std::monostate {
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer) {
+        }
+
+        static RegularSegment serializeObject() {
+            return RegularSegment();
+        }
+
+
+        bool operator==(const RegularSegment& ) {
+            return true;
+        }
+    };
+
 
     class Segment {
     public:
@@ -51,7 +75,7 @@ namespace Opm {
         Segment(const Segment& src, double new_depth, double new_length);
         Segment(const Segment& src, double new_volume);
         Segment(int segment_number_in, int branch_in, int outlet_segment_in, double length_in, double depth_in,
-                double internal_diameter_in, double roughness_in, double cross_area_in, double volume_in, bool data_ready_in, SegmentType segment_type_in);
+                double internal_diameter_in, double roughness_in, double cross_area_in, double volume_in, bool data_ready_in);
         Segment(const RestartIO::RstSegment& rst_segment);
 
         static Segment serializeObject();
@@ -80,7 +104,7 @@ namespace Opm {
         bool operator==( const Segment& ) const;
         bool operator!=( const Segment& ) const;
 
-        const std::shared_ptr<SICD>& spiralICD() const;
+        const SICD& spiralICD() const;
         const Valve* valve() const;
 
         void updatePerfLength(double perf_length);
@@ -88,6 +112,21 @@ namespace Opm {
         void updateValve(const Valve& valve, const double segment_length);
         void updateValve(const Valve& valve);
         void addInletSegment(const int segment_number);
+
+        bool isRegular() const
+        {
+            return std::holds_alternative<RegularSegment>(this->m_icd);
+        }
+
+        inline bool isSpiralICD() const
+        {
+            return std::holds_alternative<SICD>(this->m_icd);
+        }
+
+        inline bool isValve() const
+        {
+            return std::holds_alternative<Valve>(this->m_icd);
+        }
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -104,9 +143,7 @@ namespace Opm {
             serializer(m_volume);
             serializer(m_data_ready);
             serializer(m_perf_length);
-            serializer(m_segment_type);
-            serializer(m_spiral_icd);
-            serializer(m_valve);
+            serializer(m_icd);
         }
 
     private:
@@ -157,17 +194,7 @@ namespace Opm {
         bool m_data_ready;
 
         std::optional<double> m_perf_length;
-        // indicate the type of the segment
-        // regular, spiral ICD, or Valve.
-        SegmentType m_segment_type;
-
-        // information related to SpiralICD. It is nullptr for segments are not
-        // spiral ICD type
-        std::shared_ptr<SICD> m_spiral_icd;
-
-        // information related to sub-critical valve. It is nullptr for segments are not
-        // of type of Valve
-        std::shared_ptr<Valve> m_valve;
+        std::variant<RegularSegment, SICD, Valve> m_icd;
 
         // We are not handling the length of segment projected onto the X-axis and Y-axis.
         // They are not used in the simulations and we are not supporting the plotting.
@@ -175,20 +202,6 @@ namespace Opm {
         // while they are not supported by the keyword at the moment.
     };
 
-    inline bool isRegular(const Segment& segment)
-    {
-        return segment.segmentType() == Segment::SegmentType::REGULAR;
-    }
-
-    inline bool isSpiralICD(const Segment& segment)
-    {
-        return segment.segmentType() == Segment::SegmentType::SICD;
-    }
-
-    inline bool isValve(const Segment& segment)
-    {
-        return segment.segmentType() == Segment::SegmentType::VALVE;
-    }
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/icd.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/icd.hpp
@@ -28,13 +28,6 @@ enum class ICDStatus {
     SHUT
 };
 
-template<typename T>
-T from_int(int int_status);
-
-template<typename T>
-int to_int(T status);
-
 }
-
 
 #endif

--- a/src/opm/io/eclipse/rst/segment.cpp
+++ b/src/opm/io/eclipse/rst/segment.cpp
@@ -23,6 +23,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
+#include "src/opm/parser/eclipse/EclipseState/Schedule/MSW/icd_convert.hpp"
+
 namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 
 namespace Opm {

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -543,17 +543,17 @@ namespace {
             using Ix = ::Opm::RestartIO::Helpers::VectorItems::RSeg::index;
             using M  = ::Opm::UnitSystem::measure;
 
-            const auto* valve = segment.valve();
+            const auto& valve = segment.valve();
 
             rSeg[baseIndex + Ix::ValveLength] =
-                usys.from_si(M::length, valve->pipeAdditionalLength());
+                usys.from_si(M::length, valve.pipeAdditionalLength());
 
             rSeg[baseIndex + Ix::ValveArea] =
-                usys.from_si(M::length, usys.from_si(M::length, valve->conCrossArea()));
+                usys.from_si(M::length, usys.from_si(M::length, valve.conCrossArea()));
 
-            rSeg[baseIndex + Ix::ValveFlowCoeff] = valve->conFlowCoefficient();
+            rSeg[baseIndex + Ix::ValveFlowCoeff] = valve.conFlowCoefficient();
             rSeg[baseIndex + Ix::ValveMaxArea]   =
-                usys.from_si(M::length, usys.from_si(M::length, valve->conMaxCrossArea()));
+                usys.from_si(M::length, usys.from_si(M::length, valve.conMaxCrossArea()));
 
             const auto Cu   = valveFlowUnitCoefficient(usys.getType());
             const auto CvAc = rSeg[baseIndex + Ix::ValveFlowCoeff]

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -424,8 +424,8 @@ namespace {
                 VectorItems::ISeg::index;
 
             const auto& sicd = segment.spiralICD();
-            iSeg[baseIndex + Ix::ICDScalingMode] = sicd->methodFlowScaling();
-            iSeg[baseIndex + Ix::ICDOpenShutFlag] = sicd->ecl_status();
+            iSeg[baseIndex + Ix::ICDScalingMode] = sicd.methodFlowScaling();
+            iSeg[baseIndex + Ix::ICDOpenShutFlag] = sicd.ecl_status();
         }
 
         template <class ISegArray>
@@ -433,7 +433,7 @@ namespace {
                                               const std::size_t   baseIndex,
                                               ISegArray&          iSeg)
         {
-            if (isSpiralICD(segment)) {
+            if (segment.isSpiralICD()) {
                 assignSpiralICDCharacteristics(segment, baseIndex, iSeg);
             }
         }
@@ -474,7 +474,7 @@ namespace {
                     iSeg[iS + 8] = seg_reorder[ind];
 
                     iSeg[iS + Ix::SegmentType] = segment.ecl_type_id();
-                    if (! isRegular(segment)) {
+                    if (! segment.isRegular()) {
                         assignSegmentTypeCharacteristics(segment, iS, iSeg);
                     }
                 }
@@ -577,27 +577,27 @@ namespace {
             const auto& sicd = segment.spiralICD();
 
             rSeg[baseIndex + Ix::DeviceBaseStrength] =
-                usys.from_si(M::icd_strength, sicd->strength());
+                usys.from_si(M::icd_strength, sicd.strength());
 
             rSeg[baseIndex + Ix::CalibrFluidDensity] =
-                usys.from_si(M::density, sicd->densityCalibration());
+                usys.from_si(M::density, sicd.densityCalibration());
 
             rSeg[baseIndex + Ix::CalibrFluidViscosity] =
-                usys.from_si(M::viscosity, sicd->viscosityCalibration());
+                usys.from_si(M::viscosity, sicd.viscosityCalibration());
 
-            rSeg[baseIndex + Ix::CriticalWaterFraction] = sicd->criticalValue();
+            rSeg[baseIndex + Ix::CriticalWaterFraction] = sicd.criticalValue();
 
             rSeg[baseIndex + Ix::TransitionRegWidth] =
-                sicd->widthTransitionRegion();
+                sicd.widthTransitionRegion();
 
             rSeg[baseIndex + Ix::MaxEmulsionRatio] =
-                sicd->maxViscosityRatio();
+                sicd.maxViscosityRatio();
 
             rSeg[baseIndex + Ix::MaxValidFlowRate] =
-                usys.from_si(M::geometric_volume_rate, sicd->maxAbsoluteRate());
+                usys.from_si(M::geometric_volume_rate, sicd.maxAbsoluteRate());
 
             rSeg[baseIndex + Ix::ICDLength] =
-                usys.from_si(M::length, sicd->length());
+                usys.from_si(M::length, sicd.length());
         }
 
         template <class RSegArray>
@@ -606,11 +606,11 @@ namespace {
                                               const int                baseIndex,
                                               RSegArray&               rSeg)
         {
-            if (isSpiralICD(segment)) {
+            if (segment.isSpiralICD()) {
                 assignSpiralICDCharacteristics(segment, usys, baseIndex, rSeg);
             }
 
-            if (isValve(segment)) {
+            if (segment.isValve()) {
                 assignValveCharacteristics(segment, usys, baseIndex, rSeg);
             }
         }
@@ -760,7 +760,7 @@ namespace {
                     rSeg[iS + Ix::item110] = 1.0;
                     rSeg[iS + Ix::item111] = 1.0;
 
-                    if (! isRegular(segment)) {
+                    if (! segment.isRegular()) {
                         assignSegmentTypeCharacteristics(segment, units, iS, rSeg);
                     }
                 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.cpp
@@ -26,6 +26,8 @@
 #include <limits>
 #include <cmath>
 
+#include "src/opm/parser/eclipse/EclipseState/Schedule/MSW/icd_convert.hpp"
+
 
 namespace Opm {
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
@@ -274,17 +274,12 @@ namespace {
         return std::get<SICD>(this->m_icd);
     }
 
-    void Segment::updateValve(const Valve& valve) {
-        if (valve.pipeAdditionalLength() < 0)
-            throw std::logic_error("Bug in handling of pipe length for valves");
 
-    void Segment::updateValve(const Valve& input_valve, const double segment_length) {
+    void Segment::updateValve(const Valve& input_valve) {
         // we need to update some values for the vale
         auto valve = input_valve;
-
-        if (valve.pipeAdditionalLength() < 0.) { // defaulted for this
-            valve.setPipeAdditionalLength(segment_length);
-        }
+        if (valve.pipeAdditionalLength() < 0)
+            throw std::logic_error("Bug in handling of pipe length for valves");
 
         if (valve.pipeDiameter() < 0.) {
             valve.setPipeDiameter(m_internal_diameter);
@@ -330,9 +325,8 @@ namespace {
    }
 
 
-    const Valve* Segment::valve() const {
-        return &std::get<Valve>(this->m_icd);
-        //return m_valve.get();
+    const Valve& Segment::valve() const {
+        return std::get<Valve>(this->m_icd);
     }
 
     int Segment::ecl_type_id() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.cpp
@@ -142,12 +142,12 @@ namespace Opm {
         if (length_depth_type == LengthDepth::INC) {
             m_segments.emplace_back( 1, 1, 0, 0., 0.,
                                      invalid_value, invalid_value, invalid_value,
-                                     volume_top, false , Segment::SegmentType::REGULAR);
+                                     volume_top, false);
 
         } else if (length_depth_type == LengthDepth::ABS) {
             m_segments.emplace_back( 1, 1, 0, length_top, depth_top,
                                      invalid_value, invalid_value, invalid_value,
-                                     volume_top, true , Segment::SegmentType::REGULAR);
+                                     volume_top, true);
         }
 
         // read all the information out from the DECK first then process to get all the required information
@@ -207,13 +207,13 @@ namespace Opm {
 
                 if (length_depth_type == LengthDepth::INC) {
                     m_segments.emplace_back( i, branch, outlet_segment, segment_length, depth_change,
-                                             diameter, roughness, area, volume, false , Segment::SegmentType::REGULAR);
+                                             diameter, roughness, area, volume, false);
                 } else if (i == segment2) {
                     m_segments.emplace_back( i, branch, outlet_segment, segment_length, depth_change,
-                                             diameter, roughness, area, volume, true , Segment::SegmentType::REGULAR);
+                                             diameter, roughness, area, volume, true);
                 } else {
                     m_segments.emplace_back( i, branch, outlet_segment, invalid_value, invalid_value,
-                                             diameter, roughness, area, volume, false , Segment::SegmentType::REGULAR);
+                                             diameter, roughness, area, volume, false);
                 }
             }
         }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/icd.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/icd.cpp
@@ -20,6 +20,8 @@
 #include <stdexcept>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/icd.hpp>
 
+#include "icd_convert.hpp"
+
 namespace Opm {
 
 template <>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/icd_convert.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/icd_convert.hpp
@@ -1,0 +1,14 @@
+#ifndef OPM_ICD_CONVERT_HPP
+#define OPM_ICD_CONVERT_HPP
+
+namespace Opm {
+
+template<typename T>
+T from_int(int int_status);
+
+template<typename T>
+int to_int(T status);
+
+}
+
+#endif

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -402,15 +402,15 @@ BOOST_AUTO_TEST_CASE(testwsegvalv) {
     segment1.updateValve(valve1, segment_length1);
     BOOST_CHECK(Opm::Segment::SegmentType::VALVE==segment1.segmentType());
 
-    const Opm::Valve* valv1 = segment1.valve();
-    BOOST_CHECK_EQUAL(valv1->conFlowCoefficient(), 0.002);
-    BOOST_CHECK_EQUAL(valv1->conCrossArea(), 5.);
-    BOOST_CHECK_EQUAL(valv1->conMaxCrossArea(), 0.031415926535897934);
-    BOOST_CHECK_CLOSE(valv1->pipeAdditionalLength(), 0.1, 1.e-10);
-    BOOST_CHECK_EQUAL(valv1->pipeDiameter(), 0.2);
-    BOOST_CHECK_EQUAL(valv1->pipeRoughness(), 0.00015);
-    BOOST_CHECK_EQUAL(valv1->pipeCrossArea(), 0.031415926535897934);
-    BOOST_CHECK(valv1->status()==Opm::ICDStatus::OPEN);
+    const Opm::Valve& valv1 = segment1.valve();
+    BOOST_CHECK_EQUAL(valv1.conFlowCoefficient(), 0.002);
+    BOOST_CHECK_EQUAL(valv1.conCrossArea(), 5.);
+    BOOST_CHECK_EQUAL(valv1.conMaxCrossArea(), 0.031415926535897934);
+    BOOST_CHECK_CLOSE(valv1.pipeAdditionalLength(), 0.1, 1.e-10);
+    BOOST_CHECK_EQUAL(valv1.pipeDiameter(), 0.2);
+    BOOST_CHECK_EQUAL(valv1.pipeRoughness(), 0.00015);
+    BOOST_CHECK_EQUAL(valv1.pipeCrossArea(), 0.031415926535897934);
+    BOOST_CHECK(valv1.status()==Opm::ICDStatus::OPEN);
 
     const int segment_number2 = segvalv_vector[1].first;
     BOOST_CHECK_EQUAL(9, segment_number2);
@@ -425,20 +425,20 @@ BOOST_AUTO_TEST_CASE(testwsegvalv) {
     segment2.updateValve(valve2, segment_length2);
     BOOST_CHECK(Opm::Segment::SegmentType::VALVE ==segment2.segmentType());
 
-    const Opm::Valve* valv2 = segment2.valve();
-    BOOST_CHECK_EQUAL(valv2->conFlowCoefficient(), 0.001);
-    BOOST_CHECK_EQUAL(valv2->conCrossArea(), 6.);
-    BOOST_CHECK_EQUAL(valv2->conMaxCrossArea(), 9.);
-    BOOST_CHECK_EQUAL(valv2->pipeAdditionalLength(), 0.0);
-    BOOST_CHECK_EQUAL(valv2->pipeDiameter(), 1.2);
-    BOOST_CHECK_EQUAL(valv2->pipeRoughness(), 0.1);
-    BOOST_CHECK_EQUAL(valv2->pipeCrossArea(), 8.);
-    BOOST_CHECK(valv2->status()==Opm::ICDStatus::SHUT);
+    const Opm::Valve& valv2 = segment2.valve();
+    BOOST_CHECK_EQUAL(valv2.conFlowCoefficient(), 0.001);
+    BOOST_CHECK_EQUAL(valv2.conCrossArea(), 6.);
+    BOOST_CHECK_EQUAL(valv2.conMaxCrossArea(), 9.);
+    BOOST_CHECK_EQUAL(valv2.pipeAdditionalLength(), 0.0);
+    BOOST_CHECK_EQUAL(valv2.pipeDiameter(), 1.2);
+    BOOST_CHECK_EQUAL(valv2.pipeRoughness(), 0.1);
+    BOOST_CHECK_EQUAL(valv2.pipeCrossArea(), 8.);
+    BOOST_CHECK(valv2.status()==Opm::ICDStatus::SHUT);
 
     // valve changes the segment data
-    BOOST_CHECK_EQUAL(segment2.internalDiameter(), valv2->pipeDiameter());
-    BOOST_CHECK_EQUAL(segment2.roughness(), valv2->pipeRoughness());
-    BOOST_CHECK_EQUAL(segment2.crossArea(), valv2->pipeCrossArea());
+    BOOST_CHECK_EQUAL(segment2.internalDiameter(), valv2.pipeDiameter());
+    BOOST_CHECK_EQUAL(segment2.roughness(), valv2.pipeRoughness());
+    BOOST_CHECK_EQUAL(segment2.crossArea(), valv2.pipeCrossArea());
 }
 
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -126,30 +126,30 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     const auto& sicd_vector = it->second;
     BOOST_CHECK_EQUAL(1U, sicd_vector.size());
     const int segment_number = sicd_vector[0].first;
-    const Opm::SICD& sicd = sicd_vector[0].second;
+    const Opm::SICD& sicd0 = sicd_vector[0].second;
 
     BOOST_CHECK_EQUAL(8, segment_number);
 
     Opm::Segment segment = segment_set.getFromSegmentNumber(segment_number);
-    segment.updateSpiralICD(sicd);
+    segment.updateSpiralICD(sicd0);
 
     BOOST_CHECK(Opm::Segment::SegmentType::SICD==segment.segmentType());
 
-    const std::shared_ptr<Opm::SICD> sicd_ptr = segment.spiralICD();
-    BOOST_CHECK_GT(sicd_ptr->maxAbsoluteRate(), 1.e99);
-    BOOST_CHECK(sicd_ptr->status()==Opm::ICDStatus::SHUT);
+    auto sicd = segment.spiralICD();
+    BOOST_CHECK_GT(sicd.maxAbsoluteRate(), 1.e99);
+    BOOST_CHECK(sicd.status()==Opm::ICDStatus::SHUT);
     // 0.002 bars*day*day/Volume^2
-    BOOST_CHECK_EQUAL(sicd_ptr->strength(), 0.002*1.e5*86400.*86400.);
-    BOOST_CHECK_EQUAL(sicd_ptr->length(), -0.7);
-    BOOST_CHECK_EQUAL(sicd_ptr->densityCalibration(), 1000.25);
+    BOOST_CHECK_EQUAL(sicd.strength(), 0.002*1.e5*86400.*86400.);
+    BOOST_CHECK_EQUAL(sicd.length(), -0.7);
+    BOOST_CHECK_EQUAL(sicd.densityCalibration(), 1000.25);
     // 1.45 cp
-    BOOST_CHECK_EQUAL(sicd_ptr->viscosityCalibration(), 1.45 * 0.001);
-    BOOST_CHECK_EQUAL(sicd_ptr->criticalValue(), 0.6);
-    BOOST_CHECK_EQUAL(sicd_ptr->widthTransitionRegion(), 0.05);
-    BOOST_CHECK_EQUAL(sicd_ptr->maxViscosityRatio(), 5.0);
-    BOOST_CHECK_EQUAL(sicd_ptr->methodFlowScaling(), -1);
+    BOOST_CHECK_EQUAL(sicd.viscosityCalibration(), 1.45 * 0.001);
+    BOOST_CHECK_EQUAL(sicd.criticalValue(), 0.6);
+    BOOST_CHECK_EQUAL(sicd.widthTransitionRegion(), 0.05);
+    BOOST_CHECK_EQUAL(sicd.maxViscosityRatio(), 5.0);
+    BOOST_CHECK_EQUAL(sicd.methodFlowScaling(), -1);
     // the scaling factor has not been updated properly, so it will throw
-    BOOST_CHECK_THROW(sicd_ptr->scalingFactor(), std::runtime_error);
+    BOOST_CHECK_THROW(sicd.scalingFactor(), std::runtime_error);
 
     const int outlet_segment_number = segment.outletSegment();
     const double outlet_segment_length = segment_set.segmentLength(outlet_segment_number);
@@ -157,11 +157,11 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     const Opm::Connection& connection = new_connection_set.getFromIJK(15, 0, 1);
     const auto& perf_range = connection.perf_range();
     const auto connection_length = perf_range->second - perf_range->first;
-    sicd_ptr->updateScalingFactor(outlet_segment_length, connection_length);
+    sicd.updateScalingFactor(outlet_segment_length, connection_length);
 
     // updated, so it should not throw
-    BOOST_CHECK_NO_THROW(sicd_ptr->scalingFactor());
-    BOOST_CHECK_EQUAL(0.7, sicd_ptr->scalingFactor());
+    BOOST_CHECK_NO_THROW(sicd.scalingFactor());
+    BOOST_CHECK_EQUAL(0.7, sicd.scalingFactor());
 
     BOOST_CHECK_EQUAL(7U, new_connection_set.size());
 


### PR DESCRIPTION
The `Segment`type can have exactly one ICD type attached - `std::variant<>` models this quite well.

@akva2 : Any hints on how to get this through the serialization? 