### PR TITLE
WIP

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -186,9 +186,10 @@ public:
 
     virtual bool has_int(const std::string& keyword) const { return this->has<int>(keyword); }
     virtual bool has_double(const std::string& keyword) const { return this->has<double>(keyword); }
-    virtual void apply_tran(const std::string& keyword, std::vector<double>& tranx) const;
-    std::vector<char> serialize_tran() const;
-    void deserialize_tran(const std::vector<char>& buffer);
+    virtual bool tran_active(const std::string& keyword) const;
+    virtual void apply_tran(const std::string& keyword, std::vector<double>& tran_data) const;
+    virtual std::vector<char> serialize_tran() const;
+    virtual void deserialize_tran(const std::vector<char>& buffer);
 private:
     /*
       Return the keyword values as a std::vector<>. All elements in the return

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -218,7 +218,7 @@ public:
     /*
       Will check if there are any TRAN{XYZ} modifiers active in the deck.
     */
-    virtual bool tran_active(const std::string& keyword) const;
+    bool tran_active(const std::string& keyword) const;
 
 
     /*
@@ -229,7 +229,7 @@ public:
       supported by the transmissibility calculator are those given by the enum
       ScalarOperation in FieldProps.hpp.
     */
-    virtual void apply_tran(const std::string& keyword, std::vector<double>& tran_data) const;
+    void apply_tran(const std::string& keyword, std::vector<double>& tran_data) const;
 
     /*
       When using MPI the FieldPropsManager is typically only assembled on the
@@ -238,8 +238,8 @@ public:
       transmissibility calculators is in the form of custom 3D fields, they are
       distributed the same way the rest of the 3D fields are distributed.
     */
-    virtual std::vector<char> serialize_tran() const;
-    virtual void deserialize_tran(const std::vector<char>& buffer);
+    std::vector<char> serialize_tran() const;
+    void deserialize_tran(const std::vector<char>& buffer);
 private:
     /*
       Return the keyword values as a std::vector<>. All elements in the return

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -186,6 +186,7 @@ public:
 
     virtual bool has_int(const std::string& keyword) const { return this->has<int>(keyword); }
     virtual bool has_double(const std::string& keyword) const { return this->has<double>(keyword); }
+    virtual void apply_tran(const std::string& keyword, std::vector<double>& tranx) const;
 
 private:
     /*

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -187,7 +187,8 @@ public:
     virtual bool has_int(const std::string& keyword) const { return this->has<int>(keyword); }
     virtual bool has_double(const std::string& keyword) const { return this->has<double>(keyword); }
     virtual void apply_tran(const std::string& keyword, std::vector<double>& tranx) const;
-
+    std::vector<char> serialize_tran() const;
+    void deserialize_tran(const std::vector<char>& buffer);
 private:
     /*
       Return the keyword values as a std::vector<>. All elements in the return

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1193,6 +1193,10 @@ void FieldProps::deserialize_tran(const std::vector<char>& buffer) {
     }
 }
 
+bool FieldProps::tran_active(const std::string& keyword) const {
+    const auto& calculator = this->tran.at(keyword);
+    return calculator.size() > 0;
+}
 
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -655,6 +655,7 @@ public:
         return this->double_data.size();
     }
 
+    bool tran_active(const std::string& keyword) const;
     void apply_tran(const std::string& keyword, std::vector<double>& data);
     std::vector<char> serialize_tran() const;
     void deserialize_tran(const std::vector<char>& buffer);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -656,7 +656,8 @@ public:
     }
 
     void apply_tran(const std::string& keyword, std::vector<double>& data);
-
+    std::vector<char> serialize_tran() const;
+    void deserialize_tran(const std::vector<char>& buffer);
 private:
     void scanGRIDSection(const GRIDSection& grid_section);
     void scanEDITSection(const EDITSection& edit_section);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -121,6 +121,10 @@ void FieldPropsManager::deserialize_tran(const std::vector<char>& buffer) {
     this->fp->deserialize_tran(buffer);
 }
 
+bool FieldPropsManager::tran_active(const std::string& keyword) const {
+    return this->fp->tran_active(keyword);
+}
+
 
 template bool FieldPropsManager::supported<int>(const std::string&);
 template bool FieldPropsManager::supported<double>(const std::string&);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -113,6 +113,14 @@ void FieldPropsManager::apply_tran(const std::string& keyword, std::vector<doubl
     this->fp->apply_tran(keyword, data);
 }
 
+std::vector<char> FieldPropsManager::serialize_tran() const {
+    return this->fp->serialize_tran();
+}
+
+void FieldPropsManager::deserialize_tran(const std::vector<char>& buffer) {
+    this->fp->deserialize_tran(buffer);
+}
+
 
 template bool FieldPropsManager::supported<int>(const std::string&);
 template bool FieldPropsManager::supported<double>(const std::string&);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -109,6 +109,11 @@ std::size_t FieldPropsManager::active_size() const {
     return this->fp->active_size;
 }
 
+void FieldPropsManager::apply_tran(const std::string& keyword, std::vector<double>& data) const {
+    this->fp->apply_tran(keyword, data);
+}
+
+
 template bool FieldPropsManager::supported<int>(const std::string&);
 template bool FieldPropsManager::supported<double>(const std::string&);
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1841,4 +1841,6 @@ MAXVALUE
     for (std::size_t i=0; i < trany.size(); i++)
         BOOST_CHECK_EQUAL(trany[i], to_si(2.0));
 
+    auto buffer = fpm.serialize_tran();
+    fpm.deserialize_tran(buffer);
 }

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1825,6 +1825,7 @@ MAXVALUE
     BOOST_CHECK(!fpm.has_double("TRANX"));
 
     BOOST_CHECK_THROW(fpm.apply_tran("TRANA", tranx), std::out_of_range);
+    BOOST_CHECK_THROW(fpm.tran_active("TRANA"), std::out_of_range);
 
     fpm.apply_tran("TRANX", tranx);
     fpm.apply_tran("TRANY", trany);
@@ -1843,4 +1844,6 @@ MAXVALUE
 
     auto buffer = fpm.serialize_tran();
     fpm.deserialize_tran(buffer);
+
+    BOOST_CHECK(fpm.tran_active("TRANX"));
 }


### PR DESCRIPTION
This is early days; but the rough idea of functionality to store away `TRAN{XYZ}` manipulations until the actual transmissibilit is calculated. Usage from simulator:

```C++
std::vector<double> tranx(number_of_active_cells_in_process);
...
// Update the caclulated tranx value with modifications from the EDIT section
fp.apply_tran("TRANX", tranx);
```

In addition to clean up and more testing we need to update parallell code to distribute the new transmiss calculator:
```C++
class TranCalculator {
public:

    struct TranAction {
        ScalarOperation op;  // An enum
        std::string field;
    };

private:
    std::string name;
    std::vector<TranAction> actions;
};

...

FieldProps {
...
private:
    std::unordered_map<std::string, TranCalculator> tran;
}
```



