### PR TITLE
SMSPEC: Emit Empty Unit String if UDQ Unit Undefined

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2050,7 +2050,7 @@ namespace Evaluator {
         const auto& kw = this->node_->keyword;
 
         return this->udq_.has_unit(kw)
-            ?  this->udq_.unit(kw) : "?????";
+            ?  this->udq_.unit(kw) : "";
     }
 } // namespace Evaluator
 


### PR DESCRIPTION
This is guided by ECLIPSE.