### PR TITLE
Remove confusing message

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1332,7 +1332,6 @@ void SummaryConfig::handleProcessingInstruction(const std::string& keyword) {
     } else if (keyword == "NARROW") {
         runSummaryConfig.narrow = true;
     } else if (keyword == "SEPARATE") {
-        Opm::OpmLog::info("Keyword SEPARATE has no effect (treated as always on).");
         runSummaryConfig.separate = true;
     }
 }


### PR DESCRIPTION
The message is actually wrong. If we are to emit a message at all, it needs to be a warning when RUNSUM is set but SEPARATE is not set. Personally, I believe the RSM format is so rarely used that we need not cater to any messages.