### PR TITLE
Tran calc condense

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
@@ -86,9 +86,6 @@ public:
         case ScalarOperation::ADD:
             kw_info.init(0);
             break;
-        case ScalarOperation::EQUAL:
-            kw_info.init(0);
-            break;
         case ScalarOperation::MAX:
             kw_info.init(std::numeric_limits<double>::max());
             break;

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -131,11 +131,16 @@ static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {
 }
 
 namespace EDIT {
+
+/*
+  The TRANX, TRANY and TRANZ properties are handled very differently from the
+  other properties. It is important that these fields are not entered into the
+  double_keywords list of the EDIT section, that way we risk silent failures
+  due to the special treatment of the TRAN fields.
+*/
+
 static const std::unordered_map<std::string, keyword_info<double>> double_keywords = {{"MULTPV",  keyword_info<double>{}.init(1.0)},
                                                                                       {"PORV",    keyword_info<double>{}.unit_string("ReservoirVolume")},
-                                                                                      {"TRANX",   keyword_info<double>{}.unit_string("Transmissibility")},
-                                                                                      {"TRANY",   keyword_info<double>{}.unit_string("Transmissibility")},
-                                                                                      {"TRANZ",   keyword_info<double>{}.unit_string("Transmissibility")},
                                                                                       {"MULTX",   keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"MULTX-",  keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"MULTY",   keyword_info<double>{}.init(1.0).mult(true)},
@@ -479,6 +484,7 @@ private:
 
     std::string region_name(const DeckItem& region_item);
     std::vector<Box::cell_index> region_index( const std::string& region_name, int region_value );
+    void handle_OPERATE(const DeckKeyword& keyword, Box box);
     void handle_operation(const DeckKeyword& keyword, Box box);
     void handle_region_operation(const DeckKeyword& keyword);
     void handle_COPY(const DeckKeyword& keyword, Box box, bool region);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -153,7 +153,7 @@ void apply_tran(const std::unordered_map<std::string, Fieldprops::TranCalculator
 
         for (std::size_t index = 0; index < active_size; index++) {
 
-            if (action_data.value_status[index] != value::status::deck_value)
+            if (!value::has_value(action_data.value_status[index]))
                 continue;
 
             switch (action.op) {

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2156,3 +2156,66 @@ MULTIPLY
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(TRAN_OPERATE_UNSUPPORTED) {
+    std::string deck_string = R"(
+GRID
+
+PORO
+   1000*0.10 /
+
+EDIT
+
+
+OPERATE
+    TRANX 1  3   2  2   1   1  'MAXLIM'   PORO 0.25 /
+/
+)";
+    UnitSystem unit_system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
+    std::vector<int> actnum(1000, 1);
+    for (std::size_t i=0; i< 1000; i += 2)
+        actnum[i] = 0;
+    EclipseGrid grid(EclipseGrid(10,10,10), actnum);
+    Deck deck = Parser{}.parseString(deck_string);
+    BOOST_CHECK_THROW( FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager()), std::logic_error );
+}
+
+BOOST_AUTO_TEST_CASE(TRAN_REGION_UNSUPPORTED) {
+    std::string deck_base = R"(
+GRID
+
+PORO
+   1000*0.10 /
+
+EDIT
+)";
+
+    std::string multireg = R"(
+MULTIREG
+    TRANX 1.0 1 /
+/
+)";
+
+    std::string equalreg = R"(
+EQUALREG
+    TRANX 1.0 1 /
+/
+)";
+
+    std::string addreg = R"(
+ADDREG
+    TRANX 1.0 1 /
+/
+)";
+
+    UnitSystem unit_system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
+    std::vector<int> actnum(1000, 1);
+    for (std::size_t i=0; i< 1000; i += 2)
+        actnum[i] = 0;
+    EclipseGrid grid(EclipseGrid(10,10,10), actnum);
+
+    for (const auto& region_op : { multireg, equalreg, addreg }) {
+        Deck deck = Parser{}.parseString(deck_base + region_op);
+        BOOST_CHECK_THROW( FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager()), std::logic_error );
+    }
+}


### PR DESCRIPTION
This PR will condense TRAN operations like
```
MULTIPLY
    TRANX 0.50 1 10 1 10 1 1 /
    TRANX 1.25 1  10 1 10 2 2 /
    ...
/
```
to one tran calculator operation per keyword and TRAN direction. This should significantly reduce the memory consumption for this usage pattern. See the post merge disussion here: #1932 

The possible TRAN manipulations in the EDIT section are quote limited:

1. Direct assignment with e.g. `TRANX`
2. Keywords `EQUAL`, `MULTIPLY`, `ADD`, `MINVALUE` and `MAXVALUE`.

The other manipulation keywords like e.g. `OPERATE` and `EQUALREG` are not supported and will give rise to an exception. These other keywords have never really worked, but previously the failure has been silent. To support `TRAN` modifications for these additional keywords is certainly possible - in some cases quite simple, in other cases more involved.