### PR TITLE
Fix some warnings when running with valgrinds MPI wrapper.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -168,7 +168,7 @@ struct GroupProductionProperties {
     UDAValue water_target;
     UDAValue gas_target;
     UDAValue liquid_target;
-    double guide_rate;
+    double guide_rate = 0;
     GuideRateTarget guide_rate_def = GuideRateTarget::NO_GUIDE_RATE;
     double resv_target = 0;
     bool available_group_control = true;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
@@ -89,8 +89,8 @@ private:
     std::vector<RockComp> m_comp;
     std::string num_property = ParserKeywords::ROCKOPTS::TABLE_TYPE::defaultValue;
     std::size_t num_tables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
-    bool m_water_compaction;
-    Hysteresis hyst_mode;
+    bool m_water_compaction = false;
+    Hysteresis hyst_mode = Hysteresis::REVERS;
 };
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -541,7 +541,7 @@ namespace Opm {
         DenT gasDenT;
         DenT watDenT;
         StandardCond stcond;
-        std::size_t m_gas_comp_index;
+        std::size_t m_gas_comp_index = 77;
         double m_rtemp;
         double m_salinity;
 


### PR DESCRIPTION
It warns whenever uninitialized data is sent. Please check whether the selected defaults are sound.