### PR TITLE
Fix unit for salt concentration in WSALT

### DIFF
--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -75,6 +75,7 @@ namespace Opm {
             energy,
             icd_strength,
             polymer_density,
+            salinity,
             _count // New entries must be added *before* this
         };
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellBrineProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellBrineProperties.cpp
@@ -32,7 +32,7 @@ Opm::WellBrineProperties Opm::WellBrineProperties::serializeObject()
 
 void Opm::WellBrineProperties::handleWSALT(const DeckRecord& rec)
 {
-    this->m_saltConcentration = rec.getItem("CONCENTRATION").get<UDAValue>(0).get<double>();
+    this->m_saltConcentration = rec.getItem("CONCENTRATION").get<UDAValue>(0).getSI();
 }
 
 bool Opm::WellBrineProperties::operator!=(const WellBrineProperties& other) const

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -78,6 +78,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
     };
 
     static const double to_metric[] = {
@@ -116,6 +117,7 @@ namespace {
         1 / Metric::Energy,
         1 / (Metric::Pressure / Opm::unit::square(Metric::GeomVolume / Metric::Time)),
         1 / Metric::PolymerDensity,
+        1 / Metric::Salinity,
     };
 
     static const double from_metric[] = {
@@ -154,6 +156,7 @@ namespace {
         Metric::Energy,
         Metric::Pressure / Opm::unit::square(Metric::GeomVolume / Metric::Time),
         Metric::PolymerDensity,
+        Metric::Salinity,
     };
 
     static constexpr const char* metric_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -192,6 +195,7 @@ namespace {
         "KJ", /* energy */
         "BARS/(RM3/DAY)2", /* ICD strength parameter */
         "KG / SM3", /*polymer density */
+        "KG / SM3", /*salinity */
     };
 
     static_assert(
@@ -210,6 +214,7 @@ namespace {
         0.0,
         0.0,
         Field::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -276,6 +281,7 @@ namespace {
         1 / Field::Energy,
         1 / (Field::Pressure / Opm::unit::square(Field::GeomVolume / Field::Time)),
         1 / Field::PolymerDensity,
+        1 / Field::Salinity,
     };
 
     static const double from_field[] = {
@@ -314,6 +320,7 @@ namespace {
          Field::Energy,
          Field::Pressure / Opm::unit::square(Field::GeomVolume / Field::Time),
          Field::PolymerDensity,
+         Field::Salinity,
     };
 
     static constexpr const char* field_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -352,6 +359,7 @@ namespace {
         "BTU", /* energy */
         "PSI/(RFT3/DAY)2", /* ICD strength parameter */
         "LB/STB", /*polymer density */
+        "LB/STB", /*salinity */
     };
 
     static_assert(
@@ -370,6 +378,7 @@ namespace {
         0.0,
         0.0,
         Lab::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -436,6 +445,7 @@ namespace {
         1 / Lab::Energy,
         1 / (Lab::Pressure / Opm::unit::square(Lab::GeomVolume / Lab::Time)),
         1 / Lab::PolymerDensity,
+        1 / Lab::Salinity,
     };
 
     static const double from_lab[] = {
@@ -474,6 +484,7 @@ namespace {
         Lab::Energy,
         Lab::Pressure / Opm::unit::square(Lab::GeomVolume / Lab::Time),
         Lab::PolymerDensity,
+        Lab::Salinity,
     };
 
     static constexpr const char* lab_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -512,6 +523,7 @@ namespace {
         "J", /* energy */
         "ATM/(RCC/H)2", /* ICD strength parameter */
         "G/SCC", /*polymer density */
+        "G/SCC", /*salinity */
     };
 
     static_assert(
@@ -530,6 +542,7 @@ namespace {
         0.0,
         0.0,
         PVT_M::TemperatureOffset,
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -596,6 +609,7 @@ namespace {
         1 / PVT_M::Energy,
         1 / (PVT_M::Pressure / Opm::unit::square(PVT_M::GeomVolume / PVT_M::Time)),
         1 / PVT_M::PolymerDensity,
+        1 / PVT_M::Salinity,
     };
 
     static const double from_pvt_m[] = {
@@ -634,6 +648,7 @@ namespace {
         PVT_M::Energy,
         PVT_M::Pressure / Opm::unit::square(PVT_M::GeomVolume / PVT_M::Time),
         PVT_M::PolymerDensity,
+        PVT_M::Salinity,
     };
 
     static constexpr const char* pvt_m_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -672,6 +687,7 @@ namespace {
         "KJ" /* energy */,
         "ATM/(RM3/DAY)2", /* ICD strength parameter */
         "KG/SM3", /*polymer density */
+        "KG/SM3", /*salinity */
     };
 
     static_assert(
@@ -683,6 +699,7 @@ namespace {
     // INPUT Unit Conventions
 
     static const double from_input_offset[] = {
+        0.0,
         0.0,
         0.0,
         0.0,
@@ -756,9 +773,11 @@ namespace {
         1,
         1,
         1,
+        1,
     };
 
     static const double from_input[] = {
+        1,
         1,
         1,
         1,
@@ -832,6 +851,7 @@ namespace {
         "KJ", /* energy */
         "BARS/(RM3/DAY)2", /* ICD strength parameter */
         "KG/SM3", /*polymer density */
+        "KG/SM3", /*salinity */
     };
 
     static_assert(

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WSALT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WSALT
@@ -11,7 +11,8 @@
     },
     {
       "name": "CONCENTRATION",
-      "value_type": "UDA"
+      "value_type": "UDA",
+      "dimension": "Salinity"
     }
   ]
 }


### PR DESCRIPTION
The salt concentration has unit density, not identity. 