### PR TITLE
Get connections from global index

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -71,8 +71,10 @@ namespace Opm {
         const Connection& operator[](size_t index) const;
         const Connection& get(size_t index) const;
         const Connection& getFromIJK(const int i, const int j, const int k) const;
+        const Connection& getFromGlobalIndex(std::size_t global_index) const;
         const Connection& lowest() const;
         Connection& getFromIJK(const int i, const int j, const int k);
+        bool hasGlobalIndex(std::size_t global_index) const;
         double segment_perf_length(int segment) const;
 
         const_iterator begin() const { return this->m_connections.begin(); }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <fmt/format.h>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/io/eclipse/rst/connection.hpp>
@@ -471,6 +472,13 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
     }
 
 
+    bool WellConnections::hasGlobalIndex(std::size_t global_index) const {
+        auto conn_iter = std::find_if(this->begin(), this->end(),
+                                      [global_index] (const Connection& conn) {return conn.global_index() == global_index;});
+        return (conn_iter != this->end());
+    }
+
+
     const Connection& WellConnections::getFromIJK(const int i, const int j, const int k) const {
         for (size_t ic = 0; ic < size(); ++ic) {
             if (get(ic).sameCoordinate(i, j, k)) {
@@ -478,6 +486,16 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
             }
         }
         throw std::runtime_error(" the connection is not found! \n ");
+    }
+
+
+    const Connection& WellConnections::getFromGlobalIndex(std::size_t global_index) const {
+        auto conn_iter = std::find_if(this->begin(), this->end(),
+                                      [global_index] (const Connection& conn) {return conn.global_index() == global_index;});
+
+        if (conn_iter == this->end())
+            throw std::logic_error(fmt::format("No connection with global index {}", global_index));
+        return *conn_iter;
     }
 
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2199,7 +2199,7 @@ BOOST_AUTO_TEST_CASE( complump ) {
             /
 
             COMPDAT
-                'W1' 0 0 1 2 'SHUT' 1*    /
+                'W1' 0 0 1 2 'SHUT' 1*    /    Global Index = 23, 123, 223, 323, 423, 523
                 'W1' 0 0 2 3 'SHUT' 1*    /
                 'W1' 0 0 4 6 'SHUT' 1*    /
                 'W2' 0 0 3 4 'SHUT' 1*    /
@@ -2280,6 +2280,15 @@ BOOST_AUTO_TEST_CASE( complump ) {
             BOOST_CHECK( conn_iter != conn1.end() );
         }
     }
+
+    const auto& all_connections = w0.getConnections();
+    auto global_index = grid.getGlobalIndex(2,2,0);
+    BOOST_CHECK( all_connections.hasGlobalIndex(global_index));
+    const auto& conn_g = all_connections.getFromGlobalIndex(global_index);
+    const auto& conn_ijk = all_connections.getFromIJK(2,2,0);
+    BOOST_CHECK(conn_g == conn_ijk);
+
+    BOOST_CHECK_THROW( all_connections.getFromGlobalIndex(100000), std::exception );
 }
 
 


### PR DESCRIPTION
Get set of connections from one connection in the same completion - support COPRL and cousins.