### PR TITLE
Import container

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -52,6 +52,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/Deck/DeckRecord.cpp
     src/opm/parser/eclipse/Deck/DeckOutput.cpp
     src/opm/parser/eclipse/Deck/DeckSection.cpp
+    src/opm/parser/eclipse/Deck/ImportContainer.cpp
     src/opm/parser/eclipse/Deck/UDAValue.cpp
     src/opm/parser/eclipse/Python/Python.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Action/PyAction.cpp
@@ -352,6 +353,7 @@ if(ENABLE_ECL_INPUT)
     tests/parser/FunctionalTests.cpp
     tests/parser/GeomodifierTests.cpp
     tests/parser/GroupTests.cpp
+    tests/parser/ImportTests.cpp
     tests/parser/InitConfigTest.cpp
     tests/parser/IOConfigTests.cpp
     tests/parser/MessageLimitTests.cpp
@@ -809,6 +811,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/Deck/DeckValue.hpp
        opm/parser/eclipse/Deck/DeckKeyword.hpp
        opm/parser/eclipse/Deck/DeckRecord.hpp
+       opm/parser/eclipse/Deck/ImportContainer.hpp
        opm/parser/eclipse/Deck/UDAValue.hpp
        opm/parser/eclipse/Deck/value_status.hpp
        opm/parser/eclipse/Python/Python.hpp)

--- a/opm/io/eclipse/EclFile.hpp
+++ b/opm/io/eclipse/EclFile.hpp
@@ -35,7 +35,12 @@ namespace Opm { namespace EclIO {
 class EclFile
 {
 public:
+    struct Formatted {
+        bool value;
+    };
+
     explicit EclFile(const std::string& filename, bool preload = false);
+    EclFile(const std::string& filename, Formatted fmt, bool preload = false);
     bool formattedInput() const { return formatted; }
 
     void loadData();                            // load all data
@@ -114,6 +119,7 @@ private:
 
     void loadBinaryArray(std::fstream& fileH, std::size_t arrIndex);
     void loadFormattedArray(const std::string& fileStr, std::size_t arrIndex, int64_t fromPos);
+    void load(bool preload);
 
     std::vector<unsigned int> get_bin_logi_raw_values(int arrIndex) const;
     std::vector<std::string> get_fmt_real_raw_str_values(int arrIndex) const;

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -44,9 +44,9 @@ namespace Opm {
         DeckKeyword();
         explicit DeckKeyword(const ParserKeyword& parserKeyword);
         DeckKeyword(const KeywordLocation& location, const std::string& keywordName);
-        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<std::vector<DeckValue>>& record_list, UnitSystem& system_active, UnitSystem& system_default);
+        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<std::vector<DeckValue>>& record_list, const UnitSystem& system_active, const UnitSystem& system_default);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data);
-        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, UnitSystem& system_active, UnitSystem& system_default);
+        DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, const UnitSystem& system_active, const UnitSystem& system_default);
 
         static DeckKeyword serializeObject();
 

--- a/opm/parser/eclipse/Deck/ImportContainer.hpp
+++ b/opm/parser/eclipse/Deck/ImportContainer.hpp
@@ -1,0 +1,42 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define IMPORT_CONTAINER_HPP
+
+#include <vector>
+
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
+
+namespace Opm {
+
+class Parser;
+
+class ImportContainer {
+public:
+    ImportContainer(const Parser& parser, const UnitSystem& unit_system, const std::string& fname, bool formatted, std::size_t deck_size);
+
+    std::vector<DeckKeyword>::iterator begin() { return this->keywords.begin(); }
+    std::vector<DeckKeyword>::iterator end() { return this->keywords.end(); }
+private:
+    std::vector<DeckKeyword> keywords;
+};
+
+
+}

--- a/src/opm/io/eclipse/EclFile.cpp
+++ b/src/opm/io/eclipse/EclFile.cpp
@@ -38,23 +38,17 @@
 
 namespace Opm { namespace EclIO {
 
-EclFile::EclFile(const std::string& filename, bool preload) : inputFilename(filename)
-{
-    if (!fileExists(filename))
-        throw std::runtime_error(fmt::format("Can not open EclFile: {}", filename));
-
+void EclFile::load(bool preload) {
     std::fstream fileH;
 
-    formatted = isFormatted(filename);
-
     if (formatted) {
-        fileH.open(filename, std::ios::in);
+        fileH.open(this->inputFilename, std::ios::in);
     } else {
-        fileH.open(filename, std::ios::in |  std::ios::binary);
+        fileH.open(this->inputFilename, std::ios::in |  std::ios::binary);
     }
 
     if (!fileH)
-        throw std::runtime_error(fmt::format("Can not open EclFile: {}", filename));
+        throw std::runtime_error(fmt::format("Can not open EclFile: {}", this->inputFilename));
 
     int n = 0;
     while (!isEOF(&fileH)) {
@@ -100,6 +94,25 @@ EclFile::EclFile(const std::string& filename, bool preload) : inputFilename(file
 
     if (preload)
         this->loadData();
+}
+
+
+EclFile::EclFile(const std::string& filename, EclFile::Formatted fmt, bool preload) :
+    formatted(fmt.value),
+    inputFilename(filename)
+{
+    this->load(preload);
+}
+
+
+EclFile::EclFile(const std::string& filename, bool preload) :
+    inputFilename(filename)
+{
+    if (!fileExists(filename))
+        throw std::runtime_error(fmt::format("Can not open EclFile: {}", filename));
+
+    formatted = isFormatted(filename);
+    this->load(preload);
 }
 
 

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -85,7 +85,7 @@ namespace Opm {
     }
 
 
-    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword,  const std::vector<std::vector<DeckValue>>& record_list, UnitSystem& system_active, UnitSystem& system_default) :
+    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword,  const std::vector<std::vector<DeckValue>>& record_list, const UnitSystem& system_active, const UnitSystem& system_default) :
         DeckKeyword(parserKeyword)
     {
         if (parserKeyword.hasFixedSize() && (record_list.size() != parserKeyword.getFixedSize()))
@@ -115,8 +115,8 @@ namespace Opm {
                               std::vector<Dimension> active_dimensions;
                               std::vector<Dimension> default_dimensions;
                               if (dim.size() > 0) {
-                                 active_dimensions.push_back( system_active.getNewDimension(dim[0]) );
-                                 default_dimensions.push_back( system_default.getNewDimension(dim[0]) );
+                                 active_dimensions.push_back( system_active.parse(dim[0]) );
+                                 default_dimensions.push_back( system_default.parse(dim[0]) );
                               }
                               DeckItem deck_item(parser_item.name(), double(), active_dimensions, default_dimensions);
                               add_deckvalue<double>(std::move(deck_item), deck_record, parser_item, input_record, j);
@@ -164,7 +164,7 @@ namespace Opm {
     }
 
 
-    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, UnitSystem& system_active, UnitSystem& system_default) :
+    DeckKeyword::DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, const UnitSystem& system_active, const UnitSystem& system_default) :
         DeckKeyword(parserKeyword)
     {
         if (!parserKeyword.isDataKeyword())
@@ -181,8 +181,8 @@ namespace Opm {
         std::vector<Dimension> active_dimensions;
         std::vector<Dimension> default_dimensions;
         if (dim.size() > 0) {
-             active_dimensions.push_back( system_active.getNewDimension(dim[0]) );
-             default_dimensions.push_back( system_default.getNewDimension(dim[0]) );
+             active_dimensions.push_back( system_active.parse(dim[0]) );
+             default_dimensions.push_back( system_default.parse(dim[0]) );
         }
         DeckItem item(parser_item.name(), double(), active_dimensions, default_dimensions);
         for (double val : data)

--- a/src/opm/parser/eclipse/Deck/ImportContainer.cpp
+++ b/src/opm/parser/eclipse/Deck/ImportContainer.cpp
@@ -1,0 +1,71 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <unordered_set>
+
+#include <fmt/format.h>
+
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/io/eclipse/EclFile.hpp>
+#include <opm/parser/eclipse/Deck/ImportContainer.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+namespace Opm {
+
+ImportContainer::ImportContainer(const Parser& parser, const UnitSystem& unit_system, const std::string& fname, bool formatted, std::size_t deck_size) {
+    const std::unordered_set<std::string> float_kw = {"COORD", "MULTPV", "NTG", "PERMX", "PERMY", "PERMZ", "PORO", "ZCORN"};
+    const std::unordered_set<std::string> int_kw = {"ACTNUM", "FIPNUM" , "MULTNUM", "FLUXNUM", "OPERNUM"};
+
+    EclIO::EclFile ecl_file(fname, EclIO::EclFile::Formatted{formatted});
+    const auto& header = ecl_file.getList();
+    for (std::size_t kw_index = 0; kw_index < header.size(); kw_index++) {
+        const auto& [name, data_type, _] = header[kw_index];
+        (void)_;
+
+        if (float_kw.count(name)) {
+            const auto& parser_kw = parser.getKeyword(name);
+            if (data_type == EclIO::REAL) {
+                auto& float_data = ecl_file.get<float>(kw_index);
+                std::vector<double> double_data;
+                std::copy(float_data.begin(), float_data.end(), std::back_inserter(double_data));
+                this->keywords.emplace_back(parser_kw, double_data, unit_system, unit_system);
+            } else if (data_type == EclIO::DOUB) {
+                auto& double_data = ecl_file.get<double>(kw_index);
+                this->keywords.emplace_back(parser_kw, double_data, unit_system, unit_system);
+            }
+            deck_size += 1;
+            auto msg = fmt::format("{:5} Loading {:<8} from IMPORT file {}", deck_size, name, fname);
+            OpmLog::info(msg);
+            continue;
+        }
+
+        if (int_kw.count(name)) {
+            const auto& parser_kw = parser.getKeyword(name);
+            const auto& data = ecl_file.get<int>(kw_index);
+            this->keywords.emplace_back(parser_kw, data);
+            deck_size += 1;
+            auto msg = fmt::format("{:5} Loading {:<8} from IMPORT file {}", deck_size, name, fname);
+            continue;
+        }
+
+        OpmLog::info(fmt::format("{:<5} Skipping {} from IMPORT file {}", "", name, fname));
+    }
+}
+
+
+
+}

--- a/tests/parser/ImportTests.cpp
+++ b/tests/parser/ImportTests.cpp
@@ -1,0 +1,67 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE ImportTests
+#include <boost/test/unit_test.hpp>
+
+#include <opm/io/eclipse/EclOutput.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Deck/ImportContainer.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+#include <tests/WorkArea.cpp>
+#include <iostream>
+#include <fstream>
+
+using namespace Opm;
+
+BOOST_AUTO_TEST_CASE(CreateImportContainer) {
+    WorkArea work;
+    auto unit_system = UnitSystem::newMETRIC();
+    Parser parser;
+    BOOST_CHECK_THROW(ImportContainer(parser, unit_system, "/no/such/file", false, 0), std::exception);
+    {
+        EclIO::EclOutput output {"FILE_NAME", false};
+    }
+
+    ImportContainer container1(parser, unit_system, "FILE_NAME", false, 0);
+    Deck deck;
+
+    for (auto kw : container1)
+        deck.addKeyword(std::move(kw));
+
+    BOOST_CHECK_EQUAL(deck.size(), 0);
+
+
+
+    {
+        EclIO::EclOutput output {"FILE_NAME", false};
+        output.write<double>("PORO", {0, 1, 2, 3, 4});
+        output.write<float>("PERMX", {10, 20, 30, 40});
+        output.write<int>("FIPNUM", {100, 200, 300, 400});
+        output.write<int>("UNKNOWN", {100, 200, 300, 400});
+    }
+
+    ImportContainer container2(parser, unit_system, "FILE_NAME", false, 0);
+    for (auto kw : container2)
+        deck.addKeyword(std::move(kw));
+
+    BOOST_CHECK_EQUAL(deck.size(), 3);
+}


### PR DESCRIPTION
This keyword adds support for the `IMPORT`keyword which can be used to load keywords from a (typically binary) file with result formatted keywords. The list of supported keywords is hardcoded - and yet quite short, it is trivial to add new ones though. 