### PR TITLE
Add 'Inplace' Slot for Dynamic Pore Volume

### DIFF
--- a/opm/output/eclipse/Inplace.hpp
+++ b/opm/output/eclipse/Inplace.hpp
@@ -40,13 +40,15 @@ public:
         GasInGasPhase = 6,
         PoreVolume = 7,
         // The Inplace class is implemented in close relation to the
-        // ecloutputblackoilmodule in opm-simulators, ane there are certainly
-        // idiosyncracies here due to that coupling. For instance the three enum
-        // values PressurePV, HydroCarbonPV and PressureHydroCarbonPV are *not*
-        // included in the return value from phases().
+        // ecloutputblackoilmodule in opm-simulators, ane there are
+        // certainly idiosyncracies here due to that coupling. For instance
+        // the enum values PressurePV, HydroCarbonPV, PressureHydroCarbonPV,
+        // and DynamicPoreVolume are *not* included in the return value from
+        // phases().
         PressurePV = 8,
         HydroCarbonPV = 9,
-        PressureHydroCarbonPV = 10
+        PressureHydroCarbonPV = 10,
+        DynamicPoreVolume = 11,
     };
 
     /*

--- a/src/opm/output/eclipse/Inplace.cpp
+++ b/src/opm/output/eclipse/Inplace.cpp
@@ -141,7 +141,7 @@ const std::vector<Inplace::Phase>& Inplace::phases() {
         Inplace::Phase::OilInGasPhase,
         Inplace::Phase::GasInLiquidPhase,
         Inplace::Phase::GasInGasPhase,
-        Inplace::Phase::PoreVolume
+        Inplace::Phase::PoreVolume,
     };
 
     return phases_;


### PR DESCRIPTION
The `PoreVolume` value is supposed to be calculated at reference conditions (i.e., no rock compressibility or temperature effects), but being able to report the non-reference condition value is beneficial.  This commit adds a slot for accumulating that value per FIP region and transporting the aggregated values to the PRT output system.