### PR TITLE
fixed: do not use Opm:: prefix when inside namespace Opm

### DIFF
--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -53,7 +53,7 @@
     do {                                                                \
         std::ostringstream oss__;                                       \
         oss__ << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
-        Opm::OpmLog::error(oss__.str());                                \
+        ::Opm::OpmLog::error(oss__.str());                                \
         throw Exception(oss__.str());                                   \
     } while (false)
 

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -74,10 +74,10 @@ public:
     const std::string& get_unit(const SummaryNode& node) const;
 
     void write_rsm(std::ostream&) const;
-    void write_rsm_file(std::optional<Opm::filesystem::path> = std::nullopt) const;
+    void write_rsm_file(std::optional<filesystem::path> = std::nullopt) const;
 
 private:
-    Opm::filesystem::path inputFileName, lodFileName;
+    filesystem::path inputFileName, lodFileName;
     int nI, nJ, nK, nSpecFiles;
     bool fromSingleRun, lodEnabeled;
     uint64_t lod_offset, lod_arr_size;
@@ -104,13 +104,13 @@ private:
 
     time_point startdat;
 
-    std::vector<std::string> checkForMultipleResultFiles(const Opm::filesystem::path& rootN, bool formatted) const;
+    std::vector<std::string> checkForMultipleResultFiles(const filesystem::path& rootN, bool formatted) const;
 
     void getRstString(const std::vector<std::string>& restartArray,
-                      Opm::filesystem::path& pathRst,
-                      Opm::filesystem::path& rootN) const;
+                      filesystem::path& pathRst,
+                      filesystem::path& rootN) const;
 
-    void updatePathAndRootName(Opm::filesystem::path& dir, Opm::filesystem::path& rootN) const;
+    void updatePathAndRootName(filesystem::path& dir, filesystem::path& rootN) const;
 
     std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num) const;
 

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -89,9 +89,9 @@ namespace Opm {
         std::vector<std::string> getAllDeckNames () const;
 
         void loadKeywords(const Json::JsonObject& jsonKeywords);
-        bool loadKeywordFromFile(const Opm::filesystem::path& configFile);
+        bool loadKeywordFromFile(const filesystem::path& configFile);
 
-        void loadKeywordsFromDirectory(const Opm::filesystem::path& directory , bool recursive = true);
+        void loadKeywordsFromDirectory(const filesystem::path& directory , bool recursive = true);
         void applyUnitsToDeck(Deck& deck) const;
 
         /*!


### PR DESCRIPTION
this is at best bad practice and can lead to confusing
errors because compiler will interpret it as Opm:: if there
is no 'foo' symbol available in the Opm namespace and give
confusing 'no symbol Opm::Opm::foo' error messages.