### PR TITLE
Introduce named constant IGroup::ControlGroup = 5

### DIFF
--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -57,6 +57,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
     // the the IGRP vector, they should all be used as IGRP[NWGMAX + $index]
     enum index : std::vector<int>::size_type {
         ProdActiveCMode = 1,
+        ControlGroup = 5,
         GuideRateDef = 6,
         WInjCMode = 16,
         GConProdCMode = 10,

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -418,24 +418,24 @@ void productionGroup(const Opm::Schedule&     sched,
         throw std::logic_error("Got cgroup == FIELD - uncertain logic");
 
 
-    iGrp[nwgmax + 5] = -1;
+    iGrp[nwgmax + IGroup::ControlGroup] = -1;
     if (groupProductionControllable(sched, sumState, group, simStep)) {
         // this section applies if group is controllable - i.e. has wells that may be controlled
         if (!group.productionGroupControlAvailable() && (!cgroup)) {
             // group can respond to higher level control
-            iGrp[nwgmax + 5] = 0;
+            iGrp[nwgmax + IGroup::ControlGroup] = 0;
             goto CGROUP_DONE;
         }
 
 
         if (cgroup) {
-            iGrp[nwgmax + 5] = 1;
+            iGrp[nwgmax + IGroup::ControlGroup] = 1;
             if (prod_guide_rate_def != Opm::Group::GuideRateProdTarget::NO_GUIDE_RATE) {
                 if (deck_cmode == Opm::Group::ProductionCMode::FLD)
-                    iGrp[nwgmax + 5] = cgroup->insert_index();
+                    iGrp[nwgmax + IGroup::ControlGroup] = cgroup->insert_index();
 
                 if (deck_cmode == Opm::Group::ProductionCMode::NONE)
-                    iGrp[nwgmax + 5] = cgroup->insert_index();
+                    iGrp[nwgmax + IGroup::ControlGroup] = cgroup->insert_index();
             }
             goto CGROUP_DONE;
         }
@@ -452,7 +452,7 @@ void productionGroup(const Opm::Schedule&     sched,
         }
 
     } else if (deck_cmode == Opm::Group::ProductionCMode::NONE) {
-        iGrp[nwgmax + 5] = 1;
+        iGrp[nwgmax + IGroup::ControlGroup] = 1;
     }
  CGROUP_DONE:
 


### PR DESCRIPTION
Singled out possible problematic commit from https://github.com/OPM/opm-common/pull/2393#discussion_r604233674

Would appreciate some assistance as to what `IGRP[nwgmax + 5]` really represents. @jalvestad, @bska 