### PR TITLE
Refactor Damping Factor Implementation

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -312,6 +312,7 @@ if(ENABLE_ECL_INPUT)
   list(APPEND TEST_SOURCE_FILES
     tests/rst_test.cpp
     tests/test_ERsm.cpp
+    tests/test_GuideRate.cpp
     tests/parser/ACTIONX.cpp
     tests/parser/ADDREGTests.cpp
     tests/parser/AquiferTests.cpp

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -22,6 +22,8 @@
 
 #include <cstddef>
 #include <ctime>
+#include <limits>
+#include <memory>
 #include <string>
 #include <unordered_map>
 
@@ -77,11 +79,15 @@ struct GuideRateValue {
         return !(*this == other);
     }
 
-    double sim_time;
-    double value;
-    GuideRateModel::Target target;
+    double sim_time { std::numeric_limits<double>::lowest() };
+    double value { std::numeric_limits<double>::lowest() };
+    GuideRateModel::Target target { GuideRateModel::Target::NONE };
 };
 
+struct GRValState {
+    GuideRateValue curr{};
+    GuideRateValue prev{};
+};
 
 public:
     GuideRate(const Schedule& schedule);
@@ -94,11 +100,16 @@ public:
 private:
     void well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
     void group_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
-    double eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot, const GuideRateValue * prev) const;
+    double eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot) const;
     double eval_group_pot() const;
     double eval_group_resvinj() const;
 
-    std::unordered_map<std::string, GuideRateValue> values;
+    void assign_grvalue(const std::string& wgname, const GuideRateModel& model, GuideRateValue&& value);
+    double get_grvalue_result(const GRValState& gr) const;
+
+    using GRValPtr = std::unique_ptr<GRValState>;
+
+    std::unordered_map<std::string, GRValPtr> values;
     std::unordered_map<std::string, RateVector > potentials;
     const Schedule& schedule;
 };

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Equinor ASA.
+  Copyright 2019, 2020 Equinor ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -20,14 +20,16 @@
 #ifndef GUIDE_RATE_HPP
 #define GUIDE_RATE_HPP
 
-#include <string>
 #include <cstddef>
 #include <ctime>
+#include <string>
 #include <unordered_map>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <stddef.h>
+
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 
 namespace Opm {
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -20,10 +20,17 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
 
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <stddef.h>
+
 namespace Opm {
-
-
-
 
 double GuideRate::RateVector::eval(Well::GuideRateTarget target) const
 {
@@ -59,40 +66,41 @@ GuideRate::GuideRate(const Schedule& schedule_arg) :
     schedule(schedule_arg)
 {}
 
-
-
-double GuideRate::get(const std::string& well, Well::GuideRateTarget target, const RateVector& rates) const {
-    auto model_target = GuideRateModel::convert_target(target);
-    return get(well, model_target, rates);
+double GuideRate::get(const std::string& well, Well::GuideRateTarget target, const RateVector& rates) const
+{
+    return this->get(well, GuideRateModel::convert_target(target), rates);
 }
 
-double GuideRate::get(const std::string& group, Group::GuideRateTarget target, const RateVector& rates) const {
-    auto model_target = GuideRateModel::convert_target(target);
-    return get(group, model_target, rates);
+double GuideRate::get(const std::string& group, Group::GuideRateTarget target, const RateVector& rates) const
+{
+    return this->get(group, GuideRateModel::convert_target(target), rates);
 }
 
-double GuideRate::get(const std::string& name, GuideRateModel::Target model_target, const RateVector& rates) const {
-    const auto iter = this->values.find(name);
-    if (iter != this->values.end()) {
-        const auto& value = iter->second;
-        if (value.target == model_target)
-            return value.value;
-        else {
-            double model_target_rate = rates.eval(model_target);
-            double value_target_rate = rates.eval(value.target);        
-                    
-            if (model_target_rate < 1e-6)
-                return value.value;
-            if (value_target_rate < 1e-6)
-                return value.value; 
+double GuideRate::get(const std::string& name, GuideRateModel::Target model_target, const RateVector& rates) const
+{
+    using namespace unit;
+    using prefix::micro;
 
-            // scale with the current production ratio when the control target differs from the guide rate target.
-            return value.value * model_target_rate / value_target_rate;
-        }
-    } else {
-        const auto& pot = this->potentials.at(name);
-        return pot.eval(model_target);
+    auto iter = this->values.find(name);
+    if (iter == this->values.end()) {
+        return this->potentials.at(name).eval(model_target);
     }
+
+    const auto& value = *iter->second;
+    const auto grvalue = this->get_grvalue_result(value);
+    if (value.curr.target == model_target) {
+        return grvalue;
+    }
+
+    const auto value_target_rate = rates.eval(value.curr.target);
+    if (value_target_rate < 1.0*micro*liter/day) {
+        return grvalue;
+    }
+
+    // Scale with the current production ratio when the control target
+    // differs from the guide rate target.
+    const auto scale = rates.eval(model_target) / value_target_rate;
+    return grvalue * scale;
 }
 
 bool GuideRate::has(const std::string& name) const
@@ -100,127 +108,179 @@ bool GuideRate::has(const std::string& name) const
     return this->values.count(name) > 0;
 }
 
-
-
-void GuideRate::compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot) {
-    const auto& config = this->schedule.guideRateConfig(report_step);
+void GuideRate::compute(const std::string& wgname,
+                        size_t             report_step,
+                        double             sim_time,
+                        double             oil_pot,
+                        double             gas_pot,
+                        double             wat_pot)
+{
     this->potentials[wgname] = RateVector{oil_pot, gas_pot, wat_pot};
 
-    if (config.has_group(wgname))
+    const auto& config = this->schedule.guideRateConfig(report_step);
+    if (config.has_group(wgname)) {
         this->group_compute(wgname, report_step, sim_time, oil_pot, gas_pot, wat_pot);
-    else
+    }
+    else {
         this->well_compute(wgname, report_step, sim_time, oil_pot, gas_pot, wat_pot);
-
+    }
 }
 
-
-void GuideRate::group_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot) {
+void GuideRate::group_compute(const std::string& wgname,
+                              size_t             report_step,
+                              double             sim_time,
+                              double             oil_pot,
+                              double             gas_pot,
+                              double             wat_pot)
+{
     const auto& config = this->schedule.guideRateConfig(report_step);
     const auto& group = config.group(wgname);
 
-    if (group.guide_rate > 0) {
+    if (group.guide_rate > 0.0) {
         auto model_target = GuideRateModel::convert_target(group.target);
-        this->values[wgname] = GuideRateValue( sim_time, group.guide_rate, model_target );
-    } else {
+
+        const auto& model = config.has_model() ? config.model() : GuideRateModel{};
+        this->assign_grvalue(wgname, model, { sim_time, group.guide_rate, model_target });
+    }
+    else {
         auto iter = this->values.find(wgname);
 
-        // If the FORM mode is used we check if the last computation is recent enough;
-        // then we just return.
+        // If the FORM mode is used we check if the last computation is
+        // recent enough; then we just return.
         if (iter != this->values.end()) {
-            const auto& grv = iter->second;
             if (group.target == Group::GuideRateTarget::FORM) {
-                if (!config.has_model())
-                    throw std::logic_error("When specifying GUIDERATE target FORM you must enter a guiderate model with the GUIDERAT keyword");
+                if (! config.has_model()) {
+                    throw std::logic_error {
+                        "When specifying GUIDERATE target FORM you must "
+                        "enter a guiderate model with the GUIDERAT keyword"
+                    };
+                }
 
-                auto time_diff = sim_time - grv.sim_time;
-                if (config.model().update_delay() > time_diff)
+                const auto& grv = iter->second->curr;
+                const auto time_diff = sim_time - grv.sim_time;
+                if (config.model().update_delay() > time_diff) {
                     return;
+                }
             }
         }
 
-
-        if (group.target == Group::GuideRateTarget::INJV)
+        if (group.target == Group::GuideRateTarget::INJV) {
             throw std::logic_error("Group guide rate mode: INJV not implemented");
+        }
 
-        if (group.target == Group::GuideRateTarget::POTN)
+        if (group.target == Group::GuideRateTarget::POTN) {
             throw std::logic_error("Group guide rate mode: POTN not implemented");
+        }
 
         if (group.target == Group::GuideRateTarget::FORM) {
-            double guide_rate;
-            if (!config.has_model())
-                throw std::logic_error("When specifying GUIDERATE target FORM you must enter a guiderate model with the GUIDERAT keyword");
+            if (! config.has_model()) {
+                throw std::logic_error {
+                    "When specifying GUIDERATE target FORM you must "
+                    "enter a guiderate model with the GUIDERAT keyword"
+                };
+            }
 
-            if (iter != this->values.end())
-                guide_rate = this->eval_form(config.model(),  oil_pot,  gas_pot,  wat_pot, std::addressof(iter->second));
-            else
-                guide_rate = this->eval_form(config.model(),  oil_pot,  gas_pot,  wat_pot, nullptr);
-
-            this->values[wgname] = GuideRateValue{sim_time, guide_rate, config.model().target()};
+            const auto guide_rate = this->eval_form(config.model(), oil_pot, gas_pot, wat_pot);
+            this->assign_grvalue(wgname, config.model(), { sim_time, guide_rate, config.model().target() });
         }
     }
 }
 
-
-void GuideRate::well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot) {
+void GuideRate::well_compute(const std::string& wgname,
+                             size_t             report_step,
+                             double             sim_time,
+                             double             oil_pot,
+                             double             gas_pot,
+                             double             wat_pot)
+{
     const auto& config = this->schedule.guideRateConfig(report_step);
 
     // guide rates spesified with WGRUPCON
     if (config.has_well(wgname)) {
         const auto& well = config.well(wgname);
-        if (well.guide_rate > 0) {
+        if (well.guide_rate > 0.0) {
             auto model_target = GuideRateModel::convert_target(well.target);
-            this->values[wgname] = GuideRateValue( sim_time, well.guide_rate, model_target );
+
+            const auto& model = config.has_model() ? config.model() : GuideRateModel{};
+            this->assign_grvalue(wgname, model, { sim_time, well.guide_rate, model_target });
         }
-    } else if (config.has_model()) { // GUIDERAT
+    }
+    else if (config.has_model()) { // GUIDERAT
         // only look for wells not groups
-        if (!this->schedule.hasWell(wgname, report_step))
+        if (! this->schedule.hasWell(wgname, report_step)) {
             return;
+        }
 
         const auto& well = this->schedule.getWell(wgname, report_step);
 
         // GUIDERAT does not apply to injectors
-        if (well.isInjector())
+        if (well.isInjector()) {
             return;
-
-        auto iter = this->values.find(wgname);
-
-        if (iter != this->values.end()) {
-            const auto& grv = iter->second;
-            auto time_diff = sim_time - grv.sim_time;
-            if (config.model().update_delay() > time_diff)
-                return;
         }
 
-        double guide_rate;
-        if (iter == this->values.end())
-            guide_rate = this->eval_form(config.model(),  oil_pot,  gas_pot,  wat_pot, nullptr);
-        else
-            guide_rate = this->eval_form(config.model(),  oil_pot,  gas_pot,  wat_pot, std::addressof(iter->second));
+        auto iter = this->values.find(wgname);
+        if (iter != this->values.end()) {
+            const auto& grv = iter->second->curr;
+            const auto time_diff = sim_time - grv.sim_time;
+            if (config.model().update_delay() > time_diff) {
+                return;
+            }
+        }
 
-        this->values[wgname] = GuideRateValue{sim_time, guide_rate, config.model().target()};
+        const auto guide_rate = this->eval_form(config.model(), oil_pot, gas_pot, wat_pot);
+        this->assign_grvalue(wgname, config.model(), { sim_time, guide_rate, config.model().target() });
     }
-    // If neither WGRUPCON nor GUIDERAT is spesified potentials are used
+    // If neither WGRUPCON nor GUIDERAT is specified potentials are used
 }
 
-double GuideRate::eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot, const GuideRateValue * prev) const {
-    double new_guide_rate = model.eval(oil_pot, gas_pot, wat_pot);
-    if (!prev)
-        return new_guide_rate;
-
-    if (new_guide_rate > prev->value && !model.allow_increase())
-        new_guide_rate = prev->value;
-
-    auto damping_factor = model.damping_factor();
-
-    return damping_factor * new_guide_rate + (1 - damping_factor) * prev->value;
+double GuideRate::eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot) const
+{
+    return model.eval(oil_pot, gas_pot, wat_pot);
 }
 
-double GuideRate::eval_group_pot() const {
-    return 0;
+double GuideRate::eval_group_pot() const
+{
+    return 0.0;
 }
 
-double GuideRate::eval_group_resvinj() const {
-    return 0;
+double GuideRate::eval_group_resvinj() const
+{
+    return 0.0;
+}
+
+void GuideRate::assign_grvalue(const std::string&    wgname,
+                               const GuideRateModel& model,
+                               GuideRateValue&&      value)
+{
+    using std::swap;
+
+    auto& v = this->values[wgname];
+    if (v == nullptr) {
+        v = std::make_unique<GRValState>();
+    }
+
+    swap(v->prev, v->curr);
+
+    v->curr = std::move(value);
+
+    if ((v->prev.sim_time < 0.0) || ! (v->prev.value > 0.0)) {
+        // No previous non-zero guiderate exists.  No further actions.
+        return;
+    }
+
+    // Incorporate damping &c.
+    const auto new_guide_rate = model.allow_increase()
+        ? v->curr.value : std::min(v->curr.value, v->prev.value);
+
+    const auto damping_factor = model.damping_factor();
+    v->curr.value = damping_factor*new_guide_rate + (1 - damping_factor)*v->prev.value;
+}
+
+double GuideRate::get_grvalue_result(const GRValState& gr) const
+{
+    return (gr.curr.sim_time < 0.0)
+        ? 0.0
+        : std::max(gr.curr.value, 0.0);
 }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Equinor ASA.
+  Copyright 2019, 2020 Equinor ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -22,39 +22,21 @@
 
 namespace Opm {
 
-double GuideRate::RateVector::eval(Well::GuideRateTarget target) const {
-    if (target == Well::GuideRateTarget::OIL)
-        return this->oil_rat;
 
-    if (target == Well::GuideRateTarget::GAS)
-        return this->gas_rat;
 
-    if (target == Well::GuideRateTarget::LIQ)
-        return this->oil_rat + this->wat_rat;
 
-    if (target == Well::GuideRateTarget::WAT)
-        return this->wat_rat;
-
-    throw std::logic_error("Don't know how to convert .... ");
+double GuideRate::RateVector::eval(Well::GuideRateTarget target) const
+{
+    return this->eval(GuideRateModel::convert_target(target));
 }
 
-double GuideRate::RateVector::eval(Group::GuideRateTarget target) const {
-    if (target == Group::GuideRateTarget::OIL)
-        return this->oil_rat;
-
-    if (target == Group::GuideRateTarget::GAS)
-        return this->gas_rat;
-
-    if (target == Group::GuideRateTarget::LIQ)
-        return this->oil_rat + this->wat_rat;
-
-    if (target == Group::GuideRateTarget::WAT)
-        return this->wat_rat;
-
-    throw std::logic_error("Don't know how to convert .... ");
+double GuideRate::RateVector::eval(Group::GuideRateTarget target) const
+{
+    return this->eval(GuideRateModel::convert_target(target));
 }
 
-double GuideRate::RateVector::eval(GuideRateModel::Target target) const {
+double GuideRate::RateVector::eval(GuideRateModel::Target target) const
+{
     if (target == GuideRateModel::Target::OIL)
         return this->oil_rat;
 
@@ -67,7 +49,9 @@ double GuideRate::RateVector::eval(GuideRateModel::Target target) const {
     if (target == GuideRateModel::Target::WAT)
         return this->wat_rat;
 
-    throw std::logic_error("Don't know how to convert .... ");
+    throw std::logic_error {
+        "Don't know how to convert target type " + std::to_string(static_cast<int>(target))
+    };
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -252,14 +252,19 @@ void GuideRate::assign_grvalue(const std::string&    wgname,
                                const GuideRateModel& model,
                                GuideRateValue&&      value)
 {
-    using std::swap;
-
     auto& v = this->values[wgname];
     if (v == nullptr) {
         v = std::make_unique<GRValState>();
     }
 
-    swap(v->prev, v->curr);
+    if (value.sim_time > v->curr.sim_time) {
+        // We've advanced in time since we previously calculated/stored this
+        // guiderate value.  Push current value into the past and prepare to
+        // capture new value.
+        using std::swap;
+
+        swap(v->prev, v->curr);
+    }
 
     v->curr = std::move(value);
 

--- a/tests/test_GuideRate.cpp
+++ b/tests/test_GuideRate.cpp
@@ -1,0 +1,524 @@
+/*
+  Copyright (c) 2020 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE test_GuideRate
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Python/Python.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <stddef.h>
+
+namespace {
+    struct Setup
+    {
+        explicit Setup(const std::string& input)
+            : Setup { Opm::Parser{}.parseString(input) }
+        {}
+
+        explicit Setup(const Opm::Deck& deck)
+            : es    { deck }
+            , sched { deck, es, std::make_shared<const Opm::Python>() }
+            , gr    { sched }
+        {}
+
+        Opm::EclipseState es;
+        Opm::Schedule     sched;
+        Opm::GuideRate    gr;
+    };
+
+    Setup case_10x10x10_model4(const double damping_factor = 0.5)
+    {
+        const auto prolog = std::string { R"(RUNSPEC
+START
+  4 'AUG' 2020 /
+
+TITLE
+  Check GUIDERAT Formula Implementation
+
+DIMENS
+  10 10 10 /
+
+OIL
+GAS
+WATER
+DISGAS
+VAPOIL
+
+METRIC
+
+TABDIMS
+/
+
+WELLDIMS
+3 10 2 2 /
+
+GRID
+
+DXV
+  10*100 /
+
+DYV
+  10*100 /
+
+DZV
+  10*5 /
+
+DEPTHZ
+  121*2000 /
+
+PERMX
+  1000*100 /
+
+COPY
+  PERMX PERMY /
+  PERMX PERMZ /
+/
+
+MULTIPLY
+  PERMZ 0.1 /
+/
+
+PORO
+  1000*0.3 /
+
+SOLUTION
+
+PRESSURE
+  1000*320 /
+SOIL
+  1000*0.85 /
+SWAT
+  1000*0.12 /
+SGAS
+  1000*0.03 /
+RS
+  1000*226.0 /
+RV
+  1000*0.0 /
+
+SCHEDULE
+
+WELSPECS
+  P1 P 10 7 2002.5 OIL /
+  P2 P 7 10 2002.5 OIL /
+  I1 I 2  2 2002.5 GAS /
+/
+
+COMPDAT
+  P1 2* 1 10 OPEN 1* 1* 0.5 /
+  P2 2* 1 10 OPEN 1* 1* 0.5 /
+  I1 2* 1 10 OPEN 1* 1* 0.5 /
+/
+)"  };
+
+        const auto guiderat = std::string { R"(
+-- GR_{oil} = WOPP / (0.5 + (WWPP / WOPP))
+-- with a user-specified damping/time-delay factor (default 0.5).
+GUIDERAT
+--1   2   3   4   5   6   7  8  9          10
+  1.0 OIL 1.0 0.5 1.0 1.0 1* 1* YES )" } + std::to_string(damping_factor) + " /\n";
+
+        const auto epilog = std::string { R"(
+WCONPROD
+  P* OPEN GRUP 150 100 15E+3 250 1* 50 25 /
+/
+
+WCONINJE
+  I1 GAS OPEN RATE 20.0E+3 1* 500 350 /
+/
+
+GCONPROD
+  P 'ORAT' 200.0 150.0 100.0E+3 1* 1* YES 1* FORM /
+/
+
+DATES
+  5 'AUG' 2020 /
+ 10 'AUG' 2020 /
+ 20 'AUG' 2020 /
+  1 'SEP' 2020 /
+  1 'OCT' 2020 /
+  1 'NOV' 2020 /
+  1 'DEC' 2020 /
+  1 'JAN' 2021 /
+/
+
+END
+)" };
+
+        return Setup { prolog + guiderat + epilog };
+}
+} // Namespace anonymous
+
+// ======================================================================
+
+BOOST_AUTO_TEST_SUITE(GuideRate_Calculations)
+
+BOOST_AUTO_TEST_CASE(P1_First)
+{
+    auto cse = case_10x10x10_model4();
+
+    const auto wopp = 1.0;
+    const auto wgpp = 5.0;
+    const auto wwpp = 0.1;
+    const auto stm  = 0.0;
+    const auto rpt  = size_t{1};
+
+    cse.gr.compute("P1", rpt, stm, wopp, wgpp, wwpp);
+
+    const auto orat = 2.0;
+    const auto grat = 4.0;      // == 2 * orat
+    const auto wrat = 1.0;      // == orat / 2
+
+    const auto expect_gr_oil = 1.0 / (0.5 + 0.1/1.0); // wopp / (0.5 + wwpp/wopp)
+
+    // GR_{oil}
+    {
+        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+
+        BOOST_CHECK_CLOSE(grval, expect_gr_oil, 1.0e-5);
+    }
+
+    // GR_{gas}
+    {
+        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+
+        const auto expect = (grat / orat) * expect_gr_oil;
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{water}
+    {
+        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+
+        const auto expect = (wrat / orat) * expect_gr_oil;
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(P2_Second)
+{
+    auto cse = case_10x10x10_model4();
+
+    {
+        const auto wopp = 1.0;
+        const auto wgpp = 5.0;
+        const auto wwpp = 0.1;
+        const auto stm  = 0.0;
+        const auto rpt  = size_t{1};
+
+        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    {
+        const auto wopp = 10.0;
+        const auto wgpp = 50.0;
+        const auto wwpp = 1.0;
+        const auto stm  = 10.0*Opm::unit::second; // Before recalculation delay
+        const auto rpt  = size_t{1};
+
+        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    const auto orat = 2.0;
+    const auto grat = 4.0;      // == 2 * orat
+    const auto wrat = 1.0;      // == orat / 2
+
+    const auto expect_gr_oil_1 = 1.0 / (0.5 + 0.1/1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
+
+    // GR_{oil}
+    {
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+
+        BOOST_CHECK_CLOSE(grval, expect_gr_oil_1, 1.0e-5);
+    }
+
+    // GR_{gas}
+    {
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+
+        const auto expect = (grat / orat) * expect_gr_oil_1;
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{water}
+    {
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+
+        const auto expect = (wrat / orat) * expect_gr_oil_1;
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    {
+        const auto wopp = 10.0;
+        const auto wgpp = 50.0;
+        const auto wwpp = 1.0;
+        const auto stm  = 10.0*Opm::unit::day; // After recalculation delay
+        const auto rpt  = size_t{3};
+
+        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    const auto expect_gr_oil_2 = 10.0 / (0.5 + 1.0/10.0); // wopp_2 / (0.5 + wwpp_2/wopp_2)
+
+    // GR_{oil}
+    {
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+
+        const auto expect = 0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1;
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{gas}
+    {
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+
+        const auto expect = (grat / orat) * (0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1);
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{water}
+    {
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+
+        const auto expect = (wrat / orat) * (0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1);
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(P_Third)
+{
+    auto cse = case_10x10x10_model4();
+
+    {
+        const auto wopp = 1.0;
+        const auto wgpp = 5.0;
+        const auto wwpp = 0.1;
+        const auto stm  = 0.0;
+        const auto rpt  = size_t{1};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    {
+        const auto wopp = 10.0;
+        const auto wgpp = 50.0;
+        const auto wwpp = 1.0;
+        const auto stm  = 10.0*Opm::unit::day;
+        const auto rpt  = size_t{3};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    {
+        const auto wopp = 20.0;
+        const auto wgpp = 100.0;
+        const auto wwpp = 10.0;
+        const auto stm  = 20.0*Opm::unit::day;
+        const auto rpt  = size_t{4};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
+    const auto expect_gr_oil_2 = 10.0 / (0.5 +  1.0/10.0); // wopp_2 / (0.5 + wwpp_2/wopp_2)
+    const auto expect_gr_oil_3 = 20.0 / (0.5 + 10.0/20.0); // wopp_3 / (0.5 + wwpp_3/wopp_3)
+
+    const auto orat = 2.0;
+    const auto grat = 4.0;      // == 2 * orat
+    const auto wrat = 1.0;      // == orat / 2
+
+    // GR_{oil}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+
+        const auto expect = 0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1;
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{gas}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+
+        const auto expect = (grat / orat) * (0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1);
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{water}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+
+        const auto expect = (wrat / orat) * (0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1);
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(P_Third_df01)
+{
+    auto cse = case_10x10x10_model4(0.1);
+
+    {
+        const auto wopp = 1.0;
+        const auto wgpp = 5.0;
+        const auto wwpp = 0.1;
+        const auto stm  = 0.0;
+        const auto rpt  = size_t{1};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    {
+        const auto wopp = 10.0;
+        const auto wgpp = 50.0;
+        const auto wwpp = 1.0;
+        const auto stm  = 10.0*Opm::unit::day;
+        const auto rpt  = size_t{3};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    {
+        const auto wopp = 20.0;
+        const auto wgpp = 100.0;
+        const auto wwpp = 10.0;
+        const auto stm  = 20.0*Opm::unit::day;
+        const auto rpt  = size_t{4};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
+    const auto expect_gr_oil_2 = 10.0 / (0.5 +  1.0/10.0); // wopp_2 / (0.5 + wwpp_2/wopp_2)
+    const auto expect_gr_oil_3 = 20.0 / (0.5 + 10.0/20.0); // wopp_3 / (0.5 + wwpp_3/wopp_3)
+
+    const auto orat = 2.0;
+    const auto grat = 4.0;      // == 2 * orat
+    const auto wrat = 1.0;      // == orat / 2
+
+    // GR_{oil}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+
+        const auto expect = 0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1;
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{gas}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+
+        const auto expect = (grat / orat) * (0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1);
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{water}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+
+        const auto expect = (wrat / orat) * (0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1);
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(P_Third_df09)
+{
+    auto cse = case_10x10x10_model4(0.9);
+
+    {
+        const auto wopp = 1.0;
+        const auto wgpp = 5.0;
+        const auto wwpp = 0.1;
+        const auto stm  = 0.0;
+        const auto rpt  = size_t{1};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    {
+        const auto wopp = 10.0;
+        const auto wgpp = 50.0;
+        const auto wwpp = 1.0;
+        const auto stm  = 10.0*Opm::unit::day;
+        const auto rpt  = size_t{3};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    {
+        const auto wopp = 20.0;
+        const auto wgpp = 100.0;
+        const auto wwpp = 10.0;
+        const auto stm  = 20.0*Opm::unit::day;
+        const auto rpt  = size_t{4};
+
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+    }
+
+    const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
+    const auto expect_gr_oil_2 = 10.0 / (0.5 +  1.0/10.0); // wopp_2 / (0.5 + wwpp_2/wopp_2)
+    const auto expect_gr_oil_3 = 20.0 / (0.5 + 10.0/20.0); // wopp_3 / (0.5 + wwpp_3/wopp_3)
+
+    const auto orat = 2.0;
+    const auto grat = 4.0;      // == 2 * orat
+    const auto wrat = 1.0;      // == orat / 2
+
+    // GR_{oil}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+
+        const auto expect = 0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1;
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{gas}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+
+        const auto expect = (grat / orat) * (0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1);
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+
+    // GR_{water}
+    {
+        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+
+        const auto expect = (wrat / orat) * (0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1);
+        BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // GuideRate_Calculations


### PR DESCRIPTION
This PR centralises the way we incorporate damping factors (item 10 of the `GUIDERAT` keyword) into the calculation of group/well guide rates.  In particular, we create a structure that manages both the current and the previous (damped) guiderate values and ensures that the new guiderate value is
```
GR_p = f*GR_p' + (1 - f)*GR_p^{n-1}
```
with `GR_p'` denoting the "raw" guiderate value calculated directly from potential rates at the current timelevel (n).  `GR_p^{n-1}` is the damped-and previously used-guiderate value from timelevel n-1. Finally `f` denotes the damping factor.  This is the same approach used previously, but with some small changes to exclude zero-valued guiderates.

We furthermore remove one of the early returns in `GuideRate::get()`. There is no need to return the nominated phase's guiderate value if the model phase rate is very low and doing so produces incorrect water guiderates for the OPL5 well in the MOD4_GRP test case.

We finally ensure that we do replace the "previous" guiderate value **unless** the timelevel advances.  Previously we might assign the same guiderate value multiple times for the same timelevel which would reduce the impact of the damping factor.  This was especially pronounced for the group-level guiderates in `MOD4_GRP`.