### PR TITLE
Add DRSDTCON to allow for convective DRSDT

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
@@ -27,8 +27,9 @@ namespace Opm
 {
      /*
      * The OilVaporizationProperties class
-     * This classe is used to store the values from {VAPPARS, DRSDT, DRVDT}
+     * This classe is used to store the values from {VAPPARS, DRSDT, DRVDT, DRSDTCON}
      * The VAPPARS and {DRSDT, DRVDT} are mutal exclusive and will cancel previous settings of the other keywords.
+     * The DRSDTCON implements a dissolution rate based on convective mixing.
      * Ask for type first and the ask for the correct values for this type, asking for values not valid for the current type will throw a logic exception.
      */
     class OilVaporizationProperties {
@@ -36,7 +37,8 @@ namespace Opm
         enum class OilVaporization {
             UNDEF = 0,
             VAPPARS = 1,
-            DRDT = 2 // DRSDT or DRVDT
+            DRDT = 2, // DRSDT or DRVDT
+            DRSDTCON = 3 // DRSDTCON
         };
 
 
@@ -46,6 +48,7 @@ namespace Opm
         static OilVaporizationProperties serializeObject();
 
         static void updateDRSDT(Opm::OilVaporizationProperties& ovp, const std::vector<double>& maxDRSDT, const std::vector<std::string>& option);
+        static void updateDRSDTCON(Opm::OilVaporizationProperties& ovp, const std::vector<double>& maxDRSDT, const std::vector<std::string>& option);
         static void updateDRVDT(Opm::OilVaporizationProperties& ovp, const std::vector<double>& maxDRVDT);
         static void updateVAPPARS(Opm::OilVaporizationProperties& ovp, double vap1, double vap2);
 
@@ -55,6 +58,7 @@ namespace Opm
         bool getOption(const size_t pvtRegionIdx) const;
         bool drsdtActive() const;
         bool drvdtActive() const;
+        bool drsdtConvective() const;
         bool defined() const;
         size_t numPvtRegions() const {return m_maxDRSDT.size();}
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -570,6 +570,7 @@ namespace Opm
         void handleCOMPORD  (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleCOMPSEGS (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleDRSDT    (const HandlerContext&, const ParseContext&, ErrorGuard&);
+        void handleDRSDTCON (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleDRSDTR   (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleDRVDT    (const HandlerContext&, const ParseContext&, ErrorGuard&);
         void handleDRVDTR   (const HandlerContext&, const ParseContext&, ErrorGuard&);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -45,6 +45,7 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/C.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/L.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/N.hpp>
@@ -238,62 +239,70 @@ namespace {
 
     void Schedule::handleDRSDT(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
         std::size_t numPvtRegions = this->m_static.m_runspec.tabdims().getNumPVTTables();
-        std::vector<double> max(numPvtRegions);
+        std::vector<double> maximums(numPvtRegions);
         std::vector<std::string> options(numPvtRegions);
         for (const auto& record : handlerContext.keyword) {
-            std::fill(max.begin(), max.end(), record.getItem("DRSDT_MAX").getSIDouble(0));
-            std::fill(options.begin(), options.end(), record.getItem("Option").get< std::string >(0));
+            const auto& max = record.getItem<ParserKeywords::DRSDT::DRSDT_MAX>().getSIDouble(0);
+            const auto& option = record.getItem<ParserKeywords::DRSDT::OPTION>().get< std::string >(0);
+            std::fill(maximums.begin(), maximums.end(), max);
+            std::fill(options.begin(), options.end(), option);
             auto& ovp = this->snapshots.back().oilvap();
-            OilVaporizationProperties::updateDRSDT(ovp, max, options);
+            OilVaporizationProperties::updateDRSDT(ovp, maximums, options);
         }
     }
 
     void Schedule::handleDRSDTCON(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
         std::size_t numPvtRegions = this->m_static.m_runspec.tabdims().getNumPVTTables();
-        std::vector<double> max(numPvtRegions);
+        std::vector<double> maximums(numPvtRegions);
         std::vector<std::string> options(numPvtRegions);
         for (const auto& record : handlerContext.keyword) {
-            std::fill(max.begin(), max.end(), record.getItem("DRSDT_MAX").getSIDouble(0));
-            std::fill(options.begin(), options.end(), record.getItem("Option").get< std::string >(0));
+            const auto& max = record.getItem<ParserKeywords::DRSDTCON::DRSDT_MAX>().getSIDouble(0);
+            const auto& option = record.getItem<ParserKeywords::DRSDTCON::OPTION>().get< std::string >(0);
+            std::fill(maximums.begin(), maximums.end(), max);
+            std::fill(options.begin(), options.end(), option);
             auto& ovp = this->snapshots.back().oilvap();
-            OilVaporizationProperties::updateDRSDTCON(ovp, max, options);
+            OilVaporizationProperties::updateDRSDTCON(ovp, maximums, options);
         }
     }
 
     void Schedule::handleDRSDTR(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
         std::size_t numPvtRegions = this->m_static.m_runspec.tabdims().getNumPVTTables();
-        std::vector<double> max(numPvtRegions);
+        std::vector<double> maximums(numPvtRegions);
         std::vector<std::string> options(numPvtRegions);
         std::size_t pvtRegionIdx = 0;
         for (const auto& record : handlerContext.keyword) {
-            max[pvtRegionIdx] = record.getItem("DRSDT_MAX").getSIDouble(0);
-            options[pvtRegionIdx] = record.getItem("Option").get< std::string >(0);
+            const auto& max = record.getItem<ParserKeywords::DRSDTR::DRSDT_MAX>().getSIDouble(0);
+            const auto& option = record.getItem<ParserKeywords::DRSDTR::OPTION>().get< std::string >(0);
+            maximums[pvtRegionIdx] = max;
+            options[pvtRegionIdx] = option;
             pvtRegionIdx++;
         }
         auto& ovp = this->snapshots.back().oilvap();
-        OilVaporizationProperties::updateDRSDT(ovp, max, options);
+        OilVaporizationProperties::updateDRSDT(ovp, maximums, options);
     }
 
     void Schedule::handleDRVDT(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
         std::size_t numPvtRegions = this->m_static.m_runspec.tabdims().getNumPVTTables();
-        std::vector<double> max(numPvtRegions);
+        std::vector<double> maximums(numPvtRegions);
         for (const auto& record : handlerContext.keyword) {
-            std::fill(max.begin(), max.end(), record.getItem("DRVDT_MAX").getSIDouble(0));
+            const auto& max = record.getItem<ParserKeywords::DRVDTR::DRVDT_MAX>().getSIDouble(0);
+            std::fill(maximums.begin(), maximums.end(), max);
             auto& ovp = this->snapshots.back().oilvap();
-            OilVaporizationProperties::updateDRVDT(ovp, max);
+            OilVaporizationProperties::updateDRVDT(ovp, maximums);
         }
     }
 
     void Schedule::handleDRVDTR(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
         std::size_t numPvtRegions = this->m_static.m_runspec.tabdims().getNumPVTTables();
         std::size_t pvtRegionIdx = 0;
-        std::vector<double> max(numPvtRegions);
+        std::vector<double> maximums(numPvtRegions);
         for (const auto& record : handlerContext.keyword) {
-            max[pvtRegionIdx] = record.getItem("DRVDT_MAX").getSIDouble(0);
+            const auto& max = record.getItem<ParserKeywords::DRVDTR::DRVDT_MAX>().getSIDouble(0);
+            maximums[pvtRegionIdx] = max;
             pvtRegionIdx++;
         }
         auto& ovp = this->snapshots.back().oilvap();
-        OilVaporizationProperties::updateDRVDT(ovp, max);
+        OilVaporizationProperties::updateDRVDT(ovp, maximums);
     }
 
     void Schedule::handleEXIT(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -248,6 +248,18 @@ namespace {
         }
     }
 
+    void Schedule::handleDRSDTCON(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
+        std::size_t numPvtRegions = this->m_static.m_runspec.tabdims().getNumPVTTables();
+        std::vector<double> max(numPvtRegions);
+        std::vector<std::string> options(numPvtRegions);
+        for (const auto& record : handlerContext.keyword) {
+            std::fill(max.begin(), max.end(), record.getItem("DRSDT_MAX").getSIDouble(0));
+            std::fill(options.begin(), options.end(), record.getItem("Option").get< std::string >(0));
+            auto& ovp = this->snapshots.back().oilvap();
+            OilVaporizationProperties::updateDRSDTCON(ovp, max, options);
+        }
+    }
+
     void Schedule::handleDRSDTR(const HandlerContext& handlerContext, const ParseContext&, ErrorGuard&) {
         std::size_t numPvtRegions = this->m_static.m_runspec.tabdims().getNumPVTTables();
         std::vector<double> max(numPvtRegions);
@@ -1833,6 +1845,7 @@ namespace {
             { "COMPORD" , &Schedule::handleCOMPORD  },
             { "COMPSEGS", &Schedule::handleCOMPSEGS },
             { "DRSDT"   , &Schedule::handleDRSDT    },
+            { "DRSDTCON", &Schedule::handleDRSDTCON },
             { "DRSDTR"  , &Schedule::handleDRSDTR   },
             { "DRVDT"   , &Schedule::handleDRVDT    },
             { "DRVDTR"  , &Schedule::handleDRVDTR   },

--- a/src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
@@ -91,6 +91,20 @@ namespace Opm {
         }
     }
 
+    void OilVaporizationProperties::updateDRSDTCON(OilVaporizationProperties& ovp, const std::vector<double>& maximums, const std::vector<std::string>& options){
+        ovp.m_type = OilVaporization::DRSDTCON;
+        ovp.m_maxDRSDT = maximums;
+        for (size_t pvtRegionIdx = 0; pvtRegionIdx < options.size(); ++pvtRegionIdx) {
+            if (options[pvtRegionIdx] == "ALL"){
+                ovp.m_maxDRSDT_allCells[pvtRegionIdx] = true;
+            } else if (options[pvtRegionIdx] == "FREE") {
+                ovp.m_maxDRSDT_allCells[pvtRegionIdx] = false;
+            } else {
+                throw std::invalid_argument("Only ALL or FREE is allowed as option string");
+            }
+        }
+    }
+
     void OilVaporizationProperties::updateDRVDT(OilVaporizationProperties& ovp, const std::vector<double>& maximums){
         ovp.m_type = OilVaporization::DRDT;
         ovp.m_maxDRVDT = maximums;
@@ -107,7 +121,11 @@ namespace Opm {
     }
 
     bool OilVaporizationProperties::drsdtActive() const {
-        return (m_maxDRSDT[0] >= 0 && m_type == OilVaporization::DRDT);
+        return (m_maxDRSDT[0] >= 0 && (m_type == OilVaporization::DRDT || m_type == OilVaporization::DRSDTCON));
+    }
+
+    bool OilVaporizationProperties::drsdtConvective() const {
+        return this->m_type == OilVaporization::DRSDTCON;
     }
 
     bool OilVaporizationProperties::drvdtActive() const {

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DRSDT
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DRSDT
@@ -11,7 +11,7 @@
       "dimension": "GasDissolutionFactor/Time"
     },
     {
-      "name": "Option",
+      "name": "OPTION",
       "value_type": "STRING",
       "default": "ALL"
     }

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DRSDTR
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/D/DRSDTR
@@ -14,7 +14,7 @@
       "dimension": "GasDissolutionFactor/Time"
     },
     {
-      "name": "Option",
+      "name": "OPTION",
       "value_type": "STRING",
       "default": "ALL"
     }

--- a/src/opm/parser/eclipse/share/keywords/900_OPM/D/DRSDTCON
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/D/DRSDTCON
@@ -11,7 +11,7 @@
       "dimension": "1"
     },
     {
-      "name": "Option",
+      "name": "OPTION",
       "value_type": "STRING",
       "default": "ALL"
     }

--- a/src/opm/parser/eclipse/share/keywords/900_OPM/D/DRSDTCON
+++ b/src/opm/parser/eclipse/share/keywords/900_OPM/D/DRSDTCON
@@ -1,0 +1,19 @@
+{
+  "name": "DRSDTCON",
+  "sections": [
+    "SCHEDULE"
+  ],
+  "size": 1,
+  "items": [
+    {
+      "name": "DRSDT_MAX",
+      "value_type": "DOUBLE",
+      "dimension": "1"
+    },
+    {
+      "name": "Option",
+      "value_type": "STRING",
+      "default": "ALL"
+    }
+  ]
+}

--- a/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/parser/eclipse/share/keywords/keyword_list.cmake
@@ -1089,6 +1089,7 @@ set( keywords
 
      900_OPM/B/BC
      900_OPM/C/CO2STOR
+     900_OPM/D/DRSDTCON
      900_OPM/E/EXIT
      900_OPM/G/GCOMPIDX
      900_OPM/G/GRUPRIG

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1306,6 +1306,30 @@ DRSDT
     BOOST_CHECK_EQUAL(false,   ovap.drvdtActive());
 }
 
+BOOST_AUTO_TEST_CASE(createDeckWithDRSDTCON) {
+    std::string input =
+            "START             -- 0 \n"
+            "19 JUN 2007 / \n"
+            "SCHEDULE\n"
+            "DATES             -- 1\n"
+            " 10  OKT 2008 / \n"
+            "/\n"
+            "DRSDTCON\n"
+            "0.01\n"
+            "/\n";
+
+    const auto& schedule = make_schedule(input);
+    size_t currentStep = 1;
+    const auto& ovap = schedule[currentStep].oilvap();
+
+    BOOST_CHECK_EQUAL(true,   ovap.getOption(0));
+    BOOST_CHECK(ovap.getType() == OilVaporizationProperties::OilVaporization::DRSDTCON);
+
+    BOOST_CHECK_EQUAL(true,   ovap.drsdtActive());
+    BOOST_CHECK_EQUAL(false,   ovap.drvdtActive());
+    BOOST_CHECK_EQUAL(true,   ovap.drsdtConvective());
+}
+
 BOOST_AUTO_TEST_CASE(createDeckWithDRSDTR) {
     std::string input = R"(
 START             -- 0


### PR DESCRIPTION
This adds a version of DRSDT useful for co2 storage. See the corresponding PR i opm-simulators for more details.  