### PR TITLE
Special case output of UDQ and ACTIONX keywords - no split

### DIFF
--- a/opm/parser/eclipse/Deck/DeckOutput.hpp
+++ b/opm/parser/eclipse/Deck/DeckOutput.hpp
@@ -34,7 +34,6 @@ namespace Opm {
 
         void start_record( );
         void end_record( );
-        void split_record();
 
         void start_keyword(const std::string& kw);
         void end_keyword(bool add_slash);
@@ -53,8 +52,10 @@ namespace Opm {
         size_t row_count;
         bool record_on;
         int org_precision;
+        bool split_line;
 
         template <typename T> void write_value(const T& value);
+        void split_record();
         void write_sep( );
         void set_precision(int precision);
     };

--- a/src/opm/parser/eclipse/Deck/DeckOutput.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckOutput.cpp
@@ -106,6 +106,9 @@ namespace Opm {
 
     void DeckOutput::start_keyword(const std::string& kw) {
         this->os << kw << std::endl;
+        this->split_line = true;
+        if (kw == "UDQ" || kw == "ACTIONX")
+            this->split_line = false;
     }
 
 
@@ -116,7 +119,7 @@ namespace Opm {
 
 
     void DeckOutput::write_sep( ) {
-        if (record_on) {
+        if (record_on && this->split_line) {
             if ((row_count > 0) && ((row_count % columns) == 0))
                 split_record();
         }


### PR DESCRIPTION
Fix for: https://github.com/OPM/opm-common/issues/1948