### PR TITLE
Make sure original_inplace can be safely accessed

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -759,13 +759,17 @@ inline quantity bhp( const fn_args& args ) {
 */
 
 quantity roew(const fn_args& args) {
-    double oil_prod = 0;
+    const quantity zero = { 0, measure::identity };
     const auto& region_name = std::get<std::string>(*args.extra_data);
+    if (!args.initial_inplace.has( region_name, Opm::Inplace::Phase::OIL, args.num))
+        return zero;
+
+    double oil_prod = 0;
     const auto& wells = args.regionCache.wells( region_name, args.num );
     for (const auto& well : wells)
         oil_prod += args.st.get_well_var(well, "WOPT");
 
-    //oil_prod = args.unit_system.to_si(Opm::UnitSystem::measure::volume, oil_prod);
+    oil_prod = args.unit_system.to_si(Opm::UnitSystem::measure::volume, oil_prod);
     return { oil_prod / args.initial_inplace.get( region_name, Opm::Inplace::Phase::OIL, args.num ) , measure::identity };
 }
 

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1115,9 +1115,30 @@ inline void handleKW( SummaryConfig::keyword_list& list,
 
 
   inline void uniq( SummaryConfig::keyword_list& vec ) {
-    std::sort( vec.begin(), vec.end() );
-    auto logical_end = std::unique( vec.begin(), vec.end() );
-    vec.erase( logical_end, vec.end() );
+      std::sort( vec.begin(), vec.end());
+      auto logical_end = std::unique( vec.begin(), vec.end() );
+      vec.erase( logical_end, vec.end() );
+      if (vec.empty())
+          return;
+
+      /*
+        This is a desperate hack to ensure that the ROEW keywords come after
+        WOPT keywords, to ensure that the WOPT keywords have been fully
+        evaluated in the SummaryState when we evaluate the ROEW keywords.
+      */
+      std::size_t tail_index = vec.size() - 1;
+      std::size_t item_index = 0;
+      while (true) {
+          if (item_index >= tail_index)
+              break;
+
+          auto& node = vec[item_index];
+          if (node.keyword().rfind("ROEW", 0) == 0) {
+              std::swap( node, vec[tail_index] );
+              tail_index--;
+          }
+          item_index++;
+      }
   }
 }
 


### PR DESCRIPTION
Two fixes for evaluation of summary variable "ROEW":

1. Make sure the "original_inplace" variable can be safely accessed.
2. Make sure the ROEW variable is evaluated *after* "WOPT"