### PR TITLE
Make sure action results contain well for fully specified condition

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp
@@ -42,6 +42,7 @@ namespace Action {
 class Value {
 public:
     explicit Value(double value);
+    Value(const std::string& wname, double value);
     Value() = default;
 
     Result eval_cmp(TokenType op, const Value& rhs) const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
@@ -133,7 +133,13 @@ Action::Value ASTNode::value(const Action::Context& context) const {
             std::string arg_key = this->arg_list[0];
             for (size_t index = 1; index < this->arg_list.size(); index++)
                 arg_key += ":" + this->arg_list[index];
-            return Action::Value(context.get(this->func, arg_key));
+
+            auto scalar_value = context.get(this->func, arg_key);
+
+            if (this->func_type == FuncType::well)
+                return Action::Value(this->arg_list[0], scalar_value);
+            else
+                return Action::Value(scalar_value);
         }
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.cpp
@@ -81,6 +81,9 @@ Value::Value(double value) :
     is_scalar(true)
 { }
 
+Value::Value(const std::string& wname, double value) {
+    this->add_well(wname, value);
+}
 
 double Value::scalar() const {
     if (!this->is_scalar)


### PR DESCRIPTION
Action well conditions like:
```
WBHP 'P1' > 200
```
i.e. with fully specified well name - are evaluated as scalars. With this PR we ensure that the well name `P1` is still available in the result objects matching wells.