### PR TITLE
Summary/Restart: Get CTF From Simulator 

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -137,6 +137,7 @@ namespace Opm {
         double cell_saturation_water;
         double cell_saturation_gas;
         double effective_Kh;
+        double trans_factor;
 
         bool operator==(const Connection& conn2) const
         {
@@ -508,6 +509,7 @@ namespace Opm {
             buffer.write(this->cell_saturation_water);
             buffer.write(this->cell_saturation_gas);
             buffer.write(this->effective_Kh);
+            buffer.write(this->trans_factor);
     }
 
     template <class MessageBufferType>
@@ -589,6 +591,7 @@ namespace Opm {
             buffer.read(this->cell_saturation_water);
             buffer.read(this->cell_saturation_gas);
             buffer.read(this->effective_Kh);
+            buffer.read(this->trans_factor);
    }
 
     template <class MessageBufferType>

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -73,11 +73,11 @@ namespace {
     }
 
     template <class ConnOp>
-    void connectionLoop(const Opm::Schedule&        sched,
-                        const std::size_t           sim_step,
-                        const Opm::EclipseGrid&     grid,
-                        const Opm::data::WellRates& xw,
-                        ConnOp&&                    connOp)
+    void wellConnectionLoop(const Opm::Schedule&        sched,
+                            const std::size_t           sim_step,
+                            const Opm::EclipseGrid&     grid,
+                            const Opm::data::WellRates& xw,
+                            ConnOp&&                    connOp)
     {
         std::size_t wellID = 0;
         for (const auto& wname : sched.wellNames(sim_step)) {
@@ -302,7 +302,7 @@ captureDeclaredConnData(const Schedule&        sched,
                         const data::WellRates& xw,
                         const std::size_t      sim_step)
 {
-    connectionLoop(sched, sim_step, grid, xw, [&units, this]
+    wellConnectionLoop(sched, sim_step, grid, xw, [&units, this]
         (const std::size_t       wellID,
          const Connection&       conn,
          const std::size_t       connID,

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -291,12 +291,12 @@ BOOST_AUTO_TEST_CASE(test_RFT)
 
         std::vector<Opm::data::Connection> well1_comps(9);
         for (size_t i = 0; i < 9; ++i) {
-            Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 1.2e3};
+            Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 1.2e3, 4.321};
             well1_comps[i] = std::move(well_comp);
         }
         std::vector<Opm::data::Connection> well2_comps(6);
         for (size_t i = 0; i < 6; ++i) {
-            Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 0.15};
+            Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 0.15, 0.54321};
             well2_comps[i] = std::move(well_comp);
         }
 
@@ -420,12 +420,12 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
 
                 std::vector<Opm::data::Connection> well1_comps(9);
                 for (size_t i = 0; i < 9; ++i) {
-                    Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 3.14e5};
+                    Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 3.14e5, 0.1234};
                     well1_comps[i] = std::move(well_comp);
                 }
                 std::vector<Opm::data::Connection> well2_comps(6);
                 for (size_t i = 0; i < 6; ++i) {
-                    Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 355.113};
+                    Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 355.113, 0.9876};
                     well2_comps[i] = std::move(well_comp);
                 }
 
@@ -493,6 +493,7 @@ namespace {
 
             c.cell_saturation_gas   = 0.15;
             c.cell_saturation_water = 0.3 + con/20.0;
+            c.trans_factor          = 0.98765;
         }
 
         return xcon;
@@ -522,6 +523,7 @@ namespace {
 
             c.cell_saturation_gas   = 0.6 - con/20.0;
             c.cell_saturation_water = 0.25;
+            c.trans_factor          = 0.12345;
         }
 
         return xcon;

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -174,15 +174,15 @@ data::Wells mkWells() {
      *  the completion keys (active indices) and well names correspond to the
      *  input deck. All other entries in the well structures are arbitrary.
      */
-    w1.connections.push_back( { 88, rc1, 30.45, 123.4, 543.21, 0.62, 0.15, 1.0e3 } );
-    w1.connections.push_back( { 288, rc2, 33.19, 123.4, 432.1, 0.26, 0.45, 2.56 } );
+    w1.connections.push_back( { 88, rc1, 30.45, 123.4, 543.21, 0.62, 0.15, 1.0e3, 1.234 } );
+    w1.connections.push_back( { 288, rc2, 33.19, 123.4, 432.1, 0.26, 0.45, 2.56, 2.345 } );
 
     w2.rates = r2;
     w2.thp = 2.0;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
     w2.control = 2;
-    w2.connections.push_back( { 188, rc3, 36.22, 123.4, 256.1, 0.55, 0.0125, 314.15 } );
+    w2.connections.push_back( { 188, rc3, 36.22, 123.4, 256.1, 0.55, 0.0125, 314.15, 3.456 } );
 
     {
         data::Wells wellRates;

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -63,6 +63,12 @@ namespace {
        return unit::cubic(unit::meter) / unit::day;
     }
 
+    double cp_rm3_per_db()
+    {
+        return prefix::centi*unit::Poise * unit::cubic(unit::meter)
+            /  (unit::day * unit::barsa);
+    }
+
     std::string toupper(std::string input)
     {
         for (auto& c : input) {
@@ -247,11 +253,12 @@ data::Wells result_wells(const bool w3_injector = true)
       syncronized with the global index in the COMPDAT keyword in the
       input deck.
     */
-    data::Connection well1_comp1 { 0  , crates1, 1.9 , 123.4, 314.15, 0.35, 0.25, 2.718e2};
-    data::Connection well2_comp1 { 1  , crates2, 1.10 , 123.4, 212.1, 0.78, 0.0, 12.34};
-    data::Connection well2_comp2 { 101, crates3, 1.11 , 123.4, 150.6, 0.001, 0.89, 100.0};
-    data::Connection well3_comp1 { 2  , crates3, 1.11 , 123.4, 456.78, 0.0, 0.15, 432.1};
-    data::Connection well6_comp1 { 5  , crates6, 6.11 , 623.4, 656.78, 0.0, 0.65, 632.1};
+    data::Connection well1_comp1 { 0  , crates1, 1.9  , 123.4, 314.15, 0.35 , 0.25,   2.718e2, 111.222*cp_rm3_per_db() };
+    data::Connection well2_comp1 { 1  , crates2, 1.10 , 123.4, 212.1 , 0.78 , 0.0 ,  12.34   , 222.333*cp_rm3_per_db() };
+    data::Connection well2_comp2 { 101, crates3, 1.11 , 123.4, 150.6 , 0.001, 0.89, 100.0    , 333.444*cp_rm3_per_db() };
+    data::Connection well3_comp1 { 2  , crates3, 1.11 , 123.4, 456.78, 0.0  , 0.15, 432.1    , 444.555*cp_rm3_per_db() };
+    data::Connection well6_comp1 { 5  , crates6, 6.11 , 623.4, 656.78, 0.0  , 0.65, 632.1    , 555.666*cp_rm3_per_db() };
+
     /*
       The completions
     */
@@ -1477,13 +1484,13 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES) {
     BOOST_CHECK_CLOSE( 31.0  , units.to_si( UnitSystem::measure::viscosity , ecl_sum_get_general_var( resp, 1, "BVOIL:1,1,1")) , 1e-5);
     BOOST_CHECK_CLOSE( 33.0  , units.to_si( UnitSystem::measure::viscosity , ecl_sum_get_general_var( resp, 1, "BOVIS:1,1,1")) , 1e-5);
 
-    BOOST_CHECK_CLOSE( 100                , ecl_sum_get_well_completion_var( resp, 1, "W_1", "CTFAC", 1, 1, 1), 1e-5);
-    BOOST_CHECK_CLOSE( 2.1430730819702148 , ecl_sum_get_well_completion_var( resp, 1, "W_2", "CTFAC", 2, 1, 1), 1e-5);
-    BOOST_CHECK_CLOSE( 2.6788413524627686 , ecl_sum_get_well_completion_var( resp, 1, "W_2", "CTFAC", 2, 1, 2), 1e-5);
-    BOOST_CHECK_CLOSE( 2.7855057716369629 , ecl_sum_get_well_completion_var( resp, 1, "W_3", "CTFAC", 3, 1, 1), 1e-5);
+    BOOST_CHECK_CLOSE( 111.222 , ecl_sum_get_well_completion_var( resp, 1, "W_1", "CTFAC", 1, 1, 1), 1e-5);
+    BOOST_CHECK_CLOSE( 222.333 , ecl_sum_get_well_completion_var( resp, 1, "W_2", "CTFAC", 2, 1, 1), 1e-5);
+    BOOST_CHECK_CLOSE( 333.444 , ecl_sum_get_well_completion_var( resp, 1, "W_2", "CTFAC", 2, 1, 2), 1e-5);
+    BOOST_CHECK_CLOSE( 444.555 , ecl_sum_get_well_completion_var( resp, 1, "W_3", "CTFAC", 3, 1, 1), 1e-5);
 
-    BOOST_CHECK_CLOSE( 50                 , ecl_sum_get_well_completion_var( resp, 3, "W_1", "CTFAC", 1, 1, 1), 1e-5);
-    BOOST_CHECK_CLOSE( 25                 , ecl_sum_get_well_completion_var( resp, 4, "W_1", "CTFAC", 1, 1, 1), 1e-5);
+    BOOST_CHECK_CLOSE( 111.222 , ecl_sum_get_well_completion_var( resp, 3, "W_1", "CTFAC", 1, 1, 1), 1e-5);
+    BOOST_CHECK_CLOSE( 111.222 , ecl_sum_get_well_completion_var( resp, 4, "W_1", "CTFAC", 1, 1, 1), 1e-5);
 
     // Cell is not active
     BOOST_CHECK( !ecl_sum_has_general_var( resp , "BPR:2,1,10"));

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -169,7 +169,7 @@ static data::Wells result_wells() {
       syncronized with the global index in the COMPDAT keyword in the
       input deck.
     */
-    data::Connection well1_comp1 { 0  , crates1, 1.9 , 123.4, 314.15, 0.35, 0.25, 2.718e2};
+    data::Connection well1_comp1 { 0  , crates1, 1.9 , 123.4, 314.15, 0.35, 0.25, 2.718e2, 0.12345};
 
     /*
       The completions

--- a/tests/test_Wells.cpp
+++ b/tests/test_Wells.cpp
@@ -103,14 +103,14 @@ BOOST_AUTO_TEST_CASE(get_completions) {
      *  the completion keys (active indices) and well names correspond to the
      *  input deck. All other entries in the well structures are arbitrary.
      */
-    w1.connections.push_back( { 88, rc1, 30.45, 123.45, 543.21, 0.123, 0.5, 17.29 } );
-    w1.connections.push_back( { 288, rc2, 33.19, 67.89, 98.76, 0.5, 0.125, 355.113 } );
+    w1.connections.push_back( { 88, rc1, 30.45, 123.45, 543.21, 0.123, 0.5, 17.29, 0.1729 } );
+    w1.connections.push_back( { 288, rc2, 33.19, 67.89, 98.76, 0.5, 0.125, 355.113, 0.355113 } );
 
     w2.rates = r2;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
     w2.control = 2;
-    w2.connections.push_back( { 188, rc3, 36.22, 19.28, 28.91, 0.125, 0.125, 3.141 } );
+    w2.connections.push_back( { 188, rc3, 36.22, 19.28, 28.91, 0.125, 0.125, 3.141, 0.31415 } );
 
     data::Wells wellRates;
 


### PR DESCRIPTION
This PR switches to getting the output files' connection transmissibility factor from `Opm::data::Connection` instead of
`Opm::Connection`.  This is in preparation for implementing the WELPI feature, in which the CTFs are occasionally adjusted based on the dynamic simulation state.