### PR TITLE
Don't Write RSM File for Substeps

### DIFF
--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -217,7 +217,7 @@ void EclipseIO::writeTimeStep(const Action::State& action_state,
 
     bool final_step { report_step == static_cast<int>(this->impl->schedule.size()) - 1 };
 
-    if (final_step && this->impl->summaryConfig.createRunSummary()) {
+    if (final_step && !isSubstep && this->impl->summaryConfig.createRunSummary()) {
         Opm::filesystem::path outputDir { this->impl->outputDir } ;
         Opm::filesystem::path outputFile { outputDir / this->impl->baseName } ;
         EclIO::ESmry(outputFile).write_rsm_file();


### PR DESCRIPTION
If the last report step happens to be split into multiple substeps (e.g., convergence problems or TUNING settings &c), then we will write the RSM file for each substep which will slow down the process.  This commit explicitly ensures that we don't output the RSM file unless it is the last substep of the final report step.