### PR TITLE
Use normal map groups

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -162,7 +162,7 @@ namespace Opm
 
     class Schedule {
     public:
-        using GroupMap = OrderedMap<std::string, DynamicState<std::shared_ptr<Group>>>;
+        using GroupMap = std::map<std::string, DynamicState<std::shared_ptr<Group>>>;
         using WellMap = std::unordered_map<std::string, DynamicState<std::shared_ptr<Well>>>;
 
         Schedule() = default;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -360,6 +360,7 @@ namespace Opm
             pack_unpack<Action::Actions, Serializer>(serializer);
             pack_unpack<UDQActive, Serializer>(serializer);
             pack_unpack<NameOrder, Serializer>(serializer);
+            pack_unpack<GroupOrder, Serializer>(serializer);
         }
 
         template <typename T, class Serializer>

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
@@ -168,6 +168,7 @@ namespace Opm {
         ptr_member<Action::Actions> actions;
         ptr_member<UDQActive> udq_active;
         ptr_member<NameOrder> well_order;
+        ptr_member<GroupOrder> group_order;
 
         template <typename T>
         ptr_member<T>& get() {
@@ -191,6 +192,8 @@ namespace Opm {
                                   return this->udq_active;
             else if constexpr ( std::is_same_v<T, NameOrder> )
                                   return this->well_order;
+            else if constexpr ( std::is_same_v<T, GroupOrder> )
+                                  return this->group_order;
         }
 
         template <typename T>

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/NameOrder.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/NameOrder.hpp
@@ -31,10 +31,10 @@ namespace Opm {
 */
 
 
+using Map = std::unordered_map<std::string, std::size_t>;
 
 class NameOrder {
 public:
-    using Map = std::unordered_map<std::string, std::size_t>;
     NameOrder() = default;
     explicit NameOrder(const std::vector<std::string>& names);
     void add(const std::string& name);
@@ -44,8 +44,8 @@ public:
 
     template<class Serializer>
     void serializeOp(Serializer& serializer) {
-        serializer.template map<Map, false>(m_names1);
-        serializer(m_names2);
+        serializer.template map<Map, false>(m_index_map);
+        serializer(m_name_list);
     }
 
     static NameOrder serializeObject();
@@ -55,16 +55,39 @@ public:
     std::vector<std::string>::const_iterator end() const;
 
 private:
-    Map m_names1;
-    std::vector<std::string> m_names2;
+    Map m_index_map;
+    std::vector<std::string> m_name_list;
 };
 
 
-class GroupOrder : public NameOrder {
+class GroupOrder {
 public:
-    GroupOrder();
-    std::vector<std::string> restart_groups() const;
+    GroupOrder() = default;
+    explicit GroupOrder(std::size_t max_groups);
+    void add(const std::string& name);
+    const std::vector<std::string>& names() const;
+    bool has(const std::string& wname) const;
+    std::vector<std::optional<std::string>> restart_groups() const;
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer) {
+        serializer(m_name_list);
+        serializer(m_max_groups);
+    }
+    static GroupOrder serializeObject();
+
+    bool operator==(const GroupOrder& other) const;
+    std::vector<std::string>::const_iterator begin() const;
+    std::vector<std::string>::const_iterator end() const;
+
+private:
+    std::vector<std::string> m_name_list;
+    std::size_t m_max_groups;
+
 };
+
+
+
 
 }
 #endif

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1884,6 +1884,7 @@ void Schedule::create_first(const std::chrono::system_clock::time_point& start_t
     sched_state.actions.update( Action::Actions() );
     sched_state.udq_active.update( UDQActive() );
     sched_state.well_order.update( NameOrder() );
+    sched_state.group_order.update( GroupOrder( this->m_static.m_runspec.wellDimensions().maxGroupsInField()) );
     this->addGroup("FIELD", 0);
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1093,83 +1093,47 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         if (pattern.size() == 0)
             return {};
 
+        const auto& group_order = this->snapshots[timeStep].group_order();
+
         // Normal pattern matching
         auto star_pos = pattern.find('*');
         if (star_pos != std::string::npos) {
             std::vector<std::string> names;
-            for (const auto& group_pair : this->groups) {
-                if (name_match(pattern, group_pair.first)) {
-                    const auto& dynamic_state = group_pair.second;
-                    const auto& group_ptr = dynamic_state.get(timeStep);
-                    if (group_ptr)
-                        names.push_back(group_pair.first);
-                }
+            for (const auto& gname : group_order) {
+                if (name_match(pattern, gname))
+                    names.push_back(gname);
             }
             return names;
         }
 
         // Normal group name without any special characters
-        if (this->hasGroup(pattern)) {
-            const auto& dynamic_state = this->groups.at(pattern);
-            const auto& group_ptr = dynamic_state.get(timeStep);
-            if (group_ptr)
-                return { pattern };
-        }
-        return {};
-    }
-
-    std::vector<std::string> Schedule::groupNames(std::size_t timeStep) const {
-        std::vector<std::string> names;
-        for (const auto& group_pair : this->groups) {
-            const auto& dynamic_state = group_pair.second;
-            const auto& group_ptr = dynamic_state.get(timeStep);
-            if (group_ptr)
-                names.push_back(group_pair.first);
-        }
-        return names;
-    }
-
-    std::vector<std::string> Schedule::groupNames(const std::string& pattern) const {
-        if (pattern.size() == 0)
-            return {};
-
-        // Normal pattern matching
-        auto star_pos = pattern.find('*');
-        if (star_pos != std::string::npos) {
-            int flags = 0;
-            std::vector<std::string> names;
-            for (const auto& group_pair : this->groups) {
-                if (fnmatch(pattern.c_str(), group_pair.first.c_str(), flags) == 0)
-                    names.push_back(group_pair.first);
-            }
-            return names;
-        }
-
-        // Normal group name without any special characters
-        if (this->hasGroup(pattern))
+        if (group_order.has(pattern))
             return { pattern };
 
         return {};
     }
 
-    std::vector<std::string> Schedule::groupNames() const {
-        std::vector<std::string> names;
-        for (const auto& group_pair : this->groups)
-            names.push_back(group_pair.first);
+    std::vector<std::string> Schedule::groupNames(std::size_t timeStep) const {
+        const auto& group_order = this->snapshots[timeStep].group_order();
+        return group_order.names();
+    }
 
-        return names;
+    std::vector<std::string> Schedule::groupNames(const std::string& pattern) const {
+        return this->groupNames(pattern, this->snapshots.size() - 1);
+    }
+
+    std::vector<std::string> Schedule::groupNames() const {
+        const auto& group_order = this->snapshots.back().group_order();
+        return group_order.names();
     }
 
     std::vector<const Group*> Schedule::restart_groups(std::size_t timeStep) const {
-        std::size_t wdmax = this->m_static.m_runspec.wellDimensions().maxGroupsInField();
-        std::vector<const Group*> rst_groups(wdmax + 1 , nullptr );
-        for (const auto& group_name : this->groupNames(timeStep)) {
-            const auto& group = this->getGroup(group_name, timeStep);
-
-            if (group.name() == "FIELD")
-                rst_groups.back() = &group;
-            else
-                rst_groups[group.insert_index() - 1] = &group;
+        const auto& restart_groups = this->snapshots[timeStep].group_order().restart_groups();
+        std::vector<const Group*> rst_groups(restart_groups.size() , nullptr );
+        for (std::size_t restart_index = 0; restart_index < restart_groups.size(); restart_index++) {
+            const auto& group_name = restart_groups[restart_index];
+            if (group_name.has_value())
+                rst_groups[restart_index] = &this->getGroup(group_name.value(), timeStep);
         }
         return rst_groups;
     }
@@ -1181,8 +1145,14 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         auto& dynamic_state = this->groups.at(group.name());
         dynamic_state.update(timeStep, group_ptr);
 
-        this->snapshots.back().events().addEvent( ScheduleEvents::NEW_GROUP );
-        this->snapshots.back().wellgroup_events().addGroup(group.name());
+        auto& sched_state = this->snapshots.back();
+        sched_state.events().addEvent( ScheduleEvents::NEW_GROUP );
+        sched_state.wellgroup_events().addGroup(group.name());
+        {
+            auto go = sched_state.group_order.get();
+            go.add( group.name() );
+            sched_state.group_order.update( std::move(go) );
+        }
 
         // All newly created groups are attached to the field group,
         // can then be relocated with the GRUPTREE keyword.

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
@@ -170,6 +170,7 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
            this->m_nupcol == other.m_nupcol &&
            this->wtest_config.get() == other.wtest_config.get() &&
            this->well_order.get() == other.well_order.get() &&
+           this->group_order.get() == other.group_order.get() &&
            this->gconsale.get() == other.gconsale.get() &&
            this->gconsump.get() == other.gconsump.get() &&
            this->wlist_manager.get() == other.wlist_manager.get() &&
@@ -201,6 +202,7 @@ ScheduleState ScheduleState::serializeObject() {
     ts.udq_active.update( UDQActive::serializeObject() );
     ts.network.update( Network::ExtNetwork::serializeObject() );
     ts.well_order.update( NameOrder::serializeObject() );
+    ts.group_order.update( GroupOrder::serializeObject() );
     return ts;
 }
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3385,18 +3385,26 @@ BOOST_AUTO_TEST_CASE(WellOrderTest) {
 }
 
 BOOST_AUTO_TEST_CASE(GroupOrderTest) {
-    GroupOrder go;
+    const std::size_t max_groups = 9;
+    GroupOrder go(max_groups);
 
     std::vector<std::string> groups1 = {"FIELD"};
     std::vector<std::string> groups2 = {"FIELD", "G1", "G2", "G3"};
-    std::vector<std::string> groups3 = {"G1", "G2", "G3", "FIELD"};
 
     BOOST_CHECK( go.names() == groups1 );
     go.add("G1");
     go.add("G2");
     go.add("G3");
     BOOST_CHECK( go.names() == groups2 );
-    BOOST_CHECK( go.restart_groups() == groups3 );
+    const auto& restart_groups = go.restart_groups();
+    BOOST_CHECK_EQUAL(restart_groups.size(), max_groups + 1);
+    BOOST_CHECK_EQUAL( *restart_groups[0], "G1");
+    BOOST_CHECK_EQUAL( *restart_groups[1], "G2");
+    BOOST_CHECK_EQUAL( *restart_groups[2], "G3");
+    BOOST_CHECK_EQUAL( *restart_groups[max_groups], "FIELD");
+
+    for (std::size_t g=3; g < max_groups; g++)
+        BOOST_CHECK( !restart_groups[g].has_value() );
 }
 
 


### PR DESCRIPTION
With this PR the groups are managed internally with a `std::unordered_map<>` and a separate class `GroupOrder` manages the ordering.

The small `GroupOrder`class was initially implemented with inheritance from class `NameOrder`- but-I-could-just-not-get-that-to-work-for-f...-sake so I ended with a separate small class.