### PR TITLE
Add move constructor for Deck.

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -127,6 +127,7 @@ namespace Opm {
 
             Deck();
             Deck( const Deck& );
+            Deck( Deck&& );
 
             static Deck serializeObject();
 

--- a/src/opm/parser/eclipse/Deck/Deck.cpp
+++ b/src/opm/parser/eclipse/Deck/Deck.cpp
@@ -159,6 +159,19 @@ namespace Opm {
         unit_system_access_count = d.unit_system_access_count;
     }
 
+    Deck::Deck( Deck&& d ) :
+        DeckView(d.begin(), d.end()),
+        keywordList( std::move(d.keywordList) ),
+        defaultUnits( d.defaultUnits ),
+        m_dataFile( d.m_dataFile ),
+        input_path( d.input_path )
+    {
+        this->init(this->keywordList.begin(), this->keywordList.end());
+        if (d.activeUnits)
+            this->activeUnits = std::move(d.activeUnits);
+        unit_system_access_count = d.unit_system_access_count;
+    }
+
     Deck Deck::serializeObject()
     {
         Deck result;


### PR DESCRIPTION
This makes setup much faster on a case with 1M cells (3.31 minutes down to 1.48 minutes).