### PR TITLE
Add Restart Output Facility for Analytic Aquifer Data

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -282,6 +282,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/io/eclipse/rst/well.cpp
           src/opm/output/eclipse/ActiveIndexByColumns.cpp
           src/opm/output/eclipse/AggregateActionxData.cpp
+          src/opm/output/eclipse/AggregateAquiferData.cpp
           src/opm/output/eclipse/AggregateConnectionData.cpp
           src/opm/output/eclipse/AggregateGroupData.cpp
           src/opm/output/eclipse/AggregateNetworkData.cpp
@@ -409,6 +410,7 @@ if(ENABLE_ECL_OUTPUT)
   list (APPEND TEST_SOURCE_FILES
           tests/test_ActiveIndexByColumns.cpp
           tests/test_AggregateActionxData.cpp
+          tests/test_AggregateAquiferData.cpp
           tests/test_AggregateWellData.cpp
           tests/test_AggregateGroupData.cpp
           tests/test_AggregateNetworkData.cpp
@@ -856,6 +858,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/output/eclipse/VectorItems/well.hpp
         opm/output/eclipse/ActiveIndexByColumns.hpp
         opm/output/eclipse/AggregateActionxData.hpp
+        opm/output/eclipse/AggregateAquiferData.hpp
         opm/output/eclipse/AggregateGroupData.hpp
         opm/output/eclipse/AggregateNetworkData.hpp
         opm/output/eclipse/AggregateConnectionData.hpp

--- a/opm/output/eclipse/AggregateAquiferData.hpp
+++ b/opm/output/eclipse/AggregateAquiferData.hpp
@@ -1,0 +1,178 @@
+/*
+  Copyright (c) 2021 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_AGGREGATE_AQUIFER_DATA_HPP
+#define OPM_AGGREGATE_AQUIFER_DATA_HPP
+
+#include <opm/output/eclipse/InteHEAD.hpp>
+#include <opm/output/eclipse/WindowedArray.hpp>
+
+#include <vector>
+
+namespace Opm {
+    class AquiferConfig;
+    class EclipseGrid;
+    class SummaryState;
+    class UnitSystem;
+
+    struct DensityTable;
+    struct PvtwTable;
+} // Opm
+
+namespace Opm { namespace RestartIO { namespace Helpers {
+
+    class AggregateAquiferData
+    {
+    public:
+        /// Constructor.
+        ///
+        /// \param[in] aqDims Aquifer dimensions including number of active
+        ///    aquifers, maximum aquifer IDs, and number of data items per
+        ///    aquifer (or connection) in the various output arrays.
+        ///
+        /// \param[in] aqConfig Aquifer configuration object.  Keeps track
+        ///    of aquifer types (Carter-Tracy vs. Fetkovich) and provides
+        ///    read-only access to the individual aquifer objects.
+        ///
+        /// \param[in] grid Simulation grid.  Needed to map active to
+        ///    Cartesian cell indices and to extract (I,J,K) index tuples of
+        ///    the active cells.
+        explicit AggregateAquiferData(const InteHEAD::AquiferDims& aqDims,
+                                      const AquiferConfig&         aqConfig,
+                                      const EclipseGrid&           grid);
+
+        /// Linearise dynamic information pertinent to analytic aquifers
+        /// into internal arrays.
+        ///
+        /// \param[in] aqConfig Aquifer configuration object.  Keeps track
+        ///    of aquifer types (Carter-Tracy vs. Fetkovich) and provides
+        ///    read-only access to the individual aquifer objects.
+        ///
+        /// \param[in] summaryState Current state of summary variables.
+        ///    Expected to contain at least the summary variables AAQP
+        ///    (aquifer pressure), AAQR (aquifer flow rate), and AAQT (total
+        ///    produced inflow volume from aquifer).
+        ///
+        /// \param[in] pvtwTable PVT properties for water.  Needed to
+        ///    compute the water viscosity and water density at aquifer
+        ///    conditions.
+        ///
+        /// \param{in] densityTable Phase densities at surface conditions.
+        ///    Needed to compute water density at aquifer conditions.
+        ///
+        /// \param[in] usys Unit system.  Needed to convert quantities from
+        ///    internal to output units.
+        void captureDynamicdAquiferData(const AquiferConfig& aqConfig,
+                                        const SummaryState&  summaryState,
+                                        const PvtwTable&     pvtwTable,
+                                        const DensityTable&  densityTable,
+                                        const UnitSystem&    usys);
+
+        /// Retrieve the maximum active aquifer ID over all analytic
+        /// aquifers.
+        ///
+        /// Controls output of restart information pertaining to analytic
+        /// aquifer connections.
+        int maximumActiveAnalyticAquiferID() const
+        {
+            return this->maxActiveAnalyticAquiferID_;
+        }
+
+        /// Retrieve Integer Aquifer Data Array.
+        const std::vector<int>& getIntegerAquiferData() const
+        {
+            return this->integerAnalyticAq_.data();
+        }
+
+        /// Retrieve Floating-Point (Real) Aquifer Data Array.
+        const std::vector<float>& getSinglePrecAquiferData() const
+        {
+            return this->singleprecAnalyticAq_.data();
+        }
+
+        /// Retrieve Floating-Point (Double Precision) Aquifer Data Array.
+        const std::vector<double>& getDoublePrecAquiferData() const
+        {
+            return this->doubleprecAnalyticAq_.data();
+        }
+
+        /// Retrieve Integer Aquifer Connection Data Array (analytic aquifers)
+        ///
+        /// \param[in] aquiferID Aquifer for which to retrieve integer
+        ///    connection data array.  Expected to be in the range
+        ///    [1..maximumActiveAnalyticAquiferID()] (inclusive).
+        const std::vector<int>& getIntegerAquiferConnectionData(const int aquiferID) const
+        {
+            return this->integerAnalyticAquiferConn_[aquiferID - 1].data();
+        }
+
+        /// Retrieve Floating-Point (Real) Aquifer Connection Data Array (analytic aquifers)
+        ///
+        /// \param[in] aquiferID Aquifer for which to retrieve single
+        ///    precision floating point connection data array.  Expected to
+        ///    be in the range [1..maximumActiveAnalyticAquiferID()]
+        ///    (inclusive).
+        const std::vector<float>& getSinglePrecAquiferConnectionData(const int aquiferID) const
+        {
+            return this->singleprecAnalyticAquiferConn_[aquiferID - 1].data();
+        }
+
+        /// Retrieve Floating-Point (Double Precision) Aquifer Connection
+        /// Data Array (analytic aquifers)
+        ///
+        /// \param[in] aquiferID Aquifer for which to retrieve double
+        ///    precision floating point connection data array.  Expected to
+        ///    be in the range [1..maximumActiveAnalyticAquiferID()]
+        ///    (inclusive).
+        const std::vector<double>& getDoublePrecAquiferConnectionData(const int aquiferID) const
+        {
+            return this->doubleprecAnalyticAquiferConn_[aquiferID - 1].data();
+        }
+
+    private:
+        int maxActiveAnalyticAquiferID_{0};
+
+        std::vector<int> numActiveConn_{};
+        std::vector<double> totalInflux_{};
+
+        /// Aggregate 'IAAQ' array (Integer) for all analytic aquifers.
+        WindowedArray<int> integerAnalyticAq_;
+
+        /// Aggregate 'SAAQ' array (Real) for all analytic aquifers.
+        WindowedArray<float> singleprecAnalyticAq_;
+
+        /// Aggregate 'XAAQ' array (Double Precision) for all analytic aquifers.
+        WindowedArray<double> doubleprecAnalyticAq_;
+
+        /// Aggregate ICAQ array (Integer) for all analytic aquifer
+        /// connections.  Separate array for each aquifer.
+        std::vector<WindowedArray<int>> integerAnalyticAquiferConn_;
+
+        /// Aggregate SCAQ array (Real) for all analytic aquifer
+        /// connections.  Separate array for each aquifer.
+        std::vector<WindowedArray<float>> singleprecAnalyticAquiferConn_;
+
+        /// Aggregate ACAQ array (Double Precision) for all analytic aquifer
+        /// connections.  Separate array for each aquifer.
+        std::vector<WindowedArray<double>> doubleprecAnalyticAquiferConn_;
+    };
+
+}}} // Opm::RestartIO::Helpers
+
+#endif // OPM_AGGREGATE_WELL_DATA_HPP

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -1,4 +1,5 @@
 /*
+  Copyright 2021 Equinor ASA.
   Copyright 2016, 2017, 2018 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
@@ -132,6 +133,42 @@ namespace RestartIO {
             int ninobr;
         };
 
+        struct AquiferDims {
+            // Number of active analytic aquifers (# unique aquifer IDs)
+            int numAquifers {0};
+
+            // Declared maximum number of analytic aquifers in model
+            // (AQUDIMS(5))
+            int maxNumAquifers {0};
+
+            // Declared maximum number of connections in any analytic
+            // aquifer (AQUDIMS(6))
+            int maxNumAquiferConn {0};
+
+            // Maximum number of *active* connections in any analytic aquifer
+            int maxNumActiveAquiferConn {0};
+
+            // Maximum aquifer ID across all of the model's analytic aquifers.
+            int maxAquiferID {0};
+
+            // Number of data elements per aquifer in IAAQ array.
+            int numIntAquiferElem {18};
+
+            // Number of data elements per aquifer in SAAQ array.
+            int numRealAquiferElem {24};
+
+            // Number of data elements per aquifer in XAAQ array.
+            int numDoubAquiferElem {10};
+
+            // Number of data elements per coonnection in ICAQ array.
+            int numIntConnElem {7};
+
+            // Number of data elements per connecetion in SCAQ array.
+            int numRealConnElem {2};
+
+            // Number of data elements per connection in ACAQ array.
+            int numDoubConnElem {4};
+        };
      
         InteHEAD();
         ~InteHEAD() = default;

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -26,12 +26,15 @@
 #include <memory>
 #include <vector>
 
-
 namespace Opm {
 
+class EclipseGrid;
+class EclipseState;
 class UnitSystem;
 
-namespace RestartIO {
+}
+
+namespace Opm { namespace RestartIO {
 
     class InteHEAD
     {
@@ -185,13 +188,16 @@ namespace RestartIO {
 
         InteHEAD& unitConventions(const UnitSystem& usys);
         InteHEAD& wellTableDimensions(const WellTableDim& wtdim);
+        InteHEAD& aquiferDimensions(const AquiferDims& aqudims);
+
         InteHEAD& calendarDate(const TimePoint& date);
         InteHEAD& activePhases(const Phases& phases);
+
         InteHEAD& params_NWELZ(const int niwelz, const int nswelz, const int nxwelz, const int nzwelz);
         InteHEAD& params_NCON(const int niconz, const int nsconz, const int nxconz);
         InteHEAD& params_GRPZ(const std::array<int, 4>& grpz);
         InteHEAD& params_NGCTRL(const int gct);
-        InteHEAD& params_NAAQZ(const int ncamax, const int niaaqz, const int nsaaqz, const int nxaaqz, const int nicaqz, const int nscaqz, const int nacaqz);
+
         InteHEAD& stepParam(const int tstep, const int report_step);
         InteHEAD& tuningParam(const TuningPar& tunpar);
         InteHEAD& variousParam(const int version, const int iprog);
@@ -216,11 +222,12 @@ namespace RestartIO {
         std::vector<int> data_;
     };
 
-    std::time_t makeUTCTime(const std::tm& timePoint);
-
     InteHEAD::TimePoint
     getSimulationTimePoint(const std::time_t start,
                            const double      elapsed);
+
+    InteHEAD::AquiferDims
+    inferAquiferDimensions(const EclipseState& es);
 }} // Opm::RestartIO
 
 #endif // OPM_INTEHEAD_HEADER_INCLUDED

--- a/opm/output/eclipse/RestartIO.hpp
+++ b/opm/output/eclipse/RestartIO.hpp
@@ -26,7 +26,9 @@
 
 #include <opm/output/eclipse/RestartValue.hpp>
 
+#include <opm/output/eclipse/AggregateAquiferData.hpp>
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -76,17 +78,18 @@ namespace Opm { namespace Action {
 */
 namespace Opm { namespace RestartIO {
 
-    void save(EclIO::OutputStream::Restart& rstFile,
-              int                           report_step,
-              double                        seconds_elapsed,
-              RestartValue                  value,
-              const EclipseState&           es,
-              const EclipseGrid&            grid,
-              const Schedule&               schedule,
-              const Action::State&          action_state,
-              const SummaryState&           sumState,
-              const UDQState&               udqState,
-              bool                          write_double = false);
+    void save(EclIO::OutputStream::Restart&                 rstFile,
+              int                                           report_step,
+              double                                        seconds_elapsed,
+              RestartValue                                  value,
+              const EclipseState&                           es,
+              const EclipseGrid&                            grid,
+              const Schedule&                               schedule,
+              const Action::State&                          action_state,
+              const SummaryState&                           sumState,
+              const UDQState&                               udqState,
+              std::optional<Helpers::AggregateAquiferData>& aquiferData,
+              bool                                          write_double = false);
 
 
     RestartValue load(const std::string&             filename,

--- a/opm/output/eclipse/VectorItems/aquifer.hpp
+++ b/opm/output/eclipse/VectorItems/aquifer.hpp
@@ -1,4 +1,5 @@
 /*
+  Copyright (c) 2021 Equinor ASA
   Copyright (c) 2019 Equinor ASA
 
   This file is part of the Open Porous Media project (OPM).
@@ -26,42 +27,73 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
     namespace IAnalyticAquifer {
         enum index : std::vector<int>::size_type {
-            NumAquiferConn = 0,
-            WatPropTable = 1,
+            NumAquiferConn = 0, // Number of active aquifer connections for this aquifer
+            WatPropTable = 1,   // PVT number (ACUCT(10) or AQUFETP(7))
 
-            TypeRelated1 =  9,
-            TypeRelated2 = 10,
+            CTInfluenceFunction =  9, // AQUCT(11)
+            TypeRelated1 = 10,        // =1 for CT, =0 for FETP
+
+            Unknown_1 = 11,     // Unknown item.  =1 in all cases seen thus far.
         };
     } // IAnalyticAquifer
 
+    namespace IAnalyticAquiferConn {
+        enum index : std::vector<int>::size_type {
+            Index_I = 0,        // One-based I index of connecting cell
+            Index_J = 1,        // One-based J index of connecting cell
+            Index_K = 2,        // One-based K index of connecting cell
+            ActiveIndex = 3,    // One-based columnar active index of connecting cell
+            FaceDirection = 4,  // Direction of connecting face
+        };
+
+       namespace Value {
+           enum FaceDirection {
+               IMinus = 1, IPlus = 2, JMinus = 3, JPlus = 4, KMinus = 5, KPlus = 6,
+           };
+       } // Value
+   } // IAnalyticAquiferConn
+
     namespace SAnalyticAquifer {
         enum index : std::vector<float>::size_type {
-            Compressibility = 0,
+            Compressibility = 0, // Total aquifer compressibility (AQUCT(6), AQUFETP(5))
 
-            FetInitVol = 1,
-            FetProdIndex = 2,
-            FetTimeConstant = 3,
+            FetInitVol = 1,     // Initial aquifer volume (AQUFETP(4))
+            FetProdIndex = 2,   // Aquifer productivity index (AQUFETP(6))
+            FetTimeConstant = 3, // Fetkovich Aquifer time constant (Compressibility * InitVol / ProdIndex)
 
-            CTRadius = 1,
-            CTPermeability = 2,
-            CTPorosity = 3,
+            CTRadius = 1,       // CT aquifer external radius (AQUCT(7))
+            CTPermeability = 2, // CT aquifer permeability (AQUCT(4))
+            CTPorosity = 3,     // CT aquifer porosity (AQUCT(5))
 
-            InitPressure = 4,
-            DatumDepth = 5,
+            InitPressure = 4,   // Initial aquifer pressure (AQUCT(3), AQUFETP(3))
+            DatumDepth = 5,     // Aquifer datum depth (AQUCT(2), AQUFETP(2))
 
-            CTThickness = 6,
-            CTAngle = 7,
-            CTWatMassDensity = 8,
-            CTWatViscosity = 9,
+            CTThickness = 6,    // CT aquifer thickness (AQUCT(8))
+            CTAngle = 7,        // CT aquifer angle of influence (AQUCT(9) / 360.0)
+            CTWatMassDensity = 8,    // Water density at reservoir conditions
+            CTWatViscosity = 9,      // Water viscosity at reservoir conditions
         };
     } // SAnalyticAquifer
 
+    namespace SAnalyticAquiferConn {
+        enum index : std::vector<float>::size_type {
+            InfluxFraction = 0, // Connection's fraction of total aquifer influx coefficient
+            FaceAreaToInfluxCoeff = 1, // Connection's effective face area divided by aquifer's total influx coefficient
+        };
+    } // SAnalyticAquiferConn
+
     namespace XAnalyticAquifer {
         enum index : std::vector<double>::size_type {
-            FlowRate   = 0,
-            Pressure   = 1,  // Dynamic aquifer pressure
-            ProdVolume = 2,  // Liquid volume produced from aquifer (into reservoir)
-            TotalArea  = 3,
+            FlowRate = 0,         // Aquifer rate (AAQR:N)
+            Pressure = 1,         // Dynamic aquifer pressure (AAQP:N)
+            ProdVolume = 2,       // Liquid volume produced from aquifer (into reservoir, AAQT:N)
+            TotalInfluxCoeff = 3, // Total aquifer influx coefficient across all aquifer connections
+
+            CTRecipTimeConst = 4, // Reciprocal time constant for CT aquifer
+            CTInfluxConstant = 5, // Influx constant "beta" for CT aquifer
+
+            CTDimensionLessTime = 8, // Dimensionless time for CT aquifer (AAQTD:N)
+            CTDimensionLessPressure = 9, // Dimensionless pressure for CT aquifer (AAQPD:N)
         };
     } // XAnalyticAquifer
 

--- a/opm/output/eclipse/VectorItems/aquifer.hpp
+++ b/opm/output/eclipse/VectorItems/aquifer.hpp
@@ -35,6 +35,13 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
             Unknown_1 = 11,     // Unknown item.  =1 in all cases seen thus far.
         };
+
+        namespace Value {
+            enum ModelType : int {
+                Fetkovich = 0,
+                CarterTracy = 1,
+            };
+        } // Value
     } // IAnalyticAquifer
 
     namespace IAnalyticAquiferConn {

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -69,6 +69,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NXGRPZ = 38, //  Number of data elements per group in XGRP array
         NZGRPZ = 39, //  Number of data elements per group in ZGRP array
 
+        NAQUIF = 40, //  Number of *active* analytic aquifers (i.e., number of unique aquifer IDs) in model
         NCAMAX = 41, //  Maximum number of analytic aquifer connections
 
         NIAAQZ = 42, //  Number of data elements per aquifer in IAAQ array
@@ -123,6 +124,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         MAXNOLINES = 157, //  Maximum number of lines of schedule data for ACTION keyword - including ENDACTIO
         MAXNOSTRPRLINE = 158, //  Maximum number of 8-chars strings pr input line of Action data (rounded up from input)
 
+        MAX_ACT_ANLYTIC_AQUCONN = 162, // Maximum number of *active* connections across all analytic aquifers
         NWMAXZ = 163, //  Maximum number of wells in the model
 
         NSEGWL = 174, //  Number of multisegment wells defined with WELSEG
@@ -140,12 +142,16 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         WSEGITR_IT2 = 208, // NR - maximum no of times that a new iteration cycle with a reduced Wp will be started
 
         MAX_ACT_COND = 245, //  Maximum number of conditions pr action
-        MAX_AN_AQUIFERS = 252, // Maximum number of analytic aquifers
+        MAX_AN_AQUIFER_ID = 252, // Maximum aquifer ID of all analytic aquifers (<= AQUDIMS(5))
 
         NO_FIELD_UDQS = 262, //  No of Field UDQ data (parameters) /
         NO_GROUP_UDQS = 263, //  No of Group UDQ data (parameters) /
         NO_WELL_UDQS = 266, //  No of Well UDQ data (parameters) /
         UDQPAR_1 = 267, //  Integer seed value for the RAND /
+
+        AQU_UNKNOWN_1 = 269,  // Not characterised.  Equal to NAQUIF in all cases seen so far.
+        MAX_ANALYTIC_AQUIFERS = 286, // Declared maximum number of analytic aquifers in model.  AQUDIMS(5).
+
         NO_IUADS = 290, //  No IUADs
         NO_IUAPS = 291, //  No IUAPs
         RSEED = 296,

--- a/opm/output/eclipse/WindowedArray.hpp
+++ b/opm/output/eclipse/WindowedArray.hpp
@@ -79,6 +79,11 @@ namespace Opm { namespace RestartIO { namespace Helpers {
                 throw std::invalid_argument("Window array with windowsize==0 is not permitted");
         }
 
+        WindowedArray(const WindowedArray& rhs) = default;
+        WindowedArray(WindowedArray&& rhs) = default;
+        WindowedArray& operator=(const WindowedArray& rhs) = delete;
+        WindowedArray& operator=(WindowedArray&& rhs) = default;
+
         /// Retrieve number of windows allocated for this array.
         Idx numWindows() const
         {

--- a/opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp
@@ -25,21 +25,18 @@
   This includes the logic for parsing as well as the associated tables. It is meant to be used by opm-grid and opm-simulators in order to
   implement the Carter Tracy analytical aquifer model in OPM Flow.
 */
-#include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/parser/eclipse/Units/UnitSystem.hpp>
-
-#include <opm/parser/eclipse/EclipseState/Tables/Aqudims.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/AqutabTable.hpp>
+#include <cstddef>
+#include <utility>
+#include <vector>
 
 namespace Opm {
-
+    class Deck;
+    class DeckRecord;
     class TableManager;
+}
+
+namespace Opm {
 
     class AquiferCT {
         public:

--- a/opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.hpp
@@ -25,13 +25,17 @@
   This includes the logic for parsing as well as the associated tables. It is meant to be used by opm-grid and opm-simulators in order to
   implement the Fetkovich analytical aquifer model in OPM Flow.
 */
+
+#include <cstddef>
+#include <utility>
 #include <vector>
 
+namespace Opm {
+    class Deck;
+    class DeckRecord;
+}
 
 namespace Opm {
-
-class Deck;
-class DeckRecord;
 
 class Aquifetp {
     public:

--- a/src/opm/output/eclipse/AggregateAquiferData.cpp
+++ b/src/opm/output/eclipse/AggregateAquiferData.cpp
@@ -115,7 +115,7 @@ namespace {
                 iaaq[Ix::WatPropTable] = aquifer.pvttableID; // One-based (=AQUCT(10))
 
                 iaaq[Ix::CTInfluenceFunction] = aquifer.inftableID;
-                iaaq[Ix::TypeRelated1] = 1; // =1 for Carter-Tracy
+                iaaq[Ix::TypeRelated1] = VI::IAnalyticAquifer::Value::ModelType::CarterTracy;
 
                 iaaq[Ix::Unknown_1] = 1; // Not characterised; =1 in all cases seen thus far.
             }
@@ -133,6 +133,7 @@ namespace {
                 iaaq[Ix::NumAquiferConn] = numActiveConn;
                 iaaq[Ix::WatPropTable] = aquifer.pvttableID; // One-based (=AQUFETP(7))
 
+                iaaq[Ix::TypeRelated1] = VI::IAnalyticAquifer::Value::ModelType::Fetkovich;
                 iaaq[Ix::Unknown_1] = 1; // Not characterised; =1 in all cases seen thus far.
             }
         } // Fetckovich
@@ -316,11 +317,7 @@ namespace {
         {
             const auto key = fmt::format("{}:{}", variable, aquiferID);
 
-            if (summaryState.has(key)) {
-                return summaryState.get(key);
-            }
-
-            return 0.0;
+            return summaryState.get(key, 0.0);
         }
 
         Opm::RestartIO::Helpers::WindowedArray<double>

--- a/src/opm/output/eclipse/AggregateAquiferData.cpp
+++ b/src/opm/output/eclipse/AggregateAquiferData.cpp
@@ -1,0 +1,510 @@
+/*
+  Copyright (c) 2021 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/eclipse/AggregateAquiferData.hpp>
+
+#include <opm/output/eclipse/InteHEAD.hpp>
+#include <opm/output/eclipse/WindowedArray.hpp>
+#include <opm/output/eclipse/ActiveIndexByColumns.hpp>
+
+#include <opm/output/eclipse/VectorItems/aquifer.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Tables/FlatTable.hpp>
+
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <fmt/format.h>
+
+#include <array>
+#include <cstddef>
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+namespace VI = Opm::RestartIO::Helpers::VectorItems;
+
+namespace {
+    template <typename AquiferCallBack>
+    void CarterTracyAquiferLoop(const Opm::AquiferConfig& aqConfig,
+                                AquiferCallBack&&         aquiferOp)
+    {
+        for (const auto& aqData : aqConfig.ct()) {
+            aquiferOp(aqData);
+        }
+    }
+
+    template <typename AquiferCallBack>
+    void FetkovichAquiferLoop(const Opm::AquiferConfig& aqConfig,
+                              AquiferCallBack&&         aquiferOp)
+    {
+        for (const auto& aqData : aqConfig.fetp()) {
+            aquiferOp(aqData);
+        }
+    }
+
+    template <typename ConnectionCallBack>
+    void analyticAquiferConnectionLoop(const Opm::AquiferConfig& aqConfig,
+                                       ConnectionCallBack&&      connectionOp)
+    {
+        for (const auto& [aquiferID, connections] : aqConfig.connections().data()) {
+            const auto tot_influx =
+                std::accumulate(connections.begin(), connections.end(), 0.0,
+                    [](const double t, const Opm::Aquancon::AquancCell& connection) -> double
+                {
+                    return t + connection.influx_coeff;
+                });
+
+            auto connectionID = std::size_t{0};
+
+            for (const auto& connection : connections) {
+                connectionOp(aquiferID, connectionID++, tot_influx, connection);
+            }
+        }
+    }
+
+    namespace IntegerAnalyticAquifer
+    {
+        Opm::RestartIO::Helpers::WindowedArray<int>
+        allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
+        {
+            using WA = Opm::RestartIO::Helpers::WindowedArray<int>;
+
+            return WA {
+                WA::NumWindows{ static_cast<WA::Idx>(aqDims.maxAquiferID) },
+                WA::WindowSize{ static_cast<WA::Idx>(aqDims.numIntAquiferElem) }
+            };
+        }
+
+        namespace CarterTracy
+        {
+            template <typename IAaqArray>
+            void staticContrib(const Opm::AquiferCT::AQUCT_data& aquifer,
+                               const int                         numActiveConn,
+                               IAaqArray&                        iaaq)
+            {
+                using Ix = VI::IAnalyticAquifer::index;
+
+                iaaq[Ix::NumAquiferConn] = numActiveConn;
+                iaaq[Ix::WatPropTable] = aquifer.pvttableID; // One-based (=AQUCT(10))
+
+                iaaq[Ix::CTInfluenceFunction] = aquifer.inftableID;
+                iaaq[Ix::TypeRelated1] = 1; // =1 for Carter-Tracy
+
+                iaaq[Ix::Unknown_1] = 1; // Not characterised; =1 in all cases seen thus far.
+            }
+        } // CarterTracy
+
+        namespace Fetckovich
+        {
+            template <typename IAaqArray>
+            void staticContrib(const Opm::Aquifetp::AQUFETP_data& aquifer,
+                               const int                          numActiveConn,
+                               IAaqArray&                         iaaq)
+            {
+                using Ix = VI::IAnalyticAquifer::index;
+
+                iaaq[Ix::NumAquiferConn] = numActiveConn;
+                iaaq[Ix::WatPropTable] = aquifer.pvttableID; // One-based (=AQUFETP(7))
+
+                iaaq[Ix::Unknown_1] = 1; // Not characterised; =1 in all cases seen thus far.
+            }
+        } // Fetckovich
+    } // IntegerAnalyticAquifer
+
+    namespace IntegerAnalyticAquiferConn
+    {
+        std::vector<Opm::RestartIO::Helpers::WindowedArray<int>>
+        allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
+        {
+            using WA = Opm::RestartIO::Helpers::WindowedArray<int>;
+
+            return std::vector<WA>(aqDims.maxAquiferID, WA {
+                WA::NumWindows{ static_cast<WA::Idx>(aqDims.maxNumActiveAquiferConn) },
+                WA::WindowSize{ static_cast<WA::Idx>(aqDims.numIntConnElem) }
+            });
+        }
+
+        int eclipseFaceDirection(const Opm::FaceDir::DirEnum faceDir)
+        {
+            using FDValue = VI::IAnalyticAquiferConn::Value::FaceDirection;
+
+            switch (faceDir) {
+            case Opm::FaceDir::DirEnum::XMinus: return FDValue::IMinus;
+            case Opm::FaceDir::DirEnum::XPlus:  return FDValue::IPlus;
+            case Opm::FaceDir::DirEnum::YMinus: return FDValue::JMinus;
+            case Opm::FaceDir::DirEnum::YPlus:  return FDValue::JPlus;
+            case Opm::FaceDir::DirEnum::ZMinus: return FDValue::KMinus;
+            case Opm::FaceDir::DirEnum::ZPlus:  return FDValue::KPlus;
+            }
+
+            throw std::invalid_argument {
+                fmt::format("Unknown Face Direction {}", static_cast<int>(faceDir))
+            };
+        }
+
+        template <typename ICAqArray>
+        void staticContrib(const Opm::Aquancon::AquancCell& connection,
+                           const Opm::EclipseGrid&          grid,
+                           const Opm::ActiveIndexByColumns& map,
+                           ICAqArray&                       icaq)
+        {
+            using Ix = VI::IAnalyticAquiferConn::index;
+
+            const auto ijk = grid.getIJK(connection.global_index);
+            icaq[Ix::Index_I] = ijk[0] + 1;
+            icaq[Ix::Index_J] = ijk[1] + 1;
+            icaq[Ix::Index_K] = ijk[2] + 1;
+
+            icaq[Ix::ActiveIndex] = map.getColumnarActiveIndex(grid.activeIndex(connection.global_index)) + 1;
+
+            icaq[Ix::FaceDirection] = eclipseFaceDirection(connection.face_dir);
+        }
+    } // IntegerAnalyticAquiferConn
+
+    namespace SinglePrecAnalyticAquifer
+    {
+        Opm::RestartIO::Helpers::WindowedArray<float>
+        allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
+        {
+            using WA = Opm::RestartIO::Helpers::WindowedArray<float>;
+
+            return WA {
+                WA::NumWindows{ static_cast<WA::Idx>(aqDims.maxAquiferID) },
+                WA::WindowSize{ static_cast<WA::Idx>(aqDims.numRealAquiferElem) }
+            };
+        }
+
+        namespace CarterTracy {
+            template <typename SAaqArray>
+            void staticContrib(const Opm::AquiferCT::AQUCT_data& aquifer,
+                               const double                      rhoWS,
+                               const Opm::PVTWRecord&            pvtw,
+                               const Opm::UnitSystem&            usys,
+                               SAaqArray&                        saaq)
+            {
+                using M = Opm::UnitSystem::measure;
+                using Ix = VI::SAnalyticAquifer::index;
+
+                auto cvrt = [&usys](const M unit, const double x) -> float
+                {
+                    return static_cast<float>(usys.from_si(unit, x));
+                };
+
+                // Unit hack: *to_si()* here since we don't have a compressibility unit.
+                saaq[Ix::Compressibility] =
+                    static_cast<float>(usys.to_si(M::pressure, aquifer.C_t));
+
+                saaq[Ix::CTRadius] = cvrt(M::length, aquifer.r_o);
+                saaq[Ix::CTPermeability] = cvrt(M::permeability, aquifer.k_a);
+                saaq[Ix::CTPorosity] = cvrt(M::identity, aquifer.phi_aq);
+
+                saaq[Ix::InitPressure] = cvrt(M::pressure, aquifer.p0.second);
+                saaq[Ix::DatumDepth] = cvrt(M::length, aquifer.d0);
+
+                saaq[Ix::CTThickness] = cvrt(M::length, aquifer.h);
+                saaq[Ix::CTAngle] = cvrt(M::identity, aquifer.theta);
+
+                const auto dp = aquifer.p0.second - pvtw.reference_pressure;
+                const auto bw = pvtw.volume_factor * (1.0 - pvtw.compressibility*dp);
+                saaq[Ix::CTWatMassDensity] = cvrt(M::density, rhoWS / bw);
+
+                const auto mu = pvtw.viscosity * (1.0 + pvtw.viscosibility*dp);
+                saaq[Ix::CTWatViscosity] = cvrt(M::viscosity, mu);
+            }
+        } // CarterTracy
+
+        namespace Fetckovich {
+            template <typename SAaqArray>
+            void staticContrib(const Opm::Aquifetp::AQUFETP_data& aquifer,
+                               const Opm::UnitSystem&             usys,
+                               SAaqArray&                         saaq)
+            {
+                using M = Opm::UnitSystem::measure;
+                using Ix = VI::SAnalyticAquifer::index;
+
+                auto cvrt = [&usys](const M unit, const double x) -> float
+                {
+                    return static_cast<float>(usys.from_si(unit, x));
+                };
+
+                // Time constant
+                const auto Tc = aquifer.C_t * aquifer.V0 / aquifer.J;
+
+                // Unit hack: *to_si()* here since we don't have a compressibility unit.
+                saaq[Ix::Compressibility] =
+                    static_cast<float>(usys.to_si(M::pressure, aquifer.C_t));
+
+                saaq[Ix::FetInitVol] = cvrt(M::liquid_surface_volume, aquifer.V0);
+                saaq[Ix::FetProdIndex] = cvrt(M::liquid_productivity_index, aquifer.J);
+                saaq[Ix::FetTimeConstant] = cvrt(M::time, Tc);
+
+                saaq[Ix::InitPressure] = cvrt(M::pressure, aquifer.p0.second);
+                saaq[Ix::DatumDepth] = cvrt(M::length, aquifer.d0);
+            }
+        } // Fetckovich
+    } // SinglePrecAnalyticAquifer
+
+    namespace SinglePrecAnalyticAquiferConn
+    {
+        std::vector<Opm::RestartIO::Helpers::WindowedArray<float>>
+        allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
+        {
+            using WA = Opm::RestartIO::Helpers::WindowedArray<float>;
+
+            return std::vector<WA>(aqDims.maxAquiferID, WA {
+                WA::NumWindows{ static_cast<WA::Idx>(aqDims.maxNumActiveAquiferConn) },
+                WA::WindowSize{ static_cast<WA::Idx>(aqDims.numRealConnElem) }
+            });
+        }
+
+        template <typename SCAqArray>
+        void staticContrib(const Opm::Aquancon::AquancCell& connection,
+                           const double                     tot_influx,
+                           SCAqArray&                       scaq)
+        {
+            using Ix = VI::SAnalyticAquiferConn::index;
+
+            auto make_ratio = [tot_influx](const double x) -> float
+            {
+                return static_cast<float>(x / tot_influx);
+            };
+
+            scaq[Ix::InfluxFraction]        = make_ratio(connection.influx_coeff);
+            scaq[Ix::FaceAreaToInfluxCoeff] = make_ratio(connection.effective_facearea);
+        }
+    } // SingleAnalyticAquiferConn
+
+    namespace DoublePrecAnalyticAquifer
+    {
+        double totalInfluxCoefficient(const Opm::UnitSystem& usys,
+                                      const double           tot_influx)
+        {
+            using M = Opm::UnitSystem::measure;
+            return usys.from_si(M::length, usys.from_si(M::length, tot_influx));
+        }
+
+        double getSummaryVariable(const Opm::SummaryState& summaryState,
+                                  const std::string&       variable,
+                                  const int                aquiferID)
+        {
+            const auto key = fmt::format("{}:{}", variable, aquiferID);
+
+            if (summaryState.has(key)) {
+                return summaryState.get(key);
+            }
+
+            return 0.0;
+        }
+
+        Opm::RestartIO::Helpers::WindowedArray<double>
+        allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
+        {
+            using WA = Opm::RestartIO::Helpers::WindowedArray<double>;
+
+            return WA {
+                WA::NumWindows{ static_cast<WA::Idx>(aqDims.maxAquiferID) },
+                WA::WindowSize{ static_cast<WA::Idx>(aqDims.numDoubAquiferElem) }
+            };
+        }
+
+        namespace Common {
+            template <typename SummaryVariable, typename XAaqArray>
+            void dynamicContrib(SummaryVariable&&      summaryVariable,
+                                const double           tot_influx,
+                                const Opm::UnitSystem& usys,
+                                XAaqArray&             xaaq)
+            {
+                using Ix = VI::XAnalyticAquifer::index;
+
+                xaaq[Ix::FlowRate]   = summaryVariable("AAQR");
+                xaaq[Ix::Pressure]   = summaryVariable("AAQP");
+                xaaq[Ix::ProdVolume] = summaryVariable("AAQT");
+
+                xaaq[Ix::TotalInfluxCoeff] = totalInfluxCoefficient(usys, tot_influx);
+            }
+        } // Common
+
+        namespace CarterTracy {
+            template <typename SummaryVariable, typename XAaqArray>
+            void dynamicContrib(SummaryVariable&&                 summaryVariable,
+                                const Opm::AquiferCT::AQUCT_data& aquifer,
+                                const Opm::PVTWRecord&            pvtw,
+                                const double                      tot_influx,
+                                const Opm::UnitSystem&            usys,
+                                XAaqArray&                        xaaq)
+            {
+                using M = Opm::UnitSystem::measure;
+                using Ix = VI::XAnalyticAquifer::index;
+
+                Common::dynamicContrib(std::forward<SummaryVariable>(summaryVariable),
+                                       tot_influx, usys, xaaq);
+
+                const auto x = aquifer.phi_aq * aquifer.C_t * aquifer.r_o * aquifer.r_o;
+
+                const auto dp   = aquifer.p0.second - pvtw.reference_pressure;
+                const auto mu   = pvtw.viscosity * (1.0 + pvtw.viscosibility*dp);
+                const auto Tc   = mu * x / (aquifer.c1 * aquifer.k_a);
+                const auto beta = aquifer.c2 * aquifer.h * aquifer.theta * x;
+
+                // Note: *to_si()* here since this is a *reciprocal* time constant
+                xaaq[Ix::CTRecipTimeConst] = usys.to_si(M::time, 1.0 / Tc);
+
+                // Note: *to_si()* for the pressure unit here since 'beta'
+                // is total influx (volume) per unit pressure drop.
+                xaaq[Ix::CTInfluxConstant] = usys.from_si(M::volume, usys.to_si(M::pressure, beta));
+
+                xaaq[Ix::CTDimensionLessTime]     = summaryVariable("AAQTD");
+                xaaq[Ix::CTDimensionLessPressure] = summaryVariable("AAQPD");
+            }
+        } // CarterTracy
+
+        namespace Fetkovich {
+            template <typename SummaryVariable, typename XAaqArray>
+            void dynamicContrib(SummaryVariable&&      summaryVariable,
+                                const double           tot_influx,
+                                const Opm::UnitSystem& usys,
+                                XAaqArray&             xaaq)
+            {
+                Common::dynamicContrib(std::forward<SummaryVariable>(summaryVariable),
+                                       tot_influx, usys, xaaq);
+            }
+        } // Fetkovich
+    } // DoublePrecAnalyticAquifer
+
+    namespace DoublePrecAnalyticAquiferConn
+    {
+        std::vector<Opm::RestartIO::Helpers::WindowedArray<double>>
+        allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
+        {
+            using WA = Opm::RestartIO::Helpers::WindowedArray<double>;
+
+            return std::vector<WA>(aqDims.maxAquiferID, WA {
+                WA::NumWindows{ static_cast<WA::Idx>(aqDims.maxNumActiveAquiferConn) },
+                WA::WindowSize{ static_cast<WA::Idx>(aqDims.numDoubConnElem) }
+            });
+        }
+    } // SingleAnalyticAquiferConn
+} // Anonymous
+
+Opm::RestartIO::Helpers::AggregateAquiferData::
+AggregateAquiferData(const InteHEAD::AquiferDims& aqDims,
+                     const AquiferConfig&         aqConfig,
+                     const EclipseGrid&           grid)
+    : maxActiveAnalyticAquiferID_   { aqDims.maxAquiferID }
+    , numActiveConn_                ( aqDims.maxAquiferID, 0 )
+    , totalInflux_                  ( aqDims.maxAquiferID, 0.0 )
+    , integerAnalyticAq_            { IntegerAnalyticAquifer::       allocate(aqDims) }
+    , singleprecAnalyticAq_         { SinglePrecAnalyticAquifer::    allocate(aqDims) }
+    , doubleprecAnalyticAq_         { DoublePrecAnalyticAquifer::    allocate(aqDims) }
+    , integerAnalyticAquiferConn_   { IntegerAnalyticAquiferConn::   allocate(aqDims) }
+    , singleprecAnalyticAquiferConn_{ SinglePrecAnalyticAquiferConn::allocate(aqDims) }
+    , doubleprecAnalyticAquiferConn_{ DoublePrecAnalyticAquiferConn::allocate(aqDims) }
+{
+    const auto map = buildColumnarActiveIndexMappingTables(grid);
+
+    // Aquifer connections do not change in SCHEDULE.  Leverage that
+    // property to compute static connection information exactly once.
+    analyticAquiferConnectionLoop(aqConfig, [this, &grid, &map]
+        (const std::size_t           aquiferID,
+         const std::size_t           connectionID,
+         const double                tot_influx,
+         const Aquancon::AquancCell& connection) -> void
+    {
+        const auto aquIndex = static_cast<WindowedArray<int>::Idx>(aquiferID - 1);
+
+        // Note: ACAQ intentionally omitted here.  This array is not fully characterised.
+        auto icaq = this->integerAnalyticAquiferConn_   [aquIndex][connectionID];
+        auto scaq = this->singleprecAnalyticAquiferConn_[aquIndex][connectionID];
+
+        this->numActiveConn_[aquIndex] += 1;
+        this->totalInflux_  [aquIndex]  = tot_influx;
+
+        IntegerAnalyticAquiferConn::staticContrib(connection, grid, map, icaq);
+        SinglePrecAnalyticAquiferConn::staticContrib(connection, tot_influx, scaq);
+    });
+}
+
+void
+Opm::RestartIO::Helpers::AggregateAquiferData::
+captureDynamicdAquiferData(const AquiferConfig& aqConfig,
+                           const SummaryState&  summaryState,
+                           const PvtwTable&     pvtwTable,
+                           const DensityTable&  densityTable,
+                           const UnitSystem&    usys)
+{
+    FetkovichAquiferLoop(aqConfig, [this, &summaryState, &usys]
+        (const Aquifetp::AQUFETP_data& aquifer)
+    {
+        const auto aquIndex = static_cast<WindowedArray<int>::Idx>(aquifer.aquiferID - 1);
+
+        auto iaaq = this->integerAnalyticAq_[aquIndex];
+        const auto nActiveConn = this->numActiveConn_[aquIndex];
+        IntegerAnalyticAquifer::Fetckovich::staticContrib(aquifer, nActiveConn, iaaq);
+
+        auto saaq = this->singleprecAnalyticAq_[aquIndex];
+        SinglePrecAnalyticAquifer::Fetckovich::staticContrib(aquifer, usys, saaq);
+
+        auto xaaq = this->doubleprecAnalyticAq_[aquIndex];
+        const auto tot_influx = this->totalInflux_[aquIndex];
+        auto sumVar = [&summaryState, &aquifer](const std::string& vector)
+        {
+            return DoublePrecAnalyticAquifer::
+                getSummaryVariable(summaryState, vector, aquifer.aquiferID);
+        };
+        DoublePrecAnalyticAquifer::Fetkovich::dynamicContrib(sumVar, tot_influx, usys, xaaq);
+    });
+
+    CarterTracyAquiferLoop(aqConfig, [this, &summaryState, &pvtwTable, &densityTable, &usys]
+        (const AquiferCT::AQUCT_data& aquifer)
+    {
+        const auto aquIndex = static_cast<WindowedArray<int>::Idx>(aquifer.aquiferID - 1);
+        const auto pvtNum = static_cast<std::vector<double>::size_type>(aquifer.pvttableID - 1);
+
+        auto iaaq = this->integerAnalyticAq_[aquIndex];
+        const auto nActiveConn = this->numActiveConn_[aquIndex];
+        IntegerAnalyticAquifer::CarterTracy::staticContrib(aquifer, nActiveConn, iaaq);
+
+        auto saaq = this->singleprecAnalyticAq_[aquIndex];
+        const auto rhoWS = densityTable[pvtNum].water;
+        const auto& pvtw = pvtwTable[pvtNum];
+        SinglePrecAnalyticAquifer::CarterTracy::staticContrib(aquifer, rhoWS,
+                                                              pvtw, usys, saaq);
+
+        auto xaaq = this->doubleprecAnalyticAq_[aquIndex];
+        const auto tot_influx = this->totalInflux_[aquIndex];
+        auto sumVar = [&summaryState, &aquifer](const std::string& vector)
+        {
+            return DoublePrecAnalyticAquifer::
+                getSummaryVariable(summaryState, vector, aquifer.aquiferID);
+        };
+        DoublePrecAnalyticAquifer::CarterTracy::dynamicContrib(sumVar, aquifer, pvtw,
+                                                               tot_influx, usys, xaaq);
+    });
+}

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -1,4 +1,5 @@
 /*
+  Copyright (c) 2021 Equinor ASA
   Copyright (c) 2018 Statoil ASA
 
   This file is part of the Open Porous Media project (OPM).
@@ -21,6 +22,7 @@
 
 #include <opm/output/eclipse/InteHEAD.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
@@ -284,7 +286,6 @@ namespace {
         }};
     }
 
-
     Opm::RestartIO::InteHEAD::Phases
     getActivePhases(const ::Opm::Runspec& rspec)
     {
@@ -542,10 +543,7 @@ createInteHead(const EclipseState& es,
         .params_NWELZ       (155, 122, 130, 3) // n{isxz}welz: number of data elements per well in {ISXZ}WELL
         .params_NCON        (25, 41, 58)       // n{isx}conz: number of data elements per completion in ICON
         .params_GRPZ        (getNGRPZ(nwgmax, ngmax, rspec))
-             // ncamax: max number of analytical aquifer connections
-             // n{isx}aaqz: number of data elements per aquifer in {ISX}AAQ
-             // n{isa}caqz: number of data elements per aquifer connection in {ISA}CAQ
-        .params_NAAQZ       (1, 18, 24, 10, 7, 2, 4)
+        .aquiferDimensions  (inferAquiferDimensions(es))
         .stepParam          (num_solver_steps, report_step)
         .tuningParam        (getTuningPars(sched[lookup_step].tuning()))
         .liftOptParam       (getLiftOptPar(sched, lookup_step))

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -649,9 +649,9 @@ namespace {
         return rst_view.hasKeyword<double>("XAAQ");
     }
 
-    std::size_t numAnalyticAquifers(RestartFileView& rst_view)
+    std::size_t maximumAnalyticAquiferID(RestartFileView& rst_view)
     {
-        return rst_view.intehead()[VI::intehead::MAX_AN_AQUIFERS];
+        return rst_view.intehead()[VI::intehead::MAX_AN_AQUIFER_ID];
     }
 
     std::vector<double>
@@ -1340,10 +1340,10 @@ namespace {
         const auto& intehead    = rst_view->intehead();
         const auto  aquiferData = AquiferVectors{ intehead, rst_view };
 
-        const auto  numAq = numAnalyticAquifers(*rst_view);
+        const auto  maxAqID = maximumAnalyticAquiferID(*rst_view);
         const auto& units = es.getUnits();
 
-        for (auto aquiferID = 0*numAq; aquiferID < numAq; ++aquiferID) {
+        for (auto aquiferID = 0*maxAqID; aquiferID < maxAqID; ++aquiferID) {
             const auto& saaq = aquiferData.saaq(aquiferID);
             const auto& xaaq = aquiferData.xaaq(aquiferID);
 

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -569,7 +569,6 @@ public:
     Window<double> xaaq(const std::size_t aquiferID) const;
 
 private:
-    std::size_t maxAnalyticAquifer_;
     std::size_t numIntAnalyticAquiferElm_;
     std::size_t numFloatAnalyticAquiferElm_;
     std::size_t numDoubleAnalyticAquiferElm_;
@@ -579,8 +578,7 @@ private:
 
 AquiferVectors::AquiferVectors(const std::vector<int>&          intehead,
                                std::shared_ptr<RestartFileView> rst_view)
-    : maxAnalyticAquifer_         (intehead[VI::intehead::MAX_AN_AQUIFERS])
-    , numIntAnalyticAquiferElm_   (intehead[VI::intehead::NIAAQZ])
+    : numIntAnalyticAquiferElm_   (intehead[VI::intehead::NIAAQZ])
     , numFloatAnalyticAquiferElm_ (intehead[VI::intehead::NSAAQZ])
     , numDoubleAnalyticAquiferElm_(intehead[VI::intehead::NXAAQZ])
     , rstView_                    (std::move(rst_view))
@@ -1295,20 +1293,18 @@ namespace {
     determineAquiferType(const AquiferVectors::Window<int>& iaaq)
     {
         const auto t1 = iaaq[VI::IAnalyticAquifer::TypeRelated1];
-        const auto t2 = iaaq[VI::IAnalyticAquifer::TypeRelated2];
 
-        if ((t1 == 1) && (t2 == 1)) {
+        if (t1 == 1) {
             return Opm::data::AquiferType::CarterTracy;
         }
 
-        if ((t1 == 0) && (t2 == 0)) {
+        if (t1 == 0) {
             return Opm::data::AquiferType::Fetkovich;
         }
 
         throw std::runtime_error {
             "Unknown Aquifer Type:"
-                  " T1 = "  + std::to_string(t1)
-                + ", T2 = " + std::to_string(t2)
+            " T1 = "  + std::to_string(t1)
         };
     }
 

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.cpp
@@ -35,6 +35,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <map>
 #include <optional>
 #include <stdexcept>
 #include <tuple>
@@ -67,7 +68,7 @@ namespace Opm {
         }
 
         void add_cell(const KeywordLocation& location,
-                      std::unordered_map<std::size_t, Aquancon::AquancCell>& work,
+                      std::map<std::size_t, Aquancon::AquancCell>& work,
                       const EclipseGrid& grid,
                       const int aquiferID,
                       const std::size_t global_index,
@@ -108,7 +109,7 @@ namespace Opm {
 
     Aquancon::Aquancon(const EclipseGrid& grid, const Deck& deck)
     {
-        std::unordered_map<std::size_t, Aquancon::AquancCell> work;
+        std::map<std::size_t, Aquancon::AquancCell> work;
         for (std::size_t iaq = 0; iaq < deck.count("AQUANCON"); iaq++) {
             const auto& aquanconKeyword = deck.getKeyword("AQUANCON", iaq);
             OpmLog::info(OpmInputError::format("Initializing aquifer connections from {keyword} in {file} line {line}", aquanconKeyword.location()));

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.cpp
@@ -18,9 +18,28 @@
  */
 
 #include <opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp>
+
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Tables/Aqudims.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/AqutabTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
+
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
 
 namespace Opm {
 

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.cpp
@@ -17,14 +17,18 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <utility>
+#include <opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.hpp>
 
 #include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
-#include <opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.hpp>
+
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <utility>
+#include <vector>
 
 namespace Opm {
 

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -464,6 +464,7 @@ Runspec::Runspec( const Deck& deck ) :
     welldims( deck ),
     wsegdims( deck ),
     netwrkdims( deck ),
+    aquiferdims( deck ),
     udq_params( deck ),
     hystpar( deck ),
     m_actdims( deck ),

--- a/tests/test_AggregateAquiferData.cpp
+++ b/tests/test_AggregateAquiferData.cpp
@@ -473,8 +473,7 @@ AQUANCON
     template <class Coll1, class Coll2>
     void check_is_close(const Coll1& coll1, const Coll2& coll2, const double tol)
     {
-        BOOST_REQUIRE_EQUAL(std::distance(std::begin(coll1), std::end(coll1)),
-                            std::distance(std::begin(coll2), std::end(coll2)));
+        BOOST_REQUIRE_EQUAL(std::size(coll1), std::size(coll2));
 
         if (coll1.empty()) { return; }
 

--- a/tests/test_AggregateAquiferData.cpp
+++ b/tests/test_AggregateAquiferData.cpp
@@ -1,0 +1,817 @@
+/*
+  Copyright 2021 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Aggregate_Aquifer_Data
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/AggregateAquiferData.hpp>
+
+#include <opm/output/data/Aquifer.hpp>
+
+#include <opm/output/eclipse/InteHEAD.hpp>
+#include <opm/output/eclipse/VectorItems/aquifer.hpp>
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.hpp>
+#include <opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/FlatTable.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/common/utility/TimeService.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace {
+
+    class AquiferConnections
+    {
+    public:
+        using Connections = std::vector<Opm::Aquancon::AquancCell>;
+        using AllConnections = std::unordered_map<int, Connections>;
+
+        void addConnection(const int                   aquiferID,
+                           const std::size_t           cartesianCell,
+                           const double                influxCoefficient,
+                           const double                effectiveFaceArea,
+                           const Opm::FaceDir::DirEnum direction)
+        {
+            this->all_connections_[aquiferID]
+                .emplace_back(aquiferID, cartesianCell, influxCoefficient,
+                              effectiveFaceArea, direction);
+        }
+
+        const AllConnections& getAllConnections() const
+        {
+            return this->all_connections_;
+        }
+
+    private:
+        AllConnections all_connections_;
+    };
+
+    double prodIndexUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().to_si(M::liquid_productivity_index, 1.0);
+    }
+
+    double pressureUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().to_si(M::pressure, 1.0);
+    }
+
+    double compressibilityUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().from_si(M::pressure, 1.0);
+    }
+
+    double volumeUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().to_si(M::liquid_surface_volume, 1.0);
+    }
+
+    double depthUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().to_si(M::length, 1.0);
+    }
+
+    double permeabilityUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().to_si(M::permeability, 1.0);
+    }
+
+    double viscosityUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().to_si(M::viscosity, 1.0);
+    }
+
+    double viscosibilityUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().from_si(M::pressure, 1.0);
+    }
+
+    double densityUnit()
+    {
+        using M = Opm::UnitSystem::measure;
+        return Opm::UnitSystem::newMETRIC().to_si(M::density, 1.0);
+    }
+
+    Opm::PvtwTable pvtw()
+    {
+        auto table = Opm::PvtwTable{};
+
+        {
+            auto& t1 = table.emplace_back();
+
+            t1.reference_pressure = 279.0*pressureUnit();
+            t1.volume_factor = 1.038;
+            t1.compressibility = 5.0e-5*compressibilityUnit();
+            t1.viscosity = 0.318*viscosityUnit();
+            t1.viscosibility = 1.0e-4*viscosibilityUnit();
+        }
+
+        table.push_back(table.back());
+        {
+            auto& t2 = table.back();
+            t2.viscosity = 0.118*viscosityUnit();
+        }
+
+        return table;
+    }
+
+    Opm::DensityTable density()
+    {
+        auto table = Opm::DensityTable{};
+
+        {
+            auto& t1 = table.emplace_back();
+
+            t1.oil = 856.5*densityUnit();
+            t1.water = 1053.0*densityUnit();
+            t1.gas = 0.85204*densityUnit();
+        }
+
+        table.push_back(table.back());
+        {
+            auto& t2 = table.back();
+            t2.water = 1033.0*densityUnit();
+        }
+
+        return table;
+    }
+
+    std::pair<std::vector<double>, std::vector<double>> CTInfluenceFunction_1()
+    {
+        return {
+            std::vector<double> { // tD
+                0.010, 0.050, 0.100, 0.150, 0.200, 0.250, 0.300, 0.400,
+                0.500, 0.600, 0.700, 0.800, 0.900, 1.000, 1.500, 2.000,
+                2.500, 3.000, 4.000, 5.000, 6.000, 7.000, 8.000, 9.000,
+                10.00, 15.00, 20.00, 25.00, 30.00, 40.00, 50.00, 60.00,
+                70.00, 80.00, 90.00, 100.0, 150.0, 200.0, 250.0, 300.0,
+                400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000,
+            }
+            ,
+            std::vector<double> { // pD
+                0.112, 0.229, 0.315, 0.376, 0.424, 0.469, 0.503, 0.564,
+                0.616, 0.659, 0.702, 0.735, 0.772, 0.802, 0.927, 1.020,
+                1.101, 1.169, 1.275, 1.362, 1.436, 1.500, 1.556, 1.604,
+                1.651, 1.829, 1.960, 2.067, 2.147, 2.282, 2.388, 2.476,
+                2.550, 2.615, 2.672, 2.723, 2.921, 3.064, 3.173, 3.263,
+                3.406, 3.516, 3.608, 3.684, 3.750, 3.809, 3.86,
+            }
+        };
+    }
+
+    std::pair<std::vector<double>, std::vector<double>> CTInfluenceFunction_3()
+    {
+        return {
+            std::vector<double> { // tD
+                0.01, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.40, 0.50, 0.52,
+                0.54, 0.56, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95,
+                1.00, 1.20, 1.40, 1.60, 2.00, 3.00, 4.00, 5.00, 10.00,
+                20.00, 30.00, 50.00, 100.00, 200.00, 300.00, 500.00,
+                1000.00,
+            },
+            std::vector<double> { // pD
+                0.112, 0.229, 0.315, 0.376, 0.424, 0.469, 0.503, 0.564, 0.616,
+                0.627, 0.636, 0.645, 0.662, 0.683, 0.703, 0.721, 0.740, 0.758,
+                0.776, 0.791, 0.806, 0.865, 0.920, 0.973, 1.076, 1.328, 1.578,
+                1.828, 3.078, 5.578, 8.078, 13.078, 25.578, 50.578, 75.578,
+                125.578, 250.578,
+            }
+        };
+    }
+
+    void connectCarterTracy(AquiferConnections& aquancon)
+    {
+        using FDir = Opm::FaceDir::DirEnum;
+
+        {
+            const auto aquiferID = 1;
+            const auto cartCell1 = std::size_t{699}; // one-based IJK = (20,5,7)
+            const auto cartCell2 = std::size_t{799}; // one-based IJK = (20,5,8)
+            const auto cartCell3 = std::size_t{899}; // one-based IJK = (20,5,9)
+            const auto effFaceArea = 4.0 * 0.2;     // DY * DZ
+            const auto influxCoeff = effFaceArea;
+
+            aquancon.addConnection(aquiferID, cartCell1, 1.0*influxCoeff,  6.0*effFaceArea, FDir::XMinus);
+            aquancon.addConnection(aquiferID, cartCell2, 2.0*influxCoeff, 12.0*effFaceArea, FDir::YMinus);
+            aquancon.addConnection(aquiferID, cartCell3, 3.0*influxCoeff, 18.0*effFaceArea, FDir::ZMinus);
+        }
+
+        {
+            const auto aquiferID = 6;
+            const auto cartCell = std::size_t{579}; // one-based IJK = (20,4,6)
+            const auto effFaceArea = 4.0 * 0.2;     // DY * DZ
+            const auto influxCoeff = 1.0;           // [m^2]
+
+            aquancon.addConnection(aquiferID, cartCell, influxCoeff, effFaceArea, FDir::XPlus);
+        }
+    }
+
+    Opm::AquiferCT createCarterTracy()
+    {
+        const auto porosity        = 0.3;
+        const auto compr           = 3.0e-5*compressibilityUnit();
+        const auto datumDepth      = 2000.0*depthUnit();
+        const auto initialPressure = std::make_pair(true, 269.0*pressureUnit());
+
+        const auto angle = 360.0; // degrees
+        const auto thickness = 10.0*depthUnit();
+
+        const auto c1 = 1.0;
+        const auto c2 = 6.283;  // Really should be 2\pi.
+
+        auto properties = std::vector<Opm::AquiferCT::AQUCT_data>{};
+
+        {
+            const auto aquiferID = 1;
+            const auto influenceFunction = 1;
+            const auto pvtTable = 2;
+            const auto ro = 800.0*depthUnit();
+            const auto ka = 1000.0*permeabilityUnit();
+
+            const auto& [tD, pD] = CTInfluenceFunction_1();
+
+            properties.emplace_back(aquiferID, influenceFunction, pvtTable, porosity,
+                                    datumDepth, compr, ro, ka, c1, thickness,
+                                    angle / 360.0, c2, initialPressure, tD, pD);
+        }
+
+        {
+            const auto aquiferID = 6;
+            const auto influenceFunction = 3;
+            const auto pvtTable = 1;
+            const auto ro = 900.0*depthUnit();
+            const auto ka = 5000.0*permeabilityUnit();
+
+            const auto& [tD, pD] = CTInfluenceFunction_3();
+
+            properties.emplace_back(aquiferID, influenceFunction, pvtTable, porosity,
+                                    datumDepth, compr, ro, ka, c1, thickness,
+                                    angle / 360.0, c2, initialPressure, tD, pD);
+        }
+
+        return { properties };
+    }
+
+    void connectFetkovic(AquiferConnections& aquancon)
+    {
+        using FDir = Opm::FaceDir::DirEnum;
+
+        {
+            const auto aquiferID = 2;
+            const auto cartCell = std::size_t{619}; // one-based IJK = (20,1,7)
+            const auto effFaceArea = 4.0 * 0.2;     // DY * DZ
+            const auto influxCoeff = effFaceArea;
+
+            aquancon.addConnection(aquiferID, cartCell, influxCoeff, effFaceArea, FDir::YPlus);
+        }
+
+        {
+            const auto aquiferID = 4;
+            const auto cartCell = std::size_t{419}; // one-based IJK = (20,1,5)
+            const auto effFaceArea = 4.0 * 0.2;     // DY * DZ
+            const auto influxCoeff = 1.0;           // [m^2]
+
+            aquancon.addConnection(aquiferID, cartCell, influxCoeff, effFaceArea, FDir::ZPlus);
+        }
+    }
+
+    Opm::Aquifetp createFetkovich()
+    {
+        const auto compr           = 1.5312e-4*compressibilityUnit();
+        const auto datumDepth      = 2000.0*depthUnit();
+        const auto initialPressure = std::make_pair(true, 250.0*pressureUnit());
+
+        auto properties = std::vector<Opm::Aquifetp::AQUFETP_data>{};
+
+        {
+            const auto aquiferID     = 2;
+            const auto pvtTable      = 2;
+            const auto prodIndex     = 495.0*prodIndexUnit();
+            const auto initialVolume = 5.0e+10*volumeUnit();
+
+            properties.emplace_back(aquiferID, pvtTable, prodIndex, compr,
+                                    initialVolume, datumDepth, initialPressure);
+        }
+
+        {
+            const auto aquiferID     = 4;
+            const auto pvtTable      = 1;
+            const auto prodIndex     = 910.0*prodIndexUnit();
+            const auto initialVolume = 2.0e+10*volumeUnit();
+
+            properties.emplace_back(aquiferID, pvtTable, prodIndex, compr,
+                                    initialVolume, datumDepth, initialPressure);
+        }
+
+        return { properties };
+    }
+
+    Opm::AquiferConfig createAquiferConfig()
+    {
+        auto aquancon = AquiferConnections{};
+        connectCarterTracy(aquancon);
+        connectFetkovic(aquancon);
+
+        return {
+            createFetkovich(), createCarterTracy(), aquancon.getAllConnections()
+        };
+    }
+
+    Opm::EclipseGrid createGrid()
+    {
+        auto grid = Opm::EclipseGrid { 20, 5, 10, 5.0, 4.0, 0.2 };
+
+        auto actnum = std::vector<int>(grid.getCartesianSize(), 1);
+
+        actnum[grid.getGlobalIndex( 1, 1, 1)] = 0;
+        actnum[grid.getGlobalIndex( 2, 1, 1)] = 0;
+        actnum[grid.getGlobalIndex(19, 1, 6)] = 0;
+        actnum[grid.getGlobalIndex(19, 2, 6)] = 0;
+
+        grid.resetACTNUM(actnum);
+
+        return grid;
+    }
+
+    Opm::RestartIO::InteHEAD::AquiferDims syntheticAquiferDimensions()
+    {
+        auto aqDims = Opm::RestartIO::InteHEAD::AquiferDims{};
+
+        aqDims.numAquifers = 4; // 1, 2, 4, 6
+        aqDims.maxNumAquifers = 10; // >= 6
+        aqDims.maxNumAquiferConn = 5;       // >= 3
+        aqDims.maxNumActiveAquiferConn = 3; // ID = 1
+        aqDims.maxAquiferID = 6;
+
+        return aqDims;
+    }
+
+    Opm::RestartIO::InteHEAD::AquiferDims parseAquiferDimensions()
+    {
+        const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+  20 5 10 /
+
+AQUDIMS
+-- MXNAQN   MXNAQC   NIFTBL  NRIFTB   NANAQU    NNCAMAX
+    1*       1*        5       100      5         1000 /
+
+GRID
+
+DXV
+  20*100.0 /
+
+DYV
+  5*50.0 /
+
+DZV
+  10*10.0 /
+
+DEPTHZ
+  126*2000.0 /
+
+PORO
+  1000*0.25 /
+
+EQUALS
+  'PORO' 0.0 2 3 2 2 2 2 /
+  'PORO' 0.0 20 20 2 3 7 7 /
+/
+
+SOLUTION
+
+AQUFETP
+-- Aqu        depth     Pr      vol        Comp         PI        PVTW
+   2           2000.0   250.0   5.0E+10   1.5312E-4    495         2     /
+   4           2000.0   250.0   2.0E+10   1.5312E-4    910         1     /
+/
+
+AQUANCON
+-- Aq#     I1   I2    J1   J2   K1  K2  FACE
+    2      20   20     1    5    7   9   'I+'  1*   1.0 NO /
+    4      20   20     1    5    5   6   'I+'  1.0  1.0 NO /
+/
+
+)");
+
+        const auto es = Opm::EclipseState{ deck };
+
+        return Opm::RestartIO::inferAquiferDimensions(es);
+    }
+
+    Opm::SummaryState sim_state()
+    {
+        auto state = Opm::SummaryState{Opm::TimeService::now()};
+
+        state.update("AAQP:1", 123.456);
+        state.update("AAQR:1", 234.567);
+        state.update("AAQT:1", 3456.789);
+        state.update("AAQPD:1", 4.567);
+        state.update("AAQTD:1", 50.607);
+
+        state.update("AAQP:2", 121.212);
+        state.update("AAQR:2", 222.333);
+        state.update("AAQT:2", 333.444);
+
+        state.update("AAQP:4", 555.444);
+        state.update("AAQR:4", 333.222);
+        state.update("AAQT:4", 222.111);
+
+        state.update("AAQP:6", 456.123);
+        state.update("AAQR:6", 34.567);
+        state.update("AAQT:6", 4444.5555);
+        state.update("AAQPD:6", 50.706);
+        state.update("AAQTD:6", 100.321);
+
+        return state;
+    }
+
+    template <class Coll1, class Coll2>
+    void check_is_close(const Coll1& coll1, const Coll2& coll2, const double tol)
+    {
+        BOOST_REQUIRE_EQUAL(std::distance(std::begin(coll1), std::end(coll1)),
+                            std::distance(std::begin(coll2), std::end(coll2)));
+
+        if (coll1.empty()) { return; }
+
+        auto c1 = std::begin(coll1);
+        auto e1 = std::end  (coll1);
+        auto c2 = std::begin(coll2);
+        for (; c1 != e1; ++c1, ++c2) {
+            BOOST_CHECK_CLOSE(*c1, *c2, tol);
+        }
+    }
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(Aggregate_Aquifer_Data)
+
+BOOST_AUTO_TEST_CASE(AquiferDimensions)
+{
+    const auto aqDims = parseAquiferDimensions();
+
+    BOOST_CHECK_EQUAL(aqDims.numAquifers, 2); // 2 unique aquifer IDs (2 and 4)
+    BOOST_CHECK_EQUAL(aqDims.maxNumAquifers, 5);           // AQUDIMS(5)
+    BOOST_CHECK_EQUAL(aqDims.maxNumAquiferConn, 1000);     // AQUDIMS(6)
+    BOOST_CHECK_EQUAL(aqDims.maxNumActiveAquiferConn, 13); // In aquifer ID 2
+    BOOST_CHECK_EQUAL(aqDims.maxAquiferID, 4);             // Maximum aquifer ID
+
+    // # Data items per analytic aquifer
+    BOOST_CHECK_EQUAL(aqDims.numIntAquiferElem, 18);       // # Integer
+    BOOST_CHECK_EQUAL(aqDims.numRealAquiferElem, 24);      // # Single precision
+    BOOST_CHECK_EQUAL(aqDims.numDoubAquiferElem, 10);      // # Double precision
+
+    // # Data items per analytic aquifer *connection*
+    BOOST_CHECK_EQUAL(aqDims.numIntConnElem, 7);           // # Integer
+    BOOST_CHECK_EQUAL(aqDims.numRealConnElem, 2);          // # Single precision
+    BOOST_CHECK_EQUAL(aqDims.numDoubConnElem, 4);          // # Double precision
+}
+
+BOOST_AUTO_TEST_CASE(Static_Information_Analytic_Aquifers)
+{
+    const auto aqDims = syntheticAquiferDimensions();
+    const auto aqConfig = createAquiferConfig();
+
+    const auto aquiferData = Opm::RestartIO::Helpers::
+        AggregateAquiferData{ aqDims, aqConfig, createGrid() };
+
+    BOOST_CHECK_EQUAL(aquiferData.maximumActiveAnalyticAquiferID(), 6);
+
+    // ICAQ:1
+    {
+        const auto expect = std::vector<int> {
+            // Connection 0
+            20,  5,  7, 993,   1,   0, 0,
+            // Connection 1
+            20,  5,  8, 994,   3,   0, 0,
+            // Connection 2
+            20,  5,  9, 995,   5,   0, 0,
+        };
+
+        const auto& icaq = aquiferData.getIntegerAquiferConnectionData(1);
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(icaq.begin(), icaq.end(), expect.begin(), expect.end());
+    }
+
+    // SCAQ:1
+    {
+        const auto expect = std::vector<float> {
+            // Connection 0
+            1.0f/6.0f,  1.0f,
+            // Connection 1
+            1.0f/3.0f,  2.0f,
+            // Connection 2
+            1.0f/2.0f,  3.0f,
+        };
+
+        const auto& scaq = aquiferData.getSinglePrecAquiferConnectionData(1);
+
+        check_is_close(scaq, expect, 1.0e-7);
+    }
+
+    // ICAQ:2
+    {
+        const auto expect = std::vector<int> {
+            // Connection 0
+            20,  1,  7, 955,   4,   0, 0,
+            // Connection 1 (nonexistent)
+            0, 0, 0, 0, 0, 0, 0,
+            // Connection 2 (nonexistent)
+            0, 0, 0, 0, 0, 0, 0,
+        };
+
+        const auto& icaq = aquiferData.getIntegerAquiferConnectionData(2);
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(icaq.begin(), icaq.end(), expect.begin(), expect.end());
+    }
+
+    // SCAQ:2
+    {
+        const auto expect = std::vector<float> {
+            // Connection 0
+            1.0f,  1.0f,
+            // Connection 1 (nonexistent)
+            0.0f,  0.0f,
+            // Connection 2 (nonexistent)
+            0.0f,  0.0f,
+        };
+
+        const auto& scaq = aquiferData.getSinglePrecAquiferConnectionData(2);
+
+        check_is_close(scaq, expect, 1.0e-7);
+    }
+
+    // ICAQ:3 (not activated/connected)
+    {
+        const auto expect = std::vector<int> {
+            // Connection 0
+            0, 0, 0, 0, 0, 0, 0,
+            // Connection 1
+            0, 0, 0, 0, 0, 0, 0,
+            // Connection 2
+            0, 0, 0, 0, 0, 0, 0,
+        };
+
+        const auto& icaq = aquiferData.getIntegerAquiferConnectionData(3);
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(icaq.begin(), icaq.end(), expect.begin(), expect.end());
+    }
+
+    // SCAQ:3 (not activated/connected)
+    {
+        const auto expect = std::vector<float> {
+            // Connection 0
+            0.0f,  0.0f,
+            // Connection 1
+            0.0f,  0.0f,
+            // Connection 2
+            0.0f,  0.0f,
+        };
+
+        const auto& scaq = aquiferData.getSinglePrecAquiferConnectionData(3);
+
+        check_is_close(scaq, expect, 1.0e-7);
+    }
+
+    // ICAQ:4
+    {
+        const auto expect = std::vector<int> {
+            // Connection 0
+            20,  1,  5, 953,   6,   0, 0,
+            // Connection 1 (nonexistent)
+            0, 0, 0, 0, 0, 0, 0,
+            // Connection 2 (nonexistent)
+            0, 0, 0, 0, 0, 0, 0,
+        };
+
+        const auto& icaq = aquiferData.getIntegerAquiferConnectionData(4);
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(icaq.begin(), icaq.end(), expect.begin(), expect.end());
+    }
+
+    // SCAQ:4
+    {
+        const auto expect = std::vector<float> {
+            // Connection 0
+            1.0f,  0.8f,
+            // Connection 1 (nonexistent)
+            0.0f,  0.0f,
+            // Connection 2 (nonexistent)
+            0.0f,  0.0f,
+        };
+
+        const auto& scaq = aquiferData.getSinglePrecAquiferConnectionData(4);
+
+        check_is_close(scaq, expect, 1.0e-7);
+    }
+
+    // ICAQ:5 (not activated/connected)
+    {
+        const auto expect = std::vector<int> {
+            // Connection 0
+            0, 0, 0, 0, 0, 0, 0,
+            // Connection 1
+            0, 0, 0, 0, 0, 0, 0,
+            // Connection 2
+            0, 0, 0, 0, 0, 0, 0,
+        };
+
+        const auto& icaq = aquiferData.getIntegerAquiferConnectionData(5);
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(icaq.begin(), icaq.end(), expect.begin(), expect.end());
+    }
+
+    // SCAQ:5 (not activated/connected)
+    {
+        const auto expect = std::vector<float> {
+            // Connection 0
+            0.0f,  0.0f,
+            // Connection 1
+            0.0f,  0.0f,
+            // Connection 2
+            0.0f,  0.0f,
+        };
+
+        const auto& scaq = aquiferData.getSinglePrecAquiferConnectionData(5);
+
+        check_is_close(scaq, expect, 1.0e-7);
+    }
+
+    // ICAQ:6
+    {
+        const auto expect = std::vector<int> {
+            // Connection 0
+            20,  4,  6, 982,   2,   0, 0,
+            // Connection 1 (nonexistent)
+            0, 0, 0, 0, 0, 0, 0,
+            // Connection 2 (nonexistent)
+            0, 0, 0, 0, 0, 0, 0,
+        };
+
+        const auto& icaq = aquiferData.getIntegerAquiferConnectionData(6);
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(icaq.begin(), icaq.end(), expect.begin(), expect.end());
+    }
+
+    // SCAQ:6
+    {
+        const auto expect = std::vector<float> {
+            // Connection 0
+            1.0f,  0.8f,
+            // Connection 1 (nonexistent)
+            0.0f,  0.0f,
+            // Connection 2 (nonexistent)
+            0.0f,  0.0f,
+        };
+
+        const auto& scaq = aquiferData.getSinglePrecAquiferConnectionData(6);
+
+        check_is_close(scaq, expect, 1.0e-7);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Dynamic_Information_Analytic_Aquifers)
+{
+    const auto aqDims = syntheticAquiferDimensions();
+    const auto aqConfig = createAquiferConfig();
+
+    auto aquiferData = Opm::RestartIO::Helpers::
+        AggregateAquiferData{ aqDims, aqConfig, createGrid() };
+
+    aquiferData.captureDynamicdAquiferData(aqConfig, sim_state(), pvtw(), density(),
+                                           Opm::UnitSystem::newMETRIC());
+
+
+    // IAAQ
+    {
+        const auto expect = std::vector<int> {
+            // Aquifer 1
+            3, 2, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0,
+            // Aquifer 2
+            1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+            // Aquifer 3
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            // Aquifer 4
+            1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,
+            // Aquifer 5
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            // Aquifer 6
+            1, 1, 0, 0, 0, 0, 0, 0, 0, 3, 1, 1, 0, 0, 0, 0, 0, 0,
+        };
+
+        const auto& iaaq = aquiferData.getIntegerAquiferData();
+
+        BOOST_CHECK_EQUAL_COLLECTIONS(iaaq.begin(), iaaq.end(), expect.begin(), expect.end());
+    }
+
+    // SAAQ
+    {
+        const auto expect = std::vector<float> {
+            // Aquifer 1
+            3.0e-5f, 800.0f, 1000.0f, 0.3f, 269.0f, 2000.0f, 10.0f, 1.0f,  //  0.. 7
+            994.6857f, 0.117882f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,      //  8..15
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,                // 16..23
+
+            // Aquifer 2
+            1.5312e-4f, 5.0e10f, 495.0f, 1.546666666666667e+04f, 250.0f, 2000.0f, 0.0f, 0.0f, //  0.. 7 (24..31)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, //  8..15 (32..39)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, // 16..23 (40..47)
+
+            // Aquifer 3
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, //  0.. 7 (48..55)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, //  8..15 (56..63)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, // 16..23 (64..71)
+
+            // Aquifer 4
+            1.5312e-4f, 2.0e10f, 910.0f, 3.365274725274725e+03f, 250.0f, 2000.0f, 0.0f, 0.0f, //  0.. 7 (72..79)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, //  8..15 (80..87)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, // 16..23 (88..95)
+
+            // Aquifer 5
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, //  0.. 7 ( 96..103)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, //  8..15 (104..111)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, // 16..23 (112..119)
+
+            // Aquifer 6
+            3.0e-5f, 900.0f, 5000.0f, 0.3f, 269.0f, 2000.0f, 10.0f, 1.0f, //  0.. 7 (120..127)
+            1013.943893f, 0.317682f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, //  8..15 (128..135)
+            0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, // 16..23 (136..143)
+        };
+
+        const auto& saaq = aquiferData.getSinglePrecAquiferData();
+
+        check_is_close(saaq, expect, 1.0e-7);
+    }
+
+    // XAAQ
+    {
+        const auto expect = std::vector<double> {
+            // Aquifer 1
+            234.567, 123.456, 3456.789, 4.8, 12.558192939329325, 361.9008, 0.0, 0.0, 50.607, 4.567,
+
+            // Aquifer 2
+            222.333, 121.212, 333.444, 0.8, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+
+            // Aquifer 3
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+
+            // Aquifer 4
+            333.222, 555.444, 222.111, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+
+            // Aquifer 5
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+
+            // Aquifer 6
+            34.567, 456.123, 4444.5555, 1.0, 18.409712143375852, 458.0307, 0.0, 0.0, 100.321, 50.706,
+        };
+
+        const auto& xaaq = aquiferData.getDoublePrecAquiferData();
+
+        check_is_close(xaaq, expect, 1.0e-7);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -315,18 +315,28 @@ BOOST_AUTO_TEST_CASE(GroupSize_Parameters)
 BOOST_AUTO_TEST_CASE(Analytic_Aquifer_Parameters)
 {
     // https://oeis.org/A001622
+    const auto aqudims = Opm::RestartIO::InteHEAD::AquiferDims {
+        1, 61, 803, 3988, 74989, 484820, 45868, 3436, 563, 81, 1177203
+    };
+
     const auto ih = Opm::RestartIO::InteHEAD{}
-        .params_NAAQZ(1, 61, 803, 3988, 74989, 484820, 4586834);
+        .aquiferDimensions(aqudims);
 
     const auto& v = ih.data();
 
-    BOOST_CHECK_EQUAL(v[VI::intehead::NCAMAX], 1);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NIAAQZ], 61);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NSAAQZ], 803);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NXAAQZ], 3988);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NICAQZ], 74989);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NSCAQZ], 484820);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NACAQZ], 4586834);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NAQUIF], 1);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NCAMAX], 803);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NIAAQZ], 484820);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSAAQZ], 45868);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NXAAQZ], 3436);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NICAQZ], 563);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSCAQZ], 81);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NACAQZ], 1177203);
+
+    BOOST_CHECK_EQUAL(v[VI::intehead::MAX_ACT_ANLYTIC_AQUCONN], 3988);
+    BOOST_CHECK_EQUAL(v[VI::intehead::MAX_AN_AQUIFER_ID], 74989);
+    BOOST_CHECK_EQUAL(v[VI::intehead::AQU_UNKNOWN_1], 1);
+    BOOST_CHECK_EQUAL(v[VI::intehead::MAX_ANALYTIC_AQUIFERS], 61);
 }
 
 BOOST_AUTO_TEST_CASE(Time_and_report_step)
@@ -575,6 +585,10 @@ BOOST_AUTO_TEST_CASE(TestHeader) {
     const auto nmfipr = 22;
     const auto ngroup  = 8;
 
+    const auto aqudims = Opm::RestartIO::InteHEAD::AquiferDims {
+        1, 61, ncamax, 3988, 74989, niaaqz, nsaaqz, nxaaqz, nicaqz, nscaqz, nacaqz
+    };
+
     auto unit_system = Opm::UnitSystem::newMETRIC();
     auto ih = Opm::RestartIO::InteHEAD{}
          .dimensions(nx, ny, nz)
@@ -587,7 +601,7 @@ BOOST_AUTO_TEST_CASE(TestHeader) {
          .params_NWELZ(niwelz, nswelz, nxwelz, nzwelz)
          .params_NCON(niconz, nsconz, nxconz)
          .params_GRPZ({nigrpz, nsgrpz, nxgrpz, nzgrpz})
-         .params_NAAQZ(ncamax, niaaqz, nsaaqz, nxaaqz, nicaqz, nscaqz, nacaqz)
+         .aquiferDimensions(aqudims)
          .stepParam(tstep, report_step)
          .tuningParam({newtmx, newtmn, litmax, litmin, mxwsit, mxwpit, 0})
          .variousParam(version, iprog)

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -22,6 +22,7 @@
 #define BOOST_TEST_MODULE EclipseIO
 #include <boost/test/unit_test.hpp>
 
+#include <opm/output/eclipse/AggregateAquiferData.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/output/eclipse/RestartIO.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
@@ -480,6 +481,8 @@ BOOST_AUTO_TEST_CASE(ECL_FORMATTED) {
         auto wells = mkWells();
         auto groups = mkGroups();
         auto sumState = sim_state(base_setup.schedule);
+        auto udqState = UDQState{1};
+        auto aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{std::nullopt};
         Action::State action_state;
         {
             RestartValue restart_value(cells, wells, groups);
@@ -504,6 +507,8 @@ BOOST_AUTO_TEST_CASE(ECL_FORMATTED) {
                                 base_setup.schedule,
                                 action_state,
                                 sumState,
+                                udqState,
+                                aquiferData,
                                 true);
             }
 
@@ -533,6 +538,8 @@ BOOST_AUTO_TEST_CASE(ECL_FORMATTED) {
                                 base_setup.schedule,
                                 action_state,
                                 sumState,
+                                udqState,
+                                aquiferData,
                                 true);
             }
 
@@ -615,6 +622,7 @@ BOOST_AUTO_TEST_CASE(WriteWrongSOlutionSize) {
         Opm::SummaryState sumState(TimeService::now());
         Opm::Action::State action_state;
         Opm::UDQState udq_state(19);
+        auto aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{std::nullopt};
 
         const auto seqnum = 1;
         auto rstFile = OS::Restart {
@@ -630,7 +638,8 @@ BOOST_AUTO_TEST_CASE(WriteWrongSOlutionSize) {
                                            setup.schedule,
                                            action_state,
                                            sumState,
-                                           udq_state),
+                                           udq_state,
+                                           aquiferData),
                            std::runtime_error);
     }
 }
@@ -671,6 +680,7 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
         auto cells = mkSolution( num_cells );
         auto wells = mkWells();
         auto groups = mkGroups();
+        auto aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{std::nullopt};
         const auto& units = setup.es.getUnits();
         {
             RestartValue restart_value(cells, wells, groups);
@@ -696,7 +706,8 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
                                 setup.schedule,
                                 action_state,
                                 sumState,
-                                udq_state);
+                                udq_state,
+                                aquiferData);
             }
 
             const auto rstFile = ::Opm::EclIO::OutputStream::
@@ -751,6 +762,7 @@ BOOST_AUTO_TEST_CASE(STORE_THPRES) {
         auto cells = mkSolution( num_cells );
         auto wells = mkWells();
         auto groups = mkGroups();
+        auto aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{std::nullopt};
         const auto outputDir = test_area.currentWorkingDirectory();
         {
             RestartValue restart_value(cells, wells, groups);
@@ -790,7 +802,8 @@ BOOST_AUTO_TEST_CASE(STORE_THPRES) {
                                                    base_setup.schedule,
                                                    action_state,
                                                    sumState,
-                                                   udq_state),
+                                                   udq_state,
+                                                   aquiferData),
                                    std::runtime_error);
             }
 
@@ -814,7 +827,8 @@ BOOST_AUTO_TEST_CASE(STORE_THPRES) {
                                 base_setup.schedule,
                                 action_state,
                                 sumState,
-                                udq_state);
+                                udq_state,
+                                aquiferData);
             }
 
             {
@@ -868,12 +882,14 @@ BOOST_AUTO_TEST_CASE(Restore_Cumulatives)
     const auto seqnum = 1;
     {
         Action::State action_state;
+        auto aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{std::nullopt};
         auto rstFile = OS::Restart {
             rset, seqnum, OS::Formatted{ false }, OS::Unified{ true }
         };
 
         RestartIO::save(rstFile, seqnum, 100, restart_value,
-                        setup.es, setup.grid, setup.schedule, action_state, sumState, udq_state);
+                        setup.es, setup.grid, setup.schedule,
+                        action_state, sumState, udq_state, aquiferData);
     }
 
     Action::State action_state;


### PR DESCRIPTION
We support both Fetkovich and Carter-Tracy aquifers.  We presently output trivial values only in the `ACAQ` (per-connection, double precision elements), but otherwise assemble reasonable values for many items.

We leverage the fact that the aquifer connections do not change throughout the simulation run.  The "Aggregate" API is therefore constructed in such a way that most of the expensive operations (e.g., mapping active cell IDs to their columnar counterparts) happens once (in the constructor) and the per-aquifer operations are performed for each restart output step.  We intend that one aquifer output object be constructed at the start of the simulation run, if needed, and that this object will live until simulation shutdown.

If a simulation run uses analytic aquifers we construct an aquifer output object at simulation start and store this in an `optional<>` in the internal implementation object.  Otherwise the optional holds `nullopt`.  We expand `RestartIO::save()` to take such an optional by reference and aggregate/output aquifer information, directly after the well information, if the optional holds a value.  Update callers accordingly.