### PR TITLE
Add fieldprops argument to SummaryConfig constructor

### DIFF
--- a/examples/msim.cpp
+++ b/examples/msim.cpp
@@ -43,7 +43,7 @@ int main(int /* argc */, char** argv) {
     Opm::Deck deck = parser.parseFile(deck_file, parse_context, error_guard);
     Opm::EclipseState state(deck);
     Opm::Schedule schedule(deck, state, parse_context, error_guard, python);
-    Opm::SummaryConfig summary_config(deck, schedule, state.getTableManager(), state.aquifer(),
+    Opm::SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer(),
                                       parse_context, error_guard);
 
     if (error_guard) {

--- a/examples/opmi.cpp
+++ b/examples/opmi.cpp
@@ -71,7 +71,7 @@ inline void loadDeck( const char * deck_file) {
     std::cout << "creating SummaryConfig .... ";  std::cout.flush();
 
     start = Opm::TimeService::now();
-    Opm::SummaryConfig summary( deck, schedule, state.getTableManager( ), state.aquifer(),
+    Opm::SummaryConfig summary( deck, schedule, state.fieldProps(), state.getTableManager( ), state.aquifer(),
                                 parseContext, errors );
     auto summary_time = Opm::TimeService::now() - start;
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -128,6 +128,7 @@ namespace Opm {
     class Schedule;
     class TableManager;
     class AquiferConfig;
+    class FieldPropsManager;
 
     class SummaryConfig {
         public:
@@ -138,6 +139,7 @@ namespace Opm {
             SummaryConfig() = default;
             SummaryConfig( const Deck&,
                            const Schedule&,
+                           const FieldPropsManager&,
                            const TableManager&,
                            const AquiferConfig&,
                            const ParseContext&,
@@ -146,6 +148,7 @@ namespace Opm {
             template <typename T>
             SummaryConfig( const Deck&,
                            const Schedule&,
+                           const FieldPropsManager&,
                            const TableManager&,
                            const AquiferConfig&,
                            const ParseContext&,
@@ -153,6 +156,7 @@ namespace Opm {
 
             SummaryConfig( const Deck&,
                            const Schedule&,
+                           const FieldPropsManager&,
                            const TableManager&,
                            const AquiferConfig&);
 
@@ -220,6 +224,7 @@ namespace Opm {
         private:
             SummaryConfig( const Deck& deck,
                            const Schedule& schedule,
+                           const FieldPropsManager& field_props,
                            const TableManager& tables,
                            const AquiferConfig& aquiferConfig,
                            const ParseContext& parseContext,

--- a/python/cxx/eclipse_config.cpp
+++ b/python/cxx/eclipse_config.cpp
@@ -18,7 +18,7 @@ void python::common::export_EclipseConfig(py::module& module)
 
     py::class_< SummaryConfig >( module, "SummaryConfig")
         .def(py::init([](const Deck& deck, const EclipseState& state, const Schedule& schedule) {
-           return SummaryConfig( deck, schedule, state.getTableManager(), state.aquifer() );
+            return SummaryConfig( deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer() );
          }  )  )
 
         .def( "__contains__",    &SummaryConfig::hasKeyword );

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -51,6 +51,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 
 
 namespace Opm {
@@ -746,7 +747,7 @@ inline void keywordR2R( SummaryConfig::keyword_list& /* list */,
 
 inline void keywordR( SummaryConfig::keyword_list& list,
                       const DeckKeyword& deck_keyword,
-                      const Schedule& schedule, 
+                      const Schedule& schedule,
                       const TableManager& tables,
                       const ParseContext& parseContext,
                       ErrorGuard& errors ) {
@@ -1367,6 +1368,7 @@ bool operator<(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
 
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
+                              const FieldPropsManager& field_props,
                               const TableManager& tables,
                               const AquiferConfig& aquiferConfig,
                               const ParseContext& parseContext,
@@ -1418,30 +1420,33 @@ SummaryConfig::SummaryConfig( const Deck& deck,
 
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
+                              const FieldPropsManager& field_props,
                               const TableManager& tables,
                               const AquiferConfig& aquiferConfig,
                               const ParseContext& parseContext,
                               ErrorGuard& errors) :
-    SummaryConfig( deck , schedule, tables, aquiferConfig, parseContext, errors, GridDims( deck ))
+    SummaryConfig( deck , schedule, field_props, tables, aquiferConfig, parseContext, errors, GridDims( deck ))
 { }
 
 
 template <typename T>
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
+                              const FieldPropsManager& field_props,
                               const TableManager& tables,
                               const AquiferConfig& aquiferConfig,
                               const ParseContext& parseContext,
                               T&& errors) :
-        SummaryConfig(deck, schedule, tables, aquiferConfig, parseContext, errors)
+    SummaryConfig(deck, schedule, field_props, tables, aquiferConfig, parseContext, errors)
 {}
 
 
 SummaryConfig::SummaryConfig( const Deck& deck,
-               const Schedule& schedule,
-               const TableManager& tables,
-               const AquiferConfig& aquiferConfig) :
-    SummaryConfig(deck, schedule, tables, aquiferConfig, ParseContext(), ErrorGuard())
+                              const Schedule& schedule,
+                              const FieldPropsManager& field_props,
+                              const TableManager& tables,
+                              const AquiferConfig& aquiferConfig) :
+    SummaryConfig(deck, schedule, field_props, tables, aquiferConfig, ParseContext(), ErrorGuard())
 {}
 
 

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
     Deck deck = parser.parseFile("SPE1CASE1.DATA");
     EclipseState state(deck);
     Schedule schedule(deck, state, python);
-    SummaryConfig summary_config(deck, schedule, state.getTableManager(), state.aquifer());
+    SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer());
     msim msim(state);
 
     msim.well_rate("PROD", data::Rates::opt::oil, prod_opr);

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -63,7 +63,7 @@ struct test_data {
         state( this->deck ),
         python( std::make_shared<Python>() ),
         schedule( this->deck, this->state, this->python),
-        summary_config( this->deck, this->schedule, this->state.getTableManager(), this->state.aquifer() )
+        summary_config( this->deck, this->schedule, this->state.fieldProps(), this->state.getTableManager(), this->state.aquifer() )
     {
         auto& ioconfig = this->state.getIOConfig();
         ioconfig.setBaseName("MSIM");

--- a/tests/msim/test_msim_EXIT.cpp
+++ b/tests/msim/test_msim_EXIT.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(MSIM_EXIT_TEST) {
     Opm::Deck deck = parser.parseFile(deck_file);
     Opm::EclipseState state(deck);
     Opm::Schedule schedule(deck, state, python);
-    Opm::SummaryConfig summary_config(deck, schedule, state.getTableManager(), state.aquifer());
+    Opm::SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer());
 
     {
         WorkArea work_area("test_msim");

--- a/tests/parser/PAvgTests.cpp
+++ b/tests/parser/PAvgTests.cpp
@@ -193,7 +193,7 @@ END
     const auto es    = EclipseState{ deck };
     const auto grid  = es.getInputGrid();
     auto       sched = Schedule{ deck, es };
-    auto       summary_config = SummaryConfig{deck, sched, es.getTableManager(), es.aquifer()};
+    auto       summary_config = SummaryConfig{deck, sched, es.fieldProps(), es.getTableManager(), es.aquifer()};
     const auto& w1 = sched.getWell("P1", 0);
     const auto& porv = es.globalFieldProps().porv(true);
     auto calc = w1.pavg_calculator(grid, porv);

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -181,7 +181,7 @@ static SummaryConfig createSummary( std::string input , const ParseContext& pars
     auto python = std::make_shared<Python>();
     EclipseState state( deck );
     Schedule schedule(deck, state, parseContext, errors, python);
-    return SummaryConfig(deck, schedule, state.getTableManager(), state.aquifer(), parseContext, errors);
+    return SummaryConfig(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer(), parseContext, errors);
 }
 
 BOOST_AUTO_TEST_CASE(wells_all) {
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(EMPTY) {
     auto python = std::make_shared<Python>();
     EclipseState state( deck );
     Schedule schedule(deck, state, python);
-    SummaryConfig conf(deck, schedule, state.getTableManager(), state.aquifer());
+    SummaryConfig conf(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer());
     BOOST_CHECK_EQUAL( conf.size(), 0U );
 }
 
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(wells_missingI) {
     parseContext.update(ParseContext::SUMMARY_UNKNOWN_WELL, InputError::THROW_EXCEPTION);
     EclipseState state( deck );
     Schedule schedule(deck, state, parseContext, errors, python );
-    BOOST_CHECK_NO_THROW(SummaryConfig(deck, schedule, state.getTableManager(), state.aquifer(), parseContext, errors));
+    BOOST_CHECK_NO_THROW(SummaryConfig(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer(), parseContext, errors));
 }
 
 
@@ -779,7 +779,7 @@ BOOST_AUTO_TEST_CASE(Summary_Segment)
 
     const auto schedule = Schedule { deck, state, python};
     const auto summary  = SummaryConfig {
-        deck, schedule, state.getTableManager(), state.aquifer()
+        deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer()
     };
 
     // SOFR PROD01 segments 1, 10, 21.
@@ -1123,7 +1123,7 @@ END
     const auto parseContext = ParseContext{};
     const auto state = EclipseState (deck);
     const auto schedule = Schedule (deck, state, parseContext, errors, std::make_shared<const Python>());
-    const auto smry = SummaryConfig(deck, schedule, state.getTableManager(), state.aquifer(), parseContext, errors);
+    const auto smry = SummaryConfig(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer(), parseContext, errors);
 
     BOOST_CHECK_MESSAGE(deck.hasKeyword("GPR"), R"(Deck must have "GPR" keyword)");
     BOOST_CHECK_MESSAGE(smry.hasKeyword("GPR"), R"(SummaryConfig must have "GPR" keyword)");

--- a/tests/parser/integration/parse_write.cpp
+++ b/tests/parser/integration/parse_write.cpp
@@ -34,7 +34,7 @@ inline void loadDeck( const char * deck_file) {
     auto deck = parser.parseFile(deck_file);
     Opm::EclipseState state( deck);
     Opm::Schedule schedule( deck, state, python);
-    Opm::SummaryConfig summary( deck, schedule, state.getTableManager( ), state.aquifer() );
+    Opm::SummaryConfig summary( deck, schedule, state.fieldProps(), state.getTableManager( ), state.aquifer() );
     {
         std::stringstream ss;
 

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         auto& eclGrid = es.getInputGrid();
         auto python = std::make_shared<Python>();
         Schedule schedule(deck, es, python);
-        SummaryConfig summary_config( deck, schedule, es.getTableManager( ), es.aquifer());
+        SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.getTableManager( ), es.aquifer());
         SummaryState st(TimeService::now());
         es.getIOConfig().setBaseName( "FOO" );
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         const auto numCells = grid.getCartesianSize( );
 
         const Schedule schedule(deck, eclipseState, python);
-        const SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ), eclipseState.aquifer() );
+        const SummaryConfig summary_config( deck, schedule, eclipseState.fieldProps(), eclipseState.getTableManager( ), eclipseState.aquifer() );
 
         EclipseIO eclipseWriter( eclipseState, grid, schedule, summary_config );
 
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
         const auto numCells = grid.getCartesianSize( );
 
         Schedule schedule(deck, eclipseState, python);
-        SummaryConfig summary_config( deck, schedule, eclipseState.getTableManager( ), eclipseState.aquifer() );
+        SummaryConfig summary_config( deck, schedule, eclipseState.fieldProps(), eclipseState.getTableManager( ), eclipseState.aquifer() );
         SummaryState st(Opm::TimeService::now());
         Action::State action_state;
         UDQState udq_state(10);

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -362,7 +362,7 @@ struct Setup {
         grid( es.getInputGrid( ) ),
         python( std::make_shared<Python>() ),
         schedule( deck, es, python ),
-        summary_config( deck, schedule, es.getTableManager( ), es.aquifer() )
+        summary_config( deck, schedule, es.fieldProps(), es.getTableManager( ), es.aquifer() )
     {
         auto& io_config = es.getIOConfig();
         io_config.setEclCompatibleRST(false);

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -456,7 +456,7 @@ struct setup {
         grid( es.getInputGrid() ),
         python( std::make_shared<Python>() ),
         schedule( deck, es, python),
-        config( deck, schedule, es.getTableManager(), es.aquifer()),
+        config( deck, schedule, es.fieldProps(), es.getTableManager(), es.aquifer()),
         wells( result_wells(w3_injector) ),
         grp_nwrk( result_group_nwrk() ),
         name( toupper(std::move(fname)) ),

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -233,7 +233,7 @@ struct setup {
         grid( es.getInputGrid() ),
         python( std::make_shared<Python>() ),
         schedule( deck, es, python),
-        config( deck, schedule, es.getTableManager(), es.aquifer() ),
+        config( deck, schedule, es.fieldProps(), es.getTableManager(), es.aquifer() ),
         wells( result_wells() ),
         grp_nwrk( result_group_network() ),
         name( toupper(std::move(fname)) ),

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     Opm::EclipseState es(deck);
     const Opm::EclipseGrid& grid = es.getInputGrid();
     Opm::Schedule schedule( deck, es, python);
-    Opm::SummaryConfig summary_config( deck, schedule, es.getTableManager( ), es.aquifer());
+    Opm::SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.getTableManager( ), es.aquifer());
     const auto num_cells = grid.getCartesianSize();
     Opm::EclipseIO eclipseWriter( es,  grid , schedule, summary_config);
     int countTimeStep = schedule.size() - 1;


### PR DESCRIPTION
This PR is just an API change; which is to prepare for better checking of summary keywords with arbitrary FIPNUM regions - like:
```
RPR__ABC
  1 2 3 /
```