### PR TITLE
Use forwarding

### DIFF
--- a/opm/common/OpmLog/LogUtil.hpp
+++ b/opm/common/OpmLog/LogUtil.hpp
@@ -23,9 +23,9 @@
 #include <cstdint>
 #include <string>
 
-#include <opm/common/OpmLog/KeywordLocation.hpp>
-
 namespace Opm {
+
+class KeywordLocation;
 
 namespace Log {
     namespace MessageType {

--- a/opm/io/eclipse/EInit.hpp
+++ b/opm/io/eclipse/EInit.hpp
@@ -19,6 +19,7 @@
 #ifndef OPM_IO_EINIT_HPP
 #define OPM_IO_EINIT_HPP
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/io/eclipse/EclFile.hpp>
 
 #include <array>

--- a/opm/io/eclipse/EInit.hpp
+++ b/opm/io/eclipse/EInit.hpp
@@ -19,7 +19,6 @@
 #ifndef OPM_IO_EINIT_HPP
 #define OPM_IO_EINIT_HPP
 
-#include <opm/common/ErrorMacros.hpp>
 #include <opm/io/eclipse/EclFile.hpp>
 
 #include <array>
@@ -52,35 +51,7 @@ public:
 protected:
 
     template <typename T>
-    const std::vector<T>& ImplgetInitData(const std::string& name, const std::string& grid_name = "global")
-    {
-        int arr_ind = get_array_index(name, grid_name);
-
-        if constexpr (std::is_same_v<T, int>)
-            return getImpl(arr_ind, INTE, inte_array, "integer");
-
-        if constexpr (std::is_same_v<T, float>)
-            return getImpl(arr_ind, REAL, real_array, "float");
-
-        if constexpr (std::is_same_v<T, double>)
-            return getImpl(arr_ind, DOUB, doub_array, "double");
-
-        if constexpr (std::is_same_v<T, bool>)
-            return getImpl(arr_ind, LOGI, logi_array, "bool");
-
-        if constexpr (std::is_same_v<T, std::string>)
-        {
-            if (array_type[arr_ind] == Opm::EclIO::CHAR)
-                return getImpl(arr_ind, array_type[arr_ind], char_array, "char");
-
-            if (array_type[arr_ind] == Opm::EclIO::C0NN)
-                return getImpl(arr_ind, array_type[arr_ind], char_array, "c0nn");
-
-            OPM_THROW(std::runtime_error, "Array not of type CHAR or C0nn");
-        }
-
-        OPM_THROW(std::runtime_error, "type not supported");
-    }
+    const std::vector<T>& ImplgetInitData(const std::string& name, const std::string& grid_name = "global");
 
 private:
     std::array<int, 3> global_nijk;

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -19,7 +19,6 @@
 #ifndef OPM_IO_ERST_HPP
 #define OPM_IO_ERST_HPP
 
-#include <opm/common/ErrorMacros.hpp>
 #include <opm/io/eclipse/EclFile.hpp>
 
 #include <ios>
@@ -55,9 +54,6 @@ public:
     const std::vector<T>& getRestartData(const std::string& name, int reportStepNumber, int occurrence);
 
     template <typename T>
-    const std::vector<T>& getRestartData(const std::string& name, int reportStepNumber, const std::string& lgr_name);
-
-    template <typename T>
     const std::vector<T>& getRestartData(int index, int reportStepNumber)
     {
         auto indRange = this->getIndexRange(reportStepNumber);
@@ -65,16 +61,10 @@ public:
     }
 
     template <typename T>
-    const std::vector<T>& getRestartData(int index, int reportStepNumber, const std::string& lgr_name)
-    {
-        auto indRange = this->getIndexRange(reportStepNumber);
+    const std::vector<T>& getRestartData(const std::string& name, int reportStepNumber, const std::string& lgr_name);
 
-        if ((std::get<0>(indRange) + index) > std::get<1>(indRange))
-            OPM_THROW(std::invalid_argument, "getRestartData, index out of range");
-
-        int start_ind = get_start_index_lgrname(reportStepNumber, lgr_name);
-        return  this->get<T>(index + start_ind);
-    }
+    template <typename T>
+    const std::vector<T>& getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
 
     int occurrence_count(const std::string& name, int reportStepNumber) const;
     size_t numberOfReportSteps() const { return seqnum.size(); };

--- a/opm/io/eclipse/ERst.hpp
+++ b/opm/io/eclipse/ERst.hpp
@@ -19,6 +19,7 @@
 #ifndef OPM_IO_ERST_HPP
 #define OPM_IO_ERST_HPP
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/io/eclipse/EclFile.hpp>
 
 #include <ios>

--- a/opm/io/eclipse/EclFile.hpp
+++ b/opm/io/eclipse/EclFile.hpp
@@ -19,11 +19,10 @@
 #ifndef OPM_IO_ECLFILE_HPP
 #define OPM_IO_ECLFILE_HPP
 
-#include <opm/common/ErrorMacros.hpp>
-
 #include <opm/io/eclipse/EclIOdata.hpp>
 
 #include <ios>
+#include <map>
 #include <string>
 #include <stdexcept>
 #include <tuple>
@@ -97,19 +96,7 @@ protected:
     template<class T>
     const std::vector<T>& getImpl(int arrIndex, eclArrType type,
                                   const std::unordered_map<int, std::vector<T>>& array,
-                                  const std::string& typeStr)
-    {
-        if (array_type[arrIndex] != type) {
-            std::string message = "Array with index " + std::to_string(arrIndex) + " is not of type " + typeStr;
-            OPM_THROW(std::runtime_error, message);
-        }
-
-        if (!arrayLoaded[arrIndex]) {
-          loadData(arrIndex);
-        }
-
-        return array.at(arrIndex);
-    }
+                                  const std::string& typeStr);
 
     std::streampos
     seekPosition(const std::vector<std::string>::size_type arrIndex) const;

--- a/opm/output/eclipse/AggregateUDQData.hpp
+++ b/opm/output/eclipse/AggregateUDQData.hpp
@@ -23,15 +23,6 @@
 #include <opm/output/eclipse/WindowedArray.hpp>
 #include <opm/io/eclipse/PaddedOutputString.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQDefine.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -22,18 +22,16 @@
 
 #include <string>
 #include <vector>
-#include <memory>
-#include <utility>
 
-#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
-#include <opm/parser/eclipse/Deck/DeckValue.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/value_status.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
 namespace Opm {
     class DeckOutput;
+    class DeckValue;
     class ParserKeyword;
+    class UnitSystem;
 
     class DeckKeyword {
     public:

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -20,8 +20,6 @@
 #ifndef OPM_ECLIPSE_CONFIG_HPP
 #define OPM_ECLIPSE_CONFIG_HPP
 
-#include <memory>
-
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -23,7 +23,6 @@
 #include <memory>
 #include <vector>
 
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/TracerConfig.hpp>
@@ -35,28 +34,15 @@
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 namespace Opm {
 
-    bool enable3DPropsTesting();
-
-    template< typename > class GridProperty;
-    template< typename > class GridProperties;
-
-    class Box;
-    class BoxManager;
     class Deck;
-    class DeckItem;
     class DeckKeyword;
-    class DeckRecord;
-    class EclipseGrid;
     class InitConfig;
     class IOConfig;
-    class RestartConfig;
     class DeckSection;
-    class SimulationConfig;
-    class TableManager;
-    class UnitSystem;
 
 
     class EclipseState {

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -25,9 +25,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/MinpvMode.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/PinchMode.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
-
-#include <opm/io/eclipse/EclFile.hpp>
 
 #include <array>
 #include <memory>
@@ -38,8 +35,10 @@
 namespace Opm {
 
     class Deck;
+    namespace EclIO { class EclFile; }
+    struct NNCdata;
+    class UnitSystem;
     class ZcornMapper;
-    class NNC;
 
     /**
        About cell information and dimension: The actual grid

--- a/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FieldData.hpp
@@ -22,7 +22,6 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Keywords.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/FieldData.hpp>
 #include <opm/parser/eclipse/Deck/value_status.hpp>
 
 #include <string>

--- a/opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
@@ -24,10 +24,10 @@
 #include <stdexcept>
 #include <vector>
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-
 namespace Opm {
+    class Deck;
+    class DeckKeyword;
+
     class GridDims
     {
     public:

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -21,13 +21,12 @@
 #ifndef OPM_PARSER_MULTREGTSCANNER_HPP
 #define OPM_PARSER_MULTREGTSCANNER_HPP
 
-#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
 
 
 namespace Opm {
 
-    template< typename > class GridProperties;
+    class FieldPropsManager;
 
     class DeckRecord;
     class DeckKeyword;

--- a/opm/parser/eclipse/EclipseState/Grid/MinpvMode.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MinpvMode.hpp
@@ -20,8 +20,6 @@
 #ifndef OPM_MINPVMODE_HPP
 #define OPM_MINPVMODE_HPP
 
-#include <string>
-
 namespace Opm {
     
     namespace MinpvMode {

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.hpp
@@ -21,9 +21,12 @@
 #ifndef ACTDIMS_HPP_
 #define ACTDIMS_HPP_
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <cstddef>
 
 namespace Opm {
+
+class Deck;
+
 class Actdims {
 public:
     Actdims();

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GConSale.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GConSale.hpp
@@ -25,9 +25,10 @@
 
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 namespace Opm {
+
+    class SummaryState;
 
     class GConSale {
     public:

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GConSump.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GConSump.hpp
@@ -25,9 +25,10 @@
 
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 namespace Opm {
+
+    class SummaryState;
 
     class GConSump {
     public:

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.hpp
@@ -28,10 +28,11 @@
 #include <string>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/icd.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 namespace Opm {
+
+    class DeckRecord;
+    class DeckKeyword;
 
     class SICD {
     public:
@@ -89,33 +90,6 @@ namespace Opm {
             serializer(m_max_absolute_rate);
             serializer(m_status);
             serializer(m_scaling_factor);
-        }
-
-        template<class ICD>
-        static std::map<std::string, std::vector<std::pair<int, ICD> > >
-        fromWSEG(const DeckKeyword& wseg) {
-            std::map<std::string, std::vector<std::pair<int, ICD> > > res;
-
-            for (const DeckRecord &record : wseg) {
-                const std::string well_name = record.getItem("WELL").getTrimmedString(0);
-
-                const int start_segment = record.getItem("SEGMENT1").get<int>(0);
-                const int end_segment = record.getItem("SEGMENT2").get<int>(0);
-
-                if (start_segment < 2 || end_segment < 2 || end_segment < start_segment) {
-                    const std::string message = "Segment numbers " + std::to_string(start_segment) + " and "
-                        + std::to_string(end_segment) + " specified in WSEGSICD for well " +
-                        well_name
-                        + " are illegal ";
-                    throw std::invalid_argument(message);
-                }
-
-                const ICD spiral_icd(record);
-                for (int seg = start_segment; seg <= end_segment; seg++) {
-                    res[well_name].push_back(std::make_pair(seg, spiral_icd));
-                }
-            }
-            return res;
         }
 
     private:

--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
@@ -20,7 +20,6 @@
 #define DRSDT_HPP
 
 #include <string>
-#include <memory>
 #include <vector>
 
 namespace Opm

--- a/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/RFTConfig.hpp
@@ -25,8 +25,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
-
 namespace Opm {
 
 class RFTConfig {

--- a/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp
@@ -22,9 +22,9 @@
 #include <string>
 #include <unordered_map>
 
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-
 namespace Opm {
+
+class DeckKeyword;
 
 class RPTConfig {
 public:

--- a/opm/parser/eclipse/EclipseState/Schedule/RSTConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/RSTConfig.hpp
@@ -186,12 +186,12 @@
 #include <map>
 #include <optional>
 
-#include <opm/parser/eclipse/Deck/DeckSection.hpp>
-
 namespace Opm {
 
-class ParseContext;
+class DeckKeyword;
 class ErrorGuard;
+class ParseContext;
+class SOLUTIONSection;
 
 class RSTConfig {
 public:

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -24,45 +24,39 @@
 #include <optional>
 #include <unordered_set>
 
-#include <opm/parser/eclipse/Deck/DeckSection.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/GasLiftOpt.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/PAvg.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/PAvgCalculatorCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellMatcher.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
-#include <opm/common/utility/TimeService.hpp>
-
-#include <opm/common/utility/ActiveGridCells.hpp>
-#include <opm/io/eclipse/rst/state.hpp>
 
 
 
 namespace Opm
 {
+    class ActiveGridCells;
     class Deck;
     class DeckKeyword;
     class DeckRecord;
     class EclipseGrid;
     class EclipseState;
     class FieldPropsManager;
-    class Runspec;
+    class ParseContext;
     class SCHEDULESection;
     class SummaryState;
     class ErrorGuard;
     class UDQConfig;
+    namespace RestartIO { class RstState; }
 
 
     struct ScheduleStatic {
@@ -87,17 +81,7 @@ namespace Opm
                        const Runspec& runspec,
                        const std::optional<int>& output_interval_,
                        const ParseContext& parseContext,
-                       ErrorGuard& errors):
-            m_python_handle(python_handle),
-            m_input_path(deck.getInputPath()),
-            m_restart_info(restart_info),
-            m_deck_message_limits( deck ),
-            m_unit_system( deck.getActiveUnitSystem() ),
-            m_runspec( runspec ),
-            rst_config( SOLUTIONSection(deck), parseContext, errors ),
-            output_interval(output_interval_)
-        {
-        }
+                       ErrorGuard& errors);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp
@@ -30,8 +30,9 @@
 
 #include <opm/common/utility/TimeService.hpp>
 
-namespace Opm{
+namespace Opm {
 
+class UDQSet;
 
 /*
   The purpose of this class is to serve as a small container object for
@@ -64,8 +65,6 @@ namespace Opm{
       st.has("WGOR:OPY") => True
       st.has_well_var("OPY", "WGOR") => False
 */
-
-class UDQSet;
 
 class SummaryState {
 public:

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -33,7 +33,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQFunctionTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp>
-#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 
 namespace Opm {

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQContext.hpp
@@ -28,12 +28,12 @@
 
 
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellMatcher.hpp>
 
 namespace Opm {
     class SummaryState;
     class UDQFunctionTable;
+    class UDQSet;
     class UDQState;
 
     class UDQContext{

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQInput.hpp
@@ -21,8 +21,6 @@
 #ifndef UDQINPUT__HPP_
 #define UDQINPUT__HPP_
 
-#include <memory>
-
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 
 namespace Opm {

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp
@@ -26,10 +26,11 @@
 #include <unordered_map>
 #include <vector>
 
-#include <opm/common/utility/Serializer.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
 
 namespace Opm {
+
+class Serializer;
 
 class UDQScalar {
 public:

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp
@@ -29,8 +29,6 @@
 #include <vector>
 #include <optional>
 
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-
 namespace Opm {
 
 namespace RestartIO {

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -48,6 +48,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellEconProductionLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/VFPProdTable.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -32,8 +32,8 @@
 
 #include <stddef.h>
 
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/WellSegments.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp>
@@ -54,13 +54,17 @@
 
 namespace Opm {
 
-class DeckRecord;
-class EclipseGrid;
+class ActiveGridCells;
+class AutoICD;
 class DeckKeyword;
+class DeckRecord;
+class ErrorGuard;
+class EclipseGrid;
+class ParseContext;
+class SICD;
+class SummaryState;
 class UDQActive;
 class UDQConfig;
-class SICD;
-class AutoICD;
 
 namespace RestartIO {
 struct RstWell;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp
@@ -23,8 +23,6 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
 
-#include <opm/common/utility/ActiveGridCells.hpp>
-
 #include <cstddef>
 #include <optional>
 #include <vector>
@@ -32,6 +30,7 @@
 #include <stddef.h>
 
 namespace Opm {
+    class ActiveGridCells;
     class DeckRecord;
     class EclipseGrid;
     class FieldPropsManager;

--- a/opm/parser/eclipse/EclipseState/Tables/JFunc.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/JFunc.hpp
@@ -20,10 +20,9 @@
 #ifndef OPM_JFUNC_HPP_
 #define OPM_JFUNC_HPP_
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-
-
 namespace Opm {
+
+class Deck;
 
 class JFunc
 {

--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -31,7 +31,6 @@ namespace Opm {
     class Deck;
     class DeckRecord;
     class ParseContext;
-    class ParserItem;
     class RawRecord;
     class ErrorGuard;
     class UnitSystem;

--- a/python/cxx/eclipse_config.cpp
+++ b/python/cxx/eclipse_config.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>

--- a/python/cxx/parser.cpp
+++ b/python/cxx/parser.cpp
@@ -2,6 +2,7 @@
 #include <exception>
 
 #include <opm/json/JsonObject.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/Builtin.hpp>

--- a/src/opm/common/OpmLog/LogUtil.cpp
+++ b/src/opm/common/OpmLog/LogUtil.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 
 namespace Opm {

--- a/src/opm/io/eclipse/EInit.cpp
+++ b/src/opm/io/eclipse/EInit.cpp
@@ -157,5 +157,40 @@ std::vector<EclFile::EclEntry> EInit::list_arrays() const
     return array_list;
 }
 
+template <typename T>
+const std::vector<T>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name)
+{
+    int arr_ind = get_array_index(name, grid_name);
+
+    if constexpr (std::is_same_v<T, int>)
+            return getImpl(arr_ind, INTE, inte_array, "integer");
+
+    if constexpr (std::is_same_v<T, float>)
+            return getImpl(arr_ind, REAL, real_array, "float");
+
+    if constexpr (std::is_same_v<T, double>)
+            return getImpl(arr_ind, DOUB, doub_array, "double");
+
+    if constexpr (std::is_same_v<T, bool>)
+            return getImpl(arr_ind, LOGI, logi_array, "bool");
+
+    if constexpr (std::is_same_v<T, std::string>)
+    {
+        if (array_type[arr_ind] == Opm::EclIO::CHAR)
+            return getImpl(arr_ind, array_type[arr_ind], char_array, "char");
+
+        if (array_type[arr_ind] == Opm::EclIO::C0NN)
+            return getImpl(arr_ind, array_type[arr_ind], char_array, "c0nn");
+
+        OPM_THROW(std::runtime_error, "Array not of type CHAR or C0nn");
+    }
+
+    OPM_THROW(std::runtime_error, "type not supported");
+}
+
+template const std::vector<int>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
+template const std::vector<float>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
+template const std::vector<double>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
+template const std::vector<bool>& EInit::ImplgetInitData(const std::string& name, const std::string& grid_name);
 
 }} // namespace Opm::EclIO

--- a/src/opm/io/eclipse/ERst.cpp
+++ b/src/opm/io/eclipse/ERst.cpp
@@ -18,6 +18,8 @@
 
 #include <opm/io/eclipse/ERst.hpp>
 
+#include <opm/common/ErrorMacros.hpp>
+
 #include <algorithm>
 #include <cstring>
 #include <exception>
@@ -407,5 +409,22 @@ const std::vector<std::string>& ERst::getRestartData<std::string>(const std::str
     return getImpl(ind, CHAR, char_array, "char");
 }
 
+template <typename T>
+const std::vector<T>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name)
+{
+    auto indRange = this->getIndexRange(reportStepNumber);
+
+    if ((std::get<0>(indRange) + index) > std::get<1>(indRange))
+        OPM_THROW(std::invalid_argument, "getRestartData, index out of range");
+
+    int start_ind = get_start_index_lgrname(reportStepNumber, lgr_name);
+    return  this->get<T>(index + start_ind);
+}
+
+template const std::vector<int>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+template const std::vector<std::string>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+template const std::vector<float>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+template const std::vector<double>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
+template const std::vector<bool>& ERst::getRestartData(int index, int reportStepNumber, const std::string& lgr_name);
 
 }} // namespace Opm::ecl

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -17,12 +17,13 @@
    */
 
 #include <opm/io/eclipse/ESmry.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/FileSystem.hpp>
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/io/eclipse/EclFile.hpp>
 #include <opm/io/eclipse/EclUtil.hpp>
 #include <opm/io/eclipse/EclOutput.hpp>
-#include <opm/common/utility/TimeService.hpp>
 
 #include <algorithm>
 #include <chrono>

--- a/src/opm/io/eclipse/EclFile.cpp
+++ b/src/opm/io/eclipse/EclFile.cpp
@@ -631,6 +631,24 @@ const std::vector<std::string>& EclFile::get<std::string>(const std::string &nam
 }
 
 
+template<class T>
+const std::vector<T>& EclFile::getImpl(int arrIndex, eclArrType type,
+                                       const std::unordered_map<int, std::vector<T>>& array,
+                                       const std::string& typeStr)
+{
+    if (array_type[arrIndex] != type) {
+        std::string message = "Array with index " + std::to_string(arrIndex) + " is not of type " + typeStr;
+        OPM_THROW(std::runtime_error, message);
+    }
+
+    if (!arrayLoaded[arrIndex]) {
+        loadData(arrIndex);
+    }
+
+    return array.at(arrIndex);
+}
+
+
 std::size_t EclFile::size() const {
     return this->array_name.size();
 }

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -26,6 +26,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 

--- a/src/opm/output/eclipse/AggregateUDQData.cpp
+++ b/src/opm/output/eclipse/AggregateUDQData.cpp
@@ -44,6 +44,7 @@
 #include <cstring>
 #include <string>
 #include <iostream>
+#include <sstream>
 
 // #####################################################################
 // Class Opm::RestartIO::Helpers::AggregateGroupData

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -24,6 +24,8 @@
 
 #include <opm/output/eclipse/EclipseIO.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <functional>
 #include <optional>
+#include <sstream>
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp>

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -25,7 +25,7 @@
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Deck/DeckOutput.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/DeckValue.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 
 

--- a/src/opm/parser/eclipse/Deck/ImportContainer.cpp
+++ b/src/opm/parser/eclipse/Deck/ImportContainer.cpp
@@ -19,6 +19,7 @@
 
 #include <fmt/format.h>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/io/eclipse/EclFile.hpp>
 #include <opm/parser/eclipse/Deck/ImportContainer.hpp>

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -21,6 +21,7 @@
 
 #include <fmt/format.h>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/InfoLogger.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/utility/OpmInputError.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -28,6 +28,7 @@
 
 #include <fmt/format.h>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/numeric/calculateCellVol.hpp>
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -23,6 +23,7 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
@@ -68,7 +69,7 @@ namespace Opm {
 
 namespace {
 
-std::vector<int> unique(const std::vector<int> data) {
+std::vector<int> unique(const std::vector<int>& data) {
     std::set<int> set_data(data.begin(), data.end());
     return { set_data.begin(), set_data.end() };
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
 
 namespace Opm {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/AICD.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/AICD.cpp
@@ -20,6 +20,11 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/AICD.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/W.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+
+#include "src/opm/parser/eclipse/EclipseState/Schedule/MSW/FromWSEG.hpp"
+
 
 namespace Opm {
 
@@ -59,7 +64,7 @@ AutoICD::AutoICD(const DeckRecord& record) :
 //     ....
 std::map<std::string, std::vector<std::pair<int, AutoICD> > >
 AutoICD::fromWSEGAICD(const DeckKeyword& wsegaicd) {
-    return SICD::fromWSEG<AutoICD>(wsegaicd);
+    return fromWSEG<AutoICD>(wsegaicd);
 }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
@@ -24,6 +24,7 @@
 #include <fmt/format.h>
 
 #include <opm/parser/eclipse/Parser/ParserKeywords/C.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/FromWSEG.hpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/FromWSEG.hpp
@@ -1,0 +1,61 @@
+/*
+  Copyright 2020 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef FROM_WSEG_HPP
+#define FROM_WSEG_HPP
+
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Opm {
+
+template<class ICD>
+std::map<std::string, std::vector<std::pair<int, ICD> > >
+fromWSEG(const DeckKeyword& wseg) {
+         std::map<std::string, std::vector<std::pair<int, ICD> > > res;
+
+    for (const DeckRecord &record : wseg) {
+        const std::string well_name = record.getItem("WELL").getTrimmedString(0);
+
+        const int start_segment = record.getItem("SEGMENT1").get<int>(0);
+        const int end_segment = record.getItem("SEGMENT2").get<int>(0);
+
+        if (start_segment < 2 || end_segment < 2 || end_segment < start_segment) {
+            const std::string message = "Segment numbers " + std::to_string(start_segment) + " and "
+                + std::to_string(end_segment) + " specified in WSEGSICD for well " +
+                well_name
+                + " are illegal ";
+            throw std::invalid_argument(message);
+        }
+
+        const ICD spiral_icd(record);
+        for (int seg = start_segment; seg <= end_segment; seg++) {
+            res[well_name].push_back(std::make_pair(seg, spiral_icd));
+        }
+    }
+    return res;
+}
+
+}
+
+#endif

--- a/src/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/MSW/SICD.cpp
@@ -27,6 +27,8 @@
 #include <cmath>
 
 #include "src/opm/parser/eclipse/EclipseState/Schedule/MSW/icd_convert.hpp"
+#include "src/opm/parser/eclipse/EclipseState/Schedule/MSW/FromWSEG.hpp"
+
 
 
 namespace Opm {
@@ -107,7 +109,7 @@ namespace Opm {
     std::map<std::string, std::vector<std::pair<int, SICD> > >
     SICD::fromWSEGSICD(const DeckKeyword& wsegsicd)
     {
-        return SICD::fromWSEG<SICD>(wsegsicd);
+        return fromWSEG<SICD>(wsegsicd);
     }
 
     const std::optional<double>& SICD::maxAbsoluteRate() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RPTConfig.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/common/ErrorMacros.hpp>
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/RSTConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/RSTConfig.cpp
@@ -19,6 +19,8 @@
 #include <optional>
 #include <fmt/format.h>
 
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Deck/DeckSection.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/RSTConfig.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -37,6 +37,8 @@
 #include <opm/common/utility/String.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 
+#include <opm/io/eclipse/rst/state.hpp>
+
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
@@ -98,6 +100,24 @@ namespace {
             return rst->header.restart_info();
     }
 }
+
+    ScheduleStatic::ScheduleStatic(std::shared_ptr<const Python> python_handle,
+                                   const std::pair<std::time_t, std::size_t>& restart_info,
+                                   const Deck& deck,
+                                   const Runspec& runspec,
+                                   const std::optional<int>& output_interval_,
+                                   const ParseContext& parseContext,
+                                   ErrorGuard& errors) :
+        m_python_handle(python_handle),
+        m_input_path(deck.getInputPath()),
+        m_restart_info(restart_info),
+        m_deck_message_limits( deck ),
+        m_unit_system( deck.getActiveUnitSystem() ),
+        m_runspec( runspec ),
+        rst_config( SOLUTIONSection(deck), parseContext, errors ),
+        output_interval(output_interval_)
+    {
+    }
 
     Schedule::Schedule( const Deck& deck,
                         const EclipseGrid& grid,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <fmt/format.h>
 
+#include <opm/common/utility/Serializer.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 
 namespace Opm {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -31,6 +31,7 @@
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/io/eclipse/rst/connection.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.cpp
@@ -28,6 +28,8 @@
 #include <utility>
 #include <fmt/format.h>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/io/eclipse/rst/connection.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -1374,4 +1374,203 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         return result;
     }
+
+    template <class TableType>
+    void TableManager::initRockTables(const Deck& deck, const std::string& keywordName, std::vector<TableType>& rocktable ) {
+
+        if (!deck.hasKeyword(keywordName))
+            return;
+
+        if (!deck.hasKeyword("ROCKCOMP")) {
+            OpmLog::error("ROCKCOMP must be present if ROCK2DTR is used");
+        }
+
+        if (!deck.hasKeyword("ROCKWNOD")) {
+            OpmLog::error("ROCKWNOD must be present if ROCK2DTR is used");
+        }
+
+        const auto& rockcompKeyword = deck.getKeyword("ROCKCOMP");
+        const auto& record = rockcompKeyword.getRecord( 0 );
+        size_t numTables = record.getItem("NTROCC").get< int >(0);
+        rocktable.resize(numTables);
+
+        const auto& keyword = deck.getKeyword(keywordName);
+        size_t numEntries = keyword.size();
+        size_t regionIdx = 0;
+        size_t tableIdx = 0;
+        for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
+            if (keyword.getRecord(lineIdx).getItem("PRESSURE").hasValue(0)) {
+                rocktable[regionIdx].init(keyword.getRecord(lineIdx), tableIdx);
+                tableIdx++;
+            } else { // next region
+                tableIdx = 0;
+                regionIdx++;
+            }
+        }
+        assert(regionIdx == numTables - 1 );
+    }
+
+    template <class TableType>
+    void TableManager::initPvtwsaltTables(const Deck& deck,  std::vector<TableType>& pvtwtables ) {
+
+        size_t numTables = m_tabdims.getNumPVTTables();
+        pvtwtables.resize(numTables);
+
+        const auto& keyword = deck.getKeyword("PVTWSALT");
+        size_t numEntries = keyword.size();
+        size_t regionIdx = 0;
+        for (unsigned lineIdx = 0; lineIdx < numEntries; lineIdx += 2) {
+            pvtwtables[regionIdx].init(keyword.getRecord(lineIdx), keyword.getRecord(lineIdx+1));
+            ++regionIdx;
+        }
+        assert(regionIdx == numTables);
+    }
+
+    template <class TableType>
+    void TableManager::initRwgsaltTables(const Deck& deck,  std::vector<TableType>& rwgtables ) {
+
+        size_t numTables = m_tabdims.getNumPVTTables();
+        rwgtables.resize(numTables);
+
+        const auto& keyword = deck.getKeyword("RWGSALT");
+        size_t regionIdx = 0;
+        for (const auto& record : keyword) {
+            rwgtables[regionIdx].init(record);
+            ++regionIdx;
+        }
+        assert(regionIdx == numTables);
+    }
+
+
+    template <class TableType>
+    void TableManager::initBrineTables(const Deck& deck,  std::vector<TableType>& brinetables ) {
+
+        size_t numTables = m_tabdims.getNumPVTTables();
+        brinetables.resize(numTables);
+
+        const auto& keyword = deck.getKeyword("BDENSITY");
+        size_t numEntries = keyword.size();
+        assert(numEntries == numTables);
+        for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
+            brinetables[lineIdx].init(keyword.getRecord(lineIdx));
+        }
+    }
+
+    template <class TableType>
+    void TableManager::initSimpleTableContainerWithJFunc(const Deck& deck,
+                                                         const std::string& keywordName,
+                                                         const std::string& tableName,
+                                                         size_t numTables) {
+        if (!deck.hasKeyword(keywordName))
+            return; // the table is not featured by the deck...
+
+        auto& container = forceGetTables(tableName , numTables);
+
+        if (deck.count(keywordName) > 1) {
+            complainAboutAmbiguousKeyword(deck, keywordName);
+            return;
+        }
+
+        const auto& tableKeyword = deck.getKeyword(keywordName);
+        for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
+            const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
+            if (dataItem.data_size() > 0) {
+                std::shared_ptr<TableType> table = std::make_shared<TableType>( dataItem, useJFunc() );
+                container.addTable( tableIdx , table );
+            }
+        }
+    }
+
+    template <class TableType>
+    void TableManager::initSimpleTableContainer(const Deck& deck,
+                                                const std::string& keywordName,
+                                                const std::string& tableName,
+                                                size_t numTables) {
+        if (!deck.hasKeyword(keywordName))
+            return; // the table is not featured by the deck...
+
+        auto& container = forceGetTables(tableName , numTables);
+
+        if (deck.count(keywordName) > 1) {
+            complainAboutAmbiguousKeyword(deck, keywordName);
+            return;
+        }
+
+        const auto& tableKeyword = deck.getKeyword(keywordName);
+        for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
+            const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
+            if (dataItem.data_size() > 0) {
+                std::shared_ptr<TableType> table = std::make_shared<TableType>( dataItem );
+                container.addTable( tableIdx , table );
+            }
+        }
+    }
+
+    template <class TableType>
+    void TableManager::initSimpleTableContainer(const Deck& deck,
+                                                const std::string& keywordName,
+                                                size_t numTables) {
+        initSimpleTableContainer<TableType>(deck , keywordName , keywordName , numTables);
+    }
+
+
+    template <class TableType>
+    void TableManager::initSimpleTableContainerWithJFunc(const Deck& deck,
+                                                         const std::string& keywordName,
+                                                         size_t numTables) {
+        initSimpleTableContainerWithJFunc<TableType>(deck , keywordName , keywordName , numTables);
+    }
+
+    template <class TableType>
+    void TableManager::initSimpleTable(const Deck& deck,
+                                       const std::string& keywordName,
+                                       std::vector<TableType>& tableVector) {
+        if (!deck.hasKeyword(keywordName))
+            return; // the table is not featured by the deck...
+
+        if (deck.count(keywordName) > 1) {
+            complainAboutAmbiguousKeyword(deck, keywordName);
+            return;
+        }
+
+        const auto& tableKeyword = deck.getKeyword(keywordName);
+        for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
+            const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
+            if (dataItem.data_size() == 0) {
+                // for simple tables, an empty record indicates that the previous table
+                // should be copied...
+                if (tableIdx == 0) {
+                    std::string msg = "The first table for keyword "+keywordName+" must be explicitly defined! Ignoring keyword";
+                    const auto& location = tableKeyword.location();
+                    OpmLog::warning(Log::fileMessage(location, msg));
+                    return;
+                }
+                tableVector.push_back(tableVector.back());
+                continue;
+            }
+
+            tableVector.push_back(TableType());
+            tableVector[tableIdx].init(dataItem);
+        }
+    }
+
+    template <class TableType>
+    void TableManager::initFullTables(const Deck& deck,
+                                      const std::string& keywordName,
+                                      std::vector<TableType>& tableVector) {
+        if (!deck.hasKeyword(keywordName))
+            return; // the table is not featured by the deck...
+
+        if (deck.count(keywordName) > 1) {
+            complainAboutAmbiguousKeyword(deck, keywordName);
+            return;
+        }
+
+        const auto& tableKeyword = deck.getKeyword(keywordName);
+
+        int numTables = TableType::numTables( tableKeyword );
+        for (int tableIdx = 0; tableIdx < numTables; ++tableIdx)
+            tableVector.emplace_back( tableKeyword , tableIdx );
+    }
+
 }

--- a/src/opm/utility/EModel.cpp
+++ b/src/opm/utility/EModel.cpp
@@ -17,6 +17,7 @@
    */
 
 #include <opm/utility/EModel.hpp>
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/utility/FileSystem.hpp>
 
 #include <fmt/format.h>

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -31,6 +31,7 @@
 #include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/ESmry.hpp>
 #include <opm/io/eclipse/ERsm.hpp>
+#include <opm/io/eclipse/rst/state.hpp>
 
 #include <opm/output/data/Wells.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>

--- a/tests/parser/AquiferTests.cpp
+++ b/tests/parser/AquiferTests.cpp
@@ -18,6 +18,7 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #define BOOST_TEST_MODULE AquiferCTTest
 
 #include <boost/test/unit_test.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp>

--- a/tests/parser/BoxTests.cpp
+++ b/tests/parser/BoxTests.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <memory>
 
-#define BOOST_TEST_MODULE BoxManagereTests
+#define BOOST_TEST_MODULE BoxManagerTests
 
 #include <boost/test/unit_test.hpp>
 

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -24,12 +24,10 @@
 #define BOOST_TEST_MODULE CompletionTests
 #include <boost/test/unit_test.hpp>
 
+#include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Deck/DeckItem.hpp>
-#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
-#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Connection.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
@@ -37,7 +35,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 

--- a/tests/parser/CopyRegTests.cpp
+++ b/tests/parser/CopyRegTests.cpp
@@ -27,13 +27,10 @@
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
-#include <opm/parser/eclipse/Deck/DeckSection.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
 
 static Opm::Deck createDeckInvalidArray1() {

--- a/tests/parser/DeckValueTests.cpp
+++ b/tests/parser/DeckValueTests.cpp
@@ -29,8 +29,6 @@
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/B.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckValue.hpp>

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -33,7 +33,6 @@
 #define BOOST_TEST_MODULE EclipseGridTests
 #include <boost/test/unit_test.hpp>
 
-#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckSection.hpp>

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -30,7 +30,6 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>

--- a/tests/parser/EventTests.cpp
+++ b/tests/parser/EventTests.cpp
@@ -24,7 +24,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
-#include <opm/common/utility/TimeService.hpp>
 
 
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -44,8 +44,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
-#include <opm/common/utility/OpmInputError.hpp>
-
 #include "src/opm/parser/eclipse/EclipseState/Grid/FieldProps.hpp"
 
 using namespace Opm;

--- a/tests/parser/FoamTests.cpp
+++ b/tests/parser/FoamTests.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.hpp>

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -29,6 +29,7 @@
 #include <string>
 
 #include <opm/common/utility/OpmInputError.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>

--- a/tests/parser/NetworkTests.cpp
+++ b/tests/parser/NetworkTests.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Network/Node.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Network/Branch.hpp>

--- a/tests/parser/PYACTION.cpp
+++ b/tests/parser/PYACTION.cpp
@@ -22,6 +22,7 @@
 
 #define BOOST_TEST_MODULE PY_ACTION_TESTER
 #include <boost/test/unit_test.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>

--- a/tests/parser/ParseContext_EXIT1.cpp
+++ b/tests/parser/ParseContext_EXIT1.cpp
@@ -4,6 +4,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -27,8 +27,12 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/io/eclipse/ERst.hpp>
+#include <opm/io/eclipse/rst/state.hpp>
 
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>

--- a/tests/parser/TracerTests.cpp
+++ b/tests/parser/TracerTests.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/TracerConfig.hpp>

--- a/tests/parser/integration/EclipseGridCreateFromDeck.cpp
+++ b/tests/parser/integration/EclipseGridCreateFromDeck.cpp
@@ -27,7 +27,6 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/parser/eclipse/Deck/DeckSection.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -21,11 +21,13 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/common/utility/OpmInputError.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -29,6 +29,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>

--- a/tests/parser/integration/TransMultIntegrationTests.cpp
+++ b/tests/parser/integration/TransMultIntegrationTests.cpp
@@ -21,6 +21,7 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>

--- a/tests/rst_test.cpp
+++ b/tests/rst_test.cpp
@@ -21,24 +21,18 @@
 #include <unordered_map>
 #include <vector>
 
-#include <opm/io/eclipse/rst/state.hpp>
-#include <opm/io/eclipse/ERst.hpp>
-#include <opm/parser/eclipse/Units/UnitSystem.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Python/Python.hpp>
 
+#include <opm/io/eclipse/ERst.hpp>
+#include <opm/io/eclipse/rst/state.hpp>
+
 #include <opm/parser/eclipse/Parser/Parser.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Parser/ErrorGuard.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
-#include <opm/common/OpmLog/LogUtil.hpp>
 
 void initLogging() {
     std::shared_ptr<Opm::StreamLog> cout_log = std::make_shared<Opm::StreamLog>(std::cout, Opm::Log::DefaultMessageTypes);

--- a/tests/test_ActiveGridCells.cpp
+++ b/tests/test_ActiveGridCells.cpp
@@ -19,6 +19,8 @@
 
 #include "config.h"
 
+#include <set>
+
 #define BOOST_TEST_MODULE ActiveGridCells
 #include <boost/test/unit_test.hpp>
 

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -4,6 +4,7 @@
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -4,7 +4,7 @@
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
@@ -23,9 +23,6 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
-
-//#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-//#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -31,6 +31,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>

--- a/tests/test_LGOData.cpp
+++ b/tests/test_LGOData.cpp
@@ -6,6 +6,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -24,9 +24,11 @@
 #include <boost/test/unit_test.hpp>
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/SummaryState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WellConnections.hpp>


### PR DESCRIPTION
This use class forwarding in more spots where possible.

Some of the commits are possibly a little more controversial. I have opted to use private template definitions, and possibly explicit template instantations, to avoid symbol usage in headers. I also had to duplicate some parsing code in the SICD/AutoICD.

https://github.com/OPM/opm-material/pull/455, https://github.com/OPM/opm-grid/pull/526, https://github.com/OPM/opm-simulators/pull/3186 and https://github.com/OPM/opm-models/pull/651 must be merged before this.