### PR TITLE
Collect Type-Specific Aquifer Data in Single Structure 

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -321,6 +321,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/output/eclipse/WriteRFT.cpp
           src/opm/output/eclipse/WriteRPT.cpp
           src/opm/output/eclipse/report/WELSPECS.cpp
+          src/opm/output/data/Aquifer.cpp
           src/opm/output/data/Solution.cpp
           src/opm/utility/EModel.cpp
       )

--- a/src/opm/output/data/Aquifer.cpp
+++ b/src/opm/output/data/Aquifer.cpp
@@ -1,0 +1,131 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/output/data/Aquifer.hpp>
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <variant>
+
+bool Opm::data::CarterTracyData::operator==(const CarterTracyData& other) const
+{
+    return (this->timeConstant == other.timeConstant)
+        && (this->influxConstant == other.influxConstant)
+        && (this->waterDensity == other.waterDensity)
+        && (this->waterViscosity == other.waterViscosity)
+        && (this->dimensionless_time == other.dimensionless_time)
+        && (this->dimensionless_pressure == other.dimensionless_pressure);
+}
+
+bool Opm::data::FetkovichData::operator==(const FetkovichData& other) const
+{
+    return (this->initVolume == other.initVolume)
+        && (this->prodIndex == other.prodIndex)
+        && (this->timeConstant == other.timeConstant);
+}
+
+bool Opm::data::NumericAquiferData::operator==(const NumericAquiferData& other) const
+{
+    return this->initPressure == other.initPressure;
+}
+
+void Opm::data::TypeSpecificData::create(const std::size_t option)
+{
+    switch (option) {
+    case std::size_t{0}:
+    // Default constructor.  Nothing to do here
+    break;
+
+    case std::size_t{1}:
+    this->options_.emplace<std::variant_alternative_t<1, Types>>();
+    break;
+
+    case std::size_t{2}:
+    this->options_.emplace<std::variant_alternative_t<2, Types>>();
+    break;
+
+    case std::size_t{3}:
+    this->options_.emplace<std::variant_alternative_t<3, Types>>();
+    break;
+    }
+}
+
+double Opm::data::AquiferData::get(const std::string& key) const
+{
+    auto func = summaryValueDispatchTable_.find(key);
+    if (func == summaryValueDispatchTable_.end()) {
+        return 0.0;
+    }
+
+    return (this->*func->second)();
+}
+
+bool Opm::data::AquiferData::operator==(const AquiferData& other) const
+{
+    return (this->aquiferID == other.aquiferID)
+        && (this->pressure == other.pressure)
+        && (this->fluxRate == other.fluxRate)
+        && (this->volume == other.volume)
+        && (this->initPressure == other.initPressure)
+        && (this->datumDepth == other.datumDepth)
+        && (this->typeData == other.typeData);
+}
+
+double Opm::data::AquiferData::aquiferPressure() const
+{
+    return this->pressure;
+}
+
+double Opm::data::AquiferData::aquiferFlowRate() const
+{
+    return this->fluxRate;
+}
+
+double Opm::data::AquiferData::aquiferTotalProduction() const
+{
+    return this->volume;
+}
+
+double Opm::data::AquiferData::carterTracyDimensionlessTime() const
+{
+    return this->typeData.is<AquiferType::CarterTracy>()
+        ? this->typeData.get<AquiferType::CarterTracy>()->dimensionless_time
+        : 0.0;
+}
+
+double Opm::data::AquiferData::carterTracyDimensionlessPressure() const
+{
+    return this->typeData.is<AquiferType::CarterTracy>()
+        ? this->typeData.get<AquiferType::CarterTracy>()->dimensionless_pressure
+        : 0.0;
+}
+
+Opm::data::AquiferData::SummaryValueDispatchTable
+Opm::data::AquiferData::summaryValueDispatchTable_ =
+{
+    {"AAQP" , &AquiferData::aquiferPressure},
+    {"ANQP" , &AquiferData::aquiferPressure},
+    {"AAQR" , &AquiferData::aquiferFlowRate},
+    {"ANQR" , &AquiferData::aquiferFlowRate},
+    {"AAQT" , &AquiferData::aquiferTotalProduction},
+    {"ANQT" , &AquiferData::aquiferTotalProduction},
+    {"AAQTD", &AquiferData::carterTracyDimensionlessTime},
+    {"AAQPD", &AquiferData::carterTracyDimensionlessPressure},
+};

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -1190,24 +1190,24 @@ namespace {
         };
     }
 
-    std::shared_ptr<Opm::data::FetkovichData>
-    extractFetkcovichData(const Opm::UnitSystem&               usys,
-                          const AquiferVectors::Window<float>& saaq)
+    Opm::data::FetkovichData
+    extractFetkovichData(const Opm::UnitSystem&               usys,
+                         const AquiferVectors::Window<float>& saaq)
     {
         using M = ::Opm::UnitSystem::measure;
 
-        auto data = std::make_shared<Opm::data::FetkovichData>();
+        auto data = Opm::data::FetkovichData{};
 
-        data->initVolume =
+        data.initVolume =
             usys.to_si(M::liquid_surface_volume,
                        saaq[VI::SAnalyticAquifer::FetInitVol]);
 
-        data->prodIndex =
+        data.prodIndex =
             usys.to_si(M::liquid_surface_rate,
             usys.from_si(M::pressure,
                          saaq[VI::SAnalyticAquifer::FetProdIndex]));
 
-        data->timeConstant = saaq[VI::SAnalyticAquifer::FetTimeConstant];
+        data.timeConstant = saaq[VI::SAnalyticAquifer::FetTimeConstant];
 
         return data;
     }
@@ -1244,10 +1244,10 @@ namespace {
             aqData.datumDepth =
                 units.to_si(M::length, saaq[VI::SAnalyticAquifer::DatumDepth]);
 
-            aqData.type = determineAquiferType(aquiferData.iaaq(aquiferID));
-
-            if (aqData.type == Opm::data::AquiferType::Fetkovich) {
-                aqData.aquFet = extractFetkcovichData(units, saaq);
+            const auto type = determineAquiferType(aquiferData.iaaq(aquiferID));
+            if (type == Opm::data::AquiferType::Fetkovich) {
+                auto* tData = aqData.typeData.create<Opm::data::AquiferType::Fetkovich>();
+                *tData = extractFetkovichData(units, saaq);
             }
         }
 


### PR DESCRIPTION
This commit adds a new helper class,
```
Opm::data::TypeSpecificData
```
which holds type-specific sub-structures for Carter-Tracy, Fetkovich, and Numerical aquifers.  We implement this facility in terms of ~`std::variant<>` of `shared_ptr<>` to~ a `std::variant<>` of simple structures.  In turn, use the type-specific data for numerical aquifers to fill in the initial aquifer cell pressures where not available in the input data.