### PR TITLE
Remove call to udq::eval() from Summary::eval()

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
@@ -117,6 +118,8 @@ void msim::run_step(const Schedule& schedule, Action::State& action_state, Summa
                           well_data,
                           group_data,
                           {});
+
+        schedule.getUDQConfig( report_step ).eval(st);
 
         this->output(action_state,
                      st,

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2657,8 +2657,6 @@ void Summary::eval(SummaryState&                  st,
                        well_solution, group_solution, single_values,
                        region_values, block_values, st);
 
-    const auto& udq = schedule.getUDQConfig(sim_step);
-    udq.eval(st);
     st.update_elapsed(duration);
 }
 


### PR DESCRIPTION
The call to `udq::eval()` has up until now been included in the `Summary::eval()` - moved out to enable additional arguments to the `udq::eval()`function.

Dwonstream: https://github.com/OPM/opm-simulators/pull/2737