### PR TITLE
Support PERMR and PERMTHT as aliases for PERMX and PERMY

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -99,6 +99,26 @@ inline bool isFipxxx(const std::string& keyword) {
 }
 
 
+/*
+  The aliased_keywords map defines aliases for other keywords. The FieldProps
+  objects will translate those keywords before further processing. The aliases
+  will also be exposed by the FieldPropsManager object.
+ 
+  However, the following methods of FieldProps do not fully support aliases:
+  - FieldProps::keys() does not return the aliases.
+  - FieldProps::erase() and FieldProps::extract() do not support aliases. Using
+    them with an aliased keyword will also remove the alias.
+
+  Note that the aliases are also added to GRID::double_keywords.
+
+  The PERMR and PERMTHT keywords are aliases for PERMX and PERMY, respectively.
+*/
+namespace ALIAS {
+    static const std::unordered_map<std::string, std::string> aliased_keywords = {{"PERMR", "PERMX"},
+                                                                                  {"PERMTHT", "PERMY"}};
+}
+
+
 namespace GRID {
 static const std::unordered_map<std::string, keyword_info<double>> double_keywords = {{"MULTPV",  keyword_info<double>{}.init(1.0)},
                                                                                       {"NTG",     keyword_info<double>{}.init(1.0)},
@@ -106,6 +126,8 @@ static const std::unordered_map<std::string, keyword_info<double>> double_keywor
                                                                                       {"PERMX",   keyword_info<double>{}.unit_string("Permeability").distribute_top(true)},
                                                                                       {"PERMY",   keyword_info<double>{}.unit_string("Permeability").distribute_top(true)},
                                                                                       {"PERMZ",   keyword_info<double>{}.unit_string("Permeability").distribute_top(true)},
+                                                                                      {"PERMR",   keyword_info<double>{}.unit_string("Permeability").distribute_top(true)},
+                                                                                      {"PERMTHT",   keyword_info<double>{}.unit_string("Permeability").distribute_top(true)},
                                                                                       {"TEMPI",   keyword_info<double>{}.unit_string("Temperature")},
                                                                                       {"THCONR",  keyword_info<double>{}},
                                                                                       {"THCONSF", keyword_info<double>{}},

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2397,6 +2397,9 @@ OPERATE
         BOOST_CHECK_EQUAL(permz[i]  , 2*permy[i]   + to_si(1000));
         BOOST_CHECK_EQUAL(permz[i+3], 3*permx[i+3] + to_si(300));
     }
+
+    BOOST_CHECK(permx == fpm.get_double("PERMR"));
+    BOOST_CHECK(permy == fpm.get_double("PERMTHT"));
 }
 
 BOOST_AUTO_TEST_CASE(REGION_OPERATION_RADIAL_PERM) {
@@ -2445,7 +2448,9 @@ COPYREG
         BOOST_CHECK_CLOSE(to_si(multn[g]), permx[g], 1e-5);
         BOOST_CHECK_EQUAL(permx[g], permy[g]);
     }
-    
+ 
+    BOOST_CHECK(permx == fp.get_double("PERMR"));
+    BOOST_CHECK(permy == fp.get_double("PERMTHT"));
 }
 
 BOOST_AUTO_TEST_CASE(REGION_OPERATION_MIXED_PERM) {
@@ -2494,5 +2499,7 @@ COPYREG
         BOOST_CHECK_CLOSE(to_si(multn[g]), permx[g], 1e-5);
         BOOST_CHECK_EQUAL(permx[g], permy[g]);
     }
-    
+
+    BOOST_CHECK(permx == fp.get_double("PERMR"));
+    BOOST_CHECK(permy == fp.get_double("PERMTHT"));    
 }


### PR DESCRIPTION
To support PERMR and PERMTHT they are internally translated to PERMX and PERMY, since they should behave as aliases.

As a result PERMR and PERMX can be used interchangeably, and the same is true for PERMTHT and PERMY.

There are a few limitations:
- the `keys()` methods from `FieldProps` and `FieldPropsManager` will not return the aliases.
- The `erase()` and `extract()` methods from `FieldProps` will not function with the aliases. Deleteing the aliased keywords will also remove the aliased keyword. However, these methods seem not to be exposed in `FieldPropsManager()`