### PR TITLE
Add wsegiter

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -460,6 +460,7 @@ namespace Opm
         void handleDRVDTR( const DeckKeyword& keyword, size_t currentStep);
         void handleVAPPARS( const DeckKeyword& keyword, size_t currentStep);
         void handleWECON( const DeckKeyword& keyword, size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
+        void handleWSEGITER( const DeckKeyword& keyword, size_t currentStep);
         void handleWHISTCTL(const DeckKeyword& keyword, std::size_t currentStep, const ParseContext& parseContext, ErrorGuard& errors);
         void handleMESSAGES(const DeckKeyword& keyword, size_t currentStep);
         void handleRPTSCHED(const DeckKeyword& keyword, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -248,7 +248,6 @@ namespace Opm
         const Group& getGroup(const std::string& groupName, size_t timeStep) const;
 
         const Tuning& getTuning(size_t timeStep) const;
-        const DynamicState<Tuning>& getTuning() const;
         const MessageLimits& getMessageLimits() const;
         void invalidNamePattern (const std::string& namePattern, std::size_t report_step, const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword) const;
         const GuideRateConfig& guideRateConfig(size_t timeStep) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
@@ -22,10 +22,12 @@
 
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
 
 namespace Opm {
     struct Tuning {
         using TuningKw = ParserKeywords::TUNING;
+        using WsegIterKW = ParserKeywords::WSEGITER;
 
         static Tuning serializeObject()
         {
@@ -114,6 +116,19 @@ namespace Opm {
         double XXXDPR = 0.0 * Metric::Pressure;
         bool XXXDPR_has_value = false;
 
+        /*
+          In addition to the values set in the TUNING keyword this Tuning
+          implementation also contains the result of the WSEGITER keyword, which
+          is special tuning parameters to be applied to the multisegment well
+          model. Observe that the maximum number of well iterations - MXWSIT -
+          is specified by both the TUNING keyword and the WSEGITER keyword, but
+          with different defaults.
+        */
+        int WSEG_MAX_RESTART = WsegIterKW::MAX_TIMES_REDUCED::defaultValue;
+        double WSEG_REDUCTION_FACTOR = WsegIterKW::REDUCTION_FACTOR::defaultValue;
+        double WSEG_INCREASE_FACTOR = WsegIterKW::INCREASING_FACTOR::defaultValue;
+
+
         bool operator==(const Tuning& data) const {
             return TSINIT == data.TSINIT &&
                    TSMAXZ == data.TSMAXZ &&
@@ -150,7 +165,10 @@ namespace Opm {
                    DDSLIM == data.DDSLIM &&
                    TRGDPR == data.TRGDPR &&
                    XXXDPR == data.XXXDPR &&
-                   XXXDPR_has_value == data.XXXDPR_has_value;
+                   XXXDPR_has_value == data.XXXDPR_has_value &&
+                   WSEG_MAX_RESTART == data.WSEG_MAX_RESTART &&
+                   WSEG_REDUCTION_FACTOR == data.WSEG_REDUCTION_FACTOR &&
+                   WSEG_INCREASE_FACTOR == data.WSEG_INCREASE_FACTOR;
         }
 
         bool operator !=(const Tuning& data) const {
@@ -198,6 +216,10 @@ namespace Opm {
             serializer(TRGDPR);
             serializer(XXXDPR);
             serializer(XXXDPR_has_value);
+
+            serializer(WSEG_MAX_RESTART);
+            serializer(WSEG_REDUCTION_FACTOR);
+            serializer(WSEG_INCREASE_FACTOR);
         }
     };
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -2788,10 +2788,6 @@ void Schedule::invalidNamePattern( const std::string& namePattern,  std::size_t 
         return this->m_tuning.get( timeStep );
     }
 
-    const DynamicState<Tuning>& Schedule::getTuning() const {
-        return this->m_tuning;
-    }
-
     const Deck& Schedule::getModifierDeck(size_t timeStep) const {
         return m_modifierDeck.iget( timeStep );
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -440,6 +440,9 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext&
         else if (keyword.name() == "TUNING")
             handleTUNING(keyword, currentStep);
 
+        else if (keyword.name() == "WSEGITER")
+            handleWSEGITER(keyword, currentStep);
+
         else if (keyword.name() == "WRFT")
             rftProperties.push_back( std::make_pair( &keyword , currentStep ));
 
@@ -1928,10 +1931,24 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext&
     }
 
 
+    void Schedule::handleWSEGITER( const DeckKeyword& keyword, size_t currentStep) {
+        using WI = ParserKeywords::WSEGITER;
+        Tuning tuning(m_tuning.get(currentStep));
+        {
+            const auto& record = keyword.getRecord(0);
+            tuning.MXWSIT = record.getItem<WI::MAX_WELL_ITERATIONS>().get<int>(0);
+            tuning.WSEG_MAX_RESTART = record.getItem<WI::MAX_TIMES_REDUCED>().get<int>(0);
+            tuning.WSEG_REDUCTION_FACTOR = record.getItem<WI::REDUCTION_FACTOR>().get<double>(0);
+            tuning.WSEG_INCREASE_FACTOR = record.getItem<WI::INCREASING_FACTOR>().get<double>(0);
+        }
+        m_tuning.update(currentStep, tuning);
+        m_events.addEvent( ScheduleEvents::TUNING_CHANGE , currentStep);
+    }
+
+
     void Schedule::handleTUNING( const DeckKeyword& keyword, size_t currentStep) {
-
-        int numrecords = keyword.size();
-
+        using TU = ParserKeywords::TUNING;
+        auto numrecords = keyword.size();
         Tuning tuning(m_tuning.get(currentStep));
         if (numrecords > 0) {
             const auto& record1 = keyword.getRecord(0);
@@ -1994,10 +2011,11 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext&
                 tuning.XXXDPR_has_value = true;
                 tuning.XXXDPR = XXXDPRdeckItem.getSIDouble(0);
             }
-        }
+        } else
+            tuning.MXWSIT = TU::MXWSIT::defaultValue;
+
         m_tuning.update(currentStep, tuning);
         m_events.addEvent( ScheduleEvents::TUNING_CHANGE , currentStep);
-
     }
 
 

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -327,5 +327,7 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
       BOOST_CHECK(event.hasEvent(ScheduleEvents::TUNING_CHANGE, timestep));
       BOOST_CHECK_EQUAL(true, tuning.TMAXWC_has_value);
       BOOST_CHECK_CLOSE(tuning.TMAXWC, 10.0 * Metric::Time, diff);
+
+      BOOST_CHECK_EQUAL(tuning.MXWSIT, ParserKeywords::WSEGITER::MAX_WELL_ITERATIONS::defaultValue);
   }
 }

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -35,30 +35,33 @@
 using namespace Opm;
 
 
-const std::string& deckStr =  "START\n"
-                              " 21 MAY 1981 /\n"
-                              "\n"
-                              "SCHEDULE\n"
-                              "TSTEP\n"
-                              " 1 2 3 4 5 /\n"
-                              "\n"
-                              "TUNING\n"
-                              "2 300 0.3 0.30 6 0.6 0.2 2.25 2E20 /\n"
-                              "0.2 0.002 2E-7 0.0002 11 0.02 2.0E-6 0.002 0.002 0.035 66 0.02 2/\n"
-                              "13 2 26 2 9 9 4.0E6 4.0E6 4.0E6 1/\n"
-                              "DATES\n"
-                              " 1 JAN 1982 /\n"
-                              " 1 JAN 1982 13:55:44 /\n"
-                              " 3 JAN 1982 14:56:45.123 /\n"
-                              "/\n"
-                              "TSTEP\n"
-                              " 9 10 /\n"
-                              "\n"
-                              "TUNING\n"
-                              "2 300 0.3 0.30 6 0.6 0.2 2.25 2E20 10.0/\n"
-                              "/\n"
-                              "/\n";
+const std::string& deckStr =  R"(
+START
+ 21 MAY 1981 /
 
+SCHEDULE
+TSTEP
+ 1 2 3 4 5 /
+
+TUNING
+2 300 0.3 0.30 6 0.6 0.2 2.25 2E20 /
+0.2 0.002 2E-7 0.0002 11 0.02 2.0E-6 0.002 0.002 0.035 66 0.02 2/
+13 2 26 2 9 9 4.0E6 4.0E6 4.0E6 1/
+DATES
+ 1 JAN 1982 /
+ 1 JAN 1982 13:55:44 /
+ 3 JAN 1982 14:56:45.123 /
+/
+TSTEP
+ 9 10 /
+
+TUNING
+2 300 0.3 0.30 6 0.6 0.2 2.25 2E20 10.0/
+/
+/
+WSEGITER
+/
+)";
 
 
 static Deck createDeck(const std::string& input) {
@@ -77,252 +80,252 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
   Runspec runspec (deck);
   Schedule schedule( deck, grid , fp, runspec, python);
-  const auto& tuning = schedule.getTuning();
   auto event = schedule.getEvents();
 
   const double diff = 1.0e-14;
 
   /*** TIMESTEP 4***/
   /********* Record 1 ***********/
-  size_t timestep = 4;
-  BOOST_CHECK(!event.hasEvent(ScheduleEvents::TUNING_CHANGE, timestep));
 
-  double TSINIT_default = tuning.get(timestep).TSINIT;
-  BOOST_CHECK_CLOSE(TSINIT_default, 1 * Metric::Time, diff);
+  {
+      size_t timestep = 4;
+      BOOST_CHECK(!event.hasEvent(ScheduleEvents::TUNING_CHANGE, timestep));
 
-  double TSMAXZ_default = tuning.get(timestep).TSMAXZ;
-  BOOST_CHECK_CLOSE(TSMAXZ_default, 365 * Metric::Time, diff);
+      const auto& tuning = schedule.getTuning(4);
+      double TSINIT_default = tuning.TSINIT;
+      BOOST_CHECK_CLOSE(TSINIT_default, 1 * Metric::Time, diff);
 
-  double TSMINZ_default = tuning.get(timestep).TSMINZ;
-  BOOST_CHECK_CLOSE(TSMINZ_default, 0.1 * Metric::Time, diff);
+      double TSMAXZ_default = tuning.TSMAXZ;
+      BOOST_CHECK_CLOSE(TSMAXZ_default, 365 * Metric::Time, diff);
 
-  double TSMCHP_default = tuning.get(timestep).TSMCHP;
-  BOOST_CHECK_CLOSE(TSMCHP_default, 0.15 * Metric::Time, diff);
+      double TSMINZ_default = tuning.TSMINZ;
+      BOOST_CHECK_CLOSE(TSMINZ_default, 0.1 * Metric::Time, diff);
 
-  double TSFMAX_default = tuning.get(timestep).TSFMAX;
-  BOOST_CHECK_CLOSE(TSFMAX_default, 3.0, diff);
+      double TSMCHP_default = tuning.TSMCHP;
+      BOOST_CHECK_CLOSE(TSMCHP_default, 0.15 * Metric::Time, diff);
 
-  double TSFMIN_default = tuning.get(timestep).TSFMIN;
-  BOOST_CHECK_CLOSE(TSFMIN_default, 0.3, diff);
+      double TSFMAX_default = tuning.TSFMAX;
+      BOOST_CHECK_CLOSE(TSFMAX_default, 3.0, diff);
 
-  double TSFCNV_default = tuning.get(timestep).TSFCNV;
-  BOOST_CHECK_CLOSE(TSFCNV_default, 0.1, diff);
+      double TSFMIN_default = tuning.TSFMIN;
+      BOOST_CHECK_CLOSE(TSFMIN_default, 0.3, diff);
 
-  double TFDIFF_default = tuning.get(timestep).TFDIFF;
-  BOOST_CHECK_CLOSE(TFDIFF_default, 1.25, diff);
+      double TSFCNV_default = tuning.TSFCNV;
+      BOOST_CHECK_CLOSE(TSFCNV_default, 0.1, diff);
 
-  double THRUPT_default = tuning.get(timestep).THRUPT;
-  BOOST_CHECK_CLOSE(THRUPT_default, 1E20, diff);
+      double TFDIFF_default = tuning.TFDIFF;
+      BOOST_CHECK_CLOSE(TFDIFF_default, 1.25, diff);
 
-  bool TMAXWC_has_value = tuning.get(timestep).TMAXWC_has_value;
-  double TMAXWC_default = tuning.get(timestep).TMAXWC;
-  BOOST_CHECK_EQUAL(false, TMAXWC_has_value);
-  BOOST_CHECK_CLOSE(TMAXWC_default, 0.0 * Metric::Time, diff);
+      double THRUPT_default = tuning.THRUPT;
+      BOOST_CHECK_CLOSE(THRUPT_default, 1E20, diff);
 
-
-  /********* Record 2 ************/
-  double TRGTTE_default = tuning.get(timestep).TRGTTE;
-  BOOST_CHECK_CLOSE(TRGTTE_default, 0.1, diff);
-
-  double TRGCNV_default = tuning.get(timestep).TRGCNV;
-  BOOST_CHECK_CLOSE(TRGCNV_default, 0.001, diff);
-
-  double TRGMBE_default = tuning.get(timestep).TRGMBE;
-  BOOST_CHECK_CLOSE(TRGMBE_default, 0.0, diff);
-
-  double TRGLCV_default = tuning.get(timestep).TRGLCV;
-  BOOST_CHECK_CLOSE(TRGLCV_default, 0.0001, diff);
-
-  double XXXTTE_default = tuning.get(timestep).XXXTTE;
-  BOOST_CHECK_CLOSE(XXXTTE_default, 10.0, diff);
-
-  double XXXCNV_default = tuning.get(timestep).XXXCNV;
-  BOOST_CHECK_CLOSE(XXXCNV_default, 0.01, diff);
-
-  double XXXMBE_default = tuning.get(timestep).XXXMBE;
-  BOOST_CHECK_CLOSE(XXXMBE_default, 1.0E-6, diff);
-
-  double XXXLCV_default = tuning.get(timestep).XXXLCV;
-  BOOST_CHECK_CLOSE(XXXLCV_default, 0.001, diff);
-
-  double XXXWFL_default = tuning.get(timestep).XXXWFL;
-  BOOST_CHECK_CLOSE(XXXWFL_default, 0.001, diff);
-
-  double TRGFIP_default = tuning.get(timestep).TRGFIP;
-  BOOST_CHECK_CLOSE(TRGFIP_default, 0.025, diff);
-
-  bool TRGSFT_has_value = tuning.get(timestep).TRGSFT_has_value;
-  double TRGSFT_default = tuning.get(timestep).TRGSFT;
-  BOOST_CHECK_EQUAL(false, TRGSFT_has_value);
-  BOOST_CHECK_CLOSE(TRGSFT_default, 0.0, diff);
-
-  double THIONX_default = tuning.get(timestep).THIONX;
-  BOOST_CHECK_CLOSE(THIONX_default, 0.01, diff);
-
-  int TRWGHT_default = tuning.get(timestep).TRWGHT;
-  BOOST_CHECK_EQUAL(TRWGHT_default, 1);
+      bool TMAXWC_has_value = tuning.TMAXWC_has_value;
+      double TMAXWC_default = tuning.TMAXWC;
+      BOOST_CHECK_EQUAL(false, TMAXWC_has_value);
+      BOOST_CHECK_CLOSE(TMAXWC_default, 0.0 * Metric::Time, diff);
 
 
-  /********* Record 3 ************/
-  int NEWTMX_default = tuning.get(timestep).NEWTMX;
-  BOOST_CHECK_EQUAL(NEWTMX_default, 12);
+      /********* Record 2 ************/
+      double TRGTTE_default = tuning.TRGTTE;
+      BOOST_CHECK_CLOSE(TRGTTE_default, 0.1, diff);
 
-  int NEWTMN_default = tuning.get(timestep).NEWTMN;
-  BOOST_CHECK_EQUAL(NEWTMN_default, 1);
+      double TRGCNV_default = tuning.TRGCNV;
+      BOOST_CHECK_CLOSE(TRGCNV_default, 0.001, diff);
 
-  int LITMAX_default = tuning.get(timestep).LITMAX;
-  BOOST_CHECK_EQUAL(LITMAX_default, 25);
+      double TRGMBE_default = tuning.TRGMBE;
+      BOOST_CHECK_CLOSE(TRGMBE_default, 0.0, diff);
 
-  int LITMIN_default = tuning.get(timestep).LITMIN;
-  BOOST_CHECK_EQUAL(LITMIN_default, 1);
+      double TRGLCV_default = tuning.TRGLCV;
+      BOOST_CHECK_CLOSE(TRGLCV_default, 0.0001, diff);
 
-  int MXWSIT_default = tuning.get(timestep).MXWSIT;
-  BOOST_CHECK_EQUAL(MXWSIT_default, 8);
+      double XXXTTE_default = tuning.XXXTTE;
+      BOOST_CHECK_CLOSE(XXXTTE_default, 10.0, diff);
 
-  int MXWPIT_default = tuning.get(timestep).MXWPIT;
-  BOOST_CHECK_EQUAL(MXWPIT_default, 8);
+      double XXXCNV_default = tuning.XXXCNV;
+      BOOST_CHECK_CLOSE(XXXCNV_default, 0.01, diff);
 
-  double DDPLIM_default = tuning.get(timestep).DDPLIM;
-  BOOST_CHECK_CLOSE(DDPLIM_default, 1.0E6 * Metric::Pressure, diff);
+      double XXXMBE_default = tuning.XXXMBE;
+      BOOST_CHECK_CLOSE(XXXMBE_default, 1.0E-6, diff);
 
-  double DDSLIM_default = tuning.get(timestep).DDSLIM;
-  BOOST_CHECK_CLOSE(DDSLIM_default, 1.0E6, diff);
+      double XXXLCV_default = tuning.XXXLCV;
+      BOOST_CHECK_CLOSE(XXXLCV_default, 0.001, diff);
 
-  double TRGDPR_default = tuning.get(timestep).TRGDPR;
-  BOOST_CHECK_CLOSE(TRGDPR_default, 1.0E6 * Metric::Pressure, diff);
+      double XXXWFL_default = tuning.XXXWFL;
+      BOOST_CHECK_CLOSE(XXXWFL_default, 0.001, diff);
 
-  bool XXXDPR_has_value = tuning.get(timestep).XXXDPR_has_value;
-  double XXXDPR_default = tuning.get(timestep).XXXDPR;
-  BOOST_CHECK_EQUAL(false, XXXDPR_has_value);
-  BOOST_CHECK_CLOSE(XXXDPR_default, 0.0, diff);
+      double TRGFIP_default = tuning.TRGFIP;
+      BOOST_CHECK_CLOSE(TRGFIP_default, 0.025, diff);
 
+      bool TRGSFT_has_value = tuning.TRGSFT_has_value;
+      double TRGSFT_default = tuning.TRGSFT;
+      BOOST_CHECK_EQUAL(false, TRGSFT_has_value);
+      BOOST_CHECK_CLOSE(TRGSFT_default, 0.0, diff);
+
+      double THIONX_default = tuning.THIONX;
+      BOOST_CHECK_CLOSE(THIONX_default, 0.01, diff);
+
+      int TRWGHT_default = tuning.TRWGHT;
+      BOOST_CHECK_EQUAL(TRWGHT_default, 1);
+
+
+      /********* Record 3 ************/
+      int NEWTMX_default = tuning.NEWTMX;
+      BOOST_CHECK_EQUAL(NEWTMX_default, 12);
+
+      int NEWTMN_default = tuning.NEWTMN;
+      BOOST_CHECK_EQUAL(NEWTMN_default, 1);
+
+      int LITMAX_default = tuning.LITMAX;
+      BOOST_CHECK_EQUAL(LITMAX_default, 25);
+
+      int LITMIN_default = tuning.LITMIN;
+      BOOST_CHECK_EQUAL(LITMIN_default, 1);
+
+      int MXWSIT_default = tuning.MXWSIT;
+      BOOST_CHECK_EQUAL(MXWSIT_default, 8);
+
+      int MXWPIT_default = tuning.MXWPIT;
+      BOOST_CHECK_EQUAL(MXWPIT_default, 8);
+
+      double DDPLIM_default = tuning.DDPLIM;
+      BOOST_CHECK_CLOSE(DDPLIM_default, 1.0E6 * Metric::Pressure, diff);
+
+      double DDSLIM_default = tuning.DDSLIM;
+      BOOST_CHECK_CLOSE(DDSLIM_default, 1.0E6, diff);
+
+      double TRGDPR_default = tuning.TRGDPR;
+      BOOST_CHECK_CLOSE(TRGDPR_default, 1.0E6 * Metric::Pressure, diff);
+
+      bool XXXDPR_has_value = tuning.XXXDPR_has_value;
+      double XXXDPR_default = tuning.XXXDPR;
+      BOOST_CHECK_EQUAL(false, XXXDPR_has_value);
+      BOOST_CHECK_CLOSE(XXXDPR_default, 0.0, diff);
+  }
 
 
 
   /*** TIMESTEP 5***/
   /********* Record 1 ***********/
-  timestep = 5;
-  BOOST_CHECK(event.hasEvent(ScheduleEvents::TUNING_CHANGE, timestep));
-  double TSINIT = tuning.get(timestep).TSINIT;
-  BOOST_CHECK_CLOSE(TSINIT, 2 * Metric::Time, diff);
+  {
+      std::size_t timestep = 5;
+      const auto& tuning = schedule.getTuning(timestep);
 
-  double TSMAXZ = tuning.get(timestep).TSMAXZ;
-  BOOST_CHECK_CLOSE(TSMAXZ, 300 * Metric::Time, diff);
+      BOOST_CHECK(event.hasEvent(ScheduleEvents::TUNING_CHANGE, timestep));
+      double TSINIT = tuning.TSINIT;
+      BOOST_CHECK_CLOSE(TSINIT, 2 * Metric::Time, diff);
 
-  double TSMINZ = tuning.get(timestep).TSMINZ;
-  BOOST_CHECK_CLOSE(TSMINZ, 0.3 * Metric::Time, diff);
+      double TSMAXZ = tuning.TSMAXZ;
+      BOOST_CHECK_CLOSE(TSMAXZ, 300 * Metric::Time, diff);
 
-  double TSMCHP = tuning.get(timestep).TSMCHP;
-  BOOST_CHECK_CLOSE(TSMCHP, 0.30 * Metric::Time, diff);
+      double TSMINZ = tuning.TSMINZ;
+      BOOST_CHECK_CLOSE(TSMINZ, 0.3 * Metric::Time, diff);
 
-  double TSFMAX = tuning.get(timestep).TSFMAX;
-  BOOST_CHECK_CLOSE(TSFMAX, 6.0, 1.0);
+      double TSMCHP = tuning.TSMCHP;
+      BOOST_CHECK_CLOSE(TSMCHP, 0.30 * Metric::Time, diff);
 
-  double TSFMIN = tuning.get(timestep).TSFMIN;
-  BOOST_CHECK_CLOSE(TSFMIN, 0.6, 1.0);
+      double TSFMAX = tuning.TSFMAX;
+      BOOST_CHECK_CLOSE(TSFMAX, 6.0, 1.0);
 
-  double TSFCNV = tuning.get(timestep).TSFCNV;
-  BOOST_CHECK_CLOSE(TSFCNV, 0.2, diff);
+      double TSFMIN = tuning.TSFMIN;
+      BOOST_CHECK_CLOSE(TSFMIN, 0.6, 1.0);
 
-  double TFDIFF = tuning.get(timestep).TFDIFF;
-  BOOST_CHECK_CLOSE(TFDIFF, 2.25, diff);
+      double TSFCNV = tuning.TSFCNV;
+      BOOST_CHECK_CLOSE(TSFCNV, 0.2, diff);
 
-  double THRUPT = tuning.get(timestep).THRUPT;
-  BOOST_CHECK_CLOSE(THRUPT, 2E20, diff);
+      double TFDIFF = tuning.TFDIFF;
+      BOOST_CHECK_CLOSE(TFDIFF, 2.25, diff);
 
-  TMAXWC_has_value = tuning.get(timestep).TMAXWC_has_value;
-  TMAXWC_default = tuning.get(timestep).TMAXWC;
-  BOOST_CHECK_EQUAL(false, TMAXWC_has_value);
-  BOOST_CHECK_CLOSE(TMAXWC_default, 0.0 * Metric::Time, diff);
+      double THRUPT = tuning.THRUPT;
+      BOOST_CHECK_CLOSE(THRUPT, 2E20, diff);
 
-  /********* Record 2 ***********/
-  double TRGTTE = tuning.get(timestep).TRGTTE;
-  BOOST_CHECK_CLOSE(TRGTTE, 0.2, diff);
+      BOOST_CHECK_EQUAL(false, tuning.TMAXWC_has_value);
+      BOOST_CHECK_CLOSE(tuning.TMAXWC, 0.0 * Metric::Time, diff);
 
-  double TRGCNV = tuning.get(timestep).TRGCNV;
-  BOOST_CHECK_CLOSE(TRGCNV, 0.002, diff);
+      /********* Record 2 ***********/
+      double TRGTTE = tuning.TRGTTE;
+      BOOST_CHECK_CLOSE(TRGTTE, 0.2, diff);
 
-  double TRGMBE = tuning.get(timestep).TRGMBE;
-  BOOST_CHECK_CLOSE(TRGMBE, 2.0E-7, diff);
+      double TRGCNV = tuning.TRGCNV;
+      BOOST_CHECK_CLOSE(TRGCNV, 0.002, diff);
 
-  double TRGLCV = tuning.get(timestep).TRGLCV;
-  BOOST_CHECK_CLOSE(TRGLCV, 0.0002, diff);
+      double TRGMBE = tuning.TRGMBE;
+      BOOST_CHECK_CLOSE(TRGMBE, 2.0E-7, diff);
 
-  double XXXTTE = tuning.get(timestep).XXXTTE;
-  BOOST_CHECK_CLOSE(XXXTTE, 11.0, diff);
+      double TRGLCV = tuning.TRGLCV;
+      BOOST_CHECK_CLOSE(TRGLCV, 0.0002, diff);
 
-  double XXXCNV = tuning.get(timestep).XXXCNV;
-  BOOST_CHECK_CLOSE(XXXCNV, 0.02, diff);
+      double XXXTTE = tuning.XXXTTE;
+      BOOST_CHECK_CLOSE(XXXTTE, 11.0, diff);
 
-  double XXXMBE = tuning.get(timestep).XXXMBE;
-  BOOST_CHECK_CLOSE(XXXMBE, 2.0E-6, diff);
+      double XXXCNV = tuning.XXXCNV;
+      BOOST_CHECK_CLOSE(XXXCNV, 0.02, diff);
 
-  double XXXLCV = tuning.get(timestep).XXXLCV;
-  BOOST_CHECK_CLOSE(XXXLCV, 0.002, diff);
+      double XXXMBE = tuning.XXXMBE;
+      BOOST_CHECK_CLOSE(XXXMBE, 2.0E-6, diff);
 
-  double XXXWFL = tuning.get(timestep).XXXWFL;
-  BOOST_CHECK_CLOSE(XXXWFL, 0.002, diff);
+      double XXXLCV = tuning.XXXLCV;
+      BOOST_CHECK_CLOSE(XXXLCV, 0.002, diff);
 
-  double TRGFIP = tuning.get(timestep).TRGFIP;
-  BOOST_CHECK_CLOSE(TRGFIP, 0.035, diff);
+      double XXXWFL = tuning.XXXWFL;
+      BOOST_CHECK_CLOSE(XXXWFL, 0.002, diff);
 
-  TRGSFT_has_value = tuning.get(timestep).TRGSFT_has_value;
-  double TRGSFT = tuning.get(timestep).TRGSFT;
-  BOOST_CHECK_EQUAL(true, TRGSFT_has_value);
-  BOOST_CHECK_CLOSE(TRGSFT, 66.0, diff);
+      double TRGFIP = tuning.TRGFIP;
+      BOOST_CHECK_CLOSE(TRGFIP, 0.035, diff);
 
-  double THIONX = tuning.get(timestep).THIONX;
-  BOOST_CHECK_CLOSE(THIONX, 0.02, diff);
+      BOOST_CHECK_EQUAL(true, tuning.TRGSFT_has_value);
+      BOOST_CHECK_CLOSE(tuning.TRGSFT, 66.0, diff);
 
-  int TRWGHT = tuning.get(timestep).TRWGHT;
-  BOOST_CHECK_EQUAL(TRWGHT, 2);
+      double THIONX = tuning.THIONX;
+      BOOST_CHECK_CLOSE(THIONX, 0.02, diff);
 
-  /********* Record 3 ***********/
-  int NEWTMX = tuning.get(timestep).NEWTMX;
-  BOOST_CHECK_EQUAL(NEWTMX, 13);
+      int TRWGHT = tuning.TRWGHT;
+      BOOST_CHECK_EQUAL(TRWGHT, 2);
 
-  int NEWTMN = tuning.get(timestep).NEWTMN;
-  BOOST_CHECK_EQUAL(NEWTMN, 2);
+      /********* Record 3 ***********/
+      int NEWTMX = tuning.NEWTMX;
+      BOOST_CHECK_EQUAL(NEWTMX, 13);
 
-  int LITMAX = tuning.get(timestep).LITMAX;
-  BOOST_CHECK_EQUAL(LITMAX, 26);
+      int NEWTMN = tuning.NEWTMN;
+      BOOST_CHECK_EQUAL(NEWTMN, 2);
 
-  int LITMIN = tuning.get(timestep).LITMIN;
-  BOOST_CHECK_EQUAL(LITMIN, 2);
+      int LITMAX = tuning.LITMAX;
+      BOOST_CHECK_EQUAL(LITMAX, 26);
 
-  int MXWSIT = tuning.get(timestep).MXWSIT;
-  BOOST_CHECK_EQUAL(MXWSIT, 9);
+      int LITMIN = tuning.LITMIN;
+      BOOST_CHECK_EQUAL(LITMIN, 2);
 
-  int MXWPIT = tuning.get(timestep).MXWPIT;
-  BOOST_CHECK_EQUAL(MXWPIT, 9);
+      int MXWSIT = tuning.MXWSIT;
+      BOOST_CHECK_EQUAL(MXWSIT, 9);
 
-  double DDPLIM= tuning.get(timestep).DDPLIM;
-  BOOST_CHECK_CLOSE(DDPLIM, 4.0E6 * Metric::Pressure, diff);
+      int MXWPIT = tuning.MXWPIT;
+      BOOST_CHECK_EQUAL(MXWPIT, 9);
 
-  double DDSLIM= tuning.get(timestep).DDSLIM;
-  BOOST_CHECK_CLOSE(DDSLIM, 4.0E6, diff);
+      double DDPLIM = tuning.DDPLIM;
+      BOOST_CHECK_CLOSE(DDPLIM, 4.0E6 * Metric::Pressure, diff);
 
-  double TRGDPR = tuning.get(timestep).TRGDPR;
-  BOOST_CHECK_CLOSE(TRGDPR, 4.0E6 * Metric::Pressure, diff);
+      double DDSLIM = tuning.DDSLIM;
+      BOOST_CHECK_CLOSE(DDSLIM, 4.0E6, diff);
 
-  XXXDPR_has_value = tuning.get(timestep).XXXDPR_has_value;
-  double XXXDPR = tuning.get(timestep).XXXDPR;
-  BOOST_CHECK_EQUAL(true, XXXDPR_has_value);
-  BOOST_CHECK_CLOSE(XXXDPR, 1.0 * Metric::Pressure, diff);
+      double TRGDPR = tuning.TRGDPR;
+      BOOST_CHECK_CLOSE(TRGDPR, 4.0E6 * Metric::Pressure, diff);
 
+      BOOST_CHECK_EQUAL(true, tuning.XXXDPR_has_value);
+      BOOST_CHECK_CLOSE(tuning.XXXDPR, 1.0 * Metric::Pressure, diff);
+  }
 
   /*** TIMESTEP 7 ***/
-  BOOST_CHECK(!event.hasEvent(ScheduleEvents::TUNING_CHANGE, 7));
+  {
+      std::size_t timestep = 7;
+      BOOST_CHECK(!event.hasEvent(ScheduleEvents::TUNING_CHANGE, timestep));
+  }
 
   /*** TIMESTEP 10 ***/
-  /********* Record 1 ***********/
-  timestep = 10;
-  BOOST_CHECK(event.hasEvent(ScheduleEvents::TUNING_CHANGE, timestep));
-  TMAXWC_has_value = tuning.get(timestep).TMAXWC_has_value;
-  TMAXWC_default = tuning.get(timestep).TMAXWC;
-  BOOST_CHECK_EQUAL(true, TMAXWC_has_value);
-  BOOST_CHECK_CLOSE(TMAXWC_default, 10.0 * Metric::Time, diff);
-
-
-
+  {
+      /********* Record 1 ***********/
+      std::size_t timestep = 10;
+      const auto& tuning = schedule.getTuning(timestep);
+      BOOST_CHECK(event.hasEvent(ScheduleEvents::TUNING_CHANGE, timestep));
+      BOOST_CHECK_EQUAL(true, tuning.TMAXWC_has_value);
+      BOOST_CHECK_CLOSE(tuning.TMAXWC, 10.0 * Metric::Time, diff);
+  }
 }


### PR DESCRIPTION
Internalize WSEGITER settings in Tuning implementation

**Background:** The maximum number of well iterations can be set both with the `TUNING` keyword and the `WSEGITER` keyword. opm has up until now *completely* ignored the `WSEGITER` keyword. With this PR the `Tuning` implementation has been updated to also load the items from `WSEGITER`. The maximum number of well iterations is stored in the `INTEHEAD` restart vector, several of our testcases contain a essentially ignored `WSEGITER` keyword, but with this PR the maximum number of well iterations is updated and we need a data update. 