### PR TITLE
Rename group production control mode variable

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -168,7 +168,7 @@ struct GroupProductionProperties {
     {}
 
     std::string name;
-    ProductionCMode cmode = ProductionCMode::NONE;
+    ProductionCMode gconprod_cmode = ProductionCMode::NONE;
     ExceedAction exceed_action = ExceedAction::NONE;
     UDAValue oil_target;
     UDAValue water_target;
@@ -189,7 +189,7 @@ struct GroupProductionProperties {
     void serializeOp(Serializer& serializer)
     {
         serializer(name);
-        serializer(cmode);
+        serializer(gconprod_cmode);
         serializer(exceed_action);
         oil_target.serializeOp(serializer);
         water_target.serializeOp(serializer);
@@ -265,7 +265,7 @@ struct ProductionControls {
     const GroupProductionProperties& productionProperties() const;
     const std::map<Phase , GroupInjectionProperties>& injectionProperties() const;
     const GroupType& getGroupType() const;
-    ProductionCMode production_cmode() const;
+    ProductionCMode gconprod_cmode() const;
     InjectionCMode injection_cmode() const;
     Phase injection_phase() const;
     bool has_control(ProductionCMode control) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -169,6 +169,7 @@ struct GroupProductionProperties {
 
     std::string name;
     ProductionCMode gconprod_cmode = ProductionCMode::NONE;
+    ProductionCMode active_cmode = ProductionCMode::NONE;
     ExceedAction exceed_action = ExceedAction::NONE;
     UDAValue oil_target;
     UDAValue water_target;
@@ -190,6 +191,7 @@ struct GroupProductionProperties {
     {
         serializer(name);
         serializer(gconprod_cmode);
+        serializer(active_cmode);
         serializer(exceed_action);
         oil_target.serializeOp(serializer);
         water_target.serializeOp(serializer);

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -344,7 +344,6 @@ std::vector<std::size_t> groupParentSeqIndex(const Opm::Schedule& sched,
 
 
 bool higherLevelProdCMode_NotNoneFld(const Opm::Schedule& sched,
-                       const Opm::SummaryState& sumState,
                        const Opm::Group& group,
                        const size_t simStep)
 {
@@ -353,7 +352,7 @@ bool higherLevelProdCMode_NotNoneFld(const Opm::Schedule& sched,
         auto current = group;
         while (current.name() != "FIELD" && ctrl_mode_not_none_fld == false) {
             current = sched.getGroup(current.parent(), simStep);
-            const auto& prod_cmode = current.productionControls(sumState).cmode;
+            const auto& prod_cmode = group.gconprod_cmode();
             if ((prod_cmode != Opm::Group::ProductionCMode::FLD) && (prod_cmode!= Opm::Group::ProductionCMode::NONE)) {
                 ctrl_mode_not_none_fld = true;
             }
@@ -440,7 +439,7 @@ void productionGroup(const Opm::Schedule&     sched,
                      const std::map<int, Opm::Group::ProductionCMode>& pCtrlToPCmode,
                      IGrpArray&               iGrp)
 {
-    const auto& prod_cmode = group.productionControls(sumState).cmode;
+    const auto& prod_cmode = group.gconprod_cmode();
     if (group.name() == "FIELD") {
         iGrp[nwgmax + 6] = 0;
         iGrp[nwgmax + 7] = 0;
@@ -539,7 +538,7 @@ void productionGroup(const Opm::Schedule&     sched,
             } else {
                 iGrp[nwgmax + 5] = 1;
             }
-        } else if (higherLevelProdCMode_NotNoneFld(sched, sumState, group, simStep)) {
+        } else if (higherLevelProdCMode_NotNoneFld(sched, group, simStep)) {
             if (!((prod_cmode == Opm::Group::ProductionCMode::FLD)
                   || (prod_cmode == Opm::Group::ProductionCMode::NONE))) {
                 iGrp[nwgmax + 5] = -1;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -218,7 +218,7 @@ Group::GroupProductionProperties Group::GroupProductionProperties::serializeObje
 {
     Group::GroupProductionProperties result("Group123");
     result.name = "Group123";
-    result.cmode = ProductionCMode::PRBL;
+    result.gconprod_cmode = ProductionCMode::PRBL;
     result.exceed_action = ExceedAction::WELL;
     result.oil_target = UDAValue(1.0);
     result.water_target = UDAValue(2.0);
@@ -236,7 +236,7 @@ Group::GroupProductionProperties Group::GroupProductionProperties::serializeObje
 bool Group::GroupProductionProperties::operator==(const GroupProductionProperties& other) const {
     return
         this->name                    == other.name &&
-        this->cmode                   == other.cmode &&
+        this->gconprod_cmode          == other.gconprod_cmode &&
         this->exceed_action           == other.exceed_action &&
         this->oil_target              == other.oil_target &&
         this->water_target            == other.water_target &&
@@ -439,7 +439,7 @@ bool Group::updateParent(const std::string& parent) {
 Group::ProductionControls Group::productionControls(const SummaryState& st) const {
     Group::ProductionControls pc;
 
-    pc.cmode = this->production_properties.cmode;
+    pc.cmode = this->production_properties.gconprod_cmode;
     pc.exceed_action = this->production_properties.exceed_action;
     pc.oil_target = UDA::eval_group_uda(this->production_properties.oil_target, this->m_name, st, this->udq_undefined);
     pc.water_target = UDA::eval_group_uda(this->production_properties.water_target, this->m_name, st, this->udq_undefined);
@@ -479,8 +479,8 @@ bool Group::hasInjectionControl(Phase phase) const {
 
 
 
-Group::ProductionCMode Group::production_cmode() const {
-    return this->production_properties.cmode;
+Group::ProductionCMode Group::gconprod_cmode() const {
+    return this->production_properties.gconprod_cmode;
 }
 
 bool Group::ProductionControls::has_control(Group::ProductionCMode control) const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -219,6 +219,7 @@ Group::GroupProductionProperties Group::GroupProductionProperties::serializeObje
     Group::GroupProductionProperties result("Group123");
     result.name = "Group123";
     result.gconprod_cmode = ProductionCMode::PRBL;
+    result.active_cmode = ProductionCMode::PRBL;
     result.exceed_action = ExceedAction::WELL;
     result.oil_target = UDAValue(1.0);
     result.water_target = UDAValue(2.0);
@@ -236,6 +237,7 @@ Group::GroupProductionProperties Group::GroupProductionProperties::serializeObje
 bool Group::GroupProductionProperties::operator==(const GroupProductionProperties& other) const {
     return
         this->name                    == other.name &&
+        this->active_cmode            == other.active_cmode &&
         this->gconprod_cmode          == other.gconprod_cmode &&
         this->exceed_action           == other.exceed_action &&
         this->oil_target              == other.oil_target &&
@@ -439,7 +441,7 @@ bool Group::updateParent(const std::string& parent) {
 Group::ProductionControls Group::productionControls(const SummaryState& st) const {
     Group::ProductionControls pc;
 
-    pc.cmode = this->production_properties.gconprod_cmode;
+    pc.cmode = this->production_properties.active_cmode;
     pc.exceed_action = this->production_properties.exceed_action;
     pc.oil_target = UDA::eval_group_uda(this->production_properties.oil_target, this->m_name, st, this->udq_undefined);
     pc.water_target = UDA::eval_group_uda(this->production_properties.water_target, this->m_name, st, this->udq_undefined);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -367,6 +367,7 @@ namespace {
                     auto group_ptr = std::make_shared<Group>(this->getGroup(group_name, handlerContext.currentStep));
                     Group::GroupProductionProperties production(group_name);
                     production.gconprod_cmode = controlMode;
+                    production.active_cmode = controlMode;
                     production.oil_target = oil_target;
                     production.gas_target = gas_target;
                     production.water_target = water_target;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -366,7 +366,7 @@ namespace {
                 {
                     auto group_ptr = std::make_shared<Group>(this->getGroup(group_name, handlerContext.currentStep));
                     Group::GroupProductionProperties production(group_name);
-                    production.cmode = controlMode;
+                    production.gconprod_cmode = controlMode;
                     production.oil_target = oil_target;
                     production.gas_target = gas_target;
                     production.water_target = water_target;
@@ -376,10 +376,10 @@ namespace {
                     production.resv_target = resv_target;
                     production.available_group_control = availableForGroupControl;
 
-                    if ((production.cmode == Group::ProductionCMode::ORAT) ||
-                        (production.cmode == Group::ProductionCMode::WRAT) ||
-                        (production.cmode == Group::ProductionCMode::GRAT) ||
-                        (production.cmode == Group::ProductionCMode::LRAT))
+                    if ((production.gconprod_cmode == Group::ProductionCMode::ORAT) ||
+                        (production.gconprod_cmode == Group::ProductionCMode::WRAT) ||
+                        (production.gconprod_cmode == Group::ProductionCMode::GRAT) ||
+                        (production.gconprod_cmode == Group::ProductionCMode::LRAT))
                         production.exceed_action = Group::ExceedAction::RATE;
                     else
                         production.exceed_action = exceedAction;


### PR DESCRIPTION
Small preparations to facilitate restart; bith the active group control and the group control requested in the deck should be in the restart file.