### PR TITLE
fixed: serialization nupcol in Runspec

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -294,6 +294,7 @@ public:
         hystpar.serializeOp(serializer);
         m_actdims.serializeOp(serializer);
         m_sfuncctrl.serializeOp(serializer);
+        serializer(m_nupcol);
     }
 
 private:

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -343,6 +343,7 @@ Runspec Runspec::serializeObject()
     result.hystpar = EclHysterConfig::serializeObject();
     result.m_actdims = Actdims::serializeObject();
     result.m_sfuncctrl = SatFuncControls::serializeObject();
+    result.m_nupcol = 2;
 
     return result;
 }
@@ -415,7 +416,8 @@ bool Runspec::operator==(const Runspec& data) const {
            this->wellSegmentDimensions() == data.wellSegmentDimensions() &&
            this->hysterPar() == data.hysterPar() &&
            this->actdims() == data.actdims() &&
-           this->saturationFunctionControls() == data.saturationFunctionControls();
+           this->saturationFunctionControls() == data.saturationFunctionControls() &&
+           this->m_nupcol == data.m_nupcol;
 }
 
 }


### PR DESCRIPTION
also add it to comparison operator. thanks to @totto82 for noticing (https://github.com/OPM/opm-common/pull/1923)