### PR TITLE
Add function bool Well::hasCompletion( int )

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -509,6 +509,7 @@ public:
     Status getStatus() const;
     const std::string& groupName() const;
     Phase getPreferredPhase() const;
+
     const WellConnections& getConnections() const;
     const WellSegments& getSegments() const;
 
@@ -546,6 +547,14 @@ public:
       keyword.
     */
     std::map<int, std::vector<Connection>> getCompletions() const;
+    /*
+      For hasCompletion(int completion) and getConnections(int completion) the
+      completion argument is an integer ID used to denote a collection of
+      connections. The integer ID is assigned with the COMPLUMP keyword.
+     */
+    bool hasCompletion(int completion) const;
+    const std::vector<const Connection *> getConnections(int completion) const;
+
 
     bool updatePrediction(bool prediction_mode);
     bool updateAutoShutin(bool auto_shutin);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -873,6 +873,15 @@ const WellConnections& Well::getConnections() const {
     return *this->connections;
 }
 
+const std::vector<const Connection *> Well::getConnections(int completion) const {
+    std::vector<const Connection *> connvector;
+    for (const auto& conn : this->getConnections()) {
+        if (conn.complnum() == completion)
+            connvector.push_back( &conn );
+    }
+    return connvector;
+}
+
 const WellFoamProperties& Well::getFoamProperties() const {
     return *this->foam_properties;
 }
@@ -937,6 +946,16 @@ std::map<int, std::vector<Connection>> Well::getCompletions() const {
 
     return completions;
 }
+
+bool Well::hasCompletion(int completion) const {
+    for (const auto& conn : *this->connections) {
+        if (conn.complnum() == completion)
+            return true;
+    }
+    return false;
+}
+
+
 
 Phase Well::getPreferredPhase() const {
     return this->wtype.preferred_phase();

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2261,6 +2261,26 @@ BOOST_AUTO_TEST_CASE( complump ) {
         else
             BOOST_CHECK_EQUAL(pair.second.size(), 1U);
     }
+
+    const auto& w0 = schedule.getWell("W1", 0);
+    BOOST_CHECK(w0.hasCompletion(1));
+    BOOST_CHECK(!w0.hasCompletion(2));
+
+    const auto& conn0 = w0.getConnections(100);
+    BOOST_CHECK(conn0.empty());
+
+    const auto& conn_all = w0.getConnections();
+    const auto& conn1 = w0.getConnections(1);
+    BOOST_CHECK_EQUAL( conn1.size(), 3);
+    for (const auto& conn : conn_all) {
+        if (conn.complnum() == 1) {
+            auto conn_iter = std::find_if(conn1.begin(), conn1.end(), [&conn](const Connection * cptr)
+                                                                      {
+                                                                          return *cptr == conn;
+                                                                      });
+            BOOST_CHECK( conn_iter != conn1.end() );
+        }
+    }
 }
 
 


### PR DESCRIPTION
Utilities in order to support completion summary keywords like: `WOPRL`