### PR TITLE
CxL: Account for Dynamically Changing Set of Connections

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -26,6 +26,7 @@
 #include <opm/common/utility/ActiveGridCells.hpp>
 
 #include <cstddef>
+#include <optional>
 #include <vector>
 
 #include <stddef.h>
@@ -163,6 +164,10 @@ namespace Opm {
         int headI, headJ;
         std::vector< Connection > m_connections;
     };
+
+    std::optional<int>
+    getCompletionNumberFromGlobalConnectionIndex(const WellConnections& connections,
+                                                 const std::size_t      global_index);
 }
 
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -579,9 +579,13 @@ inline quantity cratel( const fn_args& args ) {
     const auto& well_data = args.wells.at( name );
     if (well_data.current_control.isProducer == injection) return zero;
 
+    const auto complnum = getCompletionNumberFromGlobalConnectionIndex(well.getConnections(), args.num - 1);
+    if (!complnum.has_value())
+        // Connection might not yet have come online.
+        return zero;
+
     double sum = 0;
-    const auto& conn0 = well.getConnections().getFromGlobalIndex( args.num - 1);
-    const auto& connections = well.getConnections(conn0.complnum()) ;
+    const auto& connections = well.getConnections(*complnum);
     for (const auto& conn_ptr : connections) {
         const size_t global_index = conn_ptr->global_index();
         const auto& conn_data = std::find_if(well_data.connections.begin(),

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -633,4 +633,20 @@ inline std::array< size_t, 3> directionIndices(const Opm::Connection::Direction 
     }
 
 
+    std::optional<int>
+    getCompletionNumberFromGlobalConnectionIndex(const WellConnections& connections,
+                                                 const std::size_t      global_index)
+    {
+        auto connPos = std::find_if(connections.begin(), connections.end(),
+            [global_index](const Connection& conn)
+        {
+            return conn.global_index() == global_index;
+        });
+
+        if (connPos == connections.end())
+            // No connection exists with the requisite 'global_index'
+            return {};
+
+        return { connPos->complnum() };
+    }
 }


### PR DESCRIPTION
This commit adds a new helper function
```
getCompletionNumberFromGlobalConnectionIndex
```
which returns an `optional<int>` containing the completion number of the connection with the associated global cell index, or `nullopt` if no such connection exists.  We then reimplement the CxL summary keywords in terms of this function to handle connections being added dynamically during the simulation.  The connections at the end of
the simulation, from which we configure all connection-related summary nodes, might not accurately reflect the connections existing at all times during the simulation.