### PR TITLE
Accept Temporary 'Dimension' Arguments in EclipseGrid Constructor

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -68,7 +68,7 @@ namespace Opm {
         EclipseGrid(size_t nx, size_t ny, size_t nz,
                     double dx = 1.0, double dy = 1.0, double dz = 1.0);
 
-        EclipseGrid(std::array<int, 3>& dims ,
+        EclipseGrid(const std::array<int, 3>& dims ,
                     const std::vector<double>& coord ,
                     const std::vector<double>& zcorn ,
                     const int * actnum = nullptr,

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -61,7 +61,7 @@
 namespace Opm {
 
 
-EclipseGrid::EclipseGrid(std::array<int, 3>& dims ,
+EclipseGrid::EclipseGrid(const std::array<int, 3>& dims ,
                          const std::vector<double>& coord ,
                          const std::vector<double>& zcorn ,
                          const int * actnum,


### PR DESCRIPTION
There's no need to require that the client creates an actual, mutable array object on the stack (or elsewhere) in order to form an `EclipseGrid` instance.

This is nevertheless mostly to make it easier to use the `COORD`/`ZCORN` constructor usable in unit tests.