### PR TITLE
update of base class EclFile

### DIFF
--- a/opm/io/eclipse/EGrid.hpp
+++ b/opm/io/eclipse/EGrid.hpp
@@ -49,7 +49,7 @@ public:
     void getCellCorners(const std::array<int, 3>& ijk, std::array<double,8>& X, std::array<double,8>& Y, std::array<double,8>& Z);
 
     std::vector<std::array<float, 3>> getXYZ_layer(int layer, bool bottom=false);
-    std::vector<std::array<float, 3>> getXYZ_layer(int layer, std::array<int, 4>& box, bool bottom=false);
+    std::vector<std::array<float, 3>> getXYZ_layer(int layer, const std::array<int, 4>& box, bool bottom=false);
 
     int activeCells() const { return nactive; }
     int totalNumberOfCells() const { return nijk[0] * nijk[1] * nijk[2]; }

--- a/src/opm/io/eclipse/EclUtil.cpp
+++ b/src/opm/io/eclipse/EclUtil.cpp
@@ -436,16 +436,19 @@ std::vector<T> Opm::EclIO::readBinaryArray(std::fstream& fileH, const int64_t si
             OPM_THROW(std::runtime_error, "Error reading binary data, inconsistent header data or incorrect number of elements");
         }
 
-        for (int i = 0; i < num; i++) {
-            T2 value;
-
-            if constexpr (std::is_same_v<T2, std::string>) {
+        if constexpr (std::is_same_v<T2, std::string>) {
+            for (int i = 0; i < num; i++) {
+                T2 value;
                 value.resize(sizeOfElement) ;
                 fileH.read(&value[0], sizeOfElement);
-            } else
-                fileH.read(reinterpret_cast<char*>(&value), sizeOfElement);
+                arr.push_back(flip(value));
+            }
+        } else {
+            std::vector<T2> buf(num);
+            fileH.read(reinterpret_cast<char*>(buf.data()), buf.size()*sizeof(T2));
 
-            arr.push_back(flip(value));
+            for (size_t n=0; n < num; n++)
+                arr.push_back(flip(buf[n]));
         }
 
         rest -= num;


### PR DESCRIPTION
 - significant improvements on performance
 - reading blocks of data from disk, rather that one by one element
 - using block sizes defined in Opm::EclIO::EclIOdata.hpp

updates of EGrid::get_zcorn_from_disk
 - using same approach as for EclFile
 - also minor change in EGrid api