### PR TITLE
Well use SchedState

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
@@ -43,6 +43,9 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/GasLiftOpt.hpp>
 
 
 namespace {
@@ -197,6 +200,7 @@ namespace Opm {
                 return as_vector;
             }
 
+
             std::vector<std::reference_wrapper<T>> operator()() {
                 std::vector<std::reference_wrapper<T>> as_vector;
                 for (const auto& [_, elm_ptr] : this->m_data) {
@@ -300,6 +304,9 @@ namespace Opm {
         ptr_member<UDQActive> udq_active;
         ptr_member<NameOrder> well_order;
         ptr_member<GroupOrder> group_order;
+        ptr_member<UDQConfig> udq;
+        ptr_member<GasLiftOpt> glo;
+        ptr_member<GuideRateConfig> guide_rate;
 
         template <typename T> struct always_false1 : std::false_type {};
 
@@ -327,6 +334,12 @@ namespace Opm {
                                   return this->well_order;
             else if constexpr ( std::is_same_v<T, GroupOrder> )
                                   return this->group_order;
+            else if constexpr ( std::is_same_v<T, UDQConfig> )
+                                  return this->udq;
+            else if constexpr ( std::is_same_v<T, GasLiftOpt> )
+                                  return this->glo;
+            else if constexpr ( std::is_same_v<T, GuideRateConfig> )
+                                  return this->guide_rate;
             else
                 static_assert(always_false1<T>::value, "Template type <T> not supported in get()");
         }
@@ -355,6 +368,12 @@ namespace Opm {
                                   return this->well_order;
             else if constexpr ( std::is_same_v<T, GroupOrder> )
                                   return this->group_order;
+            else if constexpr ( std::is_same_v<T, UDQConfig> )
+                                  return this->udq;
+            else if constexpr ( std::is_same_v<T, GasLiftOpt> )
+                                  return this->glo;
+            else if constexpr ( std::is_same_v<T, GuideRateConfig> )
+                                  return this->guide_rate;
             else
                 static_assert(always_false1<T>::value, "Template type <T> not supported in get()");
         }
@@ -369,6 +388,8 @@ namespace Opm {
                              return this->vfpinj;
             else if constexpr ( std::is_same_v<T, Group> )
                              return this->groups;
+            else if constexpr ( std::is_same_v<T, Well> )
+                                  return this->wells;
             else
                 static_assert(always_false2<K,T>::value, "Template type <K,T> not supported in get_map()");
         }
@@ -376,6 +397,7 @@ namespace Opm {
         map_member<int, VFPProdTable> vfpprod;
         map_member<int, VFPInjTable> vfpinj;
         map_member<std::string, Group> groups;
+        map_member<std::string, Well> wells;
 
 
 

--- a/python/tests/test_schedule.py
+++ b/python/tests/test_schedule.py
@@ -23,7 +23,7 @@ class TestSchedule(unittest.TestCase):
         self.assertTrue( isinstance( self.sch.get_wells(0), list) )
         self.assertEqual(2, len(self.sch.get_wells(0)))
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(Exception):
             self.sch.get_well('foo', 0)
 
     def testContains(self):

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -3210,8 +3210,10 @@ void Opm::out::Summary::SummaryImplementation::configureUDQ(const SummaryConfig&
     const std::unordered_set<std::string> time_vectors = {"TIME", "DAY", "MONTH", "YEAR", "YEARS", "MNTH"};
     auto nodes = std::vector<Opm::EclIO::SummaryNode> {};
     std::unordered_set<std::string> summary_keys;
-    for (const auto& udq_ptr : sched.udqConfigList())
-        udq_ptr->required_summary(summary_keys);
+    for (const auto& [_, udq] : sched.unique<UDQConfig>()) {
+        (void)_;
+        udq.required_summary(summary_keys);
+    }
 
     for (const auto& action : sched.back().actions.get())
         action.required_summary(summary_keys);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
@@ -153,6 +153,10 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
            this->wlist_manager.get() == other.wlist_manager.get() &&
            this->rpt_config.get() == other.rpt_config.get() &&
            this->udq_active.get() == other.udq_active.get() &&
+           this->glo.get() == other.glo.get() &&
+           this->guide_rate.get() == other.guide_rate.get() &&
+           this->udq.get() == other.udq.get() &&
+           this->wells == other.wells &&
            this->groups == other.groups &&
            this->vfpprod == other.vfpprod &&
            this->vfpinj == other.vfpinj;
@@ -184,6 +188,9 @@ ScheduleState ScheduleState::serializeObject() {
     ts.network.update( Network::ExtNetwork::serializeObject() );
     ts.well_order.update( NameOrder::serializeObject() );
     ts.group_order.update( GroupOrder::serializeObject() );
+    ts.udq.update( UDQConfig::serializeObject() );
+    ts.guide_rate.update( GuideRateConfig::serializeObject() );
+    ts.glo.update( GasLiftOpt::serializeObject() );
 
     return ts;
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1571,8 +1571,8 @@ WCONHIST
     const auto& schedule = make_schedule(input);
 
     //Start
-    BOOST_CHECK_THROW(schedule.getWell("P1", 0), std::invalid_argument);
-    BOOST_CHECK_THROW(schedule.getWell("P2", 0), std::invalid_argument);
+    BOOST_CHECK_THROW(schedule.getWell("P1", 0), std::exception);
+    BOOST_CHECK_THROW(schedule.getWell("P2", 0), std::exception);
 
     //10  OKT 2008
     BOOST_CHECK(schedule.getWell("P1", 1).getProductionProperties().controlMode == Opm::Well::ProducerCMode::ORAT);
@@ -1670,8 +1670,8 @@ DATES             -- 3
 
     const auto& schedule = make_schedule(input);
     //Start
-    BOOST_CHECK_THROW(schedule.getWell("P1", 0), std::invalid_argument);
-    BOOST_CHECK_THROW(schedule.getWell("P2", 0), std::invalid_argument);
+    BOOST_CHECK_THROW(schedule.getWell("P1", 0), std::exception);
+    BOOST_CHECK_THROW(schedule.getWell("P2", 0), std::exception);
 
     //10  OKT 2008
     BOOST_CHECK(schedule.getWell("P1", 1).getProductionProperties().controlMode == Opm::Well::ProducerCMode::ORAT);
@@ -3230,8 +3230,8 @@ BOOST_AUTO_TEST_CASE(WELL_STATIC) {
     Runspec runspec (deck);
     Schedule schedule(deck, grid1, fp, runspec, python);
 
-    BOOST_CHECK_THROW( schedule.getWell("NO_SUCH_WELL", 0), std::invalid_argument);
-    BOOST_CHECK_THROW( schedule.getWell("W_3", 0), std::invalid_argument);
+    BOOST_CHECK_THROW( schedule.getWell("NO_SUCH_WELL", 0), std::exception);
+    BOOST_CHECK_THROW( schedule.getWell("W_3", 0)         , std::exception);
 
     auto ws = schedule.getWell("W_3", 3);
     {

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -2281,17 +2281,16 @@ TSTEP
         BOOST_CHECK_EQUAL(fu_var1, 0);
     }
 
-    /*
-      const auto& unique = schedule.unique<UDQConfig>();
-      BOOST_CHECK_EQUAL( unique.size(), 3 );
-      BOOST_CHECK_EQUAL( unique[0].first, 0 );
-      BOOST_CHECK_EQUAL( unique[1].first, 5 );
-      BOOST_CHECK_EQUAL( unique[2].first, 10 );
 
-      BOOST_CHECK( unique[0].second, schedule.getUDQConfig(0));
-      BOOST_CHECK( unique[1].second, schedule.getUDQConfig(5));
-      BOOST_CHECK( unique[2].second, schedule.getUDQConfig(10));
-    */
+    const auto& unique = schedule.unique<UDQConfig>();
+    BOOST_CHECK_EQUAL( unique.size(), 3 );
+    BOOST_CHECK_EQUAL( unique[0].first, 0 );
+    BOOST_CHECK_EQUAL( unique[1].first, 5 );
+    BOOST_CHECK_EQUAL( unique[2].first, 10 );
+
+    BOOST_CHECK( unique[0].second == schedule.getUDQConfig(0));
+    BOOST_CHECK( unique[1].second == schedule.getUDQConfig(5));
+    BOOST_CHECK( unique[2].second == schedule.getUDQConfig(10));
 }
 
 

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -909,3 +909,4 @@ BOOST_AUTO_TEST_CASE(TestWellEvents) {
     BOOST_CHECK( sched[0].wellgroup_events().hasEvent( "W_1", ScheduleEvents::COMPLETION_CHANGE));
     BOOST_CHECK( sched[5].wellgroup_events().hasEvent( "W_1", ScheduleEvents::COMPLETION_CHANGE));
 }
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1321665/106958744-0d124f80-673a-11eb-8a58-1a2c6cc0e955.png)


The schedule refactoring is approaching the finishing line. When this PR is merged the `Schedule`class has been more-or-less 100% rewritten to use the `ScheduleState`class with snapshots of the entire state instead of multiple `DynamicState<T>` vectors which manage dynamic state indpendently for different properties. For this particular PR I intend to clean up the commits, and then I consider it ready for merging. When this is merged the following tasks remain:

1. The WELPI keyword is a very different beast - the implementation in this PR is just a minimal refactor based on the existing implementation. Maybe it would make sense to refactor the WELPI implementation to match the (not yet ready) ACTIONX version of the same keyword?

2. Support WELPI + ACTIONX; to enable that has been the goal of the entire excercise.

3. This work has been rushed. When point 2 is in place and working there will be cleanup PR's all over the Schedule implementation.


**Update:** This is is a real *works for me* and I am a bit uncertain how to proceed. The situation is as follows:

1. The test `MOD4_UDQ_ACTIONX` fails on jenkins.
2. The test `MOD4_UDQ_ACTIONX` fails on my machine - both with master and this PR.
3. On my machine[1] the `UNRST` and `UNSMRY`[2] files are bitwise identical between master and this PR.

So - ideas; suggestions more than welcome. Would be grateful if more people could the run locally and check if they also get the bitwise identical `UNRST` and `UNSMRY` files.

[1]: I have tested on one machine; will test on another machine with different OS/compiler version tomorrow.
[2]: Need to remove the `TCPU` keyword from the `SUMMARY` section to get the bitwise equality in the `UNSMRY` file.


