### PR TITLE
Fix gaslift output

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -484,8 +484,11 @@ inline quantity glir( const fn_args& args ) {
 
     for (const auto& well : args.schedule_wells) {
         auto xwPos = args.wells.find(well.name());
+
+        double eff_fac = efac( args.eff_factors, well.name() );
+
         if (xwPos != args.wells.end())
-            alq_rate += xwPos->second.rates.get(rt::alq, 0.0);
+            alq_rate += eff_fac*xwPos->second.rates.get(rt::alq, well.alq_value());
     }
 
     return { alq_rate, measure::gas_surface_rate };

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -484,13 +484,15 @@ inline quantity glir( const fn_args& args ) {
 
     for (const auto& well : args.schedule_wells) {
         auto xwPos = args.wells.find(well.name());
+        if (xwPos == args.wells.end())
+            continue;
+
+        if (well.isInjector())
+            continue;
 
         double eff_fac = efac( args.eff_factors, well.name() );
-
-        if (xwPos != args.wells.end())
-            alq_rate += eff_fac*xwPos->second.rates.get(rt::alq, well.alq_value());
+        alq_rate += eff_fac*xwPos->second.rates.get(rt::alq, well.alq_value());
     }
-
     return { alq_rate, measure::gas_surface_rate };
 }
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -483,11 +483,11 @@ inline quantity glir( const fn_args& args ) {
     double alq_rate = 0;
 
     for (const auto& well : args.schedule_wells) {
-        auto xwPos = args.wells.find(well.name());
-        if (xwPos == args.wells.end())
+        if (well.isInjector())
             continue;
 
-        if (well.isInjector())
+        auto xwPos = args.wells.find(well.name());
+        if (xwPos == args.wells.end())
             continue;
 
         double eff_fac = efac( args.eff_factors, well.name() );

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -872,13 +872,16 @@ namespace {
             for (const auto& well_name : well_names) {
                 this->updateWellStatus( well_name , handlerContext.currentStep , status, false, handlerContext.keyword.location() );
 
-                const auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
                 std::optional<VFPProdTable::ALQ_TYPE> alq_type;
                 auto& dynamic_state = this->wells_static.at(well_name);
                 auto well2 = std::make_shared<Well>(*dynamic_state[handlerContext.currentStep]);
                 const bool switching_from_injector = !well2->isProducer();
                 auto properties = std::make_shared<Well::WellProductionProperties>(well2->getProductionProperties());
                 bool update_well = false;
+
+                auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
+                if(record.getItem("VFP_TABLE").defaultApplied(0))
+                    table_nr = properties->VFPTableNumber;
 
                 if (table_nr != 0)
                     alq_type = this->getVFPProdTable(table_nr, handlerContext.currentStep).getALQType();
@@ -937,7 +940,6 @@ namespace {
 
             for (const auto& well_name : well_names) {
                 this->updateWellStatus(well_name, handlerContext.currentStep, status, false, handlerContext.keyword.location());
-                const auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
                 std::optional<VFPProdTable::ALQ_TYPE> alq_type;
                 auto& dynamic_state = this->wells_static.at(well_name);
                 auto well2 = std::make_shared<Well>(*dynamic_state[handlerContext.currentStep]);
@@ -947,6 +949,10 @@ namespace {
                 properties->clearControls();
                 if (well2->isAvailableForGroupControl())
                     properties->addProductionControl(Well::ProducerCMode::GRUP);
+
+                auto table_nr = record.getItem("VFP_TABLE").get< int >(0);
+                if(record.getItem("VFP_TABLE").defaultApplied(0))
+                    table_nr = properties->VFPTableNumber;
 
                 if (table_nr != 0)
                     alq_type = this->getVFPProdTable(table_nr, handlerContext.currentStep).getALQType();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -92,7 +92,8 @@ namespace Opm {
 
     void Well::WellProductionProperties::init_vfp(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type, const UnitSystem& unit_system_arg, const DeckRecord& record) {
         if (alq_type) {
-            this->VFPTableNumber = record.getItem("VFP_TABLE").get<int>(0);
+            if (!record.getItem("VFP_TABLE").defaultApplied(0))
+                this->VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
             double alq_input = record.getItem("ALQ").get<double>(0);
             const auto alq_dim = VFPProdTable::ALQDimension(*alq_type, unit_system_arg);
             this->ALQValue = alq_dim.convertRawToSi(alq_input);
@@ -279,6 +280,7 @@ void Well::WellProductionProperties::handleWCONHIST(const std::optional<VFPProdT
             && BHPH                 == other.BHPH
             && THPH                 == other.THPH
             && VFPTableNumber       == other.VFPTableNumber
+            && ALQValue             == other.ALQValue
             && controlMode          == other.controlMode
             && m_productionControls == other.m_productionControls
             && whistctl_cmode       == other.whistctl_cmode


### PR DESCRIPTION
Use value from WCONPROD as default. The simulator does not set the alqvalue if gas optimization is not used
Multiply with efficiency factor when accumulation group rates