### PR TITLE
Use std::optional<double> in UDQScalar

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
@@ -20,10 +20,11 @@
 #ifndef UDQSET_HPP
 #define UDQSET_HPP
 
+#include <optional>
 #include <stdexcept>
-#include <vector>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 
@@ -51,9 +52,8 @@ public:
     double value() const;
     const std::string& wgname() const;
 public:
-    double m_value;
+    std::optional<double> m_value;
     std::string m_wgname;
-    bool m_defined = false;
 };
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -34,14 +34,14 @@ UDQScalar::UDQScalar(const std::string& wgname) :
 {}
 
 bool UDQScalar::defined() const {
-    return this->m_defined;
+    return this->m_value.has_value();
 }
 
 double UDQScalar::value() const {
-    if (!this->m_defined)
+    if (!this->m_value.has_value())
         throw std::invalid_argument("UDQSCalar: Value not defined  wgname: " + this->m_wgname);
 
-    return this->m_value;
+    return *this->m_value;
 }
 
 const std::string& UDQScalar::wgname() const {
@@ -49,61 +49,63 @@ const std::string& UDQScalar::wgname() const {
 }
 
 void UDQScalar::assign(double value) {
-    this->m_value = value;
-    this->m_defined = std::isfinite(value);
+    if (std::isfinite(value))
+        this->m_value = value;
+    else
+        this->m_value = std::nullopt;
 }
 
 void UDQScalar::operator-=(const UDQScalar& rhs) {
-    if (this->m_defined && rhs.m_defined)
-        this->assign(this->m_value - rhs.m_value);
+    if (this->defined() && rhs.defined())
+        this->assign(*this->m_value - *rhs.m_value);
     else
-        this->m_defined = false;
+        this->m_value = std::nullopt;
 }
 
 void UDQScalar::operator-=(double rhs) {
-    if (this->m_defined)
-        this->assign(this->m_value - rhs);
+    if (this->defined())
+        this->assign(*this->m_value - rhs);
 }
 
 void UDQScalar::operator/=(const UDQScalar& rhs) {
-    if (this->m_defined && rhs.m_defined)
-        this->assign(this->m_value / rhs.m_value);
+    if (this->defined() && rhs.defined())
+        this->assign(*this->m_value / *rhs.m_value);
     else
-        this->m_defined = false;
+        this->m_value = std::nullopt;
 }
 
 void UDQScalar::operator/=(double rhs) {
-    if (this->m_defined)
-        this->assign(this->m_value / rhs);
+    if (this->defined())
+        this->assign(*this->m_value / rhs);
 }
 
 void UDQScalar::operator+=(const UDQScalar& rhs) {
-    if (this->m_defined && rhs.m_defined)
-        this->assign(this->m_value + rhs.m_value);
+    if (this->defined() && rhs.defined())
+        this->assign(*this->m_value + *rhs.m_value);
     else
-        this->m_defined = false;
+        this->m_value = std::nullopt;
 }
 
 void UDQScalar::operator+=(double rhs) {
-    if (this->m_defined)
-        this->assign(this->m_value + rhs);
+    if (this->defined())
+        this->assign(*this->m_value + rhs);
 }
 
 void UDQScalar::operator*=(const UDQScalar& rhs) {
-    if (this->m_defined && rhs.m_defined)
-        this->assign(this->m_value * rhs.m_value);
+    if (this->defined() && rhs.defined())
+        this->assign(*this->m_value * *rhs.m_value);
     else
-        this->m_defined = false;
+        this->m_value = std::nullopt;
 }
 
 void UDQScalar::operator*=(double rhs) {
-    if (this->m_defined)
-        this->assign(this->m_value * rhs);
+    if (this->defined())
+        this->assign(*this->m_value * rhs);
 }
 
 
 UDQScalar::operator bool() const {
-    return this->m_defined;
+    return this->defined();
 }
 
 


### PR DESCRIPTION
The small utility class UDQScalar reimplemented with `std::optional<double>` - this is also a small part of improved undefined handling in the UDQ code