### PR TITLE
fix max_gas_liquid_ratio

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.cpp
@@ -170,7 +170,7 @@ bool WellEconProductionLimits::onSecondaryMaxWaterCut() const {
     return (m_secondary_max_water_cut > 0.0);
 };
 
-bool WellEconProductionLimits::onMaxGasLiquidRatio() const { return (m_max_gas_oil_ratio > 0.0); };
+bool WellEconProductionLimits::onMaxGasLiquidRatio() const { return (m_max_gas_liquid_ratio > 0.0); };
 
 // assuming Celsius temperature is used internally
 bool WellEconProductionLimits::onMaxTemperature() const { return (m_max_temperature > -273.15); };


### PR DESCRIPTION
Max gas liquid ration is not supported in the simulator. But this bugs wrongly spam the log file with "max-gas-liquid... not supported" for cases where gas-oil ratio is set. 