### PR TITLE
Tag warning to silence repeats on terminal.

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/PAvgCalculator.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/PAvgCalculator.cpp
@@ -59,8 +59,7 @@ PAvgCalculator::PAvgCalculator(const std::string& well, const EclipseGrid& grid,
     m_pavg(pavg)
 {
     if (pavg.use_porv())
-        OpmLog::warning("PORV based averaging is not yet supported in WBPx");
-        //throw std::logic_error("The current implementation does not yet support PORV based averaging");
+        OpmLog::warning("Unsupported PORV averaging", "PORV based averaging is not yet supported in WBPx");
 
     if (porv.size() != grid.getCartesianSize())
         throw std::logic_error("Should pass a GLOBAL porv vector");


### PR DESCRIPTION
This new warning repeats many times for every timestep on for example Norne. Tagging it makes it silenced on the terminal after  10 warnings, which makes it a lot less annoying.

Longer term, perhaps this check can be moved somewhere it will only be done once, but not knowing the details here I did not want to mess things up.