### PR TITLE
Make method GuideRateModel::updateLINCOM() const

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.hpp
@@ -66,8 +66,8 @@ public:
 
     static GuideRateModel serializeObject();
 
-    bool updateLINCOM(const UDAValue& alpha, const UDAValue& beta, const UDAValue& gamma);
     double eval(double oil_pot, double gas_pot, double wat_pot) const;
+    bool updateLINCOM(const UDAValue& alpha, const UDAValue& beta, const UDAValue& gamma) const;
     double update_delay() const;
     bool allow_increase() const;
     double damping_factor() const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateModel.cpp
@@ -290,7 +290,7 @@ GuideRateModel::Target GuideRateModel::TargetFromString(const std::string& s) {
        the necessary SummaryState into this.
 */
 
-bool GuideRateModel::updateLINCOM(const UDAValue& , const UDAValue& , const UDAValue& ) {
+bool GuideRateModel::updateLINCOM(const UDAValue& , const UDAValue& , const UDAValue& ) const {
     if (this->m_target == Target::COMB)
         throw std::logic_error("The LINCOM keyword is not supported - at all!");
 


### PR DESCRIPTION
Not that it matters very much - but now the `GuideRateModel`class is fully const - which simplifies reasoning a bit.