### PR TITLE
fixed: make WITH_NDEBUG cmake option work again

### DIFF
--- a/cmake/Modules/UseOptimization.cmake
+++ b/cmake/Modules/UseOptimization.cmake
@@ -64,8 +64,8 @@ if (CXX_COMPAT_GCC)
   # use these options for release builds - full optimization
   add_options (ALL_LANGUAGES "${_prof_RELEASE}" ${_opt_rel} ${_opt_flags})
   option(WITH_NDEBUG "Disable asserts in release mode" ON)
-  if(WITH_NDEBUG)
-    add_options (ALL_LANGUAGES "${_prof_RELEASE}" -DNDEBUG)
+  if(NOT WITH_NDEBUG)
+    add_options (ALL_LANGUAGES "${_prof_RELEASE}" -UNDEBUG)
   endif()
 
 else ()


### PR DESCRIPTION
at some point cmake started adding -DNDEBUG to default release CXX flags.

thus we have to invert logic and use -UNDEBUG to remove instead.

note: this will uncover current issues in opm-simulators.

https://github.com/OPM/opm-simulators/pull/3462 fixed test_glift1
https://github.com/OPM/opm-models/pull/667 fixed SPE5CASE1_DYN