### PR TITLE
Defer Unit Conversion for WELPI Values

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -433,28 +433,6 @@ public:
         double getBHPLimit() const;
     };
 
-    struct WellProductivityIndex {
-        double pi_value;
-        Phase preferred_phase;
-
-        bool operator==(const WellProductivityIndex& rhs) const
-        {
-            return (this->pi_value == rhs.pi_value)
-                && (this->preferred_phase == rhs.preferred_phase);
-        }
-
-        bool operator!=(const WellProductivityIndex& rhs) const
-        {
-            return ! (*this == rhs);
-        }
-
-        template <class Serializer>
-        void serializeOp(Serializer& serializer)
-        {
-            serializer(this->pi_value);
-            serializer(this->preferred_phase);
-        }
-    };
 
     Well() = default;
     Well(const std::string& wname,
@@ -520,7 +498,6 @@ public:
     const WellPolymerProperties& getPolymerProperties() const;
     const WellBrineProperties& getBrineProperties() const;
     const WellTracerProperties& getTracerProperties() const;
-    const WellProductivityIndex& getWellProductivityIndex() const;
     /* The rate of a given phase under the following assumptions:
      * * Returns zero if production is requested for an injector (and vice
      *   versa)
@@ -580,7 +557,7 @@ public:
     bool updateEconLimits(std::shared_ptr<WellEconProductionLimits> econ_limits);
     bool updateProduction(std::shared_ptr<WellProductionProperties> production);
     bool updateInjection(std::shared_ptr<WellInjectionProperties> injection);
-    bool updateWellProductivityIndex(const WellProductivityIndex& prodIndex);
+    bool updateWellProductivityIndex(const double prodIndex);
     bool updateWSEGSICD(const std::vector<std::pair<int, SICD> >& sicd_pairs);
     bool updateWSEGVALV(const std::vector<std::pair<int, Valve> >& valve_pairs);
 
@@ -639,7 +616,7 @@ public:
         serializer(has_produced);
         serializer(has_injected);
         serializer(prediction_mode);
-        serializer.optional(productivity_index);
+        serializer(productivity_index);
         serializer(econ_limits);
         serializer(foam_properties);
         serializer(polymer_properties);
@@ -677,7 +654,7 @@ private:
     bool has_produced = false;
     bool has_injected = false;
     bool prediction_mode = true;
-    std::optional<WellProductivityIndex> productivity_index{ std::nullopt };
+    std::optional<double> productivity_index{ std::nullopt };
 
     std::shared_ptr<WellEconProductionLimits> econ_limits;
     std::shared_ptr<WellFoamProperties> foam_properties;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -1133,6 +1133,8 @@ namespace {
                 this->addWellGroupEvent(well_name, ScheduleEvents::WELL_PRODUCTIVITY_INDEX, handlerContext.currentStep);
             }
         }
+
+        this->m_events.addEvent(ScheduleEvents::WELL_PRODUCTIVITY_INDEX, handlerContext.currentStep);
     }
 
     void Schedule::handleWELSEGS(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -1124,14 +1124,8 @@ namespace {
             const auto rawProdIndex = record.getItem<PI>().get<double>(0);
             for (const auto& well_name : well_names) {
                 // All wells in a single record *hopefully* have the same preferred phase...
-                const auto& well      = this->getWell(well_name, handlerContext.currentStep);
-                const auto  preferred = well.getPreferredPhase();
-                const auto  unitPI    = (preferred == Phase::GAS) ? gasPI : liqPI;
-
-                const auto wellPI = Well::WellProductivityIndex {
-                    usys.to_si(unitPI, rawProdIndex),
-                    preferred
-                };
+                const auto& well   = this->getWell(well_name, handlerContext.currentStep);
+                const auto  unitPI = (well.getPreferredPhase() == Phase::GAS) ? gasPI : liqPI;
 
                 // Note: Need to ensure we have an independent copy of
                 // well's connections because
@@ -1140,7 +1134,7 @@ namespace {
                 auto well2       = std::make_shared<Well>(well);
                 auto connections = std::make_shared<WellConnections>(well2->getConnections());
                 well2->forceUpdateConnections(std::move(connections));
-                if (well2->updateWellProductivityIndex(wellPI))
+                if (well2->updateWellProductivityIndex(usys.to_si(unitPI, rawProdIndex)))
                     this->updateWell(std::move(well2), handlerContext.currentStep);
 
                 this->addWellGroupEvent(well_name, ScheduleEvents::WELL_PRODUCTIVITY_INDEX, handlerContext.currentStep);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -35,7 +35,6 @@
 #include <fnmatch.h>
 #include <cmath>
 #include <ostream>
-#include <stdexcept>
 #include <utility>
 
 namespace Opm {
@@ -376,7 +375,7 @@ Well Well::serializeObject()
     result.efficiency_factor = 8.0;
     result.solvent_fraction = 9.0;
     result.prediction_mode = false;
-    result.productivity_index = WellProductivityIndex { 10.0, Phase::GAS };
+    result.productivity_index = 10.0;
     result.econ_limits = std::make_shared<Opm::WellEconProductionLimits>(Opm::WellEconProductionLimits::serializeObject());
     result.foam_properties = std::make_shared<WellFoamProperties>(WellFoamProperties::serializeObject());
     result.polymer_properties =  std::make_shared<WellPolymerProperties>(WellPolymerProperties::serializeObject());
@@ -492,7 +491,7 @@ bool Well::updateInjection(std::shared_ptr<WellInjectionProperties> injection_ar
     return update;
 }
 
-bool Well::updateWellProductivityIndex(const WellProductivityIndex& prodIndex) {
+bool Well::updateWellProductivityIndex(const double prodIndex) {
     const auto update = this->productivity_index != prodIndex;
     if (update)
         this->productivity_index = prodIndex;
@@ -846,11 +845,11 @@ double Well::getWellPIScalingFactor(const double currentEffectivePI) const {
         // WELPI not activated.  Nothing to do.
         return 1.0;
 
-    if (this->productivity_index->pi_value == currentEffectivePI)
+    if (this->productivity_index == currentEffectivePI)
         // No change in scaling.
         return 1.0;
 
-    return this->productivity_index->pi_value / currentEffectivePI;
+    return *this->productivity_index / currentEffectivePI;
 }
 
 void Well::applyWellProdIndexScaling(const double scalingFactor, std::vector<bool>& scalingApplicable) {
@@ -896,16 +895,6 @@ const WellBrineProperties& Well::getBrineProperties() const {
 
 const WellTracerProperties& Well::getTracerProperties() const {
     return *this->tracer_properties;
-}
-
-const Well::WellProductivityIndex& Well::getWellProductivityIndex() const
-{
-    if (this->productivity_index)
-        return *this->productivity_index;
-    else
-        throw std::logic_error {
-            "WELPI not activated in well " + this->name()
-        };
 }
 
 const WellEconProductionLimits& Well::getEconLimits() const {

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -60,11 +60,6 @@
 using namespace Opm;
 
 namespace {
-    double liquid_PI_unit()
-    {
-        return UnitSystem::newMETRIC().to_si(UnitSystem::measure::liquid_productivity_index, 1.0);
-    }
-
     double cp_rm3_per_db()
     {
         return prefix::centi*unit::Poise * unit::cubic(unit::meter)
@@ -3816,7 +3811,7 @@ END
         const auto expectCF = (200.0 / 100.0) * 100.0*cp_rm3_per_db();
         auto wellP = sched.getWell("P", 1);
 
-        const auto scalingFactor = wellP.getWellPIScalingFactor(100.0*liquid_PI_unit());
+        const auto scalingFactor = wellP.getWellPIScalingFactor(100.0);
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
         std::vector<bool> scalingApplicable;
@@ -3835,7 +3830,7 @@ END
         const auto expectCF = (200.0 / 100.0) * 100.0*cp_rm3_per_db();
         auto wellP = sched.getWell("P", 2);
 
-        const auto scalingFactor = wellP.getWellPIScalingFactor(100.0*liquid_PI_unit());
+        const auto scalingFactor = wellP.getWellPIScalingFactor(100.0);
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
         std::vector<bool> scalingApplicable;
@@ -3959,7 +3954,7 @@ END
     // Apply WELPI scaling after end of time series => no change to CTFs
     {
         const auto report_step   = std::size_t{1};
-        const auto scalingFactor = getScalingFactor(report_step, 100.0*liquid_PI_unit());
+        const auto scalingFactor = getScalingFactor(report_step, 100.0);
 
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
@@ -4025,7 +4020,7 @@ END
     // Apply WELPI scaling after first WELPI specification
     {
         const auto report_step   = std::size_t{1};
-        const auto scalingFactor = getScalingFactor(report_step, 100.0*liquid_PI_unit());
+        const auto scalingFactor = getScalingFactor(report_step, 100.0);
 
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
@@ -4093,7 +4088,7 @@ END
     // Apply WELPI scaling after second WELPI specification
     {
         const auto report_step   = std::size_t{3};
-        const auto scalingFactor = getScalingFactor(report_step, 200.0*liquid_PI_unit());
+        const auto scalingFactor = getScalingFactor(report_step, 200.0);
 
         BOOST_CHECK_CLOSE(scalingFactor, 0.25, 1.0e-10);
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3931,9 +3931,15 @@ END
     BOOST_REQUIRE_EQUAL(sched.getTimeMap().last(),         std::size_t{5});
 
     BOOST_REQUIRE_MESSAGE(sched.hasWellGroupEvent("P", ScheduleEvents::Events::WELL_PRODUCTIVITY_INDEX, 1),
-                          "Schedule must have WELL_PRODUCTIVITY_INDEX Event at report step 1");
+                          R"(Schedule must have WELL_PRODUCTIVITY_INDEX Event for well "P" at report step 1)");
 
     BOOST_REQUIRE_MESSAGE(sched.hasWellGroupEvent("P", ScheduleEvents::Events::WELL_PRODUCTIVITY_INDEX, 3),
+                          R"(Schedule must have WELL_PRODUCTIVITY_INDEX Event for well "P" at report step 3)");
+
+    BOOST_REQUIRE_MESSAGE(sched.getEvents().hasEvent(ScheduleEvents::Events::WELL_PRODUCTIVITY_INDEX, 1),
+                          "Schedule must have WELL_PRODUCTIVITY_INDEX Event at report step 1");
+
+    BOOST_REQUIRE_MESSAGE(sched.getEvents().hasEvent(ScheduleEvents::Events::WELL_PRODUCTIVITY_INDEX, 3),
                           "Schedule must have WELL_PRODUCTIVITY_INDEX Event at report step 3");
 
     auto getScalingFactor = [&sched](const std::size_t report_step, const double wellPI) -> double

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -60,10 +60,14 @@
 using namespace Opm;
 
 namespace {
+    double liquid_PI_unit()
+    {
+        return UnitSystem::newMETRIC().to_si(UnitSystem::measure::liquid_productivity_index, 1.0);
+    }
+
     double cp_rm3_per_db()
     {
-        return prefix::centi*unit::Poise * unit::cubic(unit::meter)
-            / (unit::day * unit::barsa);
+        return UnitSystem::newMETRIC().to_si(UnitSystem::measure::transmissibility, 1.0);
     }
 }
 
@@ -3811,7 +3815,7 @@ END
         const auto expectCF = (200.0 / 100.0) * 100.0*cp_rm3_per_db();
         auto wellP = sched.getWell("P", 1);
 
-        const auto scalingFactor = wellP.getWellPIScalingFactor(100.0);
+        const auto scalingFactor = wellP.getWellPIScalingFactor(100.0*liquid_PI_unit());
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
         std::vector<bool> scalingApplicable;
@@ -3830,7 +3834,7 @@ END
         const auto expectCF = (200.0 / 100.0) * 100.0*cp_rm3_per_db();
         auto wellP = sched.getWell("P", 2);
 
-        const auto scalingFactor = wellP.getWellPIScalingFactor(100.0);
+        const auto scalingFactor = wellP.getWellPIScalingFactor(100.0*liquid_PI_unit());
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
         std::vector<bool> scalingApplicable;
@@ -3960,7 +3964,7 @@ END
     // Apply WELPI scaling after end of time series => no change to CTFs
     {
         const auto report_step   = std::size_t{1};
-        const auto scalingFactor = getScalingFactor(report_step, 100.0);
+        const auto scalingFactor = getScalingFactor(report_step, 100.0*liquid_PI_unit());
 
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
@@ -4026,7 +4030,7 @@ END
     // Apply WELPI scaling after first WELPI specification
     {
         const auto report_step   = std::size_t{1};
-        const auto scalingFactor = getScalingFactor(report_step, 100.0);
+        const auto scalingFactor = getScalingFactor(report_step, 100.0*liquid_PI_unit());
 
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
@@ -4094,7 +4098,7 @@ END
     // Apply WELPI scaling after second WELPI specification
     {
         const auto report_step   = std::size_t{3};
-        const auto scalingFactor = getScalingFactor(report_step, 200.0);
+        const auto scalingFactor = getScalingFactor(report_step, 200.0*liquid_PI_unit());
 
         BOOST_CHECK_CLOSE(scalingFactor, 0.25, 1.0e-10);
 

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -1199,8 +1199,6 @@ COMPDAT
 END
 )");
 
-    using WellPIType = Well::WellProductivityIndex;
-
     const auto es    = EclipseState{ deck };
     const auto sched = Schedule{ deck, es };
 
@@ -1232,9 +1230,9 @@ END
     //   /
     //
     // (ignoring units of measure)
-    BOOST_CHECK_MESSAGE(wellP.updateWellProductivityIndex(WellPIType{ 2.0, Phase::GAS }),
+    BOOST_CHECK_MESSAGE(wellP.updateWellProductivityIndex(2.0),
                         "First call to updateWellProductivityIndex() must be a state change");
-    BOOST_CHECK_MESSAGE(!wellP.updateWellProductivityIndex(WellPIType{ 2.0, Phase::GAS }),
+    BOOST_CHECK_MESSAGE(!wellP.updateWellProductivityIndex(2.0),
                         "Second call to updateWellProductivityIndex() must NOT be a state change");
 
     // Want PI=2, but actual/effective PI=1 => scale CF by 2.0/1.0.
@@ -1270,7 +1268,7 @@ END
     }
 
     // New WELPI record does not reset the scaling factors
-    wellP.updateWellProductivityIndex(WellPIType{ 3.0, Phase::GAS });
+    wellP.updateWellProductivityIndex(3.0);
     for (const auto& conn : wellP.getConnections()) {
         BOOST_CHECK_CLOSE(conn.CF(), 4.0*expectCF, 1.0e-10);
     }
@@ -1290,11 +1288,6 @@ END
             BOOST_CHECK_MESSAGE(applicable, "All connections must be eligible for WELPI scaling");
         }
     }
-
-    BOOST_CHECK_MESSAGE(wellP.updateWellProductivityIndex(WellPIType{ 3.0, Phase::OIL }),
-                        "Fourth call to updateWellProductivityIndex() must be a state change");
-    BOOST_CHECK_MESSAGE(!wellP.updateWellProductivityIndex(WellPIType{ 3.0, Phase::OIL }),
-                        "Fifth call to updateWellProductivityIndex() must NOT be a state change");
 }
 
 BOOST_AUTO_TEST_CASE(Has_Same_Connections_Pointers) {

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -53,10 +53,14 @@
 using namespace Opm;
 
 namespace {
+    double liquid_PI_unit()
+    {
+        return UnitSystem::newMETRIC().to_si(UnitSystem::measure::liquid_productivity_index, 1.0);
+    }
+
     double cp_rm3_per_db()
     {
-        return prefix::centi*unit::Poise * unit::cubic(unit::meter)
-            / (unit::day * unit::barsa);
+        return UnitSystem::newMETRIC().to_si(UnitSystem::measure::transmissibility, 1.0);
     }
 }
 
@@ -1237,7 +1241,7 @@ END
 
     // Want PI=2, but actual/effective PI=1 => scale CF by 2.0/1.0.
     {
-        const auto scalingFactor = wellP.getWellPIScalingFactor(1.0);
+        const auto scalingFactor = wellP.getWellPIScalingFactor(1.0*liquid_PI_unit());
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
         std::vector<bool> scalingApplicable;
@@ -1253,7 +1257,7 @@ END
 
     // Repeated application of WELPI multiplies scaling factors.
     {
-        const auto scalingFactor = wellP.getWellPIScalingFactor(1.0);
+        const auto scalingFactor = wellP.getWellPIScalingFactor(1.0*liquid_PI_unit());
         BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
 
         std::vector<bool> scalingApplicable;
@@ -1275,7 +1279,7 @@ END
 
     // Effective PI=desired PI => no scaling change
     {
-        const auto scalingFactor = wellP.getWellPIScalingFactor(3.0);
+        const auto scalingFactor = wellP.getWellPIScalingFactor(3.0*liquid_PI_unit());
         BOOST_CHECK_CLOSE(scalingFactor, 1.0, 1.0e-10);
 
         std::vector<bool> scalingApplicable;


### PR DESCRIPTION
This PR switches the WELPI scaling factor protocol to requiring that the caller convert the effective PI value to output units before calling
```
Well::getWellPIScalingFactor()
```
This clearly makes the function less convenient to use, but is on the other hand the only way to guarantee that client code has a consistent view of the "preferred" phase for injectors.  PR #2018's approach of capturing the preferred phase at the time of processing `WELPI` was, while well-intentioned, based on a misunderstanding of the way these keywords interact.  Moreover, my [answer](https://github.com/OPM/opm-common/pull/2018#issuecomment-707997529) to @joakim-hove's [question](https://github.com/OPM/opm-common/pull/2018#issuecomment-707991480) in turn was based on an incomplete understanding of what goes into the mobility term of the PI calculation.

The upside of this revised implementation is that we no longer need the more elaborate `WellProductivityIndex` structure to have enough information to correctly calculate the WELPI-based scaling factor.  We're therefore able to revert the earlier commit 3eef45e and remove all traces of that structure.

Finally record a general, `Schedule`-wide `WELL_PRODUCITIVITY_INDEX` event in addition to the well-specific events we already record when processing a WELPI keyword.  We need this information to trigger a PI calculation across all MPI processes in opm-simulators.