### PR TITLE
Expose ParseContext::ignore_keyword() in Python

### DIFF
--- a/python/cxx/parsecontext.cpp
+++ b/python/cxx/parsecontext.cpp
@@ -16,6 +16,7 @@ void python::common::export_ParseContext(py::module& module) {
     py::class_< ParseContext >(module, "ParseContext" )
         .def(py::init<>())
         .def(py::init<const std::vector<std::pair<std::string, InputError::Action>>>())
+        .def( "ignore_keyword", &ParseContext::ignoreKeyword )
         .def( "update", ctx_update );
 
     py::enum_< InputError::Action >( module, "action" )

--- a/python/tests/test_parse.py
+++ b/python/tests/test_parse.py
@@ -84,6 +84,22 @@ FIPNUM
          self.assertEqual(112, es.grid().ny)
          self.assertEqual(22, es.grid().nz)
 
+    def test_parse_ignore_keyword(self):
+        deck_string = """
+FIPNUM
+  100*1 100*2 /
+
+KEYWORD
+  1 2 3 /
+        """
+
+        parse_context = ParseContext( )
+        parser = Parser()
+        parse_context.ignore_keyword("KEYWORD")
+        deck = parser.parse_string( deck_string, parse_context )
+        self.assertEqual(len(deck), 1)
+
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
Fix of: https://github.com/OPM/opm-common/issues/2262