### PR TITLE
Allow FIPxxx keywords in FieldProps manager

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -93,8 +93,8 @@ static const std::map<std::string, int> int_scalar_init = {{"SATNUM", 1},
                                                            {"ACTNUM", 1}};
 
 
-/*
-bool isFipxxx< int >(const std::string& keyword) {
+
+bool isFipxxx(const std::string& keyword) {
     // FIPxxxx can be any keyword, e.g. FIPREG or FIPXYZ that has the pattern "FIP.+"
     // However, it can not be FIPOWG as that is an actual keyword.
     if (keyword.size() < 4 || keyword == "FIPOWG") {
@@ -102,7 +102,7 @@ bool isFipxxx< int >(const std::string& keyword) {
     }
     return keyword[0] == 'F' && keyword[1] == 'I' && keyword[2] == 'P';
 }
-*/
+
 
 namespace GRID {
 static const std::set<std::string> double_keywords = {"MULTPV", "NTG", "PORO", "PERMX", "PERMY", "PERMZ", "THCONR", "MULTX", "MULTX-", "MULTY-", "MULTY", "MULTZ", "MULTZ-",
@@ -558,7 +558,7 @@ bool FieldProps::supported<int>(const std::string& keyword) {
     if (keywords::SCHEDULE::int_keywords.count(keyword) != 0)
         return true;
 
-    return false;
+    return keywords::isFipxxx(keyword);
 }
 
 template <>
@@ -1101,7 +1101,7 @@ void FieldProps::scanREGIONSSection(const REGIONSSection& regions_section) {
 
     for (const auto& keyword : regions_section) {
         const std::string& name = keyword.name();
-        if (keywords::REGIONS::int_keywords.count(name) == 1) {
+        if (keywords::REGIONS::int_keywords.count(name) == 1 || keywords::isFipxxx(name)) {
             this->handle_int_keyword(keyword, box);
             continue;
         }

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1547,3 +1547,28 @@ BOOST_AUTO_TEST_CASE(SatFunc_EndPts_Family_II_TolCrit_Large) {
         BOOST_CHECK_CLOSE(pcg[0], 0.0, 1.0e-10);
     }
 }
+
+BOOST_AUTO_TEST_CASE(GET_FIPXYZ) {
+    std::string deck_string = R"(
+GRID
+
+PORO
+   200*0.15 /
+
+REGIONS
+
+FIPNUM
+  200*1 /
+
+FIPXYZ
+  100*1 100*2 /
+)";
+
+    EclipseGrid grid(10,10, 2);
+    Deck deck = Parser{}.parseString(deck_string);
+    BOOST_CHECK(deck.hasKeyword("FIPXYZ"));
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
+    const auto& fipxyz = fpm.get_int("FIPXYZ");
+    BOOST_CHECK_EQUAL(fipxyz[0],   1);
+    BOOST_CHECK_EQUAL(fipxyz[100], 2);
+}


### PR DESCRIPTION
It is possible to define your numerical region keywords as:
```
REGIONS

FIPXYZ
   ......  /
```

This PR adds support for them in the FieldProps system.