### PR TITLE
Use std::optional<double> for ICD maximum flow rate

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
@@ -22,6 +22,7 @@
 #define SPIRALICD_HPP_HEADER_INCLUDED
 
 #include <map>
+#include <optional>
 #include <utility>
 #include <vector>
 #include <string>
@@ -45,7 +46,7 @@ namespace Opm {
              double widthTransitionRegion,
              double maxViscosityRatio,
              int methodFlowScaling,
-             double maxAbsoluteRate,
+             const std::optional<double>& maxAbsoluteRate,
              ICDStatus status,
              double scalingFactor);
 
@@ -58,7 +59,7 @@ namespace Opm {
         static std::map<std::string, std::vector<std::pair<int, SICD> > >
         fromWSEGSICD(const DeckKeyword& wsegsicd);
 
-        double maxAbsoluteRate() const;
+        const std::optional<double>& maxAbsoluteRate() const;
         ICDStatus status() const;
         double strength() const;
         double length() const;
@@ -126,11 +127,11 @@ namespace Opm {
         double m_width_transition_region;
         double m_max_viscosity_ratio;
         int m_method_flow_scaling;
-        double m_max_absolute_rate;
+        std::optional<double> m_max_absolute_rate;
         ICDStatus m_status;
         // scaling factor is the only one can not be gotten from deck directly, needs to be
         // updated afterwards
-        double m_scaling_factor;
+        std::optional<double> m_scaling_factor;
 };
 
 }

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -603,8 +603,8 @@ namespace {
             rSeg[baseIndex + Ix::MaxEmulsionRatio] =
                 sicd.maxViscosityRatio();
 
-            rSeg[baseIndex + Ix::MaxValidFlowRate] =
-                usys.from_si(M::geometric_volume_rate, sicd.maxAbsoluteRate());
+            const auto& max_rate = sicd.maxAbsoluteRate();
+            rSeg[baseIndex + Ix::MaxValidFlowRate] = max_rate.has_value() ? usys.from_si(M::geometric_volume_rate, max_rate.value()) : -1;
 
             rSeg[baseIndex + Ix::ICDLength] =
                 usys.from_si(M::length, sicd.length());

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -129,7 +129,7 @@ WSEGAICD
     BOOST_CHECK(Opm::Segment::SegmentType::AICD == segment.segmentType());
 
     auto aicd = segment.autoICD();
-    BOOST_CHECK_GT(aicd.maxAbsoluteRate(), 1.e99);
+    BOOST_CHECK(!aicd.maxAbsoluteRate().has_value());
     BOOST_CHECK(aicd.status()==Opm::ICDStatus::SHUT);
     // 0.002 bars*day*day/Volume^2
     BOOST_CHECK_EQUAL(aicd.strength(), 0.002*1.e5*86400.*86400.);
@@ -282,7 +282,7 @@ WSEGSICD
     BOOST_CHECK(Opm::Segment::SegmentType::SICD==segment.segmentType());
 
     auto sicd = segment.spiralICD();
-    BOOST_CHECK_GT(sicd.maxAbsoluteRate(), 1.e99);
+    BOOST_CHECK(!sicd.maxAbsoluteRate().has_value());
     BOOST_CHECK(sicd.status()==Opm::ICDStatus::SHUT);
     // 0.002 bars*day*day/Volume^2
     BOOST_CHECK_EQUAL(sicd.strength(), 0.002*1.e5*86400.*86400.);


### PR DESCRIPTION
Use `std::optional<double>` to hold ICD max flow rate.

@jalvestad : with this it should be possible to avoid the ` == std::numeric_limits<double>::max` in #2319 