### PR TITLE
Support Non-Monotonic Saturated Oil FVF in PVTO

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp
@@ -17,9 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef OPM_PARSER_PVTO_TABLE_HPP
-#define	OPM_PARSER_PVTO_TABLE_HPP
+#define OPM_PARSER_PVTO_TABLE_HPP
 
 #include <opm/parser/eclipse/EclipseState/Tables/PvtxTable.hpp>
+
+#include <array>
+#include <cstddef>
+#include <vector>
 
 namespace Opm {
 
@@ -27,12 +31,20 @@ namespace Opm {
 
     class PvtoTable : public PvtxTable {
     public:
+        struct FlippedFVF {
+            std::size_t i;
+            std::array<double, std::size_t{2}> Rs;
+            std::array<double, std::size_t{2}> Bo;
+        };
+
         PvtoTable() = default;
         PvtoTable(const DeckKeyword& keyword, size_t tableIdx);
 
         static PvtoTable serializeObject();
 
         bool operator==(const PvtoTable& data) const;
+
+        std::vector<FlippedFVF> nonMonotonicSaturatedFVF() const;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtxTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtxTable.hpp
@@ -17,14 +17,18 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef OPM_PARSER_PVTX_TABLE_HPP
-#define	OPM_PARSER_PVTX_TABLE_HPP
-
-#include <vector>
+#define OPM_PARSER_PVTX_TABLE_HPP
 
 #include <opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableColumn.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableSchema.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <stddef.h>
 
 /*
   This class is a common base class for the PVTG and PVTO tables. The
@@ -47,7 +51,7 @@
                                                    |
  [ 28.19  {  70.00    1.12522     1.066 } ]        |
           {  95.00    1.12047     1.124 }          |
-          { 120.00    1.11604     1.182 }          |-- Satnum region 1
+          { 120.00    1.11604     1.182 }          |-- Pvtnum region 1
           { 145.00    1.11191     1.241 }          |
           { 170.00    1.10804     1.300 }/         |
                                                    |
@@ -59,7 +63,7 @@
 /                                                  /
   404.60    594.29    1.97527     0.21564          \
             619.29    1.96301     0.21981          |
-            644.29    1.95143     0.22393          |-- Satnum region 2
+            644.29    1.95143     0.22393          |-- Pvtnum region 2
             669.29    1.94046     0.22801          |
             694.29    1.93005     0.23204 /        |
 /                                                  /
@@ -67,7 +71,7 @@
             619.29    1.96301     0.21981          |
             644.29    1.95143     0.22393          |
             669.29    1.94046     0.22801          |
-            694.29    1.93005     0.23204 /        |-- Satnum region 3
+            694.29    1.93005     0.23204 /        |-- Pvtnum region 3
   404.60    594.29    1.97527     0.21564          |
             619.29    1.96301     0.21981          |
             644.29    1.95143     0.22393          |
@@ -76,9 +80,9 @@
 /
 
 
-In satnum region1 the saturated records are marked with [ ... ], and
+In pvtnum region1 the saturated records are marked with [ ... ], and
 the corresponding undersaturated tables are marked with { ... }. So
-for satnum region1 the table of saturated properties looks like:
+for pvtnum region1 the table of saturated properties looks like:
 
    RSO       PRESSURE    B-OIL       VISCOSITY
    20.59     50.00       1.10615     1.180
@@ -102,10 +106,9 @@ undersaturated table looks like:
 The first row actually corresponds to saturated values.
 */
 
-
  namespace Opm {
 
-     class DeckKeyword;
+    class DeckKeyword;
 
     class PvtxTable {
     public:
@@ -133,7 +136,7 @@ The first row actually corresponds to saturated values.
 
         bool operator==(const PvtxTable& data) const;
 
-        template<class Serializer>
+        template <class Serializer>
         void serializeOp(Serializer& serializer)
         {
             m_outerColumnSchema.serializeOp(serializer);
@@ -153,7 +156,6 @@ The first row actually corresponds to saturated values.
         std::vector< SimpleTable > m_underSaturatedTables;
         SimpleTable m_saturatedTable;
     };
-
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -491,6 +491,8 @@ namespace Opm {
                 tableVector.emplace_back( tableKeyword , tableIdx );
         }
 
+        void checkPVTOMonotonicity(const Deck& deck) const;
+
         std::map<std::string , TableContainer> m_simpleTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtgwTable> m_pvtgwTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -493,6 +493,10 @@ namespace Opm {
 
         void checkPVTOMonotonicity(const Deck& deck) const;
 
+        void logPVTOMonotonicityFailure(const Deck&                               deck,
+                                        const std::size_t                         tableID,
+                                        const std::vector<PvtoTable::FlippedFVF>& flipped_Bo) const;
+
         std::map<std::string , TableContainer> m_simpleTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtgwTable> m_pvtgwTables;

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -174,7 +174,7 @@ PvtoTable::PvtoTable( const DeckKeyword& keyword, size_t tableIdx) :
 
         m_saturatedSchema.addColumn( ColumnSchema( "RS" , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE ));
         m_saturatedSchema.addColumn( ColumnSchema( "P"  , Table::RANDOM , Table::DEFAULT_NONE ));
-        m_saturatedSchema.addColumn( ColumnSchema( "BO" , Table::STRICTLY_INCREASING, Table::DEFAULT_LINEAR ));
+        m_saturatedSchema.addColumn( ColumnSchema( "BO" , Table::RANDOM , Table::DEFAULT_LINEAR ));
         m_saturatedSchema.addColumn( ColumnSchema( "MU" , Table::RANDOM , Table::DEFAULT_LINEAR ));
 
         PvtxTable::init(keyword , tableIdx);

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -191,6 +191,30 @@ bool PvtoTable::operator==(const PvtoTable& data) const {
     return static_cast<const PvtxTable&>(*this) == static_cast<const PvtxTable&>(data);
 }
 
+std::vector<PvtoTable::FlippedFVF>
+PvtoTable::nonMonotonicSaturatedFVF() const
+{
+    auto nonmonoFVF = std::vector<FlippedFVF>{};
+
+    const auto& Rs = this->m_saturatedTable.getColumn("RS");
+    const auto& Bo = this->m_saturatedTable.getColumn("BO");
+
+    const auto nrec = Rs.size();
+    for (auto rec = 1 + 0*nrec; rec < nrec; ++rec) {
+        if (Bo[rec] > Bo[rec - 1]) {
+            // Normal case, Bo increases monotonically.
+            continue;
+        }
+
+        auto& flip = nonmonoFVF.emplace_back();
+
+        flip.i     = rec;
+        flip.Rs[0] = Rs[rec - 1];   flip.Rs[1] = Rs[rec];
+        flip.Bo[0] = Bo[rec - 1];   flip.Bo[1] = Bo[rec];
+    }
+
+    return nonmonoFVF;
+}
 
 SpecheatTable::SpecheatTable(const DeckItem& item)
 {
@@ -791,7 +815,7 @@ const TableColumn& WatvisctTable::getTemperatureColumn() const {
 
 const TableColumn& WatvisctTable::getWaterViscosityColumn() const {
     return SimpleTable::getColumn(1);
-} 
+}
 
 GasvisctTable::GasvisctTable( const Deck& deck, const DeckItem& deckItem ) {
     int numComponents = deck.getKeyword<ParserKeywords::COMPS>().getRecord(0).getItem(0).get< int >(0);


### PR DESCRIPTION
This PR relaxes the requirement that the saturated formation volume factor for oil ("Bo") be strictly increasing as a function of the dissolved gas/oil ratio ("Rs").  In a way, we partially revert commit dbf2a4c425af69804f552bab836ca1a3e838a2bd (PR #342).  We have seen cases for which the strictly increasing criterion fails to hold but which nevertheless run, at least if the monotonicity requirement only breaks for very high values of Rs.

We therefore introduce a special purpose system for detecting and reporting this situation.  In this case, output such as
```
Warning: Non-Monotonic Oil Formation Volume Factor Detected
  * PVTO [PVTNUM = 1]
  Record  9: FVF 1.23 at RS 123 is not greater than FVF 2.34 at RS 120
  Record 10: FVF 1.22 at RS 125 is not greater than FVF 1.23 at RS 123
  Record 11: FVF 1.21 at RS 125 is not greater than FVF 1.22 at RS 125
```
will be printed to the console and the `.PRT` file,  but the simulation will continue.

I have elected to make this a very narrow feature for the time being, but we can extend or rework this system if it proves useful.