### PR TITLE
Rawrecord error message

### DIFF
--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -123,7 +123,7 @@ namespace Opm {
         SectionNameSet::const_iterator validSectionNamesBegin() const;
         SectionNameSet::const_iterator validSectionNamesEnd() const;
 
-        DeckKeyword parse(const ParseContext& parseContext, ErrorGuard& errors, RawKeyword& rawKeyword, UnitSystem& active_unitsystem, UnitSystem& default_unitsystem, const std::string& filename) const;
+        DeckKeyword parse(const ParseContext& parseContext, ErrorGuard& errors, RawKeyword& rawKeyword, UnitSystem& active_unitsystem, UnitSystem& default_unitsystem) const;
         enum ParserKeywordSizeEnum getSizeType() const;
         const KeywordSize& getKeywordSize() const;
         bool isDataKeyword() const;

--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -35,6 +35,7 @@ namespace Opm {
     class RawRecord;
     class ErrorGuard;
     class UnitSystem;
+    class KeywordLocation;
 
     class ParserRecord {
     public:
@@ -44,7 +45,7 @@ namespace Opm {
         void addDataItem( ParserItem item );
         const ParserItem& get(size_t index) const;
         const ParserItem& get(const std::string& itemName) const;
-        DeckRecord parse( const ParseContext&, ErrorGuard&, RawRecord&, UnitSystem& active_unitsystem, UnitSystem& default_unitsystem, const std::string& keyword, const std::string& filename) const;
+        DeckRecord parse( const ParseContext&, ErrorGuard&, RawRecord&, UnitSystem& active_unitsystem, UnitSystem& default_unitsystem, const KeywordLocation& location) const;
         bool isDataRecord() const;
         bool equal(const ParserRecord& other) const;
         bool hasDimension() const;

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -919,8 +919,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
                                                                       parserState.errors,
                                                                       *rawKeyword,
                                                                       parserState.deck.getActiveUnitSystem(),
-                                                                      parserState.deck.getDefaultUnitSystem(),
-                                                                      filename ) );
+                                                                      parserState.deck.getDefaultUnitSystem()));
             } catch (const std::exception& exc) {
                 /*
                   This catch-all of parsing errors is to be able to write a good

--- a/src/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -551,7 +551,7 @@ void scan_item( DeckItem& deck_item, const ParserItem& parser_item, RawRecord& r
     std::string_view rep = !st.hasValue()
                     ? std::string_view{ one_star }
                     : std::string_view{ token.begin() + value_start, size };
-    record.prepend( st.count() - 1, rep );
+    record.push_front(rep, st.count() - 1);
 
     return;
 }

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -532,8 +532,7 @@ void set_dimensions( ParserItem& item,
                                      ErrorGuard& errors,
                                      RawKeyword& rawKeyword,
                                      UnitSystem& active_unitsystem,
-                                     UnitSystem& default_unitsystem,
-                                     const std::string& filename) const {
+                                     UnitSystem& default_unitsystem) const {
 
         if( !rawKeyword.isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword.getKeywordName());
@@ -555,8 +554,8 @@ void set_dimensions( ParserItem& item,
                      record_nr = 0;
                 }
                 else {
-                     keyword.addRecord( this->getRecord( record_nr ).parse( parseContext, errors, rawRecord, active_unitsystem, default_unitsystem, rawKeyword.getKeywordName(), filename ) );
-                     record_nr++;
+                    keyword.addRecord( this->getRecord( record_nr ).parse( parseContext, errors, rawRecord, active_unitsystem, default_unitsystem, rawKeyword.location() ) );
+                    record_nr++;
                 }
             }
         }
@@ -566,7 +565,7 @@ void set_dimensions( ParserItem& item,
                 if( m_records.size() == 0 && rawRecord.size() > 0 )
                     throw std::invalid_argument("Missing item information " + rawKeyword.getKeywordName());
 
-                keyword.addRecord( this->getRecord( record_nr ).parse( parseContext, errors, rawRecord, active_unitsystem, default_unitsystem, rawKeyword.getKeywordName(), filename ) );
+                keyword.addRecord( this->getRecord( record_nr ).parse( parseContext, errors, rawRecord, active_unitsystem, default_unitsystem, rawKeyword.location() ) );
                 record_nr++;
             }
         }

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -24,6 +24,8 @@
 #include <opm/parser/eclipse/Parser/ParserItem.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
+#include <opm/common/OpmLog/KeywordLocation.hpp>
+
 #include "raw/RawRecord.hpp"
 
 namespace Opm {
@@ -118,7 +120,7 @@ namespace {
     }
 
 
-    DeckRecord ParserRecord::parse(const ParseContext& parseContext , ErrorGuard& errors , RawRecord& rawRecord, UnitSystem& active_unitsystem, UnitSystem& default_unitsystem, const std::string& keyword, const std::string& filename) const {
+    DeckRecord ParserRecord::parse(const ParseContext& parseContext , ErrorGuard& errors , RawRecord& rawRecord, UnitSystem& active_unitsystem, UnitSystem& default_unitsystem, const KeywordLocation& location) const {
         std::vector< DeckItem > items;
         items.reserve( this->size() + 20 );
         for( const auto& parserItem : *this )

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -17,6 +17,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+
+#include <fmt/core.h>
+
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -127,9 +130,15 @@ namespace {
             items.emplace_back( parserItem.scan( rawRecord, active_unitsystem, default_unitsystem ) );
 
         if (rawRecord.size() > 0) {
-            std::string msg = "The RawRecord for keyword \""  + keyword + "\" in file\"" + filename + "\" contained " +
-                std::to_string(rawRecord.size()) +
-                " too many items according to the spec. RawRecord was: " + rawRecord.getRecordString();
+            auto msg = fmt::format("Reading keyword {} in file {} at line {},{}record \"{}\" contained {} items, expected {}.",
+                                   location.keyword,
+                                   location.filename,
+                                   location.lineno,
+                                   "\n       ",
+                                   rawRecord.getRecordString(),
+                                   rawRecord.max_size(),
+                                   this->size());
+
             parseContext.handleError(ParseContext::PARSE_EXTRA_DATA , msg, errors);
         }
 

--- a/src/opm/parser/eclipse/Parser/raw/RawRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawRecord.cpp
@@ -90,17 +90,23 @@ inline bool even_quotes( const T& str ) {
                 throw std::invalid_argument("Input string is not a complete record string, "
                                             "offending string: '" + std::string(singleRecordString) + "'");
         }
+        this->m_max_size = this->m_recordItems.size();
     }
 
     RawRecord::RawRecord(const std::string_view& singleRecordString) :
         RawRecord(singleRecordString, false)
     {}
 
-    void RawRecord::prepend( size_t count, std::string_view tok ) {
+    void RawRecord::push_front( std::string_view tok, std::size_t count ) {
         this->m_recordItems.insert( this->m_recordItems.begin(), count, tok );
+        this->m_max_size += count;
     }
 
     std::string RawRecord::getRecordString() const {
         return std::string(m_sanitizedRecordString);
+    }
+
+    std::size_t RawRecord::max_size() const {
+        return this->m_max_size;
     }
 }

--- a/src/opm/parser/eclipse/Parser/raw/RawRecord.hpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawRecord.hpp
@@ -39,9 +39,9 @@ namespace Opm {
 
         inline std::string_view pop_front();
         inline std::string_view front() const;
-        void push_front( std::string_view token );
-        void prepend( size_t count, std::string_view token );
+        void push_front( std::string_view token, std::size_t count );
         inline size_t size() const;
+        std::size_t max_size() const;
 
         std::string getRecordString() const;
         inline std::string_view getItem(size_t index) const;
@@ -49,6 +49,7 @@ namespace Opm {
     private:
         std::string_view m_sanitizedRecordString;
         std::deque< std::string_view > m_recordItems;
+        std::size_t m_max_size;
     };
 
     /*

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -485,10 +485,11 @@ BOOST_AUTO_TEST_CASE(StringsWithSpaceOK) {
     ParseContext parseContext;
     ErrorGuard errors;
     UnitSystem active_unitsystem(UnitSystem::UnitType::UNIT_TYPE_LAB);
+    KeywordLocation loc;
     record1.addItem( itemString );
 
 
-    const auto deckRecord = record1.parse( parseContext, errors , rawRecord, active_unitsystem, active_unitsystem, "KEYWORD", "filename" );
+    const auto deckRecord = record1.parse( parseContext, errors , rawRecord, active_unitsystem, active_unitsystem, loc);
     BOOST_CHECK_EQUAL(" VALUE " , deckRecord.getItem(0).get< std::string >(0));
 }
 

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1056,7 +1056,7 @@ BOOST_AUTO_TEST_CASE(parse_validRecord_noThrow) {
     ErrorGuard errors;
     RawRecord raw( std::string_view( "100 443" ) );
     UnitSystem unit_system;
-    BOOST_CHECK_NO_THROW(record.parse(parseContext, errors, raw , unit_system, unit_system, "KEYWORD", "filename") );
+    BOOST_CHECK_NO_THROW(record.parse(parseContext, errors, raw , unit_system, unit_system, KeywordLocation()) );
 }
 
 BOOST_AUTO_TEST_CASE(parse_validRecord_deckRecordCreated) {
@@ -1065,7 +1065,7 @@ BOOST_AUTO_TEST_CASE(parse_validRecord_deckRecordCreated) {
     ParseContext parseContext;
     ErrorGuard errors;
     UnitSystem unit_system;
-    const auto deckRecord = record.parse(parseContext , errors, rawRecord, unit_system, unit_system, "KEYWORD", "filename");
+    const auto deckRecord = record.parse(parseContext , errors, rawRecord, unit_system, unit_system, KeywordLocation());
     BOOST_CHECK_EQUAL(2U, deckRecord.size());
 }
 
@@ -1097,7 +1097,7 @@ BOOST_AUTO_TEST_CASE(parse_validMixedRecord_noThrow) {
     ParseContext parseContext;
     ErrorGuard errors;
     UnitSystem unit_system;
-    BOOST_CHECK_NO_THROW(record.parse(parseContext, errors, rawRecord, unit_system, unit_system, "KEYWORD", "filename"));
+    BOOST_CHECK_NO_THROW(record.parse(parseContext, errors, rawRecord, unit_system, unit_system, KeywordLocation()));
 }
 
 BOOST_AUTO_TEST_CASE(Equal_Equal_ReturnsTrue) {
@@ -1223,13 +1223,13 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooManyItems_Throws) {
 
     RawRecord rawRecord(  "3 3 3 " );
     UnitSystem unit_system;
-    BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord, unit_system, unit_system, "KEYWORD", "filename"));
+    BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord, unit_system, unit_system, KeywordLocation()));
 
     RawRecord rawRecordOneExtra(  "3 3 3 4 " );
-    BOOST_CHECK_THROW(parserRecord.parse(parseContext, errors, rawRecordOneExtra, unit_system, unit_system, "KEYWORD", "filename"), std::invalid_argument);
+    BOOST_CHECK_THROW(parserRecord.parse(parseContext, errors, rawRecordOneExtra, unit_system, unit_system, KeywordLocation()), std::invalid_argument);
 
     RawRecord rawRecordForgotRecordTerminator(  "3 3 3 \n 4 4 4 " );
-    BOOST_CHECK_THROW(parserRecord.parse(parseContext, errors, rawRecordForgotRecordTerminator, unit_system, unit_system, "KEYWORD", "filename"), std::invalid_argument);
+    BOOST_CHECK_THROW(parserRecord.parse(parseContext, errors, rawRecordForgotRecordTerminator, unit_system, unit_system, KeywordLocation()), std::invalid_argument);
 
 }
 
@@ -1248,10 +1248,11 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooFewItems) {
     ErrorGuard errors;
     RawRecord rawRecord(  "3 3  " );
     UnitSystem unit_system;
+    KeywordLocation location;
     // no default specified for the third item, record can be parsed just fine but trying
     // to access the data will raise an exception...;
-    BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord, unit_system, unit_system, "KEWYORD", "filename"));
-    auto record = parserRecord.parse(parseContext, errors , rawRecord, unit_system, unit_system, "KEYWORD", "filename");
+    BOOST_CHECK_NO_THROW(parserRecord.parse(parseContext, errors, rawRecord, unit_system, unit_system, location));
+    auto record = parserRecord.parse(parseContext, errors , rawRecord, unit_system, unit_system, location);
     BOOST_CHECK_NO_THROW(record.getItem(2));
     BOOST_CHECK_THROW(record.getItem(2).get< int >(0), std::invalid_argument);
 }
@@ -1633,7 +1634,7 @@ BOOST_AUTO_TEST_CASE(ParseEmptyRecord) {
     record.addItem(item);
     tabdimsKeyword.addRecord( record );
 
-    const auto deckKeyword = tabdimsKeyword.parse( parseContext, errors, rawkeyword , unit_system, unit_system, "filename");
+    const auto deckKeyword = tabdimsKeyword.parse( parseContext, errors, rawkeyword , unit_system, unit_system);
     BOOST_REQUIRE_EQUAL( 1U , deckKeyword.size());
 
     const auto& deckRecord = deckKeyword.getRecord(0);


### PR DESCRIPTION
On top of: https://github.com/OPM/opm-common/pull/1930

This PR reformats the error message when a record has too many items. What will end up in the terminal is now (the // 1: tags are inserted by me to be able to comment on this).
```
// 1:
Error: Reading keyword EQUIL in file /home/hove/work/OPM/opm-tests/spe1/SPE1CASE1.DATA at line 253,
       record "8400 4800 8450 0 8300 0 1 0 0 1 2 3 4 5 6 7 8 9 " contained 18 items, expected 9.

// 2: 
Error: Unrecoverable errors were encountered while loading input: 
Failed to parse keyword: EQUIL
In file /home/hove/work/OPM/opm-tests/spe1/SPE1CASE1.DATA, line 253

// 3: 
Error message: PARSE_EXTRA_DATA: Reading keyword EQUIL in file /home/hove/work/OPM/opm-tests/spe1/SPE1CASE1.DATA at line 253,
       record "8400 4800 8450 0 8300 0 1 0 0 1 2 3 4 5 6 7 8 9 " contained 18 items, expected 9.

```

The root error message (`// 1:`) has hopefully improved; but the overall picture with `// 2:` and `// 3:` is not really pretty ... These come from the complete error handling machinery which in this case goes like this:

1. The error is identified [here](https://github.com/OPM/opm-common/blob/master/src/opm/parser/eclipse/Parser/ParserRecord.cpp#L128), a message is created and the `ParseContext`error handler is invoked - specifically the error is handled [here](https://github.com/OPM/opm-common/blob/master/src/opm/parser/eclipse/Parser/ParseContext.cpp#L154) which output message `// 1` on the log and then throws an exception - with the same message.

2. The parsing of keywords takes place in a `try - catch` block [here](https://github.com/OPM/opm-common/blob/master/src/opm/parser/eclipse/Parser/Parser.cpp#L908) - this will catch the exception from `ParseContext::handleError()` - print the error message again and throw an exception again.

3. When the program exits the `ErrorGuard` will display all errors/warnings [here](https://github.com/OPM/opm-common/blob/master/src/opm/parser/eclipse/Parser/ErrorGuard.cpp#L38) before exiting - and we have got the error message third time.

What this illustrates quite forcefully is that there are several aspects to good error handling - at the very least:'

1. The formatting of the actual error message - this PR improves one error message slightly.

2. The flow of execution when an error is encountered; that is not modified in any way here, but it should be illustrated.

