### PR TITLE
Enable usage of fmtlib on the system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,20 @@ include(Findopm-tests)
 # with the find module
 include (${project}-prereqs)
 
+if(ENABLE_ECL_INPUT)
+  # source_hook runs before config_hook and the former needs fmt, hence this
+  # needs to be here.
+  if(fmt_FOUND)
+    # OpmSatellites will not add the library, do it here.
+    list(APPEND opm-common_LIBRARIES fmt::fmt)
+  else()
+    add_definitions(-DFMT_HEADER_ONLY)
+    include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
+    # Not sure why this is needed.
+    list(APPEND EXTRA_INCLUDES ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
+  endif()
+endif()
+
 # read the list of components from this file (in the project directory);
 # it should set various lists with the names of the files to include
 include (CMakeLists_files.cmake)
@@ -75,11 +89,7 @@ macro (config_hook)
     endif()
 
     # For this project
-    add_definitions(-DFMT_HEADER_ONLY)
-    include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
     include_directories(${EXTRA_INCLUDES} ${PROJECT_BINARY_DIR}/include)
-    list(APPEND EXTRA_INCLUDES ${PROJECT_SOURCE_DIR}/external/fmtlib/include)
-
     # For downstreams
     list(APPEND EXTRA_INCLUDES ${PROJECT_BINARY_DIR}/include)
     set(OPM_PROJECT_EXTRA_CODE_INTREE "${OPM_PROJECT_EXTRA_CODE_INTREE}

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -17,6 +17,10 @@ list(APPEND opm-common_DEPS
       "Boost 1.44.0 COMPONENTS system unit_test_framework REQUIRED"
       "OpenMP QUIET"
       "cjson"
+      # Still it produces compile errors complaining that it
+      # cannot format UDQVarType. Hence we use the same version
+      # as the embedded one.
+      "fmt 7.0.3"
 )
 
 find_package_deps(opm-common)


### PR DESCRIPTION
If fmtlib is present on the system we used that one in the normal mode (not header only). Otherwise we fall back to the embedded one in header only mode. Might even save some compile time (At least it feels like I am getting less compiler warnigs).

BTW There is a chicken and egg problem with config_hook and source_hook: One cannot add libraries in the former one that are needed by GenerateKeywords.cmake (which is included in the latter) as source_hook is run before config_hook. That is the reason why the fmtlib logic was moved out of the hooks.

Much cleaner than my first try #2291, anyway.
Let's hope it works with python