### PR TITLE
Use restart object in regression testing

### DIFF
--- a/opm/io/eclipse/rst/state.hpp
+++ b/opm/io/eclipse/rst/state.hpp
@@ -38,6 +38,11 @@ struct RstState {
     RstState(const ::Opm::UnitSystem& unit_system,
              const std::vector<int>& intehead,
              const std::vector<bool>& logihead,
+             const std::vector<double>& doubhead);
+
+    RstState(const ::Opm::UnitSystem& unit_system,
+             const std::vector<int>& intehead,
+             const std::vector<bool>& logihead,
              const std::vector<double>& doubhead,
              const std::vector<std::string>& zgrp,
              const std::vector<int>& igrp,

--- a/src/opm/io/eclipse/rst/state.cpp
+++ b/src/opm/io/eclipse/rst/state.cpp
@@ -37,6 +37,16 @@ namespace RestartIO {
 RstState::RstState(const ::Opm::UnitSystem& unit_system_,
                    const std::vector<int>& intehead,
                    const std::vector<bool>& logihead,
+                   const std::vector<double>& doubhead):
+    unit_system(unit_system_),
+    header(intehead, logihead, doubhead)
+{
+    this->load_tuning(intehead, doubhead);
+}
+
+RstState::RstState(const ::Opm::UnitSystem& unit_system_,
+                   const std::vector<int>& intehead,
+                   const std::vector<bool>& logihead,
                    const std::vector<double>& doubhead,
                    const std::vector<std::string>& zgrp,
                    const std::vector<int>& igrp,
@@ -49,11 +59,9 @@ RstState::RstState(const ::Opm::UnitSystem& unit_system_,
                    const std::vector<int>& icon,
                    const std::vector<float>& scon,
                    const std::vector<double>& xcon):
-    unit_system(unit_system_),
-    header(intehead, logihead, doubhead)
+    RstState(unit_system_, intehead, logihead, doubhead)
 {
     this->add_groups(zgrp, igrp, sgrp, xgrp);
-    this->load_tuning(intehead, doubhead);
 
     for (int iw = 0; iw < this->header.num_wells; iw++) {
         std::size_t zwel_offset = iw * this->header.nzwelz;
@@ -99,11 +107,9 @@ RstState::RstState(const ::Opm::UnitSystem& unit_system_,
                    const std::vector<double>& xcon,
                    const std::vector<int>& iseg,
                    const std::vector<double>& rseg) :
-    unit_system(unit_system_),
-    header(intehead, logihead, doubhead)
+    RstState(unit_system_, intehead, logihead, doubhead)
 {
     this->add_groups(zgrp, igrp, sgrp, xgrp);
-    this->load_tuning(intehead, doubhead);
 
     for (int iw = 0; iw < this->header.num_wells; iw++) {
         std::size_t zwel_offset = iw * this->header.nzwelz;
@@ -207,39 +213,43 @@ RstState RstState::load(EclIO::ERst& rst_file, int report_step) {
     const auto& logihead = rst_file.getRst<bool>("LOGIHEAD", report_step, 0);
     const auto& doubhead = rst_file.getRst<double>("DOUBHEAD", report_step, 0);
 
-    const auto& zgrp = rst_file.getRst<std::string>("ZGRP", report_step, 0);
-    const auto& igrp = rst_file.getRst<int>("IGRP", report_step, 0);
-    const auto& sgrp = rst_file.getRst<float>("SGRP", report_step, 0);
-    const auto& xgrp = rst_file.getRst<double>("XGRP", report_step, 0);
-
-    const auto& zwel = rst_file.getRst<std::string>("ZWEL", report_step, 0);
-    const auto& iwel = rst_file.getRst<int>("IWEL", report_step, 0);
-    const auto& swel = rst_file.getRst<float>("SWEL", report_step, 0);
-    const auto& xwel = rst_file.getRst<double>("XWEL", report_step, 0);
-
-    const auto& icon = rst_file.getRst<int>("ICON", report_step, 0);
-    const auto& scon = rst_file.getRst<float>("SCON", report_step, 0);
-    const auto& xcon = rst_file.getRst<double>("XCON", report_step, 0);
-
     auto unit_id = intehead[VI::intehead::UNIT];
     ::Opm::UnitSystem unit_system(unit_id);
 
-    if (rst_file.hasKey("ISEG")) {
-        const auto& iseg = rst_file.getRst<int>("ISEG", report_step, 0);
-        const auto& rseg = rst_file.getRst<double>("RSEG", report_step, 0);
+    if (intehead[VI::intehead::NWELLS] != 0) {
+        const auto& zgrp = rst_file.getRst<std::string>("ZGRP", report_step, 0);
+        const auto& igrp = rst_file.getRst<int>("IGRP", report_step, 0);
+        const auto& sgrp = rst_file.getRst<float>("SGRP", report_step, 0);
+        const auto& xgrp = rst_file.getRst<double>("XGRP", report_step, 0);
 
-        return RstState(unit_system,
-                        intehead, logihead, doubhead,
-                        zgrp, igrp, sgrp, xgrp,
-                        zwel, iwel, swel, xwel,
-                        icon, scon, xcon,
-                        iseg, rseg);
+        const auto& zwel = rst_file.getRst<std::string>("ZWEL", report_step, 0);
+        const auto& iwel = rst_file.getRst<int>("IWEL", report_step, 0);
+        const auto& swel = rst_file.getRst<float>("SWEL", report_step, 0);
+        const auto& xwel = rst_file.getRst<double>("XWEL", report_step, 0);
+
+        const auto& icon = rst_file.getRst<int>("ICON", report_step, 0);
+        const auto& scon = rst_file.getRst<float>("SCON", report_step, 0);
+        const auto& xcon = rst_file.getRst<double>("XCON", report_step, 0);
+
+
+        if (rst_file.hasKey("ISEG")) {
+            const auto& iseg = rst_file.getRst<int>("ISEG", report_step, 0);
+            const auto& rseg = rst_file.getRst<double>("RSEG", report_step, 0);
+
+            return RstState(unit_system,
+                            intehead, logihead, doubhead,
+                            zgrp, igrp, sgrp, xgrp,
+                            zwel, iwel, swel, xwel,
+                            icon, scon, xcon,
+                            iseg, rseg);
+        } else
+            return RstState(unit_system,
+                            intehead, logihead, doubhead,
+                            zgrp, igrp, sgrp, xgrp,
+                            zwel, iwel, swel, xwel,
+                            icon, scon, xcon);
     } else
-        return RstState(unit_system,
-                        intehead, logihead, doubhead,
-                        zgrp, igrp, sgrp, xgrp,
-                        zwel, iwel, swel, xwel,
-                        icon, scon, xcon);
+        return RstState(unit_system, intehead, logihead, doubhead);
 }
 
 }

--- a/tests/test_EclRegressionTest.cpp
+++ b/tests/test_EclRegressionTest.cpp
@@ -23,6 +23,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <test_util/EclRegressionTest.hpp>
+#include <opm/output/eclipse/VectorItems/group.hpp>
+#include <opm/output/eclipse/VectorItems/intehead.hpp>
 
 #include <opm/io/eclipse/EGrid.hpp>
 #include <opm/io/eclipse/ESmry.hpp>
@@ -98,6 +100,7 @@ void makeInitFile(const std::string &fileName, std::vector<std::string> floatKey
     }
 }
 
+namespace VI = Opm::RestartIO::Helpers::VectorItems;
 
 void makeUnrstFile(const std::string &fileName, std::vector<int> seqnum,
                    const std::vector<std::tuple<int,int,int>>& dates,
@@ -133,6 +136,54 @@ void makeUnrstFile(const std::string &fileName, std::vector<int> seqnum,
         eclTest.write("DOUBHEAD", doubhead);
         eclTest.write("ZGRP", zgrp);
         eclTest.write("IWEL", iwel);
+
+
+        // The blocks added below for groups, wells and connections respectively
+        // is just adding default data of correct consistent size to be able to
+        // load restart data. The content of these vectors is never used/checked.
+        {
+            std::size_t num_groups = intehead[VI::intehead::NGRP] + 1;
+            std::size_t nigrpz = intehead[VI::intehead::NIGRPZ];
+            std::size_t nsgrpz = intehead[VI::intehead::NSGRPZ];
+            std::size_t nxgrpz = intehead[VI::intehead::NXGRPZ];
+
+            std::vector<int> igrp( num_groups * nigrpz );
+            std::vector<float> sgrp( num_groups * nsgrpz );
+            std::vector<double> xgrp( num_groups * nxgrpz );
+
+            eclTest.write("IGRP", igrp);
+            eclTest.write("SGRP", sgrp);
+            eclTest.write("XGRP", xgrp);
+        }
+        {
+            std::size_t num_wells = intehead[VI::intehead::NWELLS];
+            std::size_t nzwelz = intehead[VI::intehead::NZWELZ];
+            std::size_t nswelz = intehead[VI::intehead::NSWELZ];
+            std::size_t nxwelz = intehead[VI::intehead::NXWELZ];
+
+            std::vector<std::string> zwel( num_wells * nzwelz );
+            std::vector<float> swel( num_wells * nswelz );
+            std::vector<double> xwel( num_wells * nxwelz );
+
+            eclTest.write("ZWEL", zwel);
+            eclTest.write("SWEL", swel);
+            eclTest.write("XWEL", xwel);
+        }
+        {
+            std::size_t num_wells = intehead[VI::intehead::NWELLS];
+            std::size_t num_connections = num_wells * intehead[VI::intehead::NCWMAX];
+            std::size_t niconz = intehead[VI::intehead::NICONZ];
+            std::size_t nsconz = intehead[VI::intehead::NSCONZ];
+            std::size_t nxconz = intehead[VI::intehead::NXCONZ];
+
+            std::vector<int> icon( num_connections * niconz );
+            std::vector<float> scon( num_connections * nsconz );
+            std::vector<double> xcon( num_connections * nxconz );
+
+            eclTest.write("ICON", icon);
+            eclTest.write("SCON", scon);
+            eclTest.write("XCON", xcon);
+        }
         eclTest.write("STARTSOL", std::vector<char>());
 
         for (size_t n = 0; n < solutionNames.size(); n++) {


### PR DESCRIPTION
The purpose of this PR is to enable more context rich comparisons in the regression testing; instead of
```
Keyword: IWEL, origin Restart, sequence 51
 
Value index                 = 3026
(first value, second value) = (1, 0)
 
Non floating point values not identical 
```
you can now get something like:
```
Different active_control for well: OPL1  reference: -1  simulation: 4
```
This is only a first step - just what I need right now - if it is deemed valuable it can be improved & extended. The current code is *in addition* to the existing code and will not (yet) influence the pass/fail status of a test.