### PR TITLE
Some corrections / improvements to the eclipse - compatible restart file

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -25,6 +25,7 @@
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Regdims.hpp>
 #include <opm/parser/eclipse/EclipseState/EndpointScaling.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.hpp>
@@ -385,6 +386,7 @@ public:
     const UDQParams& udqParams() const noexcept;
     const Phases& phases() const noexcept;
     const Tabdims&  tabdims() const noexcept;
+    const Regdims&  regdims() const noexcept;
     const EndpointScaling& endpointScaling() const noexcept;
     const Welldims& wellDimensions() const noexcept;
     const WellSegmentDims& wellSegmentDimensions() const noexcept;
@@ -405,6 +407,7 @@ public:
     {
         active_phases.serializeOp(serializer);
         m_tabdims.serializeOp(serializer);
+        m_regdims.serializeOp(serializer);
         endscale.serializeOp(serializer);
         welldims.serializeOp(serializer);
         wsegdims.serializeOp(serializer);
@@ -421,6 +424,7 @@ public:
 private:
     Phases active_phases;
     Tabdims m_tabdims;
+    Regdims m_regdims;
     EndpointScaling endscale;
     Welldims welldims;
     WellSegmentDims wsegdims;

--- a/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
@@ -24,6 +24,10 @@
 
 namespace Opm {
 
+    class Deck;
+    class DeckKeyword;
+    class DeckRecord;
+
 /*
   The Regdims class is a small utility class designed to hold on to
   the values from the REGDIMS keyword.
@@ -34,6 +38,9 @@ namespace Opm {
 
         Regdims();
 
+        explicit Regdims(const Deck& deck);
+
+#if 0
         Regdims(size_t ntfip , size_t nmfipr , size_t nrfregr , size_t ntfreg , size_t nplmix) :
             m_NTFIP( ntfip ),
             m_NMFIPR( nmfipr ),
@@ -41,6 +48,7 @@ namespace Opm {
             m_NTFREG(  ntfreg ),
             m_NPLMIX( nplmix )
         {}
+#endif
 
         static Regdims serializeObject()
         {

--- a/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
@@ -40,7 +40,6 @@ namespace Opm {
 
         explicit Regdims(const Deck& deck);
 
-#if 0
         Regdims(size_t ntfip , size_t nmfipr , size_t nrfregr , size_t ntfreg , size_t nplmix) :
             m_NTFIP( ntfip ),
             m_NMFIPR( nmfipr ),
@@ -48,7 +47,6 @@ namespace Opm {
             m_NTFREG(  ntfreg ),
             m_NPLMIX( nplmix )
         {}
-#endif
 
         static Regdims serializeObject()
         {

--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -75,7 +75,7 @@ namespace {
                                                     {cmp_enum::LESS,          1},
                                                     {cmp_enum::GREATER_EQUAL, 0},
                                                     {cmp_enum::LESS_EQUAL,    1},
-                                                    {cmp_enum::EQUAL,         1},
+                                                    {cmp_enum::EQUAL,         0},
                                                     {cmp_enum::INVALID,       0},
     };
 
@@ -400,10 +400,12 @@ const std::map<cmp_enum, int> cmpToIndex = {
                 }
 
                  /*item[12] - index for relational operator (<, =, > )
-                 0 - for LHS quantity greater RHS quantity
-                 1 - for LHS quantity less than or equal to RHS quantity
+                 1 - for LHS quantity of first condition greater RHS quantity
+                 0 - for LHS quantity of first condition less than RHS quantity
+                 0 - for LHS quantity of first condition equal to RHS quantity
                 */
-                const auto it_lhs_it = cmpToIacn_12.find(cond.cmp);
+                const auto& first_cond = actx_cond.begin();
+                const auto it_lhs_it = cmpToIacn_12.find(first_cond->cmp);
                 if (it_lhs_it != cmpToIacn_12.end()) {
                     iAcn[ind + 12] = it_lhs_it->second;
                 }

--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -308,7 +308,8 @@ const std::map<cmp_enum, int> cmpToIndex = {
                     zAcn[ind + 0] = z_data.lhs.quantity;
                 // right hand quantity
                 if ((z_data.rhs.quantity.substr(0,1) == "W") ||
-                    (z_data.rhs.quantity.substr(0,1) == "G"))
+                    (z_data.rhs.quantity.substr(0,1) == "G") ||
+                    (z_data.rhs.quantity.substr(0,1) == "F"))
                     zAcn[ind + 1] = z_data.rhs.quantity;
                 // operator (comparator)
                 zAcn[ind + 2] = z_data.cmp_string;

--- a/src/opm/output/eclipse/AggregateNetworkData.cpp
+++ b/src/opm/output/eclipse/AggregateNetworkData.cpp
@@ -693,8 +693,8 @@ captureDeclaredNetworkData(const Opm::EclipseState&             es,
     const std::vector<int> inobr = inobrFunc(sched, lookup_step);
 
     // Define Static Contributions to INobr Array
-    if (inobr.size() != entriesPerInobr(inteHead)) {
-        auto msg = fmt::format("Actual size of inobr: {} is different from required size: {} ", inobr.size(), entriesPerInobr(inteHead));
+    if (inobr.size() > entriesPerInobr(inteHead)) {
+        auto msg = fmt::format("Actual size of inobr: {} is larger than maximum size: {} ", inobr.size(), entriesPerInobr(inteHead));
         throw std::logic_error(msg);
     }
     auto i_nobr = this->iNobr_[0];

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -613,11 +613,6 @@ namespace {
                     sWell[Ix::ResVRateTarget]  = getRateLimit(units, M::rate, pc.resv_rate);
                     //}
                 }
-                if ((well.getStatus() == Opm::Well::Status::SHUT)) {
-                    sWell[Ix::OilRateTarget]   = 0.;
-                    sWell[Ix::WatRateTarget]   = 0.;
-                    sWell[Ix::GasRateTarget]   = 0.;
-                }
             }
             else if (well.isInjector()) {
                 const auto& ic = well.injectionControls(smry);

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -498,7 +498,7 @@ namespace {
         const int ninode = 10;
         const int nrnode = 17;
         const int nznode = 2;
-        const int ninobr = 2*noactbr;
+        const int ninobr = 2*nbrmax;
 
         return {
             noactnod,

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -404,11 +404,11 @@ namespace {
     }
 
     Opm::RestartIO::InteHEAD::RockOpts
-    getRockOpts(const ::Opm::RockConfig& rckCfg)
+    getRockOpts(const ::Opm::RockConfig& rckCfg, const Opm::Regdims& reg_dims)
     {
         int nttyp  = 1;   // Default value (PVTNUM)
         if (rckCfg.rocknum_property() == "SATNUM") nttyp = 2;
-        if (rckCfg.rocknum_property() == "ROCKNUM") nttyp = 5;
+        if (rckCfg.rocknum_property() == "ROCKNUM") nttyp = 4 + reg_dims.getNMFIPR();
 
         return {
             nttyp
@@ -571,7 +571,7 @@ createInteHead(const EclipseState& es,
         .nominatedPhaseGuideRate(setGuideRateNominatedPhase(sched, report_step, lookup_step))
         .whistControlMode   (getWhistctlMode(sched, report_step, lookup_step))
         .networkDimensions  (getNetworkDims(sched, lookup_step, rspec))
-        .rockOpts(getRockOpts(rckcfg))
+        .rockOpts(getRockOpts(rckcfg,rdim))
         ;
 
     return ih.data();

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -460,6 +460,7 @@ bool SatFuncControls::operator==(const SatFuncControls& rhs) const
 Runspec::Runspec( const Deck& deck ) :
     active_phases( inferActivePhases(deck) ),
     m_tabdims( deck ),
+    m_regdims( deck ),
     endscale( deck ),
     welldims( deck ),
     wsegdims( deck ),
@@ -498,6 +499,7 @@ Runspec Runspec::serializeObject()
     Runspec result;
     result.active_phases = Phases::serializeObject();
     result.m_tabdims = Tabdims::serializeObject();
+    result.m_regdims = Regdims::serializeObject();
     result.endscale = EndpointScaling::serializeObject();
     result.welldims = Welldims::serializeObject();
     result.wsegdims = WellSegmentDims::serializeObject();
@@ -518,6 +520,10 @@ const Phases& Runspec::phases() const noexcept {
 
 const Tabdims& Runspec::tabdims() const noexcept {
     return this->m_tabdims;
+}
+
+const Regdims& Runspec::regdims() const noexcept {
+    return this->m_regdims;
 }
 
 const Actdims& Runspec::actdims() const noexcept {
@@ -590,6 +596,7 @@ const UDQParams& Runspec::udqParams() const noexcept {
 bool Runspec::rst_cmp(const Runspec& full_spec, const Runspec& rst_spec) {
     return full_spec.phases() == rst_spec.phases() &&
         full_spec.tabdims() == rst_spec.tabdims() &&
+        full_spec.regdims() == rst_spec.regdims() &&
         full_spec.endpointScaling() == rst_spec.endpointScaling() &&
         full_spec.wellSegmentDimensions() == rst_spec.wellSegmentDimensions() &&
         full_spec.aquiferDimensions() == rst_spec.aquiferDimensions() &&
@@ -604,6 +611,7 @@ bool Runspec::rst_cmp(const Runspec& full_spec, const Runspec& rst_spec) {
 bool Runspec::operator==(const Runspec& data) const {
     return this->phases() == data.phases() &&
            this->tabdims() == data.tabdims() &&
+           this->regdims() == data.regdims() &&
            this->endpointScaling() == data.endpointScaling() &&
            this->wellDimensions() == data.wellDimensions() &&
            this->wellSegmentDimensions() == data.wellSegmentDimensions() &&

--- a/src/opm/parser/eclipse/EclipseState/Tables/Regdims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Regdims.cpp
@@ -20,6 +20,9 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Regdims.hpp>
 
 #include <opm/parser/eclipse/Parser/ParserKeywords/R.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 namespace Opm {
 
@@ -30,5 +33,18 @@ Regdims::Regdims() :
     m_NTFREG( ParserKeywords::REGDIMS::NTFREG::defaultValue ),
     m_NPLMIX( ParserKeywords::REGDIMS::NPLMIX::defaultValue )
 { }
+
+Regdims::Regdims(const Deck& deck) :
+    Regdims()
+{
+    if (deck.hasKeyword("REGDIMS")) {
+        const auto& record = deck.getKeyword( "REGDIMS" , 0 ).getRecord( 0 );
+        m_NTFIP   = record.getItem("NTFIP").get<int>(0);
+        m_NMFIPR  = record.getItem("NMFIPR").get<int>(0);
+        m_NRFREG  = record.getItem("NRFREG").get<int>(0);
+        m_NTFREG  = record.getItem("NTFREG").get<int>(0);
+        m_NPLMIX  = record.getItem("NPLMIX").get<int>(0);
+    }
+}
 
 }

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -760,9 +760,9 @@ BOOST_AUTO_TEST_CASE (Declared_Well_Data)
         const auto i1 = 4*ih_8.nswelz;
 
         const auto& swell = awd.getSWell();
-        BOOST_CHECK_CLOSE(swell[i1 + Ix::OilRateTarget], 0.0f, 1.0e-7f);
-        BOOST_CHECK_CLOSE(swell[i1 + Ix::WatRateTarget], 0.0f, 1.0e-7f);
-        BOOST_CHECK_CLOSE(swell[i1 + Ix::GasRateTarget], 0.0f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i1 + Ix::OilRateTarget], 20000.0f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i1 + Ix::WatRateTarget], 1.0e+20f, 1.0e-7f);
+        BOOST_CHECK_CLOSE(swell[i1 + Ix::GasRateTarget], 1.0e+20f, 1.0e-7f);
 
 
         const auto i2 = 5*ih_8.nswelz;


### PR DESCRIPTION
This pull request contains corrections / improvements to the following restart tables:
1. INOBR - change of dimensions to be compatible with Eclipse 100 v. 2019.2 

2. ZACN - correction to handle field properties as rhs - quantities

3. IH[ROCKOPTS_TTYP] - correction to handle the use of more than one set of fluid-in-place regions (NMFIPR)

4. SWEL - correction to handle prediction type wells correctly for SWEL [0 - 3]


The pull request is ready for review. 

