### PR TITLE
Centralise Aquifer PVT Property Calculations and Use Simulator's Values for Restart Output

### DIFF
--- a/opm/output/eclipse/AggregateAquiferData.hpp
+++ b/opm/output/eclipse/AggregateAquiferData.hpp
@@ -23,6 +23,8 @@
 #include <opm/output/eclipse/InteHEAD.hpp>
 #include <opm/output/eclipse/WindowedArray.hpp>
 
+#include <opm/output/data/Aquifer.hpp>
+
 #include <vector>
 
 namespace Opm {
@@ -30,9 +32,6 @@ namespace Opm {
     class EclipseGrid;
     class SummaryState;
     class UnitSystem;
-
-    struct DensityTable;
-    struct PvtwTable;
 } // Opm
 
 namespace Opm { namespace RestartIO { namespace Helpers {
@@ -64,25 +63,21 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         ///    of aquifer types (Carter-Tracy vs. Fetkovich) and provides
         ///    read-only access to the individual aquifer objects.
         ///
+        /// \param[in] aquData Dynamic aquifer data, including time
+        ///    constants, water mass densities, water viscosities, and
+        ///    initial aquifer pressures.
+        ///
         /// \param[in] summaryState Current state of summary variables.
         ///    Expected to contain at least the summary variables AAQP
         ///    (aquifer pressure), AAQR (aquifer flow rate), and AAQT (total
         ///    produced inflow volume from aquifer).
         ///
-        /// \param[in] pvtwTable PVT properties for water.  Needed to
-        ///    compute the water viscosity and water density at aquifer
-        ///    conditions.
-        ///
-        /// \param{in] densityTable Phase densities at surface conditions.
-        ///    Needed to compute water density at aquifer conditions.
-        ///
         /// \param[in] usys Unit system.  Needed to convert quantities from
         ///    internal to output units.
-        void captureDynamicdAquiferData(const AquiferConfig& aqConfig,
-                                        const SummaryState&  summaryState,
-                                        const PvtwTable&     pvtwTable,
-                                        const DensityTable&  densityTable,
-                                        const UnitSystem&    usys);
+        void captureDynamicdAquiferData(const AquiferConfig&  aqConfig,
+                                        const data::Aquifers& aquData,
+                                        const SummaryState&   summaryState,
+                                        const UnitSystem&     usys);
 
         /// Retrieve the maximum active aquifer ID over all analytic
         /// aquifers.

--- a/opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp
@@ -27,7 +27,7 @@
 */
 
 #include <cstddef>
-#include <utility>
+#include <optional>
 #include <vector>
 
 namespace Opm {
@@ -41,63 +41,76 @@ namespace Opm {
     class AquiferCT {
         public:
 
-        struct AQUCT_data{
-
-            AQUCT_data(const DeckRecord& record, const TableManager& tables);
+        struct AQUCT_data
+        {
             AQUCT_data() = default;
-            AQUCT_data(int aqID,
-                       int infID,
-                       int pvtID,
-                       double phi_aq_,
-                       double d0_,
-                       double C_t_,
-                       double r_o_,
-                       double k_a_,
-                       double c1_,
-                       double h_,
-                       double theta_,
-                       double c2_,
-                       const std::pair<bool, double>& p0_,
-                       const std::vector<double>& td_,
-                       const std::vector<double>& pi_);
+            AQUCT_data(const DeckRecord& record, const TableManager& tables);
+            AQUCT_data(const int aqID,
+                       const int infID,
+                       const int pvtID,
+                       const double phi_aq_,
+                       const double d0_,
+                       const double C_t_,
+                       const double r_o_,
+                       const double k_a_,
+                       const double h_,
+                       const double theta_,
+                       const double p0_);
 
-            int aquiferID;
-            int inftableID, pvttableID;
+            int aquiferID{};
+            int inftableID{};
+            int pvttableID{};
 
-            double  phi_aq , // aquifer porosity
-                    d0,      // aquifer datum depth
-                    C_t ,    // total compressibility
-                    r_o ,    // aquifer inner radius
-                    k_a ,    // aquifer permeability
-                    c1,      // 0.008527 (METRIC, PVT-M); 0.006328 (FIELD); 3.6 (LAB)
-                    h ,      // aquifer thickness
-                    theta ,  // angle subtended by the aquifer boundary
-                    c2 ;     // 6.283 (METRIC, PVT-M); 1.1191 (FIELD); 6.283 (LAB).
+            double porosity{};
+            double datum_depth{};
+            double total_compr{};
+            double inner_radius{};
+            double permeability{};
+            double thickness{};
+            double angle_fraction{};
 
-            std::pair<bool, double> p0; //Initial aquifer pressure at datum depth, d0
-            std::vector<double> td, pi;
+            std::optional<double> initial_pressure{};
+            std::vector<double> dimensionless_time{};
+            std::vector<double> dimensionless_pressure{};
+
+            static AQUCT_data serializeObject();
+
+            double timeConstant() const { return this->time_constant_; }
+            double influxConstant() const { return this->influx_constant_; }
+            double waterDensity() const { return this->water_density_; }
+            double waterViscosity() const { return this->water_viscosity_; }
 
             bool operator==(const AQUCT_data& other) const;
+
+            void finishInitialisation(const TableManager& tables);
 
             template<class Serializer>
             void serializeOp(Serializer& serializer)
             {
-                serializer(aquiferID);
-                serializer(inftableID);
-                serializer(pvttableID);
-                serializer(phi_aq);
-                serializer(d0);
-                serializer(C_t);
-                serializer(r_o);
-                serializer(k_a);
-                serializer(c1);
-                serializer(h);
-                serializer(theta);
-                serializer(c2);
-                serializer(p0);
-                serializer(td);
-                serializer(pi);
+                serializer(this->aquiferID);
+                serializer(this->inftableID);
+                serializer(this->pvttableID);
+                serializer(this->porosity);
+                serializer(this->datum_depth);
+                serializer(this->total_compr);
+                serializer(this->inner_radius);
+                serializer(this->permeability);
+                serializer(this->thickness);
+                serializer(this->angle_fraction);
+                serializer(this->initial_pressure);
+                serializer(this->dimensionless_time);
+                serializer(this->dimensionless_pressure);
+                serializer(this->time_constant_);
+                serializer(this->influx_constant_);
+                serializer(this->water_density_);
+                serializer(this->water_viscosity_);
             }
+
+        private:
+            double time_constant_{};
+            double influx_constant_{};
+            double water_density_{};
+            double water_viscosity_{};
         };
 
         AquiferCT() = default;

--- a/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
@@ -65,10 +65,10 @@ public:
     }
 
 private:
-    Aquifetp aquifetp;
-    AquiferCT aquiferct;
-    mutable NumericalAquifers numerical_aquifers;
-    Aquancon aqconn;
+    Aquifetp aquifetp{};
+    AquiferCT aquiferct{};
+    mutable NumericalAquifers numerical_aquifers{};
+    Aquancon aqconn{};
 };
 
 std::vector<int> analyticAquiferIDs(const AquiferConfig& cfg);

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -462,15 +462,13 @@ namespace {
     }
 
     void updateAndWriteAquiferData(const AquiferConfig&           aqConfig,
+                                   const data::Aquifers&          aquData,
                                    const SummaryState&            summaryState,
-                                   const TableManager&            tables,
                                    const UnitSystem&              usys,
                                    Helpers::AggregateAquiferData& aquiferData,
                                    EclIO::OutputStream::Restart&  rstFile)
     {
-        aquiferData.captureDynamicdAquiferData(aqConfig, summaryState,
-                                               tables.getPvtwTable(),
-                                               tables.getDensityTable(), usys);
+        aquiferData.captureDynamicdAquiferData(aqConfig, aquData, summaryState, usys);
 
         if (aqConfig.hasAnalyticalAquifer()) {
             writeAnalyticAquiferData(aquiferData, rstFile);
@@ -492,6 +490,7 @@ namespace {
                           const Opm::Action::State&                     action_state,
                           const Opm::SummaryState&                      sumState,
                           const std::vector<int>&                       inteHD,
+                          const data::Aquifers&                         aquDynData,
                           std::optional<Helpers::AggregateAquiferData>& aquiferData,
                           EclIO::OutputStream::Restart&                 rstFile)
     {
@@ -527,7 +526,7 @@ namespace {
         if ((es.aquifer().hasAnalyticalAquifer() || es.aquifer().hasNumericalAquifer()) &&
             aquiferData.has_value())
         {
-            updateAndWriteAquiferData(es.aquifer(), sumState, es.getTableManager(),
+            updateAndWriteAquiferData(es.aquifer(), aquDynData, sumState,
                                       units, aquiferData.value(), rstFile);
         }
     }
@@ -791,7 +790,7 @@ void save(EclIO::OutputStream::Restart&                 rstFile,
     if (report_step > 0) {
         writeDynamicData(sim_step, ecl_compatible_rst, es.runspec().phases(),
                          units, grid, es, schedule, value.wells, action_state,
-                         sumState, inteHD, aquiferData, rstFile);
+                         sumState, inteHD, value.aquifer, aquiferData, rstFile);
     }
 
     writeActionx(report_step, sim_step, es, schedule, action_state, sumState, rstFile);

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -26,17 +26,21 @@
 
 namespace Opm {
 
-AquiferConfig::AquiferConfig(const TableManager& tables, const EclipseGrid& grid,
-                             const Deck& deck, const FieldPropsManager& field_props):
-    aquifetp(deck),
-    aquiferct(tables, deck),
-    numerical_aquifers(deck, grid, field_props)
+AquiferConfig::AquiferConfig(const TableManager& tables,
+                             const EclipseGrid& grid,
+                             const Deck& deck,
+                             const FieldPropsManager& field_props)
+    : aquifetp(tables, deck)
+    , aquiferct(tables, deck)
+    , numerical_aquifers(deck, grid, field_props)
 {}
 
-AquiferConfig::AquiferConfig(const Aquifetp& fetp, const AquiferCT& ct, const Aquancon& conn) :
-    aquifetp(fetp),
-    aquiferct(ct),
-    aqconn(conn)
+AquiferConfig::AquiferConfig(const Aquifetp& fetp,
+                             const AquiferCT& ct,
+                             const Aquancon& conn)
+    : aquifetp(fetp)
+    , aquiferct(ct)
+    , aqconn(conn)
 {}
 
 void AquiferConfig::load_connections(const Deck& deck, const EclipseGrid& grid) {

--- a/tests/parser/AquiferTests.cpp
+++ b/tests/parser/AquiferTests.cpp
@@ -18,290 +18,261 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #define BOOST_TEST_MODULE AquiferCTTest
 
 #include <boost/test/unit_test.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/Parser.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Aquifer/Aquancon.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.hpp>
 #include <opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
 #include <opm/parser/eclipse/Units/Units.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
+#include <initializer_list>
+#include <stdexcept>
+
 using namespace Opm;
 
+namespace {
 
-EclipseGrid makeGrid() {
-    EclipseGrid grid(3,3,3);
-    std::vector<int> actnum(27,1);
-    actnum[0] = 0;
-    actnum[9] = 0;
-    actnum[18] = 0;
+EclipseGrid makeGrid()
+{
+    EclipseGrid grid(3, 3, 3);
+
+    std::vector<int> actnum(27, 1);
+    for (const std::size_t layer : { 0, 1, 2 })
+        actnum[grid.getGlobalIndex(0, 0, layer)] = 0;
+
     grid.resetACTNUM(actnum);
     return grid;
 }
 
+Deck createAquiferCTDeck()
+{
+    return Parser{}.parseString(R"(DIMENS
+3 3 3 /
 
+AQUDIMS
+1* 1* 2 100 1 1000 /
 
-inline Deck createAquiferCTDeck() {
-    const char *deckData =
-        "DIMENS\n"
-        "3 3 3 /\n"
-        "\n"
-        "AQUDIMS\n"
-        "1* 1* 2 100 1 1000 /\n"
-        "GRID\n"
-        "\n"
-        "ACTNUM\n"
-        " 0 8*1 0 8*1 0 8*1 /\n"
-        "DXV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DYV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DZV\n"
-        "1 1 1 /\n"
-        "\n"
-        "TOPS\n"
-        "9*100 /\n"
-        "\n"
-        "PORO\n"
-        "  27*0.15 /\n"
-        "PROPS\n"
-        "AQUTAB\n"
-        " 0.01 0.112 \n"
-        " 0.05 0.229 /\n"
-        "SOLUTION\n"
-        "\n"
-        "AQUCT\n"
-        "   1 2000.0 1.5 100 .3 3.0e-5 330 10 360.0 1 2 /\n"
-        "/ \n";
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
 
-    Parser parser;
-    return parser.parseString(deckData);
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+PROPS
+AQUTAB
+ 0.01 0.112
+ 0.05 0.229 /
+
+SOLUTION
+AQUCT
+   1 2000.0 1.5 100 .3 3.0e-5 330 10 360.0 1 2 /
+/
+)");
 }
 
-inline Deck createAquiferCTDeckDefaultP0() {
-    const char *deckData =
-        "DIMENS\n"
-        "3 3 3 /\n"
-        "\n"
-        "AQUDIMS\n"
-        "1* 1* 2 100 1 1000 /\n"
-        "GRID\n"
-        "\n"
-        "ACTNUM\n"
-        " 0 8*1 0 8*1 0 8*1 /\n"
-        "DXV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DYV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DZV\n"
-        "1 1 1 /\n"
-        "\n"
-        "TOPS\n"
-        "9*100 /\n"
-        "\n"
-        "PORO\n"
-        "  27*0.15 /\n"
-        "PROPS\n"
-        "AQUTAB\n"
-        " 0.01 0.112 \n"
-        " 0.05 0.229 /\n"
-        "SOLUTION\n"
-        "\n"
-        "AQUCT\n"
-        "   1 2000.0 1* 100 .3 3.0e-5 330 10 360.0 1 2 /\n"
-        "/ \n";
+Deck createAquiferCTDeckDefaultP0()
+{
+    return Parser{}.parseString(R"(DIMENS
+3 3 3 /
 
-    Parser parser;
-    return parser.parseString(deckData);
+AQUDIMS
+1* 1* 2 100 1 1000 /
+
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
+
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+PROPS
+AQUTAB
+ 0.01 0.112
+ 0.05 0.229 /
+
+SOLUTION
+AQUCT
+   1 2000.0 1* 100 .3 3.0e-5 330 10 360.0 1 2 /
+/
+)");
 }
 
-AquiferCT init_aquiferct(const Deck& deck){
+AquiferCT init_aquiferct(const Deck& deck)
+{
     EclipseState eclState( deck );
     return AquiferCT(eclState.getTableManager(), deck);
 }
 
-BOOST_AUTO_TEST_CASE(AquiferCTTest){
-    auto deck = createAquiferCTDeck();
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(AquiferCTTest)
+{
     {
-        auto aquiferct = init_aquiferct(deck);
-        for (const auto& it : aquiferct){
-            BOOST_CHECK_EQUAL(it.aquiferID , 1);
-            BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
-            BOOST_CHECK_EQUAL(it.inftableID , 2);
-            BOOST_CHECK(it.p0.first == true);
-            BOOST_CHECK_CLOSE(it.p0.second, 1.5e5, 1e-6);
+        const auto aquiferct = init_aquiferct(createAquiferCTDeck());
+        BOOST_REQUIRE_EQUAL(aquiferct.size(), 1U);
+
+        for (const auto& it : aquiferct) {
+            BOOST_CHECK_EQUAL(it.aquiferID, 1);
+            BOOST_CHECK_CLOSE(it.porosity, 0.3, 1.0e-8);
+            BOOST_CHECK_EQUAL(it.inftableID, 2);
+            BOOST_CHECK_MESSAGE(it.initial_pressure.has_value(), "Initial pressure must be defined in CT aquifer");
+            BOOST_CHECK_CLOSE(it.initial_pressure.value(), 1.5e5, 1e-6);
         }
-        BOOST_CHECK_EQUAL(aquiferct.size(), 1U);
     }
 
-    auto deck_default_p0 = createAquiferCTDeckDefaultP0();
     {
-        auto aquiferct = init_aquiferct(deck_default_p0);
-        for (const auto& it : aquiferct){
-            BOOST_CHECK_EQUAL(it.aquiferID , 1);
-            BOOST_CHECK_EQUAL(it.phi_aq , 0.3);
-            BOOST_CHECK_EQUAL(it.inftableID , 2);
-            BOOST_CHECK(it.p0.first == false);
+        const auto aquiferct = init_aquiferct(createAquiferCTDeckDefaultP0());
+        for (const auto& it : aquiferct) {
+            BOOST_CHECK_EQUAL(it.aquiferID, 1);
+            BOOST_CHECK_CLOSE(it.porosity, 0.3, 1.0e-8);
+            BOOST_CHECK_EQUAL(it.inftableID, 2);
+            BOOST_CHECK_MESSAGE(! it.initial_pressure.has_value(), "Initial pressure must NOT be defined in CT aquifer");
         }
+
         auto data = aquiferct.data();
         AquiferCT aq2(data);
         BOOST_CHECK( aq2 == aquiferct );
     }
 }
 
-inline Deck createAQUANCONDeck_DEFAULT_INFLUX2() {
-    const char *deckData =
-        "DIMENS\n"
-        "3 3 3 /\n"
-        "\n"
-        "GRID\n"
-        "\n"
-        "ACTNUM\n"
-        " 0 8*1 0 8*1 0 8*1 /\n"
-        "DXV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DYV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DZV\n"
-        "1 1 1 /\n"
-        "\n"
-        "TOPS\n"
-        "9*100 /\n"
-        "\n"
-        "PORO\n"
-        "  27*0.15 /\n"
-        "SOLUTION\n"
-        "\n"
-        "AQUANCON\n"
-        "   1      2  2  1    1   1  1  J-  1.0 /\n"
-        "   1      2  2  1    1   1  1  J-   /\n"
-        "/ \n";
+namespace {
 
-    Parser parser;
-    return parser.parseString(deckData);
+Deck createAQUANCONDeck_DEFAULT_INFLUX2()
+{
+    return Parser{}.parseString(R"(DIMENS
+3 3 3 /
+
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
+
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+SOLUTION
+AQUANCON
+   1      2  2  1    1   1  1  J-  1.0 /
+   1      2  2  1    1   1  1  J-   /
+/
+)");
 }
 
+Deck createAQUANCONDeck_DEFAULT_INFLUX1()
+{
+    return Parser{}.parseString(R"(DIMENS
+3 3 3 /
 
-inline Deck createAQUANCONDeck_DEFAULT_INFLUX1() {
-  const char *deckData =
-    "DIMENS\n"
-    "3 3 3 /\n"
-    "\n"
-    "GRID\n"
-    "\n"
-    "ACTNUM\n"
-    " 0 8*1 0 8*1 0 8*1 /\n"
-    "DXV\n"
-    "1 1 1 /\n"
-    "\n"
-    "DYV\n"
-    "1 1 1 /\n"
-    "\n"
-    "DZV\n"
-    "1 1 1 /\n"
-    "\n"
-    "TOPS\n"
-    "9*100 /\n"
-    "PORO\n"
-    "  27*0.15 /\n"
-    "\n"
-    "SOLUTION\n"
-    "\n"
-    "AQUANCON\n"
-    "   1      1  3  1    1   1  1  J-   /\n"
-    "/\n"
-    "AQUANCON\n"
-    "   2      1  1  2    2   1  1  J-   /\n"
-    "/ \n";
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
 
-  Parser parser;
-  return parser.parseString(deckData);
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+SOLUTION
+AQUANCON
+   1      1  3  1    1   1  1  J-   /
+/
+AQUANCON
+   2      1  1  2    2   1  1  J-   /
+/
+)");
 }
 
-inline Deck createAQUANCONDeck_DEFAULT_ILLEGAL() {
-    const char *deckData =
-        "DIMENS\n"
-        "3 3 3 /\n"
-        "\n"
-        "GRID\n"
-        "\n"
-        "ACTNUM\n"
-        " 0 8*1 0 8*1 0 8*1 /\n"
-        "DXV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DYV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DZV\n"
-        "1 1 1 /\n"
-        "\n"
-        "TOPS\n"
-        "9*100 /\n"
-        "PORO\n"
-        "  27*0.15 /\n"
-        "\n"
-        "SOLUTION\n"
-        "\n"
-        "AQUANCON\n"
-        "   1      1  3  1    1   1  1  J-   /\n"
-        "/\n"
-        "AQUANCON\n"
-        "   2      1  2  1    2   1  1  J-   /\n"
-        "/ \n";
+Deck createAQUANCONDeck_DEFAULT_ILLEGAL()
+{
+    return Parser{}.parseString(R"(DIMENS
+3 3 3 /
 
-    Parser parser;
-    return parser.parseString(deckData);
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
+
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+SOLUTION
+AQUANCON
+   1      1  3  1    1   1  1  J-   /
+/
+AQUANCON
+   2      1  2  1    2   1  1  J-   /
+/
+)");
 }
 
-inline Deck createAQUANCONDeck() {
-    const char *deckData =
-        "DIMENS\n"
-        "3 3 3 /\n"
-        "\n"
-        "GRID\n"
-        "\n"
-        "ACTNUM\n"
-        " 0 8*1 0 8*1 0 8*1 /\n"
-        "DXV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DYV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DZV\n"
-        "1 1 1 /\n"
-        "\n"
-        "TOPS\n"
-        "9*100 /\n"
-        "\n"
-        "PORO\n"
-        "  27*0.15 /\n"
-        "SOLUTION\n"
-        "\n"
-        "AQUANCON\n"
-        "   1      1  1  1    1   1  1  J-  1.0 1.0 NO /\n"
-        "   1      1  3  1    3   3  3  I+  0.5 1.0 NO /\n"
-        "   1      1  3  1    3   3  3  J+  0.75 1.0 NO /\n"
-        "   1      1  3  1    3   3  3  J-  2.75 1.0 NO /\n"
-        "   1      2  3  2    3   1  1  I+  2.75 1.0 NO /\n"
-        "/ \n";
+} // Anonymous namespace
 
-    Parser parser;
-    return parser.parseString(deckData);
-}
-
-
-
-
-BOOST_AUTO_TEST_CASE(AquanconTest_DEFAULT_INFLUX) {
+BOOST_AUTO_TEST_CASE(AquanconTest_DEFAULT_INFLUX)
+{
     auto deck1 = createAQUANCONDeck_DEFAULT_INFLUX1();
     const auto& grid = makeGrid();
     Aquancon aqcon(grid, deck1);
@@ -326,49 +297,53 @@ BOOST_AUTO_TEST_CASE(AquanconTest_DEFAULT_INFLUX) {
 
 
 // allowing aquifer exists inside the reservoir
-inline Deck createAQUANCONDeck_ALLOW_INSIDE_AQUAN_OR_NOT() {
-    const char *deckData =
-        "DIMENS\n"
-        "3 3 3 /\n"
-        "\n"
-        "GRID\n"
-        "\n"
-        "ACTNUM\n"
-        " 0 8*1 0 8*1 0 8*1 /\n"
-        "DXV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DYV\n"
-        "1 1 1 /\n"
-        "\n"
-        "DZV\n"
-        "1 1 1 /\n"
-        "\n"
-        "TOPS\n"
-        "9*100 /\n"
-        "\n"
-        "PORO\n"
-        "  27*0.15 /\n"
-        "SOLUTION\n"
-        "\n"
-        "AQUFETP\n"
-        "  1 20.0 1000.0 2000. 0.000001 200.0 /\n"
-        "  2 20.0 1000.0 2000. 0.000001 200.0 /\n"
-        "/\n"
-        "AQUANCON\n"
-        "   1      1  1   1   1   1  1  J-  2* YES /\n"
-        "   1      2  2   1   1   1  1  J-  2* YES /\n"
-        "   1      2  2   2   2   1  1  J-  2* YES /\n"
-        "   2      1  1   1   1   3  3  J-  2* NO /\n"
-        "   2      2  2   1   1   3  3  J-  2* NO /\n"
-        "   2      2  2   2   2   3  3  J-  2* NO /\n"
-        "/ \n";
 
-    Parser parser;
-    return parser.parseString(deckData);
+namespace {
+
+Deck createAQUANCONDeck_ALLOW_INSIDE_AQUAN_OR_NOT()
+{
+    return Parser{}.parseString(R"(DIMENS
+3 3 3 /
+
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
+
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+SOLUTION
+AQUFETP
+  1 20.0 1000.0 2000. 0.000001 200.0 /
+  2 20.0 1000.0 2000. 0.000001 200.0 /
+/
+AQUANCON
+   1      1  1   1   1   1  1  J-  2* YES /
+   1      2  2   1   1   1  1  J-  2* YES /
+   1      2  2   2   2   1  1  J-  2* YES /
+   2      1  1   1   1   3  3  J-  2* NO /
+   2      2  2   1   1   3  3  J-  2* NO /
+   2      2  2   2   2   3  3  J-  2* NO /
+/
+)");
 }
 
-BOOST_AUTO_TEST_CASE(AquanconTest_ALLOW_AQUIFER_INSIDE_OR_NOT) {
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(AquanconTest_ALLOW_AQUIFER_INSIDE_OR_NOT)
+{
     auto deck = createAQUANCONDeck_ALLOW_INSIDE_AQUAN_OR_NOT();
     const EclipseState eclState( deck );
     const Aquancon aqucon( eclState.getInputGrid(), deck);
@@ -383,161 +358,175 @@ BOOST_AUTO_TEST_CASE(AquanconTest_ALLOW_AQUIFER_INSIDE_OR_NOT) {
     BOOST_CHECK_EQUAL(cells2.size() , 1U);
 }
 
-inline Deck createAquifetpDeck() {
-  const char *deckData =
-  "DIMENS\n"
-  "3 3 3 /\n"
-  "\n"
-  "AQUDIMS\n"
-  "1* 1* 2 100 1 1000 /\n"
-  "GRID\n"
-  "\n"
-  "ACTNUM\n"
-  " 0 8*1 0 8*1 0 8*1 /\n"
-  "DXV\n"
-  "1 1 1 /\n"
-  "\n"
-  "DYV\n"
-  "1 1 1 /\n"
-  "\n"
-  "DZV\n"
-  "1 1 1 /\n"
-  "\n"
-  "TOPS\n"
-  "9*100 /\n"
-  "\n"
-  "PROPS\n"
-  "AQUTAB\n"
-  " 0.01 0.112 \n"
-  " 0.05 0.229 /\n"
-  "SOLUTION\n"
-  "\n"
-  "AQUFETP\n"
-  "1  70000.0  4.0e3 2.0e9 1.0e-5	500 1 0	0 /\n"
-  "/\n";
+namespace {
 
-  Parser parser;
-  return parser.parseString(deckData);
+Deck createAquifetpDeck()
+{
+    return Parser{}.parseString(R"(RUNSPEC
+DIMENS
+3 3 3 /
+
+AQUDIMS
+1* 1* 2 100 1 1000 /
+
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
+
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+PROPS
+AQUTAB
+ 0.01 0.112
+ 0.05 0.229 /
+
+SOLUTION
+AQUFETP
+1  70000.0  4.0e3 2.0e9 1.0e-5	500 1 0	0 /
+/
+)");
 }
 
-inline Deck createNullAquifetpDeck(){
-  const char *deckData =
-  "DIMENS\n"
-  "3 3 3 /\n"
-  "\n"
-  "AQUDIMS\n"
-  "1* 1* 2 100 1 1000 /\n"
-  "GRID\n"
-  "\n"
-  "ACTNUM\n"
-  " 0 8*1 0 8*1 0 8*1 /\n"
-  "DXV\n"
-  "1 1 1 /\n"
-  "\n"
-  "DYV\n"
-  "1 1 1 /\n"
-  "\n"
-  "DZV\n"
-  "1 1 1 /\n"
-  "\n"
-  "TOPS\n"
-  "9*100 /\n"
-  "\n"
-  "PROPS\n"
-  "AQUTAB\n"
-  " 0.01 0.112 \n"
-  " 0.05 0.229 /\n"
-  "SOLUTION\n"
-  ;
+Deck createNullAquifetpDeck()
+{
+    return Parser{}.parseString(R"(RUNSPEC
+DIMENS
+3 3 3 /
 
-  Parser parser;
-  return parser.parseString(deckData);
+AQUDIMS
+1* 1* 2 100 1 1000 /
+
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
+
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+PROPS
+AQUTAB
+ 0.01 0.112
+ 0.05 0.229 /
+
+SOLUTION
+)");
 }
 
-inline Deck createAquifetpDeck_defaultPressure(){
-  const char *deckData =
-  "DIMENS\n"
-  "3 3 3 /\n"
-  "\n"
-  "AQUDIMS\n"
-  "1* 1* 2 100 1 1000 /\n"
-  "GRID\n"
-  "\n"
-  "ACTNUM\n"
-  " 0 8*1 0 8*1 0 8*1 /\n"
-  "DXV\n"
-  "1 1 1 /\n"
-  "\n"
-  "DYV\n"
-  "1 1 1 /\n"
-  "\n"
-  "DZV\n"
-  "1 1 1 /\n"
-  "\n"
-  "TOPS\n"
-  "9*100 /\n"
-  "\n"
-  "PROPS\n"
-  "AQUTAB\n"
-  " 0.01 0.112 \n"
-  " 0.05 0.229 /\n"
-  "SOLUTION\n"
-  "\n"
-  "AQUFETP\n"
-  "1  70000.0  1* 2.0e9 1.0e-5	500 1 0	0 /\n"
-  "/\n";
+Deck createAquifetpDeck_defaultPressure()
+{
+    return Parser{}.parseString(R"(DIMENS
+3 3 3 /
 
-  Parser parser;
-  return parser.parseString(deckData);
+AQUDIMS
+1* 1* 2 100 1 1000 /
+
+GRID
+ACTNUM
+ 0 8*1 0 8*1 0 8*1 /
+
+DXV
+1 1 1 /
+
+DYV
+1 1 1 /
+
+DZV
+1 1 1 /
+
+TOPS
+  9*100 /
+
+PORO
+  27*0.15 /
+
+PROPS
+AQUTAB
+ 0.01 0.112
+ 0.05 0.229 /
+
+SOLUTION
+AQUFETP
+1  70000.0  1* 2.0e9 1.0e-5	500 1 0	0 /
+/
+)");
 }
 
-inline Aquifetp init_aquifetp(Deck& deck){
-  Aquifetp aqufetp(deck);
-  return aqufetp;
+Aquifetp init_aquifetp(Deck& deck)
+{
+    return { TableManager{ deck }, deck };
 }
 
-BOOST_AUTO_TEST_CASE(AquifetpTest){
-  auto aqufetp_deck = createAquifetpDeck();
-  const auto& aquifetp = init_aquifetp(aqufetp_deck);
-  for (const auto& it : aquifetp){
-    BOOST_CHECK_EQUAL(it.aquiferID , 1);
-    BOOST_CHECK_EQUAL(it.V0, 2.0e9);
-    BOOST_CHECK_EQUAL(it.J, 500/86400e5);
-    BOOST_CHECK( it.p0.first );
-  }
-  const auto& data = aquifetp.data();
-  Aquifetp aq2(data);
-  BOOST_CHECK(aq2 == aquifetp);
+} // Anonymous namespace
 
-  auto aqufetp_deck_null = createNullAquifetpDeck();
-  const auto& aquifetp_null = init_aquifetp(aqufetp_deck_null);
-  BOOST_CHECK_EQUAL(aquifetp_null.size(), 0U);
+BOOST_AUTO_TEST_CASE(AquifetpTest)
+{
+    auto aqufetp_deck = createAquifetpDeck();
+    const auto& aquifetp = init_aquifetp(aqufetp_deck);
+    for (const auto& it : aquifetp) {
+        BOOST_CHECK_EQUAL(it.aquiferID, 1);
+        BOOST_CHECK_CLOSE(it.initial_watvolume, 2.0e9, 1.0e-8);
+        BOOST_CHECK_CLOSE(it.prod_index, 500/86400e5, 1.0e-8);
+        BOOST_CHECK_MESSAGE(it.initial_pressure.has_value(), "Fetkovich aquifer must have initial pressure value");
+    }
+    const auto& data = aquifetp.data();
+    Aquifetp aq2(data);
+    BOOST_CHECK_MESSAGE(aq2 == aquifetp, "Copy constructor must produce equal object");
 
-  auto aqufetp_deck_default = createAquifetpDeck_defaultPressure();
-  const auto& aquifetp_default = init_aquifetp(aqufetp_deck_default);
-  for (const auto& it : aquifetp_default){
-    BOOST_CHECK_EQUAL(it.aquiferID , 1);
-    BOOST_CHECK_EQUAL(it.V0, 2.0e9);
-    BOOST_CHECK_EQUAL(it.J, 500/86400e5);
-    BOOST_CHECK( !it.p0.first );
-  }
+    auto aqufetp_deck_null = createNullAquifetpDeck();
+    const auto& aquifetp_null = init_aquifetp(aqufetp_deck_null);
+    BOOST_CHECK_EQUAL(aquifetp_null.size(), 0U);
 
+    auto aqufetp_deck_default = createAquifetpDeck_defaultPressure();
+    const auto& aquifetp_default = init_aquifetp(aqufetp_deck_default);
+    for (const auto& it : aquifetp_default) {
+        BOOST_CHECK_EQUAL(it.aquiferID, 1);
+        BOOST_CHECK_CLOSE(it.initial_watvolume, 2.0e9, 1.0e-8);
+        BOOST_CHECK_CLOSE(it.prod_index, 500/86400e5, 1.0e-8);
+        BOOST_CHECK_MESSAGE(!it.initial_pressure.has_value(), "Fetkovich aquifer mut NOT have initial pressure value when defaulted");
+    }
 }
 
-BOOST_AUTO_TEST_CASE(TEST_CREATE) {
-      Opm::Aqudims aqudims;
+BOOST_AUTO_TEST_CASE(TEST_CREATE)
+{
+    Opm::Aqudims aqudims;
 
-      BOOST_CHECK_EQUAL( aqudims.getNumAqunum() , 1U );
-      BOOST_CHECK_EQUAL( aqudims.getNumConnectionNumericalAquifer() , 1U );
-      BOOST_CHECK_EQUAL( aqudims.getNumInfluenceTablesCT() , 1U );
-      BOOST_CHECK_EQUAL( aqudims.getNumRowsInfluenceTable() , 36U );
-      BOOST_CHECK_EQUAL( aqudims.getNumAnalyticAquifers() , 1U );
-      BOOST_CHECK_EQUAL( aqudims.getNumRowsAquancon() , 1U );
-      BOOST_CHECK_EQUAL( aqudims.getNumAquiferLists() , 0U );
-      BOOST_CHECK_EQUAL( aqudims.getNumAnalyticAquifersSingleList() , 0U );
+    BOOST_CHECK_EQUAL( aqudims.getNumAqunum() , 1U );
+    BOOST_CHECK_EQUAL( aqudims.getNumConnectionNumericalAquifer() , 1U );
+    BOOST_CHECK_EQUAL( aqudims.getNumInfluenceTablesCT() , 1U );
+    BOOST_CHECK_EQUAL( aqudims.getNumRowsInfluenceTable() , 36U );
+    BOOST_CHECK_EQUAL( aqudims.getNumAnalyticAquifers() , 1U );
+    BOOST_CHECK_EQUAL( aqudims.getNumRowsAquancon() , 1U );
+    BOOST_CHECK_EQUAL( aqudims.getNumAquiferLists() , 0U );
+    BOOST_CHECK_EQUAL( aqudims.getNumAnalyticAquifersSingleList() , 0U );
 }
 
-BOOST_AUTO_TEST_CASE(Test_Aquifer_Config) {
+BOOST_AUTO_TEST_CASE(Test_Aquifer_Config)
+{
     const std::string deck_string = R"(
 DIMENS
    3 3 3 /
@@ -667,7 +656,10 @@ END
     }
 }
 
-inline Deck createNumericalAquiferDeck() {
+namespace {
+
+Deck createNumericalAquiferDeck()
+{
     const char *deckData = R"(
 DIMENS
  8 15 3 /
@@ -713,7 +705,10 @@ AQUCON
     return parser.parseString(deckData);
 }
 
-BOOST_AUTO_TEST_CASE(NumericalAquiferTest){
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(NumericalAquiferTest)
+{
     const Opm::Deck numaquifer_deck = createNumericalAquiferDeck();
     const Opm::EclipseState ecl_state(numaquifer_deck);
     const Opm::EclipseGrid& grid = ecl_state.getInputGrid();
@@ -838,8 +833,10 @@ BOOST_AUTO_TEST_CASE(NumericalAquiferTest){
     BOOST_CHECK_CLOSE(poro[3], 0.25, 1.e-10);
 }
 
+namespace {
 
-std::pair<Opm::Aquancon, Opm::EclipseGrid> load_aquifer(const std::string& aqucon) {
+std::pair<Opm::Aquancon, Opm::EclipseGrid> load_aquifer(const std::string& aqucon)
+{
     const std::string data1 = R"(
 DIMENS
  8 15 3 /
@@ -882,9 +879,10 @@ AQUNUM
     return { Opm::Aquancon(grid, deck), grid };
 }
 
+} // Anonymous namespace
 
-
-BOOST_AUTO_TEST_CASE(AQUCONN_FUNKYNESS ) {
+BOOST_AUTO_TEST_CASE(AQUCONN_FUNKYNESS )
+{
    {
        const std::string aq = R"(
 AQUANCON
@@ -947,5 +945,4 @@ AQUANCON
        auto cell1 = aquconn[1][0];
        BOOST_CHECK_EQUAL(cell1.influx_coeff, 2*(77 + 3*(0 + 4*100)));
    }
-
 }


### PR DESCRIPTION
This PR switches to using the simulator's notion of initial aquifer pressure, aquifer mass density of water, aquifer water viscosity, and aquifer time constants.  These values will, ultimately, come from the `*_data` structures for the analytic aquifers but the simulator is the only system that is able to compute equilibrated initial pressure values if that is defaulted in the input.

To this end, rename various data members of the `*_data` structures to aid the reader who may not be intimately familiar with the details of the analytic models.  We switch the `initial_pressure` into an `optional<double>` instead of a `pair<bool,double>` with `std::nullopt` representing defaulted initial aquifer pressure values in the input file.

We also add logic and private data members to compute/store aquifer time constants, mass density of water, water viscosity and, in the case of Carter-Tracy aquifers, also the influx constant `beta`. This centralises the requisite logic which reduces the risk of subtle errors.

In the case of defaulted initial pressures, we support deferred calculation of aquifer properties until the equilibrium pressure is known.  Users are then expected to assign a value to the initial pressure members and call `finishInitialisation()` to derive those properties.

While here, also switch to using raw string literals instead of concatenated and escaped literals for the embedded deck strings in
the `ParserTests`.