### PR TITLE
Add class Action::State to keep track of ACTIONX count

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -96,6 +96,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Events.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/GasLiftOpt.cpp
@@ -671,6 +672,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/PyAction.hpp
+       opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp
        opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp
        opm/parser/eclipse/EclipseState/Schedule/GasLiftOpt.hpp
        opm/parser/eclipse/EclipseState/Schedule/Network/Branch.hpp

--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -24,6 +24,11 @@ class ParseContext;
 class Parser;
 class Python;
 class SummaryState;
+
+namespace Action {
+class State;
+}
+
 class msim {
 
 public:
@@ -37,12 +42,12 @@ public:
     void well_rate(const std::string& well, data::Rates::opt rate, std::function<well_rate_function> func);
     void solution(const std::string& field, std::function<solution_function> func);
     void run(Schedule& schedule, EclipseIO& io, bool report_only);
-    void post_step(Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step);
+    void post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step);
 private:
 
-    void run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
-    void run_step(const Schedule& schedule, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const;
-    void output(SummaryState& st, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, double dt, EclipseIO& io) const;
+    void output(Action::State& action_state, SummaryState& st, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, EclipseIO& io) const;
     void simulate(const Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, size_t report_step, double seconds_elapsed, double time_step) const;
 
     EclipseState state;

--- a/opm/output/eclipse/AggregateActionxData.hpp
+++ b/opm/output/eclipse/AggregateActionxData.hpp
@@ -41,6 +41,10 @@ namespace Opm {
     class Schedule;
     class UDQInput;
     class UDQActive;
+
+    namespace Action {
+        class State;
+    }
 } // Opm
 
 
@@ -52,10 +56,11 @@ class AggregateActionxData
 public:
     explicit AggregateActionxData(const std::vector<int>& actDims);
 
-    void captureDeclaredActionxData(    const Opm::Schedule&    sched,
-                                        const Opm::SummaryState& st,
-                                        const std::vector<int>& actDims,
-                                        const std::size_t       simStep);
+    void captureDeclaredActionxData(    const Opm::Schedule&      sched,
+                                        const Opm::Action::State& action_state,
+                                        const Opm::SummaryState&  st,
+                                        const std::vector<int>&   actDims,
+                                        const std::size_t         simStep);
 
     const std::vector<int>& getIACT() const
     {

--- a/opm/output/eclipse/AggregateWellData.hpp
+++ b/opm/output/eclipse/AggregateWellData.hpp
@@ -33,6 +33,9 @@ namespace Opm {
     class Schedule;
     class SummaryState;
     class UnitSystem;
+    namespace Action {
+        class State;
+    }
 } // Opm
 
 namespace Opm { namespace data {
@@ -40,17 +43,18 @@ namespace Opm { namespace data {
 }} // Opm::data
 
 namespace Opm { namespace RestartIO { namespace Helpers {
-    
+
     class AggregateWellData
     {
     public:
         explicit AggregateWellData(const std::vector<int>& inteHead);
 
-	void captureDeclaredWellData(const Schedule&   	sched,
-                        const UnitSystem& 		units,
-                        const std::size_t 		sim_step,
-			const ::Opm::SummaryState&  	smry,
-			const std::vector<int>& 	inteHead);
+        void captureDeclaredWellData(const Schedule&   	sched,
+                                     const UnitSystem& 		units,
+                                     const std::size_t 		sim_step,
+                                     const ::Opm::Action::State& action_state,
+                                     const ::Opm::SummaryState&  	smry,
+                                     const std::vector<int>& 	inteHead);
 
         void captureDynamicWellData(const Opm::Schedule&        sched,
                                     const std::size_t           sim_step,
@@ -81,8 +85,8 @@ namespace Opm { namespace RestartIO { namespace Helpers {
             return this->zWell_.data();
         }
 
-        
-        
+
+
     private:
         /// Aggregate 'IWEL' array (Integer) for all wells.
         WindowedArray<int> iWell_;

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -45,7 +45,7 @@ class EclipseState;
 class Schedule;
 class SummaryConfig;
 class SummaryState;
-
+namespace Action { class State; }
 /*!
  * \brief A class to write the reservoir state and the well state of a
  *        blackoil simulation to disk using the Eclipse binary format.
@@ -174,7 +174,8 @@ public:
      *     hardcoded static map misc_units in Summary.cpp.
      */
 
-    void writeTimeStep( const SummaryState& st,
+    void writeTimeStep( const Action::State& action_state,
+                        const SummaryState& st,
                         int report_step,
                         bool isSubstep,
                         double seconds_elapsed,
@@ -220,7 +221,7 @@ public:
       missing, if the bool is false missing keywords will be ignored
       (there will *not* be an empty vector in the return value).
     */
-    RestartValue loadRestart(SummaryState& summary_state, const std::vector<RestartKey>& solution_keys, const std::vector<RestartKey>& extra_keys = {}) const;
+    RestartValue loadRestart(Action::State& action_state, SummaryState& summary_state, const std::vector<RestartKey>& solution_keys, const std::vector<RestartKey>& extra_keys = {}) const;
     const out::Summary& summary();
 
     EclipseIO( const EclipseIO& ) = delete;

--- a/opm/output/eclipse/RestartIO.hpp
+++ b/opm/output/eclipse/RestartIO.hpp
@@ -46,6 +46,12 @@ namespace Opm { namespace EclIO { namespace OutputStream {
 
 }}}
 
+namespace Opm { namespace Action {
+
+    class State;
+
+}}
+
 /*
   The two free functions RestartIO::save() and RestartIO::load() can
   be used to save and load reservoir and well state from restart
@@ -76,12 +82,14 @@ namespace Opm { namespace RestartIO {
               const EclipseState&           es,
               const EclipseGrid&            grid,
               const Schedule&               schedule,
+              const Action::State&          action_state,
               const SummaryState&           sumState,
               bool                          write_double = false);
 
 
     RestartValue load(const std::string&             filename,
                       int                            report_step,
+                      Action::State&                 action_state,
                       SummaryState&                  summary_state,
                       const std::vector<RestartKey>& solution_keys,
                       const EclipseState&            es,

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp
@@ -36,6 +36,7 @@ namespace Opm {
 class DeckKeyword;
 
 namespace Action {
+class State;
 
 /*
   The ActionX class internalizes the ACTIONX keyword. This keyword represents a
@@ -71,8 +72,8 @@ public:
     static ActionX serializeObject();
 
     void addKeyword(const DeckKeyword& kw);
-    bool ready(std::time_t sim_time) const;
-    Action::Result eval(std::time_t sim_time, const Action::Context& context) const;
+    bool ready(const State& state, std::time_t sim_time) const;
+    Action::Result eval(const Action::Context& context) const;
 
 
     std::string name() const { return this->m_name; }
@@ -105,8 +106,6 @@ public:
         serializer.vector(keywords);
         condition.serializeOp(serializer);
         serializer.vector(m_conditions);
-        serializer(run_count);
-        serializer(last_run);
     }
 
 private:
@@ -119,8 +118,6 @@ private:
     std::vector<DeckKeyword> keywords;
     Action::AST condition;
     std::vector<Condition> m_conditions;
-    mutable size_t run_count = 0;
-    mutable std::time_t last_run = 0;
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp
@@ -78,6 +78,8 @@ public:
     std::string name() const { return this->m_name; }
     size_t max_run() const { return this->m_max_run; }
     double min_wait() const { return this->m_min_wait; }
+    std::size_t id() const;
+    void update_id(std::size_t id);
     std::time_t start_time() const { return this->m_start_time; }
     std::vector<DeckKeyword>::const_iterator begin() const;
     std::vector<DeckKeyword>::const_iterator end() const;
@@ -99,6 +101,7 @@ public:
         serializer(m_max_run);
         serializer(m_min_wait);
         serializer(m_start_time);
+        serializer(m_id);
         serializer.vector(keywords);
         condition.serializeOp(serializer);
         serializer.vector(m_conditions);
@@ -111,6 +114,7 @@ private:
     size_t m_max_run = 0;
     double m_min_wait = 0.0;
     std::time_t m_start_time;
+    std::size_t m_id = 0;
 
     std::vector<DeckKeyword> keywords;
     Action::AST condition;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp
@@ -31,6 +31,8 @@
 namespace Opm {
 namespace Action {
 
+class State;
+
 /*
   The Actions class is a container of ACTIONX keywords. The main functionality
   is to provide a list of ACTIONX keywords which are ready to be evaluated.
@@ -48,10 +50,10 @@ public:
     bool empty() const;
     void add(const ActionX& action);
     void add(const PyAction& pyaction);
-    bool ready(std::time_t sim_time) const;
+    bool ready(const State& state, std::time_t sim_time) const;
     const ActionX& get(const std::string& name) const;
     const ActionX& get(std::size_t index) const;
-    std::vector<const ActionX *> pending(std::time_t sim_time) const;
+    std::vector<const ActionX *> pending(const State& state, std::time_t sim_time) const;
     std::vector<const PyAction *> pending_python() const;
 
     std::vector<ActionX>::const_iterator begin() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp
@@ -1,0 +1,59 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ACTION_STATE_HPP
+#define ACTION_STATE_HPP
+
+#include <ctime>
+#include <map>
+
+namespace Opm {
+namespace Action {
+
+class ActionX;
+class State {
+
+struct RunState {
+    RunState(std::time_t sim_time) :
+        run_count(1),
+        last_run(sim_time)
+    {}
+
+    void add_run(std::time_t sim_time) {
+        this->last_run = sim_time;
+        this->run_count += 1;
+    }
+
+
+    std::size_t run_count;
+    std::time_t last_run;
+};
+
+public:
+    void add_run(const ActionX& action, std::time_t sim_time);
+    std::size_t run_count(const ActionX& action) const;
+    std::time_t run_time(const ActionX& action) const;
+private:
+    std::map<std::pair<std::string, std::size_t>, RunState> run_state;
+};
+
+
+}
+}
+#endif

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -187,7 +187,8 @@ void EclipseIO::writeInitial( data::Solution simProps, std::map<std::string, std
 }
 
 // implementation of the writeTimeStep method
-void EclipseIO::writeTimeStep(const SummaryState& st,
+void EclipseIO::writeTimeStep(const Action::State& action_state,
+                              const SummaryState& st,
                               int report_step,
                               bool  isSubstep,
                               double secs_elapsed,
@@ -237,7 +238,7 @@ void EclipseIO::writeTimeStep(const SummaryState& st,
         };
 
         RestartIO::save(rstFile, report_step, secs_elapsed, value,
-                        es, grid, schedule, st, write_double);
+                        es, grid, schedule, action_state, st, write_double);
     }
 
     // RFT file written only if requested and never for substeps.
@@ -275,7 +276,7 @@ void EclipseIO::writeTimeStep(const SummaryState& st,
  }
 
 
-RestartValue EclipseIO::loadRestart(SummaryState& summary_state, const std::vector<RestartKey>& solution_keys, const std::vector<RestartKey>& extra_keys) const {
+RestartValue EclipseIO::loadRestart(Action::State& action_state, SummaryState& summary_state, const std::vector<RestartKey>& solution_keys, const std::vector<RestartKey>& extra_keys) const {
     const auto& es                       = this->impl->es;
     const auto& grid                     = this->impl->grid;
     const auto& schedule                 = this->impl->schedule;
@@ -286,7 +287,7 @@ RestartValue EclipseIO::loadRestart(SummaryState& summary_state, const std::vect
                                                                         report_step,
                                                                         false );
 
-    return RestartIO::load(filename, report_step, summary_state, solution_keys,
+    return RestartIO::load(filename, report_step, action_state, summary_state, solution_keys,
                            es, grid, schedule, extra_keys);
 }
 

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -1441,6 +1441,7 @@ namespace Opm { namespace RestartIO  {
     RestartValue
     load(const std::string&             filename,
          int                            report_step,
+         Action::State&                 /*  action_state  */,
          SummaryState&                  summary_state,
          const std::vector<RestartKey>& solution_keys,
          const EclipseState&            es,

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -319,6 +319,7 @@ namespace {
                       const int                     sim_step,
                       const EclipseState&           es,
                       const Schedule&               schedule,
+                      const Action::State&          action_state,
                       const SummaryState&           sum_state,
                       EclIO::OutputStream::Restart& rstFile)
     {
@@ -332,7 +333,7 @@ namespace {
         
         const auto actDims = Opm::RestartIO::Helpers::createActionxDims(es.runspec(), schedule, simStep);
         auto  actionxData = Opm::RestartIO::Helpers::AggregateActionxData(actDims);
-        actionxData.captureDeclaredActionxData(schedule, sum_state, actDims, simStep);
+        actionxData.captureDeclaredActionxData(schedule, action_state, sum_state, actDims, simStep);
         
         if (actDims[0] >= 1) {
             rstFile.write("IACT", actionxData.getIACT());
@@ -353,12 +354,13 @@ namespace {
                    const Schedule&                 schedule,
                    const std::vector<std::string>& well_names,
                    const data::Wells&              wells,
+                   const Opm::Action::State&       action_state,
                    const Opm::SummaryState&        sumState,
                    const std::vector<int>&         ih,
                    EclIO::OutputStream::Restart&   rstFile)
     {
         auto wellData = Helpers::AggregateWellData(ih);
-        wellData.captureDeclaredWellData(schedule, units, sim_step, sumState, ih);
+        wellData.captureDeclaredWellData(schedule, units, sim_step, action_state, sumState, ih);
         wellData.captureDynamicWellData(schedule, sim_step,
                                         wells, sumState);
 
@@ -396,6 +398,7 @@ namespace {
                           const EclipseGrid&            grid,
                           const Schedule&               schedule,
                           const data::WellRates&        wellSol,
+                          const Opm::Action::State&     action_state,
                           const Opm::SummaryState&      sumState,
                           const std::vector<int>&       inteHD,
                           EclIO::OutputStream::Restart& rstFile)
@@ -420,7 +423,7 @@ namespace {
 
             writeWell(sim_step, ecl_compatible_rst,
                       phases, units, grid, schedule, wells,
-                      wellSol, sumState, inteHD, rstFile);
+                      wellSol, action_state, sumState, inteHD, rstFile);
         }
     }
 
@@ -651,6 +654,7 @@ void save(EclIO::OutputStream::Restart& rstFile,
           const EclipseState&           es,
           const EclipseGrid&            grid,
           const Schedule&               schedule,
+          const Action::State&          action_state,
           const SummaryState&           sumState,
           bool                          write_double)
 {
@@ -675,11 +679,11 @@ void save(EclIO::OutputStream::Restart& rstFile,
 
     if (report_step > 0) {
         writeDynamicData(sim_step, ecl_compatible_rst, es.runspec().phases(),
-                         units, grid, schedule, value.wells, sumState,
+                         units, grid, schedule, value.wells, action_state, sumState,
                          inteHD, rstFile);
     }
 
-    writeActionx(report_step, sim_step, es, schedule, sumState, rstFile);
+    writeActionx(report_step, sim_step, es, schedule, action_state, sumState, rstFile);
 
     writeSolution(value, schedule, sumState, report_step, sim_step,
                   ecl_compatible_rst, write_double, inteHD, rstFile);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
@@ -24,6 +24,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 
 #include "ActionParser.hpp"
 
@@ -96,8 +97,6 @@ ActionX ActionX::serializeObject()
     cond.cmp = Condition::Comparator::GREATER_EQUAL;
     cond.cmp_string = "test3";
     result.m_conditions = {cond};
-    result.run_count = 4;
-    result.last_run = 5;
 
     return result;
 }
@@ -109,18 +108,8 @@ void ActionX::addKeyword(const DeckKeyword& kw) {
 
 
 
-Action::Result ActionX::eval(std::time_t sim_time, const Action::Context& context) const {
-    if (!this->ready(sim_time))
-        return Action::Result(false);
-
-    auto result = this->condition.eval(context);
-
-    if (result) {
-        this->run_count += 1;
-        this->last_run = sim_time;
-    }
-
-    return result;
+Action::Result ActionX::eval(const Action::Context& context) const {
+    return this->condition.eval(context);
 }
 
 
@@ -132,7 +121,7 @@ bool ActionX::ready(const State& state, std::time_t sim_time) const {
     if (sim_time < this->start_time())
         return false;
 
-    if (this->run_count == 0)
+    if (run_count == 0)
         return true;
 
     if (this->min_wait() <= 0)
@@ -202,9 +191,7 @@ bool ActionX::operator==(const ActionX& data) const {
            this->id() == data.id() &&
            this->keywords == data.keywords &&
            this->condition == data.condition &&
-           this->conditions() == data.conditions() &&
-           this->run_count == data.run_count &&
-           this->last_run == data.last_run;
+           this->conditions() == data.conditions();
 }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
@@ -183,12 +183,21 @@ const std::vector<Condition>& ActionX::conditions() const {
     return this->m_conditions;
 }
 
+std::size_t ActionX::id() const {
+    return this->m_id;
+}
+
+void ActionX::update_id(std::size_t id) {
+    this->m_id = id;
+}
+
 
 bool ActionX::operator==(const ActionX& data) const {
     return this->name() == data.name() &&
            this->max_run() == data.max_run() &&
            this->min_wait() == data.min_wait() &&
            this->start_time() == data.start_time() &&
+           this->id() == data.id() &&
            this->keywords == data.keywords &&
            this->condition == data.condition &&
            this->conditions() == data.conditions() &&

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
@@ -124,8 +124,9 @@ Action::Result ActionX::eval(std::time_t sim_time, const Action::Context& contex
 }
 
 
-bool ActionX::ready(std::time_t sim_time) const {
-  if (this->run_count >= this->max_run())
+bool ActionX::ready(const State& state, std::time_t sim_time) const {
+    auto run_count = state.run_count(*this);
+    if (run_count >= this->max_run())
         return false;
 
     if (sim_time < this->start_time())
@@ -137,7 +138,8 @@ bool ActionX::ready(std::time_t sim_time) const {
     if (this->min_wait() <= 0)
         return true;
 
-    return std::difftime(sim_time, this->last_run) > this->min_wait();
+    auto last_run = state.run_time(*this);
+    return std::difftime(sim_time, last_run) > this->min_wait();
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
@@ -92,9 +92,9 @@ int Actions::max_input_lines() const {
 }
 
 
-bool Actions::ready(std::time_t sim_time) const {
+bool Actions::ready(const State& state, std::time_t sim_time) const {
     for (const auto& action : this->actions) {
-        if (action.ready(sim_time))
+        if (action.ready(state, sim_time))
             return true;
     }
     return false;
@@ -111,10 +111,10 @@ std::vector<const PyAction *> Actions::pending_python() const {
 }
 
 
-std::vector<const ActionX *> Actions::pending(std::time_t sim_time) const {
+std::vector<const ActionX *> Actions::pending(const State& state, std::time_t sim_time) const {
     std::vector<const ActionX *> action_vector;
     for (const auto& action : this->actions) {
-        if (action.ready(sim_time))
+        if (action.ready(state, sim_time))
             action_vector.push_back( &action );
     }
     return action_vector;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
@@ -55,8 +55,11 @@ void Actions::add(const ActionX& action) {
     auto iter = std::find_if( this->actions.begin(), this->actions.end(), [&action](const ActionX& arg) { return arg.name() == action.name(); });
     if (iter == this->actions.end())
         this->actions.push_back(action);
-    else
+    else {
+        auto id = iter->id() + 1;
         *iter = action;
+        iter->update_id(id);
+    }
 }
 
 void Actions::add(const PyAction& pyaction) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
@@ -1,0 +1,61 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <vector>
+#include <algorithm>
+#include <stdexcept>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp>
+
+namespace Opm {
+namespace Action {
+
+namespace {
+std::pair<std::string, std::size_t> action_id(const ActionX& action) {
+    return std::make_pair(action.name(), action.id());
+}
+}
+
+
+std::size_t State::run_count(const ActionX& action) const {
+    auto count_iter = this->run_state.find(action_id(action));
+    if (count_iter == this->run_state.end())
+        return 0;
+
+    return count_iter->second.run_count;
+}
+
+std::time_t State::run_time(const ActionX& action) const {
+    auto state = this->run_state.at(action_id(action));
+    return state.last_run;
+}
+
+
+void State::add_run(const ActionX& action, std::time_t run_time) {
+    const auto& id  = action_id(action);
+    auto count_iter = this->run_state.find(id);
+    if (count_iter == this->run_state.end())
+        this->run_state.insert( std::make_pair(id, run_time) );
+    else
+        count_iter->second.add_run(run_time);
+}
+
+}
+}

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionAST.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
@@ -801,17 +802,30 @@ BOOST_AUTO_TEST_CASE(ACTIONRESULT_COPY_WELLS) {
 
 BOOST_AUTO_TEST_CASE(ActionState) {
     Action::State st;
+    Action::ActionX action1("NAME", 100, 100, 100); action1.update_id(100);
+    Action::ActionX action2("NAME", 100, 100, 100); action1.update_id(200);
 
-    BOOST_CHECK_EQUAL(0, st.run_count("NO_SUCH_ACTION"));
-    BOOST_CHECK_THROW( st.run_time("NO_SUCH_ACTION"), std::out_of_range);
+    BOOST_CHECK_EQUAL(0, st.run_count(action1));
+    BOOST_CHECK_THROW( st.run_time(action1), std::out_of_range);
 
-    st.add_run("ACT02", 100);
-    BOOST_CHECK_EQUAL(1, st.run_count("ACT02"));
-    BOOST_CHECK_EQUAL(100, st.run_time("ACT02"));
+    st.add_run(action1, 100);
+    BOOST_CHECK_EQUAL(1, st.run_count(action1));
+    BOOST_CHECK_EQUAL(100, st.run_time(action1));
 
-    st.add_run("ACT02", 1000);
-    BOOST_CHECK_EQUAL(2, st.run_count("ACT02"));
-    BOOST_CHECK_EQUAL(1000, st.run_time("ACT02"));
+    st.add_run(action1, 1000);
+    BOOST_CHECK_EQUAL(2, st.run_count(action1));
+    BOOST_CHECK_EQUAL(1000, st.run_time(action1));
+
+    BOOST_CHECK_EQUAL(0, st.run_count(action2));
+    BOOST_CHECK_THROW( st.run_time(action2), std::out_of_range);
+
+    st.add_run(action2, 100);
+    BOOST_CHECK_EQUAL(1, st.run_count(action2));
+    BOOST_CHECK_EQUAL(100, st.run_time(action2));
+
+    st.add_run(action2, 1000);
+    BOOST_CHECK_EQUAL(2, st.run_count(action2));
+    BOOST_CHECK_EQUAL(1000, st.run_time(action2));
 }
 
 BOOST_AUTO_TEST_CASE(ActionID) {
@@ -859,4 +873,9 @@ ENDACTIO
     const auto& action2 = sched.actions(2).get("A");
 
     BOOST_CHECK(action1.id() != action2.id());
+
+    Action::State st;
+    st.add_run(action1, 1000);
+    BOOST_CHECK_EQUAL( st.run_count(action1), 1);
+    BOOST_CHECK_EQUAL( st.run_count(action2), 0);
 }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -180,18 +180,19 @@ BOOST_AUTO_TEST_CASE(TestActions) {
         config.add(py_action2);
     }
     const Opm::Action::ActionX& action2 = config.get("NAME");
+    Opm::Action::State action_state;
     // The action2 instance has an empty condition, so it will never evaluate to true.
-    BOOST_CHECK(action2.ready(  asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 7, 1 }))  ));
-    BOOST_CHECK(!action2.ready(  asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 6, 1 }))   ));
-    BOOST_CHECK(!action2.eval(asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 6, 1 })), context));
+    BOOST_CHECK(action2.ready(  action_state, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 7, 1 }))  ));
+    BOOST_CHECK(!action2.ready(  action_state, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 6, 1 }))   ));
+    BOOST_CHECK(!action2.eval(context));
 
-    auto pending = config.pending( asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 8, 7 }))  );
+    auto pending = config.pending( action_state, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 8, 7 }))  );
     BOOST_CHECK_EQUAL( pending.size(), 2);
     for (auto& ptr : pending) {
-        BOOST_CHECK( ptr->ready(  asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 8, 7 }))  ));
-        BOOST_CHECK( !ptr->eval(asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 8, 7 })), context));
+        BOOST_CHECK( ptr->ready( action_state, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 8, 7 }))  ));
+        BOOST_CHECK( !ptr->eval( context));
     }
-    BOOST_CHECK(!action2.eval(asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 8, 7 })), context));
+    BOOST_CHECK(!action2.eval(context));
 
 
     const auto& python_actions = config.pending_python();

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -9,6 +9,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <opm/parser/eclipse/Python/Python.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/output/eclipse/AggregateUDQData.hpp>
 #include <opm/output/eclipse/AggregateActionxData.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
@@ -36,10 +37,10 @@
 #include <vector>
 
 namespace {
-    
+
     Opm::Deck first_sim(std::string fname) {
-        return Opm::Parser{}.parseFile(fname);        
-    } 
+        return Opm::Parser{}.parseFile(fname);
+    }
 }
 
 Opm::SummaryState sum_state_TEST1()
@@ -58,18 +59,18 @@ Opm::SummaryState sum_state_TEST1()
         state.update_group_var("UPPER", "GWPR", 36.);
         state.update_group_var("LOWER", "GWPR", 37.);
         state.update_group_var("TEST",  "GWPR", 73.);
-        
+
         state.update_group_var("UPPER", "GGPR", 460.);
         state.update_group_var("LOWER", "GGPR", 461.);
         state.update_group_var("TEST",  "GGPR", 821.);
 
-        
+
         state.update_group_var("TEST",  "GMWPR", 4);
-        
+
         state.update("FWPR", 73.);
-        
+
         state.update("FMWPR", 4);
-                
+
 
         return state;
 }
@@ -91,7 +92,7 @@ struct SimulationCase
     Opm::Schedule     sched;
 
 };
-    
+
 BOOST_AUTO_TEST_SUITE(Aggregate_Actionx)
 
 
@@ -100,10 +101,11 @@ BOOST_AUTO_TEST_SUITE(Aggregate_Actionx)
 BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
 {
     const auto simCase = SimulationCase{first_sim("UDQ_ACTIONX_TEST1.DATA")};
-        
+
     Opm::EclipseState es = simCase.es;
     Opm::Runspec rspec   = es.runspec();
     Opm::SummaryState st = sum_state_TEST1();
+    Opm::Action::State action_state;
     Opm::Schedule     sched = simCase.sched;
     Opm::EclipseGrid  grid = simCase.grid;
     const auto& ioConfig = es.getIOConfig();
@@ -111,7 +113,7 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
 
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
-    const auto rptStep = std::size_t{1};        
+    const auto rptStep = std::size_t{1};
     std::string outputDir = "./";
     std::string baseName = "UDQ_ACTIONX_TEST1";
     Opm::EclIO::OutputStream::Restart rstFile {
@@ -126,25 +128,25 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         createInteHead(es, grid, sched, secs_elapsed,
                        rptStep, rptStep, rptStep);
 
-    //set dummy value for next_step_size 
+    //set dummy value for next_step_size
     const double next_step_size= 0.1;
-    const auto dh = Opm::RestartIO::Helpers::createDoubHead(es, sched, rptStep, 
-                                                            secs_elapsed, next_step_size); 
-       
+    const auto dh = Opm::RestartIO::Helpers::createDoubHead(es, sched, rptStep,
+                                                            secs_elapsed, next_step_size);
+
     const auto udqDims = Opm::RestartIO::Helpers::createUdqDims(sched, rptStep, ih);
     auto  udqData = Opm::RestartIO::Helpers::AggregateUDQData(udqDims);
     udqData.captureDeclaredUDQData(sched, rptStep, st, ih);
-    
+
     const auto actDims = Opm::RestartIO::Helpers::createActionxDims(rspec, sched, rptStep);
     auto  actionxData = Opm::RestartIO::Helpers::AggregateActionxData(actDims);
-    actionxData.captureDeclaredActionxData(sched, st, actDims, rptStep);
-    
+    actionxData.captureDeclaredActionxData(sched, action_state, st, actDims, rptStep);
+
     {
         /*
         Check of InteHEAD and DoubHEAD data for UDQ variables
-        
-                INTEHEAD 
-                
+
+                INTEHEAD
+
                 Intehead[156]  -  The number of ACTIONS
                 Intehead[157]  -  The max number of lines of schedule data including ENDACTIO keyword for any ACTION
 
@@ -154,23 +156,23 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         const auto rptStep_1 = std::size_t{0};
         const auto ih_1 = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
                                                 secs_elapsed, rptStep, rptStep_1 + 1, rptStep_1);
-        
-        BOOST_CHECK_EQUAL(ih_1[156] ,       2); 
-        BOOST_CHECK_EQUAL(ih_1[157] ,       7); 
-        
-        
+
+        BOOST_CHECK_EQUAL(ih_1[156] ,       2);
+        BOOST_CHECK_EQUAL(ih_1[157] ,       7);
+
+
         const auto rptStep_2 = std::size_t{1};
         const auto ih_2 = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
                                                 secs_elapsed, rptStep, rptStep_2 + 1, rptStep_2);
-        BOOST_CHECK_EQUAL(ih_2[156] ,       3); 
-        BOOST_CHECK_EQUAL(ih_2[157] ,      10); 
+        BOOST_CHECK_EQUAL(ih_2[156] ,       3);
+        BOOST_CHECK_EQUAL(ih_2[157] ,      10);
 
         const auto rptStep_3 = std::size_t{2};
         const auto ih_3 = Opm::RestartIO::Helpers::createInteHead(es, grid, sched,
                                                 secs_elapsed, rptStep, rptStep_3 + 1, rptStep_3);
-        
-        BOOST_CHECK_EQUAL(ih_3[156] ,       3); 
-        BOOST_CHECK_EQUAL(ih_3[157] ,      10); 
+
+        BOOST_CHECK_EQUAL(ih_3[156] ,       3);
+        BOOST_CHECK_EQUAL(ih_3[157] ,      10);
 
     }
 
@@ -188,26 +190,26 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
             //item [7]: is unknown, (=0)
             //item [8]: The number of times the action is triggered
         */
-        
-        
+
+
         const auto& iAct = actionxData.getIACT();
-        
+
         auto start = 0*actDims[1];
-        BOOST_CHECK_EQUAL(iAct[start + 0] ,  0); 
-        BOOST_CHECK_EQUAL(iAct[start + 1] , 10); 
-        BOOST_CHECK_EQUAL(iAct[start + 2] ,  1); 
+        BOOST_CHECK_EQUAL(iAct[start + 0] ,  0);
+        BOOST_CHECK_EQUAL(iAct[start + 1] , 10);
+        BOOST_CHECK_EQUAL(iAct[start + 2] ,  1);
         BOOST_CHECK_EQUAL(iAct[start + 3] ,  7);
         BOOST_CHECK_EQUAL(iAct[start + 4] ,  0);
         BOOST_CHECK_EQUAL(iAct[start + 5] , 10);
         BOOST_CHECK_EQUAL(iAct[start + 6] ,  0);
         BOOST_CHECK_EQUAL(iAct[start + 7] ,  0);
         BOOST_CHECK_EQUAL(iAct[start + 8] ,  3);
-        
+
 
         start = 1*actDims[1];
         BOOST_CHECK_EQUAL(iAct[start + 0] ,  0);
-        BOOST_CHECK_EQUAL(iAct[start + 1] ,  7); 
-        BOOST_CHECK_EQUAL(iAct[start + 2] ,  1); 
+        BOOST_CHECK_EQUAL(iAct[start + 1] ,  7);
+        BOOST_CHECK_EQUAL(iAct[start + 2] ,  1);
         BOOST_CHECK_EQUAL(iAct[start + 3] ,  7);
         BOOST_CHECK_EQUAL(iAct[start + 4] ,  0);
         BOOST_CHECK_EQUAL(iAct[start + 5] , 11);
@@ -216,9 +218,9 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(iAct[start + 8] ,  3);
 
         start = 2*actDims[1];
-        BOOST_CHECK_EQUAL(iAct[start + 0] ,  0); 
-        BOOST_CHECK_EQUAL(iAct[start + 1] ,  4); 
-        BOOST_CHECK_EQUAL(iAct[start + 2] ,  1); 
+        BOOST_CHECK_EQUAL(iAct[start + 0] ,  0);
+        BOOST_CHECK_EQUAL(iAct[start + 1] ,  4);
+        BOOST_CHECK_EQUAL(iAct[start + 2] ,  1);
         BOOST_CHECK_EQUAL(iAct[start + 3] ,  7);
         BOOST_CHECK_EQUAL(iAct[start + 4] ,  0);
         BOOST_CHECK_EQUAL(iAct[start + 5] , 13);
@@ -227,159 +229,159 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(iAct[start + 8] ,  3);
 
     }
-    
+
     {
         /*
         ZACT
         --length 4 times 8-chars pr ACTIONX keyword
 
         Name of action 4 times 8 chars (up to 8 chars for name)
-        
+
         */
-        
+
         const auto& zAct = actionxData.getZACT();
-        
+
         auto start = 0*actDims[3];
-        BOOST_CHECK_EQUAL(zAct[start + 0].c_str() ,   "ACT01   "); 
+        BOOST_CHECK_EQUAL(zAct[start + 0].c_str() ,   "ACT01   ");
 
         start = 1*actDims[3];
-        BOOST_CHECK_EQUAL(zAct[start + 0].c_str() ,   "ACT02   "); 
+        BOOST_CHECK_EQUAL(zAct[start + 0].c_str() ,   "ACT02   ");
 
         start = 2*actDims[3];
-        BOOST_CHECK_EQUAL(zAct[start + 0].c_str() ,   "ACT03   "); 
-        
+        BOOST_CHECK_EQUAL(zAct[start + 0].c_str() ,   "ACT03   ");
+
     }
-    
+
     {
      /*
      ZLACT
         -- length = ACTDIMS_item3*(max-over-action of number of lines of data pr ACTION)
 
         */
-        
+
         const auto& zLact = actionxData.getZLACT();
-        
+
         //First action
         auto start_a = 0*actDims[4];
         auto start = start_a + 0*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN ");  
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN ");
 
         start = start_a + 1*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "   '?' '");  
-        BOOST_CHECK_EQUAL(zLact[start + 1].c_str() ,   "SHUT' 0 ");  
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "   '?' '");
+        BOOST_CHECK_EQUAL(zLact[start + 1].c_str() ,   "SHUT' 0 ");
         BOOST_CHECK_EQUAL(zLact[start + 2].c_str() ,   "0 0 /   ");
 
         start = start_a + 2*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "/       "); 
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "/       ");
 
         start = start_a +  3*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN "); 
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN ");
 
         //Second action
         start_a = 1*actDims[4];
         start = start_a + 0*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN ");  
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN ");
 
         start = start_a + 1*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "   '?' '");  
-        BOOST_CHECK_EQUAL(zLact[start + 1].c_str() ,   "SHUT' 0 ");  
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "   '?' '");
+        BOOST_CHECK_EQUAL(zLact[start + 1].c_str() ,   "SHUT' 0 ");
         BOOST_CHECK_EQUAL(zLact[start + 2].c_str() ,   "0 0 /   ");
 
         start = start_a + 2*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "/       "); 
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "/       ");
 
         start = start_a + 3*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN ");  
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "WELOPEN ");
 
         start = start_a + 4*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "   'OPL0");  
-        BOOST_CHECK_EQUAL(zLact[start + 1].c_str() ,   "1' 'OPEN");  
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "   'OPL0");
+        BOOST_CHECK_EQUAL(zLact[start + 1].c_str() ,   "1' 'OPEN");
         BOOST_CHECK_EQUAL(zLact[start + 2].c_str() ,   "' /     ");
 
         start = start_a + 5*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "/       "); 
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "/       ");
 
-        
+
         start = start_a +  6*actDims[8];
-        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "ENDACTIO"); 
+        BOOST_CHECK_EQUAL(zLact[start + 0].c_str() ,   "ENDACTIO");
 
-        
+
     }
-    
+
         {
      /*
      ZACN
         //(Max number of conditions pr ACTIONX) * ((max no characters pr line = 104) / (8 - characters pr string)(104/8 = 13)
 
         */
-        
+
         const auto& zAcn = actionxData.getZACN();
-        
+
         //First action
         auto start_a = 0*actDims[5];
         auto start = start_a + 0*13;
-        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "FMWPR   ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "FMWPR   ");
+        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");
         BOOST_CHECK_EQUAL(zAcn[start + 2].c_str() ,   ">       ");
-        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        "); 
+        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        ");
 
         start = start_a + 1*13;
-        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "WUPR3   ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "WUPR3   ");
+        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");
         BOOST_CHECK_EQUAL(zAcn[start + 2].c_str() ,   ">       ");
-        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "OP*     ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 5].c_str() ,   "        "); 
+        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "OP*     ");
+        BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");
+        BOOST_CHECK_EQUAL(zAcn[start + 5].c_str() ,   "        ");
 
         start = start_a + 2*13;
-        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "        ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "        ");
+        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");
         BOOST_CHECK_EQUAL(zAcn[start + 2].c_str() ,   ">       ");
-        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        ");
+        BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");
 
-        
-        
+
+
         //Second action
         start_a = 1*actDims[5];
         start = start_a + 0*13;
-        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "FMWPR   ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "FMWPR   ");
+        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");
         BOOST_CHECK_EQUAL(zAcn[start + 2].c_str() ,   ">       ");
-        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        "); 
+        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        ");
 
         start = start_a + 1*13;
-        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "WGPR    ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "GGPR    ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "WGPR    ");
+        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "GGPR    ");
         BOOST_CHECK_EQUAL(zAcn[start + 2].c_str() ,   ">       ");
-        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "OPL02   ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "OPL02   ");
+        BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");
         BOOST_CHECK_EQUAL(zAcn[start + 5].c_str() ,   "        ");
-        BOOST_CHECK_EQUAL(zAcn[start + 6].c_str() ,   "LOWER   "); 
+        BOOST_CHECK_EQUAL(zAcn[start + 6].c_str() ,   "LOWER   ");
 
         start = start_a + 2*13;
-        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "        ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 0].c_str() ,   "        ");
+        BOOST_CHECK_EQUAL(zAcn[start + 1].c_str() ,   "        ");
         BOOST_CHECK_EQUAL(zAcn[start + 2].c_str() ,   ">       ");
-        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        ");  
-        BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");  
+        BOOST_CHECK_EQUAL(zAcn[start + 3].c_str() ,   "        ");
+        BOOST_CHECK_EQUAL(zAcn[start + 4].c_str() ,   "        ");
     }
-    
+
         {
         /*
         IACN
-        26*Max number of conditions pr ACTIONX 
+        26*Max number of conditions pr ACTIONX
 
         */
-        
-        
+
+
         const auto& iAcn = actionxData.getIACN();
-        
+
         auto start_a = 0*actDims[6];
         auto start = start_a + 0*26;
-        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0); 
+        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  4] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  5] ,  0);
@@ -395,11 +397,11 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(iAcn[start + 15] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 16] ,  1);
         BOOST_CHECK_EQUAL(iAcn[start + 17] ,  0);
-        
+
         start = start_a + 1*26;
-        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0); 
+        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  4] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  5] ,  0);
@@ -418,9 +420,9 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
 
         start_a = 1*actDims[6];
         start = start_a + 0*26;
-        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0); 
+        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  4] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  5] ,  0);
@@ -436,11 +438,11 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(iAcn[start + 15] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 16] ,  1);
         BOOST_CHECK_EQUAL(iAcn[start + 17] ,  0);
-        
+
         start = start_a + 1*26;
-        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0); 
+        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  4] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  5] ,  0);
@@ -456,11 +458,11 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(iAcn[start + 15] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start + 16] ,  1);
         BOOST_CHECK_EQUAL(iAcn[start + 17] ,  0);
-        
+
         start = start_a + 2*26;
-        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0); 
+        BOOST_CHECK_EQUAL(iAcn[start +  0] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  1] ,  0);
+        BOOST_CHECK_EQUAL(iAcn[start +  2] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  4] ,  0);
         BOOST_CHECK_EQUAL(iAcn[start +  5] ,  0);
@@ -479,23 +481,23 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
 
     }
 
-    
-    
+
+
     {
         /*
         SACN
-        26*Max number of conditions pr ACTIONX 
+        26*Max number of conditions pr ACTIONX
 
         */
-        
-        
+
+
         const auto& sAcn = actionxData.getSACN();
-        
+
         auto start_a = 0*actDims[6];
         auto start = start_a + 0*16;
-        BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  2] , 45); 
+        BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0);
+        BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0);
+        BOOST_CHECK_EQUAL(sAcn[start +  2] , 45);
         BOOST_CHECK_EQUAL(sAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start +  4] ,  4);
         BOOST_CHECK_EQUAL(sAcn[start +  5] , 45);
@@ -509,11 +511,11 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(sAcn[start + 13] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start + 14] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start + 15] ,  0);
-        
+
         start = start_a + 1*16;
-        BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  2] , 46); 
+        BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0);
+        BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0);
+        BOOST_CHECK_EQUAL(sAcn[start +  2] , 46);
         BOOST_CHECK_EQUAL(sAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start +  4] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start +  5] , 46);
@@ -527,11 +529,11 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(sAcn[start + 13] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start + 14] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start + 15] ,  0);
-                
+
         start = start_a + 2*16;
-        BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0); 
-        BOOST_CHECK_EQUAL(sAcn[start +  2] , 10); 
+        BOOST_CHECK_EQUAL(sAcn[start +  0] ,  0);
+        BOOST_CHECK_EQUAL(sAcn[start +  1] ,  0);
+        BOOST_CHECK_EQUAL(sAcn[start +  2] , 10);
         BOOST_CHECK_EQUAL(sAcn[start +  3] ,  0);
         BOOST_CHECK_EQUAL(sAcn[start +  4] ,  1.E+20);
         BOOST_CHECK_EQUAL(sAcn[start +  5] ,  1.E+20);
@@ -547,7 +549,7 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
         BOOST_CHECK_EQUAL(sAcn[start + 15] ,  0);
 
     }
-   
+
 }
-    
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -25,6 +25,7 @@
 #include <opm/output/eclipse/AggregateWellData.hpp>
 #include <opm/output/eclipse/AggregateConnectionData.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/VectorItems/well.hpp>
@@ -40,6 +41,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 
 #include <exception>
 #include <stdexcept>
@@ -574,7 +576,7 @@ BOOST_AUTO_TEST_CASE (Constructor)
 BOOST_AUTO_TEST_CASE (Declared_Well_Data)
 {
     const auto simCase = SimulationCase{first_sim()};
-
+    Opm::Action::State action_state;
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t{1};
 
@@ -587,7 +589,7 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data)
     const auto smry = sim_state();
     auto awd = Opm::RestartIO::Helpers::AggregateWellData{ih.value};
     awd.captureDeclaredWellData(simCase.sched,
-                                simCase.es.getUnits(), rptStep, smry, ih.value);
+                                simCase.es.getUnits(), rptStep, action_state, smry, ih.value);
 
     // IWEL (OP_1)
     {
@@ -1060,6 +1062,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD) {
     const auto sim_step = rptStep - 1;
     Opm::SummaryState sumState(std::chrono::system_clock::now());
     const auto xw   = well_rates_1();
+    Opm::Action::State action_state;
 
     const auto ih = Opm::RestartIO::Helpers::createInteHead(simCase.es,
                                                             simCase.grid,
@@ -1070,7 +1073,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD) {
                                                             sim_step);
 
     auto wellData = Opm::RestartIO::Helpers::AggregateWellData(ih);
-    wellData.captureDeclaredWellData(simCase.sched, units, sim_step, sumState, ih);
+    wellData.captureDeclaredWellData(simCase.sched, units, sim_step, action_state, sumState, ih);
     wellData.captureDynamicWellData(simCase.sched, sim_step, xw , sumState);
 
     auto connectionData = Opm::RestartIO::Helpers::AggregateConnectionData(ih);

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -35,6 +35,7 @@
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 
 #include <opm/io/eclipse/EclFile.hpp>
 #include <opm/io/eclipse/EGrid.hpp>
@@ -320,9 +321,11 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
             sol.insert("KRO", measure::identity , std::vector<double>(3*3*3 , i), TargetType::RESTART_AUXILIARY);
             sol.insert("KRG", measure::identity , std::vector<double>(3*3*3 , i*10), TargetType::RESTART_AUXILIARY);
 
+            Action::State action_state;
             RestartValue restart_value(sol, wells);
             auto first_step = ecl_util_make_date( 10 + i, 11, 2008 );
-            eclWriter.writeTimeStep( st,
+            eclWriter.writeTimeStep( action_state,
+                                     st,
                                      i,
                                      false,
                                      first_step - start_time,

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
@@ -274,6 +275,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         const auto step_time  = timeStamp(::Opm::EclIO::ERft::RftDate{ 2008, 10, 10 });
 
         SummaryState st(std::chrono::system_clock::now());
+        Action::State action_state;
 
         data::Rates r1, r2;
         r1.set( data::Rates::opt::wat, 4.11 );
@@ -306,7 +308,8 @@ BOOST_AUTO_TEST_CASE(test_RFT)
 
         RestartValue restart_value(std::move(solution), std::move(wells));
 
-        eclipseWriter.writeTimeStep( st,
+        eclipseWriter.writeTimeStep( action_state,
+                                     st,
                                      2,
                                      false,
                                      step_time - start_time,
@@ -390,6 +393,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
         Schedule schedule(deck, eclipseState, python);
         SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ));
         SummaryState st(std::chrono::system_clock::now());
+        Action::State action_state;
 
         const auto  start_time = schedule.posixStartTime();
         const auto& time_map   = schedule.getTimeMap( );
@@ -430,7 +434,8 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
 
                 RestartValue restart_value(std::move(solution), std::move(wells));
 
-                eclipseWriter.writeTimeStep( st,
+                eclipseWriter.writeTimeStep( action_state,
+                                             st,
                                              step,
                                              false,
                                              step_time - start_time,

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -36,6 +36,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 
 #include <opm/io/eclipse/EclFile.hpp>
 
@@ -206,6 +207,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     Opm::EclipseIO eclipseWriter( es,  grid , schedule, summary_config);
     int countTimeStep = schedule.getTimeMap().numTimesteps();
     Opm::SummaryState st(std::chrono::system_clock::from_time_t(schedule.getStartTime()));
+    Opm::Action::State action_state;
 
     Opm::data::Solution solution;
     solution.insert( "PRESSURE", Opm::UnitSystem::measure::pressure , std::vector< double >( num_cells, 1 ) , Opm::data::TargetType::RESTART_SOLUTION);
@@ -215,7 +217,8 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
 
     for(int timestep = 0; timestep <= countTimeStep; ++timestep) {
 
-        eclipseWriter.writeTimeStep( st,
+        eclipseWriter.writeTimeStep( action_state,
+                                     st,
                                      timestep,
                                      false,
                                      schedule.seconds(timestep),

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 
 #include <opm/io/eclipse/rst/connection.hpp>
 #include <opm/io/eclipse/rst/header.hpp>
@@ -260,6 +261,7 @@ BOOST_AUTO_TEST_CASE(State_test) {
     const auto rptStep = std::size_t{4};
     const auto sim_step = rptStep - 1;
     Opm::SummaryState sumState(std::chrono::system_clock::now());
+    Opm::Action::State action_state;
 
     const auto ih = Opm::RestartIO::Helpers::createInteHead(simCase.es,
                                                             simCase.grid,
@@ -277,7 +279,7 @@ BOOST_AUTO_TEST_CASE(State_test) {
                                                             0, 0);
 
     auto wellData = Opm::RestartIO::Helpers::AggregateWellData(ih);
-    wellData.captureDeclaredWellData(simCase.sched, units, sim_step, sumState, ih);
+    wellData.captureDeclaredWellData(simCase.sched, units, sim_step, action_state, sumState, ih);
     wellData.captureDynamicWellData(simCase.sched, sim_step, {} , sumState);
 
     auto connectionData = Opm::RestartIO::Helpers::AggregateConnectionData(ih);


### PR DESCRIPTION
The purpose of this PR is to add an object `Action::State`which keeps track of how many times an action has been run (i.e. succeeded), and the last time it was run. This was previously handled with a pair of mutable members in `ActionX` class - remember this kids: `mutable` as a way to implement functionality (beyond caching) **always** comes back to bite you.

The `Action::State`object is owned by the simulator. Main content of PR is adding `Action::State&`argument all over the place.

Downstream: https://github.com/OPM/opm-simulators/pull/2674