### PR TITLE
Reshuffle segments and connections after restart

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.hpp
@@ -86,6 +86,7 @@ namespace Opm {
         void updatePerfLength(double perf_length);
         void updateSpiralICD(const SICD& spiral_icd);
         void updateValve(const Valve& valve, const double segment_length);
+        void updateValve(const Valve& valve);
         void addInletSegment(const int segment_number);
 
         template<class Serializer>
@@ -109,6 +110,7 @@ namespace Opm {
         }
 
     private:
+        void updateValve__(Valve& valve, const double segment_length);
         // segment number
         // it should work as a ID.
         int m_segment_number;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.hpp
@@ -21,15 +21,23 @@
 #ifndef COMPSEGS_HPP_
 #define COMPSEGS_HPP_
 
+#include <unordered_map>
+#include <vector>
 
 namespace Opm {
 
+    class Segment;
+    class Connection;
     class WellConnections;
     class DeckKeyword;
     class WellSegments;
     class EclipseGrid;
     class ParseContext;
     class ErrorGuard;
+
+namespace RestartIO {
+    class RstWell;
+}
 
 namespace Compsegs {
 
@@ -50,6 +58,11 @@ namespace Compsegs {
                     const ParseContext& parseContext,
                     ErrorGuard& errors);
 
+
+    std::pair<WellConnections, WellSegments>
+    rstUpdate(const RestartIO::RstWell& rst_well,
+              std::vector<Connection> input_connections,
+              const std::unordered_map<int, Segment>& input_segments);
 }
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
@@ -113,15 +113,7 @@ namespace {
                         pipeCrossA,
                         rst_segment.icd_status);
 
-            /*
-              The segment length argument should be the length of this
-              particular segment; in the input phase that is calculated from the
-              WellSegments::segmentLength() function which also uses the outlet
-              segment.
-            */
-            double segment_length = -1;
-            throw std::logic_error("Sorry can not create a Valve segment from restart file");
-            this->updateValve(valve, segment_length);
+            this->updateValve(valve);
         }
     }
 
@@ -278,14 +270,12 @@ namespace {
         return m_spiral_icd;
     }
 
+    void Segment::updateValve(const Valve& valve) {
+        if (valve.pipeAdditionalLength() < 0)
+            throw std::logic_error("Bug in handling of pipe length for valves");
 
-    void Segment::updateValve(const Valve& valve, const double segment_length) {
         // we need to update some values for the vale
         auto valve_ptr = std::make_shared<Valve>(valve);
-
-        if (valve_ptr->pipeAdditionalLength() < 0.) { // defaulted for this
-            valve_ptr->setPipeAdditionalLength(segment_length);
-        }
 
         if (valve_ptr->pipeDiameter() < 0.) {
             valve_ptr->setPipeDiameter(m_internal_diameter);
@@ -312,6 +302,19 @@ namespace {
         this->m_valve = valve_ptr;
 
         m_segment_type = SegmentType::VALVE;
+    }
+
+
+    void Segment::updateValve__(Valve& valve, const double segment_length) {
+        if (valve.pipeAdditionalLength() < 0)
+            valve.setPipeAdditionalLength(segment_length);
+
+        this->updateValve(valve);
+    }
+
+    void Segment::updateValve(const Valve& valve, const double segment_length) {
+        auto new_valve = valve;
+        this->updateValve__(new_valve, segment_length);
     }
 
 


### PR DESCRIPTION
This work aims to enable restart of segment ICD's.

@jalvestad: You could try to give this a spin to investigate the problem with restarting models with valves.