### PR TITLE
Keyword interaction

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DX
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DX
@@ -3,6 +3,7 @@
   "sections": [
     "GRID"
   ],
+    "prohibits" : ["DXV"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "Length"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DXV
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DXV
@@ -3,6 +3,7 @@
   "sections": [
     "GRID"
   ],
+  "prohibits" : ["DX"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "Length"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DY
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DY
@@ -3,6 +3,7 @@
   "sections": [
     "GRID"
   ],
+  "prohibits" : ["DYV"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "Length"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DYV
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DYV
@@ -3,6 +3,7 @@
   "sections": [
     "GRID"
   ],
+  "prohibits" : ["DY"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "Length"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/T/TRACERKM
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/T/TRACERKM
@@ -3,6 +3,9 @@
   "sections": [
     "PROPS"
   ],
+  "requires" : [
+      "PARTTRAC"
+  ],
   "size": "UNKNOWN",
   "records": [
     [


### PR DESCRIPTION
This PR is mainly to draw the attention towards the new functionality provided here: #1996

It is now possible in json to specify keyword dependencies via `"requires" : [... ]` and mutually exclusive keywords with `"prohibits": [..]`