### PR TITLE
Summary keyword ROEW is based on COPT and not WOPT

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -753,7 +753,7 @@ inline quantity bhp( const fn_args& args ) {
 
 /*
   This function is slightly ugly - the evaluation of ROEW uses the already
-  calculated WOPT results. We do not really have any formalism for such
+  calculated COPT results. We do not really have any formalism for such
   dependencies between the summary vectors. For this particualar case there is a
   hack in SummaryConfig which should ensure that this is safe.
 */
@@ -765,10 +765,10 @@ quantity roew(const fn_args& args) {
         return zero;
 
     double oil_prod = 0;
-    const auto& wells = args.regionCache.wells( region_name, args.num );
-    for (const auto& well : wells)
-        oil_prod += args.st.get_well_var(well, "WOPT");
-
+    for (const auto& [well, global_index] : args.regionCache.connections(region_name, args.num)) {
+        const auto copt_key = fmt::format("COPT:{}:{}" , well, global_index + 1);
+        oil_prod += args.st.get(copt_key);
+    }
     oil_prod = args.unit_system.to_si(Opm::UnitSystem::measure::volume, oil_prod);
     return { oil_prod / args.initial_inplace.get( region_name, Opm::Inplace::Phase::OIL, args.num ) , measure::identity };
 }

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -762,8 +762,19 @@ inline void keywordR( SummaryConfig::keyword_list& list,
     }
 
     // See comment on function roew() in Summary.cpp for this weirdness.
-    if (keyword.rfind("ROEW", 0) == 0)
-        keywordW(list, "WOPT", {}, schedule);
+    if (keyword.rfind("ROEW", 0) == 0) {
+        auto copt_node = SummaryConfigNode("COPT", SummaryConfigNode::Category::Connection, {});
+        for (const auto& wname : schedule.wellNames()) {
+            copt_node.namedEntity(wname);
+
+            const auto& well = schedule.getWellatEnd(wname);
+            for( const auto& connection : well.getConnections() ) {
+                copt_node.number( connection.global_index() + 1 );
+                list.push_back( copt_node );
+            }
+        }
+
+    }
 
 
     auto param = SummaryConfigNode {

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -1190,7 +1190,9 @@ RHPV_REG
 
 )";
     const auto& summary_config = createSummary(deck_string);
-    BOOST_CHECK_EQUAL(summary_config.size(), 15 + 4);
+    // The +5 corresponds to five additional COPT summary config keywords which
+    // have been automatically added for the ROEW calculation.
+    BOOST_CHECK_EQUAL(summary_config.size(), 15 + 5);
     BOOST_CHECK(summary_config.hasKeyword("RPR__REG"));
     BOOST_CHECK(summary_config.hasKeyword("ROPT_REG"));
     BOOST_CHECK(summary_config.hasKeyword("RRPV_REG"));
@@ -1215,7 +1217,7 @@ RHPV_REG
     BOOST_CHECK_EQUAL(rpr.size(), 3U);
 
     // See comment on the roew() function in Summary.cpp for this uglyness.
-    BOOST_CHECK(summary_config.hasKeyword("WOPT"));
+    BOOST_CHECK(summary_config.hasKeyword("COPT"));
 }
 
 BOOST_AUTO_TEST_CASE( WOPRL ) {


### PR DESCRIPTION
The summary keyword ROEW equals "Production from wells / initially_in_place". Initial implementation was based on "WOPT" - but it was not obvious how to assign wells to regions. In this PR the connections are used instead.