### PR TITLE
Require test source code to compile and fix test for dune-geometry (>2.7)

### DIFF
--- a/cmake/Modules/Finddune-geometry.cmake
+++ b/cmake/Modules/Finddune-geometry.cmake
@@ -33,8 +33,7 @@ find_opm_package (
   # test program
 "#include <dune/geometry/quadraturerules.hh>
 int main (void) {
-  Dune::GeometryType gt;
-  gt.makeQuadrilateral();
+  Dune::GeometryType gt = Dune::GeometryTypes::quadrilateral;
   Dune::QuadratureRules<double, 2>::rule(gt, 2).size();
   return 0;
 }

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -115,26 +115,34 @@ macro (find_opm_package module deps header lib defs prog conf)
   # without config.h
   config_cmd_line (${module}_CMD_CONFIG ${module}_CONFIG_VARS)
 
-  # check that we can compile a small test-program
-  include (CMakePushCheckState)
-  cmake_push_check_state ()
-  include (CheckCXXSourceCompiles)
-  # only add these if they are actually found; otherwise it won't
-  # compile and the variable won't be set
-  append_found (${module}_INCLUDE_DIRS CMAKE_REQUIRED_INCLUDES)
-  append_found (${module}_LIBRARIES CMAKE_REQUIRED_LIBRARIES)
-  # since we don't have any config.h yet
-  list (APPEND CMAKE_REQUIRED_DEFINITIONS ${${module}_DEFINITIONS})
-  list (APPEND CMAKE_REQUIRED_DEFINITIONS ${${module}_CMD_CONFIG})
-  check_cxx_source_compiles ("${prog}" HAVE_${MODULE})
-  cmake_pop_check_state ()
+  if(prog)
+    # check that we can compile a small test-program
+    include (CMakePushCheckState)
+    cmake_push_check_state ()
+    include (CheckCXXSourceCompiles)
+    # only add these if they are actually found; otherwise it won't
+    # compile and the variable won't be set
+    append_found (${module}_INCLUDE_DIRS CMAKE_REQUIRED_INCLUDES)
+    append_found (${module}_LIBRARIES CMAKE_REQUIRED_LIBRARIES)
+    # since we don't have any config.h yet
+    list (APPEND CMAKE_REQUIRED_DEFINITIONS ${${module}_DEFINITIONS})
+    list (APPEND CMAKE_REQUIRED_DEFINITIONS ${${module}_CMD_CONFIG})
+    check_cxx_source_compiles ("${prog}" HAVE_${MODULE})
+    cmake_pop_check_state ()
+  else(prog)
+    if(${module}_FOUND)
+      # No test code provided, mark compilation as successful
+      # if module was founf
+      set(HAVE_${MODULE} 1)
+    endif(${module}_FOUND)
+  endif(prog)
 
   # write status message in the same manner as everyone else
   include (FindPackageHandleStandardArgs)
   find_package_handle_standard_args (
         ${module}
         DEFAULT_MSG
-        ${module}_INCLUDE_DIRS ${module}_LIBRARIES ${module}_FOUND ${module}_ALL_PREREQS
+        ${module}_INCLUDE_DIRS ${module}_LIBRARIES ${module}_FOUND ${module}_ALL_PREREQS HAVE_${MODULE}
         )
 
   # some genius that coded the FindPackageHandleStandardArgs figured out


### PR DESCRIPTION
Finding a module always succeeded even if the test program didn't even compile (might have been a feature).