### PR TITLE
Udq scientific

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -43,7 +43,8 @@ std::vector<std::string> quote_split(const std::string& item) {
     while (true) {
         auto quote_pos1 = item.find(quote_char, offset);
         if (quote_pos1 == std::string::npos) {
-            items.push_back(item.substr(offset));
+            if (offset < item.size())
+                items.push_back(item.substr(offset));
             break;
         }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -110,7 +110,7 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
                         if (pos > offset)
                             tokens.push_back(item.substr(offset, pos - offset));
                         tokens.push_back(splitter);
-                        pos = find_pos + 1;
+                        pos = find_pos + splitter.size();
                         offset = pos;
                         break;
                     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -87,6 +87,17 @@ std::optional<std::string> next_token(const std::string& item, std::size_t offse
     if (offset == item.size())
         return {};
 
+    if (std::isdigit(item[offset])) {
+        std::size_t token_size = 0;
+        try {
+            auto substring = item.substr(offset);
+            double value = std::stod(substring, &token_size);
+        } catch (const std::invalid_argument &) {}
+
+        if (token_size > 0)
+            return item.substr(offset, token_size);
+    }
+
     std::optional<std::string> token = item.substr(offset);
     std::size_t min_pos = std::string::npos;
     for (const auto& splitter : splitters) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp
@@ -293,7 +293,7 @@ UDQASTNode UDQParser::parse(const UDQParams& udq_params, UDQVarType target_type,
     if (!parser.empty()) {
         size_t index = parser.current_pos;
         auto current = parser.current();
-        std::string msg = "Extra unhandled data starting with token[" + std::to_string(index) + "] = " + current.value;
+        std::string msg = "Extra unhandled data starting with token[" + std::to_string(index) + "] = '" + current.value + "'";
         parseContext.handleError(ParseContext::UDQ_PARSE_ERROR, msg, errors);
         return UDQASTNode( udq_params.undefinedValue() );
     }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -92,7 +92,6 @@ BOOST_AUTO_TEST_CASE(SUBTRACT)
     BOOST_CHECK_EQUAL( res2[0].value(), 16.0);
 }
 
-
 BOOST_AUTO_TEST_CASE(TEST)
 {
     UDQParams udqp;
@@ -1618,5 +1617,25 @@ WCONPROD
         BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::binary_op_sub), 1);
         BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::binary_op_mul), 1);
     }
+}
+
+
+BOOST_AUTO_TEST_CASE(UDQ_SCIENTIFIC_LITERAL) {
+    std::string deck_string = R"(
+SCHEDULE
+UDQ
+   DEFINE FU 0 -1.25E-2*(1.0E-1 + 2E-1) /
+/
+)";
+    auto schedule = make_schedule(deck_string);
+    const auto& udq = schedule.getUDQConfig(0);
+    UDQParams udqp;
+    auto def0 = udq.definitions()[0];
+    SummaryState st(std::chrono::system_clock::now());
+    UDQFunctionTable udqft(udqp);
+    UDQContext context(udqft, st);
+
+    auto res0 = def0.eval(context);
+    BOOST_CHECK_CLOSE( res0[0].value(), -0.00125*3, 1e-6);
 }
 


### PR DESCRIPTION
The UDQ tokenizer splits on the '-' character - that creates rtouble when parsing numerical literals on scientific form: 1E-5

Fixed in this PR