### PR TITLE
Support EQLOPTS option IRREVER in THPRES keyword

### DIFF
--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -39,7 +39,11 @@ namespace Opm {
                           const Deck& deck,
                           const FieldPropsManager& fp);
 
-        ThresholdPressure() { m_active = m_restart = false; }
+        ThresholdPressure()
+            : m_active(false)
+            , m_restart(false)
+            , m_irreversible(false)
+        {}
 
         //! \brief Returns an instance for serialization tests.
         static ThresholdPressure serializeObject();
@@ -82,6 +86,7 @@ namespace Opm {
         {
             serializer(m_active);
             serializer(m_restart);
+            serializer(m_irreversible);
             serializer(m_thresholdPressureTable);
             serializer(m_pressureTable);
         }
@@ -89,7 +94,8 @@ namespace Opm {
     private:
         bool m_active;
         bool m_restart;
-        static std::pair<int,int> makeIndex(int r1 , int r2);
+        bool m_irreversible;
+        std::pair<int,int> makeIndex(int r1 , int r2) const;
         void addPair(int r1 , int r2 , const std::pair<bool , double>& valuePair);
         void addBarrier(int r1 , int r2);
         void addBarrier(int r1 , int r2 , double p);

--- a/tests/parser/ThresholdPressureTest.cpp
+++ b/tests/parser/ThresholdPressureTest.cpp
@@ -37,163 +37,185 @@
 
 using namespace Opm;
 
-const std::string& inputStr = "RUNSPEC\n"
-                              "EQLOPTS\n"
-                              "THPRES /\n "
-                              "\n"
-
-                              "SOLUTION\n"
-                              "THPRES\n"
-                              "1 2 12.0/\n"
-                              "1 3 5.0/\n"
-                              "2 3 33.0 /\n"
-                              "2 3 7.0/\n"
-                              "/\n"
-                              "\n";
-const std::string& inputStr_RESTART = "RUNSPEC\n"
-  "EQLOPTS\n"
-  "THPRES /\n "
-  "\n"
-  "SOLUTION\n"
-  "RESTART\n"
-  " CASE 100 /\n"
-  "\n";
-
-const std::string& inputStr_RESTART2 = "RUNSPEC\n"
-  "EQLOPTS\n"
-  "THPRES /\n "
-  "\n"
-  "REGIONS\n"
-  "EQLNUM\n"
-  "   120*4 /\n"
-  "SOLUTION\n"
-  "RESTART\n"
-  "  CASE 100/\n"
-  "THPRES\n"
-  "1 3 5.0/\n"
-  "2 3 33.0 /\n"
-  "2 4 7.0/\n"
-  "/\n"
-  "\n";
+const std::string& inputStr = R"(
+RUNSPEC
+EQLOPTS
+THPRES /
 
 
-const std::string& inputStrWithEqlNum =
-                              "RUNSPEC\n"
-                              "EQLOPTS\n"
-                              "THPRES /\n "
-                              "\n"
-                              "REGIONS\n"
-                              "EQLNUM\n"
-                              "   120*3 /\n"
-                              "SOLUTION\n"
-                              "THPRES\n"
-                              "1 2 12.0/\n"
-                              "1 3 5.0/\n"
-                              "2 3 33.0 /\n"
-                              "2 3 7.0/\n"
-                              "/\n"
-                              "\n";
+SOLUTION
+THPRES
+1 2 12.0/
+1 3 5.0/
+2 3 33.0 /
+2 3 7.0/
+/
+)";
+
+const std::string& inputStr_RESTART = R"(
+RUNSPEC
+EQLOPTS
+THPRES /
+
+SOLUTION
+RESTART
+ CASE 100 /
+)";
 
 
-const std::string& inputStrWithEqlNumall0 =
-                              "RUNSPEC\n"
-                              "EQLOPTS\n"
-                              "THPRES /\n "
-                              "\n"
-                              "REGIONS\n"
-                              "EQLNUM\n"
-                              "   120*0 /\n"
-                              "SOLUTION\n"
-                              "THPRES\n"
-                              "1 2 12.0/\n"
-                              "1 3 5.0/\n"
-                              "2 3 33.0 /\n"
-                              "2 3 7.0/\n"
-                              "/\n"
-                              "\n";
+const std::string& inputStr_RESTART2 = R"(
+RUNSPEC
+EQLOPTS
+THPRES /
 
+REGIONS
+EQLNUM
+   120*4 /
+SOLUTION
+RESTART
+  CASE 100/
+THPRES
+1 3 5.0/
+2 3 33.0 /
+2 4 7.0/
+/
+)";
 
-const std::string& inputStrNoSolutionSection =  "RUNSPEC\n"
-                                                "EQLOPTS\n"
-                                                "THPRES /\n "
-                                                "\n";
+const std::string& inputStrWithEqlNum = R"(
+RUNSPEC
+EQLOPTS
+THPRES /
 
+REGIONS
+EQLNUM
+   120*3 /
+SOLUTION
+THPRES
+1 2 12.0/
+1 3 5.0/
+2 3 33.0 /
+2 3 7.0/
+/
+)";
 
-const std::string& inputStrNoTHPRESinSolutionNorRUNSPEC = "RUNSPEC\n"
-                                                          "\n"
-                                                          "SOLUTION\n"
-                                                          "\n"
-                                                          "SCHEDULE\n";
+const std::string& inputStrIrrevers2 = R"(
+RUNSPEC
+EQLOPTS
+THPRES IRREVERS /
 
-const std::string& inputStrTHPRESinRUNSPECnotSoultion = "RUNSPEC\n"
-                                                        "EQLOPTS\n"
-                                                        "ss /\n "
-                                                        "\n"
-                                                        "SOLUTION\n"
-                                                        "\n";
+REGIONS
+EQLNUM
+   120*3 /
+SOLUTION
+THPRES
+1 2  12.0 /
+2 1 -12.0 /
+2 3  23.0 /
+3 2 -23.0 /
+1 3  13.0 /
+3 1 -13.0 /
+/
+)";
 
 
 
-const std::string& inputStrIrrevers = "RUNSPEC\n"
-                                      "EQLOPTS\n"
-                                      "THPRES IRREVERS/\n "
-                                      "\n"
+const std::string& inputStrWithEqlNumall0 = R"(
+RUNSPEC
+EQLOPTS
+THPRES /
 
-                                      "SOLUTION\n"
-                                      "THPRES\n"
-                                      "/\n"
-                                      "\n";
-
-const std::string& inputStrInconsistency =  "RUNSPEC\n"
-                                            "EQLOPTS\n"
-                                            "THPRES /\n "
-                                            "\n"
-
-                                            "SOLUTION\n"
-                                            "\n";
-
-const std::string& inputStrTooHighRegionNumbers = "RUNSPEC\n"
-                                                  "EQLOPTS\n"
-                                                  "THPRES /\n "
-                                                  "\n"
-
-                                                  "SOLUTION\n"
-                                                  "THPRES\n"
-                                                  "1 2 12.0/\n"
-                                                  "4 3 5.0/\n"
-                                                  "2 3 7.0/\n"
-                                                  "/\n"
-                                                  "\n";
+REGIONS
+EQLNUM
+   120*0 /
+SOLUTION
+THPRES
+1 2 12.0/
+1 3 5.0/
+2 3 33.0 /
+2 3 7.0/
+/
+)";
 
 
-const std::string& inputStrMissingData = "RUNSPEC\n"
-                                         "EQLOPTS\n"
-                                         "THPRES /\n "
-                                         "\n"
+const std::string& inputStrNoSolutionSection =  R"(
+RUNSPEC
+EQLOPTS
+THPRES /
+)";
 
-                                         "SOLUTION\n"
-                                         "THPRES\n"
-                                         "1 2 12.0/\n"
-                                         "2 3 5.0/\n"
-                                         "1 /\n"
-                                         "/\n"
-                                         "\n";
+const std::string& inputStrNoTHPRESinSolutionNorRUNSPEC = R"(
+RUNSPEC
+
+SOLUTION
+
+SCHEDULE
+)";
+
+const std::string& inputStrTHPRESinRUNSPECnotSoultion = R"(
+RUNSPEC
+EQLOPTS
+ss /
+
+SOLUTION
+)";
 
 
-const std::string& inputStrMissingPressure = "RUNSPEC\n"
-                                         "EQLOPTS\n"
-                                         "THPRES /\n "
-                                         "\n"
-                                         "REGIONS\n"
-                                         "EQLNUM\n"
-                                         "   120*3 /\n"
-                                         "SOLUTION\n"
-                                         "THPRES\n"
-                                         "1 2 12.0/\n"
-                                         "2 3 5.0/\n"
-                                         "2 3 /\n"
-                                         "/\n"
-                                         "\n";
+
+
+const std::string& inputStrTooHighRegionNumbers = R"(
+RUNSPEC
+EQLOPTS
+THPRES /
+
+
+SOLUTION
+THPRES
+1 2 12.0/
+4 3 5.0/
+2 3 7.0/
+/
+)";
+
+
+const std::string& inputStrMissingData = R"(
+RUNSPEC
+EQLOPTS
+THPRES /
+
+
+SOLUTION
+THPRES
+1 2 12.0/
+2 3 5.0/
+1 /
+/
+)";
+
+
+const std::string& inputStrInconsistency =  R"(
+RUNSPEC
+EQLOPTS
+THPRES /
+
+
+SOLUTION
+)";
+
+const std::string& inputStrMissingPressure = R"(
+RUNSPEC
+EQLOPTS
+THPRES /
+
+REGIONS
+EQLNUM
+   120*3 /
+SOLUTION
+THPRES
+1 2 12.0/
+2 3 5.0/
+2 3 /
+/
+)";
 
 static Deck createDeck(const ParseContext& parseContext, const std::string& input) {
     Opm::Parser parser;
@@ -265,7 +287,6 @@ BOOST_AUTO_TEST_CASE(ThresholdPressureNoTHPREStest) {
 }
 
 BOOST_AUTO_TEST_CASE(ThresholdPressureThrowTest) {
-    BOOST_CHECK_THROW(Setup sx(inputStrIrrevers), std::runtime_error);
     BOOST_CHECK_THROW(Setup sx(inputStrInconsistency), std::runtime_error);
     BOOST_CHECK_THROW(Setup sx(inputStrTooHighRegionNumbers), std::runtime_error);
     BOOST_CHECK_THROW(Setup sx(inputStrMissingData), std::runtime_error);
@@ -311,4 +332,10 @@ BOOST_AUTO_TEST_CASE(HasPair) {
     BOOST_CHECK( s.threshPres.hasThresholdPressure(1, 2));
     BOOST_CHECK(!s.threshPres.hasThresholdPressure(1, 7));
     BOOST_CHECK_EQUAL(1200000.0, s.threshPres.getThresholdPressure(1, 2));
+}
+
+BOOST_AUTO_TEST_CASE(Irreversible) {
+    Setup s(inputStrIrrevers2);
+    const auto& thp = s.threshPres;
+    BOOST_CHECK(thp.getThresholdPressure(1,2) == -thp.getThresholdPressure(2,1));
 }


### PR DESCRIPTION
Support EQLOPTS option IRREVER in THPRES. The simulator itself does still not support IRREVER - that must be trapped by the simulator.