### PR TITLE
Add guiderate for injection groups

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include <stddef.h>
 
@@ -91,15 +92,16 @@ struct GRValState {
 
 public:
     GuideRate(const Schedule& schedule);
-    void   compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
-    double get(const std::string& well, Well::GuideRateTarget target, const RateVector& rates) const;
-    double get(const std::string& group, Group::GuideRateProdTarget target, const RateVector& rates) const;
-    double get(const std::string& name, GuideRateModel::Target model_target, const RateVector& rates) const;
-    bool has(const std::string& name) const;
-
+    double getProductionGroupOrWell(const std::string& name, GuideRateModel::Target model_target, const RateVector& rates) const;
+    double getWell(const std::string& well, Well::GuideRateTarget target, const RateVector& rates) const;
+    double getProductionGroup(const std::string& group, Group::GuideRateProdTarget target, const RateVector& rates) const;
+    double getInjectionGroup(const Phase& phase, const std::string& group) const;
+    bool hasProductionGroupOrWell(const std::string& name) const;
+    bool hasInjectionGroup(const Phase& phase, const std::string& name) const;
+    void injectionGroupCompute(const std::string& wgname, const Phase& phase, size_t report_step, double guide_rate);
+    void productionGroupCompute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
+    void wellCompute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
 private:
-    void well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
-    void group_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
     double eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot) const;
     double eval_group_pot() const;
     double eval_group_resvinj() const;
@@ -109,7 +111,19 @@ private:
 
     using GRValPtr = std::unique_ptr<GRValState>;
 
+    typedef std::pair<Phase,std::string> pair;
+
+    struct pair_hash
+    {
+        template <class T1, class T2>
+        std::size_t operator() (const std::pair<T1, T2> &pair) const
+        {
+            return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+        }
+    };
+
     std::unordered_map<std::string, GRValPtr> values;
+    std::unordered_map<pair, double, pair_hash> injection_group_values;
     std::unordered_map<std::string, RateVector > potentials;
     const Schedule& schedule;
 };

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -92,16 +92,18 @@ struct GRValState {
 
 public:
     GuideRate(const Schedule& schedule);
-    double getProductionGroupOrWell(const std::string& name, GuideRateModel::Target model_target, const RateVector& rates) const;
-    double getWell(const std::string& well, Well::GuideRateTarget target, const RateVector& rates) const;
-    double getProductionGroup(const std::string& group, Group::GuideRateProdTarget target, const RateVector& rates) const;
-    double getInjectionGroup(const Phase& phase, const std::string& group) const;
-    bool hasProductionGroupOrWell(const std::string& name) const;
-    bool hasInjectionGroup(const Phase& phase, const std::string& name) const;
-    void injectionGroupCompute(const std::string& wgname, const Phase& phase, size_t report_step, double guide_rate);
-    void productionGroupCompute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
-    void wellCompute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
+    void   compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
+    void compute(const std::string& wgname, const Phase& phase, size_t report_step, double guide_rate);
+    double get(const std::string& well, Well::GuideRateTarget target, const RateVector& rates) const;
+    double get(const std::string& group, Group::GuideRateProdTarget target, const RateVector& rates) const;
+    double get(const std::string& name, GuideRateModel::Target model_target, const RateVector& rates) const;
+    double get(const std::string& group, const Phase& phase) const;
+    bool has(const std::string& name) const;
+    bool has(const std::string& name, const Phase& phase) const;
+
 private:
+    void well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
+    void group_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
     double eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot) const;
     double eval_group_pot() const;
     double eval_group_resvinj() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp
@@ -95,7 +95,7 @@ struct GroupInjTarget {
     bool has_model() const;
     bool update_model(const GuideRateModel& model);
     void update_well(const Well& well);
-    void update_injection_group(const std::string& group_name, Group::GroupInjectionProperties& properties);
+    void update_injection_group(const std::string& group_name, const Group::GroupInjectionProperties& properties);
     void update_production_group(const Group& group);
     const WellTarget& well(const std::string& well) const;
     const GroupProdTarget& production_group(const std::string& group) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <unordered_map>
 #include <memory>
+#include <utility>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
@@ -54,11 +55,28 @@ public:
     }
 };
 
-struct GroupTarget {
+struct GroupProdTarget {
     double guide_rate;
     Group::GuideRateProdTarget target;
 
-    bool operator==(const GroupTarget& data) const {
+    bool operator==(const GroupProdTarget& data) const {
+        return guide_rate == data.guide_rate &&
+               target == data.target;
+    }
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(guide_rate);
+        serializer(target);
+    }
+};
+
+struct GroupInjTarget {
+    double guide_rate;
+    Group::GuideRateInjTarget target;
+
+    bool operator==(const GroupInjTarget& data) const {
         return guide_rate == data.guide_rate &&
                target == data.target;
     }
@@ -77,11 +95,15 @@ struct GroupTarget {
     bool has_model() const;
     bool update_model(const GuideRateModel& model);
     void update_well(const Well& well);
-    void update_group(const Group& group);
+    void update_injection_group(const std::string& group_name, Group::GroupInjectionProperties& properties);
+    void update_production_group(const Group& group);
     const WellTarget& well(const std::string& well) const;
-    const GroupTarget& group(const std::string& group) const;
+    const GroupProdTarget& production_group(const std::string& group) const;
+    const GroupInjTarget& injection_group(const Phase& phase, const std::string& group) const;
+
     bool has_well(const std::string& well) const;
-    bool has_group(const std::string& group) const;
+    bool has_injection_group(const Phase& phase, const std::string& group) const;
+    bool has_production_group(const std::string& group) const;
 
     bool operator==(const GuideRateConfig& data) const;
 
@@ -90,13 +112,28 @@ struct GroupTarget {
     {
         serializer(m_model);
         serializer.map(wells);
-        serializer.map(groups);
+        serializer.map(production_groups);
+        serializer.map(injection_groups);
     }
 
 private:
+
+    typedef std::pair<Phase,std::string> pair;
+
+    struct pair_hash
+    {
+        template <class T1, class T2>
+        std::size_t operator() (const std::pair<T1, T2> &pair) const
+        {
+            return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+        }
+    };
+
     std::shared_ptr<GuideRateModel> m_model;
     std::unordered_map<std::string, WellTarget> wells;
-    std::unordered_map<std::string, GroupTarget> groups;
+    std::unordered_map<std::string, GroupProdTarget> production_groups;
+    std::unordered_map<pair, GroupInjTarget, pair_hash> injection_groups;
+
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
@@ -83,6 +83,7 @@ public:
 
     static Target convert_target(Well::GuideRateTarget well_target);
     static Target convert_target(Group::GuideRateProdTarget group_target);
+    static Target convert_target(Phase injection_phase);
     static double pot(Target target, double oil_pot, double gas_pot, double wat_pot);
 
     template<class Serializer>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.cpp
@@ -87,7 +87,7 @@ void GuideRateConfig::update_production_group(const Group& group) {
     group_node.target = guide_target;
 }
 
-void GuideRateConfig::update_injection_group(const std::string& group_name, Group::GroupInjectionProperties& properties) {
+void GuideRateConfig::update_injection_group(const std::string& group_name, const Group::GroupInjectionProperties& properties) {
     if (group_name == "FIELD")
         return;
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
@@ -328,4 +328,17 @@ GuideRateModel::Target GuideRateModel::convert_target(Group::GuideRateProdTarget
     throw std::logic_error("Can not convert this .... ");
 }
 
+GuideRateModel::Target GuideRateModel::convert_target(Phase injection_phase) {
+    if (injection_phase == Phase::OIL)
+        return Target::OIL;
+
+    if (injection_phase == Phase::GAS)
+        return Target::GAS;
+
+    if (injection_phase == Phase::WATER)
+        return Target::WAT;
+
+    throw std::logic_error("Can not convert this .... ");
+}
+
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -350,8 +350,6 @@ namespace {
                     if (guide_rate_str) {
                         guide_rate_def = Group::GuideRateInjTargetFromString(guide_rate_str.value());
                         guide_rate = record.getItem("GUIDE_RATE").get<double>(0);
-                        if (guide_rate == 0)
-                            guide_rate_def = Group::GuideRateInjTarget::POTN;
                     }
                 }
 
@@ -389,6 +387,10 @@ namespace {
                         injection.voidage_group = record.getItem("VOIDAGE_GROUP").getTrimmedString(0);
 
                     if (new_group.updateInjection(injection)) {
+                        auto new_config = this->snapshots.back().guide_rate();
+                        new_config.update_injection_group(group_name, injection);
+                        this->snapshots.back().guide_rate.update( std::move(new_config));
+
                         this->snapshots.back().groups.update( std::move(new_group));
                         this->snapshots.back().events().addEvent( ScheduleEvents::GROUP_INJECTION_UPDATE );
                         this->snapshots.back().wellgroup_events().addEvent( group_name, ScheduleEvents::GROUP_INJECTION_UPDATE);
@@ -505,7 +507,7 @@ namespace {
 
                     if (new_group.updateProduction(production)) {
                         auto new_config = this->snapshots.back().guide_rate();
-                        new_config.update_group(new_group);
+                        new_config.update_production_group(new_group);
                         this->snapshots.back().guide_rate.update( std::move(new_config));
 
                         this->snapshots.back().groups.update( std::move(new_group));

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -465,6 +465,95 @@ BOOST_AUTO_TEST_CASE(GCONINJE_MULTIPLE_PHASES) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(GCONINJE_GUIDERATE) {
+    std::string input = R"(
+        START             -- 0
+        31 AUG 1993 /
+        SCHEDULE
+
+        GRUPTREE
+           'G1'  'FIELD' /
+           'G2'  'FIELD' /
+        /
+
+        GCONINJE
+           'G1'   'WATER'   1*  1000 /
+           'G1'   'GAS'     1*  1000 /
+           'G2'   'WATER'   1*  1000 /
+        /
+
+        TSTEP
+           10 /
+
+        GCONINJE
+           'G1'   'WATER'   1*  1000 3* 'YES' 1 'RATE'/
+           'G1'   'GAS'     1*  1000 3* 'YES' 1 'RATE'/
+           'G2'   'WATER'   1*  1000 3* 'YES' 1 'RATE'/
+        /
+
+        TSTEP
+            10 /
+
+        GCONINJE
+            'G1'   'WATER'   1*  1000 /
+            'G1'   'GAS'     1*  1000 3* 'YES' 1 'RATE'/
+            'G2'   'WATER'   1*  1000 3* 'YES' 1 'RATE'/
+        /
+
+        )";
+
+    auto schedule = create_schedule(input);
+    // Step 0
+    {
+        GuideRate gr = GuideRate(schedule);
+        const auto& g1 = schedule.getGroup("G1", 0);
+        const auto& g2 = schedule.getGroup("G2", 0);
+        gr.injectionGroupCompute(g1.name(), Phase::WATER, 0, 0.0);
+        gr.injectionGroupCompute(g1.name(), Phase::GAS, 0, 0.0);
+        gr.injectionGroupCompute(g2.name(), Phase::WATER, 0, 0.0);
+        gr.injectionGroupCompute(g2.name(), Phase::GAS, 0, 0.0);
+        BOOST_CHECK( !gr.hasInjectionGroup(Phase::WATER, g1.name()));
+        BOOST_CHECK( !gr.hasInjectionGroup(Phase::GAS, g1.name()));
+        BOOST_CHECK( !gr.hasInjectionGroup(Phase::WATER, g2.name()));
+        BOOST_CHECK( !gr.hasInjectionGroup(Phase::GAS, g2.name()));
+    }
+    // Step 1
+    {
+        GuideRate gr = GuideRate(schedule);
+        const auto& g1 = schedule.getGroup("G1", 1);
+        const auto& g2 = schedule.getGroup("G2", 1);
+        gr.injectionGroupCompute(g1.name(), Phase::WATER, 1, 0.0);
+        gr.injectionGroupCompute(g1.name(), Phase::GAS, 1, 0.0);
+        gr.injectionGroupCompute(g2.name(), Phase::WATER, 1, 0.0);
+        gr.injectionGroupCompute(g2.name(), Phase::GAS, 1, 0.0);
+
+        BOOST_CHECK( gr.hasInjectionGroup(Phase::WATER, g1.name()));
+        BOOST_CHECK( gr.hasInjectionGroup(Phase::GAS, g1.name()));
+        BOOST_CHECK( gr.hasInjectionGroup(Phase::WATER, g2.name()));
+        BOOST_CHECK( !gr.hasInjectionGroup(Phase::GAS, g2.name()));
+
+        BOOST_CHECK_EQUAL(1.0, gr.getInjectionGroup(Phase::WATER, g1.name()));
+        BOOST_CHECK_EQUAL(1.0, gr.getInjectionGroup(Phase::GAS, g1.name()));
+        BOOST_CHECK_EQUAL(1.0, gr.getInjectionGroup(Phase::WATER, g2.name()));
+        BOOST_CHECK_THROW(gr.getInjectionGroup(Phase::GAS, g2.name()), std::logic_error);
+    }
+    // Step 2
+    {
+        GuideRate gr = GuideRate(schedule);
+        const auto& g1 = schedule.getGroup("G1", 2);
+        const auto& g2 = schedule.getGroup("G2", 2);
+        gr.injectionGroupCompute(g1.name(), Phase::WATER, 2, 0.0);
+        gr.injectionGroupCompute(g1.name(), Phase::GAS, 2, 0.0);
+        gr.injectionGroupCompute(g2.name(), Phase::WATER, 2, 0.0);
+        gr.injectionGroupCompute(g2.name(), Phase::GAS, 2, 0.0);
+        BOOST_CHECK( !gr.hasInjectionGroup(Phase::WATER, g1.name()));
+        BOOST_CHECK( gr.hasInjectionGroup(Phase::GAS, g1.name()));
+        BOOST_CHECK( gr.hasInjectionGroup(Phase::WATER, g2.name()));
+        BOOST_CHECK( !gr.hasInjectionGroup(Phase::GAS, g2.name()));
+    }
+
+}
+
 BOOST_AUTO_TEST_CASE(GCONINJE_GCONPROD) {
     std::string input = R"(
         START             -- 0

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -508,48 +508,48 @@ BOOST_AUTO_TEST_CASE(GCONINJE_GUIDERATE) {
         GuideRate gr = GuideRate(schedule);
         const auto& g1 = schedule.getGroup("G1", 0);
         const auto& g2 = schedule.getGroup("G2", 0);
-        gr.injectionGroupCompute(g1.name(), Phase::WATER, 0, 0.0);
-        gr.injectionGroupCompute(g1.name(), Phase::GAS, 0, 0.0);
-        gr.injectionGroupCompute(g2.name(), Phase::WATER, 0, 0.0);
-        gr.injectionGroupCompute(g2.name(), Phase::GAS, 0, 0.0);
-        BOOST_CHECK( !gr.hasInjectionGroup(Phase::WATER, g1.name()));
-        BOOST_CHECK( !gr.hasInjectionGroup(Phase::GAS, g1.name()));
-        BOOST_CHECK( !gr.hasInjectionGroup(Phase::WATER, g2.name()));
-        BOOST_CHECK( !gr.hasInjectionGroup(Phase::GAS, g2.name()));
+        gr.compute(g1.name(), Phase::WATER, 0, 0.0);
+        gr.compute(g1.name(), Phase::GAS, 0, 0.0);
+        gr.compute(g2.name(), Phase::WATER, 0, 0.0);
+        gr.compute(g2.name(), Phase::GAS, 0, 0.0);
+        BOOST_CHECK( !gr.has(g1.name(), Phase::WATER));
+        BOOST_CHECK( !gr.has(g1.name(), Phase::GAS));
+        BOOST_CHECK( !gr.has(g2.name(), Phase::WATER));
+        BOOST_CHECK( !gr.has(g2.name(), Phase::GAS));
     }
     // Step 1
     {
         GuideRate gr = GuideRate(schedule);
         const auto& g1 = schedule.getGroup("G1", 1);
         const auto& g2 = schedule.getGroup("G2", 1);
-        gr.injectionGroupCompute(g1.name(), Phase::WATER, 1, 0.0);
-        gr.injectionGroupCompute(g1.name(), Phase::GAS, 1, 0.0);
-        gr.injectionGroupCompute(g2.name(), Phase::WATER, 1, 0.0);
-        gr.injectionGroupCompute(g2.name(), Phase::GAS, 1, 0.0);
+        gr.compute(g1.name(), Phase::WATER, 1, 0.0);
+        gr.compute(g1.name(), Phase::GAS, 1, 0.0);
+        gr.compute(g2.name(), Phase::WATER, 1, 0.0);
+        gr.compute(g2.name(), Phase::GAS, 1, 0.0);
 
-        BOOST_CHECK( gr.hasInjectionGroup(Phase::WATER, g1.name()));
-        BOOST_CHECK( gr.hasInjectionGroup(Phase::GAS, g1.name()));
-        BOOST_CHECK( gr.hasInjectionGroup(Phase::WATER, g2.name()));
-        BOOST_CHECK( !gr.hasInjectionGroup(Phase::GAS, g2.name()));
+        BOOST_CHECK( gr.has(g1.name(), Phase::WATER));
+        BOOST_CHECK( gr.has(g1.name(), Phase::GAS));
+        BOOST_CHECK( gr.has(g2.name(), Phase::WATER));
+        BOOST_CHECK( !gr.has(g2.name(), Phase::GAS));
 
-        BOOST_CHECK_EQUAL(1.0, gr.getInjectionGroup(Phase::WATER, g1.name()));
-        BOOST_CHECK_EQUAL(1.0, gr.getInjectionGroup(Phase::GAS, g1.name()));
-        BOOST_CHECK_EQUAL(1.0, gr.getInjectionGroup(Phase::WATER, g2.name()));
-        BOOST_CHECK_THROW(gr.getInjectionGroup(Phase::GAS, g2.name()), std::logic_error);
+        BOOST_CHECK_EQUAL(1.0, gr.get(g1.name(), Phase::WATER));
+        BOOST_CHECK_EQUAL(1.0, gr.get(g1.name(), Phase::GAS));
+        BOOST_CHECK_EQUAL(1.0, gr.get(g2.name(), Phase::WATER));
+        BOOST_CHECK_THROW(gr.get(g2.name(), Phase::GAS), std::logic_error);
     }
     // Step 2
     {
         GuideRate gr = GuideRate(schedule);
         const auto& g1 = schedule.getGroup("G1", 2);
         const auto& g2 = schedule.getGroup("G2", 2);
-        gr.injectionGroupCompute(g1.name(), Phase::WATER, 2, 0.0);
-        gr.injectionGroupCompute(g1.name(), Phase::GAS, 2, 0.0);
-        gr.injectionGroupCompute(g2.name(), Phase::WATER, 2, 0.0);
-        gr.injectionGroupCompute(g2.name(), Phase::GAS, 2, 0.0);
-        BOOST_CHECK( !gr.hasInjectionGroup(Phase::WATER, g1.name()));
-        BOOST_CHECK( gr.hasInjectionGroup(Phase::GAS, g1.name()));
-        BOOST_CHECK( gr.hasInjectionGroup(Phase::WATER, g2.name()));
-        BOOST_CHECK( !gr.hasInjectionGroup(Phase::GAS, g2.name()));
+        gr.compute(g1.name(), Phase::WATER, 2, 0.0);
+        gr.compute(g1.name(), Phase::GAS, 2, 0.0);
+        gr.compute(g2.name(), Phase::WATER, 2, 0.0);
+        gr.compute(g2.name(), Phase::GAS, 2, 0.0);
+        BOOST_CHECK( !gr.has(g1.name(), Phase::WATER));
+        BOOST_CHECK( gr.has(g1.name(), Phase::GAS));
+        BOOST_CHECK( gr.has(g2.name(), Phase::WATER));
+        BOOST_CHECK( !gr.has(g2.name(), Phase::GAS));
     }
 
 }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3464,8 +3464,8 @@ COMPDAT
         const auto& w2_node = grc.well("W2");
         BOOST_CHECK(w2_node.target == Well::GuideRateTarget::GAS);
 
-        BOOST_CHECK(!grc.has_group("G1"));
-        BOOST_CHECK(grc.has_group("G2"));
+        BOOST_CHECK(!grc.has_production_group("G1"));
+        BOOST_CHECK(grc.has_production_group("G2"));
     }
     {
         const auto& grc = schedule.guideRateConfig(2);
@@ -3477,8 +3477,8 @@ COMPDAT
         BOOST_CHECK(!grc.has_well("W2"));
         BOOST_CHECK_THROW( grc.well("W2"), std::out_of_range);
 
-        BOOST_CHECK(grc.has_group("G1"));
-        BOOST_CHECK(!grc.has_group("G2"));
+        BOOST_CHECK(grc.has_production_group("G1"));
+        BOOST_CHECK(!grc.has_production_group("G2"));
     }
 
     {
@@ -3487,7 +3487,7 @@ COMPDAT
         double gas_pot = 1;
         double wat_pot = 1;
 
-        gr.compute("XYZ",1, 1.0, oil_pot, gas_pot, wat_pot);
+        gr.wellCompute("XYZ",1, 1.0, oil_pot, gas_pot, wat_pot);
     }
     {
         const auto& changed_wells = schedule.changed_wells(0);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3487,7 +3487,7 @@ COMPDAT
         double gas_pot = 1;
         double wat_pot = 1;
 
-        gr.wellCompute("XYZ",1, 1.0, oil_pot, gas_pot, wat_pot);
+        gr.compute("XYZ",1, 1.0, oil_pot, gas_pot, wat_pot);
     }
     {
         const auto& changed_wells = schedule.changed_wells(0);

--- a/tests/test_GuideRate.cpp
+++ b/tests/test_GuideRate.cpp
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(P1_First)
     const auto stm  = 0.0;
     const auto rpt  = size_t{1};
 
-    cse.gr.compute("P1", rpt, stm, wopp, wgpp, wwpp);
+    cse.gr.wellCompute("P1", rpt, stm, wopp, wgpp, wwpp);
 
     const auto orat = 2.0;
     const auto grat = 4.0;      // == 2 * orat
@@ -213,14 +213,14 @@ BOOST_AUTO_TEST_CASE(P1_First)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P1", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
 
         BOOST_CHECK_CLOSE(grval, expect_gr_oil, 1.0e-5);
     }
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P1", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * expect_gr_oil;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(P1_First)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P1", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * expect_gr_oil;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto stm  = 0.0;
         const auto rpt  = size_t{1};
 
-        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.wellCompute("P2", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto stm  = 10.0*Opm::unit::second; // Before recalculation delay
         const auto rpt  = size_t{1};
 
-        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.wellCompute("P2", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto orat = 2.0;
@@ -267,14 +267,14 @@ BOOST_AUTO_TEST_CASE(P2_Second)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
 
         BOOST_CHECK_CLOSE(grval, expect_gr_oil_1, 1.0e-5);
     }
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -295,14 +295,14 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto stm  = 10.0*Opm::unit::day; // After recalculation delay
         const auto rpt  = size_t{3};
 
-        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.wellCompute("P2", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto expect_gr_oil_2 = 10.0 / (0.5 + 1.0/10.0); // wopp_2 / (0.5 + wwpp_2/wopp_2)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
 
         const auto expect = 0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * (0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * (0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto stm  = 0.0;
         const auto rpt  = size_t{1};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -346,7 +346,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto stm  = 10.0*Opm::unit::day;
         const auto rpt  = size_t{3};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto stm  = 20.0*Opm::unit::day;
         const auto rpt  = size_t{4};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
 
         const auto expect = 0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * (0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * (0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto stm  = 0.0;
         const auto rpt  = size_t{1};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto stm  = 10.0*Opm::unit::day;
         const auto rpt  = size_t{3};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto stm  = 20.0*Opm::unit::day;
         const auto rpt  = size_t{4};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
 
         const auto expect = 0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * (0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * (0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -470,7 +470,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto stm  = 0.0;
         const auto rpt  = size_t{1};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto stm  = 10.0*Opm::unit::day;
         const auto rpt  = size_t{3};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto stm  = 20.0*Opm::unit::day;
         const auto rpt  = size_t{4};
 
-        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
 
         const auto expect = 0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -511,7 +511,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * (0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.get("P", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * (0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);

--- a/tests/test_GuideRate.cpp
+++ b/tests/test_GuideRate.cpp
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(P1_First)
     const auto stm  = 0.0;
     const auto rpt  = size_t{1};
 
-    cse.gr.wellCompute("P1", rpt, stm, wopp, wgpp, wwpp);
+    cse.gr.compute("P1", rpt, stm, wopp, wgpp, wwpp);
 
     const auto orat = 2.0;
     const auto grat = 4.0;      // == 2 * orat
@@ -213,14 +213,14 @@ BOOST_AUTO_TEST_CASE(P1_First)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.getWell("P1", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
 
         BOOST_CHECK_CLOSE(grval, expect_gr_oil, 1.0e-5);
     }
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.getWell("P1", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * expect_gr_oil;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(P1_First)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.getWell("P1", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P1", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * expect_gr_oil;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto stm  = 0.0;
         const auto rpt  = size_t{1};
 
-        cse.gr.wellCompute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto stm  = 10.0*Opm::unit::second; // Before recalculation delay
         const auto rpt  = size_t{1};
 
-        cse.gr.wellCompute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto orat = 2.0;
@@ -267,14 +267,14 @@ BOOST_AUTO_TEST_CASE(P2_Second)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
 
         BOOST_CHECK_CLOSE(grval, expect_gr_oil_1, 1.0e-5);
     }
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -295,14 +295,14 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto stm  = 10.0*Opm::unit::day; // After recalculation delay
         const auto rpt  = size_t{3};
 
-        cse.gr.wellCompute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto expect_gr_oil_2 = 10.0 / (0.5 + 1.0/10.0); // wopp_2 / (0.5 + wwpp_2/wopp_2)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::OIL, { orat, grat, wrat });
 
         const auto expect = 0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * (0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.getWell("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P2", Opm::Well::GuideRateTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * (0.5*expect_gr_oil_2 + 0.5*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto stm  = 0.0;
         const auto rpt  = size_t{1};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -346,7 +346,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto stm  = 10.0*Opm::unit::day;
         const auto rpt  = size_t{3};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto stm  = 20.0*Opm::unit::day;
         const auto rpt  = size_t{4};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
 
         const auto expect = 0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * (0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * (0.5*expect_gr_oil_3 + 0.5*0.5*expect_gr_oil_2 + 0.5*0.5*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto stm  = 0.0;
         const auto rpt  = size_t{1};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto stm  = 10.0*Opm::unit::day;
         const auto rpt  = size_t{3};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto stm  = 20.0*Opm::unit::day;
         const auto rpt  = size_t{4};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
 
         const auto expect = 0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * (0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * (0.1*expect_gr_oil_3 + 0.1*0.9*expect_gr_oil_2 + 0.9*0.9*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -470,7 +470,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto stm  = 0.0;
         const auto rpt  = size_t{1};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -480,7 +480,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto stm  = 10.0*Opm::unit::day;
         const auto rpt  = size_t{3};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     {
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto stm  = 20.0*Opm::unit::day;
         const auto rpt  = size_t{4};
 
-        cse.gr.productionGroupCompute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
@@ -503,7 +503,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
 
     // GR_{oil}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::OIL, { orat, grat, wrat });
 
         const auto expect = 0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1;
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -511,7 +511,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
 
     // GR_{gas}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::GAS, { orat, grat, wrat });
 
         const auto expect = (grat / orat) * (0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
 
     // GR_{water}
     {
-        const auto grval = cse.gr.getProductionGroup("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
+        const auto grval = cse.gr.get("P", Opm::Group::GuideRateProdTarget::WAT, { orat, grat, wrat });
 
         const auto expect = (wrat / orat) * (0.9*expect_gr_oil_3 + 0.9*0.1*expect_gr_oil_2 + 0.1*0.1*expect_gr_oil_1);
         BOOST_CHECK_CLOSE(grval, expect, 1.0e-5);


### PR DESCRIPTION
This adapt the guiderate classes to handle injection groups. It needs to be merge together with downstream changes in opm-simulators. 