### PR TITLE
Correctly parse and handle UADD / UMUL / UMIN / UMAX set operations

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
@@ -65,6 +65,7 @@ public:
     UDQVarType var_type() const;
     void add_record(const std::vector<std::string>& selector, double value);
     UDQSet eval(const std::vector<std::string>& wells) const;
+    UDQSet eval() const;
 
     bool operator==(const UDQAssign& data) const;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -32,6 +32,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
+#include <opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp>
 
 
 namespace Opm {
@@ -111,6 +112,7 @@ namespace Opm {
         std::unordered_map<std::string, UDQAssign> m_assignments;
         std::unordered_map<std::string, std::string> units;
 
+        IOrderSet<std::string> define_order;
         OrderedMap<std::string, UDQIndex> input_index;
         std::map<UDQVarType, std::size_t> type_count;
     };

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -57,6 +57,7 @@ namespace Opm {
         void add_define(const std::string& quantity, const std::vector<std::string>& expression);
 
         void eval(SummaryState& st) const;
+        const UDQDefine& define(const std::string& key) const;
         std::vector<UDQDefine> definitions() const;
         std::vector<UDQDefine> definitions(UDQVarType var_type) const;
         std::vector<UDQInput> input() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -176,6 +176,7 @@ namespace UDQ {
     bool elementalUnaryFunc(UDQTokenType token_type);
     bool scalarFunc(UDQTokenType token_type);
     bool cmpFunc(UDQTokenType token_type);
+    bool setFunc(UDQTokenType token_type);
 
     std::string typeName(UDQVarType var_type);
     UDAKeyword keyword(UDAControl control);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
@@ -74,6 +74,15 @@ UDQSet UDQAssign::eval(const std::vector<std::string>& wells) const {
     throw std::invalid_argument("Not yet implemented");
 }
 
+UDQSet UDQAssign::eval() const {
+    if (this->m_var_type == UDQVarType::FIELD_VAR || this->m_var_type == UDQVarType::SCALAR ) {
+        const auto& record = this->records.back();
+        return UDQSet::scalar(this->m_keyword, record.value);
+    }
+    throw std::invalid_argument("Not yet implemented");
+}
+
+
 bool UDQAssign::operator==(const UDQAssign& data) const {
     return this->keyword() == data.keyword() &&
            this->var_type() == data.var_type() &&

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -139,6 +139,10 @@ namespace Opm {
         }
     }
 
+    const UDQDefine& UDQConfig::define(const std::string& key) const {
+        return this->m_definitions.at(key);
+    }
+
 
     std::vector<UDQDefine> UDQConfig::definitions() const {
         std::vector<UDQDefine> ret;
@@ -309,6 +313,11 @@ namespace Opm {
 
         for (const auto& def : this->definitions(UDQVarType::GROUP_VAR)) {
             auto ws = def.eval(context);
+            st.update_udq(ws);
+        }
+
+        for (const auto& assign : this->assignments(UDQVarType::FIELD_VAR)) {
+            auto ws = assign.eval();
             st.update_udq(ws);
         }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
@@ -92,6 +92,7 @@ namespace Opm {
             this->m_definitions.erase( defined_iter );
 
         this->m_definitions.insert( std::make_pair(quantity, UDQDefine(this->udq_params, quantity, expression)));
+        this->define_order.insert(quantity);
     }
 
 
@@ -146,25 +147,20 @@ namespace Opm {
 
     std::vector<UDQDefine> UDQConfig::definitions() const {
         std::vector<UDQDefine> ret;
-        for (const auto& index_pair : this->input_index) {
-            if (index_pair.second.action == UDQAction::DEFINE) {
-                const std::string& key = index_pair.first;
-                ret.push_back(this->m_definitions.at(key));
-            }
-        }
+
+        for (const auto& key : this->define_order)
+            ret.push_back(this->m_definitions.at(key));
+
         return ret;
     }
 
 
     std::vector<UDQDefine> UDQConfig::definitions(UDQVarType var_type) const {
         std::vector<UDQDefine> filtered_defines;
-        for (const auto& index_pair : this->input_index) {
-            if (index_pair.second.action == UDQAction::DEFINE) {
-                const std::string& key = index_pair.first;
-                const auto& udq_define = this->m_definitions.at(key);
-                if (udq_define.var_type() == var_type)
-                    filtered_defines.push_back(udq_define);
-            }
+        for (const auto& key : this->define_order) {
+            const auto& udq_define = this->m_definitions.at(key);
+            if (udq_define.var_type() == var_type)
+                filtered_defines.push_back(udq_define);
         }
         return filtered_defines;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -54,6 +54,10 @@ namespace {
                                                  UDQTokenType::binary_cmp_lt,
                                                  UDQTokenType::binary_cmp_gt};
 
+    const std::set<UDQTokenType> set_func = {UDQTokenType::binary_op_uadd,
+                                             UDQTokenType::binary_op_umul,
+                                             UDQTokenType::binary_op_umin,
+                                             UDQTokenType::binary_op_umax};
 
     const std::set<UDQTokenType> scalar_func = {UDQTokenType::scalar_func_sum,
                                                 UDQTokenType::scalar_func_avea,
@@ -236,6 +240,10 @@ bool elementalUnaryFunc(UDQTokenType token_type) {
 
 bool cmpFunc(UDQTokenType token_type) {
     return (cmp_func.count(token_type) > 0);
+}
+
+bool setFunc(UDQTokenType token_type) {
+    return (set_func.count(token_type) > 0);
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.hpp
@@ -82,6 +82,7 @@ private:
         tokens(tokens_)
     {}
 
+    UDQASTNode parse_set();
     UDQASTNode parse_cmp();
     UDQASTNode parse_add();
     UDQASTNode parse_factor();

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1721,3 +1721,82 @@ UDQ
     BOOST_CHECK_EQUAL( res1["W3"].value(), 0);
 }
 
+
+BOOST_AUTO_TEST_CASE(UDQ_UADD_PARSER) {
+    std::string deck_string = R"(
+SCHEDULE
+UDQ
+   ASSIGN FU_PAR1 10.0 /
+   ASSIGN FU_PAR2 2.0 /
+   ASSIGN FU_PAR3 3.0 /
+   DEFINE FU_UADD FU_PAR1 UADD FU_PAR2 /
+   DEFINE FU_UMUL FU_PAR1 UMUL FU_PAR2 + FU_PAR3 /
+   DEFINE FU_UMIN FU_PAR1 UMIN FU_PAR2 + FU_PAR3 /
+/
+)";
+
+    auto schedule = make_schedule(deck_string);
+    const auto& udq = schedule.getUDQConfig(0);
+    SummaryState st(std::chrono::system_clock::now());
+    udq.eval(st);
+
+    BOOST_CHECK_EQUAL( st.get("FU_UADD"), 12);   // 10 + 2
+
+    // The Uxxx binary set functions have absolutely lowest priority; i.e. the
+    // FU_PAR2 + FU_PAR3 expression is evaluated *before* the UMUL and UMIN operations.
+    BOOST_CHECK_EQUAL( st.get("FU_UMUL"), 50);   // 10 * (2 + 3)
+    BOOST_CHECK_EQUAL( st.get("FU_UMIN"), 5);    // min(10, 2+3)
+}
+
+
+
+BOOST_AUTO_TEST_CASE(UDQ_UADD_PARSER2) {
+    std::string deck_string = R"(
+SCHEDULE
+UDQ
+ASSIGN FU_PAR1 1.0 / -- xxxxxxxxxxxxxxxxxxxxxx
+ASSIGN FU_PAR2 0.0 /
+ASSIGN FU_PAR3 0.0 /
+ASSIGN FU_PAR4 0.0 /
+ASSIGN FU_PAR5 0.0 /
+-- xxxxx xxxx
+DEFINE FU_PAR6  FMWPR /
+-- xxxxxxxxxxxxxxxxxxxx
+DEFINE FU_PAR7 FMWIN /
+DEFINE FU_PAR8 FMWPA /
+DEFINE FU_PAR9 FMWIA /
+-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+DEFINE FU_PAR10 (FU_PAR6 - FU_PAR2) + (FU_PAR8 - FU_PAR4) /
+DEFINE FU_PAR11 (FU_PAR7 - FU_PAR3) + (FU_PAR9 - FU_PAR5) /
+DEFINE FU_PAR12 FU_PAR10 > 0 /
+DEFINE FU_PAR13 FU_PAR11 > 0 /
+DEFINE FU_PAR14 FU_PAR12 * FU_PAR10  /
+DEFINE FU_PAR15 FU_PAR13 * FU_PAR11  /
+DEFINE FU_PAR2 FU_PAR6 /
+DEFINE FU_PAR3 FU_PAR7 /
+DEFINE FU_PAR4 FU_PAR8 /
+DEFINE FU_PAR5 FU_PAR9 /
+-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ASSIGN FU_PAR16 0.08 /
+ASSIGN FU_PAR17 100.0 /
+ASSIGN FU_PAR18 6.0 /
+ASSIGN FU_PAR19 0.0 /
+-- xxxxxxxxxxxxx
+DEFINE FU_PAR19 FU_PAR19 + TIMESTEP /
+ASSIGN FU_PAR20 800.0 /
+ASSIGN FU_PAR21 0.0 /
+-- xxxxxxxxxxxxxxxxx
+DEFINE FU_PAR21 FU_PAR21 UADD FU_PAR20 * (FU_PAR14 + FU_PAR15) / ((1.0 + 0.08 ) ^ (FU_PAR19 /365)) /
+-- xxxxxxxxxxxxxxxxxxxx
+ASSIGN FU_PAR22 0.0 /
+DEFINE FU_PAR22 FU_PAR22 + FOPR * TIMESTEP * 1E-06 * 6.29 * FU_PAR17 * FU_PAR18 / ((1.0 + 0.08 ) ^ (FU_PAR19 /365)) /
+DEFINE FU_PAR23 FU_PAR22 - FU_PAR21 /
+-- xxxxxxxxxxxxxxxxxxxxxxxx
+ASSIGN FU_PAR24 0.9 /
+DEFINE FU_PAR24 FU_PAR24 UADD (FU_PAR14 + FU_PAR15) /
+-- xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+DEFINE WUGASRA  750000 - WGLIR '*' /
+/
+)";
+    BOOST_CHECK_NO_THROW( make_schedule(deck_string) );
+}

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1749,6 +1749,25 @@ UDQ
 }
 
 
+BOOST_AUTO_TEST_CASE(UDQ_DEFINE_ORDER) {
+    std::string deck_string = R"(
+SCHEDULE
+UDQ
+ASSIGN FU_PAR1 1.0 /
+ASSIGN FU_PAR2 0.0 /
+DEFINE FU_PAR3 FMWPR /
+DEFINE FU_PAR2 FU_PAR3 /
+/
+)";
+    auto schedule = make_schedule(deck_string);
+    const auto& udq = schedule.getUDQConfig(0);
+    SummaryState st(std::chrono::system_clock::now());
+    st.update("FMWPR", 100);
+    udq.eval(st);
+
+    BOOST_CHECK_EQUAL(st.get("FU_PAR2"), 100);
+}
+
 
 BOOST_AUTO_TEST_CASE(UDQ_UADD_PARSER2) {
     std::string deck_string = R"(
@@ -1798,5 +1817,18 @@ DEFINE FU_PAR24 FU_PAR24 UADD (FU_PAR14 + FU_PAR15) /
 DEFINE WUGASRA  750000 - WGLIR '*' /
 /
 )";
-    BOOST_CHECK_NO_THROW( make_schedule(deck_string) );
+    auto schedule = make_schedule(deck_string);
+    const auto& udq = schedule.getUDQConfig(0);
+    SummaryState st(std::chrono::system_clock::now());
+    st.update("FMWPR", 100);
+    st.update("FMWIN", 100);
+    st.update("FMWPA", 100);
+    st.update("FMWIA", 100);
+    st.update("FOPR", 100);
+    st.update_well_var("W1", "WGLIR", 1);
+    st.update_well_var("W2", "WGLIR", 2);
+    st.update_well_var("W3", "WGLIR", 3);
+
+    // The current testcase has some ordering & defined / undefined issues which
+    // are not yet solved; therefor no udq.eval() here.
 }


### PR DESCRIPTION
The UDQ functionality has set union functions `UADD, UMUL, UMIN` and `UMAX` - these should be evaluated with the lowest presedence - i.e. below `+`. This PR fixes that.

```
UDQ
   ASSIGN FU_PAR1 10.0 /
   ASSIGN FU_PAR2 2.0 /
   ASSIGN FU_PAR3 3.0 /
   DEFINE FU_UADD FU_PAR1 UADD FU_PAR2 /
   DEFINE FU_UMUL FU_PAR1 UMUL FU_PAR2 + FU_PAR3/
/
-- FU_UADD = 10 + 2 = 12
-- FU_UMUL = 10 * (2 + 3) = 50
```


