### PR TITLE
Add 'empty' Predicate to DeckKeyword Type

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -54,6 +54,7 @@ namespace Opm {
 
 
         size_t size() const;
+        bool empty() const;
         void addRecord(DeckRecord&& record);
         const DeckRecord& getRecord(size_t index) const;
         DeckRecord& getRecord(size_t index);

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -227,6 +227,9 @@ namespace Opm {
         return m_recordList.size();
     }
 
+    bool DeckKeyword::empty() const {
+        return this->m_recordList.empty();
+    }
 
     void DeckKeyword::addRecord(DeckRecord&& record) {
         this->m_recordList.push_back( std::move( record ) );

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -447,7 +447,7 @@ inline void keywordAquifer( SummaryConfig::keyword_list& list,
     .parameterType( parseKeywordType(keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
 
-    if (keyword.size() && keyword.getDataRecord().getDataItem().hasValue(0)) {
+    if (!keyword.empty() && keyword.getDataRecord().getDataItem().hasValue(0)) {
         for( const int id: keyword.getIntData()) {
             if (aquiferConfig.hasAquifer(id)) {
                 list.push_back(param.number(id));
@@ -580,7 +580,7 @@ inline void keywordW( SummaryConfig::keyword_list& list,
     .parameterType( parseKeywordType(keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
 
-    if (keyword.size() && keyword.getDataRecord().getDataItem().hasValue(0)) {
+    if (!keyword.empty() && keyword.getDataRecord().getDataItem().hasValue(0)) {
         for( const std::string& pattern : keyword.getStringData()) {
           auto well_names = schedule.wellNames( pattern, schedule.size() - 1 );
 
@@ -624,7 +624,7 @@ inline void keywordG( SummaryConfig::keyword_list& list,
     .parameterType( parseKeywordType(keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
 
-    if( keyword.size() == 0 ||
+    if( keyword.empty() ||
         !keyword.getDataRecord().getDataItem().hasValue( 0 ) ) {
 
         for( const auto& group : schedule.groupNames() ) {
@@ -664,7 +664,7 @@ void keyword_node( SummaryConfig::keyword_list& list,
     .parameterType( parseKeywordType(keyword.name()) )
     .isUserDefined( is_udq(keyword.name()) );
 
-    if( keyword.size() == 0 ||
+    if( keyword.empty() ||
         !keyword.getDataRecord().getDataItem().hasValue( 0 ) ) {
 
         for (const auto& node_name : node_names) {
@@ -1065,7 +1065,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
 
         const auto last_timestep = schedule.size() - 1;
 
-        if (keyword.size() > 0) {
+        if (! keyword.empty()) {
             // Keyword with explicit records.
             // Handle as alternatives SOFR and SPR above
             keywordSWithRecords(last_timestep, parseContext, errors,

--- a/tests/parser/DeckValueTests.cpp
+++ b/tests/parser/DeckValueTests.cpp
@@ -100,6 +100,7 @@ BOOST_AUTO_TEST_CASE(DeckKeywordConstructor) {
     DeckKeyword deck_kw(addreg, {record}, unit_active, unit_default);
 
     BOOST_CHECK_EQUAL( deck_kw.size(), 1U );
+    BOOST_CHECK_MESSAGE( !deck_kw.empty(), "Deck keyword must not be empty" );
 
     const DeckRecord& deck_record = deck_kw.getRecord(0);
     BOOST_CHECK_EQUAL( deck_record.size(), 4U );


### PR DESCRIPTION
Makes logic statements more explicit and removes a number of "signed vs. unsigned" comparison operations.