### PR TITLE
Mkae sure fmtlib is not a dependency in the public api

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -32,6 +32,7 @@ list (APPEND MAIN_SOURCE_FILES
       src/opm/common/utility/ActiveGridCells.cpp
       src/opm/common/utility/FileSystem.cpp
       src/opm/common/utility/numeric/MonotCubicInterpolator.cpp
+      src/opm/common/utility/OpmInputError.cpp
       src/opm/common/utility/parameters/Parameter.cpp
       src/opm/common/utility/parameters/ParameterGroup.cpp
       src/opm/common/utility/parameters/ParameterTools.cpp

--- a/GenerateKeywords.cmake
+++ b/GenerateKeywords.cmake
@@ -20,6 +20,7 @@ set(genkw_SOURCES src/opm/json/JsonObject.cpp
                   src/opm/parser/eclipse/Parser/raw/StarToken.cpp
                   src/opm/parser/eclipse/Units/Dimension.cpp
                   src/opm/parser/eclipse/Units/UnitSystem.cpp
+                  src/opm/common/utility/OpmInputError.cpp
                   src/opm/common/OpmLog/OpmLog.cpp
                   src/opm/common/OpmLog/Logger.cpp
                   src/opm/common/OpmLog/StreamLog.cpp

--- a/opm/common/utility/OpmInputError.hpp
+++ b/opm/common/utility/OpmInputError.hpp
@@ -22,9 +22,6 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <utility>
-
-#include <fmt/format.h>
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
@@ -70,8 +67,8 @@ public:
     */
 
     template<class ... Args>
-    OpmInputError(const std::string& msg_fmt, const KeywordLocation& loc, const Args ... additionalArguments) :
-        m_what   { OpmInputError::format(msg_fmt, loc, std::forward<const Args>(additionalArguments)...) },
+    OpmInputError(const std::string& msg_fmt, const KeywordLocation& loc) :
+        m_what   { OpmInputError::format(msg_fmt, loc) },
         location { loc }
     {}
 
@@ -90,8 +87,8 @@ public:
           std::throw_with_nested(Opm::OpmInputError(location, e));
       }
     */
-    OpmInputError(const KeywordLocation& loc, const std::exception& e, const std::string& reason = "Internal error message") :
-        m_what   { OpmInputError::formatException(loc, e, reason) },
+    OpmInputError(const KeywordLocation& loc, const std::exception& e) :
+        m_what   { OpmInputError::formatException(loc, e) },
         location { loc }
     {}
 
@@ -104,24 +101,9 @@ public:
         return this->m_what.c_str();
     }
 
-    template<class ... Args>
-    static std::string format(const std::string& msg_format, const KeywordLocation& loc, const Args ... additionalArguments) {
-        return fmt::format(msg_format,
-            std::forward<const Args>(additionalArguments)...,
-            fmt::arg("keyword", loc.keyword),
-            fmt::arg("file", loc.filename),
-            fmt::arg("line", loc.lineno)
-        );
-    }
 
-    static std::string formatException(const KeywordLocation& loc, const std::exception& e, const std::string& reason = "Internal error message") {
-        const std::string defaultMessage { R"(Problem parsing keyword {keyword}
-In {file} line {line}.
-{}: {})" } ;
-
-        return format(defaultMessage, loc, reason, e.what());
-    }
-
+    static std::string format(const std::string& msg_format, const KeywordLocation& loc);
+    static std::string formatException(const KeywordLocation& loc, const std::exception& e);
 
 private:
     std::string m_what;

--- a/src/opm/common/utility/OpmInputError.cpp
+++ b/src/opm/common/utility/OpmInputError.cpp
@@ -1,0 +1,49 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <utility>
+
+#include <fmt/format.h>
+#include <opm/common/utility/OpmInputError.hpp>
+
+namespace Opm {
+
+std::string OpmInputError::formatException(const KeywordLocation& loc, const std::exception& e) {
+    const std::string defaultMessage { R"(Problem parsing keyword {{keyword}}
+In {{file}} line {{line}}.
+Internal error: {})" } ;
+
+    return format(fmt::format(defaultMessage, e.what()), loc);
+}
+
+/*
+  For the format() function it is possible to have an alternative function with
+  a variaditic template which can be forwarded directly to the fmt::format()
+  function, that is an elegant way to pass arbitrary additional arguments. That
+  will require the OpmInputError::format() to become a templated function and
+  the fmtlib dependendcy will be imposed on downstream modules.
+*/
+std::string OpmInputError::format(const std::string& msg_format, const KeywordLocation& loc) {
+    return fmt::format(msg_format,
+                       fmt::arg("keyword", loc.keyword),
+                       fmt::arg("file", loc.filename),
+                       fmt::arg("line", loc.lineno)
+                       );
+}
+
+}

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -24,6 +24,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include <fmt/format.h>
+
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/parser/eclipse/Utility/Functional.hpp>
 

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -847,11 +847,9 @@ BOOST_AUTO_TEST_CASE(OPM_ERROR) {
     KeywordLocation location("kw", "file", 100);
     OpmInputError error1("Error", location);
     OpmInputError error4("{keyword}:{line}:{keyword}", location);
-    OpmInputError error5("{keyword}:{line}:{file}: {}", location, "error");
 
     BOOST_CHECK_EQUAL(error1.what(), "Error");
     BOOST_CHECK_EQUAL(error4.what(), "kw:100:kw");
-    BOOST_CHECK_EQUAL(error5.what(), "kw:100:file: error");
 
     /*
       This test is meant to emulate the typical parsing process, the blocks here

--- a/tests/test_OpmInputError_format.cpp
+++ b/tests/test_OpmInputError_format.cpp
@@ -20,6 +20,8 @@
 
 #define BOOST_TEST_MODULE OpmInputError_format
 
+#include <fmt/format.h>
+
 #include <boost/test/unit_test.hpp>
 
 #include <exception>
@@ -41,8 +43,8 @@ BOOST_AUTO_TEST_CASE(simple) {
 BOOST_AUTO_TEST_CASE(positional) {
     const std::string expected { "MXUNSUPP@FILENAME.DAT:42: Error encountered" } ;
 
-    const std::string format_string { "{keyword}@{file}:{line}: {}" } ;
-    const std::string formatted { Opm::OpmInputError::format(format_string, location, error_string) } ;
+    const std::string format_string { fmt::format("{{keyword}}@{{file}}:{{line}}: {}", error_string) } ;
+    const std::string formatted { Opm::OpmInputError::format(format_string, location) } ;
 
     BOOST_CHECK_EQUAL(formatted, expected);
 }
@@ -50,7 +52,7 @@ BOOST_AUTO_TEST_CASE(positional) {
 BOOST_AUTO_TEST_CASE(exception) {
     const std::string expected { R"(Problem parsing keyword MXUNSUPP
 In FILENAME.DAT line 42.
-Internal error message: Runtime Error)" };
+Internal error: Runtime Error)" };
 
     const std::string formatted { Opm::OpmInputError::formatException(location, std::runtime_error("Runtime Error")) } ;
 
@@ -60,9 +62,9 @@ Internal error message: Runtime Error)" };
 BOOST_AUTO_TEST_CASE(exception_reason) {
     const std::string expected { R"(Problem parsing keyword MXUNSUPP
 In FILENAME.DAT line 42.
-Reason: Runtime Error)" };
+Internal error: Runtime Error)" };
 
-    const std::string formatted { Opm::OpmInputError::formatException(location, std::runtime_error("Runtime Error"), "Reason") } ;
+    const std::string formatted { Opm::OpmInputError::formatException(location, std::runtime_error("Runtime Error")) } ;
 
     BOOST_CHECK_EQUAL(formatted, expected);
 }
@@ -70,9 +72,9 @@ Reason: Runtime Error)" };
 BOOST_AUTO_TEST_CASE(exception_init) {
     const std::string expected { R"(Problem parsing keyword MXUNSUPP
 In FILENAME.DAT line 42.
-Reason: Runtime Error)" };
+Internal error: Runtime Error)" };
 
-    const std::string formatted { Opm::OpmInputError(location, std::runtime_error("Runtime Error"), "Reason").what() } ;
+    const std::string formatted { Opm::OpmInputError(location, std::runtime_error("Runtime Error")).what() } ;
 
     BOOST_CHECK_EQUAL(formatted, expected);
 }
@@ -80,7 +82,7 @@ Reason: Runtime Error)" };
 BOOST_AUTO_TEST_CASE(exception_nest) {
     const std::string expected { R"(Problem parsing keyword MXUNSUPP
 In FILENAME.DAT line 42.
-Internal error message: Runtime Error)" };
+Internal error: Runtime Error)" };
 
     try {
         try {


### PR DESCRIPTION
As pointed out [here](https://github.com/OPM/opm-simulators/pull/2817#issuecomment-701427161) the fmtlib dependency had entered into the API of opm-common - not OK.

With this PR the `include <fmt/format.h>`is moved away from the `OPmInputError.hpp` header file - slightly unfortunate because the variadic template trickery which is now removed was quite elegant. But we can live with that. 