### PR TITLE
Rename data::WellRates -> data::Wells

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -308,7 +308,7 @@ namespace Opm {
     };
 
 
-    class WellRates : public std::map<std::string , Well> {
+    class Wells: public std::map<std::string , Well> {
     public:
 
         double get(const std::string& well_name , Rates::opt m) const {
@@ -360,8 +360,6 @@ namespace Opm {
             }
         }
     };
-
-    using Wells = WellRates;
 
 
     /* IMPLEMENTATIONS */

--- a/opm/output/eclipse/AggregateConnectionData.hpp
+++ b/opm/output/eclipse/AggregateConnectionData.hpp
@@ -34,7 +34,7 @@ namespace Opm {
 } // Opm
 
 namespace Opm { namespace data {
-    class WellRates;
+    class Wells;
 }}
 
 namespace Opm { namespace RestartIO { namespace Helpers {
@@ -47,7 +47,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         void captureDeclaredConnData(const Opm::Schedule&        sched,
                                      const Opm::EclipseGrid&     grid,
                                      const Opm::UnitSystem&      units,
-                                     const Opm::data::WellRates& xw,
+                                     const Opm::data::Wells&     xw,
                                      const Opm::SummaryState&    summary_state,
                                      const std::size_t           sim_step);
 

--- a/opm/output/eclipse/AggregateMSWData.hpp
+++ b/opm/output/eclipse/AggregateMSWData.hpp
@@ -67,7 +67,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 				     const std::vector<int>& inteHead,
 				     const Opm::EclipseGrid&  grid,
 				     const Opm::SummaryState& smry,
-				     const Opm::data::WellRates&  wr
+				     const Opm::data::Wells&  wr
 				   );
 
         /// Retrieve Integer Multisegment well data Array.

--- a/opm/output/eclipse/AggregateWListData.hpp
+++ b/opm/output/eclipse/AggregateWListData.hpp
@@ -32,7 +32,7 @@ namespace Opm {
 } // Opm
 
 namespace Opm { namespace data {
-    class WellRates;
+    class Wells;
 }} // Opm::data
 
 namespace Opm { namespace RestartIO { namespace Helpers {

--- a/opm/output/eclipse/AggregateWellData.hpp
+++ b/opm/output/eclipse/AggregateWellData.hpp
@@ -39,7 +39,7 @@ namespace Opm {
 } // Opm
 
 namespace Opm { namespace data {
-    class WellRates;
+    class Wells;
 }} // Opm::data
 
 namespace Opm { namespace RestartIO { namespace Helpers {
@@ -58,7 +58,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 
         void captureDynamicWellData(const Opm::Schedule&        sched,
                                     const std::size_t           sim_step,
-                                    const Opm::data::WellRates& xw,
+                                    const Opm::data::Wells&     xw,
                                     const Opm::SummaryState&    smry);
 
         /// Retrieve Integer Well Data Array.

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -41,7 +41,7 @@ namespace Opm {
 } // namespace Opm
 
 namespace Opm { namespace data {
-    class WellRates;
+    class Wells;
     class GroupAndNetworkValues;
 }} // namespace Opm::data
 
@@ -66,7 +66,7 @@ public:
     void eval(SummaryState&                      summary_state,
               const int                          report_step,
               const double                       secs_elapsed,
-              const data::WellRates&             well_solution,
+              const data::Wells&                 well_solution,
               const data::GroupAndNetworkValues& group_and_nwrk_solution,
               GlobalProcessParameters            single_values,
               const Inplace&                     initial_inplace,

--- a/opm/output/eclipse/WriteRFT.hpp
+++ b/opm/output/eclipse/WriteRFT.hpp
@@ -30,7 +30,7 @@ namespace Opm {
 
 namespace Opm { namespace data {
 
-    class WellRates;
+    class Wells;
 
 }} // namespace Opm::data
 
@@ -81,7 +81,7 @@ namespace Opm { namespace RftIO {
                const ::Opm::UnitSystem&         usys,
                const ::Opm::EclipseGrid&        grid,
                const ::Opm::Schedule&           schedule,
-               const ::Opm::data::WellRates&    wellSol,
+               const ::Opm::data::Wells&        wellSol,
                ::Opm::EclIO::OutputStream::RFT& rftFile);
 
 }} // namespace Opm::RftIO

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -76,7 +76,7 @@ namespace {
     void wellConnectionLoop(const Opm::Schedule&        sched,
                             const std::size_t           sim_step,
                             const Opm::EclipseGrid&     grid,
-                            const Opm::data::WellRates& xw,
+                            const Opm::data::Wells& xw,
                             ConnOp&&                    connOp)
     {
         for (const auto& wname : sched.wellNames(sim_step)) {
@@ -306,7 +306,7 @@ Opm::RestartIO::Helpers::AggregateConnectionData::
 captureDeclaredConnData(const Schedule&        sched,
                         const EclipseGrid&     grid,
                         const UnitSystem&      units,
-                        const data::WellRates& xw,
+                        const data::Wells& xw,
                         const SummaryState&    summary_state,
                         const std::size_t      sim_step)
 {

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -727,7 +727,7 @@ namespace {
                                   const Opm::EclipseGrid&     grid,
                                   const Opm::UnitSystem&      units,
                                   const ::Opm::SummaryState&  smry,
-                                  const Opm::data::WellRates& wr,
+                                  const Opm::data::Wells& wr,
                                   RSegArray&                  rSeg)
         {
             using Ix = ::Opm::RestartIO::Helpers::VectorItems::RSeg::index;
@@ -990,7 +990,7 @@ captureDeclaredMSWData(const Schedule&         sched,
                        const std::vector<int>& inteHead,
                        const Opm::EclipseGrid&  grid,
                        const Opm::SummaryState& smry,
-                       const Opm::data::WellRates&  wr
+                       const Opm::data::Wells&  wr
                        )
 {
     const auto& wells = sched.getWells(rptStep);

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -1021,7 +1021,7 @@ void
 Opm::RestartIO::Helpers::AggregateWellData::
 captureDynamicWellData(const Opm::Schedule&        sched,
                        const std::size_t           sim_step,
-                       const Opm::data::WellRates& xw,
+                       const Opm::data::Wells& xw,
                        const ::Opm::SummaryState&  smry)
 {
     const auto& wells = sched.wellNames(sim_step);

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -488,7 +488,7 @@ namespace {
                           const EclipseGrid&                            grid,
                           const EclipseState&                           es,
                           const Schedule&                               schedule,
-                          const data::WellRates&                        wellSol,
+                          const data::Wells&                        wellSol,
                           const Opm::Action::State&                     action_state,
                           const Opm::SummaryState&                      sumState,
                           const std::vector<int>&                       inteHD,

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2297,7 +2297,7 @@ namespace Evaluator {
 
     struct SimulatorResults
     {
-        const Opm::data::WellRates& wellSol;
+        const Opm::data::Wells& wellSol;
         const Opm::data::GroupAndNetworkValues& grpNwrkSol;
         const std::map<std::string, double>& single;
         const Opm::Inplace inplace;
@@ -3144,7 +3144,7 @@ public:
 
     void eval(const int                          sim_step,
               const double                       secs_elapsed,
-              const data::WellRates&             well_solution,
+              const data::Wells&             well_solution,
               const data::GroupAndNetworkValues& grp_nwrk_solution,
               GlobalProcessParameters&           single_values,
               const Inplace&                     initial_inplace,
@@ -3287,7 +3287,7 @@ void
 Opm::out::Summary::SummaryImplementation::
 eval(const int                          sim_step,
      const double                       secs_elapsed,
-     const data::WellRates&             well_solution,
+     const data::Wells&             well_solution,
      const data::GroupAndNetworkValues& grp_nwrk_solution,
      GlobalProcessParameters&           single_values,
      const Inplace&                     initial_inplace,
@@ -3717,7 +3717,7 @@ Summary::Summary(const EclipseState&  es,
 void Summary::eval(SummaryState&                      st,
                    const int                          report_step,
                    const double                       secs_elapsed,
-                   const data::WellRates&             well_solution,
+                   const data::Wells&             well_solution,
                    const data::GroupAndNetworkValues& grp_nwrk_solution,
                    GlobalProcessParameters            single_values,
                    const Inplace&                     initial_inplace,

--- a/src/opm/output/eclipse/WriteRFT.cpp
+++ b/src/opm/output/eclipse/WriteRFT.cpp
@@ -388,7 +388,7 @@ void Opm::RftIO::write(const int                        reportStep,
                        const ::Opm::UnitSystem&         usys,
                        const ::Opm::EclipseGrid&        grid,
                        const ::Opm::Schedule&           schedule,
-                       const ::Opm::data::WellRates&    wellSol,
+                       const ::Opm::data::Wells&        wellSol,
                        ::Opm::EclIO::OutputStream::RFT& rftFile)
 {
     const auto& rftCfg = schedule[reportStep].rft_config();

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -472,11 +472,11 @@ END
         return Opm::Parser{}.parseString(input);
     }
 
-    std::pair<Opm::data::WellRates, Opm::SummaryState> wr(const Opm::Schedule& sched)
+    std::pair<Opm::data::Wells, Opm::SummaryState> wr(const Opm::Schedule& sched)
     {
         using o = ::Opm::data::Rates::opt;
 
-        auto xw = ::Opm::data::WellRates {};
+        auto xw = ::Opm::data::Wells {};
         Opm::SummaryState sum_state(Opm::TimeService::now());
 
         {

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -92,11 +92,11 @@ Opm::SummaryState sim_state()
     state.update("WBHP:WINJ",  234.);
     return state;
 }
-Opm::data::WellRates wr()
+Opm::data::Wells wr()
 {
     using o = ::Opm::data::Rates::opt;
 
-    auto xw = ::Opm::data::WellRates {};
+    auto xw = ::Opm::data::Wells {};
 
     {
         xw["PROD"].rates
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
 
     //BOOST_CHECK_EQUAL(ih.nwells, MockIH::Sz{2});
 
-    const Opm::data::WellRates wrc = wr();
+    const Opm::data::Wells wrc = wr();
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
     amswd.captureDeclaredMSWData(simCase.sched,
                                  rptStep,
@@ -430,7 +430,7 @@ BOOST_AUTO_TEST_CASE(MSW_AICD) {
                                    rptStep, rptStep+1, rptStep);
 
 
-    const Opm::data::WellRates wrc = wr();
+    const Opm::data::Wells wrc = wr();
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
     amswd.captureDeclaredMSWData(simCase.sched,
                                  rptStep,
@@ -533,7 +533,7 @@ BOOST_AUTO_TEST_CASE(MSW_RST) {
                                    rptStep, rptStep+1, rptStep);
 
 
-    const Opm::data::WellRates wrc = wr();
+    const Opm::data::Wells wrc = wr();
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
     amswd.captureDeclaredMSWData(simCase.sched,
                                  rptStep,

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -485,11 +485,11 @@ TSTEP            -- 9
         return state;
     }
 
-    Opm::data::WellRates well_rates_1()
+    Opm::data::Wells well_rates_1()
     {
         using o = ::Opm::data::Rates::opt;
 
-        auto xw = ::Opm::data::WellRates{};
+        auto xw = ::Opm::data::Wells{};
 
         {
             xw["OP_1"].rates
@@ -524,11 +524,11 @@ TSTEP            -- 9
         return xw;
     }
 
-    Opm::data::WellRates well_rates_2()
+    Opm::data::Wells well_rates_2()
     {
         using o = ::Opm::data::Rates::opt;
 
-        auto xw = ::Opm::data::WellRates{};
+        auto xw = ::Opm::data::Wells{};
 
         {
             xw["OP_1"].bhp = 150.0;  // Closed

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -552,7 +552,7 @@ namespace {
         return xw;
     }
 
-    ::Opm::data::WellRates wellSol(const ::Opm::EclipseGrid& grid)
+    ::Opm::data::Wells wellSol(const ::Opm::EclipseGrid& grid)
     {
         auto xw = ::Opm::data::Wells{};
 


### PR DESCRIPTION
Class is named `WellRates`but also carries a `using Wells = WellRates`- downstream used a mix of the two.

Downstream: https://github.com/OPM/opm-simulators/pull/3379

