### PR TITLE
Corrections to InteHead to account for ROCKOPTS data and Well lists

### DIFF
--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -41,9 +41,6 @@ namespace RestartIO {
             int maxWellInGroup;
             int maxGroupInField;
             int maxWellsInField;
-        };
-
-        struct WellDims {
             int mxwlstprwel;
             int mxdynwlst;
         };
@@ -161,7 +158,6 @@ namespace RestartIO {
         InteHEAD& stepParam(const int tstep, const int report_step);
         InteHEAD& tuningParam(const TuningPar& tunpar);
         InteHEAD& variousParam(const int version, const int iprog);
-        InteHEAD& wellDimensions(const WellDims& wdims);
         InteHEAD& wellSegDimensions(const WellSegDims& wsdim);
         InteHEAD& networkDimensions(const NetworkDims& nwdim);
         InteHEAD& regionDimensions(const RegDims& rdim);

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -43,6 +43,11 @@ namespace RestartIO {
             int maxWellsInField;
         };
 
+        struct WellDims {
+            int mxwlstprwel;
+            int mxdynwlst;
+        };
+
         struct WellSegDims {
             int nsegwl;
             int nswlmx;
@@ -59,6 +64,10 @@ namespace RestartIO {
             int nrfreg;
             int ntfreg;
             int nplmix;
+        };
+
+        struct RockOpts {
+            int ttyp;
         };
 
         struct TimePoint {
@@ -152,9 +161,11 @@ namespace RestartIO {
         InteHEAD& stepParam(const int tstep, const int report_step);
         InteHEAD& tuningParam(const TuningPar& tunpar);
         InteHEAD& variousParam(const int version, const int iprog);
+        InteHEAD& wellDimensions(const WellDims& wdims);
         InteHEAD& wellSegDimensions(const WellSegDims& wsdim);
         InteHEAD& networkDimensions(const NetworkDims& nwdim);
         InteHEAD& regionDimensions(const RegDims& rdim);
+        InteHEAD& rockOpts(const RockOpts& rckop);
         InteHEAD& ngroups(const Group& gr);
         InteHEAD& udqParam_1(const UdqParam& udqpar);
         InteHEAD& actionParam(const ActionParam& act_par);

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -57,6 +57,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NXWELZ = 26, //  Number of delements per well in XWEL array
         NZWELZ = 27, //  Number of 8-character words per well in ZWEL array
 
+        MXWLSTPRWELL = 30, //  Maximum number of well lists pr well
+
         NICONZ = 32, //  Number of data elements per completion
                      //  in ICON array (default 19)
         NSCONZ = 33, //  Number of data elements per completion in SCON array
@@ -104,6 +106,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
                     //  (thermal option), negative - Other simulator,
         NMFIPR = 99, // REGDIMS item2
 
+        ROCKOPTS_TABTYP = 103, // ROCKOPTS item3 (PVTNUM=1 - default)
+
         NOACTNOD     =      129       ,              //  NOACTNOD = Number of active/defined nodes in the network
         NOACTBR      =      130       ,              //  NOACTBR = Number of active/defined branches in the network
         NODMAX       =      131       ,              //  NODMAX = maximum number of nodes in extended network option
@@ -145,6 +149,9 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NO_IUADS = 290, //  No IUADs
         NO_IUAPS = 291, //  No IUAPs
         RSEED = 296,
+
+        MAXDYNWELLST = 302, //  Maximum number of dynamic well lists (default = 1)
+
         ISECND = 410 //  ISECND = current simulation time HH:MM:SS - number of seconds (SS), reported in microseconds
                      //  (0-59,999,999)
     };

--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -110,6 +110,16 @@ public:
         return this->nWMax;
     }
 
+    int maxWellListsPrWell() const
+    {
+        return this->nWlistPrWellMax;
+    }
+
+    int maxDynamicWellLists() const
+    {
+        return this->nDynWlistMax;
+    }
+
     const std::optional<KeywordLocation>& location() const {
         return this->m_location;
     }
@@ -120,6 +130,8 @@ public:
                this->maxWellsPerGroup() == data.maxWellsPerGroup() &&
                this->maxGroupsInField() == data.maxGroupsInField() &&
                this->maxWellsInField() == data.maxWellsInField() &&
+               this->maxWellListsPrWell() == data.maxWellListsPrWell() &&
+               this->maxDynamicWellLists() == data.maxDynamicWellLists() &&
                this->location() == data.location();
     }
 
@@ -130,6 +142,8 @@ public:
         serializer(nCWMax);
         serializer(nWGMax);
         serializer(nGMax);
+        serializer(nWlistPrWellMax);
+        serializer(nDynWlistMax);
         serializer(m_location);
     }
 
@@ -138,6 +152,8 @@ private:
     int nCWMax { 0 };
     int nWGMax { 0 };
     int nGMax  { 0 };
+    int nWlistPrWellMax  { 1 };
+    int nDynWlistMax  { 1 };
     std::optional<KeywordLocation> m_location;
 };
 

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -256,7 +256,9 @@ namespace {
             maxPerf,
             maxWellInGroup,
             maxGroupInField,
-            (report_step > 0) ? std::max(nWMaxz, numWells) : nWMaxz
+            (report_step > 0) ? std::max(nWMaxz, numWells) : nWMaxz,
+            wd.maxWellListsPrWell(),
+            wd.maxDynamicWellLists()
         };
     }
 
@@ -359,17 +361,6 @@ namespace {
             max_lines_pr_action,
             static_cast<int>(max_cond_per_action),
             static_cast<int>(max_characters_per_line)
-        };
-    }
-
-    Opm::RestartIO::InteHEAD::WellDims
-    getWellDims(const ::Opm::Runspec&  rspec)
-    {
-        const auto& wdims = rspec.wellDimensions();
-
-        return {
-            wdims.maxWellListsPrWell(),
-            wdims.maxDynamicWellLists()
         };
     }
 
@@ -559,7 +550,6 @@ createInteHead(const EclipseState& es,
         .stepParam          (num_solver_steps, report_step)
         .tuningParam        (getTuningPars(sched[lookup_step].tuning()))
         .liftOptParam       (getLiftOptPar(sched, lookup_step))
-        .wellDimensions     (getWellDims(rspec))
         .wellSegDimensions  (getWellSegDims(rspec, sched, report_step, lookup_step))
         .regionDimensions   (getRegDims(tdim, rdim))
         .ngroups            ({ ngmax })

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -51,7 +51,7 @@ enum index : std::vector<int>::size_type {
   NZWELZ       =       VI::intehead::NZWELZ,   //       NZWEL       3       3       NZWEL = no of 8-character words per well in ZWEL array (= 3)
   ih_028       =       28       ,              //       0       0
   ih_029       =       29       ,              //       0       0
-  ih_030       =       30       ,              //       0       0
+  MXWLSTPW     =       VI::intehead::MXWLSTPRWELL, //   Maximum number of well lists pr well (default = 1)
   ih_031       =       31       ,              //       0       0
   NICONZ       =       VI::intehead::NICONZ,   //       25       15       25       NICON = no of data elements per completion in ICON array (default 19)
   NSCONZ       =       VI::intehead::NSCONZ,   //       41       0              NSCONZ = number of data elements per completion in SCON array
@@ -124,7 +124,7 @@ enum index : std::vector<int>::size_type {
   ih_100       =      100       ,              //       0       0
   ih_101       =      101       ,              //       0       0       1
   ih_102       =      102       ,              //       0       0
-  ih_103       =      103       ,              //       0       0       1
+  ROCKOPTS_TTYP =      VI::intehead::ROCKOPTS_TABTYP, // 0       0
   ih_104       =      104       ,              //       0       0
   ih_105       =      105       ,              //       0       0
   ih_106       =      106       ,              //       0       0
@@ -323,7 +323,7 @@ enum index : std::vector<int>::size_type {
   ih_299       =      299       ,              //       0
   ih_300       =      300       ,              //       0
   ih_301       =      301       ,              //       0
-  ih_302       =      302       ,              //       0
+  MXDYNWLST    =      VI::intehead::MAXDYNWELLST, //    Maximum number of dynamic well lists (default = 1)
   ih_303       =      303       ,              //       0
   ih_304       =      304       ,              //       0
   ih_305       =      305       ,              //       0
@@ -635,12 +635,17 @@ Opm::RestartIO::InteHEAD::variousParam(const int version,
     // ih_101: Usage unknown, value fixed across reference cases.
     this->data_[ih_101] = 1;
 
-    // ih_103: Usage unknown, value not fixed across reference cases,
-    //         experiments generate warning with 0 but not with 1.
-    this->data_[ih_103] = 1;
-
     // ih_200: Usage unknown, value fixed across reference cases.
     this->data_[ih_200] = 1;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::wellDimensions(const WellDims& wdims)
+{
+    this->data_[MXWLSTPW]  = wdims.mxwlstprwel;
+    this->data_[MXDYNWLST] = wdims.mxdynwlst;
 
     return *this;
 }
@@ -664,6 +669,14 @@ Opm::RestartIO::InteHEAD::regionDimensions(const RegDims& rdim)
 {
     this->data_[NTFIP]  = rdim.ntfip;
     this->data_[NMFIPR] = rdim.nmfipr;
+
+    return *this;
+}
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::rockOpts(const RockOpts& rckop)
+{
+    this->data_[ROCKOPTS_TTYP]  = rckop.ttyp;
 
     return *this;
 }

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -492,6 +492,9 @@ Opm::RestartIO::InteHEAD::wellTableDimensions(const WellTableDim& wtdim)
     
     this->data_[NWMAXZ] = wtdim.maxWellsInField;
 
+    this->data_[MXWLSTPW]  = wtdim.mxwlstprwel;
+    this->data_[MXDYNWLST] = wtdim.mxdynwlst;
+
     return *this;
 }
 
@@ -637,15 +640,6 @@ Opm::RestartIO::InteHEAD::variousParam(const int version,
 
     // ih_200: Usage unknown, value fixed across reference cases.
     this->data_[ih_200] = 1;
-
-    return *this;
-}
-
-Opm::RestartIO::InteHEAD&
-Opm::RestartIO::InteHEAD::wellDimensions(const WellDims& wdims)
-{
-    this->data_[MXWLSTPW]  = wdims.mxwlstprwel;
-    this->data_[MXDYNWLST] = wdims.mxdynwlst;
 
     return *this;
 }

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -191,7 +191,13 @@ Welldims::Welldims(const Deck& deck)
         //
         // i.e., the maximum of item 1 and item 4 here.
         this->nGMax = wd.getItem<WD::MAXGROUPS>().get<int>(0);
-	      this->nWMax = wd.getItem<WD::MAXWELLS>().get<int>(0);
+	    this->nWMax = wd.getItem<WD::MAXWELLS>().get<int>(0);
+
+        // maximum number of well lists pr well
+        this->nWlistPrWellMax = wd.getItem<WD::MAX_WELLIST_PR_WELL>().get<int>(0);
+        //maximum number of dynamic well lists
+        this->nDynWlistMax = wd.getItem<WD::MAX_DYNAMIC_WELLIST>().get<int>(0);
+
 
         this->m_location = keyword.location();
     }
@@ -204,6 +210,8 @@ Welldims Welldims::serializeObject()
     result.nCWMax = 2;
     result.nWGMax = 3;
     result.nGMax = 4;
+    result.nWlistPrWellMax = 5;
+    result.nDynWlistMax = 6;
     result.m_location = KeywordLocation::serializeObject();
     return result;
 }

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -161,10 +161,13 @@ BOOST_AUTO_TEST_CASE(WellTableDimensions)
     const auto maxWellsInGroup  =  3;
     const auto maxGroupInField = 14;
     const auto maxWellsInField = 25;
+    const auto mxwlstprwel = 3;
+    const auto mxdynwlst = 4;
 
     const auto ih = Opm::RestartIO::InteHEAD{}
         .wellTableDimensions({
-            numWells, maxPerf, maxWellsInGroup, maxGroupInField, maxWellsInField
+            numWells, maxPerf, maxWellsInGroup, maxGroupInField, maxWellsInField,
+            mxwlstprwel, mxdynwlst
         });
 
     const auto& v = ih.data();
@@ -174,7 +177,9 @@ BOOST_AUTO_TEST_CASE(WellTableDimensions)
     BOOST_CHECK_EQUAL(v[VI::intehead::NCWMAX], maxPerf);
     BOOST_CHECK_EQUAL(v[VI::intehead::NWGMAX], nwgmax);
     BOOST_CHECK_EQUAL(v[VI::intehead::NGMAXZ], maxGroupInField + 1);
-    //BOOST_CHECK_EQUAL(v[VI::intehead::NWMAXZ], maxWellsInField);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NWMAXZ], maxWellsInField);
+    BOOST_CHECK_EQUAL(v[VI::intehead::MXWLSTPRWELL], mxwlstprwel);
+    BOOST_CHECK_EQUAL(v[VI::intehead::MAXDYNWELLST], mxdynwlst);
 }
 
 BOOST_AUTO_TEST_CASE(CalendarDate)
@@ -372,22 +377,6 @@ BOOST_AUTO_TEST_CASE(Various_Parameters)
     BOOST_CHECK_EQUAL(v[VI::intehead::IPROG], 100);    // IPROG
     BOOST_CHECK_EQUAL(v[ 76],   5); // IH_076
     BOOST_CHECK_EQUAL(v[101],   1); // IH_101
-}
-
-BOOST_AUTO_TEST_CASE(wellDimensions)
-{
-    const auto mxwlstprwel = 3;
-    const auto mxdynwlst = 4;
-
-    const auto ih = Opm::RestartIO::InteHEAD{}
-        .wellDimensions({
-            mxwlstprwel, mxdynwlst
-        });
-
-    const auto& v = ih.data();
-
-    BOOST_CHECK_EQUAL(v[VI::intehead::MXWLSTPRWELL], mxwlstprwel);
-    BOOST_CHECK_EQUAL(v[VI::intehead::MAXDYNWELLST], mxdynwlst);
 }
 
 BOOST_AUTO_TEST_CASE(wellSegDimensions)

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -372,7 +372,22 @@ BOOST_AUTO_TEST_CASE(Various_Parameters)
     BOOST_CHECK_EQUAL(v[VI::intehead::IPROG], 100);    // IPROG
     BOOST_CHECK_EQUAL(v[ 76],   5); // IH_076
     BOOST_CHECK_EQUAL(v[101],   1); // IH_101
-    BOOST_CHECK_EQUAL(v[103],   1); // IH_103
+}
+
+BOOST_AUTO_TEST_CASE(wellDimensions)
+{
+    const auto mxwlstprwel = 3;
+    const auto mxdynwlst = 4;
+
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .wellDimensions({
+            mxwlstprwel, mxdynwlst
+        });
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[VI::intehead::MXWLSTPRWELL], mxwlstprwel);
+    BOOST_CHECK_EQUAL(v[VI::intehead::MAXDYNWELLST], mxdynwlst);
 }
 
 BOOST_AUTO_TEST_CASE(wellSegDimensions)
@@ -418,6 +433,20 @@ BOOST_AUTO_TEST_CASE(regionDimensions)
 
     BOOST_CHECK_EQUAL(v[VI::intehead::NTFIP], ntfip);
     BOOST_CHECK_EQUAL(v[VI::intehead::NMFIPR], nmfipr);
+}
+
+BOOST_AUTO_TEST_CASE(rockOptions)
+{
+    const auto ttyp  = 5;
+
+    const auto ih = Opm::RestartIO::InteHEAD{}
+        .rockOpts({
+            ttyp
+        });
+
+    const auto& v = ih.data();
+
+    BOOST_CHECK_EQUAL(v[VI::intehead::ROCKOPTS_TABTYP], ttyp);
 }
 
 BOOST_AUTO_TEST_CASE(ngroups)


### PR DESCRIPTION
This pull request containts corrections to the InteHead array to account for the use of:

1. ROCKOPTS - item 3: Table region to be used

2. Well list data in Eclipse compatible Restart file
  - WELLDIMS:
     - Item 11:  The maximum number of well lists that a well may belong to at any time
     - Item 12:  The maximum number of dynamic well lists in the simulation

The implementation of restart file output for the well lists will be a separate pullrequest (not included here).

The PR passes all unit tests and regression tests appart from test 118: 
118 - compareECLInitFiles_flow+NORNE_ATW2013
The differences are in the INIT file, and relates to value indexs [30] and [302], both should have default value equal to 1 which they have in this PR.

This PR is ready for review and merge after revision based on reviewer comments from my side. 