### PR TITLE
Partially Internalise AQUDIMS in Runspec

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -218,6 +218,36 @@ private:
     int nMaxNoBranchesConToNode;
 };
 
+class AquiferDimensions {
+public:
+    AquiferDimensions();
+    explicit AquiferDimensions(const Deck& deck);
+
+    static AquiferDimensions serializeObject();
+
+    int maxAnalyticAquifers() const
+    {
+        return this->maxNumAnalyticAquifers;
+    }
+
+    int maxAnalyticAquiferConnections() const
+    {
+        return this->maxNumAnalyticAquiferConn;
+    }
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->maxNumAnalyticAquifers);
+        serializer(this->maxNumAnalyticAquiferConn);
+    }
+
+private:
+    int maxNumAnalyticAquifers;
+    int maxNumAnalyticAquiferConn;
+};
+
+bool operator==(const AquiferDimensions& lhs, const AquiferDimensions& rhs);
 
 class EclHysterConfig
 {
@@ -339,6 +369,7 @@ public:
     const Welldims& wellDimensions() const noexcept;
     const WellSegmentDims& wellSegmentDimensions() const noexcept;
     const NetworkDims& networkDimensions() const noexcept;
+    const AquiferDimensions& aquiferDimensions() const noexcept;
     int eclPhaseMask( ) const noexcept;
     const EclHysterConfig& hysterPar() const noexcept;
     const Actdims& actdims() const noexcept;
@@ -357,6 +388,7 @@ public:
         welldims.serializeOp(serializer);
         wsegdims.serializeOp(serializer);
         netwrkdims.serializeOp(serializer);
+        aquiferdims.serializeOp(serializer);
         udq_params.serializeOp(serializer);
         hystpar.serializeOp(serializer);
         m_actdims.serializeOp(serializer);
@@ -372,6 +404,7 @@ private:
     Welldims welldims;
     WellSegmentDims wsegdims;
     NetworkDims netwrkdims;
+    AquiferDimensions aquiferdims;
     UDQParams udq_params;
     EclHysterConfig hystpar;
     Actdims m_actdims;

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -527,6 +527,79 @@ WSEGDIMS
     BOOST_CHECK_EQUAL(wsd.maxLateralBranchesPerWell(), 33); // WSEGDIMS(3)
 }
 
+BOOST_AUTO_TEST_CASE(AQUDIMS_FullSpec)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+
+AQUDIMS
+-- 1 2 3 4 5 6 7  8
+   3 4 5 6 7 8 9 10 /
+)" };
+
+    const auto ad = AquiferDimensions {
+        Parser{}.parseString(input)
+    };
+
+    BOOST_CHECK_EQUAL(ad.maxAnalyticAquifers(), 7);           // AQUDIMS(5)
+    BOOST_CHECK_EQUAL(ad.maxAnalyticAquiferConnections(), 8); // AQUDIMS(6)
+}
+
+BOOST_AUTO_TEST_CASE(AQUDIMS_AllDefaulted)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+
+AQUDIMS
+/
+)" };
+
+    const auto ad = AquiferDimensions {
+        Parser{}.parseString(input)
+    };
+
+    BOOST_CHECK_EQUAL(ad.maxAnalyticAquifers(), 1);           // AQUDIMS(5): Default = 1
+    BOOST_CHECK_EQUAL(ad.maxAnalyticAquiferConnections(), 1); // AQUDIMS(6): Default = 1
+}
+
+BOOST_AUTO_TEST_CASE(AQUDIMS_MaxAnalyticAquifers)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+
+AQUDIMS
+-- 1 2 3 4 5
+   4*      1729 /
+)" };
+
+    const auto ad = AquiferDimensions {
+        Parser{}.parseString(input)
+    };
+
+    BOOST_CHECK_EQUAL(ad.maxAnalyticAquifers(), 1729); // AQUDIMS(5)
+}
+
+BOOST_AUTO_TEST_CASE(AQUDIMS_MaxAnalyticAquiferConnections)
+{
+    const auto input = std::string {
+        R"(
+RUNSPEC
+
+AQUDIMS
+-- 1 2 3 4 5 6
+   5*        42 /
+)" };
+
+    const auto ad = AquiferDimensions {
+        Parser{}.parseString(input)
+    };
+
+    BOOST_CHECK_EQUAL(ad.maxAnalyticAquiferConnections(), 42); // AQUDIMS(6)
+}
+
 BOOST_AUTO_TEST_CASE( SWATINIT ) {
     const std::string input = R"(
     SWATINIT


### PR DESCRIPTION
This commit internalises the items `NANAQU` (5) and `NCAMAX` (6) of the `AQUDIMS` keyword into a new structure
```
AquiferDimensions
```
hooked up to the `Runspec` class.  This is in preparation of adding restart output for analytic aquifers (Carter-Tracy and Fetkovich).