### PR TITLE
[WIP] Fixing guide rates

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -92,7 +92,7 @@ struct GRValState {
 
 public:
     GuideRate(const Schedule& schedule);
-    void   compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
+    void   compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot, const bool update_now=false);
     void compute(const std::string& wgname, const Phase& phase, size_t report_step, double guide_rate);
     double get(const std::string& well, Well::GuideRateTarget target, const RateVector& rates) const;
     double get(const std::string& group, Group::GuideRateProdTarget target, const RateVector& rates) const;
@@ -101,8 +101,11 @@ public:
     bool has(const std::string& name) const;
     bool has(const std::string& name, const Phase& phase) const;
 
+    // prototyping for now, might make it private later
+    bool timeToUpdate(const double sim_time, const double time_interval) const;
+
 private:
-    void well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
+    void well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot, const bool update_now=false);
     void group_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
     double eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot) const;
     double eval_group_pot() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -49,12 +49,18 @@ struct RateVector {
         wat_rat(wrat)
     {}
 
+    static RateVector rateVectorFromGuideRate(double guide_rate, GuideRateModel::Target target, const RateVector& rates);
 
     double eval(Well::GuideRateTarget target) const;
     double eval(Group::GuideRateProdTarget target) const;
     double eval(GuideRateModel::Target target) const;
 
 
+    bool operator==(const RateVector& other) const {
+        return (this->oil_rat == other.oil_rat) &&
+                (this->gas_rat == other.gas_rat) &&
+                (this->wat_rat == other.wat_rat);
+    }
     double oil_rat;
     double gas_rat;
     double wat_rat;
@@ -65,7 +71,7 @@ private:
 
 struct GuideRateValue {
     GuideRateValue() = default;
-    GuideRateValue(double t, double v, GuideRateModel::Target tg):
+    GuideRateValue(double t, const RateVector& v, GuideRateModel::Target tg):
         sim_time(t),
         value(v),
         target(tg)
@@ -81,7 +87,7 @@ struct GuideRateValue {
     }
 
     double sim_time { std::numeric_limits<double>::lowest() };
-    double value { std::numeric_limits<double>::lowest() };
+    RateVector value { std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest() };
     GuideRateModel::Target target { GuideRateModel::Target::NONE };
 };
 
@@ -107,12 +113,12 @@ public:
 private:
     void well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot, const bool update_now=false);
     void group_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);
-    double eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot) const;
+    RateVector eval_form(const GuideRateModel& model, double oil_pot, double gas_pot, double wat_pot) const;
     double eval_group_pot() const;
     double eval_group_resvinj() const;
 
     void assign_grvalue(const std::string& wgname, const GuideRateModel& model, GuideRateValue&& value);
-    double get_grvalue_result(const GRValState& gr) const;
+    // double get_grvalue_result(const GRValState& gr) const;
 
     using GRValPtr = std::unique_ptr<GRValState>;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
@@ -40,6 +40,7 @@ public:
     };
 
     static Target TargetFromString(const std::string& s);
+    static std::string targetToString(const Target target);
 
     GuideRateModel(double time_interval_arg,
                    Target target_arg,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -30,6 +30,7 @@
 #include <utility>
 #include <fmt/core.h>
 #include <stddef.h>
+#include <iostream>
 
 namespace Opm {
 
@@ -132,7 +133,8 @@ void GuideRate::compute(const std::string& wgname,
                         double             sim_time,
                         double             oil_pot,
                         double             gas_pot,
-                        double             wat_pot)
+                        double             wat_pot,
+                        const bool update_now)
 {
     this->potentials[wgname] = RateVector{oil_pot, gas_pot, wat_pot};
 
@@ -141,7 +143,12 @@ void GuideRate::compute(const std::string& wgname,
         this->group_compute(wgname, report_step, sim_time, oil_pot, gas_pot, wat_pot);
     }
     else {
-        this->well_compute(wgname, report_step, sim_time, oil_pot, gas_pot, wat_pot);
+        std::cout << " whether config has this well " << wgname << "  " << config.has_well(wgname) << std::endl;
+        // TODO: here sometimes, it is a group entering this function
+        // at the same time, it should only happens when GCONPROD specifies `FORM`, that you can use
+        // potentials to calculate the guide rate?
+        // Let us double check whether it is always zero pot enter here.
+        this->well_compute(wgname, report_step, sim_time, oil_pot, gas_pot, wat_pot, update_now);
     }
 }
 
@@ -230,7 +237,8 @@ void GuideRate::well_compute(const std::string& wgname,
                              double             sim_time,
                              double             oil_pot,
                              double             gas_pot,
-                             double             wat_pot)
+                             double             wat_pot,
+                             const bool update_now)
 {
     const auto& config = this->schedule.guideRateConfig(report_step);
 
@@ -261,7 +269,8 @@ void GuideRate::well_compute(const std::string& wgname,
         if (iter != this->values.end()) {
             const auto& grv = iter->second->curr;
             const auto time_diff = sim_time - grv.sim_time;
-            if (config.model().update_delay() > time_diff) {
+            // if (config.model().update_delay() > time_diff) {
+            if (!update_now) {
                 return;
             }
         }
@@ -325,6 +334,20 @@ double GuideRate::get_grvalue_result(const GRValState& gr) const
     return (gr.curr.sim_time < 0.0)
         ? 0.0
         : std::max(gr.curr.value, 0.0);
+}
+
+bool GuideRate::timeToUpdate(const double sim_time, const double time_interval) const {
+    // getting the last update time
+    // TODO: using some values from std::limits
+    double last_update_time = 1.e99;
+    for ([[maybe_unused]] const auto& [wgname, value] : this->values) {
+        const double update_time = value->curr.sim_time;
+        if (update_time < last_update_time) {
+            last_update_time = update_time;
+        }
+    }
+
+    return (sim_time >= (last_update_time + time_interval));
 }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
@@ -349,4 +349,32 @@ GuideRateModel::Target GuideRateModel::convert_target(Phase injection_phase) {
     throw std::logic_error("Can not convert this .... ");
 }
 
+std::string GuideRateModel::targetToString(const Target target) {
+    switch (target) {
+        case Target::OIL:
+            return "OIL";
+            break;
+        case Target::LIQ:
+            return "LIQ";
+            break;
+        case Target::GAS:
+            return "GAS";
+            break;
+        case Target::WAT:
+            return "WAT";
+            break;
+        case Target::RES:
+            return "RES";
+            break;
+        case Target::COMB:
+            return "COMB";
+            break;
+        case Target::NONE:
+            return "NONE";
+            break;
+        default:
+            throw std::logic_error("Not knowing what kind of target it is");
+    }
+}
+
 }


### PR DESCRIPTION
Two main changes:

1. With GUIDERAT, all the guide rates should be updated at the same time. If one well needs to update GUIDERAT, all the wells need to update the guide rates. Currently, the update of the guide rates are still at each individual well level. 
2. The guide rate need to be an array or vector or structure to contain multiple values. When update the guide rate, we calculate the guide rate for the nominated phase first, then we scale for other phases using the well rates at the update time. Currently, the guide rates are scaled based on current well rates. Then as a result, even the guide rate for the nominated phase is not changing during the time step, the guide rate for other phases will change for each iterations because of the change of the well rates. The goal is that all kinds of guide rates only be updated after certain period specified by the keyword GUIDERAT, and stay const before updating the guide rates next time. 

Until today, I was struggling with the wrong results and convergence failure, while after rebasing to the updated master today, the results look much better. Without knowing the exact reason. Then I am creating this PR now. The code is still at a very rough prototyping and testing stage, and the results are not perfect either. 

Will ask for help from someone (@totto82  @joakim-hove) later when considering the code is more ready. 