### PR TITLE
Don't Needlessly Copy AQUANCON Objects

### DIFF
--- a/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp
@@ -26,15 +26,16 @@
   implement the analytical aquifer models in OPM Flow.
 */
 
-#include <unordered_map>
-
-#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
+#include <cstddef>
+#include <unordered_map>
+#include <vector>
+
+namespace Opm {
+    class EclipseGrid;
+    class Deck;
+}
 
 namespace Opm {
 
@@ -84,7 +85,7 @@ namespace Opm {
             bool operator==(const Aquancon& other) const;
             bool active() const;
 
-            const std::vector<Aquancon::AquancCell> operator[](int aquiferID) const;
+            const std::vector<Aquancon::AquancCell>& operator[](int aquiferID) const;
 
             template<class Serializer>
             void serializeOp(Serializer& serializer)

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.cpp
@@ -16,18 +16,31 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
+
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
-#include <fmt/format.h>
-#include <unordered_map>
-#include <utility>
+#include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
 #include <algorithm>
 #include <iterator>
-#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+#include <fmt/format.h>
 
 #include "AquiferHelpers.hpp"
 
@@ -128,9 +141,10 @@ namespace Opm {
         }
 
         for (const auto& gi_cell : work) {
-            const auto& cell = gi_cell.second;
+            auto cell = gi_cell.second;
+            const auto aquiferID = cell.aquiferID;
 
-            this->cells[cell.aquiferID].emplace_back(std::move(cell));
+            this->cells[aquiferID].emplace_back(std::move(cell));
         }
     }
 
@@ -144,7 +158,7 @@ namespace Opm {
     }
 
 
-    const std::vector<Aquancon::AquancCell> Aquancon::operator[](int aquiferID) const {
+    const std::vector<Aquancon::AquancCell>& Aquancon::operator[](int aquiferID) const {
         return this->cells.at( aquiferID );
     }
 


### PR DESCRIPTION
Return the `operator[]()` data by reference-to-const instead of as a freshly created `vector` object.

While here, also (slightly) reduce the compilation overhead of this module (and its users) by forward declaring interface types and moving the actual include statements to the .CPP file.