### PR TITLE
Report Element Counts for Solution Vector Size Mismatch

### DIFF
--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -50,7 +50,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cmath>
 #include <cstddef>
 #include <fstream>
 #include <initializer_list>
@@ -64,6 +63,7 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <fmt/chrono.h>
 
 namespace Opm { namespace RestartIO {
 
@@ -628,28 +628,32 @@ namespace {
         }
     }
 
-    int numChar(const std::size_t num_reports)
-    {
-        return static_cast<int>(
-            1 + std::floor(std::log10(static_cast<double>(num_reports))));
-    }
-
     void logRestartOutput(const int               report_step,
                           const std::size_t       num_reports,
                           const std::vector<int>& inteHD)
     {
+        using namespace fmt::literals;
         using Ix = ::Opm::RestartIO::Helpers::VectorItems::intehead;
 
-        std::ostringstream logmsg;
+        auto timepoint    = std::tm{};
+        timepoint.tm_year = inteHD[Ix::YEAR]  - 1900;
+        timepoint.tm_mon  = inteHD[Ix::MONTH] -    1;
+        timepoint.tm_mday = inteHD[Ix::DAY];
 
-        logmsg << "Restart file written for report step: "
-               << std::setw(numChar(num_reports)) << report_step << '/'
-               << std::setw(0) << num_reports << ".  Date: "
-               << std::setw(4) <<                      inteHD[Ix::YEAR]  << '/'
-               << std::setw(2) << std::setfill('0') << inteHD[Ix::MONTH] << '/'
-               << std::setw(2) << std::setfill('0') << inteHD[Ix::DAY];
+        timepoint.tm_hour = inteHD[Ix::IHOURZ];
+        timepoint.tm_min  = inteHD[Ix::IMINTS];
+        timepoint.tm_sec  = inteHD[Ix::ISECND] / (1000 * 1000);
 
-        ::Opm::OpmLog::info(logmsg.str());
+        const auto msg =
+            fmt::format("Restart file written for report step "
+                        "{report_step:>{width}}/{num_reports}, "
+                        "date = {timepoint:%d-%b-%Y %H:%M:%S}",
+                        "width"_a = fmt::formatted_size("{}", num_reports),
+                        "report_step"_a = report_step,
+                        "num_reports"_a = num_reports,
+                        "timepoint"_a = timepoint);
+
+        ::Opm::OpmLog::info(msg);
     }
 
 } // Anonymous namespace

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -57,10 +57,13 @@
 #include <iomanip>
 #include <iterator>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
+#include <fmt/format.h>
 
 namespace Opm { namespace RestartIO {
 
@@ -190,9 +193,13 @@ namespace {
                             const RestartValue& restart_value,
                             const EclipseGrid&  grid)
     {
-        for (const auto& elm: restart_value.solution)
-            if (elm.second.data.size() != grid.getNumActive())
-                throw std::runtime_error("Wrong size on solution vector: " + elm.first);
+        for (const auto& [name, vector] : restart_value.solution)
+            if (vector.data.size() != grid.getNumActive()) {
+                const auto msg = fmt::format("Incorrectly sized solution vector {}.  "
+                                             "Expected {} elements, but got {}.", name,
+                                             grid.getNumActive(), vector.data.size());
+                throw std::runtime_error(msg);
+            }
 
         if (es.getSimulationConfig().getThresholdPressure().size() > 0) {
             // If the the THPRES option is active the restart_value should have a


### PR DESCRIPTION
This makes it slightly easier to diagnose output errors.

While here, also convert to using libfmt to log output to the restart files.  The library knows how to format `std::tm{}` objects using format strings from `std::strftime()` which means we get month names for free.

Existing report format:
```
Restart file written for report step:  4/39.  Date: 2018/12/15
```

New report format:
```
Restart file written for report step  4/39, date = 15-Dec-2018 00:00:00
```

~Whether or not to include the time of day, `00:00:00` in the example above, is debatable and I'm open to dropping it.  It might be useful for `LAB` units or if the `START` time is not midnight though.~