### PR TITLE
Include udq summary

### DIFF
--- a/tests/msim/udq_in_actionx.include
+++ b/tests/msim/udq_in_actionx.include
@@ -330,9 +330,6 @@ WGIT
   'INJ'
 /
 
-WGPR
-/
-
 WGPT
 /
 
@@ -360,7 +357,8 @@ WUWCT
 FOPR
 
 FUOPR
-
+FUGPR
+FU_VAR2
 
 SCHEDULE
 -- -------------------------------------------------------------------------
@@ -382,6 +380,7 @@ UDQ
   UNITS  WUWCT '1' /
   DEFINE FUOPR SUM(WOPR) /
   UNITS  FUOPR 'SM3/DAY' /
+  DEFINE FUGPR FLPR /
 /
 
 
@@ -473,12 +472,22 @@ DATES            -- 3
    1 'MAR'  2015 /
 /
 
+UDQ
+  DEFINE FU_VAR2 FGLIR /
+/
+
+
+
 DATES            -- 4
    1 'APR'  2015 /
 /
 
 DATES            -- 5
    1 'MAI'  2015 /
+/
+
+UDQ
+   DEFINE FU_VAR3 WGPR P1 /
 /
 
 DATES


### PR DESCRIPTION
Will scan the UDQ expressions and assert that all required summary keys are evaluated; although they are not requested in the summary output.

This PR "requires" a data update in the the DUDW restart vector; that was not the intention and it should certainly be verified externally. The DUDW vector in the restart file manages which wells are UDQ active, and with this PR two new wells are marked as active, that was not the topic of the PR at all - but I think it is an accidental fix. My summary of what happens is:

**master**
```
SUMMARY
  
WGLIR
    P1 P2 P2 /

....

UDQ
     DEFINE WUGASRA 75000 - WGLIR '*' /
```

The `WGLIR` keyword is only defined for the producers `P1, P2` and `P3`, when expanding the `*` in the `DEFINE WUGASRA 75000 - WGLIR '*' /`expression it is expanded to these three wells, and these are the only three wells marked as "UDQ active".

**this PR**
In this PR we scan the UDQ expressions for all requested summary keywords[*] and then they are all made available for UDQ evaluation, irrespective of what is requested in the summary section. Then `WGLIR *` is expanded to include *all* wells, and we get also the injectors as "UDQ active".


In addition to actually looking at the DUDW keyword from the restart file this should probably be tested by adding the `WUGASRA` variable to the summary section and comparing the `WUGASRA` output for all wells.
 

[*]: This expansion is only based on the keyword and not any qualifiers - i.e. `WOPR` is expanded to cover all wells and `GGPR` is expanded to cover all groups.
