### PR TITLE
Add Guiderate Value Accessor for SI Units

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -98,6 +98,11 @@ public:
     double get(const std::string& group, Group::GuideRateProdTarget target, const RateVector& rates) const;
     double get(const std::string& name, GuideRateModel::Target model_target, const RateVector& rates) const;
     double get(const std::string& group, const Phase& phase) const;
+
+    double getSI(const std::string& well, const Well::GuideRateTarget target, const RateVector& rates) const;
+    double getSI(const std::string& group, const Group::GuideRateProdTarget target, const RateVector& rates) const;
+    double getSI(const std::string& wgname, const GuideRateModel::Target target, const RateVector& rates) const;
+
     bool has(const std::string& name) const;
     bool has(const std::string& name, const Phase& phase) const;
     void init_grvalue(std::size_t report_step, const std::string& wgname, GuideRateValue value);


### PR DESCRIPTION
This is mostly for reporting purposes if the calling code knows that the values stored in the `GuideRate` container are in output units. The output layer, and particularly the [`Summary`](https://github.com/OPM/opm-common/blob/f89d3fe75a5ae322524ce7744e009c856526129e/opm/output/eclipse/Summary.hpp#L68) facility, expects that its input values are strictly SI.