### PR TITLE
Add  EclipseState comparison to rst_test application

### DIFF
--- a/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
@@ -47,7 +47,7 @@ public:
     const AquiferCT& ct() const;
     const Aquifetp& fetp() const;
     const Aquancon& connections() const;
-    bool operator==(const AquiferConfig& other);
+    bool operator==(const AquiferConfig& other) const;
     bool hasAquifer(const int aquID) const;
 
     bool hasNumericalAquifer() const;

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -44,7 +44,7 @@ namespace Opm {
         const InitConfig& init() const;
 
         bool operator==(const EclipseConfig& data) const;
-
+        static bool rst_cmp(const EclipseConfig& full_config, const EclipseConfig& rst_config);
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -130,6 +130,9 @@ namespace Opm {
             tracer_config.serializeOp(serializer);
         }
 
+        static bool rst_cmp(const EclipseState& full_state, const EclipseState& rst_state);
+
+
     private:
         void initIOConfigPostSchedule(const Deck& deck);
         void initTransMult();

--- a/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
@@ -60,6 +60,15 @@ namespace Fieldprops
         std::optional<std::vector<value::status>> global_value_status;
         mutable bool all_set;
 
+        bool operator==(const FieldData& other) const {
+            return this->data == other.data &&
+                   this->value_status == other.value_status &&
+                   this->kw_info == other.kw_info &&
+                   this->global_data == other.global_data &&
+                   this->global_value_status == other.global_value_status;
+        }
+
+
         FieldData() = default;
 
         FieldData(const keywords::keyword_info<T>& info, std::size_t active_size, std::size_t global_size) :
@@ -92,6 +101,11 @@ namespace Fieldprops
 
             return this->all_set;
         }
+
+        bool valid_default() const {
+            return std::all_of( this->value_status.begin(), this->value_status.end(), [] (const value::status& status) {return status == value::status::valid_default; });
+        }
+
 
         void compress(const std::vector<bool>& active_map) {
             Fieldprops::compress(this->data, active_map);

--- a/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
@@ -25,11 +25,11 @@
 #include <opm/parser/eclipse/EclipseState/Grid/FieldData.hpp>
 #include <opm/parser/eclipse/Deck/value_status.hpp>
 
-#include<string>
-#include<vector>
-#include<optional>
-#include<array>
-#include<algorithm>
+#include <string>
+#include <vector>
+#include <optional>
+#include <array>
+#include <algorithm>
 
 namespace Opm
 {

--- a/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -55,7 +55,8 @@ public:
     */
     std::size_t active_size() const;
 
-
+    bool operator==(const FieldPropsManager& other) const;
+    static bool rst_cmp(const FieldPropsManager& full_arg, const FieldPropsManager& rst_arg);
     /*
       Because the FieldProps class can autocreate properties the semantics of
       get() and has() is slightly non intuitve:

--- a/opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
@@ -36,6 +36,15 @@ struct keyword_info {
     bool top = false;
     bool global = false;
 
+    bool operator==(const keyword_info& other) const {
+        return this->unit == other.unit &&
+               this->scalar_init == other.scalar_init &&
+               this->multiplier == other.multiplier &&
+               this->top == other.top &&
+               this->global == other.global;
+    }
+
+
     keyword_info<T>& init(T init_value) {
         this->scalar_init = init_value;
         return *this;

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -76,6 +76,15 @@ namespace Opm { namespace satfunc {
             /// region  All zero values unless gas is an active phase.
             std::vector<double> water;
         } maximum;
+
+        bool operator==(const RawTableEndPoints& other) const {
+            return this->connate.gas == other.connate.gas &&
+                   this->connate.water == other.connate.water &&
+                   this->critical.gas == other.critical.gas &&
+                   this->critical.water == other.critical.water &&
+                   this->maximum.gas == other.maximum.gas &&
+                   this->maximum.water == other.maximum.water;
+        }
     };
 
     /// Collection of unscaled/raw saturation function value range endpoints

--- a/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
@@ -45,6 +45,11 @@ public:
     struct TranAction {
         ScalarOperation op;
         std::string field;
+
+        bool operator==(const TranAction& other) const {
+            return this->op == other.op &&
+                   this->field == other.field;
+        }
     };
 
 
@@ -97,6 +102,12 @@ public:
         }
         return kw_info;
     }
+
+    bool operator==(const TranCalculator& other) const {
+        return this->m_name == other.m_name &&
+               this->actions == other.actions;
+    }
+
 private:
     std::string m_name;
     std::vector<TranAction> actions;

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -185,6 +185,8 @@ namespace Opm {
         bool initOnly() const;
 
         bool operator==(const IOConfig& data) const;
+        static bool rst_cmp(const IOConfig& full_config, const IOConfig& rst_config);
+
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -57,6 +57,9 @@ namespace Opm {
 
         bool operator==(const InitConfig& config) const;
 
+        static bool rst_cmp(const InitConfig& full_config, const InitConfig& rst_config);
+
+
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {

--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -124,19 +124,20 @@ public:
         return this->m_location;
     }
 
-    bool data_equal(const Welldims& data) const {
-        return this->maxConnPerWell() == data.maxConnPerWell() &&
-               this->maxWellsPerGroup() == data.maxWellsPerGroup() &&
-               this->maxGroupsInField() == data.maxGroupsInField() &&
-               this->maxWellsInField() == data.maxWellsInField() &&
-               this->maxWellListsPrWell() == data.maxWellListsPrWell() &&
-               this->maxDynamicWellLists() == data.maxDynamicWellLists();
+    static bool rst_cmp(const Welldims& full_dims, const Welldims& rst_dims) {
+        return full_dims.maxConnPerWell() == rst_dims.maxConnPerWell() &&
+            full_dims.maxWellsPerGroup() == rst_dims.maxWellsPerGroup() &&
+            full_dims.maxGroupsInField() == rst_dims.maxGroupsInField() &&
+            full_dims.maxWellsInField() == rst_dims.maxWellsInField() &&
+            full_dims.maxWellListsPrWell() == rst_dims.maxWellListsPrWell() &&
+            full_dims.maxDynamicWellLists() == rst_dims.maxDynamicWellLists();
     }
 
     bool operator==(const Welldims& data) const {
-        return this->data_equal(data) &&
-               this->location() == data.location();
+        return this->location() == data.location() &&
+            rst_cmp(*this, data);
     }
+
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -397,6 +398,7 @@ public:
     bool co2Storage() const noexcept;
 
     bool operator==(const Runspec& data) const;
+    static bool rst_cmp(const Runspec& full_state, const Runspec& rst_state);
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -51,6 +51,7 @@ namespace Opm {
         bool isDiffusive() const;
 
         bool operator==(const SimulationConfig& data) const;
+        static bool rst_cmp(const SimulationConfig& full_config, const SimulationConfig& rst_config);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -74,6 +74,8 @@ namespace Opm {
         bool restart() const;
 
         bool operator==(const ThresholdPressure& data) const;
+        static bool rst_cmp(const ThresholdPressure& full_arg, const ThresholdPressure& rst_arg);
+
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -104,6 +104,7 @@ namespace Opm {
 
         bool operator==( const UnitSystem& ) const;
         bool operator!=( const UnitSystem& ) const;
+        static bool rst_cmp(const UnitSystem& full_arg, const UnitSystem& rst_arg);
 
         Dimension parse(const std::string& dimension) const;
 

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -57,7 +57,7 @@ bool AquiferConfig::active() const {
            this->hasNumericalAquifer();
 }
 
-bool AquiferConfig::operator==(const AquiferConfig& other) {
+bool AquiferConfig::operator==(const AquiferConfig& other) const {
     return this->aquifetp == other.aquifetp &&
            this->aquiferct == other.aquiferct &&
            this->aqconn == other.aqconn &&

--- a/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -50,7 +50,7 @@ namespace Opm {
 
         return result;
     }
-    
+
     InitConfig& EclipseConfig::init() {
         return const_cast<InitConfig &>(this->m_initConfig);
     }
@@ -70,5 +70,11 @@ namespace Opm {
 
     const IOConfig& EclipseConfig::io() const {
         return this->io_config;
+    }
+
+
+    bool EclipseConfig::rst_cmp(const EclipseConfig& full_config, const EclipseConfig& rst_config) {
+        return IOConfig::rst_cmp(full_config.io(), rst_config.io()) &&
+               InitConfig::rst_cmp(full_config.init(), rst_config.init());
     }
 }

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -348,4 +348,35 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
             }
         }
     }
+
+
+namespace {
+
+template <typename T>
+bool rst_cmp_obj(const T& full_arg, const T& rst_arg, const std::string& object_name) {
+    if (full_arg == rst_arg)
+        return true;
+
+    fmt::print("Difference in {}\n", object_name);
+    return false;
+}
+
+}
+    bool EclipseState::rst_cmp(const EclipseState& full_state, const EclipseState& rst_state) {
+        return Runspec::rst_cmp(full_state.m_runspec, rst_state.m_runspec) &&
+            EclipseConfig::rst_cmp(full_state.m_eclipseConfig, rst_state.m_eclipseConfig) &&
+            UnitSystem::rst_cmp(full_state.m_deckUnitSystem, rst_state.m_deckUnitSystem) &&
+            FieldPropsManager::rst_cmp(full_state.field_props, rst_state.field_props) &&
+            SimulationConfig::rst_cmp(full_state.m_simulationConfig, rst_state.m_simulationConfig) &&
+            rst_cmp_obj(full_state.m_tables, rst_state.m_tables, "Tables") &&
+            rst_cmp_obj(full_state.m_inputGrid, rst_state.m_inputGrid, "Inputgrid") &&
+            rst_cmp_obj(full_state.m_inputNnc, rst_state.m_inputNnc, "NNC") &&
+            rst_cmp_obj(full_state.m_gridDims, rst_state.m_gridDims, "Grid dims") &&
+            rst_cmp_obj(full_state.aquifer_config, rst_state.aquifer_config, "AquiferConfig") &&
+            rst_cmp_obj(full_state.m_transMult, rst_state.m_transMult, "TransMult") &&
+            rst_cmp_obj(full_state.m_faults, rst_state.m_faults, "Faults") &&
+            rst_cmp_obj(full_state.m_title, rst_state.m_title, "Title") &&
+            rst_cmp_obj(full_state.tracer_config, rst_state.tracer_config, "Tracer");
+    }
+
 }

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
@@ -39,7 +40,6 @@ namespace Opm {
 
 class Deck;
 class EclipseGrid;
-class TableManager;
 class NumericalAquifers;
 
 namespace Fieldprops
@@ -532,7 +532,7 @@ private:
     std::vector<double> cell_depth;
     const std::string m_default_region;
     const EclipseGrid * grid_ptr;      // A bit undecided whether to properly use the grid or not ...
-    const TableManager& tables;
+    TableManager tables;
     std::optional<satfunc::RawTableEndPoints> m_rtep;
     std::vector<MultregpRecord> multregp;
     std::unordered_map<std::string, Fieldprops::FieldData<int>> int_data;

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -291,6 +291,12 @@ public:
             region_name(rn)
         {}
 
+
+        bool operator==(const MultregpRecord& other) const {
+            return this->region_value == other.region_value &&
+                   this->multiplier == other.multiplier &&
+                   this->region_name == other.region_name;
+        }
     };
 
 
@@ -478,6 +484,8 @@ public:
     void apply_tran(const std::string& keyword, std::vector<double>& data);
     std::vector<char> serialize_tran() const;
     void deserialize_tran(const std::vector<char>& buffer);
+    bool operator==(const FieldProps& other) const;
+    static bool rst_cmp(const FieldProps& full_arg, const FieldProps& rst_arg);
 private:
     void scanGRIDSection(const GRIDSection& grid_section);
     void scanEDITSection(const EDITSection& edit_section);

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -29,6 +29,15 @@
 
 namespace Opm {
 
+
+bool FieldPropsManager::operator==(const FieldPropsManager& other) const {
+    return *this->fp == *other.fp;
+}
+
+bool FieldPropsManager::rst_cmp(const FieldPropsManager& full_arg, const FieldPropsManager& rst_arg) {
+    return FieldProps::rst_cmp(*full_arg.fp, *rst_arg.fp);
+}
+
 FieldPropsManager::FieldPropsManager(const Deck& deck, const Phases& phases, const EclipseGrid& grid_arg, const TableManager& tables) :
     fp(std::make_shared<FieldProps>(deck, phases, grid_arg, tables))
 {}

--- a/src/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -293,6 +293,16 @@ namespace Opm {
     }
 
 
+    bool IOConfig::rst_cmp(const IOConfig& full_config, const IOConfig& rst_config) {
+        return full_config.getWriteINITFile() == rst_config.getWriteINITFile() &&
+               full_config.getWriteEGRIDFile() == rst_config.getWriteEGRIDFile() &&
+               full_config.getUNIFIN() == rst_config.getUNIFIN() &&
+               full_config.getUNIFOUT() == rst_config.getUNIFOUT() &&
+               full_config.getFMTIN() == rst_config.getFMTIN() &&
+               full_config.getFMTOUT() == rst_config.getFMTOUT();
+    }
+
+
     /*****************************************************************/
     /* Here at the bottom are some forwarding proxy methods which just
        forward to the appropriate RestartConfig method. They are

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -147,4 +147,11 @@ namespace Opm {
                m_restartRootName == data.m_restartRootName;
     }
 
+    bool InitConfig::rst_cmp(const InitConfig& full_config, const InitConfig& rst_config) {
+        return full_config.foamconfig == rst_config.foamconfig &&
+               full_config.m_filleps == rst_config.m_filleps &&
+               full_config.m_gravity == rst_config.m_gravity;
+    }
+
+
 } //namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -586,6 +586,20 @@ const UDQParams& Runspec::udqParams() const noexcept {
     return this->udq_params;
 }
 
+bool Runspec::rst_cmp(const Runspec& full_spec, const Runspec& rst_spec) {
+    return full_spec.phases() == rst_spec.phases() &&
+        full_spec.tabdims() == rst_spec.tabdims() &&
+        full_spec.endpointScaling() == rst_spec.endpointScaling() &&
+        full_spec.wellSegmentDimensions() == rst_spec.wellSegmentDimensions() &&
+        full_spec.aquiferDimensions() == rst_spec.aquiferDimensions() &&
+        full_spec.hysterPar() == rst_spec.hysterPar() &&
+        full_spec.actdims() == rst_spec.actdims() &&
+        full_spec.saturationFunctionControls() == rst_spec.saturationFunctionControls() &&
+        full_spec.m_nupcol == rst_spec.m_nupcol &&
+        full_spec.m_co2storage == rst_spec.m_co2storage &&
+        Welldims::rst_cmp(full_spec.wellDimensions(), rst_spec.wellDimensions());
+}
+
 bool Runspec::operator==(const Runspec& data) const {
     return this->phases() == data.phases() &&
            this->tabdims() == data.tabdims() &&
@@ -599,5 +613,6 @@ bool Runspec::operator==(const Runspec& data) const {
            this->m_nupcol == data.m_nupcol &&
            this->m_co2storage == data.m_co2storage;
 }
+
 
 }

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -153,4 +153,16 @@ namespace Opm {
                this->isDiffusive() == data.isDiffusive();
     }
 
+    bool SimulationConfig::rst_cmp(const SimulationConfig& full_config, const SimulationConfig& rst_config) {
+        return ThresholdPressure::rst_cmp(full_config.getThresholdPressure(), rst_config.getThresholdPressure()) &&
+               full_config.bcconfig() == rst_config.bcconfig() &&
+               full_config.rock_config() == rst_config.rock_config() &&
+               full_config.useCPR() == rst_config.useCPR() &&
+               full_config.hasDISGAS() == rst_config.hasDISGAS() &&
+               full_config.hasVAPOIL() == rst_config.hasVAPOIL() &&
+               full_config.isThermal() == rst_config.isThermal() &&
+               full_config.isDiffusive() == rst_config.isDiffusive();
+    }
+
+
 } //namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -223,4 +223,10 @@ namespace Opm {
     }
 
 
+    bool ThresholdPressure::rst_cmp(const ThresholdPressure& full_arg, const ThresholdPressure& rst_arg) {
+        return full_arg.active() == rst_arg.active() &&
+               full_arg.m_thresholdPressureTable == rst_arg.m_thresholdPressureTable &&
+               full_arg.m_pressureTable == rst_arg.m_pressureTable;
+    }
+
 } //namespace Opm

--- a/src/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -1371,17 +1371,18 @@ namespace {
         return *this == other;
     }
 
+    bool UnitSystem::rst_cmp(const UnitSystem& full_arg, const UnitSystem& rst_arg) {
+        return full_arg.m_name == rst_arg.m_name
+            && full_arg.m_unittype == rst_arg.m_unittype
+            && full_arg.measure_table_to_si_offset == rst_arg.measure_table_to_si_offset
+            && full_arg.measure_table_from_si == rst_arg.measure_table_from_si
+            && full_arg.measure_table_to_si == rst_arg.measure_table_to_si
+            && full_arg.unit_name_table == rst_arg.unit_name_table;
+    }
+
     bool UnitSystem::operator==( const UnitSystem& rhs ) const {
-        return this->m_name == rhs.m_name
-            && this->m_unittype == rhs.m_unittype
-            && this->m_dimensions.size() == rhs.m_dimensions.size()
-            && std::equal( this->m_dimensions.begin(),
-                           this->m_dimensions.end(),
-                           rhs.m_dimensions.begin() )
-            && this->measure_table_to_si_offset == rhs.measure_table_to_si_offset
-            && this->measure_table_from_si == rhs.measure_table_from_si
-            && this->measure_table_to_si == rhs.measure_table_to_si
-            && this->unit_name_table == rhs.unit_name_table;
+        return UnitSystem::rst_cmp(*this, rhs) &&
+            this->m_dimensions == rhs.m_dimensions;
     }
 
     bool UnitSystem::operator!=( const UnitSystem& rhs ) const {

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -2529,7 +2529,7 @@ COPYREG
         BOOST_CHECK_CLOSE(to_si(multn[g]), permx[g], 1e-5);
         BOOST_CHECK_EQUAL(permx[g], permy[g]);
     }
- 
+
     BOOST_CHECK(permx == fp.get_double("PERMR"));
     BOOST_CHECK(permy == fp.get_double("PERMTHT"));
 }
@@ -2572,7 +2572,8 @@ COPYREG
     auto to_si = [&unit_system](double raw_value) { return unit_system.to_si(UnitSystem::measure::permeability, raw_value); };
     EclipseGrid grid(10,10, 2);
     Deck deck1 = Parser{}.parseString(deck_string1);
-    FieldPropsManager fp(deck1, Phases{true, true, true}, grid, TableManager());
+    TableManager tables;
+    FieldPropsManager fp(deck1, Phases{true, true, true}, grid, tables);
     const auto& permx = fp.get_double("PERMX");
     const auto& permy = fp.get_double("PERMY");
     const auto& multn = fp.get_int("MULTNUM");
@@ -2582,5 +2583,20 @@ COPYREG
     }
 
     BOOST_CHECK(permx == fp.get_double("PERMR"));
-    BOOST_CHECK(permy == fp.get_double("PERMTHT"));    
+    BOOST_CHECK(permy == fp.get_double("PERMTHT"));
+
+    FieldPropsManager fp2(deck1, Phases{true, true, true}, grid, tables);
+    BOOST_CHECK( fp == fp2 );
+    BOOST_CHECK( FieldPropsManager::rst_cmp(fp, fp2) );
+
+
+    const auto& ntg = fp2.get_double("NTG");
+    BOOST_CHECK( !(fp == fp2) );
+    BOOST_CHECK( FieldPropsManager::rst_cmp(fp, fp2) );
+    (void) ntg;
+
+    const auto& satnum = fp.get_int("SATNUM");
+    BOOST_CHECK( !(fp == fp2) );
+    BOOST_CHECK( FieldPropsManager::rst_cmp(fp, fp2) );
+    (void) satnum;
 }


### PR DESCRIPTION
Also check the eclipsestate in the restart testing. 

The `xxx::rst_cmp()` family of functions compare objects in a manner where differences due to one being a restart and one not being restart are not considered.

