### PR TITLE
Refactor SUMTHIN Implementation

### DIFF
--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -232,7 +232,6 @@ public:
 private:
     class Impl;
     std::unique_ptr< Impl > impl;
-    double last_output{0};
 };
 
 } // namespace Opm

--- a/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/ScheduleState.cpp
@@ -202,8 +202,8 @@ const std::optional<double>& ScheduleState::sumthin() const {
 }
 
 void ScheduleState::update_sumthin(double sumthin) {
-    if (sumthin == 0)
-        this->m_sumthin = std::nullopt;
+    if (! (sumthin > 0.0))
+        this->m_sumthin.reset();
     else
         this->m_sumthin = sumthin;
 }


### PR DESCRIPTION
Report steps do not influence the `SUMTHIN` intervals and the special value
```
SUMTHIN
0.0 /
```
turns off the "thinning" process.  This refactoring introduces a new helper variable, `sumthin_active_`, which caches whether `SUMTHIN` is active (i.e., exists and has strictly positive value).

While here, also ensure that the ministep IDs have non-unit steps when `SUMTHIN` ends up skipping an output event.