### PR TITLE
Warnings

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2775,6 +2775,7 @@ eval(const EclipseState&                es,
     }
 
     for (auto& [_, evalPtr] : this->extra_parameters) {
+        (void)_;
         evalPtr->update(sim_step, duration, input, simRes, st);
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/PAvg.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/PAvg.cpp
@@ -69,7 +69,7 @@ PAvg::PAvg(double inner_weight, double conn_weight, DepthCorrection depth_correc
     m_open_connections(use_open_connections)
 {}
 
-static PAvg serializeObject() {
+PAvg PAvg::serializeObject() {
     return PAvg(0.10, 0.30, PAvg::DepthCorrection::NONE, false);
 }
 


### PR DESCRIPTION
The first commit fixes a real glitch.

The second supresses a unused warning - the beauty of using structured bindings for map iteration wanes a bit when this is needed to suppress warnings. Opinions?