### PR TITLE
Fix Mismatched Tags

### DIFF
--- a/opm/io/eclipse/rst/udq.hpp
+++ b/opm/io/eclipse/rst/udq.hpp
@@ -47,7 +47,7 @@ public:
     };
 
     struct RstAssign {
-        void update_value(const std::string& name, double new_value);
+        void update_value(const std::string& name_arg, double new_value);
 
         std::optional<double> value;
         std::unordered_set<std::string> selector;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -44,7 +44,7 @@ namespace Opm {
     class WellMatcher;
 
     namespace RestartIO {
-        class RstState;
+        struct RstState;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQState.hpp
@@ -30,7 +30,7 @@
 namespace Opm {
 
 namespace RestartIO {
-    class RstState;
+    struct RstState;
 }
 
 class UDQState {

--- a/src/opm/io/eclipse/rst/udq.cpp
+++ b/src/opm/io/eclipse/rst/udq.cpp
@@ -29,10 +29,10 @@ RstUDQ::RstDefine::RstDefine(const std::string& expression_arg, UDQUpdate status
 {}
 
 
-void RstUDQ::RstAssign::update_value(const std::string& name, double new_value) {
+void RstUDQ::RstAssign::update_value(const std::string& name_arg, double new_value) {
     auto current_value = this->value.value_or(new_value);
     if (current_value != new_value)
-        throw std::logic_error(fmt::format("Internal error: the UDQ {} changes value {} -> {} during restart load", name, current_value, new_value));
+        throw std::logic_error(fmt::format("Internal error: the UDQ {} changes value {} -> {} during restart load", name_arg, current_value, new_value));
 
     this->value = new_value;
 }

--- a/src/opm/output/eclipse/AggregateUDQData.cpp
+++ b/src/opm/output/eclipse/AggregateUDQData.cpp
@@ -341,19 +341,20 @@ namespace {
         // loop over high level operators to find operator with lowest precedence and highest index
 
         int curPrec  = 100;
-        int tmpPrec = 100;
         std::size_t indLowestPrecOper = 0;
-        for (std::size_t ind = 0; ind < expr.highestLevOperators.size(); ind++) {
+        for (std::size_t ind = 0; ind < expr.highestLevOperators.size(); ++ind) {
             if ((expr.highestLevOperators[ind].type() != Opm::UDQTokenType::ecl_expr) &&
                 (expr.highestLevOperators[ind].type() != Opm::UDQTokenType::comp_expr) &&
-                (expr.highestLevOperators[ind].type() != Opm::UDQTokenType::number)) {
-                tmpPrec = opFuncPrec(expr.highestLevOperators[ind].type());
+                (expr.highestLevOperators[ind].type() != Opm::UDQTokenType::number))
+            {
+                const int tmpPrec = opFuncPrec(expr.highestLevOperators[ind].type());
                 if (tmpPrec <= curPrec) {
                     curPrec = tmpPrec;
                     indLowestPrecOper = ind;
                 }
             }
         }
+
         //
         // if lowest precedence operator is the first token (and not equal to change sign)
         // NOTE: also for the case with outer () removed
@@ -399,6 +400,7 @@ namespace {
                 }
             }
         }
+
         return def_type;
     }
 


### PR DESCRIPTION
`RstState` is a `struct` and should be forward declared as such. While here, also fix a shadowing variable warning and reduce the scope of another variable to eliminate a dead store.