### PR TITLE
Always install package configuration files to multiarch library dir

### DIFF
--- a/cmake/Modules/OpmInstall.cmake
+++ b/cmake/Modules/OpmInstall.cmake
@@ -28,7 +28,7 @@ macro (opm_install opm)
   if(NOT "${${opm}_TARGET}" STREQUAL "")
     export(TARGETS ${${opm}_TARGET} ${${opm}_EXTRA_TARGETS}
             FILE ${opm}-targets.cmake)
-    install(EXPORT ${opm}-targets DESTINATION "share/cmake/${opm}")
+    install(EXPORT ${opm}-targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${opm})
   endif()
   # only /usr/lib/debug seems to be searched for debug info; if we have
   # write access to that directory (package installation), then default

--- a/cmake/Modules/OpmProject.cmake
+++ b/cmake/Modules/OpmProject.cmake
@@ -137,16 +137,31 @@ function (opm_cmake_config name)
 	FILE CMAKE "${PROJECT_BINARY_DIR}/${${name}_NAME}-install.cmake"
 	APPEND "${${name}_CONFIG_VARS}"
 	)
+
+  # put this in the right system location; if we have binaries then it
+  # should go in the arch-specific lib/ directory, otherwise use the
+  # common/noarch lib/ directory (these targets come from UseMultiArch)
+  if (${name}_TARGET)
+    set (_pkg_dir ${CMAKE_INSTALL_LIBDIR})
+  else ()
+    set (_pkg_dir lib)
+  endif ()
+
+  # If there is a library then the cmake package configuration file is architecture
+  # dependent and should move to the corresponding multiarch libdir.
+  # Really no idea what ${name}_VER_DIR is and when it is needed.
+  set (_cmake_config_dir ${CMAKE_INSTALL_PREFIX}/${_pkg_dir}/cmake${${name}_VER_DIR}/${${name}_NAME})
+
   # this file gets copied to the final installation directory
   install (
 	FILES ${PROJECT_BINARY_DIR}/${${name}_NAME}-install.cmake
-	DESTINATION share/cmake${${name}_VER_DIR}/${${name}_NAME}
+	DESTINATION ${_cmake_config_dir}
 	RENAME ${${name}_NAME}-config.cmake
 	)
   # assume that there exists a version file already
   install (
 	FILES ${PROJECT_BINARY_DIR}/${${name}_NAME}-config-version.cmake
-	DESTINATION share/cmake${${name}_VER_DIR}/${${name}_NAME}
+	DESTINATION ${_cmake_config_dir}
 	)
 
   # find-mode .pc file; use this to locate system installation
@@ -159,14 +174,6 @@ function (opm_cmake_config name)
 	${CMAKE_INSTALL_PREFIX}/include${${name}_VER_DIR}
 	)
 
-  # put this in the right system location; if we have binaries then it
-  # should go in the arch-specific lib/ directory, otherwise use the
-  # common/noarch lib/ directory (these targets come from UseMultiArch)
-  if (${name}_TARGET)
-	set (_pkg_dir ${CMAKE_INSTALL_LIBDIR})
-  else ()
-	set (_pkg_dir lib)
-  endif ()
   install (
 	FILES ${PROJECT_BINARY_DIR}/${${name}_NAME}-install.pc
 	DESTINATION ${CMAKE_INSTALL_PREFIX}/${_pkg_dir}/pkgconfig${${name}_VER_DIR}/

--- a/cmake/Modules/OpmProject.cmake
+++ b/cmake/Modules/OpmProject.cmake
@@ -138,14 +138,10 @@ function (opm_cmake_config name)
 	APPEND "${${name}_CONFIG_VARS}"
 	)
 
-  # put this in the right system location; if we have binaries then it
-  # should go in the arch-specific lib/ directory, otherwise use the
-  # common/noarch lib/ directory (these targets come from UseMultiArch)
-  if (${name}_TARGET)
-    set (_pkg_dir ${CMAKE_INSTALL_LIBDIR})
-  else ()
-    set (_pkg_dir lib)
-  endif ()
+  # Even if we do not ship a library, our pkg-config file will include
+  # architecture dependent library path and libraries that we depend on.
+  # Hence we still need to install into the multiarch library directory.
+  set (_pkg_dir ${CMAKE_INSTALL_LIBDIR})
 
   # If there is a library then the cmake package configuration file is architecture
   # dependent and should move to the corresponding multiarch libdir.

--- a/debian/libopm-common1-dev.install
+++ b/debian/libopm-common1-dev.install
@@ -1,6 +1,6 @@
 usr/include/*
 usr/lib/dunecontrol/*
 usr/lib/*/pkgconfig/*
-usr/share/cmake/*
+usr/lib/*/cmake/*
 usr/share/opm/*
 usr/lib/*/lib*.so

--- a/redhat/opm-common.spec
+++ b/redhat/opm-common.spec
@@ -196,7 +196,7 @@ rm -rf %{buildroot}
 /usr/lib/dunecontrol/*
 %{_libdir}/pkgconfig/*
 %{_includedir}/*
-%{_datadir}/cmake/*
+%{_libdir}/cmake/*
 %{_datadir}/opm/*
 %{_libdir}/*.so
 
@@ -205,7 +205,7 @@ rm -rf %{buildroot}
 %{_libdir}/openmpi/lib/dunecontrol/*
 %{_libdir}/openmpi/lib/pkgconfig/*
 %{_includedir}/openmpi-x86_64/*
-%{_libdir}/openmpi/share/cmake/*
+%{_libdir}/openmpi/lib/cmake/*
 %{_libdir}/openmpi/share/opm/*
 %{_libdir}/openmpi/lib/*.so
 
@@ -214,6 +214,6 @@ rm -rf %{buildroot}
 %{_libdir}/mpich/lib/dunecontrol/*
 %{_libdir}/mpich/lib/pkgconfig/*
 %{_includedir}/mpich-x86_64/*
-%{_libdir}/mpich/share/cmake/*
+%{_libdir}/mpich/lib/cmake/*
 %{_libdir}/mpich/share/opm/*
 %{_libdir}/mpich/lib/*.so


### PR DESCRIPTION
Due to dependencies on opm-common they will always have architecture dependent libraries in them.

I tried to fix the redhat packaging here, but this might still need changes downstream.