### PR TITLE
Test Compilation Warning Noise Fix

### DIFF
--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -157,12 +157,12 @@ BOOST_AUTO_TEST_CASE(TestActions) {
     Opm::Action::Actions config;
     std::vector<std::string> matching_wells;
     auto python = std::make_shared<Opm::Python>();
-    BOOST_CHECK_EQUAL(config.size(), 0);
+    BOOST_CHECK_EQUAL(config.size(), 0U);
     BOOST_CHECK(config.empty());
 
     Opm::Action::ActionX action1("NAME", 10, 100, 0);
     config.add(action1);
-    BOOST_CHECK_EQUAL(config.size(), 1);
+    BOOST_CHECK_EQUAL(config.size(), 1U);
     BOOST_CHECK(!config.empty());
 
     double min_wait = 86400;
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(TestActions) {
     {
         Opm::Action::ActionX action("NAME", max_eval, min_wait, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 7, 1 })) );
         config.add(action);
-        BOOST_CHECK_EQUAL(config.size(), 1);
+        BOOST_CHECK_EQUAL(config.size(), 1U);
 
 
         Opm::Action::ActionX action3("NAME3", 1000000, 0, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 7, 1 })) );
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(TestActions) {
     BOOST_CHECK(!action2.eval(context));
 
     auto pending = config.pending( action_state, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 8, 7 }))  );
-    BOOST_CHECK_EQUAL( pending.size(), 2);
+    BOOST_CHECK_EQUAL( pending.size(), 2U);
     for (auto& ptr : pending) {
         BOOST_CHECK( ptr->ready( action_state, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 8, 7 }))  ));
         BOOST_CHECK( !ptr->eval( context));
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(TestActions) {
 
 
     const auto& python_actions = config.pending_python();
-    BOOST_CHECK_EQUAL(python_actions.size(), 2);
+    BOOST_CHECK_EQUAL(python_actions.size(), 2U);
 }
 
 
@@ -216,11 +216,11 @@ BOOST_AUTO_TEST_CASE(TestContext) {
     BOOST_CHECK_EQUAL(context.get("FUNC", "ARG"), 100);
 
     const auto& wopr_wells = context.wells("WOPR");
-    BOOST_CHECK_EQUAL(wopr_wells.size(), 1);
+    BOOST_CHECK_EQUAL(wopr_wells.size(), 1U);
     BOOST_CHECK_EQUAL(wopr_wells[0], "OP1");
 
     const auto& wwct_wells = context.wells("WWCT");
-    BOOST_CHECK_EQUAL(wwct_wells.size(), 0);
+    BOOST_CHECK_EQUAL(wwct_wells.size(), 0U);
 }
 
 
@@ -531,7 +531,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells) {
     auto wells = res.wells();
     BOOST_CHECK( res);
 
-    BOOST_CHECK_EQUAL( wells.size(), 1);
+    BOOST_CHECK_EQUAL( wells.size(), 1U);
     BOOST_CHECK_EQUAL( wells[0], "OPZ" );
 }
 
@@ -556,11 +556,11 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells2) {
   auto wells1 = res1.wells();
   auto wells2 = res2.wells();
   BOOST_CHECK(res1);
-  BOOST_CHECK_EQUAL( wells1.size(), 1);
+  BOOST_CHECK_EQUAL( wells1.size(), 1U);
   BOOST_CHECK_EQUAL( wells1[0], "PZ" );
 
   BOOST_CHECK(res2);
-  BOOST_CHECK_EQUAL( wells2.size(), 2);
+  BOOST_CHECK_EQUAL( wells2.size(), 2U);
   BOOST_CHECK_EQUAL( std::count(wells2.begin(), wells2.end(), "PZ") , 1);
   BOOST_CHECK_EQUAL( std::count(wells2.begin(), wells2.end(), "IZ") , 1);
 }
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells_OR) {
     // The well 'OPZ' matches the first condition and the well 'OPY' matches the
     // second condition, since the two conditions are combined with || the
     // resulting mathcing_wells variable should contain both these wells.
-    BOOST_CHECK_EQUAL( wells.size(), 2);
+    BOOST_CHECK_EQUAL( wells.size(), 2U);
     BOOST_CHECK( std::find(wells.begin(), wells.end(), "OPZ") != wells.end());
     BOOST_CHECK( std::find(wells.begin(), wells.end(), "OPY") != wells.end());
 }
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(TestWLIST) {
     auto res = ast.eval(context);
     auto wells = res.wells();
     BOOST_CHECK(res);
-    BOOST_CHECK_EQUAL( wells.size(), 3);
+    BOOST_CHECK_EQUAL( wells.size(), 3U);
     for (const auto& w : {"W1", "W3", "W5"}) {
         auto find_iter = std::find(wells.begin(), wells.end(), w);
         BOOST_CHECK( find_iter != wells.end() );
@@ -667,7 +667,7 @@ BOOST_AUTO_TEST_CASE(TestFieldAND) {
         auto res = ast.eval(context);
         auto wells = res.wells();
         BOOST_CHECK(res);
-        BOOST_CHECK_EQUAL(wells.size(), 1);
+        BOOST_CHECK_EQUAL(wells.size(), 1U);
         BOOST_CHECK_EQUAL(wells[0], "OP3");
     }
 }
@@ -686,22 +686,22 @@ BOOST_AUTO_TEST_CASE(Conditions) {
     BOOST_CHECK(cond.cmp == Action::Condition::Comparator::GREATER);
     BOOST_CHECK(cond.cmp_string == ">" );
     BOOST_CHECK_EQUAL(cond.lhs.quantity, "WWCT");
-    BOOST_CHECK_EQUAL(cond.lhs.args.size(), 1);
+    BOOST_CHECK_EQUAL(cond.lhs.args.size(), 1U);
     BOOST_CHECK_EQUAL(cond.lhs.args[0], "OPX");
 
     BOOST_CHECK_EQUAL(cond.rhs.quantity, "0.75");
-    BOOST_CHECK_EQUAL(cond.rhs.args.size(), 0);
+    BOOST_CHECK_EQUAL(cond.rhs.args.size(), 0U);
     BOOST_CHECK(cond.logic == Action::Condition::Logical::AND);
 
     Action::Condition cond2({"WWCT", "OPX", "<=", "WSOPR", "OPX", "235"}, location);
     BOOST_CHECK(cond2.cmp == Action::Condition::Comparator::LESS_EQUAL);
     BOOST_CHECK(cond2.cmp_string == "<=" );
     BOOST_CHECK_EQUAL(cond2.lhs.quantity, "WWCT");
-    BOOST_CHECK_EQUAL(cond2.lhs.args.size(), 1);
+    BOOST_CHECK_EQUAL(cond2.lhs.args.size(), 1U);
     BOOST_CHECK_EQUAL(cond2.lhs.args[0], "OPX");
 
     BOOST_CHECK_EQUAL(cond2.rhs.quantity, "WSOPR");
-    BOOST_CHECK_EQUAL(cond2.rhs.args.size(), 2);
+    BOOST_CHECK_EQUAL(cond2.rhs.args.size(), 2U);
     BOOST_CHECK_EQUAL(cond2.rhs.args[0], "OPX");
     BOOST_CHECK_EQUAL(cond2.rhs.args[1], "235");
     BOOST_CHECK(cond2.logic == Action::Condition::Logical::END);
@@ -762,15 +762,15 @@ TSTEP
     Runspec runspec (deck);
     Schedule sched(deck, grid1, fp, runspec, python);
     const auto& actions0 = sched.actions(0);
-    BOOST_CHECK_EQUAL(actions0.size(), 0);
+    BOOST_CHECK_EQUAL(actions0.size(), 0U);
 
     const auto& actions1 = sched.actions(1);
-    BOOST_CHECK_EQUAL(actions1.size(), 1);
+    BOOST_CHECK_EQUAL(actions1.size(), 1U);
 
 
     const auto& act1 = actions1.get("B");
     const auto& strings = act1.keyword_strings();
-    BOOST_CHECK_EQUAL(strings.size(), 4);
+    BOOST_CHECK_EQUAL(strings.size(), 4U);
     BOOST_CHECK_EQUAL(strings.back(), "ENDACTIO");
 
 
@@ -783,15 +783,15 @@ TSTEP
 
 
     const auto& conditions = act1.conditions();
-    BOOST_CHECK_EQUAL(conditions.size() , 2);
+    BOOST_CHECK_EQUAL(conditions.size() , 2U);
 
     const auto& cond0 = conditions[0];
     BOOST_CHECK_EQUAL(cond0.lhs.quantity, "WWCT");
     BOOST_CHECK(cond0.cmp == Action::Condition::Comparator::GREATER);
     BOOST_CHECK(cond0.logic == Action::Condition::Logical::AND);
-    BOOST_CHECK_EQUAL(cond0.lhs.args.size(), 1);
+    BOOST_CHECK_EQUAL(cond0.lhs.args.size(), 1U);
     BOOST_CHECK_EQUAL(cond0.lhs.args[0], "OPX");
-    BOOST_CHECK_EQUAL(cond0.rhs.args.size(), 0);
+    BOOST_CHECK_EQUAL(cond0.rhs.args.size(), 0U);
     BOOST_CHECK_EQUAL(cond0.rhs.quantity, "0.75");
 
     const auto& cond1 = conditions[1];
@@ -802,11 +802,11 @@ TSTEP
     /*****************************************************************/
 
     const auto& actions2 = sched.actions(2);
-    BOOST_CHECK_EQUAL(actions2.size(), 2);
+    BOOST_CHECK_EQUAL(actions2.size(), 2U);
 
     const auto& actB = actions2.get("B");
     const auto& condB = actB.conditions();
-    BOOST_CHECK_EQUAL(condB.size() , 1);
+    BOOST_CHECK_EQUAL(condB.size() , 1U);
     BOOST_CHECK_EQUAL(condB[0].lhs.quantity, "FWCT");
     BOOST_CHECK(condB[0].cmp == Action::Condition::Comparator::LESS_EQUAL);
     BOOST_CHECK(condB[0].logic == Action::Condition::Logical::END);
@@ -814,7 +814,7 @@ TSTEP
 
     const auto& actA = actions2.get("A");
     const auto& condA = actA.conditions();
-    BOOST_CHECK_EQUAL(condA.size() , 1);
+    BOOST_CHECK_EQUAL(condA.size() , 1U);
     BOOST_CHECK_EQUAL(condA[0].lhs.quantity, "WOPR");
     BOOST_CHECK(condA[0].cmp == Action::Condition::Comparator::EQUAL);
     BOOST_CHECK(condA[0].logic == Action::Condition::Logical::END);
@@ -853,26 +853,26 @@ BOOST_AUTO_TEST_CASE(ActionState) {
     Action::ActionX action1("NAME", 100, 100, 100); action1.update_id(100);
     Action::ActionX action2("NAME", 100, 100, 100); action1.update_id(200);
 
-    BOOST_CHECK_EQUAL(0, st.run_count(action1));
+    BOOST_CHECK_EQUAL(0U, st.run_count(action1));
     BOOST_CHECK_THROW( st.run_time(action1), std::out_of_range);
 
     st.add_run(action1, 100);
-    BOOST_CHECK_EQUAL(1, st.run_count(action1));
+    BOOST_CHECK_EQUAL(1U, st.run_count(action1));
     BOOST_CHECK_EQUAL(100, st.run_time(action1));
 
     st.add_run(action1, 1000);
-    BOOST_CHECK_EQUAL(2, st.run_count(action1));
+    BOOST_CHECK_EQUAL(2U, st.run_count(action1));
     BOOST_CHECK_EQUAL(1000, st.run_time(action1));
 
-    BOOST_CHECK_EQUAL(0, st.run_count(action2));
+    BOOST_CHECK_EQUAL(0U, st.run_count(action2));
     BOOST_CHECK_THROW( st.run_time(action2), std::out_of_range);
 
     st.add_run(action2, 100);
-    BOOST_CHECK_EQUAL(1, st.run_count(action2));
+    BOOST_CHECK_EQUAL(1U, st.run_count(action2));
     BOOST_CHECK_EQUAL(100, st.run_time(action2));
 
     st.add_run(action2, 1000);
-    BOOST_CHECK_EQUAL(2, st.run_count(action2));
+    BOOST_CHECK_EQUAL(2U, st.run_count(action2));
     BOOST_CHECK_EQUAL(1000, st.run_time(action2));
 }
 
@@ -924,6 +924,6 @@ ENDACTIO
 
     Action::State st;
     st.add_run(action1, 1000);
-    BOOST_CHECK_EQUAL( st.run_count(action1), 1);
-    BOOST_CHECK_EQUAL( st.run_count(action2), 0);
+    BOOST_CHECK_EQUAL( st.run_count(action1), 1U);
+    BOOST_CHECK_EQUAL( st.run_count(action2), 0U);
 }

--- a/tests/parser/AquiferTests.cpp
+++ b/tests/parser/AquiferTests.cpp
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(AquiferCTTest){
             BOOST_CHECK(it.p0.first == true);
             BOOST_CHECK_CLOSE(it.p0.second, 1.5e5, 1e-6);
         }
-        BOOST_CHECK_EQUAL(aquiferct.size(), 1);
+        BOOST_CHECK_EQUAL(aquiferct.size(), 1U);
     }
 
     auto deck_default_p0 = createAquiferCTDeckDefaultP0();
@@ -308,10 +308,10 @@ BOOST_AUTO_TEST_CASE(AquanconTest_DEFAULT_INFLUX) {
       The cells I = 0..2 are connected to aquifer 1; cell I==0 is inactive and
       not counted here ==> a total of 2 cells are connected to aquifer 1.
     */
-    BOOST_CHECK_EQUAL(cells_aq1.size(), 2);
+    BOOST_CHECK_EQUAL(cells_aq1.size(), 2U);
 
     const auto& cells_aq2 = aqcon[2];
-    BOOST_CHECK_EQUAL(cells_aq2.size(), 1);
+    BOOST_CHECK_EQUAL(cells_aq2.size(), 1U);
     BOOST_CHECK(aqcon.active());
 
     auto deck2 = createAQUANCONDeck_DEFAULT_INFLUX2();
@@ -377,8 +377,8 @@ BOOST_AUTO_TEST_CASE(AquanconTest_ALLOW_AQUIFER_INSIDE_OR_NOT) {
     BOOST_CHECK(aqucon == aq2);
     auto cells1 = aqucon[1];
     auto cells2 = aqucon[2];
-    BOOST_CHECK_EQUAL(cells1.size() , 2);
-    BOOST_CHECK_EQUAL(cells2.size() , 1);
+    BOOST_CHECK_EQUAL(cells1.size() , 2U);
+    BOOST_CHECK_EQUAL(cells2.size() , 1U);
 }
 
 inline Deck createAquifetpDeck() {
@@ -509,7 +509,7 @@ BOOST_AUTO_TEST_CASE(AquifetpTest){
 
   auto aqufetp_deck_null = createNullAquifetpDeck();
   const auto& aquifetp_null = init_aquifetp(aqufetp_deck_null);
-  BOOST_CHECK_EQUAL(aquifetp_null.size(), 0);
+  BOOST_CHECK_EQUAL(aquifetp_null.size(), 0U);
 
   auto aqufetp_deck_default = createAquifetpDeck_defaultPressure();
   const auto& aquifetp_default = init_aquifetp(aqufetp_deck_default);
@@ -525,14 +525,14 @@ BOOST_AUTO_TEST_CASE(AquifetpTest){
 BOOST_AUTO_TEST_CASE(TEST_CREATE) {
       Opm::Aqudims aqudims;
 
-      BOOST_CHECK_EQUAL( aqudims.getNumAqunum() , 1 );
-      BOOST_CHECK_EQUAL( aqudims.getNumConnectionNumericalAquifer() , 1 );
-      BOOST_CHECK_EQUAL( aqudims.getNumInfluenceTablesCT() , 1 );
-      BOOST_CHECK_EQUAL( aqudims.getNumRowsInfluenceTable() , 36 );
-      BOOST_CHECK_EQUAL( aqudims.getNumAnalyticAquifers() , 1 );
-      BOOST_CHECK_EQUAL( aqudims.getNumRowsAquancon() , 1 );
-      BOOST_CHECK_EQUAL( aqudims.getNumAquiferLists() , 0 );
-      BOOST_CHECK_EQUAL( aqudims.getNumAnalyticAquifersSingleList() , 0 );
+      BOOST_CHECK_EQUAL( aqudims.getNumAqunum() , 1U );
+      BOOST_CHECK_EQUAL( aqudims.getNumConnectionNumericalAquifer() , 1U );
+      BOOST_CHECK_EQUAL( aqudims.getNumInfluenceTablesCT() , 1U );
+      BOOST_CHECK_EQUAL( aqudims.getNumRowsInfluenceTable() , 36U );
+      BOOST_CHECK_EQUAL( aqudims.getNumAnalyticAquifers() , 1U );
+      BOOST_CHECK_EQUAL( aqudims.getNumRowsAquancon() , 1U );
+      BOOST_CHECK_EQUAL( aqudims.getNumAquiferLists() , 0U );
+      BOOST_CHECK_EQUAL( aqudims.getNumAnalyticAquifersSingleList() , 0U );
 }
 
 BOOST_AUTO_TEST_CASE(Test_Aquifer_Config) {

--- a/tests/parser/BoxTests.cpp
+++ b/tests/parser/BoxTests.cpp
@@ -35,9 +35,9 @@ BOOST_AUTO_TEST_CASE(CreateBox) {
     Opm::Box box(grid);
     BOOST_CHECK_EQUAL( 24U , box.size() );
     BOOST_CHECK( box.isGlobal() );
-    BOOST_CHECK_EQUAL( 4 , box.getDim(0) );
-    BOOST_CHECK_EQUAL( 3 , box.getDim(1) );
-    BOOST_CHECK_EQUAL( 2 , box.getDim(2) );
+    BOOST_CHECK_EQUAL( 4U , box.getDim(0) );
+    BOOST_CHECK_EQUAL( 3U , box.getDim(1) );
+    BOOST_CHECK_EQUAL( 2U , box.getDim(2) );
 
     BOOST_CHECK_THROW( box.getDim(5) , std::invalid_argument);
 }
@@ -164,13 +164,13 @@ BOOST_AUTO_TEST_CASE(TestKeywordBox2) {
     const auto& global_index_list = box.global_index_list();
     BOOST_CHECK_EQUAL( global_index_list.size(), grid.getCartesianSize());
     const auto& c0 = global_index_list[0];
-    BOOST_CHECK_EQUAL(c0.global_index, 0);
+    BOOST_CHECK_EQUAL(c0.global_index, 0U);
     BOOST_CHECK_EQUAL(c0.active_index, c0.global_index);
-    BOOST_CHECK_EQUAL(c0.data_index, 0);
+    BOOST_CHECK_EQUAL(c0.data_index, 0U);
 
     Opm::Box box2(grid,9,9,9,9,0,9);
     const auto& il = box2.index_list();
-    BOOST_CHECK_EQUAL(il.size(), 10);
+    BOOST_CHECK_EQUAL(il.size(), 10U);
 
     for (std::size_t i=0; i < 10; i++) {
         BOOST_CHECK_EQUAL(il[i].data_index, i);

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(ActiveCompletions) {
     grid.resetACTNUM( actnum);
 
     Opm::WellConnections active_completions(completions, grid);
-    BOOST_CHECK_EQUAL( active_completions.size() , 2);
+    BOOST_CHECK_EQUAL( active_completions.size() , 2U);
     BOOST_CHECK_EQUAL( completion2, active_completions.get(0));
     BOOST_CHECK_EQUAL( completion3, active_completions.get(1));
 }

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -55,7 +55,7 @@ std::pair<std::vector<Dimension>, std::vector<Dimension>> make_dims() {
 BOOST_AUTO_TEST_CASE(getKeywordList_empty_list) {
     Deck deck;
     auto kw_list = deck.getKeywordList("TRULS");
-    BOOST_CHECK_EQUAL( kw_list.size() , 0 );
+    BOOST_CHECK_EQUAL( kw_list.size() , 0U );
 }
 
 BOOST_AUTO_TEST_CASE(getKeyword_singlekeyword_outRange_throws) {
@@ -164,10 +164,10 @@ BOOST_AUTO_TEST_CASE(set_and_get_data_file) {
 
 BOOST_AUTO_TEST_CASE(DummyDefaultsString) {
     DeckItem deckStringItem("TEST", std::string() );
-    BOOST_CHECK_EQUAL(deckStringItem.data_size(), 0);
+    BOOST_CHECK_EQUAL(deckStringItem.data_size(), 0U);
 
     deckStringItem.push_backDummyDefault<std::string>();
-    BOOST_CHECK_EQUAL(deckStringItem.data_size(), 1);
+    BOOST_CHECK_EQUAL(deckStringItem.data_size(), 1U);
     BOOST_CHECK_EQUAL(true, deckStringItem.defaultApplied(0));
     BOOST_CHECK_THROW(deckStringItem.get< std::string >(0), std::invalid_argument);
 }
@@ -268,10 +268,10 @@ BOOST_AUTO_TEST_CASE(SetInDeck) {
 BOOST_AUTO_TEST_CASE(DummyDefaultsDouble) {
     auto dims = make_dims();
     DeckItem deckDoubleItem( "TEST", double(), dims.first, dims.second);
-    BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 0);
+    BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 0U);
 
     deckDoubleItem.push_backDummyDefault<double>();
-    BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 1);
+    BOOST_CHECK_EQUAL(deckDoubleItem.data_size(), 1U);
     BOOST_CHECK_EQUAL(true, deckDoubleItem.defaultApplied(0));
     BOOST_CHECK_THROW(deckDoubleItem.get< double >(0), std::invalid_argument);
 }
@@ -342,10 +342,10 @@ BOOST_AUTO_TEST_CASE(HasValue) {
 
 BOOST_AUTO_TEST_CASE(DummyDefaultsInt) {
     DeckItem deckIntItem( "TEST", int() );
-    BOOST_CHECK_EQUAL(deckIntItem.data_size(), 0);
+    BOOST_CHECK_EQUAL(deckIntItem.data_size(), 0U);
 
     deckIntItem.push_backDummyDefault<int>();
-    BOOST_CHECK_EQUAL(deckIntItem.data_size(), 1);
+    BOOST_CHECK_EQUAL(deckIntItem.data_size(), 1U);
     BOOST_CHECK_EQUAL(true, deckIntItem.defaultApplied(0));
     BOOST_CHECK_EQUAL( false , deckIntItem.hasValue(0));
     BOOST_CHECK_EQUAL( false , deckIntItem.hasValue(1));
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(DefaultAppliedInt) {
     BOOST_CHECK_EQUAL( false, deckIntItem.defaultApplied(1) );
     deckIntItem.push_backDefault( 1 );
     BOOST_CHECK_EQUAL( true , deckIntItem.defaultApplied(2) );
-    BOOST_CHECK_EQUAL( 3 , deckIntItem.data_size() );
+    BOOST_CHECK_EQUAL( 3U, deckIntItem.data_size() );
 }
 
 

--- a/tests/parser/DeckValueTests.cpp
+++ b/tests/parser/DeckValueTests.cpp
@@ -101,10 +101,10 @@ BOOST_AUTO_TEST_CASE(DeckKeywordConstructor) {
     std::vector< DeckValue > record = {DeckValue("WORD_A"), DeckValue(16.25), DeckValue(77), DeckValue("WORD_B")};
     DeckKeyword deck_kw(addreg, {record}, unit_active, unit_default);
 
-    BOOST_CHECK_EQUAL( deck_kw.size(), 1 );
+    BOOST_CHECK_EQUAL( deck_kw.size(), 1U );
 
     const DeckRecord& deck_record = deck_kw.getRecord(0);
-    BOOST_CHECK_EQUAL( deck_record.size(), 4 );
+    BOOST_CHECK_EQUAL( deck_record.size(), 4U );
 
     const auto& array = deck_record.getItem( 0 );
     const auto& shift = deck_record.getItem( 1 );
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(DeckKeywordVectorInt) {
    BOOST_CHECK_THROW( DeckKeyword(box, data), std::invalid_argument );
    DeckKeyword hbnum_kw(hbnum, data);
    BOOST_CHECK(hbnum_kw.isDataKeyword());
-   BOOST_CHECK_EQUAL(hbnum_kw.getDataSize(), 9);
+   BOOST_CHECK_EQUAL(hbnum_kw.getDataSize(), 9U);
    BOOST_CHECK( hbnum_kw.getIntData() == data );
 
    std::vector<double> data_double = {1.1, 2.2};
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(DeckKeywordVectorDouble) {
    BOOST_CHECK_THROW(DeckKeyword(box, data, unit_active, unit_default), std::invalid_argument);
    DeckKeyword zcorn_kw(zcorn, data, unit_active, unit_default);
    BOOST_CHECK(zcorn_kw.isDataKeyword());
-   BOOST_CHECK_EQUAL(zcorn_kw.getDataSize(), 3);
+   BOOST_CHECK_EQUAL(zcorn_kw.getDataSize(), 3U);
    BOOST_CHECK( zcorn_kw.getRawDoubleData() == data );
    std::vector<double> SI_data = zcorn_kw.getSIDoubleData();
    BOOST_CHECK( cmp::scalar_equal<double>(SI_data[0], 0.011) );
@@ -204,7 +204,7 @@ PERMX
     Deck deck = parser.parseString(deck_string);
     const auto& permx = deck.getKeyword("PERMX");
     const auto& status = permx.getValueStatus();
-    BOOST_CHECK_EQUAL(status.size(), 100);
+    BOOST_CHECK_EQUAL(status.size(), 100U);
     for (const auto& vs : status) {
         BOOST_CHECK(!value::has_value(vs));
         BOOST_CHECK(vs == value::status::empty_default);

--- a/tests/parser/DynamicStateTests.cpp
+++ b/tests/parser/DynamicStateTests.cpp
@@ -202,29 +202,29 @@ BOOST_AUTO_TEST_CASE( find ) {
     Opm::TimeMap timeMap = make_timemap(6);
     Opm::DynamicState<int> state(timeMap , 137);
 
-    BOOST_CHECK_EQUAL( state.find( 137 ).value() , 0 );
-    BOOST_CHECK_EQUAL( state.find_not(200).value(), 0);
+    BOOST_CHECK_EQUAL( state.find( 137 ).value() , 0U );
+    BOOST_CHECK_EQUAL( state.find_not(200).value(), 0U);
     BOOST_CHECK( !state.find( 200 ));
     BOOST_CHECK( !state.find_not(137));
 
     state.update( 0 , 200 );
     BOOST_CHECK( !state.find( 137 ) );
-    BOOST_CHECK_EQUAL( state.find( 200 ).value() ,  0 );
+    BOOST_CHECK_EQUAL( state.find( 200 ).value() ,  0U );
 
     state.update( 2 , 300 );
-    BOOST_CHECK_EQUAL( state.find( 200 ).value() ,  0 );
-    BOOST_CHECK_EQUAL( state.find( 300 ).value() ,  2 );
-    BOOST_CHECK_EQUAL( state.find_not( 200 ).value() ,  2 );
+    BOOST_CHECK_EQUAL( state.find( 200 ).value() ,  0U );
+    BOOST_CHECK_EQUAL( state.find( 300 ).value() ,  2U );
+    BOOST_CHECK_EQUAL( state.find_not( 200 ).value() ,  2U );
 
     state.update( 4 , 400 );
-    BOOST_CHECK_EQUAL( state.find( 200 ).value() ,  0 );
-    BOOST_CHECK_EQUAL( state.find( 300 ).value() ,  2 );
-    BOOST_CHECK_EQUAL( state.find( 400 ).value() ,  4 );
+    BOOST_CHECK_EQUAL( state.find( 200 ).value() ,  0U );
+    BOOST_CHECK_EQUAL( state.find( 300 ).value() ,  2U );
+    BOOST_CHECK_EQUAL( state.find( 400 ).value() ,  4U );
     BOOST_CHECK( !state.find( 500 ));
 
 
     auto pred = [] (const int& elm) { return elm == 400 ;};
-    BOOST_CHECK_EQUAL( state.find_if(pred).value(), 4);
+    BOOST_CHECK_EQUAL( state.find_if(pred).value(), 4U);
 }
 
 
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE( update_equal ) {
         auto next_index = state.update_equal(4,50);
         BOOST_CHECK_EQUAL(state[4], 50);
         BOOST_CHECK_EQUAL(state[5], 100);
-        BOOST_CHECK_EQUAL(next_index.value() , 5);
+        BOOST_CHECK_EQUAL(next_index.value() , 5U);
     }
 
 
@@ -291,13 +291,13 @@ BOOST_AUTO_TEST_CASE( UNIQUE ) {
     Opm::TimeMap timeMap = make_timemap(11);
     Opm::DynamicState<int> state(timeMap , 13);
     auto unique0 = state.unique();
-    BOOST_CHECK_EQUAL(unique0.size(), 1);
+    BOOST_CHECK_EQUAL(unique0.size(), 1U);
     BOOST_CHECK(unique0[0] == std::make_pair(std::size_t{0}, 13));
 
     state.update(3,300);
     state.update(6,600);
     auto unique1 = state.unique();
-    BOOST_CHECK_EQUAL(unique1.size(), 3);
+    BOOST_CHECK_EQUAL(unique1.size(), 3U);
     BOOST_CHECK(unique1[0] == std::make_pair(std::size_t{0}, 13));
     BOOST_CHECK(unique1[1] == std::make_pair(std::size_t{3}, 300));
     BOOST_CHECK(unique1[2] == std::make_pair(std::size_t{6}, 600));

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -131,15 +131,15 @@ BOOST_AUTO_TEST_CASE(CreateGridNoCells) {
     BOOST_CHECK_THROW( Opm::EclipseGrid{ deck }, std::invalid_argument);
 
     const Opm::GridDims grid( deck);
-    BOOST_CHECK_EQUAL( 10 , grid.getNX());
-    BOOST_CHECK_EQUAL( 10 , grid.getNY());
-    BOOST_CHECK_EQUAL( 10 , grid.getNZ());
+    BOOST_CHECK_EQUAL( 10U , grid.getNX());
+    BOOST_CHECK_EQUAL( 10U , grid.getNY());
+    BOOST_CHECK_EQUAL( 10U , grid.getNZ());
 
-    BOOST_CHECK_EQUAL(10, grid[0]);
-    BOOST_CHECK_EQUAL(10, grid[2]);
+    BOOST_CHECK_EQUAL(10U, grid[0]);
+    BOOST_CHECK_EQUAL(10U, grid[2]);
     BOOST_CHECK_THROW( grid[10], std::invalid_argument);
 
-    BOOST_CHECK_EQUAL( 1000 , grid.getCartesianSize());
+    BOOST_CHECK_EQUAL( 1000U , grid.getCartesianSize());
 }
 
 BOOST_AUTO_TEST_CASE(CheckGridIndex) {
@@ -159,15 +159,15 @@ BOOST_AUTO_TEST_CASE(CheckGridIndex) {
     BOOST_CHECK_EQUAL(v167[0], 14);
     BOOST_CHECK_EQUAL(v167[1], 9);
     BOOST_CHECK_EQUAL(v167[2], 0);
-    BOOST_CHECK_EQUAL(grid.getGlobalIndex(14, 9, 0), 167);
+    BOOST_CHECK_EQUAL(grid.getGlobalIndex(14, 9, 0), 167U);
 
     auto v5723 = grid.getIJK(5723);
     BOOST_CHECK_EQUAL(v5723[0], 11);
     BOOST_CHECK_EQUAL(v5723[1], 13);
     BOOST_CHECK_EQUAL(v5723[2], 17);
-    BOOST_CHECK_EQUAL(grid.getGlobalIndex(11, 13, 17), 5723);
+    BOOST_CHECK_EQUAL(grid.getGlobalIndex(11, 13, 17), 5723U);
 
-    BOOST_CHECK_EQUAL(17 * 19 * 41, grid.getCartesianSize());
+    BOOST_CHECK_EQUAL(std::size_t(17 * 19 * 41), grid.getCartesianSize());
 }
 
 static Opm::Deck createCPDeck() {
@@ -352,10 +352,10 @@ static Opm::Deck createCARTInvalidDeck() {
 BOOST_AUTO_TEST_CASE(CREATE_SIMPLE) {
     Opm::EclipseGrid grid(10,20,30);
 
-    BOOST_CHECK_EQUAL( grid.getNX() , 10 );
-    BOOST_CHECK_EQUAL( grid.getNY() , 20 );
-    BOOST_CHECK_EQUAL( grid.getNZ() , 30 );
-    BOOST_CHECK_EQUAL( grid.getCartesianSize() , 6000 );
+    BOOST_CHECK_EQUAL( grid.getNX() , 10U );
+    BOOST_CHECK_EQUAL( grid.getNY() , 20U );
+    BOOST_CHECK_EQUAL( grid.getNZ() , 30U );
+    BOOST_CHECK_EQUAL( grid.getCartesianSize() , 6000U );
 }
 
 BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
@@ -567,10 +567,10 @@ BOOST_AUTO_TEST_CASE(CreateCartesianGRIDInvalidDEPTHZ2) {
 BOOST_AUTO_TEST_CASE(CreateCartesianGRIDOnlyTopLayerDZ) {
     Opm::Deck deck = createOnlyTopDZCartGrid();
     Opm::EclipseGrid grid( deck );
-    BOOST_CHECK_EQUAL( 10 , grid.getNX( ));
-    BOOST_CHECK_EQUAL(  5 , grid.getNY( ));
-    BOOST_CHECK_EQUAL( 20 , grid.getNZ( ));
-    BOOST_CHECK_EQUAL( 1000 , grid.getNumActive());
+    BOOST_CHECK_EQUAL( 10U , grid.getNX( ));
+    BOOST_CHECK_EQUAL(  5U , grid.getNY( ));
+    BOOST_CHECK_EQUAL( 20U , grid.getNZ( ));
+    BOOST_CHECK_EQUAL( 1000U , grid.getNumActive());
 }
 
 BOOST_AUTO_TEST_CASE(AllActiveExportActnum) {
@@ -579,7 +579,7 @@ BOOST_AUTO_TEST_CASE(AllActiveExportActnum) {
 
     std::vector<int> actnum = grid.getACTNUM();
 
-    BOOST_CHECK_EQUAL( 1000 , actnum.size());
+    BOOST_CHECK_EQUAL( 1000U , actnum.size());
 }
 
 BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchCOORD) {
@@ -704,12 +704,12 @@ BOOST_AUTO_TEST_CASE(ResetACTNUM) {
 
     std::vector<int> actMap = grid.getActiveMap();
 
-    BOOST_CHECK_EQUAL(actMap.size(), 993);
+    BOOST_CHECK_EQUAL(actMap.size(), 993U);
     BOOST_CHECK_THROW(grid.getGlobalIndex(993), std::out_of_range);
-    BOOST_CHECK_EQUAL(grid.getGlobalIndex(0), 3);
-    BOOST_CHECK_EQUAL(grid.getGlobalIndex(33), 38);
-    BOOST_CHECK_EQUAL(grid.getGlobalIndex(450), 457);
-    BOOST_CHECK_EQUAL(grid.getGlobalIndex(1,2,3), 321);
+    BOOST_CHECK_EQUAL(grid.getGlobalIndex(0), 3U);
+    BOOST_CHECK_EQUAL(grid.getGlobalIndex(33), 38U);
+    BOOST_CHECK_EQUAL(grid.getGlobalIndex(450), 457U);
+    BOOST_CHECK_EQUAL(grid.getGlobalIndex(1,2,3), 321U);
 }
 
 BOOST_AUTO_TEST_CASE(TestCP_example) {
@@ -981,12 +981,12 @@ BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
 
     BOOST_CHECK_NO_THROW(fp.get_int("ACTNUM"));
     BOOST_CHECK_NO_THROW(grid.getNumActive());
-    BOOST_CHECK_EQUAL(grid.getNumActive(), 2 * 2 * 2 - 1);
+    BOOST_CHECK_EQUAL(grid.getNumActive(), std::size_t(2 * 2 * 2 - 1));
 
     BOOST_CHECK_NO_THROW(grid2.getNumActive());
-    BOOST_CHECK_EQUAL(grid2.getNumActive(), 2 * 2 * 2 - 1);
+    BOOST_CHECK_EQUAL(grid2.getNumActive(), std::size_t(2 * 2 * 2 - 1));
 
-    BOOST_CHECK_EQUAL(grid3.getNumActive(), 6);
+    BOOST_CHECK_EQUAL(grid3.getNumActive(), 6U);
 }
 
 
@@ -995,25 +995,25 @@ BOOST_AUTO_TEST_CASE(GridActnumViaState) {
 
     BOOST_CHECK_NO_THROW( std::unique_ptr<Opm::EclipseState>(new Opm::EclipseState( deck)));
     Opm::EclipseState es( deck);
-    BOOST_CHECK_EQUAL(es.getInputGrid().getNumActive(), 2 * 2 * 2 - 1);
+    BOOST_CHECK_EQUAL(es.getInputGrid().getNumActive(), std::size_t(2 * 2 * 2 - 1));
 }
 
 
 BOOST_AUTO_TEST_CASE(GridDimsSPECGRID) {
     auto deck =  createDeckSPECGRID();
     auto gd = Opm::GridDims( deck );
-    BOOST_CHECK_EQUAL(gd.getNX(), 13);
-    BOOST_CHECK_EQUAL(gd.getNY(), 17);
-    BOOST_CHECK_EQUAL(gd.getNZ(), 19);
+    BOOST_CHECK_EQUAL(gd.getNX(), 13U);
+    BOOST_CHECK_EQUAL(gd.getNY(), 17U);
+    BOOST_CHECK_EQUAL(gd.getNZ(), 19U);
 }
 
 
 BOOST_AUTO_TEST_CASE(GridDimsDIMENS) {
     auto deck =  createDeckDIMENS();
     auto gd = Opm::GridDims( deck );
-    BOOST_CHECK_EQUAL(gd.getNX(), 13);
-    BOOST_CHECK_EQUAL(gd.getNY(), 17);
-    BOOST_CHECK_EQUAL(gd.getNZ(), 19);
+    BOOST_CHECK_EQUAL(gd.getNX(), 13U);
+    BOOST_CHECK_EQUAL(gd.getNY(), 17U);
+    BOOST_CHECK_EQUAL(gd.getNZ(), 19U);
 }
 
 
@@ -1043,7 +1043,7 @@ BOOST_AUTO_TEST_CASE(ProcessedCopy) {
         BOOST_CHECK( gd.equal( gd2 ));
     }
 
-    actnum.assign( gd.getCartesianSize() , 1);
+    actnum.assign( gd.getCartesianSize() , 1U);
     actnum[0] = 0;
     {
         Opm::EclipseGrid gd2(gd , actnum );
@@ -1123,10 +1123,10 @@ BOOST_AUTO_TEST_CASE(ZcornMapper) {
 
     Opm::EclipseGrid grid2(grid , zcorn.data() , actnum );
     points_adjusted = grid2.getZcornFixed();
-    BOOST_CHECK_EQUAL( points_adjusted , 4 );
+    BOOST_CHECK_EQUAL( points_adjusted , 4U );
 
     points_adjusted = grid2.fixupZCORN();
-    BOOST_CHECK_EQUAL( points_adjusted , 0 );
+    BOOST_CHECK_EQUAL( points_adjusted , 0U );
 
     zcorn = grid.getZCORN();
 
@@ -1136,14 +1136,14 @@ BOOST_AUTO_TEST_CASE(ZcornMapper) {
     zcorn[ zmp.index(0,0,0,4) ] = zcorn[ zmp.index(0,0,0,0) ] - 0.1;
     BOOST_CHECK( !zmp.validZCORN( zcorn ));
     points_adjusted = zmp.fixupZCORN( zcorn );
-    BOOST_CHECK_EQUAL( points_adjusted , 1 );
+    BOOST_CHECK_EQUAL( points_adjusted , 1U );
     BOOST_CHECK( zmp.validZCORN( zcorn ));
 
     // Manually destroy it - cell 2 cell
     zcorn[ zmp.index(0,0,0,4) ] = zcorn[ zmp.index(0,0,1,0) ] + 0.1;
     BOOST_CHECK( !zmp.validZCORN( zcorn ));
     points_adjusted = zmp.fixupZCORN( zcorn );
-    BOOST_CHECK_EQUAL( points_adjusted , 1 );
+    BOOST_CHECK_EQUAL( points_adjusted , 1U );
     BOOST_CHECK( zmp.validZCORN( zcorn ));
 
     // Manually destroy it - cell 2 cell and cell internal
@@ -1151,7 +1151,7 @@ BOOST_AUTO_TEST_CASE(ZcornMapper) {
     zcorn[ zmp.index(0,0,0,0) ] = zcorn[ zmp.index(0,0,0,4) ] + 0.1;
     BOOST_CHECK( !zmp.validZCORN( zcorn ));
     points_adjusted = zmp.fixupZCORN( zcorn );
-    BOOST_CHECK_EQUAL( points_adjusted , 2 );
+    BOOST_CHECK_EQUAL( points_adjusted , 2U );
     BOOST_CHECK( zmp.validZCORN( zcorn ));
 }
 

--- a/tests/parser/FaultTests.cpp
+++ b/tests/parser/FaultTests.cpp
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(AddFaceToFaults) {
 
 BOOST_AUTO_TEST_CASE(CreateFaultCollection) {
     Opm::FaultCollection faults;
-    BOOST_CHECK_EQUAL( faults.size() , 0 );
+    BOOST_CHECK_EQUAL( faults.size() , 0U );
     BOOST_CHECK(! faults.hasFault("NO-NotThisOne"));
     BOOST_CHECK_THROW( faults.getFault("NO") , std::invalid_argument );
 }
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(AddFaultsToCollection) {
     Opm::FaultCollection faults;
 
     faults.addFault("FAULT");
-    BOOST_CHECK_EQUAL( faults.size() , 1 );
+    BOOST_CHECK_EQUAL( faults.size() , 1U );
     BOOST_CHECK(faults.hasFault("FAULT"));
 
     const auto& fault1 = faults.getFault("FAULT");
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(AddFaultsToCollection) {
 
     faults.addFault("FAULTX");
     const auto& faultx = faults.getFault("FAULTX");
-    BOOST_CHECK_EQUAL( faults.size() , 2 );
+    BOOST_CHECK_EQUAL( faults.size() , 2U );
     BOOST_CHECK(faults.hasFault("FAULTX"));
     BOOST_CHECK_EQUAL( faultx.getName() , faults.getFault(1).getName());
 }

--- a/tests/parser/FoamTests.cpp
+++ b/tests/parser/FoamTests.cpp
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(FoamConfigTest) {
     auto deck = createDeck();
     EclipseState state(deck);
     const FoamConfig& fc = state.getInitConfig().getFoamConfig();
-    BOOST_REQUIRE_EQUAL(fc.size(), 3);
+    BOOST_REQUIRE_EQUAL(fc.size(), 3U);
     BOOST_CHECK_EQUAL(fc.getRecord(0).referenceSurfactantConcentration(), 1.0);
     BOOST_CHECK_EQUAL(fc.getRecord(0).exponent(), 2.0);
     BOOST_CHECK_EQUAL(fc.getRecord(0).minimumSurfactantConcentration(), 0.3);

--- a/tests/parser/FunctionalTests.cpp
+++ b/tests/parser/FunctionalTests.cpp
@@ -95,10 +95,10 @@ BOOST_AUTO_TEST_CASE(iotaForeach) {
 }
 
 BOOST_AUTO_TEST_CASE(iotaSize) {
-    BOOST_CHECK_EQUAL( 5, fun::iota( 5 ).size() );
-    BOOST_CHECK_EQUAL( 5, fun::iota( 1, 6 ).size() );
-    BOOST_CHECK_EQUAL( 0, fun::iota( 0 ).size() );
-    BOOST_CHECK_EQUAL( 0, fun::iota( 0, 0 ).size() );
+    BOOST_CHECK_EQUAL( 5U, fun::iota( 5 ).size() );
+    BOOST_CHECK_EQUAL( 5U, fun::iota( 1, 6 ).size() );
+    BOOST_CHECK_EQUAL( 0U, fun::iota( 0 ).size() );
+    BOOST_CHECK_EQUAL( 0U, fun::iota( 0, 0 ).size() );
 }
 
 BOOST_AUTO_TEST_CASE(iotaWithMap) {

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGEFAC) {
     auto schedule = create_schedule(input);
 
     auto group_names = schedule.groupNames("PRODUC");
-    BOOST_CHECK_EQUAL(group_names.size(), 1);
+    BOOST_CHECK_EQUAL(group_names.size(), 1U);
     BOOST_CHECK_EQUAL(group_names[0], "PRODUC");
 
     const auto& group1 = schedule.getGroup("PRODUC", 0);
@@ -226,10 +226,10 @@ BOOST_AUTO_TEST_CASE(GroupCreate) {
     BOOST_CHECK( g1.hasWell("W1"));
     BOOST_CHECK( g1.hasWell("W2"));
     BOOST_CHECK( !g1.hasWell("W3"));
-    BOOST_CHECK_EQUAL( g1.numWells(), 2);
+    BOOST_CHECK_EQUAL( g1.numWells(), 2U);
     BOOST_CHECK_THROW(g1.delWell("W3"), std::invalid_argument);
     BOOST_CHECK_NO_THROW(g1.delWell("W1"));
-    BOOST_CHECK_EQUAL( g1.numWells(), 1);
+    BOOST_CHECK_EQUAL( g1.numWells(), 1U);
 
 
     BOOST_CHECK( g2.addGroup("G1") );
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(TESTGCONSALE) {
     double metric_to_si = 1.0 / (24.0 * 3600.0);  //cubic meters / day
 
     const auto& gconsale = schedule.gConSale(0);
-    BOOST_CHECK_EQUAL(gconsale.size(), 1);
+    BOOST_CHECK_EQUAL(gconsale.size(), 1U);
     BOOST_CHECK(gconsale.has("G1"));
     BOOST_CHECK(!gconsale.has("G2"));
     const GConSale::GCONSALEGroup& group = gconsale.get("G1");
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(TESTGCONSALE) {
     BOOST_CHECK(group.max_proc == GConSale::MaxProcedure::WELL);
 
     const auto& gconsump = schedule.gConSump(0);
-    BOOST_CHECK_EQUAL(gconsump.size(), 2);
+    BOOST_CHECK_EQUAL(gconsump.size(), 2U);
     BOOST_CHECK(gconsump.has("G1"));
     BOOST_CHECK(gconsump.has("G2"));
     const GConSump::GCONSUMPGroup group1 = gconsump.get("G1");
@@ -389,7 +389,7 @@ BOOST_AUTO_TEST_CASE(TESTGCONSALE) {
     BOOST_CHECK( group1.network_node == "a_node" );
 
     const GConSump::GCONSUMPGroup group2 = gconsump.get("G2");
-    BOOST_CHECK_EQUAL( group2.network_node.size(), 0 );
+    BOOST_CHECK_EQUAL( group2.network_node.size(), 0U );
 
 
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -622,7 +622,7 @@ BOOST_AUTO_TEST_CASE(MSW_BRANCH_SEGMENTS) {
     }
     {
         auto seg1 = segments.branchSegments(1);
-        BOOST_CHECK_EQUAL( seg1.size(), 6 );
+        BOOST_CHECK_EQUAL( seg1.size(), 6U );
         const std::vector<int> expected = {1,2,3,4,5,6};
         for (std::size_t index = 0; index < seg1.size(); index++)
             BOOST_CHECK_EQUAL( expected[index], seg1[index].segmentNumber());
@@ -630,14 +630,14 @@ BOOST_AUTO_TEST_CASE(MSW_BRANCH_SEGMENTS) {
     {
         auto seg2 = segments.branchSegments(2);
         const std::vector<int> expected = {7,8,9,10,11};
-        BOOST_CHECK_EQUAL( seg2.size(), 5 );
+        BOOST_CHECK_EQUAL( seg2.size(), 5U );
         for (std::size_t index = 0; index < seg2.size(); index++)
             BOOST_CHECK_EQUAL( expected[index], seg2[index].segmentNumber());
     }
     {
         auto seg5 = segments.branchSegments(5);
         const std::vector<int> expected = {22,23,24,25,26};
-        BOOST_CHECK_EQUAL( seg5.size(), 5 );
+        BOOST_CHECK_EQUAL( seg5.size(), 5U );
         for (std::size_t index = 0; index < seg5.size(); index++)
             BOOST_CHECK_EQUAL( expected[index], seg5[index].segmentNumber());
     }

--- a/tests/parser/NetworkTests.cpp
+++ b/tests/parser/NetworkTests.cpp
@@ -222,7 +222,7 @@ BRANPROP
 
 
 
-        BOOST_CHECK_EQUAL(network.downtree_branches("PLAT-A").size(), 2);
+        BOOST_CHECK_EQUAL(network.downtree_branches("PLAT-A").size(), 2U);
         for (const auto& b : network.downtree_branches("PLAT-A")) {
             BOOST_CHECK_EQUAL(b.uptree_node(), "PLAT-A");
             BOOST_CHECK(b.downtree_node() == "B1" || b.downtree_node() == "C1");
@@ -247,7 +247,7 @@ BRANPROP
         BOOST_CHECK(b1.name() == b1.target_group());
         BOOST_CHECK(!b1.terminal_pressure());
 
-        BOOST_CHECK_EQUAL(network.downtree_branches("PLAT-A").size(), 1);
+        BOOST_CHECK_EQUAL(network.downtree_branches("PLAT-A").size(), 1U);
         for (const auto& b : network.downtree_branches("PLAT-A")) {
             BOOST_CHECK_EQUAL(b.uptree_node(), "PLAT-A");
             BOOST_CHECK(b.downtree_node() == "B1");

--- a/tests/parser/OrderedMapTests.cpp
+++ b/tests/parser/OrderedMapTests.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE( check_empty) {
     BOOST_CHECK_THROW( map.get( "KEY" ) , std::invalid_argument);
     BOOST_CHECK_THROW( map.at("KEY"), std::invalid_argument);
     BOOST_CHECK_THROW( map.at(0), std::invalid_argument);
-    BOOST_CHECK_EQUAL( map.count("NO_SUCH_KEY"), 0);
+    BOOST_CHECK_EQUAL( map.count("NO_SUCH_KEY"), 0U);
 }
 
 BOOST_AUTO_TEST_CASE( operator_square ) {
@@ -47,10 +47,10 @@ BOOST_AUTO_TEST_CASE( operator_square ) {
 
     const auto& value = map["CKEY1"];
     BOOST_CHECK_EQUAL( value, std::string("Value1"));
-    BOOST_CHECK_EQUAL( map.size(), 3);
+    BOOST_CHECK_EQUAL( map.size(), 3U);
 
     auto& new_value = map["NEW_KEY"];
-    BOOST_CHECK_EQUAL( map.size(), 4);
+    BOOST_CHECK_EQUAL( map.size(), 4U);
     BOOST_CHECK_EQUAL( new_value, "");
 }
 
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE( check_order ) {
 
     BOOST_CHECK_EQUAL( "Value1" , map.get("CKEY1"));
     BOOST_CHECK_EQUAL( "Value1" , map.iget( 0 ));
-    BOOST_CHECK_EQUAL( map.count("CKEY"), 0);
+    BOOST_CHECK_EQUAL( map.count("CKEY"), 0U);
 
     BOOST_CHECK_EQUAL( "Value2" , map.get("BKEY2"));
     BOOST_CHECK_EQUAL( "Value2" , map.iget( 1 ));
@@ -104,8 +104,8 @@ BOOST_AUTO_TEST_CASE( check_order ) {
         BOOST_CHECK_EQUAL( values[2] , "Value3");
     }
 
-    BOOST_CHECK_EQUAL(map.erase("NO_SUCH_KEY"), 0);
-    BOOST_CHECK_EQUAL(map.erase("BKEY2"), 1);
+    BOOST_CHECK_EQUAL(map.erase("NO_SUCH_KEY"), 0U);
+    BOOST_CHECK_EQUAL(map.erase("BKEY2"), 1U);
     /*
     BOOST_CHECK_EQUAL( "NewValue1" , map.get("CKEY1"));
     BOOST_CHECK_EQUAL( "NewValue1" , map.iget( 0 ));
@@ -119,18 +119,18 @@ BOOST_AUTO_TEST_CASE( check_order ) {
 BOOST_AUTO_TEST_CASE(test_IOrderSet) {
     Opm::IOrderSet<std::string> iset;
     BOOST_CHECK(iset.empty());
-    BOOST_CHECK_EQUAL(iset.size(), 0);
-    BOOST_CHECK_EQUAL(iset.count("HEI"), 0);
+    BOOST_CHECK_EQUAL(iset.size(), 0U);
+    BOOST_CHECK_EQUAL(iset.count("HEI"), 0U);
     BOOST_CHECK_EQUAL(iset.contains("HEI"), false);
 
     BOOST_CHECK(iset.insert("HEI"));
-    BOOST_CHECK_EQUAL(iset.size(), 1);
-    BOOST_CHECK_EQUAL(iset.count("HEI"), 1);
+    BOOST_CHECK_EQUAL(iset.size(), 1U);
+    BOOST_CHECK_EQUAL(iset.count("HEI"), 1U);
     BOOST_CHECK_EQUAL(iset.contains("HEI"), true);
 
     BOOST_CHECK(!iset.insert("HEI"));
-    BOOST_CHECK_EQUAL(iset.size(), 1);
-    BOOST_CHECK_EQUAL(iset.count("HEI"), 1);
+    BOOST_CHECK_EQUAL(iset.size(), 1U);
+    BOOST_CHECK_EQUAL(iset.count("HEI"), 1U);
     BOOST_CHECK_EQUAL(iset.contains("HEI"), true);
 
     BOOST_CHECK_THROW(iset[10], std::out_of_range);
@@ -161,12 +161,12 @@ BOOST_AUTO_TEST_CASE(test_IOrderSet) {
     BOOST_CHECK_EQUAL(iset3[0], "AAA");
     BOOST_CHECK_EQUAL(iset3[1], "BBB");
 
-    BOOST_CHECK_EQUAL(iset3.erase("AAA"), 1);
-    BOOST_CHECK_EQUAL(iset3.size() , 1);
+    BOOST_CHECK_EQUAL(iset3.erase("AAA"), 1U);
+    BOOST_CHECK_EQUAL(iset3.size() , 1U);
     BOOST_CHECK_EQUAL(iset3[0], "BBB");
 
-    BOOST_CHECK_EQUAL(iset3.erase("AAA"), 0);
-    BOOST_CHECK_EQUAL(iset3.size() , 1);
+    BOOST_CHECK_EQUAL(iset3.erase("AAA"), 0U);
+    BOOST_CHECK_EQUAL(iset3.size() , 1U);
     BOOST_CHECK_EQUAL(iset3[0], "BBB");
 }
 

--- a/tests/parser/RockTableTests.cpp
+++ b/tests/parser/RockTableTests.cpp
@@ -126,8 +126,8 @@ BOOST_AUTO_TEST_CASE( Rock2d ) {
 
     const OverburdTable& overburdTable = overburd.getTable<OverburdTable>(0);
     BOOST_CHECK_THROW( rock2d.at(2), std::out_of_range );
-    BOOST_REQUIRE_EQUAL(3, rec1.size());
-    BOOST_REQUIRE_EQUAL(3, rec2.size());
+    BOOST_REQUIRE_EQUAL(3U, rec1.size());
+    BOOST_REQUIRE_EQUAL(3U, rec2.size());
     BOOST_REQUIRE_EQUAL(0.0, rec1.getPressureValue(0));
     BOOST_REQUIRE_EQUAL(0.13, rec1.getPvmultValue(1,2));
     BOOST_REQUIRE_EQUAL(rec1.sizeMultValues(), rockwnodTable1.getSaturationColumn().size());

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(TwoPhase) {
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
-    BOOST_CHECK_EQUAL( 2, phases.size() );
+    BOOST_CHECK_EQUAL( 2U, phases.size() );
     BOOST_CHECK(  phases.active( Phase::OIL ) );
     BOOST_CHECK( !phases.active( Phase::GAS ) );
     BOOST_CHECK(  phases.active( Phase::WATER ) );
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(ThreePhase) {
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
-    BOOST_CHECK_EQUAL( 3, phases.size() );
+    BOOST_CHECK_EQUAL( 3U, phases.size() );
     BOOST_CHECK( phases.active( Phase::OIL ) );
     BOOST_CHECK( phases.active( Phase::GAS ) );
     BOOST_CHECK( phases.active( Phase::WATER ) );
@@ -103,12 +103,12 @@ BOOST_AUTO_TEST_CASE(TABDIMS) {
 
     Runspec runspec( deck );
     const auto& tabdims = runspec.tabdims();
-    BOOST_CHECK_EQUAL( tabdims.getNumSatTables( ) , 1 );
-    BOOST_CHECK_EQUAL( tabdims.getNumPVTTables( ) , 1 );
-    BOOST_CHECK_EQUAL( tabdims.getNumSatNodes( ) , 3 );
-    BOOST_CHECK_EQUAL( tabdims.getNumPressureNodes( ) , 20 );
-    BOOST_CHECK_EQUAL( tabdims.getNumFIPRegions( ) , 5 );
-    BOOST_CHECK_EQUAL( tabdims.getNumRSNodes( ) , 20 );
+    BOOST_CHECK_EQUAL( tabdims.getNumSatTables( ) , 1U );
+    BOOST_CHECK_EQUAL( tabdims.getNumPVTTables( ) , 1U );
+    BOOST_CHECK_EQUAL( tabdims.getNumSatNodes( ) , 3U );
+    BOOST_CHECK_EQUAL( tabdims.getNumPressureNodes( ) , 20U );
+    BOOST_CHECK_EQUAL( tabdims.getNumFIPRegions( ) , 5U );
+    BOOST_CHECK_EQUAL( tabdims.getNumRSNodes( ) , 20U );
 }
 
 BOOST_AUTO_TEST_CASE( EndpointScalingWithoutENDSCALE ) {
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE(Solvent) {
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
-    BOOST_CHECK_EQUAL( 4, phases.size() );
+    BOOST_CHECK_EQUAL( 4U, phases.size() );
     BOOST_CHECK( phases.active( Phase::OIL ) );
     BOOST_CHECK( phases.active( Phase::GAS ) );
     BOOST_CHECK( phases.active( Phase::WATER ) );
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(Polymer) {
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
-    BOOST_CHECK_EQUAL( 4, phases.size() );
+    BOOST_CHECK_EQUAL( 4U, phases.size() );
     BOOST_CHECK( phases.active( Phase::OIL ) );
     BOOST_CHECK( phases.active( Phase::GAS ) );
     BOOST_CHECK( phases.active( Phase::WATER ) );
@@ -591,7 +591,7 @@ BOOST_AUTO_TEST_CASE(PolymerMolecularWeight) {
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
-    BOOST_CHECK_EQUAL( 4, phases.size() );
+    BOOST_CHECK_EQUAL( 4U, phases.size() );
     BOOST_CHECK( phases.active( Phase::OIL ) );
     BOOST_CHECK( !phases.active( Phase::GAS ) );
     BOOST_CHECK( phases.active( Phase::WATER ) );
@@ -615,7 +615,7 @@ BOOST_AUTO_TEST_CASE(Foam) {
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
-    BOOST_CHECK_EQUAL( 4, phases.size() );
+    BOOST_CHECK_EQUAL( 4U, phases.size() );
     BOOST_CHECK( phases.active( Phase::OIL ) );
     BOOST_CHECK( phases.active( Phase::GAS ) );
     BOOST_CHECK( phases.active( Phase::WATER ) );
@@ -623,7 +623,7 @@ BOOST_AUTO_TEST_CASE(Foam) {
 
     // not in deck - default constructor.
     const auto& actdims = runspec.actdims();
-    BOOST_CHECK_EQUAL(actdims.max_keywords(), 2);
+    BOOST_CHECK_EQUAL(actdims.max_keywords(), 2U);
 }
 
 BOOST_AUTO_TEST_CASE(ACTDIMS) {
@@ -638,8 +638,8 @@ BOOST_AUTO_TEST_CASE(ACTDIMS) {
 
     Runspec runspec( deck );
     const auto& actdims = runspec.actdims();
-    BOOST_CHECK_EQUAL(actdims.max_keywords(), 2);
-    BOOST_CHECK_EQUAL(actdims.max_conditions(), 14);
+    BOOST_CHECK_EQUAL(actdims.max_keywords(), 2U);
+    BOOST_CHECK_EQUAL(actdims.max_conditions(), 14U);
 }
 
 BOOST_AUTO_TEST_CASE(Co2Storage) {
@@ -656,7 +656,7 @@ BOOST_AUTO_TEST_CASE(Co2Storage) {
 
     Runspec runspec( deck );
     const auto& phases = runspec.phases();
-    BOOST_CHECK_EQUAL( 2, phases.size() );
+    BOOST_CHECK_EQUAL( 2U, phases.size() );
     BOOST_CHECK( phases.active( Phase::OIL ) );
     BOOST_CHECK( phases.active( Phase::GAS ) );
     BOOST_CHECK( runspec.co2Storage() );

--- a/tests/parser/SaltTableTests.cpp
+++ b/tests/parser/SaltTableTests.cpp
@@ -90,62 +90,62 @@ BOOST_AUTO_TEST_CASE( Brine ) {
 
     Opm::TableManager tables(deck);
     const auto& PvtwsaltTables = tables.getPvtwSaltTables( );
-    BOOST_CHECK_EQUAL(1 , PvtwsaltTables.size() );
-    BOOST_CHECK_EQUAL(2, PvtwsaltTables[0].size());
+    BOOST_CHECK_EQUAL(1U, PvtwsaltTables.size() );
+    BOOST_CHECK_EQUAL(2U, PvtwsaltTables[0].size());
 
     const auto& PvtwsaltTable1 = PvtwsaltTables[0];
-    BOOST_CHECK_EQUAL (PvtwsaltTable1.getSaltConcentrationColumn().size(), 2);
+    BOOST_CHECK_EQUAL (PvtwsaltTable1.getSaltConcentrationColumn().size(), 2U);
     BOOST_CHECK_CLOSE (PvtwsaltTable1.getSaltConcentrationColumn()[1], 10, 1e-5);
 
-    BOOST_CHECK_EQUAL (PvtwsaltTable1.getFormationVolumeFactorColumn().size(), 2);
+    BOOST_CHECK_EQUAL (PvtwsaltTable1.getFormationVolumeFactorColumn().size(), 2U);
     BOOST_CHECK_CLOSE (PvtwsaltTable1.getFormationVolumeFactorColumn()[0], 1, 1e-5);
 
-    BOOST_CHECK_EQUAL (PvtwsaltTable1.getCompressibilityColumn().size(), 2);
+    BOOST_CHECK_EQUAL (PvtwsaltTable1.getCompressibilityColumn().size(), 2U);
     BOOST_CHECK_CLOSE (PvtwsaltTable1.getCompressibilityColumn()[1], 12/1e5, 1e-5);
 
-    BOOST_CHECK_EQUAL (PvtwsaltTable1.getViscosityColumn().size(), 2);
+    BOOST_CHECK_EQUAL (PvtwsaltTable1.getViscosityColumn().size(), 2U);
     BOOST_CHECK_CLOSE (PvtwsaltTable1.getViscosityColumn()[1], 13*0.001, 1e-5);
 
     BOOST_CHECK_CLOSE (PvtwsaltTable1.getReferencePressureValue(), 1000*1e5, 1e-5);
 
     const auto& RwgsaltTables = tables.getRwgSaltTables( );
-    BOOST_CHECK_EQUAL(1 , RwgsaltTables.size() );
-    BOOST_CHECK_EQUAL(2, RwgsaltTables[0].size());
+    BOOST_CHECK_EQUAL(1U, RwgsaltTables.size() );
+    BOOST_CHECK_EQUAL(2U, RwgsaltTables[0].size());
 
     const auto& RwgsaltTable1 = RwgsaltTables[0];
 
-    BOOST_CHECK_EQUAL (RwgsaltTable1.getPressureColumn().size(), 2);
+    BOOST_CHECK_EQUAL (RwgsaltTable1.getPressureColumn().size(), 2U);
     BOOST_CHECK_CLOSE (RwgsaltTable1.getPressureColumn()[1], Metric::Pressure * 600, 1e-5);
 
-    BOOST_CHECK_EQUAL (RwgsaltTable1.getSaltConcentrationColumn().size(), 2);
+    BOOST_CHECK_EQUAL (RwgsaltTable1.getSaltConcentrationColumn().size(), 2U);
     BOOST_CHECK_CLOSE (RwgsaltTable1.getSaltConcentrationColumn()[1], 0.5, 1e-5);
 
-    BOOST_CHECK_EQUAL (RwgsaltTable1.getVaporizedWaterGasRatioColumn().size(), 2);
+    BOOST_CHECK_EQUAL (RwgsaltTable1.getVaporizedWaterGasRatioColumn().size(), 2U);
     BOOST_CHECK_CLOSE (RwgsaltTable1.getVaporizedWaterGasRatioColumn()[0], 0.00013, 1e-5);
 
     const auto& BdensityTables = tables.getBrineDensityTables( );
     const auto& BdensityTable1 = BdensityTables[0];
 
-    BOOST_CHECK_EQUAL( 1 , BdensityTables.size() );
-    BOOST_CHECK_EQUAL (BdensityTable1.getBrineDensityColumn().size(), 2);
+    BOOST_CHECK_EQUAL(1U, BdensityTables.size() );
+    BOOST_CHECK_EQUAL (BdensityTable1.getBrineDensityColumn().size(), 2U);
     BOOST_CHECK_CLOSE (BdensityTable1.getBrineDensityColumn()[1], 1050, 1e-5);
 
     const Opm::TableContainer& saltvdTables = tables.getSaltvdTables();
     const auto& saltvdTable = saltvdTables.getTable<Opm::SaltvdTable>(0);
 
-    BOOST_CHECK_EQUAL(saltvdTable.getDepthColumn().size(), 2);
+    BOOST_CHECK_EQUAL(saltvdTable.getDepthColumn().size(), 2U);
     BOOST_CHECK_CLOSE (saltvdTable.getSaltColumn() [1],50, 1e-5);
 
     const Opm::TableContainer& saltpvdTables = tables.getSaltpvdTables();
     const auto& saltpvdTable = saltpvdTables.getTable<Opm::SaltpvdTable>(0);
 
-    BOOST_CHECK_EQUAL(saltpvdTable.getDepthColumn().size(), 2);
+    BOOST_CHECK_EQUAL(saltpvdTable.getDepthColumn().size(), 2U);
     BOOST_CHECK_CLOSE(saltpvdTable.getSaltpColumn() [1],0.5, 1e-5);
 
     const Opm::TableContainer& permfactTables = tables.getPermfactTables();
     const auto& permfactTable = permfactTables.getTable<Opm::PermfactTable>(0);
 
-    BOOST_CHECK_EQUAL(permfactTable.getPorosityChangeColumn().size(), 4);
+    BOOST_CHECK_EQUAL(permfactTable.getPorosityChangeColumn().size(), 4U);
     BOOST_CHECK_CLOSE(permfactTable.getPermeabilityMultiplierColumn() [3],1.5, 1e-5);
 
 

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -48,7 +48,7 @@ void compare_connections(const RestartIO::RstConnection& rst_conn, const Connect
     BOOST_CHECK_EQUAL(rst_conn.ijk[2], sched_conn.getK());
 
     BOOST_CHECK_EQUAL(rst_conn.segment, sched_conn.segment());
-    BOOST_CHECK_EQUAL(rst_conn.rst_index, static_cast<int>(sched_conn.sort_value()));
+    BOOST_CHECK_EQUAL(rst_conn.rst_index, sched_conn.sort_value());
     BOOST_CHECK(rst_conn.state == sched_conn.state());
     BOOST_CHECK(rst_conn.dir == sched_conn.dir());
     BOOST_CHECK_CLOSE( rst_conn.cf, sched_conn.CF() , 1e-6);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -396,13 +396,13 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     BOOST_CHECK_EQUAL( "AG", group_names[3]);
 
     auto restart_groups = schedule.restart_groups(0);
-    BOOST_REQUIRE_EQUAL(restart_groups.size(), 4);
+    BOOST_REQUIRE_EQUAL(restart_groups.size(), 4U);
     for (std::size_t group_index = 0; group_index < restart_groups.size() - 1; group_index++) {
         const auto& group_ptr = restart_groups[group_index];
         BOOST_CHECK_EQUAL(group_ptr->insert_index(), group_index + 1);
     }
     const auto& field_ptr = restart_groups.back();
-    BOOST_CHECK_EQUAL(field_ptr->insert_index(), 0);
+    BOOST_CHECK_EQUAL(field_ptr->insert_index(), 0U);
     BOOST_CHECK_EQUAL(field_ptr->name(), "FIELD");
 }
 
@@ -470,16 +470,16 @@ BOOST_AUTO_TEST_CASE(GroupTree2TEST) {
     BOOST_CHECK( cg1.hasWell("CW_1"));
 
     auto cg1_tree = schedule.groupTree("CG1", 0);
-    BOOST_CHECK_EQUAL(cg1_tree.wells().size(), 2);
+    BOOST_CHECK_EQUAL(cg1_tree.wells().size(), 2U);
 
     auto gt = schedule.groupTree(0);
-    BOOST_CHECK_EQUAL(gt.wells().size(), 0);
+    BOOST_CHECK_EQUAL(gt.wells().size(), 0U);
     BOOST_CHECK_EQUAL(gt.group().name(), "FIELD");
     BOOST_CHECK_THROW(gt.parent_name(), std::invalid_argument);
 
     auto cg = gt.groups();
     auto pg = cg[0];
-    BOOST_CHECK_EQUAL(cg.size(), 1);
+    BOOST_CHECK_EQUAL(cg.size(), 1U);
     BOOST_CHECK_EQUAL(pg.group().name(), "PLATFORM");
     BOOST_CHECK_EQUAL(pg.parent_name(), "FIELD");
 }
@@ -589,10 +589,10 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
 BOOST_AUTO_TEST_CASE(ReturnNumWellsTimestep) {
     const auto& schedule = make_schedule( createDeckWithWells() );
 
-    BOOST_CHECK_EQUAL(schedule.numWells(0), 1);
-    BOOST_CHECK_EQUAL(schedule.numWells(1), 1);
-    BOOST_CHECK_EQUAL(schedule.numWells(2), 1);
-    BOOST_CHECK_EQUAL(schedule.numWells(3), 3);
+    BOOST_CHECK_EQUAL(schedule.numWells(0), 1U);
+    BOOST_CHECK_EQUAL(schedule.numWells(1), 1U);
+    BOOST_CHECK_EQUAL(schedule.numWells(2), 1U);
+    BOOST_CHECK_EQUAL(schedule.numWells(3), 3U);
 }
 
 BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
@@ -853,7 +853,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
     const auto& schedule = make_schedule(input);
     const auto& rft_config = schedule.rftConfig();
 
-    BOOST_CHECK_EQUAL(2 , rft_config.firstRFTOutput());
+    BOOST_CHECK_EQUAL(2U, rft_config.firstRFTOutput());
     BOOST_CHECK_EQUAL(true, rft_config.rft("OP_1", 2));
     BOOST_CHECK_EQUAL(true, rft_config.rft("OP_2", 3));
 }
@@ -2240,16 +2240,16 @@ BOOST_AUTO_TEST_CASE( complump ) {
     BOOST_CHECK( shut == sc1.getFromIJK( 2, 2, 3 ).state() );
 
     const auto& completions = schedule.getWell("W1", 1).getCompletions();
-    BOOST_CHECK_EQUAL(completions.size(), 4);
+    BOOST_CHECK_EQUAL(completions.size(), 4U);
 
     const auto& c1 = completions.at(1);
-    BOOST_CHECK_EQUAL(c1.size(), 3);
+    BOOST_CHECK_EQUAL(c1.size(), 3U);
 
     for (const auto& pair : completions) {
         if (pair.first == 1)
             BOOST_CHECK(pair.second.size() > 1);
         else
-            BOOST_CHECK_EQUAL(pair.second.size(), 1);
+            BOOST_CHECK_EQUAL(pair.second.size(), 1U);
     }
 }
 
@@ -2845,12 +2845,12 @@ BOOST_AUTO_TEST_CASE(historic_BHP_and_THP) {
 
         {
             const auto& wtest_config = schedule.wtestConfig(0);
-            BOOST_CHECK_EQUAL(wtest_config.size(), 0);
+            BOOST_CHECK_EQUAL(wtest_config.size(), 0U);
         }
 
         {
             const auto& wtest_config = schedule.wtestConfig(1);
-            BOOST_CHECK_EQUAL(wtest_config.size(), 0);
+            BOOST_CHECK_EQUAL(wtest_config.size(), 0U);
         }
     }
 }
@@ -2868,8 +2868,8 @@ BOOST_AUTO_TEST_CASE(FilterCompletions2) {
     {
         const auto& c1_1 = schedule.getWell("OP_1", 1).getConnections();
         const auto& c1_3 = schedule.getWell("OP_1", 3).getConnections();
-        BOOST_CHECK_EQUAL(2, c1_1.size());
-        BOOST_CHECK_EQUAL(9, c1_3.size());
+        BOOST_CHECK_EQUAL(2U, c1_1.size());
+        BOOST_CHECK_EQUAL(9U, c1_3.size());
     }
     actnum[grid1.getGlobalIndex(8,8,1)] = 0;
     {
@@ -2883,8 +2883,8 @@ BOOST_AUTO_TEST_CASE(FilterCompletions2) {
 
         const auto& c1_1 = schedule.getWell("OP_1", 1).getConnections();
         const auto& c1_3 = schedule.getWell("OP_1", 3).getConnections();
-        BOOST_CHECK_EQUAL(1, c1_1.size());
-        BOOST_CHECK_EQUAL(8, c1_3.size());
+        BOOST_CHECK_EQUAL(1U, c1_1.size());
+        BOOST_CHECK_EQUAL(8U, c1_3.size());
     }
 }
 
@@ -2976,14 +2976,14 @@ VFPINJ \n                                       \
     BOOST_CHECK_EQUAL(vfpinjTable.getFloType(), Opm::VFPInjTable::FLO_WAT);
 
     const auto vfp_tables0 = schedule.getVFPInjTables(0);
-    BOOST_CHECK_EQUAL( vfp_tables0.size(), 1);
+    BOOST_CHECK_EQUAL( vfp_tables0.size(), 1U);
 
     const auto vfp_tables2 = schedule.getVFPInjTables(2);
-    BOOST_CHECK_EQUAL( vfp_tables2.size(), 2);
+    BOOST_CHECK_EQUAL( vfp_tables2.size(), 2U);
     //Flo axis
     {
         const std::vector<double>& flo = vfpinjTable.getFloAxis();
-        BOOST_REQUIRE_EQUAL(flo.size(), 3);
+        BOOST_REQUIRE_EQUAL(flo.size(), 3U);
 
         //Unit of FLO is SM3/day, convert to SM3/second
         double conversion_factor = 1.0 / (60*60*24);
@@ -2995,7 +2995,7 @@ VFPINJ \n                                       \
     //THP axis
     {
         const std::vector<double>& thp = vfpinjTable.getTHPAxis();
-        BOOST_REQUIRE_EQUAL(thp.size(), 2);
+        BOOST_REQUIRE_EQUAL(thp.size(), 2U);
 
         //Unit of THP is barsa => convert to pascal
         double conversion_factor = 100000.0;
@@ -3008,8 +3008,8 @@ VFPINJ \n                                       \
         typedef Opm::VFPInjTable::array_type::size_type size_type;
         const auto size = vfpinjTable.shape();
 
-        BOOST_CHECK_EQUAL(size[0], 2);
-        BOOST_CHECK_EQUAL(size[1], 3);
+        BOOST_CHECK_EQUAL(size[0], 2U);
+        BOOST_CHECK_EQUAL(size[1], 3U);
 
         //Table given as BHP => barsa. Convert to pascal
         double conversion_factor = 100000.0;
@@ -3145,12 +3145,12 @@ BOOST_AUTO_TEST_CASE(WTEST_CONFIG) {
     const auto& schedule = make_schedule(createDeckWTEST());
 
     const auto& wtest_config1 = schedule.wtestConfig(0);
-    BOOST_CHECK_EQUAL(wtest_config1.size(), 2);
+    BOOST_CHECK_EQUAL(wtest_config1.size(), 2U);
     BOOST_CHECK(wtest_config1.has("ALLOW"));
     BOOST_CHECK(!wtest_config1.has("BAN"));
 
     const auto& wtest_config2 = schedule.wtestConfig(1);
-    BOOST_CHECK_EQUAL(wtest_config2.size(), 3);
+    BOOST_CHECK_EQUAL(wtest_config2.size(), 3U);
     BOOST_CHECK(!wtest_config2.has("ALLOW"));
     BOOST_CHECK(wtest_config2.has("BAN"));
     BOOST_CHECK(wtest_config2.has("BAN", WellTestConfig::Reason::GROUP));
@@ -3198,7 +3198,7 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
     BOOST_CHECK(ws.updateStatus(Well::Status::SHUT, false));
 
     const auto& connections = ws.getConnections();
-    BOOST_CHECK_EQUAL(connections.size(), 0);
+    BOOST_CHECK_EQUAL(connections.size(), 0U);
     auto c2 = std::make_shared<WellConnections>(Connection::Order::TRACK, 1,1);
     c2->addConnection(1,1,1,
                       grid1.getGlobalIndex(1,1,1),
@@ -3219,42 +3219,42 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
 BOOST_AUTO_TEST_CASE(WellNames) {
     const auto& schedule = make_schedule(createDeckWTEST());
     auto names = schedule.wellNames("NO_SUCH_WELL", 0);
-    BOOST_CHECK_EQUAL(names.size(), 0);
+    BOOST_CHECK_EQUAL(names.size(), 0U);
 
     auto w1names = schedule.wellNames("W1", 0);
-    BOOST_CHECK_EQUAL(w1names.size(), 1);
+    BOOST_CHECK_EQUAL(w1names.size(), 1U);
     BOOST_CHECK_EQUAL(w1names[0], "W1");
 
     auto i1names = schedule.wellNames("11", 0);
-    BOOST_CHECK_EQUAL(i1names.size(), 0);
+    BOOST_CHECK_EQUAL(i1names.size(), 0U);
 
     auto listnamese = schedule.wellNames("*NO_LIST", 0);
-    BOOST_CHECK_EQUAL( listnamese.size(), 0);
+    BOOST_CHECK_EQUAL( listnamese.size(), 0U);
 
     auto listnames0 = schedule.wellNames("*ILIST", 0);
-    BOOST_CHECK_EQUAL( listnames0.size(), 0);
+    BOOST_CHECK_EQUAL( listnames0.size(), 0U);
 
     auto listnames1 = schedule.wellNames("*ILIST", 2);
-    BOOST_CHECK_EQUAL( listnames1.size(), 2);
+    BOOST_CHECK_EQUAL( listnames1.size(), 2U);
     BOOST_CHECK( has(listnames1, "I1"));
     BOOST_CHECK( has(listnames1, "I2"));
 
     auto pnames1 = schedule.wellNames("I*", 0);
-    BOOST_CHECK_EQUAL(pnames1.size(), 0);
+    BOOST_CHECK_EQUAL(pnames1.size(), 0U);
 
     auto pnames2 = schedule.wellNames("W*", 0);
-    BOOST_CHECK_EQUAL(pnames2.size(), 3);
+    BOOST_CHECK_EQUAL(pnames2.size(), 3U);
     BOOST_CHECK( has(pnames2, "W1"));
     BOOST_CHECK( has(pnames2, "W2"));
     BOOST_CHECK( has(pnames2, "W3"));
 
     auto anames = schedule.wellNames("?", 0, {"W1", "W2"});
-    BOOST_CHECK_EQUAL(anames.size(), 2);
+    BOOST_CHECK_EQUAL(anames.size(), 2U);
     BOOST_CHECK(has(anames, "W1"));
     BOOST_CHECK(has(anames, "W2"));
 
     auto all_names0 = schedule.wellNames("*", 0);
-    BOOST_CHECK_EQUAL( all_names0.size(), 6);
+    BOOST_CHECK_EQUAL( all_names0.size(), 6U);
     BOOST_CHECK( has(all_names0, "W1"));
     BOOST_CHECK( has(all_names0, "W2"));
     BOOST_CHECK( has(all_names0, "W3"));
@@ -3262,7 +3262,7 @@ BOOST_AUTO_TEST_CASE(WellNames) {
     BOOST_CHECK( has(all_names0, "ALLOW"));
 
     auto all_names = schedule.wellNames("*", 2);
-    BOOST_CHECK_EQUAL( all_names.size(), 9);
+    BOOST_CHECK_EQUAL( all_names.size(), 9U);
     BOOST_CHECK( has(all_names, "I1"));
     BOOST_CHECK( has(all_names, "I2"));
     BOOST_CHECK( has(all_names, "I3"));
@@ -3274,7 +3274,7 @@ BOOST_AUTO_TEST_CASE(WellNames) {
     BOOST_CHECK( has(all_names, "BAN"));
 
     auto abs_all = schedule.wellNames();
-    BOOST_CHECK_EQUAL(abs_all.size(), 9);
+    BOOST_CHECK_EQUAL(abs_all.size(), 9U);
 }
 
 
@@ -3331,7 +3331,7 @@ BOOST_AUTO_TEST_CASE(RFT_CONFIG2) {
     const auto& schedule = make_schedule(createDeckRFTConfig());
     const auto& rft_config = schedule.rftConfig();
 
-    BOOST_CHECK_EQUAL(2, rft_config.firstRFTOutput());
+    BOOST_CHECK_EQUAL(2U, rft_config.firstRFTOutput());
 }
 
 
@@ -3492,7 +3492,7 @@ COMPDAT
     }
     {
         const auto& changed_wells = schedule.changed_wells(0);
-        BOOST_CHECK_EQUAL( changed_wells.size() , 3);
+        BOOST_CHECK_EQUAL( changed_wells.size() , 3U);
         for (const auto& wname : {"W1", "W2", "W2"}) {
             auto find_well = std::find(changed_wells.begin(), changed_wells.end(), wname);
             BOOST_CHECK(find_well != changed_wells.end());
@@ -3500,20 +3500,20 @@ COMPDAT
     }
     {
         const auto& changed_wells = schedule.changed_wells(2);
-        BOOST_CHECK_EQUAL( changed_wells.size(), 0);
+        BOOST_CHECK_EQUAL( changed_wells.size(), 0U);
     }
     {
         const auto& changed_wells = schedule.changed_wells(4);
-        BOOST_CHECK_EQUAL( changed_wells.size(), 0);
+        BOOST_CHECK_EQUAL( changed_wells.size(), 0U);
     }
     {
         const auto& changed_wells = schedule.changed_wells(5);
-        BOOST_CHECK_EQUAL( changed_wells.size(), 1);
+        BOOST_CHECK_EQUAL( changed_wells.size(), 1U);
         BOOST_CHECK_EQUAL( changed_wells[0], "W4");
     }
     {
         const auto& changed_wells = schedule.changed_wells(6);
-        BOOST_CHECK_EQUAL( changed_wells.size(), 1);
+        BOOST_CHECK_EQUAL( changed_wells.size(), 1U);
         BOOST_CHECK_EQUAL( changed_wells[0], "W4");
     }
 }

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
 
     const auto& cpr = summary.getKeyword<ParserKeywords::CPR>();
     const auto& record = cpr.getRecord(0);
-    BOOST_CHECK_EQUAL( 1 , cpr.size());
+    BOOST_CHECK_EQUAL( 1U , cpr.size());
     BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::CPR::WELL>().get< std::string >(0) , "well1");
     BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::CPR::I>().get< int >(0) , 10);
     BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::CPR::J>().get< int >(0) , 20);
@@ -293,5 +293,5 @@ ROCKOPTS
     RockConfig rc(deck, fp);
     BOOST_CHECK_EQUAL(rc.rocknum_property(), "SATNUM");
     const auto& comp = rc.comp();
-    BOOST_CHECK_EQUAL(comp.size(), 3);
+    BOOST_CHECK_EQUAL(comp.size(), 3U);
 }

--- a/tests/parser/StringTests.cpp
+++ b/tests/parser/StringTests.cpp
@@ -105,18 +105,18 @@ BOOST_AUTO_TEST_CASE(split) {
     std::string s1 = "lorem ipsum";
 
     auto split1 = split_string(s1, ' ');
-    BOOST_CHECK_EQUAL(split1.size(), 2);
+    BOOST_CHECK_EQUAL(split1.size(), 2U);
     BOOST_CHECK_EQUAL(split1[0], "lorem");
     BOOST_CHECK_EQUAL(split1[1], "ipsum");
 
     auto split2 = split_string(s1, "r ");
-    BOOST_CHECK_EQUAL(split2.size(), 3);
+    BOOST_CHECK_EQUAL(split2.size(), 3U);
     BOOST_CHECK_EQUAL(split2[0], "lo");
     BOOST_CHECK_EQUAL(split2[1], "em");
     BOOST_CHECK_EQUAL(split2[2], "ipsum");
 
     auto split3 = split_string(s1, "m ");
-    BOOST_CHECK_EQUAL(split3.size(), 2);
+    BOOST_CHECK_EQUAL(split3.size(), 2U);
     BOOST_CHECK_EQUAL(split3[0], "lore");
     BOOST_CHECK_EQUAL(split3[1], "ipsu");
 }

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(EMPTY) {
     EclipseState state( deck );
     Schedule schedule(deck, state, python);
     SummaryConfig conf(deck, schedule, state.getTableManager());
-    BOOST_CHECK_EQUAL( conf.size(), 0 );
+    BOOST_CHECK_EQUAL( conf.size(), 0U );
 }
 
 BOOST_AUTO_TEST_CASE(wells_missingI) {
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(wells_select) {
             wells.begin(), wells.end(),
             names.begin(), names.end() );
 
-    BOOST_CHECK_EQUAL( summary.size(), 2 );
+    BOOST_CHECK_EQUAL( summary.size(), 2U );
 }
 
 BOOST_AUTO_TEST_CASE(groups_all) {
@@ -603,7 +603,7 @@ BOOST_AUTO_TEST_CASE( summary_FMWSET ) {
 BOOST_AUTO_TEST_CASE(FMWPA) {
     const auto input = "FMWPA\n";
     const auto summary = createSummary( input );
-    BOOST_CHECK_EQUAL(1 , summary.size() );
+    BOOST_CHECK_EQUAL(1U , summary.size() );
 }
 
 
@@ -1137,7 +1137,7 @@ ROPT_REG
 /
 )";
     const auto& summary_config = createSummary(deck_string);
-    BOOST_CHECK_EQUAL(summary_config.size(), 6);
+    BOOST_CHECK_EQUAL(summary_config.size(), 6U);
     BOOST_CHECK(summary_config.hasKeyword("RPR__REG"));
     BOOST_CHECK(summary_config.hasKeyword("ROPT_REG"));
     BOOST_CHECK(!summary_config.hasKeyword("RPR"));
@@ -1149,7 +1149,7 @@ ROPT_REG
     }
 
     const auto& fip_regions = summary_config.fip_regions();
-    BOOST_CHECK_EQUAL(fip_regions.size(), 1);
+    BOOST_CHECK_EQUAL(fip_regions.size(), 1U);
 
     auto reg_iter = fip_regions.find("FIPREG");
     BOOST_CHECK( reg_iter != fip_regions.end() );
@@ -1159,5 +1159,5 @@ ROPT_REG
     BOOST_CHECK(wkeywords.empty());
 
     auto rpr = summary_config.keywords("RP*");
-    BOOST_CHECK_EQUAL(rpr.size(), 3);
+    BOOST_CHECK_EQUAL(rpr.size(), 3U);
 }

--- a/tests/parser/TableColumnTests.cpp
+++ b/tests/parser/TableColumnTests.cpp
@@ -32,13 +32,13 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( CreateTest ) {
     ColumnSchema schema("COLUMN" , Table::STRICTLY_INCREASING , Table::DEFAULT_LINEAR );
     TableColumn column( schema );
-    BOOST_CHECK_EQUAL( column.size() , 0 );
+    BOOST_CHECK_EQUAL( column.size() , 0U );
 
     column.addValue( 0 );
     column.addValue( 1 );
     column.addValue( 2 );
 
-    BOOST_CHECK_EQUAL( column.size() , 3 );
+    BOOST_CHECK_EQUAL( column.size() , 3U );
 
     BOOST_CHECK_EQUAL( column[0] , 0 );
     BOOST_CHECK_EQUAL( column[1] , 1 );
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE( TestDefault ) {
     column.addDefault( );
     column.addDefault( );
     column.addDefault( );
-    BOOST_CHECK_EQUAL( column.size() , 3 );
+    BOOST_CHECK_EQUAL( column.size() , 3U );
     BOOST_CHECK_THROW( column[0] , std::invalid_argument );
 
     column.updateValue(0 , 10);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE( TestAscending ) {
     ColumnSchema schema("COLUMN" , Table::STRICTLY_INCREASING , Table::DEFAULT_LINEAR);
     TableColumn column( schema );
 
-    BOOST_CHECK_EQUAL( column.size() , 0 );
+    BOOST_CHECK_EQUAL( column.size() , 0U );
 
     column.addValue( 10 );
     BOOST_CHECK_THROW( column.addValue( 9 ) , std::invalid_argument );
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE( TestDescending ) {
     ColumnSchema schema("COLUMN" , Table::STRICTLY_DECREASING , Table::DEFAULT_LINEAR);
     TableColumn column( schema );
 
-    BOOST_CHECK_EQUAL( column.size() , 0 );
+    BOOST_CHECK_EQUAL( column.size() , 0U );
 
     column.addValue( -10 );
     BOOST_CHECK_THROW( column.addValue( -9 ) , std::invalid_argument );

--- a/tests/parser/TableContainerTests.cpp
+++ b/tests/parser/TableContainerTests.cpp
@@ -50,13 +50,13 @@ BOOST_AUTO_TEST_CASE( CreateContainer ) {
     auto deck = createSWOFDeck();
     Opm::TableContainer container(10);
     BOOST_CHECK( container.empty() );
-    BOOST_CHECK_EQUAL( 0 , container.size() );
+    BOOST_CHECK_EQUAL( 0U , container.size() );
     BOOST_CHECK_EQUAL( false , container.hasTable( 1 ));
 
     std::shared_ptr<Opm::SimpleTable> table = std::make_shared<Opm::SwofTable>( deck.getKeyword("SWOF").getRecord(0).getItem(0), false );
     BOOST_CHECK_THROW( container.addTable( 10 , table ), std::invalid_argument );
     container.addTable( 6 , table );
-    BOOST_CHECK_EQUAL( 1 , container.size() );
+    BOOST_CHECK_EQUAL( 1U , container.size() );
 
     BOOST_CHECK_EQUAL( table.get() , &(container[6]));
     BOOST_CHECK_EQUAL( table.get() , &(container[9]));

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE( CreateTables ) {
     auto deck = createSingleRecordDeck();
     Opm::TableManager tables(deck);
     auto& tabdims = tables.getTabdims();
-    BOOST_CHECK_EQUAL( tabdims.getNumSatTables() , 2 );
+    BOOST_CHECK_EQUAL( tabdims.getNumSatTables() , 2U );
     BOOST_CHECK( !tables.useImptvd() );
     BOOST_CHECK( !tables.useEnptvd() );
 }
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithVd ) {
     auto deck = createSingleRecordDeckWithVd();
     Opm::TableManager tables(deck);
     auto& tabdims = tables.getTabdims();
-    BOOST_CHECK_EQUAL( tabdims.getNumSatTables() , 2 );
+    BOOST_CHECK_EQUAL( tabdims.getNumSatTables() , 2U );
     BOOST_CHECK( tables.useImptvd() );
     BOOST_CHECK( tables.useEnptvd() );
 }
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithJFunc ) {
     auto deck = createSingleRecordDeckWithJFunc();
     Opm::TableManager tables(deck);
     const Opm::Tabdims& tabdims = tables.getTabdims();
-    BOOST_CHECK_EQUAL(tabdims.getNumSatTables(), 2);
+    BOOST_CHECK_EQUAL(tabdims.getNumSatTables(), 2U );
     BOOST_CHECK(tables.useImptvd());
     BOOST_CHECK(tables.useEnptvd());
 
@@ -252,11 +252,11 @@ BOOST_AUTO_TEST_CASE(SwofTable_Tests) {
     Opm::SwofTable swof1Table(deck.getKeyword("SWOF").getRecord(0).getItem(0), false);
     Opm::SwofTable swof2Table(deck.getKeyword("SWOF").getRecord(1).getItem(0), false);
 
-    BOOST_CHECK_EQUAL(swof1Table.numRows(), 2);
-    BOOST_CHECK_EQUAL(swof2Table.numRows(), 3);
+    BOOST_CHECK_EQUAL(swof1Table.numRows(), 2U);
+    BOOST_CHECK_EQUAL(swof2Table.numRows(), 3U);
 
-    BOOST_CHECK_EQUAL(swof1Table.numColumns(), 4);
-    BOOST_CHECK_EQUAL(swof2Table.numColumns(), 4);
+    BOOST_CHECK_EQUAL(swof1Table.numColumns(), 4U);
+    BOOST_CHECK_EQUAL(swof2Table.numColumns(), 4U);
 
     BOOST_CHECK_EQUAL(swof1Table.getSwColumn().front(), 1.0);
     BOOST_CHECK_EQUAL(swof1Table.getSwColumn().back(), 5.0);
@@ -293,8 +293,8 @@ BOOST_AUTO_TEST_CASE(PbvdTable_Tests) {
 
     Opm::PbvdTable pbvdTable1(deck.getKeyword("PBVD").getRecord(0).getItem(0));
 
-    BOOST_CHECK_EQUAL(pbvdTable1.numRows(), 2);
-    BOOST_CHECK_EQUAL(pbvdTable1.numColumns(), 2);
+    BOOST_CHECK_EQUAL(pbvdTable1.numRows(), 2U);
+    BOOST_CHECK_EQUAL(pbvdTable1.numColumns(), 2U);
     BOOST_CHECK_EQUAL(pbvdTable1.getDepthColumn().front(), 1);
     BOOST_CHECK_EQUAL(pbvdTable1.getDepthColumn().back(), 2);
     BOOST_CHECK_EQUAL(pbvdTable1.getPbubColumn().front(), 100000); // 1 barsa
@@ -321,8 +321,8 @@ BOOST_AUTO_TEST_CASE(PdvdTable_Tests) {
 
     Opm::PdvdTable pdvdTable1(deck.getKeyword("PDVD").getRecord(0).getItem(0));
 
-    BOOST_CHECK_EQUAL(pdvdTable1.numRows(), 2);
-    BOOST_CHECK_EQUAL(pdvdTable1.numColumns(), 2);
+    BOOST_CHECK_EQUAL(pdvdTable1.numRows(), 2U);
+    BOOST_CHECK_EQUAL(pdvdTable1.numColumns(), 2U);
     BOOST_CHECK_EQUAL(pdvdTable1.getDepthColumn().front(), 1);
     BOOST_CHECK_EQUAL(pdvdTable1.getDepthColumn().back(), 2);
     BOOST_CHECK_EQUAL(pdvdTable1.getPdewColumn().front(), 100000); // 1 barsa
@@ -350,11 +350,11 @@ BOOST_AUTO_TEST_CASE(SgwfnTable_Tests) {
     Opm::SgwfnTable sgwfn1Table(deck.getKeyword("SGWFN").getRecord(0).getItem(0));
     Opm::SgwfnTable sgwfn2Table(deck.getKeyword("SGWFN").getRecord(1).getItem(0));
 
-    BOOST_CHECK_EQUAL(sgwfn1Table.numRows(), 2);
-    BOOST_CHECK_EQUAL(sgwfn2Table.numRows(), 3);
+    BOOST_CHECK_EQUAL(sgwfn1Table.numRows(), 2U);
+    BOOST_CHECK_EQUAL(sgwfn2Table.numRows(), 3U);
 
-    BOOST_CHECK_EQUAL(sgwfn1Table.numColumns(), 4);
-    BOOST_CHECK_EQUAL(sgwfn2Table.numColumns(), 4);
+    BOOST_CHECK_EQUAL(sgwfn1Table.numColumns(), 4U);
+    BOOST_CHECK_EQUAL(sgwfn2Table.numColumns(), 4U);
 
     BOOST_CHECK_EQUAL(sgwfn1Table.getSgColumn().front(), 1.0);
     BOOST_CHECK_EQUAL(sgwfn1Table.getSgColumn().back(), 5.0);
@@ -392,11 +392,11 @@ BOOST_AUTO_TEST_CASE(SgofTable_Tests) {
     Opm::SgofTable sgof1Table(deck.getKeyword("SGOF").getRecord(0).getItem(0), false);
     Opm::SgofTable sgof2Table(deck.getKeyword("SGOF").getRecord(1).getItem(0), false);
 
-    BOOST_CHECK_EQUAL(sgof1Table.numRows(), 2);
-    BOOST_CHECK_EQUAL(sgof2Table.numRows(), 3);
+    BOOST_CHECK_EQUAL(sgof1Table.numRows(), 2U);
+    BOOST_CHECK_EQUAL(sgof2Table.numRows(), 3U);
 
-    BOOST_CHECK_EQUAL(sgof1Table.numColumns(), 4);
-    BOOST_CHECK_EQUAL(sgof2Table.numColumns(), 4);
+    BOOST_CHECK_EQUAL(sgof1Table.numColumns(), 4U);
+    BOOST_CHECK_EQUAL(sgof2Table.numColumns(), 4U);
 
     BOOST_CHECK_EQUAL(sgof1Table.getSgColumn().front(), 1.0);
     BOOST_CHECK_EQUAL(sgof1Table.getSgColumn().back(), 5.0);
@@ -671,7 +671,7 @@ VFPPROD \n\
     auto units = Opm::UnitSystem::newMETRIC();
     const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
 
-    BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
+    BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
     Opm::VFPProdTable vfpprodTable(vfpprodKeyword, units);
 
@@ -686,7 +686,7 @@ VFPPROD \n\
     //Flo axis
     {
         const std::vector<double>& flo = vfpprodTable.getFloAxis();
-        BOOST_REQUIRE_EQUAL(flo.size(), 3);
+        BOOST_REQUIRE_EQUAL(flo.size(), 3U);
 
         //Unit of FLO is SM3/day, convert to SM3/second
         double conversion_factor = 1.0 / (60*60*24);
@@ -698,7 +698,7 @@ VFPPROD \n\
     //THP axis
     {
         const std::vector<double>& thp = vfpprodTable.getTHPAxis();
-        BOOST_REQUIRE_EQUAL(thp.size(), 2);
+        BOOST_REQUIRE_EQUAL(thp.size(), 2U);
 
         //Unit of THP is barsa => convert to pascal
         double conversion_factor = 100000.0;
@@ -709,7 +709,7 @@ VFPPROD \n\
     //WFR axis
     {
         const std::vector<double>& wfr = vfpprodTable.getWFRAxis();
-        BOOST_REQUIRE_EQUAL(wfr.size(), 2);
+        BOOST_REQUIRE_EQUAL(wfr.size(), 2U);
 
         //Unit of WFR is SM3/SM3
         BOOST_CHECK_EQUAL(wfr[0], 13);
@@ -719,7 +719,7 @@ VFPPROD \n\
     //GFR axis
     {
         const std::vector<double>& gfr = vfpprodTable.getGFRAxis();
-        BOOST_REQUIRE_EQUAL(gfr.size(), 2);
+        BOOST_REQUIRE_EQUAL(gfr.size(), 2U);
 
         //Unit of GFR is SM3/SM3
         BOOST_CHECK_EQUAL(gfr[0], 19);
@@ -729,7 +729,7 @@ VFPPROD \n\
     //ALQ axis
     {
         const std::vector<double>& alq = vfpprodTable.getALQAxis();
-        BOOST_REQUIRE_EQUAL(alq.size(), 2);
+        BOOST_REQUIRE_EQUAL(alq.size(), 2U);
 
         //Unit of ALQ undefined
         BOOST_CHECK_EQUAL(alq[0], 29);
@@ -741,11 +741,11 @@ VFPPROD \n\
         typedef Opm::VFPProdTable::array_type::size_type size_type;
         const auto size = vfpprodTable.shape();
 
-        BOOST_CHECK_EQUAL(size[0], 2);
-        BOOST_CHECK_EQUAL(size[1], 2);
-        BOOST_CHECK_EQUAL(size[2], 2);
-        BOOST_CHECK_EQUAL(size[3], 2);
-        BOOST_CHECK_EQUAL(size[4], 3);
+        BOOST_CHECK_EQUAL(size[0], 2U);
+        BOOST_CHECK_EQUAL(size[1], 2U);
+        BOOST_CHECK_EQUAL(size[2], 2U);
+        BOOST_CHECK_EQUAL(size[3], 2U);
+        BOOST_CHECK_EQUAL(size[4], 3U);
 
         //Table given as BHP => barsa. Convert to pascal
         double conversion_factor = 100000.0;
@@ -796,7 +796,7 @@ VFPPROD \n\
     const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
     auto units = Opm::UnitSystem::newMETRIC();
 
-    BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
+    BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
     Opm::VFPProdTable vfpprodTable(vfpprodKeyword, units);
 
@@ -810,7 +810,7 @@ VFPPROD \n\
     //Flo axis
     {
         const std::vector<double>& flo = vfpprodTable.getFloAxis();
-        BOOST_REQUIRE_EQUAL(flo.size(), 1);
+        BOOST_REQUIRE_EQUAL(flo.size(), 1U);
 
         //Unit of FLO is SM3/day, convert to SM3/second
         double conversion_factor = 1.0 / (60*60*24);
@@ -820,7 +820,7 @@ VFPPROD \n\
     //THP axis
     {
         const std::vector<double>& thp = vfpprodTable.getTHPAxis();
-        BOOST_REQUIRE_EQUAL(thp.size(), 1);
+        BOOST_REQUIRE_EQUAL(thp.size(), 1U);
 
         //Unit of THP is barsa => convert to pascal
         double conversion_factor = 100000.0;
@@ -830,7 +830,7 @@ VFPPROD \n\
     //WFR axis
     {
         const std::vector<double>& wfr = vfpprodTable.getWFRAxis();
-        BOOST_REQUIRE_EQUAL(wfr.size(), 1);
+        BOOST_REQUIRE_EQUAL(wfr.size(), 1U);
 
         //Unit of WFR is SM3/SM3
         BOOST_CHECK_EQUAL(wfr[0], 13);
@@ -839,7 +839,7 @@ VFPPROD \n\
     //GFR axis
     {
         const std::vector<double>& gfr = vfpprodTable.getGFRAxis();
-        BOOST_REQUIRE_EQUAL(gfr.size(), 1);
+        BOOST_REQUIRE_EQUAL(gfr.size(), 1U);
 
         //Unit of GFR is SM3/SM3
         BOOST_CHECK_EQUAL(gfr[0], 19);
@@ -848,7 +848,7 @@ VFPPROD \n\
     //ALQ axis
     {
         const std::vector<double>& alq = vfpprodTable.getALQAxis();
-        BOOST_REQUIRE_EQUAL(alq.size(), 1);
+        BOOST_REQUIRE_EQUAL(alq.size(), 1U);
 
         //Unit of ALQ undefined
         BOOST_CHECK_EQUAL(alq[0], 29);
@@ -861,7 +861,7 @@ VFPPROD \n\
         //Table given as BHP => barsa. Convert to pascal
         double conversion_factor = 100000.0;
 
-        BOOST_CHECK_EQUAL(size[0]*size[1]*size[2]*size[3]*size[4], 1);
+        BOOST_CHECK_EQUAL(size[0]*size[1]*size[2]*size[3]*size[4], 1U);
         BOOST_CHECK_EQUAL(const_cast<const VFPProdTable&>(vfpprodTable)(0,0,0,0,0), 1.5*conversion_factor);
     }
 }
@@ -941,7 +941,7 @@ VFPPROD \n\
         auto deck = parser.parseString(missing_values);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
     }
@@ -975,7 +975,7 @@ VFPPROD \n\
         auto deck = parser.parseString(missing_values);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
     }
@@ -1007,7 +1007,7 @@ VFPPROD \n\
         auto deck = parser.parseString(missing_metadata);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
     }
@@ -1040,7 +1040,7 @@ VFPPROD \n\
         auto deck = parser.parseString(wrong_metadata);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
     }
@@ -1073,7 +1073,7 @@ VFPPROD \n\
         auto deck = parser.parseString(missing_axes);
         const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
     }
@@ -1105,7 +1105,7 @@ VFPINJ \n\
     const auto& vfpprodKeyword = deck.getKeyword("VFPINJ");
     auto units = Opm::UnitSystem::newMETRIC();
 
-    BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
+    BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
     Opm::VFPInjTable vfpinjTable(vfpprodKeyword, units);
 
@@ -1116,7 +1116,7 @@ VFPINJ \n\
     //Flo axis
     {
         const std::vector<double>& flo = vfpinjTable.getFloAxis();
-        BOOST_REQUIRE_EQUAL(flo.size(), 3);
+        BOOST_REQUIRE_EQUAL(flo.size(), 3U);
 
         //Unit of FLO is SM3/day, convert to SM3/second
         double conversion_factor = 1.0 / (60*60*24);
@@ -1128,7 +1128,7 @@ VFPINJ \n\
     //THP axis
     {
         const std::vector<double>& thp = vfpinjTable.getTHPAxis();
-        BOOST_REQUIRE_EQUAL(thp.size(), 2);
+        BOOST_REQUIRE_EQUAL(thp.size(), 2U);
 
         //Unit of THP is barsa => convert to pascal
         double conversion_factor = 100000.0;
@@ -1141,8 +1141,8 @@ VFPINJ \n\
         typedef Opm::VFPInjTable::array_type::size_type size_type;
         const auto size = vfpinjTable.shape();
 
-        BOOST_CHECK_EQUAL(size[0], 2);
-        BOOST_CHECK_EQUAL(size[1], 3);
+        BOOST_CHECK_EQUAL(size[0], 2U);
+        BOOST_CHECK_EQUAL(size[1], 3U);
 
         //Table given as BHP => barsa. Convert to pascal
         double conversion_factor = 100000.0;
@@ -1203,7 +1203,7 @@ VFPINJ \n\
         auto deck = parser.parseString(missing_values);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
     }
@@ -1231,7 +1231,7 @@ VFPINJ \n\
         auto deck = parser.parseString(missing_values);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
     }
@@ -1258,7 +1258,7 @@ VFPINJ \n\
         auto deck = parser.parseString(missing_metadata);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
     }
@@ -1286,7 +1286,7 @@ VFPINJ \n\
         auto deck = parser.parseString(wrong_metadata);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units(Opm::UnitSystem::newMETRIC());
-        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
     }
@@ -1314,7 +1314,7 @@ VFPINJ \n\
         auto deck = parser.parseString(missing_axes);
         const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
         auto units = Opm::UnitSystem::newMETRIC();
-        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1);
+        BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
         BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
     }
@@ -1348,7 +1348,7 @@ BOOST_AUTO_TEST_CASE( TestPLYMWINJ ) {
     const Opm::TableManager tables( deck );
     const auto& plymwinjtables = tables.getPlymwinjTables();
 
-    BOOST_CHECK_EQUAL( plymwinjtables.size(), 2 );
+    BOOST_CHECK_EQUAL( plymwinjtables.size(), 2U );
 
     BOOST_CHECK( plymwinjtables.find(1) == plymwinjtables.end() );
 
@@ -1360,10 +1360,10 @@ BOOST_AUTO_TEST_CASE( TestPLYMWINJ ) {
         BOOST_CHECK_EQUAL( table2.getTableNumber(), 2 );
 
         const std::vector<double>& throughputs = table2.getThroughputs();
-        BOOST_CHECK_EQUAL( throughputs.size(), 3 );
+        BOOST_CHECK_EQUAL( throughputs.size(), 3U );
         BOOST_CHECK_EQUAL( throughputs[1], 200.0 );
         const std::vector<double>& velocities = table2.getVelocities();
-        BOOST_CHECK_EQUAL( velocities.size(), 4 );
+        BOOST_CHECK_EQUAL( velocities.size(), 4U );
         constexpr double dayinseconds = 86400.;
         BOOST_CHECK_EQUAL( velocities[2], 2.0 / dayinseconds );
         const std::vector<std::vector<double>>& mwdata = table2.getMoleWeights();
@@ -1384,10 +1384,10 @@ BOOST_AUTO_TEST_CASE( TestPLYMWINJ ) {
         BOOST_CHECK_EQUAL( table3.getTableNumber(), 3 );
 
         const std::vector<double>& throughputs = table3.getThroughputs();
-        BOOST_CHECK_EQUAL( throughputs.size(), 2 );
+        BOOST_CHECK_EQUAL( throughputs.size(), 2U );
         BOOST_CHECK_EQUAL( throughputs[1], 100.0 );
         const std::vector<double>& velocities = table3.getVelocities();
-        BOOST_CHECK_EQUAL( velocities.size(), 3 );
+        BOOST_CHECK_EQUAL( velocities.size(), 3U );
         constexpr double dayinseconds = 86400.;
         BOOST_CHECK_EQUAL( velocities[2], 2.0 / dayinseconds );
         const std::vector<std::vector<double>>& mwdata = table3.getMoleWeights();
@@ -1430,7 +1430,7 @@ BOOST_AUTO_TEST_CASE( TestSKPRWAT ) {
     const Opm::TableManager tables( deck );
     const auto& skprwattables = tables.getSkprwatTables();
 
-    BOOST_CHECK_EQUAL( skprwattables.size(), 2 );
+    BOOST_CHECK_EQUAL( skprwattables.size(), 2U );
 
     BOOST_CHECK( skprwattables.find(3) == skprwattables.end() );
 
@@ -1442,10 +1442,10 @@ BOOST_AUTO_TEST_CASE( TestSKPRWAT ) {
         BOOST_CHECK_EQUAL( table1.getTableNumber(), 1 );
 
         const std::vector<double>& throughputs = table1.getThroughputs();
-        BOOST_CHECK_EQUAL( throughputs.size(), 3 );
+        BOOST_CHECK_EQUAL( throughputs.size(), 3U );
         BOOST_CHECK_EQUAL( throughputs[1], 200.0 );
         const std::vector<double>& velocities = table1.getVelocities();
-        BOOST_CHECK_EQUAL( velocities.size(), 4 );
+        BOOST_CHECK_EQUAL( velocities.size(), 4U );
         constexpr double dayinseconds = 86400.;
         BOOST_CHECK_EQUAL( velocities[2], 2.0 / dayinseconds );
         const std::vector<std::vector<double>>& skindata = table1.getSkinPressures();
@@ -1467,10 +1467,10 @@ BOOST_AUTO_TEST_CASE( TestSKPRWAT ) {
         BOOST_CHECK_EQUAL( table2.getTableNumber(), 2 );
 
         const std::vector<double>& throughputs = table2.getThroughputs();
-        BOOST_CHECK_EQUAL( throughputs.size(), 2 );
+        BOOST_CHECK_EQUAL( throughputs.size(), 2U );
         BOOST_CHECK_EQUAL( throughputs[1], 100.0 );
         const std::vector<double>& velocities = table2.getVelocities();
-        BOOST_CHECK_EQUAL( velocities.size(), 3 );
+        BOOST_CHECK_EQUAL( velocities.size(), 3U );
         constexpr double dayinseconds = 86400.;
         BOOST_CHECK_EQUAL( velocities[2], 2.0 / dayinseconds );
         const std::vector<std::vector<double>>& skindata = table2.getSkinPressures();
@@ -1512,7 +1512,7 @@ BOOST_AUTO_TEST_CASE( TestSKPRPOLY ) {
     const Opm::TableManager tables( deck );
     const auto& skprpolytables = tables.getSkprpolyTables();
 
-    BOOST_CHECK_EQUAL( skprpolytables.size(), 2 );
+    BOOST_CHECK_EQUAL( skprpolytables.size(), 2U );
 
     BOOST_CHECK( skprpolytables.find(4) == skprpolytables.end() );
 
@@ -1525,10 +1525,10 @@ BOOST_AUTO_TEST_CASE( TestSKPRPOLY ) {
 
         BOOST_CHECK_EQUAL( table1.referenceConcentration(), 2.0 );
         const std::vector<double>& throughputs = table1.getThroughputs();
-        BOOST_CHECK_EQUAL( throughputs.size(), 3 );
+        BOOST_CHECK_EQUAL( throughputs.size(), 3U );
         BOOST_CHECK_EQUAL( throughputs[1], 200.0 );
         const std::vector<double>& velocities = table1.getVelocities();
-        BOOST_CHECK_EQUAL( velocities.size(), 4 );
+        BOOST_CHECK_EQUAL( velocities.size(), 4U );
         constexpr double dayinseconds = 86400.;
         BOOST_CHECK_EQUAL( velocities[2], 2.0 / dayinseconds );
         const std::vector<std::vector<double>>& skindata = table1.getSkinPressures();
@@ -1551,10 +1551,10 @@ BOOST_AUTO_TEST_CASE( TestSKPRPOLY ) {
 
         BOOST_CHECK_EQUAL( table2.referenceConcentration(), 3.0 );
         const std::vector<double>& throughputs = table2.getThroughputs();
-        BOOST_CHECK_EQUAL( throughputs.size(), 2 );
+        BOOST_CHECK_EQUAL( throughputs.size(), 2U );
         BOOST_CHECK_EQUAL( throughputs[1], 100.0 );
         const std::vector<double>& velocities = table2.getVelocities();
-        BOOST_CHECK_EQUAL( velocities.size(), 3 );
+        BOOST_CHECK_EQUAL( velocities.size(), 3U );
         constexpr double dayinseconds = 86400.;
         BOOST_CHECK_EQUAL( velocities[2], 2.0 / dayinseconds );
         const std::vector<std::vector<double>>& skindata = table2.getSkinPressures();
@@ -1583,15 +1583,15 @@ BOOST_AUTO_TEST_CASE( TestPLYROCK ) {
     Opm::TableManager tables( deck );
     const Opm::TableContainer& plyrock = tables.getPlyrockTables();
 
-    BOOST_CHECK_EQUAL( plyrock.size() , 2 ) ;
+    BOOST_CHECK_EQUAL( plyrock.size() , 2U ) ;
     const Opm::PlyrockTable& table0 = plyrock.getTable<Opm::PlyrockTable>(0);
     const Opm::PlyrockTable& table1 = plyrock.getTable<Opm::PlyrockTable>(1);
 
-    BOOST_CHECK_EQUAL( table0.numColumns() , 5 );
+    BOOST_CHECK_EQUAL( table0.numColumns() , 5U );
     BOOST_CHECK_EQUAL( table0.getDeadPoreVolumeColumn()[0] , 1.0 );
     BOOST_CHECK_EQUAL( table0.getMaxAdsorbtionColumn()[0] , 5.0 );
 
-    BOOST_CHECK_EQUAL( table1.numColumns() , 5 );
+    BOOST_CHECK_EQUAL( table1.numColumns() , 5U );
     BOOST_CHECK_EQUAL( table1.getDeadPoreVolumeColumn()[0] , 10.0 );
     BOOST_CHECK_EQUAL( table1.getMaxAdsorbtionColumn()[0] , 50.0 );
 }
@@ -1611,15 +1611,15 @@ BOOST_AUTO_TEST_CASE( TestPLYMAX ) {
     Opm::TableManager tables( deck );
     const Opm::TableContainer& plymax = tables.getPlymaxTables();
 
-    BOOST_CHECK_EQUAL( plymax.size() , 2 ) ;
+    BOOST_CHECK_EQUAL( plymax.size() , 2U ) ;
     const Opm::PlymaxTable& table0 = plymax.getTable<Opm::PlymaxTable>(0);
     const Opm::PlymaxTable& table1 = plymax.getTable<Opm::PlymaxTable>(1);
 
-    BOOST_CHECK_EQUAL( table0.numColumns() , 2 );
+    BOOST_CHECK_EQUAL( table0.numColumns() , 2U );
     BOOST_CHECK_EQUAL( table0.getPolymerConcentrationColumn()[0] , 1.0 );
     BOOST_CHECK_EQUAL( table0.getMaxPolymerConcentrationColumn()[0] , 2.0 );
 
-    BOOST_CHECK_EQUAL( table1.numColumns() , 2 );
+    BOOST_CHECK_EQUAL( table1.numColumns() , 2U );
     BOOST_CHECK_EQUAL( table1.getPolymerConcentrationColumn()[0] , 10.0 );
     BOOST_CHECK_EQUAL( table1.getMaxPolymerConcentrationColumn()[0] , 20.0 );
 }
@@ -1663,7 +1663,7 @@ BOOST_AUTO_TEST_CASE( TestParseROCK ) {
     BOOST_CHECK_EQUAL( 2.2 * 1e-5, rock[1].compressibility );
 
     BOOST_CHECK_THROW( rock.at( 2 ), std::out_of_range );
-    BOOST_CHECK_EQUAL( 8 , tables.numFIPRegions( ));
+    BOOST_CHECK_EQUAL( 8U , tables.numFIPRegions( ));
 }
 
 BOOST_AUTO_TEST_CASE( TestParsePVCDO ) {
@@ -1690,7 +1690,7 @@ BOOST_AUTO_TEST_CASE( TestParsePVCDO ) {
     BOOST_CHECK_CLOSE( 0.0,     pvcdo[ 0 ].viscosibility * 1e5, 1e-5 );
 
     BOOST_CHECK_THROW( pvcdo.at( 1 ), std::out_of_range );
-    BOOST_CHECK_EQUAL( 25 , tables.numFIPRegions( ));
+    BOOST_CHECK_EQUAL( 25U , tables.numFIPRegions( ));
 
     const std::string malformed = R"(
       TABDIMS
@@ -1788,7 +1788,7 @@ OILDENT
     Opm::DenT od(deck.getKeyword("OILDENT"));
     const auto& wd = tables.WatDenT();
 
-    BOOST_CHECK_EQUAL(gd.size(), 3);
+    BOOST_CHECK_EQUAL(gd.size(), 3U);
     BOOST_CHECK( gd == od );
     BOOST_CHECK( wd.size() == 0);
 }
@@ -1812,7 +1812,7 @@ TLMIXPAR
     Opm::Parser parser;
     const auto& deck = parser.parseString(deck_string);
     Opm::TLMixpar tlm(deck);
-    BOOST_CHECK_EQUAL(tlm.size(), 2);
+    BOOST_CHECK_EQUAL(tlm.size(), 2U);
 
     const auto& r0 = tlm[0];
     const auto& r1 = tlm[1];

--- a/tests/parser/TableSchemaTests.cpp
+++ b/tests/parser/TableSchemaTests.cpp
@@ -33,13 +33,13 @@ BOOST_AUTO_TEST_CASE( CreateTest ) {
     TableSchema schema;
     ColumnSchema col1("Name1" , Table::INCREASING , Table::DEFAULT_NONE);
     ColumnSchema col2("Name2" , Table::INCREASING , Table::DEFAULT_NONE);
-    BOOST_CHECK_EQUAL( 0 , schema.size( ) );
+    BOOST_CHECK_EQUAL( 0U , schema.size( ) );
 
     schema.addColumn( col1 );
-    BOOST_CHECK_EQUAL( 1 , schema.size( ) );
+    BOOST_CHECK_EQUAL( 1U , schema.size( ) );
 
     schema.addColumn( col2 );
-    BOOST_CHECK_EQUAL( 2 , schema.size( ) );
+    BOOST_CHECK_EQUAL( 2U , schema.size( ) );
 
     BOOST_CHECK_THROW( schema.getColumn( "NO/NOT/THIS/COLUMN" ) , std::invalid_argument );
     BOOST_CHECK_THROW( schema.getColumn( 5 ) , std::invalid_argument );

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -254,15 +254,15 @@ BOOST_AUTO_TEST_CASE(ThresholdPressureTest) {
 
 BOOST_AUTO_TEST_CASE(ThresholdPressureEmptyTest) {
     Setup s(inputStrNoSolutionSection);
-    BOOST_CHECK_EQUAL(0, s.threshPres.size());
+    BOOST_CHECK_EQUAL(0U, s.threshPres.size());
 }
 
 BOOST_AUTO_TEST_CASE(ThresholdPressureNoTHPREStest) {
     Setup s(inputStrNoTHPRESinSolutionNorRUNSPEC);
     Setup s2(inputStrTHPRESinRUNSPECnotSoultion);
 
-    BOOST_CHECK_EQUAL(0, s.threshPres.size());
-    BOOST_CHECK_EQUAL(0, s.threshPres.size());
+    BOOST_CHECK_EQUAL(0U, s.threshPres.size());
+    BOOST_CHECK_EQUAL(0U, s.threshPres.size());
 }
 
 BOOST_AUTO_TEST_CASE(ThresholdPressureThrowTest) {
@@ -290,14 +290,14 @@ BOOST_AUTO_TEST_CASE(ThresholdPressureThrowTest) {
 BOOST_AUTO_TEST_CASE(Restart) {
     Setup sx(inputStr_RESTART);
     BOOST_CHECK(sx.threshPres.active());
-    BOOST_CHECK_EQUAL(sx.threshPres.size(), 0);
+    BOOST_CHECK_EQUAL(sx.threshPres.size(), 0U);
     BOOST_CHECK(sx.threshPres.restart());
 }
 
 BOOST_AUTO_TEST_CASE(Restart2) {
   Setup sx(inputStr_RESTART2);
   BOOST_CHECK(sx.threshPres.active());
-  BOOST_CHECK_EQUAL(sx.threshPres.size(), 3);
+  BOOST_CHECK_EQUAL(sx.threshPres.size(), 3U);
   BOOST_CHECK(sx.threshPres.restart());
 }
 

--- a/tests/parser/TracerTests.cpp
+++ b/tests/parser/TracerTests.cpp
@@ -80,11 +80,11 @@ BOOST_AUTO_TEST_CASE(TracerConfigTest) {
     BOOST_CHECK_EQUAL(it->name, "SEA");
     BOOST_CHECK_EQUAL(it->phase, Phase::WATER);
     BOOST_CHECK(it->concentration.empty());
-    BOOST_CHECK_EQUAL(it->tvdpf.numColumns(), 2);
+    BOOST_CHECK_EQUAL(it->tvdpf.numColumns(), 2U);
 
     ++it;
     BOOST_CHECK_EQUAL(it->name, "OCE");
     BOOST_CHECK_EQUAL(it->phase, Phase::GAS);
     BOOST_CHECK_EQUAL(it->concentration.size(), 3U);
-    BOOST_CHECK_EQUAL(it->tvdpf.numColumns(), 0);
+    BOOST_CHECK_EQUAL(it->tvdpf.numColumns(), 0U);
 }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -221,11 +221,11 @@ BOOST_AUTO_TEST_CASE(UDQWellSetNANTest) {
     for (std::size_t i = 0; i < 4; i++)
         ws.assign(i, i*1.0);
 
-    BOOST_CHECK_EQUAL(ws.defined_size(), 4);
+    BOOST_CHECK_EQUAL(ws.defined_size(), 4U);
 
     ws.assign(1,std::numeric_limits<double>::quiet_NaN());
     ws.assign(3,std::numeric_limits<double>::quiet_NaN());
-    BOOST_CHECK_EQUAL(ws.defined_size(), 2);
+    BOOST_CHECK_EQUAL(ws.defined_size(), 2U);
 
     BOOST_CHECK(ws.has("P1"));
     BOOST_CHECK(ws.has("P2"));
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(UDQWellSetTest) {
     UDQSet ws = UDQSet::wells("NAME", wells);
     UDQSet ws2 = UDQSet::wells("NAME", wells, 100.0);
 
-    BOOST_CHECK_EQUAL(4, ws.size());
+    BOOST_CHECK_EQUAL(4U, ws.size());
     ws.assign("P1", 1.0);
 
     const auto& value = ws["P1"];
@@ -268,11 +268,11 @@ BOOST_AUTO_TEST_CASE(UDQWellSetTest) {
         BOOST_CHECK_EQUAL(ws2[w].get(), 100.0);
 
     UDQSet scalar = UDQSet::scalar("NAME", 1.0);
-    BOOST_CHECK_EQUAL(scalar.size() , 1);
+    BOOST_CHECK_EQUAL(scalar.size() , 1U);
     BOOST_CHECK_EQUAL(scalar[0].get(), 1.0);
 
     UDQSet empty = UDQSet::empty("EMPTY");
-    BOOST_CHECK_EQUAL(empty.size() , 0);
+    BOOST_CHECK_EQUAL(empty.size() , 0U);
 }
 
 
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(UDQ_GROUP_TEST) {
     std::vector<std::string> groups = {"G1", "G2", "G3", "G4"};
     UDQSet gs = UDQSet::groups("NAME", groups);
 
-    BOOST_CHECK_EQUAL(4, gs.size());
+    BOOST_CHECK_EQUAL(4U, gs.size());
     gs.assign("G1", 1.0);
 
     const auto& value = gs["G1"];
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
         st.update_well_var("W2", "WBHP", 2);
         st.update_well_var("W3", "WBHP", 3);
         auto res = def.eval(context);
-        BOOST_CHECK_EQUAL(res.size(), 3);
+        BOOST_CHECK_EQUAL(res.size(), 3U);
         BOOST_CHECK_EQUAL( res["W1"].get(), 11 );
         BOOST_CHECK_EQUAL( res["W2"].get(), 2 );
         BOOST_CHECK_EQUAL( res["W3"].get(), 3 );
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
         st.update_well_var("I1", "WBHP", 1);
         st.update_well_var("I2", "WBHP", 2);
         auto res = def.eval(context);
-        BOOST_CHECK_EQUAL(res.size(), 4);
+        BOOST_CHECK_EQUAL(res.size(), 4U);
         BOOST_CHECK_EQUAL( res["P1"].get(), 1 );
         BOOST_CHECK_EQUAL( res["P2"].get(), 2 );
         BOOST_CHECK_EQUAL( res["I1"].defined(), false);
@@ -446,7 +446,7 @@ UDQ
 
     auto schedule = make_schedule(input);
     const auto& udq = schedule.getUDQConfig(0);
-    BOOST_CHECK_EQUAL(2, udq.assignments().size());
+    BOOST_CHECK_EQUAL(2U, udq.assignments().size());
 
     BOOST_CHECK_THROW( udq.unit("NO_SUCH_KEY"), std::invalid_argument );
     BOOST_CHECK_EQUAL( udq.unit("WUBHP"), "BARSA");
@@ -580,7 +580,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SET) {
         BOOST_CHECK_EQUAL(false, v.defined());
         BOOST_REQUIRE_THROW( v.get(), std::invalid_argument);
     }
-    BOOST_CHECK_EQUAL(s1.defined_size(), 0);
+    BOOST_CHECK_EQUAL(s1.defined_size(), 0U);
 
     s1.assign(1);
     for (const auto& v : s1) {
@@ -711,7 +711,7 @@ BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
     {
         auto result = UDQBinaryFunction::EQ(0, arg1, arg2);
 
-        BOOST_CHECK_EQUAL( result.defined_size(), 3 );
+        BOOST_CHECK_EQUAL( result.defined_size(), 3U );
         BOOST_CHECK_EQUAL( result[0].get(), 0);
         BOOST_CHECK_EQUAL( result[2].get(), 0);
         BOOST_CHECK_EQUAL( result[4].get(), 1);
@@ -730,7 +730,7 @@ BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
     {
         const auto& func = dynamic_cast<const UDQBinaryFunction&>(udqft.get("<"));
         auto result = func.eval(arg1, arg2);
-        BOOST_CHECK_EQUAL( result.defined_size(), 3 );
+        BOOST_CHECK_EQUAL( result.defined_size(), 3U );
         BOOST_CHECK_EQUAL( result[0].get(), 0);
         BOOST_CHECK_EQUAL( result[2].get(), 1);
         BOOST_CHECK_EQUAL( result[4].get(), 0);
@@ -738,7 +738,7 @@ BOOST_AUTO_TEST_CASE(CMP_FUNCTIONS) {
     {
         const auto& func = dynamic_cast<const UDQBinaryFunction&>(udqft.get(">"));
         auto result = func.eval(arg1, arg2);
-        BOOST_CHECK_EQUAL( result.defined_size(), 3 );
+        BOOST_CHECK_EQUAL( result.defined_size(), 3U );
         BOOST_CHECK_EQUAL( result[0].get(), 1);
         BOOST_CHECK_EQUAL( result[2].get(), 0);
         BOOST_CHECK_EQUAL( result[4].get(), 0);
@@ -817,7 +817,7 @@ BOOST_AUTO_TEST_CASE(ELEMENTAL_UNARY_FUNCTIONS) {
         auto result = func.eval(arg);
         BOOST_CHECK_EQUAL( result[1].get(), 1);
         BOOST_CHECK_EQUAL( result[3].get(), 1);
-        BOOST_CHECK_EQUAL( result.defined_size(), 2);
+        BOOST_CHECK_EQUAL( result.defined_size(), 2U);
     }
     {
         const auto& func = dynamic_cast<const UDQUnaryElementalFunction&>(udqft.get("EXP"));
@@ -908,7 +908,7 @@ BOOST_AUTO_TEST_CASE(UNION_FUNCTIONS) {
 
     const auto& func = dynamic_cast<const UDQBinaryFunction&>(udqft.get("UADD"));
     auto result = func.eval(arg1, arg2);
-    BOOST_CHECK_EQUAL( 3, result.defined_size() );
+    BOOST_CHECK_EQUAL( 3U, result.defined_size() );
     BOOST_CHECK_EQUAL( 2, result[0].get() );
     BOOST_CHECK_EQUAL( 2, result[2].get() );
     BOOST_CHECK_EQUAL( 3, result[3].get() );
@@ -933,7 +933,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SET_DIV) {
     s.assign(5,0);
 
     auto result = 10 / s;
-    BOOST_CHECK_EQUAL( result.defined_size(), 3);
+    BOOST_CHECK_EQUAL( result.defined_size(), 3U);
     BOOST_CHECK_EQUAL( result[0].get(), 10);
     BOOST_CHECK_EQUAL( result[2].get(), 5);
     BOOST_CHECK_EQUAL( result[4].get(), 2);
@@ -948,7 +948,7 @@ BOOST_AUTO_TEST_CASE(UDQASSIGN_TEST) {
     std::vector<std::string> ws1 = {"P1", "P2", "I1", "I2"};
 
     auto res1 = as1.eval(ws1);
-    BOOST_CHECK_EQUAL(res1.size(), 4);
+    BOOST_CHECK_EQUAL(res1.size(), 4U);
     BOOST_CHECK_EQUAL(res1["P1"].get(), 1.0);
     BOOST_CHECK_EQUAL(res1["I2"].get(), 1.0);
 
@@ -1035,7 +1035,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SCALAR_SET) {
     {
         UDQDefine def(udqp, "WUOPR", {"WOPR", "'*1'"});
         auto res = def.eval(context);
-        BOOST_CHECK_EQUAL(4, res.size());
+        BOOST_CHECK_EQUAL(4U, res.size());
         auto well1 = res["P1"];
         BOOST_CHECK( well1.defined() );
         BOOST_CHECK_EQUAL(well1.get() , 1);
@@ -1049,7 +1049,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SCALAR_SET) {
     {
         UDQDefine def(udqp, "WUOPR", {"1"});
         auto res = def.eval(context);
-        BOOST_CHECK_EQUAL(4, res.size());
+        BOOST_CHECK_EQUAL(4U, res.size());
         auto well1 = res["P1"];
         BOOST_CHECK( well1.defined() );
         BOOST_CHECK_EQUAL(well1.get() , 1);
@@ -1065,7 +1065,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SCALAR_SET) {
     {
         UDQDefine def(udqp, "WUOPR", {"WOPR", "'P1'"});
         auto res = def.eval(context);
-        BOOST_CHECK_EQUAL(4, res.size());
+        BOOST_CHECK_EQUAL(4U, res.size());
         auto well1 = res["P1"];
         BOOST_CHECK( well1.defined() );
         BOOST_CHECK_EQUAL(well1.get() , 1);
@@ -1110,13 +1110,13 @@ BOOST_AUTO_TEST_CASE(UDQ_SORTD_NAN) {
 
     st.update_well_var("OP1", "WWIR", 0);
     auto res2 = def.eval(context);
-    BOOST_CHECK_EQUAL(res2.defined_size(), 3);
+    BOOST_CHECK_EQUAL(res2.defined_size(), 3U);
     st.update_udq( res2, 0 );
     BOOST_CHECK( st.has_well_var("OP4", "WUPR1"));
 
     auto res_sort2 = def_sort.eval(context);
     st.update_udq( res_sort2, 0 );
-    BOOST_CHECK_EQUAL(res_sort2.defined_size(), 3);
+    BOOST_CHECK_EQUAL(res_sort2.defined_size(), 3U);
     BOOST_CHECK_EQUAL(res_sort2["OP2"].get(), 1.0);
     BOOST_CHECK_EQUAL(res_sort2["OP3"].get(), 2.0);
     BOOST_CHECK_EQUAL(res_sort2["OP4"].get(), 3.0);
@@ -1177,42 +1177,42 @@ BOOST_AUTO_TEST_CASE(UDQ_BASIC_MATH_TEST) {
     st.update_well_var("P4", "WWPR", 4);
 
     auto res_add = def_add.eval(context);
-    BOOST_CHECK_EQUAL( res_add.size(), 4);
+    BOOST_CHECK_EQUAL( res_add.size(), 4U);
     BOOST_CHECK_EQUAL( res_add["P1"].get(), 2);
     BOOST_CHECK_EQUAL( res_add["P2"].get(), 4);
     BOOST_CHECK_EQUAL( res_add["P3"].get(), 6);
     BOOST_CHECK_EQUAL( res_add["P4"].get(), 8);
 
     auto res_sub = def_sub.eval(context);
-    BOOST_CHECK_EQUAL( res_sub.size(), 4);
+    BOOST_CHECK_EQUAL( res_sub.size(), 4U);
     BOOST_CHECK_EQUAL( res_sub["P1"].get(), 0);
     BOOST_CHECK_EQUAL( res_sub["P2"].get(), 0);
     BOOST_CHECK_EQUAL( res_sub["P3"].get(), 0);
     BOOST_CHECK_EQUAL( res_sub["P4"].get(), 0);
 
     auto res_div = def_div.eval(context);
-    BOOST_CHECK_EQUAL( res_div.size(), 4);
+    BOOST_CHECK_EQUAL( res_div.size(), 4U);
     BOOST_CHECK_EQUAL( res_div["P1"].get(), 1);
     BOOST_CHECK_EQUAL( res_div["P2"].get(), 1);
     BOOST_CHECK_EQUAL( res_div["P3"].get(), 1);
     BOOST_CHECK_EQUAL( res_div["P4"].get(), 1);
 
     auto res_mul = def_mul.eval(context);
-    BOOST_CHECK_EQUAL( res_mul.size(), 4);
+    BOOST_CHECK_EQUAL( res_mul.size(), 4U);
     BOOST_CHECK_EQUAL( res_mul["P1"].get(), 1);
     BOOST_CHECK_EQUAL( res_mul["P2"].get(), 4);
     BOOST_CHECK_EQUAL( res_mul["P3"].get(), 9);
     BOOST_CHECK_EQUAL( res_mul["P4"].get(),16);
 
     auto res_muladd = def_muladd.eval(context);
-    BOOST_CHECK_EQUAL( res_muladd.size(), 4);
+    BOOST_CHECK_EQUAL( res_muladd.size(), 4U);
     BOOST_CHECK_EQUAL( res_muladd["P1"].get(), 1 + 1);
     BOOST_CHECK_EQUAL( res_muladd["P2"].get(), 4 + 2);
     BOOST_CHECK_EQUAL( res_muladd["P3"].get(), 9 + 3);
     BOOST_CHECK_EQUAL( res_muladd["P4"].get(),16 + 4);
 
     auto res_wuwct= def_wuwct.eval(context);
-    BOOST_CHECK_EQUAL( res_wuwct.size(), 4);
+    BOOST_CHECK_EQUAL( res_wuwct.size(), 4U);
     BOOST_CHECK_EQUAL( res_wuwct["P1"].get(),0.50);
     BOOST_CHECK_EQUAL( res_wuwct["P2"].get(),0.50);
     BOOST_CHECK_EQUAL( res_wuwct["P3"].get(),0.50);
@@ -1232,7 +1232,7 @@ BOOST_AUTO_TEST_CASE(DECK_TEST) {
     st.update_well_var("OP3", "WOPR", 30000);
 
     auto res = def.eval(context);
-    BOOST_CHECK_EQUAL(res.size(), 3);
+    BOOST_CHECK_EQUAL(res.size(), 3U);
     for (std::size_t index = 0; index < res.size(); index++)
         BOOST_CHECK( res[index].get() == (300 - 150)*0.90);
 }
@@ -1381,8 +1381,8 @@ UDQ
 
     const auto& input = udq.input();
     const auto& def = udq.definitions();
-    BOOST_CHECK_EQUAL(input.size(), 9);
-    BOOST_CHECK_EQUAL(udq.size(), 9);
+    BOOST_CHECK_EQUAL(input.size(), 9U);
+    BOOST_CHECK_EQUAL(udq.size(), 9U);
 
     BOOST_CHECK( input[0].is<UDQAssign>() );
     BOOST_CHECK( input[1].is<UDQAssign>() );
@@ -1435,8 +1435,8 @@ UDQ
 
 
     const auto& input = udq.input();
-    BOOST_CHECK_EQUAL(input.size(), 6);
-    BOOST_CHECK_EQUAL(udq.size(), 6);
+    BOOST_CHECK_EQUAL(input.size(), 6U);
+    BOOST_CHECK_EQUAL(udq.size(), 6U);
 
     BOOST_CHECK( input[0].is<UDQDefine>());
     BOOST_CHECK_EQUAL( input[0].keyword(), "WUBHP1");
@@ -1452,18 +1452,18 @@ BOOST_AUTO_TEST_CASE(UDQ_USAGE) {
     UDQActive usage;
     UDQParams params;
     UDQConfig conf(params);
-    BOOST_CHECK_EQUAL( usage.IUAD_size(), 0 );
+    BOOST_CHECK_EQUAL( usage.IUAD_size(), 0U );
 
     UDAValue uda1("WUX");
     conf.add_assign(uda1.get<std::string>(), {}, 100, 0);
 
     usage.update(conf, uda1, "W1", UDAControl::WCONPROD_ORAT);
-    BOOST_CHECK_EQUAL( usage.IUAD_size(), 1 );
-    BOOST_CHECK_EQUAL( usage[0].use_count, 1);
+    BOOST_CHECK_EQUAL( usage.IUAD_size(), 1U);
+    BOOST_CHECK_EQUAL( usage[0].use_count, 1U);
 
     usage.update(conf, uda1, "W1", UDAControl::WCONPROD_GRAT);
-    BOOST_CHECK_EQUAL( usage.IUAD_size(), 2 );
-    BOOST_CHECK_EQUAL( usage[1].use_count, 1);
+    BOOST_CHECK_EQUAL( usage.IUAD_size(), 2U);
+    BOOST_CHECK_EQUAL( usage[1].use_count, 1U);
 
     const auto& rec = usage[0];
     BOOST_CHECK_EQUAL(rec.udq, "WUX");
@@ -1472,7 +1472,7 @@ BOOST_AUTO_TEST_CASE(UDQ_USAGE) {
 
     for (std::size_t index = 0; index < usage.IUAD_size(); index++) {
         const auto& record = usage[index];
-        BOOST_CHECK_EQUAL(record.input_index, 0);
+        BOOST_CHECK_EQUAL(record.input_index, 0U);
 
         if (index == 0)
             BOOST_CHECK(record.control == UDAControl::WCONPROD_ORAT);
@@ -1490,7 +1490,7 @@ BOOST_AUTO_TEST_CASE(IntegrationTest) {
     auto schedule = make_schedule(deck_string);
     {
         const auto& active = schedule.udqActive(1);
-        BOOST_CHECK_EQUAL(active.IUAD_size(), 6);
+        BOOST_CHECK_EQUAL(active.IUAD_size(), 6U);
 
         BOOST_CHECK(active[0].control == UDAControl::WCONPROD_ORAT);
         BOOST_CHECK(active[1].control == UDAControl::WCONPROD_LRAT);
@@ -1571,19 +1571,19 @@ WCONPROD
     {
         const auto& udq_active = schedule.udqActive(0);
         BOOST_CHECK(udq_active);
-        BOOST_CHECK_EQUAL(udq_active.IUAD_size(), 2);
+        BOOST_CHECK_EQUAL(udq_active.IUAD_size(), 2U);
 
         const auto& record0 = udq_active[0];
         BOOST_CHECK_EQUAL( record0.uad_code, 300004);
-        BOOST_CHECK_EQUAL( record0.input_index, 2);
-        BOOST_CHECK_EQUAL( record0.use_count, 2);
-        BOOST_CHECK_EQUAL( record0.use_index, 0);
+        BOOST_CHECK_EQUAL( record0.input_index, 2U);
+        BOOST_CHECK_EQUAL( record0.use_count, 2U);
+        BOOST_CHECK_EQUAL( record0.use_index, 0U);
 
         const auto& record1 = udq_active[1];
         BOOST_CHECK_EQUAL( record1.uad_code, 600004);
-        BOOST_CHECK_EQUAL( record1.input_index, 3);
-        BOOST_CHECK_EQUAL( record1.use_count, 2);
-        BOOST_CHECK_EQUAL( record1.use_index, 2);
+        BOOST_CHECK_EQUAL( record1.input_index, 3U);
+        BOOST_CHECK_EQUAL( record1.use_count, 2U);
+        BOOST_CHECK_EQUAL( record1.use_index, 2U);
     }
 
     {
@@ -1592,31 +1592,31 @@ WCONPROD
         //  - The new UDQs WUXO and WUXL are now used for the PROD2 well.
         const auto& udq_active = schedule.udqActive(1);
         BOOST_CHECK(udq_active);
-        BOOST_CHECK_EQUAL(udq_active.IUAD_size(), 4);
+        BOOST_CHECK_EQUAL(udq_active.IUAD_size(), 4U);
 
         const auto& record0 = udq_active[0];
         BOOST_CHECK_EQUAL( record0.uad_code, 300004);
-        BOOST_CHECK_EQUAL( record0.input_index, 2);
-        BOOST_CHECK_EQUAL( record0.use_count, 1);
-        BOOST_CHECK_EQUAL( record0.use_index, 0);
+        BOOST_CHECK_EQUAL( record0.input_index, 2U);
+        BOOST_CHECK_EQUAL( record0.use_count, 1U);
+        BOOST_CHECK_EQUAL( record0.use_index, 0U);
 
         const auto& record1 = udq_active[1];
         BOOST_CHECK_EQUAL( record1.uad_code, 600004);
-        BOOST_CHECK_EQUAL( record1.input_index, 3);
-        BOOST_CHECK_EQUAL( record1.use_count, 1);
-        BOOST_CHECK_EQUAL( record1.use_index, 1);
+        BOOST_CHECK_EQUAL( record1.input_index, 3U);
+        BOOST_CHECK_EQUAL( record1.use_count, 1U);
+        BOOST_CHECK_EQUAL( record1.use_index, 1U);
 
         const auto& record2 = udq_active[2];
         BOOST_CHECK_EQUAL( record2.uad_code, 300004);
-        BOOST_CHECK_EQUAL( record2.input_index, 4);
-        BOOST_CHECK_EQUAL( record2.use_count, 1);
-        BOOST_CHECK_EQUAL( record2.use_index, 2);
+        BOOST_CHECK_EQUAL( record2.input_index, 4U);
+        BOOST_CHECK_EQUAL( record2.use_count, 1U);
+        BOOST_CHECK_EQUAL( record2.use_index, 2U);
 
         const auto& record3 = udq_active[3];
         BOOST_CHECK_EQUAL( record3.uad_code, 600004);
-        BOOST_CHECK_EQUAL( record3.input_index, 5);
-        BOOST_CHECK_EQUAL( record3.use_count, 1);
-        BOOST_CHECK_EQUAL( record3.use_index, 3);
+        BOOST_CHECK_EQUAL( record3.input_index, 5U);
+        BOOST_CHECK_EQUAL( record3.use_count, 1U);
+        BOOST_CHECK_EQUAL( record3.use_index, 3U);
     }
 
     {
@@ -1625,29 +1625,29 @@ WCONPROD
         //  - The PROD1 well does not use UDQ
         const auto& udq_active = schedule.udqActive(2);
         BOOST_CHECK(udq_active);
-        BOOST_CHECK_EQUAL(udq_active.IUAD_size(), 2);
+        BOOST_CHECK_EQUAL(udq_active.IUAD_size(), 2U);
 
         const auto& record0 = udq_active[0];
         BOOST_CHECK_EQUAL( record0.uad_code, 300004);
-        BOOST_CHECK_EQUAL( record0.input_index, 4);
-        BOOST_CHECK_EQUAL( record0.use_count, 1);
-        BOOST_CHECK_EQUAL( record0.use_index, 0);
+        BOOST_CHECK_EQUAL( record0.input_index, 4U);
+        BOOST_CHECK_EQUAL( record0.use_count, 1U);
+        BOOST_CHECK_EQUAL( record0.use_index, 0U);
 
         const auto& record1 = udq_active[1];
         BOOST_CHECK_EQUAL( record1.uad_code, 600004);
-        BOOST_CHECK_EQUAL( record1.input_index, 5);
-        BOOST_CHECK_EQUAL( record1.use_count, 1);
-        BOOST_CHECK_EQUAL( record1.use_index, 1);
+        BOOST_CHECK_EQUAL( record1.input_index, 5U);
+        BOOST_CHECK_EQUAL( record1.use_count, 1U);
+        BOOST_CHECK_EQUAL( record1.use_index, 1U);
     }
     {
         const auto& udq_config = schedule.getUDQConfig(2);
         const auto& def = udq_config.definitions();
         const auto& def1 = def[0];
         const auto& tokens = def1.func_tokens();
-        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::number ), 1);
-        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::ecl_expr), 1);
-        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::binary_op_sub), 1);
-        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::binary_op_mul), 1);
+        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::number ), 1U);
+        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::ecl_expr), 1U);
+        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::binary_op_sub), 1U);
+        BOOST_CHECK_EQUAL( tokens.count( UDQTokenType::binary_op_mul), 1U);
     }
 }
 

--- a/tests/parser/WLIST.cpp
+++ b/tests/parser/WLIST.cpp
@@ -38,23 +38,23 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE(CreateWLIST) {
     Opm::WList wlist;
-    BOOST_CHECK_EQUAL(wlist.size(), 0);
+    BOOST_CHECK_EQUAL(wlist.size(), 0U);
     wlist.add("W1");
-    BOOST_CHECK_EQUAL(wlist.size(), 1);
+    BOOST_CHECK_EQUAL(wlist.size(), 1U);
 
 
     wlist.del("NO_SUCH_WELL");
-    BOOST_CHECK_EQUAL(wlist.size(), 1);
+    BOOST_CHECK_EQUAL(wlist.size(), 1U);
 
     wlist.del("W1");
-    BOOST_CHECK_EQUAL(wlist.size(), 0);
+    BOOST_CHECK_EQUAL(wlist.size(), 0U);
 
     wlist.add("W1");
     wlist.add("W2");
     wlist.add("W3");
 
     auto wells = wlist.wells();
-    BOOST_CHECK_EQUAL(wells.size(), 3);
+    BOOST_CHECK_EQUAL(wells.size(), 3U);
     BOOST_CHECK( std::find(wells.begin(), wells.end(), "W1") != wells.end());
     BOOST_CHECK( std::find(wells.begin(), wells.end(), "W2") != wells.end());
     BOOST_CHECK( std::find(wells.begin(), wells.end(), "W3") != wells.end());
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(CreateWLIST) {
     for (const auto& well : wlist)
         wells2.push_back(well);
 
-    BOOST_CHECK_EQUAL(wells2.size(), 3);
+    BOOST_CHECK_EQUAL(wells2.size(), 3U);
     BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W1") != wells2.end());
     BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W2") != wells2.end());
     BOOST_CHECK( std::find(wells2.begin(), wells2.end(), "W3") != wells2.end());
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(WLISTManager) {
     // list is dropped and a new list is created.
     {
         auto& wlist1 = wlm.newList("LIST1");
-        BOOST_CHECK_EQUAL(wlist1.size(), 0);
+        BOOST_CHECK_EQUAL(wlist1.size(), 0U);
     }
     auto& wlist1 = wlm.newList("LIST1");
     auto& wlist2 = wlm.newList("LIST2");
@@ -240,11 +240,11 @@ BOOST_AUTO_TEST_CASE(Wlist) {
       const auto& wl5 = wlm.getList("*LIST5");
       const auto& wl6 = wlm.getList("*LIST6");
 
-      BOOST_CHECK_EQUAL(wl1.wells().size(), 4 );
-      BOOST_CHECK_EQUAL(wl2.wells().size(), 2 );
-      BOOST_CHECK_EQUAL(wl4.wells().size(), 4 );
-      BOOST_CHECK_EQUAL(wl5.wells().size(), 4 );
-      BOOST_CHECK_EQUAL(wl6.wells().size(), 0 );
+      BOOST_CHECK_EQUAL(wl1.wells().size(), 4U );
+      BOOST_CHECK_EQUAL(wl2.wells().size(), 2U );
+      BOOST_CHECK_EQUAL(wl4.wells().size(), 4U );
+      BOOST_CHECK_EQUAL(wl5.wells().size(), 4U );
+      BOOST_CHECK_EQUAL(wl6.wells().size(), 0U );
   }
   {
       const auto& wlm = sched.getWListManager(2);
@@ -252,9 +252,9 @@ BOOST_AUTO_TEST_CASE(Wlist) {
       const auto& wl2 = wlm.getList("*LIST2");
       const auto& wl3 = wlm.getList("*LIST3");
 
-      BOOST_CHECK_EQUAL(wl1.wells().size(), 2 );
-      BOOST_CHECK_EQUAL(wl2.wells().size(), 0 );
-      BOOST_CHECK_EQUAL(wl3.wells().size(), 2 );
+      BOOST_CHECK_EQUAL(wl1.wells().size(), 2U );
+      BOOST_CHECK_EQUAL(wl2.wells().size(), 0U );
+      BOOST_CHECK_EQUAL(wl3.wells().size(), 2U );
 
       BOOST_CHECK( wl1.has("W2"));
       BOOST_CHECK( wl1.has("W4"));

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -42,20 +42,20 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(CreateWellTestConfig) {
     WellTestConfig wc;
 
-    BOOST_CHECK_EQUAL(wc.size() , 0);
+    BOOST_CHECK_EQUAL(wc.size() , 0U);
 
 
     wc.add_well("NAME", WellTestConfig::Reason::PHYSICAL, 10, 10, 10, 1);
-    BOOST_CHECK_EQUAL(wc.size(), 1);
+    BOOST_CHECK_EQUAL(wc.size(), 1U);
     BOOST_CHECK_THROW(wc.add_well("NAME2", "", 10.0,10,10.0, 1), std::invalid_argument);
     BOOST_CHECK_THROW(wc.add_well("NAME3", "X", 1,2,3, 1), std::invalid_argument);
 
     wc.add_well("NAME", "PEGDC", 10, 10, 10, 1);
-    BOOST_CHECK_EQUAL(wc.size(), 5);
+    BOOST_CHECK_EQUAL(wc.size(), 5U);
     wc.add_well("NAMEX", "PGDC", 10, 10, 10, 1);
-    BOOST_CHECK_EQUAL(wc.size(), 9);
+    BOOST_CHECK_EQUAL(wc.size(), 9U);
     wc.drop_well("NAME");
-    BOOST_CHECK_EQUAL(wc.size(), 4);
+    BOOST_CHECK_EQUAL(wc.size(), 4U);
     BOOST_CHECK(wc.has("NAMEX"));
     BOOST_CHECK(wc.has("NAMEX", WellTestConfig::Reason::PHYSICAL));
     BOOST_CHECK(!wc.has("NAMEX", WellTestConfig::Reason::ECONOMIC));
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE2) {
     WellTestState st;
     wc.add_well("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 0, 0, 0, 0);
     st.closeWell("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 100);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 1);
+    BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
 
     const UnitSystem us{};
     std::vector<Well> wells;
@@ -81,13 +81,13 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE2) {
     {
         wells[0].updateStatus(Well::Status::SHUT, false);
         auto shut_wells = st.updateWells(wc, wells, 5000);
-        BOOST_CHECK_EQUAL(shut_wells.size(), 0);
+        BOOST_CHECK_EQUAL(shut_wells.size(), 0U);
     }
 
     {
         wells[0].updateStatus(Well::Status::OPEN, false);
         auto shut_wells = st.updateWells(wc, wells, 5000);
-        BOOST_CHECK_EQUAL( shut_wells.size(), 1);
+        BOOST_CHECK_EQUAL( shut_wells.size(), 1U);
     }
 }
 
@@ -95,19 +95,19 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
     const double day = 86400.;
     WellTestState st;
     st.closeWell("WELL_NAME", WellTestConfig::Reason::ECONOMIC, 100. * day);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 1);
+    BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
 
     st.openWell("WELL_NAME", WellTestConfig::Reason::ECONOMIC);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 1);
+    BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
 
     st.closeWell("WELL_NAME", WellTestConfig::Reason::ECONOMIC, 100. * day);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 1);
+    BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
 
     st.closeWell("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 100. * day);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 2);
+    BOOST_CHECK_EQUAL(st.sizeWells(), 2U);
 
     st.closeWell("WELLX", WellTestConfig::Reason::PHYSICAL, 100. * day);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 3);
+    BOOST_CHECK_EQUAL(st.sizeWells(), 3U);
 
     const UnitSystem us{};
     std::vector<Well> wells;
@@ -118,50 +118,50 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
     {
         wells[0].updateStatus(Well::Status::SHUT, false);
         auto shut_wells = st.updateWells(wc, wells, 110. * day);
-        BOOST_CHECK_EQUAL(shut_wells.size(), 0);
+        BOOST_CHECK_EQUAL(shut_wells.size(), 0U);
     }
     {
         wells[0].updateStatus(Well::Status::OPEN, false);
         auto shut_wells = st.updateWells(wc, wells, 110. * day);
-        BOOST_CHECK_EQUAL(shut_wells.size(), 0);
+        BOOST_CHECK_EQUAL(shut_wells.size(), 0U);
     }
 
     wc.add_well("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 1000. * day, 2, 0, 1);
     // Not sufficient time has passed.
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 200. * day).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 200. * day).size(), 0U);
 
     // We should test it:
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 1200. * day).size(), 1);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 1200. * day).size(), 1U);
 
     // Not sufficient time has passed.
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 1700. * day).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 1700. * day).size(), 0U);
 
     st.openWell("WELL_NAME", WellTestConfig::Reason::PHYSICAL);
 
     st.closeWell("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 1900. * day);
 
     // We should not test it:
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 2400. * day).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 2400. * day).size(), 0U);
 
     // We should test it now:
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 3000. * day).size(), 1);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 3000. * day).size(), 1U);
 
     // Too many attempts:
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4000. * day).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4000. * day).size(), 0U);
 
     wc.add_well("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 1000. * day, 3, 0, 5);
 
 
     wells[0].updateStatus(Well::Status::SHUT, false);
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4100. * day).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4100. * day).size(), 0U);
 
     wells[0].updateStatus(Well::Status::OPEN, false);
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4100. * day).size(), 1);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4100. * day).size(), 1U);
 
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 5200. * day).size(), 1);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 5200. * day).size(), 1U);
 
     wc.drop_well("WELL_NAME");
-    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 6300. * day).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 6300. * day).size(), 0U);
 }
 
 
@@ -169,16 +169,16 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
     WellTestConfig wc;
     WellTestState st;
     st.addClosedCompletion("WELL_NAME", 2, 100);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1);
+    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1U);
 
     st.addClosedCompletion("WELL_NAME", 2, 100);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1);
+    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1U);
 
     st.addClosedCompletion("WELL_NAME", 3, 100);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 2);
+    BOOST_CHECK_EQUAL(st.sizeCompletions(), 2U);
 
     st.addClosedCompletion("WELLX", 3, 100);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 3);
+    BOOST_CHECK_EQUAL(st.sizeCompletions(), 3U);
 
     const UnitSystem us{};
     std::vector<Well> wells;
@@ -188,27 +188,27 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
     wells[1].updateStatus(Well::Status::OPEN, false);
 
     auto closed_completions = st.updateWells(wc, wells, 5000);
-    BOOST_CHECK_EQUAL( closed_completions.size(), 0);
+    BOOST_CHECK_EQUAL( closed_completions.size(), 0U);
 
     wc.add_well("WELL_NAME", WellTestConfig::Reason::COMPLETION, 1000, 2, 0, 0);
     // Not sufficient time has passed.
-    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 200).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 200).size(), 0U);
 
     // We should test it:
-    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 1200).size(), 2);
+    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 1200).size(), 2U);
 
     // Not sufficient time has passed.
-    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 1700).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 1700).size(), 0U);
 
     // We should test it:
-    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 2400).size(), 2);
+    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 2400).size(), 2U);
 
     // Too many attempts:
-    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 24000).size(), 0);
+    BOOST_CHECK_EQUAL( st.updateCompletion(wc, 24000).size(), 0U);
 
     st.dropCompletion("WELL_NAME", 2);
     st.dropCompletion("WELLX", 3);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1);
+    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1U);
 }
 
 

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
     Schedule schedule(deck, grid , fp, runspec, python);
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
     const auto& keyword = deck.getKeyword("WSOLVENT");
-    BOOST_CHECK_EQUAL(keyword.size(),1);
+    BOOST_CHECK_EQUAL(keyword.size(),1U);
     const auto& record = keyword.getRecord(0);
     const std::string& well_name = record.getItem("WELL").getTrimmedString(0);
     BOOST_CHECK_EQUAL(well_name, "W_1");

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
 
     //Verify TRACK completion ordering
     for (size_t k = 0; k < completions.size(); ++k) {
-        BOOST_CHECK_EQUAL(completions.get( k ).getK(), k);
+        BOOST_CHECK_EQUAL(completions.get( k ).getK(), int(k));
     }
 
     // Output / input ordering
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestDefaultTRACK) {
 
     //Verify TRACK completion ordering
     for (size_t k = 0; k < completions.size(); ++k) {
-        BOOST_CHECK_EQUAL(completions.get( k ).getK(), k);
+        BOOST_CHECK_EQUAL(completions.get( k ).getK(), int(k));
     }
 }
 

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER) {
     Schedule schedule(deck, grid , fp, runspec, python);
     BOOST_CHECK(deck.hasKeyword("WTRACER"));
     const auto& keyword = deck.getKeyword("WTRACER");
-    BOOST_CHECK_EQUAL(keyword.size(),1);
+    BOOST_CHECK_EQUAL(keyword.size(),1U);
     const auto& record = keyword.getRecord(0);
     const std::string& well_name = record.getItem("WELL").getTrimmedString(0);
     BOOST_CHECK_EQUAL(well_name, "W_1");

--- a/tests/parser/test_ReportConfig.cpp
+++ b/tests/parser/test_ReportConfig.cpp
@@ -126,7 +126,7 @@ RPTSCHED
     // Empty initial report configuration
     {
         auto report_config = sched.report_config(0);
-        BOOST_CHECK_EQUAL(report_config.size(), 0);
+        BOOST_CHECK_EQUAL(report_config.size(), 0U);
 
         BOOST_CHECK(!report_config.contains("FIPFOAM"));
         BOOST_CHECK_THROW( report_config.at("FIPFOAM"), std::out_of_range);
@@ -135,26 +135,26 @@ RPTSCHED
     // Configuration at step 1
     {
         auto report_config = sched.report_config(1);
-        BOOST_CHECK_EQUAL( report_config.size() , 2);
+        BOOST_CHECK_EQUAL( report_config.size() , 2U);
 
         for (const auto& p : report_config) {
             if (p.first == "FIPSOL")
-                BOOST_CHECK_EQUAL(p.second, 1);
+                BOOST_CHECK_EQUAL(p.second, 1U);
 
             if (p.first == "FIP")
-                BOOST_CHECK_EQUAL(p.second, 3);
+                BOOST_CHECK_EQUAL(p.second, 3U);
         }
 
         BOOST_CHECK(!report_config.contains("FIPFOAM"));
         BOOST_CHECK(report_config.contains("FIP"));
-        BOOST_CHECK_EQUAL(report_config.at("FIP"), 3);
-        BOOST_CHECK_EQUAL(report_config.at("FIPSOL"), 1);
+        BOOST_CHECK_EQUAL(report_config.at("FIP"), 3U);
+        BOOST_CHECK_EQUAL(report_config.at("FIPSOL"), 1U);
     }
 
     // Configuration at step 2 - the special 'NOTHING' has cleared everything
     {
         auto report_config = sched.report_config(2);
-        BOOST_CHECK_EQUAL(report_config.size(), 0);
+        BOOST_CHECK_EQUAL(report_config.size(), 0U);
 
         BOOST_CHECK(!report_config.contains("FIPFOAM"));
         BOOST_CHECK_THROW( report_config.at("FIPFOAM"), std::out_of_range);

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -1188,7 +1188,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD) {
     BOOST_CHECK_EQUAL(well2.ij[1], 8);
     BOOST_CHECK_EQUAL(well2.name, "OP_2");
 
-    BOOST_CHECK_EQUAL(well2.connections.size(), 1);
+    BOOST_CHECK_EQUAL(well2.connections.size(), 1U);
     const auto& conn1 = well2.connections[0];
     BOOST_CHECK_EQUAL(conn1.ijk[0], 8);
     BOOST_CHECK_EQUAL(conn1.ijk[1], 8);

--- a/tests/test_ERft.cpp
+++ b/tests/test_ERft.cpp
@@ -135,9 +135,9 @@ BOOST_AUTO_TEST_CASE(TestERft_1) {
     std::vector<float> vect2=rft1.getRft<float>("PRESSURE","B-2H", Date{2016,5,31});
     std::vector<std::string> vect3=rft1.getRft<std::string>("WELLETC","B-2H", Date{2016,5,31});
 
-    BOOST_CHECK_EQUAL(vect1.size(), 3);
-    BOOST_CHECK_EQUAL(vect2.size(), 3);
-    BOOST_CHECK_EQUAL(vect3.size(), 16);
+    BOOST_CHECK_EQUAL(vect1.size(), 3U);
+    BOOST_CHECK_EQUAL(vect2.size(), 3U);
+    BOOST_CHECK_EQUAL(vect3.size(), 16U);
 
    // test member function getRft(name, reportIndex)
 

--- a/tests/test_ERsm.cpp
+++ b/tests/test_ERsm.cpp
@@ -178,13 +178,13 @@ BOOST_AUTO_TEST_CASE(ERsm) {
     BOOST_CHECK_THROW( rsm1.get("NO_SUCH_KEY"), std::out_of_range);
 
     const auto& wwit_c_2h = rsm2.get("WWIT:C-2H");
-    BOOST_CHECK_EQUAL( wwit_c_2h.size(), 4 );
+    BOOST_CHECK_EQUAL( wwit_c_2h.size(), 4U );
     std::vector<double> expected = {227.7381, 238.5447, 243.9480, 249.3513};
     for (std::size_t index = 0; index < 4; index++)
         BOOST_CHECK_CLOSE( expected[index] * 1000 , wwit_c_2h[index], 1e-6);
 
     const auto& wwit_c_4h = rsm2.get("WWIT:C-4H");
-    BOOST_CHECK_EQUAL( wwit_c_4h.size(), 4 );
+    BOOST_CHECK_EQUAL( wwit_c_4h.size(), 4U );
     std::vector<double> expected2 = {46279.20, 63147.95, 71582.33, 80016.70};
     for (std::size_t index = 0; index < 4; index++)
         BOOST_CHECK_CLOSE( expected2[index] * 1 , wwit_c_4h[index], 1e-6);

--- a/tests/test_EclIO.cpp
+++ b/tests/test_EclIO.cpp
@@ -165,32 +165,32 @@ BOOST_AUTO_TEST_CASE(TestEclFile_BINARY) {
     std::vector<int> vect1a=file1.get<int>(0);
     std::vector<int> vect1b=file1.get<int>("ICON");
 
-    BOOST_CHECK_EQUAL(vect1a.size(), 1875);
-    BOOST_CHECK_EQUAL(vect1b.size(), 1875);
+    BOOST_CHECK_EQUAL(vect1a.size(), 1875U);
+    BOOST_CHECK_EQUAL(vect1b.size(), 1875U);
 
     std::vector<bool> vect2a=file1.get<bool>(1);
     std::vector<bool> vect2b=file1.get<bool>("LOGIHEAD");
 
-    BOOST_CHECK_EQUAL(vect2a.size(), 121);
-    BOOST_CHECK_EQUAL(vect2b.size(), 121);
+    BOOST_CHECK_EQUAL(vect2a.size(), 121U);
+    BOOST_CHECK_EQUAL(vect2b.size(), 121U);
 
     std::vector<float> vect3a=file1.get<float>(2);
     std::vector<float> vect3b=file1.get<float>("PORV");
 
-    BOOST_CHECK_EQUAL(vect3a.size(), 3146);
-    BOOST_CHECK_EQUAL(vect3b.size(), 3146);
+    BOOST_CHECK_EQUAL(vect3a.size(), 3146U);
+    BOOST_CHECK_EQUAL(vect3b.size(), 3146U);
 
     std::vector<double> vect4a=file1.get<double>(3);
     std::vector<double> vect4b=file1.get<double>("XCON");
 
-    BOOST_CHECK_EQUAL(vect4a.size(), 1740);
-    BOOST_CHECK_EQUAL(vect4b.size(), 1740);
+    BOOST_CHECK_EQUAL(vect4a.size(), 1740U);
+    BOOST_CHECK_EQUAL(vect4b.size(), 1740U);
 
     std::vector<std::string> vect5a=file1.get<std::string>(4);
     std::vector<std::string> vect5b=file1.get<std::string>("KEYWORDS");
 
-    BOOST_CHECK_EQUAL(vect5a.size(), 312);
-    BOOST_CHECK_EQUAL(vect5b.size(), 312);
+    BOOST_CHECK_EQUAL(vect5a.size(), 312U);
+    BOOST_CHECK_EQUAL(vect5b.size(), 312U);
 }
 
 BOOST_AUTO_TEST_CASE(TestEclFile_FORMATTED) {
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(TestEcl_Write_formatted_not_finite) {
     BOOST_CHECK(std::isnan(f[1]));
     BOOST_CHECK(std::isnan(d[1]));
 
-    BOOST_CHECK_EQUAL(file1.size(), 2);
+    BOOST_CHECK_EQUAL(file1.size(), 2U);
 }
 
 

--- a/tests/test_OpmLog.cpp
+++ b/tests/test_OpmLog.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(Test_Logger) {
         auto counter2 = logger.getBackend<CounterLog>("COUNTER");
         BOOST_CHECK_EQUAL( 1U , counter2->numMessages( Log::MessageType::Warning));
         BOOST_CHECK_EQUAL( 1U , counter2->numMessages( Log::MessageType::Error));
-        BOOST_CHECK_EQUAL( 0  , counter2->numMessages( Log::MessageType::Info));
+        BOOST_CHECK_EQUAL( 0U , counter2->numMessages( Log::MessageType::Info));
     }
 
     BOOST_CHECK_EQUAL( false , logger.removeBackend("NO-not-found"));
@@ -177,14 +177,14 @@ BOOST_AUTO_TEST_CASE( CounterLogTesting) {
 
     BOOST_CHECK_EQUAL(1U , counter.numMessages( Log::MessageType::Error ));
     BOOST_CHECK_EQUAL(1U , counter.numMessages( Log::MessageType::Warning ));
-    BOOST_CHECK_EQUAL(0  , counter.numMessages( Log::MessageType::Info ));
+    BOOST_CHECK_EQUAL(0U , counter.numMessages( Log::MessageType::Info ));
     BOOST_CHECK_EQUAL(1U  , counter.numMessages( Log::MessageType::Note ));
 
     {
         int64_t not_enabled = 4096;
         int64_t not_power2  = 4095;
 
-        BOOST_CHECK_EQUAL( 0 , counter.numMessages( not_enabled ));
+        BOOST_CHECK_EQUAL( 0U , counter.numMessages( not_enabled ));
         BOOST_CHECK_THROW( counter.numMessages( not_power2 ) , std::invalid_argument);
     }
 }
@@ -231,9 +231,9 @@ BOOST_AUTO_TEST_CASE(TestOpmLog) {
     {
         auto counter = OpmLog::getBackend<CounterLog>("COUNTER");
 
-        BOOST_CHECK_EQUAL( 1 , counter->numMessages(Log::MessageType::Error) );
-        BOOST_CHECK_EQUAL( 1 , counter->numMessages(Log::MessageType::Warning) );
-        BOOST_CHECK_EQUAL( 0 , counter->numMessages(Log::MessageType::Info) );
+        BOOST_CHECK_EQUAL( 1U , counter->numMessages(Log::MessageType::Error) );
+        BOOST_CHECK_EQUAL( 1U , counter->numMessages(Log::MessageType::Warning) );
+        BOOST_CHECK_EQUAL( 0U , counter->numMessages(Log::MessageType::Info) );
     }
 
     BOOST_CHECK_EQUAL( log_stream.str() , "Warning\n");
@@ -301,10 +301,10 @@ BOOST_AUTO_TEST_CASE(TestOpmLogWithColors)
     {
         auto counter = OpmLog::getBackend<CounterLog>("COUNTER");
 
-        BOOST_CHECK_EQUAL( 1 , counter->numMessages(Log::MessageType::Error) );
-        BOOST_CHECK_EQUAL( 1 , counter->numMessages(Log::MessageType::Warning) );
-        BOOST_CHECK_EQUAL( 1 , counter->numMessages(Log::MessageType::Info) );
-        BOOST_CHECK_EQUAL( 1 , counter->numMessages(Log::MessageType::Bug) );
+        BOOST_CHECK_EQUAL( 1U , counter->numMessages(Log::MessageType::Error) );
+        BOOST_CHECK_EQUAL( 1U , counter->numMessages(Log::MessageType::Warning) );
+        BOOST_CHECK_EQUAL( 1U , counter->numMessages(Log::MessageType::Info) );
+        BOOST_CHECK_EQUAL( 1U , counter->numMessages(Log::MessageType::Bug) );
     }
 
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1659,7 +1659,7 @@ BOOST_AUTO_TEST_CASE(READ_WRITE_WELLDATA) {
             BOOST_CHECK_CLOSE(seg.rates.get(rt::gas), 1729.496*sm3_pr_day(), 1.0e-10);
             const auto pres_idx = Opm::data::SegmentPressures::Value::Pressure;
             BOOST_CHECK_CLOSE(seg.pressures[pres_idx], 314.159*unit::barsa, 1.0e-10);
-            BOOST_CHECK_EQUAL(seg.segNumber, 1);
+            BOOST_CHECK_EQUAL(seg.segNumber, 1U);
 
             // No data for segment 10 of well W_2 (or no such segment).
             const auto& W2 = wellRatesCopy.at("W_2");
@@ -1874,13 +1874,13 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
     BOOST_CHECK_EQUAL( st.get_well_var("OP1", "WWCT"), 0.75);
     BOOST_CHECK_EQUAL( st.get_well_var("OP1", "WWCT"), st.get("WWCT:OP1"));
     const auto& wopr_wells = st.wells("WOPR");
-    BOOST_CHECK_EQUAL( wopr_wells.size() , 0);
+    BOOST_CHECK_EQUAL( wopr_wells.size() , 0U);
 
     BOOST_CHECK_EQUAL( st.get_well_var("OP99", "WWCT", 0.50), 0.50);
 
 
     const auto& wwct_wells = st.wells("WWCT");
-    BOOST_CHECK_EQUAL( wwct_wells.size(), 2);
+    BOOST_CHECK_EQUAL( wwct_wells.size(), 2U);
 
     st.update_group_var("G1", "GWCT", 0.25);
     st.update_group_var("G2", "GWCT", 0.25);
@@ -1890,29 +1890,29 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
     BOOST_CHECK_EQUAL( st.get_group_var("G1", "GWCT"), st.get("GWCT:G1"));
     BOOST_CHECK_EQUAL( st.get_group_var("G99", "GWCT", 1.00), 1.00);
     const auto& gopr_groups = st.groups("GOPR");
-    BOOST_CHECK_EQUAL( gopr_groups.size() , 0);
+    BOOST_CHECK_EQUAL( gopr_groups.size() , 0U);
 
     const auto& gwct_groups = st.groups("GWCT");
-    BOOST_CHECK_EQUAL( gwct_groups.size(), 2);
-    BOOST_CHECK_EQUAL(std::count(gwct_groups.begin(), gwct_groups.end(), "G1"), 1);
-    BOOST_CHECK_EQUAL(std::count(gwct_groups.begin(), gwct_groups.end(), "G2"), 1);
+    BOOST_CHECK_EQUAL( gwct_groups.size(), 2U);
+    BOOST_CHECK_EQUAL(std::count(gwct_groups.begin(), gwct_groups.end(), "G1"), 1U);
+    BOOST_CHECK_EQUAL(std::count(gwct_groups.begin(), gwct_groups.end(), "G2"), 1U);
     const auto& all_groups = st.groups();
-    BOOST_CHECK_EQUAL( all_groups.size(), 3);
-    BOOST_CHECK_EQUAL(std::count(all_groups.begin(), all_groups.end(), "G1"), 1);
-    BOOST_CHECK_EQUAL(std::count(all_groups.begin(), all_groups.end(), "G2"), 1);
-    BOOST_CHECK_EQUAL(std::count(all_groups.begin(), all_groups.end(), "G3"), 1);
+    BOOST_CHECK_EQUAL( all_groups.size(), 3U);
+    BOOST_CHECK_EQUAL(std::count(all_groups.begin(), all_groups.end(), "G1"), 1U);
+    BOOST_CHECK_EQUAL(std::count(all_groups.begin(), all_groups.end(), "G2"), 1U);
+    BOOST_CHECK_EQUAL(std::count(all_groups.begin(), all_groups.end(), "G3"), 1U);
 
     const auto& all_wells = st.wells();
-    BOOST_CHECK_EQUAL( all_wells.size(), 3);
-    BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP1"), 1);
-    BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP2"), 1);
-    BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP3"), 1);
+    BOOST_CHECK_EQUAL( all_wells.size(), 3U);
+    BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP1"), 1U);
+    BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP2"), 1U);
+    BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP3"), 1U);
 
-    BOOST_CHECK_EQUAL(st.size(), 11); // Size = 8 + 3 - where the the three are DAY, MNTH and YEAR
+    BOOST_CHECK_EQUAL(st.size(), 11U); // Size = 8 + 3 - where the the three are DAY, MNTH and YEAR
 
     // The well 'OP_2' which was indirectly added with the
     // st.update("WWCT:OP_2", 100) call is *not* counted as a well!
-    BOOST_CHECK_EQUAL(st.num_wells(), 3);
+    BOOST_CHECK_EQUAL(st.num_wells(), 3U);
 
 
     BOOST_CHECK( st.erase("WWCT:OP2") );

--- a/tests/test_Tables.cpp
+++ b/tests/test_Tables.cpp
@@ -2458,8 +2458,8 @@ PVDO
     {
         const auto& tabd = es.runspec().tabdims();
 
-        BOOST_CHECK_EQUAL(tabd.getNumPVTTables(),     2);
-        BOOST_CHECK_EQUAL(tabd.getNumPressureNodes(), 2);
+        BOOST_CHECK_EQUAL(tabd.getNumPVTTables(),     2U);
+        BOOST_CHECK_EQUAL(tabd.getNumPressureNodes(), 2U);
     }
 
     const auto pvdo = std::vector<double> {
@@ -2859,9 +2859,9 @@ PVTO
     {
         const auto& tabd = es.runspec().tabdims();
 
-        BOOST_CHECK_EQUAL(tabd.getNumPVTTables(),     2);
-        BOOST_CHECK_EQUAL(tabd.getNumRSNodes(),       1);
-        BOOST_CHECK_EQUAL(tabd.getNumPressureNodes(), 2);
+        BOOST_CHECK_EQUAL(tabd.getNumPVTTables(),     2U);
+        BOOST_CHECK_EQUAL(tabd.getNumRSNodes(),       1U);
+        BOOST_CHECK_EQUAL(tabd.getNumPressureNodes(), 2U);
     }
 
     // Verify active TABDIMS from dynamic sizes

--- a/tests/test_regionCache.cpp
+++ b/tests/test_regionCache.cpp
@@ -49,12 +49,12 @@ BOOST_AUTO_TEST_CASE(create) {
     out::RegionCache rc({"FIPNUM"}, es.fieldProps(), grid, schedule);
     {
         const auto& empty = rc.connections( "FIPNUM", 4 );
-        BOOST_CHECK_EQUAL( empty.size() , 0 );
+        BOOST_CHECK_EQUAL( empty.size() , 0U );
     }
 
     {
         const auto& top_layer = rc.connections(  "FIPNUM", 1 );
-        BOOST_CHECK_EQUAL( top_layer.size() , 3 );
+        BOOST_CHECK_EQUAL( top_layer.size() , 3U );
         {
             auto pair = top_layer[0];
             BOOST_CHECK_EQUAL( pair.first , "W_1");

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -123,7 +123,7 @@ void verifyWellState(const std::string& rst_filename, const Opm::Schedule& sched
     std::vector<std::string> wellList = schedule.wellNames(step);
 
     //Verify number of active wells
-    BOOST_CHECK_EQUAL( wellList.size(), intehead[16]);
+    BOOST_CHECK_EQUAL( wellList.size(), static_cast<std::size_t>(intehead[16]));
 
     for (size_t i=0; i< wellList.size(); i++) {
 
@@ -170,7 +170,7 @@ void verifyWellState(const std::string& rst_filename, const Opm::Schedule& sched
 
         // Verify number of connections
 
-        BOOST_CHECK_EQUAL(iwel[i*niwelz + 4], connections_set.size() );
+        BOOST_CHECK_EQUAL(static_cast<std::size_t>(iwel[i*niwelz + 4]), connections_set.size() );
         BOOST_CHECK_EQUAL(ref_wellConn[step][i].size(), connections_set.size() );
 
 


### PR DESCRIPTION
This feature resolves an issue where when compiling opm-common with certain compiler combinations could result in an untoward amount of warning noise when compiling tests.
