### PR TITLE
Add Support Infrastructure for WELPI Feature 

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
@@ -35,22 +35,22 @@ namespace Opm
                the Schedule object the NEW_WELL event is triggered
                every time a WELSPECS keyword is encountered.
             */
-            NEW_WELL = 1,
+            NEW_WELL = (1 << 0),
 
             /*
               WHen the well data is updated with the WELSPECS keyword
               this event is triggered. Only applies to individual
               wells, and not the global Schedule object.
             */
-            WELL_WELSPECS_UPDATE = 2,
+            WELL_WELSPECS_UPDATE = (1 << 1),
 
 
-            //WELL_POLYMER_UPDATE = 4,
+            //WELL_POLYMER_UPDATE = (1 << 2),
             /*
                The NEW_GROUP event is triggered by the WELSPECS and
                GRUPTREE keywords.
             */
-            NEW_GROUP = 8,
+            NEW_GROUP = (1 << 3),
 
             /*
                The PRODUCTION_UPDATE event is triggered by the
@@ -59,48 +59,48 @@ namespace Opm
                is changed. Quite simlar for INJECTION_UPDATE and
                POLYMER_UPDATE.
             */
-            PRODUCTION_UPDATE = 16,
-            INJECTION_UPDATE = 32,
-            //POLYMER_UPDATES = 64,
+            PRODUCTION_UPDATE = (1 << 4),
+            INJECTION_UPDATE = (1 << 5),
+            //POLYMER_UPDATES = (1 << 6),
 
             /*
               This event is triggered if the well status is changed
               between {OPEN,SHUT,STOP,AUTO}. There are many keywords
               which can trigger a well status change.
             */
-            WELL_STATUS_CHANGE = 128,
+            WELL_STATUS_CHANGE = (1 << 7),
 
             /*
               COMPDAT and WELOPEN
             */
-            COMPLETION_CHANGE = 256,
+            COMPLETION_CHANGE = (1 << 8),
 
             /*
               The well group topolyg has changed.
             */
-            GROUP_CHANGE = 512,
+            GROUP_CHANGE = (1 << 9),
 
 
             /*
               Geology modifier.
             */
-            GEO_MODIFIER = 1024,
+            GEO_MODIFIER = (1 << 10),
 
             /*
               TUNING has changed
             */
-            TUNING_CHANGE = 2048,
+            TUNING_CHANGE = (1 << 11),
 
             /* The VFP tables have changed */
-            VFPINJ_UPDATE = 4096,
-            VFPPROD_UPDATE = 8192,
+            VFPINJ_UPDATE = (1 << 12),
+            VFPPROD_UPDATE = (1 << 13),
 
 
             /*
               GROUP production or injection targets has changed
             */
-            GROUP_PRODUCTION_UPDATE = 16384,
-            GROUP_INJECTION_UPDATE = 32768
+            GROUP_PRODUCTION_UPDATE = (1 << 14),
+            GROUP_INJECTION_UPDATE = (1 << 15),
         };
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
@@ -101,6 +101,11 @@ namespace Opm
             */
             GROUP_PRODUCTION_UPDATE = (1 << 14),
             GROUP_INJECTION_UPDATE = (1 << 15),
+
+            /*
+             * New explicit well productivity/injectivity assignment.
+             */
+            WELL_PRODUCTIVITY_INDEX = (1 << 16),
         };
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -521,6 +521,7 @@ namespace Opm
         void handleWECON    (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWEFAC    (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWELOPEN  (const HandlerContext&, const ParseContext&, ErrorGuard&);
+        void handleWELPI    (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWELSEGS  (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWELSPECS (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWELTARG  (const HandlerContext&, const ParseContext&, ErrorGuard&);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -122,6 +122,8 @@ namespace RestartIO {
         void setState(State state);
         void setComplnum(int compnum);
         void scaleWellPi(double wellPi);
+        bool prepareWellPIScaling();
+        void applyWellPIScaling(const double scaleFactor);
         void updateSegmentRST(int segment_number_arg,
                               double center_depth_arg);
         void updateSegment(int segment_number_arg,
@@ -161,6 +163,7 @@ namespace RestartIO {
             serializer(m_perf_range);
             serializer(m_defaultSatTabId);
             serializer(segment_number);
+            serializer(m_subject_to_welpi);
         }
 
     private:
@@ -237,6 +240,9 @@ namespace RestartIO {
         // related segment number
         // 0 means the completion is not related to segment
         int segment_number = 0;
+
+        // Whether or not this Connection is subject to WELPI scaling.
+        bool m_subject_to_welpi = false;
 
         static std::string CTFKindToString(const CTFKind);
     };

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 #include <iosfwd>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -544,6 +545,7 @@ public:
     bool updateEconLimits(std::shared_ptr<WellEconProductionLimits> econ_limits);
     bool updateProduction(std::shared_ptr<WellProductionProperties> production);
     bool updateInjection(std::shared_ptr<WellInjectionProperties> injection);
+    bool updateWellProductivityIndex(const double prodIndex);
     bool updateWSEGSICD(const std::vector<std::pair<int, SICD> >& sicd_pairs);
     bool updateWSEGVALV(const std::vector<std::pair<int, Valve> >& valve_pairs);
 
@@ -568,6 +570,7 @@ public:
     bool cmp_structure(const Well& other) const;
     bool operator==(const Well& data) const;
     void setInsertIndex(std::size_t index);
+    void applyWellProdIndexScaling(const double currentEffectivePI);
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -593,6 +596,7 @@ public:
         serializer(solvent_fraction);
         serializer(has_produced);
         serializer(prediction_mode);
+        serializer(productivity_index);
         serializer(econ_limits);
         serializer(foam_properties);
         serializer(polymer_properties);
@@ -629,14 +633,14 @@ private:
     double solvent_fraction;
     bool has_produced = false;
     bool prediction_mode = true;
-
+    double productivity_index{ std::numeric_limits<double>::lowest() };
 
     std::shared_ptr<WellEconProductionLimits> econ_limits;
     std::shared_ptr<WellFoamProperties> foam_properties;
     std::shared_ptr<WellPolymerProperties> polymer_properties;
     std::shared_ptr<WellBrineProperties> brine_properties;
     std::shared_ptr<WellTracerProperties> tracer_properties;
-    std::shared_ptr<WellConnections> connections; // The WellConnections object can not be const because of the filterConnections method - would be beneficial to rewrite to enable const
+    std::shared_ptr<WellConnections> connections; // The WellConnections object cannot be const because of WELPI and the filterConnections method
     std::shared_ptr<WellProductionProperties> production;
     std::shared_ptr<WellInjectionProperties> injection;
     std::shared_ptr<WellSegments> segments;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -23,9 +23,9 @@
 
 #include <cstddef>
 #include <iosfwd>
-#include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -633,7 +633,7 @@ private:
     double solvent_fraction;
     bool has_produced = false;
     bool prediction_mode = true;
-    double productivity_index{ std::numeric_limits<double>::lowest() };
+    std::optional<double> productivity_index{ std::nullopt };
 
     std::shared_ptr<WellEconProductionLimits> econ_limits;
     std::shared_ptr<WellFoamProperties> foam_properties;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -21,8 +21,15 @@
 #ifndef WELL2_HPP
 #define WELL2_HPP
 
+#include <cstddef>
 #include <iosfwd>
+#include <map>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
+
+#include <stddef.h>
 
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
@@ -45,8 +52,6 @@ namespace Opm {
 class DeckRecord;
 class EclipseGrid;
 class DeckKeyword;
-struct WellInjectionProperties;
-class WellProductionProperties;
 class UDQActive;
 class UDQConfig;
 class SICD;
@@ -638,7 +643,7 @@ private:
 };
 
 std::ostream& operator<<( std::ostream&, const Well::WellInjectionProperties& );
-std::ostream& operator<<( std::ostream&, const WellProductionProperties& );
+std::ostream& operator<<( std::ostream&, const Well::WellProductionProperties& );
 
 int eclipseControlMode(const Well::InjectorCMode imode,
                        const InjectorType        itype);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -25,6 +25,8 @@
 
 #include <opm/common/utility/ActiveGridCells.hpp>
 
+#include <stddef.h>
+
 namespace Opm {
     class EclipseGrid;
     class FieldPropsManager;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -121,8 +121,6 @@ namespace Opm {
             serializer(headI);
             serializer(headJ);
             serializer.vector(m_connections);
-            serializer(m_hasWellPIAdjustment);
-            serializer(m_wellPIConnections);
         }
 
     private:
@@ -154,23 +152,9 @@ namespace Opm {
         void orderTRACK();
         void orderMSW();
 
-        // Exclude specific connection from WELPI CF scaling.  No action unless
-        // this connection set has been prepared for WELPI.
-        void excludeFromWellPI(const std::size_t connID);
-
         Connection::Order m_ordering = Connection::Order::TRACK;
         int headI, headJ;
         std::vector< Connection > m_connections;
-
-        // Backing data for 'WELPI'.
-        //   1. No adjustment if this set of connections has not been prepared
-        //      for WELPI (m_hasWellPIAdjustment == false, default value).
-        //
-        //   2. Otherwise, scale Connection::CF() by supplied scaling factor
-        //      for those connections that are marked in m_wellPIConnections.
-        //      Apply scaling to all connections if m_wellPIConnections.empty().
-        bool m_hasWellPIAdjustment{false};
-        std::vector<bool> m_wellPIConnections{};
     };
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1285,22 +1285,6 @@ namespace {
                     well_pair.second->filterConnections(grid);
             }
         }
-
-        for (auto& dynamic_pair : this->wells_static) {
-            auto& dynamic_state = dynamic_pair.second;
-            for (auto& well_pair : dynamic_state.unique()) {
-                if (well_pair.second)
-                    well_pair.second->filterConnections(grid);
-            }
-        }
-
-        for (auto& dynamic_pair : this->wells_static) {
-            auto& dynamic_state = dynamic_pair.second;
-            for (auto& well_pair : dynamic_state.unique()) {
-                if (well_pair.second)
-                    well_pair.second->filterConnections(grid);
-            }
-        }
     }
 
     const VFPProdTable& Schedule::getVFPProdTable(int table_id, std::size_t timeStep) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -127,6 +127,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         result.m_sort_value = 14;
         result.m_defaultSatTabId = true;
         result.segment_number = 16;
+        result.m_subject_to_welpi = true;
 
         return result;
     }
@@ -247,7 +248,20 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
         this->m_CF *= wellPi;
     }
 
+    bool Connection::prepareWellPIScaling() {
+        const auto update = !this->m_subject_to_welpi;
 
+        this->m_subject_to_welpi = true;
+
+        return update;
+    }
+
+    void Connection::applyWellPIScaling(const double scaleFactor) {
+        if (! this->m_subject_to_welpi)
+            return;
+
+        this->scaleWellPi(scaleFactor);
+    }
 
     std::string Connection::str() const {
         std::stringstream ss;
@@ -283,7 +297,8 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
             && this->direction == rhs.direction
             && this->segment_number == rhs.segment_number
             && this->center_depth == rhs.center_depth
-            && this->m_sort_value == rhs.m_sort_value;
+            && this->m_sort_value == rhs.m_sort_value
+            && this->m_subject_to_welpi == rhs.m_subject_to_welpi;
     }
 
     bool Connection::operator!=( const Connection& rhs ) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -488,6 +488,15 @@ bool Well::updateInjection(std::shared_ptr<WellInjectionProperties> injection_ar
     return false;
 }
 
+bool Well::updateWellProductivityIndex(const double prodIndex) {
+    const auto update = this->productivity_index != prodIndex;
+    if (update)
+        this->productivity_index = prodIndex;
+
+    // Note order here: We must always run prepareWellPIScaling(), but that operation
+    // *may* not lead to requiring updating the well state, so return 'update' if not.
+    return this->connections->prepareWellPIScaling() || update;
+}
 
 bool Well::updateHasProduced() {
     if (this->wtype.producer() && this->status == Status::OPEN) {
@@ -801,6 +810,21 @@ void Well::setInsertIndex(std::size_t index) {
     this->insert_index = index;
 }
 
+void Well::applyWellProdIndexScaling(const double currentEffectivePI) {
+    if (this->connections->empty())
+        // No connections for this well.  Unexpected.
+        return;
+
+    if (this->productivity_index < 0.0)
+        // WELPI not activated.  Nothing to do.
+        return;
+
+    if (this->productivity_index == currentEffectivePI)
+        // No change in scaling.
+        return;
+
+    this->connections->applyWellPIScaling(this->productivity_index / currentEffectivePI);
+}
 
 const WellConnections& Well::getConnections() const {
     return *this->connections;
@@ -1486,6 +1510,10 @@ bool Well::operator==(const Well& data) const {
            this->getFoamProperties() == data.getFoamProperties() &&
            this->getStatus() == data.getStatus() &&
            this->guide_rate == data.guide_rate &&
+           this->solvent_fraction == data.solvent_fraction &&
+           this->hasProduced() == data.hasProduced() &&
+           this->predictionMode() == data.predictionMode() &&
+           this->productivity_index == data.productivity_index &&
            this->getTracerProperties() == data.getTracerProperties() &&
            this->getProductionProperties() == data.getProductionProperties() &&
            this->getInjectionProperties() == data.getInjectionProperties();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -816,7 +816,7 @@ void Well::applyWellProdIndexScaling(const double currentEffectivePI) {
         // No connections for this well.  Unexpected.
         return;
 
-    if (this->productivity_index < 0.0)
+    if (!this->productivity_index)
         // WELPI not activated.  Nothing to do.
         return;
 
@@ -824,7 +824,7 @@ void Well::applyWellProdIndexScaling(const double currentEffectivePI) {
         // No change in scaling.
         return;
 
-    this->connections->applyWellPIScaling(this->productivity_index / currentEffectivePI);
+    this->connections->applyWellPIScaling(*this->productivity_index / currentEffectivePI);
 }
 
 const WellConnections& Well::getConnections() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -375,6 +375,7 @@ Well Well::serializeObject()
     result.efficiency_factor = 8.0;
     result.solvent_fraction = 9.0;
     result.prediction_mode = false;
+    result.productivity_index = 10.0;
     result.econ_limits = std::make_shared<Opm::WellEconProductionLimits>(Opm::WellEconProductionLimits::serializeObject());
     result.foam_properties = std::make_shared<WellFoamProperties>(WellFoamProperties::serializeObject());
     result.polymer_properties =  std::make_shared<WellPolymerProperties>(WellPolymerProperties::serializeObject());

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
+#include <initializer_list>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -152,6 +153,8 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         result.headI = 1;
         result.headJ = 2;
         result.m_connections = {Connection::serializeObject()};
+        result.m_hasWellPIAdjustment = true;
+        result.m_wellPIConnections.assign({true, true, false, true, false, false});
 
         return result;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -17,10 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <limits>
+#include <cstddef>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/io/eclipse/rst/connection.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -22,7 +22,6 @@
 #include <cmath>
 #include <cstddef>
 #include <iostream>
-#include <initializer_list>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -153,8 +152,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         result.headI = 1;
         result.headJ = 2;
         result.m_connections = {Connection::serializeObject()};
-        result.m_hasWellPIAdjustment = true;
-        result.m_wellPIConnections.assign({true, true, false, true, false, false});
 
         return result;
     }
@@ -191,33 +188,17 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
 
     bool WellConnections::prepareWellPIScaling()
     {
-        // New WELPI adjustment applies to all connections.
-        auto update = ! (this->m_hasWellPIAdjustment && this->m_wellPIConnections.empty());
-
-        this->m_hasWellPIAdjustment = true;
-        this->m_wellPIConnections.clear();
+        auto update = false;
+        for (auto& conn : this->m_connections)
+            update = conn.prepareWellPIScaling() || update;
 
         return update;
     }
 
     void WellConnections::applyWellPIScaling(const double scaleFactor)
     {
-        if (! this->m_hasWellPIAdjustment)
-            return;
-
-        if (this->m_wellPIConnections.empty())
-            // Apply to all connections
-            for (auto& conn : this->m_connections)
-                conn.scaleWellPi(scaleFactor);
-        else {
-            // Apply to active subset
-            const auto nConn = std::min(this->m_wellPIConnections.size(),
-                                        this->m_connections.size());
-
-            for (auto conn = 0*nConn; conn < nConn; ++conn)
-                if (this->m_wellPIConnections[conn])
-                    this->m_connections[conn].scaleWellPi(scaleFactor);
-        }
+        for (auto& conn : this->m_connections)
+            conn.applyWellPIScaling(scaleFactor);
     }
 
     void WellConnections::addConnection(int i, int j , int k ,
@@ -446,8 +427,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
                                     depth,
                                     css_ind,
                                     *perf_range);
-
-                this->excludeFromWellPI(std::distance(this->m_connections.begin(), prev));
             }
         }
     }
@@ -507,7 +486,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
 
     void WellConnections::add( Connection connection ) {
         m_connections.emplace_back( connection );
-        this->excludeFromWellPI(this->m_connections.size() - 1);
     }
 
     bool WellConnections::allConnectionsShut( ) const {
@@ -569,33 +547,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         }
     }
 
-    void WellConnections::excludeFromWellPI(const std::size_t connID) {
-        assert (!this->m_connections.empty() &&
-                "Connection set must be non-empty before calling excludeFromWellPI");
-
-        if (!this->m_hasWellPIAdjustment)
-            // Connection set not prepared for WELPI.  Common case.  Nothing to do.
-            return;
-
-        if (connID >= this->m_connections.size())
-            throw std::invalid_argument {
-                "Cannot exclude connection ID outside known range. "
-                "Expected 0.." + std::to_string(this->m_connections.size() - 1)
-                + ", but got " + std::to_string(connID)
-            };
-
-        if (this->m_wellPIConnections.empty())
-            // WELPI applies to all connections.  Prepare to exclude 'connID'.
-            this->m_wellPIConnections.assign(this->m_connections.size(), true);
-
-        if (this->m_wellPIConnections.size() < this->m_connections.size())
-            // WELPI applies to subset of connections.  Must also exclude those
-            // that are not already in set of explicitly included connections.
-            this->m_wellPIConnections.resize(this->m_connections.size(), false);
-
-        this->m_wellPIConnections[connID] = false;
-    }
-
     size_t WellConnections::findClosestConnection(int oi, int oj, double oz, size_t start_pos)
     {
         size_t closest = std::numeric_limits<size_t>::max();
@@ -628,8 +579,6 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
     bool WellConnections::operator==( const WellConnections& rhs ) const {
         return this->size() == rhs.size() &&
             this->m_ordering == rhs.m_ordering &&
-            this->m_hasWellPIAdjustment == rhs.m_hasWellPIAdjustment &&
-            this->m_wellPIConnections == rhs.m_wellPIConnections &&
             std::equal( this->begin(), this->end(), rhs.begin() );
     }
 
@@ -637,60 +586,13 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
         return !( *this == rhs );
     }
 
-namespace {
-    template <typename S1FwdIter, typename S2FwdIter, typename Predicate>
-    std::pair<S1FwdIter, S2FwdIter>
-    remove_if(S1FwdIter s1begin, S1FwdIter s1end, S2FwdIter s2begin, Predicate&& predicate)
-    {
-        auto ret = std::make_pair(s1begin, s2begin);
-
-        for (; s1begin != s1end; ++s1begin, ++s2begin) {
-            if (predicate(*s1begin))
-                // Skip those elements that match the predicate.
-                continue;
-
-            if (ret.first != s1begin) {
-                // Do nothing if src == dest, i.e. if we've not
-                // skipped any sequence elements.  Otherwise, move
-                // down.
-                *ret.first  = std::move(*s1begin);
-                *ret.second = *s2begin;
-            }
-
-            ++ret.first;
-            ++ret.second;
-        }
-
-        return ret;
-    }
-}
-
     void WellConnections::filter(const ActiveGridCells& grid) {
         auto isInactive = [&grid](const Connection& c) {
             return !grid.cellActive(c.getI(), c.getJ(), c.getK());
         };
 
-        if (!this->m_hasWellPIAdjustment || this->m_wellPIConnections.empty()) {
-            // Common case.  Either no WELPI or WELPI applies to all connections.
-            // Don't need to take WELPI scaling subset into account.
-            auto new_end = std::remove_if(m_connections.begin(), m_connections.end(), isInactive);
-            m_connections.erase(new_end, m_connections.end());
-        }
-        else {
-            // Special case.  Subset of connections subject to WELPI scaling.
-            // Preserve those too.
-            if (this->m_wellPIConnections.size() < this->m_connections.size())
-                this->m_wellPIConnections.resize(this->m_connections.size(), false);
-
-            auto new_end = remove_if(this->m_connections.begin(), this->m_connections.end(),
-                                     this->m_wellPIConnections.begin(), isInactive);
-
-            if (new_end.first != this->m_connections.end()) {
-                // Prune moved from sequence elements.
-                this->m_connections.erase(new_end.first, this->m_connections.end());
-                this->m_wellPIConnections.erase(new_end.second, this->m_wellPIConnections.end());
-            }
-        }
+        auto new_end = std::remove_if(m_connections.begin(), m_connections.end(), isInactive);
+        m_connections.erase(new_end, m_connections.end());
     }
 
 

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -43,7 +43,15 @@
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
+#include <opm/parser/eclipse/Units/Units.hpp>
+
 namespace {
+    double cp_rm3_per_db()
+    {
+        return Opm::prefix::centi*Opm::unit::Poise * Opm::unit::cubic(Opm::unit::meter)
+            / (Opm::unit::day * Opm::unit::barsa);
+    }
+
 Opm::WellConnections loadCOMPDAT(const std::string& compdat_keyword) {
     Opm::EclipseGrid grid(10,10,10);
     Opm::TableManager tables;
@@ -339,4 +347,150 @@ BOOST_AUTO_TEST_CASE(loadCOMPDATTESTSPE9) {
        BOOST_CHECK_CLOSE( conn.Kh(), units.to_si(Opm::UnitSystem::measure::effective_Kh, ec.Kh), 1e-1);
        BOOST_CHECK_MESSAGE( !conn.ctfAssignedFromInput(), "Calculated SPE9 CTF values must NOT be assigned from input");
    }
+}
+
+BOOST_AUTO_TEST_CASE(ApplyWellPI) {
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+10 10 3 /
+
+START
+  5 OCT 2020 /
+
+GRID
+DXV
+  10*100 /
+DYV
+  10*100 /
+DZV
+  3*10 /
+DEPTHZ
+  121*2000 /
+
+ACTNUM
+  100*1
+  99*1 0
+  100*1
+/
+
+PERMX
+  300*100 /
+PERMY
+  300*100 /
+PERMZ
+  300*100 /
+PORO
+  300*0.3 /
+
+SCHEDULE
+WELSPECS
+  'P' 'G' 10 10 2005 'LIQ' /
+/
+
+COMPDAT
+  'P' 0 0 1 3 OPEN 1 100 /
+/
+
+TSTEP
+  10
+/
+
+END
+)");
+
+    const auto es    = Opm::EclipseState{ deck };
+    const auto sched = Opm::Schedule{ deck, es };
+
+    const auto expectCF = 100.0*cp_rm3_per_db();
+
+    auto connP = sched.getWell("P", 0).getConnections();
+    for (const auto& conn : connP) {
+        BOOST_CHECK_CLOSE(conn.CF(), expectCF, 1.0e-10);
+    }
+
+    connP.applyWellPIScaling(2.0);  // No "prepare" -> no change.
+    for (const auto& conn : connP) {
+        BOOST_CHECK_CLOSE(conn.CF(), expectCF, 1.0e-10);
+    }
+
+    // All CFs scaled by factor 2.
+    BOOST_CHECK_MESSAGE( connP.prepareWellPIScaling(), "First call to prepareWellPIScaling must be a state change");
+    BOOST_CHECK_MESSAGE(!connP.prepareWellPIScaling(), "Second call to prepareWellPIScaling must NOT be a state change");
+    connP.applyWellPIScaling(2.0);
+    for (const auto& conn : connP) {
+        BOOST_CHECK_CLOSE(conn.CF(), 2.0*expectCF, 1.0e-10);
+    }
+
+    // Reset CF -- simulating COMPDAT record (inactive cell)
+    connP.addConnection(9, 9, 1, // 10, 10, 2
+        199,
+        2015.0,
+        Opm::Connection::State::OPEN,
+        50.0*cp_rm3_per_db(),
+        0.123,
+        0.234,
+        0.157,
+        0.0,
+        1);
+
+    BOOST_REQUIRE_EQUAL(connP.size(), std::size_t{3});
+
+    BOOST_CHECK_CLOSE(connP[0].CF(),  2.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[1].CF(),  2.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[2].CF(), 50.0*cp_rm3_per_db(), 1.0e-10);
+
+    // Should not apply to connection whose CF was manually specified
+    connP.applyWellPIScaling(2.0);
+
+    BOOST_CHECK_CLOSE(connP[0].CF(),  4.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[1].CF(),  4.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[2].CF(), 50.0*cp_rm3_per_db(), 1.0e-10);
+
+    // Prepare new scaling.  Simulating new WELPI record.
+    // New scaling applies to all connections.
+    BOOST_CHECK_MESSAGE(connP.prepareWellPIScaling(), "Third call to prepareWellPIScaling must be a state change");
+    connP.applyWellPIScaling(2.0);
+
+    BOOST_CHECK_CLOSE(connP[0].CF(),   8.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[1].CF(),   8.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[2].CF(), 100.0*cp_rm3_per_db(), 1.0e-10);
+
+    // Reset CF -- simulating COMPDAT record (active cell)
+    connP.addConnection(8, 9, 1, // 10, 10, 2
+        198,
+        2015.0,
+        Opm::Connection::State::OPEN,
+        50.0*cp_rm3_per_db(),
+        0.123,
+        0.234,
+        0.157,
+        0.0,
+        1);
+
+    BOOST_REQUIRE_EQUAL(connP.size(), std::size_t{4});
+    connP.applyWellPIScaling(2.0);
+
+    BOOST_CHECK_CLOSE(connP[0].CF(),  16.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[1].CF(),  16.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[2].CF(), 200.0*cp_rm3_per_db(), 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[3].CF(),  50.0*cp_rm3_per_db(), 1.0e-10);
+
+    const auto& grid = es.getInputGrid();
+    const auto actCells = Opm::ActiveGridCells {
+        std::size_t{10}, std::size_t{10}, std::size_t{3},
+        grid.getActiveMap().data(),
+        grid.getNumActive()
+    };
+
+    connP.filter(actCells);
+
+    BOOST_REQUIRE_EQUAL(connP.size(), std::size_t{3});
+    BOOST_CHECK_CLOSE(connP[0].CF(), 16.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[1].CF(), 16.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[2].CF(), 50.0*cp_rm3_per_db(), 1.0e-10);
+
+    connP.applyWellPIScaling(2.0);
+    BOOST_CHECK_CLOSE(connP[0].CF(), 32.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[1].CF(), 32.0*expectCF       , 1.0e-10);
+    BOOST_CHECK_CLOSE(connP[2].CF(), 50.0*cp_rm3_per_db(), 1.0e-10);
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -17,18 +17,16 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdexcept>
+#include <algorithm>
 #include <iostream>
-#include <boost/filesystem.hpp>
+#include <stdexcept>
 
 #define BOOST_TEST_MODULE ScheduleTests
 
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
-
 
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
@@ -61,7 +59,7 @@
 using namespace Opm;
 
 
-Schedule make_schedule(const std::string& deck_string) {
+static Schedule make_schedule(const std::string& deck_string) {
     const auto& deck = Parser{}.parseString(deck_string);
     auto python = std::make_shared<Python>();
     EclipseGrid grid(10,10,10);
@@ -408,7 +406,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
 }
 
 
-bool has_well( const std::vector<Well>& wells, const std::string& well_name) {
+static bool has_well( const std::vector<Well>& wells, const std::string& well_name) {
     for (const auto& well : wells )
         if (well.name( ) == well_name)
             return true;
@@ -3159,7 +3157,7 @@ BOOST_AUTO_TEST_CASE(WTEST_CONFIG) {
 }
 
 
-bool has(const std::vector<std::string>& l, const std::string& s) {
+static bool has(const std::vector<std::string>& l, const std::string& s) {
     auto f = std::find(l.begin(), l.end(), s);
     return (f != l.end());
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -58,6 +58,18 @@
 
 using namespace Opm;
 
+namespace {
+    double liquid_PI_unit()
+    {
+        return UnitSystem::newMETRIC().to_si(UnitSystem::measure::liquid_productivity_index, 1.0);
+    }
+
+    double cp_rm3_per_db()
+    {
+        return prefix::centi*unit::Poise * unit::cubic(unit::meter)
+            / (unit::day * unit::barsa);
+    }
+}
 
 static Schedule make_schedule(const std::string& deck_string) {
     const auto& deck = Parser{}.parseString(deck_string);
@@ -3702,3 +3714,82 @@ WLIFTOPT
     BOOST_CHECK(w3.alloc_extra_gas());
 }
 
+BOOST_AUTO_TEST_CASE(WellPI) {
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+START
+7 OCT 2020 /
+
+DIMENS
+  10 10 3 /
+
+GRID
+DXV
+  10*100.0 /
+DYV
+  10*100.0 /
+DZV
+  3*10.0 /
+
+DEPTHZ
+  121*2000.0 /
+
+PERMX
+  300*100.0 /
+PERMY
+  300*100.0 /
+PERMZ
+  300*10.0 /
+PORO
+  300*0.3 /
+
+SCHEDULE
+WELSPECS
+  'P' 'G' 10 10 2005 'LIQ' /
+/
+COMPDAT
+  'P' 0 0 1 3 OPEN 1 100 /
+/
+
+TSTEP
+  10
+/
+
+WELPI
+  'P'  200.0 /
+/
+
+TSTEP
+  10
+/
+
+END
+)");
+
+    const auto es    = EclipseState{ deck };
+    const auto sched = Schedule{ deck, es };
+
+    // Apply WELPI before seeing WELPI data
+    {
+        const auto expectCF = 100.0*cp_rm3_per_db();
+        auto wellP = sched.getWell("P", 0);
+
+        wellP.applyWellProdIndexScaling(2.7182818);
+        for (const auto& conn : wellP.getConnections()) {
+            BOOST_CHECK_CLOSE(conn.CF(), expectCF, 1.0e-10);
+        }
+    }
+
+    // Apply WELPI after seeing WELPI data.
+    {
+        const auto expectCF = (200.0 / 100.0) * 100.0*cp_rm3_per_db();
+        auto wellP = sched.getWell("P", 1);
+
+        wellP.applyWellProdIndexScaling(100.0*liquid_PI_unit());
+        for (const auto& conn : wellP.getConnections()) {
+            BOOST_CHECK_CLOSE(conn.CF(), expectCF, 1.0e-10);
+        }
+    }
+
+    BOOST_CHECK_MESSAGE(sched.hasWellGroupEvent("P", ScheduleEvents::WELL_PRODUCTIVITY_INDEX, 1),
+                        "Must have WELL_PRODUCTIVITY_INDEX event at report step 1");
+}

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -49,14 +49,12 @@
 
 using namespace Opm;
 
-
-namespace Opm {
-inline std::ostream& operator<<( std::ostream& stream, const Connection& c ) {
-    return stream << "(" << c.getI() << "," << c.getJ() << "," << c.getK() << ")";
-}
-inline std::ostream& operator<<( std::ostream& stream, const Well& well ) {
-    return stream << "(" << well.name() << ")";
-}
+namespace {
+    double cp_rm3_per_db()
+    {
+        return prefix::centi*unit::Poise * unit::cubic(unit::meter)
+            / (unit::day * unit::barsa);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
@@ -1159,3 +1157,93 @@ WCONINJE
 }
 
 
+BOOST_AUTO_TEST_CASE(WellPI) {
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+START
+7 OCT 2020 /
+
+DIMENS
+  10 10 3 /
+
+GRID
+DXV
+  10*100.0 /
+DYV
+  10*100.0 /
+DZV
+  3*10.0 /
+
+DEPTHZ
+  121*2000.0 /
+
+PERMX
+  300*100.0 /
+PERMY
+  300*100.0 /
+PERMZ
+  300*10.0 /
+PORO
+  300*0.3 /
+
+SCHEDULE
+WELSPECS
+  'P' 'G' 10 10 2005 'LIQ' /
+/
+COMPDAT
+  'P' 0 0 1 3 OPEN 1 100 /
+/
+
+END
+)");
+
+    const auto es    = EclipseState{ deck };
+    const auto sched = Schedule{ deck, es };
+
+    const auto expectCF = 100.0*cp_rm3_per_db();
+
+    auto wellP = sched.getWell("P", 0);
+
+    for (const auto& conn : wellP.getConnections()) {
+        BOOST_CHECK_CLOSE(conn.CF(), expectCF, 1.0e-10);
+    }
+
+    // Simulate applying WELPI before WELPI keyword.  No effect.
+    wellP.applyWellProdIndexScaling(2.7182818);
+    for (const auto& conn : wellP.getConnections()) {
+        BOOST_CHECK_CLOSE(conn.CF(), expectCF, 1.0e-10);
+    }
+
+    // Simulate applying WELPI after seeing
+    //
+    //   WELPI
+    //     P 2 /
+    //   /
+    //
+    // (ignoring units of measure)
+    BOOST_CHECK_MESSAGE( wellP.updateWellProductivityIndex(2.0), "First call to updateWellProductivityIndex() must be a state change");
+    BOOST_CHECK_MESSAGE(!wellP.updateWellProductivityIndex(2.0), "Second call to updateWellProductivityIndex() must NOT be a state change");
+
+    // Want PI=2, but actual/effective PI=1 => scale CF by 2.0/1.0.
+    wellP.applyWellProdIndexScaling(1.0);
+    for (const auto& conn : wellP.getConnections()) {
+        BOOST_CHECK_CLOSE(conn.CF(), 2.0*expectCF, 1.0e-10);
+    }
+
+    // Repeated application of WELPI multiplies scaling factors.
+    wellP.applyWellProdIndexScaling(1.0);
+    for (const auto& conn : wellP.getConnections()) {
+        BOOST_CHECK_CLOSE(conn.CF(), 4.0*expectCF, 1.0e-10);
+    }
+
+    // New WELPI record does not reset the scaling factors
+    wellP.updateWellProductivityIndex(3.0);
+    for (const auto& conn : wellP.getConnections()) {
+        BOOST_CHECK_CLOSE(conn.CF(), 4.0*expectCF, 1.0e-10);
+    }
+
+    // Effective PI=desired PI => no scaling change
+    wellP.applyWellProdIndexScaling(3.0);
+    for (const auto& conn : wellP.getConnections()) {
+        BOOST_CHECK_CLOSE(conn.CF(), 4.0*expectCF, 1.0e-10);
+    }
+}

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -59,8 +59,6 @@ inline std::ostream& operator<<( std::ostream& stream, const Well& well ) {
 }
 }
 
-
-
 BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
     Opm::Parser parser;
     std::string input =


### PR DESCRIPTION
This PR adds logic implementing the static parts of the WELPI keyword.  We internalize the keyword data, record appropriate events and provide hooks for dynamically adjusting the per-connection transmissibility factor (`Connection::CF()`) when those events occur.

We implement support at ~~three~~ four levels

  * **Connection**:
    Add new public member functions `prepareWellPIScaling` and `applyWellPIScaling` which, respectively, creates bookkeeping data to track if the connection is subject to CF scaling and actually applies that CF scaling.

  * **WellConnections**:
    Add new public member functions `prepareWellPIScaling` and `applyWellPIScaling` which, respectively, creates bookkeeping data to track those connections which are subject to CF scaling and actually applies that CF scaling.

  * **Well**:
    Add new data member `productivity_index` which holds the `WELPI` data value from the input keyword (converted to SI) and new member functions `updateWellProductivityIndex` and `applyWellProdIndexScaling`.  The first follows the `update*` protocol (return `true` if state change) and assigns new values to `productivity_index` while the second uses the stored PI value and a dynamically calculated effective PI value to rescale the pertinent connections' CF value.

  * **Schedule**:
    Add new member function `handleWELPI` which internalizes the `WELPI` keyword and its data and records `WELPI` events for subsequent playback in the simulator layer.

Also add a set of unit tests to exercise the new features at all levels.

Note: We also apply a few tangential cleanup changes which resolves #1998 and a few other latent issues (missing declarations, headers &c).

---

Clients are mainly intended to query the `Schedule` object for `WELPI` events and then use `Well::applyWellProdIndexScaling()` with a dynamically calculated PI value.  The immediate use case is [`BlackoilWellModel<>::beginReportStep()`](https://github.com/OPM/opm-simulators/blob/f528adb604bfc1628b1537f601e826b6ef14f415/opm/simulators/wells/BlackoilWellModel_impl.hpp#L219) which makes a process-aware [copy](https://github.com/OPM/opm-simulators/blob/f528adb604bfc1628b1537f601e826b6ef14f415/opm/simulators/wells/BlackoilWellModel_impl.hpp#L228-L233) of the `Well` objects.  At that point we'll have a loop, probably in a separate helper function, which looks a bit like
```C++
for (auto& well : wells_ecl_) {
    if (schedule().hasWellGroupEvent(well.name(), Events::WELL_PRODUCTIVITY_INDEX, timeStepId)) {
        const auto wellPI = calculate_productivity_index(well);
        well.applyWellProdIndexScaling(wellPI);
    }
}
```
There are some additional complexities in that we copy the wells at every call to `beginReportStep()` so we'll need to persist some information across those calls, but this is the gist of the current proposal.