### PR TITLE
Ensure clang uses the normal standard headers.

### DIFF
--- a/opm/common/utility/FileSystem.hpp
+++ b/opm/common/utility/FileSystem.hpp
@@ -20,7 +20,7 @@
 #define OPM_FILESYSTEM_HPP
 
 #if __cplusplus < 201703L || \
-    (defined(__GNUC__) && __GNUC__ < 8)
+    (defined(__GNUC__) && __GNUC__ < 8 && !defined(__clang__))
 #include <experimental/filesystem>
 #else
 #include <filesystem>
@@ -32,7 +32,7 @@
 namespace Opm
 {
 #if __cplusplus < 201703L || \
-    (defined(__GNUC__) && __GNUC__ < 8)
+    (defined(__GNUC__) && __GNUC__ < 8 && !defined(__clang__))
     namespace filesystem = std::experimental::filesystem;
 #else
     namespace filesystem = std::filesystem;


### PR DESCRIPTION
Clang defines `__GNUC__` to 4, as that represents its level of support for the GNU C dialect. The gcc compiler does not provide a macro indicating the compiler separately from the dialect supported. We must therefore use the `__clang__` macro to avoid false positives.