### PR TITLE
Add OpmLog overload which accepts a list of strings

### DIFF
--- a/opm/common/OpmLog/CounterLog.hpp
+++ b/opm/common/OpmLog/CounterLog.hpp
@@ -19,9 +19,10 @@
 #ifndef OPM_COUNTERLOG_HPP
 #define OPM_COUNTERLOG_HPP
 
-#include <string>
-#include <memory>
 #include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include <opm/common/OpmLog/LogBackend.hpp>
 
@@ -43,6 +44,9 @@ namespace Opm {
     protected:
         void addMessageUnconditionally(int64_t messageFlag,
                                        const std::string& message) override;
+
+        void addMessageUnconditionally(int64_t messageFlag,
+                                       std::vector<std::string> message_list) override;
     private:
         std::map<int64_t , size_t> m_count;
     };

--- a/opm/common/OpmLog/EclipsePRTLog.hpp
+++ b/opm/common/OpmLog/EclipsePRTLog.hpp
@@ -55,6 +55,7 @@ public:
 
 protected:
     void addMessageUnconditionally(int64_t messageType, const std::string& message) override;
+    void addMessageUnconditionally(int64_t messageType, std::vector<std::string> message_list) override;
 
 private:
     std::map<int64_t, size_t> m_count;

--- a/opm/common/OpmLog/LogBackend.hpp
+++ b/opm/common/OpmLog/LogBackend.hpp
@@ -55,6 +55,15 @@ namespace Opm
                               const std::string& messageTag,
                               const std::string& message);
 
+        /// Add a multiline message to the backend if accepted by the message limiter.
+        void addMessage(int64_t messageFlag, const std::vector<std::string>& message_list);
+
+        /// Add a tagged multiline message to the backend if accepted by the message limiter.
+        void addTaggedMessage(int64_t messageFlag,
+                              const std::string& messageTag,
+                              const std::vector<std::string>& message_list);
+
+        /// The message mask types are specified in the
         /// The message mask types are specified in the
         /// Opm::Log::MessageType namespace, in file LogUtils.hpp.
         int64_t getMask() const;
@@ -67,13 +76,18 @@ namespace Opm
         virtual void addMessageUnconditionally(int64_t messageFlag,
                                                const std::string& message) = 0;
 
+        virtual void addMessageUnconditionally(int64_t messageFlag,
+                                               std::vector<std::string> message_list) = 0;
+
         /// Return decorated version of message depending on configureDecoration() arguments.
         std::string formatMessage(int64_t messageFlag, const std::string& message);
+        void formatMessage(int64_t messageFlag, std::vector<std::string>& message_list) const;
 
     private:
         /// Return true if all bits of messageFlag are also set in our mask,
         /// and the message limiter returns a PrintMessage response.
         bool includeMessage(int64_t messageFlag, const std::string& messageTag);
+        bool includeMessage(int64_t messageFlag) const;
 
         int64_t m_mask;
         std::shared_ptr<MessageFormatterInterface> m_formatter;

--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -29,13 +29,14 @@ namespace Opm {
 
 namespace Log {
     namespace MessageType {
-        const int64_t Debug     =  1;   /* Excessive information */
-        const int64_t Note      =  2;  /* Information that should only go into print file.*/
-        const int64_t Info      =  4;   /* Normal status information */
-        const int64_t Warning   =  8;   /* Input anomaly - possible error */
-        const int64_t Error     = 16;   /* Error in the input data - should probably exit. */
-        const int64_t Problem   = 32;   /* Calculation problems - e.g. convergence failure. */
-        const int64_t Bug       = 64;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
+        const int64_t Continuation =  0;   /* Dummy message type only used for formatting multiline messages. */
+        const int64_t Debug        =  1;   /* Excessive information */
+        const int64_t Note         =  2;   /* Information that should only go into print file.*/
+        const int64_t Info         =  4;   /* Normal status information */
+        const int64_t Warning      =  8;   /* Input anomaly - possible error */
+        const int64_t Error        = 16;   /* Error in the input data - should probably exit. */
+        const int64_t Problem      = 32;   /* Calculation problems - e.g. convergence failure. */
+        const int64_t Bug          = 64;   /* An inconsistent state has been encountered in the simulator - should probably exit. */
     }
 
     const int64_t DefaultMessageTypes = MessageType::Debug + MessageType::Note + MessageType::Info + MessageType::Warning + MessageType::Error + MessageType::Problem + MessageType::Bug;

--- a/opm/common/OpmLog/Logger.hpp
+++ b/opm/common/OpmLog/Logger.hpp
@@ -25,6 +25,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace Opm {
 
@@ -36,6 +37,8 @@ public:
     Logger();
     void addMessage(int64_t messageType , const std::string& message) const;
     void addTaggedMessage(int64_t messageType, const std::string& tag, const std::string& message) const;
+    void addMessage(int64_t messageType , const std::vector<std::string>& message_list) const;
+    void addTaggedMessage(int64_t messageType, const std::string& tag, const std::vector<std::string>& message_list) const;
 
     static bool enabledDefaultMessageType( int64_t messageType);
     bool enabledMessageType( int64_t messageType) const;

--- a/opm/common/OpmLog/MessageFormatter.hpp
+++ b/opm/common/OpmLog/MessageFormatter.hpp
@@ -20,8 +20,10 @@
 #ifndef OPM_MESSAGEFORMATTER_HEADER_INCLUDED
 #define OPM_MESSAGEFORMATTER_HEADER_INCLUDED
 
-#include <opm/common/OpmLog/LogUtil.hpp>
 #include <string>
+#include <vector>
+
+#include <opm/common/OpmLog/LogUtil.hpp>
 
 namespace Opm
 {
@@ -37,6 +39,7 @@ namespace Opm
         /// input string, the formatting applied depending on the
         /// message_flag.
         virtual std::string format(const int64_t message_flag, const std::string& message) = 0;
+        virtual void format(const int64_t message_flag, std::vector<std::string>& message_list) = 0;
     };
 
 
@@ -83,6 +86,22 @@ namespace Opm
                 msg = Log::colorCodeMessage(message_flag, msg);
             }
             return msg;
+        }
+
+        virtual void format(const int64_t message_flag, std::vector<std::string>& message_list) override
+        {
+            for (std::size_t index = 0; index < message_list.size(); index++) {
+                auto& msg = message_list[index];
+                if (message_flag & this->prefix_flag_) {
+                    if (index == 0)
+                        msg = Log::prefixMessage(message_flag, msg);
+                    else
+                        msg = Log::prefixMessage(Log::MessageType::Continuation, msg);
+                }
+
+                if (this->use_color_coding_)
+                    msg = Log::colorCodeMessage(message_flag, msg);
+            }
         }
     private:
         bool use_color_coding_ = false;

--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -20,8 +20,9 @@
 #ifndef OPMLOG_HPP
 #define OPMLOG_HPP
 
-#include <memory>
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 #include <opm/common/OpmLog/Logger.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
@@ -40,7 +41,9 @@ class OpmLog {
 
 public:
     static void addMessage(int64_t messageFlag , const std::string& message);
+    static void addMessage(int64_t messageFlag , const std::vector<std::string>& message_list);
     static void addTaggedMessage(int64_t messageFlag, const std::string& tag, const std::string& message);
+    static void addTaggedMessage(int64_t messageFlag, const std::string& tag, const std::vector<std::string>& message_list);
 
     static void info(const std::string& message);
     static void warning(const std::string& message);
@@ -50,6 +53,14 @@ public:
     static void debug(const std::string& message);
     static void note(const std::string& message);
 
+    static void info(const std::vector<std::string>& message_list);
+    static void warning(const std::vector<std::string>& message_list);
+    static void error(const std::vector<std::string>& message_list);
+    static void problem(const std::vector<std::string>& message_list);
+    static void bug(const std::vector<std::string>& message_list);
+    static void debug(const std::vector<std::string>& message_list);
+    static void note(const std::vector<std::string>& message_list);
+
     static void info(const std::string& tag, const std::string& message);
     static void warning(const std::string& tag, const std::string& message);
     static void error(const std::string& tag, const std::string& message);
@@ -57,6 +68,14 @@ public:
     static void bug(const std::string& tag, const std::string& message);
     static void debug(const std::string& tag, const std::string& message);
     static void note(const std::string& tag, const std::string& message);
+
+    static void info(const std::string& tag, const std::vector<std::string>& message_list);
+    static void warning(const std::string& tag, const std::vector<std::string>& message_list);
+    static void error(const std::string& tag, const std::vector<std::string>& message_list);
+    static void problem(const std::string& tag, const std::vector<std::string>& message_list);
+    static void bug(const std::string& tag, const std::vector<std::string>& message_list);
+    static void debug(const std::string& tag, const std::vector<std::string>& message_list);
+    static void note(const std::string& tag, const std::vector<std::string>& message_list);
 
     static bool hasBackend( const std::string& backendName );
     static void addBackend(const std::string& name , std::shared_ptr<LogBackend> backend);

--- a/opm/common/OpmLog/StreamLog.hpp
+++ b/opm/common/OpmLog/StreamLog.hpp
@@ -20,9 +20,10 @@
 #ifndef STREAMLOG_H
 #define STREAMLOG_H
 
+#include <cstdint>
 #include <fstream>
 #include <iostream>
-#include <cstdint>
+#include <vector>
 
 #include <opm/common/OpmLog/LogBackend.hpp>
 
@@ -37,6 +38,7 @@ public:
 
 protected:
     virtual void addMessageUnconditionally(int64_t messageType, const std::string& message) override;
+    virtual void addMessageUnconditionally(int64_t messageType, std::vector<std::string> message_list) override;
 
 private:
     void close();

--- a/src/opm/common/OpmLog/CounterLog.cpp
+++ b/src/opm/common/OpmLog/CounterLog.cpp
@@ -52,6 +52,10 @@ void CounterLog::addMessageUnconditionally(int64_t messageType, const std::strin
     m_count[messageType]++;
 }
 
+void CounterLog::addMessageUnconditionally(int64_t messageType, std::vector<std::string> ) {
+    m_count[messageType]++;
+}
+
 
 void CounterLog::clear()
 {

--- a/src/opm/common/OpmLog/EclipsePRTLog.cpp
+++ b/src/opm/common/OpmLog/EclipsePRTLog.cpp
@@ -29,6 +29,11 @@ namespace Opm {
         m_count[messageType]++;
     }
 
+    void EclipsePRTLog::addMessageUnconditionally(int64_t messageType, std::vector<std::string> message_list)
+    {
+        StreamLog::addMessageUnconditionally(messageType, message_list);
+        m_count[messageType]++;
+    }
 
     size_t EclipsePRTLog::numMessages(int64_t messageType) const 
     {

--- a/src/opm/common/OpmLog/LogUtil.cpp
+++ b/src/opm/common/OpmLog/LogUtil.cpp
@@ -26,6 +26,18 @@ namespace Opm {
 
 namespace Log {
 
+namespace {
+
+static const std::string debugPrefix   = std::string{"Debug  : "};
+static const std::string notePrefix    = std::string{"Note   : "};
+static const std::string infoPrefix    = std::string{"Info   : "};
+static const std::string warningPrefix = std::string{"\nWarning: "};
+static const std::string errorPrefix   = std::string{"\nError  : "};
+static const std::string problemPrefix = std::string{"\nProblem: "};
+static const std::string bugPrefix     = std::string{"\nBug    : "};
+static const std::string blankPrefix   = std::string{"         "};
+}
+
     bool isPower2(int64_t x) {
         return ((x != 0) && !(x & (x - 1)));
     }
@@ -46,36 +58,35 @@ namespace Log {
 
 
     std::string prefixMessage(int64_t messageType, const std::string& message) {
-        std::string prefix;
         switch (messageType) {
+        case MessageType::Continuation:
+            return blankPrefix + message;
+
         case MessageType::Debug:
-            prefix = "Debug";
-            break;
+            return debugPrefix + message;
+
         case MessageType::Note:
-            prefix = "Note";
-            break;
+            return notePrefix + message;
+
         case MessageType::Info:
-            prefix = "Info";
-            break;
+            return infoPrefix + message;
+
         case MessageType::Warning:
-            prefix = "\nWarning";
-            break;
+            return warningPrefix + message;
+
         case MessageType::Error:
-            prefix = "\nError";
-            break;
+            return errorPrefix + message;
+
         case MessageType::Problem:
-            prefix = "\nProblem";
-            break;
+            return problemPrefix + message;
+
         case MessageType::Bug:
-            prefix = "\nBug";
-            break;
+            return bugPrefix + message;
+
         default:
             throw std::invalid_argument("Unhandled messagetype");
         }
-
-        return prefix + ": " + message;
     }
-
 
     std::string colorCodeMessage(int64_t messageType, const std::string& message) {
         switch (messageType) {

--- a/src/opm/common/OpmLog/Logger.cpp
+++ b/src/opm/common/OpmLog/Logger.cpp
@@ -40,11 +40,11 @@ namespace Opm {
     }
 
     void Logger::addTaggedMessage(int64_t messageType, const std::string& tag, const std::string& message) const {
-        if ((m_enabledTypes & messageType) == 0)
+        if ((this->m_enabledTypes & messageType) == 0)
             throw std::invalid_argument("Tried to issue message with unrecognized message ID");
 
-        if (m_globalMask & messageType) {
-            for (auto iter : m_backends) {
+        if (this->m_globalMask & messageType) {
+            for (auto iter : this->m_backends) {
                 LogBackend& backend = *(iter.second);
                 backend.addTaggedMessage( messageType, tag, message );
             }
@@ -53,6 +53,22 @@ namespace Opm {
 
     void Logger::addMessage(int64_t messageType , const std::string& message) const {
         addTaggedMessage(messageType, "", message);
+    }
+
+    void Logger::addTaggedMessage(int64_t messageType, const std::string& tag, const std::vector<std::string>& message_list) const {
+        if ((this->m_enabledTypes & messageType) == 0)
+            throw std::invalid_argument("Tried to issue message with unrecognized message ID");
+
+        if (this->m_globalMask & messageType) {
+            for (auto iter : this->m_backends) {
+                LogBackend& backend = *(iter.second);
+                backend.addTaggedMessage( messageType, tag, message_list );
+            }
+        }
+    }
+
+    void Logger::addMessage(int64_t messageType , const std::vector<std::string>& message_list) const {
+        addTaggedMessage(messageType, "", message_list);
     }
 
 
@@ -92,7 +108,7 @@ namespace Opm {
         return m_enabledTypes;
     }
 
-    //static: 
+    //static:
     bool Logger::enabledMessageType( int64_t enabledTypes , int64_t messageType) {
         if (Log::isPower2( messageType)) {
             if ((messageType & enabledTypes) == 0)

--- a/src/opm/common/OpmLog/OpmLog.cpp
+++ b/src/opm/common/OpmLog/OpmLog.cpp
@@ -69,10 +69,19 @@ namespace Opm {
             m_logger->addMessage( messageFlag , message );
     }
 
+    void OpmLog::addMessage(int64_t messageFlag , const std::vector<std::string>& message_list) {
+        if (m_logger)
+            m_logger->addMessage( messageFlag , message_list );
+    }
 
     void OpmLog::addTaggedMessage(int64_t messageFlag, const std::string& tag, const std::string& message) {
         if (m_logger)
             m_logger->addTaggedMessage( messageFlag, tag, message );
+    }
+
+    void OpmLog::addTaggedMessage(int64_t messageFlag, const std::string& tag, const std::vector<std::string>& message_list) {
+        if (m_logger)
+            m_logger->addTaggedMessage( messageFlag, tag, message_list );
     }
 
 
@@ -105,7 +114,7 @@ namespace Opm {
         addMessage(Log::MessageType::Bug, message);
     }
 
-    
+
     void OpmLog::debug(const std::string& message)
     {
         addMessage(Log::MessageType::Debug, message);
@@ -117,6 +126,46 @@ namespace Opm {
         addMessage(Log::MessageType::Note, message);
     }
 
+    void OpmLog::info(const std::vector<std::string>& message_list)
+    {
+        addMessage(Log::MessageType::Info, message_list);
+    }
+
+
+    void OpmLog::warning(const std::vector<std::string>& message_list)
+    {
+        addMessage(Log::MessageType::Warning, message_list);
+    }
+
+
+    void OpmLog::problem(const std::vector<std::string>& message_list)
+    {
+        addMessage(Log::MessageType::Problem, message_list);
+    }
+
+
+    void OpmLog::error(const std::vector<std::string>& message_list)
+    {
+        addMessage(Log::MessageType::Error, message_list);
+    }
+
+
+    void OpmLog::bug(const std::vector<std::string>& message_list)
+    {
+        addMessage(Log::MessageType::Bug, message_list);
+    }
+
+
+    void OpmLog::debug(const std::vector<std::string>& message_list)
+    {
+        addMessage(Log::MessageType::Debug, message_list);
+    }
+
+
+    void OpmLog::note(const std::vector<std::string>& message_list)
+    {
+        addMessage(Log::MessageType::Note, message_list);
+    }
 
 
     void OpmLog::info(const std::string& tag, const std::string& message)
@@ -162,6 +211,47 @@ namespace Opm {
     }
 
 
+    void OpmLog::info(const std::string& tag, const std::vector<std::string>& message_list)
+    {
+        addTaggedMessage(Log::MessageType::Info, tag, message_list);
+    }
+
+
+    void OpmLog::warning(const std::string& tag, const std::vector<std::string>& message_list)
+    {
+        addTaggedMessage(Log::MessageType::Warning, tag, message_list);
+    }
+
+
+    void OpmLog::problem(const std::string& tag, const std::vector<std::string>& message_list)
+    {
+        addTaggedMessage(Log::MessageType::Problem, tag, message_list);
+    }
+
+
+    void OpmLog::error(const std::string& tag, const std::vector<std::string>& message_list)
+    {
+        addTaggedMessage(Log::MessageType::Error, tag, message_list);
+    }
+
+
+    void OpmLog::bug(const std::string& tag, const std::vector<std::string>& message_list)
+    {
+        addTaggedMessage(Log::MessageType::Bug, tag, message_list);
+    }
+
+
+    void OpmLog::debug(const std::string& tag, const std::vector<std::string>& message_list)
+    {
+        addTaggedMessage(Log::MessageType::Debug, tag, message_list);
+    }
+
+
+
+    void OpmLog::note(const std::string& tag, const std::vector<std::string>& message_list)
+    {
+        addTaggedMessage(Log::MessageType::Note, tag, message_list);
+    }
 
 
     bool OpmLog::enabledMessageType( int64_t messageType ) {

--- a/src/opm/common/OpmLog/StreamLog.cpp
+++ b/src/opm/common/OpmLog/StreamLog.cpp
@@ -59,6 +59,17 @@ void StreamLog::addMessageUnconditionally(int64_t messageType, const std::string
     }
 }
 
+void StreamLog::addMessageUnconditionally(int64_t messageType, std::vector<std::string> message_list)
+{
+    this->formatMessage(messageType, message_list);
+    for (const auto& msg : message_list)
+        (*m_ostream) << msg << std::endl;
+
+    if (m_ofstream.is_open()) {
+        m_ofstream.flush();
+    }
+}
+
 
 StreamLog::~StreamLog() {
     close();

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -50,9 +50,9 @@ BOOST_AUTO_TEST_CASE(DoLogging) {
 BOOST_AUTO_TEST_CASE(Test_Format) {
     BOOST_CHECK_EQUAL( "There is an error here?\nIn file /path/to/file, line 100\n" , Log::fileMessage(KeywordLocation("Keyword", "/path/to/file" , 100) , "There is an error here?"));
 
-    BOOST_CHECK_EQUAL( "\nError: This is the error" ,     Log::prefixMessage(Log::MessageType::Error , "This is the error"));
+    BOOST_CHECK_EQUAL( "\nError  : This is the error" ,     Log::prefixMessage(Log::MessageType::Error , "This is the error"));
     BOOST_CHECK_EQUAL( "\nWarning: This is the warning" , Log::prefixMessage(Log::MessageType::Warning , "This is the warning"));
-    BOOST_CHECK_EQUAL( "Info: This is the info" ,       Log::prefixMessage(Log::MessageType::Info , "This is the info"));
+    BOOST_CHECK_EQUAL( "Info   : This is the info" ,       Log::prefixMessage(Log::MessageType::Info , "This is the info"));
 }
 
 
@@ -128,6 +128,8 @@ public:
         else
             m_specialMessages += 1;
     }
+
+    void addMessageUnconditionally(int64_t , const std::vector<std::string> /* message_list */) override {}
 
     int m_defaultMessages;
     int m_specialMessages;
@@ -253,12 +255,12 @@ BOOST_AUTO_TEST_CASE(TestHelperFunctions)
 
     // fileMessage
     BOOST_CHECK_EQUAL(fileMessage(KeywordLocation("Keyword", "foo/bar", 1), "message"), "message\nIn file foo/bar, line 1\n");
-    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, KeywordLocation("Keyword", "foo/bar", 1), "message"), "\nError: message\nIn file foo/bar, line 1\n");
+    BOOST_CHECK_EQUAL(fileMessage(MessageType::Error, KeywordLocation("Keyword", "foo/bar", 1), "message"), "\nError  : message\nIn file foo/bar, line 1\n");
 
     // prefixMessage
-    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "\nError: message");
-    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "Info: message");
-    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Note, "message"), "Note: message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Error, "message"), "\nError  : message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Info, "message"), "Info   : message");
+    BOOST_CHECK_EQUAL(prefixMessage(MessageType::Note, "message"), "Note   : message");
 
     // colorCode Message
     BOOST_CHECK_EQUAL(colorCodeMessage(MessageType::Info, "message"), "message");
@@ -412,7 +414,7 @@ BOOST_AUTO_TEST_CASE(TestFormat)
 
     const std::string expected2 = Log::colorCodeMessage(Log::MessageType::Warning, "Warning") + "\n"
         + Log::colorCodeMessage(Log::MessageType::Error, "Error") + "\n"
-        + Log::colorCodeMessage(Log::MessageType::Info, "Info: Info") + "\n"
+        + Log::colorCodeMessage(Log::MessageType::Info, "Info   : Info") + "\n"
         + Log::colorCodeMessage(Log::MessageType::Bug, "Bug") + "\n";
 
     const std::string expected3 = Log::prefixMessage(Log::MessageType::Warning, "Warning") + "\n"


### PR DESCRIPTION
This PR adds a multiline overload to the `OpmLog::xxxx()` logger functions. This is to enable formatting of multiline messages like:

```
Error  : Record contains too many items in keyword EQUIL. Expected 9 items, found 18.
         In file /home/hove/work/OPM/opm-tests/spe1/SPE1CASE1.DATA at line 253.  
         Record is: "8400 4800 8450 0 8300 0 1 0 0 1 2 3 4 5 6 7 8 9"  

```