### PR TITLE
Add summary keywords of the form MSUMxxx

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MSUM_PROBE
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/M/MSUM_PROBE
@@ -1,0 +1,17 @@
+{
+  "name": "MSUM_PROBE",
+  "sections": [
+    "SUMMARY"
+  ],
+  "deck_names": [
+  "MSUMLINP",
+  "MSUMBUG",
+  "MSUMCOMM",
+  "MSUMERR",
+  "MSUMLINS",
+  "MSUMMESS",
+  "MSUMNEWT",
+  "MSUMPROB",
+  "MSUMWARN"
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -488,6 +488,7 @@ set( keywords
      000_Eclipse100/M/MPFNNC
      000_Eclipse100/M/MSFN
      000_Eclipse100/M/MSGFILE
+     000_Eclipse100/M/MSUM_PROBE
      000_Eclipse100/M/MULSGGD
      000_Eclipse100/M/MULSGGDV
      000_Eclipse100/M/MULTFLT

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -1336,6 +1336,10 @@ COPRL
 
 BOOST_AUTO_TEST_CASE( WBP ) {
     const std::string input = R"(
+MSUMERR
+
+MSUMLINP
+
 WBP
 /
 


### PR DESCRIPTION
We currently load and internalize all the keywords .... except those we do not load. 

There is a *myriad* of summary keywords and many of these we do not load at all; let all alone handle sensibly ...

This PR adds loading to some of them and should fix: #2232