### PR TITLE
add CO2STORE as alias for CO2STOR

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -403,9 +403,11 @@ Runspec::Runspec( const Deck& deck ) :
                 OpmLog::note(msg);
             }
         }
-        if (runspecSection.hasKeyword<ParserKeywords::CO2STOR>()) {
+        if (runspecSection.hasKeyword<ParserKeywords::CO2STORE>() ||
+                runspecSection.hasKeyword<ParserKeywords::CO2STOR>()) {
             m_co2storage = true;
-            std::string msg = "The CO2 storage option is given. PVT properties from the Brine-CO2 system is used";
+            std::string msg = "The CO2 storage option is given. PVT properties from the Brine-CO2 system is used \n"
+                              "See the OPM manual for details on the used models.";
             OpmLog::note(msg);
         }
     }

--- a/src/opm/parser/eclipse/share/keywords/001_Eclipse300/C/CO2STORE
+++ b/src/opm/parser/eclipse/share/keywords/001_Eclipse300/C/CO2STORE
@@ -1,0 +1,6 @@
+{
+  "name": "CO2STORE",
+  "sections": [
+    "RUNSPEC"
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -1046,6 +1046,7 @@ set( keywords
      001_Eclipse300/B/BLOCK_PROBE300
      001_Eclipse300/C/CIRCLE
      001_Eclipse300/C/COMPS
+     001_Eclipse300/C/CO2STORE
      001_Eclipse300/C/CREF
      001_Eclipse300/C/CREFS
      001_Eclipse300/D/DREF

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -888,7 +888,7 @@ BOOST_AUTO_TEST_CASE(Co2Storage) {
     RUNSPEC
     OIL
     GAS
-    CO2STOR
+    CO2STORE
     )";
 
     Parser parser;


### PR DESCRIPTION
According to the OPM manual CO2STORE and not CO2STOR should be used to enable the co2 storage option. This makes aligns the simulator with the manual. CO2STORE is also used by E300 to enable its co2 storage option.  