### PR TITLE
Adding connection length and effective radius to the connection

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -89,6 +89,8 @@ namespace RestartIO {
                    double Kh,
                    double rw,
                    double r0,
+                   double re,
+                   double connection_length,
                    double skin_factor,
                    const int satTableId,
                    const Direction direction,
@@ -116,6 +118,8 @@ namespace RestartIO {
         double Kh() const;
         double rw() const;
         double r0() const;
+        double re() const;
+        double connectionLength() const;
         double skinFactor() const;
         CTFKind kind() const;
 
@@ -155,6 +159,8 @@ namespace RestartIO {
             serializer(m_Kh);
             serializer(m_rw);
             serializer(m_r0);
+            serializer(m_re);
+            serializer(m_connection_length);
             serializer(m_skin_factor);
             serializer(ijk);
             serializer(m_global_index);
@@ -176,6 +182,8 @@ namespace RestartIO {
         double m_Kh;
         double m_rw;
         double m_r0;
+        double m_re;
+        double m_connection_length;
         double m_skin_factor;
 
         std::array<int,3> ijk;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -49,6 +49,7 @@ namespace Opm {
 
         // cppcheck-suppress noExplicitConstructor
         WellConnections(const WellConnections& src, const EclipseGrid& grid);
+
         void addConnection(int i, int j , int k ,
                            std::size_t global_index,
                            double depth,
@@ -57,6 +58,8 @@ namespace Opm {
                            double Kh,
                            double rw,
                            double r0,
+                           double re,
+                           double connection_length,
                            double skin_factor,
                            const int satTableId,
                            const Connection::Direction direction = Connection::Direction::Z,
@@ -142,6 +145,8 @@ namespace Opm {
                            double Kh,
                            double rw,
                            double r0,
+                           double re,
+                           double connection_length,
                            double skin_factor,
                            const int satTableId,
                            const Connection::Direction direction = Connection::Direction::Z,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
@@ -47,6 +47,8 @@ namespace Opm {
                            double Kh,
                            double rw,
                            double r0,
+                           double re,
+                           double connection_length,
                            double skin_factor,
                            const int satTableId,
                            const Direction directionArg,
@@ -62,6 +64,8 @@ namespace Opm {
           m_Kh(Kh),
           m_rw(rw),
           m_r0(r0),
+          m_re(re),
+          m_connection_length(connection_length),
           m_skin_factor(skin_factor),
           ijk({i,j,k}),
           m_ctfkind(ctf_kind),
@@ -85,6 +89,8 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         m_Kh(rst_connection.kh),
         m_rw(rst_connection.diameter / 2),
         m_r0(rst_connection.r0),
+        m_re(0.0),
+        m_connection_length(0.0),
         m_skin_factor(rst_connection.skin_factor),
         ijk(rst_connection.ijk),
         m_ctfkind(rst_connection.cf_kind),
@@ -100,10 +106,12 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         }
         if (this->segment_number > 0)
             this->m_perf_range = std::make_pair(rst_connection.segdist_start, rst_connection.segdist_end);
+
+        //TODO recompute re and perf_length from the grid
     }
 
     Connection::Connection()
-          : Connection(0, 0, 0, 0, 0, 0.0, State::SHUT, 0.0, 0.0, 0.0, 0.0, 0.0,
+          : Connection(0, 0, 0, 0, 0, 0.0, State::SHUT, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                        0, Direction::X, CTFKind::DeckValue, 0, false)
     {}
 
@@ -119,6 +127,8 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Ecl
         result.m_Kh = 5.0;
         result.m_rw = 6.0;
         result.m_r0 = 7.0;
+        result.m_re = 7.1;
+        result.m_connection_length = 7.2;
         result.m_skin_factor = 8.0;
         result.ijk = {9, 10, 11};
         result.m_ctfkind = CTFKind::Defaulted;
@@ -216,6 +226,14 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
         return this->m_r0;
     }
 
+    double Connection::re() const {
+        return this->m_re;
+    }
+
+    double Connection::connectionLength() const {
+        return this->m_connection_length;
+    }
+
     double Connection::skinFactor() const {
         return this->m_skin_factor;
     }
@@ -271,6 +289,8 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
         ss << "CF " << this->m_CF << std::endl;
         ss << "RW " << this->m_rw << std::endl;
         ss << "R0 " << this->m_r0 << std::endl;
+        ss << "Re " << this->m_re << std::endl;
+        ss << "connection length " << this->m_connection_length << std::endl;
         ss << "skinf " << this->m_skin_factor << std::endl;
         ss << "kh " << this->m_Kh << std::endl;
         ss << "sat_tableId " << this->sat_tableId << std::endl;
@@ -291,6 +311,8 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
             && this->m_CF == rhs.m_CF
             && this->m_rw == rhs.m_rw
             && this->m_r0 == rhs.m_r0
+            && this->m_re == rhs.m_re
+            && this->m_connection_length == rhs.m_connection_length
             && this->m_skin_factor == rhs.m_skin_factor
             && this->m_Kh == rhs.m_Kh
             && this->sat_tableId == rhs.sat_tableId

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -99,8 +99,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
-    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
-    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
     BOOST_CHECK_MESSAGE( !completionSet.empty(), "Non-empty completion set must not be empty" );
@@ -115,8 +115,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
 BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,true);
-    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0,true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0,true);
+    Opm::Connection completion2( 10,10,11, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0,true);
     Opm::WellConnections completionSet(Opm::Connection::Order::TRACK, 1,1);
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
@@ -136,9 +136,9 @@ BOOST_AUTO_TEST_CASE(AddCompletionCopy) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
 
-    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
-    Opm::Connection completion2( 10,10,11, 101, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
-    Opm::Connection completion3( 10,10,12, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion1( 10,10,10, 100, 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion2( 10,10,11, 101, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion3( 10,10,12, 102, 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true);
 
     completionSet.add( completion1 );
     completionSet.add( completion2 );
@@ -159,9 +159,9 @@ BOOST_AUTO_TEST_CASE(ActiveCompletions) {
     auto dir = Opm::Connection::Direction::Z;
     const auto kind = Opm::Connection::CTFKind::Defaulted;
     Opm::WellConnections completions(Opm::Connection::Order::TRACK, 10,10);
-    Opm::Connection completion1( 0,0,0, grid.getGlobalIndex(0,0,0), 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
-    Opm::Connection completion2( 0,0,1, grid.getGlobalIndex(0,0,1), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
-    Opm::Connection completion3( 0,0,2, grid.getGlobalIndex(0,0,2), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion1( 0,0,0, grid.getGlobalIndex(0,0,0), 1, 0.0, Opm::Connection::State::OPEN , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion2( 0,0,1, grid.getGlobalIndex(0,0,1), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true);
+    Opm::Connection completion3( 0,0,2, grid.getGlobalIndex(0,0,2), 1, 0.0, Opm::Connection::State::SHUT , 99.88, 355.113, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true);
 
     completions.add( completion1 );
     completions.add( completion2 );
@@ -441,6 +441,8 @@ END
         0.234,
         0.157,
         0.0,
+        0.0,
+        0.0,
         1);
 
     BOOST_REQUIRE_EQUAL(connP.size(), std::size_t{3});
@@ -481,6 +483,8 @@ END
         0.123,
         0.234,
         0.157,
+        0.0,
+        0.0,
         0.0,
         1);
 
@@ -602,4 +606,20 @@ END
         BOOST_CHECK_EQUAL(complnum_100.value(), 1);
         BOOST_CHECK_EQUAL(complnum_200.value(), 2);
     }
+}
+
+BOOST_AUTO_TEST_CASE(testReAndConnectionLength) {
+    Opm::Parser parser;
+
+    const auto deck = parser.parseFile("SPE1CASE1.DATA");
+    auto python = std::make_shared<Opm::Python>();
+    Opm::EclipseState state(deck);
+    Opm::Schedule sched(deck, state, python);
+    const auto& units = deck.getActiveUnitSystem();
+
+    const auto& prod = sched.getWell("PROD", 0);
+    const auto& connections = prod.getConnections();
+    const auto& conn0 = connections[0];
+    BOOST_CHECK_CLOSE(conn0.re(), 171.96498506535622 , 2e-2);
+    BOOST_CHECK_CLOSE(conn0.connectionLength(),15.239999999999782, 1e-6);
 }

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -53,14 +53,14 @@ BOOST_AUTO_TEST_CASE(AICDWellTest) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0,grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 1,grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 2,grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 0,grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1,grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2,grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1,grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 17, 0, 1,grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 16, 0, 1,grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 15, 0, 1,grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 18, 0, 1,grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1,grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1,grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1,grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -198,14 +198,14 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0,grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 1,grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 2,grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 0,grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1,grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2,grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1,grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 17, 0, 1,grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 16, 0, 1,grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 15, 0, 1,grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 18, 0, 1,grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1,grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1,grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1,grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -350,14 +350,14 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -407,14 +407,14 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1),1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 
@@ -464,14 +464,14 @@ BOOST_AUTO_TEST_CASE(testwsegvalv) {
     const auto kind = Opm::Connection::CTFKind::DeckValue;
     Opm::WellConnections connection_set(Opm::Connection::Order::TRACK, 10,10);
     Opm::EclipseGrid grid(20,20,20);
-    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
-    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 0, grid.getGlobalIndex(19,0,0), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 1, grid.getGlobalIndex(19,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
+    connection_set.add(Opm::Connection( 19, 0, 2, grid.getGlobalIndex(19,0,2), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0, dir, kind, 0, true) );
 
-    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
-    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 18, 0, 1, grid.getGlobalIndex(18,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 17, 0, 1, grid.getGlobalIndex(17,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 16, 0, 1, grid.getGlobalIndex(16,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
+    connection_set.add(Opm::Connection( 15, 0, 1, grid.getGlobalIndex(15,0,1), 1, 0.0, Opm::Connection::State::OPEN , 200, 17.29, 0.25, 0.0, 0.0, 0.0, 0.0, 0,  Opm::Connection::Direction::X, kind, 0, true) );
 
     BOOST_CHECK_EQUAL( 7U , connection_set.size() );
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3261,6 +3261,8 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
                       10,
                       10,
                       10,
+                      10,
+                      10,
                       100);
 
     BOOST_CHECK(  ws.updateConnections(c2, 0, false) );


### PR DESCRIPTION
The connection length and effective radius is used by the exotic MW polymer model. Storing it here removes this explicit usage of the grid in the well model. 