### PR TITLE
Summary Test Deck: Open Wells 1, 2, 3, and 6 at First Step

### DIFF
--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -871,21 +871,22 @@ WCONHIST
 -- history rates are set so that W_1 produces 1, W_2 produces 2 etc.
 -- index.offset.
 -- organised as oil-water-gas
-    W_1 SHUT ORAT 10.1 10 10.2 2* 0.2 0.1 /
-    W_2 SHUT ORAT 20.1 20 20.2 2* 1.2 1.1 /
+    W_1 OPEN ORAT 10.1 10 10.2 2* 0.2 0.1 /
+    W_2 OPEN ORAT 20.1 20 20.2 2* 1.2 1.1 /
 /
 
 WCONINJH
 -- Injection historical rates (water only, as we only support pure injectors)
-    W_3 WATER STOP 30.0 2.1 2.2 /
+    W_3 WATER OPEN 30.0 2.1 2.2 /
 /
 
 WPOLYMER
 'W_3' 1.5 1.0 /
 /
+
 WCONINJH
 -- Injection historical rates (water only, as we only support pure injectors)
-    W_6 GAS STOP 30000.0  /
+    W_6 GAS OPEN 30000.0  /
 /
 
 WCONPROD


### PR DESCRIPTION
This restores `test_Summary` for WPI vectors.

This PR supersedes and closes #2152.