### PR TITLE
fixed: do not assign value to nonexistent variable

### DIFF
--- a/examples/make_ext_smry.cpp
+++ b/examples/make_ext_smry.cpp
@@ -62,7 +62,11 @@ int main(int argc, char **argv) {
             printHelp();
             return 0;
         case 'n':
+#ifdef _OPENMP
             max_threads = atoi(optarg);
+#else
+            std::cerr << "OpenMP is disabled - using single thread only\n";
+#endif
             break;
         default:
             return EXIT_FAILURE;


### PR DESCRIPTION
Making only the variable declaration and not the assignment conditional was stupid of me.