### PR TITLE
fixed: reorder logging and update call

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2796,11 +2796,11 @@ void Schedule::invalidNamePattern( const std::string& namePattern,  std::size_t 
             const auto& well = this->getWell(wname, timeStep);
             const auto& connections = well.getConnections();
             if (connections.allConnectionsShut() && well.getStatus() != Well::Status::SHUT) {
-                this->updateWellStatus( well.name(), timeStep, Well::Status::SHUT, false);
                 std::string msg =
                     "All completions in well " + well.name() + " is shut at " + std::to_string ( m_timeMap.getTimePassedUntil(timeStep) / (60*60*24) ) + " days. \n" +
                     "The well is therefore also shut.";
                 OpmLog::note(msg);
+                this->updateWellStatus( well.name(), timeStep, Well::Status::SHUT, false);
             }
         }
     }


### PR DESCRIPTION
the update call can invalidate the reference since the underlying
smart pointer is replaced, and when there are no remaining references,
it is deleted.