### PR TITLE
Adds a calculator for modifying transmissibilities.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -572,6 +572,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
        opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
        opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp
+       opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
        opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
        opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
        opm/parser/eclipse/EclipseState/Grid/PinchMode.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -574,6 +574,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp
        opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
        opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
+       opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
        opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
        opm/parser/eclipse/EclipseState/Grid/PinchMode.hpp
        opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -572,6 +572,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
        opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
        opm/parser/eclipse/EclipseState/Edit/EDITNNC.hpp
+       opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
        opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
        opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
        opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp

--- a/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
@@ -29,6 +29,7 @@
 #include<vector>
 #include<optional>
 #include<array>
+#include<algorithm>
 
 namespace Opm
 {

--- a/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
@@ -33,8 +33,10 @@
 
 namespace Opm
 {
+namespace Fieldprops
+{
    template<typename T>
-    static void fieldprops_compress(std::vector<T>& data, const std::vector<bool>& active_map) {
+    static void compress(std::vector<T>& data, const std::vector<bool>& active_map) {
         std::size_t shift = 0;
         for (std::size_t g = 0; g < active_map.size(); g++) {
             if (active_map[g] && shift > 0) {
@@ -92,8 +94,8 @@ namespace Opm
         }
 
         void compress(const std::vector<bool>& active_map) {
-            fieldprops_compress(this->data, active_map);
-            fieldprops_compress(this->value_status, active_map);
+            Fieldprops::compress(this->data, active_map);
+            Fieldprops::compress(this->value_status, active_map);
         }
 
         void copy(const FieldData<T>& src, const std::vector<Box::cell_index>& index_list) {
@@ -139,6 +141,6 @@ namespace Opm
         }
 
     };
-
+} // end namespace Fieldprops
 } // end namespace Opm
 #endif // FIELD_DATA_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
@@ -1,0 +1,143 @@
+/*
+  Copyright 2020 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef FIELD_DATA_HPP
+#define FIELD_DATA_HPP
+
+#include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldData.hpp>
+#include <opm/parser/eclipse/Deck/value_status.hpp>
+
+#include<string>
+#include<vector>
+#include<optional>
+#include<array>
+
+namespace Opm
+{
+   template<typename T>
+    static void fieldprops_compress(std::vector<T>& data, const std::vector<bool>& active_map) {
+        std::size_t shift = 0;
+        for (std::size_t g = 0; g < active_map.size(); g++) {
+            if (active_map[g] && shift > 0) {
+                data[g - shift] = data[g];
+                continue;
+            }
+
+            if (!active_map[g])
+                shift += 1;
+        }
+
+        data.resize(data.size() - shift);
+    }
+
+    template<typename T>
+    struct FieldData {
+        std::vector<T> data;
+        std::vector<value::status> value_status;
+        keywords::keyword_info<T> kw_info;
+        std::optional<std::vector<T>> global_data;
+        std::optional<std::vector<value::status>> global_value_status;
+        mutable bool all_set;
+
+        FieldData() = default;
+
+        FieldData(const keywords::keyword_info<T>& info, std::size_t active_size, std::size_t global_size) :
+            data(std::vector<T>(active_size)),
+            value_status(active_size, value::status::uninitialized),
+            kw_info(info),
+            all_set(false)
+        {
+            if (global_size != 0) {
+                this->global_data = std::vector<T>(global_size);
+                this->global_value_status = std::vector<value::status>(global_size, value::status::uninitialized);
+            }
+
+            if (info.scalar_init)
+                this->default_assign( *info.scalar_init );
+        }
+
+
+        std::size_t size() const {
+            return this->data.size();
+        }
+
+        bool valid() const {
+            if (this->all_set)
+                return true;
+
+            static const std::array<value::status,2> invalid_value = {value::status::uninitialized, value::status::empty_default};
+            const auto& it = std::find_first_of(this->value_status.begin(), this->value_status.end(), invalid_value.begin(), invalid_value.end());
+            this->all_set = (it == this->value_status.end());
+
+            return this->all_set;
+        }
+
+        void compress(const std::vector<bool>& active_map) {
+            fieldprops_compress(this->data, active_map);
+            fieldprops_compress(this->value_status, active_map);
+        }
+
+        void copy(const FieldData<T>& src, const std::vector<Box::cell_index>& index_list) {
+            for (const auto& ci : index_list) {
+                this->data[ci.active_index] = src.data[ci.active_index];
+                this->value_status[ci.active_index] = src.value_status[ci.active_index];
+            }
+        }
+
+        void default_assign(T value) {
+            std::fill(this->data.begin(), this->data.end(), value);
+            std::fill(this->value_status.begin(), this->value_status.end(), value::status::valid_default);
+
+            if (this->global_data) {
+                std::fill(this->global_data->begin(), this->global_data->end(), value);
+                std::fill(this->global_value_status->begin(), this->global_value_status->end(), value::status::valid_default);
+            }
+        }
+
+        void default_assign(const std::vector<T>& src) {
+            if (src.size() != this->size())
+                throw std::invalid_argument("Size mismatch got: " + std::to_string(src.size()) + " expected: " + std::to_string(this->size()));
+
+            std::copy(src.begin(), src.end(), this->data.begin());
+            std::fill(this->value_status.begin(), this->value_status.end(), value::status::valid_default);
+        }
+
+        void default_update(const std::vector<T>& src) {
+            if (src.size() != this->size())
+                throw std::invalid_argument("Size mismatch got: " + std::to_string(src.size()) + " expected: " + std::to_string(this->size()));
+
+            for (std::size_t i = 0; i < src.size(); i++) {
+                if (!value::has_value(this->value_status[i])) {
+                    this->value_status[i] = value::status::valid_default;
+                    this->data[i] = src[i];
+                }
+            }
+        }
+
+        void update(std::size_t index, T value, value::status status) {
+            this->data[index] = value;
+            this->value_status[index] = status;
+        }
+
+    };
+
+} // end namespace Opm
+#endif // FIELD_DATA_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -186,9 +186,10 @@ public:
 
     virtual bool has_int(const std::string& keyword) const { return this->has<int>(keyword); }
     virtual bool has_double(const std::string& keyword) const { return this->has<double>(keyword); }
-    virtual void apply_tran(const std::string& keyword, std::vector<double>& tranx) const;
-    std::vector<char> serialize_tran() const;
-    void deserialize_tran(const std::vector<char>& buffer);
+    virtual bool tran_active(const std::string& keyword) const;
+    virtual void apply_tran(const std::string& keyword, std::vector<double>& tran_data) const;
+    virtual std::vector<char> serialize_tran() const;
+    virtual void deserialize_tran(const std::vector<char>& buffer);
 private:
     /*
       Return the keyword values as a std::vector<>. All elements in the return

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <vector>
+#include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
 
 namespace Opm {
 

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <vector>
+#include <unordered_map>
 #include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldData.hpp>
 
@@ -285,6 +286,16 @@ private:
 
     std::shared_ptr<FieldProps> fp;
 };
+
+
+void deserialize_tran(std::unordered_map<std::string, TranCalculator>& tran,
+                      const std::vector<char>& buffer);
+
+template<class MapType>
+void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
+                const MapType& double_data,
+                std::size_t active_size,
+                const std::string& keyword, std::vector<double>& data);
 
 }
 

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -183,8 +183,12 @@ public:
 
     const FieldData<int>&
     get_int_field_data(const std::string& keyword) const;
+
+    /// \brief Get double field data associated with a keyword
+    /// \param allow_unsupported If true we deactivate some checks on the
+    ///        keyword and thus allow getting FieldData used by the TranCalculator.
     const FieldData<double>&
-    get_double_field_data(const std::string& keyword) const;
+    get_double_field_data(const std::string& keyword, bool allow_unsupported=false) const;
     virtual const std::vector<int>& get_int(const std::string& keyword) const { return this->get<int>(keyword); }
     virtual std::vector<int> get_global_int(const std::string& keyword) const { return this->get_global<int>(keyword); }
 

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -181,13 +181,13 @@ public:
     template <typename T>
     std::vector<std::string> keys() const;
 
-    const FieldData<int>&
+    const Fieldprops::FieldData<int>&
     get_int_field_data(const std::string& keyword) const;
 
     /// \brief Get double field data associated with a keyword
     /// \param allow_unsupported If true we deactivate some checks on the
     ///        keyword and thus allow getting FieldData used by the TranCalculator.
-    const FieldData<double>&
+    const Fieldprops::FieldData<double>&
     get_double_field_data(const std::string& keyword, bool allow_unsupported=false) const;
     virtual const std::vector<int>& get_int(const std::string& keyword) const { return this->get<int>(keyword); }
     virtual std::vector<int> get_global_int(const std::string& keyword) const { return this->get_global<int>(keyword); }
@@ -292,11 +292,11 @@ private:
 };
 
 
-void deserialize_tran(std::unordered_map<std::string, TranCalculator>& tran,
+void deserialize_tran(std::unordered_map<std::string, Fieldprops::TranCalculator>& tran,
                       const std::vector<char>& buffer);
 
 template<class MapType>
-void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
+void apply_tran(const std::unordered_map<std::string, Fieldprops::TranCalculator>& tran,
                 const MapType& double_data,
                 std::size_t active_size,
                 const std::string& keyword, std::vector<double>& data);

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <vector>
 #include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldData.hpp>
 
 namespace Opm {
 

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -186,6 +186,7 @@ public:
 
     virtual bool has_int(const std::string& keyword) const { return this->has<int>(keyword); }
     virtual bool has_double(const std::string& keyword) const { return this->has<double>(keyword); }
+    virtual void apply_tran(const std::string& keyword, std::vector<double>& tranx) const;
 
 private:
     /*

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -187,7 +187,8 @@ public:
     virtual bool has_int(const std::string& keyword) const { return this->has<int>(keyword); }
     virtual bool has_double(const std::string& keyword) const { return this->has<double>(keyword); }
     virtual void apply_tran(const std::string& keyword, std::vector<double>& tranx) const;
-
+    std::vector<char> serialize_tran() const;
+    void deserialize_tran(const std::vector<char>& buffer);
 private:
     /*
       Return the keyword values as a std::vector<>. All elements in the return

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -180,6 +180,10 @@ public:
     template <typename T>
     std::vector<std::string> keys() const;
 
+    const FieldData<int>&
+    get_int_field_data(const std::string& keyword) const;
+    const FieldData<double>&
+    get_double_field_data(const std::string& keyword) const;
     virtual const std::vector<int>& get_int(const std::string& keyword) const { return this->get<int>(keyword); }
     virtual std::vector<int> get_global_int(const std::string& keyword) const { return this->get_global<int>(keyword); }
 

--- a/opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
@@ -23,6 +23,9 @@
 namespace Opm
 {
 
+namespace Fieldprops
+{
+
 namespace keywords {
 
 template <typename T>
@@ -59,6 +62,6 @@ struct keyword_info {
     }
 };
 } // end namespace Keywords
-
+} // end namespace Fieldprops
 } //end namespace Opm
 #endif //OPM_KEYWORDS_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
@@ -1,0 +1,64 @@
+/*
+  Copyright 2020 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_KEYWORDS_HPP
+#define OPM_KEYWORDS_HPP
+
+namespace Opm
+{
+
+namespace keywords {
+
+template <typename T>
+struct keyword_info {
+    std::optional<std::string> unit = std::nullopt;
+    std::optional<T> scalar_init = std::nullopt;
+    bool multiplier = false;
+    bool top = false;
+    bool global = false;
+
+    keyword_info<T>& init(T init_value) {
+        this->scalar_init = init_value;
+        return *this;
+    }
+
+    keyword_info<T>& unit_string(const std::string& unit_string) {
+        this->unit = unit_string;
+        return *this;
+    }
+
+    keyword_info<T>& distribute_top(bool dtop) {
+        this->top = dtop;
+        return *this;
+    }
+
+    keyword_info<T>& mult(bool m) {
+        this->multiplier = m;
+        return *this;
+    }
+
+    keyword_info<T>& global_kw(bool g) {
+        this->global = g;
+        return *this;
+    }
+};
+} // end namespace Keywords
+
+} //end namespace Opm
+#endif //OPM_KEYWORDS_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
@@ -1,0 +1,106 @@
+/*
+  Copyright 2020 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef TRAN_CALCULATOR_HPP
+#define TRAN_CALCULATOR_HPP
+
+#include<string>
+
+#include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
+
+
+namespace Opm
+{
+
+
+
+enum class ScalarOperation {
+    ADD = 1,
+    EQUAL = 2,
+    MUL = 3,
+    MIN = 4,
+    MAX = 5
+};
+
+
+class TranCalculator {
+public:
+
+    struct TranAction {
+        ScalarOperation op;
+        std::string field;
+    };
+
+
+    TranCalculator(const std::string& name_arg) :
+        m_name(name_arg)
+    {}
+
+    std::string next_name() const {
+        return this->m_name + std::to_string( this->actions.size() );
+    }
+
+    std::vector<TranAction>::const_iterator begin() const {
+        return this->actions.begin();
+    }
+
+    std::vector<TranAction>::const_iterator end() const {
+        return this->actions.end();
+    }
+
+    void add_action(ScalarOperation op, const std::string& field) {
+        this->actions.push_back(TranAction{op, field});
+    }
+
+    std::size_t size() const {
+        return this->actions.size();
+    }
+
+    const std::string& name() const {
+        return this->m_name;
+    }
+
+
+    keywords::keyword_info<double> make_kw_info(ScalarOperation op) {
+        keywords::keyword_info<double> kw_info;
+        switch (op) {
+        case ScalarOperation::MUL:
+            kw_info.init(1);
+            break;
+        case ScalarOperation::ADD:
+            kw_info.init(0);
+            break;
+        case ScalarOperation::MAX:
+            kw_info.init(std::numeric_limits<double>::min());
+            break;
+        case ScalarOperation::MIN:
+            kw_info.init(std::numeric_limits<double>::max());
+            break;
+        default:
+            break;
+        }
+        return kw_info;
+    }
+private:
+    std::string m_name;
+    std::vector<TranAction> actions;
+};
+
+
+} // end namespace Opm
+#endif // TRAN_CALCULATOR_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
@@ -27,7 +27,8 @@
 namespace Opm
 {
 
-
+namespace Fieldprops
+{
 
 enum class ScalarOperation {
     ADD = 1,
@@ -101,6 +102,6 @@ private:
     std::vector<TranAction> actions;
 };
 
-
+} // namespace Fieldprops
 } // end namespace Opm
 #endif // TRAN_CALCULATOR_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
@@ -86,10 +86,10 @@ public:
             kw_info.init(0);
             break;
         case ScalarOperation::MAX:
-            kw_info.init(std::numeric_limits<double>::min());
+            kw_info.init(std::numeric_limits<double>::max());
             break;
         case ScalarOperation::MIN:
-            kw_info.init(std::numeric_limits<double>::max());
+            kw_info.init(std::numeric_limits<double>::lowest());
             break;
         default:
             break;

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1154,8 +1154,8 @@ void FieldProps::deserialize_tran(const std::vector<char>& buffer) {
 }
 
 bool FieldProps::tran_active(const std::string& keyword) const {
-    const auto& calculator = this->tran.at(keyword);
-    return calculator.size() > 0;
+    auto calculator = this->tran.find(keyword);
+    return calculator != this->tran.end() && calculator->second.size() > 0;
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1193,6 +1193,10 @@ void FieldProps::deserialize_tran(const std::vector<char>& buffer) {
     }
 }
 
+bool FieldProps::tran_active(const std::string& keyword) const {
+    const auto& calculator = this->tran.at(keyword);
+    return calculator.size() > 0;
+}
 
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -50,7 +50,8 @@ static const std::set<std::string> region_oper_keywords = {"ADDREG", "EQUALREG",
 static const std::set<std::string> box_keywords = {"BOX", "ENDBOX"};
 
 template <>
-keyword_info<double> global_kw_info(const std::string& name) {
+keyword_info<double> global_kw_info(const std::string& name,
+                                    bool allow_unsupported) {
     if (GRID::double_keywords.count(name))
         return GRID::double_keywords.at(name);
 
@@ -69,12 +70,15 @@ keyword_info<double> global_kw_info(const std::string& name) {
     if (SCHEDULE::double_keywords.count(name))
         return SCHEDULE::double_keywords.at(name);
 
+    if (allow_unsupported)
+        return keyword_info<double>{};
+
     throw std::out_of_range("INFO: No such keyword: " + name);
 }
 
 
 template <>
-keyword_info<int> global_kw_info(const std::string& name) {
+keyword_info<int> global_kw_info(const std::string& name, bool) {
     if (GRID::int_keywords.count(name))
         return GRID::int_keywords.at(name);
 
@@ -496,8 +500,9 @@ FieldData<double>& FieldProps::init_get(const std::string& keyword, const keywor
 }
 
 template <>
-FieldData<double>& FieldProps::init_get(const std::string& keyword) {
-    keywords::keyword_info<double> kw_info = keywords::global_kw_info<double>(keyword);
+FieldData<double>& FieldProps::init_get(const std::string& keyword,
+                                        bool allow_unsupported) {
+    keywords::keyword_info<double> kw_info = keywords::global_kw_info<double>(keyword, allow_unsupported);
     return this->init_get(keyword, kw_info);
 }
 
@@ -513,7 +518,7 @@ FieldData<int>& FieldProps::init_get(const std::string& keyword, const keywords:
 }
 
 template <>
-FieldData<int>& FieldProps::init_get(const std::string& keyword) {
+FieldData<int>& FieldProps::init_get(const std::string& keyword, bool) {
     if (keywords::isFipxxx(keyword)) {
         auto kw_info = keywords::keyword_info<int>{};
         kw_info.init(1);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -43,6 +43,9 @@
 
 namespace Opm {
 
+namespace Fieldprops
+{
+
 namespace keywords {
 
 static const std::set<std::string> oper_keywords = {"ADD", "EQUALS", "MAXVALUE", "MINVALUE", "MULTIPLY", "OPERATE"};
@@ -97,8 +100,9 @@ keyword_info<int> global_kw_info(const std::string& name, bool) {
     throw std::out_of_range("No such keyword: " + name);
 }
 
+} // end namespace keywords
 
-}
+} // end namespace Fieldprops
 
 
 namespace {
@@ -157,7 +161,7 @@ void verify_deck_data(const DeckKeyword& keyword, const std::vector<T>& deck_dat
 
 
 template <typename T>
-void assign_deck(const keywords::keyword_info<T>& kw_info, const DeckKeyword& keyword, FieldData<T>& field_data, const std::vector<T>& deck_data, const std::vector<value::status>& deck_status, const Box& box) {
+void assign_deck(const Fieldprops::keywords::keyword_info<T>& kw_info, const DeckKeyword& keyword, Fieldprops::FieldData<T>& field_data, const std::vector<T>& deck_data, const std::vector<value::status>& deck_status, const Box& box) {
     verify_deck_data(keyword, deck_data, box);
     for (const auto& cell_index : box.index_list()) {
         auto active_index = cell_index.active_index;
@@ -187,7 +191,7 @@ void assign_deck(const keywords::keyword_info<T>& kw_info, const DeckKeyword& ke
 
 
 template <typename T>
-void multiply_deck(const keywords::keyword_info<T>& kw_info, const DeckKeyword& keyword, FieldData<T>& field_data, const std::vector<T>& deck_data, const std::vector<value::status>& deck_status, const Box& box) {
+void multiply_deck(const Fieldprops::keywords::keyword_info<T>& kw_info, const DeckKeyword& keyword, Fieldprops::FieldData<T>& field_data, const std::vector<T>& deck_data, const std::vector<value::status>& deck_status, const Box& box) {
     verify_deck_data(keyword, deck_data, box);
     for (const auto& cell_index : box.index_list()) {
         auto active_index = cell_index.active_index;
@@ -271,21 +275,21 @@ std::string make_region_name(const std::string& deck_value) {
     throw std::invalid_argument("The input string: " + deck_value + " was invalid. Expected: O/F/M");
 }
 
-ScalarOperation fromString(const std::string& keyword) {
+Fieldprops::ScalarOperation fromString(const std::string& keyword) {
     if (keyword == ParserKeywords::ADD::keywordName || keyword == ParserKeywords::ADDREG::keywordName)
-        return ScalarOperation::ADD;
+        return Fieldprops::ScalarOperation::ADD;
 
     if (keyword == ParserKeywords::EQUALS::keywordName || keyword == ParserKeywords::EQUALREG::keywordName)
-        return ScalarOperation::EQUAL;
+        return Fieldprops::ScalarOperation::EQUAL;
 
     if (keyword == ParserKeywords::MULTIPLY::keywordName || keyword == ParserKeywords::MULTIREG::keywordName)
-        return ScalarOperation::MUL;
+        return Fieldprops::ScalarOperation::MUL;
 
     if (keyword == ParserKeywords::MINVALUE::keywordName)
-        return ScalarOperation::MIN;
+        return Fieldprops::ScalarOperation::MIN;
 
     if (keyword == ParserKeywords::MAXVALUE::keywordName)
-        return ScalarOperation::MAX;
+        return Fieldprops::ScalarOperation::MAX;
 
     throw std::invalid_argument("Keyword operation not recognized");
 }
@@ -330,9 +334,9 @@ FieldProps::FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid
     grid_ptr(&grid),
     tables(tables_arg)
 {
-    this->tran.emplace( "TRANX", TranCalculator("TRANX") );
-    this->tran.emplace( "TRANY", TranCalculator("TRANY") );
-    this->tran.emplace( "TRANZ", TranCalculator("TRANZ") );
+    this->tran.emplace( "TRANX", Fieldprops::TranCalculator("TRANX") );
+    this->tran.emplace( "TRANY", Fieldprops::TranCalculator("TRANY") );
+    this->tran.emplace( "TRANZ", Fieldprops::TranCalculator("TRANZ") );
 
     if (deck.hasKeyword<ParserKeywords::MULTREGP>()) {
         const DeckKeyword& multregpKeyword = deck.getKeyword("MULTREGP");
@@ -405,17 +409,17 @@ void FieldProps::reset_actnum(const std::vector<int>& new_actnum) {
     for (auto& data : this->int_data)
         data.second.compress(active_map);
 
-    fieldprops_compress(this->cell_volume, active_map);
-    fieldprops_compress(this->cell_depth, active_map);
+    Fieldprops::compress(this->cell_volume, active_map);
+    Fieldprops::compress(this->cell_depth, active_map);
 
     this->m_actnum = std::move(new_actnum);
     this->active_size = new_active_size;
 }
 
 
-void FieldProps::distribute_toplayer(FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box) {
+void FieldProps::distribute_toplayer(Fieldprops::FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box) {
     const std::size_t layer_size = this->nx * this->ny;
-    FieldData<double> toplayer(field_data.kw_info, layer_size, 0);
+    Fieldprops::FieldData<double> toplayer(field_data.kw_info, layer_size, 0);
     for (const auto& cell_index : box.index_list()) {
         if (cell_index.global_index < layer_size) {
             toplayer.data[cell_index.global_index] = deck_data[cell_index.data_index];
@@ -446,19 +450,19 @@ void FieldProps::distribute_toplayer(FieldData<double>& field_data, const std::v
 
 template <>
 bool FieldProps::supported<double>(const std::string& keyword) {
-    if (keywords::GRID::double_keywords.count(keyword) != 0)
+    if (Fieldprops::keywords::GRID::double_keywords.count(keyword) != 0)
         return true;
 
-    if (keywords::EDIT::double_keywords.count(keyword) != 0)
+    if (Fieldprops::keywords::EDIT::double_keywords.count(keyword) != 0)
         return true;
 
-    if (keywords::PROPS::double_keywords.count(keyword) != 0)
+    if (Fieldprops::keywords::PROPS::double_keywords.count(keyword) != 0)
         return true;
 
-    if (keywords::PROPS::satfunc.count(keyword) != 0)
+    if (Fieldprops::keywords::PROPS::satfunc.count(keyword) != 0)
         return true;
 
-    if (keywords::SOLUTION::double_keywords.count(keyword) != 0)
+    if (Fieldprops::keywords::SOLUTION::double_keywords.count(keyword) != 0)
         return true;
 
     return false;
@@ -466,26 +470,26 @@ bool FieldProps::supported<double>(const std::string& keyword) {
 
 template <>
 bool FieldProps::supported<int>(const std::string& keyword) {
-    if (keywords::REGIONS::int_keywords.count(keyword) != 0)
+    if (Fieldprops::keywords::REGIONS::int_keywords.count(keyword) != 0)
         return true;
 
-    if (keywords::GRID::int_keywords.count(keyword) != 0)
+    if (Fieldprops::keywords::GRID::int_keywords.count(keyword) != 0)
         return true;
 
-    if (keywords::SCHEDULE::int_keywords.count(keyword) != 0)
+    if (Fieldprops::keywords::SCHEDULE::int_keywords.count(keyword) != 0)
         return true;
 
-    return keywords::isFipxxx(keyword);
+    return Fieldprops::keywords::isFipxxx(keyword);
 }
 
 
 template <>
-FieldData<double>& FieldProps::init_get(const std::string& keyword, const keywords::keyword_info<double>& kw_info) {
+Fieldprops::FieldData<double>& FieldProps::init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<double>& kw_info) {
     auto iter = this->double_data.find(keyword);
     if (iter != this->double_data.end())
         return iter->second;
 
-    this->double_data[keyword] = FieldData<double>(kw_info, this->active_size, kw_info.global ? this->global_size : 0);
+    this->double_data[keyword] = Fieldprops::FieldData<double>(kw_info, this->active_size, kw_info.global ? this->global_size : 0);
 
     if (keyword == ParserKeywords::PORV::keywordName)
         this->init_porv(this->double_data[keyword]);
@@ -493,38 +497,38 @@ FieldData<double>& FieldProps::init_get(const std::string& keyword, const keywor
     if (keyword == ParserKeywords::TEMPI::keywordName)
         this->init_tempi(this->double_data[keyword]);
 
-    if (keywords::PROPS::satfunc.count(keyword) == 1)
+    if (Fieldprops::keywords::PROPS::satfunc.count(keyword) == 1)
         this->init_satfunc(keyword, this->double_data[keyword]);
 
     return this->double_data[keyword];
 }
 
 template <>
-FieldData<double>& FieldProps::init_get(const std::string& keyword,
+Fieldprops::FieldData<double>& FieldProps::init_get(const std::string& keyword,
                                         bool allow_unsupported) {
-    keywords::keyword_info<double> kw_info = keywords::global_kw_info<double>(keyword, allow_unsupported);
+    Fieldprops::keywords::keyword_info<double> kw_info = Fieldprops::keywords::global_kw_info<double>(keyword, allow_unsupported);
     return this->init_get(keyword, kw_info);
 }
 
 
 template <>
-FieldData<int>& FieldProps::init_get(const std::string& keyword, const keywords::keyword_info<int>& kw_info) {
+Fieldprops::FieldData<int>& FieldProps::init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<int>& kw_info) {
     auto iter = this->int_data.find(keyword);
     if (iter != this->int_data.end())
         return iter->second;
 
-    this->int_data[keyword] = FieldData<int>(kw_info, this->active_size, kw_info.global ? this->global_size : 0);
+    this->int_data[keyword] = Fieldprops::FieldData<int>(kw_info, this->active_size, kw_info.global ? this->global_size : 0);
     return this->int_data[keyword];
 }
 
 template <>
-FieldData<int>& FieldProps::init_get(const std::string& keyword, bool) {
-    if (keywords::isFipxxx(keyword)) {
-        auto kw_info = keywords::keyword_info<int>{};
+Fieldprops::FieldData<int>& FieldProps::init_get(const std::string& keyword, bool) {
+    if (Fieldprops::keywords::isFipxxx(keyword)) {
+        auto kw_info = Fieldprops::keywords::keyword_info<int>{};
         kw_info.init(1);
         return this->init_get(keyword, kw_info);
     } else {
-        const keywords::keyword_info<int>& kw_info = keywords::global_kw_info<int>(keyword);
+        const Fieldprops::keywords::keyword_info<int>& kw_info = Fieldprops::keywords::global_kw_info<int>(keyword);
         return this->init_get(keyword, kw_info);
     }
 }
@@ -626,7 +630,7 @@ std::vector<double> FieldProps::extract<double>(const std::string& keyword) {
 
 
 double FieldProps::getSIValue(const std::string& keyword, double raw_value) const {
-    const auto& kw_info = keywords::global_kw_info<double>(keyword);
+    const auto& kw_info = Fieldprops::keywords::global_kw_info<double>(keyword);
     if (kw_info.unit) {
         const auto& dim = this->unit_system.parse( *kw_info.unit );
         return dim.convertRawToSi(raw_value);
@@ -638,7 +642,7 @@ double FieldProps::getSIValue(const std::string& keyword, double raw_value) cons
 
 
 
-void FieldProps::handle_int_keyword(const keywords::keyword_info<int>& kw_info, const DeckKeyword& keyword, const Box& box) {
+void FieldProps::handle_int_keyword(const Fieldprops::keywords::keyword_info<int>& kw_info, const DeckKeyword& keyword, const Box& box) {
     auto& field_data = this->init_get<int>(keyword.name());
     const auto& deck_data = keyword.getIntData();
     const auto& deck_status = keyword.getValueStatus();
@@ -646,7 +650,7 @@ void FieldProps::handle_int_keyword(const keywords::keyword_info<int>& kw_info, 
 }
 
 
-void FieldProps::handle_double_keyword(Section section, const keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const std::string& keyword_name, const Box& box) {
+void FieldProps::handle_double_keyword(Section section, const Fieldprops::keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const std::string& keyword_name, const Box& box) {
     auto& field_data = this->init_get<double>(keyword_name, kw_info);
     const auto& deck_data = keyword.getSIDoubleData();
     const auto& deck_status = keyword.getValueStatus();
@@ -666,27 +670,27 @@ void FieldProps::handle_double_keyword(Section section, const keywords::keyword_
     }
 }
 
-void FieldProps::handle_double_keyword(Section section, const keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const Box& box) {
+void FieldProps::handle_double_keyword(Section section, const Fieldprops::keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const Box& box) {
     this->handle_double_keyword(section, kw_info, keyword, keyword.name(), box );
 }
 
 
 
 template <typename T>
-void FieldProps::apply(ScalarOperation op, std::vector<T>& data, std::vector<value::status>& value_status, T scalar_value, const std::vector<Box::cell_index>& index_list) {
-    if (op == ScalarOperation::EQUAL)
+void FieldProps::apply(Fieldprops::ScalarOperation op, std::vector<T>& data, std::vector<value::status>& value_status, T scalar_value, const std::vector<Box::cell_index>& index_list) {
+    if (op == Fieldprops::ScalarOperation::EQUAL)
         assign_scalar(data, value_status, scalar_value, index_list);
 
-    else if (op == ScalarOperation::MUL)
+    else if (op == Fieldprops::ScalarOperation::MUL)
         multiply_scalar(data, value_status, scalar_value, index_list);
 
-    else if (op == ScalarOperation::ADD)
+    else if (op == Fieldprops::ScalarOperation::ADD)
         add_scalar(data, value_status, scalar_value, index_list);
 
-    else if (op == ScalarOperation::MIN)
+    else if (op == Fieldprops::ScalarOperation::MIN)
         min_value(data, value_status, scalar_value, index_list);
 
-    else if (op == ScalarOperation::MAX)
+    else if (op == Fieldprops::ScalarOperation::MAX)
         max_value(data, value_status, scalar_value, index_list);
 }
 
@@ -705,7 +709,7 @@ double FieldProps::get_beta(const std::string& func_name, const std::string& tar
 }
 
 template <typename T>
-void FieldProps::operate(const DeckRecord& record, FieldData<T>& target_data, const FieldData<T>& src_data, const std::vector<Box::cell_index>& index_list) {
+void FieldProps::operate(const DeckRecord& record, Fieldprops::FieldData<T>& target_data, const Fieldprops::FieldData<T>& src_data, const std::vector<Box::cell_index>& index_list) {
     const std::string& func_name = record.getItem("OPERATION").get< std::string >(0);
     const std::string& target_array = record.getItem("TARGET_ARRAY").get<std::string>(0);
     const double alpha           = this->get_alpha(func_name, target_array, record.getItem("PARAM1").get< double >(0));
@@ -792,14 +796,14 @@ void FieldProps::handle_operation(const DeckKeyword& keyword, Box box) {
                 std::string unique_name = target_kw;
                 auto operation = fromString(keyword.name());
                 double scalar_value = record.getItem(1).get<double>(0);
-                keywords::keyword_info<double> kw_info;
+                Fieldprops::keywords::keyword_info<double> kw_info;
                 auto tran_iter = this->tran.find(target_kw);
                 if (tran_iter != this->tran.end()) {
                     kw_info = tran_iter->second.make_kw_info(operation);
                     unique_name = tran_iter->second.next_name();
                     tran_iter->second.add_action(operation, unique_name);
                 } else
-                    kw_info = keywords::global_kw_info<double>(target_kw);
+                    kw_info = Fieldprops::keywords::global_kw_info<double>(target_kw);
 
                 auto& field_data = this->init_get<double>(unique_name, kw_info);
 
@@ -871,13 +875,13 @@ void FieldProps::handle_COPY(const DeckKeyword& keyword, Box box, bool region) {
 void FieldProps::handle_keyword(const DeckKeyword& keyword, Box& box) {
     const std::string& name = keyword.name();
 
-    if (keywords::oper_keywords.count(name) == 1)
+    if (Fieldprops::keywords::oper_keywords.count(name) == 1)
         this->handle_operation(keyword, box);
 
-    else if (keywords::region_oper_keywords.count(name) == 1)
+    else if (Fieldprops::keywords::region_oper_keywords.count(name) == 1)
         this->handle_region_operation(keyword);
 
-    else if (keywords::box_keywords.count(name) == 1)
+    else if (Fieldprops::keywords::box_keywords.count(name) == 1)
         handle_box_keyword(keyword, box);
 
     else if (name == ParserKeywords::COPY::keywordName)
@@ -890,7 +894,7 @@ void FieldProps::handle_keyword(const DeckKeyword& keyword, Box& box) {
 /**********************************************************************/
 
 
-void FieldProps::init_tempi(FieldData<double>& tempi) {
+void FieldProps::init_tempi(Fieldprops::FieldData<double>& tempi) {
     if (this->tables.hasTables("RTEMPVD")) {
         const auto& eqlnum = this->get<int>("EQLNUM");
         const auto& rtempvd = this->tables.getRtempvdTables();
@@ -907,7 +911,7 @@ void FieldProps::init_tempi(FieldData<double>& tempi) {
         tempi.default_assign(this->tables.rtemp());
 }
 
-void FieldProps::init_porv(FieldData<double>& porv) {
+void FieldProps::init_porv(Fieldprops::FieldData<double>& porv) {
     auto& porv_data = porv.data;
     auto& porv_status = porv.value_status;
 
@@ -993,13 +997,13 @@ void FieldProps::scanGRIDSection(const GRIDSection& grid_section) {
     for (const auto& keyword : grid_section) {
         const std::string& name = keyword.name();
 
-        if (keywords::GRID::double_keywords.count(name) == 1) {
-            this->handle_double_keyword(Section::GRID, keywords::GRID::double_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::GRID::double_keywords.count(name) == 1) {
+            this->handle_double_keyword(Section::GRID, Fieldprops::keywords::GRID::double_keywords.at(name), keyword, box);
             continue;
         }
 
-        if (keywords::GRID::int_keywords.count(name) == 1) {
-            this->handle_int_keyword(keywords::GRID::int_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::GRID::int_keywords.count(name) == 1) {
+            this->handle_int_keyword(Fieldprops::keywords::GRID::int_keywords.at(name), keyword, box);
             continue;
         }
 
@@ -1016,19 +1020,19 @@ void FieldProps::scanEDITSection(const EDITSection& edit_section) {
         if (tran_iter!= this->tran.end()) {
             auto& tran_calc = tran_iter->second;
             auto unique_name = tran_calc.next_name();
-            keywords::keyword_info<double> kw_info;
+            Fieldprops::keywords::keyword_info<double> kw_info;
             this->handle_double_keyword(Section::EDIT, kw_info, keyword, unique_name, box);
-            tran_calc.add_action( ScalarOperation::EQUAL, unique_name );
+            tran_calc.add_action( Fieldprops::ScalarOperation::EQUAL, unique_name );
             continue;
         }
 
-        if (keywords::EDIT::double_keywords.count(name) == 1) {
-            this->handle_double_keyword(Section::EDIT, keywords::EDIT::double_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::EDIT::double_keywords.count(name) == 1) {
+            this->handle_double_keyword(Section::EDIT, Fieldprops::keywords::EDIT::double_keywords.at(name), keyword, box);
             continue;
         }
 
-        if (keywords::EDIT::int_keywords.count(name) == 1) {
-            this->handle_int_keyword(keywords::GRID::int_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::EDIT::int_keywords.count(name) == 1) {
+            this->handle_int_keyword(Fieldprops::keywords::GRID::int_keywords.at(name), keyword, box);
             continue;
         }
 
@@ -1037,7 +1041,7 @@ void FieldProps::scanEDITSection(const EDITSection& edit_section) {
 }
 
 
-void FieldProps::init_satfunc(const std::string& keyword, FieldData<double>& satfunc) {
+void FieldProps::init_satfunc(const std::string& keyword, Fieldprops::FieldData<double>& satfunc) {
     if (this->m_rtep == nullptr)
         this->m_rtep = satfunc::getRawTableEndpoints(this->tables, this->m_phases,
                                                      this->m_satfuncctrl.minimumRelpermMobilityThreshold());
@@ -1056,19 +1060,19 @@ void FieldProps::scanPROPSSection(const PROPSSection& props_section) {
 
     for (const auto& keyword : props_section) {
         const std::string& name = keyword.name();
-        if (keywords::PROPS::satfunc.count(name) == 1) {
-            keywords::keyword_info<double> sat_info{};
+        if (Fieldprops::keywords::PROPS::satfunc.count(name) == 1) {
+            Fieldprops::keywords::keyword_info<double> sat_info{};
             this->handle_double_keyword(Section::PROPS, sat_info, keyword, box);
             continue;
         }
 
-        if (keywords::PROPS::double_keywords.count(name) == 1) {
-            this->handle_double_keyword(Section::PROPS, keywords::PROPS::double_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::PROPS::double_keywords.count(name) == 1) {
+            this->handle_double_keyword(Section::PROPS, Fieldprops::keywords::PROPS::double_keywords.at(name), keyword, box);
             continue;
         }
 
-        if (keywords::PROPS::int_keywords.count(name) == 1) {
-            this->handle_int_keyword(keywords::PROPS::int_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::PROPS::int_keywords.count(name) == 1) {
+            this->handle_int_keyword(Fieldprops::keywords::PROPS::int_keywords.at(name), keyword, box);
             continue;
         }
 
@@ -1082,13 +1086,13 @@ void FieldProps::scanREGIONSSection(const REGIONSSection& regions_section) {
 
     for (const auto& keyword : regions_section) {
         const std::string& name = keyword.name();
-        if (keywords::REGIONS::int_keywords.count(name)) {
-            this->handle_int_keyword(keywords::REGIONS::int_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::REGIONS::int_keywords.count(name)) {
+            this->handle_int_keyword(Fieldprops::keywords::REGIONS::int_keywords.at(name), keyword, box);
             continue;
         }
 
-        if (keywords::isFipxxx(name)) {
-            auto kw_info = keywords::keyword_info<int>{};
+        if (Fieldprops::keywords::isFipxxx(name)) {
+            auto kw_info = Fieldprops::keywords::keyword_info<int>{};
             kw_info.init(1);
             this->handle_int_keyword(kw_info, keyword, box);
             continue;
@@ -1103,8 +1107,8 @@ void FieldProps::scanSOLUTIONSection(const SOLUTIONSection& solution_section) {
     Box box(*this->grid_ptr);
     for (const auto& keyword : solution_section) {
         const std::string& name = keyword.name();
-        if (keywords::SOLUTION::double_keywords.count(name) == 1) {
-            this->handle_double_keyword(Section::SOLUTION, keywords::SOLUTION::double_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::SOLUTION::double_keywords.count(name) == 1) {
+            this->handle_double_keyword(Section::SOLUTION, Fieldprops::keywords::SOLUTION::double_keywords.at(name), keyword, box);
             continue;
         }
 
@@ -1116,13 +1120,13 @@ void FieldProps::scanSCHEDULESection(const SCHEDULESection& schedule_section) {
     Box box(*this->grid_ptr);
     for (const auto& keyword : schedule_section) {
         const std::string& name = keyword.name();
-        if (keywords::SCHEDULE::double_keywords.count(name) == 1) {
-            this->handle_double_keyword(Section::SCHEDULE, keywords::SCHEDULE::double_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::SCHEDULE::double_keywords.count(name) == 1) {
+            this->handle_double_keyword(Section::SCHEDULE, Fieldprops::keywords::SCHEDULE::double_keywords.at(name), keyword, box);
             continue;
         }
 
-        if (keywords::SCHEDULE::int_keywords.count(name) == 1) {
-            this->handle_int_keyword(keywords::SCHEDULE::int_keywords.at(name), keyword, box);
+        if (Fieldprops::keywords::SCHEDULE::int_keywords.count(name) == 1) {
+            this->handle_int_keyword(Fieldprops::keywords::SCHEDULE::int_keywords.at(name), keyword, box);
             continue;
         }
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -152,7 +152,7 @@ void verify_deck_data(const DeckKeyword& keyword, const std::vector<T>& deck_dat
 
 
 template <typename T>
-void assign_deck(const keywords::keyword_info<T>& kw_info, const DeckKeyword& keyword, FieldProps::FieldData<T>& field_data, const std::vector<T>& deck_data, const std::vector<value::status>& deck_status, const Box& box) {
+void assign_deck(const keywords::keyword_info<T>& kw_info, const DeckKeyword& keyword, FieldData<T>& field_data, const std::vector<T>& deck_data, const std::vector<value::status>& deck_status, const Box& box) {
     verify_deck_data(keyword, deck_data, box);
     for (const auto& cell_index : box.index_list()) {
         auto active_index = cell_index.active_index;
@@ -182,7 +182,7 @@ void assign_deck(const keywords::keyword_info<T>& kw_info, const DeckKeyword& ke
 
 
 template <typename T>
-void multiply_deck(const keywords::keyword_info<T>& kw_info, const DeckKeyword& keyword, FieldProps::FieldData<T>& field_data, const std::vector<T>& deck_data, const std::vector<value::status>& deck_status, const Box& box) {
+void multiply_deck(const keywords::keyword_info<T>& kw_info, const DeckKeyword& keyword, FieldData<T>& field_data, const std::vector<T>& deck_data, const std::vector<value::status>& deck_status, const Box& box) {
     verify_deck_data(keyword, deck_data, box);
     for (const auto& cell_index : box.index_list()) {
         auto active_index = cell_index.active_index;
@@ -400,17 +400,17 @@ void FieldProps::reset_actnum(const std::vector<int>& new_actnum) {
     for (auto& data : this->int_data)
         data.second.compress(active_map);
 
-    FieldProps::compress(this->cell_volume, active_map);
-    FieldProps::compress(this->cell_depth, active_map);
+    fieldprops_compress(this->cell_volume, active_map);
+    fieldprops_compress(this->cell_depth, active_map);
 
     this->m_actnum = std::move(new_actnum);
     this->active_size = new_active_size;
 }
 
 
-void FieldProps::distribute_toplayer(FieldProps::FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box) {
+void FieldProps::distribute_toplayer(FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box) {
     const std::size_t layer_size = this->nx * this->ny;
-    FieldProps::FieldData<double> toplayer(field_data.kw_info, layer_size, 0);
+    FieldData<double> toplayer(field_data.kw_info, layer_size, 0);
     for (const auto& cell_index : box.index_list()) {
         if (cell_index.global_index < layer_size) {
             toplayer.data[cell_index.global_index] = deck_data[cell_index.data_index];
@@ -475,7 +475,7 @@ bool FieldProps::supported<int>(const std::string& keyword) {
 
 
 template <>
-FieldProps::FieldData<double>& FieldProps::init_get(const std::string& keyword, const keywords::keyword_info<double>& kw_info) {
+FieldData<double>& FieldProps::init_get(const std::string& keyword, const keywords::keyword_info<double>& kw_info) {
     auto iter = this->double_data.find(keyword);
     if (iter != this->double_data.end())
         return iter->second;
@@ -495,14 +495,14 @@ FieldProps::FieldData<double>& FieldProps::init_get(const std::string& keyword, 
 }
 
 template <>
-FieldProps::FieldData<double>& FieldProps::init_get(const std::string& keyword) {
+FieldData<double>& FieldProps::init_get(const std::string& keyword) {
     keywords::keyword_info<double> kw_info = keywords::global_kw_info<double>(keyword);
     return this->init_get(keyword, kw_info);
 }
 
 
 template <>
-FieldProps::FieldData<int>& FieldProps::init_get(const std::string& keyword, const keywords::keyword_info<int>& kw_info) {
+FieldData<int>& FieldProps::init_get(const std::string& keyword, const keywords::keyword_info<int>& kw_info) {
     auto iter = this->int_data.find(keyword);
     if (iter != this->int_data.end())
         return iter->second;
@@ -512,7 +512,7 @@ FieldProps::FieldData<int>& FieldProps::init_get(const std::string& keyword, con
 }
 
 template <>
-FieldProps::FieldData<int>& FieldProps::init_get(const std::string& keyword) {
+FieldData<int>& FieldProps::init_get(const std::string& keyword) {
     if (keywords::isFipxxx(keyword)) {
         auto kw_info = keywords::keyword_info<int>{};
         kw_info.init(1);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -655,6 +655,7 @@ public:
         return this->double_data.size();
     }
 
+    bool tran_active(const std::string& keyword) const;
     void apply_tran(const std::string& keyword, std::vector<double>& data);
     std::vector<char> serialize_tran() const;
     void deserialize_tran(const std::vector<char>& buffer);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -34,6 +34,7 @@
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldData.hpp>
 
 namespace Opm {
 
@@ -262,21 +263,6 @@ public:
     };
 
 
-    template<typename T>
-    static void compress(std::vector<T>& data, const std::vector<bool>& active_map) {
-        std::size_t shift = 0;
-        for (std::size_t g = 0; g < active_map.size(); g++) {
-            if (active_map[g] && shift > 0) {
-                data[g - shift] = data[g];
-                continue;
-            }
-
-            if (!active_map[g])
-                shift += 1;
-        }
-
-        data.resize(data.size() - shift);
-    }
 
     enum class GetStatus {
          OK = 1,
@@ -285,99 +271,6 @@ public:
          NOT_SUPPPORTED_KEYWORD = 4      // std::logic_error
     };
 
-
-
-
-    template<typename T>
-    struct FieldData {
-        std::vector<T> data;
-        std::vector<value::status> value_status;
-        keywords::keyword_info<T> kw_info;
-        std::optional<std::vector<T>> global_data;
-        std::optional<std::vector<value::status>> global_value_status;
-        mutable bool all_set;
-
-        FieldData() = default;
-
-        FieldData(const keywords::keyword_info<T>& info, std::size_t active_size, std::size_t global_size) :
-            data(std::vector<T>(active_size)),
-            value_status(active_size, value::status::uninitialized),
-            kw_info(info),
-            all_set(false)
-        {
-            if (global_size != 0) {
-                this->global_data = std::vector<T>(global_size);
-                this->global_value_status = std::vector<value::status>(global_size, value::status::uninitialized);
-            }
-
-            if (info.scalar_init)
-                this->default_assign( *info.scalar_init );
-        }
-
-
-        std::size_t size() const {
-            return this->data.size();
-        }
-
-        bool valid() const {
-            if (this->all_set)
-                return true;
-
-            static const std::array<value::status,2> invalid_value = {value::status::uninitialized, value::status::empty_default};
-            const auto& it = std::find_first_of(this->value_status.begin(), this->value_status.end(), invalid_value.begin(), invalid_value.end());
-            this->all_set = (it == this->value_status.end());
-
-            return this->all_set;
-        }
-
-        void compress(const std::vector<bool>& active_map) {
-            FieldProps::compress(this->data, active_map);
-            FieldProps::compress(this->value_status, active_map);
-        }
-
-        void copy(const FieldData<T>& src, const std::vector<Box::cell_index>& index_list) {
-            for (const auto& ci : index_list) {
-                this->data[ci.active_index] = src.data[ci.active_index];
-                this->value_status[ci.active_index] = src.value_status[ci.active_index];
-            }
-        }
-
-        void default_assign(T value) {
-            std::fill(this->data.begin(), this->data.end(), value);
-            std::fill(this->value_status.begin(), this->value_status.end(), value::status::valid_default);
-
-            if (this->global_data) {
-                std::fill(this->global_data->begin(), this->global_data->end(), value);
-                std::fill(this->global_value_status->begin(), this->global_value_status->end(), value::status::valid_default);
-            }
-        }
-
-        void default_assign(const std::vector<T>& src) {
-            if (src.size() != this->size())
-                throw std::invalid_argument("Size mismatch got: " + std::to_string(src.size()) + " expected: " + std::to_string(this->size()));
-
-            std::copy(src.begin(), src.end(), this->data.begin());
-            std::fill(this->value_status.begin(), this->value_status.end(), value::status::valid_default);
-        }
-
-        void default_update(const std::vector<T>& src) {
-            if (src.size() != this->size())
-                throw std::invalid_argument("Size mismatch got: " + std::to_string(src.size()) + " expected: " + std::to_string(this->size()));
-
-            for (std::size_t i = 0; i < src.size(); i++) {
-                if (!value::has_value(this->value_status[i])) {
-                    this->value_status[i] = value::status::valid_default;
-                    this->data[i] = src[i];
-                }
-            }
-        }
-
-        void update(std::size_t index, T value, value::status status) {
-            this->data[index] = value;
-            this->value_status[index] = status;
-        }
-
-    };
 
 
     template<typename T>
@@ -580,7 +473,7 @@ private:
     void handle_operation(const DeckKeyword& keyword, Box box);
     void handle_region_operation(const DeckKeyword& keyword);
     void handle_COPY(const DeckKeyword& keyword, Box box, bool region);
-    void distribute_toplayer(FieldProps::FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box);
+    void distribute_toplayer(FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box);
     double get_beta(const std::string& func_name, const std::string& target_array, double raw_beta);
     double get_alpha(const std::string& func_name, const std::string& target_array, double raw_alpha);
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -239,7 +239,7 @@ static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {
 }
 
 template <typename T>
-keyword_info<T> global_kw_info(const std::string& name);
+keyword_info<T> global_kw_info(const std::string& name, bool allow_unsupported = false);
 
 }
 
@@ -343,14 +343,16 @@ public:
 
 
     template <typename T>
-    FieldDataManager<T> try_get(const std::string& keyword) {
-        if (!FieldProps::supported<T>(keyword))
+    FieldDataManager<T> try_get(const std::string& keyword,
+                                bool allow_unsupported=false) {
+        if (!allow_unsupported && !FieldProps::supported<T>(keyword))
             return FieldDataManager<T>(keyword, GetStatus::NOT_SUPPPORTED_KEYWORD, nullptr);
 
         const FieldData<T> * field_data;
         bool has0 = this->has<T>(keyword);
 
-        field_data = std::addressof(this->init_get<T>(keyword));
+        field_data = std::addressof(this->init_get<T>(keyword,
+                                                      std::is_same<T,double>::value && allow_unsupported));
         if (field_data->valid())
             return FieldDataManager<T>(keyword, GetStatus::OK, field_data);
 
@@ -463,7 +465,7 @@ private:
     static void apply(ScalarOperation op, std::vector<T>& data, std::vector<value::status>& value_status, T scalar_value, const std::vector<Box::cell_index>& index_list);
 
     template <typename T>
-    FieldData<T>& init_get(const std::string& keyword);
+    FieldData<T>& init_get(const std::string& keyword, bool allow_unsupported = false);
 
     template <typename T>
     FieldData<T>& init_get(const std::string& keyword, const keywords::keyword_info<T>& kw_info);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -42,6 +42,9 @@ class Deck;
 class EclipseGrid;
 class TableManager;
 
+namespace Fieldprops
+{
+
 namespace keywords {
 
 /*
@@ -241,12 +244,14 @@ static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {
 template <typename T>
 keyword_info<T> global_kw_info(const std::string& name, bool allow_unsupported = false);
 
-}
+} // end namespace keywords
+
+} // end namespace FieldProps
 
 class FieldProps {
 public:
 
-
+    using ScalarOperation = Fieldprops::ScalarOperation;
 
     struct MultregpRecord {
         int region_value;
@@ -277,9 +282,10 @@ public:
     struct FieldDataManager {
         const std::string& keyword;
         GetStatus status;
-        const FieldData<T> * data_ptr;
+        using Data = Fieldprops::FieldData<T>;
+        const Data * data_ptr;
 
-        FieldDataManager(const std::string& k, GetStatus s, const FieldData<T> * d) :
+        FieldDataManager(const std::string& k, GetStatus s, const Data * d) :
             keyword(k),
             status(s),
             data_ptr(d)
@@ -311,7 +317,7 @@ public:
             return this->data_ptr->data;
         }
 
-        const FieldData<T>& field_data() const {
+        const Data& field_data() const {
             this->verify_status();
             return *this->data_ptr;
         }
@@ -348,7 +354,7 @@ public:
         if (!allow_unsupported && !FieldProps::supported<T>(keyword))
             return FieldDataManager<T>(keyword, GetStatus::NOT_SUPPPORTED_KEYWORD, nullptr);
 
-        const FieldData<T> * field_data;
+        const Fieldprops::FieldData<T> * field_data;
         bool has0 = this->has<T>(keyword);
 
         field_data = std::addressof(this->init_get<T>(keyword,
@@ -375,7 +381,7 @@ public:
     std::vector<T> get_global(const std::string& keyword) {
         const auto& managed_field_data = this->try_get<T>(keyword);
         const auto& field_data = managed_field_data.field_data();
-        const auto& kw_info = keywords::global_kw_info<T>(keyword);
+        const auto& kw_info = Fieldprops::keywords::global_kw_info<T>(keyword);
         if (kw_info.global)
             return *field_data.global_data;
         else
@@ -395,7 +401,7 @@ public:
                 return field_data.data;
         } else {
             if (global) {
-                const auto& kw_info = keywords::global_kw_info<T>(keyword);
+                const auto& kw_info = Fieldprops::keywords::global_kw_info<T>(keyword);
                 return this->global_copy(this->extract<T>(keyword), kw_info.scalar_init);
             } else
                 return this->extract<T>(keyword);
@@ -459,33 +465,33 @@ private:
     std::vector<T> extract(const std::string& keyword);
 
     template <typename T>
-    void operate(const DeckRecord& record, FieldData<T>& target_data, const FieldData<T>& src_data, const std::vector<Box::cell_index>& index_list);
+    void operate(const DeckRecord& record, Fieldprops::FieldData<T>& target_data, const Fieldprops::FieldData<T>& src_data, const std::vector<Box::cell_index>& index_list);
 
     template <typename T>
     static void apply(ScalarOperation op, std::vector<T>& data, std::vector<value::status>& value_status, T scalar_value, const std::vector<Box::cell_index>& index_list);
 
     template <typename T>
-    FieldData<T>& init_get(const std::string& keyword, bool allow_unsupported = false);
+    Fieldprops::FieldData<T>& init_get(const std::string& keyword, bool allow_unsupported = false);
 
     template <typename T>
-    FieldData<T>& init_get(const std::string& keyword, const keywords::keyword_info<T>& kw_info);
+    Fieldprops::FieldData<T>& init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<T>& kw_info);
 
     std::string region_name(const DeckItem& region_item);
     std::vector<Box::cell_index> region_index( const std::string& region_name, int region_value );
     void handle_operation(const DeckKeyword& keyword, Box box);
     void handle_region_operation(const DeckKeyword& keyword);
     void handle_COPY(const DeckKeyword& keyword, Box box, bool region);
-    void distribute_toplayer(FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box);
+    void distribute_toplayer(Fieldprops::FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box);
     double get_beta(const std::string& func_name, const std::string& target_array, double raw_beta);
     double get_alpha(const std::string& func_name, const std::string& target_array, double raw_alpha);
 
     void handle_keyword(const DeckKeyword& keyword, Box& box);
-    void handle_double_keyword(Section section, const keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const std::string& keyword_name, const Box& box);
-    void handle_double_keyword(Section section, const keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const Box& box);
-    void handle_int_keyword(const keywords::keyword_info<int>& kw_info, const DeckKeyword& keyword, const Box& box);
-    void init_satfunc(const std::string& keyword, FieldData<double>& satfunc);
-    void init_porv(FieldData<double>& porv);
-    void init_tempi(FieldData<double>& tempi);
+    void handle_double_keyword(Section section, const Fieldprops::keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const std::string& keyword_name, const Box& box);
+    void handle_double_keyword(Section section, const Fieldprops::keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const Box& box);
+    void handle_int_keyword(const Fieldprops::keywords::keyword_info<int>& kw_info, const DeckKeyword& keyword, const Box& box);
+    void init_satfunc(const std::string& keyword, Fieldprops::FieldData<double>& satfunc);
+    void init_porv(Fieldprops::FieldData<double>& porv);
+    void init_tempi(Fieldprops::FieldData<double>& tempi);
 
     const UnitSystem unit_system;
     std::size_t nx,ny,nz;
@@ -499,10 +505,10 @@ private:
     const TableManager& tables;
     std::shared_ptr<satfunc::RawTableEndPoints> m_rtep;
     std::vector<MultregpRecord> multregp;
-    std::unordered_map<std::string, FieldData<int>> int_data;
-    std::unordered_map<std::string, FieldData<double>> double_data;
+    std::unordered_map<std::string, Fieldprops::FieldData<int>> int_data;
+    std::unordered_map<std::string, Fieldprops::FieldData<double>> double_data;
 
-    std::unordered_map<std::string, TranCalculator> tran;
+    std::unordered_map<std::string, Fieldprops::TranCalculator> tran;
 };
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -33,6 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
 
 namespace Opm {
 
@@ -240,82 +241,6 @@ template <typename T>
 keyword_info<T> global_kw_info(const std::string& name);
 
 }
-
-enum class ScalarOperation {
-    ADD = 1,
-    EQUAL = 2,
-    MUL = 3,
-    MIN = 4,
-    MAX = 5
-};
-
-
-class TranCalculator {
-public:
-
-    struct TranAction {
-        ScalarOperation op;
-        std::string field;
-    };
-
-
-    TranCalculator(const std::string& name_arg) :
-        m_name(name_arg)
-    {}
-
-    std::string next_name() const {
-        return this->m_name + std::to_string( this->actions.size() );
-    }
-
-    std::vector<TranAction>::const_iterator begin() const {
-        return this->actions.begin();
-    }
-
-    std::vector<TranAction>::const_iterator end() const {
-        return this->actions.end();
-    }
-
-    void add_action(ScalarOperation op, const std::string& field) {
-        this->actions.push_back(TranAction{op, field});
-    }
-
-    std::size_t size() const {
-        return this->actions.size();
-    }
-
-    const std::string& name() const {
-        return this->m_name;
-    }
-
-
-    keywords::keyword_info<double> make_kw_info(ScalarOperation op) {
-        keywords::keyword_info<double> kw_info;
-        switch (op) {
-        case ScalarOperation::MUL:
-            kw_info.init(1);
-            break;
-        case ScalarOperation::ADD:
-            kw_info.init(0);
-            break;
-        case ScalarOperation::MAX:
-            kw_info.init(std::numeric_limits<double>::min());
-            break;
-        case ScalarOperation::MIN:
-            kw_info.init(std::numeric_limits<double>::max());
-            break;
-        default:
-            break;
-        }
-        return kw_info;
-    }
-
-private:
-    std::string m_name;
-    std::vector<TranAction> actions;
-};
-
-
-
 
 class FieldProps {
 public:

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -32,6 +32,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
 
 namespace Opm {
 
@@ -80,42 +81,6 @@ namespace keywords {
   The operations which are not properly implemented will be intercepted and a
   std::logic_error() exception will be thrown.
 */
-
-
-
-template <typename T>
-struct keyword_info {
-    std::optional<std::string> unit = std::nullopt;
-    std::optional<T> scalar_init = std::nullopt;
-    bool multiplier = false;
-    bool top = false;
-    bool global = false;
-
-    keyword_info<T>& init(T init_value) {
-        this->scalar_init = init_value;
-        return *this;
-    }
-
-    keyword_info<T>& unit_string(const std::string& unit_string) {
-        this->unit = unit_string;
-        return *this;
-    }
-
-    keyword_info<T>& distribute_top(bool dtop) {
-        this->top = dtop;
-        return *this;
-    }
-
-    keyword_info<T>& mult(bool m) {
-        this->multiplier = m;
-        return *this;
-    }
-
-    keyword_info<T>& global_kw(bool g) {
-        this->global = g;
-        return *this;
-    }
-};
 
 
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -656,7 +656,8 @@ public:
     }
 
     void apply_tran(const std::string& keyword, std::vector<double>& data);
-
+    std::vector<char> serialize_tran() const;
+    void deserialize_tran(const std::vector<char>& buffer);
 private:
     void scanGRIDSection(const GRIDSection& grid_section);
     void scanEDITSection(const EDITSection& edit_section);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -55,7 +55,7 @@ const std::vector<T>* FieldPropsManager::try_get(const std::string& keyword) con
     return nullptr;
 }
 
-const FieldData<int>&
+const Fieldprops::FieldData<int>&
 FieldPropsManager::get_int_field_data(const std::string& keyword) const
 {
     const auto& data = this->fp->try_get<int>(keyword);
@@ -64,7 +64,7 @@ FieldPropsManager::get_int_field_data(const std::string& keyword) const
     return data.field_data();
 }
 
-const FieldData<double>&
+const Fieldprops::FieldData<double>&
 FieldPropsManager::get_double_field_data(const std::string& keyword,
                                          bool allow_unsupported) const
 {
@@ -145,7 +145,7 @@ bool FieldPropsManager::tran_active(const std::string& keyword) const {
 }
 
 template<class MapType>
-void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
+void apply_tran(const std::unordered_map<std::string, Fieldprops::TranCalculator>& tran,
                 const MapType& double_data,
                 std::size_t active_size,
                 const std::string& keyword, std::vector<double>& data)
@@ -160,23 +160,23 @@ void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
                 continue;
 
             switch (action.op) {
-            case ScalarOperation::EQUAL:
+            case Fieldprops::ScalarOperation::EQUAL:
                 data[index] = action_data.data[index];
                 break;
 
-            case ScalarOperation::MUL:
+            case Fieldprops::ScalarOperation::MUL:
                 data[index] *= action_data.data[index];
                 break;
 
-            case ScalarOperation::ADD:
+            case Fieldprops::ScalarOperation::ADD:
                 data[index] += action_data.data[index];
                 break;
 
-            case ScalarOperation::MAX:
+            case Fieldprops::ScalarOperation::MAX:
                 data[index] = std::min(action_data.data[index], data[index]);
                 break;
 
-            case ScalarOperation::MIN:
+            case Fieldprops::ScalarOperation::MIN:
                 data[index] = std::max(action_data.data[index], data[index]);
                 break;
 
@@ -187,17 +187,17 @@ void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
     }
 }
 
-void deserialize_tran(std::unordered_map<std::string, TranCalculator>& tran, const std::vector<char>& buffer) {
+void deserialize_tran(std::unordered_map<std::string, Fieldprops::TranCalculator>& tran, const std::vector<char>& buffer) {
     tran.clear();
 
     Serializer ser(buffer);
     std::size_t size = ser.get<std::size_t>();
     for (std::size_t calc_index = 0; calc_index < size; calc_index++) {
         std::string calc_name = ser.get<std::string>();
-        TranCalculator calc(calc_name);
+        Fieldprops::TranCalculator calc(calc_name);
         std::size_t calc_size = ser.get<std::size_t>();
         for (std::size_t action_index = 0; action_index < calc_size; action_index++) {
-            auto op = static_cast<ScalarOperation>(ser.get<int>());
+            auto op = static_cast<Fieldprops::ScalarOperation>(ser.get<int>());
             auto field = ser.get<std::string>();
 
             calc.add_action(op, field);
@@ -208,13 +208,13 @@ void deserialize_tran(std::unordered_map<std::string, TranCalculator>& tran, con
 
 
 template
-void apply_tran(const std::unordered_map<std::string, TranCalculator>&,
-                const std::unordered_map<std::string, FieldData<double>>&,
+void apply_tran(const std::unordered_map<std::string, Fieldprops::TranCalculator>&,
+                const std::unordered_map<std::string, Fieldprops::FieldData<double>>&,
                 std::size_t, const std::string&, std::vector<double>&);
 
 template
-void apply_tran(const std::unordered_map<std::string, TranCalculator>&,
-                const std::map<std::string, FieldData<double>>&,
+void apply_tran(const std::unordered_map<std::string, Fieldprops::TranCalculator>&,
+                const std::map<std::string, Fieldprops::FieldData<double>>&,
                 std::size_t, const std::string&, std::vector<double>&);
 
 template bool FieldPropsManager::supported<int>(const std::string&);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -121,6 +121,10 @@ void FieldPropsManager::deserialize_tran(const std::vector<char>& buffer) {
     this->fp->deserialize_tran(buffer);
 }
 
+bool FieldPropsManager::tran_active(const std::string& keyword) const {
+    return this->fp->tran_active(keyword);
+}
+
 
 template bool FieldPropsManager::supported<int>(const std::string&);
 template bool FieldPropsManager::supported<double>(const std::string&);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -113,6 +113,14 @@ void FieldPropsManager::apply_tran(const std::string& keyword, std::vector<doubl
     this->fp->apply_tran(keyword, data);
 }
 
+std::vector<char> FieldPropsManager::serialize_tran() const {
+    return this->fp->serialize_tran();
+}
+
+void FieldPropsManager::deserialize_tran(const std::vector<char>& buffer) {
+    this->fp->deserialize_tran(buffer);
+}
+
 
 template bool FieldPropsManager::supported<int>(const std::string&);
 template bool FieldPropsManager::supported<double>(const std::string&);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -167,6 +167,10 @@ void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
                 data[index] *= action_data.data[index];
                 break;
 
+            case ScalarOperation::ADD:
+                data[index] += action_data.data[index];
+                break;
+
             case ScalarOperation::MAX:
                 data[index] = std::min(action_data.data[index], data[index]);
                 break;
@@ -174,6 +178,7 @@ void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
             case ScalarOperation::MIN:
                 data[index] = std::max(action_data.data[index], data[index]);
                 break;
+
             default:
                 throw std::logic_error("Unhandled value in switch");
             }

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -109,6 +109,11 @@ std::size_t FieldPropsManager::active_size() const {
     return this->fp->active_size;
 }
 
+void FieldPropsManager::apply_tran(const std::string& keyword, std::vector<double>& data) const {
+    this->fp->apply_tran(keyword, data);
+}
+
+
 template bool FieldPropsManager::supported<int>(const std::string&);
 template bool FieldPropsManager::supported<double>(const std::string&);
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -54,6 +54,23 @@ const std::vector<T>* FieldPropsManager::try_get(const std::string& keyword) con
     return nullptr;
 }
 
+const FieldData<int>&
+FieldPropsManager::get_int_field_data(const std::string& keyword) const
+{
+    const auto& data = this->fp->try_get<int>(keyword);
+    if (!data.valid())
+        throw std::out_of_range("Invalid field data requested.");
+    return data.field_data();
+}
+
+const FieldData<double>&
+FieldPropsManager::get_double_field_data(const std::string& keyword) const
+{
+    const auto& data = this->fp->try_get<double>(keyword);
+    if (!data.valid())
+        throw std::out_of_range("Invalid field data requested.");
+    return data.field_data();
+}
 
 template <typename T>
 std::vector<T> FieldPropsManager::get_global(const std::string& keyword) const {

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -171,6 +171,9 @@ void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
                 data[index] = std::min(action_data.data[index], data[index]);
                 break;
 
+            case ScalarOperation::MIN:
+                data[index] = std::max(action_data.data[index], data[index]);
+                break;
             default:
                 throw std::logic_error("Unhandled value in switch");
             }

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -65,9 +65,10 @@ FieldPropsManager::get_int_field_data(const std::string& keyword) const
 }
 
 const FieldData<double>&
-FieldPropsManager::get_double_field_data(const std::string& keyword) const
+FieldPropsManager::get_double_field_data(const std::string& keyword,
+                                         bool allow_unsupported) const
 {
-    const auto& data = this->fp->try_get<double>(keyword);
+    const auto& data = this->fp->try_get<double>(keyword, allow_unsupported);
     if (!data.valid())
         throw std::out_of_range("Invalid field data requested.");
     return data.field_data();

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -168,7 +168,7 @@ void apply_tran(const std::unordered_map<std::string, TranCalculator>& tran,
                 break;
 
             case ScalarOperation::MAX:
-                data[index] = std::max(action_data.data[index], data[index]);
+                data[index] = std::min(action_data.data[index], data[index]);
                 break;
 
             default:

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1841,4 +1841,6 @@ MAXVALUE
     for (std::size_t i=0; i < trany.size(); i++)
         BOOST_CHECK_EQUAL(trany[i], to_si(2.0));
 
+    auto buffer = fpm.serialize_tran();
+    fpm.deserialize_tran(buffer);
 }

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -208,7 +208,7 @@ ADDREG
 
 
 BOOST_AUTO_TEST_CASE(ASSIGN) {
-    FieldData<int> data({}, 100, 0);
+    Fieldprops::FieldData<int> data({}, 100, 0);
     std::vector<int> wrong_size(50);
 
     BOOST_CHECK_THROW( data.default_assign( wrong_size ), std::invalid_argument );

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1825,6 +1825,7 @@ MAXVALUE
     BOOST_CHECK(!fpm.has_double("TRANX"));
 
     BOOST_CHECK_THROW(fpm.apply_tran("TRANA", tranx), std::out_of_range);
+    BOOST_CHECK_THROW(fpm.tran_active("TRANA"), std::out_of_range);
 
     fpm.apply_tran("TRANX", tranx);
     fpm.apply_tran("TRANY", trany);
@@ -1843,4 +1844,6 @@ MAXVALUE
 
     auto buffer = fpm.serialize_tran();
     fpm.deserialize_tran(buffer);
+
+    BOOST_CHECK(fpm.tran_active("TRANX"));
 }

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1843,7 +1843,7 @@ MAXVALUE
         BOOST_CHECK_EQUAL(trany[i], to_si(2.0));
 
     for (std::size_t i=0; i < 50; i++)
-        BOOST_CHECK(tranz[i]>=to_si(0));
+        BOOST_CHECK(tranz[i]<=to_si(0));
 
     for (std::size_t i=50; i < tranz.size(); i++)
         BOOST_CHECK_EQUAL(tranz[i], to_si(1.0));

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1835,15 +1835,22 @@ MAXVALUE
     for (std::size_t i=0; i < 50; i++)
         BOOST_CHECK_EQUAL(tranx[i], to_si(0.20));
 
-    for (std::size_t i=100; i < tranx.size(); i++)
+    for (std::size_t i=50; i < tranx.size(); i++)
         BOOST_CHECK_EQUAL(tranx[i], to_si(0.10));
 
     BOOST_CHECK_EQUAL(trany[0], to_si(2.0));
     for (std::size_t i=0; i < trany.size(); i++)
         BOOST_CHECK_EQUAL(trany[i], to_si(2.0));
 
+    for (std::size_t i=0; i < 50; i++)
+        BOOST_CHECK(tranz[i]>=to_si(0));
+
+    for (std::size_t i=50; i < tranz.size(); i++)
+        BOOST_CHECK_EQUAL(tranz[i], to_si(1.0));
     auto buffer = fpm.serialize_tran();
     fpm.deserialize_tran(buffer);
 
     BOOST_CHECK(fpm.tran_active("TRANX"));
+    BOOST_CHECK(fpm.tran_active("TRANY"));
+    BOOST_CHECK(fpm.tran_active("TRANZ"));
 }

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1805,12 +1805,18 @@ MULTIPLY
   TRANY  2.0 /
 /
 
+ADD
+  TRANY 3 1 10 1 10 2 2 /
+/
+
 MAXVALUE
   TRANZ 0 1 10 1 10 1 1 /
 /
+
 MINVALUE
   TRANZ 3 1 10 1 10 2 2 /
 /
+
 )";
     UnitSystem unit_system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
     auto to_si = [&unit_system](double raw_value) { return unit_system.to_si(UnitSystem::measure::transmissibility, raw_value); };
@@ -1840,7 +1846,14 @@ MINVALUE
         BOOST_CHECK_EQUAL(tranx[i], to_si(0.10));
 
     BOOST_CHECK_EQUAL(trany[0], to_si(2.0));
-    for (std::size_t i=0; i < trany.size(); i++)
+
+    for (std::size_t i=0; i < 50; i++)
+        BOOST_CHECK_EQUAL(trany[i], to_si(2.0));
+
+    for (std::size_t i=50; i < 100; i++)
+        BOOST_CHECK_EQUAL(trany[i], to_si(5.0));
+
+    for (std::size_t i=100; i < trany.size(); i++)
         BOOST_CHECK_EQUAL(trany[i], to_si(2.0));
 
     for (std::size_t i=0; i < 50; i++)

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1825,7 +1825,7 @@ MAXVALUE
     BOOST_CHECK(!fpm.has_double("TRANX"));
 
     BOOST_CHECK_THROW(fpm.apply_tran("TRANA", tranx), std::out_of_range);
-    BOOST_CHECK_THROW(fpm.tran_active("TRANA"), std::out_of_range);
+    BOOST_CHECK(!fpm.tran_active("TRANA"));
 
     fpm.apply_tran("TRANX", tranx);
     fpm.apply_tran("TRANY", trany);

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -208,7 +208,7 @@ ADDREG
 
 
 BOOST_AUTO_TEST_CASE(ASSIGN) {
-    FieldProps::FieldData<int> data({}, 100, 0);
+    FieldData<int> data({}, 100, 0);
     std::vector<int> wrong_size(50);
 
     BOOST_CHECK_THROW( data.default_assign( wrong_size ), std::invalid_argument );

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1808,8 +1808,9 @@ MULTIPLY
 MAXVALUE
   TRANZ 0 1 10 1 10 1 1 /
 /
-
-
+MINVALUE
+  TRANZ 3 1 10 1 10 2 2 /
+/
 )";
     UnitSystem unit_system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
     auto to_si = [&unit_system](double raw_value) { return unit_system.to_si(UnitSystem::measure::transmissibility, raw_value); };
@@ -1845,7 +1846,10 @@ MAXVALUE
     for (std::size_t i=0; i < 50; i++)
         BOOST_CHECK(tranz[i]<=to_si(0));
 
-    for (std::size_t i=50; i < tranz.size(); i++)
+    for (std::size_t i=50; i < 10; i++)
+        BOOST_CHECK(tranz[i]>=to_si(3));
+
+    for (std::size_t i=100; i < tranz.size(); i++)
         BOOST_CHECK_EQUAL(tranz[i], to_si(1.0));
     auto buffer = fpm.serialize_tran();
     fpm.deserialize_tran(buffer);


### PR DESCRIPTION
Previously modifications were applied directly to the field properties. Unfortunately, for unset TRANX this resulted in modifying 1.0 even if the simulator is calculating transmissibilities itself. This was one of the reasons why we got wrong results (others are in the simulator code).
    
Now these operations recorded in a calculator which can later be applied to compressed arrays using apply_tran.

Based upon #1919. I needed to reorganize quite some stuff to support parallel in opm-simulators. Among other things, FieldData is now accessible from there (previously that was a nested class of FieldProps).

There will come a downstream PR in opm-simulators once my code is cleaned up and test. 