### PR TITLE
Numerical Aquifer continue

### DIFF
--- a/opm/output/data/Aquifer.hpp
+++ b/opm/output/data/Aquifer.hpp
@@ -34,7 +34,7 @@ namespace Opm { namespace data {
      */
     enum class AquiferType
     {
-        Fetkovich, CarterTracey,
+        Fetkovich, CarterTracey, Numerical,
     };
 
     struct FetkovichData {
@@ -57,11 +57,11 @@ namespace Opm { namespace data {
 
         double get(const std::string& key) const
         {
-            if ( key == "AAQR" ) {
+            if ( key == "AAQR" || key == "ANQR" ) {
                 return this->fluxRate;
-            } else if ( key == "AAQT" ) {
+            } else if ( key == "AAQT" || key == "ANQT" ) {
                 return this->volume;
-            } else if ( key == "AAQP" ) {
+            } else if ( key == "AAQP" || key == "ANQP" ) {
                 return this->pressure;
             }
             return 0.;

--- a/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
@@ -48,6 +48,9 @@ public:
     bool operator==(const AquiferConfig& other);
     bool hasAquifer(const int aquID) const;
 
+    bool hasNumericalAquifer() const;
+    const NumericalAquifers& numericalAquifers() const;
+
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -48,6 +48,7 @@ namespace Opm {
                              std::vector<double>& pore_volume,
                              std::vector<int>& satnum,
                              std::vector<int>& pvtnum) const;
+        void appendNNC(const EclipseGrid& grid, const FieldPropsManager& fp, NNC& nnc) const;
 
         static NumericalAquifers serializeObject();
         template <class Serializer>

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -44,6 +44,11 @@ namespace Opm {
 
         std::unordered_map<size_t, const NumericalAquiferCell*> allAquiferCells() const;
 
+        void updateCellProps(const EclipseGrid& grid,
+                             std::vector<double>& pore_volume,
+                             std::vector<int>& satnum,
+                             std::vector<int>& pvtnum) const;
+
         static NumericalAquifers serializeObject();
         template <class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -41,8 +41,6 @@ namespace Opm {
         const std::unordered_map <size_t, SingleNumericalAquifer>& aquifers() const;
         bool operator==(const NumericalAquifers& other) const;
 
-        std::array<std::set<size_t>, 3> transToRemove(const EclipseGrid& grid) const;
-
         std::unordered_map<size_t, const NumericalAquiferCell*> allAquiferCells() const;
 
         std::vector<NNCdata> aquiferNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const;
@@ -60,7 +58,6 @@ namespace Opm {
         std::unordered_map <size_t, SingleNumericalAquifer> m_aquifers;
 
         void addAquiferCell(const NumericalAquiferCell& aqu_cell);
-
         void addAquiferConnections(const Deck &deck, const EclipseGrid &grid);
     };
 }

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -38,6 +38,7 @@ namespace Opm {
         size_t numAquifer() const;
         bool hasAquifer(size_t aquifer_id) const;
         const SingleNumericalAquifer& getAquifer(size_t aquifer_id) const;
+        const std::unordered_map <size_t, SingleNumericalAquifer>& aquifers() const;
         bool operator==(const NumericalAquifers& other) const;
 
         std::array<std::set<size_t>, 3> transToRemove(const EclipseGrid& grid) const;

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -35,7 +35,7 @@ namespace Opm {
         NumericalAquifers() = default;
         NumericalAquifers(const Deck& deck, const EclipseGrid& grid, const FieldPropsManager& field_props);
 
-        size_t numAquifer() const;
+        size_t size() const;
         bool hasAquifer(size_t aquifer_id) const;
         const SingleNumericalAquifer& getAquifer(size_t aquifer_id) const;
         const std::unordered_map <size_t, SingleNumericalAquifer>& aquifers() const;
@@ -45,11 +45,9 @@ namespace Opm {
 
         std::unordered_map<size_t, const NumericalAquiferCell*> allAquiferCells() const;
 
-        void updateCellProps(const EclipseGrid& grid,
-                             std::vector<double>& pore_volume,
-                             std::vector<int>& satnum,
-                             std::vector<int>& pvtnum) const;
-        void appendNNC(const EclipseGrid& grid, const FieldPropsManager& fp, NNC& nnc) const;
+        std::vector<NNCdata> aquiferNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const;
+
+        std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
 
         static NumericalAquifers serializeObject();
         template <class Serializer>

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -40,6 +40,8 @@ namespace Opm {
         const SingleNumericalAquifer& getAquifer(size_t aquifer_id) const;
         bool operator==(const NumericalAquifers& other) const;
 
+        std::array<std::set<size_t>, 3> transToRemove(const EclipseGrid& grid) const;
+
         std::unordered_map<size_t, const NumericalAquiferCell*> allAquiferCells() const;
 
         static NumericalAquifers serializeObject();

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -55,14 +55,8 @@ namespace Opm {
         size_t numConnections() const;
         const NumericalAquiferCell* getCellPrt(size_t index) const;
 
-        // we remove the connection around the aquifer cells to isolate aquifer cells
-        // from the other part of the reservoir
-        // the removing of the connection is done by make transmissiblities to be zero
-        std::array<std::set<size_t>, 3> transToRemove(const EclipseGrid& grid) const;
-
         std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
 
-        void appendNNC(const EclipseGrid& grid, const FieldPropsManager& fp, NNC& nnc) const;
         std::vector<NNCdata> aquiferNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const;
 
         bool operator==(const SingleNumericalAquifer& other) const;

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -21,6 +21,7 @@
 #define OPM_SINGLENUMERICALAQUIFER_HPP
 
 #include <vector>
+#include <set>
 
 #include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferConnection.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
@@ -40,6 +41,11 @@ namespace Opm {
         size_t numCells() const;
         size_t numConnections() const;
         const NumericalAquiferCell* getCellPrt(size_t index) const;
+
+        // we remove the connection around the aquifer cells to isolate aquifer cells
+        // from the other part of the reservoir
+        // the removing of the connection is done by make transmissiblities to be zero
+        std::array<std::set<size_t>, 3> transToRemove(const EclipseGrid& grid) const;
 
         bool operator==(const SingleNumericalAquifer& other) const;
 

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -28,7 +28,14 @@
 
 namespace Opm {
     class NNC;
+    class NNCdata;
     class FieldPropsManager;
+
+    struct AquiferCellProps {
+        double pore_volume;
+        int satnum;
+        int pvtnum;
+    };
 
     class SingleNumericalAquifer {
     public:
@@ -50,15 +57,10 @@ namespace Opm {
         // the removing of the connection is done by make transmissiblities to be zero
         std::array<std::set<size_t>, 3> transToRemove(const EclipseGrid& grid) const;
 
-        // aquifer cells are still cells in the grid, but AQUNUM can modify the grid properties
-        // in a relatively arbitrary way. As a result, related and field properties need to be updated
-        // with the numerical aquifer keywords
-        void updateCellProps(const EclipseGrid& grid,
-                             std::vector<double>& pore_volume,
-                             std::vector<int>& satnum,
-                             std::vector<int>& pvtnum) const;
+        std::unordered_map<size_t, AquiferCellProps> aquiferCellProps() const;
 
-        void appendNNC(const EclipseGrid &grid, const FieldPropsManager &fp, NNC &nnc) const;
+        void appendNNC(const EclipseGrid& grid, const FieldPropsManager& fp, NNC& nnc) const;
+        std::vector<NNCdata> aquiferNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const;
 
         bool operator==(const SingleNumericalAquifer& other) const;
 
@@ -78,8 +80,8 @@ namespace Opm {
             std::vector<NumericalAquiferCell> cells_;
             std::vector<NumericalAquiferConnection> connections_;
 
-            void appendCellNNC(NNC &nnc) const;
-            void appendConnectionNNC(const EclipseGrid &grid, const FieldPropsManager &fp, NNC &nnc) const;
+            std::vector<NNCdata> aquiferCellNNCs() const;
+            std::vector<NNCdata> aquiferConnectionNNCs(const EclipseGrid &grid, const FieldPropsManager &fp) const;
         };
 }
 

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -32,7 +32,10 @@ namespace Opm {
     class FieldPropsManager;
 
     struct AquiferCellProps {
+        double volume;
         double pore_volume;
+        double depth;
+        double porosity;
         int satnum;
         int pvtnum;
     };

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -47,6 +47,14 @@ namespace Opm {
         // the removing of the connection is done by make transmissiblities to be zero
         std::array<std::set<size_t>, 3> transToRemove(const EclipseGrid& grid) const;
 
+        // aquifer cells are still cells in the grid, but AQUNUM can modify the grid properties
+        // in a relatively arbitrary way. As a result, related and field properties need to be updated
+        // with the numerical aquifer keywords
+        void updateCellProps(const EclipseGrid& grid,
+                             std::vector<double>& pore_volume,
+                             std::vector<int>& satnum,
+                             std::vector<int>& pvtnum) const;
+
         bool operator==(const SingleNumericalAquifer& other) const;
 
         template<class Serializer>

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -41,6 +41,7 @@ namespace Opm {
         // TODO: the following two can be made one function. Let us see
         // how we use them at the end
         size_t numCells() const;
+        size_t id() const;
         size_t numConnections() const;
         const NumericalAquiferCell* getCellPrt(size_t index) const;
 

--- a/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp
@@ -27,6 +27,8 @@
 #include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 
 namespace Opm {
+    class NNC;
+    class FieldPropsManager;
 
     class SingleNumericalAquifer {
     public:
@@ -55,6 +57,8 @@ namespace Opm {
                              std::vector<int>& satnum,
                              std::vector<int>& pvtnum) const;
 
+        void appendNNC(const EclipseGrid &grid, const FieldPropsManager &fp, NNC &nnc) const;
+
         bool operator==(const SingleNumericalAquifer& other) const;
 
         template<class Serializer>
@@ -72,6 +76,9 @@ namespace Opm {
             size_t id_;
             std::vector<NumericalAquiferCell> cells_;
             std::vector<NumericalAquiferConnection> connections_;
+
+            void appendCellNNC(NNC &nnc) const;
+            void appendConnectionNNC(const EclipseGrid &grid, const FieldPropsManager &fp, NNC &nnc) const;
         };
 }
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -122,11 +122,11 @@ namespace Opm {
             m_deckUnitSystem.serializeOp(serializer);
             m_inputNnc.serializeOp(serializer);
             m_gridDims.serializeOp(serializer);
+            aquifer_config.serializeOp(serializer);
             m_simulationConfig.serializeOp(serializer);
             m_transMult.serializeOp(serializer);
             m_faults.serializeOp(serializer);
             serializer(m_title);
-            aquifer_config.serializeOp(serializer);
             tracer_config.serializeOp(serializer);
         }
 
@@ -149,12 +149,12 @@ namespace Opm {
         NNC m_inputNnc;
         GridDims m_gridDims;
         FieldPropsManager field_props;
+        AquiferConfig aquifer_config;
         SimulationConfig m_simulationConfig;
         TransMult m_transMult;
 
         FaultCollection m_faults;
         std::string m_title;
-        AquiferConfig aquifer_config;
         TracerConfig tracer_config;
     };
 }

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -32,6 +32,7 @@ class Deck;
 class FieldProps;
 class Phases;
 class TableManager;
+class NumericalAquifers;
 
 class FieldPropsManager {
 
@@ -216,6 +217,9 @@ public:
       ScalarOperation in FieldProps.hpp.
     */
     virtual void apply_tran(const std::string& keyword, std::vector<double>& tran_data) const;
+
+    void applyNumericalAquifer(const NumericalAquifers& aquifers);
+
 
     /*
       When using MPI the FieldPropsManager is typically only assembled on the

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -218,7 +218,7 @@ public:
     */
     virtual void apply_tran(const std::string& keyword, std::vector<double>& tran_data) const;
 
-    void applyNumericalAquifer(const NumericalAquifers& aquifers);
+    void apply_numerical_aquifers(const NumericalAquifers& aquifers);
 
 
     /*

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1783,6 +1783,9 @@ static const std::unordered_map< std::string, Opm::UnitSystem::measure> aquifer_
     {"AAQT", Opm::UnitSystem::measure::liquid_surface_volume},
     {"AAQR", Opm::UnitSystem::measure::liquid_surface_rate},
     {"AAQP", Opm::UnitSystem::measure::pressure},
+    {"ANQP", Opm::UnitSystem::measure::pressure},
+    {"ANQT", Opm::UnitSystem::measure::liquid_surface_volume},
+    {"ANQR", Opm::UnitSystem::measure::liquid_surface_rate},
 };
 
 inline std::vector<Opm::Well> find_wells( const Opm::Schedule& schedule,

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -80,4 +80,12 @@ bool AquiferConfig::hasAquifer(const int aquID) const {
            numerical_aquifers.hasAquifer(aquID);
 }
 
+bool AquiferConfig::hasNumericalAquifer() const {
+    return this->numerical_aquifers.numAquifer();
+}
+
+const NumericalAquifers& AquiferConfig::numericalAquifers() const {
+    return this->numerical_aquifers;
+}
+
 }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -52,7 +52,7 @@ AquiferConfig AquiferConfig::serializeObject()
 bool AquiferConfig::active() const {
     return this->aquiferct.size() > 0 ||
            this->aquifetp.size() > 0 ||
-           this->numerical_aquifers.numAquifer() > 0;
+            this->numerical_aquifers.size() > 0;
 }
 
 bool AquiferConfig::operator==(const AquiferConfig& other) {
@@ -81,7 +81,7 @@ bool AquiferConfig::hasAquifer(const int aquID) const {
 }
 
 bool AquiferConfig::hasNumericalAquifer() const {
-    return this->numerical_aquifers.numAquifer();
+    return this->numerical_aquifers.size() > 0;
 }
 
 const NumericalAquifers& AquiferConfig::numericalAquifers() const {

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -25,6 +25,7 @@
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquiferCell.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
@@ -115,7 +116,7 @@ namespace Opm {
         return this->m_aquifers == other.m_aquifers;
     }
 
-    size_t NumericalAquifers::numAquifer() const {
+    size_t NumericalAquifers::size() const {
         return this->m_aquifers.size();
     }
 
@@ -157,24 +158,25 @@ namespace Opm {
         return  trans;
     }
 
-    void NumericalAquifers::updateCellProps(const EclipseGrid& grid,
-                                            std::vector<double>& pore_volume,
-                                            std::vector<int>& satnum,
-                                            std::vector<int>& pvtnum) const {
-        for (const auto& [id, aquifer]: this->m_aquifers) {
-            aquifer.updateCellProps(grid, pore_volume, satnum, pvtnum);
-        }
-
-    }
-
-    void NumericalAquifers::appendNNC(const EclipseGrid& grid, const FieldPropsManager& fp, NNC& nnc) const {
-        for (const auto& [id, aquifer]: this->m_aquifers) {
-            aquifer.appendNNC(grid, fp, nnc);
-        }
-
-    }
-
     const std::unordered_map<size_t, SingleNumericalAquifer>& NumericalAquifers::aquifers() const {
         return this->m_aquifers;
+    }
+
+    std::unordered_map<size_t, AquiferCellProps> NumericalAquifers::aquiferCellProps() const {
+        std::unordered_map<size_t, AquiferCellProps> cell_props;
+        for ([[maybe_unused]]const auto& [id, aquifer] : this->m_aquifers ) {
+            auto aqu_cell_props = aquifer.aquiferCellProps();
+            cell_props.insert(aqu_cell_props.begin(), aqu_cell_props.end());
+        }
+        return cell_props;
+    }
+
+    std::vector<NNCdata> NumericalAquifers::aquiferNNCs(const EclipseGrid& grid, const FieldPropsManager& fp) const {
+        std::vector<NNCdata> nncs;
+        for ([[maybe_unused]] const auto& [id, aquifer] : this->m_aquifers) {
+            auto aqu_nncs = aquifer.aquiferNNCs(grid, fp);
+            nncs.insert(nncs.end(), aqu_nncs.begin(), aqu_nncs.end());
+        }
+        return nncs;
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -147,17 +147,6 @@ namespace Opm {
         return cells;
     }
 
-    std::array<std::set<size_t>, 3> NumericalAquifers::transToRemove(const EclipseGrid& grid) const {
-        std::array<std::set<size_t>, 3> trans;
-        for (const auto& [id, aquifer] : this->m_aquifers) {
-            auto trans_aquifer = aquifer.transToRemove(grid);
-            for (size_t i = 0; i < 3; ++i) {
-                trans[i].merge(trans_aquifer[i]);
-            }
-        }
-        return  trans;
-    }
-
     const std::unordered_map<size_t, SingleNumericalAquifer>& NumericalAquifers::aquifers() const {
         return this->m_aquifers;
     }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -173,4 +173,8 @@ namespace Opm {
         }
 
     }
+
+    const std::unordered_map<size_t, SingleNumericalAquifer>& NumericalAquifers::aquifers() const {
+        return this->m_aquifers;
+    }
 }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -145,4 +145,15 @@ namespace Opm {
         }
         return cells;
     }
+
+    std::array<std::set<size_t>, 3> NumericalAquifers::transToRemove(const EclipseGrid& grid) const {
+        std::array<std::set<size_t>, 3> trans;
+        for (const auto& [id, aquifer] : this->m_aquifers) {
+            auto trans_aquifer = aquifer.transToRemove(grid);
+            for (size_t i = 0; i < 3; ++i) {
+                trans[i].merge(trans_aquifer[i]);
+            }
+        }
+        return  trans;
+    }
 }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -166,4 +166,11 @@ namespace Opm {
         }
 
     }
+
+    void NumericalAquifers::appendNNC(const EclipseGrid& grid, const FieldPropsManager& fp, NNC& nnc) const {
+        for (const auto& [id, aquifer]: this->m_aquifers) {
+            aquifer.appendNNC(grid, fp, nnc);
+        }
+
+    }
 }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -156,4 +156,14 @@ namespace Opm {
         }
         return  trans;
     }
+
+    void NumericalAquifers::updateCellProps(const EclipseGrid& grid,
+                                            std::vector<double>& pore_volume,
+                                            std::vector<int>& satnum,
+                                            std::vector<int>& pvtnum) const {
+        for (const auto& [id, aquifer]: this->m_aquifers) {
+            aquifer.updateCellProps(grid, pore_volume, satnum, pvtnum);
+        }
+
+    }
 }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -94,7 +94,8 @@ namespace Opm {
         std::unordered_map<size_t, AquiferCellProps> aqucellprops;
         for (const auto& cell : this->cells_) {
             aqucellprops.emplace(std::make_pair(cell.global_index,
-                               AquiferCellProps{cell.poreVolume(), cell.sattable, cell.pvttable}));
+                               AquiferCellProps{cell.cellVolume(), cell.poreVolume(), cell.depth,
+                                                cell.porosity, cell.sattable, cell.pvttable}));
         }
         return aqucellprops;
     }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -103,7 +103,7 @@ namespace Opm {
         this->appendConnectionNNC(grid, fp, nnc);
     }
 
-    void Opm::SingleNumericalAquifer::appendCellNNC(NNC& nnc) const {
+    void SingleNumericalAquifer::appendCellNNC(NNC& nnc) const {
         // aquifer cells are connected to each other through NNCs to form the aquifer
         for (size_t i = 0; i < this->cells_.size() - 1; ++i) {
             const double trans1 = this->cells_[i].transmissiblity();
@@ -115,7 +115,7 @@ namespace Opm {
         }
     }
 
-    void Opm::SingleNumericalAquifer::appendConnectionNNC(const EclipseGrid& grid, const FieldPropsManager &fp, NNC& nnc) const {
+    void SingleNumericalAquifer::appendConnectionNNC(const EclipseGrid& grid, const FieldPropsManager &fp, NNC& nnc) const {
         // aquifer connections are connected to aquifer cells through NNCs
         const std::vector<double>& ntg = fp.get_double("NTG");
         const auto& cell1 = this->cells_[0];
@@ -155,5 +155,9 @@ namespace Opm {
             const double tran = trans_con * trans_cell / (trans_con + trans_cell) * con.trans_multipler;
             nnc.addNNC(gc1, gc2, tran);
         }
+    }
+
+    size_t SingleNumericalAquifer::id() const {
+        return this->id_;
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -83,4 +83,16 @@ namespace Opm {
         }
         return trans;
     }
+
+    void SingleNumericalAquifer::updateCellProps(const EclipseGrid& grid,
+                                                 std::vector<double>& pore_volume,
+                                                 std::vector<int>& satnum,
+                                                 std::vector<int>& pvtnum) const {
+        for (const auto& cell : this->cells_) {
+            const size_t activel_index =  grid.activeIndex(cell.global_index);
+            pore_volume[activel_index] = cell.poreVolume();
+            satnum[activel_index] = cell.sattable;
+            pvtnum[activel_index] = cell.pvttable;
+        }
+    }
 }

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -58,34 +58,6 @@ namespace Opm {
         return this->connections_.size();
     }
 
-    std::array<std::set<size_t>, 3> SingleNumericalAquifer::transToRemove(const EclipseGrid& grid) const {
-        std::array<std::set<size_t>, 3> trans;
-        for (const auto& cell : this->cells_) {
-            const size_t i = cell.I;
-            const size_t j = cell.J;
-            const size_t k = cell.K;
-            if (AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, FaceDir::XPlus)) {
-                trans[0].insert(cell.global_index);
-            }
-            if (AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, FaceDir::XMinus)) {
-                trans[0].insert(grid.getGlobalIndex(i-1, j, k));
-            }
-            if (AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, FaceDir::YPlus)) {
-                trans[1].insert(cell.global_index);
-            }
-            if (AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, FaceDir::YMinus)) {
-                trans[1].insert(grid.getGlobalIndex(i, j-1, k));
-            }
-            if (AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, FaceDir::ZPlus)) {
-                trans[2].insert(cell.global_index);
-            }
-            if (AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, FaceDir::ZMinus)) {
-                trans[2].insert(grid.getGlobalIndex(i, j, k-1));
-            }
-        }
-        return trans;
-    }
-
     size_t SingleNumericalAquifer::id() const {
         return this->id_;
     }

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -61,15 +61,19 @@ namespace Opm {
           m_inputNnc(          m_inputGrid, deck),
           m_gridDims(          deck ),
           field_props(         deck, m_runspec.phases(), m_inputGrid, m_tables),
+          aquifer_config(this->m_tables, this->m_inputGrid, deck, this->field_props),
           m_simulationConfig(  m_eclipseConfig.getInitConfig().restartRequested(), deck, field_props),
           m_transMult(         GridDims(deck), deck, field_props),
           tracer_config(       m_deckUnitSystem, deck)
     {
+        if (this->aquifer().hasNumericalAquifer()) {
+            const auto& numerical_aquifer = this->aquifer().numericalAquifers();
+            this->field_props.applyNumericalAquifer(numerical_aquifer);
+        }
+
         m_inputGrid.resetACTNUM(this->field_props.actnum());
         if( this->runspec().phases().size() < 3 )
             OpmLog::info(fmt::format("Only {} fluid phases are enabled",  this->runspec().phases().size() ));
-
-        this->aquifer_config = AquiferConfig(this->m_tables, this->m_inputGrid, deck, this->field_props);
 
         if (deck.hasKeyword( "TITLE" )) {
             const auto& titleKeyword = deck.getKeyword( "TITLE" );

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -68,8 +68,15 @@ namespace Opm {
     {
         if (this->aquifer().hasNumericalAquifer()) {
             const auto& numerical_aquifer = this->aquifer().numericalAquifers();
-            this->field_props.applyNumericalAquifer(numerical_aquifer);
-            numerical_aquifer.appendNNC(this->m_inputGrid, this->field_props, this->m_inputNnc);
+            // update field_props for numerical aquifer cells, and set the transmissiblity related to aquifer cells to
+            // be zero
+            this->field_props.apply_numerical_aquifers(numerical_aquifer);
+
+            // add NNCs between aquifer cells and first aquifer cell and aquifer connections
+            const auto& aquifer_nncs = numerical_aquifer.aquiferNNCs(this->m_inputGrid, this->field_props);
+            for (const auto& nnc_data : aquifer_nncs) {
+                this->m_inputNnc.addNNC(nnc_data.cell1, nnc_data.cell2, nnc_data.trans);
+            }
         }
 
         m_inputGrid.resetACTNUM(this->field_props.actnum());

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -69,6 +69,7 @@ namespace Opm {
         if (this->aquifer().hasNumericalAquifer()) {
             const auto& numerical_aquifer = this->aquifer().numericalAquifers();
             this->field_props.applyNumericalAquifer(numerical_aquifer);
+            numerical_aquifer.appendNNC(this->m_inputGrid, this->field_props, this->m_inputNnc);
         }
 
         m_inputGrid.resetACTNUM(this->field_props.actnum());

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1216,6 +1216,14 @@ bool FieldProps::tran_active(const std::string& keyword) const {
 }
 
 void FieldProps::applyNumericalAquifers(const NumericalAquifers& numerical_aquifers) {
+    // TODO: ideally, we should also update the cell_depth, but it is not used for later
+    // in the simulator. So we do not update it here.
+    // Maybe also cell volume? Not sure whether it is used later
+    auto& porv_data = this->init_get<double>("PORV").data;
+    auto& satnum_data = this->int_data["SATNUM"].data;
+    auto& pvtnum_data = this->int_data["PVTNUM"].data;
+    numerical_aquifers.updateCellProps(*(this->grid_ptr), porv_data, satnum_data, pvtnum_data);
+
     this->updateTransWithNumericalAquifer(numerical_aquifers);
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -18,6 +18,9 @@
 #include <functional>
 #include <algorithm>
 #include <unordered_map>
+#include <array>
+#include <vector>
+#include <set>
 
 #include <opm/common/utility/OpmInputError.hpp>
 
@@ -39,6 +42,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/common/utility/Serializer.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 
 #include "FieldProps.hpp"
 #include "Operate.hpp"
@@ -1211,6 +1215,40 @@ bool FieldProps::tran_active(const std::string& keyword) const {
     return calculator != this->tran.end() && calculator->second.size() > 0;
 }
 
+void FieldProps::applyNumericalAquifers(const NumericalAquifers& numerical_aquifers) {
+    this->updateTransWithNumericalAquifer(numerical_aquifers);
+}
+
+void FieldProps::updateTransWithNumericalAquifer(const NumericalAquifers& numerical_aquifers) {
+    const std::array<std::set<size_t>, 3> trans_to_remove = numerical_aquifers.transToRemove(*(this->grid_ptr));
+    std::array<std::vector<Box::cell_index>, 3> index_lists;
+    for (int i = 0; i < 3; ++i) {
+        size_t num = 0;
+        for (const auto& elem : trans_to_remove[i]) {
+            const size_t active_index = this->grid_ptr->activeIndex(elem);
+            index_lists[i].emplace_back(elem, active_index, num);
+            num++;
+        }
+    }
+
+    const std::array<std::string, 3> trans_string {"TRANX", "TRANY", "TRANZ"};
+    for (int i = 0; i < 3; ++i) {
+        const std::string& target_kw = trans_string[i];
+        const std::vector<Box::cell_index>& single_index_list = index_lists[i];
+        auto tran_iter = this->tran.find(target_kw);
+        assert(tran_iter != this->tran.end());
+        const std::string unique_name = tran_iter->second.next_name();
+        const auto operation = Fieldprops::ScalarOperation::EQUAL;
+        tran_iter->second.add_action(operation, unique_name);
+        const auto kw_info = tran_iter->second.make_kw_info(operation);
+        auto& field_data = this->init_get<double>(unique_name, kw_info);
+        // setting the transmissiblity to be zero to remove the connection between specific cells
+        FieldProps::apply(operation, field_data.data, field_data.value_status, 0.0, single_index_list);
+        // TODO: not sure when we need the following. If we need, we also need to make a global_index_list;
+        /* if (field_data.global_data)
+             FieldProps::apply(operation, *field_data.global_data, *field_data.global_value_status, scalar_value, box.global_index_list()); */
+    }
+}
 
 
 template std::vector<bool> FieldProps::defaulted<int>(const std::string& keyword);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -41,6 +41,7 @@ namespace Opm {
 class Deck;
 class EclipseGrid;
 class TableManager;
+class NumericalAquifers;
 
 namespace Fieldprops
 {
@@ -359,6 +360,11 @@ public:
 
     FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid& grid, const TableManager& table_arg);
     void reset_actnum(const std::vector<int>& actnum);
+
+    void applyNumericalAquifers(const NumericalAquifers& numerical_aquifers);
+    // set the transmissiblities around the numerical aquifer cells to be zero, so we can isolate them
+    // from the other reservoir cells
+    void updateTransWithNumericalAquifer(const NumericalAquifers& numerical_aquifer);
 
     const std::string& default_region() const;
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -361,7 +361,7 @@ public:
     FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid& grid, const TableManager& table_arg);
     void reset_actnum(const std::vector<int>& actnum);
 
-    void applyNumericalAquifers(const NumericalAquifers& numerical_aquifers);
+    void apply_numerical_aquifers(const NumericalAquifers& numerical_aquifers);
     // set the transmissiblities around the numerical aquifer cells to be zero, so we can isolate them
     // from the other reservoir cells
     void updateTransWithNumericalAquifer(const NumericalAquifers& numerical_aquifer);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -362,9 +362,6 @@ public:
     void reset_actnum(const std::vector<int>& actnum);
 
     void apply_numerical_aquifers(const NumericalAquifers& numerical_aquifers);
-    // set the transmissiblities around the numerical aquifer cells to be zero, so we can isolate them
-    // from the other reservoir cells
-    void updateTransWithNumericalAquifer(const NumericalAquifers& numerical_aquifer);
 
     const std::string& default_region() const;
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -142,8 +142,8 @@ bool FieldPropsManager::tran_active(const std::string& keyword) const {
     return this->fp->tran_active(keyword);
 }
 
-void FieldPropsManager::applyNumericalAquifer(const NumericalAquifers& aquifers) {
-    return this->fp->applyNumericalAquifers(aquifers);
+void FieldPropsManager::apply_numerical_aquifers(const NumericalAquifers& aquifers) {
+    return this->fp->apply_numerical_aquifers(aquifers);
 }
 
 template<class MapType>

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -22,6 +22,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/common/utility/Serializer.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 
 #include "FieldProps.hpp"
 
@@ -139,6 +140,10 @@ void FieldPropsManager::deserialize_tran(const std::vector<char>& buffer) {
 
 bool FieldPropsManager::tran_active(const std::string& keyword) const {
     return this->fp->tran_active(keyword);
+}
+
+void FieldPropsManager::applyNumericalAquifer(const NumericalAquifers& aquifers) {
+    return this->fp->applyNumericalAquifers(aquifers);
 }
 
 template<class MapType>

--- a/tests/parser/AquiferTests.cpp
+++ b/tests/parser/AquiferTests.cpp
@@ -617,7 +617,7 @@ BOOST_AUTO_TEST_CASE(NumericalAquiferTest){
 
     const Opm::NumericalAquifers num_aqu{numaquifer_deck, grid, ecl_state.fieldProps()};
     BOOST_CHECK(num_aqu.hasAquifer(1));
-    BOOST_CHECK(num_aqu.numAquifer() == 1);
+    BOOST_CHECK(num_aqu.size() == 1);
     const auto all_aquifer_cells = num_aqu.allAquiferCells();
     BOOST_CHECK(all_aquifer_cells.count(0) > 0);
     BOOST_CHECK(all_aquifer_cells.count(2) > 0);

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -2586,7 +2586,7 @@ BOOST_AUTO_TEST_CASE(TEST_constructFromEgrid) {
     auto deck = parser.parseString( deckData) ;
 
     Opm::EclipseGrid grid1( deck);
-    Opm::EclipseGrid grid2( "");
+    Opm::EclipseGrid grid2( "SPE1CASE1.EGRID");
 
     // compare actnum
     std::vector<int> actGrid1 = grid1.getACTNUM();

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -2366,6 +2366,12 @@ BOOST_AUTO_TEST_CASE(TESTCP_ACTNUM_AQUNUM) {
           0 0 1 1 0 1 /
          PORO
           6*0.15 /
+         PERMX
+          6*100. /
+         PERMY
+          6*100. /
+         PERMZ
+          6*10. /
          AQUNUM
             1     1  1  1   1000000.0   10000   0.25   400    2585.00   285.00    1   1  /
             1     2  1  1   1000000.0   10000   0.25   400    2585.00   285.00    1   1  /
@@ -2580,7 +2586,7 @@ BOOST_AUTO_TEST_CASE(TEST_constructFromEgrid) {
     auto deck = parser.parseString( deckData) ;
 
     Opm::EclipseGrid grid1( deck);
-    Opm::EclipseGrid grid2( "SPE1CASE1.EGRID");
+    Opm::EclipseGrid grid2( "");
 
     // compare actnum
     std::vector<int> actGrid1 = grid1.getACTNUM();


### PR DESCRIPTION
This is a continuation of PR https://github.com/OPM/opm-common/pull/2246. 

Numerical aquifer cells technically are cells belong to the grid, while they can be specified with relatively arbitrary properties to these cells, like porosity, volume, pore volume, depth, pvtnum, satnum... they can have properties totally independent of the other parts of the grid.  We need to update some of the field props due to numerical aquifer cells.  We did not update all of them in the field props, because downstream are not using them. But maybe we should update them anyway?

To make the numerical aquifer work, we also need to do the following:
1. isolate numerical aquifer cells with other reservoir grid cells
2. connect the aquifer cells with NNCs
3. connect the reservoir cells  (connection cells) to the first aquifer cell with NNCs. 

The above is basically what this PR about.  FieldProps are very complicated to be honest. Some help is needed there. 