### PR TITLE
Add shrink_to_fit() for underlying storage in DeckItem

### DIFF
--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -77,6 +77,10 @@ namespace Opm {
         const std::vector< double >& getSIDoubleData() const;
         const std::vector<value::status>& getValueStatus() const;
 
+        template< typename T>
+        void shrink_to_fit();
+
+
         void push_back( UDAValue );
         void push_back( int );
         void push_back( double );

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -188,6 +188,16 @@ UDAValue DeckItem::get( size_t index ) const {
     }
 }
 
+template <>
+void DeckItem::shrink_to_fit<int>() {
+    this->ival.shrink_to_fit();
+}
+
+template <>
+void DeckItem::shrink_to_fit<double>() {
+    this->dval.shrink_to_fit();
+}
+
 
 template< typename T >
 const std::vector< T >& DeckItem::getData() const {

--- a/src/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -568,6 +568,7 @@ DeckItem ParserItem::scan( RawRecord& record, UnitSystem& active_unitsystem, Uni
         {
             DeckItem item( this->name(), int());
             scan_item< int >( item, *this, record );
+            item.shrink_to_fit<int>();
             return item;
         }
         break;
@@ -582,6 +583,7 @@ DeckItem ParserItem::scan( RawRecord& record, UnitSystem& active_unitsystem, Uni
 
             DeckItem item(this->name(), double(), active_dimensions, default_dimensions);
             scan_item< double >( item, *this, record );
+            item.shrink_to_fit<double>();
             return item;
         }
         break;


### PR DESCRIPTION
This should on average save a fraction of 0.5 * (1 - 1/g) of memory - where 'g' is the `std::vector` growth factor (guessing for 2?).