### PR TITLE
Add Support for 'GPR' (Network Node Pressure) Summary Keyword 

### DIFF
--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -15,7 +15,7 @@
 
    You should have received a copy of the GNU General Public License
    along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-   */
+*/
 
 #ifndef OPM_IO_SUMMARYNODE_HPP
 #define OPM_IO_SUMMARYNODE_HPP
@@ -29,7 +29,6 @@ namespace Opm { namespace EclIO {
 
 struct SummaryNode {
     enum class Category {
-        Aquifer,
         Well,
         Group,
         Field,
@@ -37,6 +36,8 @@ struct SummaryNode {
         Block,
         Connection,
         Segment,
+        Aquifer,
+        Node,
         Miscellaneous,
     };
 
@@ -73,6 +74,6 @@ struct SummaryNode {
     std::optional<std::string> display_number(number_renderer) const;
 };
 
- }} // namespace Opm::EclIO
+}} // namespace Opm::EclIO
 
 #endif // OPM_IO_SUMMARYNODE_HPP

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -286,6 +286,7 @@ namespace Opm {
         */
         const static std::string SUMMARY_UNKNOWN_WELL;
         const static std::string SUMMARY_UNKNOWN_GROUP;
+        const static std::string SUMMARY_UNKNOWN_NODE;
         const static std::string SUMMARY_UNHANDLED_KEYWORD;
         const static std::string SUMMARY_UNDEFINED_UDQ;
         const static std::string SUMMARY_UDQ_MISSING_UNIT;

--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -15,15 +15,15 @@
 
    You should have received a copy of the GNU General Public License
    along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-   */
+*/
+
+#include <opm/io/eclipse/SummaryNode.hpp>
 
 #include <numeric>
 #include <regex>
 #include <string>
 #include <unordered_set>
 #include <vector>
-
-#include <opm/io/eclipse/SummaryNode.hpp>
 
 namespace {
 
@@ -37,6 +37,7 @@ constexpr bool use_number(Opm::EclIO::SummaryNode::Category category) {
         return true;
     case Opm::EclIO::SummaryNode::Category::Field:         [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Group:         [[fallthrough]];
+    case Opm::EclIO::SummaryNode::Category::Node:          [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Miscellaneous: [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Well:
         return false;
@@ -51,6 +52,7 @@ constexpr bool use_name(Opm::EclIO::SummaryNode::Category category) {
     case Opm::EclIO::SummaryNode::Category::Connection:    [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Group:         [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Segment:       [[fallthrough]];
+    case Opm::EclIO::SummaryNode::Category::Node:          [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Well:
         return true;
     case Opm::EclIO::SummaryNode::Category::Aquifer:       [[fallthrough]];
@@ -69,7 +71,23 @@ std::string default_number_renderer(const Opm::EclIO::SummaryNode& node) {
     return std::to_string(node.number);
 }
 
-};
+bool is_node_keyword(const std::string& keyword)
+{
+    static const auto node_kw = std::unordered_set<std::string> {
+        "GPR",
+    };
+
+    return node_kw.find(keyword) != node_kw.end();
+}
+
+Opm::EclIO::SummaryNode::Category
+distinguish_group_from_node(const std::string& keyword)
+{
+    return is_node_keyword(keyword)
+        ? Opm::EclIO::SummaryNode::Category::Node
+        : Opm::EclIO::SummaryNode::Category::Group;
+}
+}
 
 std::string Opm::EclIO::SummaryNode::unique_key(number_renderer render_number) const {
     std::vector<std::string> key_parts { keyword } ;
@@ -145,7 +163,7 @@ Opm::EclIO::SummaryNode::Category Opm::EclIO::SummaryNode::category_from_keyword
     case 'B': return Category::Block;
     case 'C': return Category::Connection;
     case 'F': return Category::Field;
-    case 'G': return Category::Group;
+    case 'G': return distinguish_group_from_node(keyword);
     case 'R': return Category::Region;
     case 'S': return Category::Segment;
     case 'W': return Category::Well;

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1456,6 +1456,7 @@ inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,
 
     case Opm::EclIO::SummaryNode::Category::Aquifer:       [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Block:         [[fallthrough]];
+    case Opm::EclIO::SummaryNode::Category::Node:          [[fallthrough]];
     case Opm::EclIO::SummaryNode::Category::Miscellaneous:
         return {};
     }
@@ -1487,6 +1488,8 @@ bool need_wells(const Opm::EclIO::SummaryNode& node)
 
     case Cat::Aquifer:       [[fallthrough]];
     case Cat::Miscellaneous: [[fallthrough]];
+    case Cat::Node:          [[fallthrough]];
+        // Node values directly available in solution.
     case Cat::Block:
         return false;
     }

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -650,6 +650,16 @@ inline quantity thp_history( const fn_args& args ) {
     return { thp_hist, measure::pressure };
 }
 
+inline quantity node_pressure(const fn_args& args)
+{
+    auto nodePos = args.grp_nwrk.nodeData.find(args.group_name);
+    if (nodePos == args.grp_nwrk.nodeData.end()) {
+        return { 0.0, measure::pressure };
+    }
+
+    return { nodePos->second.pressure, measure::pressure };
+}
+
 template< Opm::Phase phase >
 inline quantity production_history( const fn_args& args ) {
     /*
@@ -1062,6 +1072,8 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "GGPGR", group_guiderate<producer, Opm::data::GuideRateValue::Item::Gas> },
     { "GWPGR", group_guiderate<producer, Opm::data::GuideRateValue::Item::Water> },
     { "GVPGR", group_guiderate<producer, Opm::data::GuideRateValue::Item::ResV> },
+
+    { "GPR", node_pressure },
 
     { "GWPT", mul( rate< rt::wat, producer >, duration ) },
     { "GOPT", mul( rate< rt::oil, producer >, duration ) },
@@ -1623,8 +1635,7 @@ namespace Evaluator {
                     const SimulatorResults& simRes,
                     Opm::SummaryState&      st) const override
         {
-            const auto get_wells =
-                need_wells(node_);
+            const auto get_wells = need_wells(this->node_);
 
             const auto wells = get_wells
                 ? find_wells(input.sched, this->node_,
@@ -1636,13 +1647,11 @@ namespace Evaluator {
                 // wells apply at this sim_step.  Nothing to do.
                 return;
 
-            std::string group_name = this->node_.category == Opm::EclIO::SummaryNode::Category::Group ? this->node_.wgname : "";
-
             EfficiencyFactor efac{};
             efac.setFactors(this->node_, input.sched, wells, sim_step);
 
             const fn_args args {
-                wells, group_name, stepSize, static_cast<int>(sim_step),
+                wells, this->group_name(), stepSize, static_cast<int>(sim_step),
                 std::max(0, this->node_.number),
                 this->node_.fip_region,
                 st, simRes.wellSol, simRes.grpNwrkSol, input.reg, input.grid,
@@ -1657,7 +1666,19 @@ namespace Evaluator {
 
     private:
         Opm::EclIO::SummaryNode node_;
-        ofun             fcn_;
+        ofun                    fcn_;
+
+        std::string group_name() const
+        {
+            using Cat = ::Opm::EclIO::SummaryNode::Category;
+
+            const auto need_grp_name =
+                (this->node_.category == Cat::Group) ||
+                (this->node_.category == Cat::Node);
+
+            return need_grp_name
+                ? this->node_.wgname : std::string{""};
+        }
     };
 
     class BlockValue : public Base

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -96,6 +96,7 @@ namespace Opm {
 
         addKey(SUMMARY_UNKNOWN_WELL, InputError::THROW_EXCEPTION);
         addKey(SUMMARY_UNKNOWN_GROUP, InputError::THROW_EXCEPTION);
+        addKey(SUMMARY_UNKNOWN_NODE, InputError::THROW_EXCEPTION);
         addKey(SUMMARY_UNHANDLED_KEYWORD, InputError::WARN);
         addKey(SUMMARY_UNDEFINED_UDQ, InputError::WARN);
         addKey(SUMMARY_UDQ_MISSING_UNIT, InputError::WARN);
@@ -334,6 +335,7 @@ namespace Opm {
 
     const std::string ParseContext::SUMMARY_UNKNOWN_WELL  = "SUMMARY_UNKNOWN_WELL";
     const std::string ParseContext::SUMMARY_UNKNOWN_GROUP = "SUMMARY_UNKNOWN_GROUP";
+    const std::string ParseContext::SUMMARY_UNKNOWN_NODE = "SUMMARY_UNKNOWN_NODE";
     const std::string ParseContext::SUMMARY_UNHANDLED_KEYWORD = "SUMMARY_UNHANDLED_KEYWORD";
     const std::string ParseContext::SUMMARY_UNDEFINED_UDQ = "SUMMARY_UNDEFINED_UDQ";
     const std::string ParseContext::SUMMARY_UDQ_MISSING_UNIT = "SUMMARY_UDQ_MISSING_UNIT";

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -464,6 +464,10 @@ GGIGR
 GWIGR
  G_1 /
 
+-- Network reporting (extended network, node level)
+GPR
+/
+
 -- Well Data
 -- Production Rates
 WWPR
@@ -788,6 +792,19 @@ SCHEDULE
 
 UDQ
   UNITS  WUBHP  'BARSA' /
+/
+
+BRANPROP
+--  Downtree  Uptree   #VFP    ALQ
+    G_1        PLAT-A   5       1* /
+    G_2        PLAT-A   4       1* /
+/
+
+NODEPROP
+--  Node_name  Press  autoChoke?  addGasLift?  Group_name
+     PLAT-A    21.0   NO          NO           1*  /
+     G_1        1*    NO          NO           1*  /
+     G_2        1*    NO          NO           1*  /
 /
 
 -- Three wells, two producers (so that we can form a group) and one injector


### PR DESCRIPTION
This PR adds an evaluation function for the `GPR` summary vector.  We assume that the actual value is calculated elsewhere and passed in unchanged from the caller of `Summary::eval()`.  We therefore need only convert the value to output units and hook this procedure up to the table of known output functions.

As a prerequisite we add a new `Node` category to the `SummaryConfigNode` and a processor for this category which knows about the distinction between nodes and groups.  It uses member function `ExtNetwork::node_names()` to produce configuration nodes whose named entity is the node rather than a group.  Deriving this list of node names across all timesteps is potentially expensive, so perform this operation at most once and pass the result into the processor from the `SummaryConfig` constructor.

Add a unit tests for demonstration.