### PR TITLE
Add mutable overloads for map_member methods get() and operator()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
@@ -183,12 +183,25 @@ namespace Opm {
                 return *this->m_data.at(key);
             }
 
+            T& get(const K& key) {
+                return *this->m_data.at(key);
+            }
+
 
             std::vector<std::reference_wrapper<const T>> operator()() const {
                 std::vector<std::reference_wrapper<const T>> as_vector;
                 for (const auto& [_, elm_ptr] : this->m_data) {
                     (void)_;
                     as_vector.push_back( std::cref(*elm_ptr));
+                }
+                return as_vector;
+            }
+
+            std::vector<std::reference_wrapper<T>> operator()() {
+                std::vector<std::reference_wrapper<T>> as_vector;
+                for (const auto& [_, elm_ptr] : this->m_data) {
+                    (void)_;
+                    as_vector.push_back( std::ref(*elm_ptr));
                 }
                 return as_vector;
             }


### PR DESCRIPTION
A small part of #2269