### PR TITLE
Support PATHS in IMPORT keyword

### DIFF
--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -1042,10 +1042,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
 
                     if (deck_keyword.name() == ParserKeywords::IMPORT::keywordName) {
                         bool formatted = deck_keyword.getRecord(0).getItem(1).get<std::string>(0)[0] == 'F';
-                        auto import_file = Opm::filesystem::path(deck_keyword.getRecord(0).getItem(0).get<std::string>(0));
-
-                        if (import_file.is_relative())
-                            import_file = parserState.rootPath / import_file;
+                        Opm::filesystem::path import_file = parserState.getIncludeFilePath(deck_keyword.getRecord(0).getItem(0).get<std::string>(0));
 
                         ImportContainer import(parser, parserState.deck.getActiveUnitSystem(), import_file.string(), formatted, parserState.deck.size());
                         for (auto kw : import)

--- a/tests/parser/ImportTests.cpp
+++ b/tests/parser/ImportTests.cpp
@@ -81,6 +81,10 @@ BOOST_AUTO_TEST_CASE(ImportDeck) {
     const std::string deck_string = R"(
 RUNSPEC
 
+PATHS
+'IMPPATH' 'import' /
+/
+
 DIMENS
    10 10 10 /
 
@@ -90,7 +94,7 @@ IMPORT
    'import/GRID' /
 
 IMPORT
-   'import/PROPS' /
+   '$IMPPATH/PROPS' /
 )";
 
     WorkArea work;


### PR DESCRIPTION
Closes #2599

Utilizes the function used for `INCLUDE` to process the path given to `IMPORT`.
Also added the scenario to one of the existing tests