### PR TITLE
[CMake] Support system fmtlib and always use imported target to link to it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ macro (config_hook)
     endif()
 
     # For this project
-    find_package(fmt 7.1.3)
+    find_package(fmt 7.0.3)
     if(NOT TARGET fmt::fmt-header-only)
       add_library(fmt::fmt-header-only INTERFACE IMPORTED)
       set_target_properties(fmt::fmt-header-only PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,21 @@ macro (config_hook)
     endif()
 
     # For this project
-    add_definitions(-DFMT_HEADER_ONLY)
-    include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
+    find_package(fmt 7.1.3)
+    if(NOT TARGET fmt::fmt-header-only)
+      add_library(fmt::fmt-header-only INTERFACE IMPORTED)
+      set_target_properties(fmt::fmt-header-only PROPERTIES
+	INTERFACE_COMPILE_DEFINITIONS "FMT_HEADER_ONLY=1"
+	INTERFACE_COMPILE_FEATURES "cxx_variadic_templates"
+	INTERFACE_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
+    endif()
+    # Use generator expression to hide lib in export,
+    # see https://gitlab.kitware.com/cmake/cmake/-/issues/15415#note_634114
+    # ${project}_PRIVATE_LIBRARIES will be used with keyword PRIVATE in command
+    # target_link_libraries()
+    set(opm-common_PRIVATE_LIBRARIES "$<BUILD_INTERFACE:fmt::fmt-header-only>")
+
     include_directories(${EXTRA_INCLUDES} ${PROJECT_BINARY_DIR}/include)
-    list(APPEND EXTRA_INCLUDES ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
 
     # For downstreams
     list(APPEND EXTRA_INCLUDES ${PROJECT_BINARY_DIR}/include)
@@ -166,7 +177,7 @@ include (OpmLibMain)
 if (ENABLE_MOCKSIM)
   add_library(mocksim
               msim/src/msim.cpp)
-  target_link_libraries(mocksim opmcommon)
+  target_link_libraries(mocksim PUBLIC opmcommon PRIVATE ${opm-common_PRIVATE_LIBRARIES})
   target_include_directories(mocksim PUBLIC msim/include)
   add_executable(msim examples/msim.cpp)
   target_link_libraries(msim mocksim)
@@ -209,7 +220,7 @@ if(ENABLE_ECL_INPUT)
     )
 
   foreach(target compareECL convertECL summary rewriteEclFile)
-    target_link_libraries(${target} opmcommon)
+    target_link_libraries(${target} PUBLIC opmcommon PRIVATE ${opm-common_PRIVATE_LIBRARIES})
     install(TARGETS ${target} DESTINATION bin)
   endforeach()
 
@@ -383,7 +394,7 @@ if (OPM_ENABLE_PYTHON)
   add_subdirectory(python/pybind11)
   target_include_directories(opmcommon SYSTEM PRIVATE "python/pybind11/include;${PYTHON_INCLUDE_DIRS}")
   if (OPM_ENABLE_EMBEDDED_PYTHON)
-    target_link_libraries(opmcommon PUBLIC ${PYTHON_LIBRARY})
+    target_link_libraries(opmcommon PUBLIC ${PYTHON_LIBRARY PRIVATE ${opm-common_PRIVATE_LIBRARIES})
     add_definitions(-DEMBEDDED_PYTHON)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ if(ENABLE_ECL_INPUT)
       test_util/EclFilesComparator.cpp
       test_util/EclRegressionTest.cpp
     LIBRARIES
-      ${_libs}
+      ${_libs} ${${project}_PRIVATE_LIBRARIES}
     WORKING_DIRECTORY
       ${PROJECT_BINARY_DIR}/tests
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ macro (config_hook)
     endif()
 
     # For this project
-    find_package(fmt 7.0.3)
+    find_package(fmt 4.0.0)
     if(NOT TARGET fmt::fmt-header-only)
       add_library(fmt::fmt-header-only INTERFACE IMPORTED)
       set_target_properties(fmt::fmt-header-only PROPERTIES

--- a/ExtraTests.cmake
+++ b/ExtraTests.cmake
@@ -1,5 +1,5 @@
 # Libs to link tests against
-set(TEST_LIBS opmcommon Boost::unit_test_framework)
+set(TEST_LIBS opmcommon Boost::unit_test_framework ${opm-common_PRIVATE_LIBRARIES})
 set(EXTRA_TESTS)
 
 if (Boost_UNIT_TEST_FRAMEWORK_FOUND)

--- a/GenerateKeywords.cmake
+++ b/GenerateKeywords.cmake
@@ -32,7 +32,8 @@ if(NOT cjson_FOUND)
 endif()
 add_executable(genkw ${genkw_SOURCES})
 
-target_link_libraries(genkw ${opm-common_LIBRARIES})
+# opm-common_PRIVATE_LIBRARIES not defined at this point.
+target_link_libraries(genkw PUBLIC ${opm-common_LIBRARIES} PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
 
 # Generate keyword list
 include(src/opm/parser/eclipse/share/keywords/keyword_list.cmake)

--- a/cmake/Modules/OpmCompile.cmake
+++ b/cmake/Modules/OpmCompile.cmake
@@ -52,8 +52,8 @@ macro (opm_compile opm)
           set(_public_libs ${${opm}_LIBRARIES})
           unset(_interface)
         endif()
-        target_link_libraries (${${opm}_TARGET} PUBLIC ${_public_libs}
-          INTERFACE ${_interface_libs})
+        target_link_libraries (${${opm}_TARGET}  PUBLIC ${_public_libs}
+          INTERFACE ${_interface_libs} PRIVATE "${${opm}_PRIVATE_LIBRARIES}")
 
         if (STRIP_DEBUGGING_SYMBOLS)
 	  # queue this executable to be stripped

--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -21,6 +21,11 @@
 #   - CMP0074 to indicate that <PackageName>_ROOT can be used to find package
 #             config files
 macro(OpmSetPolicies)
+  if (POLICY CMP0022)
+    # Needed to not export the imported (and sometimes embedded) header only libraries
+    # See https://gitlab.kitware.com/cmake/cmake/-/issues/15415#note_634114
+    cmake_policy(SET CMP0022 NEW)
+  endif()
   if (POLICY CMP0026)
     # Needed as we query LOCATION in OpmCompile.cmake and OpmSatellites.cmake
     cmake_policy(SET CMP0026 OLD)

--- a/cmake/Modules/OpmSatellites.cmake
+++ b/cmake/Modules/OpmSatellites.cmake
@@ -77,7 +77,7 @@ macro (opm_compile_satellites opm satellite excl_all test_regexp)
       set (_test_lib "")
       add_static_analysis_tests(_sat_FILE ${opm}_INCLUDE_DIRS)
     endif (NOT "${test_regexp}" STREQUAL "")
-    target_link_libraries (${_sat_NAME} ${${opm}_TARGET} ${${opm}_LIBRARIES} ${_test_lib})
+    target_link_libraries (${_sat_NAME} ${${opm}_TARGET} ${${opm}_LIBRARIES} ${_test_lib} ${${project}_PRIVATE_LIBRARIES})
     if (STRIP_DEBUGGING_SYMBOLS)
       strip_debug_symbols (${_sat_NAME} _sat_DEBUG)
       list (APPEND ${satellite}_DEBUG ${_sat_DEBUG})
@@ -283,6 +283,9 @@ macro(opm_add_test TestName)
   # the libraries to link against
   if (NOT CURTEST_LIBRARIES)
     SET(CURTEST_LIBRARIES "${${project}_LIBRARIES}")
+    if(${project}_PRIVATE_LIBRARIES})
+      list(APPEND CURTEST_LIBRARIES ${${project}_PRIVATE_LIBRARIES})
+      endif()
   endif()
 
   # determine if the test should be completely ignored, i.e., the


### PR DESCRIPTION
It is a bit tricky to persuade CMake to not export any information about fmtlib. We use
```cmake
target_link_libraries(lib PRIVATE $<BUILD_INTERFACE:fmt::fmt-header-only>)
```
to accomplish this. See https://gitlab.kitware.com/cmake/cmake/-/issues/15415#note_634114

There is a variable `${project}_PRIVATE_LIBRARIES` to tell our system which libraries to link via PRIVATE.

Only in the target file of the cmake package configuration (opm-common-targets.cmake) there will be reference to the library 
```cmake
set_target_properties(opmcommon PROPERTIES
  INTERFACE_LINK_LIBRARIES "...;\$<LINK_ONLY:fmt::fmt-header-only>")
```
but it has no effect as there is no library and the generator expression makes sure that is only when linking.

This is needed as for some linux distributions using embedded version of other software is considered a bug.