### PR TITLE
Record Dynamic Well Status in Output Wells

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -255,6 +255,9 @@ namespace Opm {
         double thp;
         double temperature;
         int control;
+
+        ::Opm::Well::Status dynamicStatus { Opm::Well::Status::OPEN };
+
         std::vector< Connection > connections;
         std::unordered_map<std::size_t, Segment> segments;
         CurrentControl current_control;
@@ -538,6 +541,12 @@ namespace Opm {
         buffer.write(this->thp);
         buffer.write(this->temperature);
         buffer.write(this->control);
+
+        {
+            const auto status = ::Opm::Well::Status2String(this->dynamicStatus);
+            buffer.write(status);
+        }
+
         unsigned int size = this->connections.size();
         buffer.write(size);
         for (const Connection& comp : this->connections)
@@ -620,6 +629,12 @@ namespace Opm {
         buffer.read(this->thp);
         buffer.read(this->temperature);
         buffer.read(this->control);
+
+        {
+            auto status = std::string{};
+            buffer.read(status);
+            this->dynamicStatus = ::Opm::Well::StatusFromString(status);
+        }
 
         // Connection information
         unsigned int size = 0.0; //this->connections.size();

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -1038,13 +1038,11 @@ captureDynamicWellData(const Opm::Schedule&        sched,
         auto iWell = this->iWell_[wellID];
 
         auto i = xw.find(well.name());
-        if ((i == std::end(xw)) || (well.getStatus() != Opm::Well::Status::OPEN)) {
-            if ((i == std::end(xw)) || (well.getStatus() == Opm::Well::Status::SHUT))  {
-                IWell::dynamicContribShut(iWell);
-            }
-            else {
-                IWell::dynamicContribStop(i->second, iWell);
-            }
+        if ((i == std::end(xw)) || (i->second.dynamicStatus == Opm::Well::Status::SHUT)) {
+            IWell::dynamicContribShut(iWell);
+        }
+        else if (i->second.dynamicStatus == Opm::Well::Status::STOP) {
+            IWell::dynamicContribStop(i->second, iWell);
         }
         else {
             IWell::dynamicContribOpen(well, i->second, iWell);

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -532,6 +532,7 @@ TSTEP            -- 9
 
         {
             xw["OP_1"].bhp = 150.0;  // Closed
+            xw["OP_1"].dynamicStatus = ::Opm::Well::Status::STOP;
 
             xw["OP_1"].connections.emplace_back();
             auto& c = xw["OP_1"].connections.back();
@@ -557,8 +558,6 @@ TSTEP            -- 9
 
         return xw;
     }
-
-
 } // namespace
 
 struct SimulationCase
@@ -1002,8 +1001,6 @@ BOOST_AUTO_TEST_CASE (Dynamic_Well_Data_Step2)
         const auto i0 = 0*ih.niwelz;
 
         const auto& iwell = awd.getIWell();
-
-
 
         BOOST_CHECK_EQUAL(iwell[i0 + Ix::item9] , 0);
         BOOST_CHECK_EQUAL(iwell[i0 + Ix::Status], 0);

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -308,8 +308,16 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         using SegRes = decltype(wells["w"].segments);
         using Ctrl = decltype(wells["w"].current_control);
 
-        wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{}, Ctrl{} };
-        wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{}, Ctrl{} };
+        wells["OP_1"] = {
+            std::move(r1), 1.0, 1.1, 3.1, 1,
+            ::Opm::Well::Status::OPEN,
+            std::move(well1_comps), SegRes{}, Ctrl{}
+        };
+        wells["OP_2"] = {
+            std::move(r2), 1.0, 1.1, 3.2, 1,
+            ::Opm::Well::Status::OPEN,
+            std::move(well2_comps), SegRes{}, Ctrl{}
+        };
 
         RestartValue restart_value(std::move(solution), std::move(wells), std::move(group_nwrk));
 
@@ -434,8 +442,16 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
                 using SegRes = decltype(wells["w"].segments);
                 using Ctrl = decltype(wells["w"].current_control);
 
-                wells["OP_1"] = { std::move(r1), 1.0, 1.1, 3.1, 1, std::move(well1_comps), SegRes{}, Ctrl{} };
-                wells["OP_2"] = { std::move(r2), 1.0, 1.1, 3.2, 1, std::move(well2_comps), SegRes{}, Ctrl{} };
+                wells["OP_1"] = {
+                    std::move(r1), 1.0, 1.1, 3.1, 1,
+                    ::Opm::Well::Status::OPEN,
+                    std::move(well1_comps), SegRes{}, Ctrl{}
+                };
+                wells["OP_2"] = {
+                    std::move(r2), 1.0, 1.1, 3.2, 1,
+                    ::Opm::Well::Status::OPEN,
+                    std::move(well2_comps), SegRes{}, Ctrl{}
+                };
 
                 RestartValue restart_value(std::move(solution), std::move(wells), data::GroupAndNetworkValues());
 

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -178,6 +178,7 @@ static data::Wells result_wells() {
     */
     data::Well well1 {
         rates1, 0.1 * ps, 0.2 * ps, 0.3 * ps, 1,
+        ::Opm::Well::Status::OPEN,
         { {well1_comp1} },
         { { segment.segNumber, segment } },
         data::CurrentControl{}


### PR DESCRIPTION
This PR adds a new data member
```
Well::Status dynamicStatus
```
to the `data::Well` object.  This member records the simulator's notion of a well's open/shut/stop status and is especially needed to support `WECON`-type status changes once the simulator maintains both open and shut wells.

While here, also change multiple summary primitives to not look up the same values repeatedly.