### PR TITLE
Fix bug in ArradDimChecker message

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
@@ -142,7 +142,7 @@ namespace {
                 if (location) {
                     std::string fmt_message = fmt::format("Problem with keyword {{keyword}}\n"
                                                           "In {{file}} line {{line}}\n"
-                                                          "The case has a maximum group size of {0} wells, the WELLDIMS keyword specifies {1}.\n"
+                                                          "The case has a maximum group size of {0} wells/groups, the WELLDIMS keyword specifies {1}.\n"
                                                           "Please increase item 4 in WELLDIMS to at least {0}", size, wdims.maxWellsPerGroup());
 
                     ctxt.handleError(Opm::ParseContext::RUNSPEC_GROUPSIZE_TOO_LARGE,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
@@ -142,8 +142,8 @@ namespace {
                 if (location) {
                     std::string fmt_message = fmt::format("Problem with keyword {{keyword}}\n"
                                                           "In {{file}} line {{line}}\n"
-                                                          "The case has a maximum group size of {0} wells, the WELLDIMS keyword specifies {1}\n."
-                                                          "Please increase item 4 in WELLDIMS to at least {0}", size, wdims.maxGroupsInField());
+                                                          "The case has a maximum group size of {0} wells, the WELLDIMS keyword specifies {1}.\n"
+                                                          "Please increase item 4 in WELLDIMS to at least {0}", size, wdims.maxWellsPerGroup());
 
                     ctxt.handleError(Opm::ParseContext::RUNSPEC_GROUPSIZE_TOO_LARGE,
                                      fmt_message, *location, guard);


### PR DESCRIPTION
A wrong value was used in the ArrayDimChecker error message. Fix bug which sneaked in here: #1946