### PR TITLE
fixed: add missing include for boost version

### DIFF
--- a/tests/test_ArrayDimChecker.cpp
+++ b/tests/test_ArrayDimChecker.cpp
@@ -20,6 +20,7 @@
 #define BOOST_TEST_MODULE Array_Dimension_Checker
 
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 #if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
 #include <boost/test/output_test_stream.hpp>
 #else


### PR DESCRIPTION
My bad, forgot this include when quelling the warning the other day..