### PR TITLE
Make sure precision is retained in very small default values

### DIFF
--- a/src/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -652,11 +652,11 @@ std::string ParserItem::inlineClassInit(const std::string& parentClass,
             case type_tag::integer:
                 return std::to_string( this->getDefault< int >() );
             case type_tag::fdouble:
-                return std::to_string( this->getDefault< double >() );
+                return as_string( this->getDefault< double >() );
             case type_tag::uda:
                 {
                     double value = this->getDefault<UDAValue>().get<double>();
-                    return "UDAValue(" + std::to_string(value) + ")";
+                    return "UDAValue(" + as_string(value) + ")";
                 }
             case type_tag::string:
                 return "\"" + this->getDefault< std::string >() + "\"";

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
       BOOST_CHECK_CLOSE(TRGCNV_default, 0.001, diff);
 
       double TRGMBE_default = tuning.TRGMBE;
-      BOOST_CHECK_CLOSE(TRGMBE_default, 0.0, diff);
+      BOOST_CHECK_CLOSE(TRGMBE_default, 1e-7, diff);
 
       double TRGLCV_default = tuning.TRGLCV;
       BOOST_CHECK_CLOSE(TRGLCV_default, 0.0001, diff);


### PR DESCRIPTION
For very small values the default used in the 
```
ParserKeywords::Keyword::Item::defaultValue = ...
```
initializations was incorrectly set to zero; the "normal" defaults was already correct. Discovered through this: https://github.com/OPM/opm-common/issues/2448