### PR TITLE
Add missing <string> include.

### DIFF
--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -18,6 +18,7 @@
 */
 
 #include <cstring>
+#include <string>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
Fixes compile error on clang.

Both critical and trivial, so will self-merge when green.