### PR TITLE
Expose function stdoutIsTerminal() as static member in OpmLog

### DIFF
--- a/opm/common/OpmLog/OpmLog.hpp
+++ b/opm/common/OpmLog/OpmLog.hpp
@@ -88,6 +88,8 @@ public:
     }
 
 
+    static bool stdoutIsTerminal();
+
 private:
     static std::shared_ptr<Logger> getLogger();
     static std::shared_ptr<Logger> m_logger;

--- a/src/opm/common/OpmLog/OpmLog.cpp
+++ b/src/opm/common/OpmLog/OpmLog.cpp
@@ -40,18 +40,16 @@
 
 namespace Opm {
 
-    namespace {
-        bool stdoutIsTerminal()
-        {
-            const int errno_save = errno; // For playing nice with C error handling.
-            const int file_descriptor = fileno(stdout);
-            if (file_descriptor == -1) {
-                // stdout is an invalid stream
-                errno = errno_save;
-                return false;
-            } else {
-                return isatty(file_descriptor);
-            }
+    bool OpmLog::stdoutIsTerminal()
+    {
+        const int errno_save = errno; // For playing nice with C error handling.
+        const int file_descriptor = fileno(stdout);
+        if (file_descriptor == -1) {
+            // stdout is an invalid stream
+            errno = errno_save;
+            return false;
+        } else {
+            return isatty(file_descriptor);
         }
     }
 


### PR DESCRIPTION
IN order to implement: https://github.com/OPM/opm-simulators/pull/3310