### PR TITLE
Schedule error msg

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -153,7 +153,7 @@ namespace {
         throw;
     }
     catch (const std::exception& std_error) {
-        OpmLog::error(fmt::format("An error occured while creating the reservoir schedule\n",
+        OpmLog::error(fmt::format("An error occured while creating the reservoir schedule\n"
                                   "Internal error: {}", std_error.what()));
         throw;
     }


### PR DESCRIPTION
The dates keywords are parsed in the `Schedule`initializer list - they did not get the full error handling fairy dust; now they do.

```bash
Error: Problem with keyword DATES
In /home/hove/work/OPM/opm-tests/udq_actionx/include/schedule_dates line 68.
Internal error: map::at
```