### PR TITLE
Required and Prohibited Keywords

### DIFF
--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -198,6 +198,14 @@ class KeywordLocation;
         */
         const static std::string PARSE_MISSING_INCLUDE;
 
+        /*
+          For certain keywords, other, specific keywords are either
+          required or prohibited. When such keywords are found in an
+          invalid combination (missing required or present prohibited
+          keyword), this error situation occurs.
+         */
+        const static std::string PARSE_INVALID_KEYWORD_COMBINATION;
+
         /// Dynamic number of wells exceeds maximum declared in
         /// RUNSPEC keyword WELLDIMS (item 1).
         const static std::string RUNSPEC_NUMWELLS_TOO_LARGE;

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -171,6 +171,8 @@ namespace Opm {
         void initMatchRegex( const Json::JsonObject& jsonObject );
         void initCode( const Json::JsonObject& jsonConfig );
         void initData( const Json::JsonObject& jsonConfig );
+        void initProhibitedKeywords(const Json::JsonObject& keywordList);
+        void initRequiredKeywords(const Json::JsonObject& keywordList);
         void initSize( const Json::JsonObject& jsonConfig );
         void initSizeKeyword(const Json::JsonObject& sizeObject);
         void commonInit(const std::string& name, ParserKeywordSizeEnum sizeType);

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -117,6 +117,11 @@ namespace Opm {
         DeckNameSet::const_iterator deckNamesBegin() const;
         DeckNameSet::const_iterator deckNamesEnd() const;
 
+        const std::vector<std::string>& requiredKeywords() const;
+        const std::vector<std::string>& prohibitedKeywords() const;
+        void setRequiredKeywords(const std::vector<std::string>&);
+        void setProhibitedKeywords(const std::vector<std::string>&);
+
         void clearValidSectionNames();
         void addValidSectionName(const std::string& sectionName);
         bool isValidSection(const std::string& sectionName) const;
@@ -157,6 +162,8 @@ namespace Opm {
         bool alternating_keyword = false;
         bool double_records = false;
         std::string code_end;
+        std::vector<std::string> m_requires;
+        std::vector<std::string> m_prohibits;
 
         static bool validNameStart(const std::string_view& name);
         void initDeckNames( const Json::JsonObject& jsonConfig );

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -81,6 +81,7 @@ namespace Opm {
         addKey(PARSE_MISSING_INCLUDE, InputError::EXIT1);
         addKey(PARSE_LONG_KEYWORD, InputError::WARN);
         addKey(PARSE_WGNAME_SPACE, InputError::THROW_EXCEPTION);
+        addKey(PARSE_INVALID_KEYWORD_COMBINATION, InputError::THROW_EXCEPTION);
 
         addKey(UNIT_SYSTEM_MISMATCH, InputError::THROW_EXCEPTION);
 
@@ -325,6 +326,7 @@ namespace Opm {
     const std::string ParseContext::PARSE_MISSING_INCLUDE = "PARSE_MISSING_INCLUDE";
     const std::string ParseContext::PARSE_LONG_KEYWORD = "PARSE_LONG_KEYWORD";
     const std::string ParseContext::PARSE_WGNAME_SPACE = "PARSE_WGNAME_SPACE";
+    const std::string ParseContext::PARSE_INVALID_KEYWORD_COMBINATION = "PARSE_INVALID_KEYWORD_COMBINATION";
 
     const std::string ParseContext::UNIT_SYSTEM_MISMATCH = "UNIT_SYSTEM_MISMATCH";
 

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -581,6 +581,32 @@ void ParserState::addPathAlias( const std::string& alias, const std::string& pat
 
 
 RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string& keywordString, ParserState& parserState, const Parser& parser) {
+    for (const auto& keyword : parserKeyword.prohibitedKeywords()) {
+        if (parserState.deck.hasKeyword(keyword)) {
+            parserState
+                .parseContext
+                .handleError(
+                    ParseContext::PARSE_INVALID_KEYWORD_COMBINATION,
+                    fmt::format("Incompatible keyword combination: {} declared when {} is already present.", keywordString, keyword),
+                    KeywordLocation { keywordString, parserState.current_path(), parserState.line() } ,
+                    parserState.errors
+                );
+        }
+    }
+
+    for (const auto& keyword : parserKeyword.requiredKeywords()) {
+        if (!parserState.deck.hasKeyword(keyword)) {
+            parserState
+                .parseContext
+                .handleError(
+                    ParseContext::PARSE_INVALID_KEYWORD_COMBINATION,
+                    fmt::format("Incompatible keyword combination: {} declared, but {} is missing.", keywordString, keyword),
+                    KeywordLocation { keywordString, parserState.current_path(), parserState.line() } ,
+                    parserState.errors
+                );
+        }
+    }
+
     bool raw_string_keyword = parserKeyword.rawStringKeyword();
 
     if( parserKeyword.getSizeType() == SLASH_TERMINATED || parserKeyword.getSizeType() == UNKNOWN || parserKeyword.getSizeType() == DOUBLE_SLASH_TERMINATED) {

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -528,6 +528,22 @@ void set_dimensions( ParserItem& item,
         return m_deckNames.end();
     }
 
+    const std::vector<std::string>& ParserKeyword::requiredKeywords() const {
+        return m_requires;
+    }
+
+    const std::vector<std::string>& ParserKeyword::prohibitedKeywords() const {
+        return m_prohibits;
+    }
+
+    void ParserKeyword::setRequiredKeywords(const std::vector<std::string>& keywordNames) {
+        m_requires = keywordNames;
+    }
+
+    void ParserKeyword::setProhibitedKeywords(const std::vector<std::string>& keywordNames) {
+        m_prohibits = keywordNames;
+    }
+
     DeckKeyword ParserKeyword::parse(const ParseContext& parseContext,
                                      ErrorGuard& errors,
                                      RawKeyword& rawKeyword,

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUCT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUCT
@@ -6,6 +6,9 @@
     "SOLUTION",
     "SCHEDULE"
   ],
+  "requires": [
+    "AQUDIMS"
+  ],
   "items": [
     {
       "name": "AQUIFER_ID",

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RTEMPVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/R/RTEMPVD
@@ -4,6 +4,9 @@
     "PROPS",
     "SOLUTION"
   ],
+  "prohibits": [
+    "TEMPVD"
+  ],
   "size": {
     "keyword": "EQLDIMS",
     "item": "NTEQUL"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/T/TEMPVD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/T/TEMPVD
@@ -3,6 +3,9 @@
   "sections": [
     "PROPS"
   ],
+  "prohibits": [
+    "RTEMPVD"
+  ],
   "items": [
     {
       "name": "DEPTH",

--- a/src/opm/parser/eclipse/share/keywords/001_Eclipse300/T/TEMPVD
+++ b/src/opm/parser/eclipse/share/keywords/001_Eclipse300/T/TEMPVD
@@ -4,6 +4,9 @@
     "PROPS",
     "SOLUTION"
   ],
+  "prohibits": [
+    "RTEMPVD"
+  ],
   "size": {
     "keyword": "EQLDIMS",
     "item": "NTEQUL"

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -518,12 +518,19 @@ BOOST_AUTO_TEST_CASE( test_invalid_keyword_combination_required ) {
     const std::string deckString = R"(
 AQUCT
     1 2000.0 1.5 100 .3 3.0e-5 330 10 360.0 1 2 /
+/
 )";
 
     ParseContext parseContext;
     Parser parser;
     ErrorGuard errors;
 
+    BOOST_CHECK_THROW(parser.parseString(deckString, parseContext, errors), OpmInputError);
+
+    parseContext.update(ParseContext::PARSE_INVALID_KEYWORD_COMBINATION , InputError::IGNORE );
+    BOOST_CHECK_NO_THROW(parser.parseString(deckString, parseContext, errors));
+
+    parseContext.update(ParseContext::PARSE_INVALID_KEYWORD_COMBINATION , InputError::THROW_EXCEPTION );
     BOOST_CHECK_THROW(parser.parseString(deckString, parseContext, errors), OpmInputError);
 }
 
@@ -543,6 +550,12 @@ RTEMPVD
     Parser parser;
     ErrorGuard errors;
 
+    BOOST_CHECK_THROW(parser.parseString(deckString, parseContext, errors), OpmInputError);
+
+    parseContext.update(ParseContext::PARSE_INVALID_KEYWORD_COMBINATION , InputError::IGNORE );
+    BOOST_CHECK_NO_THROW(parser.parseString(deckString, parseContext, errors));
+
+    parseContext.update(ParseContext::PARSE_INVALID_KEYWORD_COMBINATION , InputError::THROW_EXCEPTION );
     BOOST_CHECK_THROW(parser.parseString(deckString, parseContext, errors), OpmInputError);
 }
 

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -514,6 +514,38 @@ BOOST_AUTO_TEST_CASE(test_1arg_constructor) {
     }
 }
 
+BOOST_AUTO_TEST_CASE( test_invalid_keyword_combination_required ) {
+    const std::string deckString = R"(
+AQUCT
+    1 2000.0 1.5 100 .3 3.0e-5 330 10 360.0 1 2 /
+)";
+
+    ParseContext parseContext;
+    Parser parser;
+    ErrorGuard errors;
+
+    BOOST_CHECK_THROW(parser.parseString(deckString, parseContext, errors), OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE( test_invalid_keyword_combination_prohibited ) {
+    const std::string deckString = R"(
+EQLDIMS
+/
+
+TEMPVD
+   0.5 0 /
+
+RTEMPVD
+   0.5 0 /
+)";
+
+    ParseContext parseContext;
+    Parser parser;
+    ErrorGuard errors;
+
+    BOOST_CHECK_THROW(parser.parseString(deckString, parseContext, errors), OpmInputError);
+}
+
 BOOST_AUTO_TEST_CASE( test_invalid_wtemplate_config ) {
     const std::string defDeckString = R"(
     START  -- 0


### PR DESCRIPTION
This feature adds support in `/src/opm/parser/eclipse/share/keywords/**` for two new root level items in keyword definitions:

## `requires`

This entry is a list of strings, which are the names of other keywords that are required to be present at a point before the keyword is read, such as in `AQUCT`:

```json
{
  "name": "AQUCT",
  "sections": [
    "GRID",
    "PROPS",
    "SOLUTION",
    "SCHEDULE"
  ],
  "//": "New entry.",
  "requires": [
    "AQUDIMS"
  ],
  "items": [
    { . . . }
  ]
}
```

If all of the required keywords are not present at the time at which this keyword is reached, an exception is thrown.

# `prohibits`

This entry is a list of strings, which are the names of other keywords that may not be present in the file when this keyword is reached, such as in `RTEMPVD`:

```json
{
  "name": "RTEMPVD",
  "sections": [
    "PROPS",
    "SOLUTION"
  ],
  "//": "New entry",
  "prohibits": [
    "TEMPVD"
  ],
  "size": {
    "keyword": "EQLDIMS",
    "item": "NTEQUL"
  },
  "items": [
    {
      "name": "DATA",
      "value_type": "DOUBLE",
      "size_type": "ALL",
      "dimension": [
        "Length",
        "Temperature"
      ]
    }
  ]
}
```

If any of the prohibited keywords are present at the time at which this keyword is reached, an exception is thrown.