### PR TITLE
Add build dependency on fmtlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,17 @@ macro (config_hook)
     if(NOT cjson_FOUND)
       list(APPEND EXTRA_INCLUDES ${PROJECT_SOURCE_DIR}/external/cjson)
     endif()
+    if(TARGET fmt::fmt)
+      get_target_property(fmt_INCLUDES fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+    elseif(TARGET fmt)
+      get_target_property(fmt_INCLUDES fmt INTERFACE_INCLUDE_DIRECTORIES)
+    else()
+      message(FATAL_ERROR "Cannot identify fmt target to use")
+    endif()
+    add_definitions(-DFMT_HEADER_ONLY)
+
     # For this project
-    include_directories(${EXTRA_INCLUDES} ${PROJECT_BINARY_DIR}/include)
+    include_directories(${EXTRA_INCLUDES} ${PROJECT_BINARY_DIR}/include ${fmt_INCLUDES})
 
     # For downstreams
     list(APPEND EXTRA_INCLUDES ${PROJECT_BINARY_DIR}/include)

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: build-essential, debhelper (>= 9),
                ghostscript, libboost-system-dev, libboost-test-dev,
                zlib1g-dev, libpython3-dev, python3-numpy, python3-distutils,
                python3-setuptools, python3-setuptools-scm, python3-pytest-runner,
-               python3-decorator
+               python3-decorator libfmt-dev
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://opm-project.org

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -15,6 +15,7 @@ set (opm-common_DEPS
 list(APPEND opm-common_DEPS
       # various runtime library enhancements
       "Boost 1.44.0 COMPONENTS system unit_test_framework REQUIRED"
+      "fmt REQUIRED"
       "OpenMP QUIET"
 )
 

--- a/redhat/opm-common.spec
+++ b/redhat/opm-common.spec
@@ -12,7 +12,7 @@ License:        GPL-3.0
 Group:          Development/Libraries/C and C++
 Url:            http://www.opm-project.org/
 Source0:        https://github.com/OPM/%{name}/archive/release/%{version}/%{tag}.tar.gz#/%{name}-%{version}.tar.gz
-BuildRequires:  git doxygen bc openmpi-devel mpich-devel
+BuildRequires:  git doxygen bc openmpi-devel mpich-devel format-devel
 %{?!el8:BuildRequires: devtoolset-8-toolchain}
 %{?el8:BuildRequires: boost-devel}
 %{?!el8:BuildRequires: boost148-devel}


### PR DESCRIPTION
In C++20 the library `fmt`which replaces `printf()` and `<<` based formatting - looks very good. 

Before C++20 we can use the external library: https://github.com/fmtlib/fmt/ - which is essentially what was included for C++20. 

For the ongoing work with improvements in error messages this would be extremely valuable, I therefor suggest that we use `fmtlib` until we switch to C++20. 

This PR assumes that fmtlib is installed on your system (it is available as binary package on RH, Ubuntu & Debian) and integrates that in the build system - the cmake integration is quite naive and probably needs some love and attention from someone in the know.