### PR TITLE
Revert "Use std::map for groups"

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -163,7 +163,7 @@ namespace Opm
     class Schedule {
     public:
         using WellMap = OrderedMap<std::string, DynamicState<std::shared_ptr<Well>>>;
-        using GroupMap = std::map<std::string, DynamicState<std::shared_ptr<Group>>>;
+        using GroupMap = OrderedMap<std::string, DynamicState<std::shared_ptr<Group>>>;
 
         Schedule() = default;
         explicit Schedule(std::shared_ptr<const Python> python_handle);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -402,13 +402,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     BOOST_CHECK_EQUAL( schedule.getStartTime() , TimeMap::mkdate(1983, 1 , 1));
 }
 
-
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
-    auto has_name = [](const std::vector<std::string>& names, const std::string& name) {
-        auto iter = std::find(names.begin(), names.end(), name);
-        return (iter != names.end());
-    };
-
     const auto& schedule = make_schedule( createDeckWithWellsOrdered() );
     auto well_names = schedule.wellNames();
 
@@ -417,10 +411,10 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     BOOST_CHECK( has_name(well_names, "AW_3"));
 
     auto group_names = schedule.groupNames();
-    BOOST_CHECK( has_name(group_names, "FIELD"));
-    BOOST_CHECK( has_name(group_names, "CG"));
-    BOOST_CHECK( has_name(group_names, "BG"));
-    BOOST_CHECK( has_name(group_names, "AG"));
+    BOOST_CHECK_EQUAL( "FIELD", group_names[0]);
+    BOOST_CHECK_EQUAL( "CG", group_names[1]);
+    BOOST_CHECK_EQUAL( "BG", group_names[2]);
+    BOOST_CHECK_EQUAL( "AG", group_names[3]);
 
     auto restart_groups = schedule.restart_groups(0);
     BOOST_REQUIRE_EQUAL(restart_groups.size(), 4U);


### PR DESCRIPTION
Reverts OPM/opm-common#2215

Damn - merged the wrong PR.