### PR TITLE
Unconditionally include TRAN? keywords in FieldProps::keys<double>()

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -592,17 +592,28 @@ bool FieldProps::has<int>(const std::string& keyword) const {
   postprocessing, and should be access through the special ::porv() and
   ::actnum() methods instead of the general ::get<T>( ) method. These two
   keywords are also hidden from the keys<T>() vectors.
+
+  If there are TRAN? fields in the container they are transferred even if they
+  are not completely defined. This is because that TRAN? fields will ultimately
+  be combined with the TRAN? values calculated from the simulator, it does
+  therefor not make sense to require that these fields are fully defined.
 */
 
 template <>
 std::vector<std::string> FieldProps::keys<double>() const {
     std::vector<std::string> klist;
-    for (const auto& data_pair : this->double_data) {
-        if (data_pair.second.valid() && data_pair.first != "PORV")
-            klist.push_back(data_pair.first);
+    for (const auto& [key, field] : this->double_data) {
+        if (key.rfind("TRAN", 0) == 0) {
+            klist.push_back(key);
+            continue;
+        }
+
+        if (field.valid() && key != "PORV")
+            klist.push_back(key);
     }
     return klist;
 }
+
 
 template <>
 std::vector<std::string> FieldProps::keys<int>() const {

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2092,6 +2092,29 @@ MINVALUE
     BOOST_CHECK(fpm.tran_active("TRANZ"));
 }
 
+BOOST_AUTO_TEST_CASE(TRAN_KEYS) {
+    std::string deck_string = R"(
+GRID
+
+PORO
+   300*0.10 /
+
+EDIT
+
+EQUALS
+  TRANX 0 1 1 1 1 1 1 /
+/
+
+)";
+    EclipseGrid grid(10,10,3);
+    Deck deck = Parser{}.parseString(deck_string);
+    FieldPropsManager fpm(deck, Phases{true, true, true}, grid, TableManager());
+
+    const auto& keys = fpm.keys<double>();
+    BOOST_CHECK_EQUAL(keys.size(), 2);
+}
+
+
 
 
 BOOST_AUTO_TEST_CASE(TRAN2) {


### PR DESCRIPTION
Alternative to #2289