### PR TITLE
Schedule::applyAction() will return a set of wells affected

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -257,7 +257,7 @@ namespace Opm
         int  first_rst_step() const;
         const std::map< std::string, int >& rst_keywords( size_t timestep ) const;
 
-        void applyAction(std::size_t reportStep, const time_point& sim_time, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& wellpi);
+        std::unordered_set<std::string> applyAction(std::size_t reportStep, const time_point& sim_time, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& wellpi);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
 
@@ -505,13 +505,14 @@ namespace Opm
                            const FieldPropsManager* fp,
                            const std::vector<std::string>& matching_wells,
                            bool runtime,
+                           std::unordered_set<std::string> * affected_wells,
                            const std::unordered_map<std::string, double> * target_wellpi);
 
         static std::string formatDate(std::time_t t);
         std::string simulationDays(std::size_t currentStep) const;
 
         void applyEXIT(const DeckKeyword&, std::size_t currentStep);
-        void applyWELOPEN(const DeckKeyword&, std::size_t currentStep, bool runtime, const ParseContext&, ErrorGuard&, const std::vector<std::string>& matching_wells = {});
+        void applyWELOPEN(const DeckKeyword&, std::size_t currentStep, bool runtime, const ParseContext&, ErrorGuard&, const std::vector<std::string>& matching_wells = {}, std::unordered_set<std::string> * affected_wells = nullptr);
 
         struct HandlerContext {
             const ScheduleBlock& block;
@@ -519,6 +520,7 @@ namespace Opm
             const std::size_t currentStep;
             const std::vector<std::string>& matching_wells;
             const bool runtime;
+            std::unordered_set<std::string> * affected_wells;
             const std::unordered_map<std::string, double> * target_wellpi;
             const EclipseGrid* grid_ptr;
             const FieldPropsManager* fp_ptr;
@@ -528,12 +530,14 @@ namespace Opm
                            const std::size_t currentStep_,
                            const std::vector<std::string>& matching_wells_,
                            bool runtime_,
+                           std::unordered_set<std::string> * affected_wells_,
                            const std::unordered_map<std::string, double> * target_wellpi_):
                 block(block_),
                 keyword(keyword_),
                 currentStep(currentStep_),
                 matching_wells(matching_wells_),
                 runtime(runtime_),
+                affected_wells(affected_wells_),
                 target_wellpi(target_wellpi_),
                 grid_ptr(nullptr),
                 fp_ptr(nullptr)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -1199,6 +1199,9 @@ namespace {
                 new_well.applyWellProdIndexScaling(scalingFactor, scalingApplicable);
                 this->snapshots.back().wells.update( std::move(new_well) );
                 this->snapshots.back().target_wellpi[well_name] = targetPI;
+
+                if (handlerContext.affected_wells)
+                    handlerContext.affected_wells->insert(well_name);
             }
         }
     }
@@ -1298,6 +1301,8 @@ namespace {
                 }
                 this->addWell(wellName, record, handlerContext.currentStep, wellConnectionOrder);
                 this->addWellToGroup(groupName, wellName, handlerContext.currentStep);
+                if (handlerContext.affected_wells)
+                    handlerContext.affected_wells->insert(wellName);
             } else {
                 const auto headI = record.getItem<ParserKeywords::WELSPECS::HEAD_I>().get<int>(0) - 1;
                 const auto headJ = record.getItem<ParserKeywords::WELSPECS::HEAD_J>().get<int>(0) - 1;
@@ -1319,6 +1324,8 @@ namespace {
                         well2.updateRefDepth();
                         this->snapshots.back().wellgroup_events().addEvent( wellName, ScheduleEvents::WELL_WELSPECS_UPDATE);
                         this->snapshots.back().wells.update( std::move(well2) );
+                        if (handlerContext.affected_wells)
+                            handlerContext.affected_wells->insert(wellName);
                     }
                 }
             }


### PR DESCRIPTION
When Actionx has updated well(s) we must notify the simulator of which wells have been updated.

Downstream: https://github.com/OPM/opm-simulators/pull/3116