### PR TITLE
add FSIP to summary

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1921,6 +1921,7 @@ static const std::unordered_map< std::string, Opm::UnitSystem::measure> single_v
   {"FWIP"     , Opm::UnitSystem::measure::liquid_surface_volume },
   {"FOIP"     , Opm::UnitSystem::measure::liquid_surface_volume },
   {"FGIP"     , Opm::UnitSystem::measure::gas_surface_volume },
+  {"FSIP"     , Opm::UnitSystem::measure::mass },
   {"FOIPL"    , Opm::UnitSystem::measure::liquid_surface_volume },
   {"FOIPG"    , Opm::UnitSystem::measure::liquid_surface_volume },
   {"FGIPL"    , Opm::UnitSystem::measure::gas_surface_volume },

--- a/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -69,7 +69,7 @@ struct SummaryConfigContext {
         "FGIR",  "FGIT",  "FGOR", "FGPR",  "FGPT", "FOIP",  "FOIPG",
         "FOIPL", "FOIR",  "FOIT", "FOPR",  "FOPT", "FPR",   "FVIR",
         "FVIT",  "FVPR",  "FVPT", "FWCT",  "FWGR", "FWIP",  "FWIR",
-        "FWIT",  "FWPR",  "FWPT",
+        "FWIT",  "FWPR",  "FWPT", "FSIP",
         "GGIR",  "GGIT",  "GGOR", "GGPR",  "GGPT", "GOIR",  "GOIT",
         "GOPR",  "GOPT",  "GVIR", "GVIT",  "GVPR", "GVPT",  "GWCT",
         "GWGR",  "GWIR",  "GWIT", "GWPR",  "GWPT",
@@ -136,7 +136,8 @@ struct SummaryConfigContext {
          {"GIPG" , {"RGIPG", "FGIPG"}},
          {"WIP"  , {"RWIP" , "FWIP"}},
          {"SWAT" , {"BSWAT"}},
-         {"SGAS" , {"BSGAS"}}
+         {"SGAS" , {"BSGAS"}},
+         {"SALT", {"FSIP"}}
     };
 
     using keyword_set = std::unordered_set<std::string>;

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -444,7 +444,7 @@ static const auto ALL_keywords = {
         "FGIR",  "FGIT",  "FGOR", "FGPR",  "FGPT", "FOIP",  "FOIPG",
         "FOIPL", "FOIR",  "FOIT", "FOPR",  "FOPT", "FPR",   "FVIR",
         "FVIT",  "FVPR",  "FVPT", "FWCT",  "FWGR", "FWIP",  "FWIR",
-        "FWIT",  "FWPR",  "FWPT",
+        "FWIT",  "FWPR",  "FWPT", "FSIP",
         "GGIR",  "GGIT",  "GGOR", "GGPR",  "GGPT", "GOIR",  "GOIT",
         "GOPR",  "GOPT",  "GVIR", "GVIT",  "GVPR", "GVPT",  "GWCT",
         "GWGR",  "GWIR",  "GWIT", "GWPR",  "GWPT",


### PR DESCRIPTION
Add FSIP vector to summary file. Work is in progress in opm-simulators to compute FSIP. 