### PR TITLE
Fix UDQ parsing for mix of '*' and *

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -175,6 +175,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQToken.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunction.cpp

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
@@ -20,10 +20,11 @@
 #ifndef UDQASTNODE_HPP
 #define UDQASTNODE_HPP
 
-#include <string>
-#include <set>
-#include <vector>
 #include <memory>
+#include <set>
+#include <string>
+#include <variant>
+#include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp>
@@ -38,10 +39,10 @@ public:
     UDQASTNode();
     explicit UDQASTNode(UDQTokenType type_arg);
     explicit UDQASTNode(double scalar_value);
-    UDQASTNode(UDQTokenType type_arg, const std::string& func_name, const UDQASTNode& arg);
-    UDQASTNode(UDQTokenType type_arg, const std::string& func_name, const UDQASTNode& left, const UDQASTNode& right);
-    UDQASTNode(UDQTokenType type_arg, const std::string& func_name);
-    UDQASTNode(UDQTokenType type_arg, const std::string& string_value, const std::vector<std::string>& selector);
+    UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg, const UDQASTNode& arg);
+    UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg, const UDQASTNode& left, const UDQASTNode& right);
+    UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg);
+    UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg, const std::vector<std::string>& selector);
 
     static UDQASTNode serializeObject();
 
@@ -63,9 +64,8 @@ public:
     {
         serializer(var_type);
         serializer(type);
-        serializer(string_value);
+        serializer(value);
         serializer(selector);
-        serializer(scalar_value);
         serializer(left);
         serializer(right);
     }
@@ -74,9 +74,8 @@ private:
     UDQTokenType type;
     void func_tokens(std::set<UDQTokenType>& tokens) const;
 
-    std::string string_value;
+    std::variant<std::string, double> value;
     std::vector<std::string> selector;
-    double scalar_value;
     std::shared_ptr<UDQASTNode> left;
     std::shared_ptr<UDQASTNode> right;
 };

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -170,6 +170,7 @@ namespace UDQ {
     UDQVarType varType(const std::string& keyword);
     UDQVarType coerce(UDQVarType t1, UDQVarType t2);
     UDQAction actionType(const std::string& action_string);
+    UDQTokenType tokenType(const std::string& func_name);
     UDQTokenType funcType(const std::string& func_name);
     bool binaryFunc(UDQTokenType token_type);
     bool elementalUnaryFunc(UDQTokenType token_type);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -28,6 +28,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 
 #include "../../../Parser/raw/RawConsts.hpp"
+#include "UDQToken.hpp"
 #include "UDQParser.hpp"
 
 namespace Opm {
@@ -59,6 +60,48 @@ std::vector<std::string> quote_split(const std::string& item) {
     }
     return items;
 }
+
+
+
+
+std::vector<UDQToken> make_tokens(const std::vector<std::string>& string_tokens) {
+    if (string_tokens.empty())
+        return {};
+
+    std::vector<UDQToken> tokens;
+    std::size_t token_index = 0;
+    while (true) {
+        const auto& string_token = string_tokens[token_index];
+        auto token_type = UDQ::tokenType(string_tokens[token_index]);
+        token_index += 1;
+
+        if (token_type == UDQTokenType::ecl_expr) {
+            std::vector<std::string> selector;
+            while (true) {
+                if (token_index == string_tokens.size())
+                    break;
+
+                auto next_type = UDQ::tokenType(string_tokens[token_index]);
+                if (next_type == UDQTokenType::ecl_expr) {
+                    const auto& select_token = string_tokens[token_index];
+                    if (RawConsts::is_quote()(select_token[0]))
+                        selector.push_back(select_token.substr(1, select_token.size() - 2));
+                    else
+                        selector.push_back(select_token);
+                    token_index += 1;
+                } else
+                    break;
+            }
+            tokens.emplace_back( string_token, selector );
+        } else
+            tokens.emplace_back( string_token, token_type );
+
+        if (token_index == string_tokens.size())
+            break;
+    }
+    return tokens;
+}
+
 
 }
 
@@ -122,11 +165,11 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
     m_keyword(keyword),
     m_var_type(UDQ::varType(keyword))
 {
-    std::vector<std::string> tokens;
+    std::vector<std::string> string_tokens;
     for (const std::string& deck_item : deck_data) {
         for (const std::string& item : quote_split(deck_item)) {
             if (RawConsts::is_quote()(item[0])) {
-                tokens.push_back(item.substr(1, item.size() - 2));
+                string_tokens.push_back(item);
                 continue;
             }
 
@@ -135,7 +178,7 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
             while (true) {
                 auto token = next_token(item, offset, splitters);
                 if (token) {
-                    tokens.push_back( *token );
+                    string_tokens.push_back( *token );
                     offset += token->size();
                 } else
                     break;
@@ -147,8 +190,9 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
       leading '-' to change sign; we just hack it up by adding a fictious '0'
       token in front.
     */
-    if (tokens[0] == "-")
-        tokens.insert( tokens.begin(), "0" );
+    if (string_tokens[0] == "-")
+        string_tokens.insert( string_tokens.begin(), "0" );
+    std::vector<UDQToken> tokens = make_tokens(string_tokens);
 
 
     this->ast = std::make_shared<UDQASTNode>( UDQParser::parse(udq_params, this->m_var_type, this->m_keyword, tokens, parseContext, errors) );

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -250,6 +250,25 @@ UDQTokenType funcType(const std::string& func_name) {
     return UDQTokenType::error;
 }
 
+UDQTokenType tokenType(const std::string& token) {
+    auto token_type = funcType(token);
+    if (token_type == UDQTokenType::error) {
+        if (token == "(")
+            token_type = UDQTokenType::open_paren;
+        else if (token == ")")
+            token_type = UDQTokenType::close_paren;
+        else {
+            try {
+                std::stod(token);
+                token_type = UDQTokenType::number;
+            } catch(const std::invalid_argument& exc) {
+                token_type = UDQTokenType::ecl_expr;
+            }
+        }
+    }
+    return token_type;
+}
+
 
 UDQVarType coerce(UDQVarType t1, UDQVarType t2) {
     if (t1 == t2)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQToken.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQToken.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include "UDQToken.hpp"
+
+namespace Opm {
+
+UDQToken::UDQToken(const std::string& string_token, UDQTokenType token_type_) :
+    token_type(token_type_)
+{
+    if (this->token_type == UDQTokenType::number)
+        this->m_value = stod(string_token);
+    else
+        this->m_value = string_token;
+
+}
+
+UDQToken::UDQToken(const std::string& string_token, const std::vector<std::string>& selector_):
+    token_type(UDQTokenType::ecl_expr),
+    m_value(string_token),
+    m_selector(selector_)
+{
+}
+
+const std::variant<std::string, double>& UDQToken::value() const {
+    return this->m_value;
+}
+
+const std::vector<std::string>& UDQToken::selector() const {
+    return this->m_selector;
+}
+
+UDQTokenType UDQToken::type() const {
+    return this->token_type;
+}
+
+}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQToken.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQToken.hpp
@@ -1,0 +1,48 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef UDQ_TOKEN_HPP
+#define UDQ_TOKEN_HPP
+
+#include <string>
+#include <vector>
+#include <variant>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
+
+namespace Opm {
+
+class UDQToken {
+public:
+    UDQToken(const std::string& string_token, UDQTokenType token_type);
+    UDQToken(const std::string& string_token, const std::vector<std::string>& selector);
+
+    const std::vector<std::string>& selector() const;
+    const std::variant<std::string, double>& value() const;
+    UDQTokenType type() const;
+private:
+    UDQTokenType token_type;
+    std::variant<std::string,double> m_value;
+    std::vector<std::string> m_selector;
+};
+
+}
+
+
+#endif

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1681,6 +1681,43 @@ UDQ
     BOOST_CHECK_EQUAL( res1[0].value(), -1.5*fwpr*std::pow(fgpr+fopr, 3) - 2*flpr );
 
     auto res2 = def2.eval(context);
-    BOOST_CHECK_CLOSE( res2[0].value(), -2.5394E-14 * std::pow(fup1 + fup2, 3) + 1.4464E-8*std::pow(fup1 + fup2, 2) + 0.00028875*(fup1 + fup2) + 2.8541, 1e-6);
+    auto right = -2.5394E-14 * std::pow(fup1 + fup2, 3) + 1.4464E-8*std::pow(fup1 + fup2, 2) + 0.00028875*(fup1 + fup2) + 2.8541;
+    BOOST_CHECK_CLOSE( res2[0].value(), right, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(UDQ_STARSTAR) {
+    std::string deck_string = R"(
+SCHEDULE
+UDQ
+   DEFINE WUOPR2   WOPR '*' * WOPR '*' /
+   DEFINE WUGASRA  3 - WGLIR '*' /
+/
+)";
+
+    auto schedule = make_schedule(deck_string);
+    const auto& udq = schedule.getUDQConfig(0);
+    UDQParams udqp;
+    auto def0 = udq.definitions()[0];
+    auto def1 = udq.definitions()[1];
+    SummaryState st(std::chrono::system_clock::now());
+    UDQFunctionTable udqft(udqp);
+    UDQContext context(udqft, st);
+    st.update_well_var("W1", "WOPR", 1);
+    st.update_well_var("W2", "WOPR", 2);
+    st.update_well_var("W3", "WOPR", 3);
+
+    st.update_well_var("W1", "WGLIR", 1);
+    st.update_well_var("W2", "WGLIR", 2);
+    st.update_well_var("W3", "WGLIR", 3);
+
+    auto res0 = def0.eval(context);
+    BOOST_CHECK_EQUAL( res0["W1"].value(), 1);
+    BOOST_CHECK_EQUAL( res0["W2"].value(), 4);
+    BOOST_CHECK_EQUAL( res0["W3"].value(), 9);
+
+    auto res1 = def1.eval(context);
+    BOOST_CHECK_EQUAL( res1["W1"].value(), 2);
+    BOOST_CHECK_EQUAL( res1["W2"].value(), 1);
+    BOOST_CHECK_EQUAL( res1["W3"].value(), 0);
 }
 


### PR DESCRIPTION
The UDQ syntax is .... weird; in particular the token `*` can be both a multiplier sign - and all wells/groups; i..e. this is a legit way to calculalte GOR:
```
UDQ
    DEFINE WUGOR  WGPR '*' * 1 / WOPR '*' /
/

```

Previosuly to this PR the '*' might in some situations be mistaken for a multipler. 

Dwonstream: https://github.com/OPM/opm-simulators/pull/2733