### PR TITLE
Add Special Purpose Active Cell Enumeration by Columns 

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -278,6 +278,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/io/eclipse/rst/segment.cpp
           src/opm/io/eclipse/rst/state.cpp
           src/opm/io/eclipse/rst/well.cpp
+          src/opm/output/eclipse/ActiveIndexByColumns.cpp
           src/opm/output/eclipse/AggregateActionxData.cpp
           src/opm/output/eclipse/AggregateConnectionData.cpp
           src/opm/output/eclipse/AggregateGroupData.cpp
@@ -403,6 +404,7 @@ if(ENABLE_ECL_INPUT)
 endif()
 if(ENABLE_ECL_OUTPUT)
   list (APPEND TEST_SOURCE_FILES
+          tests/test_ActiveIndexByColumns.cpp
           tests/test_AggregateActionxData.cpp
           tests/test_AggregateWellData.cpp
           tests/test_AggregateGroupData.cpp
@@ -848,6 +850,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/VectorItems/msw.hpp
         opm/output/eclipse/VectorItems/tabdims.hpp
         opm/output/eclipse/VectorItems/well.hpp
+        opm/output/eclipse/ActiveIndexByColumns.hpp
         opm/output/eclipse/AggregateActionxData.hpp
         opm/output/eclipse/AggregateGroupData.hpp
         opm/output/eclipse/AggregateNetworkData.hpp

--- a/opm/output/eclipse/ActiveIndexByColumns.hpp
+++ b/opm/output/eclipse/ActiveIndexByColumns.hpp
@@ -46,9 +46,9 @@ public:
     /// \param[in] cartDims Model's Cartesian dimensions.
     /// \param[in] getIJK Call-back routine for retrieving the Cartesian
     ///    (I,J,K) tuple of an active cell index.
-    void buildMappingTables(const std::size_t                                           numActive,
-                            const std::array<int, 3>&                                   cartDims,
-                            const std::function<std::array<int, 3>(const std::size_t)>& getIJK);
+    explicit ActiveIndexByColumns(const std::size_t                                           numActive,
+                                  const std::array<int, 3>&                                   cartDims,
+                                  const std::function<std::array<int, 3>(const std::size_t)>& getIJK);
 
     /// Map active index in natural order to active index in columnar order.
     ///
@@ -67,8 +67,7 @@ private:
 };
 
 /// Build natural->columnar active cell index mapping from an EclipseGrid instance.
-void buildColumnarActiveIndexMappingTables(const EclipseGrid&    grid,
-                                           ActiveIndexByColumns& map);
+ActiveIndexByColumns buildColumnarActiveIndexMappingTables(const EclipseGrid& grid);
 
 } // namespace Opm
 

--- a/opm/output/eclipse/ActiveIndexByColumns.hpp
+++ b/opm/output/eclipse/ActiveIndexByColumns.hpp
@@ -1,0 +1,76 @@
+/*
+  Copyright (c) 2021 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ACTIVE_INDEX_BY_COLUMNS_HPP
+#define OPM_ACTIVE_INDEX_BY_COLUMNS_HPP
+
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+namespace Opm {
+    class EclipseGrid;
+}
+
+namespace Opm {
+
+/// Special purpose mapping facility to handle the output code's need to
+/// enumerate the active cells by columns (layer ID (K) cycling fastest,
+/// followed by J, followed by I) for aquifer connections.
+class ActiveIndexByColumns
+{
+public:
+    bool operator==(const ActiveIndexByColumns& rhs) const;
+
+    /// Create natural->columnar active cell index mapping.
+    ///
+    /// \param[in] numActive Number of active cells in model.
+    /// \param[in] cartDims Model's Cartesian dimensions.
+    /// \param[in] getIJK Call-back routine for retrieving the Cartesian
+    ///    (I,J,K) tuple of an active cell index.
+    void buildMappingTables(const std::size_t                                           numActive,
+                            const std::array<int, 3>&                                   cartDims,
+                            const std::function<std::array<int, 3>(const std::size_t)>& getIJK);
+
+    /// Map active index in natural order to active index in columnar order.
+    ///
+    /// The output code needs return type \c int here, so use that instead
+    /// of \code std::size_t \endcode.
+    int getColumnarActiveIndex(const std::size_t naturalActiveIndex) const
+    {
+        assert ((naturalActiveIndex < this->natural2columnar_.size())
+                && "Natural active cell index out of bounds");
+
+        return this->natural2columnar_[naturalActiveIndex];
+    }
+
+private:
+    std::vector<int> natural2columnar_;
+};
+
+/// Build natural->columnar active cell index mapping from an EclipseGrid instance.
+void buildColumnarActiveIndexMappingTables(const EclipseGrid&    grid,
+                                           ActiveIndexByColumns& map);
+
+} // namespace Opm
+
+
+#endif // OPM_ACTIVE_INDEX_BY_COLUMNS_HPP

--- a/src/opm/output/eclipse/ActiveIndexByColumns.cpp
+++ b/src/opm/output/eclipse/ActiveIndexByColumns.cpp
@@ -1,0 +1,98 @@
+/*
+  Copyright (c) 2021 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/ActiveIndexByColumns.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <numeric>
+#include <vector>
+
+namespace {
+    std::size_t columnarGlobalIdx(const std::array<int, 3>& dims,
+                                  const std::array<int, 3>& ijk)
+    {
+        // Linear index assuming C-like loop order
+        //
+        //     for (i = 0 .. Nx - 1)
+        //         for (j = 0 .. Ny - 1)
+        //             for (k = 0 .. Nz - 1)
+        //
+        // as opposed to the usual Fortran-like loop order ("natural ordering")
+        //
+        //     for (k = 0 .. Nz - 1)
+        //         for (j = 0 .. Ny - 1)
+        //             for (i = 0 .. Nx - 1)
+        //
+        return ijk[2] + dims[2]*(ijk[1] + dims[1]*ijk[0]);
+    }
+}
+
+bool Opm::ActiveIndexByColumns::operator==(const ActiveIndexByColumns& rhs) const
+{
+    return this->natural2columnar_ == rhs.natural2columnar_;
+}
+
+void
+Opm::ActiveIndexByColumns::
+buildMappingTables(const std::size_t                                           numActive,
+                   const std::array<int, 3>&                                   cartDims,
+                   const std::function<std::array<int, 3>(const std::size_t)>& getIJK)
+{
+    // Algorithm:
+    //
+    //   1. Mark active cells as such, using column-based active index in global array.
+    //   2. Accumulate number of active cells in global array.
+    //   3. Extract column-based active index from global array, push back
+    //      into natural2columnar_ according to natural numbering of active cells.
+
+    auto cartesianActive = std::vector<int>(cartDims[0] * cartDims[1] * cartDims[2], 0);
+    auto colActIx = [&cartDims, &getIJK, &cartesianActive](const std::size_t activeCell) -> int&
+    {
+        return cartesianActive[columnarGlobalIdx(cartDims, getIJK(activeCell))];
+    };
+
+    for (auto activeCell = 0*numActive; activeCell < numActive; ++activeCell) {
+        colActIx(activeCell) = 1;
+    }
+
+    // Counts number of active cells (by columns) up to and including current.
+    std::partial_sum(cartesianActive.begin(), cartesianActive.end(), cartesianActive.begin());
+
+    this->natural2columnar_.clear();
+    this->natural2columnar_.reserve(numActive);
+    for (auto activeCell = 0*numActive; activeCell < numActive; ++activeCell) {
+        // Subtract 1 to discount current active cell.  We only need number
+        // of active cells PRIOR to current.
+        this->natural2columnar_.push_back(colActIx(activeCell) - 1);
+    }
+}
+
+void Opm::buildColumnarActiveIndexMappingTables(const EclipseGrid&    grid,
+                                                ActiveIndexByColumns& map)
+{
+    map.buildMappingTables(grid.getNumActive(), grid.getNXYZ(),
+        [&grid](const std::size_t activeCell)
+    {
+        return grid.getIJK(grid.getGlobalIndex(activeCell));
+    });
+}

--- a/tests/test_ActiveIndexByColumns.cpp
+++ b/tests/test_ActiveIndexByColumns.cpp
@@ -35,10 +35,21 @@ BOOST_AUTO_TEST_SUITE(Basic_Mapping)
 
 BOOST_AUTO_TEST_CASE(Constructor)
 {
-    auto map = Opm::ActiveIndexByColumns{};
-    auto map2 = map;
+    const auto cartDims = std::array<int,3>{ { 1, 1, 4 } };
+    const auto actIJK = std::vector<std::array<int,3>> {
+        { 0, 0, 0 },
+        { 0, 0, 1 },
+        { 0, 0, 3 },
+    };
 
-    auto map3 = std::move(map2);
+    const auto map = Opm::ActiveIndexByColumns { actIJK.size(), cartDims,
+        [&actIJK](const std::size_t i)
+    {
+        return actIJK[i];
+    }};
+
+    auto map2 = map;
+    const auto map3 = std::move(map2);
     BOOST_CHECK_MESSAGE(map3 == map, "Copied Map object must equal initial");
 }
 
@@ -51,12 +62,11 @@ BOOST_AUTO_TEST_CASE(Single_Column)
         { 0, 0, 3 },
     };
 
-    auto map = Opm::ActiveIndexByColumns{};
-    map.buildMappingTables(actIJK.size(), cartDims,
+    const auto map = Opm::ActiveIndexByColumns { actIJK.size(), cartDims,
         [&actIJK](const std::size_t i)
     {
         return actIJK[i];
-    });
+    }};
 
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(0), 0);
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(1), 1);
@@ -73,12 +83,11 @@ BOOST_AUTO_TEST_CASE(Two_Columns)
         { 0, 0, 3 },  { 1, 0, 3 },
     };
 
-    auto map = Opm::ActiveIndexByColumns{};
-    map.buildMappingTables(actIJK.size(), cartDims,
+    const auto map = Opm::ActiveIndexByColumns { actIJK.size(), cartDims,
         [&actIJK](const std::size_t i)
     {
         return actIJK[i];
-    });
+    }};
 
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(0), 0);
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(1), 3);
@@ -100,12 +109,11 @@ BOOST_AUTO_TEST_CASE(Four_Columns)
         { 0, 0, 3 },  { 1, 0, 3 },  { 0, 1, 3 },  { 1, 1, 3 },
     };
 
-    auto map = Opm::ActiveIndexByColumns{};
-    map.buildMappingTables(actIJK.size(), cartDims,
+    const auto map = Opm::ActiveIndexByColumns { actIJK.size(), cartDims,
         [&actIJK](const std::size_t i)
     {
         return actIJK[i];
-    });
+    }};
 
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  0);
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  6);
@@ -256,8 +264,7 @@ BOOST_AUTO_TEST_CASE(Cube_3x3x3_Full)
 {
     const auto grid = Opm::EclipseGrid {{3, 3, 3}, coord_3x3x3(), zcorn_3x3x3() };
 
-    auto map = Opm::ActiveIndexByColumns{};
-    buildColumnarActiveIndexMappingTables(grid, map);
+    const auto map = Opm::buildColumnarActiveIndexMappingTables(grid);
 
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  0);
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  9);
@@ -321,8 +328,7 @@ BOOST_AUTO_TEST_CASE(Cube_3x3x3_exclude_centre_cell)
     const auto actnum = actnum_3x3x3_exclude_centre_cell();
     const auto grid = Opm::EclipseGrid {{3, 3, 3}, coord_3x3x3(), zcorn_3x3x3(), actnum.data() };
 
-    auto map = Opm::ActiveIndexByColumns{};
-    buildColumnarActiveIndexMappingTables(grid, map);
+    const auto map = Opm::buildColumnarActiveIndexMappingTables(grid);
 
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  0);
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  9);
@@ -385,8 +391,7 @@ BOOST_AUTO_TEST_CASE(Cube_3x3x3_exclude_centre_column)
     const auto actnum = actnum_3x3x3_exclude_centre_column();
     const auto grid = Opm::EclipseGrid {{3, 3, 3}, coord_3x3x3(), zcorn_3x3x3(), actnum.data() };
 
-    auto map = Opm::ActiveIndexByColumns{};
-    buildColumnarActiveIndexMappingTables(grid, map);
+    const auto map = Opm::buildColumnarActiveIndexMappingTables(grid);
 
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  0);
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  9);
@@ -447,8 +452,7 @@ BOOST_AUTO_TEST_CASE(Cube_3x3x3_exclude_diagonals)
     const auto actnum = actnum_3x3x3_exclude_diagonals();
     const auto grid = Opm::EclipseGrid {{3, 3, 3}, coord_3x3x3(), zcorn_3x3x3(), actnum.data() };
 
-    auto map = Opm::ActiveIndexByColumns{};
-    buildColumnarActiveIndexMappingTables(grid, map);
+    const auto map = Opm::buildColumnarActiveIndexMappingTables(grid);
 
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  5);
     BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  1);

--- a/tests/test_ActiveIndexByColumns.cpp
+++ b/tests/test_ActiveIndexByColumns.cpp
@@ -1,0 +1,475 @@
+/*
+  Copyright 2021 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Active_Index_by_Columns
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/ActiveIndexByColumns.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <array>
+#include <utility>
+#include <vector>
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE(Basic_Mapping)
+
+BOOST_AUTO_TEST_CASE(Constructor)
+{
+    auto map = Opm::ActiveIndexByColumns{};
+    auto map2 = map;
+
+    auto map3 = std::move(map2);
+    BOOST_CHECK_MESSAGE(map3 == map, "Copied Map object must equal initial");
+}
+
+BOOST_AUTO_TEST_CASE(Single_Column)
+{
+    const auto cartDims = std::array<int,3>{ { 1, 1, 4 } };
+    const auto actIJK = std::vector<std::array<int,3>> {
+        { 0, 0, 0 },
+        { 0, 0, 1 },
+        { 0, 0, 3 },
+    };
+
+    auto map = Opm::ActiveIndexByColumns{};
+    map.buildMappingTables(actIJK.size(), cartDims,
+        [&actIJK](const std::size_t i)
+    {
+        return actIJK[i];
+    });
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(0), 0);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(1), 1);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(2), 2);
+}
+
+BOOST_AUTO_TEST_CASE(Two_Columns)
+{
+    const auto cartDims = std::array<int,3>{ { 2, 1, 4 } };
+    const auto actIJK = std::vector<std::array<int,3>> {
+        { 0, 0, 0 },  { 1, 0, 0 },
+        { 0, 0, 1 },  { 1, 0, 1 },
+                      { 1, 0, 2 },
+        { 0, 0, 3 },  { 1, 0, 3 },
+    };
+
+    auto map = Opm::ActiveIndexByColumns{};
+    map.buildMappingTables(actIJK.size(), cartDims,
+        [&actIJK](const std::size_t i)
+    {
+        return actIJK[i];
+    });
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(0), 0);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(1), 3);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(2), 1);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(3), 4);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(4), 5);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(5), 2);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(6), 6);
+}
+
+BOOST_AUTO_TEST_CASE(Four_Columns)
+{
+    const auto cartDims = std::array<int,3>{ { 2, 2, 4 } };
+    const auto actIJK = std::vector<std::array<int,3>> {
+        //   0             2             1             3
+        { 0, 0, 0 },  { 1, 0, 0 },  { 0, 1, 0 },  { 1, 1, 0 },
+        { 0, 0, 1 },  { 1, 0, 1 },  { 0, 1, 1 },
+                      { 1, 0, 2 },                { 1, 1, 2 },
+        { 0, 0, 3 },  { 1, 0, 3 },  { 0, 1, 3 },  { 1, 1, 3 },
+    };
+
+    auto map = Opm::ActiveIndexByColumns{};
+    map.buildMappingTables(actIJK.size(), cartDims,
+        [&actIJK](const std::size_t i)
+    {
+        return actIJK[i];
+    });
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  0);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  6);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 2),  3);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 3), 10);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 4),  1);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 5),  7);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 6),  4);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 7),  8);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 8), 11);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 9),  2);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(10),  9);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(11),  5);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(12), 12);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Basic_Mapping
+
+// =====================================================================
+
+BOOST_AUTO_TEST_SUITE(Grid_Based)
+
+namespace {
+    std::vector<double> coord_3x3x3()
+    {
+        return {
+            0.0, 0.0, 0.0,   0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   1.0, 0.0, 0.0,   2.0, 0.0, 0.0,   2.0, 0.0, 0.0,   3.0, 0.0, 0.0,   3.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,   0.0, 1.0, 0.0,   1.0, 1.0, 0.0,   1.0, 1.0, 0.0,   2.0, 1.0, 0.0,   2.0, 1.0, 0.0,   3.0, 1.0, 0.0,   3.0, 1.0, 0.0,
+            0.0, 2.0, 0.0,   0.0, 2.0, 0.0,   1.0, 2.0, 0.0,   1.0, 2.0, 0.0,   2.0, 2.0, 0.0,   2.0, 2.0, 0.0,   3.0, 2.0, 0.0,   3.0, 2.0, 0.0,
+            0.0, 3.0, 0.0,   0.0, 3.0, 0.0,   1.0, 3.0, 0.0,   1.0, 3.0, 0.0,   2.0, 3.0, 0.0,   2.0, 3.0, 0.0,   3.0, 3.0, 0.0,   3.0, 3.0, 0.0,
+        };
+    }
+
+    std::vector<double> zcorn_3x3x3()
+    {
+        return {
+            // Top, layer 1
+            0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0, //  0.. 2
+            0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0, //  3.. 5
+            0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0,    0.0, 0.0, //  6.. 8
+
+            // Bottom, layer 1
+            1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0, //  0.. 2
+            1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0, //  3.. 5
+            1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0, //  6.. 8
+
+            // Top, layer 2
+            1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0, //  9..11
+            1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0, // 12..14
+            1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0,    1.0, 1.0, // 15..17
+
+            // Bottom, layer 2
+            2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0, //  9..11
+            2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0, // 12..14
+            2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0, // 15..17
+
+            // Top, layer 3
+            2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0, // 18..20
+            2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0, // 21..23
+            2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0,    2.0, 2.0, // 24..26
+
+            // Bottom, layer 3
+            3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0, // 18..20
+            3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0, // 21..23
+            3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0,    3.0, 3.0, // 24..26
+        };
+    }
+
+    std::vector<int> actnum_3x3x3_exclude_centre_cell()
+    {
+        return {
+            1, 1, 1,
+            1, 1, 1,
+            1, 1, 1,
+
+            1, 1, 1,
+            1, 0, 1,
+            1, 1, 1,
+
+            1, 1, 1,
+            1, 1, 1,
+            1, 1, 1,
+        };
+    }
+
+    std::vector<int> actnum_3x3x3_exclude_centre_column()
+    {
+        return {
+            1, 1, 1,
+            1, 0, 1,
+            1, 1, 1,
+
+            1, 1, 1,
+            1, 0, 1,
+            1, 1, 1,
+
+            1, 1, 1,
+            1, 0, 1,
+            1, 1, 1,
+        };
+    }
+
+    std::vector<int> actnum_3x3x3_exclude_diagonals()
+    {
+        return {
+            0, 1, 0,
+            1, 1, 1,
+            0, 1, 0,
+
+            1, 1, 1,
+            1, 0, 1,
+            1, 1, 1,
+
+            0, 1, 0,
+            1, 1, 1,
+            0, 1, 0,
+        };
+    }
+}
+
+// K = 0
+// +------+------+------+
+// |   6  |  15  |  24  |
+// +------+------+------+
+// |   3  |  12  |  21  |
+// +------+------+------+
+// |   0  |   9  |  18  |
+// +------+------+------+
+//
+// K = 1
+// +------+------+------+
+// |   7  |  16  |  25  |
+// +------+------+------+
+// |   4  |  13  |  22  |
+// +------+------+------+
+// |   1  |  10  |  19  |
+// +------+------+------+
+//
+// K = 2
+// +------+------+------+
+// |   8  |  17  |  26  |
+// +------+------+------+
+// |   5  |  14  |  23  |
+// +------+------+------+
+// |   2  |  11  |  20  |
+// +------+------+------+
+BOOST_AUTO_TEST_CASE(Cube_3x3x3_Full)
+{
+    const auto grid = Opm::EclipseGrid {{3, 3, 3}, coord_3x3x3(), zcorn_3x3x3() };
+
+    auto map = Opm::ActiveIndexByColumns{};
+    buildColumnarActiveIndexMappingTables(grid, map);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  0);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  9);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 2), 18);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 3),  3);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 4), 12);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 5), 21);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 6),  6);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 7), 15);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 8), 24);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 9),  1);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(10), 10);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(11), 19);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(12),  4);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(13), 13);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(14), 22);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(15),  7);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(16), 16);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(17), 25);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(18),  2);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(19), 11);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(20), 20);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(21),  5);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(22), 14);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(23), 23);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(24),  8);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(25), 17);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(26), 26);
+}
+
+// K = 0
+// +------+------+------+
+// |   6  |  14  |  23  |
+// +------+------+------+
+// |   3  |  12  |  20  |
+// +------+------+------+
+// |   0  |   9  |  17  |
+// +------+------+------+
+//
+// K = 1
+// +------+------+------+
+// |   7  |  15  |  24  |
+// +------+------+------+
+// |   4  | :::: |  21  |
+// +------+------+------+
+// |   1  |  10  |  18  |
+// +------+------+------+
+//
+// K = 2
+// +------+------+------+
+// |   8  |  16  |  25  |
+// +------+------+------+
+// |   5  |  13  |  22  |
+// +------+------+------+
+// |   2  |  11  |  19  |
+// +------+------+------+
+BOOST_AUTO_TEST_CASE(Cube_3x3x3_exclude_centre_cell)
+{
+    const auto actnum = actnum_3x3x3_exclude_centre_cell();
+    const auto grid = Opm::EclipseGrid {{3, 3, 3}, coord_3x3x3(), zcorn_3x3x3(), actnum.data() };
+
+    auto map = Opm::ActiveIndexByColumns{};
+    buildColumnarActiveIndexMappingTables(grid, map);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  0);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  9);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 2), 17);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 3),  3);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 4), 12);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 5), 20);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 6),  6);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 7), 14);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 8), 23);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 9),  1);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(10), 10);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(11), 18);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(12),  4);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(13), 21);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(14),  7);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(15), 15);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(16), 24);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(17),  2);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(18), 11);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(19), 19);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(20),  5);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(21), 13);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(22), 22);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(23),  8);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(24), 16);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(25), 25);
+}
+
+// K = 0
+// +------+------+------+
+// |   6  |  12  |  21  |
+// +------+------+------+
+// |   3  | :::: |  18  |
+// +------+------+------+
+// |   0  |   9  |  15  |
+// +------+------+------+
+//
+// K = 1
+// +------+------+------+
+// |   7  |  13  |  22  |
+// +------+------+------+
+// |   4  | :::: |  19  |
+// +------+------+------+
+// |   1  |  10  |  16  |
+// +------+------+------+
+//
+// K = 2
+// +------+------+------+
+// |   8  |  14  |  23  |
+// +------+------+------+
+// |   5  | :::: |  20  |
+// +------+------+------+
+// |   2  |  11  |  17  |
+// +------+------+------+
+BOOST_AUTO_TEST_CASE(Cube_3x3x3_exclude_centre_column)
+{
+    const auto actnum = actnum_3x3x3_exclude_centre_column();
+    const auto grid = Opm::EclipseGrid {{3, 3, 3}, coord_3x3x3(), zcorn_3x3x3(), actnum.data() };
+
+    auto map = Opm::ActiveIndexByColumns{};
+    buildColumnarActiveIndexMappingTables(grid, map);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  0);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  9);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 2), 15);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 3),  3);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 4), 18);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 5),  6);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 6), 12);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 7), 21);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 8),  1);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 9), 10);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(10), 16);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(11),  4);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(12), 19);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(13),  7);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(14), 13);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(15), 22);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(16),  2);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(17), 11);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(18), 17);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(19),  5);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(20), 20);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(21),  8);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(22), 14);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(23), 23);
+}
+
+// K = 0
+// +------+------+------+
+// | :::: |  10  | :::: |
+// +------+------+------+
+// |   1  |   8  |  14  |
+// +------+------+------+
+// | :::: |   5  | :::: |
+// +------+------+------+
+//
+// K = 1
+// +------+------+------+
+// |   4  |  11  |  17  |
+// +------+------+------+
+// |   2  | :::: |  15  |
+// +------+------+------+
+// |   0  |   6  |  13  |
+// +------+------+------+
+//
+// K = 2
+// +------+------+------+
+// | :::: |  12  | :::: |
+// +------+------+------+
+// |   3  |   9  |  16  |
+// +------+------+------+
+// | :::: |   7  | :::: |
+// +------+------+------+
+BOOST_AUTO_TEST_CASE(Cube_3x3x3_exclude_diagonals)
+{
+    const auto actnum = actnum_3x3x3_exclude_diagonals();
+    const auto grid = Opm::EclipseGrid {{3, 3, 3}, coord_3x3x3(), zcorn_3x3x3(), actnum.data() };
+
+    auto map = Opm::ActiveIndexByColumns{};
+    buildColumnarActiveIndexMappingTables(grid, map);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 0),  5);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 1),  1);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 2),  8);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 3), 14);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 4), 10);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 5),  0);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 6),  6);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 7), 13);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 8),  2);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex( 9), 15);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(10),  4);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(11), 11);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(12), 17);
+
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(13),  7);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(14),  3);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(15),  9);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(16), 16);
+    BOOST_CHECK_EQUAL(map.getColumnarActiveIndex(17), 12);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Grid_Based


### PR DESCRIPTION
The protocol for outputting an aquifer's active cell IDs to the restart file requires that the cells be enumerated according to their column.  In particular, the aquifer's notion of a model's active cells correspond to a cell ordering of the form
```C++
for (i = 0; i < Nx; ++i)
    for (j = 0; j < Ny; ++j)
        for (k = 0; k < Nz; ++k)
            use(X(i, j, k))
```
instead of the common ordering, sometimes referred to as "natural ordering"
```C++
for (k = 0; k < Nz; ++k)
    for (j = 0; j < Ny; ++j)
        for (i = 0; i < Nx; ++i)
            use(X(i, j, k))
```
which is employed elsewhere.

This commit adds a special purpose mapping facility which will translate active cell IDs from natural ordering to the columnar enumeration.  The facility is intentionally bare-bones because we do not expect to use it outside of the restart writing code, and only in a limited fashion within that context.  We will however consider adding more features if the need arises.