### PR TITLE
Communicate Dynamic Aquifer Data

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <iostream>
+#include <utility>
 
 #include <opm/output/eclipse/Inplace.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
@@ -141,14 +142,14 @@ void msim::run_step(const Schedule& schedule, Action::State& action_state, Summa
 
 
 void msim::output(Action::State& action_state, SummaryState& st, const UDQState& udq_state, size_t report_step, bool substep, double seconds_elapsed, const data::Solution& sol, const data::Wells& well_data, const data::GroupAndNetworkValues& group_nwrk_data, EclipseIO& io) const {
-    RestartValue value(sol, well_data, group_nwrk_data);
+    RestartValue value(sol, well_data, group_nwrk_data, {});
     io.writeTimeStep(action_state,
                      st,
                      udq_state,
                      report_step,
                      substep,
                      seconds_elapsed,
-                     value);
+                     std::move(value));
 }
 
 

--- a/opm/output/eclipse/RestartValue.hpp
+++ b/opm/output/eclipse/RestartValue.hpp
@@ -69,15 +69,19 @@ namespace Opm {
     class RestartValue {
     public:
         using ExtraVector = std::vector<std::pair<RestartKey, std::vector<double>>>;
-        data::Solution solution;
-        data::Wells wells;
-        data::GroupAndNetworkValues grp_nwrk;
-        ExtraVector extra;
-        std::vector<data::AquiferData> aquifer;
 
-        RestartValue(data::Solution sol, data::Wells wells_arg, data::GroupAndNetworkValues grpn_nwrk_arg);
+        data::Solution solution{};
+        data::Wells wells{};
+        data::GroupAndNetworkValues grp_nwrk{};
+        data::Aquifers aquifer{};
+        ExtraVector extra{};
 
-        RestartValue() {}
+        RestartValue(data::Solution sol,
+                     data::Wells wells_arg,
+                     data::GroupAndNetworkValues grpn_nwrk_arg,
+                     data::Aquifers aquifer_arg);
+
+        RestartValue() = default;
 
         bool hasExtra(const std::string& key) const;
         void addExtra(const std::string& key, UnitSystem::measure dimension, std::vector<double> data);
@@ -89,10 +93,11 @@ namespace Opm {
 
         bool operator==(const RestartValue& val2) const
         {
-          return solution == val2.solution &&
-                 wells == val2.wells &&
-                 grp_nwrk == val2.grp_nwrk &&
-                 extra == val2.extra;
+            return (this->solution == val2.solution)
+                && (this->wells == val2.wells)
+                && (this->grp_nwrk == val2.grp_nwrk)
+                && (this->aquifer == val2.aquifer)
+                && (this->extra == val2.extra);
         }
     };
 

--- a/src/opm/output/eclipse/RestartValue.cpp
+++ b/src/opm/output/eclipse/RestartValue.cpp
@@ -31,12 +31,14 @@ namespace Opm {
 
     }
 
-
-
-    RestartValue::RestartValue(data::Solution sol, data::Wells wells_arg, data::GroupAndNetworkValues grp_nwrk_arg) :
-        solution(std::move(sol)),
-        wells(std::move(wells_arg)),
-        grp_nwrk(std::move(grp_nwrk_arg))
+    RestartValue::RestartValue(data::Solution sol,
+                               data::Wells wells_arg,
+                               data::GroupAndNetworkValues grp_nwrk_arg,
+                               data::Aquifers aquifer_arg)
+        : solution { std::move(sol) }
+        , wells    { std::move(wells_arg) }
+        , grp_nwrk { std::move(grp_nwrk_arg) }
+        , aquifer  { std::move(aquifer_arg) }
     {
     }
 
@@ -102,6 +104,5 @@ namespace Opm {
             units.to_si(restart_key.dim, data);
         }
     }
-
 
 }

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -50,6 +50,7 @@
 #include <numeric>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include <time.h>
@@ -326,7 +327,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
 
             Action::State action_state;
             UDQState udq_state(1);
-            RestartValue restart_value(sol, wells, grp_nwrk);
+            RestartValue restart_value(sol, wells, grp_nwrk, {});
             auto first_step = ecl_util_make_date( 10 + i, 11, 2008 );
             eclWriter.writeTimeStep( action_state,
                                      st,
@@ -334,7 +335,7 @@ BOOST_AUTO_TEST_CASE(EclipseIOIntegration) {
                                      i,
                                      false,
                                      first_step - start_time,
-                                     restart_value);
+                                     std::move(restart_value));
 
             checkRestartFile( i );
         }

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
             std::move(well2_comps), SegRes{}, Ctrl{}
         };
 
-        RestartValue restart_value(std::move(solution), std::move(wells), std::move(group_nwrk));
+        RestartValue restart_value(std::move(solution), std::move(wells), std::move(group_nwrk), {});
 
         eclipseWriter.writeTimeStep( action_state,
                                      st,
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
                     std::move(well2_comps), SegRes{}, Ctrl{}
                 };
 
-                RestartValue restart_value(std::move(solution), std::move(wells), data::GroupAndNetworkValues());
+                RestartValue restart_value(std::move(solution), std::move(wells), data::GroupAndNetworkValues(), {});
 
                 eclipseWriter.writeTimeStep( action_state,
                                              st,

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -400,7 +400,7 @@ RestartValue first_sim(const Setup& setup, Action::State& action_state, SummaryS
     auto wells = mkWells();
     auto groups = mkGroups();
     const auto& udq = setup.schedule.getUDQConfig(report_step);
-    RestartValue restart_value(sol, wells, groups);
+    RestartValue restart_value(sol, wells, groups, {});
 
     udq.eval(report_step, setup.schedule.wellMatcher(report_step), st, udq_state);
     eclWriter.writeTimeStep( action_state,
@@ -486,7 +486,7 @@ BOOST_AUTO_TEST_CASE(ECL_FORMATTED) {
         auto aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{std::nullopt};
         Action::State action_state;
         {
-            RestartValue restart_value(cells, wells, groups);
+            RestartValue restart_value(cells, wells, groups, {});
 
             io_config.setEclCompatibleRST( false );
             restart_value.addExtra("EXTRA", UnitSystem::measure::pressure, {10,1,2,3});
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE(WriteWrongSOlutionSize) {
 
         BOOST_CHECK_THROW( RestartIO::save(rstFile, seqnum,
                                            100,
-                                           RestartValue(cells, wells, groups),
+                                           RestartValue(cells, wells, groups, {}),
                                            setup.es,
                                            setup.grid ,
                                            setup.schedule,
@@ -652,7 +652,7 @@ BOOST_AUTO_TEST_CASE(ExtraData_KEYS) {
     auto cells = mkSolution( num_cells );
     auto wells = mkWells();
     auto groups = mkGroups();
-    RestartValue restart_value(cells, wells, groups);
+    RestartValue restart_value(cells, wells, groups, {});
 
     BOOST_CHECK_THROW( restart_value.addExtra("TOO-LONG-KEY", {0,1,2}), std::runtime_error);
 
@@ -684,7 +684,7 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
         auto aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{std::nullopt};
         const auto& units = setup.es.getUnits();
         {
-            RestartValue restart_value(cells, wells, groups);
+            RestartValue restart_value(cells, wells, groups, {});
             SummaryState st(TimeService::now());
             const auto sumState = sim_state(setup.schedule);
 
@@ -766,8 +766,8 @@ BOOST_AUTO_TEST_CASE(STORE_THPRES) {
         auto aquiferData = std::optional<Opm::RestartIO::Helpers::AggregateAquiferData>{std::nullopt};
         const auto outputDir = test_area.currentWorkingDirectory();
         {
-            RestartValue restart_value(cells, wells, groups);
-            RestartValue restart_value2(cells, wells, groups);
+            RestartValue restart_value(cells, wells, groups, {});
+            RestartValue restart_value2(cells, wells, groups, {});
 
             /* Missing THPRES data in extra container. */
             /* Because it proved to difficult to update the legacy simulators
@@ -873,7 +873,8 @@ BOOST_AUTO_TEST_CASE(Restore_Cumulatives)
     const auto restart_value = RestartValue {
         mkSolution(setup.grid.getNumActive()),
         mkWells(),
-        mkGroups()
+        mkGroups(),
+        {}
     };
     const auto sumState = sim_state(setup.schedule);
     UDQState udq_state(98);

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(EclipseWriteRestartWellInfo) {
                                      timestep,
                                      false,
                                      schedule.seconds(timestep),
-                                     Opm::RestartValue(solution, wells, group_nwrk));
+                                     Opm::RestartValue(solution, wells, group_nwrk, {}));
     }
 
     for (int i=1; i <=4; i++) {


### PR DESCRIPTION
This PR prepares for using more dynamic aquifer quantities from the simulator layer as part of the restart I/O process.  We add `MessageBuffer` support to the `CarterTracyData` and `FetkovichData` sub structures in order to hook into the `CollectToIORank` system and promote the `aquifer` member of `RestartValue` to first class status.  The latter means that clients will always need to form a `data::Aquifers` object when constructing a non-defaulted `RestartValue` object.