### PR TITLE
Also remove fmtlib from opm-common-prereqs.cmake

### DIFF
--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -15,7 +15,6 @@ set (opm-common_DEPS
 list(APPEND opm-common_DEPS
       # various runtime library enhancements
       "Boost 1.44.0 COMPONENTS system unit_test_framework REQUIRED"
-      "fmt REQUIRED"
       "OpenMP QUIET"
 )
 


### PR DESCRIPTION
Otherwise the user still needs to have an installed version on the system in addition.

I thought the aim of embedding was to save users from installing it, but ithout this I got:
```
CMake Error at cmake/Modules/OpmFind.cmake:135 (find_package):
  By not providing "Findfmt.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "fmt", but
  CMake did not find one.

  Could not find a package configuration file provided by "fmt" with any of
  the following names:

    fmtConfig.cmake
    fmt-config.cmake

  Add the installation prefix of "fmt" to CMAKE_PREFIX_PATH or set "fmt_DIR"
  to a directory containing one of the above files.  If "fmt" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  cmake/Modules/OpmPackage.cmake:180 (find_and_append_package_to)
  opm-common-prereqs.cmake:22 (find_package_deps)
  CMakeLists.txt:65 (include)


```
with current master