### PR TITLE
[cmake] Use scotch include dir for parmetis bindings of scotch.

### DIFF
--- a/cmake/Modules/FindParMETIS.cmake
+++ b/cmake/Modules/FindParMETIS.cmake
@@ -60,6 +60,19 @@ set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${MPI_C_COMPILE_FLAGS}")
 
 include(CheckIncludeFile)
 check_include_file(parmetis.h PARMETIS_FOUND)
+
+if(NOT PARMETIS_FOUND)
+  # If we are using the ParMETIS bindings of PTScotch, we need
+  # to use the scotch include path as partmetis.h includes scotch.h
+  find_package(PTScotch)
+  set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${PTSCOTCH_INCLUDE_DIR})
+    unset(PARMETIS_FOUND CACHE) # force recheck of include file
+    check_include_file(parmetis.h PARMETIS_FOUND)
+    if(PARMETIS_FOUND)
+      set(PARMETIS_SCOTCH_INCLUDE_DIRS ${PTSCOTCH_INCLUDE_DIRS})
+    endif()
+endif()
+
 _search_parmetis_lib(PARMETIS_LIBRARY parmetis "The main ParMETIS library.")
 
 # behave like a CMake module is supposed to behave
@@ -77,7 +90,7 @@ find_package_handle_standard_args(
 cmake_pop_check_state()
 
 if(PARMETIS_FOUND)
-  set(PARMETIS_INCLUDE_DIRS ${PARMETIS_INCLUDE_DIR})
+  set(PARMETIS_INCLUDE_DIRS ${PARMETIS_INCLUDE_DIR} ${PARMETIS_SCOTCH_INCLUDE_DIRS})
   set(PARMETIS_LIBRARIES ${PARMETIS_LIBRARY} ${METIS_LIBRARIES} ${MPI_C_LIBRARIES}
     CACHE FILEPATH "All libraries needed to link programs using ParMETIS")
   set(PARMETIS_LINK_FLAGS "${DUNE_C_LINK_FLAGS}"


### PR DESCRIPTION
The `parmetis.h` distributed via the parmetis binding of scotch with Ubuntu 18.04 (`libscotchparmetis-dev`) includes the header `scotch.h` located in `/usr/include/scotch/`. Therefore our check of the include file failed. With this commit we check the `parmetis.h` header another time with the scotch include path added.

Now parmetis is found on my Ubuntu.