### PR TITLE
Udq rst

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -284,6 +284,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/io/eclipse/rst/connection.cpp
           src/opm/io/eclipse/rst/group.cpp
           src/opm/io/eclipse/rst/header.cpp
+          src/opm/io/eclipse/rst/udq.cpp
           src/opm/io/eclipse/rst/segment.cpp
           src/opm/io/eclipse/rst/state.cpp
           src/opm/io/eclipse/rst/well.cpp
@@ -852,6 +853,7 @@ if(ENABLE_ECL_OUTPUT)
         opm/io/eclipse/rst/header.hpp
         opm/io/eclipse/rst/segment.hpp
         opm/io/eclipse/rst/state.hpp
+        opm/io/eclipse/rst/udq.hpp
         opm/io/eclipse/rst/well.hpp
         opm/output/data/Aquifer.hpp
         opm/output/data/Cells.hpp

--- a/opm/io/eclipse/rst/header.hpp
+++ b/opm/io/eclipse/rst/header.hpp
@@ -86,6 +86,10 @@ struct RstHeader {
     int nmfipr;
     int ngroup;
     int nwgmax;
+    int nwell_udq;
+    int ngroup_udq;
+    int nfield_udq;
+
 
     bool e300_radial;
     bool e100_radial;
@@ -118,6 +122,7 @@ struct RstHeader {
     double udq_eps;
 
     std::pair<std::time_t, std::size_t> restart_info() const;
+    int num_udq() const;
 };
 
 

--- a/opm/io/eclipse/rst/state.hpp
+++ b/opm/io/eclipse/rst/state.hpp
@@ -19,13 +19,14 @@
 #ifndef RST_STATE
 #define RST_STATE
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/rst/header.hpp>
 #include <opm/io/eclipse/rst/group.hpp>
 #include <opm/io/eclipse/rst/well.hpp>
+#include <opm/io/eclipse/rst/udq.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
@@ -48,6 +49,7 @@ struct RstState {
     RstHeader header;
     std::vector<RstWell> wells;
     std::vector<RstGroup> groups;
+    std::vector<RstUDQ> udqs;
     Tuning tuning;
 
 private:
@@ -76,6 +78,14 @@ private:
                  const std::vector<double>& xcon,
                  const std::vector<int>& iseg,
                  const std::vector<double>& rseg);
+
+    void add_udqs(const std::vector<int>& iudq,
+                  const std::vector<std::string>& zudn,
+                  const std::vector<std::string>& zudl,
+                  const std::vector<double>& dudw,
+                  const std::vector<double>& dudg,
+                  const std::vector<double>& dudf);
+
 };
 }
 }

--- a/opm/io/eclipse/rst/udq.hpp
+++ b/opm/io/eclipse/rst/udq.hpp
@@ -1,0 +1,67 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef RST_UDQ
+#define RST_UDQ
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp>
+
+namespace Opm {
+
+namespace RestartIO {
+
+struct RstHeader;
+
+struct RstUDQ {
+    RstUDQ(const std::string& name_arg,
+           const std::string& unit_arg,
+           const std::string& define_arg,
+           UDQUpdate status_arg);
+
+    RstUDQ(const std::string& name_arg,
+           const std::string& unit_arg);
+
+    void add_well_value(const std::string& wname, double value);
+    void add_group_value(const std::string& wname, double value);
+    void add_field_value(double value);
+
+    std::string name;
+    std::string unit;
+    UDQVarType var_type;
+
+    std::optional<std::string> define;
+    UDQUpdate status;
+    std::vector<std::pair<std::string, double>> well_values;
+    std::vector<std::pair<std::string, double>> group_values;
+    double field_value;
+};
+
+
+}
+}
+
+
+
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -179,6 +179,7 @@ namespace UDQ {
     UDQVarType coerce(UDQVarType t1, UDQVarType t2);
     UDQAction actionType(const std::string& action_string);
     UDQUpdate updateType(const std::string& update_string);
+    UDQUpdate updateType(int int_value);
     UDQTokenType tokenType(const std::string& func_name);
     UDQTokenType funcType(const std::string& func_name);
     bool binaryFunc(UDQTokenType token_type);

--- a/src/opm/io/eclipse/rst/header.cpp
+++ b/src/opm/io/eclipse/rst/header.cpp
@@ -87,6 +87,9 @@ RstHeader::RstHeader(const Opm::UnitSystem& unit_system, const std::vector<int>&
     nmfipr(intehead[VI::intehead::NMFIPR]),
     ngroup(intehead[VI::intehead::NGRP]),
     nwgmax(intehead[VI::intehead::NWGMAX]),
+    nwell_udq(intehead[VI::intehead::NO_WELL_UDQS]),
+    ngroup_udq(intehead[VI::intehead::NO_GROUP_UDQS]),
+    nfield_udq(intehead[VI::intehead::NO_FIELD_UDQS]),
     //
     e300_radial(logihead[VI::logihead::E300Radial]),
     e100_radial(logihead[VI::logihead::E100Radial]),
@@ -124,6 +127,11 @@ std::pair<std::time_t, std::size_t> RstHeader::restart_info() const {
     return std::make_pair(asTimeT(TimeStampUTC(this->year, this->month, this->mday)),
                           std::size_t(this->report_step));
 }
+
+int RstHeader::num_udq() const {
+    return this->nwell_udq + nfield_udq + ngroup_udq;
+}
+
 
 
 }

--- a/src/opm/io/eclipse/rst/udq.cpp
+++ b/src/opm/io/eclipse/rst/udq.cpp
@@ -1,0 +1,52 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/io/eclipse/rst/udq.hpp>
+
+namespace Opm {
+namespace RestartIO {
+
+RstUDQ::RstUDQ(const std::string& name_arg, const std::string& unit_arg, const std::string& define_arg, UDQUpdate update_arg)
+    : name(name_arg)
+    , unit(unit_arg)
+    , var_type(UDQ::varType(name_arg))
+    , define(define_arg)
+    , status(update_arg)
+{}
+
+RstUDQ::RstUDQ(const std::string& name_arg, const std::string& unit_arg)
+    : name(name_arg)
+    , unit(unit_arg)
+    , var_type(UDQ::varType(name_arg))
+{}
+
+
+void RstUDQ::add_well_value(const std::string& wname, double value) {
+    this->well_values.emplace_back( wname, value );
+}
+
+void RstUDQ::add_group_value(const std::string& wname, double value) {
+    this->group_values.emplace_back( wname, value );
+}
+
+void RstUDQ::add_field_value(double value) {
+    this->field_value = value;
+}
+
+}
+}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -238,6 +238,15 @@ UDQUpdate updateType(const std::string& update_string) {
     throw std::invalid_argument("Invalid status update string " + update_string);
 }
 
+UDQUpdate updateType(int int_value) {
+    switch (int_value) {
+    case 0: return UDQUpdate::OFF;
+    case 1: return UDQUpdate::NEXT;
+    case 2: return UDQUpdate::ON;
+    default:
+        throw std::logic_error("Invalid integer for UDQUpdate type");
+    }
+}
 
 
 bool binaryFunc(UDQTokenType token_type) {

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -722,6 +722,34 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
         BOOST_CHECK_EQUAL(dUdf[start + 0] ,       460); // duDf NO. 1
 
     }
+
+    {
+        Opm::EclIO::ERst rst_file("TEST_UDQRST.UNRST");
+        auto rst_state = Opm::RestartIO::RstState::load(rst_file, 1);
+        BOOST_CHECK_EQUAL(rst_state.header.nwell_udq, 4);
+        BOOST_CHECK_EQUAL(rst_state.header.ngroup_udq, 1);
+        BOOST_CHECK_EQUAL(rst_state.header.nfield_udq, 39);
+        BOOST_CHECK_EQUAL(rst_state.header.num_udq(), 44);
+        BOOST_CHECK_EQUAL(rst_state.udqs.size(), 44);
+
+        std::vector<std::pair<std::string, std::string>> expected = {
+            {"WUOPRL", "SM3/DAY"},
+            {"WULPRL", "SM3/DAY"},
+            {"WUOPRU", "SM3/DAY"},
+            {"GUOPRU", "SM3/DAY"},
+            {"WULPRU", "SM3/DAY"},
+            {"FULPR" , "SM3/DAY"}};
+
+        std::size_t iudq = 0;
+        for (const auto& [name, unit] : expected) {
+            BOOST_CHECK_EQUAL(name, rst_state.udqs[iudq].name);
+            BOOST_CHECK_EQUAL(unit, rst_state.udqs[iudq].unit);
+            iudq += 1;
+        }
+
+
+        BOOST_CHECK_EQUAL(rst_state.udqs[0].define.value(), "(WOPR PROD1 - 170) * 0.60");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR will load UDQ data from the restart file. This is only a first step, and specifically does *not* 

1. Create proper `Schedule::UDQ` datastructures.
2. Consider `UDA` usage.