### PR TITLE
Implement WALQ Summary Vector

### DIFF
--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -591,11 +591,13 @@ namespace {
                 sWell[Ix::HistBHPTarget] = sWell[Ix::BHPTarget];
                 
                 if (pc.alq_value != 0.0) {
-                    auto vfpTable = sched[sim_step].vfpprod(pc.vfp_table_number);
-                    if (vfpTable.getALQType() == Opm::VFPProdTable::ALQ_TYPE::ALQ_GRAT) {
+                    const auto alqType = sched[sim_step].vfpprod(pc.vfp_table_number).getALQType();
+                    if (alqType == Opm::VFPProdTable::ALQ_TYPE::ALQ_GRAT) {
                         sWell[Ix::Alq_value] = static_cast<float>(units.from_si(M::gas_surface_rate, pc.alq_value));
                     }
-                    else if ((vfpTable.getALQType() == Opm::VFPProdTable::ALQ_TYPE::ALQ_IGLR) || (vfpTable.getALQType() == Opm::VFPProdTable::ALQ_TYPE::ALQ_TGLR)) {
+                    else if ((alqType == Opm::VFPProdTable::ALQ_TYPE::ALQ_IGLR) ||
+                             (alqType == Opm::VFPProdTable::ALQ_TYPE::ALQ_TGLR))
+                    {
                         sWell[Ix::Alq_value] = static_cast<float>(units.from_si(M::gas_oil_ratio, pc.alq_value));
                     }
                     else {

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WELL_PROBE
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WELL_PROBE
@@ -193,7 +193,6 @@
     "WGPRFP",
     "WTHPFP",
     "WBHPFP",
-    "WGLIR",
     "WOGLR",
     "WGCV",
     "WGQ",

--- a/tests/2_WLIFT_MODEL5_NOINC.DATA
+++ b/tests/2_WLIFT_MODEL5_NOINC.DATA
@@ -10291,6 +10291,9 @@ WWPRH
 WGLIR
  'B-*' 'C-*' /
 
+WALQ
+ 'B-*' /
+
 -- Production cumulatives
 WOPT
  'B-*' 'C-*' /

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1155,7 +1155,59 @@ BOOST_AUTO_TEST_CASE(group_group) {
     }
 }
 
+namespace {
+    data::Wells glir_alq_data()
+    {
+        auto wells = data::Wells{};
 
+        using opt = data::Rates::opt;
+        auto& b1h = wells["B-1H"];
+        auto& b2h = wells["B-2H"];
+        auto& b3h = wells["B-3H"];
+
+        b1h.rates.set(opt::alq, 1234.56*unit::cubic(unit::meter)/unit::day);
+        b2h.rates.set(opt::alq, 2345.67*unit::cubic(unit::meter)/unit::day);
+        b3h.rates.set(opt::alq, 3456.78*unit::cubic(unit::meter)/unit::day);
+
+        return wells;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(GLIR_and_ALQ)
+{
+    const auto deck  = Parser{}.parseFile("2_WLIFT_MODEL5_NOINC.DATA");
+    const auto es    = EclipseState { deck };
+    const auto sched = Schedule { deck, es, std::make_shared<Python>() };
+    const auto cfg   = SummaryConfig { deck, sched, es.fieldProps(), es.aquifer() };
+    const auto name  = "glir_and_alq";
+
+    WorkArea ta{ "summary_test" };
+    ta.makeSubDir(name);
+
+    const auto wellData = glir_alq_data();
+
+    auto st = SummaryState { TimeService::now() };
+    auto writer = out::Summary{ es, cfg, es.getInputGrid(), sched, name };
+    writer.eval(st, 0, 0*day, wellData, {}, {}, {}, {}, {});
+    writer.add_timestep(st, 0, false);
+
+    writer.eval(st, 1, 1*day, wellData, {}, {}, {}, {}, {});
+    writer.add_timestep(st, 1, false);
+
+    writer.eval(st, 2, 2*day, wellData, {}, {}, {}, {}, {});
+    writer.add_timestep(st, 2, false);
+    writer.write();
+
+    auto res = readsum(name);
+    const auto* resp = res.get();
+
+    BOOST_CHECK_CLOSE(1234.56, ecl_sum_get_well_var(resp, 1, "B-1H", "WGLIR"), 1.0e-5);
+    BOOST_CHECK_CLOSE(2345.67, ecl_sum_get_well_var(resp, 1, "B-2H", "WGLIR"), 1.0e-5);
+    BOOST_CHECK_CLOSE(3456.78, ecl_sum_get_well_var(resp, 1, "B-3H", "WGLIR"), 1.0e-5);
+
+    BOOST_CHECK_CLOSE(1234.56 + 2345.67 + 3456.78,
+                      ecl_sum_get_group_var(resp, 1, "B1", "GGLIR"), 1.0e-5);
+}
 
 BOOST_AUTO_TEST_CASE(connection_kewords) {
     setup cfg( "test_summary_connection" );

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1207,6 +1207,10 @@ BOOST_AUTO_TEST_CASE(GLIR_and_ALQ)
 
     BOOST_CHECK_CLOSE(1234.56 + 2345.67 + 3456.78,
                       ecl_sum_get_group_var(resp, 1, "B1", "GGLIR"), 1.0e-5);
+
+    BOOST_CHECK_CLOSE(0.0, ecl_sum_get_well_var(resp, 1, "B-1H", "WALQ"), 1.0e-5);
+    BOOST_CHECK_CLOSE(0.0, ecl_sum_get_well_var(resp, 1, "B-2H", "WALQ"), 1.0e-5);
+    BOOST_CHECK_CLOSE(0.0, ecl_sum_get_well_var(resp, 1, "B-3H", "WALQ"), 1.0e-5);
 }
 
 BOOST_AUTO_TEST_CASE(connection_kewords) {


### PR DESCRIPTION
This PR adds a guard to the `xGLIR` accumulation procedure.  In particular, we do not accumulate anything unless the ALQ type is gas rate.  We do however output a well-level value if the ALQ type is gas/liquid ratio.  This guard requires passing the `Schedule` object as part of the `fn_args`, so update the call sites accordingly.

With this in place we also implement the `WALQ` summary vector which essentially copies the simulation model's VFP input ALQ value to the summary output.