### PR TITLE
Udqdefine location

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -33,6 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp>
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 
 namespace Opm {

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
@@ -30,13 +30,13 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.hpp>
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 namespace Opm {
 
 class UDQASTNode;
 class ParseContext;
 class ErrorGuard;
-class KeywordLocation;
 
 class UDQDefine{
 public:
@@ -63,6 +63,7 @@ public:
               T&& errors);
 
     UDQDefine(const std::string& keyword,
+              const KeywordLocation& location,
               std::shared_ptr<UDQASTNode> astPtr,
               UDQVarType type,
               const std::string& string_data);
@@ -72,6 +73,7 @@ public:
     UDQSet eval(const UDQContext& context) const;
     const std::string& keyword() const;
     const std::string& input_string() const;
+    const KeywordLocation& location() const;
     UDQVarType  var_type() const;
     std::set<UDQTokenType> func_tokens() const;
     void required_summary(std::unordered_set<std::string>& summary_keys) const;
@@ -84,6 +86,7 @@ public:
         serializer(m_keyword);
         serializer(ast);
         serializer(m_var_type);
+        m_location.serializeOp(serializer);
         serializer(string_data);
     }
 
@@ -91,6 +94,7 @@ private:
     std::string m_keyword;
     std::shared_ptr<UDQASTNode> ast;
     UDQVarType m_var_type;
+    KeywordLocation m_location;
     std::string string_data;
 };
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp
@@ -62,12 +62,6 @@ public:
               const ParseContext& parseContext,
               T&& errors);
 
-    UDQDefine(const std::string& keyword,
-              const KeywordLocation& location,
-              std::shared_ptr<UDQASTNode> astPtr,
-              UDQVarType type,
-              const std::string& string_data);
-
     static UDQDefine serializeObject();
 
     UDQSet eval(const UDQContext& context) const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -166,7 +166,8 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
                      const ParseContext& parseContext,
                      ErrorGuard& errors) :
     m_keyword(keyword),
-    m_var_type(UDQ::varType(keyword))
+    m_var_type(UDQ::varType(keyword)),
+    m_location(location)
 {
     std::vector<std::string> string_tokens;
     for (const std::string& deck_item : deck_data) {
@@ -198,7 +199,7 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
     std::vector<UDQToken> tokens = make_tokens(string_tokens);
 
 
-    this->ast = std::make_shared<UDQASTNode>( UDQParser::parse(udq_params, this->m_var_type, this->m_keyword, location, tokens, parseContext, errors) );
+    this->ast = std::make_shared<UDQASTNode>( UDQParser::parse(udq_params, this->m_var_type, this->m_keyword, this->m_location, tokens, parseContext, errors) );
     this->string_data = "";
     for (std::size_t index = 0; index < deck_data.size(); index++) {
         this->string_data += deck_data[index];
@@ -209,14 +210,17 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
 
 
 UDQDefine::UDQDefine(const std::string& keyword,
+                     const KeywordLocation& location,
                      std::shared_ptr<UDQASTNode> astPtr,
                      UDQVarType type,
                      const std::string& stringData)
     : m_keyword(keyword)
     , ast(astPtr)
     , m_var_type(type)
+    , m_location(location)
     , string_data(stringData)
 {}
+
 
 
 UDQDefine UDQDefine::serializeObject()
@@ -226,6 +230,7 @@ UDQDefine UDQDefine::serializeObject()
     result.ast = std::make_shared<UDQASTNode>(UDQASTNode::serializeObject());
     result.m_var_type = UDQVarType::SEGMENT_VAR;
     result.string_data = "test2";
+    result.m_location = KeywordLocation{"KEYWOR", "file", 100};
 
     return result;
 }
@@ -307,6 +312,9 @@ UDQSet UDQDefine::eval(const UDQContext& context) const {
     return res;
 }
 
+const KeywordLocation& UDQDefine::location() const {
+    return this->m_location;
+}
 
 UDQVarType UDQDefine::var_type() const {
     return this->m_var_type;
@@ -332,6 +340,7 @@ bool UDQDefine::operator==(const UDQDefine& data) const {
         return false;
 
     return this->keyword() == data.keyword() &&
+           this->m_location == data.location() &&
            this->var_type() == data.var_type() &&
            this->input_string() == data.input_string();
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.cpp
@@ -209,19 +209,6 @@ UDQDefine::UDQDefine(const UDQParams& udq_params,
 }
 
 
-UDQDefine::UDQDefine(const std::string& keyword,
-                     const KeywordLocation& location,
-                     std::shared_ptr<UDQASTNode> astPtr,
-                     UDQVarType type,
-                     const std::string& stringData)
-    : m_keyword(keyword)
-    , ast(astPtr)
-    , m_var_type(type)
-    , m_location(location)
-    , string_data(stringData)
-{}
-
-
 
 UDQDefine UDQDefine::serializeObject()
 {


### PR DESCRIPTION
"No it doesn't work - but we have got the best error messages!"

Adding a `KeywordLocation` member to the `UDQDefine` structure to provide better error messages.