### PR TITLE
Debian spelling and encoding fixes

### DIFF
--- a/docs/keywords.txt
+++ b/docs/keywords.txt
@@ -153,7 +153,7 @@ we currently have five different categories:
 
      To infer the number of records in the keyword based on an
      internal calculation is not supported, hence for these keywords
-     size is given as unkown, and the keywords are terminated when the
+     size is given as unknown, and the keywords are terminated when the
      next valid keyword is found:
 
         {"name" : "VFPPROD" , "size" : "UNKNOWN", ....

--- a/opm/common/utility/numeric/SparseVector.hpp
+++ b/opm/common/utility/numeric/SparseVector.hpp
@@ -5,7 +5,7 @@
 // Created: Mon Jun 29 15:28:59 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //

--- a/opm/common/utility/parameters/Parameter.hpp
+++ b/opm/common/utility/parameters/Parameter.hpp
@@ -4,7 +4,7 @@
 //
 // Created: Tue Jun  2 16:00:21 2009
 //
-// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+// Author(s): BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //            Atgeirr F Rasmussen <atgeirr@sintef.no>
 //
 // $Date$

--- a/opm/common/utility/parameters/ParameterGroup.hpp
+++ b/opm/common/utility/parameters/ParameterGroup.hpp
@@ -4,7 +4,7 @@
 //
 // Created: Tue Jun  2 19:11:11 2009
 //
-// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+// Author(s): BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //            Atgeirr F Rasmussen <atgeirr@sintef.no>
 //
 // $Date$

--- a/opm/common/utility/parameters/ParameterGroup_impl.hpp
+++ b/opm/common/utility/parameters/ParameterGroup_impl.hpp
@@ -4,7 +4,7 @@
 //
 // Created: Tue Jun  2 19:06:46 2009
 //
-// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+// Author(s): BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //            Atgeirr F Rasmussen <atgeirr@sintef.no>
 //
 // $Date$

--- a/opm/common/utility/parameters/ParameterMapItem.hpp
+++ b/opm/common/utility/parameters/ParameterMapItem.hpp
@@ -4,7 +4,7 @@
 //
 // Created: Tue Jun  2 19:05:54 2009
 //
-// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+// Author(s): BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //            Atgeirr F Rasmussen <atgeirr@sintef.no>
 //
 // $Date$

--- a/opm/common/utility/parameters/ParameterRequirement.hpp
+++ b/opm/common/utility/parameters/ParameterRequirement.hpp
@@ -4,7 +4,7 @@
 //
 // Created: Tue Jun  2 19:05:02 2009
 //
-// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+// Author(s): BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //            Atgeirr F Rasmussen <atgeirr@sintef.no>
 //
 // $Date$

--- a/opm/common/utility/parameters/ParameterStrings.hpp
+++ b/opm/common/utility/parameters/ParameterStrings.hpp
@@ -4,7 +4,7 @@
 //
 // Created: Tue Jun  2 19:04:15 2009
 //
-// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+// Author(s): BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //            Atgeirr F Rasmussen <atgeirr@sintef.no>
 //
 // $Date$

--- a/opm/common/utility/parameters/ParameterTools.hpp
+++ b/opm/common/utility/parameters/ParameterTools.hpp
@@ -4,7 +4,7 @@
 //
 // Created: Tue Jun  2 19:02:19 2009
 //
-// Author(s): Bård Skaflestad     <bard.skaflestad@sintef.no>
+// Author(s): BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //            Atgeirr F Rasmussen <atgeirr@sintef.no>
 //
 // $Date$

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -28,7 +28,7 @@ namespace Opm {
     class GRIDSection;
     class RUNSPECSection;
 
-    /*The IOConfig class holds data about input / ouput configurations
+    /*The IOConfig class holds data about input / output configurations
 
       Amongst these configuration settings, a IOConfig object knows if
       a restart file should be written for a specific report step

--- a/python/cxx/deck_keyword.cpp
+++ b/python/cxx/deck_keyword.cpp
@@ -168,7 +168,7 @@ void python::common::export_DeckKeyword(py::module& module) {
                       }
                       catch (const std::exception& e_string) {}
 
-                      throw py::type_error("DeckKeyword: tried to add unkown type to record.");
+                      throw py::type_error("DeckKeyword: tried to add unknown type to record.");
 
                  }
                  value_record_list.push_back( value_record );

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -512,11 +512,11 @@ void ESmry::inspect_lodsmry()
 
         if (keyword[n].size() > 24) {
             if (keyword[n].substr(0,24) != test_str) {
-                OPM_THROW(std::invalid_argument, "keycheck not maching keyword array");
+                OPM_THROW(std::invalid_argument, "keycheck not matching keyword array");
             }
         } else {
             if (keyword[n] != test_str) {
-                OPM_THROW(std::invalid_argument, "keycheck not maching keyword array");
+                OPM_THROW(std::invalid_argument, "keycheck not matching keyword array");
             }
         }
     }

--- a/src/opm/io/eclipse/EclOutput.cpp
+++ b/src/opm/io/eclipse/EclOutput.cpp
@@ -102,7 +102,7 @@ void EclOutput::write(const std::string& name, const std::vector<std::string>& d
         });
 
         if (it->size() > static_cast<size_t>(element_size))
-            OPM_THROW(std::runtime_error, "specified element size for type C0NN less than maximum string length in ouput data");
+            OPM_THROW(std::runtime_error, "specified element size for type C0NN less than maximum string length in output data");
     }
 
     if (isFormatted)

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -152,7 +152,7 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
         throw;
     }
     catch (const std::exception& std_error) {
-        OpmLog::error(fmt::format("\nAn error occured while creating the reservoir properties\n"
+        OpmLog::error(fmt::format("\nAn error occurred while creating the reservoir properties\n"
                                   "Internal error: {}\n", std_error.what()));
         throw;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/KeywordHandlers.cpp
@@ -1381,7 +1381,7 @@ namespace {
       is not checked or verified that the well is initialized with any
       WCONxxxx keyword).
 
-      Update: See the discussion following the defintions of the SI factors, due
+      Update: See the discussion following the definitions of the SI factors, due
       to a bad design we currently need the well to be specified with
       WCONPROD / WCONHIST before WELTARG is applied, if not the units for the
       rates will be wrong.

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -144,7 +144,7 @@ namespace {
         throw;
     }
     catch (const std::exception& std_error) {
-        OpmLog::error(fmt::format("An error occured while creating the reservoir schedule\n"
+        OpmLog::error(fmt::format("An error occurred while creating the reservoir schedule\n"
                                   "Internal error: {}", std_error.what()));
         throw;
     }

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -550,7 +550,7 @@ inline void keywordCL( SummaryConfig::keyword_list& list,
                 } else {
                     std::string msg = fmt::format("Problem with keyword {{keyword}}\n"
                                                   "In {{file}} line {{line}}\n"
-                                                  "Connnection ({},{},{}) not defined for well {} ", ijk[0], ijk[1], ijk[2], wname);
+                                                  "Connection ({},{},{}) not defined for well {} ", ijk[0], ijk[1], ijk[2], wname);
                     parseContext.handleError( ParseContext::SUMMARY_UNHANDLED_KEYWORD, msg, keyword.location(), errors);
                 }
             }
@@ -1159,7 +1159,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
         if (!udq.has_keyword(location.keyword)) {
             std::string msg = "Summary output requested for UDQ {keyword}\n"
                               "In {file} line {line}\n"
-                              "No defintion for this UDQ found in the SCHEDULE section";
+                              "No definition for this UDQ found in the SCHEDULE section";
             parseContext.handleError(ParseContext::SUMMARY_UNDEFINED_UDQ, msg, location, errors);
             return;
         }
@@ -1524,7 +1524,7 @@ SummaryConfig::SummaryConfig( const Deck& deck,
         throw;
     }
     catch (const std::exception& std_error) {
-        OpmLog::error(fmt::format("An error occured while configuring the summary properties\n"
+        OpmLog::error(fmt::format("An error occurred while configuring the summary properties\n"
                                   "Internal error: {}", std_error.what()));
         throw;
     }

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -175,7 +175,7 @@ namespace Opm {
 
         if (action == InputError::EXIT1) {
             OpmLog::error(msg);
-            std::cerr << "A fatal error has occured and the application will stop." << std::endl;
+            std::cerr << "A fatal error has occurred and the application will stop." << std::endl;
             std::cerr << msg << std::endl;
             std::exit(1);
         }

--- a/src/opm/parser/eclipse/Parser/raw/StarToken.cpp
+++ b/src/opm/parser/eclipse/Parser/raw/StarToken.cpp
@@ -152,7 +152,7 @@ namespace Opm {
 
             if (cnt < 1)
                 // TODO: decorate the deck with a warning instead?
-                throw std::invalid_argument("Specifing zero repetitions is not allowed. Token: \'" + std::string(token) + "\'.");
+                throw std::invalid_argument("Specifying zero repetitions is not allowed. Token: \'" + std::string(token) + "\'.");
 
             m_count = static_cast<std::size_t>(cnt);
         }


### PR DESCRIPTION
Cool, that lintian even checks spelling adn proposes fixes.
Ecoding should always be UTF-8 as national encodings are being phased out (at least on Debian). There might be more such problems in cpp files that are not checked, though.