### PR TITLE
fixed: add missing initializer

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -117,7 +117,7 @@ struct GroupInjectionProperties {
     UDAValue target_void_fraction;
     std::string reinj_group;
     std::string voidage_group;
-    bool available_group_control;
+    bool available_group_control = true;
 
     static GroupInjectionProperties serializeObject();
 


### PR DESCRIPTION
If GCONSALE is used, we do https://github.com/OPM/opm-common/blob/master/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp#L1860

ie we pass class with an unitialized member. Inside updateInjection we do https://github.com/OPM/opm-common/blob/master/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp#L129

this means the unitialized value ends up in the map. This led to indeterminism in data output causing havoc in https://github.com/OPM/opm-common/pull/1408