### PR TITLE
Store action results

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp
@@ -20,10 +20,10 @@
 #ifndef ACTION_RESULT_HPP
 #define ACTION_RESULT_HPP
 
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <memory>
 
 namespace Opm {
 namespace Action {
@@ -91,7 +91,6 @@ public:
     explicit Result(bool result_arg);
     Result(bool result_arg, const std::vector<std::string>& wells);
     Result(bool result_arg, const WellSet& wells);
-    Result(const Result& src);
 
     explicit operator bool() const;
     std::vector<std::string> wells() const;
@@ -101,19 +100,12 @@ public:
     void add_well(const std::string& well);
 
     Result& operator|=(const Result& other);
-    Result& operator=(const Result& src);
     Result& operator&=(const Result& other);
 
 private:
     void assign(bool value);
     bool result;
-    /*
-      The set of matching wells is implemented with pointer semantics to be able
-      to differentiate between an empty set of wells - like all the wells with
-      WWCT > 1, and a result set which does not have well information at all -
-      e.g. FOPR > 0.
-    */
-    std::unique_ptr<WellSet> matching_wells;
+    std::optional<WellSet> matching_wells;
 };
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp
@@ -80,6 +80,7 @@ public:
 
     WellSet& intersect(const WellSet& other);
     WellSet& add(const WellSet& other);
+    bool operator==(const WellSet& other) const;
 private:
     std::unordered_set<std::string> well_set;
 };
@@ -101,6 +102,7 @@ public:
 
     Result& operator|=(const Result& other);
     Result& operator&=(const Result& other);
+    bool operator==(const Result& other) const;
 
 private:
     void assign(bool value);

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp
@@ -23,6 +23,8 @@
 #include <ctime>
 #include <map>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp>
+
 namespace Opm {
 namespace Action {
 
@@ -45,13 +47,15 @@ struct RunState {
 };
 
 public:
-    void add_run(const ActionX& action, std::time_t sim_time);
+    void add_run(const ActionX& action, std::time_t sim_time, Result result);
     std::size_t run_count(const ActionX& action) const;
     std::time_t run_time(const ActionX& action) const;
+    std::optional<Result> result(const std::string& action) const;
 private:
     using action_id = std::pair<std::string, std::size_t>;
     static action_id make_id(const ActionX& action);
     std::map<action_id, RunState> run_state;
+    std::map<std::string, Result> last_result;
 };
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp
@@ -30,16 +30,15 @@ class ActionX;
 class State {
 
 struct RunState {
-    RunState(std::time_t sim_time) :
-        run_count(1),
-        last_run(sim_time)
+    RunState(std::time_t sim_time)
+        : run_count(1)
+        , last_run(sim_time)
     {}
 
     void add_run(std::time_t sim_time) {
         this->last_run = sim_time;
         this->run_count += 1;
     }
-
 
     std::size_t run_count;
     std::time_t last_run;
@@ -50,7 +49,9 @@ public:
     std::size_t run_count(const ActionX& action) const;
     std::time_t run_time(const ActionX& action) const;
 private:
-    std::map<std::pair<std::string, std::size_t>, RunState> run_state;
+    using action_id = std::pair<std::string, std::size_t>;
+    static action_id make_id(const ActionX& action);
+    std::map<action_id, RunState> run_state;
 };
 
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.cpp
@@ -81,6 +81,11 @@ Result& Result::operator&=(const Result& other) {
     return *this;
 }
 
+bool Result::operator==(const Result& other) const {
+    return this->result == other.result &&
+           this->matching_wells == other.matching_wells;
+}
+
 void Result::assign(bool value) {
     this->result = value;
 }
@@ -143,6 +148,11 @@ WellSet& WellSet::add(const WellSet& other) {
 
 bool WellSet::contains(const std::string& well) const {
     return (this->well_set.find(well) != this->well_set.end());
+}
+
+
+bool WellSet::operator==(const WellSet& other) const {
+    return this->well_set == other.well_set;
 }
 
 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
@@ -27,15 +27,13 @@
 namespace Opm {
 namespace Action {
 
-namespace {
-std::pair<std::string, std::size_t> action_id(const ActionX& action) {
+State::action_id State::make_id(const ActionX& action) {
     return std::make_pair(action.name(), action.id());
-}
 }
 
 
 std::size_t State::run_count(const ActionX& action) const {
-    auto count_iter = this->run_state.find(action_id(action));
+    auto count_iter = this->run_state.find(this->make_id(action));
     if (count_iter == this->run_state.end())
         return 0;
 
@@ -43,13 +41,13 @@ std::size_t State::run_count(const ActionX& action) const {
 }
 
 std::time_t State::run_time(const ActionX& action) const {
-    auto state = this->run_state.at(action_id(action));
+    auto state = this->run_state.at(this->make_id(action));
     return state.last_run;
 }
 
 
 void State::add_run(const ActionX& action, std::time_t run_time) {
-    const auto& id  = action_id(action);
+    const auto& id  = this->make_id(action);
     auto count_iter = this->run_state.find(id);
     if (count_iter == this->run_state.end())
         this->run_state.insert( std::make_pair(id, run_time) );

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
@@ -46,13 +46,24 @@ std::time_t State::run_time(const ActionX& action) const {
 }
 
 
-void State::add_run(const ActionX& action, std::time_t run_time) {
+void State::add_run(const ActionX& action, std::time_t run_time, Result result) {
     const auto& id  = this->make_id(action);
     auto count_iter = this->run_state.find(id);
     if (count_iter == this->run_state.end())
         this->run_state.insert( std::make_pair(id, run_time) );
     else
         count_iter->second.add_run(run_time);
+
+    this->last_result.insert_or_assign(action.name(), std::move(result));
+}
+
+
+std::optional<Result> State::result(const std::string& action) const {
+    auto iter = this->last_result.find(action);
+    if (iter == this->last_result.end())
+        return std::nullopt;
+
+    return iter->second;
 }
 
 }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -873,28 +873,41 @@ BOOST_AUTO_TEST_CASE(ActionState) {
     Action::State st;
     Action::ActionX action1("NAME", 100, 100, 100); action1.update_id(100);
     Action::ActionX action2("NAME", 100, 100, 100); action1.update_id(200);
+    Action::Result res1(true, {"W1"});
+    Action::Result res2(true, {"W2"});
+    Action::Result res3(true, {"W3"});
 
     BOOST_CHECK_EQUAL(0U, st.run_count(action1));
     BOOST_CHECK_THROW( st.run_time(action1), std::out_of_range);
 
-    st.add_run(action1, 100);
+    st.add_run(action1, 100, res1);
     BOOST_CHECK_EQUAL(1U, st.run_count(action1));
     BOOST_CHECK_EQUAL(100, st.run_time(action1));
+    auto r1 = st.result("NAME");
+    BOOST_CHECK(r1.value() == res1);
 
-    st.add_run(action1, 1000);
+    st.add_run(action1, 1000, res2);
     BOOST_CHECK_EQUAL(2U, st.run_count(action1));
     BOOST_CHECK_EQUAL(1000, st.run_time(action1));
+    auto r2 = st.result("NAME");
+    BOOST_CHECK(r2.value() == res2);
 
     BOOST_CHECK_EQUAL(0U, st.run_count(action2));
     BOOST_CHECK_THROW( st.run_time(action2), std::out_of_range);
 
-    st.add_run(action2, 100);
+    st.add_run(action2, 100, res3);
     BOOST_CHECK_EQUAL(1U, st.run_count(action2));
     BOOST_CHECK_EQUAL(100, st.run_time(action2));
+    auto r3 = st.result("NAME");
+    BOOST_CHECK(r3.value() == res3);
 
-    st.add_run(action2, 1000);
+    st.add_run(action2, 1000, res1);
     BOOST_CHECK_EQUAL(2U, st.run_count(action2));
     BOOST_CHECK_EQUAL(1000, st.run_time(action2));
+
+
+    auto res = st.result("NAME-HIDDEN");
+    BOOST_CHECK(!res.has_value());
 }
 
 BOOST_AUTO_TEST_CASE(ActionID) {
@@ -944,7 +957,7 @@ ENDACTIO
     BOOST_CHECK(action1.id() != action2.id());
 
     Action::State st;
-    st.add_run(action1, 1000);
+    st.add_run(action1, 1000, Action::Result{true});
     BOOST_CHECK_EQUAL( st.run_count(action1), 1U);
     BOOST_CHECK_EQUAL( st.run_count(action2), 0U);
 }


### PR DESCRIPTION
Store the `Action::Result`instance when an action has evaluated to true. NB: This is quite naive - it will currently store the result when an action evaluates to true, if a new true value comes around it will be updated. If the action evaluates to false it will not be cleared (maybe it should?). 

Restart testing will reveal the correct semantics here.

Downstream: https://github.com/OPM/opm-simulators/pull/3482

This should update some elements in the ZWEL vector for models with ACTIONX - i.e. an update_data will be required