### PR TITLE
Fix handling of too long 8 characters keywords like GUIDERATE

### DIFF
--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -637,12 +637,6 @@ RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string
 
 
 RawKeyword * newRawKeyword( const std::string& deck_name, ParserState& parserState, const Parser& parser, const string_view& line ) {
-    if (parser.isRecognizedKeyword(deck_name)) {
-        parserState.unknown_keyword = false;
-        const auto& parserKeyword = parser.getParserKeywordFromDeckName(deck_name);
-        return newRawKeyword(parserKeyword, deck_name, parserState, parser);
-    }
-
     if (deck_name.size() > RawConsts::maxKeywordLength) {
         const std::string keyword8 = deck_name.substr(0, RawConsts::maxKeywordLength);
         if (parser.isRecognizedKeyword(keyword8)) {
@@ -652,7 +646,17 @@ RawKeyword * newRawKeyword( const std::string& deck_name, ParserState& parserSta
             parserState.unknown_keyword = false;
             const auto& parserKeyword = parser.getParserKeywordFromDeckName( keyword8 );
             return newRawKeyword(parserKeyword, keyword8, parserState, parser);
+        } else {
+            parserState.parseContext.handleUnknownKeyword( deck_name, parserState.errors );
+            parserState.unknown_keyword = true;
+            return nullptr;
         }
+    }
+
+    if (parser.isRecognizedKeyword(deck_name)) {
+        parserState.unknown_keyword = false;
+        const auto& parserKeyword = parser.getParserKeywordFromDeckName(deck_name);
+        return newRawKeyword(parserKeyword, deck_name, parserState, parser);
     }
 
     if( ParserKeyword::validDeckName(deck_name) ) {

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.cpp
@@ -34,9 +34,6 @@ namespace {
          if (!ParserKeyword::validDeckName(name))
             throw std::invalid_argument("Not a valid keyword:" + name);
 
-         if (name.size() > Opm::RawConsts::maxKeywordLength)
-            throw std::invalid_argument("Too long keyword:" + name);
-
          if (name[0] == ' ')
              throw std::invalid_argument("Illegal whitespace start of keyword:" + name);
 

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -2318,3 +2318,23 @@ auto record = kw.getRecord(1);
 BOOST_CHECK_EQUAL( record.getItem(5).get<double>(0), 0.9 );
 BOOST_CHECK( !deck.hasKeyword("LANGMUIR") );
 }
+
+
+
+
+BOOST_AUTO_TEST_CASE(ParseLONGKeywords) {
+   Parser parser;
+   ParseContext parseContext;
+   ErrorGuard errors;
+   const auto deck_string = R"(
+GUIDERATE
+/
+)";
+
+   parseContext.update(ParseContext::PARSE_LONG_KEYWORD, Opm::InputError::THROW_EXCEPTION);
+   BOOST_CHECK_THROW(parser.parseString(deck_string, parseContext, errors), std::invalid_argument);
+
+   parseContext.update(ParseContext::PARSE_LONG_KEYWORD, Opm::InputError::IGNORE);
+   auto deck = parser.parseString(deck_string, parseContext, errors);
+   BOOST_CHECK( deck.hasKeyword("GUIDERAT") );
+}


### PR DESCRIPTION
See: #1856 

We have `ParseContext` configuration of keywords which are too long - i.e. like `GUIDERATE` - where the default behavior is to warn about the too long keyword, but still continue parsing. Unfortunately this did not work for two reasons:

1. There was another check of keyword length before the one with `ParseContext` configurability - so the exception was thrown anyway.

2. The regular expression based matching for the `xxx_PROBE` keywords is too gready - and would in this case match. That problem is still there - but the two long check is performed before the regexp matching. 