### PR TITLE
Output Summary for all Numeric Aquifers When ID Defaulted

### DIFF
--- a/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
@@ -71,6 +71,8 @@ private:
     Aquancon aqconn;
 };
 
+std::vector<int> analyticAquiferIDs(const AquiferConfig& cfg);
+std::vector<int> numericAquiferIDs(const AquiferConfig& cfg);
 }
 
 #endif

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -3604,15 +3604,7 @@ configureRequiredRestartParameters(const SummaryConfig& sumcfg,
         makeEvaluator(node);
 
     if (aqConfig.hasAnalyticalAquifer()) {
-        auto aquiferIDs = std::vector<int>{};
-
-        for (const auto& aquifer : aqConfig.ct())
-            aquiferIDs.push_back(aquifer.aquiferID);
-
-        for (const auto& aquifer : aqConfig.fetp())
-            aquiferIDs.push_back(aquifer.aquiferID);
-
-        std::sort(aquiferIDs.begin(), aquiferIDs.end());
+        const auto aquiferIDs = analyticAquiferIDs(aqConfig);
 
         for (const auto& node : requiredAquiferVectors(aquiferIDs))
             makeEvaluator(node);

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -22,6 +22,8 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
+#include <algorithm>
+
 namespace Opm {
 
 AquiferConfig::AquiferConfig(const TableManager& tables, const EclipseGrid& grid,
@@ -99,4 +101,39 @@ bool AquiferConfig::hasAnalyticalAquifer() const {
            this->aquifetp.size() > 0;
 }
 
+}
+
+std::vector<int> Opm::analyticAquiferIDs(const AquiferConfig& cfg)
+{
+    auto aquiferIDs = std::vector<int>{};
+
+    if (! cfg.hasAnalyticalAquifer())
+        return aquiferIDs;
+
+    for (const auto& aquifer : cfg.ct())
+        aquiferIDs.push_back(aquifer.aquiferID);
+
+    for (const auto& aquifer : cfg.fetp())
+        aquiferIDs.push_back(aquifer.aquiferID);
+
+    std::sort(aquiferIDs.begin(), aquiferIDs.end());
+
+    return aquiferIDs;
+}
+
+std::vector<int> Opm::numericAquiferIDs(const AquiferConfig& cfg)
+{
+    auto aquiferIDs = std::vector<int>{};
+
+    if (! cfg.hasNumericalAquifer())
+        return aquiferIDs;
+
+    const auto& aqunum = cfg.numericalAquifers();
+
+    for (const auto& aq : aqunum.aquifers())
+        aquiferIDs.push_back(static_cast<int>(aq.first));
+
+    std::sort(aquiferIDs.begin(), aquiferIDs.end());
+
+    return aquiferIDs;
 }


### PR DESCRIPTION
This PR extends the `SummaryConfig` aquifer processing to recognize numeric aquifer keywords without an explicit list of aquifer IDs, i.e., summary keywords of the form
```
ANQR
/
```
To this end, we add new helper functions `{analytic,numeric}AquiferIDs()` which form lists of pertinent IDs.  We then ensure that we create nodes only for proper subsets of these ID sets.

Add unit tests to both the analytic and numeric configurations to ensure that we generate these output sets or input errors when the input file refers to IDs of incorrect type or out of range.