### PR TITLE
Alternative selector implementation for UDQAssign loaded from rst

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQAssign.cpp
@@ -27,11 +27,18 @@ UDQAssign::UDQAssign() :
 {
 }
 
-UDQAssign::UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value, std::size_t report_step) :
+UDQAssign::UDQAssign(const std::string& keyword, const std::vector<std::string>& input_selector, double value, std::size_t report_step) :
     m_keyword(keyword),
     m_var_type(UDQ::varType(keyword))
 {
-    this->add_record(selector, value, report_step);
+    this->add_record(input_selector, value, report_step);
+}
+
+UDQAssign::UDQAssign(const std::string& keyword, const std::unordered_set<std::string>& rst_selector, double value, std::size_t report_step) :
+    m_keyword(keyword),
+    m_var_type(UDQ::varType(keyword))
+{
+    this->add_record(rst_selector, value, report_step);
 }
 
 UDQAssign UDQAssign::serializeObject()
@@ -39,13 +46,17 @@ UDQAssign UDQAssign::serializeObject()
     UDQAssign result;
     result.m_keyword = "test";
     result.m_var_type = UDQVarType::CONNECTION_VAR;
-    result.records = {{{"test1"}, 1.0, 0}};
+    result.records = {{std::vector<std::string>{"test1"}, 1.0, 0}};
 
     return result;
 }
 
-void UDQAssign::add_record(const std::vector<std::string>& selector, double value, std::size_t report_step) {
-    this->records.push_back({selector, value, report_step});
+void UDQAssign::add_record(const std::vector<std::string>& input_selector, double value, std::size_t report_step) {
+    this->records.push_back({input_selector, value, report_step});
+}
+
+void UDQAssign::add_record(const std::unordered_set<std::string>& rst_selector, double value, std::size_t report_step) {
+    this->records.push_back({rst_selector, value, report_step});
 }
 
 const std::string& UDQAssign::keyword() const {
@@ -66,14 +77,8 @@ UDQSet UDQAssign::eval(const std::vector<std::string>& wells) const {
     if (this->m_var_type == UDQVarType::WELL_VAR) {
         UDQSet ws = UDQSet::wells(this->m_keyword, wells);
 
-        for (const auto& record : this->records) {
-            const auto& selector = record.selector;
-            double value = record.value;
-            if (selector.empty())
-                ws.assign(value);
-            else
-                ws.assign(selector[0], value);
-        }
+        for (const auto& record : this->records)
+            record.eval(ws);
 
         return ws;
     }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -965,9 +965,9 @@ BOOST_AUTO_TEST_CASE(UDQ_SET_DIV) {
 
 
 BOOST_AUTO_TEST_CASE(UDQASSIGN_TEST) {
-    UDQAssign as1("WUPR", {}, 1.0, 1);
-    UDQAssign as2("WUPR", {"P*"}, 2.0, 2);
-    UDQAssign as3("WUPR", {"P1"}, 4.0, 3);
+    UDQAssign as1("WUPR", std::vector<std::string>{}, 1.0, 1);
+    UDQAssign as2("WUPR", std::vector<std::string>{"P*"}, 2.0, 2);
+    UDQAssign as3("WUPR", std::vector<std::string>{"P1"}, 4.0, 3);
     std::vector<std::string> ws1 = {"P1", "P2", "I1", "I2"};
 
     auto res1 = as1.eval(ws1);
@@ -2602,4 +2602,15 @@ UDQ
     BOOST_CHECK_EQUAL(res["W1"].get(), 300);
     BOOST_CHECK_EQUAL(res["W2"].get(), 200);
     BOOST_CHECK_EQUAL(res["W3"].get(), 100);
+}
+
+
+BOOST_AUTO_TEST_CASE(UDQ_ASSIGN_RST) {
+    std::unordered_set<std::string> selector{"W1", "W2"};
+    UDQAssign assign("WUBHP", selector, 100, 2);
+    auto res = assign.eval( {"W1", "W2", "W3"});
+    BOOST_CHECK_EQUAL(res.size(), 3);
+    BOOST_CHECK_EQUAL(res["W1"].get(), 100);
+    BOOST_CHECK_EQUAL(res["W2"].get(), 100);
+    BOOST_CHECK_EQUAL(res["W3"].defined(), false);
 }


### PR DESCRIPTION
When the UDQs are loaded from the restart file the arguments are provided differently - create a new constructor++ for `UDQAssign` to prepare for loading from restart file.