### PR TITLE
Add UDQState argument to output writer

### DIFF
--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -25,6 +25,7 @@ class ParseContext;
 class Parser;
 class Python;
 class SummaryState;
+class UDQState;
 
 namespace Action {
 class State;
@@ -46,9 +47,9 @@ public:
     void post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step);
 private:
 
-    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step, EclipseIO& io) const;
-    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step, double dt, EclipseIO& io) const;
-    void output(Action::State& action_state, SummaryState& st, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, const data::GroupValues& group_data, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, UDQState& udq_state, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, UDQState& udq_state, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step, double dt, EclipseIO& io) const;
+    void output(Action::State& action_state, SummaryState& st, const UDQState& udq_state, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, const data::GroupValues& group_data, EclipseIO& io) const;
     void simulate(const Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step, double seconds_elapsed, double time_step) const;
 
     EclipseState state;

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -45,6 +45,7 @@ class EclipseState;
 class Schedule;
 class SummaryConfig;
 class SummaryState;
+class UDQState;
 namespace Action { class State; }
 /*!
  * \brief A class to write the reservoir state and the well state of a
@@ -176,6 +177,7 @@ public:
 
     void writeTimeStep( const Action::State& action_state,
                         const SummaryState& st,
+                        const UDQState& udq_state,
                         int report_step,
                         bool isSubstep,
                         double seconds_elapsed,

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -189,6 +189,7 @@ void EclipseIO::writeInitial( data::Solution simProps, std::map<std::string, std
 // implementation of the writeTimeStep method
 void EclipseIO::writeTimeStep(const Action::State& action_state,
                               const SummaryState& st,
+                              const UDQState& /* udq_state */,
                               int report_step,
                               bool  isSubstep,
                               double secs_elapsed,

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -36,6 +36,7 @@
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 
 #include <opm/io/eclipse/EclFile.hpp>
 #include <opm/io/eclipse/EGrid.hpp>
@@ -323,10 +324,12 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
             sol.insert("KRG", measure::identity , std::vector<double>(3*3*3 , i*10), TargetType::RESTART_AUXILIARY);
 
             Action::State action_state;
+            UDQState udq_state(1);
             RestartValue restart_value(sol, wells, groups);
             auto first_step = ecl_util_make_date( 10 + i, 11, 2008 );
             eclWriter.writeTimeStep( action_state,
                                      st,
+                                     udq_state,
                                      i,
                                      false,
                                      first_step - start_time,

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -39,6 +39,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
@@ -277,6 +278,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
 
         SummaryState st(std::chrono::system_clock::now());
         Action::State action_state;
+        UDQState udq_state(1234);
 
         data::Rates r1, r2;
         r1.set( data::Rates::opt::wat, 4.11 );
@@ -312,6 +314,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
 
         eclipseWriter.writeTimeStep( action_state,
                                      st,
+                                     udq_state,
                                      2,
                                      false,
                                      step_time - start_time,
@@ -396,6 +399,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
         SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ));
         SummaryState st(std::chrono::system_clock::now());
         Action::State action_state;
+        UDQState udq_state(10);
 
         const auto  start_time = schedule.posixStartTime();
         const auto& time_map   = schedule.getTimeMap( );
@@ -438,6 +442,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
 
                 eclipseWriter.writeTimeStep( action_state,
                                              st,
+                                             udq_state,
                                              step,
                                              false,
                                              step_time - start_time,

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -42,6 +42,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 
 #include <opm/io/eclipse/OutputStream.hpp>
 #include <opm/io/eclipse/EclIOdata.hpp>
@@ -384,7 +385,7 @@ void init_st(SummaryState& st) {
     st.update("FLPR", 100);
 }
 
-RestartValue first_sim(const Setup& setup, Action::State& action_state, SummaryState& st, bool write_double) {
+RestartValue first_sim(const Setup& setup, Action::State& action_state, SummaryState& st, UDQState& udq_state, bool write_double) {
     EclipseIO eclWriter( setup.es, setup.grid, setup.schedule, setup.summary_config);
     auto num_cells = setup.grid.getNumActive( );
     int report_step = 1;
@@ -401,6 +402,7 @@ RestartValue first_sim(const Setup& setup, Action::State& action_state, SummaryS
     udq.eval(st);
     eclWriter.writeTimeStep( action_state,
                              st,
+                             udq_state,
                              report_step,
                              false,
                              std::difftime(first_step, start_time),
@@ -451,7 +453,8 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData) {
     Setup base_setup("BASE_SIM.DATA");
     SummaryState st(std::chrono::system_clock::now());
     Action::State action_state;
-    auto state1 = first_sim( base_setup , action_state, st, false );
+    UDQState udq_state(19);
+    auto state1 = first_sim( base_setup , action_state, st, udq_state, false );
 
     Setup restart_setup("RESTART_SIM.DATA");
     auto state2 = second_sim( restart_setup , action_state, st , keys );
@@ -586,8 +589,9 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData_double) {
     Setup base_setup("BASE_SIM.DATA");
     SummaryState st(std::chrono::system_clock::now());
     Action::State action_state;
+    UDQState udq_state(1);
 
-    auto state1 = first_sim( base_setup , action_state, st, true);
+    auto state1 = first_sim( base_setup , action_state, st, udq_state, true);
     Setup restart_setup("RESTART_SIM.DATA");
 
     auto state2 = second_sim( restart_setup, action_state, st, solution_keys );
@@ -1001,7 +1005,8 @@ BOOST_AUTO_TEST_CASE(UDQ_RESTART) {
     SummaryState st1(std::chrono::system_clock::now());
     SummaryState st2(std::chrono::system_clock::now());
     Action::State action_state;
-    auto state1 = first_sim( base_setup , action_state, st1, false );
+    UDQState udq_state(1);
+    auto state1 = first_sim( base_setup , action_state, st1, udq_state, false );
 
     Setup restart_setup("UDQ_RESTART.DATA");
     auto state2 = second_sim( restart_setup , action_state, st2 , keys );

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 
 #include <opm/io/eclipse/EclFile.hpp>
 
@@ -208,6 +209,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     int countTimeStep = schedule.getTimeMap().numTimesteps();
     Opm::SummaryState st(std::chrono::system_clock::from_time_t(schedule.getStartTime()));
     Opm::Action::State action_state;
+    Opm::UDQState udq_state(123);
 
     Opm::data::Solution solution;
     solution.insert( "PRESSURE", Opm::UnitSystem::measure::pressure , std::vector< double >( num_cells, 1 ) , Opm::data::TargetType::RESTART_SOLUTION);
@@ -220,6 +222,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
 
         eclipseWriter.writeTimeStep( action_state,
                                      st,
+                                     udq_state,
                                      timestep,
                                      false,
                                      schedule.seconds(timestep),


### PR DESCRIPTION
To enable keeping track of defined / undefined UDQ values in the restart files.

Downstream: https://github.com/OPM/opm-simulators/pull/2748