### PR TITLE
Reimplement RstState::load In Terms of RestartFileView

### DIFF
--- a/opm/io/eclipse/rst/state.hpp
+++ b/opm/io/eclipse/rst/state.hpp
@@ -19,29 +19,33 @@
 #ifndef RST_STATE
 #define RST_STATE
 
+#include <memory>
 #include <string>
 #include <vector>
 
-#include <opm/io/eclipse/ERst.hpp>
 #include <opm/io/eclipse/rst/header.hpp>
 #include <opm/io/eclipse/rst/group.hpp>
 #include <opm/io/eclipse/rst/well.hpp>
 #include <opm/io/eclipse/rst/udq.hpp>
+
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
 
 
-namespace Opm {
+namespace Opm { namespace EclIO {
+    class RestartFileView;
+}} // namespace Opm::EclIO
 
-namespace RestartIO {
+namespace Opm { namespace RestartIO {
+
 struct RstState {
     RstState(const ::Opm::UnitSystem& unit_system,
              const std::vector<int>& intehead,
              const std::vector<bool>& logihead,
              const std::vector<double>& doubhead);
 
-    static RstState load(EclIO::ERst& rst_file, int report_step);
+    static RstState load(std::shared_ptr<EclIO::RestartFileView> rstView);
 
     const RstWell& get_well(const std::string& wname) const;
 
@@ -87,10 +91,7 @@ private:
                   const std::vector<double>& dudf);
 
 };
-}
-}
 
-
-
+}} // namespace Opm::RestartIO
 
 #endif

--- a/src/opm/io/eclipse/RestartFileView.cpp
+++ b/src/opm/io/eclipse/RestartFileView.cpp
@@ -42,6 +42,12 @@ namespace {
     };
 
     template<>
+    struct ArrayType<bool>
+    {
+        static Opm::EclIO::eclArrType T;
+    };
+
+    template<>
     struct ArrayType<float>
     {
         static Opm::EclIO::eclArrType T;
@@ -60,6 +66,7 @@ namespace {
     };
 
     Opm::EclIO::eclArrType ArrayType<int>::T         = ::Opm::EclIO::eclArrType::INTE;
+    Opm::EclIO::eclArrType ArrayType<bool>::T        = ::Opm::EclIO::eclArrType::LOGI;
     Opm::EclIO::eclArrType ArrayType<float>::T       = ::Opm::EclIO::eclArrType::REAL;
     Opm::EclIO::eclArrType ArrayType<double>::T      = ::Opm::EclIO::eclArrType::DOUB;
     Opm::EclIO::eclArrType ArrayType<std::string>::T = ::Opm::EclIO::eclArrType::CHAR;
@@ -242,12 +249,16 @@ Opm::EclIO::RestartFileView::getKeyword(const std::string& vector,
 namespace Opm { namespace EclIO {
 
 template bool RestartFileView::hasKeyword<int>        (const std::string&) const;
+template bool RestartFileView::hasKeyword<bool>       (const std::string&) const;
 template bool RestartFileView::hasKeyword<float>      (const std::string&) const;
 template bool RestartFileView::hasKeyword<double>     (const std::string&) const;
 template bool RestartFileView::hasKeyword<std::string>(const std::string&) const;
 
 template const std::vector<int>&
 RestartFileView::getKeyword<int>(const std::string&, const int) const;
+
+template const std::vector<bool>&
+RestartFileView::getKeyword<bool>(const std::string&, const int) const;
 
 template const std::vector<float>&
 RestartFileView::getKeyword<float>(const std::string&, const int) const;

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -36,6 +36,11 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/io/eclipse/rst/state.hpp>
 #include <opm/io/eclipse/ERst.hpp>
+#include <opm/io/eclipse/RestartFileView.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
 
 using namespace Opm;
 
@@ -71,8 +76,9 @@ void compare_wells(const RestartIO::RstWell& rst_well, const Well& sched_well) {
 BOOST_AUTO_TEST_CASE(LoadRST) {
     Parser parser;
     auto deck = parser.parseFile("SPE1CASE2.DATA");
-    EclIO::ERst rst_file("SPE1CASE2.X0060");
-    auto rst_state = RestartIO::RstState::load(rst_file, 60);
+    auto rst_file = std::make_shared<EclIO::ERst>("SPE1CASE2.X0060");
+    auto rst_view = std::make_shared<EclIO::RestartFileView>(std::move(rst_file), 60);
+    auto rst_state = RestartIO::RstState::load(std::move(rst_view));
     BOOST_REQUIRE_THROW( rst_state.get_well("NO_SUCH_WELL"), std::out_of_range);
     auto python = std::make_shared<Python>();
     EclipseState ecl_state(deck);
@@ -95,8 +101,9 @@ BOOST_AUTO_TEST_CASE(LoadRestartSim) {
     Schedule sched(deck, ecl_state, python);
 
     auto restart_deck = parser.parseFile("SPE1CASE2_RESTART.DATA");
-    EclIO::ERst rst_file("SPE1CASE2.X0060");
-    auto rst_state = RestartIO::RstState::load(rst_file, 60);
+    auto rst_file = std::make_shared<EclIO::ERst>("SPE1CASE2.X0060");
+    auto rst_view = std::make_shared<EclIO::RestartFileView>(std::move(rst_file), 60);
+    auto rst_state = RestartIO::RstState::load(std::move(rst_view));
     EclipseState ecl_state_restart(restart_deck);
     Schedule restart_sched(restart_deck, ecl_state_restart, python, {}, &rst_state);
 

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -31,6 +31,7 @@
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/io/eclipse/ERst.hpp>
+#include <opm/io/eclipse/RestartFileView.hpp>
 #include <opm/io/eclipse/rst/state.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/output/data/Wells.hpp>
@@ -724,8 +725,9 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
     }
 
     {
-        Opm::EclIO::ERst rst_file("TEST_UDQRST.UNRST");
-        auto rst_state = Opm::RestartIO::RstState::load(rst_file, 1);
+        auto rst_file = std::make_shared<Opm::EclIO::ERst>("TEST_UDQRST.UNRST");
+        auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>(std::move(rst_file), 1);
+        auto rst_state = Opm::RestartIO::RstState::load(std::move(rst_view));
         BOOST_CHECK_EQUAL(rst_state.header.nwell_udq, 4);
         BOOST_CHECK_EQUAL(rst_state.header.ngroup_udq, 1);
         BOOST_CHECK_EQUAL(rst_state.header.nfield_udq, 39);


### PR DESCRIPTION
This is in preparation of unconditionally loading analytic aquifer information from the restart file.  Update callers to new API.