### PR TITLE
Manage well status with a shared pointer: To enable/improve runtime updates

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
@@ -173,6 +173,19 @@ class DynamicState {
         return std::distance(this->m_data.begin(), update_end);
     }
 
+
+    void update_range(std::size_t start_index, std::size_t end_index, const T& value) {
+        if (end_index < start_index)
+            throw std::invalid_argument("Must have growing index");
+
+        if (end_index > this->m_data.size())
+            throw std::invalid_argument("Invalid range");
+
+        std::fill(this->m_data.begin() + start_index, this->m_data.begin() + end_index, value);
+    }
+
+
+
     /// Will return the index of the first occurence of @value
     std::optional<std::size_t> find(const T& value) const {
         auto iter = std::find( m_data.begin() , m_data.end() , value);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -404,7 +404,7 @@ namespace Opm
         void updateGroup(std::shared_ptr<Group> group, std::size_t reportStep);
         bool checkGroups(const ParseContext& parseContext, ErrorGuard& errors);
         void updateUDQActive( std::size_t timeStep, std::shared_ptr<UDQActive> udq );
-        bool updateWellStatus( const std::string& well, std::size_t reportStep , Well::Status status, bool update_connections, std::optional<KeywordLocation> = {});
+        bool updateWellStatus( const std::string& well, std::size_t reportStep, bool runtime, Well::Status status, bool update_connections, std::optional<KeywordLocation> = {});
         void addWellToGroup( const std::string& group_name, const std::string& well_name , std::size_t timeStep);
         void iterateScheduleSection(std::shared_ptr<const Python> python, const std::string& input_path, const ParseContext& parseContext ,  ErrorGuard& errors, const SCHEDULESection& , const EclipseGrid& grid,
                                     const FieldPropsManager& fp);
@@ -460,7 +460,7 @@ namespace Opm
 
         void applyEXIT(const DeckKeyword&, std::size_t currentStep);
         void applyMESSAGES(const DeckKeyword&, std::size_t currentStep);
-        void applyWELOPEN(const DeckKeyword&, std::size_t currentStep, const ParseContext&, ErrorGuard&, const std::vector<std::string>& matching_wells = {});
+        void applyWELOPEN(const DeckKeyword&, std::size_t currentStep, bool runtime, const ParseContext&, ErrorGuard&, const std::vector<std::string>& matching_wells = {});
         void applyWRFT(const DeckKeyword&, std::size_t currentStep);
         void applyWRFTPLT(const DeckKeyword&, std::size_t currentStep);
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -404,7 +404,7 @@ namespace Opm
         void updateGroup(std::shared_ptr<Group> group, std::size_t reportStep);
         bool checkGroups(const ParseContext& parseContext, ErrorGuard& errors);
         void updateUDQActive( std::size_t timeStep, std::shared_ptr<UDQActive> udq );
-        bool updateWellStatus( const std::string& well, std::size_t reportStep, bool runtime, Well::Status status, bool update_connections, std::optional<KeywordLocation> = {});
+        bool updateWellStatus( const std::string& well, std::size_t reportStep, bool runtime, Well::Status status, std::optional<KeywordLocation> = {});
         void addWellToGroup( const std::string& group_name, const std::string& well_name , std::size_t timeStep);
         void iterateScheduleSection(std::shared_ptr<const Python> python, const std::string& input_path, const ParseContext& parseContext ,  ErrorGuard& errors, const SCHEDULESection& , const EclipseGrid& grid,
                                     const FieldPropsManager& fp);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -79,6 +79,31 @@ public:
     static Status StatusFromString(const std::string& stringValue);
 
 
+    struct WellStatus {
+        Status status;
+
+        WellStatus() = default;
+
+        WellStatus(Status st) :
+            status(st)
+        {}
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(status);
+        }
+
+        bool operator==(const WellStatus& other) const {
+            return this->status == other.status;
+        }
+
+        static WellStatus serializeObject() {
+            WellStatus ws(Well::Status::AUTO);
+            return ws;
+        }
+    };
+
 
 
     /*
@@ -545,7 +570,7 @@ public:
     void updateSegments(std::shared_ptr<WellSegments> segments_arg);
     bool updateConnections(std::shared_ptr<WellConnections> connections, bool force = false);
     bool updateConnections(std::shared_ptr<WellConnections> connections, const EclipseGrid& grid, const std::vector<int>& pvtnum);
-    bool updateStatus(Status status, bool update_connections);
+    bool updateStatus(Status status, bool runtime, bool update_connections);
     bool updateGroup(const std::string& group);
     bool updateWellGuideRate(bool available, double guide_rate, GuideRateTarget guide_phase, double scale_factor);
     bool updateWellGuideRate(double guide_rate);
@@ -650,7 +675,6 @@ private:
     GasInflowEquation gas_inflow = GasInflowEquation::STD;  // Will NOT be loaded/assigned from restart file
     UnitSystem unit_system;
     double udq_undefined;
-    Status status;
     WellType wtype;
     WellGuideRate guide_rate;
     double efficiency_factor;
@@ -669,6 +693,7 @@ private:
     std::shared_ptr<WellProductionProperties> production;
     std::shared_ptr<WellInjectionProperties> injection;
     std::shared_ptr<WellSegments> segments;
+    std::shared_ptr<WellStatus> status;
     PAvg m_pavg;
 };
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -154,7 +154,7 @@ namespace {
                 auto well2 = std::shared_ptr<Well>(new Well( this->getWell(name, handlerContext.currentStep)));
                 auto connections = std::shared_ptr<WellConnections>( new WellConnections( well2->getConnections()));
                 connections->loadCOMPDAT(record, handlerContext.grid, handlerContext.fieldPropsManager, name, handlerContext.keyword.location());
-                if (well2->updateConnections(connections, handlerContext.grid, handlerContext.fieldPropsManager.get_int("PVTNUM"))) {
+                if (well2->updateConnections(connections, handlerContext.currentStep, handlerContext.grid, handlerContext.fieldPropsManager.get_int("PVTNUM"))) {
                     this->updateWell(std::move(well2), handlerContext.currentStep);
                     wells.insert( name );
                 }
@@ -190,7 +190,7 @@ namespace {
             for (const auto& wname : well_names) {
                 auto& dynamic_state = this->wells_static.at(wname);
                 auto well_ptr = std::make_shared<Well>( *dynamic_state[handlerContext.currentStep] );
-                if (well_ptr->handleCOMPLUMP(record))
+                if (well_ptr->handleCOMPLUMP(record, handlerContext.currentStep))
                     this->updateWell(std::move(well_ptr), handlerContext.currentStep);
             }
         }
@@ -228,7 +228,7 @@ namespace {
             return;
         }
 
-        if (well_ptr->handleCOMPSEGS(handlerContext.keyword, handlerContext.grid, parseContext, errors))
+        if (well_ptr->handleCOMPSEGS(handlerContext.keyword, handlerContext.currentStep, handlerContext.grid, parseContext, errors))
             this->updateWell(std::move(well_ptr), handlerContext.currentStep);
     }
 
@@ -466,6 +466,7 @@ namespace {
                 }
             }
         }
+        printf("GCONPROD complete\n");
     }
 
     void Schedule::handleGCONSALE(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
@@ -870,7 +871,7 @@ namespace {
             const Well::Status status = Well::StatusFromString(record.getItem("STATUS").getTrimmedString(0));
 
             for (const auto& well_name : well_names) {
-                this->updateWellStatus( well_name , handlerContext.currentStep , false, status, false, handlerContext.keyword.location() );
+                this->updateWellStatus( well_name , handlerContext.currentStep , false, status, handlerContext.keyword.location() );
 
                 std::optional<VFPProdTable::ALQ_TYPE> alq_type;
                 auto& dynamic_state = this->wells_static.at(well_name);
@@ -922,7 +923,7 @@ namespace {
                             "Well " + well2->name() + " is a history matched well with zero rate where crossflow is banned. " +
                             "This well will be closed at " + std::to_string(m_timeMap.getTimePassedUntil(handlerContext.currentStep) / (60*60*24)) + " days";
                         OpmLog::note(msg);
-                        this->updateWellStatus( well_name, handlerContext.currentStep, false, Well::Status::SHUT, false );
+                        this->updateWellStatus( well_name, handlerContext.currentStep, false, Well::Status::SHUT);
                     }
                 }
             }
@@ -939,7 +940,7 @@ namespace {
             const Well::Status status = Well::StatusFromString(record.getItem("STATUS").getTrimmedString(0));
 
             for (const auto& well_name : well_names) {
-                bool update_well = this->updateWellStatus(well_name, handlerContext.currentStep, false, status, false, handlerContext.keyword.location());
+                bool update_well = this->updateWellStatus(well_name, handlerContext.currentStep, false, status, handlerContext.keyword.location());
                 std::optional<VFPProdTable::ALQ_TYPE> alq_type;
                 auto& dynamic_state = this->wells_static.at(well_name);
                 auto well2 = std::make_shared<Well>(*dynamic_state[handlerContext.currentStep]);
@@ -994,7 +995,7 @@ namespace {
             const Well::Status status = Well::StatusFromString(record.getItem("STATUS").getTrimmedString(0));
 
             for (const auto& well_name : well_names) {
-                this->updateWellStatus(well_name, handlerContext.currentStep, false, status, false, handlerContext.keyword.location());
+                this->updateWellStatus(well_name, handlerContext.currentStep, false, status, handlerContext.keyword.location());
 
                 bool update_well = false;
                 auto& dynamic_state = this->wells_static.at(well_name);
@@ -1027,14 +1028,14 @@ namespace {
                     if (injection->surfaceInjectionRate.is<double>()) {
                         if (injection->hasInjectionControl(Well::InjectorCMode::RATE) && injection->surfaceInjectionRate.zero()) {
                             OpmLog::note(msg);
-                            this->updateWellStatus( well_name, handlerContext.currentStep, false, Well::Status::SHUT, false );
+                            this->updateWellStatus( well_name, handlerContext.currentStep, false, Well::Status::SHUT);
                         }
                     }
 
                     if (injection->reservoirInjectionRate.is<double>()) {
                         if (injection->hasInjectionControl(Well::InjectorCMode::RESV) && injection->reservoirInjectionRate.zero()) {
                             OpmLog::note(msg);
-                            this->updateWellStatus( well_name, handlerContext.currentStep, false, Well::Status::SHUT, false );
+                            this->updateWellStatus( well_name, handlerContext.currentStep, false, Well::Status::SHUT);
                         }
                     }
                 }
@@ -1056,7 +1057,7 @@ namespace {
             const Well::Status status = Well::StatusFromString( record.getItem("STATUS").getTrimmedString(0));
 
             for (const auto& well_name : well_names) {
-                this->updateWellStatus(well_name, handlerContext.currentStep, false, status, false, handlerContext.keyword.location());
+                this->updateWellStatus(well_name, handlerContext.currentStep, false, status, handlerContext.keyword.location());
 
                 bool update_well = false;
                 auto& dynamic_state = this->wells_static.at(well_name);
@@ -1084,7 +1085,7 @@ namespace {
                         "Well " + well_name + " is an injector with zero rate where crossflow is banned. " +
                         "This well will be closed at " + std::to_string ( m_timeMap.getTimePassedUntil(handlerContext.currentStep) / (60*60*24) ) + " days";
                     OpmLog::note(msg);
-                    this->updateWellStatus( well_name, handlerContext.currentStep, false, Well::Status::SHUT, false );
+                    this->updateWellStatus( well_name, handlerContext.currentStep, false, Well::Status::SHUT);
                 }
             }
         }
@@ -1169,7 +1170,7 @@ namespace {
                 // Well::updateWellProductivityIndex() implicitly mutates
                 // internal state in the WellConnections class.
                 auto connections = std::make_shared<WellConnections>(well2->getConnections());
-                well2->updateConnections(std::move(connections), true);
+                well2->updateConnections(std::move(connections), report_step, false, true);
                 if (well2->updateWellProductivityIndex(rawProdIndex))
                     this->updateWell(std::move(well2), report_step);
 
@@ -1556,7 +1557,7 @@ namespace {
             for (const auto& wname : well_names) {
                 auto& dynamic_state = this->wells_static.at(wname);
                 auto well_ptr = std::make_shared<Well>( *dynamic_state[handlerContext.currentStep] );
-                if (well_ptr->handleWPIMULT(record))
+                if (well_ptr->handleWPIMULT(record, handlerContext.currentStep))
                     this->updateWell(std::move(well_ptr), handlerContext.currentStep);
             }
         }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -140,7 +140,6 @@ Well::Well(const RestartIO::RstWell& rst_well,
     pvt_table(rst_well.pvt_table),
     unit_system(unit_system_arg),
     udq_undefined(udq_undefined_arg),
-    status(status_from_int(rst_well.well_status)),
     wtype(rst_well.wtype),
     guide_rate(def_guide_rate),
     efficiency_factor(rst_well.efficiency_factor),
@@ -153,7 +152,8 @@ Well::Well(const RestartIO::RstWell& rst_well,
     tracer_properties(std::make_shared<WellTracerProperties>()),
     connections(std::make_shared<WellConnections>(order_from_int(rst_well.completion_ordering), headI, headJ)),
     production(std::make_shared<WellProductionProperties>(unit_system_arg, wname)),
-    injection(std::make_shared<WellInjectionProperties>(unit_system_arg, wname))
+    injection(std::make_shared<WellInjectionProperties>(unit_system_arg, wname)),
+    status(std::make_shared<WellStatus>(status_from_int(rst_well.well_status)))
 {
     using CModeVal = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
 
@@ -335,7 +335,6 @@ Well::Well(const std::string& wname_arg,
     gas_inflow(inflow_eq),
     unit_system(unit_system_arg),
     udq_undefined(udq_undefined_arg),
-    status(Status::SHUT),
     wtype(wtype_arg),
     guide_rate({true, -1, Well::GuideRateTarget::UNDEFINED,ParserKeywords::WGRUPCON::SCALING_FACTOR::defaultValue}),
     efficiency_factor(1.0),
@@ -347,7 +346,8 @@ Well::Well(const std::string& wname_arg,
     tracer_properties(std::make_shared<WellTracerProperties>()),
     connections(std::make_shared<WellConnections>(ordering_arg, headI, headJ)),
     production(std::make_shared<WellProductionProperties>(unit_system, wname)),
-    injection(std::make_shared<WellInjectionProperties>(unit_system, wname))
+    injection(std::make_shared<WellInjectionProperties>(unit_system, wname)),
+    status(std::make_shared<WellStatus>(Status::SHUT))
 {
     auto p = std::make_shared<WellProductionProperties>(this->unit_system, this->wname);
     p->whistctl_cmode = whistctl_cmode;
@@ -366,7 +366,7 @@ Well Well::serializeObject()
     result.ref_depth = 5;
     result.unit_system = UnitSystem::serializeObject();
     result.udq_undefined = 6.0;
-    result.status = Status::SHUT;
+    result.status = std::make_shared<WellStatus>(Status::SHUT);
     result.drainage_radius = 7.0;
     result.allow_cross_flow = true;
     result.automatic_shutin = false;
@@ -515,7 +515,7 @@ bool Well::updateWellProductivityIndex(const double prodIndex) {
 }
 
 bool Well::updateHasProduced() {
-    if (this->wtype.producer() && this->status == Status::OPEN) {
+    if (this->wtype.producer() && this->getStatus() == Status::OPEN) {
         if (this->has_produced)
             return false;
 
@@ -526,7 +526,7 @@ bool Well::updateHasProduced() {
 }
 
 bool Well::updateHasInjected() {
-    if (this->wtype.injector() && this->status == Status::OPEN) {
+    if (this->wtype.injector() && this->getStatus() == Status::OPEN) {
         if (this->has_injected)
             return false;
 
@@ -610,10 +610,108 @@ bool Well::updateHead(int I, int J) {
 }
 
 
-bool Well::updateStatus(Status well_state, bool update_connections) {
-    bool update = false;
+/*
+  The fileformat used by OPM/flow seems to work as an imperative programming
+  language. The simulator can be percieved as a mutable imperative programming
+  environment. The simulator program has an implicit DOM and the various
+  keywords manipulate the elements in this DOM.
+
+  In opm flow the approach to the input file is not that of an imperative
+  programming language, rather the entire input file is parsed and internalized
+  into the mainly EclipseState and Schedule instances. For the most part this
+  has worked out nicely, but some of the more advanced features of the simulator
+  (notably ACTIONX) requires an interaction between the simulator and the
+  Schedule datastructure which becomes awkward in the current implementation.
+  E.g the complexity to shut/open a well is quite immense. To understand how
+  this complexity arises it is important to understand:
+
+     1. How the DynamicState<T> class works.
+
+     2. How a new Well instance is created for each keyword which manipulates
+        the well state.
+
+     3. How the well class uses pointer semantics to manage objects which should
+        remane unchanged across several well keywords.
+
+
+   START
+       1  'JAN' 2000 /
+
+   SCHEDULE
+
+   WELSPECS
+      W1 .... /
+   /
+
+   WCONPROD
+      W1  'OPEN'  /
+   /
+
+   DATES
+      1 'FEB' 2000 /
+   /
+
+   WELPI
+      W1 1000 /
+   /
+
+   DATES
+      1 'MAR' 2000 /
+   /
+
+   WCONPROD
+      W1 'OPEN'  /
+   /
+
+   DATES
+   1 'APR' 2000 /
+   /
+
+   WELPI
+      W1 1000 /
+   /
+
+   0--------------------1--------------------2--------------------3-------------------->
+
+   [ W0 ---------------->
+     |
+     |                  [ W1 ---------------->
+     |                    |
+     |                    |                  [ W2 ---------------->
+     |                    |                    |
+     |                    |                    |                  [ W3 ---------------->
+     |                    |                    |                    |
+     |                    |                    |                    |
+    \|/                   |                   \|/                   |
+                          |                                         |
+   [ WellStatus 0 ] <-----/                  [ WellStatus 1] <------/
+
+
+This illustration shows "many things":
+
+  1. For each of the kewyords which manipulates wells a new well object are
+     created. These are illustrated as W0, W1, W2 and W3. As illustrated the
+     well objects have a validity in the time direction.
+
+  2. Each of the keywords which changes/sets the state of a well will create a
+     new WellStatus object; these are illustrated as WellStatus 0 and WellStatus
+     1. As we can see the WellStatus in general have different temporal ranges
+     of validity than the well objects.
+
+  3. The main point of this complexity is to support runtime altering of the
+     wells status - with ACTIONX or other means. If the runtime argument is true
+     when calling Well::updateStatus() we update the wells status directly, and
+     not go through creating a new WellStatus object. As a consequence the
+     updated status will apply to all well/time points which share WellStatus
+     object - this can even go backwards in time!
+*/
+
+bool Well::updateStatus(Status well_state, bool runtime, bool update_connections) {
     if (update_connections) {
         Connection::State connection_state;
+        if (runtime)
+            throw std::logic_error("runtime and update_connections can not be combined");
+
 
         switch (well_state) {
         case Status::OPEN:
@@ -638,15 +736,15 @@ bool Well::updateStatus(Status well_state, bool update_connections) {
             new_connections->add(c);
         }
 
-        update = this->updateConnections(std::move(new_connections));
+        this->updateConnections(std::move(new_connections));
     }
 
-    if (this->status != well_state) {
-        this->status = well_state;
-        update = true;
-    }
+    if (runtime)
+        this->status->status = well_state;
+    else
+        this->status = std::make_shared<WellStatus>(well_state);
 
-    return update;
+    return true;
 }
 
 
@@ -693,7 +791,7 @@ bool Well::updateConnections(std::shared_ptr<WellConnections> connections_arg, b
     if (force || *this->connections != *connections_arg) {
         this->connections = connections_arg;
         if (this->connections->empty())
-            this->status = Status::SHUT;
+            this->status = std::make_shared<WellStatus>(Well::Status::SHUT);
 
         return true;
     }
@@ -957,7 +1055,7 @@ const Well::WellInjectionProperties& Well::getInjectionProperties() const {
 }
 
 Well::Status Well::getStatus() const {
-    return this->status;
+    return this->status->status;
 }
 
 const PAvg& Well::pavg() const {
@@ -1011,14 +1109,14 @@ int Well::fip_region_number() const {
   because there is some twisted logic aggregating connection changes over a
   complete report step.
 
-  However - when the WELOPEN is called as a ACTIONX action the full
-  Schedule::iterateScheduleSection() is not run and the check if all connections
-  is closed is not done. Therefor we have a action_mode flag here which makes
-  sure to close the well in this case.
+  However - when the WELOPEN is called runtime (typically as an ACTIONX action)
+  the full Schedule::iterateScheduleSection() is not run and the check if all
+  connections is closed is not done. Therefor we have a runtime flag here
+  which makes sure to close the well in this case.
 */
 
 
-bool Well::handleWELOPEN(const DeckRecord& record, Connection::State state_arg, bool action_mode) {
+bool Well::handleWELOPEN(const DeckRecord& record, Connection::State state_arg, bool runtime) {
 
     auto match = [=]( const Connection &c) -> bool {
         if (!match_eq(c.getI(), record, "I" , -1)) return false;
@@ -1038,9 +1136,9 @@ bool Well::handleWELOPEN(const DeckRecord& record, Connection::State state_arg, 
 
         new_connections->add(c);
     }
-    if (action_mode) {
+    if (runtime) {
         if (new_connections->allConnectionsShut())
-            this->status = Status::SHUT;
+            this->updateStatus(Well::Status::SHUT, true, false);
     }
 
     return this->updateConnections(std::move(new_connections));

--- a/tests/msim/actionx2.include
+++ b/tests/msim/actionx2.include
@@ -425,6 +425,14 @@ DATES
    1 'FEB'  2015 /
 /
 
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+	'P1' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P2' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P3' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P4' 'OPEN' 'ORAT' 5000 4* 1000 /
+/
+
 DATES
    1 'MAR'  2015 /
 /

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -241,15 +241,11 @@ BOOST_AUTO_TEST_CASE(WELL_CLOSE_EXAMPLE) {
             BOOST_CHECK(w3.getStatus() ==  Well::Status::OPEN );
         }
         {
-            const auto& w2_5 = td.schedule.getWell("P2", 5);
             const auto& w2_6 = td.schedule.getWell("P2", 6);
-            BOOST_CHECK(w2_5.getStatus() == Well::Status::OPEN );
             BOOST_CHECK(w2_6.getStatus() == Well::Status::SHUT );
         }
         {
-            const auto& w4_10 = td.schedule.getWell("P4", 10);
             const auto& w4_11 = td.schedule.getWell("P4", 11);
-            BOOST_CHECK(w4_10.getStatus() == Well::Status::OPEN );
             BOOST_CHECK(w4_11.getStatus() == Well::Status::SHUT );
         }
     }
@@ -502,15 +498,11 @@ BOOST_AUTO_TEST_CASE(PYTHON_WELL_CLOSE_EXAMPLE) {
             BOOST_CHECK(w3.getStatus() ==  Well::Status::OPEN );
         }
         {
-            const auto& w2_5 = td.schedule.getWell("P2", 5);
             const auto& w2_6 = td.schedule.getWell("P2", 6);
-            BOOST_CHECK(w2_5.getStatus() == Well::Status::OPEN );
             BOOST_CHECK(w2_6.getStatus() == Well::Status::SHUT );
         }
         {
-            const auto& w4_10 = td.schedule.getWell("P4", 10);
             const auto& w4_11 = td.schedule.getWell("P4", 11);
-            BOOST_CHECK(w4_10.getStatus() == Well::Status::OPEN );
             BOOST_CHECK(w4_11.getStatus() == Well::Status::SHUT );
         }
     }

--- a/tests/parser/DynamicStateTests.cpp
+++ b/tests/parser/DynamicStateTests.cpp
@@ -284,6 +284,17 @@ BOOST_AUTO_TEST_CASE( update_equal ) {
 }
 
 
+BOOST_AUTO_TEST_CASE( update_range) {
+    Opm::TimeMap timeMap = make_timemap(11);
+    Opm::DynamicState<int> state(timeMap , 0);
+
+    BOOST_CHECK_THROW( state.update_range(5,1,99), std::exception);
+    BOOST_CHECK_THROW( state.update_range(10,200,99), std::exception);
+    state.update_range(3,5,99);
+    BOOST_CHECK_EQUAL( state[3], 99);
+    BOOST_CHECK_EQUAL( state[4], 99);
+    BOOST_CHECK_EQUAL( state[5], 0);
+}
 
 
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3233,9 +3233,8 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
     BOOST_CHECK(ws.updateRefDepth(1.0));
     BOOST_CHECK(!ws.updateRefDepth(1.0));
 
-    ws.updateStatus(Well::Status::OPEN, false);
-    BOOST_CHECK(!ws.updateStatus(Well::Status::OPEN, false));
-    BOOST_CHECK(ws.updateStatus(Well::Status::SHUT, false));
+    ws.updateStatus(Well::Status::OPEN, false, false);
+    ws.updateStatus(Well::Status::SHUT, false, false);
 
     const auto& connections = ws.getConnections();
     BOOST_CHECK_EQUAL(connections.size(), 0U);
@@ -4350,6 +4349,114 @@ END
         BOOST_CHECK(w3.pavg() == pavg4);
         BOOST_CHECK(w4.pavg() == pavg4);
     }
+}
+
+
+BOOST_AUTO_TEST_CASE(WELL_STATUS) {
+    const std::string deck_string = R"(
+START
+7 OCT 2020 /
+
+DIMENS
+  10 10 3 /
+
+GRID
+DXV
+  10*100.0 /
+DYV
+  10*100.0 /
+DZV
+  3*10.0 /
+
+DEPTHZ
+  121*2000.0 /
+
+PORO
+  300*0.3 /
+
+SCHEDULE
+WELSPECS -- 0
+  'P1' 'G' 10 10 2005 'LIQ' /
+/
+
+COMPDAT
+  'P1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+
+WCONPROD
+  'P1' 'OPEN' 'ORAT'  123.4  4*  50.0 /
+/
+
+
+TSTEP -- 1
+  10 /
+
+WELPI
+  'P1'  200.0 /
+/
+
+TSTEP -- 2
+  10 /
+
+WELOPEN
+   'P1' SHUT /
+/
+
+TSTEP -- 3,4,5
+  10 10 10 /
+
+WELOPEN
+   'P1' OPEN /
+/
+
+TSTEP -- 6,7,8
+  10 10 10/
+
+END
+
+END
+)";
+
+    const auto deck = Parser{}.parseString(deck_string);
+    const auto es    = EclipseState{ deck };
+    auto       sched = Schedule{ deck, es };
+    {
+        const auto& well = sched.getWell("P1", 0);
+        BOOST_CHECK( well.getStatus() ==  Well::Status::OPEN);
+    }
+    {
+        const auto& well = sched.getWell("P1", 1);
+        BOOST_CHECK( well.getStatus() ==  Well::Status::OPEN);
+    }
+
+    {
+        const auto& well = sched.getWell("P1", 2);
+        BOOST_CHECK( well.getStatus() ==  Well::Status::SHUT);
+    }
+    {
+        const auto& well = sched.getWell("P1", 5);
+        BOOST_CHECK( well.getStatus() ==  Well::Status::OPEN);
+    }
+
+    sched.shut_well("P1", 0);
+    {
+        const auto& well = sched.getWell("P1", 0);
+        BOOST_CHECK( well.getStatus() ==  Well::Status::SHUT);
+    }
+    {
+        const auto& well = sched.getWell("P1", 1);
+        BOOST_CHECK( well.getStatus() ==  Well::Status::SHUT);
+    }
+    {
+        const auto& well = sched.getWell("P1", 2);
+        BOOST_CHECK( well.getStatus() ==  Well::Status::SHUT);
+    }
+    {
+        const auto& well = sched.getWell("P1", 5);
+        BOOST_CHECK( well.getStatus() ==  Well::Status::OPEN);
+    }
+
+    //sched.open_well("P1", 2);
 }
 
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3233,8 +3233,8 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
     BOOST_CHECK(ws.updateRefDepth(1.0));
     BOOST_CHECK(!ws.updateRefDepth(1.0));
 
-    ws.updateStatus(Well::Status::OPEN, false, false);
-    ws.updateStatus(Well::Status::SHUT, false, false);
+    ws.updateStatus(Well::Status::OPEN, 0, false);
+    ws.updateStatus(Well::Status::SHUT, 0, false);
 
     const auto& connections = ws.getConnections();
     BOOST_CHECK_EQUAL(connections.size(), 0U);
@@ -3250,8 +3250,8 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
                       10,
                       100);
 
-    BOOST_CHECK(  ws.updateConnections(c2) );
-    BOOST_CHECK( !ws.updateConnections(c2) );
+    BOOST_CHECK(  ws.updateConnections(c2, 0, false) );
+    BOOST_CHECK( !ws.updateConnections(c2, 0, false) );
 }
 
 

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -79,13 +79,13 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE2) {
     std::vector<Well> wells;
     wells.emplace_back("WELL_NAME", "A", 0, 0, 1, 1, 200., WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true, 0, Well::GasInflowEquation::STD);
     {
-        wells[0].updateStatus(Well::Status::SHUT, false);
+        wells[0].updateStatus(Well::Status::SHUT, false, false);
         auto shut_wells = st.updateWells(wc, wells, 5000);
         BOOST_CHECK_EQUAL(shut_wells.size(), 0U);
     }
 
     {
-        wells[0].updateStatus(Well::Status::OPEN, false);
+        wells[0].updateStatus(Well::Status::OPEN, false, false);
         auto shut_wells = st.updateWells(wc, wells, 5000);
         BOOST_CHECK_EQUAL( shut_wells.size(), 1U);
     }
@@ -116,12 +116,12 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
 
     WellTestConfig wc;
     {
-        wells[0].updateStatus(Well::Status::SHUT, false);
+        wells[0].updateStatus(Well::Status::SHUT, false, false);
         auto shut_wells = st.updateWells(wc, wells, 110. * day);
         BOOST_CHECK_EQUAL(shut_wells.size(), 0U);
     }
     {
-        wells[0].updateStatus(Well::Status::OPEN, false);
+        wells[0].updateStatus(Well::Status::OPEN, false, false);
         auto shut_wells = st.updateWells(wc, wells, 110. * day);
         BOOST_CHECK_EQUAL(shut_wells.size(), 0U);
     }
@@ -152,10 +152,10 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
     wc.add_well("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 1000. * day, 3, 0, 5);
 
 
-    wells[0].updateStatus(Well::Status::SHUT, false);
+    wells[0].updateStatus(Well::Status::SHUT, false, false);
     BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4100. * day).size(), 0U);
 
-    wells[0].updateStatus(Well::Status::OPEN, false);
+    wells[0].updateStatus(Well::Status::OPEN, false, false);
     BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4100. * day).size(), 1U);
 
     BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 5200. * day).size(), 1U);
@@ -183,9 +183,9 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
     const UnitSystem us{};
     std::vector<Well> wells;
     wells.emplace_back("WELL_NAME", "A", 0, 0, 1, 1, 200., WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true, 0, Well::GasInflowEquation::STD);
-    wells[0].updateStatus(Well::Status::OPEN, false);
+    wells[0].updateStatus(Well::Status::OPEN, false, false);
     wells.emplace_back("WELLX", "A", 0, 0, 2, 2, 200., WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true, 0, Well::GasInflowEquation::STD);
-    wells[1].updateStatus(Well::Status::OPEN, false);
+    wells[1].updateStatus(Well::Status::OPEN, false, false);
 
     auto closed_completions = st.updateWells(wc, wells, 5000);
     BOOST_CHECK_EQUAL( closed_completions.size(), 0U);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -1343,7 +1343,7 @@ END
                         "P and Q must have the same internal connections pointers");
 
     auto connQ = std::make_shared<WellConnections>(wellP.getConnections());
-    wellQ.updateConnections(std::move(connQ), true);
+    wellQ.updateConnections(std::move(connQ), 0, true, true);
     BOOST_CHECK_MESSAGE(! wellP.hasSameConnectionsPointers(wellQ),
                         "P and Q must NOT have the same internal connections pointers "
                         "after forcibly updating the connections structure");


### PR DESCRIPTION
Picture this:

![image](https://user-images.githubusercontent.com/1321665/101532971-90f7c780-3995-11eb-83e9-f1d6b2d12ef2.png)


Eclipse will interpret the keywords in an imperative fashion - as if Eclipse was a DSL for reservoir simulation. This is particularly appearant when it comes to the Schedule section where well controls and timestepping is controlled through a series of keywords. In opm we do it differently - all the information from the entire .DATA file is parsed and internalized and the rest of simulation uses the `EclipseState` and `Schedule` datastructures. This has worked quite well, but the ACTIONX stuff which allows for dynamic updates to the the schedule information does *not* fit very well into the existing `Schedule`class - it is a bit like:

![image](https://user-images.githubusercontent.com/1321665/101534312-3d867900-3997-11eb-82ca-bbefd87d2fe1.png)
 
In this PR we record the time-range for the active well open events, this is an attempt to update the correct time-range for well information when wells are subsequently updated with ACTIONX. It seems to work for the current tests - but this if fragile, and I expect there will be new faulty corner cases around every twist in the road. If we are to get a Schedule implementation which is solid in the face of "every possible ACTIONX quirk" I think the entire Schedule implementation needs to be reworked. This is a large task which many stakeholders need to have an opinion about; but I encourage you all to think about it - maybe your favorite dislike with the current `Schedule` implementation can be refactored away? 


Changes to Well status implementation

1. The status of a well is maintened as a small object which is managed by a new
   std::shared_ptr member in the well objects. The consequence of this is that
   several well objects can share the same underlying status object. The
   advantage of this is that runtime (i.e. ACTIONX) updates of well status will
   affect the correct set of wells.

2. The general Schedule::updateWell() will use the DynamicState::upadte_equal()

-----

If someone feels like reviewing this - that is cool; but more important is that you all take five minutes to ponder the "square peg in a round hole" described above.
