### PR TITLE
Use add_compile_definitions to add defintions

### DIFF
--- a/cmake/Modules/OpmCompile.cmake
+++ b/cmake/Modules/OpmCompile.cmake
@@ -29,7 +29,11 @@ macro (opm_compile opm)
 
   # create this library, if there are any compilation units
   link_directories (${${opm}_LIBRARY_DIRS})
-  add_definitions (${${opm}_DEFINITIONS})
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
+    add_compile_definitions (${${opm}_DEFINITIONS})
+  else()
+    add_definitions(${${opm}_DEFINITIONS})
+  endif()
   set (${opm}_VERSION "${${opm}_VERSION_MAJOR}.${${opm}_VERSION_MINOR}")
   if (${opm}_SOURCES)
         add_library (${${opm}_TARGET} ${${opm}_LIBRARY_TYPE} ${${opm}_SOURCES})

--- a/cmake/Modules/OpmCompile.cmake
+++ b/cmake/Modules/OpmCompile.cmake
@@ -30,7 +30,9 @@ macro (opm_compile opm)
   # create this library, if there are any compilation units
   link_directories (${${opm}_LIBRARY_DIRS})
   if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
-    add_compile_definitions (${${opm}_DEFINITIONS})
+    # Some modules may still export definitions using -D, strip it
+    string(REGEX REPLACE "-D" "" _clean_defs "${${opm}_DEFINITIONS}")
+    add_compile_definitions(${_clean_defs})
   else()
     add_definitions(${${opm}_DEFINITIONS})
   endif()

--- a/cmake/Modules/OpmFind.cmake
+++ b/cmake/Modules/OpmFind.cmake
@@ -163,7 +163,21 @@ macro (find_and_append_package_to prefix name)
   string (REPLACE "-" "_" NAME "${NAME}")
 
   if (${name}_FOUND OR ${NAME}_FOUND)
-	foreach (var IN LISTS _opm_proj_vars)
+      foreach (var IN LISTS _opm_proj_vars)
+          if("${var}" STREQUAL "DEFINITIONS"
+            AND CMAKE_VERSION VERSION_LESS "3.12")
+            # For old Cmake versions we use add_definitions which
+            # requires -D qualifier add that
+            set(_defs)
+            foreach(_def IN LISTS ${name}_${var})
+              if(_def MATCHES "^[a-zA-Z].*")
+                list(APPEND _defs "-D${_def}")
+              else()
+                list(APPEND _defs "${_def}")
+              endif()
+            endforeach()
+            set(${name}_${var} "${_defs}")
+          endif()
 	  if (DEFINED ${name}_${var})
 		list (APPEND ${prefix}_${var} ${${name}_${var}})
 	  # some packages define an uppercase version of their own name

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -96,8 +96,12 @@ macro (find_opm_package module deps header lib defs prog conf)
   # compile with this option to avoid avalanche of warnings
   set (${module}_DEFINITIONS "${${module}_DEFINITIONS}")
   foreach (_def IN ITEMS ${defs})
-	list (APPEND ${module}_DEFINITIONS "-D${_def}")
+    if(_def MATCHES "^[A-Za-z].*")
+      list (APPEND ${module}_DEFINITIONS "-D${_def}")
+    endif()
   endforeach (_def)
+
+  list (APPEND ${module}_DEFINITIONS ${defs})
 
   # tidy the lists before returning them
   remove_dup_deps (${module})

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -95,9 +95,14 @@ macro (find_opm_package module deps header lib defs prog conf)
 
   # compile with this option to avoid avalanche of warnings
   set (${module}_DEFINITIONS "${${module}_DEFINITIONS}")
+  # -D to compile definitions for older CMake versions
+  set (_D_PREFIX "")
+  if(CMAKE_VERSION VERSION_LESS "3.12")
+    set(_D_PREFIX "-D")
+  endif()
   foreach (_def IN ITEMS ${defs})
     if(_def MATCHES "^[A-Za-z].*")
-      list (APPEND ${module}_DEFINITIONS "-D${_def}")
+      list (APPEND ${module}_DEFINITIONS "${_D_PREFIX}${_def}")
     endif()
   endforeach (_def)
 


### PR DESCRIPTION
add_definitions is deprecated or at least its use discoraged. This also saves manually adding the -D qualifier!

This is actually needed by our buildsystem magic if it searches for packages written for newer versions. Some of these projects omit the -D qualifiers and the definitions would end up on the command line as e.g `c++ USE_pybind11` instead of `c++ -DUSE_pybind` and we will get errors about not exising files (define is intepreted as source file).

Tested also on Ubuntu 18.04