### PR TITLE
Use general datatype for extra data in summary keywords

### DIFF
--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -56,7 +56,8 @@ struct SummaryNode {
     Type        type;
     std::string wgname;
     int         number;
-    std::string fip_region;
+
+    std::optional<std::string> fip_region;
 
     constexpr static int default_number { std::numeric_limits<int>::min() };
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -22,9 +22,11 @@
 
 #include <array>
 #include <limits>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
+
 
 #include <opm/io/eclipse/SummaryNode.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
@@ -59,7 +61,7 @@ namespace Opm {
         const std::string& namedEntity() const { return this->name_; }
         int number() const { return this->number_; }
         bool isUserDefined() const { return this->userDefined_; }
-        const std::string& fip_region() const { return this->fip_region_; }
+        const std::string& fip_region() const { return *this->fip_region_ ; }
 
         std::string uniqueNodeKey() const;
         const KeywordLocation& location( ) const { return this->loc; }
@@ -88,7 +90,7 @@ namespace Opm {
         Type        type_{ Type::Undefined };
         std::string name_{};
         int         number_{std::numeric_limits<int>::min()};
-        std::string fip_region_;
+        std::optional<std::string> fip_region_;
         bool        userDefined_{false};
     };
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -398,7 +398,7 @@ struct fn_args {
     double duration;
     const int sim_step;
     int  num;
-    const std::string fip_region;
+    const std::optional<std::variant<std::string, int>> extra_data;
     const Opm::SummaryState& st;
     const Opm::data::Wells& wells;
     const Opm::data::GroupAndNetworkValues& grp_nwrk;
@@ -783,7 +783,7 @@ inline quantity duration( const fn_args& args ) {
 template<rt phase , bool injection>
 quantity region_rate( const fn_args& args ) {
     double sum = 0;
-    const auto& well_connections = args.regionCache.connections( args.fip_region, args.num );
+    const auto& well_connections = args.regionCache.connections( std::get<std::string>(*args.extra_data), args.num );
 
     for (const auto& pair : well_connections) {
 
@@ -1522,7 +1522,7 @@ inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,
 
         const auto region = node.number;
 
-        for ( const auto& connection : regionCache.connections( node.fip_region, region ) ){
+        for ( const auto& connection : regionCache.connections( *node.fip_region , region ) ){
             const auto& w_name = connection.first;
             if (schedule.hasWell(w_name, sim_step)) {
                 const auto& well = schedule.getWell( w_name, sim_step );

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1057,6 +1057,7 @@ SummaryConfigNode& SummaryConfigNode::fip_region(const std::string& fip_region)
     return *this;
 }
 
+
 SummaryConfigNode& SummaryConfigNode::parameterType(const Type type)
 {
     this->type_ = type;
@@ -1376,9 +1377,8 @@ bool SummaryConfig::require3DField( const std::string& keyword ) const {
 std::set<std::string> SummaryConfig::fip_regions() const {
     std::set<std::string> reg_set;
     for (const auto& node : this->m_keywords) {
-        const auto& fip_region = node.fip_region();
-        if (fip_region.size() > 0)
-            reg_set.insert( fip_region );
+        if (node.category() == EclIO::SummaryNode::Category::Region)
+            reg_set.insert( node.fip_region() );
     }
     return reg_set;
 }


### PR DESCRIPTION
~~Some summary keywords can have optional qualifying data following the keyword
name, like RPR__REG for region pressure based on FIP region FIPREG and WOPRL__2
for oil production rate from completion 2.~~

My `std::variant`based solution was a bit over engineering .... simplified significantly ...