### PR TITLE
correcting the definition of the keyword AQUCON

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUCON
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/A/AQUCON
@@ -39,27 +39,27 @@
     {
       "name": "TRANS_MULT",
       "value_type": "DOUBLE",
-      "default_value": 1
+      "default": 1
     },
     {
       "name": "TRANS_OPTION",
       "value_type": "INT",
-      "default_value": 0
+      "default": 0
     },
     {
       "name": "ALLOW_INTERNAL_CELLS",
       "value_type": "STRING",
-      "default_value": "NO"
+      "default": "NO"
     },
     {
       "name": "VEFRAC",
       "value_type": "DOUBLE",
-      "default_value": 1
+      "default": 1
     },
     {
       "name": "VEFRACP",
       "value_type": "DOUBLE",
-      "default_value": 1
+      "default": 1
     }
   ]
 }


### PR DESCRIPTION
mostly related to default value.

default_value is used, while it looks like not working.