### PR TITLE
Add reference depth member to PAvg and PAvgCalculator

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -560,6 +560,7 @@ namespace Opm
         void handleWLIFTOPT (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWLIST    (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWPAVE    (const HandlerContext&, const ParseContext&, ErrorGuard&);
+        void handleWPAVEDEP (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWWPAVE   (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWPIMULT  (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleWPMITAB  (const HandlerContext&, const ParseContext&, ErrorGuard&);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/PAvgCalculator.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/PAvgCalculator.hpp
@@ -37,7 +37,7 @@ class Serializer;
 class PAvgCalculator {
 public:
 
-    PAvgCalculator(const std::string& well, const EclipseGrid& grid, const std::vector<double>& porv, const WellConnections& connections, const PAvg& pavg);
+    PAvgCalculator(const std::string& well, double well_ref_depth, const EclipseGrid& grid, const std::vector<double>& porv, const WellConnections& connections, const PAvg& pavg);
 
     enum class WBPMode {
         WBP,
@@ -102,6 +102,7 @@ private:
     std::vector<std::size_t> m_index_list;
     std::vector<double> pressure;
     std::vector<char> valid_pressure;
+    double ref_depth;
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -516,6 +516,7 @@ public:
     const std::string& name() const;
     int getHeadI() const;
     int getHeadJ() const;
+    double getWPaveRefDepth() const;
     double getRefDepth() const;
     double getDrainageRadius() const;
     double getEfficiencyFactor() const;
@@ -599,6 +600,7 @@ public:
     bool updateWSEGVALV(const std::vector<std::pair<int, Valve> >& valve_pairs);
     bool updateWSEGAICD(const std::vector<std::pair<int, AutoICD> >& aicd_pairs, const KeywordLocation& location);
     bool updateWPAVE(const PAvg& pavg);
+    void updateWPaveRefDepth(double ref_depth);
 
     bool handleWELSEGS(const DeckKeyword& keyword);
     bool handleCOMPSEGS(const DeckKeyword& keyword, std::size_t report_step, const EclipseGrid& grid, const ParseContext& parseContext, ErrorGuard& errors);
@@ -640,6 +642,7 @@ public:
         serializer(headI);
         serializer(headJ);
         serializer(ref_depth);
+        serializer(wpave_ref_depth);
         unit_system.serializeOp(serializer);
         serializer(udq_undefined);
         serializer(status);
@@ -679,6 +682,7 @@ private:
     int headI;
     int headJ;
     std::optional<double> ref_depth;
+    std::optional<double> wpave_ref_depth;
     double drainage_radius;
     bool allow_cross_flow;
     bool automatic_shutin;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/PAvgCalculator.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/PAvgCalculator.cpp
@@ -54,9 +54,10 @@ const std::string& PAvgCalculator::wname() const {
 }
 
 
-PAvgCalculator::PAvgCalculator(const std::string& well, const EclipseGrid& grid, const std::vector<double>& porv, const WellConnections& connections, const PAvg& pavg) :
+PAvgCalculator::PAvgCalculator(const std::string& well, double well_ref_depth, const EclipseGrid& grid, const std::vector<double>& porv, const WellConnections& connections, const PAvg& pavg) :
     well_name(well),
-    m_pavg(pavg)
+    m_pavg(pavg),
+    ref_depth(well_ref_depth)
 {
     if (porv.size() != grid.getCartesianSize())
         throw std::logic_error("Should pass a GLOBAL porv vector");

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -944,6 +944,10 @@ double Well::getRefDepth() const {
     return *this->ref_depth;
 }
 
+double Well::getWPaveRefDepth() const {
+    return this->wpave_ref_depth.value_or( this->getRefDepth() );
+}
+
 void Well::updateRefDepth() {
     if( !this->ref_depth ) {
         // ref depth was defaulted and we get the depth of the first completion
@@ -956,6 +960,9 @@ void Well::updateRefDepth() {
     }
 }
 
+void Well::updateWPaveRefDepth(double depth) {
+    this->wpave_ref_depth = depth;
+}
 
 double Well::getDrainageRadius() const {
     return this->drainage_radius;
@@ -1772,7 +1779,7 @@ bool Well::operator==(const Well& data) const {
 
 
 PAvgCalculator Well::pavg_calculator(const EclipseGrid& grid, const std::vector<double>& porv) const {
-    return PAvgCalculator(this->name(), grid, porv, this->getConnections(), this->m_pavg);
+    return PAvgCalculator(this->name(), this->getWPaveRefDepth(), grid, porv, this->getConnections(), this->m_pavg);
 }
 
 

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WPAVEDEP
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WPAVEDEP
@@ -3,16 +3,15 @@
   "sections": [
     "SCHEDULE"
   ],
-  "size": 1,
   "items": [
     {
-      "name": "WELLNAME",
+      "name": "WELL",
       "value_type": "STRING"
     },
     {
       "name": "REFDEPTH",
       "value_type": "DOUBLE",
-      "default": 0
+      "dimension" : "Length"
     }
   ]
 }

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -1421,6 +1421,10 @@ WELSPECS
 /
 -- W3
 
+WPAVEDEP
+  'W1'  0 /
+/
+
 TSTEP
 1  /
 
@@ -1453,9 +1457,11 @@ END
 
 
     BOOST_CHECK_EQUAL(w0.getRefDepth(), grid.getCellDepth(0,0,2));
+    BOOST_CHECK_EQUAL(w0.getRefDepth(), w0.getWPaveRefDepth());
     BOOST_CHECK_EQUAL(w1.getRefDepth(), w0.getRefDepth());
     BOOST_CHECK_EQUAL(w2.getRefDepth(), 2005 );
     BOOST_CHECK_EQUAL(w3.getRefDepth(), grid.getCellDepth(0,0,1));
     BOOST_CHECK_EQUAL(w4.getRefDepth(), w3.getRefDepth());
     BOOST_CHECK_EQUAL(w5.getRefDepth(), grid.getCellDepth(0,0,0));
+    BOOST_CHECK_EQUAL(w5.getWPaveRefDepth(), 0);
 }


### PR DESCRIPTION
Minor preparation to handle variable reference depth through the `WPAVEDEP` keyword in the `WBPx` calculations. NB: The actual `WPAVEDEP` keyword will be handled after: #2178