### PR TITLE
Eclipsestate error msg

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -88,7 +88,7 @@ namespace Opm {
         throw;
     }
     catch (const std::exception& std_error) {
-        OpmLog::error(fmt::format("An error occured while creating the reservoir properties\n",
+        OpmLog::error(fmt::format("An error occured while creating the reservoir properties\n"
                                   "Internal error: {}", std_error.what()));
         throw;
     }

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -88,8 +88,8 @@ namespace Opm {
         throw;
     }
     catch (const std::exception& std_error) {
-        OpmLog::error(fmt::format("An error occured while creating the reservoir properties\n"
-                                  "Internal error: {}", std_error.what()));
+        OpmLog::error(fmt::format("\nAn error occured while creating the reservoir properties\n"
+                                  "Internal error: {}\n", std_error.what()));
         throw;
     }
 


### PR DESCRIPTION
Extra `,` while concatenating strings completely f..ed up the varargs function call. Now error message from EclipseState construction should be correctly displayed.