### PR TITLE
Allow listing keys of FieĺdProps including those for TransCalculator

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -152,9 +152,11 @@ public:
       special cases the PORV and ACTNUM keywords, since these are present with
       special functions porv(bool) and actnum() the "PORV" and "ACTNUM" string
       literals are excluded from the keys() list.
+      \param allow_unsupported If true we deactivate some checks on the
+            keyword and thus allow getting keys used by the TranCalculator.
     */
     template <typename T>
-    std::vector<std::string> keys() const;
+    std::vector<std::string> keys(bool allow_unsupported = false) const;
 
     const Fieldprops::FieldData<int>&
     get_int_field_data(const std::string& keyword) const;

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -591,20 +591,20 @@ bool FieldProps::has<int>(const std::string& keyword) const {
 */
 
 template <>
-std::vector<std::string> FieldProps::keys<double>() const {
+std::vector<std::string> FieldProps::keys<double>(bool allow_unsupported) const {
     std::vector<std::string> klist;
     for (const auto& data_pair : this->double_data) {
-        if (data_pair.second.valid() && data_pair.first != "PORV")
+        if ((allow_unsupported || data_pair.second.valid()) && data_pair.first != "PORV")
             klist.push_back(data_pair.first);
     }
     return klist;
 }
 
 template <>
-std::vector<std::string> FieldProps::keys<int>() const {
+std::vector<std::string> FieldProps::keys<int>(bool allow_unsupported) const {
     std::vector<std::string> klist;
     for (const auto& data_pair : this->int_data) {
-        if (data_pair.second.valid() && data_pair.first != "ACTNUM")
+        if ((allow_unsupported || data_pair.second.valid()) && data_pair.first != "ACTNUM")
             klist.push_back(data_pair.first);
     }
     return klist;

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -343,8 +343,9 @@ public:
             return this->data_ptr->data;
         }
 
-        const Data& field_data() const {
-            this->verify_status();
+        const Data& field_data(bool allow_unsupported = false) const {
+            if (!allow_unsupported)
+                this->verify_status();
             return *this->data_ptr;
         }
 
@@ -371,7 +372,7 @@ public:
     bool has(const std::string& keyword) const;
 
     template <typename T>
-    std::vector<std::string> keys() const;
+    std::vector<std::string> keys(bool allow_unsupported = false) const;
 
 
     template <typename T>
@@ -385,7 +386,7 @@ public:
 
         field_data = std::addressof(this->init_get<T>(keyword,
                                                       std::is_same<T,double>::value && allow_unsupported));
-        if (field_data->valid())
+        if (allow_unsupported || field_data->valid())
             return FieldDataManager<T>(keyword, GetStatus::OK, field_data);
 
         if (!has0) {

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -66,9 +66,9 @@ FieldPropsManager::get_double_field_data(const std::string& keyword,
                                          bool allow_unsupported) const
 {
     const auto& data = this->fp->try_get<double>(keyword, allow_unsupported);
-    if (!data.valid())
+    if (!allow_unsupported && !data.valid())
         throw std::out_of_range("Invalid field data requested.");
-    return data.field_data();
+    return data.field_data(allow_unsupported);
 }
 
 template <typename T>
@@ -105,8 +105,8 @@ const std::string& FieldPropsManager::default_region() const {
 }
 
 template <typename T>
-std::vector<std::string> FieldPropsManager::keys() const {
-    return this->fp->keys<T>();
+std::vector<std::string> FieldPropsManager::keys(bool allow_unsupported) const {
+    return this->fp->keys<T>(allow_unsupported);
 }
 
 std::vector<int> FieldPropsManager::actnum() const {
@@ -223,8 +223,8 @@ template bool FieldPropsManager::has<double>(const std::string&) const;
 template std::vector<bool> FieldPropsManager::defaulted<int>(const std::string&) const;
 template std::vector<bool> FieldPropsManager::defaulted<double>(const std::string&) const;
 
-template std::vector<std::string> FieldPropsManager::keys<int>() const;
-template std::vector<std::string> FieldPropsManager::keys<double>() const;
+template std::vector<std::string> FieldPropsManager::keys<int>(bool allow_unsupported) const;
+template std::vector<std::string> FieldPropsManager::keys<double>(bool allow_unsupported) const;
 
 template std::vector<int> FieldPropsManager::get_global(const std::string& keyword) const;
 template std::vector<double> FieldPropsManager::get_global(const std::string& keyword) const;


### PR DESCRIPTION
Those are invalid and would not be listed. With this commit we add a bool to the keys method to also request those of data needed by the TransCalculator, also to the other methods that are called.
