### PR TITLE
Fix fallout from PR #2438

### DIFF
--- a/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
@@ -87,7 +87,7 @@ private:
     bool m_active = false;
     std::vector<RockComp> m_comp;
     std::string num_property;
-    std::size_t num_tables;
+    std::size_t num_tables = 0;
     bool m_water_compaction = false;
     Hysteresis hyst_mode = Hysteresis::REVERS;
 };

--- a/tests/rst_test.cpp
+++ b/tests/rst_test.cpp
@@ -107,7 +107,7 @@ int main(int argc, char ** argv) {
             std::cout << "EclipseState objects were equal!" << std::endl;
         else {
             std::cout << "EclipseState objects were different!" << std::endl;
-            //equal = false;
+            equal = false;
         }
 
         if (Opm::Schedule::cmp(sched, rst_sched, static_cast<std::size_t>(report_step)) )


### PR DESCRIPTION
This fixes the breakage in opm-common seen after merging PR #2438.

Note that the PR was not the cause of the problem as such.