### PR TITLE
Add sched tstep

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -127,6 +127,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -743,6 +744,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp
        opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
        opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp
+       opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
        opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
        opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group/GPMaint.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -51,6 +51,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellMatcher.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/io/eclipse/rst/state.hpp>
@@ -293,6 +294,13 @@ namespace Opm
         bool operator==(const Schedule& data) const;
         std::shared_ptr<const Python> python() const;
 
+
+        const ScheduleState& operator[](std::size_t index) const;
+        std::vector<ScheduleState>::const_iterator begin() const;
+        std::vector<ScheduleState>::const_iterator end() const;
+        ScheduleState& create_next(const ScheduleBlock& block);
+
+
         /*
           The cmp() function compares two schedule instances in a context aware
           manner. Floating point numbers are compared with a tolerance. The
@@ -335,7 +343,6 @@ namespace Opm
             m_actions.serializeOp(serializer);
             m_network.serializeOp(serializer);
             m_glo.serializeOp(serializer);
-            m_pavg.serializeOp(serializer);
             rft_config.serializeOp(serializer);
             m_nupcol.template serializeOp<Serializer, false>(serializer);
             restart_config.serializeOp(serializer);
@@ -347,6 +354,7 @@ namespace Opm
                 reconstructDynMap<Map2>(splitvfpinj.first, splitvfpinj.second, vfpinj_tables);
             }
             unit_system.serializeOp(serializer);
+            serializer.vector(snapshots);
         }
 
     private:
@@ -375,14 +383,16 @@ namespace Opm
         DynamicState<std::shared_ptr<Action::Actions>> m_actions;
         DynamicState<std::shared_ptr<Network::ExtNetwork>> m_network;
         DynamicState<std::shared_ptr<GasLiftOpt>> m_glo;
-        DynamicState<std::shared_ptr<PAvg>> m_pavg;
         RFTConfig rft_config;
         DynamicState<int> m_nupcol;
         RestartConfig restart_config;
         UnitSystem unit_system;
         std::optional<int> exit_status;
-
         std::map<std::string,Events> wellgroup_events;
+        DynamicState<std::shared_ptr<RPTConfig>> rpt_config;
+        std::vector<ScheduleState> snapshots;
+
+
         void load_rst(const RestartIO::RstState& rst,
                       const EclipseGrid& grid,
                       const FieldPropsManager& fp);
@@ -402,7 +412,6 @@ namespace Opm
                      Connection::Order wellConnectionOrder);
         bool updateWPAVE(const std::string& wname, std::size_t report_step, const PAvg& pavg);
 
-        DynamicState<std::shared_ptr<RPTConfig>> rpt_config;
         void updateNetwork(std::shared_ptr<Network::ExtNetwork> network, std::size_t report_step);
         void updateGuideRateModel(const GuideRateModel& new_model, std::size_t report_step);
 

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp
@@ -54,7 +54,7 @@ namespace Opm {
         void push_back(const DeckKeyword& keyword);
         std::optional<DeckKeyword> get(const std::string& kw) const;
         const std::chrono::system_clock::time_point& start_time() const;
-        const std::chrono::system_clock::time_point& end_time() const;
+        const std::optional<std::chrono::system_clock::time_point>& end_time() const;
         void end_time(const std::chrono::system_clock::time_point& t);
         ScheduleTimeType time_type() const;
         const KeywordLocation& location() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
@@ -1,0 +1,74 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SCHEDULE_TSTEP_HPP
+#define SCHEDULE_TSTEP_HPP
+
+#include <chrono>
+#include <memory>
+#include <optional>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Well/PAvg.hpp>
+
+namespace Opm {
+
+    /*
+      The purpose of the ScheduleState class is to hold the entire Schedule
+      information, i.e. wells and groups and so on, at exactly one point in
+      time. The ScheduleState class itself has no dynamic behavior, the dynamics
+      is handled by the Schedule instance owning the ScheduleState instance.
+    */
+
+
+    class ScheduleState {
+    public:
+        ScheduleState() = default;
+        explicit ScheduleState(const std::chrono::system_clock::time_point& start_time);
+        ScheduleState(const std::chrono::system_clock::time_point& start_time, const std::chrono::system_clock::time_point& end_time);
+        ScheduleState(const ScheduleState& src, const std::chrono::system_clock::time_point& start_time);
+        ScheduleState(const ScheduleState& src, const std::chrono::system_clock::time_point& start_time, const std::chrono::system_clock::time_point& end_time);
+
+
+        std::chrono::system_clock::time_point start_time() const;
+        std::chrono::system_clock::time_point end_time() const;
+        ScheduleState next(const std::chrono::system_clock::time_point& next_start);
+
+        bool operator==(const ScheduleState& other) const;
+        static ScheduleState serializeObject();
+
+        void pavg(PAvg pavg);
+        const PAvg& pavg() const;
+
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer) {
+            serializer(m_start_time);
+            serializer(m_end_time);
+            serializer(m_pavg);
+        }
+
+    private:
+        std::chrono::system_clock::time_point m_start_time;
+        std::optional<std::chrono::system_clock::time_point> m_end_time;
+
+        std::shared_ptr<PAvg> m_pavg;
+    };
+}
+
+#endif

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -1821,11 +1821,12 @@ namespace {
     }
 
     void Schedule::handleWPAVE(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
-        auto wpave = std::make_shared<PAvg>( handlerContext.keyword.getRecord(0) );
+        auto wpave = PAvg( handlerContext.keyword.getRecord(0) );
         for (const auto& wname : this->wellNames(handlerContext.currentStep))
-            this->updateWPAVE(wname, handlerContext.currentStep, *wpave );
+            this->updateWPAVE(wname, handlerContext.currentStep, wpave );
 
-        this->m_pavg.update( handlerContext.currentStep, std::move(wpave) );
+        auto& sched_state = this->snapshots.back();
+        sched_state.pavg(std::move(wpave));
     }
 
     void Schedule::handleWWPAVE(const HandlerContext& handlerContext, const ParseContext& parseContext, ErrorGuard& errors) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.cpp
@@ -61,8 +61,8 @@ const std::chrono::system_clock::time_point& ScheduleBlock::start_time() const {
     return this->m_start_time;
 }
 
-const std::chrono::system_clock::time_point& ScheduleBlock::end_time() const {
-    return this->m_end_time.value();
+const std::optional<std::chrono::system_clock::time_point>& ScheduleBlock::end_time() const {
+    return this->m_end_time;
 }
 
 ScheduleTimeType ScheduleBlock::time_type() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
@@ -1,0 +1,80 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp>
+
+namespace Opm {
+
+ScheduleState::ScheduleState(const std::chrono::system_clock::time_point& t1):
+    m_start_time(t1),
+    m_pavg( std::make_shared<PAvg>())
+{
+}
+
+ScheduleState::ScheduleState(const std::chrono::system_clock::time_point& start_time, const std::chrono::system_clock::time_point& end_time) :
+    ScheduleState(start_time)
+{
+    this->m_end_time = end_time;
+}
+
+ScheduleState::ScheduleState(const ScheduleState& src, const std::chrono::system_clock::time_point& start_time) :
+    ScheduleState(src)
+{
+    this->m_start_time = start_time;
+    this->m_end_time = std::nullopt;
+}
+
+ScheduleState::ScheduleState(const ScheduleState& src, const std::chrono::system_clock::time_point& start_time, const std::chrono::system_clock::time_point& end_time) :
+    ScheduleState(src)
+{
+    this->m_start_time = start_time;
+    this->m_end_time = end_time;
+}
+
+
+std::chrono::system_clock::time_point ScheduleState::start_time() const {
+    return this->m_start_time;
+}
+
+std::chrono::system_clock::time_point ScheduleState::end_time() const {
+    return this->m_end_time.value();
+}
+
+
+void ScheduleState::pavg(PAvg arg) {
+    this->m_pavg = std::make_shared<PAvg>( std::move(arg) );
+}
+
+const PAvg& ScheduleState::pavg() const {
+    return *this->m_pavg;
+}
+
+
+bool ScheduleState::operator==(const ScheduleState& other) const {
+    return this->m_start_time == other.m_start_time &&
+           this->m_end_time   == other.m_end_time;
+}
+
+ScheduleState ScheduleState::serializeObject() {
+    auto t1 = std::chrono::system_clock::now();
+    auto t2 = t1 + std::chrono::hours(48);
+    ScheduleState ts(t1, t2);
+    return ts;
+}
+}

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -4489,6 +4489,42 @@ std::string dates_msg(const std::chrono::system_clock::time_point& t, std::array
 }
 
 
+BOOST_AUTO_TEST_CASE(ScheduleStateDatesTest) {
+    const auto& sched = make_schedule(createDeckWTEST());
+    BOOST_CHECK_EQUAL(sched.size(), 6);
+    BOOST_CHECK( compare_dates(sched[0].start_time(), 2007, 5, 10 ));
+    BOOST_CHECK( compare_dates(sched[0].end_time(), 2007, 6, 10 ));
+
+    BOOST_CHECK( compare_dates(sched[1].start_time(), 2007, 6, 10));
+    BOOST_CHECK( compare_dates(sched[1].end_time(), 2007, 7, 10 ));
+
+    BOOST_CHECK( compare_dates(sched[2].start_time(), 2007, 7, 10));
+    BOOST_CHECK( compare_dates(sched[2].end_time(), 2007, 8, 10 ));
+
+    BOOST_CHECK( compare_dates(sched[3].start_time(), 2007, 8, 10));
+    BOOST_CHECK( compare_dates(sched[3].end_time(), 2007, 9, 10 ));
+
+    BOOST_CHECK( compare_dates(sched[4].start_time(), 2007, 9, 10));
+    BOOST_CHECK( compare_dates(sched[4].end_time(), 2007, 11, 10 ));
+
+    BOOST_CHECK( compare_dates(sched[5].start_time(), 2007, 11, 10));
+    BOOST_CHECK_THROW( sched[5].end_time(), std::exception );
+}
+
+
+BOOST_AUTO_TEST_CASE(ScheduleStateTest) {
+    auto t1 = std::chrono::system_clock::now();
+    auto t2 = t1 + std::chrono::hours(48);
+
+    ScheduleState ts1(t1);
+    BOOST_CHECK( t1 == ts1.start_time() );
+    BOOST_CHECK_THROW( ts1.end_time(), std::exception );
+
+    ScheduleState ts2(t1, t2);
+    BOOST_CHECK( t1 == ts2.start_time() );
+    BOOST_CHECK( t2 == ts2.end_time() );
+}
+
 BOOST_AUTO_TEST_CASE(ScheduleDeckTest) {
     {
         ScheduleDeck sched_deck;


### PR DESCRIPTION
This is a first PR in the #2176 effort. With this PR a new `ScheduleState[1]` class is created, and the `Schedule` class gets a new member `std::vector<ScheduleState>`. One `ScheduleState`contains the accumulated scehdule state up until this time. Currently it only internalizes the `WPAVE` keyword in the form of a `std::shared_ptr<PAvg>` member, but eventually the goal is that the `Schedule` class should only consist of container of report step indexed `ScheduleState` instances.

When this work has been completed everything about time can (hopefully!) be greatly simplified, in particular the long term members `DynamicState<T>` and `TimeMap` can just be removed. This will make the time handling in the `Schedule`class less special cased. 

The PR: #2183 should only affect `Schedule` development and not downstream  users. This PR is the start of changes which will affect downstream users. Currently downstream will fetch a well object like:
```C++
auto well = schedule.getWell( report_step, well_name );
```
when this work is completed downstream will first fetch a `ScheduleState`object for the relevant report step, and then query that object for the well information:
```C++
auto sched_state = schedule[report_step];
auto well = sched_state.getWell( well_name );
```
For the current PR the `PAvg` member is the only member which has been transferred to `ScheduleState` - and that does not yet have any downstream users - so no downstream PR for this. This is early days for the refactoring #2176, and a good time to comment.

[1]: Not overly happy with the name - feel free to suggest alternatives.