### PR TITLE
Handle NUPCOL in RUNSPEC correctly

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -278,6 +278,7 @@ public:
     const EclHysterConfig& hysterPar() const noexcept;
     const Actdims& actdims() const noexcept;
     const SatFuncControls& saturationFunctionControls() const noexcept;
+    int nupcol() const noexcept;
 
     bool operator==(const Runspec& data) const;
 
@@ -305,6 +306,7 @@ private:
     EclHysterConfig hystpar;
     Actdims m_actdims;
     SatFuncControls m_sfuncctrl;
+    int m_nupcol;
 };
 
 

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -20,10 +20,13 @@
 #include <type_traits>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckSection.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/N.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
 
 namespace Opm {
 
@@ -311,8 +314,22 @@ Runspec::Runspec( const Deck& deck ) :
     udq_params( deck ),
     hystpar( deck ),
     m_actdims( deck ),
-    m_sfuncctrl( deck )
-{}
+    m_sfuncctrl( deck ),
+    m_nupcol( ParserKeywords::NUPCOL::NUM_ITER::defaultValue )
+{
+    if (DeckSection::hasRUNSPEC(deck)) {
+        const RUNSPECSection runspecSection{deck};
+        if (runspecSection.hasKeyword("NUPCOL")) {
+            using NC = ParserKeywords::NUPCOL;
+            const auto& item = runspecSection.getKeyword<NC>().getRecord(0).getItem<NC::NUM_ITER>();
+            m_nupcol = item.get<int>(0);
+            if (item.defaultApplied(0)) {
+                std::string msg = "OPM Flow uses 12 as default NUPCOL value";
+                OpmLog::note(msg);
+            }
+        }
+    }
+}
 
 Runspec Runspec::serializeObject()
 {
@@ -364,6 +381,11 @@ const EclHysterConfig& Runspec::hysterPar() const noexcept
 const SatFuncControls& Runspec::saturationFunctionControls() const noexcept
 {
     return this->m_sfuncctrl;
+}
+
+int Runspec::nupcol() const noexcept
+{
+    return this->m_nupcol;
 }
 
 /*

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -150,7 +150,7 @@ std::pair<std::time_t, std::size_t> restart_info(const RestartIO::RstState * rst
         m_network(this->m_timeMap, std::make_shared<Network::ExtNetwork>()),
         m_glo(this->m_timeMap, std::make_shared<GasLiftOpt>()),
         rft_config(this->m_timeMap),
-        m_nupcol(this->m_timeMap, ParserKeywords::NUPCOL::NUM_ITER::defaultValue),
+        m_nupcol(this->m_timeMap, runspec.nupcol()),
         restart_config(m_timeMap, deck, parseContext, errors),
         rpt_config(this->m_timeMap, std::make_shared<RPTConfig>())
     {

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3324,8 +3324,11 @@ BOOST_AUTO_TEST_CASE(RFT_CONFIG2) {
 
 BOOST_AUTO_TEST_CASE(nupcol) {
     std::string input =
+        "RUNSPEC\n"
         "START             -- 0 \n"
         "19 JUN 2007 / \n"
+        "NUPCOL\n"
+        "  20 /\n"
         "SCHEDULE\n"
         "DATES\n             -- 1\n"
         " 10  OKT 2008 / \n"
@@ -3346,7 +3349,7 @@ BOOST_AUTO_TEST_CASE(nupcol) {
     const auto& schedule = make_schedule(input);
     {
         // Flow uses 12 as default
-        BOOST_CHECK_EQUAL(schedule.getNupcol(0),12);
+        BOOST_CHECK_EQUAL(schedule.getNupcol(0),20);
         BOOST_CHECK_EQUAL(schedule.getNupcol(1),12);
         BOOST_CHECK_EQUAL(schedule.getNupcol(2),10);
     }


### PR DESCRIPTION
It seems NUPCOL is only properly dealt with if in the SCHEDULE section, not RUNSPEC section.

Opening this PR with just the failing test now.