### PR TITLE
Work around issue in FindPythonInterp in CMake version 3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,8 +171,13 @@ if (OPM_ENABLE_PYTHON)
       find_package(PythonLibs REQUIRED)
       list(APPEND opm-common_LIBRARIES ${PYTHON_LIBRARIES})
     endif()
-    if(PYTHON_VERSION_MAJOR LESS 3)
-      message(SEND_ERROR "OPM requires version 3 of Python but only version ${PYTHON_VERSION_STRING} was found")
+    # FindPythonInterp in CMake version 3.10.2 (used on Ubuntu LTS 18.04) is so
+    # buggy that it will always report Python version as 1.4 even with python3,
+    # skip the version check in this case
+    if(NOT PYTHON_VERSION_STRING STREQUAL "1.4")
+      if(PYTHON_VERSION_MAJOR LESS 3)
+	message(SEND_ERROR "OPM requires version 3 of Python but only version ${PYTHON_VERSION_STRING} was found")
+      endif()
     endif()
     set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
     set(Python3_LIBRARIES ${PYTHON_LIBRARIES})


### PR DESCRIPTION
FindPythonInterp in CMake version 3.10.2 (used on Ubuntu LTS 18.04) is so buggy that it will always report Python version as 1.4 even with python3, we skip the version check in this case.

Error messages are:
```
-- Found PythonInterp: /use/bin/python3 (found version "1.4")
-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.6m.so (found version "3.6.9")
CMake Error at CMakeLists.txt:175 (message):
  OPM requires version 3 of Python but only version 1.4 was found

CMake Error at /usr/lib/cmake/pybind11/FindPythonLibsNew.cmake:94 (message):
  Python config failure:

Call Stack (most recent call first):
  /usr/lib/cmake/pybind11/pybind11Tools.cmake:14 (find_package)
  /usr/lib/cmake/pybind11/pybind11Config.cmake:91 (include)
````