### PR TITLE
Udq state

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -181,6 +181,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunction.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
     src/opm/parser/eclipse/Parser/ErrorGuard.cpp
@@ -745,6 +746,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp
+       opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
        opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
@@ -76,6 +76,7 @@ public:
     void assign(std::size_t index, double value);
     void assign(const std::string& wgname, double value);
 
+    bool has(const std::string& name) const;
     std::size_t size() const;
     void operator+=(const UDQSet& rhs);
     void operator+=(double rhs);

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp
@@ -1,0 +1,50 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef UDQSTATE_HPP_
+#define UDQSTATE_HPP_
+
+#include <string>
+#include <unordered_map>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
+
+
+namespace Opm {
+class UDQState {
+public:
+    UDQState(double undefined);
+
+    bool has(const std::string& key) const;
+    bool has_well_var(const std::string& well, const std::string& key) const;
+    bool has_group_var(const std::string& group, const std::string& key) const;
+
+    double get(const std::string& key) const;
+    double get_group_var(const std::string& well, const std::string& var) const;
+    double get_well_var(const std::string& well, const std::string& var) const;
+    void add(const UDQSet& result);
+
+private:
+    double get_wg_var(const std::string& well, const std::string& key, UDQVarType var_type) const;
+    double undefined_value;
+    std::unordered_map<std::string, UDQSet> values;
+};
+}
+
+#endif

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -189,6 +189,13 @@ UDQSet UDQSet::groups(const std::string& name, const std::vector<std::string>& g
 }
 
 
+bool UDQSet::has(const std::string& name) const {
+    for (const auto& res : this->values) {
+        if (res.wgname() == name)
+            return true;
+    }
+    return false;
+}
 
 std::size_t UDQSet::size() const {
     return this->values.size();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.cpp
@@ -1,0 +1,124 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include <stdexcept>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
+
+namespace Opm {
+
+namespace {
+
+bool is_udq(const std::string& key) {
+    if (key.size() < 2)
+        return false;
+
+    if (key[1] != 'U')
+        return false;
+
+    return true;
+}
+
+}
+
+
+UDQState::UDQState(double undefined) :
+    undefined_value(undefined)
+{}
+
+bool UDQState::has(const std::string& key) const {
+    auto res_iter = this->values.find(key);
+    if (res_iter == this->values.end())
+        return false;
+
+    const auto& result = res_iter->second[0];
+    return result.defined();
+}
+
+bool UDQState::has_well_var(const std::string& well, const std::string& key) const {
+    auto res_iter = this->values.find(key);
+    if (res_iter == this->values.end())
+        return false;
+
+    for (const auto& scalar : res_iter->second) {
+        if (scalar.wgname() == well)
+            return scalar.defined();
+    }
+
+    return false;
+}
+
+bool UDQState::has_group_var(const std::string& group, const std::string& key) const {
+    return this->has_well_var(group, key);
+}
+
+
+void UDQState::add(const UDQSet& result) {
+    if (!is_udq(result.name()))
+        throw std::logic_error("Key is not a UDQ variable:" + result.name());
+
+    auto res_iter = this->values.find(result.name());
+    if (res_iter == this->values.end())
+        this->values.insert( std::make_pair( result.name(), result ));
+    else
+        res_iter->second = result;
+}
+
+double UDQState::get(const std::string& key) const {
+    if (!is_udq(key))
+        throw std::logic_error("Key is not a UDQ variable:" + key);
+
+    const auto& result = this->values.at(key)[0];
+    if (result.defined())
+        return result.value();
+    else
+        return this->undefined_value;
+}
+
+double UDQState::get_wg_var(const std::string& wgname, const std::string& key, UDQVarType var_type) const {
+    auto res_iter = this->values.find(key);
+    if (res_iter == this->values.end()) {
+        if (is_udq(key))
+            throw std::out_of_range("No such UDQ variable: " + key);
+        else
+            throw std::logic_error("No such UDQ variable: " + key);
+    }
+    const auto& result_set = res_iter->second;
+    if (result_set.var_type() != var_type)
+        throw std::logic_error("Incompatible query function used");
+
+    const auto& result = result_set[wgname];
+    if (result.defined())
+        return result.value();
+    else
+        return this->undefined_value;
+}
+
+double UDQState::get_well_var(const std::string& well, const std::string& key) const {
+    return this->get_wg_var(well, key, UDQVarType::WELL_VAR);
+}
+
+double UDQState::get_group_var(const std::string& group, const std::string& key) const {
+    return this->get_wg_var(group, key, UDQVarType::GROUP_VAR);
+}
+
+}
+
+


### PR DESCRIPTION
Small class to keep track of the result of UDQ evaluations. Up until now the result of evaluating a UDQ has been injected directly into the `SummaryState`where it is maintained as `std::map<KeyType, double>` mapping - that has worked well up until now, but the problem is that in some situations:

1. Further UDQ evaluation
2. Restart output

We need to keep track of whether a UDQ has a valid value or not and then a plain `double`does not suffice; to complicate matters further the `ACTIONX` and summary output will transparently use a default value in the case of undefined UDQ values. The `UDQState`class introduced here will be owned by the simulator, and be used alongside with `SummaryState`. Right now the code has no users - but that will come.

Dwonstream: https://github.com/OPM/opm-simulators/pull/2736