### PR TITLE
Handle UDA values for ALQ in WCONPROD / WCONHIST

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -351,6 +351,7 @@ public:
         UDAValue  ResVRate;
         UDAValue  BHPTarget;
         UDAValue  THPTarget;
+        UDAValue  ALQValue;
 
         // BHP and THP limit
         double  bhp_hist_limit = 0.0;
@@ -360,7 +361,6 @@ public:
         double  BHPH        = 0.0;
         double  THPH        = 0.0;
         int     VFPTableNumber = 0;
-        double  ALQValue    = 0.0;
         bool    predictionMode = false;
         ProducerCMode controlMode = ProducerCMode::CMODE_UNDEFINED;
         ProducerCMode whistctl_cmode = ProducerCMode::CMODE_UNDEFINED;
@@ -411,12 +411,12 @@ public:
             ResVRate.serializeOp(serializer);
             BHPTarget.serializeOp(serializer);
             THPTarget.serializeOp(serializer);
+            ALQValue.serializeOp(serializer);
             serializer(bhp_hist_limit);
             serializer(thp_hist_limit);
             serializer(BHPH);
             serializer(THPH);
             serializer(VFPTableNumber);
-            serializer(ALQValue);
             serializer(predictionMode);
             serializer(controlMode);
             serializer(whistctl_cmode);

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -496,7 +496,8 @@ inline quantity glir( const fn_args& args ) {
             continue;
 
         double eff_fac = efac( args.eff_factors, well.name() );
-        alq_rate += eff_fac*xwPos->second.rates.get(rt::alq, well.alq_value());
+        const auto& production = well.productionControls(args.st);
+        alq_rate += eff_fac*xwPos->second.rates.get(rt::alq, production.alq_value);
     }
     return { alq_rate, measure::gas_surface_rate };
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -168,7 +168,7 @@ Well::Well(const RestartIO::RstWell& rst_well,
         p->LiquidRate.update(rst_well.lrat_target) ;
         p->ResVRate.update(rst_well.resv_target);
         p->VFPTableNumber = rst_well.vfp_table;
-        p->ALQValue = rst_well.alq_value;
+        p->ALQValue.update(rst_well.alq_value); // Uncertain of whether the dimension comes through correct here.
         p->predictionMode = this->prediction_mode;
 
         if (rst_well.orat_target != 0)
@@ -1307,10 +1307,10 @@ Well::InjectionControls Well::injectionControls(const SummaryState& st) const {
 
 
 /*
-  These three accessor functions are at the "wrong" level of abstraction;
-  the same properties are part of the InjectionControls and
-  ProductionControls structs. They are made available here to avoid passing
-  a SummaryState instance in situations where it is not really needed.
+  These accessor functions are at the "wrong" level of abstraction; the same
+  properties are part of the InjectionControls and ProductionControls structs.
+  They are made available here to avoid passing a SummaryState instance in
+  situations where it is not really needed.
 */
 
 
@@ -1321,9 +1321,12 @@ int Well::vfp_table_number() const {
         return this->injection->VFPTableNumber;
 }
 
+/*
+  This short circuits the UDA and assumes the UDA contains a double.
+*/
 double Well::alq_value() const {
     if (this->wtype.producer())
-        return this->production->ALQValue;
+        return this->production->ALQValue.getSI();
 
     throw std::runtime_error("Can not ask for ALQ value in an injector");
 }

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WCONHIST
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WCONHIST
@@ -43,7 +43,7 @@
     },
     {
       "name": "ALQ",
-      "value_type": "DOUBLE",
+      "value_type": "UDA",
       "default": 0,
       "comment": "The default is a state variable"
     },

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WCONPROD
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WCONPROD
@@ -66,7 +66,7 @@
     },
     {
       "name": "ALQ",
-      "value_type": "DOUBLE",
+      "value_type": "UDA",
       "default": 0
     },
     {

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -677,7 +677,7 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_NON_Defaulted_VFP)
 
     BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::Well::ProducerCMode::BHP));
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 3);
-    BOOST_CHECK_EQUAL(p.ALQValue, 10.);
+    BOOST_CHECK_EQUAL(p.ALQValue.get<double>(), 10.);
     const auto& controls = p.controls(st, 0);
     BOOST_CHECK_EQUAL(controls.bhp_limit, 101325.);
 }
@@ -717,7 +717,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_ORAT_CMode)
     BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::Well::ProducerCMode::BHP));
 
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 0);
-    BOOST_CHECK_EQUAL(p.ALQValue, 0.);
+    BOOST_CHECK_EQUAL(p.ALQValue.get<double>(), 0.);
 }
 
 BOOST_AUTO_TEST_CASE(WCONPROD_THP_CMode)
@@ -737,7 +737,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_THP_CMode)
     BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::Well::ProducerCMode::BHP));
 
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 8);
-    BOOST_CHECK_EQUAL(p.ALQValue, 13.);
+    BOOST_CHECK_EQUAL(p.ALQValue.get<double>(), 13.);
     BOOST_CHECK_EQUAL(p.THPTarget.getSI(), 1000000.); // 10 barsa
     BOOST_CHECK_EQUAL(p.BHPTarget.getSI(), 101325.); // 1 atm.
 }
@@ -759,7 +759,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_BHP_CMode)
     BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::Well::ProducerCMode::BHP));
 
     BOOST_CHECK_EQUAL(p.VFPTableNumber, 8);
-    BOOST_CHECK_EQUAL(p.ALQValue, 13.);
+    BOOST_CHECK_EQUAL(p.ALQValue.get<double>(), 13.);
     BOOST_CHECK_EQUAL(p.THPTarget.get<double>(), 10.); // 10 barsa
     BOOST_CHECK_EQUAL(p.BHPTarget.get<double>(), 20.); // 20 barsa
     BOOST_CHECK_EQUAL(p.THPTarget.getSI(), 1000000.); // 10 barsa
@@ -822,7 +822,6 @@ BOOST_AUTO_TEST_CASE(ExtraAccessors) {
     prod_props->VFPTableNumber = 200;
     prod.updateProduction(prod_props);
 
-    BOOST_CHECK_THROW(inj.alq_value(), std::runtime_error);
     BOOST_CHECK_THROW(prod.temperature(), std::runtime_error);
     BOOST_CHECK_EQUAL(inj.vfp_table_number(), 100);
     BOOST_CHECK_EQUAL(prod.vfp_table_number(), 200);


### PR DESCRIPTION
With this PR opm-common accepts 'UDA' values for ALQ in WCONPROD / WCONHIST. Downstream the simulator will still access the ALQ values as double only - and there weill be an exception if trying to simulate with UDA values for ALQ.

Updating the simulator to handle UDA values is actually a quite small task; I started on it - but I would prefer to get this in first. 