### PR TITLE
Udq allow missing well

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.cpp
@@ -16,6 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <fmt/format.h>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
@@ -89,7 +90,13 @@ bool is_udq(const std::string& key) {
 
             return std::nullopt;
         }
-        return this->summary_state.get_well_var(well, var);
+        if (this->summary_state.has_well_var(var)) {
+            if (this->summary_state.has_well_var(well, var))
+                return this->summary_state.get_well_var(well, var);
+            else
+                return std::nullopt;
+        }
+        throw std::logic_error(fmt::format("Summary well variable: {} not registered", var));
     }
 
     std::optional<double> UDQContext::get_group_var(const std::string& group, const std::string& var) const {
@@ -99,7 +106,14 @@ bool is_udq(const std::string& key) {
 
             return std::nullopt;
         }
-        return this->summary_state.get_group_var(group, var);
+
+        if (this->summary_state.has_group_var(var)) {
+            if (this->summary_state.has_group_var(group, var))
+                return this->summary_state.get_group_var(group, var);
+            else
+                return std::nullopt;
+        }
+        throw std::logic_error(fmt::format("Summary group variable: {} not registered", var));
     }
 
     std::vector<std::string> UDQContext::wells() const {

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -91,6 +91,10 @@ BOOST_AUTO_TEST_CASE(GROUP_VARIABLES)
     auto res_group = def_group.eval(context);
     BOOST_CHECK_EQUAL( res_group["UPPER"].get(), (5000 - gopr_lower*0.13 - gopr_upper*0.15)*0.89);
     BOOST_CHECK_EQUAL( res_group["UPPER"].get(), (5000 - gopr_lower*0.13 - gopr_upper*0.15)*0.89);
+
+    BOOST_CHECK_THROW(context.get_group_var("LOWER", "GGPR"), std::exception);
+    auto empty_value = context.get_group_var("NO_SUCH_GROUP", "GOPR");
+    BOOST_CHECK(!empty_value);
 }
 
 
@@ -332,6 +336,10 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
         BOOST_CHECK_EQUAL( res["W1"].get(), 11 );
         BOOST_CHECK_EQUAL( res["W2"].get(), 2 );
         BOOST_CHECK_EQUAL( res["W3"].get(), 3 );
+
+        BOOST_CHECK_THROW( context.get_well_var("W3", "WWCT"), std::exception);
+        auto empty_value = context.get_well_var("NO_SUCH_WELL", "WBHP");
+        BOOST_CHECK(!empty_value);
     }
     {
         UDQDefine def(udqp, "WUBHP", location, {"WBHP" , "'P*'"});


### PR DESCRIPTION
When asking for a well result like like `WWCT:OP1` - differentiate between invalid variable like `WWXT` which gives an exception and invalid well which gives an empty `std::optional<double>`.