### PR TITLE
Prevent reallocations where possible when parsing items.

### DIFF
--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -90,15 +90,15 @@ namespace Opm {
         void push_back( int, size_t );
         void push_back( double, size_t );
         void push_back( std::string, size_t );
-        void push_backDefault( UDAValue );
-        void push_backDefault( int );
-        void push_backDefault( double );
-        void push_backDefault( std::string );
-        void push_backDefault( RawString );
+        void push_backDefault( UDAValue, std::size_t n = 1 );
+        void push_backDefault( int, std::size_t n = 1 );
+        void push_backDefault( double, std::size_t n = 1 );
+        void push_backDefault( std::string, std::size_t n = 1 );
+        void push_backDefault( RawString, std::size_t n = 1 );
         // trying to access the data of a "dummy default item" will raise an exception
 
         template <typename T>
-        void push_backDummyDefault();
+        void push_backDummyDefault( std::size_t n = 1 );
 
         type_tag getType() const;
 
@@ -149,6 +149,7 @@ namespace Opm {
             serializer.vector(default_dimensions);
         }
 
+        void reserve_additionalRawString(std::size_t);
     private:
         mutable std::vector< double > dval;
         std::vector< int > ival;
@@ -173,7 +174,7 @@ namespace Opm {
         template< typename T > const std::vector< T >& value_ref() const;
         template< typename T > void push( T );
         template< typename T > void push( T, size_t );
-        template< typename T > void push_default( T );
+        template< typename T > void push_default( T, std::size_t n );
         template< typename T > void write_vector(DeckOutput& writer, const std::vector<T>& data) const;
     };
 }

--- a/src/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -258,42 +258,42 @@ void DeckItem::push_back( UDAValue x, size_t n ) {
 }
 
 template< typename T >
-void DeckItem::push_default( T x ) {
+void DeckItem::push_default( T x, std::size_t n ) {
     auto& val = this->value_ref< T >();
     if( this->value_status.size() != val.size() )
         throw std::logic_error("To add a value to an item, "
                 "no 'pseudo defaults' can be added before");
 
-    val.push_back( std::move( x ) );
-    this->value_status.push_back( value::status::valid_default );
+    val.insert(val.end(), n, std::move( x ) );
+    this->value_status.insert( this->value_status.end(), n, value::status::valid_default );
 }
 
-void DeckItem::push_backDefault( int x ) {
-    this->push_default( x );
+void DeckItem::push_backDefault( int x, std::size_t n ) {
+    this->push_default( x, n );
 }
 
-void DeckItem::push_backDefault( double x ) {
-    this->push_default( x );
+void DeckItem::push_backDefault( double x, std::size_t n ) {
+    this->push_default( x, n );
 }
 
-void DeckItem::push_backDefault( std::string x ) {
-    this->push_default( std::move( x ) );
+void DeckItem::push_backDefault( std::string x, std::size_t n ) {
+    this->push_default( std::move( x ), n );
 }
 
-void DeckItem::push_backDefault( RawString x ) {
-    this->push_default( std::move( x ) );
+void DeckItem::push_backDefault( RawString x, std::size_t n ) {
+    this->push_default( std::move( x ), n );
 }
 
-void DeckItem::push_backDefault( UDAValue x ) {
-    this->push_default( std::move( x ) );
+void DeckItem::push_backDefault( UDAValue x, std::size_t n ) {
+    this->push_default( std::move( x ), n );
 }
 
 
 template<typename T>
-void DeckItem::push_backDummyDefault() {
+void DeckItem::push_backDummyDefault( std::size_t n ) {
     auto& val = this->value_ref< T >();
-    val.push_back( T() );
-    this->value_status.push_back( value::status::empty_default );
+    val.insert( val.end(), n, T() );
+    this->value_status.insert( this->value_status.end(), n, value::status::empty_default );
 }
 
 std::string DeckItem::getTrimmedString( size_t index ) const {
@@ -521,6 +521,11 @@ bool DeckItem::to_bool(std::string string_value) {
     throw std::invalid_argument("Could not convert string " + string_value + " to bool ");
 }
 
+void DeckItem::reserve_additionalRawString(std::size_t n)
+{
+    this->rsval.reserve(rsval.size() + n);
+}
+
 /*
  * Explicit template instantiations. These must be manually maintained and
  * updated with changes in DeckItem so that code is emitted.
@@ -531,11 +536,11 @@ template double DeckItem::get< double >( size_t ) const;
 template std::string DeckItem::get< std::string >( size_t ) const;
 template RawString DeckItem::get< RawString >( size_t ) const;
 
-template void DeckItem::push_backDummyDefault<int>();
-template void DeckItem::push_backDummyDefault<double>();
-template void DeckItem::push_backDummyDefault<std::string>();
-template void DeckItem::push_backDummyDefault<RawString>();
-template void DeckItem::push_backDummyDefault<UDAValue>();
+template void DeckItem::push_backDummyDefault<int>( std::size_t );
+template void DeckItem::push_backDummyDefault<double>( std::size_t );
+template void DeckItem::push_backDummyDefault<std::string>( std::size_t );
+template void DeckItem::push_backDummyDefault<RawString>( std::size_t );
+template void DeckItem::push_backDummyDefault<UDAValue>( std::size_t );
 
 template const std::vector< int >& DeckItem::getData< int >() const;
 template const std::vector< UDAValue >& DeckItem::getData< UDAValue >() const;

--- a/src/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -461,6 +461,7 @@ void scan_item( DeckItem& deck_item, const ParserItem& parser_item, RawRecord& r
 
     if( parser_item.sizeType() == ParserItem::item_size::ALL ) {
         if (parse_raw) {
+            deck_item.reserve_additionalRawString(record.size());
             while (record.size()) {
                 auto token = record.pop_front();
                 auto raw_string = RawString{ std::string(token) };
@@ -489,11 +490,9 @@ void scan_item( DeckItem& deck_item, const ParserItem& parser_item, RawRecord& r
 
             if (parser_item.hasDefault()) {
                 auto value = parser_item.getDefault< T >();
-                for (size_t i=0; i < st.count(); i++)
-                    deck_item.push_backDefault( value );
+                deck_item.push_backDefault( value, st.count());
             } else {
-                for (size_t i=0; i < st.count(); i++)
-                    deck_item.push_backDummyDefault<T>();
+                deck_item.push_backDummyDefault<T>(st.count());
             }
         }
 


### PR DESCRIPTION
Another low hanging fruit for reducing the memory consumption like #2488.
We either reserve or use std::vector::insert instead of just blindly using push_back.