### PR TITLE
Add Guiderate Summary Output

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -187,11 +187,13 @@ namespace {
     bool is_rate(const std::string& keyword) {
         static const keyword_set ratekw {
             "OPR", "GPR", "WPR", "LPR", "NPR", "VPR",
+            "OPGR", "GPGR", "WPGR", "VPGR",
             "OPRH", "GPRH", "WPRH", "LPRH",
             "OVPR", "GVPR", "WVPR",
             "OPRS", "GPRS", "OPRF", "GPRF",
 
             "OIR", "GIR", "WIR", "LIR", "NIR", "VIR",
+            "OIGR", "GIGR", "WIGR",
             "OIRH", "GIRH", "WIRH",
             "OVIR", "GVIR", "WVIR",
 

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -443,6 +443,27 @@ GSPR
 /
 GSPT
 /
+
+-- Production and injection guide rates (group level)
+
+GOPGR
+ G_1 /
+
+GGPGR
+ G_1 /
+
+GWPGR
+ G_1 /
+
+GVPGR
+ G_1 /
+
+GGIGR
+ G_1 /
+
+GWIGR
+ G_1 /
+
 -- Well Data
 -- Production Rates
 WWPR
@@ -648,6 +669,26 @@ WSPR
 
 WSPT
 /
+
+-- Production and injection guide rates (well level)
+WOPGR
+/
+
+WGPGR
+/
+
+WWPGR
+/
+
+WVPGR
+/
+
+WGIGR
+/
+
+WWIGR
+/
+
 -- Water injection per connection
 CWIR
   * /


### PR DESCRIPTION
This PR adds support for outputting the guiderate summary vectors
```
[GW][OGWV]PGR, [GW][GW]IGR
```
under the assumption that the values are fully calculated at another level and that we therefore only need to extract the numerical values and convert the rate units to output conventions.  We assume that such values are communicated to the summary output layer by means of a `GuideRateValue` object.

The assumption of values already being calculated leads to a small change in the `need_wells()` function.  We're now able to exclude guiderate values at the group level from those vectors that require setting up a well vector.  This is a (tiny) performance improvement.