### PR TITLE
changed: move build timestamp to separate header

### DIFF
--- a/cmake/Modules/UseVersion.cmake
+++ b/cmake/Modules/UseVersion.cmake
@@ -24,9 +24,16 @@ if (cmake_build_type_upper_ MATCHES DEBUG)
         "#define PROJECT_VERSION_NAME \"${${project}_LABEL}\"\n"
         "#define PROJECT_VERSION_HASH \"debug\"\n"
         "#define PROJECT_VERSION \"${${project}_LABEL} (debug)\"\n"
-        "#define BUILD_TIMESTAMP \"${build_timestamp}\"\n"
         "#endif // OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
 	)
+
+  # Write header file with build timestamp
+  file (WRITE "${PROJECT_BINARY_DIR}/project-timestamp.h"
+      "#ifndef OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      "#define OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      "#define BUILD_TIMESTAMP \"${build_timestamp}\"\n"
+      "#endif // OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      )
 else ()
   if (NOT GIT_FOUND)
 	find_package (Git)
@@ -43,9 +50,15 @@ else ()
               "#define PROJECT_VERSION_NAME \"${${project}_LABEL}\"\n"
               "#define PROJECT_VERSION_HASH \"unknown git version\"\n"
               "#define PROJECT_VERSION \"${${project}_LABEL} (unknown git version)\"\n"
-              "#define BUILD_TIMESTAMP \"${build_timestamp}\"\n"
               "#endif // OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
               )
+  # Write header file with build timestamp
+  file (WRITE "${PROJECT_BINARY_DIR}/project-timestamp.h"
+      "#ifndef OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      "#define OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      "#define BUILD_TIMESTAMP \"${build_timestamp}\"\n"
+      "#endif // OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      )
   else ()
 	add_custom_target (update-version ALL
 	  COMMAND ${CMAKE_COMMAND}

--- a/cmake/Scripts/WriteVerSHA.cmake
+++ b/cmake/Scripts/WriteVerSHA.cmake
@@ -56,7 +56,6 @@ file (WRITE "${PROJECT_BINARY_DIR}/project-version.tmp"
       "#define PROJECT_VERSION_NAME \"${PROJECT_LABEL}\"\n"
       "#define PROJECT_VERSION_HASH \"${sha1}\"\n"
       "#define PROJECT_VERSION \"${PROJECT_LABEL} (${sha1})\"\n"
-      "#define BUILD_TIMESTAMP \"${build_timestamp}\"\n"
       "#endif // OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
       )
 
@@ -66,3 +65,11 @@ file (WRITE "${PROJECT_BINARY_DIR}/project-version.tmp"
 execute_process (COMMAND
   ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_BINARY_DIR}/project-version.tmp" "${PROJECT_BINARY_DIR}/project-version.h"
   )
+
+# Write header file with build timestamp
+file (WRITE "${PROJECT_BINARY_DIR}/project-timestamp.h"
+      "#ifndef OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      "#define OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      "#define BUILD_TIMESTAMP \"${build_timestamp}\"\n"
+      "#endif // OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      )


### PR DESCRIPTION
to avoid rebuilds for things only needing project versions