### PR TITLE
Summary invalid fipnum

### DIFF
--- a/examples/msim.cpp
+++ b/examples/msim.cpp
@@ -43,7 +43,7 @@ int main(int /* argc */, char** argv) {
     Opm::Deck deck = parser.parseFile(deck_file, parse_context, error_guard);
     Opm::EclipseState state(deck);
     Opm::Schedule schedule(deck, state, parse_context, error_guard, python);
-    Opm::SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer(),
+    Opm::SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.aquifer(),
                                       parse_context, error_guard);
 
     if (error_guard) {

--- a/examples/opmi.cpp
+++ b/examples/opmi.cpp
@@ -71,7 +71,7 @@ inline void loadDeck( const char * deck_file) {
     std::cout << "creating SummaryConfig .... ";  std::cout.flush();
 
     start = Opm::TimeService::now();
-    Opm::SummaryConfig summary( deck, schedule, state.fieldProps(), state.getTableManager( ), state.aquifer(),
+    Opm::SummaryConfig summary( deck, schedule, state.fieldProps(), state.aquifer(),
                                 parseContext, errors );
     auto summary_time = Opm::TimeService::now() - start;
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -126,7 +126,6 @@ namespace Opm {
     class GridDims;
     class ParseContext;
     class Schedule;
-    class TableManager;
     class AquiferConfig;
     class FieldPropsManager;
 
@@ -140,7 +139,6 @@ namespace Opm {
             SummaryConfig( const Deck&,
                            const Schedule&,
                            const FieldPropsManager&,
-                           const TableManager&,
                            const AquiferConfig&,
                            const ParseContext&,
                            ErrorGuard&);
@@ -149,7 +147,6 @@ namespace Opm {
             SummaryConfig( const Deck&,
                            const Schedule&,
                            const FieldPropsManager&,
-                           const TableManager&,
                            const AquiferConfig&,
                            const ParseContext&,
                            T&&);
@@ -157,7 +154,6 @@ namespace Opm {
             SummaryConfig( const Deck&,
                            const Schedule&,
                            const FieldPropsManager&,
-                           const TableManager&,
                            const AquiferConfig&);
 
             SummaryConfig(const keyword_list& kwds,
@@ -225,7 +221,6 @@ namespace Opm {
             SummaryConfig( const Deck& deck,
                            const Schedule& schedule,
                            const FieldPropsManager& field_props,
-                           const TableManager& tables,
                            const AquiferConfig& aquiferConfig,
                            const ParseContext& parseContext,
                            ErrorGuard& errors,

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -304,6 +304,8 @@ class KeywordLocation;
         const static std::string SUMMARY_UNDEFINED_UDQ;
         const static std::string SUMMARY_UDQ_MISSING_UNIT;
         const static std::string SUMMARY_INVALID_FIPNUM;
+        const static std::string SUMMARY_EMPTY_REGION;
+        const static std::string SUMMARY_REGION_TOO_LARGE;
         /*
           A well must be specified (e.g. WELSPECS) and have completions
           (e.g. COMPDAT) to be able to set control mode (e.g. WCONPROD).

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -303,7 +303,7 @@ class KeywordLocation;
         const static std::string SUMMARY_UNHANDLED_KEYWORD;
         const static std::string SUMMARY_UNDEFINED_UDQ;
         const static std::string SUMMARY_UDQ_MISSING_UNIT;
-
+        const static std::string SUMMARY_INVALID_FIPNUM;
         /*
           A well must be specified (e.g. WELSPECS) and have completions
           (e.g. COMPDAT) to be able to set control mode (e.g. WCONPROD).

--- a/python/cxx/eclipse_config.cpp
+++ b/python/cxx/eclipse_config.cpp
@@ -18,7 +18,7 @@ void python::common::export_EclipseConfig(py::module& module)
 
     py::class_< SummaryConfig >( module, "SummaryConfig")
         .def(py::init([](const Deck& deck, const EclipseState& state, const Schedule& schedule) {
-            return SummaryConfig( deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer() );
+            return SummaryConfig( deck, schedule, state.fieldProps(), state.aquifer() );
          }  )  )
 
         .def( "__contains__",    &SummaryConfig::hasKeyword );

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -22,8 +22,10 @@
 #include <array>
 #include <iostream>
 #include <map>
+#include <set>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -40,7 +42,6 @@
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
@@ -57,6 +58,11 @@
 namespace Opm {
 
 namespace {
+
+struct SummaryConfigContext {
+    std::unordered_map<std::string, std::set<int>> regions;
+};
+
 
     const std::vector<std::string> ALL_keywords = {
         "FAQR",  "FAQRG", "FAQT", "FAQTG", "FGIP", "FGIPG", "FGIPL",
@@ -746,10 +752,10 @@ inline void keywordR2R( SummaryConfig::keyword_list& /* list */,
 
 
 inline void keywordR( SummaryConfig::keyword_list& list,
+                      SummaryConfigContext& context,
                       const DeckKeyword& deck_keyword,
                       const Schedule& schedule,
                       const FieldPropsManager& field_props,
-                      const TableManager& tables,
                       const ParseContext& parseContext,
                       ErrorGuard& errors ) {
 
@@ -764,21 +770,61 @@ inline void keywordR( SummaryConfig::keyword_list& list,
         if (!field_props.has_int(region_name)) {
             std::string msg_fmt = fmt::format("Problem with summary keyword {{keyword}}\n"
                                               "In {{file}} line {{line}}\n"
-                                              "FIP region {} not defined in REGIONS section - {keyword} ignored", region_name);
+                                              "FIP region {} not defined in REGIONS section - {{keyword}} ignored", region_name);
             parseContext.handleError(ParseContext::SUMMARY_INVALID_FIPNUM, msg_fmt, deck_keyword.location(), errors);
             return;
         }
     }
+    if (context.regions.count(region_name) == 0) {
+        const auto& fipnum = field_props.get_int(region_name);
+        context.regions.emplace( region_name, std::set<int>{ fipnum.begin(), fipnum.end()});
+    }
 
-    const size_t numfip = tables.numFIPRegions( );
     const auto& item = deck_keyword.getDataRecord().getDataItem();
     std::vector<int> regions;
 
-    if (item.data_size() > 0)
-        regions = item.getData< int >();
-    else {
-        for (size_t region=1; region <= numfip; region++)
-            regions.push_back( region );
+
+
+    /*
+      Assume that the FIPNUM array contains the values {1,2,4}; i.e. the maximum
+      value is 4 and the value 3 is missing. Values which are too large, i.e. >
+      4 in this case - and values which are missing in the range are treated
+      differently:
+
+         region_id >= 5: The requested region results are completely ignored.
+
+         region_id == 3: The summary file will contain a vector Rxxx:3 with the
+         value 0.
+
+      These behaviors are closely tied to the implementation in opm-simulators
+      which actually performs the region summation; and that is also the main
+      reason to treat these quite similar error conditions differently.
+    */
+
+    if (item.data_size() > 0) {
+        for (const auto& region_id : item.getData<int>()) {
+            const auto& region_set = context.regions.at(region_name);
+            auto max_iter = region_set.rbegin();
+            if (region_id > *max_iter) {
+                std::string msg_fmt = fmt::format("Problem with summary keyword {{keyword}}\n"
+                                                  "In {{file}} line {{line}}\n"
+                                                  "FIP region {} not present in {} - ignored", region_id, region_name);
+                parseContext.handleError(ParseContext::SUMMARY_REGION_TOO_LARGE, msg_fmt, deck_keyword.location(), errors);
+                continue;
+            }
+
+            if (region_set.count(region_id) == 0) {
+                std::string msg_fmt = fmt::format("Problem with summary keyword {{keyword}}\n"
+                                                  "In {{file}} line {{line}}\n"
+                                                  "FIP region {} not present in {} - will use 0", region_id, region_name);
+                parseContext.handleError(ParseContext::SUMMARY_EMPTY_REGION, msg_fmt, deck_keyword.location(), errors);
+            }
+
+            regions.push_back( region_id );
+        }
+    } else {
+        for (const auto& region_id : context.regions.at(region_name))
+            regions.push_back( region_id );
     }
 
     // See comment on function roew() in Summary.cpp for this weirdness.
@@ -803,10 +849,8 @@ inline void keywordR( SummaryConfig::keyword_list& list,
     .fip_region( region_name )
     .isUserDefined( is_udq(keyword) );
 
-    for( const int region : regions ) {
-        if (region >= 1 && region <= static_cast<int>(numfip))
-            list.push_back( param.number( region ) );
-    }
+    for( const auto& region : regions )
+        list.push_back( param.number( region ) );
 }
 
 
@@ -1081,11 +1125,11 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
     }
 
   inline void handleKW( SummaryConfig::keyword_list& list,
+                        SummaryConfigContext& context,
                         const std::vector<std::string>& node_names,
                         const DeckKeyword& keyword,
                         const Schedule& schedule,
                         const FieldPropsManager& field_props,
-                        const TableManager& tables,
                         const AquiferConfig& aquiferConfig,
                         const ParseContext& parseContext,
                         ErrorGuard& errors,
@@ -1101,7 +1145,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
         case Cat::Group: return keywordG( list, parseContext, errors, keyword, schedule );
         case Cat::Field: return keywordF( list, keyword );
         case Cat::Block: return keywordB( list, keyword, dims );
-        case Cat::Region: return keywordR( list, keyword, schedule, field_props, tables, parseContext, errors );
+        case Cat::Region: return keywordR( list, context, keyword, schedule, field_props, parseContext, errors );
         case Cat::Connection: return keywordC( list, parseContext, errors, keyword, schedule, dims);
         case Cat::Segment: return keywordS( list, parseContext, errors, keyword, schedule );
         case Cat::Node: return keyword_node( list, node_names, parseContext, errors, keyword );
@@ -1120,7 +1164,6 @@ inline void handleKW( SummaryConfig::keyword_list& list,
                       const std::string& keyword,
                       const KeywordLocation& location,
                       const Schedule& schedule,
-                      const FieldPropsManager& field_props,
                       const AquiferConfig& aquiferConfig,
                       const ParseContext& /* parseContext */,
                       ErrorGuard& /* errors */) {
@@ -1380,21 +1423,20 @@ bool operator<(const SummaryConfigNode& lhs, const SummaryConfigNode& rhs)
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
                               const FieldPropsManager& field_props,
-                              const TableManager& tables,
                               const AquiferConfig& aquiferConfig,
                               const ParseContext& parseContext,
                               ErrorGuard& errors,
                               const GridDims& dims) {
     try {
         SUMMARYSection section( deck );
-
+        SummaryConfigContext context;
         const auto node_names = need_node_names(section) ? collect_node_names(schedule) : std::vector<std::string> {};
 
         for (const auto& kw : section) {
             if (is_processing_instruction(kw.name())) {
                 handleProcessingInstruction(kw.name());
             } else {
-                handleKW(this->m_keywords, node_names, kw, schedule, field_props, tables, aquiferConfig, parseContext, errors, dims);
+                handleKW(this->m_keywords, context, node_names, kw, schedule, field_props, aquiferConfig, parseContext, errors, dims);
             }
         }
 
@@ -1406,7 +1448,7 @@ SummaryConfig::SummaryConfig( const Deck& deck,
                         KeywordLocation location = deck_keyword.location();
                         location.keyword = fmt::format("{}/{}", meta_pair.first, kw);
 
-                        handleKW(this->m_keywords, kw, location, schedule, field_props, aquiferConfig, parseContext, errors);
+                        handleKW(this->m_keywords, kw, location, schedule, aquiferConfig, parseContext, errors);
                     }
                 }
             }
@@ -1432,11 +1474,10 @@ SummaryConfig::SummaryConfig( const Deck& deck,
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
                               const FieldPropsManager& field_props,
-                              const TableManager& tables,
                               const AquiferConfig& aquiferConfig,
                               const ParseContext& parseContext,
                               ErrorGuard& errors) :
-    SummaryConfig( deck , schedule, field_props, tables, aquiferConfig, parseContext, errors, GridDims( deck ))
+    SummaryConfig( deck , schedule, field_props, aquiferConfig, parseContext, errors, GridDims( deck ))
 { }
 
 
@@ -1444,20 +1485,18 @@ template <typename T>
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
                               const FieldPropsManager& field_props,
-                              const TableManager& tables,
                               const AquiferConfig& aquiferConfig,
                               const ParseContext& parseContext,
                               T&& errors) :
-    SummaryConfig(deck, schedule, field_props, tables, aquiferConfig, parseContext, errors)
+    SummaryConfig(deck, schedule, field_props, aquiferConfig, parseContext, errors)
 {}
 
 
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,
                               const FieldPropsManager& field_props,
-                              const TableManager& tables,
                               const AquiferConfig& aquiferConfig) :
-    SummaryConfig(deck, schedule, field_props, tables, aquiferConfig, ParseContext(), ErrorGuard())
+    SummaryConfig(deck, schedule, field_props, aquiferConfig, ParseContext(), ErrorGuard())
 {}
 
 

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -104,7 +104,7 @@ namespace Opm {
         addKey(SUMMARY_UNHANDLED_KEYWORD, InputError::WARN);
         addKey(SUMMARY_UNDEFINED_UDQ, InputError::WARN);
         addKey(SUMMARY_UDQ_MISSING_UNIT, InputError::WARN);
-        addKey(SCHEDULE_INVALID_NAME, InputError::THROW_EXCEPTION);
+        this->addKey(SUMMARY_INVALID_FIPNUM, InputError::WARN);
 
         addKey(ACTIONX_ILLEGAL_KEYWORD, InputError::THROW_EXCEPTION);
 
@@ -122,6 +122,7 @@ namespace Opm {
         this->addKey(SCHEDULE_IGNORED_GUIDE_RATE, InputError::WARN);
         this->addKey(SCHEDULE_COMPSEGS_INVALID, InputError::THROW_EXCEPTION);
         this->addKey(SCHEDULE_COMPSEGS_NOT_SUPPORTED, InputError::THROW_EXCEPTION);
+        addKey(SCHEDULE_INVALID_NAME, InputError::THROW_EXCEPTION);
     }
 
     void ParseContext::initEnv() {
@@ -350,6 +351,7 @@ namespace Opm {
     const std::string ParseContext::SUMMARY_UNHANDLED_KEYWORD = "SUMMARY_UNHANDLED_KEYWORD";
     const std::string ParseContext::SUMMARY_UNDEFINED_UDQ = "SUMMARY_UNDEFINED_UDQ";
     const std::string ParseContext::SUMMARY_UDQ_MISSING_UNIT = "SUMMARY_UDQ_MISSING_UNIT";
+    const std::string ParseContext::SUMMARY_INVALID_FIPNUM = "SUMMARY_INVALID_FIPNUM";
 
     const std::string ParseContext::RPT_MIXED_STYLE = "RPT_MIXED_STYLE";
     const std::string ParseContext::RPT_UNKNOWN_MNEMONIC = "RPT_UNKNOWN_MNEMONIC";

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -105,6 +105,8 @@ namespace Opm {
         addKey(SUMMARY_UNDEFINED_UDQ, InputError::WARN);
         addKey(SUMMARY_UDQ_MISSING_UNIT, InputError::WARN);
         this->addKey(SUMMARY_INVALID_FIPNUM, InputError::WARN);
+        this->addKey(SUMMARY_EMPTY_REGION, InputError::WARN);
+        this->addKey(SUMMARY_REGION_TOO_LARGE, InputError::WARN);
 
         addKey(ACTIONX_ILLEGAL_KEYWORD, InputError::THROW_EXCEPTION);
 
@@ -352,6 +354,8 @@ namespace Opm {
     const std::string ParseContext::SUMMARY_UNDEFINED_UDQ = "SUMMARY_UNDEFINED_UDQ";
     const std::string ParseContext::SUMMARY_UDQ_MISSING_UNIT = "SUMMARY_UDQ_MISSING_UNIT";
     const std::string ParseContext::SUMMARY_INVALID_FIPNUM = "SUMMARY_INVALID_FIPNUM";
+    const std::string ParseContext::SUMMARY_EMPTY_REGION = "SUMMARY_EMPTY_REGION";
+    const std::string ParseContext::SUMMARY_REGION_TOO_LARGE = "SUMMARY_REGION_TOO_LARGE";
 
     const std::string ParseContext::RPT_MIXED_STYLE = "RPT_MIXED_STYLE";
     const std::string ParseContext::RPT_UNKNOWN_MNEMONIC = "RPT_UNKNOWN_MNEMONIC";

--- a/tests/SPE1CASE1.DATA
+++ b/tests/SPE1CASE1.DATA
@@ -246,6 +246,10 @@ PVTO
 -- so it is possible to use the assumption described above. 
 -- An equivalent approximation for the viscosity has been used.
 /
+REGIONS
+
+FIPNUM
+  300*1 / 
 
 SOLUTION
 -- -------------------------------------------------------------------------

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
     Deck deck = parser.parseFile("SPE1CASE1.DATA");
     EclipseState state(deck);
     Schedule schedule(deck, state, python);
-    SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer());
+    SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.aquifer());
     msim msim(state);
 
     msim.well_rate("PROD", data::Rates::opt::oil, prod_opr);

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -63,7 +63,7 @@ struct test_data {
         state( this->deck ),
         python( std::make_shared<Python>() ),
         schedule( this->deck, this->state, this->python),
-        summary_config( this->deck, this->schedule, this->state.fieldProps(), this->state.getTableManager(), this->state.aquifer() )
+        summary_config( this->deck, this->schedule, this->state.fieldProps(), this->state.aquifer() )
     {
         auto& ioconfig = this->state.getIOConfig();
         ioconfig.setBaseName("MSIM");

--- a/tests/msim/test_msim_EXIT.cpp
+++ b/tests/msim/test_msim_EXIT.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(MSIM_EXIT_TEST) {
     Opm::Deck deck = parser.parseFile(deck_file);
     Opm::EclipseState state(deck);
     Opm::Schedule schedule(deck, state, python);
-    Opm::SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer());
+    Opm::SummaryConfig summary_config(deck, schedule, state.fieldProps(), state.aquifer());
 
     {
         WorkArea work_area("test_msim");

--- a/tests/parser/PAvgTests.cpp
+++ b/tests/parser/PAvgTests.cpp
@@ -193,7 +193,7 @@ END
     const auto es    = EclipseState{ deck };
     const auto grid  = es.getInputGrid();
     auto       sched = Schedule{ deck, es };
-    auto       summary_config = SummaryConfig{deck, sched, es.fieldProps(), es.getTableManager(), es.aquifer()};
+    auto       summary_config = SummaryConfig{deck, sched, es.fieldProps(), es.aquifer()};
     const auto& w1 = sched.getWell("P1", 0);
     const auto& porv = es.globalFieldProps().porv(true);
     auto calc = w1.pavg_calculator(grid, porv);

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -1364,3 +1364,25 @@ WBP9
     BOOST_CHECK(summary_config.hasKeyword("WBP5"));
     BOOST_CHECK(summary_config.hasKeyword("WBP9"));
 }
+
+BOOST_AUTO_TEST_CASE( SUMMARY_INVALID_FIPNUM ) {
+    const std::string input = R"(
+RPR__ABC
+1 2 3 /
+
+RWIP_REG
+1 2 3 /
+)";
+
+    ParseContext parse_context;
+    {
+        parse_context.update(ParseContext::SUMMARY_INVALID_FIPNUM, InputError::IGNORE);
+        const auto& summary_config = createSummary(input, parse_context);
+        BOOST_CHECK(summary_config.hasKeyword("RWIP_REG"));
+        BOOST_CHECK(!summary_config.hasKeyword("RPR__ABC"));
+    }
+    {
+        parse_context.update(ParseContext::SUMMARY_INVALID_FIPNUM, InputError::THROW_EXCEPTION);
+        BOOST_CHECK_THROW(createSummary(input, parse_context), std::exception);
+    }
+}

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -181,7 +181,7 @@ static SummaryConfig createSummary( std::string input , const ParseContext& pars
     auto python = std::make_shared<Python>();
     EclipseState state( deck );
     Schedule schedule(deck, state, parseContext, errors, python);
-    return SummaryConfig(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer(), parseContext, errors);
+    return SummaryConfig(deck, schedule, state.fieldProps(), state.aquifer(), parseContext, errors);
 }
 
 BOOST_AUTO_TEST_CASE(wells_all) {
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(EMPTY) {
     auto python = std::make_shared<Python>();
     EclipseState state( deck );
     Schedule schedule(deck, state, python);
-    SummaryConfig conf(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer());
+    SummaryConfig conf(deck, schedule, state.fieldProps(), state.aquifer());
     BOOST_CHECK_EQUAL( conf.size(), 0U );
 }
 
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(wells_missingI) {
     parseContext.update(ParseContext::SUMMARY_UNKNOWN_WELL, InputError::THROW_EXCEPTION);
     EclipseState state( deck );
     Schedule schedule(deck, state, parseContext, errors, python );
-    BOOST_CHECK_NO_THROW(SummaryConfig(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer(), parseContext, errors));
+    BOOST_CHECK_NO_THROW(SummaryConfig(deck, schedule, state.fieldProps(), state.aquifer(), parseContext, errors));
 }
 
 
@@ -779,7 +779,7 @@ BOOST_AUTO_TEST_CASE(Summary_Segment)
 
     const auto schedule = Schedule { deck, state, python};
     const auto summary  = SummaryConfig {
-        deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer()
+        deck, schedule, state.fieldProps(), state.aquifer()
     };
 
     // SOFR PROD01 segments 1, 10, 21.
@@ -1123,7 +1123,7 @@ END
     const auto parseContext = ParseContext{};
     const auto state = EclipseState (deck);
     const auto schedule = Schedule (deck, state, parseContext, errors, std::make_shared<const Python>());
-    const auto smry = SummaryConfig(deck, schedule, state.fieldProps(), state.getTableManager(), state.aquifer(), parseContext, errors);
+    const auto smry = SummaryConfig(deck, schedule, state.fieldProps(), state.aquifer(), parseContext, errors);
 
     BOOST_CHECK_MESSAGE(deck.hasKeyword("GPR"), R"(Deck must have "GPR" keyword)");
     BOOST_CHECK_MESSAGE(smry.hasKeyword("GPR"), R"(SummaryConfig must have "GPR" keyword)");
@@ -1374,6 +1374,15 @@ RWIP_REG
 1 2 3 /
 )";
 
+    const std::string input_too_large = R"(
+RPR
+1 2 3  99 /
+)";
+
+    const std::string input_empty= R"(
+RPR__REG
+15 /
+)";
     ParseContext parse_context;
     {
         parse_context.update(ParseContext::SUMMARY_INVALID_FIPNUM, InputError::IGNORE);
@@ -1384,5 +1393,27 @@ RWIP_REG
     {
         parse_context.update(ParseContext::SUMMARY_INVALID_FIPNUM, InputError::THROW_EXCEPTION);
         BOOST_CHECK_THROW(createSummary(input, parse_context), std::exception);
+    }
+
+    {
+        parse_context.update(ParseContext::SUMMARY_REGION_TOO_LARGE, InputError::THROW_EXCEPTION);
+        BOOST_CHECK_THROW(createSummary(input_too_large, parse_context), std::exception);
+    }
+
+    {
+        parse_context.update(ParseContext::SUMMARY_REGION_TOO_LARGE, InputError::IGNORE);
+        const auto& summary_config = createSummary(input_too_large, parse_context);
+        BOOST_CHECK_EQUAL( summary_config.size(), 3);
+    }
+
+    {
+        parse_context.update(ParseContext::SUMMARY_EMPTY_REGION, InputError::THROW_EXCEPTION);
+        BOOST_CHECK_THROW(createSummary(input_empty, parse_context), std::exception);
+    }
+
+    {
+        parse_context.update(ParseContext::SUMMARY_EMPTY_REGION, InputError::IGNORE);
+        const auto& summary_config = createSummary(input_empty, parse_context);
+        BOOST_CHECK_EQUAL( summary_config.size(), 1);
     }
 }

--- a/tests/parser/integration/parse_write.cpp
+++ b/tests/parser/integration/parse_write.cpp
@@ -34,7 +34,7 @@ inline void loadDeck( const char * deck_file) {
     auto deck = parser.parseFile(deck_file);
     Opm::EclipseState state( deck);
     Opm::Schedule schedule( deck, state, python);
-    Opm::SummaryConfig summary( deck, schedule, state.fieldProps(), state.getTableManager( ), state.aquifer() );
+    Opm::SummaryConfig summary( deck, schedule, state.fieldProps(), state.aquifer() );
     {
         std::stringstream ss;
 

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
         auto& eclGrid = es.getInputGrid();
         auto python = std::make_shared<Python>();
         Schedule schedule(deck, es, python);
-        SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.getTableManager( ), es.aquifer());
+        SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.aquifer());
         SummaryState st(TimeService::now());
         es.getIOConfig().setBaseName( "FOO" );
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         const auto numCells = grid.getCartesianSize( );
 
         const Schedule schedule(deck, eclipseState, python);
-        const SummaryConfig summary_config( deck, schedule, eclipseState.fieldProps(), eclipseState.getTableManager( ), eclipseState.aquifer() );
+        const SummaryConfig summary_config( deck, schedule, eclipseState.fieldProps(), eclipseState.aquifer() );
 
         EclipseIO eclipseWriter( eclipseState, grid, schedule, summary_config );
 
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
         const auto numCells = grid.getCartesianSize( );
 
         Schedule schedule(deck, eclipseState, python);
-        SummaryConfig summary_config( deck, schedule, eclipseState.fieldProps(), eclipseState.getTableManager( ), eclipseState.aquifer() );
+        SummaryConfig summary_config( deck, schedule, eclipseState.fieldProps(), eclipseState.aquifer() );
         SummaryState st(Opm::TimeService::now());
         Action::State action_state;
         UDQState udq_state(10);

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -362,7 +362,7 @@ struct Setup {
         grid( es.getInputGrid( ) ),
         python( std::make_shared<Python>() ),
         schedule( deck, es, python ),
-        summary_config( deck, schedule, es.fieldProps(), es.getTableManager( ), es.aquifer() )
+        summary_config( deck, schedule, es.fieldProps(), es.aquifer() )
     {
         auto& io_config = es.getIOConfig();
         io_config.setEclCompatibleRST(false);

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -456,7 +456,7 @@ struct setup {
         grid( es.getInputGrid() ),
         python( std::make_shared<Python>() ),
         schedule( deck, es, python),
-        config( deck, schedule, es.fieldProps(), es.getTableManager(), es.aquifer()),
+        config( deck, schedule, es.fieldProps(), es.aquifer()),
         wells( result_wells(w3_injector) ),
         grp_nwrk( result_group_nwrk() ),
         name( toupper(std::move(fname)) ),
@@ -1365,7 +1365,7 @@ BOOST_AUTO_TEST_CASE(region_vars) {
 
     BOOST_CHECK( ecl_sum_has_general_var( resp , "RPR:1"));
     BOOST_CHECK( ecl_sum_has_general_var( resp , "RPR:10"));
-    BOOST_CHECK( !ecl_sum_has_general_var( resp , "RPR:11"));
+    BOOST_CHECK( !ecl_sum_has_general_var( resp , "RPR:21"));
     UnitSystem units( UnitSystem::UnitType::UNIT_TYPE_METRIC );
 
     for (size_t r=1; r <= 10; r++) {

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -233,7 +233,7 @@ struct setup {
         grid( es.getInputGrid() ),
         python( std::make_shared<Python>() ),
         schedule( deck, es, python),
-        config( deck, schedule, es.fieldProps(), es.getTableManager(), es.aquifer() ),
+        config( deck, schedule, es.fieldProps(), es.aquifer() ),
         wells( result_wells() ),
         grp_nwrk( result_group_network() ),
         name( toupper(std::move(fname)) ),

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
     Opm::EclipseState es(deck);
     const Opm::EclipseGrid& grid = es.getInputGrid();
     Opm::Schedule schedule( deck, es, python);
-    Opm::SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.getTableManager( ), es.aquifer());
+    Opm::SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.aquifer());
     const auto num_cells = grid.getCartesianSize();
     Opm::EclipseIO eclipseWriter( es,  grid , schedule, summary_config);
     int countTimeStep = schedule.size() - 1;


### PR DESCRIPTION
Handle various types of invalid summary region keywords; check that the FIPNUM region is defined; both in sense of the actual keyword and the numerical value.

Behavior controlled with ParseCOntext - default is a warning.
