### PR TITLE
Support system pybind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ if (OPM_ENABLE_PYTHON)
   # find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
   # Hence we overwrite them here.
   if(NOT PYTHON_INCLUDE_DIRS)
-    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "from distutils import sysconfig; print(sysconfig.get_python_inc(plat_specific=True));"
+    execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "from distutils import sysconfig; print(sysconfig.get_python_inc(plat_specific=True), end=\"\");"
       RESULT_VARIABLE _PYTHON_DIR_SUCCESS
       OUTPUT_VARIABLE PYTHON_INCLUDE_DIR
       ERROR_VARIABLE _PYTHON_ERROR_VALUE)
@@ -362,7 +362,7 @@ if (OPM_ENABLE_PYTHON)
 
   # Generate versioned setup.py
   if (pybind11_INCLUDE_DIRS)
-    string(REGEX REPLACE ";" "', '"  _tmp "${pybind11_INCLUDE_DIRS}" )
+    string(REGEX REPLACE ";" "', '"  _tmp "${pybind11_INCLUDE_DIRS}")
     set(SETUP_PY_PYBIND_INCLUDE_DIR "'${_tmp}'")
   endif()
   configure_file (${PROJECT_SOURCE_DIR}/python/setup.py.in ${PROJECT_BINARY_DIR}/python/setup.py)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,11 @@ if (OPM_ENABLE_PYTHON)
     endif()
     set(PYTHON_INCLUDE_DIRS ${PYTHON_INCLUDE_DIR})
   endif()
+  find_package(pybind11 2.2 CONFIG)
+  if (NOT pybind11_FOUND)
+    # Use full path for reuse with pypi
+    set(pybind11_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/python/pybind11/include ${PYTHON_INCLUDE_DIRS})
+  endif()
 endif()
 
 
@@ -356,6 +361,10 @@ if (OPM_ENABLE_PYTHON)
   set(opm-common_PYTHON_PACKAGE_VERSION ${OPM_PYTHON_PACKAGE_VERSION_TAG})
 
   # Generate versioned setup.py
+  if (pybind11_INCLUDE_DIRS)
+    string(REGEX REPLACE ";" "', '"  _tmp "${pybind11_INCLUDE_DIRS}" )
+    set(SETUP_PY_PYBIND_INCLUDE_DIR "'${_tmp}'")
+  endif()
   configure_file (${PROJECT_SOURCE_DIR}/python/setup.py.in ${PROJECT_BINARY_DIR}/python/setup.py)
   file(COPY ${PROJECT_SOURCE_DIR}/python/README.md DESTINATION ${PROJECT_BINARY_DIR}/python)
   execute_process(COMMAND ${Python3_EXECUTABLE} target_name.py
@@ -433,7 +442,7 @@ if (OPM_ENABLE_PYTHON)
 
   # -------------------------------------------------------------------------
   # 2: Embed the Python interpreter for keywords like PYACTION and PYINPUT
-  target_include_directories(opmcommon SYSTEM PRIVATE "python/pybind11/include;${PYTHON_INCLUDE_DIRS}")
+  target_include_directories(opmcommon SYSTEM PRIVATE "${pybind11_INCLUDE_DIRS}")
   if (OPM_ENABLE_EMBEDDED_PYTHON)
     target_link_libraries(opmcommon PUBLIC ${PYTHON_LIBRARY})
     add_definitions(-DEMBEDDED_PYTHON)

--- a/cmake/Modules/Finddune-common.cmake
+++ b/cmake/Modules/Finddune-common.cmake
@@ -28,7 +28,7 @@ find_opm_package (
   "dunecommon"
 
   # defines to be added to compilations
-  "DUNE_COMMON_FIELDVECTOR_SIZE_IS_METHOD=1"
+  ""
 
   # test program
 "#include <dune/common/fvector.hh>

--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -135,6 +135,18 @@ if (NOT USE_MPI)
   set (CMAKE_DISABLE_FIND_PACKAGE_MPI TRUE)
 endif ()
 
+# Compiler standard version needs to be requested here as prereqs is included
+# before OpmLibMain and some tests need/use CXX_STANDARD_VERSION (e.g. pybind11)
+# Languages and global compiler settings
+if(CMAKE_VERSION VERSION_LESS 3.8)
+  message(WARNING "CMake version does not support c++17, guessing -std=c++17")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+else()
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
 # quadmath must be explicitly enabled
 # This needs to be in OpmInit as prereqs is called before OpmLibMain is included.
 option (USE_QUADMATH "Use high precision floating point library (slow)" OFF)

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -20,16 +20,6 @@
 include (AddOptions)
 no_default_options ()
 
-# Languages and global compiler settings
-if(CMAKE_VERSION VERSION_LESS 3.8)
-  message(WARNING "CMake version does not support c++17, guessing -std=c++17")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-else()
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
 # Various compiler extension checks
 include(OpmCompilerChecks)
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -65,7 +65,7 @@ ext_modules = [
         libraries=libs,
         language='c++',
         undef_macros=["NDEBUG"],
-        include_dirs=["pybind11/include"],
+        include_dirs=[@SETUP_PY_PYBIND_INCLUDE_DIR@],
         extra_compile_args=['-std=c++17', '-fopenmp'],
         extra_link_args=['-fopenmp', @opm-common_PYTHON_LINKAGE@]
     )


### PR DESCRIPTION
to ease packaging process.

Currently we will always use the system's pybind. We could make that optional,