### PR TITLE
Optimize further for large NNC case

### DIFF
--- a/opm/parser/eclipse/Deck/DeckRecord.hpp
+++ b/opm/parser/eclipse/Deck/DeckRecord.hpp
@@ -34,7 +34,7 @@ namespace Opm {
         typedef std::vector< DeckItem >::const_iterator const_iterator;
 
         DeckRecord() = default;
-        DeckRecord( std::vector< DeckItem >&& );
+        DeckRecord( std::vector< DeckItem >&& items, const bool check_for_duplicate_names = true );
 
         static DeckRecord serializeObject();
 

--- a/src/opm/parser/eclipse/Deck/DeckRecord.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckRecord.cpp
@@ -31,26 +31,28 @@
 namespace Opm {
 
 
-    DeckRecord::DeckRecord( std::vector< DeckItem >&& items ) :
+    DeckRecord::DeckRecord( std::vector< DeckItem >&& items, const bool check_for_duplicate_names ) :
         m_items( std::move( items ) ) {
 
-        std::unordered_set< std::string > names;
-        for( const auto& item : this->m_items )
-            names.insert( item.name() );
+        if (check_for_duplicate_names) {
+            std::unordered_set< std::string > names;
+            for( const auto& item : this->m_items )
+                names.insert( item.name() );
 
-        if( names.size() == this->m_items.size() )
-            return;
+            if( names.size() == this->m_items.size() )
+                return;
 
-        names.clear();
-        std::string msg = "Duplicate item names in DeckRecord:";
-        for( const auto& item : this->m_items ) {
-            if( names.count( item.name() ) != 0 )
-                msg += std::string( " " ) += item.name();
+            names.clear();
+            std::string msg = "Duplicate item names in DeckRecord:";
+            for( const auto& item : this->m_items ) {
+                if( names.count( item.name() ) != 0 )
+                    msg += std::string( " " ) += item.name();
 
-            names.insert( item.name() );
+                names.insert( item.name() );
+            }
+
+            throw std::invalid_argument( msg );
         }
-
-        throw std::invalid_argument( msg );
     }
 
     DeckRecord DeckRecord::serializeObject()

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -134,7 +134,7 @@ namespace {
             parseContext.handleError(ParseContext::PARSE_EXTRA_DATA , msg_format, location, errors);
         }
 
-        return { std::move( items ) };
+        return { std::move( items ), false };
     }
 
     bool ParserRecord::equal(const ParserRecord& other) const {

--- a/src/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -123,7 +123,7 @@ namespace {
 
     DeckRecord ParserRecord::parse(const ParseContext& parseContext , ErrorGuard& errors , RawRecord& rawRecord, UnitSystem& active_unitsystem, UnitSystem& default_unitsystem, const KeywordLocation& location) const {
         std::vector< DeckItem > items;
-        items.reserve( this->size() + 20 );
+        items.reserve( this->size() );
         for( const auto& parserItem : *this )
             items.emplace_back( parserItem.scan( rawRecord, active_unitsystem, default_unitsystem ) );
 


### PR DESCRIPTION
These optimizations should help in the general case, but in particular with cases are constructed using large numbers of NNCs (i.e. general graph solves not using a grid geometry).

Tested on a case with ~1.1M cells. The first commit saves 12 seconds in the deck processing. The second also saves 12 seconds in startup, and also 12 seconds in destructors at the end (it still takes 25 seconds, down from 37 seconds, to destroy the Deck object, this may deserve a separate look). @joakim-hove if there is a reason I do not see for the extra reserve, please inform. The second commit also reduces peak memory usage from approx. 43 GB to approx. 27 GB (not measured quite as precisely as the timing profile though), which could mean the difference between running and not.