### PR TITLE
AggregateGroupData - refactoring

### DIFF
--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -61,6 +61,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         WInjCMode = 16,
         GConProdCMode = 10,
         GInjCMode = 21,
+        GroupType = 26,
+        GroupLevel = 27,
         ParentGroup = 28,
         FlowingWells = 33,
     };
@@ -76,6 +78,12 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         Form = 8,
         Comb = 9,
     };
+
+    enum GroupType : int {
+        WellGroup = 0,
+        TreeGroup = 1,
+    };
+
     }
 
     }

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -453,16 +453,13 @@ void productionGroup(const Opm::Schedule&     sched,
 
     const auto& production_controls = group.productionControls(sumState);
     const auto& prod_guide_rate_def = production_controls.guide_rate_def;
-    const auto& p_exceed_act = production_controls.exceed_action;
-    // Find production control mode for group
-    const double cur_prod_ctrl = sumState.get_group_var(group.name(), "GMCTP", -1);
     Opm::Group::ProductionCMode active_cmode = Opm::Group::ProductionCMode::NONE;
-    if (cur_prod_ctrl >= 0) {
-        const auto it_ctrl = pCtrlToPCmode.find(cur_prod_ctrl);
-        if (it_ctrl != pCtrlToPCmode.end()) {
-            active_cmode = it_ctrl->second;
-        }
+    {
+        auto cur_prod_ctrl = sumState.get_group_var(group.name(), "GMCTP", -1);
+        if (cur_prod_ctrl >= 0)
+            active_cmode = pCtrlToPCmode.at(static_cast<int>(cur_prod_ctrl));
     }
+
 #if ENABLE_GCNTL_DEBUG_OUTPUT
     else {
         // std::stringstream str;
@@ -586,6 +583,7 @@ void productionGroup(const Opm::Schedule&     sched,
 
     iGrp[nwgmax + IGroup::GuideRateDef] = Value::GuideRateMode::None;
 
+    const auto& p_exceed_act = production_controls.exceed_action;
     switch (deck_cmode) {
     case Opm::Group::ProductionCMode::NONE:
         iGrp[nwgmax + 7] = (p_exceed_act == Opm::Group::ExceedAction::NONE) ? 0 : 4;

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -455,14 +455,6 @@ void productionGroup(const Opm::Schedule&     sched,
         }
 
 
-        if (((active_cmode != Opm::Group::ProductionCMode::NONE)) && (!cgroup)) {
-            // group is constrained by its own limits or controls
-            // if (active_cmode != Opm::Group::ProductionCMode::FLD)  -  need to use this test? - else remove
-            iGrp[nwgmax + 5] = -1; // only value that seems to work when no group at higher level has active control
-            goto CGROUP_DONE;
-        }
-
-
         if (cgroup) {
             if (((deck_cmode == Opm::Group::ProductionCMode::FLD) || (deck_cmode == Opm::Group::ProductionCMode::NONE))
                 && (prod_guide_rate_def != Opm::Group::GuideRateTarget::NO_GUIDE_RATE)) {
@@ -475,7 +467,6 @@ void productionGroup(const Opm::Schedule&     sched,
 
 
         if (higherLevelProdCMode_NotNoneFld(sched, group, simStep)) {
-            iGrp[nwgmax + 5] = -1;
 
             if (deck_cmode == Opm::Group::ProductionCMode::FLD)
                 iGrp[nwgmax] = 1;

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -274,23 +274,19 @@ bool higherLevelProdCMode_NotNoneFld(const Opm::Schedule& sched,
                                      const Opm::Group& group,
                                      const size_t simStep)
 {
-    bool ctrl_mode_not_none_fld = false;
-    if (group.defined( simStep )) {
-        auto current = group;
-        while (current.name() != "FIELD" && ctrl_mode_not_none_fld == false) {
-            current = sched.getGroup(current.parent(), simStep);
-            const auto& prod_cmode = group.gconprod_cmode();
-            if ((prod_cmode != Opm::Group::ProductionCMode::FLD) && (prod_cmode!= Opm::Group::ProductionCMode::NONE)) {
-                ctrl_mode_not_none_fld = true;
-            }
-        }
-        return ctrl_mode_not_none_fld;
+    auto current = group;
+    while (current.name() != "FIELD") {
+        current = sched.getGroup(current.parent(), simStep);
+        const auto& prod_cmode = group.gconprod_cmode();
+
+        if (prod_cmode != Opm::Group::ProductionCMode::FLD)
+            return true;
+
+        if (prod_cmode != Opm::Group::ProductionCMode::NONE)
+            return true;
+
     }
-    else {
-        std::stringstream str;
-        str << "actual group has not been defined at report time: " << simStep;
-        throw std::invalid_argument(str.str());
-    }
+    return false;
 }
 
 int higherLevelInjCMode_NotNoneFld_SeqIndex(const Opm::Schedule& sched,

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -451,9 +451,9 @@ void productionGroup(const Opm::Schedule&     sched,
         return;
     }
 
-
-    const auto& prod_guide_rate_def = group.productionControls(sumState).guide_rate_def;
-    const auto& p_exceed_act = group.productionControls(sumState).exceed_action;
+    const auto& production_controls = group.productionControls(sumState);
+    const auto& prod_guide_rate_def = production_controls.guide_rate_def;
+    const auto& p_exceed_act = production_controls.exceed_action;
     // Find production control mode for group
     const double cur_prod_ctrl = sumState.get_group_var(group.name(), "GMCTP", -1);
     Opm::Group::ProductionCMode pctl_mode = Opm::Group::ProductionCMode::NONE;
@@ -514,7 +514,7 @@ void productionGroup(const Opm::Schedule&     sched,
             iGrp[nwgmax + 5] = -1; // only value that seems to work when no group at higher level has active control
         } else if (higher_lev_ctrl > 0) {
             if (((prod_cmode == Opm::Group::ProductionCMode::FLD) || (prod_cmode == Opm::Group::ProductionCMode::NONE))
-                && (group.productionControls(sumState).guide_rate_def != Opm::Group::GuideRateTarget::NO_GUIDE_RATE)) {
+                && (prod_guide_rate_def != Opm::Group::GuideRateTarget::NO_GUIDE_RATE)) {
                 iGrp[nwgmax + 5] = higher_lev_ctrl;
             } else {
                 iGrp[nwgmax + 5] = 1;

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -456,11 +456,11 @@ void productionGroup(const Opm::Schedule&     sched,
     const auto& p_exceed_act = production_controls.exceed_action;
     // Find production control mode for group
     const double cur_prod_ctrl = sumState.get_group_var(group.name(), "GMCTP", -1);
-    Opm::Group::ProductionCMode pctl_mode = Opm::Group::ProductionCMode::NONE;
+    Opm::Group::ProductionCMode active_cmode = Opm::Group::ProductionCMode::NONE;
     if (cur_prod_ctrl >= 0) {
         const auto it_ctrl = pCtrlToPCmode.find(cur_prod_ctrl);
         if (it_ctrl != pCtrlToPCmode.end()) {
-            pctl_mode = it_ctrl->second;
+            active_cmode = it_ctrl->second;
         }
     }
 #if ENABLE_GCNTL_DEBUG_OUTPUT
@@ -508,9 +508,9 @@ void productionGroup(const Opm::Schedule&     sched,
         if (!group.productionGroupControlAvailable() && (higher_lev_ctrl <= 0)) {
             // group can respond to higher level control
             iGrp[nwgmax + 5] = 0;
-        } else if (((pctl_mode != Opm::Group::ProductionCMode::NONE)) && (higher_lev_ctrl < 0)) {
+        } else if (((active_cmode != Opm::Group::ProductionCMode::NONE)) && (higher_lev_ctrl < 0)) {
             // group is constrained by its own limits or controls
-            // if (pctl_mode != Opm::Group::ProductionCMode::FLD)  -  need to use this test? - else remove
+            // if (active_cmode != Opm::Group::ProductionCMode::FLD)  -  need to use this test? - else remove
             iGrp[nwgmax + 5] = -1; // only value that seems to work when no group at higher level has active control
         } else if (higher_lev_ctrl > 0) {
             if (((deck_cmode == Opm::Group::ProductionCMode::FLD) || (deck_cmode == Opm::Group::ProductionCMode::NONE))
@@ -556,7 +556,7 @@ void productionGroup(const Opm::Schedule&     sched,
         iGrp[nwgmax + IGroup::ProdActiveCMode]
             = (prod_guide_rate_def != Opm::Group::GuideRateTarget::NO_GUIDE_RATE) ? higher_lev_ctrl_mode : 0;
     } else {
-        switch (pctl_mode) {
+        switch (active_cmode) {
         case Opm::Group::ProductionCMode::NONE:
             iGrp[nwgmax + IGroup::ProdActiveCMode] = 0;
             break;

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -500,7 +500,7 @@ void productionGroup(const Opm::Schedule&     sched,
     iGrp[nwgmax + 5] = -1;
     const int higher_lev_ctrl = higherLevelProdControlGroupSeqIndex(sched, sumState, group, simStep);
     const int higher_lev_ctrl_mode = higherLevelProdControlMode(sched, sumState, group, simStep);
-    const auto& prod_cmode = group.gconprod_cmode();
+    const auto& deck_cmode = group.gconprod_cmode();
     // Start branching for determining iGrp[nwgmax + 5]
     // use default value if group is not available for group control
     if (groupProductionControllable(sched, sumState, group, simStep)) {
@@ -513,26 +513,26 @@ void productionGroup(const Opm::Schedule&     sched,
             // if (pctl_mode != Opm::Group::ProductionCMode::FLD)  -  need to use this test? - else remove
             iGrp[nwgmax + 5] = -1; // only value that seems to work when no group at higher level has active control
         } else if (higher_lev_ctrl > 0) {
-            if (((prod_cmode == Opm::Group::ProductionCMode::FLD) || (prod_cmode == Opm::Group::ProductionCMode::NONE))
+            if (((deck_cmode == Opm::Group::ProductionCMode::FLD) || (deck_cmode == Opm::Group::ProductionCMode::NONE))
                 && (prod_guide_rate_def != Opm::Group::GuideRateTarget::NO_GUIDE_RATE)) {
                 iGrp[nwgmax + 5] = higher_lev_ctrl;
             } else {
                 iGrp[nwgmax + 5] = 1;
             }
         } else if (higherLevelProdCMode_NotNoneFld(sched, group, simStep)) {
-            if (!((prod_cmode == Opm::Group::ProductionCMode::FLD)
-                  || (prod_cmode == Opm::Group::ProductionCMode::NONE))) {
+            if (!((deck_cmode == Opm::Group::ProductionCMode::FLD)
+                  || (deck_cmode == Opm::Group::ProductionCMode::NONE))) {
                 iGrp[nwgmax + 5] = -1;
             } else {
                 iGrp[nwgmax + 5] = 1;
             }
-        } else if ((prod_cmode == Opm::Group::ProductionCMode::FLD)
-                   || (prod_cmode == Opm::Group::ProductionCMode::NONE)) {
+        } else if ((deck_cmode == Opm::Group::ProductionCMode::FLD)
+                   || (deck_cmode == Opm::Group::ProductionCMode::NONE)) {
             iGrp[nwgmax + 5] = -1;
         } else {
             iGrp[nwgmax + 5] = -1;
         }
-    } else if (prod_cmode == Opm::Group::ProductionCMode::NONE) {
+    } else if (deck_cmode == Opm::Group::ProductionCMode::NONE) {
         iGrp[nwgmax + 5] = 1;
     }
 
@@ -586,7 +586,7 @@ void productionGroup(const Opm::Schedule&     sched,
 
     iGrp[nwgmax + IGroup::GuideRateDef] = Value::GuideRateMode::None;
 
-    switch (prod_cmode) {
+    switch (deck_cmode) {
     case Opm::Group::ProductionCMode::NONE:
         iGrp[nwgmax + 7] = (p_exceed_act == Opm::Group::ExceedAction::NONE) ? 0 : 4;
         break;

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -456,11 +456,13 @@ void productionGroup(const Opm::Schedule&     sched,
 
 
         if (cgroup) {
-            if (((deck_cmode == Opm::Group::ProductionCMode::FLD) || (deck_cmode == Opm::Group::ProductionCMode::NONE))
-                && (prod_guide_rate_def != Opm::Group::GuideRateTarget::NO_GUIDE_RATE)) {
-                iGrp[nwgmax + 5] = cgroup->insert_index();
-            } else {
-                iGrp[nwgmax + 5] = 1;
+            iGrp[nwgmax + 5] = 1;
+            if (prod_guide_rate_def != Opm::Group::GuideRateTarget::NO_GUIDE_RATE) {
+                if (deck_cmode == Opm::Group::ProductionCMode::FLD)
+                    iGrp[nwgmax + 5] = cgroup->insert_index();
+
+                if (deck_cmode == Opm::Group::ProductionCMode::NONE)
+                    iGrp[nwgmax + 5] = cgroup->insert_index();
             }
             goto CGROUP_DONE;
         }
@@ -476,7 +478,6 @@ void productionGroup(const Opm::Schedule&     sched,
             goto CGROUP_DONE;
         }
 
-        goto CGROUP_DONE;
     } else if (deck_cmode == Opm::Group::ProductionCMode::NONE) {
         iGrp[nwgmax + 5] = 1;
     }


### PR DESCRIPTION
I am currently working on reading Schedule information from the restart file, this obviously requires understanding the content of the restart files. This is complex and I am struggling a bit getting a complete understanding of the code writing restart files, currently focusing on the `IGRP` array assembled in [AggregateGroupData.cpp](https://github.com/OPM/opm-common/blob/master/src/opm/output/eclipse/AggregateGroupData.cpp#L863). When just reading the code is not enough to get a full understanding my normal way to "get into" a code is to start making small changes, move some code around, extract blocks of code into functions, reduce nesting by e.g. early return and so on.

The main focus of the current PR is the [branching logic](https://github.com/OPM/opm-common/blob/master/src/opm/output/eclipse/AggregateGroupData.cpp#L503) for production groups which I suggest rewriting with `goto: considered_cool`. Type of changes include:

1. Several checks of `group.defined(simStep)` have been removed - this code starts with a loop over groups defined at the current simulation step, we are then guaranteed to be in a "space of existing groups" - the check is not required.

2. The upward search for a active controlling group returns a `std::optional<Group>` instead of an index.

3. Complex logical conditions have been expanded to multiple simpler conditions.

4. Default assignment has been pulled out to the front of the loop; and assignments to the default have been removed.

5. Several checks for empty containers in range based for loops have been removed as superfluous.

6. Functions recursively walking the group tree down towards the well nodes goes depth first.

7. Have introduced some named constants for some lookup indices and values.

8. Extracted some code to separate functions.

9. Some variable renames: `pctl_mode -> active_cmode` and `prod_cmode -> deck_cmode`.


 
@jalvestad : Cool if you would look through this

 