### PR TITLE
Prepare for Outputting Network Node Pressure to Summary File

### DIFF
--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -44,13 +44,13 @@ public:
     void well_rate(const std::string& well, data::Rates::opt rate, std::function<well_rate_function> func);
     void solution(const std::string& field, std::function<solution_function> func);
     void run(Schedule& schedule, EclipseIO& io, bool report_only);
-    void post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step);
+    void post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step);
 private:
 
-    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, UDQState& udq_state, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step, EclipseIO& io) const;
-    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, UDQState& udq_state, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step, double dt, EclipseIO& io) const;
-    void output(Action::State& action_state, SummaryState& st, const UDQState& udq_state, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, const data::GroupValues& group_data, EclipseIO& io) const;
-    void simulate(const Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupValues& group_data, size_t report_step, double seconds_elapsed, double time_step) const;
+    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, UDQState& udq_state, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step, EclipseIO& io) const;
+    void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, UDQState& udq_state, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step, double dt, EclipseIO& io) const;
+    void output(Action::State& action_state, SummaryState& st, const UDQState& udq_state, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, const data::GroupAndNetworkValues& group_data, EclipseIO& io) const;
+    void simulate(const Schedule& schedule, const SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step, double seconds_elapsed, double time_step) const;
 
     EclipseState state;
     std::map<std::string, std::map<data::Rates::opt, std::function<well_rate_function>>> well_rates;

--- a/opm/output/eclipse/RestartValue.hpp
+++ b/opm/output/eclipse/RestartValue.hpp
@@ -71,11 +71,11 @@ namespace Opm {
         using ExtraVector = std::vector<std::pair<RestartKey, std::vector<double>>>;
         data::Solution solution;
         data::Wells wells;
-        data::GroupValues groups;
+        data::GroupAndNetworkValues grp_nwrk;
         ExtraVector extra;
         std::vector<data::AquiferData> aquifer;
 
-        RestartValue(data::Solution sol, data::Wells wells_arg, data::GroupValues groups_arg);
+        RestartValue(data::Solution sol, data::Wells wells_arg, data::GroupAndNetworkValues grpn_nwrk_arg);
 
         RestartValue() {}
 
@@ -91,7 +91,7 @@ namespace Opm {
         {
           return solution == val2.solution &&
                  wells == val2.wells &&
-                 groups == val2.groups &&
+                 grp_nwrk == val2.grp_nwrk &&
                  extra == val2.extra;
         }
     };

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -38,7 +38,7 @@ namespace Opm {
 
 namespace Opm { namespace data {
     class WellRates;
-    class GroupValues;
+    class GroupAndNetworkValues;
 }} // namespace Opm::data
 
 namespace Opm { namespace out {
@@ -59,16 +59,16 @@ public:
 
     void add_timestep(const SummaryState& st, const int report_step);
 
-    void eval(SummaryState&                  summary_state,
-              const int                      report_step,
-              const double                   secs_elapsed,
-              const EclipseState&            es,
-              const Schedule&                schedule,
-              const data::WellRates&         well_solution,
-              const data::GroupValues&       group_solution,
-              GlobalProcessParameters        single_values,
-              const RegionParameters&        region_values = {},
-              const BlockValues&             block_values  = {}) const;
+    void eval(SummaryState&                      summary_state,
+              const int                          report_step,
+              const double                       secs_elapsed,
+              const EclipseState&                es,
+              const Schedule&                    schedule,
+              const data::WellRates&             well_solution,
+              const data::GroupAndNetworkValues& group_and_nwrk_solution,
+              GlobalProcessParameters            single_values,
+              const RegionParameters&            region_values = {},
+              const BlockValues&                 block_values  = {}) const;
 
     void write() const;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.hpp
@@ -45,7 +45,7 @@ public:
     const Node& root() const;
     std::vector<Branch> downtree_branches(const std::string& node) const;
     std::optional<Branch> uptree_branch(const std::string& node) const;
-
+    std::vector<std::string> node_names() const;
 
     bool operator==(const ExtNetwork& other) const;
     static ExtNetwork serializeObject();

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -1562,9 +1562,9 @@ namespace Opm { namespace RestartIO  {
         auto xw = rst_view->hasKeyword<double>("OPM_XWEL")
             ? restore_wells_opm(es, grid, schedule, *rst_view)
             : restore_wells_ecl(es, grid, schedule,  rst_view);
-        data::GroupValues xg;
+        data::GroupAndNetworkValues xg_nwrk;
 
-        auto rst_value = RestartValue{ std::move(xr), std::move(xw) , std::move(xg)};
+        auto rst_value = RestartValue{ std::move(xr), std::move(xw), std::move(xg_nwrk)};
 
         if (! extra_keys.empty()) {
             restoreExtra(extra_keys, es.getUnits(), *rst_view, rst_value);

--- a/src/opm/output/eclipse/RestartValue.cpp
+++ b/src/opm/output/eclipse/RestartValue.cpp
@@ -17,8 +17,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <set>
 #include <iostream>
+#include <set>
+#include <utility>
 
 #include <opm/output/eclipse/RestartValue.hpp>
 
@@ -32,10 +33,10 @@ namespace Opm {
 
 
 
-    RestartValue::RestartValue(data::Solution sol, data::Wells wells_arg, data::GroupValues groups_arg) :
+    RestartValue::RestartValue(data::Solution sol, data::Wells wells_arg, data::GroupAndNetworkValues grp_nwrk_arg) :
         solution(std::move(sol)),
         wells(std::move(wells_arg)),
-        groups(std::move(groups_arg))
+        grp_nwrk(std::move(grp_nwrk_arg))
     {
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 #include <algorithm>
+#include <iterator>
 #include <stdexcept>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.hpp>
@@ -146,5 +147,18 @@ void ExtNetwork::add_node(Node node)
     this->m_nodes.insert({ name, std::move(node) });
 }
 
+std::vector<std::string> ExtNetwork::node_names() const
+{
+    auto nodes = std::vector<std::string>{};
+    nodes.reserve(this->m_nodes.size());
+
+    std::transform(this->m_nodes.begin(), this->m_nodes.end(), std::back_inserter(nodes),
+        [](const auto& node_pair)
+    {
+        return node_pair.first;
+    });
+
+    return nodes;
+}
 }
 }

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         eclWriter.writeInitial( eGridProps , int_data );
 
         data::Wells wells;
-        data::GroupValues groups;
+        data::GroupAndNetworkValues grp_nwrk;
 
         for( int i = first; i < last; ++i ) {
             data::Solution sol = createBlackoilState( i, 3 * 3 * 3 );
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
 
             Action::State action_state;
             UDQState udq_state(1);
-            RestartValue restart_value(sol, wells, groups);
+            RestartValue restart_value(sol, wells, grp_nwrk);
             auto first_step = ecl_util_make_date( 10 + i, 11, 2008 );
             eclWriter.writeTimeStep( action_state,
                                      st,

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
 
         Opm::data::Solution solution = createBlackoilState(2, numCells);
         Opm::data::Wells wells;
-        Opm::data::GroupValues groups;
+        Opm::data::GroupAndNetworkValues group_nwrk;
 
         using SegRes = decltype(wells["w"].segments);
         using Ctrl = decltype(wells["w"].current_control);
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{}, Ctrl{} };
         wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{}, Ctrl{} };
 
-        RestartValue restart_value(std::move(solution), std::move(wells), std::move(groups));
+        RestartValue restart_value(std::move(solution), std::move(wells), std::move(group_nwrk));
 
         eclipseWriter.writeTimeStep( action_state,
                                      st,
@@ -438,7 +438,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
                 wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{}, Ctrl{} };
                 wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{}, Ctrl{} };
 
-                RestartValue restart_value(std::move(solution), std::move(wells), data::GroupValues());
+                RestartValue restart_value(std::move(solution), std::move(wells), data::GroupAndNetworkValues());
 
                 eclipseWriter.writeTimeStep( action_state,
                                              st,
@@ -469,13 +469,11 @@ namespace {
 
         explicit Setup(const ::Opm::Deck& deck)
             : es    { deck }
-            , python{ std::make_shared<::Opm::Python>() }
-            , sched { deck, es , python }
+            , sched { deck, es, std::make_shared<const ::Opm::Python>() }
         {
         }
 
         ::Opm::EclipseState es;
-        std::shared_ptr<::Opm::Python> python;
         ::Opm::Schedule     sched;
     };
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -137,7 +137,7 @@ std::ostream& operator<<( std::ostream& stream,
 
 }
 
-data::GroupValues mkGroups() {
+data::GroupAndNetworkValues mkGroups() {
     return {};
 }
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -305,16 +305,16 @@ data::Wells result_wells(const bool w3_injector = true)
     return wellrates;
 }
 
-data::GroupValues result_groups()
+data::GroupAndNetworkValues result_group_nwrk()
 {
     using GRValue = data::GuideRateValue;
 
-    data::GroupValues groups;
+    data::GroupAndNetworkValues grp_nwrk;
     data::GroupConstraints cgc_group;
 
     cgc_group.set(p_cmode::NONE, i_cmode::VREP, i_cmode::RATE);
     {
-        auto& grp = groups["G_1"];
+        auto& grp = grp_nwrk.groupData["G_1"];
         grp.currentControl = cgc_group;
 
         grp.guideRates.production
@@ -329,15 +329,15 @@ data::GroupValues result_groups()
     }
 
     cgc_group.set(p_cmode::ORAT, i_cmode::RESV, i_cmode::FLD);
-    groups["G_2"].currentControl = cgc_group;
+    grp_nwrk.groupData["G_2"].currentControl = cgc_group;
 
     cgc_group.set(p_cmode::GRAT, i_cmode::REIN, i_cmode::VREP);
-    groups["G_3"].currentControl = cgc_group;
+    grp_nwrk.groupData["G_3"].currentControl = cgc_group;
 
     cgc_group.set(p_cmode::NONE, i_cmode::NONE, i_cmode::NONE);
-    groups["FIELD"].currentControl = cgc_group;
+    grp_nwrk.groupData["FIELD"].currentControl = cgc_group;
 
-    return groups;
+    return grp_nwrk;
 }
 
 std::unique_ptr< EclIO::ESmry > readsum( const std::string& base ) {
@@ -419,7 +419,7 @@ struct setup {
     Schedule schedule;
     SummaryConfig config;
     data::Wells wells;
-    data::GroupValues groups;
+    data::GroupAndNetworkValues grp_nwrk;
     std::string name;
     WorkArea ta;
 
@@ -433,7 +433,7 @@ struct setup {
         schedule( deck, es, python),
         config( deck, schedule, es.getTableManager()),
         wells( result_wells(w3_injector) ),
-        groups( result_groups() ),
+        grp_nwrk( result_group_nwrk() ),
         name( toupper(std::move(fname)) ),
         ta( "summary_test" )
     {}
@@ -456,13 +456,13 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     SummaryState st(std::chrono::system_clock::now());
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    writer.eval(st, 0, 0*day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+    writer.eval(st, 0, 0*day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
 
-    writer.eval(st, 1, 1*day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+    writer.eval(st, 1, 1*day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
 
-    writer.eval(st, 2, 2*day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+    writer.eval(st, 2, 2*day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -681,11 +681,11 @@ BOOST_AUTO_TEST_CASE(udq_keywords) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -706,13 +706,13 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
 
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
 
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
 
     writer.write();
@@ -863,11 +863,11 @@ BOOST_AUTO_TEST_CASE(group_group) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -919,11 +919,11 @@ BOOST_AUTO_TEST_CASE(completion_kewords) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -980,13 +980,13 @@ BOOST_AUTO_TEST_CASE(DATE) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
-    writer.eval( st, 3, 18 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 3, 18 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 3);
-    writer.eval( st, 4, 22 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 4, 22 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 4);
     writer.write();
 
@@ -1017,11 +1017,11 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -1154,11 +1154,11 @@ BOOST_AUTO_TEST_CASE(report_steps_time) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 10 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 10 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -1181,11 +1181,11 @@ BOOST_AUTO_TEST_CASE(skip_unknown_var) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 1, 2 *  day, cfg.es,  cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 2 *  day, cfg.es,  cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 1, 5 *  day, cfg.es,  cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 5 *  day, cfg.es,  cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 10 * day, cfg.es,  cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 10 * day, cfg.es,  cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -1292,11 +1292,11 @@ BOOST_AUTO_TEST_CASE(region_vars) {
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
         SummaryState st(std::chrono::system_clock::now());
-        writer.eval( st, 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {}, region_values);
+        writer.eval( st, 1, 2 *  day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {}, region_values);
         writer.add_timestep( st, 1);
-        writer.eval( st, 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {}, region_values);
+        writer.eval( st, 1, 5 *  day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {}, region_values);
         writer.add_timestep( st, 1);
-        writer.eval( st, 2, 10 * day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {}, region_values);
+        writer.eval( st, 2, 10 * day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {}, region_values);
         writer.add_timestep( st, 2);
         writer.write();
     }
@@ -1343,11 +1343,11 @@ BOOST_AUTO_TEST_CASE(region_production) {
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
         SummaryState st(std::chrono::system_clock::now());
-        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
         writer.add_timestep( st, 0);
-        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
         writer.add_timestep( st, 1);
-        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
         writer.add_timestep( st, 2);
         writer.write();
     }
@@ -1375,11 +1375,11 @@ BOOST_AUTO_TEST_CASE(region_injection) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -1431,15 +1431,15 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {},{}, block_values);
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {},{}, block_values);
     writer.add_timestep( st, 0);
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {},{}, block_values);
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {},{}, block_values);
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {},{}, block_values);
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {},{}, block_values);
     writer.add_timestep( st, 2);
-    writer.eval( st, 3, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {},{}, block_values);
+    writer.eval( st, 3, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {},{}, block_values);
     writer.add_timestep( st, 3);
-    writer.eval( st, 4, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {},{}, block_values);
+    writer.eval( st, 4, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {},{}, block_values);
     writer.add_timestep( st, 4);
     writer.write();
 
@@ -1526,11 +1526,11 @@ BOOST_AUTO_TEST_CASE(MISC) {
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
-    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
-    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, {});
+    writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, {});
     writer.add_timestep( st, 2);
     writer.write();
 
@@ -1546,19 +1546,19 @@ BOOST_AUTO_TEST_CASE(EXTRA) {
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
         SummaryState st(std::chrono::system_clock::now());
-        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, { {"TCPU" , 0 }});
+        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, { {"TCPU" , 0 }});
         writer.add_timestep( st, 0);
-        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, { {"TCPU" , 1 }});
+        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, { {"TCPU" , 1 }});
         writer.add_timestep( st, 1);
-        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, { {"TCPU" , 2}});
+        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, { {"TCPU" , 2}});
         writer.add_timestep( st, 2);
 
         /* Add a not-recognized key; that is OK */
-        BOOST_CHECK_NO_THROW(  writer.eval( st, 3, 3 * day, cfg.es, cfg.schedule, cfg.wells , cfg.groups, { {"MISSING" , 2 }}));
+        BOOST_CHECK_NO_THROW(  writer.eval( st, 3, 3 * day, cfg.es, cfg.schedule, cfg.wells , cfg.grp_nwrk, { {"MISSING" , 2 }}));
         BOOST_CHECK_NO_THROW(  writer.add_timestep( st, 3));
 
         /* Override a NOT MISC variable - ignored. */
-        writer.eval( st, 4, 4 * day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+        writer.eval( st, 4, 4 * day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
         writer.add_timestep( st, 4);
         writer.write();
     }
@@ -1677,11 +1677,11 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
 
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
         SummaryState st(std::chrono::system_clock::now());
-        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+        writer.eval( st, 0, 0 * day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
         writer.add_timestep( st, 0);
-        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+        writer.eval( st, 1, 1 * day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
         writer.add_timestep( st, 1);
-        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+        writer.eval( st, 2, 2 * day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
         writer.add_timestep( st, 2);
         writer.write();
         auto res = readsum( cfg.name );
@@ -1915,11 +1915,11 @@ namespace {
         };
 
       SummaryState st(std::chrono::system_clock::now());
-      smry.eval(st, 0, 0*day, config.es, config.schedule, config.wells, config.groups, {});
+      smry.eval(st, 0, 0*day, config.es, config.schedule, config.wells, config.grp_nwrk, {});
       smry.add_timestep(st, 0);
-      smry.eval(st, 1, 1*day, config.es, config.schedule, config.wells, config.groups, {});
+      smry.eval(st, 1, 1*day, config.es, config.schedule, config.wells, config.grp_nwrk, {});
       smry.add_timestep(st, 1);
-      smry.eval(st, 2, 2*day, config.es, config.schedule, config.wells, config.groups, {});
+      smry.eval(st, 2, 2*day, config.es, config.schedule, config.wells, config.grp_nwrk, {});
       smry.add_timestep(st, 2);
 
       return st;
@@ -2915,11 +2915,11 @@ BOOST_AUTO_TEST_CASE(Write_Read)
     };
 
     SummaryState st(std::chrono::system_clock::now());
-    writer.eval(st, 0, 0*day, config.es, config.schedule, config.wells, config.groups, {});
+    writer.eval(st, 0, 0*day, config.es, config.schedule, config.wells, config.grp_nwrk, {});
     writer.add_timestep(st, 0);
-    writer.eval(st, 1, 1*day, config.es, config.schedule, config.wells, config.groups, {});
+    writer.eval(st, 1, 1*day, config.es, config.schedule, config.wells, config.grp_nwrk, {});
     writer.add_timestep(st, 1);
-    writer.eval(st, 2, 2*day, config.es, config.schedule, config.wells, config.groups, {});
+    writer.eval(st, 2, 2*day, config.es, config.schedule, config.wells, config.grp_nwrk, {});
     writer.add_timestep(st, 2);
     writer.write();
 

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -191,23 +191,23 @@ static data::Wells result_wells() {
 
 }
 
-static data::GroupValues result_groups() {
-    data::GroupValues groups;
+static data::GroupAndNetworkValues result_group_network() {
+    data::GroupAndNetworkValues grp_nwrk;
     data::GroupConstraints cgc_group;
 
     cgc_group.set(p_cmode::NONE, i_cmode::VREP, i_cmode::RATE);
-    groups["TEST"].currentControl = cgc_group;
+    grp_nwrk.groupData["TEST"].currentControl = cgc_group;
 
     cgc_group.set(p_cmode::ORAT, i_cmode::RESV, i_cmode::REIN);
-    groups["LOWER"].currentControl = cgc_group;
+    grp_nwrk.groupData["LOWER"].currentControl = cgc_group;
 
     cgc_group.set(p_cmode::GRAT, i_cmode::REIN, i_cmode::VREP);
-    groups["UPPER"].currentControl = cgc_group;
+    grp_nwrk.groupData["UPPER"].currentControl = cgc_group;
 
     cgc_group.set(p_cmode::NONE, i_cmode::NONE, i_cmode::NONE);
-    groups["FIELD"].currentControl = cgc_group;
+    grp_nwrk.groupData["FIELD"].currentControl = cgc_group;
 
-    return groups;
+    return grp_nwrk;
 }
 
 
@@ -219,7 +219,7 @@ struct setup {
     Schedule schedule;
     SummaryConfig config;
     data::Wells wells;
-    data::GroupValues groups;
+    data::GroupAndNetworkValues grp_nwrk;
     std::string name;
     WorkArea ta;
 
@@ -233,7 +233,7 @@ struct setup {
         schedule( deck, es, python),
         config( deck, schedule, es.getTableManager()),
         wells( result_wells() ),
-        groups( result_groups() ),
+        grp_nwrk( result_group_network() ),
         name( toupper(std::move(fname)) ),
         ta( "test_summary_group_constraints" )
     {}
@@ -258,10 +258,10 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     SummaryState st(std::chrono::system_clock::now());
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    writer.eval(st, 0, 0*day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+    writer.eval(st, 0, 0*day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
     writer.add_timestep( st, 0);
 
-    writer.eval(st, 1, 1*day, cfg.es, cfg.schedule, cfg.wells, cfg.groups, {});
+    writer.eval(st, 1, 1*day, cfg.es, cfg.schedule, cfg.wells, cfg.grp_nwrk, {});
     writer.add_timestep( st, 1);
 
     writer.write();

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     solution.insert( "SWAT"    , Opm::UnitSystem::measure::identity , std::vector< double >( num_cells, 1 ) , Opm::data::TargetType::RESTART_SOLUTION);
     solution.insert( "SGAS"    , Opm::UnitSystem::measure::identity , std::vector< double >( num_cells, 1 ) , Opm::data::TargetType::RESTART_SOLUTION);
     Opm::data::Wells wells;
-    Opm::data::GroupValues groups;
+    Opm::data::GroupAndNetworkValues group_nwrk;
 
     for(int timestep = 0; timestep <= countTimeStep; ++timestep) {
 
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
                                      timestep,
                                      false,
                                      schedule.seconds(timestep),
-                                     Opm::RestartValue(solution, wells, groups));
+                                     Opm::RestartValue(solution, wells, group_nwrk));
     }
 
     for (int i=1; i <=4; i++) {


### PR DESCRIPTION
This commit adds a level of indirection to the existing group-level data (active controls and guiderates), and adds a new `NodeData` level to the `data::` protocol for transporting values from the simulator to the output layer.

Update all call sites and users accordingly.

While here, also add a way of retrieving all network nodenames in anticipation of handling node-level summary output requests like
```
GPR
/
```
in the `SummaryConfig` class.

Note: This is an API break and is accompanied by a follow-up PR in the opm-simulators module.  This PR cannot be merged unless the two are merged in concert.