### PR TITLE
UDQSet will check for nan values

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -20,12 +20,13 @@
 #ifndef SUMMARY_STATE_H
 #define SUMMARY_STATE_H
 
-#include <string>
 #include <chrono>
-#include <vector>
+#include <iosfwd>
+#include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <iosfwd>
+#include <vector>
 
 namespace Opm{
 
@@ -94,9 +95,9 @@ public:
     double get_well_var(const std::string& well, const std::string& var) const;
     double get_group_var(const std::string& group, const std::string& var) const;
 
-    std::vector<std::string> wells() const;
+    const std::vector<std::string>& wells() const;
     std::vector<std::string> wells(const std::string& var) const;
-    std::vector<std::string> groups() const;
+    const std::vector<std::string>& groups() const;
     std::vector<std::string> groups(const std::string& var) const;
     std::vector<char> serialize() const;
     void deserialize(const std::vector<char>& buffer);
@@ -112,10 +113,12 @@ private:
     // The first key is the variable and the second key is the well.
     std::unordered_map<std::string, std::unordered_map<std::string, double>> well_values;
     std::unordered_set<std::string> m_wells;
+    mutable std::optional<std::vector<std::string>> well_names;
 
     // The first key is the variable and the second key is the group.
     std::unordered_map<std::string, std::unordered_map<std::string, double>> group_values;
     std::unordered_set<std::string> m_groups;
+    mutable std::optional<std::vector<std::string>> group_names;
 };
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -73,6 +73,10 @@ public:
     */
     void set(const std::string& key, double value);
 
+    bool erase(const std::string& key);
+    bool erase_well_var(const std::string& well, const std::string& var);
+    bool erase_group_var(const std::string& group, const std::string& var);
+
     bool has(const std::string& key) const;
     bool has_well_var(const std::string& well, const std::string& var) const;
     bool has_group_var(const std::string& group, const std::string& var) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -62,6 +62,8 @@ namespace Opm{
       st.has_well_var("OPY", "WGOR") => False
 */
 
+class UDQSet;
+
 class SummaryState {
 public:
     typedef std::unordered_map<std::string, double>::const_iterator const_iterator;
@@ -85,6 +87,7 @@ public:
     void update_well_var(const std::string& well, const std::string& var, double value);
     void update_group_var(const std::string& group, const std::string& var, double value);
     void update_elapsed(double delta);
+    void update_udq(const UDQSet& udq_set);
 
     double get(const std::string&) const;
     double get_elapsed() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
@@ -95,6 +95,7 @@ public:
     std::vector<double> defined_values() const;
     std::size_t defined_size() const;
     const std::string& name() const;
+    void name(const std::string& name);
     UDQVarType var_type() const;
 private:
     UDQSet() = default;

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1380,64 +1380,29 @@ void eval_udq(const Opm::Schedule& schedule, std::size_t sim_step, Opm::SummaryS
     const UDQConfig& udq = schedule.getUDQConfig(sim_step);
     const auto& func_table = udq.function_table();
     UDQContext context(func_table, st);
-    {
-        const std::vector<std::string> wells = st.wells();
-
-        for (const auto& assign : udq.assignments(UDQVarType::WELL_VAR)) {
-            auto ws = assign.eval(wells);
-            for (const auto& well : wells) {
-                const auto& udq_value = ws[well];
-                if (udq_value)
-                    st.update_well_var(well, ws.name(), udq_value.value());
-                else
-                    st.del_well_var(well, ws.name());
-            }
-        }
-
-        for (const auto& def : udq.definitions(UDQVarType::WELL_VAR)) {
-            auto ws = def.eval(context);
-            for (const auto& well : wells) {
-                const auto& udq_value = ws[well];
-                if (udq_value)
-                    st.update_well_var(well, def.keyword(), udq_value.value());
-                else
-                    st.del_well_var(well, ws.name());
-            }
-        }
+    for (const auto& assign : udq.assignments(UDQVarType::WELL_VAR)) {
+        auto ws = assign.eval(st.wells());
+        st.update_udq(ws);
     }
 
-    {
-        const std::vector<std::string> groups = st.groups();
+    for (const auto& def : udq.definitions(UDQVarType::WELL_VAR)) {
+        auto ws = def.eval(context);
+        st.update_udq(ws);
+    }
 
-        for (const auto& assign : udq.assignments(UDQVarType::GROUP_VAR)) {
-            auto ws = assign.eval(groups);
-            for (const auto& group : groups) {
-                const auto& udq_value = ws[group];
-                if (udq_value)
-                    st.update_group_var(group, ws.name(), udq_value.value());
-                else
-                    st.del_group_var(group, ws.name());
-            }
-        }
+    for (const auto& assign : udq.assignments(UDQVarType::GROUP_VAR)) {
+        auto ws = assign.eval(st.groups());
+        st.update_udq(ws);
+    }
 
-        for (const auto& def : udq.definitions(UDQVarType::GROUP_VAR)) {
-            auto ws = def.eval(context);
-            for (const auto& group : groups) {
-                const auto& udq_value = ws[group];
-                if (udq_value)
-                    st.update_group_var(group, def.keyword(), udq_value.value());
-                else
-                    st.del_group_var(group, ws.name());
-            }
-        }
+    for (const auto& def : udq.definitions(UDQVarType::GROUP_VAR)) {
+        auto ws = def.eval(context);
+        st.update_udq(ws);
     }
 
     for (const auto& def : udq.definitions(UDQVarType::FIELD_VAR)) {
         auto field_udq = def.eval(context);
-        if (field_udq[0])
-            st.update(def.keyword(), field_udq[0].value());
-        else
-            st.del(def.keyword());
+        st.update_udq(field_udq);
     }
 }
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1389,6 +1389,8 @@ void eval_udq(const Opm::Schedule& schedule, std::size_t sim_step, Opm::SummaryS
                 const auto& udq_value = ws[well];
                 if (udq_value)
                     st.update_well_var(well, ws.name(), udq_value.value());
+                else
+                    st.del_well_var(well, ws.name());
             }
         }
 
@@ -1398,6 +1400,8 @@ void eval_udq(const Opm::Schedule& schedule, std::size_t sim_step, Opm::SummaryS
                 const auto& udq_value = ws[well];
                 if (udq_value)
                     st.update_well_var(well, def.keyword(), udq_value.value());
+                else
+                    st.del_well_var(well, ws.name());
             }
         }
     }
@@ -1411,6 +1415,8 @@ void eval_udq(const Opm::Schedule& schedule, std::size_t sim_step, Opm::SummaryS
                 const auto& udq_value = ws[group];
                 if (udq_value)
                     st.update_group_var(group, ws.name(), udq_value.value());
+                else
+                    st.del_group_var(group, ws.name());
             }
         }
 
@@ -1420,6 +1426,8 @@ void eval_udq(const Opm::Schedule& schedule, std::size_t sim_step, Opm::SummaryS
                 const auto& udq_value = ws[group];
                 if (udq_value)
                     st.update_group_var(group, def.keyword(), udq_value.value());
+                else
+                    st.del_group_var(group, ws.name());
             }
         }
     }
@@ -1428,6 +1436,8 @@ void eval_udq(const Opm::Schedule& schedule, std::size_t sim_step, Opm::SummaryS
         auto field_udq = def.eval(context);
         if (field_udq[0])
             st.update(def.keyword(), field_udq[0].value());
+        else
+            st.del(def.keyword());
     }
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <iomanip>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 namespace Opm{
@@ -144,6 +145,33 @@ namespace {
             this->well_values[var][well] = value;
         }
         this->m_wells.insert(well);
+    }
+
+    void SummaryState::update_udq(const UDQSet& udq_set) {
+        auto var_type = udq_set.var_type();
+        if (var_type == UDQVarType::WELL_VAR) {
+            const std::vector<std::string> wells = this->wells();
+            for (const auto& well : wells) {
+                const auto& udq_value = udq_set[well];
+                if (udq_value)
+                    this->update_well_var(well, udq_set.name(), udq_value.value());
+                else
+                    this->erase_well_var(well, udq_set.name());
+            }
+        } else if (var_type == UDQVarType::GROUP_VAR) {
+            const std::vector<std::string> groups = this->groups();
+            for (const auto& group : groups) {
+                const auto& udq_value = udq_set[group];
+                if (udq_value)
+                    this->update_group_var(group, udq_set.name(), udq_value.value());
+                else
+                    this->erase_group_var(group, udq_set.name());
+            }
+        } else {
+            const auto& udq_var = udq_set[0];
+            if (udq_var)
+                this->update(udq_set.name(), udq_var.value());
+        }
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -132,7 +132,10 @@ namespace {
             this->values[key] = value;
             this->group_values[var][group] = value;
         }
-        this->m_groups.insert(group);
+        if (this->m_groups.count(group) == 0) {
+            this->m_groups.insert(group);
+            this->group_names.reset();
+        }
     }
 
     void SummaryState::update_well_var(const std::string& well, const std::string& var, double value) {
@@ -144,7 +147,10 @@ namespace {
             this->values[key] = value;
             this->well_values[var][well] = value;
         }
-        this->m_wells.insert(well);
+        if (this->m_wells.count(well) == 0) {
+            this->m_wells.insert(well);
+            this->well_names.reset();
+        }
     }
 
     void SummaryState::update_udq(const UDQSet& udq_set) {
@@ -189,6 +195,7 @@ namespace {
             return false;
 
         erase_var(this->well_values, var, well);
+        this->well_names.reset();
         return true;
     }
 
@@ -198,6 +205,7 @@ namespace {
             return false;
 
         erase_var(this->group_values, var, group);
+        this->group_names.reset();
         return true;
     }
 
@@ -245,8 +253,11 @@ namespace {
     }
 
 
-    std::vector<std::string> SummaryState::wells() const {
-        return std::vector<std::string>(this->m_wells.begin(), this->m_wells.end());
+    const std::vector<std::string>& SummaryState::wells() const {
+        if (!this->well_names)
+            this->well_names = std::vector<std::string>(this->m_wells.begin(), this->m_wells.end());
+
+        return *this->well_names;
     }
 
 
@@ -255,8 +266,11 @@ namespace {
     }
 
 
-    std::vector<std::string> SummaryState::groups() const {
-        return std::vector<std::string>(this->m_groups.begin(), this->m_groups.end());
+    const std::vector<std::string>& SummaryState::groups() const {
+        if (!this->group_names)
+            this->group_names = std::vector<std::string>(this->m_groups.begin(), this->m_groups.end());
+
+        return *this->group_names;
     }
 
     std::size_t SummaryState::num_wells() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -224,6 +224,7 @@ UDQSet UDQDefine::eval(const UDQContext& context) const {
         }
     }
 
+    res.name( this->m_keyword );
     return res;
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -38,7 +38,7 @@ bool UDQScalar::defined() const {
 
 double UDQScalar::value() const {
     if (!this->m_defined)
-        throw std::invalid_argument("UDQSCalar: Value not defined");
+        throw std::invalid_argument("UDQSCalar: Value not defined  wgname:" + this->m_wgname);
 
     return this->m_value;
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -110,6 +110,10 @@ const std::string& UDQSet::name() const {
     return this->m_name;
 }
 
+void UDQSet::name(const std::string& name) {
+    this->m_name = name;
+}
+
 UDQSet::UDQSet(const std::string& name, UDQVarType var_type, const std::vector<std::string>& wgnames) :
     m_name(name),
     m_var_type(var_type)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -18,15 +18,16 @@
 */
 #include <fnmatch.h>
 #include <algorithm>
+#include <cmath>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 
 namespace Opm {
 
-UDQScalar::UDQScalar(double value) :
-    m_value(value),
-    m_defined(true)
-{}
+UDQScalar::UDQScalar(double value)
+{
+    this->assign(value);
+}
 
 UDQScalar::UDQScalar(const std::string& wgname) :
     m_wgname(wgname)
@@ -38,7 +39,7 @@ bool UDQScalar::defined() const {
 
 double UDQScalar::value() const {
     if (!this->m_defined)
-        throw std::invalid_argument("UDQSCalar: Value not defined  wgname:" + this->m_wgname);
+        throw std::invalid_argument("UDQSCalar: Value not defined  wgname: " + this->m_wgname);
 
     return this->m_value;
 }
@@ -49,55 +50,55 @@ const std::string& UDQScalar::wgname() const {
 
 void UDQScalar::assign(double value) {
     this->m_value = value;
-    this->m_defined = true;
+    this->m_defined = std::isfinite(value);
 }
 
 void UDQScalar::operator-=(const UDQScalar& rhs) {
     if (this->m_defined && rhs.m_defined)
-        this->m_value -= rhs.m_value;
+        this->assign(this->m_value - rhs.m_value);
     else
         this->m_defined = false;
 }
 
 void UDQScalar::operator-=(double rhs) {
     if (this->m_defined)
-        this->m_value -= rhs;
+        this->assign(this->m_value - rhs);
 }
 
 void UDQScalar::operator/=(const UDQScalar& rhs) {
     if (this->m_defined && rhs.m_defined)
-        this->m_value /= rhs.m_value;
+        this->assign(this->m_value / rhs.m_value);
     else
         this->m_defined = false;
 }
 
 void UDQScalar::operator/=(double rhs) {
     if (this->m_defined)
-        this->m_value /= rhs;
+        this->assign(this->m_value / rhs);
 }
 
 void UDQScalar::operator+=(const UDQScalar& rhs) {
     if (this->m_defined && rhs.m_defined)
-        this->m_value += rhs.m_value;
+        this->assign(this->m_value + rhs.m_value);
     else
         this->m_defined = false;
 }
 
 void UDQScalar::operator+=(double rhs) {
     if (this->m_defined)
-        this->m_value += rhs;
+        this->assign(this->m_value + rhs);
 }
 
 void UDQScalar::operator*=(const UDQScalar& rhs) {
     if (this->m_defined && rhs.m_defined)
-        this->m_value *= rhs.m_value;
+        this->assign(this->m_value * rhs.m_value);
     else
         this->m_defined = false;
 }
 
 void UDQScalar::operator*=(double rhs) {
     if (this->m_defined)
-        this->m_value *= rhs;
+        this->assign(this->m_value * rhs);
 }
 
 

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1039,6 +1039,30 @@ BOOST_AUTO_TEST_CASE(UDQ_SCALAR_SET) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(UDQ_SORTD_NAN) {
+    UDQParams udqp;
+    UDQFunctionTable udqft;
+    UDQDefine def1(udqp, "WUPR1" , {"1", "/", "(", "WWIR", "'OP*'" , ")"});
+    UDQDefine def_sort(udqp , "WUPR3", {"SORTD", "(", "WUPR1", ")" });
+    SummaryState st(std::chrono::system_clock::now());
+    UDQContext context(udqft, st);
+
+    st.update_well_var("OP1", "WWIR", 1.0);
+    st.update_well_var("OP2", "WWIR", 2.0);
+    st.update_well_var("OP3", "WWIR", 3.0);
+    st.update_well_var("OP4", "WWIR", 4.0);
+
+    auto res1 = def1.eval(context);
+    st.update_udq( res1 );
+
+    auto res_sort = def_sort.eval(context);
+    BOOST_CHECK_EQUAL(res_sort["OP1"].value(), 1.0);
+    BOOST_CHECK_EQUAL(res_sort["OP2"].value(), 2.0);
+    BOOST_CHECK_EQUAL(res_sort["OP3"].value(), 3.0);
+    BOOST_CHECK_EQUAL(res_sort["OP4"].value(), 4.0);
+}
+
+
 
 BOOST_AUTO_TEST_CASE(UDQ_SORTA) {
     UDQParams udqp;

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1034,6 +1034,8 @@ BOOST_AUTO_TEST_CASE(UDQ_SCALAR_SET) {
         auto well4 = res["P4"];
         BOOST_CHECK( well4.defined() );
         BOOST_CHECK_EQUAL(well4.value() , 1);
+
+        BOOST_CHECK_EQUAL( "WUOPR", res.name() );
     }
 }
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1815,6 +1815,19 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
     // The well 'OP_2' which was indirectly added with the
     // st.update("WWCT:OP_2", 100) call is *not* counted as a well!
     BOOST_CHECK_EQUAL(st.num_wells(), 3);
+
+
+    BOOST_CHECK( st.erase("WWCT:OP2") );
+    BOOST_CHECK( !st.has("WWCT:OP2") );
+    BOOST_CHECK( !st.erase("WWCT:OP2") );
+
+    BOOST_CHECK( st.erase_well_var("OP1", "WWCT") );
+    BOOST_CHECK( !st.has_well_var("OP1", "WWCT"));
+    BOOST_CHECK( !st.has("WWCT:OP1") );
+
+    BOOST_CHECK( st.erase_group_var("G1", "GWCT") );
+    BOOST_CHECK( !st.has_group_var("G1", "GWCT"));
+    BOOST_CHECK( !st.has("GWCT:G1") );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This will ensure that an values will not escape from the UDQ evaluation.

@alfbr: I will continue with adding more tests, both here in opm-common and also in opm-tests - but the "UDQSet will check for nan values" commit should be the immediate fix to the problem we discussed on :phone: 