### PR TITLE
MSW: Support Connection Results for All Connections

### DIFF
--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -180,6 +180,7 @@ namespace {
         return segmentOrder(segSet, 0);
     }
 
+    /// Accumulate connection flow rates (surface conditions) to their connecting segment.
     Opm::RestartIO::Helpers::SegmentSetSourceSinkTerms
     getSegmentSetSSTerms(const Opm::WellSegments& segSet,
                          const std::vector<Opm::data::Connection>& rateConns,
@@ -241,7 +242,7 @@ namespace {
         std::vector<double> sgfr (segSet.size(), 0.);
         //
         //call function to calculate the individual segment source/sink terms
-        auto sSSST = getSegmentSetSSTerms(segSet, rateConns, welConns, units);
+        auto segmentSources = getSegmentSetSSTerms(segSet, rateConns, welConns, units);
 
         // find an ordered list of segments
         auto orderedSegmentInd = segmentOrder(segSet);
@@ -252,9 +253,9 @@ namespace {
             const auto& segInd = sNFOSN[indOSN];
             // the segment flow rates is the sum of the the source/sink terms for each segment plus the flow rates from the inflow segments
             // add source sink terms
-            sofr[segInd] += sSSST.qosc[segInd];
-            swfr[segInd] += sSSST.qwsc[segInd];
-            sgfr[segInd] += sSSST.qgsc[segInd];
+            sofr[segInd] += segmentSources.qosc[segInd];
+            swfr[segInd] += segmentSources.qwsc[segInd];
+            sgfr[segInd] += segmentSources.qgsc[segInd];
             // add flow from all inflow segments
             for (const auto& segNo : segSet[segInd].inletSegments()) {
                 const auto & ifSegInd = segSet.segmentNumberToIndex(segNo);

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -551,6 +551,7 @@ END
 	    double qo = 5.;
 	    double qw = 4.;
 	    double qg = 50.;
+	    int firstConnectedCell = 90; // zero-based linear index of (1,5,2)
             for (int i = 0; i < 5; i++) {
 		xw["PROD"].connections.emplace_back();
 		auto& c = xw["PROD"].connections.back();
@@ -559,7 +560,7 @@ END
                    .set(o::oil, qo*(float(i)+1.))
                    .set(o::gas, qg*(float(i)+1.));
 
-		c.index = 90 + i; // zero-based global index
+		c.index = firstConnectedCell + i;
 	    }
 	    auto seg = Opm::data::Segment{};
 	    for (std::size_t i = 1; i < 5; i++) {
@@ -571,6 +572,7 @@ END
 	    xw["WINJ"].rates.set(o::oil, 0.0);
 	    xw["WINJ"].rates.set(o::gas, 0.0);
 	    qw = 7.;
+	    firstConnectedCell = 409; // zero-based linear index of (10,1,9)
             for (int i = 0; i < 5; i++) {
 		xw["WINJ"].connections.emplace_back();
 		auto& c = xw["WINJ"].connections.back();
@@ -578,7 +580,8 @@ END
 		c.rates.set(o::wat, qw*(float(i)+1.))
 		       .set(o::oil, 0.)
 		       .set(o::gas, 0.);
-		c.index = 409 - i; // zero-based global index
+
+		c.index = firstConnectedCell - i;
 	    }
         }
         return xw;

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -558,6 +558,8 @@ END
 		c.rates.set(o::wat, qw*(float(i)+1.))
                    .set(o::oil, qo*(float(i)+1.))
                    .set(o::gas, qg*(float(i)+1.));
+
+		c.index = 90 + i; // zero-based global index
 	    }
 	    auto seg = Opm::data::Segment{};
 	    for (std::size_t i = 1; i < 5; i++) {
@@ -576,6 +578,7 @@ END
 		c.rates.set(o::wat, qw*(float(i)+1.))
 		       .set(o::oil, 0.)
 		       .set(o::gas, 0.);
+		c.index = 409 - i; // zero-based global index
 	    }
         }
         return xw;


### PR DESCRIPTION
The current code that aggregates flow rates from connection to segment levels assumes that the simulator generates connection results for the open connections only.  Relax this restriction as upcoming work in the context of WELPI will require generating at least the CTFs even for shut connections.