### PR TITLE
Add default empty well list for WLIST

### DIFF
--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WLIST
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/W/WLIST
@@ -15,7 +15,8 @@
     {
       "name": "WELLS",
       "value_type": "STRING",
-      "size_type": "ALL"
+      "size_type": "ALL",
+      "default": ""
     }
   ]
 }


### PR DESCRIPTION
The Eclipse manual states that an empty list of wellnames in WLIST means that the
well list should be reset to contain no wells if it already exists.

Without this default setting in the json, OPM will not be able
to parse a deck record with no wells specified