### PR TITLE
Restart config make time map

### DIFF
--- a/examples/opmi.cpp
+++ b/examples/opmi.cpp
@@ -34,6 +34,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 
 void initLogging() {
@@ -49,30 +50,30 @@ inline void loadDeck( const char * deck_file) {
 
     std::cout << "Loading deck: " << deck_file << " ..... "; std::cout.flush();
 
-    std::chrono::system_clock::time_point start;
+    Opm::time_point start;
 
-    start = std::chrono::system_clock::now();
+    start = Opm::TimeService::now();
     auto deck = parser.parseFile(deck_file, parseContext, errors);
-    auto deck_time = std::chrono::system_clock::now() - start;
+    auto deck_time = Opm::TimeService::now() - start;
 
     std::cout << "parse complete - creating EclipseState .... ";  std::cout.flush();
 
-    start = std::chrono::system_clock::now();
+    start = Opm::TimeService::now();
     Opm::EclipseState state( deck );
-    auto state_time = std::chrono::system_clock::now() - start;
+    auto state_time = Opm::TimeService::now() - start;
 
     std::cout << "creating Schedule .... ";  std::cout.flush();
 
-    start = std::chrono::system_clock::now();
+    start = Opm::TimeService::now();
     Opm::Schedule schedule( deck, state, python);
-    auto schedule_time = std::chrono::system_clock::now() - start;
+    auto schedule_time = Opm::TimeService::now() - start;
 
     std::cout << "creating SummaryConfig .... ";  std::cout.flush();
 
-    start = std::chrono::system_clock::now();
+    start = Opm::TimeService::now();
     Opm::SummaryConfig summary( deck, schedule, state.getTableManager( ), state.aquifer(),
                                 parseContext, errors );
-    auto summary_time = std::chrono::system_clock::now() - start;
+    auto summary_time = Opm::TimeService::now() - start;
 
     std::cout << "complete." << std::endl << std::endl;
     std::cout << "Time: " << std::endl;

--- a/examples/wellgraph.cpp
+++ b/examples/wellgraph.cpp
@@ -45,7 +45,7 @@ inline void createDot(const Opm::Schedule& schedule, const std::string& casename
     os << "// Convert output to PDF with 'dot -Tpdf " << casename << ".gv > " << casename << ".pdf'\n";
     os << "strict digraph \"" << casename << "\"\n{\n";
     const auto groupnames = schedule.groupNames();
-    const std::size_t last = schedule.getTimeMap().last();
+    const std::size_t last = schedule.size() - 1;
     // Group -> Group relations.
     for (const auto& gn : groupnames) {
         const auto& g = schedule.getGroup(gn, last);

--- a/msim/include/opm/msim/msim.hpp
+++ b/msim/include/opm/msim/msim.hpp
@@ -45,7 +45,7 @@ public:
     void well_rate(const std::string& well, data::Rates::opt rate, std::function<well_rate_function> func);
     void solution(const std::string& field, std::function<solution_function> func);
     void run(Schedule& schedule, EclipseIO& io, bool report_only);
-    void post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step, const std::chrono::system_clock::time_point& sim_time);
+    void post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step, const time_point& sim_time);
 private:
 
     void run_step(const Schedule& schedule, Action::State& action_state, SummaryState& st, UDQState& udq_state, data::Solution& sol, data::Wells& well_data, data::GroupAndNetworkValues& group_nwrk_data, size_t report_step, EclipseIO& io) const;

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -47,7 +47,7 @@ msim::msim(const EclipseState& state_arg) :
 void msim::run(Schedule& schedule, EclipseIO& io, bool report_only) {
     const double week = 7 * 86400;
     data::Solution sol;
-    SummaryState st(std::chrono::system_clock::from_time_t(schedule.getStartTime()));
+    SummaryState st(TimeService::from_time_t(schedule.getStartTime()));
     UDQState udq_state(schedule.getUDQConfig(0).params().undefinedValue());
     Action::State action_state;
     Python python;
@@ -62,7 +62,7 @@ void msim::run(Schedule& schedule, EclipseIO& io, bool report_only) {
             double time_step = std::min(week, 0.5*schedule.stepLength(report_step - 1));
             run_step(schedule, action_state, st, udq_state, sol, well_data, group_nwrk_data, report_step, time_step, io);
         }
-        auto sim_time = std::chrono::system_clock::from_time_t( schedule.simTime(report_step) );
+        auto sim_time = TimeService::from_time_t( schedule.simTime(report_step) );
         post_step(schedule, action_state, st, sol, well_data, group_nwrk_data, report_step, sim_time);
         const auto& exit_status = schedule.exitStatus();
         if (exit_status.has_value())
@@ -75,7 +75,7 @@ UDAValue msim::uda_val() {
 }
 
 
-void msim::post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& /* sol */, data::Wells& /* well_data */, data::GroupAndNetworkValues& /* grp_nwrk_data */, size_t report_step, const std::chrono::system_clock::time_point& sim_time) {
+void msim::post_step(Schedule& schedule, Action::State& action_state, SummaryState& st, data::Solution& /* sol */, data::Wells& /* well_data */, data::GroupAndNetworkValues& /* grp_nwrk_data */, size_t report_step, const time_point& sim_time) {
     const auto& actions = schedule[report_step].actions.get();
     if (actions.empty())
         return;

--- a/opm/common/utility/TimeService.hpp
+++ b/opm/common/utility/TimeService.hpp
@@ -25,6 +25,11 @@
 
 namespace Opm {
 
+    namespace TimeService {
+    std::time_t advance(const std::time_t tp, const double sec);
+    std::time_t makeUTCTime(std::tm timePoint);
+    }
+
     class TimeStampUTC
     {
     public:

--- a/opm/common/utility/TimeService.hpp
+++ b/opm/common/utility/TimeService.hpp
@@ -25,7 +25,13 @@
 
 namespace Opm {
 
+    using time_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<int64_t, std::ratio<1,1000>>>;
+
     namespace TimeService {
+    std::time_t to_time_t(const time_point& tp);
+    time_point from_time_t(std::time_t t);
+    time_point now();
+
     std::time_t advance(const std::time_t tp, const double sec);
     std::time_t makeUTCTime(std::tm timePoint);
     }

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 #include <opm/common/utility/FileSystem.hpp>
+#include <opm/common/utility/TimeService.hpp>
 #include <opm/io/eclipse/SummaryNode.hpp>
 
 namespace Opm { namespace EclIO {
@@ -48,18 +49,18 @@ public:
 
     const std::vector<float>& get(const std::string& name) const;
     const std::vector<float>& get(const SummaryNode& node) const;
-    std::vector<std::chrono::system_clock::time_point> dates() const;
+    std::vector<time_point> dates() const;
 
     std::vector<float> get_at_rstep(const std::string& name) const;
     std::vector<float> get_at_rstep(const SummaryNode& node) const;
-    std::vector<std::chrono::system_clock::time_point> dates_at_rstep() const;
+    std::vector<time_point> dates_at_rstep() const;
 
     void LoadData(const std::vector<std::string>& vectList) const;
     void LoadData() const;
 
     bool make_lodsmry_file();
 
-    std::chrono::system_clock::time_point startdate() const { return startdat; }
+    time_point startdate() const { return startdat; }
 
     const std::vector<std::string>& keywordList() const;
     std::vector<std::string> keywordList(const std::string& pattern) const;
@@ -101,7 +102,7 @@ private:
     std::vector<SummaryNode> summaryNodes;
     std::unordered_map<std::string, std::string> kwunits;
 
-    std::chrono::system_clock::time_point startdat;
+    time_point startdat;
 
     std::vector<std::string> checkForMultipleResultFiles(const Opm::filesystem::path& rootN, bool formatted) const;
 

--- a/opm/io/eclipse/OutputStream.hpp
+++ b/opm/io/eclipse/OutputStream.hpp
@@ -21,6 +21,7 @@
 #define OPM_IO_OUTPUTSTREAM_HPP_INCLUDED
 
 #include <opm/io/eclipse/PaddedOutputString.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <array>
 #include <chrono>
@@ -362,7 +363,7 @@ namespace Opm { namespace EclIO { namespace OutputStream {
     class SummarySpecification
     {
     public:
-        using StartTime = std::chrono::system_clock::time_point;
+        using StartTime = time_point;
 
         enum class UnitConvention
         {

--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -328,9 +328,9 @@ namespace Opm {
         RestartConfig() = default;
 
         template<typename T>
-        RestartConfig( const TimeMap& time_map, const Deck&, const ParseContext& parseContext, T&& errors );
-        RestartConfig( const TimeMap& time_map, const Deck&, const ParseContext& parseContext, ErrorGuard& errors );
-        RestartConfig( const TimeMap& time_map, const Deck& );
+        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart, const ParseContext& parseContext, T&& errors );
+        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart, const ParseContext& parseContext, ErrorGuard& errors );
+        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart);
 
         static RestartConfig serializeObject();
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -285,6 +285,7 @@ namespace Opm
             restart_config.serializeOp(serializer);
             serializer.vector(snapshots);
             m_static.serializeOp(serializer);
+            serializer(m_restart_info);
 
             pack_unpack<PAvg, Serializer>(serializer);
             pack_unpack<WellTestConfig, Serializer>(serializer);
@@ -443,12 +444,12 @@ namespace Opm
 
     private:
         ScheduleStatic m_static;
+        std::pair<std::time_t, std::size_t> m_restart_info;
         ScheduleDeck m_sched_deck;
         TimeMap m_timeMap;
         RestartConfig restart_config;
         std::optional<int> exit_status;
         std::vector<ScheduleState> snapshots;
-
 
         void load_rst(const RestartIO::RstState& rst,
                       const EclipseGrid& grid,

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -60,7 +60,6 @@ namespace Opm
     class Runspec;
     class SCHEDULESection;
     class SummaryState;
-    class TimeMap;
     class ErrorGuard;
     class UDQConfig;
 
@@ -187,8 +186,6 @@ namespace Opm
         std::optional<int> exitStatus() const;
         const UnitSystem& getUnits() const { return this->m_static.m_unit_system; }
 
-        const TimeMap& getTimeMap() const;
-
         std::size_t numWells() const;
         std::size_t numWells(std::size_t timestep) const;
         bool hasWell(const std::string& wellName) const;
@@ -281,7 +278,6 @@ namespace Opm
         void serializeOp(Serializer& serializer)
         {
             m_sched_deck.serializeOp(serializer);
-            m_timeMap.serializeOp(serializer);
             restart_config.serializeOp(serializer);
             serializer.vector(snapshots);
             m_static.serializeOp(serializer);
@@ -446,7 +442,6 @@ namespace Opm
         ScheduleStatic m_static;
         std::pair<std::time_t, std::size_t> m_restart_info;
         ScheduleDeck m_sched_deck;
-        TimeMap m_timeMap;
         RestartConfig restart_config;
         std::optional<int> exit_status;
         std::vector<ScheduleState> snapshots;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -43,6 +43,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/io/eclipse/rst/state.hpp>
@@ -247,7 +248,7 @@ namespace Opm
         const RestartConfig& restart() const;
         RestartConfig& restart();
 
-        void applyAction(std::size_t reportStep, const std::chrono::system_clock::time_point& sim_time, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& wellpi);
+        void applyAction(std::size_t reportStep, const time_point& sim_time, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& wellpi);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
 
@@ -261,9 +262,9 @@ namespace Opm
         const ScheduleState& operator[](std::size_t index) const;
         std::vector<ScheduleState>::const_iterator begin() const;
         std::vector<ScheduleState>::const_iterator end() const;
-        void create_next(const std::chrono::system_clock::time_point& start_time, const std::optional<std::chrono::system_clock::time_point>& end_time);
+        void create_next(const time_point& start_time, const std::optional<time_point>& end_time);
         void create_next(const ScheduleBlock& block);
-        void create_first(const std::chrono::system_clock::time_point& start_time, const std::optional<std::chrono::system_clock::time_point>& end_time);
+        void create_first(const time_point& start_time, const std::optional<time_point>& end_time);
 
 
         /*

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp
@@ -104,6 +104,7 @@ namespace Opm {
         std::size_t size() const;
         std::size_t restart_offset() const;
         const KeywordLocation& location() const;
+        double seconds(std::size_t timeStep) const;
 
         bool operator==(const ScheduleDeck& other) const;
         static ScheduleDeck serializeObject();

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp
@@ -26,6 +26,7 @@
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 
 namespace Opm {
@@ -36,6 +37,7 @@ namespace Opm {
         TSTEP = 2,
         RESTART = 3
     };
+
 
     class Deck;
     struct ScheduleDeckContext;
@@ -49,13 +51,13 @@ namespace Opm {
     class ScheduleBlock {
     public:
         ScheduleBlock() = default;
-        ScheduleBlock(const KeywordLocation& location, ScheduleTimeType time_type, const std::chrono::system_clock::time_point& start_time);
+        ScheduleBlock(const KeywordLocation& location, ScheduleTimeType time_type, const time_point& start_time);
         std::size_t size() const;
         void push_back(const DeckKeyword& keyword);
         std::optional<DeckKeyword> get(const std::string& kw) const;
-        const std::chrono::system_clock::time_point& start_time() const;
-        const std::optional<std::chrono::system_clock::time_point>& end_time() const;
-        void end_time(const std::chrono::system_clock::time_point& t);
+        const time_point& start_time() const;
+        const std::optional<time_point>& end_time() const;
+        void end_time(const time_point& t);
         ScheduleTimeType time_type() const;
         const KeywordLocation& location() const;
         const DeckKeyword& operator[](const std::size_t index) const;
@@ -74,8 +76,8 @@ namespace Opm {
         }
     private:
         ScheduleTimeType m_time_type;
-        std::chrono::system_clock::time_point m_start_time;
-        std::optional<std::chrono::system_clock::time_point> m_end_time;
+        time_point m_start_time;
+        std::optional<time_point> m_end_time;
         KeywordLocation m_location;
         std::vector<DeckKeyword> m_keywords;
     };
@@ -95,7 +97,7 @@ namespace Opm {
     public:
         explicit ScheduleDeck(const Deck& deck, const std::pair<std::time_t, std::size_t>& restart);
         ScheduleDeck();
-        void add_block(ScheduleTimeType time_type, const std::chrono::system_clock::time_point& t, ScheduleDeckContext& context, const KeywordLocation& location);
+        void add_block(ScheduleTimeType time_type, const time_point& t, ScheduleDeckContext& context, const KeywordLocation& location);
         void add_TSTEP(const DeckKeyword& TSTEPKeyword, ScheduleDeckContext& context);
         ScheduleBlock& operator[](const std::size_t index);
         const ScheduleBlock& operator[](const std::size_t index) const;
@@ -117,7 +119,7 @@ namespace Opm {
         }
 
     private:
-        std::chrono::system_clock::time_point m_restart_time;
+        time_point m_restart_time;
         std::size_t m_restart_offset;
         KeywordLocation m_location;
         std::vector<ScheduleBlock> m_blocks;

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/PAvg.hpp>
@@ -260,15 +261,15 @@ namespace Opm {
 
 
         ScheduleState() = default;
-        explicit ScheduleState(const std::chrono::system_clock::time_point& start_time);
-        ScheduleState(const std::chrono::system_clock::time_point& start_time, const std::chrono::system_clock::time_point& end_time);
-        ScheduleState(const ScheduleState& src, const std::chrono::system_clock::time_point& start_time);
-        ScheduleState(const ScheduleState& src, const std::chrono::system_clock::time_point& start_time, const std::chrono::system_clock::time_point& end_time);
+        explicit ScheduleState(const time_point& start_time);
+        ScheduleState(const time_point& start_time, const time_point& end_time);
+        ScheduleState(const ScheduleState& src, const time_point& start_time);
+        ScheduleState(const ScheduleState& src, const time_point& start_time, const time_point& end_time);
 
 
-        std::chrono::system_clock::time_point start_time() const;
-        std::chrono::system_clock::time_point end_time() const;
-        ScheduleState next(const std::chrono::system_clock::time_point& next_start);
+        time_point start_time() const;
+        time_point end_time() const;
+        ScheduleState next(const time_point& next_start);
 
         bool operator==(const ScheduleState& other) const;
         static ScheduleState serializeObject();
@@ -436,8 +437,8 @@ namespace Opm {
 
 
     private:
-        std::chrono::system_clock::time_point m_start_time;
-        std::optional<std::chrono::system_clock::time_point> m_end_time;
+        time_point m_start_time;
+        std::optional<time_point> m_end_time;
 
         Tuning m_tuning;
         int m_nupcol;

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -28,6 +28,8 @@
 #include <set>
 #include <vector>
 
+#include <opm/common/utility/TimeService.hpp>
+
 namespace Opm{
 
 
@@ -68,7 +70,10 @@ class UDQSet;
 class SummaryState {
 public:
     typedef std::unordered_map<std::string, double>::const_iterator const_iterator;
-    explicit SummaryState(std::chrono::system_clock::time_point sim_start_arg);
+    explicit SummaryState(time_point sim_start_arg);
+
+    // The std::time_t constructor is only for export to Python
+    explicit SummaryState(std::time_t sim_start_arg);
 
     /*
       The set() function has to be retained temporarily to support updating of
@@ -112,7 +117,7 @@ public:
     std::size_t size() const;
     bool operator==(const SummaryState& other) const;
 private:
-    std::chrono::system_clock::time_point sim_start;
+    time_point sim_start;
     double elapsed = 0;
     std::unordered_map<std::string,double> values;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -52,8 +52,6 @@ namespace Opm {
         size_t numTimesteps() const;
         double getTotalTime() const;
         double seconds(size_t timeStep) const;
-        std::size_t restart_offset() const;
-        std::time_t restart_time() const;
 
         std::time_t operator[] (size_t index) const;
         /// Return the date and time where a given time step starts.

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -48,8 +48,6 @@ namespace Opm {
         static TimeMap serializeObject();
 
         size_t size() const;
-        size_t last() const;
-        size_t numTimesteps() const;
         double getTotalTime() const;
         double seconds(size_t timeStep) const;
 

--- a/python/cxx/eclipse_io.cpp
+++ b/python/cxx/eclipse_io.cpp
@@ -291,12 +291,12 @@ npArray get_rft_vector_Index(Opm::EclIO::ERft * file_ptr,const std::string& name
      the pybind11 conversion.
 */
 
-std::chrono::system_clock::time_point esmry_start_date(const Opm::EclIO::ESmry * esmry) {
+time_point esmry_start_date(const Opm::EclIO::ESmry * esmry) {
     auto utc_chrono   = esmry->startdate();
     auto utc_time_t   = std::chrono::system_clock::to_time_t( utc_chrono );
     auto utc_ts       = Opm::TimeStampUTC( utc_time_t );
     auto local_time_t = Opm::asLocalTimeT( utc_ts );
-    return std::chrono::system_clock::from_time_t( local_time_t );
+    return TimeService::from_time_t( local_time_t );
 }
 
 

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -63,12 +63,10 @@ namespace {
     }
 
     std::vector<system_clock::time_point> get_timesteps( const Schedule& s ) {
-        const auto& tm = s.getTimeMap();
         std::vector< system_clock::time_point > v;
-        v.reserve( tm.size() );
 
-        for( size_t i = 0; i < tm.size(); ++i )
-            v.push_back( datetime( tm[ i ] ));
+        for( size_t i = 0; i < s.size(); ++i )
+            v.push_back( datetime( std::chrono::system_clock::to_time_t(s[i].start_time() )));
 
         return v;
     }

--- a/python/cxx/summary_state.cpp
+++ b/python/cxx/summary_state.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <pybind11/stl.h>
 #include <pybind11/chrono.h>
@@ -42,7 +43,7 @@ std::vector<std::string> wells(const SummaryState * st) {
 void python::common::export_SummaryState(py::module& module) {
 
     py::class_<SummaryState>(module, "SummaryState")
-        .def(py::init<std::chrono::system_clock::time_point>())
+        .def(py::init<std::time_t>())
         .def("update", &SummaryState::update)
         .def("update_well_var", &SummaryState::update_well_var)
         .def("update_group_var", &SummaryState::update_group_var)

--- a/python/tests/test_summarystate.py
+++ b/python/tests/test_summarystate.py
@@ -9,7 +9,7 @@ class TestSummaryState(unittest.TestCase):
         pass
 
     def test_create(self):
-        st = opm.io.sim.SummaryState(datetime.datetime.now())
+        st = opm.io.sim.SummaryState(int(datetime.datetime.now().timestamp()))
         st.update("FOPT", 100)
         self.assertEqual(st["FOPT"], 100)
         self.assertTrue("FOPT" in st)

--- a/src/opm/common/utility/TimeService.cpp
+++ b/src/opm/common/utility/TimeService.cpp
@@ -26,6 +26,23 @@
 namespace Opm {
 namespace TimeService {
 
+const time_t system_clock_epoch = std::chrono::system_clock::to_time_t({});
+
+time_point from_time_t(std::time_t t) {
+    auto diff = std::difftime(t, system_clock_epoch);
+    return time_point(std::chrono::seconds(static_cast<std::chrono::seconds::rep>(diff)));
+}
+
+std::time_t to_time_t(const time_point& tp) {
+    return std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()).count() + system_clock_epoch;
+}
+
+
+time_point now() {
+    time_point epoch;
+    auto default_now = std::chrono::system_clock::now();
+    return epoch + std::chrono::duration_cast<Opm::time_point::duration>(default_now.time_since_epoch());
+}
 
 std::time_t advance(const std::time_t tp, const double sec)
 {

--- a/src/opm/io/eclipse/ERsm.cpp
+++ b/src/opm/io/eclipse/ERsm.cpp
@@ -30,6 +30,7 @@
 #include <opm/common/utility/String.hpp>
 #include <opm/common/utility/numeric/cmp.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 namespace Opm {
 namespace EclIO {
@@ -287,9 +288,7 @@ bool cmp(const ESmry& smry, const ERsm& rsm) {
             return false;
 
         for (std::size_t time_index = 0; time_index < rsm_days.size(); time_index++) {
-            using namespace std::chrono;
-            using TP      = time_point<system_clock>;
-            auto smry_days = duration_cast<TP::duration>(summary_dates[time_index] - summary_dates[0]).count() / 86400.0 ;
+            auto smry_days = std::chrono::duration_cast<std::chrono::seconds>(summary_dates[time_index] - summary_dates[0]).count() / 86400.0 ;
 
             if (!cmp::scalar_equal(smry_days, rsm_days[time_index])) {
                 fmt::print(stderr, "time_index: {}  summary.days: {}   rsm.days: {}", time_index, smry_days, rsm_days[time_index]);

--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -52,15 +52,15 @@ namespace {
 
     const std::vector<std::string> month_names = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
 
-    std::string format_date(const std::chrono::system_clock::time_point& tp) {
-        auto ts = Opm::TimeStampUTC( std::chrono::system_clock::to_time_t(tp) );
+    std::string format_date(const Opm::time_point& tp) {
+        auto ts = Opm::TimeStampUTC( Opm::TimeService::to_time_t(tp) );
         char buffer[12];
         std::snprintf(buffer, 12, "%2d-%3s-%4d", ts.day(), month_names[ts.month() - 1].c_str(), ts.year());
         return std::string(buffer, 11);
     }
 
     const std::string block_header_line(const std::string& run_name) {
-        std::string date_string = format_date( std::chrono::system_clock::from_time_t( std::time(nullptr)));
+        std::string date_string = format_date( Opm::TimeService::from_time_t( std::time(nullptr)));
         return "SUMMARY OF RUN " + run_name + " at: " + date_string + "  OPM FLOW " + PROJECT_VERSION_NAME;
     }
 

--- a/src/opm/output/eclipse/CreateDoubHead.cpp
+++ b/src/opm/output/eclipse/CreateDoubHead.cpp
@@ -28,6 +28,7 @@
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <chrono>
 #include <cstddef>
@@ -39,7 +40,7 @@ namespace {
                      const double           elapsed)
     {
         return {
-            std::chrono::system_clock::from_time_t(sched.getStartTime()),
+            Opm::TimeService::from_time_t(sched.getStartTime()),
             std::chrono::duration<
                 double, std::chrono::seconds::period>{ elapsed },
         };

--- a/src/opm/output/eclipse/DoubHEAD.cpp
+++ b/src/opm/output/eclipse/DoubHEAD.cpp
@@ -358,7 +358,7 @@ namespace {
         tm1.tm_sec   = 0;
         tm1.tm_isdst = 0;
 
-        const auto t1 = ::Opm::RestartIO::makeUTCTime(tm1);
+        const auto t1 = Opm::TimeService::makeUTCTime(tm1);
 
         if (t1 != static_cast<std::time_t>(-1)) {
             tm1 = *std::gmtime(&t1); // Get new tm_yday.

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -735,7 +735,7 @@ void save(EclIO::OutputStream::Restart& rstFile,
         writeExtraData(value.extra, rstFile);
     }
 
-    logRestartOutput(report_step, schedule.getTimeMap().numTimesteps(), inteHD);
+    logRestartOutput(report_step, schedule.size() - 1, inteHD);
 }
 
 }} // Opm::RestartIO

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -23,6 +23,7 @@
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/output/eclipse/Inplace.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -2729,7 +2730,7 @@ SMSpecStreamDeferredCreation(const Opm::InitConfig&          initcfg,
                              const Opm::UnitSystem::UnitType utype)
     : utype_   (utype)
     , cartDims_(grid.getNXYZ())
-    , start_   (std::chrono::system_clock::from_time_t(start))
+    , start_   (Opm::TimeService::from_time_t(start))
 {
     if (initcfg.restartRequested()) {
         this->restart_.root = initcfg.getRestartRootName();
@@ -3110,7 +3111,7 @@ configureSummaryInput(const EclipseState&  es,
                       const Schedule&      sched)
 {
     const auto st = SummaryState {
-        std::chrono::system_clock::from_time_t(sched.getStartTime())
+        TimeService::from_time_t(sched.getStartTime())
     };
 
     Evaluator::Factory fact {

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -526,17 +526,17 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
     }
 
     template<typename T>
-    RestartConfig::RestartConfig( const TimeMap& time_map, const Deck& deck, const ParseContext& parseContext, T&& errors ) :
-        RestartConfig(time_map, deck, parseContext, errors)
+    RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart, const ParseContext& parseContext, T&& errors ) :
+        RestartConfig( deck, restart, parseContext, errors)
     {}
 
-    RestartConfig::RestartConfig( const TimeMap& time_map, const Deck& deck) :
-        RestartConfig(time_map, deck, ParseContext(), ErrorGuard())
+    RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart) :
+        RestartConfig( deck, restart, ParseContext(), ErrorGuard())
     {}
 
 
-    RestartConfig::RestartConfig( const TimeMap& time_map, const Deck& deck, const ParseContext& parseContext, ErrorGuard& errors ) :
-        m_timemap( time_map ),
+RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart, const ParseContext& parseContext, ErrorGuard& errors ) :
+    m_timemap( TimeMap(deck, restart) ),
         m_first_restart_step( -1 ),
         restart_schedule( m_timemap, {0,0,1}),
         restart_keywords( m_timemap, {} ),

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
@@ -127,7 +127,7 @@ namespace {
                             const Opm::ParseContext& ctxt,
                             Opm::ErrorGuard&         guard)
         {
-            const auto numSteps = sched.getTimeMap().numTimesteps();
+            const auto numSteps = sched.size() - 1;
 
             auto size = std::size_t{0};
             for (auto step = 0*numSteps; step < numSteps; ++step) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -927,7 +927,7 @@ namespace {
                     if (oil_rate.zero() && water_rate.zero() && gas_rate.zero()) {
                         std::string msg =
                             "Well " + well2.name() + " is a history matched well with zero rate where crossflow is banned. " +
-                            "This well will be closed at " + std::to_string(m_timeMap.getTimePassedUntil(handlerContext.currentStep) / (60*60*24)) + " days";
+                            "This well will be closed at " + std::to_string(this->seconds(handlerContext.currentStep) / (60*60*24)) + " days";
                         OpmLog::note(msg);
                         this->updateWellStatus( well_name, handlerContext.currentStep, Well::Status::SHUT);
                     }
@@ -1028,7 +1028,7 @@ namespace {
                 if ( ! well2.getAllowCrossFlow() ) {
                     std::string msg =
                         "Well " + well_name + " is an injector with zero rate where crossflow is banned. " +
-                        "This well will be closed at " + std::to_string ( m_timeMap.getTimePassedUntil(handlerContext.currentStep) / (60*60*24) ) + " days";
+                        "This well will be closed at " + std::to_string ( this->seconds(handlerContext.currentStep) / (60*60*24) ) + " days";
 
                     if (injection->surfaceInjectionRate.is<double>()) {
                         if (injection->hasInjectionControl(Well::InjectorCMode::RATE) && injection->surfaceInjectionRate.zero()) {
@@ -1086,7 +1086,7 @@ namespace {
                 if ( ! well2.getAllowCrossFlow() && (injection->surfaceInjectionRate.zero())) {
                     std::string msg =
                         "Well " + well_name + " is an injector with zero rate where crossflow is banned. " +
-                        "This well will be closed at " + std::to_string ( m_timeMap.getTimePassedUntil(handlerContext.currentStep) / (60*60*24) ) + " days";
+                        "This well will be closed at " + std::to_string ( this->seconds(handlerContext.currentStep) / (60*60*24) ) + " days";
                     OpmLog::note(msg);
                     this->updateWellStatus( well_name, handlerContext.currentStep, Well::Status::SHUT);
                 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -112,7 +112,7 @@ namespace {
         m_static( python, deck, runspec ),
         m_sched_deck(deck, restart_info(rst) ),
         m_timeMap( deck , restart_info( rst )),
-        restart_config(m_timeMap, deck, parseContext, errors)
+        restart_config(deck, restart_info(rst), parseContext, errors)
     {
         if (rst) {
             auto restart_step = rst->header.restart_info().second;
@@ -222,6 +222,7 @@ namespace {
 
     time_t Schedule::posixStartTime() const {
         return m_timeMap.getStartTime( 0 );
+        //return std::chrono::system_clock::to_time_t(this->snapshots[0].start_time());
     }
 
     time_t Schedule::posixEndTime() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -353,9 +353,9 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
             }
             logger(fmt::format("Initializing report step {}/{} at {} {} {} line {}",
                                load_start + 1,
-                               this->size(),
+                               this->m_sched_deck.size() - 1,
                                Schedule::formatDate(this->getStartTime()),
-                               deck_time(this->seconds(load_start)),
+                               deck_time(this->m_sched_deck.seconds(load_start)),
                                time_unit,
                                location.lineno));
         }
@@ -377,7 +377,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
 
                 logger(fmt::format("Initializing report step {}/{} at {} ({} {}) - line {}",
                                    report_step + 1,
-                                   this->size(),
+                                   this->m_sched_deck.size() - 1,
                                    start_date,
                                    days_total,
                                    time_unit,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.cpp
@@ -223,6 +223,17 @@ void ScheduleDeck::add_TSTEP(const DeckKeyword& TSTEPKeyword, ScheduleDeckContex
 }
 
 
+double ScheduleDeck::seconds(std::size_t timeStep) const {
+    if (this->m_blocks.empty())
+        return 0;
+
+    if (timeStep >= this->m_blocks.size())
+        throw std::logic_error(fmt::format("seconds({}) - invalid timeStep. Valid range [0,{}>", timeStep, this->m_blocks.size()));
+
+    std::chrono::duration<double> elapsed = this->m_blocks[timeStep].start_time() - this->m_blocks[0].start_time();
+    return std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+}
+
 
 ScheduleDeck::ScheduleDeck() {
     std::chrono::system_clock::time_point start_time;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
@@ -36,26 +36,26 @@ namespace {
   that the serialization code in
   opm-simulators:opm/simulators/utils/ParallelRestart.cpp goes via std::time_t.
 */
-std::chrono::system_clock::time_point clamp_time(std::chrono::system_clock::time_point t) {
-    return std::chrono::system_clock::from_time_t( std::chrono::system_clock::to_time_t( t ) );
+time_point clamp_time(time_point t) {
+    return TimeService::from_time_t( TimeService::to_time_t( t ) );
 }
 
 }
 
 
 
-ScheduleState::ScheduleState(const std::chrono::system_clock::time_point& t1):
+ScheduleState::ScheduleState(const time_point& t1):
     m_start_time(clamp_time(t1))
 {
 }
 
-ScheduleState::ScheduleState(const std::chrono::system_clock::time_point& start_time, const std::chrono::system_clock::time_point& end_time) :
+ScheduleState::ScheduleState(const time_point& start_time, const time_point& end_time) :
     ScheduleState(start_time)
 {
     this->m_end_time = clamp_time(end_time);
 }
 
-ScheduleState::ScheduleState(const ScheduleState& src, const std::chrono::system_clock::time_point& start_time) :
+ScheduleState::ScheduleState(const ScheduleState& src, const time_point& start_time) :
     ScheduleState(src)
 {
     this->m_start_time = clamp_time(start_time);
@@ -71,18 +71,18 @@ ScheduleState::ScheduleState(const ScheduleState& src, const std::chrono::system
         this->rft_config.update( std::move(*next_rft) );
 }
 
-ScheduleState::ScheduleState(const ScheduleState& src, const std::chrono::system_clock::time_point& start_time, const std::chrono::system_clock::time_point& end_time) :
+ScheduleState::ScheduleState(const ScheduleState& src, const time_point& start_time, const time_point& end_time) :
     ScheduleState(src, start_time)
 {
     this->m_end_time = end_time;
 }
 
 
-std::chrono::system_clock::time_point ScheduleState::start_time() const {
+time_point ScheduleState::start_time() const {
     return this->m_start_time;
 }
 
-std::chrono::system_clock::time_point ScheduleState::end_time() const {
+time_point ScheduleState::end_time() const {
     return this->m_end_time.value();
 }
 
@@ -172,7 +172,7 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
 
 
 ScheduleState ScheduleState::serializeObject() {
-    auto t1 = std::chrono::system_clock::now();
+    auto t1 = TimeService::now();
     auto t2 = t1 + std::chrono::hours(48);
     ScheduleState ts(t1, t2);
     ts.vfpprod = map_member<int, VFPProdTable>::serializeObject();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -97,11 +97,15 @@ namespace {
 }
 
 
-    SummaryState::SummaryState(std::chrono::system_clock::time_point sim_start_arg):
+    SummaryState::SummaryState(time_point sim_start_arg):
         sim_start(sim_start_arg)
     {
         this->update_elapsed(0);
     }
+
+    SummaryState::SummaryState(std::time_t sim_start_arg):
+        SummaryState(TimeService::from_time_t(sim_start_arg))
+    {}
 
 
     void SummaryState::update_elapsed(double delta) {
@@ -340,7 +344,7 @@ namespace {
 
     void  SummaryState::deserialize(const std::vector<char>& buffer) {
         Serializer ser(buffer);
-        this->sim_start = ser.get<std::chrono::system_clock::time_point>();
+        this->sim_start = ser.get<time_point>();
         this->elapsed = ser.get<double>();
         this->values = ser.get_map<std::string, double>();
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -439,14 +439,6 @@ struct TimeMapContext {
         return t + seconds + minutes * 60 + hours * 3600;
     }
 
-    std::size_t TimeMap::restart_offset() const {
-        return this->m_restart_offset;
-    }
-
-    std::time_t TimeMap::restart_time() const {
-        return this->m_restart_time;
-    }
-
 
 std::ostream& operator<<(std::ostream& stream, const TimeMap& tm) {
     std::stringstream ss;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -165,10 +165,6 @@ struct TimeMapContext {
     }
 
 
-    size_t TimeMap::numTimesteps() const {
-        return m_timeList.size() - 1;
-    }
-
 
     std::time_t TimeMap::getStartTime(size_t tStepIdx) const {
         return this->operator[](tStepIdx);
@@ -235,10 +231,6 @@ struct TimeMapContext {
         return m_timeList.size();
     }
 
-    size_t TimeMap::last() const {
-        return this->numTimesteps();
-    }
-
     const std::map<std::string , int>& TimeMap::eclipseMonthIndices() {
         return month_indices;
     }
@@ -291,7 +283,7 @@ struct TimeMapContext {
 
     double TimeMap::getTimeStepLength(size_t tStepIdx) const
     {
-        assert(tStepIdx < numTimesteps());
+        assert(tStepIdx < (this->size() - 1));
 
         return std::difftime(this->m_timeList[tStepIdx + 1],
                              this->m_timeList[tStepIdx + 0]);

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -351,7 +351,7 @@ namespace {
         auto node_names = std::vector<std::string>{};
         auto names = std::unordered_set<std::string>{};
 
-        const auto nstep = sched.getTimeMap().numTimesteps();
+        const auto nstep = sched.size() - 1;
         for (auto step = 0*nstep; step < nstep; ++step) {
             const auto& nodes = sched[step].network.get().node_names();
             names.insert(nodes.begin(), nodes.end());
@@ -1012,7 +1012,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
             return;
         }
 
-        const auto last_timestep = schedule.getTimeMap().last();
+        const auto last_timestep = schedule.size() - 1;
 
         if (keyword.size() > 0) {
             // Keyword with explicit records.

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -152,7 +152,7 @@ TSTEP
 
 
 BOOST_AUTO_TEST_CASE(TestActions) {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     Opm::WListManager wlm;
     Opm::Action::Context context(st, wlm);
     Opm::Action::Actions config;
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(TestActions) {
 
 
 BOOST_AUTO_TEST_CASE(TestContext) {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     st.update_well_var("OP1", "WOPR", 100);
     Opm::WListManager wlm;
     Opm::Action::Context context(st, wlm);
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(TestAction_AST_BASIC) {
     Action::AST ast1({"WWCT", "OPX", ">", "0.75"});
     Action::AST ast2({"WWCT", "OPX", "=", "WWCT", "OPX"});
     Action::AST ast3({"WWCT", "OPY", ">", "0.75"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
     std::vector<std::string> matching_wells;
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(TestAction_AST_OR_AND) {
     Action::AST ast_or({"WWCT", "OPX", ">", "0.75", "OR", "WWCT", "OPY", ">", "0.75"});
     Action::AST ast_and({"WWCT", "OPX", ">", "0.75", "AND", "WWCT", "OPY", ">", "0.75"});
     Action::AST par({"WWCT", "OPX", ">", "0.75", "AND", "(", "WWCT", "OPY", ">", "0.75", "OR", "WWCT", "OPZ", ">", "0.75", ")"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(TestAction_AST_OR_AND) {
 
 BOOST_AUTO_TEST_CASE(DATE) {
     Action::AST ast(std::vector<std::string>{"MNTH", ">=", "JUN"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(DATE) {
 
 BOOST_AUTO_TEST_CASE(MANUAL1) {
     Action::AST ast({"GGPR", "FIELD", ">", "50000", "AND", "WGOR", "PR", ">" ,"GGOR", "FIELD"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(MANUAL1) {
 
 BOOST_AUTO_TEST_CASE(MANUAL2) {
     Action::AST ast({"GWCT", "LIST1", ">", "0.70", "AND", "(", "GWPR", "LIST1", ">", "GWPR", "LIST2", "OR", "GWPR", "LIST1", ">", "GWPR", "LIST3", ")"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE(MANUAL2) {
 
 BOOST_AUTO_TEST_CASE(MANUAL3) {
     Action::AST ast({"MNTH", ".GE.", "MAR", "AND", "MNTH", ".LE.", "OCT", "AND", "GMWL", "HIGH", ".GE.", "4"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(MANUAL3) {
 
 BOOST_AUTO_TEST_CASE(MANUAL4) {
     Action::AST ast({"GWCT", "FIELD", ">", "0.8", "AND", "DAY", ">", "1", "AND", "MNTH", ">", "JUN", "AND", "YEAR", ">=", "2021"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -440,7 +440,7 @@ BOOST_AUTO_TEST_CASE(MANUAL4) {
 
 BOOST_AUTO_TEST_CASE(MANUAL5) {
     Action::AST ast({"WCG2", "PROD1", ">", "WCG5", "PROD2", "AND", "GCG3", "G1", ">", "GCG7", "G2", "OR", "FCG1", ">", "FCG7"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -481,7 +481,7 @@ BOOST_AUTO_TEST_CASE(MANUAL5) {
 
 BOOST_AUTO_TEST_CASE(LGR) {
     Action::AST ast({"LWCC" , "OPX", "LOCAL", "1", "2", "3", ">", "100"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -494,7 +494,7 @@ BOOST_AUTO_TEST_CASE(LGR) {
 
 
 BOOST_AUTO_TEST_CASE(Action_ContextTest) {
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     st.update("WWCT:OP1", 100);
     WListManager wlm;
     Action::Context context(st, wlm);
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(Action_ContextTest) {
 //Groupnames w/ astirisks wil eventually work with ACTIONX
 BOOST_AUTO_TEST_CASE(TestGroupList) {
     Action::AST ast({"GWPR", "*", ">", "1.0"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
     BOOST_CHECK_THROW( ast.eval(context), std::logic_error );
@@ -520,7 +520,7 @@ BOOST_AUTO_TEST_CASE(TestGroupList) {
 
 BOOST_AUTO_TEST_CASE(TestMatchingWells) {
     Action::AST ast({"WOPR", "*", ">", "1.0"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     st.update_well_var("OPX", "WOPR", 0);
     st.update_well_var("OPY", "WOPR", 0.50);
@@ -540,7 +540,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells) {
 BOOST_AUTO_TEST_CASE(TestMatchingWells2) {
   Action::AST ast1({"WOPR", "P*", ">", "1.0"});
   Action::AST ast2({"WOPR", "*", ">", "1.0"});
-  SummaryState st(std::chrono::system_clock::now());
+  SummaryState st(TimeService::now());
 
   st.update_well_var("PX", "WOPR", 0);
   st.update_well_var("PY", "WOPR", 0.50);
@@ -570,7 +570,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells2) {
 
 BOOST_AUTO_TEST_CASE(TestMatchingWells_AND) {
     Action::AST ast({"WOPR", "*", ">", "1.0", "AND", "WWCT", "*", "<", "0.50"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     st.update_well_var("OPX", "WOPR", 0);
     st.update_well_var("OPY", "WOPR", 0.50);
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells_AND) {
 
 BOOST_AUTO_TEST_CASE(TestMatchingWells_OR) {
     Action::AST ast({"WOPR", "*", ">", "1.0", "OR", "WWCT", "*", "<", "0.50"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     st.update_well_var("OPX", "WOPR", 0);
     st.update_well_var("OPY", "WOPR", 0.50);
@@ -620,7 +620,7 @@ BOOST_AUTO_TEST_CASE(TestMatchingWells_OR) {
 BOOST_AUTO_TEST_CASE(TestWLIST) {
     WListManager wlm;
     Action::AST ast({"WOPR", "*LIST1", ">", "1.0"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     st.update_well_var("W1", "WOPR", 2.0);
     st.update_well_var("W2", "WOPR", 2.50);
@@ -646,7 +646,7 @@ BOOST_AUTO_TEST_CASE(TestWLIST) {
 
 BOOST_AUTO_TEST_CASE(TestFieldAND) {
     Action::AST ast({"FMWPR", ">=", "4", "AND", "WUPR3", "OP*", "=", "1"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     WListManager wlm;
     Action::Context context(st, wlm);
 
@@ -974,7 +974,7 @@ TSTEP
         )"};
 
     auto unit_system =  UnitSystem::newMETRIC();
-    const auto st = SummaryState{ std::chrono::system_clock::now() };
+    const auto st = SummaryState{ TimeService::now() };
     Schedule sched = make_schedule(deck_string);
     const auto& action1 = sched[0].actions.get().get("A");
     {
@@ -988,7 +988,7 @@ TSTEP
 
 
     Action::Result action_result(true);
-    auto sim_time = std::chrono::system_clock::now();
+    auto sim_time = TimeService::now();
     sched.applyAction(0, sim_time, action1, action_result, {});
 
     {
@@ -1100,7 +1100,7 @@ TSTEP
 
 
     Action::Result action_result(true);
-    sched.applyAction(0, std::chrono::system_clock::now(), action1, action_result, {});
+    sched.applyAction(0, TimeService::now(), action1, action_result, {});
 
     {
         const auto& glo = sched.glo(0);
@@ -1142,7 +1142,7 @@ TSTEP
 
         )"};
 
-    const auto st = SummaryState{ std::chrono::system_clock::now() };
+    const auto st = SummaryState{ TimeService::now() };
     Schedule sched = make_schedule(deck_string);
     const auto& action1 = sched[0].actions.get().get("A");
     double CF0;
@@ -1156,10 +1156,10 @@ TSTEP
 
 
     Action::Result action_result(true);
-    BOOST_CHECK_THROW( sched.applyAction(0, std::chrono::system_clock::now(), action1, action_result, {}), std::exception);
+    BOOST_CHECK_THROW( sched.applyAction(0, TimeService::now(), action1, action_result, {}), std::exception);
     {
         const auto& well = sched.getWell("PROD1", 0);
-        sched.applyAction(0, std::chrono::system_clock::now(), action1, action_result, {{"PROD1", well.convertDeckPI(500)}});
+        sched.applyAction(0, TimeService::now(), action1, action_result, {{"PROD1", well.convertDeckPI(500)}});
     }
     {
         const auto& target_wellpi = sched[0].target_wellpi;
@@ -1194,7 +1194,7 @@ ENDACTIO
 
         )"};
 
-    auto st = SummaryState{ std::chrono::system_clock::now() };
+    auto st = SummaryState{ TimeService::now() };
     Schedule sched = make_schedule(deck_string);
     Opm::WListManager wlm;
     Opm::Action::Context context(st, wlm);

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -46,6 +46,8 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 using namespace Opm;
 
+constexpr std::pair<std::time_t, std::size_t> restart_info = std::make_pair(std::time_t{0}, std::size_t{0});
+
 inline std::string prepath() {
     return boost::unit_test::framework::master_test_suite().argv[1];
 }
@@ -498,7 +500,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
 
     Parser parser{};
     auto deck = parser.parseString(deckData) ;
-    RestartConfig rstConfig(TimeMap(deck), deck);
+    RestartConfig rstConfig(deck, restart_info);
 
     BOOST_CHECK_EQUAL(false, rstConfig.getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false, rstConfig.getWriteRestartFile(1));
@@ -549,7 +551,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
 
     Parser parser;
     auto deck = parser.parseString(deckData) ;
-    RestartConfig rstConfig(TimeMap(deck), deck);
+    RestartConfig rstConfig(deck, restart_info);
 
     BOOST_CHECK_EQUAL(true  ,  rstConfig.getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false ,  rstConfig.getWriteRestartFile(1));
@@ -641,14 +643,14 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
 
     {   //mnemnonics
         auto deck = parser.parseString(deckData) ;
-        RestartConfig rstConfig(TimeMap(deck), deck);
+        RestartConfig rstConfig(deck, restart_info);
 
         BOOST_CHECK_EQUAL(true, rstConfig.getWriteRestartFile(0));
     }
 
     {   //old fashion integer mnemonics
         auto deck = parser.parseString(deckData2) ;
-        RestartConfig rstConfig(TimeMap(deck), deck);
+        RestartConfig rstConfig(deck, restart_info);
 
         BOOST_CHECK_EQUAL(true, rstConfig.getWriteRestartFile(0));
     }

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -31,6 +31,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 using namespace Opm;
 
@@ -118,7 +119,7 @@ BOOST_AUTO_TEST_CASE(PYACTION) {
     auto ecl_state = EclipseState(deck);
     auto schedule = Schedule(deck, ecl_state, python);
 
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     const auto& pyaction_kw = deck.getKeyword<ParserKeywords::PYACTION>(0);
     const std::string& fname = pyaction_kw.getRecord(1).getItem(0).get<std::string>(0);
     Action::PyAction py_action(python, "WCLOSE", Action::PyAction::RunCount::unlimited, deck.makeDeckPath(fname));

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -42,6 +42,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 using namespace Opm;
 
@@ -251,7 +252,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGCONPROD) {
         /)";
 
     auto schedule = create_schedule(input);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     const auto& group1 = schedule.getGroup("G1", 0);
     const auto& group2 = schedule.getGroup("G2", 0);
@@ -417,7 +418,7 @@ BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
         )";
 
     auto schedule = create_schedule(input);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     // Step 0
     {
         const auto& g1 = schedule.getGroup("G1", 0);

--- a/tests/parser/IOConfigTests.cpp
+++ b/tests/parser/IOConfigTests.cpp
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(DefaultProperties) {
 
     auto deck = Parser().parseString( data);
     IOConfig ioConfig( deck );
-    RestartConfig rstConfig( TimeMap(deck), deck);
+    RestartConfig rstConfig( deck, std::make_pair(std::time_t{0}, std::size_t{0}));
 
     /*If no GRIDFILE nor NOGGF keywords are specified, default output an EGRID file*/
     BOOST_CHECK( ioConfig.getWriteEGRIDFile() );

--- a/tests/parser/RestartConfigTests.cpp
+++ b/tests/parser/RestartConfigTests.cpp
@@ -82,7 +82,6 @@ END
     const auto rstcfg = RestartConfig { deck, restart_info };
 
     BOOST_REQUIRE_EQUAL(tm.size(), std::size_t{19});
-    BOOST_REQUIRE_EQUAL(tm.last(), std::size_t{18});
 
     for (const std::size_t stepID : { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 15, 16, 18 }) {
         BOOST_CHECK_MESSAGE(! rstcfg.getWriteRestartFile(stepID),

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -837,7 +837,7 @@ WELTARG
     double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
     double siFactorG = unitSystem.parse("GasSurfaceVolume/Time").getSIScaling();
     double siFactorP = unitSystem.parse("Pressure").getSIScaling();
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     const auto& well_1 = schedule.getWell("OP_1", 1);
     const auto wpp_1 = well_1.getProductionProperties();
@@ -900,7 +900,7 @@ WELTARG
 )";
 
     const auto& schedule = make_schedule(input);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     Opm::UnitSystem unitSystem = UnitSystem( UnitSystem::UnitType::UNIT_TYPE_METRIC );
     double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
 
@@ -1110,7 +1110,7 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
         )";
 
         const auto& schedule = make_schedule(input);
-        Opm::SummaryState st(std::chrono::system_clock::now());
+        Opm::SummaryState st(TimeService::now());
 
         Opm::UnitSystem unitSystem = UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC);
         double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
@@ -1360,7 +1360,7 @@ WCONINJH
 )";
 
     const auto& sched = make_schedule(input);
-    const auto st = ::Opm::SummaryState{ std::chrono::system_clock::now() };
+    const auto st = ::Opm::SummaryState{ TimeService::now() };
     UnitSystem unit_system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
 
     // The BHP limit should not be effected by WCONHIST
@@ -3516,7 +3516,7 @@ END
 )";
 
     const auto sched = make_schedule(input);
-    const auto st = ::Opm::SummaryState{ std::chrono::system_clock::now() };
+    const auto st = ::Opm::SummaryState{ TimeService::now() };
 
     BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W1", 10), st), -1);
     BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W2", 10), st), 3);
@@ -3560,7 +3560,7 @@ END
 )";
 
     const auto sched = make_schedule(input);
-    const auto st = ::Opm::SummaryState{ std::chrono::system_clock::now() };
+    const auto st = ::Opm::SummaryState{ TimeService::now() };
 
     BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W1", 10), st), -1);
     BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W2", 10), st), 1);
@@ -4361,15 +4361,15 @@ END
     //}
 }
 
-bool compare_dates(const std::chrono::system_clock::time_point& t, int year, int month, int day) {
-    return t == std::chrono::system_clock::from_time_t( asTimeT( TimeStampUTC(year, month, day)));
+bool compare_dates(const time_point& t, int year, int month, int day) {
+    return t == TimeService::from_time_t( asTimeT( TimeStampUTC(year, month, day)));
 }
 
-bool compare_dates(const std::chrono::system_clock::time_point& t, std::array<int, 3>& ymd) {
+bool compare_dates(const time_point& t, std::array<int, 3>& ymd) {
     return compare_dates(t, ymd[0], ymd[1], ymd[2]);
 }
 
-std::string dates_msg(const std::chrono::system_clock::time_point& t, std::array<int,3>& ymd) {
+std::string dates_msg(const time_point& t, std::array<int,3>& ymd) {
     auto ts = TimeStampUTC( std::chrono::system_clock::to_time_t(t) );
     return fmt::format("Different dates: {}-{}-{} != {}-{}-{}", ts.year(), ts.month(), ts.day(), ymd[0], ymd[1], ymd[2]);
 }
@@ -4399,7 +4399,7 @@ BOOST_AUTO_TEST_CASE(ScheduleStateDatesTest) {
 
 
 BOOST_AUTO_TEST_CASE(ScheduleStateTest) {
-    auto t1 = std::chrono::system_clock::from_time_t( std::chrono::system_clock::to_time_t( std::chrono::system_clock::now() ) );
+    auto t1 = TimeService::from_time_t( std::chrono::system_clock::to_time_t( TimeService::now() ) );
     auto t2 = t1 + std::chrono::hours(48);
 
     ScheduleState ts1(t1);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3881,9 +3881,9 @@ END
     const auto es    = EclipseState{ deck };
     auto       sched = Schedule{ deck, es };
 
-    BOOST_REQUIRE_EQUAL(sched.getTimeMap().size(),         std::size_t{6});
-    BOOST_REQUIRE_EQUAL(sched.getTimeMap().numTimesteps(), std::size_t{5});
-    BOOST_REQUIRE_EQUAL(sched.getTimeMap().last(),         std::size_t{5});
+    BOOST_REQUIRE_EQUAL(sched.size(),         std::size_t{6});
+    //BOOST_REQUIRE_EQUAL(sched.getTimeMap().numTimesteps(), std::size_t{5});
+    //BOOST_REQUIRE_EQUAL(sched.getTimeMap().last(),         std::size_t{5});
 
     BOOST_REQUIRE_MESSAGE(sched[1].wellgroup_events().hasEvent("P", ScheduleEvents::Events::WELL_PRODUCTIVITY_INDEX),
                           R"(Schedule must have WELL_PRODUCTIVITY_INDEX Event for well "P" at report step 1)");

--- a/tests/parser/TimeMapTest.cpp
+++ b/tests/parser/TimeMapTest.cpp
@@ -818,3 +818,30 @@ TSTEP
     BOOST_CHECK(Opm::TimeMap::valid_month("MAR"));
     BOOST_CHECK(!Opm::TimeMap::valid_month("Tulleogtøys"));
 }
+
+
+
+BOOST_AUTO_TEST_CASE(Overflow) {
+    auto year = 226300;
+    auto month = 1;
+    auto day = 2;
+    auto ts0 = Opm::TimeStampUTC(year, month, day);
+    auto t0 = Opm::asTimeT(ts0);
+
+    {
+        auto ts = Opm::TimeStampUTC(t0);
+        BOOST_CHECK_EQUAL(ts.year(), year);
+        BOOST_CHECK_EQUAL(ts.month(), month);
+        BOOST_CHECK_EQUAL(ts.day(), day);
+    }
+
+    {
+        auto tc = Opm::TimeService::from_time_t(t0);
+        auto ts = Opm::TimeStampUTC( Opm::TimeService::to_time_t(tc) );
+        BOOST_CHECK_EQUAL(ts.year(), year);
+        BOOST_CHECK_EQUAL(ts.month(), month);
+        BOOST_CHECK_EQUAL(ts.day(), day);
+    }
+}
+
+

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -41,6 +41,7 @@ Copyright 2018 Statoil ASA.
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellMatcher.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/NameOrder.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 using namespace Opm;
 
@@ -81,7 +82,7 @@ BOOST_AUTO_TEST_CASE(GROUP_VARIABLES)
     UDQParams udqp;
     UDQFunctionTable udqft;
     UDQDefine def_group(udqp, "GUOPRL", 0, location, {"(", "5000",  "-",  "GOPR",  "LOWER",  "*", "0.13",  "-",  "GOPR",  "UPPER",  "*", "0.15", ")" , "*",  "0.89"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, {}, st, udq_state);
     double gopr_lower = 1234;
@@ -109,7 +110,7 @@ BOOST_AUTO_TEST_CASE(SUBTRACT)
     UDQDefine def(udqp, "WU", 0, location, {"16", "-", "8", "-", "4", "-", "2", "-", "1"});
     UDQDefine scalar(udqp, "WU", 0, location, {"16"});
 
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"P1"})), st, udq_state);
 
@@ -131,7 +132,7 @@ BOOST_AUTO_TEST_CASE(TEST)
     UDQDefine def3(udqp, "WUWI3",0, location, {"GOPR" , "FIELD", "-", "2.0", "*", "3"});
     UDQDefine def4(udqp, "WUWI3",0, location, {"FOPR" , "/",  "2"});
 
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"P1", "P2"})), st, udq_state);
 
@@ -176,7 +177,7 @@ BOOST_AUTO_TEST_CASE(MIX_SCALAR) {
     UDQParams udqp;
     KeywordLocation location;
     UDQDefine def_add(udqp, "WU",0, location, {"WOPR", "+", "1"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"P1"})), st, udq_state);
 
@@ -200,7 +201,7 @@ BOOST_AUTO_TEST_CASE(UDQFieldSetTest) {
     KeywordLocation location;
     UDQParams udqp;
     UDQFunctionTable udqft(udqp);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"P1", "P2", "P3", "P4"})), st, udq_state);
 
@@ -303,7 +304,7 @@ BOOST_AUTO_TEST_CASE(UDQ_GROUP_TEST) {
         UDQParams udqp;
         UDQFunctionTable udqft(udqp);
         UDQDefine def_fopr(udqp, "FUOPR",0, location, {"SUM", "(", "GOPR", ")"});
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         UDQState udq_state(udqp.undefinedValue());
         UDQContext context(udqft, {}, st, udq_state);
 
@@ -326,7 +327,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     KeywordLocation location;
     {
         UDQDefine def(udqp, "WUBHP",0, location, {"WBHP"});
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         UDQState udq_state(udqp.undefinedValue());
         UDQContext context(udqft, WellMatcher(NameOrder({"W1", "W2", "W3"})), st, udq_state);
 
@@ -345,7 +346,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     }
     {
         UDQDefine def(udqp, "WUBHP",0, location, {"WBHP" , "'P*'"});
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         UDQState udq_state(udqp.undefinedValue());
         UDQContext context(udqft, WellMatcher(NameOrder({"I1", "I2", "P1", "P2"})), st, udq_state);
 
@@ -363,7 +364,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     }
     {
         UDQDefine def(udqp, "WUBHP",0, location, {"NINT" , "(", "WBHP", ")"});
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         UDQState udq_state(udqp.undefinedValue());
         UDQContext context(udqft, WellMatcher(NameOrder({"P1", "P2", "I1", "I2"})), st, udq_state);
         st.update_well_var("P1", "WBHP", 4);
@@ -577,7 +578,7 @@ ASSIGN WU2 8.0 /
 
 
 BOOST_AUTO_TEST_CASE(UDQ_CONTEXT) {
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQFunctionTable func_table;
     UDQParams udqp;
     UDQState udq_state(udqp.undefinedValue());
@@ -990,7 +991,7 @@ BOOST_AUTO_TEST_CASE(UDQ_POW_TEST) {
     UDQParams udqp;
     UDQDefine def_pow1(udqp, "WU",0, location, {"WOPR", "+", "WWPR", "*", "WGOR", "^", "WWIR"});
     UDQDefine def_pow2(udqp, "WU",0, location, {"(", "WOPR", "+", "WWPR", ")", "^", "(", "WOPR", "+" , "WGOR", "*", "WWIR", "-", "WBHP", ")"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     NameOrder wo; wo.add("P1");
     UDQContext context(udqft, WellMatcher(wo), st, udq_state);
@@ -1012,7 +1013,7 @@ BOOST_AUTO_TEST_CASE(UDQ_CMP_TEST) {
     UDQFunctionTable udqft;
     UDQParams udqp;
     UDQDefine def_cmp(udqp, "WU",0, location, {"WOPR", ">", "WWPR", "+", "WGOR", "*", "WWIR"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"P1", "P2"})), st, udq_state);
 
@@ -1041,7 +1042,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SCALAR_SET) {
     KeywordLocation location;
     UDQParams udqp;
     UDQFunctionTable udqft;
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"PA1", "PB2", "PC3", "PD4"})), st, udq_state);
 
@@ -1111,7 +1112,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SORTD_NAN) {
     KeywordLocation location;
     UDQDefine def(udqp, "WUPR1" ,0, location, {"1", "/", "(", "WWIR", "'OP*'" , ")"});
     UDQDefine def_sort(udqp , "WUPR3",0, location, {"SORTD", "(", "WUPR1", ")" });
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"OP1", "OP2", "OP3", "OP4"})), st, udq_state);
 
@@ -1157,7 +1158,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SORTA) {
     UDQFunctionTable udqft;
     UDQDefine def1(udqp, "WUPR1" ,0, location, {"1", "/", "(", "WWCT", "'OP*'", "+", "0.00001", ")"});
     UDQDefine def_sort(udqp , "WUPR3",0, location, {"SORTA", "(", "WUPR1", ")" });
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"OPL01", "OPL02", "OPU01", "OPU02"})), st, udq_state);
 
@@ -1187,7 +1188,7 @@ BOOST_AUTO_TEST_CASE(UDQ_BASIC_MATH_TEST) {
     UDQDefine def_div(udqp, "WU2OPR",0, location, {"WOPR", "/", "WOPR"});
     UDQDefine def_muladd(udqp, "WUX",0, location, {"WOPR", "+", "WOPR", "*", "WOPR"});
     UDQDefine def_wuwct(udqp , "WUWCT",0, location, {"WWPR", "/", "(", "WOPR", "+", "WWPR", ")"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"P1", "P2", "P3", "P4"})), st, udq_state);
 
@@ -1249,7 +1250,7 @@ BOOST_AUTO_TEST_CASE(DECK_TEST) {
     UDQParams udqp;
     UDQFunctionTable udqft(udqp);
     UDQDefine def(udqp, "WUOPRL",0, location, {"(", "WOPR", "OP1", "-", "150", ")", "*", "0.90"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"OP1", "OP2", "OP3"})), st, udq_state);
 
@@ -1284,7 +1285,7 @@ BOOST_AUTO_TEST_CASE(UDQ_PARSE_ERROR) {
     parseContext.update(ParseContext::UDQ_PARSE_ERROR, InputError::IGNORE);
     {
         UDQDefine def1(udqp, "WUBHP",0, location, tokens, parseContext, errors);
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         UDQFunctionTable udqft(udqp);
         UDQState udq_state(udqp.undefinedValue());
         UDQContext context(udqft, WellMatcher(NameOrder({"P1"})), st, udq_state);
@@ -1310,7 +1311,7 @@ BOOST_AUTO_TEST_CASE(UDQ_TYPE_ERROR) {
         UDQDefine def1(udqp, "FUBHP",0, location, tokens1, parseContext, errors);
         UDQDefine def2(udqp, "WUBHP",0, location, tokens2, parseContext, errors);
 
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         UDQFunctionTable udqft(udqp);
         UDQState udq_state(udqp.undefinedValue());
         UDQContext context(udqft, WellMatcher(NameOrder({"P1", "P2"})), st, udq_state);
@@ -1693,7 +1694,7 @@ UDQ
     const auto& udq = schedule.getUDQConfig(0);
     UDQParams udqp;
     auto def0 = udq.definitions()[0];
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQFunctionTable udqft(udqp);
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, {}, st, udq_state);
@@ -1719,7 +1720,7 @@ UDQ
     auto def0 = udq.definitions()[0];
     auto def1 = udq.definitions()[1];
     auto def2 = udq.definitions()[2];
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQFunctionTable udqft(udqp);
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, {}, st, udq_state);
@@ -1761,7 +1762,7 @@ UDQ
     UDQParams udqp;
     auto def0 = udq.definitions()[0];
     auto def1 = udq.definitions()[1];
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQFunctionTable udqft(udqp);
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, WellMatcher(NameOrder({"W1", "W2", "W3"})), st, udq_state);
@@ -1800,7 +1801,7 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
     udq.eval(0, {}, st, udq_state);
@@ -1826,7 +1827,7 @@ DEFINE FU_PAR2 FU_PAR3 /
 )";
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
     st.update("FMWPR", 100);
@@ -1845,7 +1846,7 @@ DEFINE FU_PAR3 FU_PAR2 + 1/
 )";
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
     udq.eval(0, {}, st, udq_state);
@@ -1954,7 +1955,7 @@ DEFINE WUGASRA  750000 - WGLIR '*' /
     const auto& udq = schedule.getUDQConfig(0);
     auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     st.update("TIMESTEP", 100);
     st.update("FMWPR", 100);
@@ -2160,7 +2161,7 @@ DEFINE FU_VAR91 GOPR TEST  /
     const auto& udq = schedule.getUDQConfig(0);
     auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     st.update("FMWPR", 100);
     st.update("FMWIN", 100);
     st.update("FMWPA", 100);
@@ -2191,7 +2192,7 @@ UDQ
     const auto& udq = schedule.getUDQConfig(0);
     auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     BOOST_CHECK_THROW(udq.eval(0, {}, st, udq_state), std::exception);
 }
@@ -2212,7 +2213,7 @@ UDQ
     const auto& udq = schedule.getUDQConfig(0);
     auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     {
         std::unordered_set<std::string> required_keys;
         udq.required_summary(required_keys);
@@ -2255,7 +2256,7 @@ TSTEP
 
     auto schedule = make_schedule(deck_string);
     UDQState udq_state(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     // Counting: 1,2,3,4,5
     for (std::size_t report_step = 0; report_step < 5; report_step++) {
@@ -2299,7 +2300,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DIV_TEST) {
     UDQFunctionTable udqft;
     UDQParams udqp;
     UDQDefine def_div(udqp, "FU",0, location, {"128", "/", "2", "/", "4", "/", "8"});
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, {}, st, udq_state);
 
@@ -2326,7 +2327,7 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     UDQState udq_state(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     const auto& udq = schedule.getUDQConfig(0);
     udq.eval(0, {}, st, udq_state);
@@ -2367,7 +2368,7 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     UDQState udq_state(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     const auto& udq = schedule.getUDQConfig(0);
     st.update_well_var("P1", "WOPR", 1);
     st.update_well_var("P2", "WOPR", 2);
@@ -2398,7 +2399,7 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     UDQState udq_state(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     const auto& udq = schedule.getUDQConfig(0);
     udq.eval(0, schedule.wellMatcher(0), st, udq_state);
 
@@ -2464,7 +2465,7 @@ TSTEP
     BOOST_CHECK_THROW(make_schedule(invalid1), std::exception);
     auto schedule = make_schedule(valid);
     UDQState udq_state(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQSet result = UDQSet::scalar("RES", 0);
     {
         const auto& udq = schedule.getUDQConfig(0);
@@ -2525,7 +2526,7 @@ UDQ
 
     auto schedule = make_schedule(valid);
     UDQState udq_state(0);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     UDQFunctionTable udqft;
     UDQContext context(udqft, WellMatcher(NameOrder({"W1", "W2", "W3"})), st, udq_state);
     st.update_well_var("W1", "WBHP", 400);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -46,6 +46,7 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
@@ -569,7 +570,7 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
 {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     const Opm::Well::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_specified());
 
@@ -589,7 +590,7 @@ BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
 
 BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
 {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     const Opm::Well::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::orat_defaulted());
 
@@ -607,7 +608,7 @@ BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
 
 BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
 {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     const Opm::Well::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::owrat_defaulted());
 
@@ -625,7 +626,7 @@ BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
 {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     const Opm::Well::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_defaulted());
 
@@ -643,7 +644,7 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
 {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     const Opm::Well::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_defaulted_with_bhp());
 
@@ -662,7 +663,7 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_NON_Defaulted_VFP)
 {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     const Opm::Well::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_defaulted_with_bhp_vfp_table(), VFPProdTable::ALQ_TYPE::ALQ_UNDEF);
 
@@ -683,7 +684,7 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_NON_Defaulted_VFP)
 
 BOOST_AUTO_TEST_CASE(WCH_BHP_Specified)
 {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     const Opm::Well::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::bhp_defaulted());
 
@@ -791,7 +792,7 @@ BOOST_AUTO_TEST_CASE(WELL_CONTROLS) {
     auto unit_system = UnitSystem::newMETRIC();
     Opm::Well well("WELL", "GROUP", 0, 0, 0, 0, 1000, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Opm::Connection::Order::DEPTH, unit_system, 0, 1.0, false, false, 0, Opm::Well::GasInflowEquation::STD);
     Opm::Well::WellProductionProperties prod(unit_system, "OP1");
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(Opm::TimeService::now());
     well.productionControls(st);
 
     // Use a scalar FIELD variable - that should work; although it is a bit weird.

--- a/tests/parser/integration/IOConfigIntegrationTest.cpp
+++ b/tests/parser/integration/IOConfigIntegrationTest.cpp
@@ -40,8 +40,8 @@ inline std::string path_prefix() {
     return boost::unit_test::framework::master_test_suite().argv[1];
 }
 
-inline void verifyRestartConfig( const TimeMap& tm, const RestartConfig& rst, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
-
+inline void verifyRestartConfig( const Schedule& sched, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
+    const auto& rst = sched.restart();
     for (auto rptrst : rptConfig) {
         int report_step                    = std::get<0>(rptrst);
         bool save                          = std::get<1>(rptrst);
@@ -49,7 +49,7 @@ inline void verifyRestartConfig( const TimeMap& tm, const RestartConfig& rst, st
 
         BOOST_CHECK_EQUAL( save, rst.getWriteRestartFile( report_step ) );
         if (save) {
-            std::time_t t = tm[report_step];
+            std::time_t t = sched.simTime(report_step);
             boost::posix_time::ptime epoch(boost::gregorian::date(1970,1,1));
             boost::posix_time::ptime report_date_ptime(report_date);
             boost::posix_time::time_duration::sec_type duration = (report_date_ptime - epoch).total_seconds();
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE( NorneRestartConfig ) {
     EclipseState state(deck);
     Schedule schedule(deck, state, python);
 
-    verifyRestartConfig(schedule.getTimeMap(), schedule.restart(), rptConfig);
+    verifyRestartConfig(schedule, rptConfig);
 }
 
 
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     EclipseState state( deck);
     Schedule schedule(deck, state, python);
     const auto& rstConfig = schedule.restart();
-    verifyRestartConfig(schedule.getTimeMap(), rstConfig, rptConfig);
+    verifyRestartConfig(schedule, rptConfig);
 
     BOOST_CHECK_EQUAL( rstConfig.getFirstRestartStep() , 0 );
 }

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -34,6 +34,7 @@
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
@@ -1428,7 +1429,7 @@ BOOST_AUTO_TEST_CASE( WCONINJE ) {
     FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     Runspec runspec (deck);
     Schedule sched( deck, grid, fp, runspec, python);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     BOOST_CHECK_EQUAL(5U, sched.numWells());
     BOOST_CHECK(sched.hasWell("PROD1"));

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -59,9 +59,8 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
         FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
         Runspec runspec (deck);
         Schedule sched(deck,  grid , fp, runspec, python);
-        const auto& timeMap = sched.getTimeMap();
         BOOST_CHECK_EQUAL(TimeMap::mkdate(2007 , 5 , 10), sched.getStartTime());
-        BOOST_CHECK_EQUAL(9U, timeMap.size());
+        BOOST_CHECK_EQUAL(9U, sched.size());
         BOOST_CHECK( deck.hasKeyword("NETBALAN") );
     }
 }
@@ -77,9 +76,8 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
     Runspec runspec (deck);
     auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
-    const auto& timeMap = sched.getTimeMap();
     BOOST_CHECK_EQUAL(TimeMap::mkdate(2007, 5 , 10) , sched.getStartTime());
-    BOOST_CHECK_EQUAL(9U, timeMap.size());
+    BOOST_CHECK_EQUAL(9U, sched.size());
 }
 
 

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -34,6 +34,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
@@ -238,7 +239,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
         BOOST_CHECK( sched.getWell("W_1", 9).isInjector());
         {
-            SummaryState st(std::chrono::system_clock::now());
+            SummaryState st(TimeService::now());
             const auto controls = sched.getWell("W_1", 9).injectionControls(st);
             BOOST_CHECK_CLOSE(20000/Metric::Time ,  controls.surface_rate  , 0.001);
             BOOST_CHECK_CLOSE(200000/Metric::Time , controls.reservoir_rate, 0.001);
@@ -257,7 +258,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
         BOOST_CHECK( Well::Status::SHUT == sched.getWell("W_1", 13).getStatus( ));
         BOOST_CHECK( Well::Status::OPEN == sched.getWell("W_1", 14).getStatus( ));
         {
-            SummaryState st(std::chrono::system_clock::now());
+            SummaryState st(TimeService::now());
             const auto controls = sched.getWell("W_1", 12).injectionControls(st);
             BOOST_CHECK(  controls.hasControl(Well::InjectorCMode::RATE ));
             BOOST_CHECK( !controls.hasControl(Well::InjectorCMode::RESV));
@@ -375,7 +376,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     Runspec runspec (deck);
     auto python = std::make_shared<Python>();
     Schedule sched(deck,  grid , fp, runspec, python);
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     BOOST_CHECK_EQUAL( 3U , sched.back().groups.size() );
     BOOST_CHECK( sched.back().groups.has( "INJ" ));

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -27,6 +27,7 @@
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/io/eclipse/OutputStream.hpp>
 
@@ -46,7 +47,7 @@ namespace {
 
 Opm::SummaryState sum_state_TEST1()
     {
-        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now()};
         state.update_well_var("OPU01", "WWPR", 21.);
         state.update_well_var("OPU02", "WWPR", 22.);
         state.update_well_var("OPL01", "WWPR", 23.);

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -36,6 +36,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <exception>
 #include <stdexcept>
@@ -432,7 +433,7 @@ END
 
     Opm::SummaryState sim_state()
     {
-        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now()};
 
         state.update("GOPR:GRP1",   235.);
         state.update("GGPR:GRP1",   100237.);

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -36,6 +36,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <exception>
 #include <stdexcept>
@@ -501,7 +502,7 @@ END
 
         Opm::SummaryState sim_state()
     {
-        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now()};
 
 	state.update("SPR:PROD:1",   235.);
 	state.update("SPR:PROD:2",   237.);

--- a/tests/test_AggregateNetworkData.cpp
+++ b/tests/test_AggregateNetworkData.cpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 #include <opm/io/eclipse/OutputStream.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <exception>
 #include <stdexcept>
@@ -57,7 +58,7 @@ namespace {
 
     Opm::SummaryState sum_state()
     {
-        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now()};
 
         state.update_well_var("P1", "WOPR", 3342.673828);
         state.update_well_var("P1", "WWPR", 0.000005);

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -29,6 +29,7 @@
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/io/eclipse/OutputStream.hpp>
 
@@ -118,7 +119,7 @@ Opm::UDQSet make_udq_set(const std::string& name, Opm::UDQVarType var_type, cons
 
     Opm::SummaryState sum_state()
     {
-        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now()};
         state.update_well_var("PROD1", "WUOPRL", 210.);
         state.update_well_var("PROD2", "WUOPRL", 211.);
         state.update_well_var("WINJ1", "WUOPRL", 212.);

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -30,6 +30,7 @@
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/VectorItems/well.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/io/eclipse/rst/well.hpp>
 #include <opm/io/eclipse/rst/header.hpp>
@@ -392,7 +393,7 @@ TSTEP            -- 9
 
    Opm::SummaryState sim_state()
     {
-        auto state = Opm::SummaryState{std::chrono::system_clock::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now()};
 
         state.update_well_var("OP_1", "WOPR" ,    1.0);
         state.update_well_var("OP_1", "WWPR" ,    2.0);
@@ -1173,7 +1174,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD) {
     // Report Step 2: 2011-01-20 --> 2013-06-15
     const auto rptStep = std::size_t{2};
     const auto sim_step = rptStep - 1;
-    Opm::SummaryState sumState(std::chrono::system_clock::now());
+    Opm::SummaryState sumState(Opm::TimeService::now());
     const auto xw   = well_rates_1();
     Opm::Action::State action_state;
 

--- a/tests/test_DoubHEAD.cpp
+++ b/tests/test_DoubHEAD.cpp
@@ -22,6 +22,7 @@
 #include <boost/test/unit_test.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/output/eclipse/DoubHEAD.hpp>
 #include <opm/output/eclipse/VectorItems/doubhead.hpp>
@@ -82,8 +83,7 @@ namespace {
         timePoint.tm_mon  =   4 - 1; // April
         timePoint.tm_mday =   9;     // 9th
 
-        return std::chrono::system_clock::from_time_t(
-            ::Opm::RestartIO::makeUTCTime(timePoint));
+        return Opm::TimeService::from_time_t( Opm::TimeService::makeUTCTime(timePoint) );
     }
 
     std::chrono::duration<double, std::chrono::seconds::period> tstep_123()

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         auto python = std::make_shared<Python>();
         Schedule schedule(deck, es, python);
         SummaryConfig summary_config( deck, schedule, es.getTableManager( ), es.aquifer());
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         es.getIOConfig().setBaseName( "FOO" );
 
         EclipseIO eclWriter( es, eclGrid , schedule, summary_config);

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -48,10 +48,10 @@ namespace {
     {
         auto elapsed = std::vector<double>{};
 
-        elapsed.reserve(tmap.numTimesteps() + 1);
+        elapsed.reserve(tmap.size());
         elapsed.push_back(0.0);
 
-        for (auto nstep = tmap.numTimesteps(),
+        for (auto nstep = tmap.size() - 1,
                   step  = 0*nstep; step < nstep; ++step)
         {
             elapsed.push_back(tmap.getTimeStepLength(step));

--- a/tests/test_LGOData.cpp
+++ b/tests/test_LGOData.cpp
@@ -21,6 +21,7 @@
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <exception>
 #include <iostream>
@@ -44,7 +45,7 @@ first_sim(std::string fname)
 Opm::SummaryState
 sum_state()
 {
-    auto state = Opm::SummaryState {std::chrono::system_clock::now()};
+    auto state = Opm::SummaryState {Opm::TimeService::now()};
     state.update("FULPR", 460.);
 
     return state;

--- a/tests/test_OutputStream.cpp
+++ b/tests/test_OutputStream.cpp
@@ -27,6 +27,7 @@
 #include <opm/io/eclipse/EclOutput.hpp>
 #include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/PaddedOutputString.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/io/eclipse/EclIOdata.hpp>
 
@@ -1777,8 +1778,6 @@ namespace {
     start(const int year, const int month, const int day,
           const int hour, const int minute, const int second)
     {
-        using std::chrono::system_clock;
-
         auto timepoint = std::tm {};
 
         timepoint.tm_sec  = second;
@@ -1788,7 +1787,7 @@ namespace {
         timepoint.tm_mon  = month - 1;
         timepoint.tm_year = year - 1900;
 
-        return system_clock::from_time_t(makeUTCTime(timepoint));
+        return Opm::TimeService::from_time_t(makeUTCTime(timepoint));
     }
 
     Opm::EclIO::OutputStream::SummarySpecification::RestartSpecification

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -402,12 +402,10 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
         UDQState udq_state(10);
 
         const auto  start_time = schedule.posixStartTime();
-        const auto& time_map   = schedule.getTimeMap( );
-
         for (int counter = 0; counter < 2; counter++) {
             EclipseIO eclipseWriter( eclipseState, grid, schedule, summary_config );
-            for (size_t step = 0; step < time_map.size(); step++) {
-                const auto step_time = time_map[step];
+            for (size_t step = 0; step < schedule.size(); step++) {
+                const auto step_time = schedule.simTime(step);
 
                 data::Rates r1, r2;
                 r1.set( data::Rates::opt::wat, 4.11 );

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -60,6 +60,7 @@
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <opm/common/utility/FileSystem.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 using namespace Opm;
 
@@ -240,7 +241,7 @@ namespace {
         tp.tm_mon  = std::get<1>(date) -    1; // 0..11
         tp.tm_mday = std::get<2>(date);        // 1..31
 
-        return ::Opm::RestartIO::makeUTCTime(tp);
+        return Opm::TimeService::makeUTCTime(tp);
     }
 } // Anonymous namespace
 
@@ -276,7 +277,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         const auto start_time = schedule.posixStartTime();
         const auto step_time  = timeStamp(::Opm::EclIO::ERft::RftDate{ 2008, 10, 10 });
 
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         Action::State action_state;
         UDQState udq_state(1234);
 
@@ -397,7 +398,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
 
         Schedule schedule(deck, eclipseState, python);
         SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ), eclipseState.aquifer() );
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(Opm::TimeService::now());
         Action::State action_state;
         UDQState udq_state(10);
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -223,7 +223,7 @@ data::Solution mkSolution( int numCells ) {
 
 Opm::SummaryState sim_state()
 {
-    auto state = Opm::SummaryState{std::chrono::system_clock::now()};
+    auto state = Opm::SummaryState{TimeService::now()};
     state.update_well_var("OP_1", "WOPR", 1.0);
     state.update_well_var("OP_1", "WWPR", 2.0);
     state.update_well_var("OP_1", "WGPR", 3.0);
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData) {
     test_area.copyIn("RESTART_SIM.DATA");
 
     Setup base_setup("BASE_SIM.DATA");
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     Action::State action_state;
     UDQState udq_state(19);
     auto state1 = first_sim( base_setup , action_state, st, udq_state, false );
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData_double) {
     test_area.copyIn("RESTART_SIM.DATA");
     test_area.copyIn("BASE_SIM.DATA");
     Setup base_setup("BASE_SIM.DATA");
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     Action::State action_state;
     UDQState udq_state(1);
 
@@ -613,7 +613,7 @@ BOOST_AUTO_TEST_CASE(WriteWrongSOlutionSize) {
         auto cells = mkSolution( num_cells );
         auto wells = mkWells();
         auto groups = mkGroups();
-        Opm::SummaryState sumState(std::chrono::system_clock::now());
+        Opm::SummaryState sumState(TimeService::now());
         Opm::Action::State action_state;
         Opm::UDQState udq_state(19);
 
@@ -675,7 +675,7 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
         const auto& units = setup.es.getUnits();
         {
             RestartValue restart_value(cells, wells, groups);
-            SummaryState st(std::chrono::system_clock::now());
+            SummaryState st(TimeService::now());
             const auto sumState = sim_state();
 
             restart_value.addExtra("EXTRA", UnitSystem::measure::pressure, {10,1,2,3});
@@ -878,7 +878,7 @@ BOOST_AUTO_TEST_CASE(Restore_Cumulatives)
     }
 
     Action::State action_state;
-    SummaryState rstSumState(std::chrono::system_clock::now());
+    SummaryState rstSumState(TimeService::now());
     RestartIO::load(OS::outputFileName(rset, "UNRST"), seqnum, action_state, rstSumState,
                     /* solution_keys = */ {
                                            RestartKey("SWAT", UnitSystem::measure::identity),
@@ -1011,8 +1011,8 @@ BOOST_AUTO_TEST_CASE(UDQ_RESTART) {
     test_area.copyIn("UDQ_RESTART.DATA");
 
     Setup base_setup("UDQ_BASE.DATA");
-    SummaryState st1(std::chrono::system_clock::now());
-    SummaryState st2(std::chrono::system_clock::now());
+    SummaryState st1(TimeService::now());
+    SummaryState st2(TimeService::now());
     Action::State action_state;
     UDQState udq_state(1);
     auto state1 = first_sim( base_setup , action_state, st1, udq_state, false );

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -35,6 +35,7 @@
 #include <opm/output/data/GuideRateValue.hpp>
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/Summary.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/output/eclipse/Inplace.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
@@ -477,7 +478,7 @@ BOOST_AUTO_TEST_CASE(well_keywords) {
     cfg.ta.makeSubDir( "PATH" );
     cfg.name = "PATH/CASE";
 
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
     writer.eval(st, 0, 0*day, cfg.wells, cfg.grp_nwrk, {}, {}, {}, {});
@@ -726,7 +727,7 @@ BOOST_AUTO_TEST_CASE(udq_keywords) {
     setup cfg( "test_summary_udq" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -751,7 +752,7 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     setup cfg( "test_summary_group" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0);
 
@@ -908,7 +909,7 @@ BOOST_AUTO_TEST_CASE(group_group) {
     setup cfg( "test_summary_group_group" , "group_group.DATA");
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -964,7 +965,7 @@ BOOST_AUTO_TEST_CASE(connection_kewords) {
     setup cfg( "test_summary_connection" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -1038,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(DATE) {
     setup cfg( "test_summary_DATE" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1);
     writer.eval( st, 2, 2 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -1075,7 +1076,7 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
     setup cfg( "test_summary_field" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -1212,7 +1213,7 @@ BOOST_AUTO_TEST_CASE(report_steps_time) {
     setup cfg( "test_summary_report_steps_time" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 1, 2 *  day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1);
     writer.eval( st, 1, 5 *  day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -1239,7 +1240,7 @@ BOOST_AUTO_TEST_CASE(skip_unknown_var) {
     setup cfg( "test_summary_skip_unknown_var" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 1, 2 *  day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1);
     writer.eval( st, 1, 5 *  day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -1349,7 +1350,7 @@ BOOST_AUTO_TEST_CASE(region_vars) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         writer.eval( st, 1, 2 *  day, cfg.wells, cfg.grp_nwrk, {}, {}, {}, {}, region_values);
         writer.add_timestep( st, 1);
         writer.eval( st, 1, 5 *  day, cfg.wells, cfg.grp_nwrk, {}, {}, {}, {}, region_values);
@@ -1400,7 +1401,7 @@ BOOST_AUTO_TEST_CASE(region_production) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
         writer.add_timestep( st, 0);
         writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -1432,7 +1433,7 @@ BOOST_AUTO_TEST_CASE(region_injection) {
     setup cfg( "region_injection" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -1490,7 +1491,7 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES) {
     block_values[std::make_pair("BOVIS", 1)] = 33.0;
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {},{}, {}, {}, {}, block_values);
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {},{}, {}, {}, {}, block_values);
@@ -1551,7 +1552,7 @@ BOOST_AUTO_TEST_CASE(NODE_VARIABLES) {
     setup cfg( "test_summary_node" );
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0);
 
@@ -1609,7 +1610,7 @@ BOOST_AUTO_TEST_CASE(MISC) {
     setup cfg( "test_misc");
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0);
     writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, {}, {}, {}, {});
@@ -1629,7 +1630,7 @@ BOOST_AUTO_TEST_CASE(EXTRA) {
 
     {
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         writer.eval( st, 0, 0 * day, cfg.wells , cfg.grp_nwrk, { {"TCPU" , 0 }}, {}, {}, {});
         writer.add_timestep( st, 0);
         writer.eval( st, 1, 1 * day, cfg.wells , cfg.grp_nwrk, { {"TCPU" , 1 }}, {}, {}, {});
@@ -1760,7 +1761,7 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
         setup cfg( "test_efficiency_factor", "SUMMARY_EFF_FAC.DATA", false );
 
         out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
-        SummaryState st(std::chrono::system_clock::now());
+        SummaryState st(TimeService::now());
         writer.eval( st, 0, 0 * day, cfg.wells, cfg.grp_nwrk, {}, {}, {}, {});
         writer.add_timestep( st, 0);
         writer.eval( st, 1, 1 * day, cfg.wells, cfg.grp_nwrk, {}, {}, {}, {});
@@ -1916,7 +1917,7 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
 
 
 BOOST_AUTO_TEST_CASE(Test_SummaryState) {
-    Opm::SummaryState st(std::chrono::system_clock::now());
+    Opm::SummaryState st(TimeService::now());
     st.update("WWCT:OP_2", 100);
     BOOST_CHECK_CLOSE(st.get("WWCT:OP_2"), 100, 1e-5);
     BOOST_CHECK_THROW(st.get("NO_SUCH_KEY"), std::out_of_range);
@@ -1989,7 +1990,7 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
     BOOST_CHECK( !st.has("GWCT:G1") );
 
     auto buffer = st.serialize();
-    Opm::SummaryState st2(std::chrono::system_clock::now());
+    Opm::SummaryState st2(TimeService::now());
     st2.deserialize(buffer);
 
     BOOST_CHECK( st == st2 );
@@ -2007,7 +2008,7 @@ namespace {
             config.schedule, "Ignore.This"
         };
 
-      SummaryState st(std::chrono::system_clock::now());
+      SummaryState st(TimeService::now());
       smry.eval(st, 0, 0*day, config.wells, config.grp_nwrk, {}, {}, {}, {});
       smry.add_timestep(st, 0);
       smry.eval(st, 1, 1*day, config.wells, config.grp_nwrk, {}, {}, {}, {});
@@ -3007,7 +3008,7 @@ BOOST_AUTO_TEST_CASE(Write_Read)
         config.es, config.config, config.grid, config.schedule
     };
 
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     writer.eval(st, 0, 0*day, config.wells, config.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep(st, 0);
     writer.eval(st, 1, 1*day, config.wells, config.grp_nwrk, {}, {}, {}, {});
@@ -3502,7 +3503,7 @@ BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE(Reset_Cumulative_Vectors)
 
 BOOST_AUTO_TEST_CASE(SummaryState_TOTAL) {
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     st.update("FOPR", 100);
     BOOST_CHECK_EQUAL(st.get("FOPR"), 100);
     st.update("FOPR", 100);
@@ -3564,7 +3565,7 @@ BOOST_AUTO_TEST_CASE(SummaryState_TOTAL) {
 
 
 void test_serialize(const SummaryState& st) {
-    SummaryState st2(std::chrono::system_clock::now());
+    SummaryState st2(TimeService::now());
     auto serial = st.serialize();
     st2.deserialize(serial);
     BOOST_CHECK( st == st2 );
@@ -3576,7 +3577,7 @@ void test_serialize(const SummaryState& st) {
 }
 
 BOOST_AUTO_TEST_CASE(serialize_sumary_state) {
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
     test_serialize(st);
 
     st.update_elapsed(1000);
@@ -3612,7 +3613,7 @@ BOOST_AUTO_TEST_CASE(SummaryState__TIME) {
     ts.tm_min = 0;
     ts.tm_sec = 0;
     auto start_time = timegm(&ts);
-    SummaryState st(std::chrono::system_clock::from_time_t(start_time));
+    SummaryState st(TimeService::from_time_t(start_time));
     BOOST_CHECK_EQUAL(st.get("YEAR"), 2000);
     BOOST_CHECK_EQUAL(st.get("DAY"), 1);
     BOOST_CHECK_EQUAL(st.get("MNTH"), 1);

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -49,6 +49,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
 
@@ -256,7 +257,7 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     cfg.ta.makeSubDir( "PATH" );
     cfg.name = "PATH/CASE";
 
-    SummaryState st(std::chrono::system_clock::now());
+    SummaryState st(TimeService::now());
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
     writer.eval(st, 0, 0*day, cfg.wells, cfg.grp_nwrk, {}, {}, {}, {});

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -33,6 +33,7 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
+#include <opm/common/utility/TimeService.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellInjectionProperties.hpp>
@@ -207,7 +208,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     const auto num_cells = grid.getCartesianSize();
     Opm::EclipseIO eclipseWriter( es,  grid , schedule, summary_config);
     int countTimeStep = schedule.size() - 1;
-    Opm::SummaryState st(std::chrono::system_clock::from_time_t(schedule.getStartTime()));
+    Opm::SummaryState st(Opm::TimeService::from_time_t(schedule.getStartTime()));
     Opm::Action::State action_state;
     Opm::UDQState udq_state(123);
 

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     Opm::SummaryConfig summary_config( deck, schedule, es.getTableManager( ), es.aquifer());
     const auto num_cells = grid.getCartesianSize();
     Opm::EclipseIO eclipseWriter( es,  grid , schedule, summary_config);
-    int countTimeStep = schedule.getTimeMap().numTimesteps();
+    int countTimeStep = schedule.size() - 1;
     Opm::SummaryState st(std::chrono::system_clock::from_time_t(schedule.getStartTime()));
     Opm::Action::State action_state;
     Opm::UDQState udq_state(123);

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -23,6 +23,7 @@
 
 #include <vector>
 
+#include <opm/common/utility/TimeService.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/output/eclipse/WriteRestartHelpers.hpp>
 #include <opm/output/eclipse/AggregateWellData.hpp>
@@ -209,7 +210,7 @@ BOOST_AUTO_TEST_CASE(group_test) {
     // Report Step 2: 2011-01-20 --> 2013-06-15
     const auto rptStep = std::size_t{2};
     const auto sim_step = rptStep - 1;
-    Opm::SummaryState sumState(std::chrono::system_clock::now());
+    Opm::SummaryState sumState(Opm::TimeService::now());
 
     const auto ih = Opm::RestartIO::Helpers::createInteHead(simCase.es,
                                                             simCase.grid,
@@ -261,7 +262,7 @@ BOOST_AUTO_TEST_CASE(State_test) {
     // Report Step 2: 2011-01-20 --> 2013-06-15
     const auto rptStep = std::size_t{4};
     const auto sim_step = rptStep - 1;
-    Opm::SummaryState sumState(std::chrono::system_clock::now());
+    Opm::SummaryState sumState(Opm::TimeService::now());
     Opm::Action::State action_state;
 
     const auto ih = Opm::RestartIO::Helpers::createInteHead(simCase.es,


### PR DESCRIPTION
This PR removes the timemap member from the Schedule class. This is more cleanup following #2176 - the last substantial part of #2176 is now to implement also the `RestartConfig` class in with the `ScheduleState` approach. This PR is a step in that direction.

Downstream: https://github.com/OPM/opm-simulators/pull/3073