### PR TITLE
Relax EPS Activation Criterion

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/IPCG
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/IPCG
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["ENDSCALE"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "Pressure"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/IPCW
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/I/IPCW
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["ENDSCALE"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "Pressure"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PCG
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PCG
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["ENDSCALE"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "Pressure"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PCW
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/P/PCW
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["ENDSCALE"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "Pressure"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGCR
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGCR
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["GAS"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "1"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGL
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGL
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["GAS"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "1"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGLPC
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGLPC
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["GAS"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "1"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGU
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGU
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["GAS"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "1"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOGCR
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOGCR
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires" : ["GAS", "OIL", "ENDSCALE"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "1"

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOWCR
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOWCR
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["OIL", "WATER", "ENDSCALE"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "1"

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -126,7 +126,71 @@ BOOST_AUTO_TEST_CASE( EndpointScalingWithoutENDSCALE ) {
     BOOST_CHECK( !endscale.irreversible() );
 }
 
+BOOST_AUTO_TEST_CASE ( EndpointScalingWithoutENDSCALE_WithEPSProps ) {
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+DIMENS
+10 10 3/
 
+PROPS
+SWL
+300*0.125 /
+END
+)");
+
+    const auto endscale = Runspec { deck }.endpointScaling();
+
+    BOOST_CHECK_MESSAGE( static_cast<bool>(endscale),
+                         "End-point scaling must be activated by SWL keyword");
+
+    BOOST_CHECK_MESSAGE( !endscale.directional(),
+                         "Directional end-point scaling must NOT "
+                         "be activated by SWL keyword" );
+
+    BOOST_CHECK_MESSAGE( endscale.nondirectional(),
+                         "Non-directional end-point scaling must "
+                         "be activated by SWL keyword" );
+
+    BOOST_CHECK_MESSAGE( endscale.reversible(),
+                         "Reversible nend-point scaling must "
+                         "be activated by SWL keyword" );
+
+    BOOST_CHECK_MESSAGE( !endscale.irreversible(),
+                         "Irreversible end-point scaling must NOT "
+                         "be activated by SWL keyword" );
+}
+
+BOOST_AUTO_TEST_CASE ( EndpointScalingWithoutENDSCALE_WithVertProps ) {
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+DIMENS
+10 10 3/
+
+PROPS
+KRORW
+300*0.25 /
+END
+)");
+
+    const auto endscale = Runspec { deck }.endpointScaling();
+
+    BOOST_CHECK_MESSAGE( static_cast<bool>(endscale),
+                         "End-point scaling must be activated by KRORW keyword");
+
+    BOOST_CHECK_MESSAGE( !endscale.directional(),
+                         "Directional end-point scaling must NOT "
+                         "be activated by KRORW keyword" );
+
+    BOOST_CHECK_MESSAGE( endscale.nondirectional(),
+                         "Non-directional end-point scaling must "
+                         "be activated by KRORW keyword" );
+
+    BOOST_CHECK_MESSAGE( endscale.reversible(),
+                         "Reversible nend-point scaling must "
+                         "be activated by KRORW keyword" );
+
+    BOOST_CHECK_MESSAGE( !endscale.irreversible(),
+                         "Irreversible end-point scaling must NOT "
+                         "be activated by KRORW keyword" );
+}
 
 BOOST_AUTO_TEST_CASE( EndpointScalingDefaulted ) {
     const std::string input = R"(


### PR DESCRIPTION
Existence of certain EPS keywords (`SWL`, `SGCR`, others) is sufficient to activate the end-point scaling option.  The deck does not **need** to have the `ENDSCALE` keyword in these cases, but it is recommended that `ENDSCALE` nevertheless be used.

On the other hand, certain other keywords do require the presence of `ENDSCALE` so record this in "requires" clauses.