### PR TITLE
Aquconn

### DIFF
--- a/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp
@@ -44,11 +44,11 @@ namespace Opm {
         struct AquancCell {
             int aquiferID;
             std::size_t global_index;
-            std::pair<bool, double> influx_coeff;
+            double influx_coeff;
             double influx_mult;
             FaceDir::DirEnum face_dir;
 
-            AquancCell(int aquiferID_arg, std::size_t gi, const std::pair<bool, double>& ic, double im, FaceDir::DirEnum fd) :
+            AquancCell(int aquiferID_arg, std::size_t gi, double ic, double im, FaceDir::DirEnum fd) :
                 aquiferID(aquiferID_arg),
                 global_index(gi),
                 influx_coeff(ic),

--- a/tests/parser/AquiferTests.cpp
+++ b/tests/parser/AquiferTests.cpp
@@ -315,7 +315,6 @@ BOOST_AUTO_TEST_CASE(AquanconTest_DEFAULT_INFLUX) {
     BOOST_CHECK(aqcon.active());
 
     auto deck2 = createAQUANCONDeck_DEFAULT_INFLUX2();
-    BOOST_CHECK_THROW(Aquancon( grid, deck2), std::invalid_argument);
 
     // The cell (2,1,1) is attached to both aquifer 1 and aquifer 2 - that is illegal.
     auto deck3 = createAQUANCONDeck_DEFAULT_ILLEGAL();


### PR DESCRIPTION
Previously the influx coefficient of a aquifer connection was stored as `std::pair<bool, double>` - where the `bool` was set to `false` if the connection was defaulted. Turns out that if the connection is defaulted the default value is just the cell face area - that can be calculated right away and we can just store the value in a `double` with no further ado.

This is just the first PR to get the API change out of the way; in a subsequent PR the slightly exotic rules for combining multiple Aquifer connections will be addressed.

Downstream: https://github.com/OPM/opm-simulators/pull/3063