### PR TITLE
changed: remove unnecessary boost includes

### DIFF
--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -19,12 +19,10 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE ACTIONX
 
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/common/utility/OpmInputError.hpp>

--- a/tests/parser/ADDREGTests.cpp
+++ b/tests/parser/ADDREGTests.cpp
@@ -19,12 +19,10 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 #include <cstdio>
 
 #define BOOST_TEST_MODULE EqualRegTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
 

--- a/tests/parser/BoxTests.cpp
+++ b/tests/parser/BoxTests.cpp
@@ -24,8 +24,6 @@
 #define BOOST_TEST_MODULE BoxManagereTests
 
 #include <boost/test/unit_test.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/BoxManager.hpp>

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -20,12 +20,9 @@
 #include <cstddef>
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE CompletionTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-
 
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/parser/CopyRegTests.cpp
+++ b/tests/parser/CopyRegTests.cpp
@@ -19,12 +19,10 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 #include <cstdio>
 
 #define BOOST_TEST_MODULE CopyRegTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -32,7 +32,6 @@
 
 #define BOOST_TEST_MODULE EclipseGridTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -19,12 +19,10 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE EclipseStateTests
 
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>

--- a/tests/parser/EqualRegTests.cpp
+++ b/tests/parser/EqualRegTests.cpp
@@ -19,12 +19,10 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 #include <cstdio>
 
 #define BOOST_TEST_MODULE EqualRegTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/parser/EventTests.cpp
+++ b/tests/parser/EventTests.cpp
@@ -19,11 +19,9 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE EventTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/common/utility/TimeService.hpp>

--- a/tests/parser/FaceDirTests.cpp
+++ b/tests/parser/FaceDirTests.cpp
@@ -20,11 +20,9 @@
 #include <stdexcept>
 #include <iostream>
 #include <memory>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE FaceDirTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
 

--- a/tests/parser/FaultTests.cpp
+++ b/tests/parser/FaultTests.cpp
@@ -23,8 +23,6 @@
 #define BOOST_TEST_MODULE FaultTests
 
 #include <boost/test/unit_test.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -28,9 +28,7 @@
 
 #define BOOST_TEST_MODULE FieldPropsTests
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/parser/GeomodifierTests.cpp
+++ b/tests/parser/GeomodifierTests.cpp
@@ -19,7 +19,6 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 #define BOOST_TEST_MODULE GeoModifiersTests
 #include <boost/test/unit_test.hpp>
 

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -19,11 +19,9 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE GroupTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -19,11 +19,9 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE MULTREGTScannerTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 

--- a/tests/parser/MultiRegTests.cpp
+++ b/tests/parser/MultiRegTests.cpp
@@ -19,12 +19,10 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 #include <cstdio>
 
 #define BOOST_TEST_MODULE MultiRegTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -22,11 +22,9 @@
 #include <stdexcept>
 #include <set>
 
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE WellConnectionsTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <string>
 

--- a/tests/parser/OrderedMapTests.cpp
+++ b/tests/parser/OrderedMapTests.cpp
@@ -19,11 +19,9 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE ScheduleTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp>

--- a/tests/parser/ParseContextTests.cpp
+++ b/tests/parser/ParseContextTests.cpp
@@ -21,7 +21,6 @@
 #include <memory>
 #include <stdlib.h>
 #include <iostream>
-#include <boost/filesystem.hpp>
 #define BOOST_TEST_MODULE ParseContextTests
 #include <boost/test/unit_test.hpp>
 

--- a/tests/parser/RockTableTests.cpp
+++ b/tests/parser/RockTableTests.cpp
@@ -40,9 +40,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPInjTable.hpp>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem.hpp>
-
 #include <stdexcept>
 #include <iostream>
 

--- a/tests/parser/SaltTableTests.cpp
+++ b/tests/parser/SaltTableTests.cpp
@@ -38,9 +38,6 @@
 
 // keyword specific table classes
 
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem.hpp>
-
 #include <stdexcept>
 #include <iostream>
 

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -20,7 +20,6 @@
 #define BOOST_TEST_MODULE ScheduleTests
 
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -22,7 +22,6 @@
 #define BOOST_TEST_MODULE SimulationConfigTests
 
 #include <boost/test/unit_test.hpp>
-#include <boost/filesystem.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -24,7 +24,6 @@
 #define BOOST_TEST_MODULE ThresholdPressureTests
 
 #include <boost/test/unit_test.hpp>
-#include <boost/filesystem.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>

--- a/tests/parser/TimeMapTest.cpp
+++ b/tests/parser/TimeMapTest.cpp
@@ -19,7 +19,6 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE TimeMapTests
 

--- a/tests/parser/TransMultTests.cpp
+++ b/tests/parser/TransMultTests.cpp
@@ -19,11 +19,9 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE EclipseGridTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -19,7 +19,6 @@
 
 #include <stdexcept>
 #include <iostream>
-#include <boost/filesystem.hpp>
 
 #define BOOST_TEST_MODULE WTEST
 #include <boost/test/unit_test.hpp>

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -19,7 +19,6 @@
 
 #define BOOST_TEST_MODULE WellSolventTests
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/Python/Python.hpp>

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -19,7 +19,6 @@
 
 #define BOOST_TEST_MODULE WellTracerTests
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <opm/common/utility/OpmInputError.hpp>

--- a/tests/parser/integration/EclipseGridCreateFromDeck.cpp
+++ b/tests/parser/integration/EclipseGridCreateFromDeck.cpp
@@ -22,7 +22,6 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/common/utility/FileSystem.hpp>
 

--- a/tests/parser/integration/TransMultIntegrationTests.cpp
+++ b/tests/parser/integration/TransMultIntegrationTests.cpp
@@ -18,7 +18,6 @@
 
 #define BOOST_TEST_MODULE TransMultTests
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -58,7 +58,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <opm/common/utility/FileSystem.hpp>
 #include <opm/common/utility/TimeService.hpp>
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -21,7 +21,6 @@
 
 #define BOOST_TEST_MODULE Wells
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -21,7 +21,6 @@
 
 #define BOOST_TEST_MODULE Wells
 #include <boost/test/unit_test.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <cctype>
 #include <chrono>


### PR DESCRIPTION
This is the first PR in a series of PRs that aim to reduce build times.

I don't know exactly how much this one is responsible for, but in a rather non-scientific test the build time on my box
with all changes was reduced from 47 min to 43 min.