### PR TITLE
Throw opm error

### DIFF
--- a/opm/common/utility/OpmInputError.hpp
+++ b/opm/common/utility/OpmInputError.hpp
@@ -16,14 +16,15 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#ifndef OPM_ERROR_HPP
+#define OPM_ERROR_HPP
 
 #include <stdexcept>
 #include <string>
 
 #include <fmt/format.h>
 
-#ifndef OPM_ERROR_HPP
-#define OPM_ERROR_HPP
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 namespace Opm {
 
@@ -73,16 +74,21 @@ public:
 
 
     OpmInputError(const std::string& msg_fmt, const KeywordLocation& loc) :
-        m_what(fmt::format(msg_fmt,
-                           fmt::arg("keyword", loc.keyword),
-                           fmt::arg("file", loc.filename),
-                           fmt::arg("line", loc.lineno))),
+        m_what(OpmInputError::format(msg_fmt, loc)),
         location(loc)
     {}
 
     const char * what() const throw()
     {
         return this->m_what.c_str();
+    }
+
+
+    static std::string format(const std::string& msg_fmt, const KeywordLocation& loc) {
+        return fmt::format(msg_fmt,
+                           fmt::arg("keyword", loc.keyword),
+                           fmt::arg("file", loc.filename),
+                           fmt::arg("line", loc.lineno));
     }
 
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -22,6 +22,7 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -151,7 +151,7 @@ namespace {
         throw;
     }
     catch (const std::exception& std_error) {
-        OpmLog::error(fmt::format("An error occured while creating the reservior schedule\n",
+        OpmLog::error(fmt::format("An error occured while creating the reservoir schedule\n",
                                   "Internal error: {}", std_error.what()));
         throw;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -25,9 +25,12 @@
 #include <unordered_set>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/utility/numeric/cmp.hpp>
 #include <opm/common/utility/String.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
@@ -97,7 +100,8 @@ namespace {
                         const ParseContext& parseContext,
                         ErrorGuard& errors,
                         [[maybe_unused]] std::shared_ptr<const Python> python,
-                        const RestartIO::RstState * rst) :
+                        const RestartIO::RstState * rst)
+    try :
         python_handle(python),
         m_timeMap( deck , restart_info( rst )),
         m_oilvaporizationproperties( this->m_timeMap, OilVaporizationProperties(runspec.tabdims().getNumPVTTables()) ),
@@ -143,6 +147,16 @@ namespace {
         if (DeckSection::hasSCHEDULE(deck))
             iterateScheduleSection( python, deck.getInputPath(), parseContext, errors, SCHEDULESection( deck ), grid, fp);
     }
+    catch (const OpmInputError& opm_error) {
+        throw;
+    }
+    catch (const std::exception& std_error) {
+        OpmLog::error(fmt::format("An error occured while creating the reservior schedule\n",
+                                  "Internal error: {}", std_error.what()));
+        throw;
+    }
+
+
 
 
     template <typename T>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.cpp
@@ -22,6 +22,8 @@
 #include <cmath>
 #include <iostream>
 
+#include <fmt/format.h>
+
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>


### PR DESCRIPTION
Wrap construction of all the "big four" in `try catch` blocks.

Messages should be refined - but this should be enough to guarantee that all errors have been logged before leaving opm-common.

OK guys: This was new syntax to ya?!