### PR TITLE
Serializer vector

### DIFF
--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -62,7 +62,7 @@ public:
     }
 
     template<typename K, typename T>
-    void put(const std::unordered_map<K,T>& values) {
+    void put_map(const std::unordered_map<K,T>& values) {
         this->put(values.size());
         for (const auto& value_pair : values) {
             this->put(value_pair.first);
@@ -71,7 +71,7 @@ public:
     }
 
     template<typename K, typename T>
-    std::unordered_map<K,T> get() {
+    std::unordered_map<K,T> get_map() {
         std::unordered_map<K,T> values;
         auto size = this->get<std::size_t>();
         for (std::size_t index = 0; index < size; index++) {

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -61,6 +61,24 @@ public:
         return value;
     }
 
+    template<typename T>
+    void put_vector(const std::vector<T>& values) {
+        this->put(values.size());
+        this->pack(values.data(), values.size() * sizeof(T));
+    }
+
+
+
+    template<typename T>
+    std::vector<T> get_vector() {
+        std::size_t size = this->get<std::size_t>();
+        std::vector<T> values(size);
+        for (std::size_t index=0; index < size; index++)
+            values[index] = this->get<T>();
+
+        return values;
+    }
+
     template<typename K, typename T>
     void put_map(const std::unordered_map<K,T>& values) {
         this->put(values.size());

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -25,7 +25,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 namespace Opm{
@@ -118,12 +118,12 @@ private:
 
     // The first key is the variable and the second key is the well.
     std::unordered_map<std::string, std::unordered_map<std::string, double>> well_values;
-    std::unordered_set<std::string> m_wells;
+    std::set<std::string> m_wells;
     mutable std::optional<std::vector<std::string>> well_names;
 
     // The first key is the variable and the second key is the group.
     std::unordered_map<std::string, std::unordered_map<std::string, double>> group_values;
-    std::unordered_set<std::string> m_groups;
+    std::set<std::string> m_groups;
     mutable std::optional<std::vector<std::string>> group_names;
 };
 

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -110,6 +110,7 @@ public:
     const_iterator end() const;
     std::size_t num_wells() const;
     std::size_t size() const;
+    bool operator==(const SummaryState& other) const;
 private:
     std::chrono::system_clock::time_point sim_start;
     double elapsed = 0;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -68,12 +68,20 @@ namespace {
         return true;
     }
 
-    bool erase_var(map2& values, const std::string& var1, const std::string var2) {
+    void erase_var(map2& values, std::set<std::string>& var2_set, const std::string& var1, const std::string var2) {
         const auto& var1_iter = values.find(var1);
         if (var1_iter == values.end())
-            return false;
+            return;
 
-        return (var1_iter->second.erase(var2) > 0);
+        var1_iter->second.erase(var2);
+        var2_set.clear();
+        for (const auto& [_, var2_map] : values) {
+            (void)_;
+            for (const auto& [v2, __] : var2_map) {
+                (void)__;
+                var2_set.insert(v2);
+            }
+        }
     }
 
     std::vector<std::string> var2_list(const map2& values, const std::string& var1) {
@@ -189,7 +197,7 @@ namespace {
         if (!this->erase(key))
             return false;
 
-        erase_var(this->well_values, var, well);
+        erase_var(this->well_values, this->m_wells, var, well);
         this->well_names.reset();
         return true;
     }
@@ -199,7 +207,7 @@ namespace {
         if (!this->erase(key))
             return false;
 
-        erase_var(this->group_values, var, group);
+        erase_var(this->group_values, this->m_groups, var, group);
         this->group_names.reset();
         return true;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -376,4 +376,17 @@ namespace {
 
         return stream;
     }
+
+
+    bool SummaryState::operator==(const SummaryState& other) const {
+        return this->sim_start == other.sim_start &&
+               this->elapsed == other.elapsed &&
+               this->values == other.values &&
+               this->well_values == other.well_values &&
+               this->m_wells == other.m_wells &&
+               this->wells() == other.wells();
+               this->group_values == other.group_values &&
+               this->m_groups == other.m_groups &&
+               this->groups() == other.groups();
+    }
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -310,18 +310,18 @@ namespace {
     std::vector<char> SummaryState::serialize() const {
         Serializer ser;
         ser.put(this->elapsed);
-        ser.put(values);
+        ser.put_map(values);
 
         ser.put(this->well_values.size());
         for (const auto& well_var_pair : this->well_values) {
             ser.put(well_var_pair.first);
-            ser.put(well_var_pair.second);
+            ser.put_map(well_var_pair.second);
         }
 
         ser.put(this->group_values.size());
         for (const auto& group_var_pair : this->group_values) {
             ser.put(group_var_pair.first);
-            ser.put(group_var_pair.second);
+            ser.put_map(group_var_pair.second);
         }
 
         return std::move(ser.buffer);
@@ -338,7 +338,7 @@ namespace {
 
         Serializer ser(buffer);
         this->elapsed = ser.get<double>();
-        this->values = ser.get<std::string, double>();
+        this->values = ser.get_map<std::string, double>();
 
         {
             std::size_t num_well_var = ser.get<std::size_t>();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.cpp
@@ -174,8 +174,8 @@ std::vector<char> UDQState::serialize() const {
         ser.put( set_pair.first );
         set_pair.second.serialize( ser );
     }
-    ser.put(this->assignments);
-    ser.put(this->defines);
+    ser.put_map(this->assignments);
+    ser.put_map(this->defines);
     return ser.buffer;
 }
 
@@ -194,8 +194,8 @@ void UDQState::deserialize(const std::vector<char>& buffer) {
             this->values.insert( std::make_pair(key, udq_set) );
         }
     }
-    this->assignments = ser.get<std::string, std::size_t>();
-    this->defines = ser.get<std::string, std::size_t>();
+    this->assignments = ser.get_map<std::string, std::size_t>();
+    this->defines = ser.get_map<std::string, std::size_t>();
 }
 }
 

--- a/tests/test_Serializer.cpp
+++ b/tests/test_Serializer.cpp
@@ -32,11 +32,13 @@ BOOST_AUTO_TEST_CASE(SERIALIZER) {
     double double_value = 3.14;
     std::string string_value = "String";
     std::unordered_map<std::string, int> m = {{"A", 1}, {"B", 2}, {"C", 3}};
+    std::vector<int> v = {1,2,3,4,5,6,7,8,9,10};
 
     ser.put(int_value);
     ser.put(double_value);
     ser.put(string_value);
     ser.put_map(m);
+    ser.put_vector(v);
 
     Opm::Serializer ser2(ser.buffer);
     BOOST_CHECK_EQUAL(ser2.get<int>(), int_value);
@@ -46,6 +48,9 @@ BOOST_AUTO_TEST_CASE(SERIALIZER) {
 
     std::unordered_map<std::string, int> m2 = ser2.get_map<std::string,int>();
     BOOST_CHECK(m2 == m);
+
+    std::vector<int> v2 = ser2.get_vector<int>();
+    BOOST_CHECK(v2 == v);
 }
 
 BOOST_AUTO_TEST_CASE(EMPTY_STRING) {

--- a/tests/test_Serializer.cpp
+++ b/tests/test_Serializer.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(SERIALIZER) {
     ser.put(int_value);
     ser.put(double_value);
     ser.put(string_value);
-    ser.put(m);
+    ser.put_map(m);
 
     Opm::Serializer ser2(ser.buffer);
     BOOST_CHECK_EQUAL(ser2.get<int>(), int_value);
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(SERIALIZER) {
     BOOST_CHECK_EQUAL(ser2.get<std::string>(), string_value);
 
 
-    std::unordered_map<std::string, int> m2 = ser2.get<std::string,int>();
+    std::unordered_map<std::string, int> m2 = ser2.get_map<std::string,int>();
     BOOST_CHECK(m2 == m);
 }
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -3523,59 +3523,18 @@ BOOST_AUTO_TEST_CASE(SummaryState_TOTAL) {
     BOOST_CHECK_EQUAL(st.get_elapsed(), 200);
 }
 
-namespace {
-bool equal(const SummaryState& st1 , const SummaryState& st2) {
-    if (st1.size() != st2.size())
-        return false;
-
-    {
-        const auto& wells2 = st2.wells();
-        if (wells2.size() != st1.wells().size())
-            return false;
-
-        for (const auto& well : st1.wells()) {
-            auto f = std::find(wells2.begin(), wells2.end(), well);
-            if (f == wells2.end())
-                return false;
-        }
-    }
-
-    {
-        const auto& groups2 = st2.groups();
-        if (groups2.size() != st1.groups().size())
-            return false;
-
-        for (const auto& group : st1.groups()) {
-            auto f = std::find(groups2.begin(), groups2.end(), group);
-            if (f == groups2.end())
-                return false;
-        }
-    }
-
-
-    for (const auto& value_pair : st1) {
-        const std::string& key = value_pair.first;
-        double value = value_pair.second;
-        if (value != st2.get(key))
-            return false;
-    }
-
-    return st1.get_elapsed() == st2.get_elapsed();
-}
-
 
 void test_serialize(const SummaryState& st) {
     SummaryState st2(std::chrono::system_clock::now());
     auto serial = st.serialize();
     st2.deserialize(serial);
-    BOOST_CHECK( equal(st, st2));
+    BOOST_CHECK( st == st2 );
 
     st2.update_elapsed(1234567.09);
     st2.update("FOPT", 200);
     st2.deserialize(serial);
-    BOOST_CHECK( equal(st, st2));
+    BOOST_CHECK(st == st2);
 }
-} // Anonymous namespace
 
 BOOST_AUTO_TEST_CASE(serialize_sumary_state) {
     SummaryState st(std::chrono::system_clock::now());

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1954,6 +1954,12 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
     BOOST_CHECK( st.erase_group_var("G1", "GWCT") );
     BOOST_CHECK( !st.has_group_var("G1", "GWCT"));
     BOOST_CHECK( !st.has("GWCT:G1") );
+
+    auto buffer = st.serialize();
+    Opm::SummaryState st2(std::chrono::system_clock::now());
+    st2.deserialize(buffer);
+
+    BOOST_CHECK( st == st2 );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add methods `put_vector() / get_vector()` and rename map overloads to `put_map() / get_map() `

The serializer in opm-common is used to serialize (and then collect on IO Rank) some classes from opm-common. The current use of this serializer is [here](https://github.com/OPM/opm-simulators/blob/ebf0d2d0d7582c94b2622d0773d72d05c9528fee/ebos/eclwriter.hh#L335). A bit more coming up with #2124

I realize this is a bit on the side of my main competence and I know the current implementation is not something to brag about. If someone want to flex their C++ muscles and improve it  - or rewrite to use the existing system I am all smiles.