### PR TITLE
workaround cmake issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,9 @@ macro (config_hook)
 
     # For this project
     add_definitions(-DFMT_HEADER_ONLY)
-    list(APPEND EXTRA_INCLUDES SYSTEM ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
+    include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
     include_directories(${EXTRA_INCLUDES} ${PROJECT_BINARY_DIR}/include)
+    list(APPEND EXTRA_INCLUDES ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
 
     # For downstreams
     list(APPEND EXTRA_INCLUDES ${PROJECT_BINARY_DIR}/include)


### PR DESCRIPTION
cmake does not properly interpret the SYSTEM marker in lists of include directories. this causes issues downstream when using dunecontrol / the in-tree cmake config files.