### PR TITLE
cleanup after renaming from LODSMRY -> ESMRY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,7 @@ if(ENABLE_ECL_INPUT)
       ${PROJECT_BINARY_DIR}/tests
     )
 
-  foreach(test test_EclIO test_EGrid test_ERft test_ERst test_ESmry test_EInit)
+  foreach(test test_EclIO test_EGrid test_ERft test_ERst test_ESmry test_EInit test_ExtESmry)
     opm_add_test(${test} CONDITION ENABLE_ECL_INPUT AND Boost_UNIT_TEST_FRAMEWORK_FOUND
                          LIBRARIES ${_libs}
                          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -278,9 +278,10 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/io/eclipse/ERst.cpp
           src/opm/io/eclipse/ERsm.cpp
           src/opm/io/eclipse/ESmry.cpp
+          src/opm/io/eclipse/ExtESmry.cpp
           src/opm/io/eclipse/ESmry_write_rsm.cpp
           src/opm/io/eclipse/OutputStream.cpp
-          src/opm/io/eclipse/ESmryOutput.cpp
+          src/opm/io/eclipse/ExtSmryOutput.cpp
           src/opm/io/eclipse/RestartFileView.cpp
           src/opm/io/eclipse/SummaryNode.cpp
           src/opm/io/eclipse/rst/connection.cpp
@@ -546,7 +547,7 @@ if(ENABLE_ECL_INPUT)
     examples/opmpack.cpp
     examples/opmhash.cpp
     examples/wellgraph.cpp
-    examples/make_lodsmry.cpp
+    examples/make_ext_smry.cpp
   )
 endif()
 
@@ -559,7 +560,7 @@ if(ENABLE_ECL_INPUT)
     examples/opmi.cpp
     examples/opmpack.cpp
     examples/opmhash.cpp
-    examples/make_lodsmry.cpp
+    examples/make_esmry.cpp
   )
 endif()
 
@@ -854,9 +855,10 @@ if(ENABLE_ECL_OUTPUT)
         opm/io/eclipse/ERst.hpp
         opm/io/eclipse/ERsm.hpp
         opm/io/eclipse/ESmry.hpp
+        opm/io/eclipse/ExtESmry.hpp
         opm/io/eclipse/PaddedOutputString.hpp
         opm/io/eclipse/OutputStream.hpp
-        opm/io/eclipse/ESmryOutput.hpp
+        opm/io/eclipse/ExtSmryOutput.hpp
         opm/io/eclipse/RestartFileView.hpp
         opm/io/eclipse/SummaryNode.hpp
         opm/io/eclipse/rst/connection.hpp

--- a/examples/make_ext_smry.cpp
+++ b/examples/make_ext_smry.cpp
@@ -39,7 +39,7 @@ static void printHelp() {
     std::cout << "\nThis program create one or more lodsmry files, designed for effective load on the demand.   \n"
               << "These files are created with input from the smspec and unsmry file. \n"
               << "\nIn addition, the program takes these options (which must be given before the arguments):\n\n"
-              << "-f if LODSMRY file exist, this will be replaced. Default behaviour is that existing file is kept.\n"
+              << "-f if ESMRY file exist, this will be replaced. Default behaviour is that existing file is kept.\n"
               << "-n Maximum number of threads to be used if mulitple files should be created.\n"
               << "-h Print help and exit.\n\n";
 }
@@ -89,21 +89,21 @@ int main(int argc, char **argv) {
     for (int f = argOffset; f < argc; f ++){
         Opm::filesystem::path inputFileName = argv[f];
 
-        Opm::filesystem::path lodFileName = inputFileName.parent_path() / inputFileName.stem();
-        lodFileName = lodFileName += ".LODSMRY";
+        Opm::filesystem::path esmryFileName = inputFileName.parent_path() / inputFileName.stem();
+        esmryFileName = esmryFileName += ".ESMRY";
 
-        if (Opm::EclIO::fileExists(lodFileName) && (force))
-            remove (lodFileName);
+        if (Opm::EclIO::fileExists(esmryFileName) && (force))
+            remove (esmryFileName);
 
         Opm::EclIO::ESmry smryFile(argv[f]);
-        if (!smryFile.make_lodsmry_file()){
+        if (!smryFile.make_esmry_file()){
             std::cout << "\n! Warning, smspec already have one lod file, existing kept use option -f to replace this" << std::endl;
         }
     }
 
     auto lap1 = std::chrono::system_clock::now();
     std::chrono::duration<double> elapsed_seconds1 = lap1-lap0;
-    std::cout << "\nruntime for creating " << (argc-argOffset) << " LODSMRY files: " << elapsed_seconds1.count() << " seconds\n" << std::endl;
+    std::cout << "\nruntime for creating " << (argc-argOffset) << " ESMRY files: " << elapsed_seconds1.count() << " seconds\n" << std::endl;
 
     return 0;
 }

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -35,6 +35,7 @@ namespace Opm { namespace EclIO {
 
 using ArrSourceEntry = std::tuple<std::string, std::string, int, uint64_t>;
 using TimeStepEntry = std::tuple<int, int, uint64_t>;
+using RstEntry = std::tuple<std::string, int>;
 
 class ESmry
 {
@@ -58,7 +59,7 @@ public:
     void LoadData(const std::vector<std::string>& vectList) const;
     void LoadData() const;
 
-    bool make_lodsmry_file();
+    bool make_esmry_file();
 
     time_point startdate() const { return startdat; }
 
@@ -79,7 +80,10 @@ public:
     bool all_steps_available();
 
 private:
+
     filesystem::path inputFileName;
+    RstEntry restart_info;
+
     int nI, nJ, nK, nSpecFiles;
     bool fromSingleRun;
     size_t nVect, nTstep;
@@ -98,6 +102,7 @@ private:
     std::vector<std::vector<std::string>> keywordListSpecFile;
 
     std::vector<int> seqIndex;
+    std::vector<int> mini_steps;
 
     void ijk_from_global_index(int glob, int &i, int &j, int &k) const;
 
@@ -138,6 +143,7 @@ private:
     std::vector<int> makeKeywPosVector(int speInd) const;
     std::string read_string_from_disk(std::fstream& fileH, uint64_t size) const;
 
+    void read_ministeps_from_disk();
     int read_ministep_formatted(std::fstream& fileH);
 };
 

--- a/opm/io/eclipse/ExtESmry.hpp
+++ b/opm/io/eclipse/ExtESmry.hpp
@@ -1,0 +1,104 @@
+/*
+   Copyright 2019 Equinor ASA.
+
+   This file is part of the Open Porous Media project (OPM).
+
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OPM is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+   */
+
+#ifndef OPM_IO_ExtESmry_HPP
+#define OPM_IO_ExtESmry_HPP
+
+#include <chrono>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <map>
+#include <stdint.h>
+
+#include <opm/common/utility/FileSystem.hpp>
+#include <opm/common/utility/TimeService.hpp>
+
+namespace Opm { namespace EclIO {
+
+using ArrSourceEntry = std::tuple<std::string, std::string, int, uint64_t>;
+using TimeStepEntry = std::tuple<int, int, uint64_t>;
+using RstEntry = std::tuple<std::string, int>;
+
+// start, rstart + rstnum, keycheck, units, rstep, tstep
+using LodsmryHeadType = std::tuple<time_point, RstEntry, std::vector<std::string>, std::vector<std::string>,
+                                    std::vector<int>, std::vector<int>>;
+
+class ExtESmry
+{
+public:
+
+    // input is esmry, only binary supported.
+    explicit ExtESmry(const std::string& filename, bool loadBaseRunData=false);
+
+    const std::vector<float>& get(const std::string& name);
+    std::vector<float> get_at_rstep(const std::string& name);
+    std::string& get_unit(const std::string& name);
+
+    void loadData();
+    void loadData(const std::vector<std::string>& stringVect);
+
+    bool hasKey(const std::string& key) const;
+
+    size_t numberOfTimeSteps() const { return m_nTstep; }
+    size_t numberOfVectors() const { return m_nVect; }
+
+    const std::vector<std::string>& keywordList() const { return m_keyword;}
+    std::vector<std::string> keywordList(const std::string& pattern) const;
+
+    std::vector<time_point> dates();
+
+    bool all_steps_available();
+
+
+private:
+    filesystem::path m_inputFileName;
+    std::vector<filesystem::path> m_lodsmry_files;
+
+    bool m_loadBaseRun;
+    std::vector<std::map<std::string, int>> m_keyword_index;
+    std::vector<std::tuple<int,int>> m_tstep_range;
+    std::vector<std::string> m_keyword;
+    std::vector<int> m_rstep;
+    std::vector<int> m_tstep;
+    std::vector<std::vector<int>> m_rstep_v;
+    std::vector<std::vector<int>> m_tstep_v;
+    std::vector<std::vector<float>> m_vectorData;
+    std::vector<bool> m_vectorLoaded;
+    std::unordered_map<std::string, std::string> kwunits;
+
+    size_t m_nVect;
+    std::vector<size_t> m_nTstep_v;
+    size_t m_nTstep;
+    std::vector<int> m_seqIndex;
+
+    std::vector<uint64_t> m_lod_offset;
+    std::vector<uint64_t> m_lod_arr_size;
+
+    time_point m_startdat;
+
+    uint64_t open_esmry(Opm::filesystem::path& inputFileName, LodsmryHeadType& lodsmry_head);
+
+    void updatePathAndRootName(Opm::filesystem::path& dir, Opm::filesystem::path& rootN);
+};
+
+}} // namespace Opm::EclIO
+
+
+#endif // OPM_IO_ExtESmry_HPP

--- a/opm/io/eclipse/ExtSmryOutput.hpp
+++ b/opm/io/eclipse/ExtSmryOutput.hpp
@@ -16,8 +16,8 @@
    along with OPM.  If not, see <http://www.gnu.org/licenses/>.
    */
 
-#ifndef OPM_IO_ESMRYOUTPUT_HPP
-#define OPM_IO_ESMRYOUTPUT_HPP
+#ifndef OPM_IO_ExtSmryOutput_HPP
+#define OPM_IO_ExtSmryOutput_HPP
 
 #include <string>
 
@@ -33,11 +33,11 @@ class EclipseState;
 namespace Opm { namespace EclIO {
 
 
-class ESmryOutput
+class ExtSmryOutput
 {
 
 public:
-    ESmryOutput(const std::vector<std::string>& valueKeys, const std::vector<std::string>& valueUnits,
+    ExtSmryOutput(const std::vector<std::string>& valueKeys, const std::vector<std::string>& valueUnits,
                  const EclipseState& es, const time_t start_time);
 
     void write(const std::vector<float>& ts_data, int report_step);
@@ -65,4 +65,4 @@ private:
 
 }} // namespace Opm::EclIO
 
-#endif // OPM_IO_ESMRYOUTPUT_HPP
+#endif // OPM_IO_ExtSmryOutput_HPP

--- a/src/opm/io/eclipse/ExtESmry.cpp
+++ b/src/opm/io/eclipse/ExtESmry.cpp
@@ -1,0 +1,474 @@
+/*
+   Copyright 2019 Equinor ASA.
+
+   This file is part of the Open Porous Media project (OPM).
+
+   OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OPM is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+   */
+
+#include <opm/io/eclipse/ExtESmry.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/utility/FileSystem.hpp>
+#include <opm/common/utility/TimeService.hpp>
+#include <opm/io/eclipse/EclFile.hpp>
+#include <opm/io/eclipse/EclUtil.hpp>
+
+#include <algorithm>
+#include <numeric>
+#include <chrono>
+#include <exception>
+#include <iterator>
+#include <limits>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <fnmatch.h>
+#include <fstream>
+#include <cmath>
+#include <cstring>
+#include <iostream>
+
+
+namespace {
+
+Opm::time_point make_date(const std::vector<int>& datetime) {
+    auto day = datetime[0];
+    auto month = datetime[1];
+    auto year = datetime[2];
+    auto hour = 0;
+    auto minute = 0;
+    auto second = 0;
+
+    if (datetime.size() == 6) {
+        hour = datetime[3];
+        minute = datetime[4];
+        auto total_usec = datetime[5];
+        second = total_usec / 1000000;
+    }
+
+
+    const auto ts = Opm::TimeStampUTC{ Opm::TimeStampUTC::YMD{ year, month, day}}.hour(hour).minutes(minute).seconds(second);
+    return Opm::TimeService::from_time_t( Opm::asTimeT(ts) );
+}
+
+
+}
+
+
+/*
+
+     KEYWORDS       WGNAMES        NUMS              |   PARAM index   Corresponding ERT key
+     ------------------------------------------------+--------------------------------------------------
+     WGOR           OP_1           0                 |        0        WGOR:OP_1
+     FOPT           +-+-+-+-       0                 |        1        FOPT
+     WWCT           OP_1           0                 |        2        WWCT:OP_1
+     WIR            OP_1           0                 |        3        WIR:OP_1
+     WGOR           WI_1           0                 |        4        WWCT:OP_1
+     WWCT           W1_1           0                 |        5        WWCT:WI_1
+     BPR            +-+-+-         12675             |        6        BPR:12675, BPR:i,j,k
+     RPR            +-+-+-         1                 |        7        RPR:1
+     FOPT           +-+-+-         0                 |        8        FOPT
+     GGPR           NORTH          0                 |        9        GGPR:NORTH
+     COPR           OP_1           5628              |       10        COPR:OP_1:56286, COPR:OP_1:i,j,k
+     RXF            +-+-+-         32768*R1(R2 + 10) |       11        RXF:2-3
+     SOFX           OP_1           12675             |       12        SOFX:OP_1:12675, SOFX:OP_1:i,j,jk
+
+*/
+
+
+namespace Opm { namespace EclIO {
+
+ExtESmry::ExtESmry(const std::string &filename, bool loadBaseRunData) :
+    m_inputFileName { filename },
+    m_loadBaseRun(loadBaseRunData)
+{
+    if (m_inputFileName.extension()=="")
+        m_inputFileName+=".ESMRY";
+
+    if (m_inputFileName.extension()!=".ESMRY")
+        throw std::invalid_argument("Input file should have extension .ESMRY");
+
+    m_lodsmry_files.push_back(m_inputFileName);
+
+    Opm::filesystem::path rootName = m_inputFileName.parent_path() / m_inputFileName.stem();
+    Opm::filesystem::path path = Opm::filesystem::current_path();
+
+    Opm::filesystem::path rstRootN;
+
+    updatePathAndRootName(path, rootName);
+
+    LodsmryHeadType lodsmry_head;
+
+    auto lod_offset = open_esmry(m_inputFileName, lodsmry_head);
+
+    m_startdat = std::get<0>(lodsmry_head);
+
+    m_lod_offset.push_back(lod_offset);
+
+    std::map<std::string, int> key_index;
+
+    auto keyword = std::get<2>(lodsmry_head);
+    auto units = std::get<3>(lodsmry_head);
+
+    for (size_t n = 0; n < keyword.size(); n++){
+        key_index[keyword[n]] = n;
+        m_keyword.push_back(keyword[n]);
+    }
+
+    m_keyword_index.push_back(key_index);
+
+    for (size_t n = 0; n < m_keyword.size(); n++)
+        kwunits[m_keyword[n]] = units[n];
+
+    RstEntry rst_entry = std::get<1>(lodsmry_head);
+
+    m_rstep_v.push_back(std::get<4>(lodsmry_head));
+    m_tstep_v.push_back(std::get<5>(lodsmry_head));
+
+    m_nTstep_v.push_back(m_tstep_v.back().size());
+
+    auto lod_arr_size = sizeOnDiskBinary(m_nTstep_v.back(), Opm::EclIO::REAL, sizeOfReal);
+
+    m_lod_arr_size.push_back(lod_arr_size);
+
+    m_tstep_range.push_back(std::make_tuple(0, m_tstep_v.back().size() - 1));
+
+    int sim_ind = 0;
+
+    if ((loadBaseRunData) and (std::get<0>(rst_entry) !="")){
+
+        auto restart = std::get<0>(rst_entry);
+        auto rstNum = std::get<1>(rst_entry);
+
+        while (restart != ""){
+            sim_ind++;
+
+            rstRootN = Opm::filesystem::path(restart);
+
+            updatePathAndRootName(path, rstRootN);
+
+            Opm::filesystem::path rstLodSmryFile = path / rstRootN;
+            rstLodSmryFile += ".ESMRY";
+
+            m_lodsmry_files.push_back(rstLodSmryFile);
+
+            lod_offset = open_esmry(rstLodSmryFile, lodsmry_head);
+
+            m_lod_offset.push_back(lod_offset);
+
+            m_rstep_v.push_back(std::get<4>(lodsmry_head));
+            m_tstep_v.push_back(std::get<5>(lodsmry_head));
+
+            m_nTstep_v.push_back(m_tstep_v.back().size());
+
+            lod_arr_size = sizeOnDiskBinary(m_nTstep_v.back(), Opm::EclIO::REAL, sizeOfReal);
+            m_lod_arr_size.push_back(lod_arr_size);
+
+            int cidx = 0;
+
+            auto it = std::find_if(m_rstep_v[sim_ind].begin(), m_rstep_v[sim_ind].end(),
+                           [&cidx, &rstNum](const int & val)
+                           {
+                              if (val == 1)
+                                  ++cidx;
+
+                              return cidx == rstNum;
+                           });
+
+            size_t ind =  std::distance(m_rstep_v[sim_ind].begin(), it);
+
+            m_tstep_range.push_back(std::make_tuple(0, ind));
+
+            key_index.clear();
+            keyword = std::get<2>(lodsmry_head);
+
+            for (size_t n = 0; n < keyword.size(); n++)
+                key_index[keyword[n]] = n;
+
+            m_keyword_index.push_back(key_index);
+
+            rst_entry = std::get<1>(lodsmry_head);
+            restart = std::get<0>(rst_entry);
+            rstNum = std::get<1>(rst_entry);
+        }
+    }
+
+    m_nVect = m_keyword.size();
+
+    m_vectorData.resize(m_nVect, {});
+    m_vectorLoaded.resize(m_nVect, false);
+
+    int ind = static_cast<int>(m_tstep_range.size()) - 1 ;
+
+    while (ind > -1) {
+        int to_ind = std::get<1>(m_tstep_range[ind]);
+        m_rstep.insert(m_rstep.end(), m_rstep_v[ind].begin(), m_rstep_v[ind].begin() + to_ind + 1);
+        m_tstep.insert(m_tstep.end(), m_tstep_v[ind].begin(), m_tstep_v[ind].begin() + to_ind + 1);
+        ind--;
+    }
+
+    m_nTstep = m_rstep.size();
+
+    for (size_t m = 0; m < m_rstep.size(); m++)
+        if (m_rstep[m] == 1)
+            m_seqIndex.push_back(m);
+}
+
+
+std::vector<float> ExtESmry::get_at_rstep(const std::string& name)
+{
+    auto full_vect = this->get(name);
+
+    std::vector<float> rs_vect;
+    rs_vect.reserve(m_seqIndex.size());
+
+    for (auto r : m_seqIndex)
+        rs_vect.push_back(full_vect[r]);
+
+    return rs_vect;
+}
+
+std::string& ExtESmry::get_unit(const std::string& name)
+{
+    if ( m_keyword_index[0].find(name) == m_keyword_index[0].end() )
+        throw std::invalid_argument("summary key '" + name + "' not found");
+
+    return kwunits.at(name);
+}
+
+bool ExtESmry::all_steps_available()
+{
+    for (size_t n = 1; n < m_tstep.size(); n++)
+        if ((m_tstep[n] - m_tstep[n-1]) > 1)
+            return false;
+
+    return true;
+}
+
+uint64_t ExtESmry::open_esmry(Opm::filesystem::path& inputFileName, LodsmryHeadType& lodsmry_head)
+{
+    std::fstream fileH;
+
+    fileH.open(inputFileName, std::ios::in |  std::ios::binary);
+
+    if (!fileH)
+        throw std::runtime_error("Can not open file ");
+
+
+    std::string arrName;
+    int64_t arr_size;
+    Opm::EclIO::eclArrType arrType;
+    int sizeOfElement;
+
+    Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);
+
+    if ((arrName != "START   ") or (arrType != Opm::EclIO::INTE))
+        OPM_THROW(std::invalid_argument, "reading start, invalid lod file");
+
+    auto start_vect = Opm::EclIO::readBinaryInteArray(fileH, arr_size);
+
+    auto startdat = make_date(start_vect);
+
+    Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);
+
+    Opm::EclIO::RstEntry rst_entry = std::make_tuple("", 0);
+
+    if (arrName == "RESTART "){
+
+        if (m_loadBaseRun) {
+
+            std::vector<std::string> rstfile = Opm::EclIO::readBinaryC0nnArray(fileH, arr_size, sizeOfElement);
+            Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);
+            std::vector<int> rst_num  = Opm::EclIO::readBinaryInteArray(fileH, arr_size);
+
+            rst_entry = std::make_tuple(rstfile[0], rst_num[0]);
+
+        } else {
+            uint64_t numIgnore = sizeOnDiskBinary(arr_size, arrType, sizeOfElement);
+            numIgnore = numIgnore + 24 + sizeOnDiskBinary(1, Opm::EclIO::INTE, Opm::EclIO::sizeOfInte);
+            fileH.seekg(static_cast<std::streamoff>(numIgnore), std::ios_base::cur);
+        }
+
+        Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);
+    }
+
+    if (arrName != "KEYCHECK")
+        OPM_THROW(std::invalid_argument, "!!reading keycheck, invalid lod file");
+
+    std::vector<std::string> keywords;
+
+    keywords = Opm::EclIO::readBinaryC0nnArray(fileH, arr_size, sizeOfElement);
+
+    Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);
+
+    if (arrName != "UNITS   ")
+        OPM_THROW(std::invalid_argument, "reading UNITS, invalid lod file");
+
+    auto units = Opm::EclIO::readBinaryC0nnArray(fileH, arr_size, sizeOfElement);
+
+    if (keywords.size() != units.size())
+        throw std::runtime_error("invalied LODSMRY file, size of units not equal size of keywords");
+
+    Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);
+
+    if ((arrName != "RSTEP   ") or (arrType != Opm::EclIO::INTE))
+        OPM_THROW(std::invalid_argument, "reading RSTEP, invalid lod file");
+
+    auto rstep = Opm::EclIO::readBinaryInteArray(fileH, arr_size);
+
+    Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);
+
+    if ((arrName != "TSTEP   ") or (arrType != Opm::EclIO::INTE))
+        OPM_THROW(std::invalid_argument, "reading TSTEP, invalid lod file");
+
+    auto tstep = Opm::EclIO::readBinaryInteArray(fileH, arr_size);
+
+    lodsmry_head = std::make_tuple(startdat, rst_entry, keywords, units, rstep, tstep);
+
+    uint64_t lodsmry_offset = static_cast<uint64_t>(fileH.tellg());
+
+    fileH.close();
+
+    return lodsmry_offset;
+}
+
+
+void ExtESmry::updatePathAndRootName(Opm::filesystem::path& dir, Opm::filesystem::path& rootN) {
+
+    if (rootN.parent_path().is_absolute()){
+        dir = rootN.parent_path();
+    } else {
+        dir = dir / rootN.parent_path();
+    }
+
+    rootN = rootN.stem();
+}
+
+
+void ExtESmry::loadData(const std::vector<std::string>& stringVect)
+{
+    std::vector<int> keyIndexVect;
+
+    for (auto key: stringVect)
+        keyIndexVect.push_back(m_keyword_index[0].at(key));
+
+    std::fstream fileH;
+
+    int ind = static_cast<int>(m_tstep_range.size()) - 1 ;
+
+    while (ind > -1) {
+
+        int to_ind = std::get<1>(m_tstep_range[ind]);
+
+        fileH.open(m_lodsmry_files[ind], std::ios::in |  std::ios::binary);
+
+        if (!fileH)
+            throw std::runtime_error("Can not open file lodFile");
+
+        for (size_t n = 0 ; n < stringVect.size(); n++) {
+
+            std::string key = stringVect[n];
+
+            std::string arrName;
+            int64_t size;
+            Opm::EclIO::eclArrType arrType;
+            int sizeOfElement;
+
+            if ( m_keyword_index[ind].find(key) == m_keyword_index[ind].end() ) {
+
+                for (int m = 0; m < to_ind + 1; m++)
+                    m_vectorData[keyIndexVect[n]].push_back(0.0);
+
+            } else {
+
+                int key_ind = m_keyword_index[ind].at(key);
+
+                uint64_t pos = m_lod_offset[ind] + m_lod_arr_size[ind]*static_cast<uint64_t>(key_ind);
+                pos = pos + static_cast<uint64_t>(key_ind * 24);  // adding size of binary headers
+
+                fileH.seekg (pos, fileH.beg);
+
+                readBinaryHeader(fileH, arrName, size, arrType, sizeOfElement);
+
+                arrName = Opm::EclIO::trimr(arrName);
+
+                std::string checkName = "V" + std::to_string(key_ind);
+
+                if (arrName != checkName)
+                    OPM_THROW(std::invalid_argument, "lodsmry, wrong header expecting  " + checkName + " found " +  arrName);
+
+                auto smry_data = readBinaryRealArray(fileH, size);
+
+                m_vectorData[keyIndexVect[n]].insert(m_vectorData[keyIndexVect[n]].end(), smry_data.begin(), smry_data.begin() + to_ind + 1);
+            }
+
+            fileH.close();
+
+            ind--;
+        }
+    }
+
+    for (auto kind : keyIndexVect)
+        m_vectorLoaded[kind] = true;
+}
+
+void ExtESmry::loadData()
+{
+    this->loadData(m_keyword);
+}
+
+const std::vector<float>& ExtESmry::get(const std::string& name)
+{
+    if ( m_keyword_index[0].find(name) == m_keyword_index[0].end() )
+        throw std::invalid_argument("summary key '" + name + "' not found");
+
+    int index = m_keyword_index[0].at(name);
+
+    if (!m_vectorLoaded[index]){
+        loadData({name});
+    }
+
+    return m_vectorData[index];
+}
+
+std::vector<Opm::time_point> ExtESmry::dates() {
+    double time_unit = 24 * 3600;
+    std::vector<Opm::time_point> d;
+
+    for (const auto& t : this->get("TIME"))
+        d.push_back( this->m_startdat + std::chrono::duration_cast<std::chrono::seconds>( std::chrono::duration<double, std::chrono::seconds::period>( t * time_unit)));
+
+    return d;
+}
+
+std::vector<std::string> ExtESmry::keywordList(const std::string& pattern) const
+{
+    std::vector<std::string> list;
+
+    for (auto key : m_keyword)
+        if (fnmatch( pattern.c_str(), key.c_str(), 0 ) == 0 )
+            list.push_back(key);
+
+    return list;
+}
+
+bool ExtESmry::hasKey(const std::string &key) const
+{
+    return std::find(m_keyword.begin(), m_keyword.end(), key) != m_keyword.end();
+}
+
+
+
+}} // namespace Opm::ecl
+

--- a/src/opm/io/eclipse/ExtSmryOutput.cpp
+++ b/src/opm/io/eclipse/ExtSmryOutput.cpp
@@ -18,7 +18,7 @@
 
 #include <opm/io/eclipse/EclUtil.hpp>
 #include <opm/io/eclipse/EclFile.hpp>
-#include <opm/io/eclipse/ESmryOutput.hpp>
+#include <opm/io/eclipse/ExtSmryOutput.hpp>
 #include <opm/io/eclipse/EclOutput.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -32,7 +32,7 @@
 namespace Opm { namespace EclIO {
 
 
-ESmryOutput::ESmryOutput(const std::vector<std::string>& valueKeys, const std::vector<std::string>& valueUnits,
+ExtSmryOutput::ExtSmryOutput(const std::vector<std::string>& valueKeys, const std::vector<std::string>& valueUnits,
                  const EclipseState& es, const time_t start_time)
 {
     m_nVect = valueKeys.size();
@@ -71,7 +71,7 @@ ESmryOutput::ESmryOutput(const std::vector<std::string>& valueKeys, const std::v
 }
 
 
-void ESmryOutput::write(const std::vector<float>& ts_data, int report_step)
+void ExtSmryOutput::write(const std::vector<float>& ts_data, int report_step)
 {
 
     if (ts_data.size() != static_cast<size_t>(m_nVect))
@@ -116,7 +116,7 @@ void ESmryOutput::write(const std::vector<float>& ts_data, int report_step)
 }
 
 
-std::vector<std::string> ESmryOutput::make_modified_keys(const std::vector<std::string> valueKeys, const GridDims& dims)
+std::vector<std::string> ExtSmryOutput::make_modified_keys(const std::vector<std::string> valueKeys, const GridDims& dims)
 {
     std::vector<std::string> mod_keys;
     mod_keys.reserve(valueKeys.size());
@@ -164,7 +164,7 @@ std::vector<std::string> ESmryOutput::make_modified_keys(const std::vector<std::
 
 }
 
-std::array<int, 3> ESmryOutput::ijk_from_global_index(const GridDims& dims, int globInd) const
+std::array<int, 3> ExtSmryOutput::ijk_from_global_index(const GridDims& dims, int globInd) const
 {
 
     if (globInd < 0 || static_cast<size_t>(globInd) >= dims[0] * dims[1] * dims[2])

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -52,7 +52,7 @@
 
 #include <opm/io/eclipse/EclOutput.hpp>
 #include <opm/io/eclipse/OutputStream.hpp>
-#include <opm/io/eclipse/ESmryOutput.hpp>
+#include <opm/io/eclipse/ExtSmryOutput.hpp>
 
 #include <opm/output/data/Groups.hpp>
 #include <opm/output/data/GuideRateValue.hpp>
@@ -3251,7 +3251,7 @@ private:
     std::unique_ptr<Opm::EclIO::OutputStream::SummarySpecification> smspec_{};
     std::unique_ptr<Opm::EclIO::EclOutput> stream_{};
 
-    std::unique_ptr<Opm::EclIO::ESmryOutput> esmry_;
+    std::unique_ptr<Opm::EclIO::ExtSmryOutput> esmry_;
 
     void configureTimeVectors(const EclipseState& es, const SummaryConfig& sumcfg);
 
@@ -3314,7 +3314,7 @@ SummaryImplementation(const EclipseState&  es,
         Opm::filesystem::remove(esmryFileName);
 
     if ((writeEsmry) and (es.cfg().io().getFMTOUT()==false))
-        this->esmry_ = std::make_unique<Opm::EclIO::ESmryOutput>(this->valueKeys_, this->valueUnits_, es, sched.posixStartTime());
+        this->esmry_ = std::make_unique<Opm::EclIO::ExtSmryOutput>(this->valueKeys_, this->valueUnits_, es, sched.posixStartTime());
 
     if ((writeEsmry) and (es.cfg().io().getFMTOUT()))
         OpmLog::warning("ESMRY only supported for unformatted output.  Request ignored.");

--- a/test_util/convertECL.cpp
+++ b/test_util/convertECL.cpp
@@ -196,10 +196,10 @@ int main(int argc, char **argv) {
     }
 
     std::map<std::string, std::string> to_formatted = {{".EGRID", ".FEGRID"}, {".INIT", ".FINIT"}, {".SMSPEC", ".FSMSPEC"},
-        {".UNSMRY", ".FUNSMRY"}, {".UNRST", ".FUNRST"}, {".RFT", ".FRFT"}, {".LODSMRY", ".FLODSMRY"}};
+        {".UNSMRY", ".FUNSMRY"}, {".UNRST", ".FUNRST"}, {".RFT", ".FRFT"}, {".ESMRY", ".FESMRY"}};
 
     std::map<std::string, std::string> to_binary = {{".FEGRID", ".EGRID"}, {".FINIT", ".INIT"}, {".FSMSPEC", ".SMSPEC"},
-        {".FUNSMRY", ".UNSMRY"}, {".FUNRST", ".UNRST"}, {".FRFT", ".RFT"}, {".FLODSMRY", ".LODSMRY"}};
+        {".FUNSMRY", ".UNSMRY"}, {".FUNRST", ".UNRST"}, {".FRFT", ".RFT"}, {".FESMRY", ".ESMRY"}};
 
     if (formattedOutput) {
 


### PR DESCRIPTION
The LODSMRY file name has been part of opm-common for nearly one year.
 - converting from SMSPEC/UNSMRY to LODSMRY
 - converting from binary LODSMRY to formatted FLODSMRY

I have tried to clean up all of these after the decision to go further with ESMRY instead of LODSMRY.  

I have also updated the summary application to support both SMSPEC/UNSMRY and ESMRY file format

A new class ExtESmry has been added. This class has more or less same design and functionality as ESmry, except this this class will work on ESMRY files.
