### PR TITLE
Add Utility to Track Restart Output Events

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -139,6 +139,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/Connection.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/injection.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Well/PAvg.cpp
@@ -415,6 +416,7 @@ if(ENABLE_ECL_INPUT)
     tests/parser/WellTracerTests.cpp
     tests/parser/WellTests.cpp
     tests/parser/WLIST.cpp
+    tests/parser/WriteRestartFileEventsTests.cpp
     tests/parser/WTEST.cpp)
 endif()
 if(ENABLE_ECL_OUTPUT)
@@ -785,6 +787,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp
        opm/parser/eclipse/EclipseState/Schedule/ScheduleTypes.hpp
        opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
+       opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group/GPMaint.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group/GTNode.hpp
        opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.hpp
@@ -1,0 +1,58 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_WRITE_RESTART_FILE_EVENTS_HPP
+#define OPM_WRITE_RESTART_FILE_EVENTS_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace Opm {
+
+class WriteRestartFileEvents
+{
+public:
+    void resize(const std::size_t numReportSteps);
+    void clearRemainingEvents(const std::size_t start);
+    void addRestartOutput(const std::size_t reportStep);
+
+    bool writeRestartFile(const std::size_t reportStep) const;
+
+    std::optional<std::size_t>
+    lastRestartEventBefore(const std::size_t reportStep) const;
+
+    bool operator==(const WriteRestartFileEvents& that) const;
+
+    static WriteRestartFileEvents serializeObject();
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->write_restart_file_);
+    }
+
+private:
+    std::vector<std::uint_fast64_t> write_restart_file_{};
+};
+
+}
+
+#endif // OPM_WRITE_RESTART_FILE_EVENTS_HPP

--- a/src/opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.cpp
@@ -1,0 +1,195 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.hpp>
+
+#include <algorithm>
+#include <climits>
+#include <cstddef>
+#include <cstdlib>
+#include <cstdint>
+#include <optional>
+#include <iterator>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace {
+    constexpr auto nbits = sizeof(std::uint_fast64_t) * CHAR_BIT;
+    constexpr auto zero  = std::uint_fast64_t{0};
+
+    std::pair<std::vector<std::uint_fast64_t>::size_type, unsigned char>
+    array_location(const std::size_t i)
+    {
+        return { i / nbits, static_cast<unsigned char>(i % nbits) };
+    }
+
+    void clear_bits(std::size_t start, std::uint_fast64_t& bits)
+    {
+        for (; start < nbits; ++start) {
+            bits &= ~(1ULL << start);
+        }
+    }
+
+    // In C++20 this is std::countl_zero().
+    //
+    // Using compiler intrinsics this is __builtin_clzl in GCC and Clang,
+    // __lzcnt in MSVC, and _bit_scan_reverse in ICC.  POSIX has ffs but
+    // only for 'int'.  Glibc additionally provides ffsl and ffsll, but
+    // these require signed integer inputs.
+    //
+    // Note: There are more efficient approaches to computing this quantity
+    // as evidenced by the existence of compiler intrinsics.  This binary
+    // search is a reasonable compromise between efficiency, portability,
+    // and readability outside Flow's hot path.
+    std::uint_fast64_t count_leading_zeros(std::uint_fast64_t bits)
+    {
+        if (bits == zero) {
+            return nbits;
+        }
+
+        auto count = zero;
+        if ((bits & 0xFFFF'FFFF'0000'0000ULL) == zero) {
+            count += 32;
+            bits   = bits << 32;
+        }
+
+        if ((bits & 0xFFFF'0000'0000'0000ULL) == zero) {
+            count += 16;
+            bits   = bits << 16;
+        }
+
+        if ((bits & 0xFF00'0000'0000'0000ULL) == zero) {
+            count += 8;
+            bits   = bits << 8;
+        }
+
+        if ((bits & 0xF000'0000'0000'0000ULL) == zero) {
+            count += 4;
+            bits   = bits << 4;
+        }
+
+        if ((bits & 0xC000'0000'0000'0000ULL) == zero) {
+            count += 2;
+            bits   = bits << 2;
+        }
+
+        if ((bits & 0x8000'0000'0000'0000ULL) == zero) {
+            ++count;
+        }
+
+        return count;
+    }
+}
+
+void Opm::WriteRestartFileEvents::resize(const std::size_t numReportSteps)
+{
+    const auto loc = array_location(numReportSteps);
+
+    if (loc.first < this->write_restart_file_.size()) {
+        return;
+    }
+
+    this->write_restart_file_.resize(loc.first + 1, zero);
+}
+
+void Opm::WriteRestartFileEvents::clearRemainingEvents(const std::size_t start)
+{
+    const auto loc = array_location(start);
+
+    if (loc.first >= this->write_restart_file_.size()) {
+        return;
+    }
+
+    clear_bits(loc.second, this->write_restart_file_[loc.first]);
+
+    auto begin = this->write_restart_file_.begin();
+    std::advance(begin, loc.first + 1);
+    std::fill(begin, this->write_restart_file_.end(), zero);
+}
+
+void Opm::WriteRestartFileEvents::addRestartOutput(const std::size_t reportStep)
+{
+    this->resize(reportStep + 1);
+
+    const auto loc = array_location(reportStep);
+    this->write_restart_file_[loc.first] |= (1ULL << loc.second);
+}
+
+bool Opm::WriteRestartFileEvents::writeRestartFile(const std::size_t reportStep) const
+{
+    const auto loc = array_location(reportStep);
+
+    if (loc.first >= this->write_restart_file_.size()) {
+        return false;
+    }
+
+    return (this->write_restart_file_[loc.first] & (1ULL << loc.second)) != zero;
+}
+
+std::optional<std::size_t>
+Opm::WriteRestartFileEvents::lastRestartEventBefore(const std::size_t reportStep) const
+{
+    if (this->write_restart_file_.empty()) {
+        return std::nullopt;
+    }
+
+    const auto loc = array_location(reportStep);
+    if ((loc.first < this->write_restart_file_.size()) &&
+        (loc.second > 0))
+    {
+        const auto prev = this->write_restart_file_[loc.first]
+            & ((1ULL << loc.second) - 1);
+        const auto zeros = count_leading_zeros(prev);
+        if (zeros < nbits) {
+            return { nbits*loc.first + nbits - zeros - 1 };
+        }
+    }
+
+    auto bin = std::min(loc.first, this->write_restart_file_.size());
+    auto zeros = nbits;
+    while ((bin > zero) && (zeros == nbits)) {
+        --bin;
+        zeros = count_leading_zeros(this->write_restart_file_[bin]);
+    }
+
+    return (zeros == nbits)
+        ? std::nullopt
+        : std::optional<std::size_t>(nbits*bin + nbits - zeros - 1);
+}
+
+bool Opm::WriteRestartFileEvents::operator==(const WriteRestartFileEvents& that) const
+{
+    return this->write_restart_file_ == that.write_restart_file_;
+}
+
+Opm::WriteRestartFileEvents
+Opm::WriteRestartFileEvents::serializeObject()
+{
+    auto events = WriteRestartFileEvents{};
+
+    events.addRestartOutput(11);
+    events.addRestartOutput(22);
+    events.addRestartOutput(33);
+    events.addRestartOutput(128);
+
+    events.resize(256);
+
+    return events;
+}

--- a/tests/parser/WriteRestartFileEventsTests.cpp
+++ b/tests/parser/WriteRestartFileEventsTests.cpp
@@ -1,0 +1,267 @@
+/*
+  Copyright 2021 Equinor.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Restart File Events
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Schedule/WriteRestartFileEvents.hpp>
+
+#include <cstddef>
+
+BOOST_AUTO_TEST_SUITE(Basic_Operations)
+
+BOOST_AUTO_TEST_CASE(Default_Constructor)
+{
+    const auto events = Opm::WriteRestartFileEvents{};
+
+    BOOST_CHECK_MESSAGE(!events.writeRestartFile(0),
+                        "Default constructed events object must not "
+                        "have events at report step zero");
+
+    BOOST_CHECK_MESSAGE(!events.writeRestartFile(11),
+                        "Default constructed events object must not "
+                        "have events at report step 11");
+
+    BOOST_CHECK_MESSAGE(!events.writeRestartFile(1729),
+                        "Default constructed events object must not "
+                        "have events at report step 1729");
+}
+
+BOOST_AUTO_TEST_CASE(Add_Events)
+{
+    auto events = Opm::WriteRestartFileEvents{};
+
+    events.addRestartOutput(11);
+    events.addRestartOutput(22);
+    events.addRestartOutput(33);
+    events.addRestartOutput(59);
+    events.addRestartOutput(64);
+    BOOST_CHECK_MESSAGE(events.writeRestartFile(11),
+                        "Events object must have restart event at "
+                        "report step 11 after 'add'");
+
+    BOOST_CHECK_MESSAGE(events.writeRestartFile(22),
+                        "Events object must have restart event at "
+                        "report step 22 after 'add'");
+
+    BOOST_CHECK_MESSAGE(events.writeRestartFile(33),
+                        "Events object must have restart event at "
+                        "report step 33 after 'add'");
+
+    BOOST_CHECK_MESSAGE(events.writeRestartFile(59),
+                        "Events object must have restart event at "
+                        "report step 59 after 'add'");
+
+    BOOST_CHECK_MESSAGE(events.writeRestartFile(64),
+                        "Events object must have restart event at "
+                        "report step 64 after 'add'");
+
+    BOOST_CHECK_MESSAGE(!events.writeRestartFile(0),
+                        "Events object must have NOT restart event at "
+                        "report step 0 after 'add(64)'");
+
+    BOOST_CHECK_MESSAGE(!events.writeRestartFile(42),
+                        "Events object must have NOT restart event at "
+                        "report step 42 after 'add(64)'");
+
+    BOOST_CHECK_MESSAGE(!events.writeRestartFile(65),
+                        "Events object must have NOT restart event at "
+                        "report step 65 after 'add(64)'");
+
+    BOOST_CHECK_MESSAGE(!events.writeRestartFile(1729),
+                        "Events object must have NOT restart event at "
+                        "report step 1729 after 'add(64)'");
+}
+
+BOOST_AUTO_TEST_CASE(Clear_Remaining_Events)
+{
+    auto events = Opm::WriteRestartFileEvents{};
+
+    events.addRestartOutput(11);
+    events.addRestartOutput(22);
+    events.addRestartOutput(33);
+    events.addRestartOutput(59);
+
+    events.clearRemainingEvents(33);
+
+    BOOST_CHECK_MESSAGE(events.writeRestartFile(11),
+                        "Events object must have restart event at "
+                        "report step 11 after 'add'");
+
+    BOOST_CHECK_MESSAGE(events.writeRestartFile(22),
+                        "Events object must have restart event at "
+                        "report step 22 after 'add'");
+
+    for (auto i = 33; i < 64; ++i) {
+        BOOST_CHECK_MESSAGE(!events.writeRestartFile(i),
+                            "Events object must have NOT restart event at "
+                            "report step " << i << " after 'clearRemainingEvents(33)'");
+    }
+
+    events.addRestartOutput(33);
+    events.clearRemainingEvents(34);
+
+    BOOST_CHECK_MESSAGE(events.writeRestartFile(33),
+                        "Events object must have restart event at "
+                        "report step 33 after 'clearRemainingEvents(34)'");
+
+    for (auto i = 34; i < 64; ++i) {
+        BOOST_CHECK_MESSAGE(!events.writeRestartFile(i),
+                            "Events object must have NOT restart event at "
+                            "report step " << i << " after 'clearRemainingEvents(34)'");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(Last_Restart_Event_Before)
+{
+    auto events = Opm::WriteRestartFileEvents{};
+
+    {
+        const auto event = events.lastRestartEventBefore(271828);
+        BOOST_CHECK_MESSAGE(!event.has_value(), "There must be no output events before report step 271828");
+    }
+
+    events.addRestartOutput(11);
+    events.addRestartOutput(22);
+    events.addRestartOutput(33);
+    events.addRestartOutput(59);
+
+    {
+        const auto event = events.lastRestartEventBefore(11);
+        BOOST_CHECK_MESSAGE(!event.has_value(), "There must be no output events before report step 11");
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(12);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 12");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{11});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(22);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 22");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{11});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(23);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 23");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{22});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(28);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 28");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{22});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(33);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 33");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{22});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(34);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 34");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{33});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(50);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 50");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{33});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(59);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 59");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{33});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(60);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 60");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{59});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(64);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 64");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{59});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(1729);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 1729");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{59});
+    }
+
+    events.addRestartOutput(42);
+
+    {
+        const auto event = events.lastRestartEventBefore(42);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 42");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{33});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(43);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 43");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{42});
+    }
+
+    events.addRestartOutput(128);
+
+    {
+        const auto event = events.lastRestartEventBefore(1729);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 1729");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{128});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(128);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 128");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{59});
+    }
+
+    {
+        const auto event = events.lastRestartEventBefore(129);
+        BOOST_CHECK_MESSAGE(event.has_value(), "There must be an output event before report step 129");
+
+        BOOST_CHECK_EQUAL(event.value(), std::size_t{128});
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()    // Basic_Operations


### PR DESCRIPTION
This commit adds a new helper object
```
Opm::WriteRestartFileEvents
```
that identifies when a restart file output event occurs as well as the most recent output event prior to a particular report step.  We implement this facility in terms of a dense bit vector that wastes up to 63 bits of space.  Most of the logic is devoted to finding the most recent previous output event, of which the core routine is counting the number of leading zero bits in a 64 bit value.  We've elected to implement this in a portable manner using binary search, although most implementations provide efficient intrinsics for this operation, e.g., GCC's `__builtin_clzl`.  In C++20 we can use the new function `std::countl_zero()` from `<bit>`.