### PR TITLE
Use consistent names in WSEG* keywords

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
@@ -98,8 +98,8 @@ namespace Opm {
             for (const DeckRecord &record : wseg) {
                 const std::string well_name = record.getItem("WELL").getTrimmedString(0);
 
-                const int start_segment = record.getItem("SEG1").get<int>(0);
-                const int end_segment = record.getItem("SEG2").get<int>(0);
+                const int start_segment = record.getItem("SEGMENT1").get<int>(0);
+                const int end_segment = record.getItem("SEGMENT2").get<int>(0);
 
                 if (start_segment < 2 || end_segment < 2 || end_segment < start_segment) {
                     const std::string message = "Segment numbers " + std::to_string(start_segment) + " and "

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WSEGAICD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WSEGAICD
@@ -9,11 +9,11 @@
       "value_type": "STRING"
     },
     {
-      "name": "SEG1",
+      "name": "SEGMENT1",
       "value_type": "INT"
     },
     {
-      "name": "SEG2",
+      "name": "SEGMENT2",
       "value_type": "INT"
     },
     {

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WSEGSICD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WSEGSICD
@@ -9,11 +9,11 @@
       "value_type": "STRING"
     },
     {
-      "name": "SEG1",
+      "name": "SEGMENT1",
       "value_type": "INT"
     },
     {
-      "name": "SEG2",
+      "name": "SEGMENT2",
       "value_type": "INT"
     },
     {

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -256,8 +256,8 @@ WSEGSICD
     const Opm::DeckKeyword wsegsicd = deck.getKeyword("WSEGSICD");
     BOOST_CHECK_EQUAL(1U, wsegsicd.size());
     const Opm::DeckRecord& record = wsegsicd.getRecord(0);
-    const int start_segment = record.getItem("SEG1").get< int >(0);
-    const int end_segment = record.getItem("SEG2").get< int >(0);
+    const int start_segment = record.getItem("SEGMENT1").get< int >(0);
+    const int end_segment = record.getItem("SEGMENT2").get< int >(0);
     BOOST_CHECK_EQUAL(8, start_segment);
     BOOST_CHECK_EQUAL(8, end_segment);
 


### PR DESCRIPTION
WSEGAICD and WSEGSICD used SEG1 and SEG2, while all
other WSEG* keywords use SEGMENT1 and SEGMENT2 for the same
item.