### PR TITLE
Using pinched grid for generating aquifer connections

### DIFF
--- a/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
@@ -53,6 +53,7 @@ public:
     bool hasNumericalAquifer() const;
     bool hasAnalyticalAquifer() const;
     const NumericalAquifers& numericalAquifers() const;
+    NumericalAquifers& mutableNumericalAquifers() const;
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -66,7 +67,7 @@ public:
 private:
     Aquifetp aquifetp;
     AquiferCT aquiferct;
-    NumericalAquifers numerical_aquifers;
+    mutable NumericalAquifers numerical_aquifers;
     Aquancon aqconn;
 };
 

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp
@@ -65,9 +65,11 @@ namespace Opm {
             serializer(this->ve_frac_cappress);
         }
 
-        static std::map<size_t, std::map<size_t, NumericalAquiferConnection>> generateConnections(const Deck& deck, const EclipseGrid& grid);
+        static std::map<size_t, std::map<size_t, NumericalAquiferConnection>>
+                generateConnections(const Deck& deck, const EclipseGrid& grid, const std::vector<int>& actnum);
     private:
-        static std::vector<NumericalAquiferConnection> connectionsFromSingleRecord(const EclipseGrid& grid, const DeckRecord& record);
+        static std::vector<NumericalAquiferConnection>
+                connectionsFromSingleRecord(const EclipseGrid& grid, const DeckRecord& record, const std::vector<int>& actnum);
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -48,7 +48,13 @@ namespace Opm {
 
         std::vector<NNCdata> aquiferNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const;
 
+        std::vector<NNCdata> aquiferCellNNCs() const;
+
+        std::vector<NNCdata> aquiferConnectionNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const;
+
         std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
+
+        void addAquiferConnections(const Deck& deck, const EclipseGrid& grid, const std::vector<int>& actnum);
 
         static NumericalAquifers serializeObject();
         template <class Serializer>
@@ -61,7 +67,6 @@ namespace Opm {
         std::map<size_t, SingleNumericalAquifer> m_aquifers;
 
         void addAquiferCell(const NumericalAquiferCell& aqu_cell);
-        void addAquiferConnections(const Deck &deck, const EclipseGrid &grid);
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -57,7 +57,9 @@ namespace Opm {
 
         std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
 
-        std::vector<NNCdata> aquiferNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const;
+        std::vector<NNCdata> aquiferCellNNCs() const;
+        std::vector<NNCdata> aquiferConnectionNNCs(const EclipseGrid &grid, const FieldPropsManager &fp) const;
+
         const std::vector<NumericalAquiferConnection>& connections() const;
 
         bool operator==(const SingleNumericalAquifer& other) const;
@@ -77,9 +79,6 @@ namespace Opm {
             size_t id_;
             std::vector<NumericalAquiferCell> cells_;
             std::vector<NumericalAquiferConnection> connections_;
-
-            std::vector<NNCdata> aquiferCellNNCs() const;
-            std::vector<NNCdata> aquiferConnectionNNCs(const EclipseGrid &grid, const FieldPropsManager &fp) const;
         };
 }
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -87,6 +87,7 @@ namespace Opm {
         /// non-neighboring connections
         /// the non-standard adjacencies as specified in input deck
         const NNC& getInputNNC() const;
+        void appendInputNNC(const std::vector<NNCdata>& nnc);
         bool hasInputNNC() const;
 
         // The potentially parallelized field properties

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.cpp
@@ -108,6 +108,7 @@ namespace Opm {
 
     Aquancon::Aquancon(const EclipseGrid& grid, const Deck& deck)
     {
+        const std::vector<int>& actnum = grid.getACTNUM();
         std::unordered_map<std::size_t, Aquancon::AquancCell> work;
         for (std::size_t iaq = 0; iaq < deck.count("AQUANCON"); iaq++) {
             const auto& aquanconKeyword = deck.getKeyword("AQUANCON", iaq);
@@ -132,9 +133,9 @@ namespace Opm {
                 for (int k = k1; k <= k2; k++) {
                     for (int j = j1; j <= j2; j++) {
                         for (int i = i1; i <= i2; i++) {
-                            if (grid.cellActive(i, j, k)) { // the cell itself needs to be active
+                            if (actnum[grid.getGlobalIndex(i, j, k)]) { // the cell itself needs to be active
                                 if (allow_aquifer_inside_reservoir
-                                    || !AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, faceDir)) {
+                                    || !AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, faceDir, actnum)) {
                                     std::optional<double> influx_coeff;
                                     if (aquanconRecord.getItem("INFLUX_COEFF").hasValue(0))
                                         influx_coeff = aquanconRecord.getItem("INFLUX_COEFF").getSIDouble(0);

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -38,7 +38,7 @@ AquiferConfig::AquiferConfig(const Aquifetp& fetp, const AquiferCT& ct, const Aq
 {}
 
 void AquiferConfig::load_connections(const Deck& deck, const EclipseGrid& grid) {
-    this->aqconn = Aquancon(grid,deck);
+    this->aqconn = Aquancon(grid, deck);
 }
 
 AquiferConfig AquiferConfig::serializeObject()

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -90,6 +90,10 @@ const NumericalAquifers& AquiferConfig::numericalAquifers() const {
     return this->numerical_aquifers;
 }
 
+NumericalAquifers& AquiferConfig::mutableNumericalAquifers() const {
+    return this->numerical_aquifers;
+}
+
 bool AquiferConfig::hasAnalyticalAquifer() const {
     return this->aquiferct.size() > 0 ||
            this->aquifetp.size() > 0;

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferHelpers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferHelpers.cpp
@@ -21,7 +21,8 @@
 #include "AquiferHelpers.hpp"
 
 namespace Opm::AquiferHelpers {
-    bool cellInsideReservoirAndActive(const Opm::EclipseGrid& grid, const int i, const int j, const int k)
+    bool cellInsideReservoirAndActive(const EclipseGrid& grid, const int i, const int j, const int k,
+                                      const std::vector<int>& actnum)
     {
         if ( i < 0 || j < 0 || k < 0
              || size_t(i) > grid.getNX() - 1
@@ -31,26 +32,26 @@ namespace Opm::AquiferHelpers {
             return false;
         }
 
-        return grid.cellActive(i, j, k );
+        const size_t globalIndex = grid.getGlobalIndex(i,j,k);
+        return actnum[globalIndex];
     }
 
-    bool neighborCellInsideReservoirAndActive(const Opm::EclipseGrid& grid,
-                                              const int i, const int j, const int k,
-                                              const FaceDir::DirEnum faceDir)
+    bool neighborCellInsideReservoirAndActive(const EclipseGrid& grid, const int i, const int j, const int k,
+                                              const Opm::FaceDir::DirEnum faceDir, const std::vector<int>& actnum)
     {
         switch(faceDir) {
             case FaceDir::XMinus:
-                return cellInsideReservoirAndActive(grid, i - 1, j, k);
+                return cellInsideReservoirAndActive(grid, i - 1, j, k, actnum);
             case FaceDir::XPlus:
-                return cellInsideReservoirAndActive(grid, i + 1, j, k);
+                return cellInsideReservoirAndActive(grid, i + 1, j, k, actnum);
             case FaceDir::YMinus:
-                return cellInsideReservoirAndActive(grid, i, j - 1, k);
+                return cellInsideReservoirAndActive(grid, i, j - 1, k, actnum);
             case FaceDir::YPlus:
-                return cellInsideReservoirAndActive(grid, i, j + 1, k);
+                return cellInsideReservoirAndActive(grid, i, j + 1, k, actnum);
             case FaceDir::ZMinus:
-                return cellInsideReservoirAndActive(grid, i, j, k - 1);
+                return cellInsideReservoirAndActive(grid, i, j, k - 1, actnum);
             case FaceDir::ZPlus:
-                return cellInsideReservoirAndActive(grid, i, j, k + 1);
+                return cellInsideReservoirAndActive(grid, i, j, k + 1, actnum);
             default:
                 throw std::runtime_error("Unknown FaceDir enum " + std::to_string(faceDir));
         }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferHelpers.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferHelpers.hpp
@@ -21,10 +21,13 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
 
+#include <vector>
+
 namespace Opm {
     class EclipseGrid;
     namespace AquiferHelpers {
-        bool neighborCellInsideReservoirAndActive(const EclipseGrid &grid, int i, int j, int k, FaceDir::DirEnum faceDir);
+        bool neighborCellInsideReservoirAndActive(const EclipseGrid &grid, int i, int j, int k,
+                                                  FaceDir::DirEnum faceDir, const std::vector<int>& actnum);
     }
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.cpp
@@ -32,7 +32,7 @@
 namespace Opm {
 
     std::map<size_t, std::map<size_t, NumericalAquiferConnection>>
-    NumericalAquiferConnection::generateConnections(const Deck &deck, const EclipseGrid &grid)
+    NumericalAquiferConnection::generateConnections(const Deck &deck, const EclipseGrid &grid, const std::vector<int>& actnum)
     {
         using AQUCON=ParserKeywords::AQUCON;
         if ( !deck.hasKeyword<AQUCON>() ) return {};
@@ -43,7 +43,7 @@ namespace Opm {
         for (const auto& keyword : aqucon_keywords) {
             OpmLog::info(OpmInputError::format("Initializing numerical aquifer connections from {keyword} in {file} line {line}", keyword->location()));
             for (const auto& record : *keyword) {
-                const auto cons_from_record = NumericalAquiferConnection::connectionsFromSingleRecord(grid, record);
+                const auto cons_from_record = NumericalAquiferConnection::connectionsFromSingleRecord(grid, record, actnum);
                 for (auto con : cons_from_record) {
                     const size_t aqu_id = con.aquifer_id;
                     const size_t global_index = con.global_index;
@@ -80,10 +80,10 @@ namespace Opm {
     {
     }
 
-    std::vector<NumericalAquiferConnection> NumericalAquiferConnection::connectionsFromSingleRecord(const EclipseGrid& grid, const DeckRecord& record) {
+    std::vector<NumericalAquiferConnection>
+    NumericalAquiferConnection::
+    connectionsFromSingleRecord(const EclipseGrid& grid, const DeckRecord& record,const std::vector<int>& actnum) {
         std::vector<NumericalAquiferConnection> cons;
-
-        const auto& actnum = grid.getACTNUM();
 
         const size_t i1 = record.getItem<AQUCON::I1>().get<int>(0) - 1;
         const size_t j1 = record.getItem<AQUCON::J1>().get<int>(0) - 1;

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.cpp
@@ -83,6 +83,8 @@ namespace Opm {
     std::vector<NumericalAquiferConnection> NumericalAquiferConnection::connectionsFromSingleRecord(const EclipseGrid& grid, const DeckRecord& record) {
         std::vector<NumericalAquiferConnection> cons;
 
+        const auto& actnum = grid.getACTNUM();
+
         const size_t i1 = record.getItem<AQUCON::I1>().get<int>(0) - 1;
         const size_t j1 = record.getItem<AQUCON::J1>().get<int>(0) - 1;
         const size_t k1 = record.getItem<AQUCON::K1>().get<int>(0) - 1;
@@ -100,11 +102,11 @@ namespace Opm {
             for (size_t j = j1; j <=j2; ++j) {
                 for (size_t i = i1; i <= i2; ++i) {
                     // TODO: we probably should give a message here
-                    if (!grid.cellActive(i, j, k)) {
+                    if (!actnum[grid.getGlobalIndex(i, j, k)]) {
                         continue;
                     }
                     if (allow_internal_cells ||
-                        !AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, face_dir)) {
+                        !AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, face_dir, actnum) ) {
                         const size_t global_index = grid.getGlobalIndex(i, j, k);
                         cons.emplace_back(i, j, k, global_index, allow_internal_cells, record);
                     }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -72,14 +72,6 @@ namespace Opm {
         return aqucellprops;
     }
 
-    std::vector<NNCdata>
-    SingleNumericalAquifer::aquiferNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const {
-        auto nncs = this->aquiferCellNNCs();
-        auto con_nncs = this->aquiferConnectionNNCs(grid, fp);
-        nncs.insert(nncs.end(), con_nncs.begin(), con_nncs.end());
-        return nncs;
-    }
-
     std::vector<NNCdata> SingleNumericalAquifer::aquiferCellNNCs() const {
         std::vector<NNCdata> nncs;
         // aquifer cells are connected to each other through NNCs to form the aquifer

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -100,8 +100,8 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
         aquifer_config.load_connections(deck, grid);
 
         // add NNCs between aquifer cells and first aquifer cell and aquifer connections
-        const auto& aquifer_nncs = numerical_aquifer.aquiferNNCs(grid, fp);
-        for (const auto& nnc_data : aquifer_nncs) {
+        const auto& aquifer_cell_nncs = numerical_aquifer.aquiferCellNNCs();
+        for (const auto& nnc_data : aquifer_cell_nncs) {
             input_nnc.addNNC(nnc_data.cell1, nnc_data.cell2, nnc_data.trans);
         }
     } else
@@ -236,6 +236,12 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
 
     const NNC& EclipseState::getInputNNC() const {
         return m_inputNnc;
+    }
+
+    void EclipseState::appendInputNNC(const std::vector<NNCdata>& nnc) {
+        for (const auto& nnc_data : nnc ) {
+            this->m_inputNnc.addNNC(nnc_data.cell1, nnc_data.cell2, nnc_data.trans);
+        }
     }
 
     bool EclipseState::hasInputNNC() const {


### PR DESCRIPTION
For aquifer connections, typically/by default, the connections can only be placed on the boundary faces, which means, for these faces, the cell on one side is inside the reservoir, the cell on the other side is outside the reservoir. 

PINCH and MINPV process will deactivate the some of the cells. 

Which means, before we process the grid (PINCH, MINPV and so on), we will not be able to decide the boundary faces for the purpose of the aquifer connections. 

The purpose of this PR is to use the processed grid to generate the aquifer connections.  It is found when development numerical aquifers, but the current PR is on the setting for the existing analytical aquifers.  It improves the results for some troubling field case with analytical aquifers (generate closer numbers of the connections, but not identical yet). It does not change the results for the other field case with analytical aquifer that master branch can handle successfully. 

For numerical aquifer case, it improves the counting of the connections greatly (although there is still very small difference in the number of the connections for one of the aquifers.) .

Current understanding is that there is more logic needed for aquifers when facing non-neighboring cells (how to say whether a cell is inside or outside of the reservoirs, maybe a pinched cell should be considered still inside the reservoir? need more study here) .

Basically, it is a needed features.  

Before finishing, I would like to have some comments what is good way in handling this.  Thanks. @joakim-hove @bska 

The downsteam PRs are https://github.com/OPM/opm-grid/pull/508 , https://github.com/OPM/opm-grid/pull/508
 

