### PR TITLE
fix packaging files for libfmt

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: build-essential, debhelper (>= 9),
                ghostscript, libboost-system-dev, libboost-test-dev,
                zlib1g-dev, libpython3-dev, python3-numpy, python3-distutils,
                python3-setuptools, python3-setuptools-scm, python3-pytest-runner,
-               python3-decorator libfmt-dev
+               python3-decorator, libfmt-dev
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://opm-project.org

--- a/redhat/opm-common.spec
+++ b/redhat/opm-common.spec
@@ -12,7 +12,7 @@ License:        GPL-3.0
 Group:          Development/Libraries/C and C++
 Url:            http://www.opm-project.org/
 Source0:        https://github.com/OPM/%{name}/archive/release/%{version}/%{tag}.tar.gz#/%{name}-%{version}.tar.gz
-BuildRequires:  git doxygen bc openmpi-devel mpich-devel format-devel
+BuildRequires:  git doxygen bc openmpi-devel mpich-devel fmt-devel
 %{?!el8:BuildRequires: devtoolset-8-toolchain}
 %{?el8:BuildRequires: boost-devel}
 %{?!el8:BuildRequires: boost148-devel}


### PR DESCRIPTION
- missing comma in debian control
- wrong name for redhat