### PR TITLE
Udq assign

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp
@@ -42,10 +42,12 @@ public:
     struct AssignRecord {
         std::vector<std::string> selector;
         double value;
+        std::size_t report_step;
 
         bool operator==(const AssignRecord& data) const {
             return selector == data.selector &&
-                   value == data.value;
+                report_step == data.report_step &&
+                      value == data.value;
         }
 
         template<class Serializer>
@@ -53,19 +55,21 @@ public:
         {
             serializer(selector);
             serializer(value);
+            serializer(report_step);
         }
     };
 
     UDQAssign();
-    UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value);
+    UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value, std::size_t report_step);
 
     static UDQAssign serializeObject();
 
     const std::string& keyword() const;
     UDQVarType var_type() const;
-    void add_record(const std::vector<std::string>& selector, double value);
+    void add_record(const std::vector<std::string>& selector, double value, std::size_t report_step);
     UDQSet eval(const std::vector<std::string>& wells) const;
     UDQSet eval() const;
+    std::size_t report_step() const;
 
     bool operator==(const UDQAssign& data) const;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -53,10 +53,10 @@ namespace Opm {
         const std::string& unit(const std::string& key) const;
         bool has_unit(const std::string& keyword) const;
         bool has_keyword(const std::string& keyword) const;
-        void add_record(const DeckRecord& record);
+        void add_record(const DeckRecord& record, std::size_t report_step);
 
         void add_unit(const std::string& keyword, const std::string& unit);
-        void add_assign(const std::string& quantity, const std::vector<std::string>& selector, double value);
+        void add_assign(const std::string& quantity, const std::vector<std::string>& selector, double value, std::size_t report_step);
         void add_define(const std::string& quantity, const std::vector<std::string>& expression);
 
         void eval(std::size_t report_step, SummaryState& st, UDQState& udq_state) const;
@@ -96,6 +96,8 @@ namespace Opm {
 
     private:
         void add_node(const std::string& quantity, UDQAction action);
+        UDQAction action_type(const std::string& udq_key) const;
+
 
         UDQParams udq_params;
         UDQFunctionTable udqft;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp
@@ -42,7 +42,8 @@ namespace Opm {
         std::optional<double> get_well_var(const std::string& well, const std::string& var) const;
         std::optional<double> get_group_var(const std::string& group, const std::string& var) const;
         void add(const std::string& key, double value);
-        void update(const std::string& keyword, const UDQSet& udq_result);
+        void update_assign(std::size_t report_step, const std::string& keyword, const UDQSet& udq_result);
+        void update_define(const std::string& keyword, const UDQSet& udq_result);
         const UDQFunctionTable& function_table() const;
         std::vector<std::string> wells() const;
         std::vector<std::string> groups() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp
@@ -39,15 +39,19 @@ public:
     double get(const std::string& key) const;
     double get_group_var(const std::string& well, const std::string& var) const;
     double get_well_var(const std::string& well, const std::string& var) const;
-    void add(const std::string& udq_key, const UDQSet& result);
+    void add_define(const std::string& udq_key, const UDQSet& result);
+    void add_assign(std::size_t report_step, const std::string& udq_key, const UDQSet& result);
+    bool assign(std::size_t report_step, const std::string& udq_key) const;
 
     std::vector<char> serialize() const;
     void deserialize(const std::vector<char>& buffer);
     bool operator==(const UDQState& other) const;
 private:
+    void add(const std::string& udq_key, const UDQSet& result);
     double get_wg_var(const std::string& well, const std::string& key, UDQVarType var_type) const;
     double undefined_value;
     std::unordered_map<std::string, UDQSet> values;
+    std::unordered_map<std::string, std::size_t> assignments;
 };
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1389,7 +1389,7 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext&
         const auto& current = *this->udq_config.get(currentStep);
         std::shared_ptr<UDQConfig> new_udq = std::make_shared<UDQConfig>(current);
         for (const auto& record : keyword)
-            new_udq->add_record(record);
+            new_udq->add_record(record, currentStep);
 
         this->udq_config.update(currentStep, new_udq);
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
@@ -27,11 +27,11 @@ UDQAssign::UDQAssign() :
 {
 }
 
-UDQAssign::UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value) :
+UDQAssign::UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value, std::size_t report_step) :
     m_keyword(keyword),
     m_var_type(UDQ::varType(keyword))
 {
-    this->add_record(selector, value);
+    this->add_record(selector, value, report_step);
 }
 
 UDQAssign UDQAssign::serializeObject()
@@ -39,13 +39,13 @@ UDQAssign UDQAssign::serializeObject()
     UDQAssign result;
     result.m_keyword = "test";
     result.m_var_type = UDQVarType::CONNECTION_VAR;
-    result.records = {{{"test1"}, 1.0}};
+    result.records = {{{"test1"}, 1.0, 0}};
 
     return result;
 }
 
-void UDQAssign::add_record(const std::vector<std::string>& selector, double value) {
-    this->records.push_back({selector, value});
+void UDQAssign::add_record(const std::vector<std::string>& selector, double value, std::size_t report_step) {
+    this->records.push_back({selector, value, report_step});
 }
 
 const std::string& UDQAssign::keyword() const {
@@ -55,6 +55,12 @@ const std::string& UDQAssign::keyword() const {
 UDQVarType UDQAssign::var_type() const {
     return this->m_var_type;
 }
+
+
+std::size_t UDQAssign::report_step() const {
+    return this->records.back().report_step;
+}
+
 
 UDQSet UDQAssign::eval(const std::vector<std::string>& wells) const {
     if (this->m_var_type == UDQVarType::WELL_VAR) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.cpp
@@ -62,9 +62,6 @@ bool is_udq(const std::string& key) {
         this->add("TIME", 0.0);
     }
 
-    void UDQContext::update(const std::string& keyword, const UDQSet& udq_result) {
-        this->udq_state.add(keyword, udq_result);
-    }
 
     void UDQContext::add(const std::string& key, double value) {
         this->values[key] = value;
@@ -115,5 +112,13 @@ bool is_udq(const std::string& key) {
 
     const UDQFunctionTable& UDQContext::function_table() const {
         return this->udqft;
+    }
+
+    void UDQContext::update_assign(std::size_t report_step, const std::string& keyword, const UDQSet& udq_result) {
+        this->udq_state.add_assign(report_step, keyword, udq_result);
+    }
+
+    void UDQContext::update_define(const std::string& keyword, const UDQSet& udq_result) {
+        this->udq_state.add_define(keyword, udq_result);
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -254,7 +254,7 @@ UDQSet UDQDefine::eval(UDQContext& context) const {
         std::string msg = "Invalid runtime type conversion detected when evaluating UDQ";
         throw std::invalid_argument(msg);
     }
-    context.update(this->keyword(), res);
+    context.update_define(this->keyword(), res);
 
     if (res.var_type() == UDQVarType::SCALAR) {
         /*

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -87,32 +87,32 @@ Opm::UDQSet make_udq_set(const std::string& name, Opm::UDQVarType var_type, cons
     {
         auto state = Opm::UDQState{0};
 
-        state.add("WUOPRL", make_udq_set("WUOPRL",
-                                         Opm::UDQVarType::WELL_VAR,
-                                         {"PROD1", "PROD2", "WINJ1", "WINJ2"},
-                                         {210, 211, 212, 213}));
+        state.add_define("WUOPRL", make_udq_set("WUOPRL",
+                                                Opm::UDQVarType::WELL_VAR,
+                                                {"PROD1", "PROD2", "WINJ1", "WINJ2"},
+                                                {210, 211, 212, 213}));
 
-        state.add("WUOPRU", make_udq_set("WUOPRU",
-                                         Opm::UDQVarType::WELL_VAR,
-                                         {"PROD1", "PROD2", "WINJ1", "WINJ2"},
-                                         {220, 221, 222, 223}));
+        state.add_define("WUOPRU", make_udq_set("WUOPRU",
+                                                Opm::UDQVarType::WELL_VAR,
+                                                {"PROD1", "PROD2", "WINJ1", "WINJ2"},
+                                                {220, 221, 222, 223}));
 
-        state.add("WULPRL", make_udq_set("WULPRL",
-                                         Opm::UDQVarType::WELL_VAR,
-                                         {"PROD1", "PROD2", "WINJ1", "WINJ2"},
-                                         {230, 231, 232, 233}));
+        state.add_define("WULPRL", make_udq_set("WULPRL",
+                                                Opm::UDQVarType::WELL_VAR,
+                                                {"PROD1", "PROD2", "WINJ1", "WINJ2"},
+                                                {230, 231, 232, 233}));
 
-        state.add("WULPRU", make_udq_set("WULPRU",
-                                         Opm::UDQVarType::WELL_VAR,
-                                         {"PROD1", "PROD2", "WINJ1", "WINJ2"},
-                                         {160, 161, 162, 163}));
+        state.add_define("WULPRU", make_udq_set("WULPRU",
+                                                Opm::UDQVarType::WELL_VAR,
+                                                {"PROD1", "PROD2", "WINJ1", "WINJ2"},
+                                                {160, 161, 162, 163}));
 
-        state.add("GUOPRU", make_udq_set("GUOPRU",
-                                         Opm::UDQVarType::GROUP_VAR,
-                                         {"WGRP1", "WGRP2", "GRP1"},
-                                         {360, 361, 362}));
+        state.add_define("GUOPRU", make_udq_set("GUOPRU",
+                                                Opm::UDQVarType::GROUP_VAR,
+                                                {"WGRP1", "WGRP2", "GRP1"},
+                                                {360, 361, 362}));
 
-        state.add("FULPR", Opm::UDQSet::scalar("FULPR", 460));
+        state.add_define("FULPR", Opm::UDQSet::scalar("FULPR", 460));
         return state;
     }
 


### PR DESCRIPTION
Commit message from second commit:

**Differentiate better between UDQ ASSIGN and UDQ DEFINE**

A quite typical situation is that a UDQ keyword is first initialized with UDQ
ASSIGN statement, and then subsequently a formula for updates every timestep is
entered with UDQ DEFINE:

```
UDQ
     ASSIGN FU_VAR1 0 /
     DEFINE FU_VAR1 FU_VAR1 + 1 /
/
```

Then the assign statement should be run once, and the define formula should be
evaluated for every subsequent timestep.

