### PR TITLE
Some fixes to pypi packaging

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,7 +2,7 @@
 # Example use:
 # sudo docker build -t manylinux2014_opm:built . -f python/Dockerfile
 
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64 AS stage1
 ARG version_tag=""
 WORKDIR /tmp/opm-common
 RUN echo "Using package version tag: $version_tag"
@@ -10,3 +10,5 @@ ADD . .
 RUN /bin/bash /tmp/opm-common/python/generate-pypi-package.sh $version_tag
 # docker run -e PLAT=manylinux2014_x86_64 -it lindkvis/manylinux2014_opm:latest
 
+FROM scratch AS export_stage
+COPY --from=stage1 /tmp/opm-common/build/wheelhouse .

--- a/python/Dockerfile.create
+++ b/python/Dockerfile.create
@@ -1,8 +1,0 @@
-# Docker file to generate a Docker image capable of building PyPI packages
-# Example use:
-# Use sudo docker build -t lindkvis/manylinux2014_opm:latest -f Dockerfile.create .
-
-FROM quay.io/pypa/manylinux2014_x86_64
-WORKDIR /tmp
-COPY setup-docker-image.sh .
-RUN /bin/bash /tmp/setup-docker-image.sh

--- a/python/generate-pypi-package.sh
+++ b/python/generate-pypi-package.sh
@@ -23,7 +23,7 @@ fi
 mkdir build && cd build
 
 cmake3 -DPYTHON_EXECUTABLE=${PYTHON35} -DBOOST_INCLUDEDIR=/usr/include/boost169 -DBOOST_LIBRARYDIR=/usr/lib64/boost169 \
--DOPM_ENABLE_PYTHON=ON -DOPM_PYTHON_PACKAGE_VERSION_TAG=${VERSION_TAG} ..
+-DOPM_ENABLE_PYTHON=ON -DOPM_PYTHON_PACKAGE_VERSION_TAG=${VERSION_TAG} -DBUILD_TESTING=0 ..
 
 # make step is necessary until the generated ParserKeywords/*.hpp are generated in the Python step
 make -j4

--- a/python/generate-pypi-package.sh
+++ b/python/generate-pypi-package.sh
@@ -5,11 +5,11 @@
 
 VERSION_TAG=${1:-""}
 
-#export PYTHON27=/usr/bin/python2.7
 export PYTHON35=/opt/python/cp35-cp35m/bin/python
 export PYTHON36=/opt/python/cp36-cp36m/bin/python
 export PYTHON37=/opt/python/cp37-cp37m/bin/python
 export PYTHON38=/opt/python/cp38-cp38/bin/python
+export PYTHON39=/opt/python/cp39-cp39/bin/python
 
 /bin/bash /tmp/opm-common/python/setup-docker-image.sh
 
@@ -26,7 +26,7 @@ cmake3 -DPYTHON_EXECUTABLE=${PYTHON35} -DBOOST_INCLUDEDIR=/usr/include/boost169 
 -DOPM_ENABLE_PYTHON=ON -DOPM_PYTHON_PACKAGE_VERSION_TAG=${VERSION_TAG} ..
 
 # make step is necessary until the generated ParserKeywords/*.hpp are generated in the Python step
-make -j2
+make -j4
 
 ./setup-package.sh
 ${PYTHON35} -m auditwheel repair python/dist/*cp35*.whl
@@ -47,11 +47,10 @@ cmake3 -DPYTHON_EXECUTABLE=${PYTHON38} -DBOOST_INCLUDEDIR=/usr/include/boost169 
 ./setup-package.sh
 ${PYTHON38} -m auditwheel repair python/dist/*cp38*.whl
 
-#cmake3 -DPYTHON_EXECUTABLE=${PYTHON27} -DBOOST_INCLUDEDIR=/usr/include/boost169 -DBOOST_LIBRARYDIR=/usr/lib64/boost169 \
-#-DOPM_ENABLE_PYTHON=ON -DOPM_ENABLE_DYNAMIC_BOOST=OFF -DOPM_ENABLE_DYNAMIC_PYTHON_LINKING=OFF ..
-#./setup-package.sh
-#${PYTHON27} -m auditwheel repair python/dist/*cp27*.whl
-
+cmake3 -DPYTHON_EXECUTABLE=${PYTHON39} -DBOOST_INCLUDEDIR=/usr/include/boost169 -DBOOST_LIBRARYDIR=/usr/lib64/boost169 \
+-DOPM_ENABLE_PYTHON=ON -DOPM_PYTHON_PACKAGE_VERSION_TAG=${VERSION_TAG} ..
+./setup-package.sh
+${PYTHON39} -m auditwheel repair python/dist/*cp39*.whl
 
 # Example of upload
 # /usr/bin/python3 -m twine upload --repository testpypi wheelhouse/*

--- a/python/setup-docker-image.sh
+++ b/python/setup-docker-image.sh
@@ -21,4 +21,5 @@ ${PYTHON37} -m pip install pip --upgrade
 ${PYTHON37} -m pip install wheel setuptools twine pytest-runner auditwheel
 ${PYTHON38} -m pip install pip --upgrade
 ${PYTHON38} -m pip install wheel setuptools twine pytest-runner auditwheel
-
+${PYTHON39} -m pip install pip --upgrade
+${PYTHON39} -m pip install wheel setuptools twine pytest-runner auditwheel


### PR DESCRIPTION
- add python 39
- add exports from docker container to host
- disable building tests for opm-common.

probably quite some overlap with https://github.com/OPM/opm-common/pull/2129  i did this in parallel without noticing the other PR. have successfully deployed nightly builds from jenkins with these changes.