### PR TITLE
Add optional argument to override output interval - EBOS paramstyle

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -20,8 +20,9 @@
 #ifndef OPM_RESTART_CONFIG_HPP
 #define OPM_RESTART_CONFIG_HPP
 
-#include <vector>
+#include <optional>
 #include <set>
+#include <vector>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 
@@ -328,9 +329,9 @@ namespace Opm {
         RestartConfig() = default;
 
         template<typename T>
-        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart, const ParseContext& parseContext, T&& errors );
-        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart, const ParseContext& parseContext, ErrorGuard& errors );
-        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart);
+        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart, const std::optional<int>& output_interval, const ParseContext& parseContext, T&& errors );
+        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart, const std::optional<int>& output_interval, const ParseContext& parseContext, ErrorGuard& errors );
+        RestartConfig( const Deck&, const std::pair<std::time_t, std::size_t>& restart, const std::optional<int>& output_interval);
 
         static RestartConfig serializeObject();
 
@@ -339,7 +340,6 @@ namespace Opm {
         const std::map< std::string, int >& getRestartKeywords( size_t timestep ) const;
         int getKeyword( const std::string& keyword, size_t timeStep) const;
 
-        void overrideRestartWriteInterval(size_t interval);
         void handleSolutionSection(const SOLUTIONSection& solutionSection, const ParseContext& parseContext, ErrorGuard& errors);
         void setWriteInitialRestartFile(bool writeInitialRestartFile);
 
@@ -364,6 +364,7 @@ namespace Opm {
         /// zero, for subsequent output steps we should append.
         void initFirstOutput( );
         RestartSchedule getNode( size_t timestep ) const;
+         void overrideRestartWriteInterval(size_t interval);
 
         bool getWriteRestartFileFrequency(size_t timestep,
                                           size_t start_timestep,

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -480,7 +480,6 @@ namespace Opm
         bool updateWPAVE(const std::string& wname, std::size_t report_step, const PAvg& pavg);
 
         void updateGuideRateModel(const GuideRateModel& new_model, std::size_t report_step);
-        void rst_override_interval(std::size_t output_interval);
         GTNode groupTree(const std::string& root_node, std::size_t report_step, std::size_t level, const std::optional<std::string>& parent_name) const;
         bool checkGroups(const ParseContext& parseContext, ErrorGuard& errors);
         bool updateWellStatus( const std::string& well, std::size_t reportStep, Well::Status status, std::optional<KeywordLocation> = {});

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -128,6 +128,7 @@ namespace Opm
                  const ParseContext& parseContext,
                  ErrorGuard& errors,
                  std::shared_ptr<const Python> python,
+                 const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
         template<typename T>
@@ -138,6 +139,7 @@ namespace Opm
                  const ParseContext& parseContext,
                  T&& errors,
                  std::shared_ptr<const Python> python,
+                 const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
@@ -145,6 +147,7 @@ namespace Opm
                  const FieldPropsManager& fp,
                  const Runspec &runspec,
                  std::shared_ptr<const Python> python,
+                 const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
@@ -152,6 +155,7 @@ namespace Opm
                  const ParseContext& parseContext,
                  ErrorGuard& errors,
                  std::shared_ptr<const Python> python,
+                 const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
         template <typename T>
@@ -160,16 +164,19 @@ namespace Opm
                  const ParseContext& parseContext,
                  T&& errors,
                  std::shared_ptr<const Python> python,
+                 const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
         Schedule(const Deck& deck,
                  const EclipseState& es,
                  std::shared_ptr<const Python> python,
+                 const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
         // The constructor *without* the Python arg should really only be used from Python itself
         Schedule(const Deck& deck,
                  const EclipseState& es,
+                 const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
         static Schedule serializeObject();
@@ -250,7 +257,6 @@ namespace Opm
         int  first_rst_step() const;
         const std::map< std::string, int >& rst_keywords( size_t timestep ) const;
         bool rst_keyword(std::size_t timestep, const std::string& keyword) const;
-        void rst_override_interval(std::size_t output_interval);
 
         void applyAction(std::size_t reportStep, const time_point& sim_time, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& wellpi);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
@@ -474,7 +480,7 @@ namespace Opm
         bool updateWPAVE(const std::string& wname, std::size_t report_step, const PAvg& pavg);
 
         void updateGuideRateModel(const GuideRateModel& new_model, std::size_t report_step);
-
+        void rst_override_interval(std::size_t output_interval);
         GTNode groupTree(const std::string& root_node, std::size_t report_step, std::size_t level, const std::optional<std::string>& parent_name) const;
         bool checkGroups(const ParseContext& parseContext, ErrorGuard& errors);
         bool updateWellStatus( const std::string& well, std::size_t reportStep, Well::Status status, std::optional<KeywordLocation> = {});

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -525,16 +525,16 @@ void RestartConfig::handleScheduleSection(const SCHEDULESection& schedule, const
     }
 
     template<typename T>
-    RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart, const ParseContext& parseContext, T&& errors ) :
-        RestartConfig( deck, restart, parseContext, errors)
+    RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart, const std::optional<int>& output_interval, const ParseContext& parseContext, T&& errors ) :
+        RestartConfig( deck, restart, output_interval, parseContext, errors)
     {}
 
-    RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart) :
-        RestartConfig( deck, restart, ParseContext(), ErrorGuard())
+    RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart, const std::optional<int>& output_interval) :
+        RestartConfig( deck, restart, output_interval, ParseContext(), ErrorGuard())
     {}
 
 
-RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart, const ParseContext& parseContext, ErrorGuard& errors ) :
+    RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std::size_t>& restart, const std::optional<int>& output_interval, const ParseContext& parseContext, ErrorGuard& errors ) :
     m_timemap( TimeMap(deck, restart) ),
         m_first_restart_step( -1 ),
         restart_schedule( m_timemap, {0,0,1}),
@@ -544,6 +544,9 @@ RestartConfig::RestartConfig( const Deck& deck, const std::pair<std::time_t, std
         handleSolutionSection( SOLUTIONSection(deck), parseContext, errors );
         handleScheduleSection( SCHEDULESection(deck), parseContext, errors );
         initFirstOutput( );
+
+        if (output_interval.has_value())
+            this->overrideRestartWriteInterval(output_interval.value());
     }
 
     RestartConfig RestartConfig::serializeObject()

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -105,6 +105,7 @@ namespace {
                         const ParseContext& parseContext,
                         ErrorGuard& errors,
                         [[maybe_unused]] std::shared_ptr<const Python> python,
+                        const std::optional<int>& output_interval,
                         const RestartIO::RstState * rst)
     try :
         m_static( python, deck, runspec ),
@@ -120,6 +121,8 @@ namespace {
         } else
             this->iterateScheduleSection( 0, this->m_sched_deck.size(), parseContext, errors, false, nullptr, &grid, &fp);
 
+        if (output_interval.has_value())
+            this->rst_override_interval(output_interval.value());
     }
     catch (const OpmInputError& opm_error) {
         throw;
@@ -141,8 +144,9 @@ namespace {
                         const ParseContext& parseContext,
                         T&& errors,
                         std::shared_ptr<const Python> python,
+                        const std::optional<int>& output_interval,
                         const RestartIO::RstState * rst) :
-        Schedule(deck, grid, fp, runspec, parseContext, errors, python, rst)
+        Schedule(deck, grid, fp, runspec, parseContext, errors, python, output_interval, rst)
     {}
 
 
@@ -151,12 +155,13 @@ namespace {
                         const FieldPropsManager& fp,
                         const Runspec &runspec,
                         std::shared_ptr<const Python> python,
+                        const std::optional<int>& output_interval,
                         const RestartIO::RstState * rst) :
-        Schedule(deck, grid, fp, runspec, ParseContext(), ErrorGuard(), python, rst)
+        Schedule(deck, grid, fp, runspec, ParseContext(), ErrorGuard(), python, output_interval, rst)
     {}
 
 
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, ErrorGuard& errors, std::shared_ptr<const Python> python, const RestartIO::RstState * rst) :
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, ErrorGuard& errors, std::shared_ptr<const Python> python, const std::optional<int>& output_interval, const RestartIO::RstState * rst) :
         Schedule(deck,
                  es.getInputGrid(),
                  es.fieldProps(),
@@ -164,12 +169,13 @@ namespace {
                  parse_context,
                  errors,
                  python,
+                 output_interval,
                  rst)
     {}
 
 
     template <typename T>
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, T&& errors, std::shared_ptr<const Python> python, const RestartIO::RstState * rst) :
+    Schedule::Schedule(const Deck& deck, const EclipseState& es, const ParseContext& parse_context, T&& errors, std::shared_ptr<const Python> python, const std::optional<int>& output_interval, const RestartIO::RstState * rst) :
         Schedule(deck,
                  es.getInputGrid(),
                  es.fieldProps(),
@@ -177,17 +183,18 @@ namespace {
                  parse_context,
                  errors,
                  python,
+                 output_interval,
                  rst)
     {}
 
 
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, std::shared_ptr<const Python> python, const RestartIO::RstState * rst) :
-        Schedule(deck, es, ParseContext(), ErrorGuard(), python, rst)
-    {}
+Schedule::Schedule(const Deck& deck, const EclipseState& es, std::shared_ptr<const Python> python, const std::optional<int>& output_interval, const RestartIO::RstState * rst) :
+    Schedule(deck, es, ParseContext(), ErrorGuard(), python, output_interval, rst)
+{}
 
 
-    Schedule::Schedule(const Deck& deck, const EclipseState& es, const RestartIO::RstState * rst) :
-        Schedule(deck, es, ParseContext(), ErrorGuard(), std::make_shared<const Python>(), rst)
+Schedule::Schedule(const Deck& deck, const EclipseState& es, const std::optional<int>& output_interval, const RestartIO::RstState * rst) :
+    Schedule(deck, es, ParseContext(), ErrorGuard(), std::make_shared<const Python>(), output_interval, rst)
     {}
 
     Schedule::Schedule(std::shared_ptr<const Python> python_handle) :

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -111,7 +111,7 @@ namespace {
         m_static( python, deck, runspec ),
         m_restart_info( restart_info(rst)),
         m_sched_deck(deck, m_restart_info ),
-        restart_config(deck, m_restart_info, parseContext, errors)
+        restart_config(deck, m_restart_info, output_interval, parseContext, errors)
     {
         if (rst) {
             auto restart_step = this->m_restart_info.second;
@@ -120,9 +120,6 @@ namespace {
             this->iterateScheduleSection( restart_step, this->m_sched_deck.size(), parseContext, errors, false, nullptr, &grid, &fp);
         } else
             this->iterateScheduleSection( 0, this->m_sched_deck.size(), parseContext, errors, false, nullptr, &grid, &fp);
-
-        if (output_interval.has_value())
-            this->rst_override_interval(output_interval.value());
     }
     catch (const OpmInputError& opm_error) {
         throw;
@@ -1206,10 +1203,6 @@ bool Schedule::write_rst_file(std::size_t report_step, bool log) const {
 
     bool Schedule::rst_keyword(std::size_t timeStep, const std::string& keyword) const {
         return this->restart_config.getKeyword(keyword, timeStep);
-    }
-
-    void Schedule::rst_override_interval(std::size_t output_interval) {
-        this->restart_config.overrideRestartWriteInterval(output_interval);
     }
 
     bool Schedule::operator==(const Schedule& data) const {

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
 
             const int report_step = 50;
             const auto& rst_state = Opm::RestartIO::RstState::load(rst, report_step);
-            Schedule sched_rst(deck, state, python, &rst_state);
+            Schedule sched_rst(deck, state, python, {}, &rst_state);
             const auto& rfti_well = sched_rst.getWell("RFTI", report_step);
             const auto& rftp_well = sched_rst.getWell("RFTP", report_step);
             BOOST_CHECK(rftp_well.getStatus() == Well::Status::SHUT);

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -500,7 +500,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
 
     Parser parser{};
     auto deck = parser.parseString(deckData) ;
-    RestartConfig rstConfig(deck, restart_info);
+    RestartConfig rstConfig(deck, restart_info, {});
 
     BOOST_CHECK_EQUAL(false, rstConfig.getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false, rstConfig.getWriteRestartFile(1));
@@ -551,7 +551,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
 
     Parser parser;
     auto deck = parser.parseString(deckData) ;
-    RestartConfig rstConfig(deck, restart_info);
+    RestartConfig rstConfig(deck, restart_info, {});
 
     BOOST_CHECK_EQUAL(true  ,  rstConfig.getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false ,  rstConfig.getWriteRestartFile(1));
@@ -643,14 +643,14 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
 
     {   //mnemnonics
         auto deck = parser.parseString(deckData) ;
-        RestartConfig rstConfig(deck, restart_info);
+        RestartConfig rstConfig(deck, restart_info, {});
 
         BOOST_CHECK_EQUAL(true, rstConfig.getWriteRestartFile(0));
     }
 
     {   //old fashion integer mnemonics
         auto deck = parser.parseString(deckData2) ;
-        RestartConfig rstConfig(deck, restart_info);
+        RestartConfig rstConfig(deck, restart_info, {});
 
         BOOST_CHECK_EQUAL(true, rstConfig.getWriteRestartFile(0));
     }

--- a/tests/parser/IOConfigTests.cpp
+++ b/tests/parser/IOConfigTests.cpp
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(DefaultProperties) {
 
     auto deck = Parser().parseString( data);
     IOConfig ioConfig( deck );
-    RestartConfig rstConfig( deck, std::make_pair(std::time_t{0}, std::size_t{0}));
+    RestartConfig rstConfig( deck, std::make_pair(std::time_t{0}, std::size_t{0}), {});
 
     /*If no GRIDFILE nor NOGGF keywords are specified, default output an EGRID file*/
     BOOST_CHECK( ioConfig.getWriteEGRIDFile() );

--- a/tests/parser/RestartConfigTests.cpp
+++ b/tests/parser/RestartConfigTests.cpp
@@ -79,7 +79,7 @@ END
 
     const auto deck   = Parser{}.parseString(input);
     const auto tm     = TimeMap { deck };
-    const auto rstcfg = RestartConfig { deck, restart_info };
+    const auto rstcfg = RestartConfig { deck, restart_info, {} };
 
     BOOST_REQUIRE_EQUAL(tm.size(), std::size_t{19});
 
@@ -175,7 +175,7 @@ END
 
     const auto deck   = Parser{}.parseString(input);
     const auto tm     = TimeMap { deck };
-    const auto rstcfg = RestartConfig { deck, restart_info };
+    const auto rstcfg = RestartConfig { deck, restart_info, {} };
 
     for (std::size_t step = 0; step < tm.size(); step++) {
         if (step == 0 || step == 38 || step == 51)
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED_INTEGER) {
     Parser parser;
 
     auto deck1 = parser.parseString( deckData1);
-    RestartConfig rstConfig1( deck1, restart_info);
+    RestartConfig rstConfig1( deck1, restart_info, {});
 
     BOOST_CHECK(  rstConfig1.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 1 ) );
@@ -406,7 +406,7 @@ BOOST_AUTO_TEST_CASE(RPTRST_mixed_mnemonics_int_list) {
     ErrorGuard errors;
     auto deck = Parser().parseString( data, parseContext, errors );
     parseContext.update(ParseContext::RPT_MIXED_STYLE, InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW( RestartConfig( deck, restart_info, parseContext, errors ), OpmInputError);
+    BOOST_CHECK_THROW( RestartConfig( deck, restart_info, {}, parseContext, errors ), OpmInputError);
 }
 
 BOOST_AUTO_TEST_CASE(RPTRST) {
@@ -477,7 +477,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     Opm::Parser parser;
 
     auto deck1 = parser.parseString( deckData1);
-    RestartConfig rstConfig1( deck1, restart_info );
+    RestartConfig rstConfig1( deck1, restart_info, {} );
 
     // Observe that this is true due to some undocumented guessing that
     // the initial restart file should be written if a RPTRST keyword is
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     BOOST_CHECK_EQUAL( rstConfig1.getKeyword( "ALLPROPS" , 2 ) , 0);
 
     auto deck2 = parser.parseString( deckData2 );
-    RestartConfig rstConfig2( deck2, restart_info );
+    RestartConfig rstConfig2( deck2, restart_info, {} );
 
     const auto expected2 = { "BASIC", "FLOWS", "FREQ" };
     const auto kw_list2 = fun::map( fst, rstConfig2.getRestartKeywords( 2 ) );
@@ -510,7 +510,7 @@ BOOST_AUTO_TEST_CASE(RPTRST) {
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 3 ) );
 
     auto deck3 = parser.parseString( deckData3 );
-    RestartConfig rstConfig3( deck3, restart_info );
+    RestartConfig rstConfig3( deck3, restart_info, {} );
 
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 1 ) );
@@ -614,15 +614,15 @@ BOOST_AUTO_TEST_CASE(RPTRST_FORMAT_ERROR) {
     auto deck1 = parser.parseString( deckData1, ctx, errors );
     ctx.update(ParseContext::RPT_UNKNOWN_MNEMONIC, InputError::IGNORE);
     ctx.update(ParseContext::RPT_MIXED_STYLE, InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW(RestartConfig(deck1, restart_info, ctx, errors), OpmInputError);
+    BOOST_CHECK_THROW(RestartConfig(deck1, restart_info, {}, ctx, errors), OpmInputError);
 
     ctx.update(ParseContext::RPT_MIXED_STYLE, InputError::IGNORE);
-    RestartConfig rstConfig1( deck1, restart_info, ctx, errors );
+    RestartConfig rstConfig1( deck1, restart_info, {}, ctx, errors );
 
 
     // The case "BASIC 1" - i.e. without '=' can not be salvaged; this should
     // give an exception whatever is the value of ParseContext::RPT_MIXED_STYLE:
-    BOOST_CHECK_THROW(RestartConfig(deck0, restart_info, ctx, errors), OpmInputError);
+    BOOST_CHECK_THROW(RestartConfig(deck0, restart_info, {}, ctx, errors), OpmInputError);
 
 
     // Observe that this is true due to some undocumented guessing that
@@ -645,10 +645,10 @@ BOOST_AUTO_TEST_CASE(RPTRST_FORMAT_ERROR) {
     auto deck2 = parser.parseString( deckData2, ctx, errors );
 
     ctx.update(ParseContext::RPT_UNKNOWN_MNEMONIC, InputError::THROW_EXCEPTION);
-    BOOST_CHECK_THROW(RestartConfig(deck2, restart_info, ctx, errors), OpmInputError);
+    BOOST_CHECK_THROW(RestartConfig(deck2, restart_info, {}, ctx, errors), OpmInputError);
     ctx.update(ParseContext::RPT_UNKNOWN_MNEMONIC, InputError::IGNORE);
 
-    RestartConfig rstConfig2( deck2, restart_info, ctx, errors );
+    RestartConfig rstConfig2( deck2, restart_info, {}, ctx, errors );
 
     const auto expected2 = { "BASIC", "FLOWS", "FREQ" };
     const auto kw_list2 = fun::map( fst, rstConfig2.getRestartKeywords( 2 ) );
@@ -661,7 +661,7 @@ BOOST_AUTO_TEST_CASE(RPTRST_FORMAT_ERROR) {
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 3 ) );
 
     auto deck3 = parser.parseString( deckData3, ctx, errors );
-    RestartConfig rstConfig3( deck3, restart_info, ctx, errors );
+    RestartConfig rstConfig3( deck3, restart_info, {}, ctx, errors );
 
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 1 ) );
@@ -755,7 +755,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
     Parser parser;
 
     auto deck1 = parser.parseString( deckData1 );
-    RestartConfig rstConfig1( deck1, restart_info );
+    RestartConfig rstConfig1( deck1, restart_info , {});
 
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig1.getWriteRestartFile( 1 ) );
@@ -764,7 +764,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
 
 
     auto deck2 = parser.parseString( deckData2 );
-    RestartConfig rstConfig2( deck2, restart_info );
+    RestartConfig rstConfig2( deck2, restart_info, {} );
 
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig2.getWriteRestartFile( 1 ) );
@@ -778,7 +778,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED) {
 
 
     auto deck3 = parser.parseString( deckData3 );
-    RestartConfig rstConfig3( deck3, restart_info );
+    RestartConfig rstConfig3( deck3, restart_info , {});
     //Older ECLIPSE 100 data set may use integer controls instead of mnemonics
     BOOST_CHECK(  rstConfig3.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig3.getWriteRestartFile( 1 ) );
@@ -820,7 +820,7 @@ BOOST_AUTO_TEST_CASE(RPTSCHED_and_RPTRST) {
     Opm::Parser parser;
 
     auto deck = parser.parseString( deckData );
-    RestartConfig rstConfig( deck, restart_info );
+    RestartConfig rstConfig( deck, restart_info, {} );
 
     BOOST_CHECK( !rstConfig.getWriteRestartFile( 0 ) );
     BOOST_CHECK( !rstConfig.getWriteRestartFile( 1 ) );
@@ -850,7 +850,7 @@ BOOST_AUTO_TEST_CASE(NO_BASIC) {
                        "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck, restart_info);
+    RestartConfig ioConfig( deck, restart_info, {});
 
     for( size_t ts = 0; ts < 4; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -881,7 +881,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_1) {
                        "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck, restart_info);
+    RestartConfig ioConfig( deck, restart_info, {});
 
     for( size_t ts = 0; ts < 3; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -916,7 +916,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_3) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig(  deck, restart_info);
+    RestartConfig ioConfig(  deck, restart_info, {});
 
     const size_t freq = 3;
 
@@ -953,7 +953,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_4) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck, restart_info);
+    RestartConfig ioConfig( deck, restart_info, {});
 
     /* BASIC=4, restart file is written at the first report step of each year.
      */
@@ -991,7 +991,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_4_FREQ_2) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck, restart_info);
+    RestartConfig ioConfig( deck, restart_info, {});
 
     /* BASIC=4, restart file is written at the first report step of each year.
      * Optionally, if the mnemonic FREQ is set >1 the restart is written only
@@ -1033,7 +1033,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_5) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck, restart_info);
+    RestartConfig ioConfig( deck, restart_info,{});
 
     /* BASIC=5, restart file is written at the first report step of each month.
      */
@@ -1071,7 +1071,7 @@ BOOST_AUTO_TEST_CASE(BASIC_EQ_0) {
                         "/\n";
 
     auto deck = Parser().parseString( data ) ;
-    RestartConfig ioConfig( deck, restart_info);
+    RestartConfig ioConfig( deck, restart_info, {});
 
     /* RESTART=0, no restart file is written
      */
@@ -1107,7 +1107,7 @@ BOOST_AUTO_TEST_CASE(RESTART_EQ_0) {
                         "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck, restart_info);
+    RestartConfig ioConfig( deck, restart_info, {});
 
     /* RESTART=0, no restart file is written
      */
@@ -1147,7 +1147,7 @@ BOOST_AUTO_TEST_CASE(RESTART_BASIC_GT_2) {
                        "/\n";
 
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck, restart_info);
+    RestartConfig ioConfig( deck, restart_info, {});
 
     for( size_t ts : { 1, 2, 3, 4, 5, 7, 8, 10, 11  } )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );
@@ -1188,7 +1188,7 @@ BOOST_AUTO_TEST_CASE(RESTART_BASIC_LEQ_2) {
                        "/\n";
 
     auto deck = Parser().parseString( data );
-    RestartConfig ioConfig( deck, restart_info );
+    RestartConfig ioConfig( deck, restart_info , {});
 
     BOOST_CHECK( ioConfig.getWriteRestartFile( 1 ) );
     for( size_t ts = 2; ts < 11; ++ts )
@@ -1223,7 +1223,7 @@ BOOST_AUTO_TEST_CASE(RESTART_SAVE) {
                         "TSTEP \n"
                         " 1 /\n";
     auto deck = Parser().parseString( data);
-    RestartConfig ioConfig( deck, restart_info );
+    RestartConfig ioConfig( deck, restart_info, {} );
 
     for( size_t ts = 1; ts < 11; ++ts )
         BOOST_CHECK( !ioConfig.getWriteRestartFile( ts ) );

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(LoadRestartSim) {
     EclIO::ERst rst_file("SPE1CASE2.X0060");
     auto rst_state = RestartIO::RstState::load(rst_file, 60);
     EclipseState ecl_state_restart(restart_deck);
-    Schedule restart_sched(restart_deck, ecl_state_restart, python, &rst_state);
+    Schedule restart_sched(restart_deck, ecl_state_restart, python, {}, &rst_state);
 
     // Verify that sched and restart_sched are identical from report_step 60 and onwords.
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3584,7 +3584,7 @@ BOOST_AUTO_TEST_CASE(SKIPREST_VFP) {
     const auto& rst_filename = es.getIOConfig().getRestartFileName( init_config.getRestartRootName(), report_step, false );
     Opm::EclIO::ERst rst_file(rst_filename);
     const auto& rst = Opm::RestartIO::RstState::load(rst_file, report_step);
-    const auto sched = Schedule{ deck, es, python , &rst};
+    const auto sched = Schedule{ deck, es, python , {}, &rst};
     BOOST_CHECK_NO_THROW( sched[3].vfpprod(5) );
 }
 

--- a/tests/rst_test.cpp
+++ b/tests/rst_test.cpp
@@ -78,7 +78,7 @@ Opm::Schedule load_schedule(std::shared_ptr<const Opm::Python> python, const std
         Opm::EclIO::ERst rst_file(rst_filename);
 
         const auto& rst = Opm::RestartIO::RstState::load(rst_file, report_step);
-        return Opm::Schedule(deck, state, python, &rst);
+        return Opm::Schedule(deck, state, python, {}, &rst);
     } else
         return Opm::Schedule(deck, state, python);
 }


### PR DESCRIPTION
To avoid overriding the Schedule object after construction; again a part of the Schedule refactor cleanup effort.