### PR TITLE
Avoid headers in headers

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -138,6 +138,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/injection.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/PAvg.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -170,6 +170,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Tables/Eqldims.cpp
     src/opm/parser/eclipse/EclipseState/Tables/JFunc.cpp
     src/opm/parser/eclipse/EclipseState/Tables/PvtxTable.cpp
+    src/opm/parser/eclipse/EclipseState/Tables/Regdims.cpp
     src/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
     src/opm/parser/eclipse/EclipseState/Tables/PolyInjTables.cpp
     src/opm/parser/eclipse/EclipseState/Tables/StandardCond.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -164,6 +164,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
     src/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
     src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+    src/opm/parser/eclipse/EclipseState/Tables/Aqudims.cpp
     src/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.cpp
     src/opm/parser/eclipse/EclipseState/Tables/DenT.cpp
     src/opm/parser/eclipse/EclipseState/Tables/JFunc.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -85,6 +85,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Grid/PinchMode.cpp
     src/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
     src/opm/parser/eclipse/EclipseState/Grid/setKeywordBox.cpp
+    src/opm/parser/eclipse/EclipseState/Grid/TranCalculator.cpp
     src/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
     src/opm/parser/eclipse/EclipseState/InitConfig/Equil.cpp
     src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -167,6 +167,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Tables/Aqudims.cpp
     src/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.cpp
     src/opm/parser/eclipse/EclipseState/Tables/DenT.cpp
+    src/opm/parser/eclipse/EclipseState/Tables/Eqldims.cpp
     src/opm/parser/eclipse/EclipseState/Tables/JFunc.cpp
     src/opm/parser/eclipse/EclipseState/Tables/PvtxTable.cpp
     src/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -187,6 +187,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Tables/BrineDensityTable.cpp
     src/opm/parser/eclipse/EclipseState/Tables/RwgsaltTable.cpp
     src/opm/parser/eclipse/EclipseState/Tables/SolventDensityTable.cpp
+    src/opm/parser/eclipse/EclipseState/Tables/Tabdims.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQASTNode.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParser.cpp

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -17,13 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef OPM_SERIALIZER_HPP
+#define OPM_SERIALIZER_HPP
+
 #include <cstring>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#ifndef OPM_SERIALIZER_HPP
-#define OPM_SERIALIZER_HPP
 
 namespace Opm {
 /*

--- a/opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Keywords.hpp
@@ -20,6 +20,8 @@
 #ifndef OPM_KEYWORDS_HPP
 #define OPM_KEYWORDS_HPP
 
+#include <optional>
+
 namespace Opm
 {
 

--- a/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp
@@ -19,16 +19,16 @@
 #ifndef TRAN_CALCULATOR_HPP
 #define TRAN_CALCULATOR_HPP
 
-#include<string>
-
-#include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
-
+#include <string>
+#include <vector>
 
 namespace Opm
 {
 
 namespace Fieldprops
 {
+
+namespace keywords { template<class T> class keyword_info; }
 
 enum class ScalarOperation {
     ADD = 1,
@@ -81,27 +81,7 @@ public:
         return this->m_name;
     }
 
-
-    keywords::keyword_info<double> make_kw_info(ScalarOperation op) {
-        keywords::keyword_info<double> kw_info;
-        switch (op) {
-        case ScalarOperation::MUL:
-            kw_info.init(1);
-            break;
-        case ScalarOperation::ADD:
-            kw_info.init(0);
-            break;
-        case ScalarOperation::MAX:
-            kw_info.init(std::numeric_limits<double>::max());
-            break;
-        case ScalarOperation::MIN:
-            kw_info.init(std::numeric_limits<double>::lowest());
-            break;
-        default:
-            break;
-        }
-        return kw_info;
-    }
+    keywords::keyword_info<double> make_kw_info(ScalarOperation op);
 
     bool operator==(const TranCalculator& other) const {
         return this->m_name == other.m_name &&

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
@@ -17,14 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef GROUPTREE2
+#define GROUPTREE2
+
 #include <optional>
 #include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
-
-#ifndef GROUPTREE2
-#define GROUPTREE2
 
 namespace Opm {
 
@@ -57,5 +57,3 @@ private:
 
 }
 #endif
-
-

--- a/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
@@ -20,8 +20,6 @@
 #ifndef OPM_MESSAGES_HPP
 #define OPM_MESSAGES_HPP
 
-#include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
-
 namespace Opm {
 
     class Deck;
@@ -29,7 +27,7 @@ namespace Opm {
 
     class MessageLimits {
     public:
-        MessageLimits() = default;
+        MessageLimits();
         explicit MessageLimits(const Deck& deck);
 
         static MessageLimits serializeObject();
@@ -82,18 +80,18 @@ namespace Opm {
         }
 
     private:
-        int message_print_limit = ParserKeywords::MESSAGES::MESSAGE_PRINT_LIMIT::defaultValue;
-        int comment_print_limit = ParserKeywords::MESSAGES::COMMENT_PRINT_LIMIT::defaultValue;
-        int warning_print_limit = ParserKeywords::MESSAGES::WARNING_PRINT_LIMIT::defaultValue;
-        int problem_print_limit = ParserKeywords::MESSAGES::PROBLEM_PRINT_LIMIT::defaultValue;
-        int error_print_limit   = ParserKeywords::MESSAGES::ERROR_PRINT_LIMIT::defaultValue;
-        int bug_print_limit     = ParserKeywords::MESSAGES::BUG_PRINT_LIMIT::defaultValue;
-        int message_stop_limit  = ParserKeywords::MESSAGES::MESSAGE_STOP_LIMIT::defaultValue;
-        int comment_stop_limit  = ParserKeywords::MESSAGES::COMMENT_STOP_LIMIT::defaultValue;
-        int warning_stop_limit  = ParserKeywords::MESSAGES::WARNING_STOP_LIMIT::defaultValue;
-        int problem_stop_limit  = ParserKeywords::MESSAGES::PROBLEM_STOP_LIMIT::defaultValue;
-        int error_stop_limit    = ParserKeywords::MESSAGES::ERROR_STOP_LIMIT::defaultValue;
-        int bug_stop_limit      = ParserKeywords::MESSAGES::BUG_STOP_LIMIT::defaultValue;
+        int message_print_limit;
+        int comment_print_limit;
+        int warning_print_limit;
+        int problem_print_limit;
+        int error_print_limit;
+        int bug_print_limit;
+        int message_stop_limit;
+        int comment_stop_limit;
+        int warning_stop_limit;
+        int problem_stop_limit;
+        int error_stop_limit;
+        int bug_stop_limit;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
@@ -20,100 +20,52 @@
 #ifndef OPM_TUNING_HPP
 #define OPM_TUNING_HPP
 
-#include <opm/parser/eclipse/Units/Units.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
-
 namespace Opm {
     struct Tuning {
-        using TuningKw = ParserKeywords::TUNING;
-        using WsegIterKW = ParserKeywords::WSEGITER;
+        Tuning();
 
-        static Tuning serializeObject()
-        {
-            Tuning result;
-            result.TSINIT = 1.0;
-            result.TSMAXZ = 2.0;
-            result.TSMINZ = 3.0;
-            result.TSMCHP = 4.0;
-            result.TSFMAX = 5.0;
-            result.TSFMIN = 6.0;
-            result.TFDIFF = 7.0;
-            result.TSFCNV = 8.0;
-            result.THRUPT = 9.0;
-            result.TMAXWC = 10.0;
-            result.TMAXWC_has_value = true;
-
-            result.TRGTTE = 11.0;
-            result.TRGCNV = 12.0;
-            result.TRGMBE = 13.0;
-            result.TRGLCV = 14.0;
-            result.XXXTTE = 15.0;
-            result.XXXCNV = 16.0;
-            result.XXXMBE = 17.0;
-            result.XXXLCV = 18.0;
-            result.XXXWFL = 19.0;
-            result.TRGFIP = 20.0;
-            result.TRGSFT = 21.0;
-            result.TRGSFT_has_value = true;
-            result.THIONX = 22.0;
-            result.TRWGHT = 23.0;
-
-            result.NEWTMX = 24;
-            result.NEWTMN = 25;
-            result.LITMAX = 26;
-            result.LITMIN = 27;
-            result.MXWSIT = 28;
-            result.MXWPIT = 29;
-            result.DDPLIM = 30.0;
-            result.DDSLIM = 31.0;
-            result.TRGDPR = 32.0;
-            result.XXXDPR = 33.0;
-            result.XXXDPR_has_value = true;
-
-            return result;
-        }
+        static Tuning serializeObject();
 
         // Record1
-        double TSINIT = TuningKw::TSINIT::defaultValue * Metric::Time;
-        double TSMAXZ = TuningKw::TSMAXZ::defaultValue * Metric::Time;
-        double TSMINZ = TuningKw::TSMINZ::defaultValue * Metric::Time;
-        double TSMCHP = TuningKw::TSMCHP::defaultValue * Metric::Time;
-        double TSFMAX = TuningKw::TSFMAX::defaultValue;
-        double TSFMIN = TuningKw::TSFMIN::defaultValue;
-        double TFDIFF = TuningKw::TFDIFF::defaultValue;
-        double TSFCNV = TuningKw::TSFCNV::defaultValue;
-        double THRUPT = TuningKw::THRUPT::defaultValue;
+        double TSINIT;
+        double TSMAXZ;
+        double TSMINZ;
+        double TSMCHP;
+        double TSFMAX;
+        double TSFMIN;
+        double TFDIFF;
+        double TSFCNV;
+        double THRUPT;
         double TMAXWC = 0.0;
         bool TMAXWC_has_value = false;
 
         // Record 2
-        double TRGTTE = TuningKw::TRGTTE::defaultValue;
-        double TRGCNV = TuningKw::TRGCNV::defaultValue;
-        double TRGMBE = TuningKw::TRGMBE::defaultValue;
-        double TRGLCV = TuningKw::TRGLCV::defaultValue;
-        double XXXTTE = TuningKw::XXXTTE::defaultValue;
-        double XXXCNV = TuningKw::XXXCNV::defaultValue;
-        double XXXMBE = TuningKw::XXXMBE::defaultValue;
-        double XXXLCV = TuningKw::XXXLCV::defaultValue;
-        double XXXWFL = TuningKw::XXXWFL::defaultValue;
-        double TRGFIP = TuningKw::TRGFIP::defaultValue;
+        double TRGTTE;
+        double TRGCNV;
+        double TRGMBE;
+        double TRGLCV;
+        double XXXTTE;
+        double XXXCNV;
+        double XXXMBE;
+        double XXXLCV;
+        double XXXWFL;
+        double TRGFIP;
         double TRGSFT = 0.0;
         bool TRGSFT_has_value = false;
-        double THIONX = TuningKw::THIONX::defaultValue;
-        double TRWGHT = TuningKw::TRWGHT::defaultValue;
+        double THIONX;
+        double TRWGHT;
 
         // Record 3
-        int NEWTMX = TuningKw::NEWTMX::defaultValue;
-        int NEWTMN = TuningKw::NEWTMN::defaultValue;
-        int LITMAX = TuningKw::LITMAX::defaultValue;
-        int LITMIN = TuningKw::LITMIN::defaultValue;
-        int MXWSIT = TuningKw::MXWSIT::defaultValue;
-        int MXWPIT = TuningKw::MXWPIT::defaultValue;
-        double DDPLIM = TuningKw::DDPLIM::defaultValue * Metric::Pressure;
-        double DDSLIM = TuningKw::DDSLIM::defaultValue;
-        double TRGDPR = TuningKw::TRGDPR::defaultValue * Metric::Pressure;
-        double XXXDPR = 0.0 * Metric::Pressure;
+        int NEWTMX;
+        int NEWTMN;
+        int LITMAX;
+        int LITMIN;
+        int MXWSIT;
+        int MXWPIT;
+        double DDPLIM;
+        double DDSLIM;
+        double TRGDPR;
+        double XXXDPR;
         bool XXXDPR_has_value = false;
 
         /*
@@ -124,53 +76,12 @@ namespace Opm {
           is specified by both the TUNING keyword and the WSEGITER keyword, but
           with different defaults.
         */
-        int WSEG_MAX_RESTART = WsegIterKW::MAX_TIMES_REDUCED::defaultValue;
-        double WSEG_REDUCTION_FACTOR = WsegIterKW::REDUCTION_FACTOR::defaultValue;
-        double WSEG_INCREASE_FACTOR = WsegIterKW::INCREASING_FACTOR::defaultValue;
+        int WSEG_MAX_RESTART;
+        double WSEG_REDUCTION_FACTOR;
+        double WSEG_INCREASE_FACTOR;
 
 
-        bool operator==(const Tuning& data) const {
-            return TSINIT == data.TSINIT &&
-                   TSMAXZ == data.TSMAXZ &&
-                   TSMINZ == data.TSMINZ &&
-                   TSMCHP == data.TSMCHP &&
-                   TSFMAX == data.TSFMAX &&
-                   TSFMIN == data.TSFMIN &&
-                   TSFCNV == data.TSFCNV &&
-                   TFDIFF == data.TFDIFF &&
-                   THRUPT == data.THRUPT &&
-                   TMAXWC == data.TMAXWC &&
-                   TMAXWC_has_value == data.TMAXWC_has_value &&
-                   TRGTTE == data.TRGTTE &&
-                   TRGCNV == data.TRGCNV &&
-                   TRGMBE == data.TRGMBE &&
-                   TRGLCV == data.TRGLCV &&
-                   XXXTTE == data.XXXTTE &&
-                   XXXCNV == data.XXXCNV &&
-                   XXXMBE == data.XXXMBE &&
-                   XXXLCV == data.XXXLCV &&
-                   XXXWFL == data.XXXWFL &&
-                   TRGFIP == data.TRGFIP &&
-                   TRGSFT == data.TRGSFT &&
-                   TRGSFT_has_value == data.TRGSFT_has_value &&
-                   THIONX == data.THIONX &&
-                   TRWGHT == data.TRWGHT &&
-                   NEWTMX == data.NEWTMX &&
-                   NEWTMN == data.NEWTMN &&
-                   LITMAX == data.LITMAX &&
-                   LITMIN == data.LITMIN &&
-                   MXWSIT == data.MXWSIT &&
-                   MXWPIT == data.MXWPIT &&
-                   DDPLIM == data.DDPLIM &&
-                   DDSLIM == data.DDSLIM &&
-                   TRGDPR == data.TRGDPR &&
-                   XXXDPR == data.XXXDPR &&
-                   XXXDPR_has_value == data.XXXDPR_has_value &&
-                   WSEG_MAX_RESTART == data.WSEG_MAX_RESTART &&
-                   WSEG_REDUCTION_FACTOR == data.WSEG_REDUCTION_FACTOR &&
-                   WSEG_INCREASE_FACTOR == data.WSEG_INCREASE_FACTOR;
-        }
-
+        bool operator==(const Tuning& data) const;
         bool operator !=(const Tuning& data) const {
             return !(*this == data);
         }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
@@ -21,7 +21,6 @@
 #define OPM_ROCK_CONFIG_HPP
 
 #include <string>
-#include <opm/parser/eclipse/Parser/ParserKeywords/R.hpp>
 
 namespace Opm {
 
@@ -59,7 +58,7 @@ struct RockComp {
 };
 
 
-    RockConfig() = default;
+    RockConfig();
     RockConfig(const Deck& deck, const FieldPropsManager& fp);
 
     static RockConfig serializeObject();
@@ -87,8 +86,8 @@ struct RockComp {
 private:
     bool m_active = false;
     std::vector<RockComp> m_comp;
-    std::string num_property = ParserKeywords::ROCKOPTS::TABLE_TYPE::defaultValue;
-    std::size_t num_tables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
+    std::string num_property;
+    std::size_t num_tables;
     bool m_water_compaction = false;
     Hysteresis hyst_mode = Hysteresis::REVERS;
 };

--- a/opm/parser/eclipse/EclipseState/Tables/Aqudims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Aqudims.hpp
@@ -20,47 +20,23 @@
 #ifndef AQUDIMS_HPP
 #define AQUDIMS_HPP
 
+#include <cstddef>
+
 /*
   The Aqudims class is a small utility class designed to hold on to
   the values from the AQUDIMS keyword.
 */
 
-#include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-
 namespace Opm {
+
+    class Deck;
+
     class Aqudims {
     public:
 
-        Aqudims() :
-            m_mxnaqn( ParserKeywords::AQUDIMS::MXNAQN::defaultValue ),
-            m_mxnaqc( ParserKeywords::AQUDIMS::MXNAQC::defaultValue ),
-            m_niftbl( ParserKeywords::AQUDIMS::NIFTBL::defaultValue ),
-            m_nriftb( ParserKeywords::AQUDIMS::NRIFTB::defaultValue ),
-            m_nanaqu( ParserKeywords::AQUDIMS::NANAQU::defaultValue ),
-            m_ncamax( ParserKeywords::AQUDIMS::NCAMAX::defaultValue ),
-            m_mxnali( ParserKeywords::AQUDIMS::MXNALI::defaultValue ),
-            m_mxaaql( ParserKeywords::AQUDIMS::MXAAQL::defaultValue )
-            
-        { }
+        Aqudims();
 
-        explicit Aqudims(const Deck& deck) :
-            Aqudims()
-        {
-            if (deck.hasKeyword("AQUDIMS")) {
-                const auto& record = deck.getKeyword( "AQUDIMS" , 0 ).getRecord( 0 );
-                m_mxnaqn  = record.getItem("MXNAQN").get<int>(0);
-                m_mxnaqc  = record.getItem("MXNAQC").get<int>(0);
-                m_niftbl  = record.getItem("NIFTBL").get<int>(0);
-                m_nriftb  = record.getItem("NRIFTB").get<int>(0);
-                m_nanaqu  = record.getItem("NANAQU").get<int>(0);
-                m_ncamax  = record.getItem("NCAMAX").get<int>(0);
-                m_mxnali  = record.getItem("MXNALI").get<int>(0);
-                m_mxaaql  = record.getItem("MXAAQL").get<int>(0);
-            }
-        }
+        explicit Aqudims(const Deck& deck);
 
         static Aqudims serializeObject()
         {

--- a/opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp
@@ -20,25 +20,19 @@
 #ifndef EQLDIMS_HPP
 #define EQLDIMS_HPP
 
+#include <cstddef>
+
+namespace Opm {
+
 /*
   The Eqldims class is a small utility class designed to hold on to
   the values from the EQLDIMS keyword.
 */
 
-#include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
-
-namespace Opm {
     class Eqldims {
     public:
 
-        Eqldims() :
-            m_ntequl( ParserKeywords::EQLDIMS::NTEQUL::defaultValue ),
-            m_depth_nodes_p( ParserKeywords::EQLDIMS::DEPTH_NODES_P::defaultValue ),
-            m_depth_nodes_tab( ParserKeywords::EQLDIMS::DEPTH_NODES_TAB::defaultValue ),
-            m_nttrvd(  ParserKeywords::EQLDIMS::NTTRVD::defaultValue ),
-            m_nstrvd(  ParserKeywords::EQLDIMS::NSTRVD::defaultValue )
-        { }
-
+        Eqldims();
 
         Eqldims( size_t ntequl , size_t depth_nodes_p , size_t depth_nodes_tab , size_t nttrvd , size_t nstrvd) :
             m_ntequl( ntequl ),

--- a/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -19,7 +19,6 @@
 #ifndef OPM_PARSER_PLYSHLOG_TABLE_HPP
 #define	OPM_PARSER_PLYSHLOG_TABLE_HPP
 
-#include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
 #include "SimpleTable.hpp"
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
@@ -20,24 +20,19 @@
 #ifndef REGDIMS_HPP
 #define REGDIMS_HPP
 
+#include <cstddef>
+
+namespace Opm {
+
 /*
   The Regdims class is a small utility class designed to hold on to
   the values from the REGDIMS keyword.
 */
 
-#include <opm/parser/eclipse/Parser/ParserKeywords/R.hpp>
-
-namespace Opm {
     class Regdims {
     public:
 
-        Regdims() :
-            m_NTFIP( ParserKeywords::REGDIMS::NTFIP::defaultValue ),
-            m_NMFIPR( ParserKeywords::REGDIMS::NMFIPR::defaultValue ),
-            m_NRFREG( ParserKeywords::REGDIMS::NRFREG::defaultValue ),
-            m_NTFREG( ParserKeywords::REGDIMS::NTFREG::defaultValue ),
-            m_NPLMIX( ParserKeywords::REGDIMS::NPLMIX::defaultValue )
-        { }
+        Regdims();
 
         Regdims(size_t ntfip , size_t nmfipr , size_t nrfregr , size_t ntfreg , size_t nplmix) :
             m_NTFIP( ntfip ),

--- a/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
@@ -20,17 +20,19 @@
 #ifndef TABDIMS_HPP
 #define TABDIMS_HPP
 
+#include <cstddef>
+
 /*
   The Tabdims class is a small utility class designed to hold on to
   the values from the TABDIMS keyword.
 */
 
-#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-
 namespace Opm {
+
+    class Deck;
+    class DeckKeyword;
+    class DeckRecord;
+
     class Tabdims {
     public:
 
@@ -39,29 +41,9 @@ namespace Opm {
           are ECLIPSE300 only and quite exotic. Here we only
           internalize the most common items.
         */
-        Tabdims() :
-            m_ntsfun( ParserKeywords::TABDIMS::NTSFUN::defaultValue ),
-            m_ntpvt( ParserKeywords::TABDIMS::NTPVT::defaultValue ),
-            m_nssfun( ParserKeywords::TABDIMS::NSSFUN::defaultValue ),
-            m_nppvt(  ParserKeywords::TABDIMS::NPPVT::defaultValue ),
-            m_ntfip(  ParserKeywords::TABDIMS::NTFIP::defaultValue ),
-            m_nrpvt(  ParserKeywords::TABDIMS::NRPVT::defaultValue )
-        { }
+        Tabdims();
 
-
-        explicit Tabdims(const Deck& deck) :
-            Tabdims()
-        {
-            if (deck.hasKeyword("TABDIMS")) {
-                const auto& record = deck.getKeyword( "TABDIMS" , 0 ).getRecord( 0 );
-                m_ntsfun = record.getItem("NTSFUN").get<int>(0);
-                m_ntpvt  = record.getItem("NTPVT").get<int>(0);
-                m_nssfun = record.getItem("NSSFUN").get<int>(0);
-                m_nppvt  = record.getItem("NPPVT").get<int>(0);
-                m_ntfip  = record.getItem("NTFIP").get<int>(0);
-                m_nrpvt  = record.getItem("NRPVT").get<int>(0);
-            }
-        }
+        explicit Tabdims(const Deck& deck);
 
         static Tabdims serializeObject()
         {

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -32,6 +32,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/O.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Grid/TranCalculator.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/TranCalculator.cpp
@@ -1,0 +1,51 @@
+/*
+  Copyright 2020 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/EclipseState/Grid/TranCalculator.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
+
+namespace Opm
+{
+
+namespace Fieldprops
+{
+
+keywords::keyword_info<double> TranCalculator::make_kw_info(ScalarOperation op) {
+    keywords::keyword_info<double> kw_info;
+    switch (op) {
+    case ScalarOperation::MUL:
+        kw_info.init(1);
+        break;
+    case ScalarOperation::ADD:
+        kw_info.init(0);
+        break;
+    case ScalarOperation::MAX:
+        kw_info.init(std::numeric_limits<double>::max());
+        break;
+    case ScalarOperation::MIN:
+        kw_info.init(std::numeric_limits<double>::lowest());
+        break;
+    default:
+        break;
+    }
+    return kw_info;
+}
+
+} // end namespace Fieldprops
+} // end namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -50,6 +50,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeywords/L.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/N.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/V.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.cpp
@@ -27,6 +27,21 @@
 
 namespace Opm {
 
+    MessageLimits::MessageLimits()
+    {
+        message_print_limit = ParserKeywords::MESSAGES::MESSAGE_PRINT_LIMIT::defaultValue;
+        comment_print_limit = ParserKeywords::MESSAGES::COMMENT_PRINT_LIMIT::defaultValue;
+        warning_print_limit = ParserKeywords::MESSAGES::WARNING_PRINT_LIMIT::defaultValue;
+        problem_print_limit = ParserKeywords::MESSAGES::PROBLEM_PRINT_LIMIT::defaultValue;
+        error_print_limit   = ParserKeywords::MESSAGES::ERROR_PRINT_LIMIT::defaultValue;
+        bug_print_limit     = ParserKeywords::MESSAGES::BUG_PRINT_LIMIT::defaultValue;
+        message_stop_limit  = ParserKeywords::MESSAGES::MESSAGE_STOP_LIMIT::defaultValue;
+        comment_stop_limit  = ParserKeywords::MESSAGES::COMMENT_STOP_LIMIT::defaultValue;
+        warning_stop_limit  = ParserKeywords::MESSAGES::WARNING_STOP_LIMIT::defaultValue;
+        problem_stop_limit  = ParserKeywords::MESSAGES::PROBLEM_STOP_LIMIT::defaultValue;
+        error_stop_limit    = ParserKeywords::MESSAGES::ERROR_STOP_LIMIT::defaultValue;
+        bug_stop_limit      = ParserKeywords::MESSAGES::BUG_STOP_LIMIT::defaultValue;
+    }
 
     MessageLimits::MessageLimits(const Deck& deck ) :
         MessageLimits()

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -44,6 +44,7 @@
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
@@ -1,0 +1,161 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
+
+namespace Opm {
+
+Tuning::Tuning() {
+    using TuningKw = ParserKeywords::TUNING;
+    using WsegIterKW = ParserKeywords::WSEGITER;
+
+    // Record1
+    TSINIT = TuningKw::TSINIT::defaultValue * Metric::Time;
+    TSMAXZ = TuningKw::TSMAXZ::defaultValue * Metric::Time;
+    TSMINZ = TuningKw::TSMINZ::defaultValue * Metric::Time;
+    TSMCHP = TuningKw::TSMCHP::defaultValue * Metric::Time;
+    TSFMAX = TuningKw::TSFMAX::defaultValue;
+    TSFMIN = TuningKw::TSFMIN::defaultValue;
+    TFDIFF = TuningKw::TFDIFF::defaultValue;
+    TSFCNV = TuningKw::TSFCNV::defaultValue;
+    THRUPT = TuningKw::THRUPT::defaultValue;
+
+    // Record 2
+    TRGTTE = TuningKw::TRGTTE::defaultValue;
+    TRGCNV = TuningKw::TRGCNV::defaultValue;
+    TRGMBE = TuningKw::TRGMBE::defaultValue;
+    TRGLCV = TuningKw::TRGLCV::defaultValue;
+    XXXTTE = TuningKw::XXXTTE::defaultValue;
+    XXXCNV = TuningKw::XXXCNV::defaultValue;
+    XXXMBE = TuningKw::XXXMBE::defaultValue;
+    XXXLCV = TuningKw::XXXLCV::defaultValue;
+    XXXWFL = TuningKw::XXXWFL::defaultValue;
+    TRGFIP = TuningKw::TRGFIP::defaultValue;
+    THIONX = TuningKw::THIONX::defaultValue;
+    TRWGHT = TuningKw::TRWGHT::defaultValue;
+
+    // Record 3
+    NEWTMX = TuningKw::NEWTMX::defaultValue;
+    NEWTMN = TuningKw::NEWTMN::defaultValue;
+    LITMAX = TuningKw::LITMAX::defaultValue;
+    LITMIN = TuningKw::LITMIN::defaultValue;
+    MXWSIT = TuningKw::MXWSIT::defaultValue;
+    MXWPIT = TuningKw::MXWPIT::defaultValue;
+    DDPLIM = TuningKw::DDPLIM::defaultValue * Metric::Pressure;
+    DDSLIM = TuningKw::DDSLIM::defaultValue;
+    TRGDPR = TuningKw::TRGDPR::defaultValue * Metric::Pressure;
+    XXXDPR = 0.0 * Metric::Pressure;
+
+    WSEG_MAX_RESTART = WsegIterKW::MAX_TIMES_REDUCED::defaultValue;
+    WSEG_REDUCTION_FACTOR = WsegIterKW::REDUCTION_FACTOR::defaultValue;
+    WSEG_INCREASE_FACTOR = WsegIterKW::INCREASING_FACTOR::defaultValue;
+}
+
+
+Tuning Tuning::serializeObject() {
+    Tuning result;
+    result.TSINIT = 1.0;
+    result.TSMAXZ = 2.0;
+    result.TSMINZ = 3.0;
+    result.TSMCHP = 4.0;
+    result.TSFMAX = 5.0;
+    result.TSFMIN = 6.0;
+    result.TFDIFF = 7.0;
+    result.TSFCNV = 8.0;
+    result.THRUPT = 9.0;
+    result.TMAXWC = 10.0;
+    result.TMAXWC_has_value = true;
+
+    result.TRGTTE = 11.0;
+    result.TRGCNV = 12.0;
+    result.TRGMBE = 13.0;
+    result.TRGLCV = 14.0;
+    result.XXXTTE = 15.0;
+    result.XXXCNV = 16.0;
+    result.XXXMBE = 17.0;
+    result.XXXLCV = 18.0;
+    result.XXXWFL = 19.0;
+    result.TRGFIP = 20.0;
+    result.TRGSFT = 21.0;
+    result.TRGSFT_has_value = true;
+    result.THIONX = 22.0;
+    result.TRWGHT = 23.0;
+
+    result.NEWTMX = 24;
+    result.NEWTMN = 25;
+    result.LITMAX = 26;
+    result.LITMIN = 27;
+    result.MXWSIT = 28;
+    result.MXWPIT = 29;
+    result.DDPLIM = 30.0;
+    result.DDSLIM = 31.0;
+    result.TRGDPR = 32.0;
+    result.XXXDPR = 33.0;
+    result.XXXDPR_has_value = true;
+
+    return result;
+}
+
+bool Tuning::operator==(const Tuning& data) const {
+    return TSINIT == data.TSINIT &&
+           TSMAXZ == data.TSMAXZ &&
+           TSMINZ == data.TSMINZ &&
+           TSMCHP == data.TSMCHP &&
+           TSFMAX == data.TSFMAX &&
+           TSFMIN == data.TSFMIN &&
+           TSFCNV == data.TSFCNV &&
+           TFDIFF == data.TFDIFF &&
+           THRUPT == data.THRUPT &&
+           TMAXWC == data.TMAXWC &&
+           TMAXWC_has_value == data.TMAXWC_has_value &&
+           TRGTTE == data.TRGTTE &&
+           TRGCNV == data.TRGCNV &&
+           TRGMBE == data.TRGMBE &&
+           TRGLCV == data.TRGLCV &&
+           XXXTTE == data.XXXTTE &&
+           XXXCNV == data.XXXCNV &&
+           XXXMBE == data.XXXMBE &&
+           XXXLCV == data.XXXLCV &&
+           XXXWFL == data.XXXWFL &&
+           TRGFIP == data.TRGFIP &&
+           TRGSFT == data.TRGSFT &&
+           TRGSFT_has_value == data.TRGSFT_has_value &&
+           THIONX == data.THIONX &&
+           TRWGHT == data.TRWGHT &&
+           NEWTMX == data.NEWTMX &&
+           NEWTMN == data.NEWTMN &&
+           LITMAX == data.LITMAX &&
+           LITMIN == data.LITMIN &&
+           MXWSIT == data.MXWSIT &&
+           MXWPIT == data.MXWPIT &&
+           DDPLIM == data.DDPLIM &&
+           DDSLIM == data.DDSLIM &&
+           TRGDPR == data.TRGDPR &&
+           XXXDPR == data.XXXDPR &&
+           XXXDPR_has_value == data.XXXDPR_has_value &&
+           WSEG_MAX_RESTART == data.WSEG_MAX_RESTART &&
+           WSEG_REDUCTION_FACTOR == data.WSEG_REDUCTION_FACTOR &&
+           WSEG_INCREASE_FACTOR == data.WSEG_INCREASE_FACTOR;
+}
+
+}

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
@@ -66,6 +66,11 @@ RockConfig::Hysteresis hysteresis(const std::string& s) {
 
 }
 
+RockConfig::RockConfig() :
+    num_property(ParserKeywords::ROCKOPTS::TABLE_TYPE::defaultValue),
+    num_tables(ParserKeywords::ROCKCOMP::NTROCC::defaultValue)
+{
+}
 
 bool RockConfig::RockComp::operator==(const RockConfig::RockComp& other) const {
     return this->pref == other.pref &&

--- a/src/opm/parser/eclipse/EclipseState/Tables/Aqudims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Aqudims.cpp
@@ -1,0 +1,57 @@
+/*
+  Copyright (C) 2017 TNO
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/Tables/Aqudims.hpp>
+
+#include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
+namespace Opm {
+
+Aqudims::Aqudims() :
+    m_mxnaqn( ParserKeywords::AQUDIMS::MXNAQN::defaultValue ),
+    m_mxnaqc( ParserKeywords::AQUDIMS::MXNAQC::defaultValue ),
+    m_niftbl( ParserKeywords::AQUDIMS::NIFTBL::defaultValue ),
+    m_nriftb( ParserKeywords::AQUDIMS::NRIFTB::defaultValue ),
+    m_nanaqu( ParserKeywords::AQUDIMS::NANAQU::defaultValue ),
+    m_ncamax( ParserKeywords::AQUDIMS::NCAMAX::defaultValue ),
+    m_mxnali( ParserKeywords::AQUDIMS::MXNALI::defaultValue ),
+    m_mxaaql( ParserKeywords::AQUDIMS::MXAAQL::defaultValue )
+
+{ }
+
+Aqudims::Aqudims(const Deck& deck) :
+    Aqudims()
+{
+    if (deck.hasKeyword("AQUDIMS")) {
+        const auto& record = deck.getKeyword( "AQUDIMS" , 0 ).getRecord( 0 );
+        m_mxnaqn  = record.getItem("MXNAQN").get<int>(0);
+        m_mxnaqc  = record.getItem("MXNAQC").get<int>(0);
+        m_niftbl  = record.getItem("NIFTBL").get<int>(0);
+        m_nriftb  = record.getItem("NRIFTB").get<int>(0);
+        m_nanaqu  = record.getItem("NANAQU").get<int>(0);
+        m_ncamax  = record.getItem("NCAMAX").get<int>(0);
+        m_mxnali  = record.getItem("MXNALI").get<int>(0);
+        m_mxaaql  = record.getItem("MXAAQL").get<int>(0);
+    }
+}
+
+}

--- a/src/opm/parser/eclipse/EclipseState/Tables/Eqldims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Eqldims.cpp
@@ -1,0 +1,34 @@
+/*
+  Copyright (C) 2015 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp>
+
+#include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
+
+namespace Opm {
+
+Eqldims::Eqldims() :
+    m_ntequl( ParserKeywords::EQLDIMS::NTEQUL::defaultValue ),
+    m_depth_nodes_p( ParserKeywords::EQLDIMS::DEPTH_NODES_P::defaultValue ),
+    m_depth_nodes_tab( ParserKeywords::EQLDIMS::DEPTH_NODES_TAB::defaultValue ),
+    m_nttrvd(  ParserKeywords::EQLDIMS::NTTRVD::defaultValue ),
+    m_nstrvd(  ParserKeywords::EQLDIMS::NSTRVD::defaultValue )
+{ }
+
+}

--- a/src/opm/parser/eclipse/EclipseState/Tables/Regdims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Regdims.cpp
@@ -1,0 +1,34 @@
+/*
+  Copyright (C) 2015 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANREGILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/Tables/Regdims.hpp>
+
+#include <opm/parser/eclipse/Parser/ParserKeywords/R.hpp>
+
+namespace Opm {
+
+Regdims::Regdims() :
+    m_NTFIP( ParserKeywords::REGDIMS::NTFIP::defaultValue ),
+    m_NMFIPR( ParserKeywords::REGDIMS::NMFIPR::defaultValue ),
+    m_NRFREG( ParserKeywords::REGDIMS::NRFREG::defaultValue ),
+    m_NTFREG( ParserKeywords::REGDIMS::NTFREG::defaultValue ),
+    m_NPLMIX( ParserKeywords::REGDIMS::NPLMIX::defaultValue )
+{ }
+
+}

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tabdims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tabdims.cpp
@@ -1,0 +1,53 @@
+/*
+  Copyright (C) 2015 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
+
+#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
+namespace Opm {
+
+Tabdims::Tabdims() :
+    m_ntsfun( ParserKeywords::TABDIMS::NTSFUN::defaultValue ),
+    m_ntpvt( ParserKeywords::TABDIMS::NTPVT::defaultValue ),
+    m_nssfun( ParserKeywords::TABDIMS::NSSFUN::defaultValue ),
+    m_nppvt(  ParserKeywords::TABDIMS::NPPVT::defaultValue ),
+    m_ntfip(  ParserKeywords::TABDIMS::NTFIP::defaultValue ),
+    m_nrpvt(  ParserKeywords::TABDIMS::NRPVT::defaultValue )
+{ }
+
+
+Tabdims::Tabdims(const Deck& deck) :
+    Tabdims()
+{
+    if (deck.hasKeyword("TABDIMS")) {
+        const auto& record = deck.getKeyword( "TABDIMS" , 0 ).getRecord( 0 );
+        m_ntsfun = record.getItem("NTSFUN").get<int>(0);
+        m_ntpvt  = record.getItem("NTPVT").get<int>(0);
+        m_nssfun = record.getItem("NSSFUN").get<int>(0);
+        m_nppvt  = record.getItem("NPPVT").get<int>(0);
+        m_ntfip  = record.getItem("NTFIP").get<int>(0);
+        m_nrpvt  = record.getItem("NRPVT").get<int>(0);
+    }
+}
+
+}

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -29,6 +29,7 @@
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 
 


### PR DESCRIPTION
This avoid including headers in headers. In particular, these are somewhat large, generated headers, and they sit in classes that are pulled in a lot of places.