### PR TITLE
Output: Transport Guiderate Values to Output Layer

### DIFF
--- a/opm/output/data/Groups.hpp
+++ b/opm/output/data/Groups.hpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include <opm/output/data/GuideRateValue.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 
@@ -54,26 +55,53 @@ namespace Opm { namespace data {
                                      Opm::Group::InjectionCMode  cwic);
     };
 
+    struct GroupGuideRates {
+        GuideRateValue production{};
+        GuideRateValue injection{};
 
+        template <class MessageBufferType>
+        void write(MessageBufferType& buffer) const
+        {
+            this->production.write(buffer);
+            this->injection .write(buffer);
+        }
+
+        template <class MessageBufferType>
+        void read(MessageBufferType& buffer)
+        {
+            this->production.read(buffer);
+            this->injection .read(buffer);
+        }
+
+        bool operator==(const GroupGuideRates& other) const
+        {
+            return this->production == other.production
+                && this->injection  == other.injection;
+        }
+    };
 
     struct GroupData {
         GroupConstraints currentControl;
+        GroupGuideRates  guideRates{};
 
         template <class MessageBufferType>
         void write(MessageBufferType& buffer) const
         {
             this->currentControl.write(buffer);
+            this->guideRates    .write(buffer);
         }
 
         template <class MessageBufferType>
         void read(MessageBufferType& buffer)
         {
             this->currentControl.read(buffer);
+            this->guideRates    .read(buffer);
         }
 
         bool operator==(const GroupData& other) const
         {
-            return this->currentControl == other.currentControl;
+            return this->currentControl == other.currentControl
+                && this->guideRates     == other.guideRates;
         }
     };
 

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -30,6 +30,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <opm/output/data/GuideRateValue.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 
 namespace Opm {
@@ -253,6 +255,7 @@ namespace Opm {
         std::vector< Connection > connections;
         std::unordered_map<std::size_t, Segment> segments;
         CurrentControl current_control;
+        GuideRateValue guide_rates{};
 
         inline bool flowing() const noexcept;
         template <class MessageBufferType>
@@ -293,7 +296,8 @@ namespace Opm {
                  control == well2.control &&
                  connections == well2.connections &&
                  segments == well2.segments &&
-                 current_control == well2.current_control;
+                 current_control == well2.current_control &&
+                 guide_rates == well2.guide_rates;
         }
     };
 
@@ -543,6 +547,7 @@ namespace Opm {
         }
 
         this->current_control.write(buffer);
+        this->guide_rates.write(buffer);
     }
 
     template <class MessageBufferType>
@@ -635,6 +640,7 @@ namespace Opm {
         }
 
         this->current_control.read(buffer);
+        this->guide_rates.read(buffer);
     }
 
 }} // Opm::data


### PR DESCRIPTION
This commit introduces datamembers of type
```C++
Opm::data::GuideRateValue
```
to the `Opm::data::Well` and `Opm::data::GroupData` structures. Collectively, these datamembers enable transporting guiderate values calculated elsewhere&mdash;e.g., in the opm-simulators module&mdash;to the output layer for final processing and output to the summary and/or the restart files.

We support outputting both production and injection guiderate values at the group level.  Guiderate values at the well level are interpreted as production or injection according to the well type.