### PR TITLE
Record Event if WellConnections Change

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
@@ -106,6 +106,12 @@ namespace Opm
              * New explicit well productivity/injectivity assignment.
              */
             WELL_PRODUCTIVITY_INDEX = (1 << 16),
+
+            /*
+             * Well's internal WellConnections structure changed.
+             * Rerun WELPI scaling if applicable.
+             */
+            WELL_CONNECTIONS_UPDATED = (1 << 17),
         };
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -152,8 +152,10 @@ namespace {
                 auto connections = std::shared_ptr<WellConnections>( new WellConnections( well2->getConnections()));
                 connections->loadCOMPDAT(record, handlerContext.grid, handlerContext.fieldPropsManager);
 
-                if (well2->updateConnections(connections, handlerContext.grid, handlerContext.fieldPropsManager.get_int("PVTNUM")))
+                if (well2->updateConnections(connections, handlerContext.grid, handlerContext.fieldPropsManager.get_int("PVTNUM"))) {
                     this->updateWell(well2, handlerContext.currentStep);
+                    this->addWellGroupEvent(name, ScheduleEvents::WELL_CONNECTIONS_UPDATED, handlerContext.currentStep);
+                }
 
                 this->addWellGroupEvent(name, ScheduleEvents::COMPLETION_CHANGE, handlerContext.currentStep);
             }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3790,6 +3790,12 @@ END
         }
     }
 
+    BOOST_CHECK_MESSAGE(sched.hasWellGroupEvent("P", ScheduleEvents::WELL_CONNECTIONS_UPDATED, 0),
+                        "Well P must have WELL_CONNECTIONS_UPDATED event at report step 0");
+
+    BOOST_CHECK_MESSAGE(!sched.hasWellGroupEvent("P", ScheduleEvents::WELL_CONNECTIONS_UPDATED, 1),
+                        "Well P must NOT have WELL_CONNECTIONS_UPDATED event at report step 0");
+
     BOOST_CHECK_MESSAGE(sched.hasWellGroupEvent("P", ScheduleEvents::WELL_PRODUCTIVITY_INDEX, 1),
                         "Must have WELL_PRODUCTIVITY_INDEX event at report step 1");
 }


### PR DESCRIPTION
This is different from `COMPLETION_CHANGE` which is unconditionally recorded when processing `COMPDAT`.  This event is recorded only when the `Well`'s internal `WellConnections` structure actually changes and informs clients that they may need to rerun any dynamic `WELPI` scaling.  Such scaling will not be automatically forwarded onto the
new `WellConnections` structure.

This is arguably a hack.