### PR TITLE
Add method Group::is_field()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -231,6 +231,7 @@ struct ProductionControls {
     bool defined(std::size_t timeStep) const;
     std::size_t insert_index() const;
     const std::string& name() const;
+    bool is_field() const;
     int getGroupNetVFPTable() const;
 
     bool updateNetVFPTable(int vfp_arg);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -134,6 +134,10 @@ const std::string& Group::name() const {
     return this->m_name;
 }
 
+bool Group::is_field() const {
+    return (this->m_name == "FIELD");
+}
+
 const Group::GroupProductionProperties& Group::productionProperties() const {
     return this->production_properties;
 }

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -523,6 +523,9 @@ BOOST_AUTO_TEST_CASE(GCONINJE_GCONPROD) {
         BOOST_CHECK(!g2.injectionGroupControlAvailable(Phase::WATER));
         BOOST_CHECK( g1.injectionGroupControlAvailable(Phase::GAS));
         BOOST_CHECK( g2.injectionGroupControlAvailable(Phase::GAS));
+
+        BOOST_CHECK(f.is_field());
+        BOOST_CHECK(!g1.is_field());
     }
     {
         const auto& g1 = schedule.getGroup("G1", 1);


### PR DESCRIPTION
To replace numerous `group.name() == "FIELD"` checks.