### PR TITLE
rewriting a for loop for intel compilers

### DIFF
--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -411,7 +411,7 @@ namespace {
             {
                 units.from_si(prop.unit, value);
 
-                for (auto n = dflt.size(), i = decltype(n){}; i < n; ++i) {
+                for (auto n = dflt.size(), i = 0*n; i < n; ++i) {
                     if (dflt[i]) {
                         // Element defaulted.  Output sentinel value
                         // (-1.0e+20) to signify defaulted element.
@@ -426,7 +426,7 @@ namespace {
             });
         }
         else {
-            writeCellPropertiesValuesOnly(propList, fp, 
+            writeCellPropertiesValuesOnly(propList, fp,
                 [&units, &initFile](const CellProperty&   prop,
                                     std::vector<double>&& value)
             {


### PR DESCRIPTION
It happens when we tried to compile OPM on a cluster with Intel compilers. 

It failed in the compiling the related line due to 

identifier "n" is undefined. I believe it is related to the implementation of the compiler. 

It can be verified through the following sample code

``` c++
int main()
{
    for (auto max_n=10, j = decltype(max_n){}; j < 10 * max_n; ++j) {
        j += j;
    }
}
```

There are much more to make the OPM can be compiled by Intel compilers, and we did not succeed in the end. 

But I think it might be good to use code compatible with more compilers. 