### PR TITLE
Changes for SWEL  for correct handling of lift gas plus improvements to XCONN

### DIFF
--- a/opm/output/eclipse/VectorItems/connection.hpp
+++ b/opm/output/eclipse/VectorItems/connection.hpp
@@ -67,6 +67,10 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             WaterRate  =  1,  // Surface flow rate (water)
             GasRate    =  2,  // Surface Flow rate (gas)
 
+            OilRate_Copy    =  17,  // Surface flow rate (oil)
+            WaterRate_Copy  =  18,  // Surface flow rate (water)
+            GasRate_Copy    =  19,  // Surface Flow rate (gas)
+
             Pressure   = 34,  // Connection pressure value
 
             ResVRate   = 49,  // Reservoir voidage rate

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -253,16 +253,19 @@ namespace {
             if (Q.has(R::oil)) {
                 xConn[Ix::OilRate] =
                     - units.from_si(M::liquid_surface_rate, Q.get(R::oil));
+                xConn[Ix::OilRate_Copy] = xConn[Ix::OilRate];
             }
 
             if (Q.has(R::wat)) {
                 xConn[Ix::WaterRate] =
                     - units.from_si(M::liquid_surface_rate, Q.get(R::wat));
+                xConn[Ix::WaterRate_Copy] = xConn[Ix::WaterRate];
             }
 
             if (Q.has(R::gas)) {
                 xConn[Ix::GasRate] =
                     - units.from_si(M::gas_surface_rate, Q.get(R::gas));
+                xConn[Ix::GasRate_Copy] = xConn[Ix::GasRate];
             }
 
             xConn[Ix::ResVRate] = 0.0;


### PR DESCRIPTION
SWEL: improvements to handle lift gas correctly depending on which units are used for lift gas rates
XCON: Improvements needed in some cases to get (more) correct eclipse restart from flow run.

NOTE: these changes has been copied from PR 2160 to be treated as a separate PR (here).

This PR is then ready for review  and merge when OK.

NOTE: I have run tests, ctest gives no errors. However, when I run make check all checks fail due to  differences between Jenkins and local machine results. I would  appreciate if @bska could help run tests to check if the results are OK. 