### PR TITLE
summary support for numerical aquifer keywords

### DIFF
--- a/opm/output/data/Aquifer.hpp
+++ b/opm/output/data/Aquifer.hpp
@@ -34,7 +34,7 @@ namespace Opm { namespace data {
      */
     enum class AquiferType
     {
-        Fetkovich, CarterTracey,
+        Fetkovich, CarterTracey, Numerical,
     };
 
     struct FetkovichData {
@@ -57,11 +57,11 @@ namespace Opm { namespace data {
 
         double get(const std::string& key) const
         {
-            if ( key == "AAQR" ) {
+            if ( key == "AAQR" || key == "ANQR" ) {
                 return this->fluxRate;
-            } else if ( key == "AAQT" ) {
+            } else if ( key == "AAQT" || key == "ANQT" ) {
                 return this->volume;
-            } else if ( key == "AAQP" ) {
+            } else if ( key == "AAQP" || key == "ANQP" ) {
                 return this->pressure;
             }
             return 0.;

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1782,6 +1782,9 @@ static const std::unordered_map< std::string, Opm::UnitSystem::measure> aquifer_
     {"AAQT", Opm::UnitSystem::measure::liquid_surface_volume},
     {"AAQR", Opm::UnitSystem::measure::liquid_surface_rate},
     {"AAQP", Opm::UnitSystem::measure::pressure},
+    {"ANQP", Opm::UnitSystem::measure::pressure},
+    {"ANQT", Opm::UnitSystem::measure::liquid_surface_volume},
+    {"ANQR", Opm::UnitSystem::measure::liquid_surface_rate},
 };
 
 inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,


### PR DESCRIPTION
It is just the support from opm-common side. Downstream PRs from simulators side are not there yet. 
