### PR TITLE
Apply WELPI is based on newWellPI and not scaling factor

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1296,7 +1296,7 @@ void Schedule::applyAction(std::size_t reportStep, const std::chrono::system_clo
 
 
 
-    void Schedule::applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor) {
+    void Schedule::applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double newWellPI) {
         auto wstat = this->wells_static.find(well_name);
         if (wstat == this->wells_static.end())
             return;
@@ -1319,6 +1319,7 @@ void Schedule::applyAction(std::size_t reportStep, const std::chrono::system_clo
         // which means unique_well_instances is a vector<pair<report_step, shared_ptr<>>>
         std::vector<bool> scalingApplicable;
         auto wellPtr = start->second;
+        auto scalingFactor = wellPtr->getWellPIScalingFactor(newWellPI);
         wellPtr->applyWellProdIndexScaling(scalingFactor, scalingApplicable);
 
         for (; start != end; ++start)

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -4053,9 +4053,9 @@ END
         return sched.getWell("P", report_step).getWellPIScalingFactor(wellPI);
     };
 
-    auto applyWellPIScaling = [&sched](const std::size_t report_step, const double scalingFactor)
+    auto applyWellPIScaling = [&sched](const std::size_t report_step, const double newWellPI)
     {
-        sched.applyWellProdIndexScaling("P", report_step, scalingFactor);
+        sched.applyWellProdIndexScaling("P", report_step, newWellPI);
     };
 
     auto getConnections = [&sched](const std::size_t report_step)
@@ -4132,11 +4132,9 @@ END
     // Apply WELPI scaling after first WELPI specification
     {
         const auto report_step   = std::size_t{1};
-        const auto scalingFactor = getScalingFactor(report_step, 100.0*liquid_PI_unit());
+        const auto newWellPI     = 100.0*liquid_PI_unit();
 
-        BOOST_CHECK_CLOSE(scalingFactor, 2.0, 1.0e-10);
-
-        applyWellPIScaling(report_step, scalingFactor);
+        applyWellPIScaling(report_step, newWellPI);
 
         {
             const auto expectCF = 100.0*cp_rm3_per_db();
@@ -4200,11 +4198,9 @@ END
     // Apply WELPI scaling after second WELPI specification
     {
         const auto report_step   = std::size_t{3};
-        const auto scalingFactor = getScalingFactor(report_step, 200.0*liquid_PI_unit());
+        double newWellPI = 200*liquid_PI_unit();
 
-        BOOST_CHECK_CLOSE(scalingFactor, 0.25, 1.0e-10);
-
-        applyWellPIScaling(report_step, scalingFactor);
+        applyWellPIScaling(report_step, newWellPI);
 
         {
             const auto expectCF = 100.0*cp_rm3_per_db();


### PR DESCRIPTION
A preparation for WELPI + ACTIONX. Pass the simulated WellPI from the simulator, and let the opm-common code handle the scaling.