### PR TITLE
Include OpmPackage in opm-project-config.cmake and force -std=c++17

### DIFF
--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -138,14 +138,9 @@ endif ()
 # Compiler standard version needs to be requested here as prereqs is included
 # before OpmLibMain and some tests need/use CXX_STANDARD_VERSION (e.g. pybind11)
 # Languages and global compiler settings
-if(CMAKE_VERSION VERSION_LESS 3.8)
-  message(WARNING "CMake version does not support c++17, guessing -std=c++17")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-else()
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # quadmath must be explicitly enabled
 # This needs to be in OpmInit as prereqs is called before OpmLibMain is included.

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -93,6 +93,16 @@ if(NOT @opm-project_NAME@_FOUND)
 
   # this is the contents of config.h as far as our probes can tell:
 
+  # Require correct CMake standard. Needed for user modules as
+  # some software will add incompatible compile switches like
+  # -std=gnu++11 otherwise when search for (I guess because of
+  # imported targets using INTERFACE_COMPILE_FEATURES), and will
+  # break compilation because of missing c++17 features.
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+  endif()
 
   # The settings in this block do not mix well with the DEST_PREFIX
   # setting.
@@ -104,6 +114,7 @@ if(NOT @opm-project_NAME@_FOUND)
     @OPM_PROJECT_EXTRA_CODE@
     # end extra code
 
+    include(OpmPackage)
     include(@opm-project_NAME@-prereqs)
   endif()
 endif()

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -99,7 +99,7 @@ if(NOT @opm-project_NAME@_FOUND)
   # imported targets using INTERFACE_COMPILE_FEATURES), and will
   # break compilation because of missing c++17 features.
   if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD @CMAKE_CXX_STANDARD@)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     set(CMAKE_CXX_EXTENSIONS OFF)
   endif()


### PR DESCRIPTION
OpmPackage is needed as it defines find_package_deps. The CXX standard needs to be set as some cmake package config scripts will add incompatible compile switches like -std=gnu++11 otherwise (I guess because of import targets with INTERFACE_COMPILE_FEATURES), that will break the build.

Note that this is only an issue if an OPM module is used outside of OPM.

@totto82 Should be part of the release, too. There are users...