### PR TITLE
Make Saturation Function Family Available in Runspec

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -241,11 +241,17 @@ public:
         Stone2
     };
 
+    enum class KeywordFamily {
+        Family_I,               // SGOF, SWOF, SLGOF
+        Family_II,              // SGFN, SOF{2,3}, SWFN
+        Undefined,
+    };
+
     SatFuncControls();
     explicit SatFuncControls(const Deck& deck);
-    SatFuncControls(const double tolcritArg,
-                    ThreePhaseOilKrModel model);
-
+    explicit SatFuncControls(const double tolcritArg,
+                             const ThreePhaseOilKrModel model,
+                             const KeywordFamily family);
 
     static SatFuncControls serializeObject();
 
@@ -259,6 +265,11 @@ public:
         return this->krmodel;
     }
 
+    KeywordFamily family() const
+    {
+        return this->satfunc_family;
+    }
+
     bool operator==(const SatFuncControls& rhs) const;
 
     template<class Serializer>
@@ -266,11 +277,13 @@ public:
     {
         serializer(tolcrit);
         serializer(krmodel);
+        serializer(satfunc_family);
     }
 
 private:
     double tolcrit;
     ThreePhaseOilKrModel krmodel = ThreePhaseOilKrModel::Default;
+    KeywordFamily satfunc_family = KeywordFamily::Undefined;
 };
 
 class Runspec {

--- a/python/tests/data/CORNERPOINT_ACTNUM.DATA
+++ b/python/tests/data/CORNERPOINT_ACTNUM.DATA
@@ -1,10 +1,13 @@
-RUNSPEC
+RUNSPEC 
+
+OIL
+WATER
 
 DIMENS
   10  10  5 /
 
 TABDIMS
- 2 /
+ 2 / 
 
 GRID
 
@@ -1197,10 +1200,10 @@ ZCORN
 /
 
 ACTNUM
-  200*0 100*1 200*0 /
+  200*0 100*1 200*0 /      
 
 PORO
-  500*0.15 /
+   500*0.15 /
 
 EDIT
 
@@ -1210,3 +1213,4 @@ SWOF
  1 2 3 4
  5 6 7 8 /
  9 10 11 12 /
+

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -95,21 +95,6 @@ namespace {
                      (twoP && deck.hasKeyword<Opm::ParserKeywords::SOF2>()))) ||
             (wat && deck.hasKeyword<Opm::ParserKeywords::SWFN>());
 
-        if (gas &&
-            deck.hasKeyword<Opm::ParserKeywords::SGOF>() &&
-            deck.hasKeyword<Opm::ParserKeywords::SLGOF>())
-            throw std::invalid_argument {
-                "Both SGOF and SLGOF have been specified "
-                "but these tables are mutually exclusive!"
-            };
-
-        if (family1 && family2)
-            throw std::invalid_argument {
-                "Saturation families should not be mixed\n"
-                "Use either SGOF (or SLGOF) and/or SWOF "
-                "or SGFN/SWFN and SOF2/SOF3"
-            };
-
         if (family1)
             return Opm::SatFuncControls::KeywordFamily::Family_I;
 

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGFN
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGFN
@@ -7,6 +7,7 @@
     "keyword": "TABDIMS",
     "item": "NTSFUN"
   },
+  "requires": ["GAS"],
   "items": [
     {
       "name": "DATA",

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGOF
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SGOF
@@ -7,6 +7,8 @@
     "keyword": "TABDIMS",
     "item": "NTSFUN"
   },
+  "requires": ["GAS", "OIL"],
+  "prohibits": ["SLGOF"],
   "items": [
     {
       "name": "DATA",

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SLGOF
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SLGOF
@@ -7,6 +7,8 @@
     "keyword": "TABDIMS",
     "item": "NTSFUN"
   },
+  "requires": ["GAS"],
+  "prohibits": ["SGOF"],
   "items": [
     {
       "name": "DATA",

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOF2
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOF2
@@ -7,6 +7,7 @@
     "keyword": "TABDIMS",
     "item": "NTSFUN"
   },
+  "requires": ["OIL"],
   "items": [
     {
       "name": "DATA",

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOF3
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SOF3
@@ -7,6 +7,7 @@
     "keyword": "TABDIMS",
     "item": "NTSFUN"
   },
+  "requires": ["OIL", "GAS", "WATER"],
   "items": [
     {
       "name": "DATA",

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SWFN
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SWFN
@@ -7,6 +7,7 @@
     "keyword": "TABDIMS",
     "item": "NTSFUN"
   },
+  "requires": ["WATER"],
   "items": [
     {
       "name": "DATA",

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SWOF
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SWOF
@@ -7,6 +7,7 @@
     "keyword": "TABDIMS",
     "item": "NTSFUN"
   },
+  "requires": ["OIL", "WATER"],
   "items": [
     {
       "name": "DATA",

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -352,6 +352,9 @@ BOOST_AUTO_TEST_CASE( handle_empty_title ) {
 
 BOOST_AUTO_TEST_CASE( deck_comma_separated_fields ) {
     const char* deck = R"(
+WATER
+OIL
+
 TABDIMS
     2*    24 2*    20    20 1*     1 7* /
 

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -547,26 +547,6 @@ BOOST_AUTO_TEST_CASE(SatFunc_Family)
 {
     {
         const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
-TABDIMS
-/
-
-PROPS
-
-SGOF
-0 0 1 0
-1 1 0 0 /
-END
-)");
-
-        const auto rspec = ::Opm::Runspec{deck};
-        const auto sfctrl = rspec.saturationFunctionControls();
-
-        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Undefined,
-                            "SatFuncControl Deck-constructor must infer Undefined when Phases missing");
-    }
-
-    {
-        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
 OIL
 GAS
 
@@ -680,30 +660,6 @@ END
         const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
 OIL
 GAS
-
-TABDIMS
-/
-
-PROPS
-
-SGOF
-0 0 1 0
-1 1 0 0 /
-
-SLGOF
-0 0 1 0
-1 1 0 0 /
-END
-)");
-
-        // Both SGOF and SLGOF in same input => invalid_argument
-        BOOST_CHECK_THROW(const auto rspec = ::Opm::Runspec{deck}, std::invalid_argument);
-    }
-
-    {
-        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
-OIL
-GAS
 WATER
 
 TABDIMS
@@ -759,31 +715,6 @@ END
 
         BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Family_II,
                             "SatFuncControl Deck-constructor must infer Family II from SGFN/SOF2");
-    }
-
-    {
-        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
-OIL
-GAS
-WATER
-
-TABDIMS
-/
-
-PROPS
-
-SWFN
-0 0 0
-1 1 0 /
-
-SLGOF
-0 0 1 0
-1 1 0 0 /
-END
-)");
-
-        // Both SWFN and SLGOF in same input => invalid_argument
-        BOOST_CHECK_THROW(const auto rspec = ::Opm::Runspec{deck}, std::invalid_argument);
     }
 }
 

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -25,6 +25,8 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
+#include <stdexcept>
+
 using namespace Opm;
 
 BOOST_AUTO_TEST_CASE(PhaseFromString) {
@@ -541,6 +543,250 @@ BOOST_AUTO_TEST_CASE( SWATINIT ) {
 
 }
 
+BOOST_AUTO_TEST_CASE(SatFunc_Family)
+{
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+TABDIMS
+/
+
+PROPS
+
+SGOF
+0 0 1 0
+1 1 0 0 /
+END
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Undefined,
+                            "SatFuncControl Deck-constructor must infer Undefined when Phases missing");
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+
+TABDIMS
+/
+
+PROPS
+
+END
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Undefined,
+                            "SatFuncControl Deck-constructor must infer Undefined when Tables missing");
+    }
+
+    {
+        const auto sfctrl = ::Opm::SatFuncControls{};
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Undefined,
+                            "Default-constructed SatFuncControl must have Undefined keyword family");
+    }
+
+    {
+        const auto sfctrl = ::Opm::SatFuncControls{ 5.0e-7, ::Opm::SatFuncControls::ThreePhaseOilKrModel::Default, ::Opm::SatFuncControls::KeywordFamily::Family_II };
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Family_II,
+                            "SatFuncControl constructor must assign keyword family");
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+
+TABDIMS
+/
+
+PROPS
+
+SWOF
+0 0 1 0
+1 1 0 0 /
+
+SGOF
+0 0 1 0
+1 1 0 0 /
+END
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Family_I,
+                            "SatFuncControl Deck-constructor must infer Family I from SWOF/SGOF");
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
+
+TABDIMS
+/
+
+PROPS
+
+SWOF
+0 0 1 0
+1 1 0 0 /
+END
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Family_I,
+                            "SatFuncControl Deck-constructor must infer Family I from SWOF");
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+
+TABDIMS
+/
+
+PROPS
+
+SWOF
+0 0 1 0
+1 1 0 0 /
+
+SLGOF
+0 0 1 0
+1 1 0 0 /
+END
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Family_I,
+                            "SatFuncControl Deck-constructor must infer Family I from SWOF/SLGOF");
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+
+TABDIMS
+/
+
+PROPS
+
+SGOF
+0 0 1 0
+1 1 0 0 /
+
+SLGOF
+0 0 1 0
+1 1 0 0 /
+END
+)");
+
+        // Both SGOF and SLGOF in same input => invalid_argument
+        BOOST_CHECK_THROW(const auto rspec = ::Opm::Runspec{deck}, std::invalid_argument);
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+
+TABDIMS
+/
+
+PROPS
+
+SWFN
+0 0 0
+1 1 0 /
+
+SGFN
+0 0 0
+1 1 0 /
+
+SOF3
+0 0 0
+1 1 1 /
+
+END
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Family_II,
+                            "SatFuncControl Deck-constructor must infer Family II from SWFN/SGFN/SOF3");
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+
+TABDIMS
+/
+
+PROPS
+
+SGFN
+0 0 0
+1 1 0 /
+
+SOF2
+0 0
+1 1 /
+
+END
+)");
+
+        const auto rspec = ::Opm::Runspec{deck};
+        const auto sfctrl = rspec.saturationFunctionControls();
+
+        BOOST_CHECK_MESSAGE(sfctrl.family() == ::Opm::SatFuncControls::KeywordFamily::Family_II,
+                            "SatFuncControl Deck-constructor must infer Family II from SGFN/SOF2");
+    }
+
+    {
+        const auto deck = ::Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+
+TABDIMS
+/
+
+PROPS
+
+SWFN
+0 0 0
+1 1 0 /
+
+SLGOF
+0 0 1 0
+1 1 0 0 /
+END
+)");
+
+        // Both SWFN and SLGOF in same input => invalid_argument
+        BOOST_CHECK_THROW(const auto rspec = ::Opm::Runspec{deck}, std::invalid_argument);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(TolCrit)
 {
     {
@@ -551,7 +797,7 @@ BOOST_AUTO_TEST_CASE(TolCrit)
     }
 
     {
-        const auto sfctrl = ::Opm::SatFuncControls{ 5.0e-7, ::Opm::SatFuncControls::ThreePhaseOilKrModel::Default };
+        const auto sfctrl = ::Opm::SatFuncControls{ 5.0e-7, ::Opm::SatFuncControls::ThreePhaseOilKrModel::Default, ::Opm::SatFuncControls::KeywordFamily::Family_II };
         BOOST_CHECK_CLOSE(sfctrl.minimumRelpermMobilityThreshold(), 5.0e-7, 1.0e-10);
         BOOST_CHECK_MESSAGE(!(sfctrl == ::Opm::SatFuncControls{}),
                             "Default-constructed SatFuncControl must NOT equal non-default");

--- a/tests/parser/TableContainerTests.cpp
+++ b/tests/parser/TableContainerTests.cpp
@@ -31,18 +31,24 @@
 #include <string>
 #include <memory>
 
-inline Opm::Deck createSWOFDeck() {
-    const char *deckData =
-        "TABDIMS\n"
-        " 2 /\n"
-        "\n"
-        "SWOF\n"
-        " 1 2 3 4\n"
-        " 5 6 7 8 /\n"
-        " 9 10 11 12 /\n";
+namespace {
+    Opm::Deck createSWOFDeck()
+    {
+        return Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
 
-    Opm::Parser parser;
-    return parser.parseString(deckData);
+TABDIMS
+2 /
+
+PROPS
+SWOF
+1 2 3 4
+5 6 7 8 /
+9 10 11 12 /
+END
+)");
+    }
 }
 
 BOOST_AUTO_TEST_CASE( CreateContainer ) {
@@ -64,4 +70,3 @@ BOOST_AUTO_TEST_CASE( CreateContainer ) {
     BOOST_CHECK_THROW( container[5] , std::invalid_argument );
     BOOST_CHECK_THROW( container[10] , std::invalid_argument );
 }
-

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -57,77 +57,94 @@ using namespace Opm;
 
 namespace {
 
-Opm::Deck createSingleRecordDeck() {
-    const char *deckData =
-        "TABDIMS\n"
-        " 2 /\n"
-        "\n"
-        "SWOF\n"
-        " 1 2 3 4\n"
-        " 5 6 7 8 /\n"
-        " 9 10 11 12 /\n";
+Opm::Deck createSingleRecordDeck()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
 
-    Opm::Parser parser;
-    return parser.parseString(deckData);
+TABDIMS
+ 2 /
+
+PROPS
+SWOF
+ 1 2 3 4
+ 5 6 7 8 /
+ 9 10 11 12 /
+
+END
+)");
 }
 
+Opm::Deck createSingleRecordDeckWithVd()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+WATER
 
-Opm::Deck createSingleRecordDeckWithVd() {
-    const char *deckData =
-        "RUNSPEC\n"
-        "ENDSCALE\n"
-        "2* 1 2 /\n"
-        "PROPS\n"
-        "TABDIMS\n"
-        " 2 /\n"
-        "\n"
-        "SWFN\n"
-        "0.22 .0   7.0 \n"
-        "0.3  .0   4.0 \n"
-        "0.5  .24  2.5 \n"
-        "0.8  .65  1.0 \n"
-        "0.9  .83  .5  \n"
-        "1.0  1.00 .0 /\n"
-        "/\n"
-        "IMPTVD\n"
-        "3000.0 6*0.1 0.31 1*0.1\n"
-        "9000.0 6*0.1 0.32 1*0.1/\n"
-        "ENPTVD\n"
-        "3000.0 0.20 0.20 1.0 0.0 0.04 1.0 0.18 0.22\n"
-        "9000.0 0.22 0.22 1.0 0.0 0.04 1.0 0.18 0.22 /";
+TABDIMS
+ 2 /
 
-    Opm::Parser parser;
-    return parser.parseString(deckData);
+ENDSCALE
+2* 1 2 /
+
+PROPS
+
+SWFN
+0.22 .0   7.0
+0.3  .0   4.0
+0.5  .24  2.5
+0.8  .65  1.0
+0.9  .83   .5
+1.0  1.00  .0 /
+/
+
+IMPTVD
+3000.0 6*0.1 0.31 1*0.1
+9000.0 6*0.1 0.32 1*0.1/
+
+ENPTVD
+3000.0 0.20 0.20 1.0 0.0 0.04 1.0 0.18 0.22
+9000.0 0.22 0.22 1.0 0.0 0.04 1.0 0.18 0.22 /
+
+END
+)");
 }
 
-Opm::Deck createSingleRecordDeckWithJFunc() {
-    const char *deckData =
-        "RUNSPEC\n"
-        "ENDSCALE\n"
-        "2* 1 2 /\n"
-        "PROPS\n"
-        "JFUNC\n"
-        "  WATER 22.0 /\n"
-        "TABDIMS\n"
-        " 2 /\n"
-        "\n"
-        "SWFN\n"
-        "0.22 .0   7.0 \n"
-        "0.3  .0   4.0 \n"
-        "0.5  .24  2.5 \n"
-        "0.8  .65  1.0 \n"
-        "0.9  .83  .5  \n"
-        "1.0  1.00 .0 /\n"
-        "/\n"
-        "IMPTVD\n"
-        "3000.0 6*0.1 0.31 1*0.1\n"
-        "9000.0 6*0.1 0.32 1*0.1/\n"
-        "ENPTVD\n"
-        "3000.0 0.20 0.20 1.0 0.0 0.04 1.0 0.18 0.22\n"
-        "9000.0 0.22 0.22 1.0 0.0 0.04 1.0 0.18 0.22 /";
+Opm::Deck createSingleRecordDeckWithJFunc()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+WATER
 
-    Opm::Parser parser;
-    return parser.parseString(deckData);
+TABDIMS
+ 2 /
+
+ENDSCALE
+2* 1 2 /
+
+PROPS
+
+JFUNC
+  WATER 22.0 /
+
+SWFN
+0.22 .0   7.0
+0.3  .0   4.0
+0.5  .24  2.5
+0.8  .65  1.0
+0.9  .83   .5
+1.0  1.00  .0 /
+/
+
+IMPTVD
+3000.0 6*0.1 0.31 1*0.1
+9000.0 6*0.1 0.32 1*0.1/
+
+ENPTVD
+3000.0 0.20 0.20 1.0 0.0 0.04 1.0 0.18 0.22
+9000.0 0.22 0.22 1.0 0.0 0.04 1.0 0.18 0.22 /
+
+END
+)");
 }
 
 Opm::Deck createSingleRecordDeckWithJFuncBoth() {
@@ -169,7 +186,7 @@ Opm::Deck createSingleRecordDeckWithJFuncBrokenDirection() {
 
 /// used in BOOST_CHECK_CLOSE
 static float epsilon() {
-    return 0.00001;
+    return 0.00001f;
 }
 }
 
@@ -235,19 +252,24 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithJFunc ) {
 
 
 BOOST_AUTO_TEST_CASE(SwofTable_Tests) {
-    const char *deckData =
-        "TABDIMS\n"
-        "2 /\n"
-        "\n"
-        "SWOF\n"
-        " 1 2 3 4\n"
-        " 5 6 7 8/\n"
-        "  9 10 11 12\n"
-        " 13 14 15 16\n"
-        " 17 18 19 20/\n";
+    auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
 
-    Opm::Parser parser;
-    auto deck = parser.parseString(deckData);
+TABDIMS
+2 /
+
+PROPS
+
+SWOF
+  1 2 3 4
+  5 6 7 8/
+  9 10 11 12
+ 13 14 15 16
+ 17 18 19 20/
+
+END
+)");
 
     Opm::SwofTable swof1Table(deck.getKeyword("SWOF").getRecord(0).getItem(0), false);
     Opm::SwofTable swof2Table(deck.getKeyword("SWOF").getRecord(1).getItem(0), false);
@@ -375,19 +397,22 @@ BOOST_AUTO_TEST_CASE(SgwfnTable_Tests) {
 }
 
 BOOST_AUTO_TEST_CASE(SgofTable_Tests) {
-    const char *deckData =
-        "TABDIMS\n"
-        "2 /\n"
-        "\n"
-        "SGOF\n"
-        " 1 2 3 4\n"
-        " 5 6 7 8/\n"
-        "  9 10 11 12\n"
-        " 13 14 15 16\n"
-        " 17 18 19 20/\n";
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+GAS
+OIL
 
-    Opm::Parser parser;
-    auto deck = parser.parseString(deckData);
+TABDIMS
+2 /
+
+SGOF
+  1 2 3 4
+  5 6 7 8/
+  9 10 11 12
+ 13 14 15 16
+ 17 18 19 20/
+
+END
+)");
 
     Opm::SgofTable sgof1Table(deck.getKeyword("SGOF").getRecord(0).getItem(0), false);
     Opm::SgofTable sgof2Table(deck.getKeyword("SGOF").getRecord(1).getItem(0), false);

--- a/tests/parser/data/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA
+++ b/tests/parser/data/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA
@@ -1,5 +1,8 @@
 RUNSPEC 
 
+OIL
+WATER
+
 DIMENS
   10  10  5 /
 

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -939,6 +939,9 @@ PVTO
 
 BOOST_AUTO_TEST_CASE( SGOF ) {
 const std::string parserData = R"(
+GAS
+OIL
+
 TABDIMS
 -- NTSFUN NTPVT NSSFUN NPPVT NTFIP NRPVT
         1     1     30     1     1     1 /
@@ -977,6 +980,9 @@ SGOF
 BOOST_AUTO_TEST_CASE( SWOF ) {
 
     const std::string parserData = R"(
+OIL
+WATER
+
 TABDIMS
 -- NTSFUN NTPVT NSSFUN NPPVT NTFIP NRPVT
         1     1     30     1     1     1 /
@@ -1032,6 +1038,8 @@ SWOF
 BOOST_AUTO_TEST_CASE( SLGOF ) {
 
 const std::string parserData = R"(
+GAS
+
 TABDIMS
 -- NTSFUN NTPVT NSSFUN NPPVT NTFIP NRPVT
         1     1     30     1     1     1 /
@@ -1469,6 +1477,9 @@ BOOST_AUTO_TEST_CASE(PVTWSALT) {
     const std::string input = R"(
 RUNSPEC
 
+OIL
+GAS
+
 TABDIMS
  1 2 /
 
@@ -1493,10 +1504,9 @@ SGOF
     0.7 0.8 0.3 6.0
     0.8 0.9 0.2 7.0
     0.9 0.5 0.1 8.0
-    1.0 1.0 0.1 9.0 /;
-
-
+    1.0 1.0 0.1 9.0 /
 )";
+
     auto deck = Parser{}.parseString(input);
     const auto& pvtwsalt = deck.getKeyword("PVTWSALT");
     BOOST_CHECK_EQUAL(pvtwsalt.size(), 4);


### PR DESCRIPTION
This information is generally useful so we should have a single source of truth and not have to reimplement the logic every time we need it.