### PR TITLE
add a cmake flag to disable warnings

### DIFF
--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -62,7 +62,10 @@ include (UseOptimization)
 
 # turn on all warnings; this must be done before adding any
 # dependencies, in case they alter the list of warnings
-include (UseWarnings)
+option(OPM_DISABLE_WARNINGS "Disable warning flags" OFF)
+if(NOT OPM_DISABLE_WARNINGS)
+  include (UseWarnings)
+endif()
 
 # parallel programming
 include (UseOpenMP)


### PR DESCRIPTION
These can be really annoying if dependencies are not in system include directories. Let users disable them if they so please.