### PR TITLE
Fix some valgrind errors in test_ParallelRestart

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -197,7 +197,7 @@ namespace Opm {
     private:
         constexpr static std::size_t numvals = 5;
 
-        std::array<double, numvals> values_;
+        std::array<double, numvals> values_ = {0};
 
         std::size_t index(const Value ix) const
         {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -419,7 +419,8 @@ namespace Opm
                 for (const auto& key : key_list) {
                     auto& value = current_map.get_ptr(key);
                     if (value) {
-                        if (!(*value == current_value[key])) {
+                        auto it = current_value.find(key);
+                        if (it == current_value.end() || !(*value == it->second)) {
                             value_list.push_back( *value );
                             index_list.push_back( index );
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -398,7 +398,7 @@ namespace Opm
                 pack_map<K,T>(value_list, index_list);
 
             serializer.vector(value_list);
-            serializer.template vector<std::size_t, false>(index_list);
+            serializer(index_list);
 
             if (!serializer.isSerializing())
                 unpack_map<K,T>(value_list, index_list);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -210,6 +210,7 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const std::optional
 
         result.m_static = ScheduleStatic::serializeObject();
         result.snapshots = { ScheduleState::serializeObject() };
+        result.m_sched_deck = ScheduleDeck::serializeObject();
 
         return result;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.cpp
@@ -142,9 +142,11 @@ const KeywordLocation& ScheduleBlock::location() const {
 
 ScheduleBlock ScheduleBlock::serializeObject() {
     ScheduleBlock block;
+    block.m_time_type = ScheduleTimeType::TSTEP;
     block.m_start_time = TimeService::from_time_t( asTimeT( TimeStampUTC( 2003, 10, 10 )));
     block.m_end_time = TimeService::from_time_t( asTimeT( TimeStampUTC( 1993, 07, 06 )));
-    block.m_location = KeywordLocation{ "Dummy", "File", 123 };
+    block.m_location = KeywordLocation::serializeObject();
+    block.m_keywords = {DeckKeyword::serializeObject()};
     return block;
 }
 
@@ -324,7 +326,7 @@ ScheduleDeck ScheduleDeck::serializeObject() {
     ScheduleDeck deck;
     deck.m_restart_time = TimeService::from_time_t( asTimeT( TimeStampUTC( 2013, 12, 12 )));
     deck.m_restart_offset = 123;
-    deck.m_location = KeywordLocation{ "Deck", "DeckFile", 321 };
+    deck.m_location = KeywordLocation::serializeObject();
     deck.m_blocks = { ScheduleBlock::serializeObject(), ScheduleBlock::serializeObject() };
     return deck;
 }


### PR DESCRIPTION
Various serialization ickies. These really only affects the test where default constructed objects are in use and not real code where a deck is loaded. The exception is the Schedule.hpp operator[] usage fix.