### PR TITLE
Add CO2STOR keyword in Runspec section

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -279,6 +279,7 @@ public:
     const Actdims& actdims() const noexcept;
     const SatFuncControls& saturationFunctionControls() const noexcept;
     int nupcol() const noexcept;
+    bool co2Storage() const noexcept;
 
     bool operator==(const Runspec& data) const;
 
@@ -295,6 +296,7 @@ public:
         m_actdims.serializeOp(serializer);
         m_sfuncctrl.serializeOp(serializer);
         serializer(m_nupcol);
+        serializer(m_co2storage);
     }
 
 private:
@@ -308,6 +310,7 @@ private:
     Actdims m_actdims;
     SatFuncControls m_sfuncctrl;
     int m_nupcol;
+    bool m_co2storage;
 };
 
 

--- a/src/opm/parser/eclipse/share/keywords/900_OPM/C/CO2STOR
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/C/CO2STOR
@@ -1,0 +1,6 @@
+{
+  "name": "CO2STOR",
+  "sections": [
+    "RUNSPEC"
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -1085,6 +1085,7 @@ set( keywords
      002_Frontsim/N/NOGRAV
 
      900_OPM/B/BC
+     900_OPM/C/CO2STOR
      900_OPM/E/EXIT
      900_OPM/G/GCOMPIDX
      900_OPM/G/GRUPRIG

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -641,3 +641,25 @@ BOOST_AUTO_TEST_CASE(ACTDIMS) {
     BOOST_CHECK_EQUAL(actdims.max_keywords(), 2);
     BOOST_CHECK_EQUAL(actdims.max_conditions(), 14);
 }
+
+BOOST_AUTO_TEST_CASE(Co2Storage) {
+    const std::string input = R"(
+    RUNSPEC
+    OIL
+    GAS
+    CO2STOR
+    )";
+
+    Parser parser;
+
+    auto deck = parser.parseString(input);
+
+    Runspec runspec( deck );
+    const auto& phases = runspec.phases();
+    BOOST_CHECK_EQUAL( 2, phases.size() );
+    BOOST_CHECK( phases.active( Phase::OIL ) );
+    BOOST_CHECK( phases.active( Phase::GAS ) );
+    BOOST_CHECK( runspec.co2Storage() );
+
+
+}


### PR DESCRIPTION
The flag is used to trigger a CO2-BRINE specific PVT model. 