### PR TITLE
Export VFP tables as reference wrappers instead of pointers

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
@@ -121,11 +121,11 @@ namespace Opm {
         const RPTConfig& rpt_config() const;
         void rpt_config(RPTConfig rpt_config);
 
-        std::vector<const VFPProdTable*> vfpprod() const;
+        std::vector<std::reference_wrapper<const VFPProdTable>> vfpprod() const;
         const VFPProdTable& vfpprod(int table_id) const;
         void vfpprod(VFPProdTable vfpprod);
 
-        std::vector<const VFPInjTable*> vfpinj() const;
+        std::vector<std::reference_wrapper<const VFPInjTable>> vfpinj() const;
         const VFPInjTable& vfpinj(int table_id) const;
         void vfpinj(VFPInjTable vfpinj);
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
@@ -295,11 +295,11 @@ void ScheduleState::rpt_config(RPTConfig rpt_config) {
     this->m_rptconfig = std::make_shared<RPTConfig>(std::move(rpt_config));
 }
 
-std::vector<const VFPProdTable*> ScheduleState::vfpprod() const {
-    std::vector<const VFPProdTable*> tables;
+std::vector<std::reference_wrapper<const VFPProdTable>> ScheduleState::vfpprod() const {
+    std::vector<std::reference_wrapper<const VFPProdTable>> tables;
     for (const auto& [_, table] : this->m_vfpprod) {
         (void)_;
-        tables.push_back( table.get() );
+        tables.push_back( std::cref( *table ));
     }
     return tables;
 }
@@ -317,11 +317,11 @@ void ScheduleState::vfpprod(VFPProdTable vfpprod) {
     this->m_vfpprod[table_id] = std::make_shared<VFPProdTable>( std::move(vfpprod) );
 }
 
-std::vector<const VFPInjTable*> ScheduleState::vfpinj() const {
-    std::vector<const VFPInjTable*> tables;
+std::vector<std::reference_wrapper<const VFPInjTable>> ScheduleState::vfpinj() const {
+    std::vector<std::reference_wrapper<const VFPInjTable>> tables;
     for (const auto& [_, table] : this->m_vfpinj) {
         (void)_;
-        tables.push_back( table.get() );
+        tables.push_back( std::cref( *table ));
     }
     return tables;
 }


### PR DESCRIPTION
Small step on the #2176 journey

Downstream: https://github.com/OPM/opm-simulators/pull/3027