### PR TITLE
Track UDA Active Status for Group Injection Controls

### DIFF
--- a/jenkins/update-opm-tests.sh
+++ b/jenkins/update-opm-tests.sh
@@ -90,7 +90,7 @@ fi
 
 if [ -n "$DATA_PR" ]
 then
-  curl -d "{ \"body\": \"Existing PR https://github.com/OPM/opm-tests/pull/$DATA_PR was updated\" }" -X POST https://api.github.com/repos/OPM/$MAIN_REPO/issues/$PRNUMBER/comments?access_token=$GH_TOKEN
+  curl -d "{ \"body\": \"Existing PR https://github.com/OPM/opm-tests/pull/$DATA_PR was updated\" }" -H "Authorization: token ${GH_TOKEN}" -X POST https://api.github.com/repos/OPM/$MAIN_REPO/issues/$PRNUMBER/comments
 else
   git-open-pull -u jenkins4opm --base-account OPM --base-repo opm-tests -r /tmp/cmsg $BRANCH_NAME
 fi

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -20,11 +20,10 @@
 #ifndef GROUP2_HPP
 #define GROUP2_HPP
 
-
+#include <algorithm>
 #include <map>
 #include <optional>
 #include <string>
-#include <algorithm>
 
 #include <opm/parser/eclipse/Deck/UDAValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/IOrderSet.hpp>
@@ -128,9 +127,11 @@ static GuideRateInjTarget GuideRateInjTargetFromInt(int ecl_id);
 
 
 struct GroupInjectionProperties {
-    GroupInjectionProperties();
-    GroupInjectionProperties(Phase phase, const UnitSystem& unit_system);
+    GroupInjectionProperties() = default;
+    explicit GroupInjectionProperties(std::string group_name_arg);
+    GroupInjectionProperties(std::string group_name_arg, Phase phase, const UnitSystem& unit_system);
 
+    std::string group_name{};
     Phase phase = Phase::WATER;
     InjectionCMode cmode = InjectionCMode::NONE;
     UDAValue surface_max_rate;
@@ -152,6 +153,7 @@ struct GroupInjectionProperties {
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
+        serializer(this->group_name);
         serializer(phase);
         serializer(cmode);
         surface_max_rate.serializeOp(serializer);

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -149,6 +149,7 @@ struct GroupInjectionProperties {
     int injection_controls = 0;
     bool operator==(const GroupInjectionProperties& other) const;
     bool operator!=(const GroupInjectionProperties& other) const;
+    bool updateUDQActive(const UDQConfig& udq_config, UDQActive& active) const;
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -17,9 +17,11 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef UDQ_ENUMS_HPP
 #define UDQ_ENUMS_HPP
+
+#include <string>
+#include <vector>
 
 namespace Opm {
 
@@ -68,8 +70,6 @@ enum class UDQVarType {
     WELL_VAR = 8,
     GROUP_VAR = 9
 };
-
-
 
 enum class UDQTokenType{
     error = 0,
@@ -139,7 +139,6 @@ enum class UDQUpdate {
     NEXT
 };
 
-
 enum class UDAControl {
     WCONPROD_ORAT,
     WCONPROD_GRAT,
@@ -157,9 +156,13 @@ enum class UDAControl {
     GCONPROD_OIL_TARGET,
     GCONPROD_WATER_TARGET,
     GCONPROD_GAS_TARGET,
-    GCONPROD_LIQUID_TARGET
+    GCONPROD_LIQUID_TARGET,
+    //
+    GCONINJE_SURFACE_MAX_RATE,
+    GCONINJE_RESV_MAX_RATE,
+    GCONINJE_TARGET_REINJ_FRACTION,
+    GCONINJE_TARGET_VOID_FRACTION,
 };
-
 
 enum class UDAKeyword {
     WCONPROD,
@@ -167,8 +170,6 @@ enum class UDAKeyword {
     GCONINJE,
     GCONPROD
 };
-
-
 
 namespace UDQ {
 
@@ -191,7 +192,7 @@ namespace UDQ {
     int uadCode(UDAControl control);
 
     constexpr double restart_default = -0.3E+21;
-}
-}
+} // UDQ
+} // Opm
 
-#endif
+#endif  // UDQ_ENUMS_HPP

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -269,9 +269,19 @@ bool Group::GroupInjectionProperties::operator==(const GroupInjectionProperties&
         this->voidage_group           == other.voidage_group;
 }
 
-
 bool Group::GroupInjectionProperties::operator!=(const GroupInjectionProperties& other) const {
     return !(*this == other);
+}
+
+bool Group::GroupInjectionProperties::updateUDQActive(const UDQConfig& udq_config, UDQActive& active) const {
+    int update_count = 0;
+
+    update_count += active.update(udq_config, this->surface_max_rate, this->group_name, UDAControl::GCONINJE_SURFACE_MAX_RATE);
+    update_count += active.update(udq_config, this->resv_max_rate, this->group_name, UDAControl::GCONINJE_RESV_MAX_RATE);
+    update_count += active.update(udq_config, this->target_reinj_fraction, this->group_name, UDAControl::GCONINJE_TARGET_REINJ_FRACTION);
+    update_count += active.update(udq_config, this->target_void_fraction, this->group_name, UDAControl::GCONINJE_TARGET_VOID_FRACTION);
+
+    return (update_count > 0);
 }
 
 Group::GroupProductionProperties::GroupProductionProperties() :

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -359,7 +359,7 @@ namespace {
                     // FLD overrides item 8 (is_free i.e if FLD the group is available for higher up groups)
                     const bool availableForGroupControl = (is_free || controlMode == Group::InjectionCMode::FLD)&& !is_field;
                     auto new_group = this->snapshots.back().groups.get(group_name);
-                    Group::GroupInjectionProperties injection;
+                    Group::GroupInjectionProperties injection{group_name};
                     injection.phase = phase;
                     injection.cmode = controlMode;
                     injection.surface_max_rate = surfaceInjectionRate;
@@ -539,7 +539,7 @@ namespace {
             new_gconsale.add(groupName, sales_target, max_rate, min_rate, procedure, udqconfig, this->m_static.m_unit_system);
 
             auto new_group = this->snapshots.back().groups.get( groupName );
-            Group::GroupInjectionProperties injection;
+            Group::GroupInjectionProperties injection{groupName};
             injection.phase = Phase::GAS;
             if (new_group.updateInjection(injection))
                 this->snapshots.back().groups.update(new_group);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -397,6 +397,10 @@ namespace {
                         this->snapshots.back().groups.update( std::move(new_group));
                         this->snapshots.back().events().addEvent( ScheduleEvents::GROUP_INJECTION_UPDATE );
                         this->snapshots.back().wellgroup_events().addEvent( group_name, ScheduleEvents::GROUP_INJECTION_UPDATE);
+
+                        auto udq_active = this->snapshots.back().udq_active.get();
+                        if (injection.updateUDQActive(this->getUDQConfig(current_step), udq_active))
+                            this->snapshots.back().udq_active.update( std::move(udq_active));
                     }
                 }
             }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -17,18 +17,17 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <string>
-#include <unordered_map>
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
+
 #include <map>
 #include <set>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
+namespace Opm { namespace UDQ {
 
-
-namespace Opm {
-namespace UDQ {
 namespace {
 
     const std::set<UDQTokenType> cmp_func = {UDQTokenType::binary_cmp_eq,
@@ -364,54 +363,81 @@ std::string typeName(UDQVarType var_type) {
     }
 }
 
+namespace {
+    template <typename Value>
+    Value lookup_control_map_value(const std::map<UDAControl, Value>& map, const UDAControl control)
+    {
+        auto pos = map.find(control);
+        if (pos == map.end()) {
+            throw std::logic_error {
+                "Unrecognized enum type (" +
+                std::to_string(static_cast<int>(control)) +
+                "- internal error"
+            };
+        }
 
-UDAKeyword keyword(UDAControl control) {
-    const std::map<UDAControl, UDAKeyword> c2k = {{UDAControl::WCONPROD_ORAT, UDAKeyword::WCONPROD},
-                                                  {UDAControl::WCONPROD_GRAT, UDAKeyword::WCONPROD},
-                                                  {UDAControl::WCONPROD_WRAT, UDAKeyword::WCONPROD},
-                                                  {UDAControl::WCONPROD_LRAT, UDAKeyword::WCONPROD},
-                                                  {UDAControl::WCONPROD_RESV, UDAKeyword::WCONPROD},
-                                                  {UDAControl::WCONPROD_BHP,  UDAKeyword::WCONPROD},
-                                                  {UDAControl::WCONPROD_THP,  UDAKeyword::WCONPROD},
-                                                  {UDAControl::WCONINJE_RATE, UDAKeyword::WCONINJE},
-                                                  {UDAControl::WCONINJE_RESV, UDAKeyword::WCONINJE},
-                                                  {UDAControl::WCONINJE_BHP,  UDAKeyword::WCONINJE},
-                                                  {UDAControl::WCONINJE_THP,  UDAKeyword::WCONINJE},
-                                                  {UDAControl::GCONPROD_OIL_TARGET,    UDAKeyword::GCONPROD},
-                                                  {UDAControl::GCONPROD_WATER_TARGET,  UDAKeyword::GCONPROD},
-                                                  {UDAControl::GCONPROD_GAS_TARGET,    UDAKeyword::GCONPROD},
-                                                  {UDAControl::GCONPROD_LIQUID_TARGET, UDAKeyword::GCONPROD}};
+        return pos->second;
+    }
+} // Anonymous
 
-    auto it = c2k.find(control);
-    if (it != c2k.end())
-      return it->second;
+UDAKeyword keyword(UDAControl control)
+{
+    static const auto c2k = std::map<UDAControl, UDAKeyword> {
+        {UDAControl::WCONPROD_ORAT, UDAKeyword::WCONPROD},
+        {UDAControl::WCONPROD_GRAT, UDAKeyword::WCONPROD},
+        {UDAControl::WCONPROD_WRAT, UDAKeyword::WCONPROD},
+        {UDAControl::WCONPROD_LRAT, UDAKeyword::WCONPROD},
+        {UDAControl::WCONPROD_RESV, UDAKeyword::WCONPROD},
+        {UDAControl::WCONPROD_BHP,  UDAKeyword::WCONPROD},
+        {UDAControl::WCONPROD_THP,  UDAKeyword::WCONPROD},
+        {UDAControl::WCONINJE_RATE, UDAKeyword::WCONINJE},
+        {UDAControl::WCONINJE_RESV, UDAKeyword::WCONINJE},
+        {UDAControl::WCONINJE_BHP,  UDAKeyword::WCONINJE},
+        {UDAControl::WCONINJE_THP,  UDAKeyword::WCONINJE},
+        {UDAControl::GCONPROD_OIL_TARGET,    UDAKeyword::GCONPROD},
+        {UDAControl::GCONPROD_WATER_TARGET,  UDAKeyword::GCONPROD},
+        {UDAControl::GCONPROD_GAS_TARGET,    UDAKeyword::GCONPROD},
+        {UDAControl::GCONPROD_LIQUID_TARGET, UDAKeyword::GCONPROD},
+        {UDAControl::GCONINJE_SURFACE_MAX_RATE,      UDAKeyword::GCONINJE},
+        {UDAControl::GCONINJE_RESV_MAX_RATE,         UDAKeyword::GCONINJE},
+        {UDAControl::GCONINJE_TARGET_REINJ_FRACTION, UDAKeyword::GCONINJE},
+        {UDAControl::GCONINJE_TARGET_VOID_FRACTION,  UDAKeyword::GCONINJE},
+    };
 
-    throw std::logic_error("Unrecognized enum type - internal error");
+    return lookup_control_map_value(c2k, control);
 }
 
+int uadCode(UDAControl control)
+{
+    static const auto c2uad = std::map<UDAControl, int> {
+        {UDAControl::WCONPROD_ORAT,  300004},
+        {UDAControl::WCONPROD_GRAT,  500004},
+        {UDAControl::WCONPROD_WRAT,  400004},
+        {UDAControl::WCONPROD_LRAT,  600004},
+        {UDAControl::WCONPROD_RESV,  999999},
+        {UDAControl::WCONPROD_BHP,   999999},
+        {UDAControl::WCONPROD_THP,   999999},
 
-int uadCode(UDAControl control) {
-    const std::map<UDAControl, int> c2uad = {{UDAControl::WCONPROD_ORAT,  300004},
-                                             {UDAControl::WCONPROD_GRAT,  500004},
-                                             {UDAControl::WCONPROD_WRAT,  400004},
-                                             {UDAControl::WCONPROD_LRAT,  600004},
-                                             {UDAControl::WCONPROD_RESV,  999999},
-                                             {UDAControl::WCONPROD_BHP,   999999},
-                                             {UDAControl::WCONPROD_THP,   999999},
-                                             {UDAControl::WCONINJE_RATE,  400003},
-                                             {UDAControl::WCONINJE_RESV,  500003},
-                                             {UDAControl::WCONINJE_BHP,   999999},
-                                             {UDAControl::WCONINJE_THP,   999999},
-                                             {UDAControl::GCONPROD_OIL_TARGET,    200019},
-                                             {UDAControl::GCONPROD_WATER_TARGET,  300019},
-                                             {UDAControl::GCONPROD_GAS_TARGET,    400019},
-                                             {UDAControl::GCONPROD_LIQUID_TARGET, 500019}};
+        // --------------------------------------------------------------
+        {UDAControl::WCONINJE_RATE,  400003},
+        {UDAControl::WCONINJE_RESV,  500003},
+        {UDAControl::WCONINJE_BHP,   999999},
+        {UDAControl::WCONINJE_THP,   999999},
 
-    auto it = c2uad.find(control);
-    if (it != c2uad.end())
-      return it->second;
+        // --------------------------------------------------------------
+        {UDAControl::GCONPROD_OIL_TARGET,    200019},
+        {UDAControl::GCONPROD_WATER_TARGET,  300019},
+        {UDAControl::GCONPROD_GAS_TARGET,    400019},
+        {UDAControl::GCONPROD_LIQUID_TARGET, 500019},
 
-    throw std::logic_error("Unrecognized enum type - internal error");
+        // --------------------------------------------------------------
+        {UDAControl::GCONINJE_SURFACE_MAX_RATE,      300017}, // Surface injection rate
+        {UDAControl::GCONINJE_RESV_MAX_RATE,         400017}, // Reservoir volume injection rate
+        {UDAControl::GCONINJE_TARGET_REINJ_FRACTION, 500017}, // Reinjection fraction
+        {UDAControl::GCONINJE_TARGET_VOID_FRACTION,  600017}, // Voidage replacement fraction
+    };
+
+    return lookup_control_map_value(c2uad, control);
 }
-}
-}
+
+}} // Opm::UDQ

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -14,8 +14,11 @@ Copyright 2018 Statoil ASA.
 */
 
 #define BOOST_TEST_MODULE UDQTests
+
 #include <boost/test/unit_test.hpp>
+
 #include <limits>
+#include <stdexcept>
 
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/parser/eclipse/Utility/Typetools.hpp>
@@ -1512,6 +1515,63 @@ BOOST_AUTO_TEST_CASE(UDQ_USAGE) {
 
 }
 
+BOOST_AUTO_TEST_CASE(UDQControl_Keyword)
+{
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONPROD_ORAT) == UDAKeyword::WCONPROD, "WCONPROD_ORAT control keyword must be WCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONPROD_GRAT) == UDAKeyword::WCONPROD, "WCONPROD_GRAT control keyword must be WCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONPROD_WRAT) == UDAKeyword::WCONPROD, "WCONPROD_WRAT control keyword must be WCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONPROD_LRAT) == UDAKeyword::WCONPROD, "WCONPROD_LRAT control keyword must be WCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONPROD_RESV) == UDAKeyword::WCONPROD, "WCONPROD_RESV control keyword must be WCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONPROD_BHP)  == UDAKeyword::WCONPROD, "WCONPROD_BHP control keyword must be WCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONPROD_THP)  == UDAKeyword::WCONPROD, "WCONPROD_THP control keyword must be WCONPROD");
+
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONINJE_RATE) == UDAKeyword::WCONINJE, "WCONINJE_RATE control keyword must be WCONINJE");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONINJE_RESV) == UDAKeyword::WCONINJE, "WCONINJE_RESV control keyword must be WCONINJE");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONINJE_BHP)  == UDAKeyword::WCONINJE, "WCONINJE_BHP control keyword must be WCONINJE");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::WCONINJE_THP)  == UDAKeyword::WCONINJE, "WCONINJE_THP control keyword must be WCONINJE");
+
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::GCONPROD_OIL_TARGET)    == UDAKeyword::GCONPROD, "GCONPROD_OIL_TARGET control keyword must be GCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::GCONPROD_WATER_TARGET)  == UDAKeyword::GCONPROD, "GCONPROD_WATER_TARGET control keyword must be GCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::GCONPROD_GAS_TARGET)    == UDAKeyword::GCONPROD, "GCONPROD_GAS_TARGET control keyword must be GCONPROD");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::GCONPROD_LIQUID_TARGET) == UDAKeyword::GCONPROD, "GCONPROD_LIQUID_TARGET control keyword must be GCONPROD");
+
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::GCONINJE_SURFACE_MAX_RATE)      == UDAKeyword::GCONINJE, "GCONINJE_SURFACE_MAX_RATE control keyword must be GCONINJE");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::GCONINJE_RESV_MAX_RATE)         == UDAKeyword::GCONINJE, "GCONINJE_RESV_MAX_RATE control keyword must be GCONINJE");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::GCONINJE_TARGET_REINJ_FRACTION) == UDAKeyword::GCONINJE, "GCONINJE_TARGET_REINJ_FRACTION control keyword must be GCONINJE");
+    BOOST_CHECK_MESSAGE(UDQ::keyword(UDAControl::GCONINJE_TARGET_VOID_FRACTION)  == UDAKeyword::GCONINJE, "GCONINJE_TARGET_VOID_FRACTION control keyword must be GCONINJE");
+
+    BOOST_CHECK_THROW(UDQ::keyword(static_cast<UDAControl>(1729)),
+                      std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(UDAControl_IUAD_0)
+{
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONPROD_ORAT), 300004);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONPROD_GRAT), 500004);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONPROD_WRAT), 400004);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONPROD_LRAT), 600004);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONPROD_RESV), 999999);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONPROD_BHP),  999999);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONPROD_THP),  999999);
+
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONINJE_RATE), 400003);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONINJE_RESV), 500003);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONINJE_BHP),  999999);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::WCONINJE_THP),  999999);
+
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::GCONPROD_OIL_TARGET),     200019);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::GCONPROD_WATER_TARGET),   300019);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::GCONPROD_GAS_TARGET),     400019);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::GCONPROD_LIQUID_TARGET),  500019);
+
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::GCONINJE_SURFACE_MAX_RATE),       300017);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::GCONINJE_RESV_MAX_RATE),          400017);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::GCONINJE_TARGET_REINJ_FRACTION),  500017);
+    BOOST_CHECK_EQUAL(UDQ::uadCode(UDAControl::GCONINJE_TARGET_VOID_FRACTION),   600017);
+
+    BOOST_CHECK_THROW(UDQ::uadCode(static_cast<UDAControl>(1729)),
+                      std::logic_error);
+}
 
 BOOST_AUTO_TEST_CASE(IntegrationTest) {
 #include "data/integration_tests/udq.data"


### PR DESCRIPTION
This PR adds a new member function, `updateUDQActive`, to the group injection properties.  This is inspired by the function of the same name in the group production properties and fills the same purpose.  This, in turn, enables tracking whether a `GCONINJE` keyword activates a user-defined argument.  That status is in turn needed to generate the `IUAD` and `IUAP` restart vectors in the restart file in the face of models for which the only UDA is in `GCONINJE`.  To this end, also identify the integer values corresponding to `GCONINJE` UAD modes.