### PR TITLE
add WELTARG and WEFAC to events

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
@@ -106,6 +106,11 @@ namespace Opm
              * New explicit well productivity/injectivity assignment.
              */
             WELL_PRODUCTIVITY_INDEX = (1 << 16),
+
+            /*
+             * Well/group efficiency factor has changed
+             */
+            WELLGROUP_EFFICIENCY_UPDATE = (1 << 17),
         };
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
@@ -54,7 +54,7 @@ namespace Opm
 
             /*
                The PRODUCTION_UPDATE event is triggered by the
-               WCONPROD and WCONHIST keywords. The event will be
+               WCONPROD, WCONHIST, WELTARG, WEFAC keywords. The event will be
                triggered if *any* of the elements in one of keywords
                is changed. Quite simlar for INJECTION_UPDATE and
                POLYMER_UPDATE.

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -1118,8 +1118,16 @@ namespace {
             for (const auto& well_name : well_names) {
                 auto& dynamic_state = this->wells_static.at(well_name);
                 auto well2 = std::make_shared<Well>(*dynamic_state[handlerContext.currentStep]);
-                if (well2->updateEfficiencyFactor(efficiencyFactor))
+                if (well2->updateEfficiencyFactor(efficiencyFactor)){
+                    if (well2->isProducer()) {
+                        this->addWellGroupEvent( well_name, ScheduleEvents::PRODUCTION_UPDATE, handlerContext.currentStep);
+                        m_events.addEvent( ScheduleEvents::PRODUCTION_UPDATE , handlerContext.currentStep);
+                    } else {
+                        this->addWellGroupEvent( well_name, ScheduleEvents::INJECTION_UPDATE, handlerContext.currentStep);
+                        m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , handlerContext.currentStep);
+                    }
                     this->updateWell(std::move(well2), handlerContext.currentStep);
+                }
             }
         }
     }
@@ -1321,7 +1329,16 @@ namespace {
                         update |= well2->updateWellGuideRate(new_arg.get<double>());
                 }
                 if (update)
+                {
+                    if (well2->isProducer()) {
+                        this->addWellGroupEvent( well_name, ScheduleEvents::PRODUCTION_UPDATE, handlerContext.currentStep);
+                        m_events.addEvent( ScheduleEvents::PRODUCTION_UPDATE , handlerContext.currentStep);
+                    } else {
+                        this->addWellGroupEvent( well_name, ScheduleEvents::INJECTION_UPDATE, handlerContext.currentStep);
+                        m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , handlerContext.currentStep);
+                    }
                     this->updateWell(std::move(well2), handlerContext.currentStep);
+                }
             }
         }
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -523,8 +523,11 @@ namespace {
 
             for (const auto& group_name : group_names) {
                 auto group_ptr = std::make_shared<Group>(this->getGroup(group_name, handlerContext.currentStep));
-                if (group_ptr->update_gefac(gefac, transfer))
+                if (group_ptr->update_gefac(gefac, transfer)) {
+                    this->addWellGroupEvent( group_name, ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE, handlerContext.currentStep);
+                    m_events.addEvent( ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE , handlerContext.currentStep);
                     this->updateGroup(std::move(group_ptr), handlerContext.currentStep);
+                }
             }
         }
     }
@@ -1119,13 +1122,8 @@ namespace {
                 auto& dynamic_state = this->wells_static.at(well_name);
                 auto well2 = std::make_shared<Well>(*dynamic_state[handlerContext.currentStep]);
                 if (well2->updateEfficiencyFactor(efficiencyFactor)){
-                    if (well2->isProducer()) {
-                        this->addWellGroupEvent( well_name, ScheduleEvents::PRODUCTION_UPDATE, handlerContext.currentStep);
-                        m_events.addEvent( ScheduleEvents::PRODUCTION_UPDATE , handlerContext.currentStep);
-                    } else {
-                        this->addWellGroupEvent( well_name, ScheduleEvents::INJECTION_UPDATE, handlerContext.currentStep);
-                        m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , handlerContext.currentStep);
-                    }
+                    this->addWellGroupEvent( well_name, ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE, handlerContext.currentStep);
+                    m_events.addEvent( ScheduleEvents::WELLGROUP_EFFICIENCY_UPDATE , handlerContext.currentStep);
                     this->updateWell(std::move(well2), handlerContext.currentStep);
                 }
             }


### PR DESCRIPTION
This adds PRODUCTION/INJECTION_UPDATE event for WELTARG and WEFAC.

For the usage I need, I don't see any point of keeping separate events types for WELTARGS and WEFAC but maybe I am wrong.  