### PR TITLE
Expand KeywordSize class

### DIFF
--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -49,13 +49,16 @@ namespace Opm {
     */
     class KeywordSize {
     public:
+        KeywordSize();
         KeywordSize(const std::string& in_keyword, const std::string& in_item, int in_shift);
         KeywordSize(const std::string& in_keyword, const std::string& in_item);
         KeywordSize(const std::string& in_keyword, const std::string& in_item, bool table_collection, int in_shift);
-        KeywordSize();
-        KeywordSize(ParserKeywordSizeEnum size_type);
-        KeywordSize(std::size_t fixed_size);
+
+        KeywordSize(std::size_t min_size, const std::string& in_keyword, const std::string& in_item, bool table_collection, int in_shift);
+        explicit KeywordSize(ParserKeywordSizeEnum size_type);
+        explicit KeywordSize(std::size_t fixed_size);
         KeywordSize(std::size_t fixed_size, bool code);
+        KeywordSize(std::size_t min_size, std::size_t fixed_size, bool code);
 
         bool table_collection() const;
         ParserKeywordSizeEnum size_type() const;
@@ -64,6 +67,7 @@ namespace Opm {
         const std::string& keyword() const;
         const std::string& item() const;
         std::optional<std::size_t> min_size() const;
+        void min_size(int s);
         const std::optional<std::variant<std::size_t, std::pair<std::string, std::string>>>& max_size() const;
         std::string construct() const;
 
@@ -101,6 +105,7 @@ namespace Opm {
         std::vector< ParserRecord >::const_iterator end() const;
         const std::string className() const;
         const std::string& getName() const;
+        std::optional<std::size_t> min_size() const;
         size_t getFixedSize() const;
         bool hasFixedSize() const;
         bool isTableCollection() const;

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -696,10 +696,10 @@ RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string
     const auto& deck = parserState.deck;
     auto size_type = parserKeyword.isTableCollection() ? Raw::TABLE_COLLECTION : Raw::FIXED;
 
-    if( deck.hasKeyword(keyword_size.keyword ) ) {
-        const auto& sizeDefinitionKeyword = deck.getKeyword(keyword_size.keyword);
+    if( deck.hasKeyword(keyword_size.keyword() ) ) {
+        const auto& sizeDefinitionKeyword = deck.getKeyword(keyword_size.keyword());
         const auto& record = sizeDefinitionKeyword.getRecord(0);
-        auto targetSize = record.getItem( keyword_size.item ).get< int >( 0 ) + keyword_size.shift;
+        auto targetSize = record.getItem( keyword_size.item() ).get< int >( 0 ) + keyword_size.size_shift();
         if (parserKeyword.isAlternatingKeyword())
             targetSize *= std::distance( parserKeyword.begin(), parserKeyword.end() );
 
@@ -713,17 +713,17 @@ RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string
 
     std::string msg_fmt = fmt::format("Problem with {{keyword}} - missing {0}\n"
                                       "In {{file}} line {{line}}\n"
-                                      "For the keyword {{keyword}} we expect to read the number of records from keyword {0}, {0} was not found", keyword_size.keyword);
+                                      "For the keyword {{keyword}} we expect to read the number of records from keyword {0}, {0} was not found", keyword_size.keyword());
     parserState.parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD ,
                                          msg_fmt,
                                          KeywordLocation{keywordString, parserState.current_path().string(), parserState.line()},
                                          parserState.errors );
 
-    const auto& keyword = parser.getKeyword( keyword_size.keyword );
+    const auto& keyword = parser.getKeyword( keyword_size.keyword() );
     const auto& record = keyword.getRecord(0);
-    const auto& int_item = record.get( keyword_size.item);
+    const auto& int_item = record.get( keyword_size.item());
 
-    const auto targetSize = int_item.getDefault< int >( ) + keyword_size.shift;
+    const auto targetSize = int_item.getDefault< int >( ) + keyword_size.size_shift();
     return new RawKeyword( keywordString,
                            parserState.current_path().string(),
                            parserState.line(),

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -689,6 +689,7 @@ RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string
                                parserState.line(),
                                raw_string_keyword,
                                size_type,
+                               parserKeyword.min_size(),
                                parserKeyword.getFixedSize());
     }
 
@@ -708,6 +709,7 @@ RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string
                                parserState.line(),
                                raw_string_keyword,
                                size_type,
+                               parserKeyword.min_size(),
                                targetSize);
     }
 
@@ -729,6 +731,7 @@ RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string
                            parserState.line(),
                            raw_string_keyword,
                            size_type,
+                           parserKeyword.min_size(),
                            targetSize);
 }
 
@@ -867,7 +870,7 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
                 continue;
             }
 
-            if (rawKeyword->getSizeType() == Raw::UNKNOWN) {
+            if (rawKeyword->can_complete()) {
                 /*
                   When we are spinning through a keyword of size type UNKNOWN it
                   is essential to recognize a string as the next keyword. The
@@ -923,7 +926,7 @@ std::unique_ptr<RawKeyword> tryParseKeyword( ParserState& parserState, const Par
     }
 
     if (rawKeyword) {
-        if (rawKeyword->getSizeType() == Raw::UNKNOWN)
+        if (rawKeyword->can_complete())
             rawKeyword->terminateKeyword();
 
         if (!rawKeyword->isFinished())

--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <fmt/format.h>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -36,43 +37,147 @@
 #include "raw/RawRecord.hpp"
 
 namespace Opm {
+KeywordSize::KeywordSize(const std::string& in_keyword, const std::string& in_item, int in_shift)
+    : KeywordSize(in_keyword, in_item, false, in_shift)
+{
+}
 
-    void ParserKeyword::setSizeType( ParserKeywordSizeEnum sizeType ) {
-        m_keywordSizeType = sizeType;
-        if (sizeType == FIXED_CODE)
-            this->m_fixedSize = 1;
+KeywordSize::KeywordSize(const std::string& in_keyword, const std::string& in_item)
+    : KeywordSize(in_keyword, in_item, false, 0)
+{
+}
+
+KeywordSize::KeywordSize(const std::string& in_keyword, const std::string& in_item, bool table_collection, int in_shift)
+    : shift(in_shift)
+    , is_table_collection(table_collection)
+    , m_size_type(OTHER_KEYWORD_IN_DECK)
+    , m_max_size(std::make_pair(in_keyword, in_item))
+{
+}
+
+KeywordSize::KeywordSize()
+    : KeywordSize(SLASH_TERMINATED)
+{
+}
+
+KeywordSize::KeywordSize(ParserKeywordSizeEnum size_type)
+    : m_size_type(size_type)
+{
+    if (size_type == SLASH_TERMINATED)
+        return;
+
+    if (size_type == UNKNOWN)
+        return;
+
+    if (size_type == DOUBLE_SLASH_TERMINATED)
+        return;
+
+    throw std::logic_error("This constructor only allows size type UNKNOWN and SLASH_TERMINATED");
+}
+
+KeywordSize::KeywordSize(std::size_t fixed_size)
+    : KeywordSize(fixed_size, false)
+{
+}
+
+KeywordSize::KeywordSize(std::size_t fixed_size, bool code)
+    : m_size_type(code ? FIXED_CODE : FIXED)
+    , m_max_size(fixed_size)
+    , is_code(code)
+{
+}
+
+bool
+KeywordSize::operator==(const KeywordSize&) const
+{
+    return true;
+}
+
+bool
+KeywordSize::operator!=(const KeywordSize& other) const
+{
+    return !(*this == other);
+}
+
+bool
+KeywordSize::table_collection() const
+{
+    return this->is_table_collection;
+}
+
+ParserKeywordSizeEnum
+KeywordSize::size_type() const
+{
+    return this->m_size_type;
+}
+
+bool
+KeywordSize::code() const
+{
+    return this->is_code;
+}
+
+int
+KeywordSize::size_shift() const
+{
+    return this->shift;
+}
+
+const std::string&
+KeywordSize::keyword() const
+{
+    return std::get<1>(this->m_max_size.value()).first;
+}
+
+const std::string&
+KeywordSize::item() const
+{
+    return std::get<1>(this->m_max_size.value()).second;
+}
+
+std::optional<std::size_t> KeywordSize::min_size() const
+{
+    return this->m_min_size;
+}
+
+const std::optional<std::variant<std::size_t, std::pair<std::string, std::string>>>&
+KeywordSize::max_size() const
+{
+    return this->m_max_size;
+}
+
+std::string
+KeywordSize::construct() const
+{
+    if (this->m_size_type == SLASH_TERMINATED)
+        return "KeywordSize()";
+
+    if (this->m_size_type == UNKNOWN || this->m_size_type == DOUBLE_SLASH_TERMINATED)
+        return fmt::format("KeywordSize({})", ParserKeywordSizeEnum2String(this->m_size_type));
+
+    if (this->m_size_type == FIXED || this->m_size_type == FIXED_CODE)
+        return fmt::format("KeywordSize({}, {})", std::get<std::size_t>(this->m_max_size.value()), this->is_code);
+
+    if (this->m_size_type == OTHER_KEYWORD_IN_DECK) {
+        const auto& [size_kw, size_item] = std::get<1>(this->m_max_size.value());
+        return fmt::format(
+            "KeywordSize(\"{}\", \"{}\", {}, {})", size_kw, size_item, this->is_table_collection, this->shift);
     }
 
-    void ParserKeyword::setFixedSize( size_t keywordSize) {
-        m_keywordSizeType = FIXED;
-        m_fixedSize = keywordSize;
-    }
-
-    void ParserKeyword::setTableCollection(bool _isTableCollection) {
-        m_isTableCollection = _isTableCollection;
-    }
+    throw std::logic_error("No string serialization known?");
+}
 
 
-    void ParserKeyword::commonInit(const std::string& name, ParserKeywordSizeEnum sizeType) {
-        m_isTableCollection = false;
-        m_name = name;
-        m_keywordSizeType = sizeType;
-        m_Description = "";
-        m_fixedSize = 0;
-
-        m_deckNames.insert(m_name);
-    }
-
-    ParserKeyword::ParserKeyword(const std::string& name) {
-        commonInit(name, FIXED);
-    }
-
-
-    ParserKeyword::ParserKeyword(const std::string& name, const std::string& sizeKeyword, const std::string& sizeItem, int size_shift, bool _isTableCollection)
+    ParserKeyword::ParserKeyword(const std::string& name)
+        : ParserKeyword(name, KeywordSize{})
     {
-        commonInit( name , OTHER_KEYWORD_IN_DECK);
-        m_isTableCollection = _isTableCollection;
-        initSizeKeyword(sizeKeyword, sizeItem, size_shift);
+    }
+
+    ParserKeyword::ParserKeyword(const std::string& name, KeywordSize kw_size)
+        : m_name(name)
+        , keyword_size(std::move(kw_size))
+    {
+        this->m_deckNames.insert(m_name);
     }
 
     void ParserKeyword::clearDeckNames() {
@@ -93,7 +198,7 @@ namespace Opm {
 
 
     bool ParserKeyword::isTableCollection() const {
-        return m_isTableCollection;
+        return this->keyword_size.table_collection();
     }
 
     std::string ParserKeyword::getDescription() const {
@@ -118,11 +223,10 @@ namespace Opm {
         if (jsonConfig.has_item("size")) {
             Json::JsonObject sizeObject = jsonConfig.get_item("size");
 
-            if (sizeObject.is_number()) {
-                m_fixedSize = (size_t) sizeObject.as_int();
-                m_keywordSizeType = FIXED;
-            } else
-                initSizeKeyword(sizeObject);
+            if (sizeObject.is_number())
+                this->keyword_size = KeywordSize( sizeObject.as_int() );
+            else
+                initSizeKeyword(false, sizeObject);
 
             return;
         }
@@ -134,27 +238,34 @@ namespace Opm {
               throw std::invalid_argument(
                   "The num_tables key must point to a {} object");
 
-            initSizeKeyword(numTablesObject);
-            m_isTableCollection = true;
-
+            initSizeKeyword(true, numTablesObject);
             return;
         }
 
         if (jsonConfig.has_item("records_set")) {
-           m_keywordSizeType = DOUBLE_SLASH_TERMINATED;
+           this->keyword_size = KeywordSize(DOUBLE_SLASH_TERMINATED);
            return;
+        }
+
+        if (jsonConfig.has_item("code")) {
+            this->keyword_size = KeywordSize(1, true);
+            return;
+        }
+
+        if (jsonConfig.has_item("data")) {
+            this->keyword_size = KeywordSize(1);
+            return;
         }
 
         if (jsonConfig.has_item("items") || jsonConfig.has_item("records")) {
             // The number of records is undetermined - the keyword will be '/'
             // terminated.
-            m_keywordSizeType = SLASH_TERMINATED;
+            this->keyword_size = KeywordSize(SLASH_TERMINATED);
             return;
-        } else {
-            m_keywordSizeType = FIXED;
-            m_fixedSize = 0;
         }
 
+        // No data associated with this keyword - like e.g. section headers
+        this->keyword_size = KeywordSize(0);
     }
 
 
@@ -170,13 +281,9 @@ namespace Opm {
     }
 
 
-    ParserKeyword::ParserKeyword(const Json::JsonObject& jsonConfig) {
-
-      if (jsonConfig.has_item("name")) {
-            ParserKeywordSizeEnum sizeType = UNKNOWN;
-            commonInit(jsonConfig.get_string("name"), sizeType);
-        } else
-            throw std::invalid_argument("Json object is missing the 'name' property");
+    ParserKeyword::ParserKeyword(const Json::JsonObject& jsonConfig) :
+        ParserKeyword(jsonConfig.get_string("name"))
+    {
 
         if (jsonConfig.has_item("deck_names") || jsonConfig.has_item("deck_name_regex") )
             // if either the deck names or the regular expression for deck names are
@@ -197,7 +304,7 @@ namespace Opm {
             initRequiredKeywords(jsonConfig.get_item("requires"));
         }
 
-        if (jsonConfig.has_item("items") && (jsonConfig.has_item("records") || 
+        if (jsonConfig.has_item("items") && (jsonConfig.has_item("records") ||
                                              jsonConfig.has_item("alternating_records") ||
                                              jsonConfig.has_item("records_set") ))
             throw std::invalid_argument("Fatal error in " + getName() + " configuration. Can NOT have both records: and items:");
@@ -263,12 +370,11 @@ namespace Opm {
         }
     }
 
-    void ParserKeyword::initSizeKeyword(const std::string& sizeKeyword, const std::string& sizeItem, int size_shift) {
-        keyword_size = KeywordSize(sizeKeyword, sizeItem, size_shift); 
-        m_keywordSizeType = OTHER_KEYWORD_IN_DECK;
+    void ParserKeyword::initSizeKeyword(const std::string& sizeKeyword, const std::string& sizeItem, bool table_collection, int size_shift) {
+        this->keyword_size = KeywordSize(sizeKeyword, sizeItem, table_collection, size_shift);
     }
 
-    void ParserKeyword::initSizeKeyword(const Json::JsonObject& sizeObject) {
+    void ParserKeyword::initSizeKeyword(bool table_collection, const Json::JsonObject& sizeObject) {
         if (sizeObject.is_object()) {
             std::string sizeKeyword = sizeObject.get_string("keyword");
             std::string sizeItem = sizeObject.get_string("item");
@@ -276,9 +382,10 @@ namespace Opm {
             if (sizeObject.has_item("shift"))
                 size_shift = sizeObject.get_int("shift");
 
-            initSizeKeyword(sizeKeyword, sizeItem, size_shift);
+            this->keyword_size = KeywordSize{sizeKeyword, sizeItem, table_collection, size_shift};
         } else {
-            m_keywordSizeType = ParserKeywordSizeEnumFromString( sizeObject.as_string() );
+            auto size_type = ParserKeywordSizeEnumFromString( sizeObject.as_string() );
+            this->keyword_size = KeywordSize(size_type);
         }
     }
 
@@ -408,9 +515,6 @@ void set_dimensions( ParserItem& item,
 }
 
     void ParserKeyword::initCode(const Json::JsonObject& jsonConfig) {
-        this->m_fixedSize = 1U;
-        this->m_keywordSizeType = FIXED_CODE;
-
         const Json::JsonObject codeConfig = jsonConfig.get_item("code");
         if (!codeConfig.has_item("end"))
             throw std::invalid_argument("The end: is missing from the code block");
@@ -428,9 +532,6 @@ void set_dimensions( ParserItem& item,
 
 
     void ParserKeyword::initData(const Json::JsonObject& jsonConfig) {
-        this->m_fixedSize = 1U;
-        this->m_keywordSizeType = FIXED;
-
         const Json::JsonObject dataConfig = jsonConfig.get_item("data");
         if (!dataConfig.has_item("value_type") )
             throw std::invalid_argument("The 'value_type' JSON item of keyword "+getName()+" is missing");
@@ -525,10 +626,14 @@ void set_dimensions( ParserItem& item,
 
 
     void ParserKeyword::addDataRecord( ParserRecord record) {
-        if ((m_keywordSizeType == FIXED) && (m_fixedSize == 1U))
-            addRecord( std::move( record ) );
-        else
+        if (this->keyword_size.size_type() != FIXED)
             throw std::invalid_argument("When calling addDataRecord() for keyword " + getName() + ", it must be configured with fixed size == 1.");
+
+        auto max_size = std::get<std::size_t>(this->keyword_size.max_size().value());
+        if (max_size != 1)
+            throw std::invalid_argument("When calling addDataRecord() for keyword " + getName() + ", it must be configured with fixed size == 1.");
+
+        this->addRecord(std::move(record));
     }
 
 
@@ -613,12 +718,13 @@ void set_dimensions( ParserItem& item,
         if (this->hasFixedSize( ))
             keyword.setFixedSize( );
 
-        if (this->m_keywordSizeType == OTHER_KEYWORD_IN_DECK) {
-            if (!m_isTableCollection)
+        const auto& kw_size = this->keyword_size;
+        if (kw_size.size_type() == OTHER_KEYWORD_IN_DECK) {
+            if (!kw_size.table_collection())
                 keyword.setFixedSize( );
         }
 
-        if (this->m_keywordSizeType == UNKNOWN)
+        if (kw_size.size_type() == UNKNOWN)
             keyword.setFixedSize( );
 
         return keyword;
@@ -627,15 +733,17 @@ void set_dimensions( ParserItem& item,
     size_t ParserKeyword::getFixedSize() const {
         if (!hasFixedSize())
             throw std::logic_error("The parser keyword "+getName()+" does not have a fixed size!");
-        return m_fixedSize;
+        const auto& max_size = this->keyword_size.max_size();
+        return std::get<std::size_t>(max_size.value());
     }
 
     bool ParserKeyword::hasFixedSize() const {
-        return (this->m_keywordSizeType == FIXED || this->m_keywordSizeType == FIXED_CODE);
+        auto size_type = this->keyword_size.size_type();
+        return (size_type == FIXED || size_type == FIXED_CODE);
     }
 
     enum ParserKeywordSizeEnum ParserKeyword::getSizeType() const {
-        return m_keywordSizeType;
+        return this->keyword_size.size_type();
     }
 
     bool ParserKeyword::rawStringKeyword() const {
@@ -653,7 +761,7 @@ void set_dimensions( ParserItem& item,
     }
 
     bool ParserKeyword::isCodeKeyword() const {
-        return (this->m_keywordSizeType == FIXED_CODE);
+        return this->keyword_size.code();
     }
 
     bool ParserKeyword::isAlternatingKeyword() const {
@@ -744,28 +852,30 @@ void set_dimensions( ParserItem& item,
         const std::string lhs = "keyword";
         const std::string indent = "  ";
 
-        ss << className() << "::" << className() << "( ) : ParserKeyword(\"" << m_name << "\")" << '\n' << "{" << '\n';
-        {
-            const std::string sizeString(ParserKeywordSizeEnum2String(m_keywordSizeType));
-            ss << indent;
-            switch (m_keywordSizeType) {
-            case SLASH_TERMINATED:
-            case FIXED_CODE:
-            case DOUBLE_SLASH_TERMINATED:
-            case UNKNOWN:
-                ss << "setSizeType(" << sizeString << ");" << '\n';
-                break;
-            case FIXED:
-                ss << "setFixedSize( (size_t) " << m_fixedSize << ");" << '\n';
-                break;
-            case OTHER_KEYWORD_IN_DECK:
-                ss << "setSizeType(" << sizeString << ");" << '\n';
-                ss << indent << "initSizeKeyword(\"" << keyword_size.keyword << "\",\"" << keyword_size.item << "\"," << keyword_size.shift << ");" << '\n';
-                if (m_isTableCollection)
-                    ss << indent << "setTableCollection( true );" << '\n';
-                break;
-            }
-        }
+        ss << fmt::format("{0}::{0}() : ParserKeyword(\"{1}\", {2}) {{\n",
+                          this->className(),
+                          this->m_name,
+                          this->keyword_size.construct());
+
+        //{
+        //    const std::string sizeString(ParserKeywordSizeEnum2String(m_keywordSizeType));
+        //    ss << indent;
+        //    switch (m_keywordSizeType) {
+        //    case SLASH_TERMINATED:
+        //    case FIXED_CODE:
+        //    case DOUBLE_SLASH_TERMINATED:
+        //    case UNKNOWN:
+        //        ss << "setSizeType(" << sizeString << ");" << '\n';
+        //        break;
+        //    case FIXED:
+        //        ss << "setFixedSize( (size_t) " << m_fixedSize << ");" << '\n';
+        //        break;
+        //    case OTHER_KEYWORD_IN_DECK:
+        //        ss << "setSizeType(" << sizeString << ");" << '\n';
+        //        ss << indent << "initSizeKeyword(\"" << keyword_size.keyword << "\",\"" << keyword_size.item << "\"," << fmt::format("{}", this->isTableCollection()) << "," << keyword_size.shift << ");" << '\n';
+        //        break;
+        //    }
+        //}
 
         // add the valid sections for the keyword
         for (auto sectionNameIt = m_validSectionNames.begin();
@@ -813,7 +923,7 @@ void set_dimensions( ParserItem& item,
         if (hasMatchRegex())
             ss << indent << "setMatchRegex(\"" << m_matchRegexString << "\");" << '\n';
 
-        if (this->m_keywordSizeType == FIXED_CODE)
+        if (this->keyword_size.code())
             ss << indent << "setCodeEnd(\"" << this->code_end << "\");" << '\n';
 
         {
@@ -856,6 +966,10 @@ void set_dimensions( ParserItem& item,
             }
         }
         ss << '\n';
+
+        const auto& kw_size = this->getKeywordSize();
+        std::cout << kw_size.construct() << std::endl;
+
         return ss.str();
     }
 
@@ -869,26 +983,28 @@ void set_dimensions( ParserItem& item,
         if(    m_name              != rhs.m_name
             || this->code_end      != rhs.code_end
             || m_matchRegexString  != rhs.m_matchRegexString
-            || m_keywordSizeType   != rhs.m_keywordSizeType
             || isCodeKeyword()     != rhs.isCodeKeyword()
-            || isDataKeyword()     != rhs.isDataKeyword()
-            || m_isTableCollection != rhs.m_isTableCollection )
+            || isDataKeyword()     != rhs.isDataKeyword())
           return false;
 
+        return true;
 
-        switch( m_keywordSizeType ) {
-            case FIXED:
-                if( m_fixedSize != rhs.m_fixedSize )
-                    return false;
-                break;
+        //switch( m_keywordSizeType ) {
+        //    case FIXED:
+        //        if( m_fixedSize != rhs.m_fixedSize )
+        //            return false;
+        //        break;
 
-            case OTHER_KEYWORD_IN_DECK:
-                if (this->keyword_size != rhs.keyword_size)
-                    return false;
-                break;
-            default:
-                break;
-        }
+        //    case OTHER_KEYWORD_IN_DECK:
+        //        if (this->keyword_size != rhs.keyword_size)
+        //            return false;
+        //        break;
+        //    default:
+        //        break;
+        //}
+
+        if (this->keyword_size != rhs.keyword_size)
+            return false;
 
         return this->m_records.size() == rhs.m_records.size()
             && std::equal( this->begin(), this->end(), rhs.begin() );

--- a/src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp
+++ b/src/opm/parser/eclipse/Parser/raw/RawKeyword.hpp
@@ -20,10 +20,11 @@
 #ifndef RAWKEYWORD_HPP
 #define RAWKEYWORD_HPP
 
+#include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
-#include <cstddef>
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
@@ -36,7 +37,7 @@ namespace Opm {
     class RawKeyword {
     public:
         RawKeyword(const std::string& name, const std::string& filename, std::size_t lineNR, bool raw_string, Raw::KeywordSizeEnum sizeType);
-        RawKeyword(const std::string& name, const std::string& filename, std::size_t lineNR, bool raw_string, Raw::KeywordSizeEnum sizeType, std::size_t size_arg);
+        RawKeyword(const std::string& name, const std::string& filename, std::size_t lineNR, bool raw_string, Raw::KeywordSizeEnum sizeType, const std::optional<std::size_t>& min_size, std::size_t size_arg);
         bool terminateKeyword();
         bool addRecord(RawRecord record);
 
@@ -49,9 +50,9 @@ namespace Opm {
         const RawRecord& getFirstRecord( ) const;
 
         bool isFinished() const;
-        bool unKnownSize() const;
         bool rawStringKeyword() const;
         const KeywordLocation& location() const;
+        bool can_complete() const;
 
         using const_iterator = std::vector< RawRecord >::const_iterator;
         using iterator = std::vector< RawRecord >::iterator;
@@ -67,9 +68,10 @@ namespace Opm {
         bool raw_string_keyword;
         Raw::KeywordSizeEnum m_sizeType;
 
-        size_t m_fixedSize = 0;
-        size_t m_numTables = 0;
-        size_t m_currentNumTables = 0;
+        std::size_t m_min_size = 0;
+        std::size_t m_fixedSize = 0;
+        std::size_t m_numTables = 0;
+        std::size_t m_currentNumTables = 0;
         bool m_isTempFinished = false;
         bool m_isFinished = false;
 

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/B/BRINE
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/B/BRINE
@@ -3,5 +3,13 @@
   "sections": [
     "RUNSPEC"
   ],
-  "comment": "Multi-Component Brine Model not supported"
+    "min_size" : 0,
+    "size" : 1,
+    "items" : [
+        {
+            "name" : "SALTS",
+            "size_type" : "ALL",
+            "value_type" : "STRING"
+        }
+    ]
 }

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SAVE
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/S/SAVE
@@ -1,6 +1,7 @@
 {
   "name": "SAVE",
-  "size": "UNKNOWN",
+    "size": 1,
+    "min_size" : 0,
   "sections": [
     "RUNSPEC",
     "SCHEDULE"

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -1627,7 +1627,7 @@ BOOST_AUTO_TEST_CASE(ParseEmptyRecord) {
     auto tabdimsKeyword = createFixedSized("TEST" , 1);
     ParserRecord record;
     ParserItem item("ITEM", INT);
-    RawKeyword rawkeyword( tabdimsKeyword.getName() , "FILE" , 10U , false, Raw::FIXED, 1);
+    RawKeyword rawkeyword( tabdimsKeyword.getName() , "FILE" , 10U , false, Raw::FIXED, {}, 1);
     ParseContext parseContext;
     ErrorGuard errors;
     UnitSystem unit_system;

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -2294,7 +2294,12 @@ ROCK
 3600.00 .40E-05 /
 3000 0 /
 
+SAVE
+  FORMATTED /
+
 SCHEDULE
+SAVE
+
 UDT
 -- here comes a comment
 -- and another comment
@@ -2327,6 +2332,7 @@ BOOST_CHECK_EQUAL( record.getItem(5).get<double>(0), 0.9 );
 BOOST_CHECK( !deck.hasKeyword("LANGMUIR") );
  const auto& tracerkm = deck.getKeyword<ParserKeywords::TRACERKM>();
 BOOST_CHECK_EQUAL(tracerkm.size(), 5);
+ BOOST_CHECK_EQUAL(deck.count<ParserKeywords::SAVE>(), 2);
 }
 
 

--- a/tests/parser/RawKeywordTests.cpp
+++ b/tests/parser/RawKeywordTests.cpp
@@ -34,13 +34,13 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(RawKeywordConstructor) {
     BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::FIXED), std::logic_error);
     BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::TABLE_COLLECTION), std::logic_error);
-    BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::TABLE_COLLECTION, 0), std::logic_error);
-    BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::SLASH_TERMINATED, 5), std::logic_error);
-    BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::UNKNOWN, 5), std::logic_error);
-    BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::CODE, 2), std::logic_error);
+    BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::TABLE_COLLECTION, {}, 0), std::logic_error);
+    BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::SLASH_TERMINATED, {}, 5), std::logic_error);
+    BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::UNKNOWN, {}, 5), std::logic_error);
+    BOOST_CHECK_THROW( RawKeyword("NAME", "file", 10, false, Raw::CODE, {}, 2), std::logic_error);
     RawKeyword kw1("NAME", "file", 10, false, Raw::SLASH_TERMINATED);
-    RawKeyword kw2("NAME", "file", 10, false, Raw::FIXED, 10);
-    RawKeyword kw3("NAME", "file", 10, false, Raw::TABLE_COLLECTION, 7);
+    RawKeyword kw2("NAME", "file", 10, false, Raw::FIXED, {}, 10);
+    RawKeyword kw3("NAME", "file", 10, false, Raw::TABLE_COLLECTION, {}, 7);
     RawKeyword kw4("NAME", "file", 10, false, Raw::CODE);
 }
 
@@ -49,11 +49,11 @@ BOOST_AUTO_TEST_CASE(IsFinished) {
     std::string_view line(storage);
     RawRecord rec(line, KeywordLocation("KW", "file", 100 ));
 
-    RawKeyword kw1("NAME", "file", 10, false, Raw::FIXED, 0);
+    RawKeyword kw1("NAME", "file", 10, false, Raw::FIXED, {}, 0);
     BOOST_CHECK(kw1.isFinished());
 
     {
-        RawKeyword kw2("NAME", "file", 10, false, Raw::FIXED, 2);
+        RawKeyword kw2("NAME", "file", 10, false, Raw::FIXED, {}, 2);
         BOOST_CHECK(!kw2.isFinished());
 
         BOOST_CHECK(!kw2.addRecord(rec));
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(IsFinished) {
     }
 
     {
-        RawKeyword kw3("NAME", "file", 10, false, Raw::TABLE_COLLECTION, 2);
+        RawKeyword kw3("NAME", "file", 10, false, Raw::TABLE_COLLECTION, {}, 2);
         BOOST_CHECK(!kw3.isFinished());
 
         BOOST_CHECK(!kw3.terminateKeyword());

--- a/tests/parser/integration/IntegrationTests.cpp
+++ b/tests/parser/integration/IntegrationTests.cpp
@@ -42,14 +42,12 @@ inline std::string pathprefix() {
 namespace {
 
 ParserKeyword createFixedSized(const std::string& kw , size_t size) {
-    ParserKeyword pkw(kw);
-    pkw.setFixedSize( size );
+    ParserKeyword pkw(kw, KeywordSize(size));
     return pkw;
 }
 
 ParserKeyword createDynamicSized(const std::string& kw) {
-    ParserKeyword  pkw( kw );
-    pkw.setSizeType(SLASH_TERMINATED);
+    ParserKeyword  pkw( kw, KeywordSize(SLASH_TERMINATED) );
     return pkw;
 }
 

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -64,19 +64,25 @@ CECON
 BOOST_AUTO_TEST_CASE( COORDSYS ) {
     const std::string input = R"(
 RUNSPEC
-    NUMRES
-        1 /
+
+BRINE
+
+NUMRES
+    1 /
 GRID
-    COORDSYS
-        1 1141 /
-    COORDSYS
-        1 1141 'COMP' 'JOIN' 1 2 /
-    COORDSYS
-        1 1141 'COMP' 'JOIN' /
-    COORDSYS
-        1 1141 'INCOMP' /
+COORDSYS
+    1 1141 /
+COORDSYS
+    1 1141 'COMP' 'JOIN' 1 2 /
+COORDSYS
+    1 1141 'COMP' 'JOIN' /
+COORDSYS
+    1 1141 'INCOMP' /
 )";
-    Parser().parseString( input );
+    const auto& deck = Parser().parseString( input );
+
+    const auto& brine = deck.getKeyword("BRINE");
+    BOOST_CHECK_EQUAL(brine.size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE( DENSITY ) {
@@ -1477,6 +1483,9 @@ RUNSPEC
 OIL
 GAS
 
+BRINE
+NACL KCL /
+
 TABDIMS
  1 2 /
 
@@ -1503,11 +1512,21 @@ SGOF
     0.9 0.5 0.1 8.0
     1.0 1.0 0.1 9.0 /
 )";
+    Parser parser;
 
-    auto deck = Parser{}.parseString(input);
+    const auto& keyword = parser.getParserKeywordFromDeckName("BRINE");
+    BOOST_CHECK_EQUAL(keyword.getFixedSize(), 1);
+    BOOST_CHECK_EQUAL(keyword.min_size().value(), 0);
+
+
+    auto deck = parser.parseString(input);
     const auto& pvtwsalt = deck.getKeyword("PVTWSALT");
     BOOST_CHECK_EQUAL(pvtwsalt.size(), 4);
 
     const auto& sgof = deck.getKeyword("SGOF");
     BOOST_CHECK_EQUAL(sgof.size(), 1);
+
+    const auto& brine = deck.getKeyword("BRINE");
+    const auto& salts = brine.getRecord(0).getItem(0);
+    BOOST_CHECK_EQUAL( salts.data_size(), 2);
 }


### PR DESCRIPTION
This PR will refactor the configuration of the number of records in a deck keyword. The purpose of this is to support / enable some of the ongoing keyword validation effort; but it will also increase the parsing quality of some "difficult keywords".

Main result of this refactoring is an optional "min_size" : "XXX" setting.