### PR TITLE
update the guide rates for all the production wells and groups at the same time.

### DIFF
--- a/tests/test_GuideRate.cpp
+++ b/tests/test_GuideRate.cpp
@@ -204,6 +204,7 @@ BOOST_AUTO_TEST_CASE(P1_First)
     const auto rpt  = size_t{1};
 
     cse.gr.compute("P1", rpt, stm, wopp, wgpp, wwpp);
+    cse.gr.update_time_stamp(stm, rpt);
 
     const auto orat = 2.0;
     const auto grat = 4.0;      // == 2 * orat
@@ -247,6 +248,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto rpt  = size_t{1};
 
         cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     {
@@ -257,6 +259,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto rpt  = size_t{1};
 
         cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     const auto orat = 2.0;
@@ -296,6 +299,7 @@ BOOST_AUTO_TEST_CASE(P2_Second)
         const auto rpt  = size_t{3};
 
         cse.gr.compute("P2", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     const auto expect_gr_oil_2 = 10.0 / (0.5 + 1.0/10.0); // wopp_2 / (0.5 + wwpp_2/wopp_2)
@@ -337,6 +341,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto rpt  = size_t{1};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     {
@@ -347,6 +352,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto rpt  = size_t{3};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     {
@@ -357,6 +363,7 @@ BOOST_AUTO_TEST_CASE(P_Third)
         const auto rpt  = size_t{4};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
@@ -404,6 +411,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto rpt  = size_t{1};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     {
@@ -414,6 +422,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto rpt  = size_t{3};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     {
@@ -424,6 +433,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df01)
         const auto rpt  = size_t{4};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)
@@ -471,6 +481,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto rpt  = size_t{1};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     {
@@ -481,6 +492,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto rpt  = size_t{3};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     {
@@ -491,6 +503,7 @@ BOOST_AUTO_TEST_CASE(P_Third_df09)
         const auto rpt  = size_t{4};
 
         cse.gr.compute("P", rpt, stm, wopp, wgpp, wwpp);
+        cse.gr.update_time_stamp(stm, rpt);
     }
 
     const auto expect_gr_oil_1 =  1.0 / (0.5 +  0.1/ 1.0); // wopp_1 / (0.5 + wwpp_1/wopp_1)


### PR DESCRIPTION
This is the first part of the PR https://github.com/OPM/opm-common/pull/2502 . 

The main idea is that the guide rates of all the wells should be updated all together based on the delay specification from the keyword `GUIDERAT`.  When a new well is added, it always need to update the guide rates, for this reason, other wells do not need to update along with the new well. 

I believe the same thing should also include the guide rates for the groups, this has not been addressed. 

Creating this PR is to get input and suggestions.  The guide rates related now is becoming complicated, it is good to get input about how it should be done properly. The tests are not fixed yet. @bska @joakim-hove  

This PR is related to producers, but I found the guide rates of the injectors are not output properly. 