### PR TITLE
GuideRate / restart - minor stuff

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -61,8 +61,6 @@ struct RateVector {
 };
 
 
-private:
-
 struct GuideRateValue {
     GuideRateValue() = default;
     GuideRateValue(double t, double v, GuideRateModel::Target tg):
@@ -85,6 +83,8 @@ struct GuideRateValue {
     GuideRateModel::Target target { GuideRateModel::Target::NONE };
 };
 
+private:
+
 struct GRValState {
     GuideRateValue curr{};
     GuideRateValue prev{};
@@ -100,6 +100,7 @@ public:
     double get(const std::string& group, const Phase& phase) const;
     bool has(const std::string& name) const;
     bool has(const std::string& name, const Phase& phase) const;
+    void init_grvalue(std::size_t report_step, const std::string& wgname, GuideRateValue value);
 
 private:
     void well_compute(const std::string& wgname, size_t report_step, double sim_time, double oil_pot, double gas_pot, double wat_pot);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -245,7 +245,6 @@ namespace Opm
         const Group& getGroup(const std::string& groupName, std::size_t timeStep) const;
 
         void invalidNamePattern (const std::string& namePattern, std::size_t report_step, const ParseContext& parseContext, ErrorGuard& errors, const DeckKeyword& keyword) const;
-        const GuideRateConfig& guideRateConfig(std::size_t timeStep) const;
 
         std::optional<std::size_t> first_RFT() const;
         /*

--- a/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/Well.hpp
@@ -440,6 +440,14 @@ public:
         double getBHPLimit() const;
     };
 
+    static int eclipseControlMode(const Well::InjectorCMode imode,
+                                  const InjectorType        itype);
+
+    static int eclipseControlMode(const Well::ProducerCMode pmode);
+
+    static int eclipseControlMode(const Well&         well,
+                                  const SummaryState& st);
+
 
     Well() = default;
     Well(const std::string& wname,
@@ -684,13 +692,6 @@ private:
 std::ostream& operator<<( std::ostream&, const Well::WellInjectionProperties& );
 std::ostream& operator<<( std::ostream&, const Well::WellProductionProperties& );
 
-int eclipseControlMode(const Well::InjectorCMode imode,
-                       const InjectorType        itype);
-
-int eclipseControlMode(const Well::ProducerCMode pmode);
-
-int eclipseControlMode(const Well&         well,
-                       const SummaryState& st);
 
 std::ostream& operator<<(std::ostream& os, const Well::Status& st);
 std::ostream& operator<<(std::ostream& os, const Well::ProducerCMode& cm);

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -167,10 +167,10 @@ namespace {
             const auto& curr = xw.current_control;
 
             if (curr.isProducer) {
-                return ::Opm::eclipseControlMode(curr.prod);
+                return Opm::Well::eclipseControlMode(curr.prod);
             }
             else { // injector
-                return ::Opm::eclipseControlMode(curr.inj, well.injectorType());
+                return Opm::Well::eclipseControlMode(curr.inj, well.injectorType());
             }
         }
 
@@ -334,8 +334,8 @@ namespace {
             //
             // Observe that the setupCurrentContro() function is called again
             // for open wells in the dynamicContrib() function.
-            setCurrentControl(eclipseControlMode(well, st), iWell);
-            setHistoryControlMode(well, eclipseControlMode(well, st), iWell);
+            setCurrentControl(Opm::Well::eclipseControlMode(well, st), iWell);
+            setHistoryControlMode(well, Opm::Well::eclipseControlMode(well, st), iWell);
 
             // Multi-segmented well information
             iWell[Ix::MsWID] = 0;  // MS Well ID (0 or 1..#MS wells)

--- a/src/opm/output/eclipse/CreateDoubHead.cpp
+++ b/src/opm/output/eclipse/CreateDoubHead.cpp
@@ -84,7 +84,7 @@ namespace {
             double delay = 0.;
             double damping_fact = 0.;
             
-            const auto& guideCFG = sched.guideRateConfig(lookup_step);
+            const auto& guideCFG = sched[lookup_step].guide_rate();
             if (guideCFG.has_model()) {
                 const auto& guideRateModel = guideCFG.model();
                 

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -445,7 +445,7 @@ namespace {
             return { nom_phase };
         }
 
-        const auto& guideCFG = sched.guideRateConfig(lookup_step);
+        const auto& guideCFG = sched[lookup_step].guide_rate();
         if (guideCFG.has_model()) {
             const auto& guideRateModel = guideCFG.model();
             

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1341,7 +1341,7 @@ inline quantity well_control_mode( const fn_args& args )
 
     if (! well_control_mode_defined(xwPos->second)) {
         // No dynamic control mode defined.  Use input control.
-        const auto wmctl = ::Opm::eclipseControlMode(*well, args.st);
+        const auto wmctl = Opm::Well::eclipseControlMode(*well, args.st);
 
         return { static_cast<double>(wmctl), unit };
     }
@@ -1350,8 +1350,8 @@ inline quantity well_control_mode( const fn_args& args )
     // appropriate value depending on well type (producer/injector).
     const auto& curr = xwPos->second.current_control;
     const auto wmctl = curr.isProducer
-        ? ::Opm::eclipseControlMode(curr.prod)
-        : ::Opm::eclipseControlMode(curr.inj, well->injectorType());
+        ? Opm::Well::eclipseControlMode(curr.prod)
+        : Opm::Well::eclipseControlMode(curr.inj, well->injectorType());
 
     return { static_cast<double>(wmctl), unit };
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -320,6 +320,13 @@ void GuideRate::assign_grvalue(const std::string&    wgname,
     v->curr.value = damping_factor*new_guide_rate + (1 - damping_factor)*v->prev.value;
 }
 
+
+void GuideRate::init_grvalue(std::size_t report_step, const std::string& wgname, GuideRateValue value) {
+    const auto& model = this->schedule[report_step].guide_rate().model();
+    this->assign_grvalue(wgname, model, std::move(value));
+}
+
+
 double GuideRate::get_grvalue_result(const GRValState& gr) const
 {
     return (gr.curr.sim_time < 0.0)

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -136,7 +136,7 @@ void GuideRate::compute(const std::string& wgname,
 {
     this->potentials[wgname] = RateVector{oil_pot, gas_pot, wat_pot};
 
-    const auto& config = this->schedule.guideRateConfig(report_step);
+    const auto& config = this->schedule[report_step].guide_rate();
     if (config.has_production_group(wgname)) {
         this->group_compute(wgname, report_step, sim_time, oil_pot, gas_pot, wat_pot);
     }
@@ -152,7 +152,7 @@ void GuideRate::group_compute(const std::string& wgname,
                               double             gas_pot,
                               double             wat_pot)
 {
-    const auto& config = this->schedule.guideRateConfig(report_step);
+    const auto& config = this->schedule[report_step].guide_rate();
     const auto& group = config.production_group(wgname);
     if (group.guide_rate > 0.0) {
         auto model_target = GuideRateModel::convert_target(group.target);
@@ -209,7 +209,7 @@ void GuideRate::compute(const std::string& wgname,
                         size_t report_step,
                         double guide_rate)
 {
-    const auto& config = this->schedule.guideRateConfig(report_step);
+    const auto& config = this->schedule[report_step].guide_rate();
     if (!config.has_injection_group(phase, wgname))
         return;
 
@@ -232,7 +232,7 @@ void GuideRate::well_compute(const std::string& wgname,
                              double             gas_pot,
                              double             wat_pot)
 {
-    const auto& config = this->schedule.guideRateConfig(report_step);
+    const auto& config = this->schedule[report_step].guide_rate();
 
     // guide rates spesified with WGRUPCON
     if (config.has_well(wgname)) {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1141,10 +1141,6 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         return this->snapshots[timeStep].udq.get();
     }
 
-    const GuideRateConfig& Schedule::guideRateConfig(std::size_t timeStep) const {
-        return this->snapshots[timeStep].guide_rate();
-    }
-
     std::optional<int> Schedule::exitStatus() const {
         return this->exit_status;
     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -1631,8 +1631,8 @@ PAvgCalculator Well::pavg_calculator(const EclipseGrid& grid, const std::vector<
 
 }
 
-int Opm::eclipseControlMode(const Opm::Well::InjectorCMode imode,
-                            const Opm::InjectorType        itype)
+int Opm::Well::eclipseControlMode(const Well::InjectorCMode imode,
+                             const InjectorType        itype)
 {
     using IMode = ::Opm::Well::InjectorCMode;
     using Val   = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
@@ -1658,7 +1658,7 @@ int Opm::eclipseControlMode(const Opm::Well::InjectorCMode imode,
     return Val::WMCtlUnk;
 }
 
-int Opm::eclipseControlMode(const Opm::Well::ProducerCMode pmode)
+int Opm::Well::eclipseControlMode(const Opm::Well::ProducerCMode pmode)
 {
     using PMode = ::Opm::Well::ProducerCMode;
     using Val   = ::Opm::RestartIO::Helpers::VectorItems::IWell::Value::WellCtrlMode;
@@ -1692,8 +1692,8 @@ int Opm::eclipseControlMode(const Opm::Well::ProducerCMode pmode)
   corresponding to the currently active control is writte to the restart file.
 */
 
-int Opm::eclipseControlMode(const Well&         well,
-                            const SummaryState& st)
+int Opm::Well::eclipseControlMode(const Well&         well,
+                                  const SummaryState& st)
 {
     if (well.isProducer()) {
         const auto& ctrl = well.productionControls(st);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3448,7 +3448,7 @@ COMPDAT
 
     const auto& schedule = make_schedule(input);
     {
-        const auto& grc = schedule.guideRateConfig(0);
+        const auto& grc = schedule[0].guide_rate();
         const auto& w1_node = grc.well("W1");
         BOOST_CHECK(w1_node.target == Well::GuideRateTarget::OIL);
 
@@ -3459,7 +3459,7 @@ COMPDAT
         BOOST_CHECK(grc.has_production_group("G2"));
     }
     {
-        const auto& grc = schedule.guideRateConfig(2);
+        const auto& grc = schedule[2].guide_rate();
         const auto& w1_node = grc.well("W1");
         BOOST_CHECK(w1_node.target == Well::GuideRateTarget::WAT);
         BOOST_CHECK_EQUAL(w1_node.guide_rate, 0.75);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3541,13 +3541,13 @@ END
     const auto sched = make_schedule(input);
     const auto st = ::Opm::SummaryState{ TimeService::now() };
 
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W1", 10), st), -1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W2", 10), st), 3);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W3", 10), st), 1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W4", 10), st), 2);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W5", 10), st), 5);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W6", 10), st), 7);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W7", 10), st), 6);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W1", 10), st), -1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W2", 10), st), 3);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W3", 10), st), 1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W4", 10), st), 2);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W5", 10), st), 5);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W6", 10), st), 7);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W7", 10), st), 6);
 }
 
 BOOST_AUTO_TEST_CASE(Production_Control_Mode_From_Well) {
@@ -3585,14 +3585,14 @@ END
     const auto sched = make_schedule(input);
     const auto st = ::Opm::SummaryState{ TimeService::now() };
 
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W1", 10), st), -1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W2", 10), st), 1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W3", 10), st), 2);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W4", 10), st), 3);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W5", 10), st), 4);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W6", 10), st), 5);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W7", 10), st), 7);
-    BOOST_CHECK_EQUAL(eclipseControlMode(sched.getWell("W8", 10), st), 6);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W1", 10), st), -1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W2", 10), st), 1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W3", 10), st), 2);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W4", 10), st), 3);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W5", 10), st), 4);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W6", 10), st), 5);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W7", 10), st), 7);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W8", 10), st), 6);
 }
 
 

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -921,47 +921,47 @@ BOOST_AUTO_TEST_CASE(Injector_Control_Mode) {
     using IMode = ::Opm::Well::InjectorCMode;
     using IType = ::Opm::InjectorType;
 
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::GRUP, IType::GAS), -1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::GRUP, IType::WATER), -1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::GRUP, IType::MULTI), -1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::GRUP, IType::OIL), -1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::RATE, IType::OIL), 1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::RATE, IType::WATER), 2);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::RATE, IType::GAS), 3);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::RATE, IType::MULTI), -10);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::RESV, IType::GAS), 5);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::RESV, IType::WATER), 5);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::RESV, IType::MULTI), 5);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::RESV, IType::OIL), 5);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::THP, IType::GAS), 6);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::THP, IType::WATER), 6);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::THP, IType::MULTI), 6);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::THP, IType::OIL), 6);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::BHP, IType::GAS), 7);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::BHP, IType::WATER), 7);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::BHP, IType::MULTI), 7);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::BHP, IType::OIL), 7);
-    BOOST_CHECK_EQUAL(eclipseControlMode(IMode::CMODE_UNDEFINED, IType::WATER), -10);
-    BOOST_CHECK_EQUAL(eclipseControlMode(static_cast<IMode>(1729), IType::WATER), -10);
-    BOOST_CHECK_EQUAL(eclipseControlMode(static_cast<IMode>(1729), IType::WATER), -10); // Unknown combination
-    BOOST_CHECK_EQUAL(eclipseControlMode(static_cast<IMode>(1729), IType::WATER), -10); // Unknown combination
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::GRUP, IType::GAS), -1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::GRUP, IType::WATER), -1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::GRUP, IType::MULTI), -1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::GRUP, IType::OIL), -1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::RATE, IType::OIL), 1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::RATE, IType::WATER), 2);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::RATE, IType::GAS), 3);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::RATE, IType::MULTI), -10);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::RESV, IType::GAS), 5);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::RESV, IType::WATER), 5);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::RESV, IType::MULTI), 5);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::RESV, IType::OIL), 5);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::THP, IType::GAS), 6);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::THP, IType::WATER), 6);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::THP, IType::MULTI), 6);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::THP, IType::OIL), 6);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::BHP, IType::GAS), 7);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::BHP, IType::WATER), 7);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::BHP, IType::MULTI), 7);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::BHP, IType::OIL), 7);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(IMode::CMODE_UNDEFINED, IType::WATER), -10);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(static_cast<IMode>(1729), IType::WATER), -10);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(static_cast<IMode>(1729), IType::WATER), -10); // Unknown combination
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(static_cast<IMode>(1729), IType::WATER), -10); // Unknown combination
 }
 
 BOOST_AUTO_TEST_CASE(Producer_Control_Mode) {
     using PMode = ::Opm::Well::ProducerCMode;
 
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::GRUP), -1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::ORAT), 1);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::WRAT), 2);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::GRAT), 3);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::LRAT), 4);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::RESV), 5);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::THP ), 6);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::BHP ), 7);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::CRAT), 9);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::NONE), -10);
-    BOOST_CHECK_EQUAL(eclipseControlMode(PMode::CMODE_UNDEFINED), -10);
-    BOOST_CHECK_EQUAL(eclipseControlMode(static_cast<PMode>(271828)), -10);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::GRUP), -1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::ORAT), 1);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::WRAT), 2);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::GRAT), 3);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::LRAT), 4);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::RESV), 5);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::THP ), 6);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::BHP ), 7);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::CRAT), 9);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::NONE), -10);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(PMode::CMODE_UNDEFINED), -10);
+    BOOST_CHECK_EQUAL(Well::eclipseControlMode(static_cast<PMode>(271828)), -10);
 }
 
 BOOST_AUTO_TEST_CASE(WPIMULT) {


### PR DESCRIPTION
Some minor changes (hopefully improvements) falling off the restart chore. The commit "Add method GuideRate::init_grvalue()" is needed from the simulator when setting guiderates