### PR TITLE
Pass simulation time argument to Schedule::applyAction()

### DIFF
--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -1,9 +1,10 @@
 #ifndef ISIM_MAIN_HPP
 #define ISIM_MAIN_HPP
 
+#include <chrono>
 #include <functional>
-#include <string>
 #include <map>
+#include <string>
 
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -44,7 +45,7 @@ public:
     void well_rate(const std::string& well, data::Rates::opt rate, std::function<well_rate_function> func);
     void solution(const std::string& field, std::function<solution_function> func);
     void run(Schedule& schedule, EclipseIO& io, bool report_only);
-    void post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step);
+    void post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step, const std::chrono::system_clock::time_point& sim_time);
 private:
 
     void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, UDQState& udq_state, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step, EclipseIO& io) const;

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -62,7 +62,8 @@ void msim::run(Schedule& schedule, EclipseIO& io, bool report_only) {
             double time_step = std::min(week, 0.5*schedule.stepLength(report_step - 1));
             run_step(schedule, action_state, st, udq_state, sol, well_data, group_nwrk_data, report_step, time_step, io);
         }
-        post_step(schedule, action_state, st, sol, well_data, group_nwrk_data, report_step);
+        auto sim_time = std::chrono::system_clock::from_time_t( schedule.simTime(report_step) );
+        post_step(schedule, action_state, st, sol, well_data, group_nwrk_data, report_step, sim_time);
         const auto& exit_status = schedule.exitStatus();
         if (exit_status.has_value())
             return;
@@ -74,18 +75,17 @@ UDAValue msim::uda_val() {
 }
 
 
-void msim::post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& /* sol */, data::Wells& /* well_data */, data::GroupAndNetworkValues& /* grp_nwrk_data */, size_t report_step) {
+void msim::post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& /* sol */, data::Wells& /* well_data */, data::GroupAndNetworkValues& /* grp_nwrk_data */, size_t report_step, const std::chrono::system_clock::time_point& sim_time) {
     const auto& actions = schedule[report_step].actions.get();
     if (actions.empty())
         return;
 
     Action::Context context( st , schedule[report_step].wlist_manager.get());
 
-    auto sim_time = schedule.simTime(report_step);
-    for (const auto& action : actions.pending(action_state, sim_time)) {
+    for (const auto& action : actions.pending(action_state, std::chrono::system_clock::to_time_t(sim_time))) {
         auto result = action->eval(context);
         if (result)
-            schedule.applyAction(report_step, *action, result);
+            schedule.applyAction(report_step, sim_time, *action, result);
     }
 
     for (const auto& pyaction : actions.pending_python())

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -298,7 +298,7 @@ namespace Opm
         const RestartConfig& restart() const;
         RestartConfig& restart();
 
-        void applyAction(std::size_t reportStep, const Action::ActionX& action, const Action::Result& result);
+        void applyAction(std::size_t reportStep, const std::chrono::system_clock::time_point& sim_time, const Action::ActionX& action, const Action::Result& result);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1240,7 +1240,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
     }
 
 
-    void Schedule::applyAction(std::size_t reportStep, const Action::ActionX& action, const Action::Result& result) {
+void Schedule::applyAction(std::size_t reportStep, const std::chrono::system_clock::time_point&, const Action::ActionX& action, const Action::Result& result) {
         ParseContext parseContext;
         ErrorGuard errors;
 

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -987,7 +987,8 @@ TSTEP
     }
 
     Action::Result action_result(true);
-    sched.applyAction(0, action1, action_result);
+    auto sim_time = std::chrono::system_clock::now();
+    sched.applyAction(0, sim_time, action1, action_result);
 
     {
         const auto& group = sched.getGroup("G1", 1);
@@ -1052,7 +1053,7 @@ TSTEP
 
 
     Action::Result action_result(true);
-    sched.applyAction(0, action1, action_result);
+    sched.applyAction(0, std::chrono::system_clock::now(), action1, action_result);
 
     {
         const auto& glo = sched.glo(0);
@@ -1106,7 +1107,7 @@ TSTEP
     BOOST_CHECK_EQUAL( required_summary.count("WWCT"), 1);
 
     Action::Result action_result(true);
-    sched.applyAction(0, action1, action_result);
+    sched.applyAction(0, std::chrono::system_clock::now(), action1, action_result);
     {
         auto unit_system =  UnitSystem::newMETRIC();
         const auto& well = sched.getWell("PROD1", 1);


### PR DESCRIPTION
Part of #2176 

To enable better messages when the ACTIONX keywords are applied.

Downstream: https://github.com/OPM/opm-simulators/pull/3047