### PR TITLE
Add Restart Output for Numeric Aquifers

### DIFF
--- a/opm/output/eclipse/AggregateAquiferData.hpp
+++ b/opm/output/eclipse/AggregateAquiferData.hpp
@@ -112,6 +112,18 @@ namespace Opm { namespace RestartIO { namespace Helpers {
             return this->doubleprecAnalyticAq_.data();
         }
 
+        /// Retrieve Integer Aquifer Data Array for Numeric Aquifers.
+        const std::vector<int>& getNumericAquiferIntegerData() const
+        {
+            return this->integerNumericAq_.data();
+        }
+
+        /// Retrieve Double Precision Aquifer Data Array for Numeric Aquifers.
+        const std::vector<double>& getNumericAquiferDoublePrecData() const
+        {
+            return this->doubleprecNumericAq_.data();
+        }
+
         /// Retrieve Integer Aquifer Connection Data Array (analytic aquifers)
         ///
         /// \param[in] aquiferID Aquifer for which to retrieve integer
@@ -159,6 +171,12 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 
         /// Aggregate 'XAAQ' array (Double Precision) for all analytic aquifers.
         WindowedArray<double> doubleprecAnalyticAq_;
+
+        /// Aggregate 'IAQN' array (integer) for all numeric aquifers.
+        WindowedArray<int> integerNumericAq_;
+
+        /// Aggregate 'RAQN' array (Double Precision) for all numeric aquifers.
+        WindowedArray<double> doubleprecNumericAq_;
 
         /// Aggregate ICAQ array (Integer) for all analytic aquifer
         /// connections.  Separate array for each aquifer.

--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -154,6 +154,9 @@ namespace Opm { namespace RestartIO {
             // Maximum aquifer ID across all of the model's analytic aquifers.
             int maxAquiferID {0};
 
+            // Number of numeric aquifer records (lines of AQUNUM data)
+            int numNumericAquiferRecords {0};
+
             // Number of data elements per aquifer in IAAQ array.
             int numIntAquiferElem {18};
 
@@ -162,6 +165,12 @@ namespace Opm { namespace RestartIO {
 
             // Number of data elements per aquifer in XAAQ array.
             int numDoubAquiferElem {10};
+
+            // Number of data elements in IAQN array per numeric aquifer record.
+            int numNumericAquiferIntElem {10};
+
+            // Number of data elements in RAQN array per numeric aquifer record.
+            int numNumericAquiferDoubleElem {13};
 
             // Number of data elements per coonnection in ICAQ array.
             int numIntConnElem {7};

--- a/opm/output/eclipse/VectorItems/aquifer.hpp
+++ b/opm/output/eclipse/VectorItems/aquifer.hpp
@@ -60,6 +60,38 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
        } // Value
    } // IAnalyticAquiferConn
 
+    namespace INumericAquifer {
+        enum index : std::vector<int>::size_type {
+            AquiferID = 0,      // ID of numeric aquifer
+            Cell_I = 1,         // I coordinate of aquifer cell
+            Cell_J = 2,         // J coordinate of aquifer cell
+            Cell_K = 3,         // K coordinate of aquifer cell
+            PVTTableID = 4,     // PVT Table ID of numeric aquifer
+            SatFuncID = 5,      // Saturation function ID of numeric aquifer
+        };
+    } // INumericAquifer
+
+    namespace RNumericAquifer {
+        enum index : std::vector<double>::size_type {
+            Area = 0,           // Aquifer inflow area, AQUNUM(5)
+            Length = 1,         // Aquifer length, AQUNUM(6)
+            Porosity = 2,       // Aquifer porosity, AQUNUM(7)
+            Permeability = 3,   // Aquifer permeability, AQUNUM(8)
+            Depth = 4,          // Aquifer depth, AQUNUM(9)
+            Pressure = 5,       // Aquifer pressure, AQUNUM(10)
+
+            Unknown_1 = 6,      // Unknown item, = 1.0
+            Unknown_2 = 7,      // Unknown item, = 1.0
+            Unknown_3 = 8,      // Unknown item, = 1.0
+
+            PoreVolume = 9,     // Total aquifer pore-volume (= Area * Length * Porosity)
+
+            FlowRate = 10,      // Aquifer inflow rate (ANQR:N)
+            ProdVolume = 11,    // Total liquid volume produced from aquifer (AQNT:N)
+            DynPressure = 12,   // Dynamic aquifer pressure (ANQP:N)
+        };
+    } // RNumericAquifer
+
     namespace SAnalyticAquifer {
         enum index : std::vector<float>::size_type {
             Compressibility = 0, // Total aquifer compressibility (AQUCT(6), AQUFETP(5))

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -141,6 +141,11 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         
         WSEGITR_IT2 = 208, // NR - maximum no of times that a new iteration cycle with a reduced Wp will be started
 
+        NIIAQN = 223, // Number of data elements in IAQN array pr AQUNUM record
+        NIRAQN = 224, // Number of data elements in RAQN array pr AQUNUM record
+
+        NUM_AQUNUM_RECORDS = 226, // Number of AQUNUM records (lines of AQUNUM data)
+
         MAX_ACT_COND = 245, //  Maximum number of conditions pr action
         MAX_AN_AQUIFER_ID = 252, // Maximum aquifer ID of all analytic aquifers (<= AQUDIMS(5))
 

--- a/src/opm/output/eclipse/AggregateAquiferData.cpp
+++ b/src/opm/output/eclipse/AggregateAquiferData.cpp
@@ -51,6 +51,15 @@
 namespace VI = Opm::RestartIO::Helpers::VectorItems;
 
 namespace {
+    double getSummaryVariable(const Opm::SummaryState& summaryState,
+                              const std::string&       variable,
+                              const int                aquiferID)
+    {
+        const auto key = fmt::format("{}:{}", variable, aquiferID);
+
+        return summaryState.get(key, 0.0);
+    }
+
     template <typename AquiferCallBack>
     void CarterTracyAquiferLoop(const Opm::AquiferConfig& aqConfig,
                                 AquiferCallBack&&         aquiferOp)
@@ -66,6 +75,24 @@ namespace {
     {
         for (const auto& aqData : aqConfig.fetp()) {
             aquiferOp(aqData);
+        }
+    }
+
+    template <typename AquiferCallBack>
+    void numericAquiferLoop(const Opm::AquiferConfig& aqConfig,
+                            AquiferCallBack&&         aquiferOp)
+    {
+        if (! aqConfig.hasNumericalAquifer()) {
+            return;
+        }
+
+        for (const auto& [aquiferID, aquifer] : aqConfig.numericalAquifers().aquifers()) {
+            const auto numCells = aquifer.numCells();
+
+            for (auto cellIndex = 0*numCells; cellIndex < numCells; ++cellIndex) {
+                const auto* aqCell = aquifer.getCellPrt(cellIndex);
+                aquiferOp(static_cast<int>(aquiferID), cellIndex == 0*numCells, *aqCell);
+            }
         }
     }
 
@@ -138,6 +165,37 @@ namespace {
             }
         } // Fetckovich
     } // IntegerAnalyticAquifer
+
+    namespace IntegerNumericAquifer
+    {
+        Opm::RestartIO::Helpers::WindowedArray<int>
+        allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
+        {
+            using WA = Opm::RestartIO::Helpers::WindowedArray<int>;
+
+            return WA {
+                WA::NumWindows{ static_cast<WA::Idx>(aqDims.numNumericAquiferRecords) },
+                WA::WindowSize{ static_cast<WA::Idx>(aqDims.numNumericAquiferIntElem) }
+            };
+        }
+
+        template <typename IAqnArray>
+        void staticContrib(const Opm::NumericalAquiferCell& aqCell,
+                           const int                        aquiferID,
+                           IAqnArray&                       iaqn)
+        {
+            using Ix = VI::INumericAquifer::index;
+
+            iaqn[Ix::AquiferID] = aquiferID;
+
+            iaqn[Ix::Cell_I] = static_cast<int>(aqCell.I) + 1;
+            iaqn[Ix::Cell_J] = static_cast<int>(aqCell.J) + 1;
+            iaqn[Ix::Cell_K] = static_cast<int>(aqCell.K) + 1;
+
+            iaqn[Ix::PVTTableID] = aqCell.pvttable;
+            iaqn[Ix::SatFuncID] = aqCell.sattable;
+        }
+    } // IntegerNumericAquifer
 
     namespace IntegerAnalyticAquiferConn
     {
@@ -311,15 +369,6 @@ namespace {
             return usys.from_si(M::length, usys.from_si(M::length, tot_influx));
         }
 
-        double getSummaryVariable(const Opm::SummaryState& summaryState,
-                                  const std::string&       variable,
-                                  const int                aquiferID)
-        {
-            const auto key = fmt::format("{}:{}", variable, aquiferID);
-
-            return summaryState.get(key, 0.0);
-        }
-
         Opm::RestartIO::Helpers::WindowedArray<double>
         allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
         {
@@ -395,6 +444,50 @@ namespace {
         } // Fetkovich
     } // DoublePrecAnalyticAquifer
 
+    namespace DoublePrecNumericAquifer
+    {
+        Opm::RestartIO::Helpers::WindowedArray<double>
+        allocate(const Opm::RestartIO::InteHEAD::AquiferDims& aqDims)
+        {
+            using WA = Opm::RestartIO::Helpers::WindowedArray<double>;
+
+            return WA {
+                WA::NumWindows{ static_cast<WA::Idx>(aqDims.numNumericAquiferRecords) },
+                WA::WindowSize{ static_cast<WA::Idx>(aqDims.numNumericAquiferDoubleElem) }
+            };
+        }
+
+        template <typename SummaryVariable, typename RAqnArray>
+        void dynamicContrib(const Opm::NumericalAquiferCell& aqCell,
+                            SummaryVariable&&                summaryVariable,
+                            const Opm::UnitSystem&           usys,
+                            RAqnArray&                       raqn)
+        {
+            using M = Opm::UnitSystem::measure;
+            using Ix = VI::RNumericAquifer::index;
+
+            raqn[Ix::Area] = usys.from_si(M::length, usys.from_si(M::length, aqCell.area));
+            raqn[Ix::Length] = usys.from_si(M::length, aqCell.length);
+            raqn[Ix::Porosity] = aqCell.porosity;
+            raqn[Ix::Permeability] = usys.from_si(M::permeability, aqCell.permeability);
+            raqn[Ix::Depth] = usys.from_si(M::length, aqCell.depth);
+
+            if (aqCell.init_pressure.has_value()) {
+                raqn[Ix::Pressure] = usys.from_si(M::pressure, aqCell.init_pressure.value());
+            }
+
+            raqn[Ix::Unknown_1] = 1.0; // Unknown item.  1.0 in all cases so far.
+            raqn[Ix::Unknown_2] = 1.0; // Unknown item.  1.0 in all cases so far.
+            raqn[Ix::Unknown_3] = 1.0; // Unknown item.  1.0 in all cases so far.
+
+            raqn[Ix::PoreVolume] = usys.from_si(M::volume, aqCell.poreVolume());
+
+            raqn[Ix::FlowRate]    = summaryVariable("ANQR");
+            raqn[Ix::ProdVolume]  = summaryVariable("ANQT");
+            raqn[Ix::DynPressure] = summaryVariable("ANQP");
+        }
+    } // IntegerNumericAquifer
+
     namespace DoublePrecAnalyticAquiferConn
     {
         std::vector<Opm::RestartIO::Helpers::WindowedArray<double>>
@@ -420,10 +513,16 @@ AggregateAquiferData(const InteHEAD::AquiferDims& aqDims,
     , integerAnalyticAq_            { IntegerAnalyticAquifer::       allocate(aqDims) }
     , singleprecAnalyticAq_         { SinglePrecAnalyticAquifer::    allocate(aqDims) }
     , doubleprecAnalyticAq_         { DoublePrecAnalyticAquifer::    allocate(aqDims) }
+    , integerNumericAq_             { IntegerNumericAquifer::        allocate(aqDims) }
+    , doubleprecNumericAq_          { DoublePrecNumericAquifer::     allocate(aqDims) }
     , integerAnalyticAquiferConn_   { IntegerAnalyticAquiferConn::   allocate(aqDims) }
     , singleprecAnalyticAquiferConn_{ SinglePrecAnalyticAquiferConn::allocate(aqDims) }
     , doubleprecAnalyticAquiferConn_{ DoublePrecAnalyticAquiferConn::allocate(aqDims) }
 {
+    if (! aqConfig.hasAnalyticalAquifer()) {
+        return;
+    }
+
     const auto map = buildColumnarActiveIndexMappingTables(grid);
 
     // Aquifer connections do not change in SCHEDULE.  Leverage that
@@ -472,8 +571,7 @@ captureDynamicdAquiferData(const AquiferConfig& aqConfig,
         const auto tot_influx = this->totalInflux_[aquIndex];
         auto sumVar = [&summaryState, &aquifer](const std::string& vector)
         {
-            return DoublePrecAnalyticAquifer::
-                getSummaryVariable(summaryState, vector, aquifer.aquiferID);
+            return getSummaryVariable(summaryState, vector, aquifer.aquiferID);
         };
         DoublePrecAnalyticAquifer::Fetkovich::dynamicContrib(sumVar, tot_influx, usys, xaaq);
     });
@@ -498,10 +596,23 @@ captureDynamicdAquiferData(const AquiferConfig& aqConfig,
         const auto tot_influx = this->totalInflux_[aquIndex];
         auto sumVar = [&summaryState, &aquifer](const std::string& vector)
         {
-            return DoublePrecAnalyticAquifer::
-                getSummaryVariable(summaryState, vector, aquifer.aquiferID);
+            return getSummaryVariable(summaryState, vector, aquifer.aquiferID);
         };
         DoublePrecAnalyticAquifer::CarterTracy::dynamicContrib(sumVar, aquifer, pvtw,
                                                                tot_influx, usys, xaaq);
+    });
+
+    numericAquiferLoop(aqConfig, [this, &summaryState, &usys]
+        (const int aquiferID, const bool isNewID, const NumericalAquiferCell& aqCell)
+    {
+        auto iaqn = this->integerNumericAq_[aqCell.record_id];
+        IntegerNumericAquifer::staticContrib(aqCell, aquiferID, iaqn);
+
+        auto raqn = this->doubleprecNumericAq_[aqCell.record_id];
+        auto sumVar = [&summaryState, aquiferID, isNewID](const std::string& vector)
+        {
+            return !isNewID ? 0.0 : getSummaryVariable(summaryState, vector, aquiferID);
+        };
+        DoublePrecNumericAquifer::dynamicContrib(aqCell, sumVar, usys, raqn);
     });
 }

--- a/src/opm/output/eclipse/EclipseIO.cpp
+++ b/src/opm/output/eclipse/EclipseIO.cpp
@@ -131,10 +131,12 @@ EclipseIO::Impl::Impl( const EclipseState& eclipseState,
     , summary( eclipseState, summaryConfig, grid , schedule )
     , output_enabled( eclipseState.getIOConfig().getOutputEnabled() )
 {
-    if (this->es.aquifer().hasAnalyticalAquifer()) {
+    const auto& aqConfig = this->es.aquifer();
+
+    if (aqConfig.hasAnalyticalAquifer() || aqConfig.hasNumericalAquifer()) {
         this->aquiferData = RestartIO::Helpers::AggregateAquiferData {
             RestartIO::inferAquiferDimensions(this->es),
-            this->es.aquifer(),
+            aqConfig,
             this->grid
         };
     }

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -271,10 +271,10 @@ enum index : std::vector<int>::size_type {
   ih_220       =      220       ,              //       0
   ih_221       =      221       ,              //       0
   ih_222       =      222       ,              //       0
-  NIIAQN       =      223       ,              //       0                     NIIAQN = number of lines of integer AQUNUM data.
-  NIRAQN       =      224       ,              //       0                     NIRAQN = number of lines of real AQUNUM data.
+  NIIAQN       =      VI::intehead::NIIAQN,    //       0                     NIIAQN = Number of integer data elements in IAQN array pr. numeric aquifer record in AQUNUM.
+  NIRAQN       =      VI::intehead::NIRAQN,    //       0                     NIRAQN = number of double precision data elements in RAQN array pr. numeric aquifer record in AQUNUM.
   ih_225       =      225       ,              //       0
-  NUMAQN       =      226       ,              //       0                     NUMAQN = number of lines of AQUNUM data entered.
+  NUMAQN       =      VI::intehead::NUM_AQUNUM_RECORDS, // 0                  NUMAQN = number of lines of AQUNUM data entered (#records).
   ih_227       =      227       ,              //       0
   ih_228       =      228       ,              //       0
   ih_229       =      229       ,              //       0

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -615,6 +615,11 @@ aquiferDimensions(const AquiferDims& aqdims)
     this -> data_[NACAQZ] = aqdims.numDoubConnElem;
 
     this -> data_[NGCAUS] = aqdims.maxNumActiveAquiferConn;
+
+    this -> data_[NIIAQN] = aqdims.numNumericAquiferIntElem;
+    this -> data_[NIRAQN] = aqdims.numNumericAquiferDoubleElem;
+    this -> data_[NUMAQN] = aqdims.numNumericAquiferRecords;
+
     this -> data_[MAAQID] = aqdims.maxAquiferID;
 
     // Not characterised.  Equal to NAQUIF in all cases seen this far.
@@ -895,6 +900,10 @@ Opm::RestartIO::inferAquiferDimensions(const EclipseState& es)
             getMaximumNumberOfActiveAnalyticAquiferConnections(cfg);
 
         dim.maxAquiferID = getMaximumAnalyticAquiferID(cfg);
+    }
+
+    if (cfg.hasNumericalAquifer()) {
+        dim.numNumericAquiferRecords = cfg.numericalAquifers().numRecords();
     }
 
     return dim;

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -316,7 +316,20 @@ BOOST_AUTO_TEST_CASE(Analytic_Aquifer_Parameters)
 {
     // https://oeis.org/A001622
     const auto aqudims = Opm::RestartIO::InteHEAD::AquiferDims {
-        1, 61, 803, 3988, 74989, 484820, 45868, 3436, 563, 81, 1177203
+        1,                      // numAquifers
+        61,                     // maxNumAquifers
+        803,                    // maxNumAquiferConn
+        3988,                   // maxNumActiveAquiferConn
+        74989,                  // maxAquiferID
+        484820,                 // numNumericAquiferRecords
+        45868,                  // numIntAquiferElem
+        3436,                   // numRealAquiferElem
+        563,                    // numDoubAquiferElem
+        81,                     // numNumericAquiferIntElem
+        17,                     // numNumericAquiferDoubleElem
+        720,                    // numIntConnElem
+        30,                     // numRealConnElem
+        9,                      // numDoubConnElem
     };
 
     const auto ih = Opm::RestartIO::InteHEAD{}
@@ -326,17 +339,21 @@ BOOST_AUTO_TEST_CASE(Analytic_Aquifer_Parameters)
 
     BOOST_CHECK_EQUAL(v[VI::intehead::NAQUIF], 1);
     BOOST_CHECK_EQUAL(v[VI::intehead::NCAMAX], 803);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NIAAQZ], 484820);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NSAAQZ], 45868);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NXAAQZ], 3436);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NICAQZ], 563);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NSCAQZ], 81);
-    BOOST_CHECK_EQUAL(v[VI::intehead::NACAQZ], 1177203);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NIAAQZ], 45868);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSAAQZ], 3436);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NXAAQZ], 563);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NICAQZ], 720);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NSCAQZ], 30);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NACAQZ], 9);
 
     BOOST_CHECK_EQUAL(v[VI::intehead::MAX_ACT_ANLYTIC_AQUCONN], 3988);
     BOOST_CHECK_EQUAL(v[VI::intehead::MAX_AN_AQUIFER_ID], 74989);
     BOOST_CHECK_EQUAL(v[VI::intehead::AQU_UNKNOWN_1], 1);
     BOOST_CHECK_EQUAL(v[VI::intehead::MAX_ANALYTIC_AQUIFERS], 61);
+
+    BOOST_CHECK_EQUAL(v[VI::intehead::NIIAQN], 81);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NIRAQN], 17);
+    BOOST_CHECK_EQUAL(v[VI::intehead::NUM_AQUNUM_RECORDS], 484820);
 }
 
 BOOST_AUTO_TEST_CASE(Time_and_report_step)
@@ -564,6 +581,9 @@ BOOST_AUTO_TEST_CASE(TestHeader) {
     const auto nicaqz = 111111;
     const auto nscaqz = 1111111;
     const auto nacaqz = 11111111;
+    const auto niiaqn = 22222222;
+    const auto niraqn = 2222222;
+    const auto numaqn = 222222;
     const auto tstep  = 78;
     const auto report_step = 12;
     const auto newtmx	= 17;
@@ -586,7 +606,10 @@ BOOST_AUTO_TEST_CASE(TestHeader) {
     const auto ngroup  = 8;
 
     const auto aqudims = Opm::RestartIO::InteHEAD::AquiferDims {
-        1, 61, ncamax, 3988, 74989, niaaqz, nsaaqz, nxaaqz, nicaqz, nscaqz, nacaqz
+        1, 61, ncamax, 3988, 74989,
+        numaqn, niaaqz, nsaaqz, nxaaqz,
+        niiaqn, niraqn,
+        nicaqz, nscaqz, nacaqz
     };
 
     auto unit_system = Opm::UnitSystem::newMETRIC();


### PR DESCRIPTION
This PR generates the `IAQN` and `RAQN` restart vectors pertaining to numeric aquifers.  The arrays are sized according to the number of records in the input `AQUNUM` keyword.  `RAQN` is a mix of static and dynamic information, including the cumulative total inflow volume of water from the aquifer into the model.  IAQN is exclusively static information.

We add new members to `AggregateAquiferData` and ensure that the numeric aquifer arrays remain empty when no numeric aquifers exist in the model.  Add unit tests for these new arrays and update existing unit tests to account for new dimension items.

We also ensure that we always generate the `ANQP`, `ANQR`, and `ANQT` summary vectors in models with numeric aquifers since those values go into `RAQN`.