### PR TITLE
Changes to well reference depth

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -376,7 +376,7 @@ namespace Opm
                      int headI,
                      int headJ,
                      Phase preferredPhase,
-                     double refDepth,
+                     const std::optional<double>& refDepth,
                      double drainageRadius,
                      bool allowCrossFlow,
                      bool automaticShutIn,

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -463,7 +463,7 @@ public:
          std::size_t insert_index,
          int headI,
          int headJ,
-         double ref_depth,
+         const std::optional<double>& ref_depth,
          const WellType& wtype_arg,
          ProducerCMode whistctl_cmode,
          Connection::Order ordering,
@@ -552,7 +552,8 @@ public:
     bool updateCrossFlow(bool allow_cross_flow);
     bool updatePVTTable(int pvt_table);
     bool updateHead(int I, int J);
-    bool updateRefDepth(double ref_dpeth);
+    void updateRefDepth();
+    bool updateRefDepth(const std::optional<double>& ref_dpeth);
     bool updateDrainageRadius(double drainage_radius);
     void updateSegments(std::shared_ptr<WellSegments> segments_arg);
     bool updateConnections(std::shared_ptr<WellConnections> connections);
@@ -651,7 +652,7 @@ private:
     std::size_t insert_index;
     int headI;
     int headJ;
-    double ref_depth;
+    std::optional<double> ref_depth;
     double drainage_radius;
     bool allow_cross_flow;
     bool automatic_shutin;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -799,9 +799,9 @@ private:
             }
         }
         const auto& refDepthItem = record.getItem("REF_DEPTH");
-        double refDepth = refDepthItem.hasValue( 0 )
-            ? refDepthItem.getSIDouble( 0 )
-            : -1.0;
+        std::optional<double> ref_depth;
+        if (refDepthItem.hasValue( 0 ))
+            ref_depth = refDepthItem.getSIDouble( 0 );
 
         double drainageRadius = record.getItem( "D_RADIUS" ).getSIDouble(0);
 
@@ -825,7 +825,7 @@ private:
                       headI,
                       headJ,
                       preferredPhase,
-                      refDepth,
+                      ref_depth,
                       drainageRadius,
                       allowCrossFlow,
                       automaticShutIn,
@@ -854,7 +854,7 @@ private:
                            int headI,
                            int headJ,
                            Phase preferredPhase,
-                           double refDepth,
+                           const std::optional<double>& ref_depth,
                            double drainageRadius,
                            bool allowCrossFlow,
                            bool automaticShutIn,
@@ -869,7 +869,7 @@ private:
                   timeStep,
                   0,
                   headI, headJ,
-                  refDepth,
+                  ref_depth,
                   WellType(preferredPhase),
                   this->global_whistctl_mode[timeStep],
                   wellConnectionOrder,


### PR DESCRIPTION
1. The well reference depth should *not* be updated when new connections are
   added with COMPDAT.

2. The well reference depth should be recalculated when the well is updated with
   the WELSPECS keyword.