### PR TITLE
Normal summmary keys

### DIFF
--- a/src/opm/io/eclipse/ExtSmryOutput.cpp
+++ b/src/opm/io/eclipse/ExtSmryOutput.cpp
@@ -122,14 +122,7 @@ std::vector<std::string> ExtSmryOutput::make_modified_keys(const std::vector<std
     mod_keys.reserve(valueKeys.size());
 
     for (size_t n=0; n < valueKeys.size(); n++){
-
-        if (valueKeys[n].substr(0,15) == "SMSPEC.Internal"){
-            std::string mod_key = valueKeys[n].substr(16);
-            int p = mod_key.find_first_of(".");
-            mod_key=mod_key.substr(0,p);
-            mod_keys.push_back(mod_key);
-
-        } else if (valueKeys[n].substr(0,1) == "C"){
+        if (valueKeys[n].substr(0,1) == "C"){
             size_t p = valueKeys[n].find_first_of(":");
             p = valueKeys[n].find_first_of(":", p + 1);
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -3512,21 +3512,14 @@ configureTimeVectors(const EclipseState& es, const SummaryConfig& sumcfg)
     const auto dfltwgname = std::string(":+:+:+:+");
     const auto dfltnum    = 0;
 
-    // XXX: Save keys might need/want to include a random component too.
-    auto makeKey = [this](const std::string& keyword) -> void
-    {
-        this->valueKeys_.push_back(
-            "SMSPEC.Internal." + keyword + ".Value.SAVE"
-        );
-    };
 
     // TIME
     {
-        const auto kw = std::string("TIME");
-        makeKey(kw);
+        std::string kw = "TIME";
+        this->valueKeys_.push_back(kw);
 
         const std::string& unit_string = es.getUnits().name(UnitSystem::measure::time);
-        auto eval = std::make_unique<Evaluator::Time>(this->valueKeys_.back());
+        auto eval = std::make_unique<Evaluator::Time>(kw);
 
         valueUnits_.push_back(unit_string);
 
@@ -3536,10 +3529,10 @@ configureTimeVectors(const EclipseState& es, const SummaryConfig& sumcfg)
     }
 
     if (sumcfg.hasKeyword("DAY")) {
-        const auto kw = std::string("DAY");
-        makeKey(kw);
+        std::string kw = "DAY";
+        this->valueKeys_.push_back(kw);
 
-        auto eval = std::make_unique<Evaluator::Day>(this->valueKeys_.back());
+        auto eval = std::make_unique<Evaluator::Day>(kw);
         valueUnits_.push_back("");
 
         this->outputParameters_
@@ -3547,10 +3540,10 @@ configureTimeVectors(const EclipseState& es, const SummaryConfig& sumcfg)
     }
 
     if (sumcfg.hasKeyword("MONTH")) {
-        const auto kw = std::string("MONTH");
-        makeKey(kw);
+        std::string kw = "MONTH";
+        this->valueKeys_.push_back(kw);
 
-        auto eval = std::make_unique<Evaluator::Month>(this->valueKeys_.back());
+        auto eval = std::make_unique<Evaluator::Month>(kw);
         valueUnits_.push_back("");
 
         this->outputParameters_
@@ -3558,10 +3551,10 @@ configureTimeVectors(const EclipseState& es, const SummaryConfig& sumcfg)
     }
 
     if (sumcfg.hasKeyword("YEAR")) {
-        const auto kw = std::string("YEAR");
-        makeKey(kw);
+        std::string kw = "YEAR";
+        this->valueKeys_.push_back(kw);
 
-        auto eval = std::make_unique<Evaluator::Year>(this->valueKeys_.back());
+        auto eval = std::make_unique<Evaluator::Year>(kw);
         valueUnits_.push_back("");
         this->outputParameters_
             .makeParameter(kw, dfltwgname, dfltnum, "", std::move(eval));
@@ -3569,10 +3562,10 @@ configureTimeVectors(const EclipseState& es, const SummaryConfig& sumcfg)
 
     // YEARS
     {
-        const auto kw = std::string("YEARS");
-        makeKey(kw);
+        std::string kw = "YEARS";
+        this->valueKeys_.push_back(kw);
 
-        auto eval = std::make_unique<Evaluator::Years>(this->valueKeys_.back());
+        auto eval = std::make_unique<Evaluator::Years>(kw);
         valueUnits_.push_back("");
 
         this->outputParameters_

--- a/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/SummaryState.cpp
@@ -113,16 +113,6 @@ namespace {
 
     void SummaryState::update_elapsed(double delta) {
         this->elapsed += delta;
-        std::time_t sim_time = std::chrono::system_clock::to_time_t( this->sim_start + std::chrono::microseconds(static_cast<std::size_t>(1000000*delta)));
-        struct tm ts;
-        gmtime_r(&sim_time, &ts);
-        int year = ts.tm_year + 1900;
-        int month = ts.tm_mon;
-        int day = ts.tm_mday;
-
-        this->update("YEAR", year);
-        this->update("MNTH", month);
-        this->update("DAY", day);
     }
 
 

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -73,7 +73,8 @@ Opm::SummaryState sum_state_TEST1()
         state.update("FWPR", 73.);
 
         state.update("FMWPR", 4);
-
+        state.update("MNTH", 1);
+        state.update("YEAR", 2020);
 
         return state;
 }

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -2290,8 +2290,6 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
     BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP2"), 1U);
     BOOST_CHECK_EQUAL(std::count(all_wells.begin(), all_wells.end(), "OP3"), 1U);
 
-    BOOST_CHECK_EQUAL(st.size(), 11U); // Size = 8 + 3 - where the the three are DAY, MNTH and YEAR
-
     // The well 'OP_2' which was indirectly added with the
     // st.update("WWCT:OP_2", 100) call is *not* counted as a well!
     BOOST_CHECK_EQUAL(st.num_wells(), 3U);
@@ -3935,29 +3933,5 @@ BOOST_AUTO_TEST_CASE(serialize_sumary_state) {
 
 }
 
-BOOST_AUTO_TEST_CASE(SummaryState__TIME) {
-    struct tm ts;
-    ts.tm_year = 100;
-    ts.tm_mon = 1;
-    ts.tm_mday = 1;
-    ts.tm_hour = 0;
-    ts.tm_min = 0;
-    ts.tm_sec = 0;
-    auto start_time = timegm(&ts);
-    SummaryState st(TimeService::from_time_t(start_time));
-    BOOST_CHECK_EQUAL(st.get("YEAR"), 2000);
-    BOOST_CHECK_EQUAL(st.get("DAY"), 1);
-    BOOST_CHECK_EQUAL(st.get("MNTH"), 1);
-
-    // Next day
-    st.update_elapsed(100000);
-    BOOST_CHECK_EQUAL(st.get("YEAR"), 2000);
-    BOOST_CHECK_EQUAL(st.get("DAY"), 2);
-    BOOST_CHECK_EQUAL(st.get("MNTH"), 1);
-
-    // Well into 2001
-    st.update_elapsed(400 * 86400);
-    BOOST_CHECK_EQUAL(st.get("YEAR"), 2001);
-}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The time related summary keywords, TIME, DAY, ... were treated in a special way. That came in conflict with the automatic creation of summary evaluators for ACTIONX. As part of the PR the SummaryState will no longer automatically contain "DAY", "MONTH", "YEAR".

The use of the special keys "SMSPEC.Internal.XXX" was quite elaborate - so I fear I have missed something when taking it out? The original plan was to make a PR with only the first commit, but things are interconnected and in order to get the whole thing green I had to complete the refactoring with two additional commits.