### PR TITLE
add missing includes of standard library headers

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/SpiralICD.hpp
@@ -24,6 +24,7 @@
 #include <map>
 #include <utility>
 #include <vector>
+#include <string>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/icd.hpp>
 

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp
@@ -23,6 +23,7 @@
 #include <map>
 #include <utility>
 #include <vector>
+#include <string>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/icd.hpp>
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <fnmatch.h>
+#include <stdexcept>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cstring>
 #include <cstdlib>
+#include <stdexcept>
 
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.cpp
@@ -1,5 +1,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp>
 
+#include <stdexcept>
 
 namespace Opm {
 namespace Action {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Segment.cpp
@@ -23,7 +23,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/Valve.hpp>
 
 #include <cassert>
-
+#include <stdexcept>
 #include <string>
 
 namespace Opm {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
@@ -18,6 +18,8 @@
 */
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 
+#include <stdexcept>
+
 namespace Opm {
 
     OilVaporizationProperties::OilVaporizationProperties()


### PR DESCRIPTION
The missing includes lead to compiler errors on Ubuntu 20.10.

Note that this only concerns the 2020.04 release branch, more recent branches are fine.