### PR TITLE
Fieldprops: Correct default

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -217,8 +217,8 @@ private:
 
     /*
       This is exactly like the get() method, but the returned vector will have
-      global cartesian size, where all inactive cells have been filled with
-      zeros.
+      global cartesian size. If the field has a default value that value will be
+      used for filling in in the inactive cells, otherwise zero is used.
     */
     template <typename T>
     std::vector<T> get_global(const std::string& keyword) const;

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -404,7 +404,7 @@ void FieldProps::reset_actnum(const std::vector<int>& new_actnum) {
 
 void FieldProps::distribute_toplayer(FieldProps::FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box) {
     const std::size_t layer_size = this->nx * this->ny;
-    FieldProps::FieldData<double> toplayer(layer_size);
+    FieldProps::FieldData<double> toplayer(field_data.kw_info, layer_size);
     for (const auto& cell_index : box.index_list()) {
         if (cell_index.global_index < layer_size) {
             toplayer.data[cell_index.global_index] = deck_data[cell_index.data_index];
@@ -474,10 +474,8 @@ FieldProps::FieldData<double>& FieldProps::init_get(const std::string& keyword) 
     if (iter != this->double_data.end())
         return iter->second;
 
-    this->double_data[keyword] = FieldData<double>(this->active_size);
     const keywords::keyword_info<double>& kw_info = keywords::global_kw_info<double>(keyword);
-    if (kw_info.scalar_init)
-        this->double_data[keyword].default_assign(*kw_info.scalar_init);
+    this->double_data[keyword] = FieldData<double>(kw_info, this->active_size);
 
     if (keyword == ParserKeywords::PORV::keywordName)
         this->init_porv(this->double_data[keyword]);
@@ -500,14 +498,12 @@ FieldProps::FieldData<int>& FieldProps::init_get(const std::string& keyword) {
     if (iter != this->int_data.end())
         return iter->second;
 
-    this->int_data[keyword] = FieldData<int>(this->active_size);
     if (keywords::isFipxxx(keyword)) {
         int default_value = 1;
         this->int_data[keyword].default_assign(default_value);
     } else {
         const keywords::keyword_info<int>& kw_info = keywords::global_kw_info<int>(keyword);
-        if (kw_info.scalar_init)
-            this->int_data[keyword].default_assign(*kw_info.scalar_init);
+        this->int_data[keyword] = FieldData<int>(kw_info, this->active_size);
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -499,8 +499,9 @@ FieldProps::FieldData<int>& FieldProps::init_get(const std::string& keyword) {
         return iter->second;
 
     if (keywords::isFipxxx(keyword)) {
-        int default_value = 1;
-        this->int_data[keyword].default_assign(default_value);
+        auto kw_info = keywords::keyword_info<int>{};
+        kw_info.init(1);
+        this->int_data[keyword] = FieldData<int>(kw_info, this->active_size);
     } else {
         const keywords::keyword_info<int>& kw_info = keywords::global_kw_info<int>(keyword);
         this->int_data[keyword] = FieldData<int>(kw_info, this->active_size);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -457,6 +457,15 @@ public:
         return data.data();
     }
 
+    template <typename T>
+    std::vector<T> get_global(const std::string& keyword) {
+        const auto& managed_field_data = this->try_get<T>(keyword);
+        const auto& field_data = managed_field_data.field_data();
+        if (field_data.global_data)
+            return *field_data.global_data;
+        else
+            return this->global_copy(field_data.data);
+    }
 
 
     template <typename T>

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -98,11 +98,11 @@ std::vector<int> FieldPropsManager::actnum() const {
 }
 
 std::vector<double> FieldPropsManager::porv(bool global) const {
-    const auto& data = this->get<double>("PORV");
+    const auto& field_data = this->fp->try_get<double>("PORV").field_data();
     if (global)
-        return this->fp->global_copy(data);
+        return this->fp->global_copy(field_data.data, field_data.kw_info.scalar_init);
     else
-        return data;
+        return field_data.data;
 }
 
 std::size_t FieldPropsManager::active_size() const {

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -57,8 +57,7 @@ const std::vector<T>* FieldPropsManager::try_get(const std::string& keyword) con
 
 template <typename T>
 std::vector<T> FieldPropsManager::get_global(const std::string& keyword) const {
-    const auto& data = this->get<T>(keyword);
-    return this->fp->global_copy(data);
+    return this->fp->get_global<T>(keyword);
 }
 
 template <typename T>

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -208,7 +208,7 @@ ADDREG
 
 
 BOOST_AUTO_TEST_CASE(ASSIGN) {
-    FieldProps::FieldData<int> data(100);
+    FieldProps::FieldData<int> data({}, 100);
     std::vector<int> wrong_size(50);
 
     BOOST_CHECK_THROW( data.default_assign( wrong_size ), std::invalid_argument );
@@ -221,8 +221,7 @@ BOOST_AUTO_TEST_CASE(ASSIGN) {
     BOOST_CHECK(data.data == ext_data);
 }
 
-
-BOOST_AUTO_TEST_CASE(Defaulted) {
+BOOST_AUTO_TEST_CASE(Defaulted1) {
     std::string deck_string = R"(
 GRID
 
@@ -246,6 +245,34 @@ NTG
 
         BOOST_CHECK_EQUAL(ntg[g + 100], 1);
         BOOST_CHECK_EQUAL(defaulted[g + 100], true);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Defaulted2) {
+    std::string deck_string = R"(
+GRID
+
+BOX
+  1 10 1 10 1 1 /
+
+NTG
+  100*2 /
+
+)";
+
+    std::vector<int> actnum(150, 1);
+    {
+        for (std::size_t i = 0; i < 50; i++)
+            actnum.push_back(0);
+    }
+    EclipseGrid grid(EclipseGrid(10,10, 2), actnum);
+    Deck deck = Parser{}.parseString(deck_string);
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
+    const auto& ntg = fpm.get_global_double("NTG");
+
+    for (std::size_t g=0; g < 100; g++) {
+        BOOST_CHECK_EQUAL(ntg[g], 2);
+        BOOST_CHECK_EQUAL(ntg[g + 100], 1);
     }
 }
 


### PR DESCRIPTION
The `FieldProps::get_global<T>()` function will create a vector with `nx*ny*nz` elements and fill in a default value for the inactive cells. Previously the function would *always* use the fill value 0; now it will use the field specific default value - e.g. 1.0 for `MULT?`, if no default is specified for a keyword the value 0 is used.