### PR TITLE
For discussion: Deactive timestamping in doxygen for reproducible builds.

### DIFF
--- a/cmake/Templates/Doxyfile
+++ b/cmake/Templates/Doxyfile
@@ -816,7 +816,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # page will contain the date and time when the page was generated. Setting
 # this to NO can help when comparing the output of multiple runs.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_SECTIONS tag is set to YES then the generated HTML
 # documentation will contain sections that can be hidden and shown after the

--- a/opm/output/OutputWriter.hpp
+++ b/opm/output/OutputWriter.hpp
@@ -42,7 +42,6 @@ struct PhaseUsage;
  * Use the create() function to setup a chain of writer based on the
  * configuration values, e.g.
  *
- * \example
  * \code{.cpp}
  *  ParameterGroup params (argc, argv, false);
  *  auto parser = std::make_shared <const Deck> (


### PR DESCRIPTION
This deactivates the message that the doxygen documentation was build at a certain time.

In Debian builds should be reproducible, i.e. packages build at a different time, by a different use, with a different local, etc should be identical. Still not there yet, but this is at least a small step towards it.