### PR TITLE
fixing invalid write in src/opm/io/eclipse/ESmry.cpp

### DIFF
--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -851,8 +851,9 @@ ESmry::getListOfArrays(std::string filename, bool formatted)
     std::vector<std::tuple <std::string, uint64_t>> resultVect;
 
     FILE *ptr;
-    char* arrName  = new char[9];
-    char* numstr  = new char[12];
+    char arrName[9];
+    char numstr[13];
+
     int64_t num;
 
     if (formatted)
@@ -909,6 +910,7 @@ ESmry::getListOfArrays(std::string filename, bool formatted)
                 throw std::runtime_error("fread error when loading summary data");
 
             num = static_cast<int64_t>(Opm::EclIO::flipEndianInt(num_int));
+
             fseek(ptr, 8, SEEK_CUR);
 
             if ((strcmp(arrName, "SEQHDR  ") == 0) || (strcmp(arrName, "MINISTEP") == 0))
@@ -916,7 +918,6 @@ ESmry::getListOfArrays(std::string filename, bool formatted)
             else if (strcmp(arrName, "PARAMS  ") == 0)
                 arrType = Opm::EclIO::REAL;
             else {
-                arrName[8]='\0';
                 throw std::invalid_argument("unknown array in UNSMRY file ");
             }
         }
@@ -942,9 +943,6 @@ ESmry::getListOfArrays(std::string filename, bool formatted)
         else
             fseek(ptr, -1, SEEK_CUR);
     }
-
-    delete[] arrName;
-    delete[] numstr;
 
     fclose(ptr);
 


### PR DESCRIPTION
fixing invalid write in src/opm/io/eclipse/ESmry.cpp, Reported by @berndflemisch ,   [issue #1813](https://github.com/OPM/opm-common/issues/1813).
