### PR TITLE
FieldProps can return invalid data if allow_unsupported is true

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -388,7 +388,7 @@ public:
 
         field_data = std::addressof(this->init_get<T>(keyword,
                                                       std::is_same<T,double>::value && allow_unsupported));
-        if (field_data->valid())
+        if (field_data->valid() || allow_unsupported)
             return FieldDataManager<T>(keyword, GetStatus::OK, field_data);
 
         if (!has0) {

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -67,9 +67,10 @@ FieldPropsManager::get_double_field_data(const std::string& keyword,
                                          bool allow_unsupported) const
 {
     const auto& data = this->fp->try_get<double>(keyword, allow_unsupported);
-    if (!data.valid())
-        throw std::out_of_range("Invalid field data requested.");
-    return data.field_data();
+    if (allow_unsupported || data.valid())
+        return data.field_data();
+
+    throw std::out_of_range("Invalid field data requested.");
 }
 
 template <typename T>

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2112,6 +2112,9 @@ EQUALS
 
     const auto& keys = fpm.keys<double>();
     BOOST_CHECK_EQUAL(keys.size(), 2);
+
+    BOOST_CHECK_THROW( fpm.get_double_field_data("TRANX0"), std::exception );
+    BOOST_CHECK_NO_THROW( fpm.get_double_field_data("TRANX0", true));
 }
 
 


### PR DESCRIPTION
Must allow the fieldprops to return invalid vectors to fully support the TRAN calculator