### PR TITLE
Rename actDims in AggregateActionxData

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -302,7 +302,7 @@ if(ENABLE_ECL_OUTPUT)
           src/opm/output/eclipse/AggregateUDQData.cpp
           src/opm/output/eclipse/AggregateWellData.cpp
           src/opm/output/eclipse/AggregateWListData.cpp
-          src/opm/output/eclipse/CreateActionxDims.cpp
+          src/opm/output/eclipse/CreateActionRSTDims.cpp
           src/opm/output/eclipse/CreateDoubHead.cpp
           src/opm/output/eclipse/CreateInteHead.cpp
           src/opm/output/eclipse/CreateLogiHead.cpp

--- a/opm/output/eclipse/AggregateActionxData.hpp
+++ b/opm/output/eclipse/AggregateActionxData.hpp
@@ -54,14 +54,11 @@ namespace Opm { namespace RestartIO { namespace Helpers {
 class AggregateActionxData
 {
 public:
-    explicit AggregateActionxData(const std::vector<int>& actDims);
 
-    void captureDeclaredActionxData(    const Opm::Schedule&      sched,
-                                        const Opm::UnitSystem&    units,
-                                        const Opm::Action::State& action_state,
-                                        const Opm::SummaryState&  st,
-                                        const std::vector<int>&   actDims,
-                                        const std::size_t         simStep);
+    AggregateActionxData(const Opm::Schedule&      sched,
+                         const Opm::Action::State& action_state,
+                         const Opm::SummaryState&  st,
+                         const std::size_t         simStep);
 
     const std::vector<int>& getIACT() const
     {
@@ -100,6 +97,12 @@ public:
     }
 
 private:
+    AggregateActionxData( const std::vector<int>& rst_dims,
+                          const Opm::Schedule&      sched,
+                          const Opm::Action::State& action_state,
+                          const Opm::SummaryState&  st,
+                          const std::size_t         simStep);
+
     /// Aggregate 'IACT' array (Integer) for all ACTIONX data  (9 integers pr UDQ)
     WindowedArray<int> iACT_;
 

--- a/opm/output/eclipse/WriteRestartHelpers.hpp
+++ b/opm/output/eclipse/WriteRestartHelpers.hpp
@@ -63,8 +63,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
                   const std::vector<int>& inteHead);
 
     std::vector<int>
-    createActionxDims(  const Runspec&      rspec,
-                        const Schedule&     sched,
+    createActionRSTDims(const Schedule&     sched,
                         const std::size_t   simStep);
 
 }}} // Opm::RestartIO::Helpers

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp
@@ -45,7 +45,8 @@ public:
 
     static Actions serializeObject();
 
-    size_t size() const;
+    std::size_t py_size() const;
+    std::size_t ecl_size() const;
     int max_input_lines() const;
     bool empty() const;
     void add(const ActionX& action);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -197,6 +197,7 @@ namespace Opm
         double stepLength(std::size_t timeStep) const;
         std::optional<int> exitStatus() const;
         const UnitSystem& getUnits() const { return this->m_static.m_unit_system; }
+        const Runspec& runspec() const { return this->m_static.m_runspec; }
 
         std::size_t numWells() const;
         std::size_t numWells(std::size_t timestep) const;

--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -667,27 +667,20 @@ const std::map<cmp_enum, int> cmpToIndex = {
 // =====================================================================
 
 Opm::RestartIO::Helpers::AggregateActionxData::
-AggregateActionxData(const std::vector<int>& actDims)
-    : iACT_ (iACT::allocate(actDims)),
-      sACT_ (sACT::allocate(actDims)),
-      zACT_ (zACT::allocate(actDims)),
-      zLACT_(zLACT::allocate(actDims)),
-      zACN_ (zACN::allocate(actDims)),
-      iACN_ (iACN::allocate(actDims)),
-      sACN_ (sACN::allocate(actDims))
-{}
-
-// ---------------------------------------------------------------------
-
-void
-Opm::RestartIO::Helpers::AggregateActionxData::
-captureDeclaredActionxData( const Opm::Schedule&      sched,
-                            const Opm::UnitSystem& units,
-                            const Opm::Action::State& action_state,
-                            const Opm::SummaryState&  st,
-                            const std::vector<int>&   actDims,
-                            const std::size_t         simStep)
+AggregateActionxData( const std::vector<int>&   rst_dims,
+                      const Opm::Schedule&      sched,
+                      const Opm::Action::State& action_state,
+                      const Opm::SummaryState&  st,
+                      const std::size_t         simStep)
+    : iACT_ (iACT::allocate(rst_dims))
+    , sACT_ (sACT::allocate(rst_dims))
+    , zACT_ (zACT::allocate(rst_dims))
+    , zLACT_(zLACT::allocate(rst_dims))
+    , zACN_ (zACN::allocate(rst_dims))
+    , iACN_ (iACN::allocate(rst_dims))
+    , sACN_ (sACN::allocate(rst_dims))
 {
+
     const auto& acts = sched[simStep].actions.get();
     std::size_t act_ind = 0;
     for (auto actx_it = acts.begin(); actx_it < acts.end(); actx_it++) {
@@ -698,7 +691,7 @@ captureDeclaredActionxData( const Opm::Schedule&      sched,
 
         {
             auto s_act = this->sACT_[act_ind];
-            sACT::staticContrib(*actx_it, units, s_act);
+            sACT::staticContrib(*actx_it, sched.getUnits(), s_act);
         }
 
         {
@@ -708,7 +701,7 @@ captureDeclaredActionxData( const Opm::Schedule&      sched,
 
         {
             auto z_lact = this->zLACT_[act_ind];
-            zLACT::staticContrib(*actx_it, actDims[8], z_lact);
+            zLACT::staticContrib(*actx_it, rst_dims[8], z_lact);
         }
 
         {
@@ -728,5 +721,18 @@ captureDeclaredActionxData( const Opm::Schedule&      sched,
 
         act_ind +=1;
     }
+}
+
+Opm::RestartIO::Helpers::AggregateActionxData::
+AggregateActionxData( const Opm::Schedule&      sched,
+                      const Opm::Action::State& action_state,
+                      const Opm::SummaryState&  st,
+                      const std::size_t         simStep)
+    : AggregateActionxData( Opm::RestartIO::Helpers::createActionRSTDims(sched, simStep),
+                            sched,
+                            action_state,
+                            st,
+                            simStep )
+{
 }
 

--- a/src/opm/output/eclipse/CreateActionRSTDims.cpp
+++ b/src/opm/output/eclipse/CreateActionRSTDims.cpp
@@ -43,7 +43,7 @@ namespace {
 // The number of actions (no of Actionx)
 std::size_t noOfActions(const Opm::Action::Actions& acts)
 {
-    std::size_t no_entries = acts.size();
+    std::size_t no_entries = acts.ecl_size();
     return no_entries;
 }
     
@@ -67,9 +67,9 @@ std::size_t entriesPerZACT()
 }
 
 // (The max number of characters in an action statement / (8 - chars pr string)) * (max over actions of number of lines pr ACTIONX)
-std::size_t entriesPerZLACT(const Opm::Runspec& rspec, const Opm::Action::Actions& acts)
+std::size_t entriesPerZLACT(const Opm::Actdims& actdims, const Opm::Action::Actions& acts)
 {
-    int max_char_pr_line = rspec.actdims().max_characters();
+    int max_char_pr_line = actdims.max_characters();
     std::size_t no_entries_pr_line = ((max_char_pr_line % 8) == 0) ? max_char_pr_line / 8 : (max_char_pr_line / 8) + 1;
     std::size_t no_entries = no_entries_pr_line * acts.max_input_lines();
 
@@ -77,33 +77,33 @@ std::size_t entriesPerZLACT(const Opm::Runspec& rspec, const Opm::Action::Action
 }
 
 // The max number of characters in an action statement * (max over actions of number of lines pr ACTIONX) / (8 - chars pr string)
-std::size_t entriesPerLine(const Opm::Runspec& rspec)
+std::size_t entriesPerLine(const Opm::Actdims& actdims)
 {
-    int max_char_pr_line = rspec.actdims().max_characters();
+    int max_char_pr_line = actdims.max_characters();
     std::size_t no_entries_pr_line = ((max_char_pr_line % 8) == 0) ? max_char_pr_line / 8 : (max_char_pr_line / 8) + 1;
 
     return no_entries_pr_line;
 }
 
 
-std::size_t entriesPerZACN(const Opm::Runspec& rspec)
+std::size_t entriesPerZACN(const Opm::Actdims& actdims)
 {
     //(Max number of conditions pr ACTIONX) * ((max no characters pr line = 104) / (8 - characters pr string)(104/8 = 13)
-    std::size_t no_entries = rspec.actdims().max_conditions() * 13;
+    std::size_t no_entries = actdims.max_conditions() * 13;
     return no_entries;
 }
 
-std::size_t entriesPerIACN(const Opm::Runspec& rspec)
+std::size_t entriesPerIACN(const Opm::Actdims& actdims)
 {
     //26*Max number of conditions pr ACTIONX 
-    std::size_t no_entries = 26 * rspec.actdims().max_conditions();
+    std::size_t no_entries = 26 * actdims.max_conditions();
     return no_entries;
 }
 
-std::size_t entriesPerSACN(const Opm::Runspec& rspec)
+std::size_t entriesPerSACN(const Opm::Actdims& actdims)
 {
     //16 
-    std::size_t no_entries = 16 * rspec.actdims().max_conditions();
+    std::size_t no_entries = 16 * actdims.max_conditions();
     return no_entries;
 }
 
@@ -117,23 +117,23 @@ std::size_t entriesPerSACN(const Opm::Runspec& rspec)
 
 std::vector<int>
 Opm::RestartIO::Helpers::
-createActionxDims(  const Runspec& rspec,
-                    const Schedule&     sched,
-                    const std::size_t       simStep)
+createActionRSTDims(const Schedule&     sched,
+                    const std::size_t   simStep)
 {
     const auto& acts = sched[simStep].actions.get();
-    std::vector<int> actDims(9);
+    const auto& actdims = sched.runspec().actdims();
+    std::vector<int> action_rst_dims(9);
     
     //No of Actionx keywords
-    actDims[0] = noOfActions(acts);
-    actDims[1] = entriesPerIACT();
-    actDims[2] = entriesPerSACT();
-    actDims[3] = entriesPerZACT();
-    actDims[4] = entriesPerZLACT(rspec, acts);
-    actDims[5] = entriesPerZACN(rspec);
-    actDims[6] = entriesPerIACN(rspec);
-    actDims[7] = entriesPerSACN(rspec);
-    actDims[8] = entriesPerLine(rspec);
+    action_rst_dims[0] = noOfActions(acts);
+    action_rst_dims[1] = entriesPerIACT();
+    action_rst_dims[2] = entriesPerSACT();
+    action_rst_dims[3] = entriesPerZACT();
+    action_rst_dims[4] = entriesPerZLACT(actdims, acts);
+    action_rst_dims[5] = entriesPerZACN(actdims);
+    action_rst_dims[6] = entriesPerIACN(actdims);
+    action_rst_dims[7] = entriesPerSACN(actdims);
+    action_rst_dims[8] = entriesPerLine(actdims);
     
-    return actDims;
+    return action_rst_dims;
 }

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -353,7 +353,7 @@ namespace {
             return { 0, 0, 0, 0 };
         }
 
-        const auto& no_act = acts.size();
+        const auto& no_act = acts.ecl_size();
         const auto max_lines_pr_action = acts.max_input_lines();
         const auto max_cond_per_action = rspec.actdims().max_conditions();
         const auto max_characters_per_line = rspec.actdims().max_characters();

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -351,34 +351,27 @@ namespace {
 
     void writeActionx(const int                     report_step,
                       const int                     sim_step,
-                      const EclipseState&           es,
                       const Schedule&               schedule,
-                      const Opm::UnitSystem&        units,
                       const Action::State&          action_state,
                       const SummaryState&           sum_state,
                       EclIO::OutputStream::Restart& rstFile)
     {
-        if (report_step == 0) {
-            // Initial condition.  No ACTION* data yet.
+        if (report_step == 0)
             return;
-        }
 
-        // write ACTIONX - data to restart file
+        if (schedule[sim_step].actions().ecl_size() == 0)
+            return;
+
         const std::size_t simStep = static_cast<size_t> (sim_step);
-        
-        const auto actDims = Opm::RestartIO::Helpers::createActionxDims(es.runspec(), schedule, simStep);
-        auto  actionxData = Opm::RestartIO::Helpers::AggregateActionxData(actDims);
-        actionxData.captureDeclaredActionxData(schedule, units, action_state, sum_state, actDims, simStep);
-        
-        if (actDims[0] >= 1) {
-            rstFile.write("IACT", actionxData.getIACT());
-            rstFile.write("SACT", actionxData.getSACT());
-            rstFile.write("ZACT", actionxData.getZACT());
-            rstFile.write("ZLACT", actionxData.getZLACT());
-            rstFile.write("ZACN", actionxData.getZACN());
-            rstFile.write("IACN", actionxData.getIACN());
-            rstFile.write("SACN", actionxData.getSACN());
-        }
+        Opm::RestartIO::Helpers::AggregateActionxData actionxData{schedule, action_state, sum_state, simStep};
+
+        rstFile.write("IACT", actionxData.getIACT());
+        rstFile.write("SACT", actionxData.getSACT());
+        rstFile.write("ZACT", actionxData.getZACT());
+        rstFile.write("ZLACT", actionxData.getZLACT());
+        rstFile.write("ZACN", actionxData.getZACN());
+        rstFile.write("IACN", actionxData.getIACN());
+        rstFile.write("SACN", actionxData.getSACN());
     }
 
     void writeWell(int                             sim_step,
@@ -794,7 +787,7 @@ void save(EclIO::OutputStream::Restart&                 rstFile,
                          sumState, inteHD, value.aquifer, aquiferData, rstFile);
     }
 
-    writeActionx(report_step, sim_step, es, schedule, units, action_state, sumState, rstFile);
+    writeActionx(report_step, sim_step, schedule, action_state, sumState, rstFile);
 
     writeSolution(value, schedule, udqState, report_step, sim_step,
                   ecl_compatible_rst, write_double, inteHD, rstFile);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actions.cpp
@@ -41,10 +41,13 @@ Actions Actions::serializeObject()
 }
 
 
-size_t Actions::size() const {
+std::size_t Actions::ecl_size() const {
     return this->actions.size();
 }
 
+std::size_t Actions::py_size() const {
+    return this->pyactions.size();
+}
 
 bool Actions::empty() const {
     return this->actions.empty() && this->pyactions.empty();

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -179,12 +179,12 @@ BOOST_AUTO_TEST_CASE(TestActions) {
     Opm::Action::Actions config;
     std::vector<std::string> matching_wells;
     auto python = std::make_shared<Opm::Python>();
-    BOOST_CHECK_EQUAL(config.size(), 0U);
+    BOOST_CHECK_EQUAL(config.ecl_size(), 0U);
     BOOST_CHECK(config.empty());
 
     Opm::Action::ActionX action1("NAME", 10, 100, 0);
     config.add(action1);
-    BOOST_CHECK_EQUAL(config.size(), 1U);
+    BOOST_CHECK_EQUAL(config.ecl_size(), 1U);
     BOOST_CHECK(!config.empty());
 
     double min_wait = 86400;
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(TestActions) {
     {
         Opm::Action::ActionX action("NAME", max_eval, min_wait, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 7, 1 })) );
         config.add(action);
-        BOOST_CHECK_EQUAL(config.size(), 1U);
+        BOOST_CHECK_EQUAL(config.ecl_size(), 1U);
 
 
         Opm::Action::ActionX action3("NAME3", 1000000, 0, asTimeT(TimeStampUTC(TimeStampUTC::YMD{ 2000, 7, 1 })) );
@@ -783,10 +783,10 @@ TSTEP
     Runspec runspec (deck);
     Schedule sched(deck, grid1, fp, runspec, python);
     const auto& actions0 = sched[0].actions.get();
-    BOOST_CHECK_EQUAL(actions0.size(), 0U);
+    BOOST_CHECK_EQUAL(actions0.ecl_size(), 0U);
 
     const auto& actions1 = sched[1].actions.get();
-    BOOST_CHECK_EQUAL(actions1.size(), 1U);
+    BOOST_CHECK_EQUAL(actions1.ecl_size(), 1U);
 
 
     const auto& act1 = actions1.get("B");
@@ -823,7 +823,7 @@ TSTEP
     /*****************************************************************/
 
     const auto& actions2 = sched[2].actions.get();
-    BOOST_CHECK_EQUAL(actions2.size(), 2U);
+    BOOST_CHECK_EQUAL(actions2.ecl_size(), 2U);
 
     const auto& actB = actions2.get("B");
     const auto& condB = actB.conditions();

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -113,7 +113,6 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
     Opm::Action::State action_state;
     Opm::Schedule     sched = simCase.sched;
     Opm::EclipseGrid  grid = simCase.grid;
-    const auto& usys = es.getUnits();
     const auto& ioConfig = es.getIOConfig();
     //const auto& restart = es.cfg().restart();
 
@@ -146,10 +145,8 @@ BOOST_AUTO_TEST_CASE (Declared_Actionx_data)
     auto  udqData = Opm::RestartIO::Helpers::AggregateUDQData(udqDims);
     udqData.captureDeclaredUDQData(sched, rptStep, udq_state, ih);
 
-    const auto actDims = Opm::RestartIO::Helpers::createActionxDims(rspec, sched, rptStep);
-    auto  actionxData = Opm::RestartIO::Helpers::AggregateActionxData(actDims);
-    actionxData.captureDeclaredActionxData(sched, usys, action_state, st, actDims, rptStep);
-
+    const auto actDims = Opm::RestartIO::Helpers::createActionRSTDims(sched, rptStep);
+    Opm::RestartIO::Helpers::AggregateActionxData actionxData{sched, action_state, st, rptStep};
     {
         /*
         Check of InteHEAD and DoubHEAD data for UDQ variables


### PR DESCRIPTION
The AggregateActionxData class makes extensive use of an instance variable `std::vector<int> actDims` - the content of this vector is partly related to the class `Actdims` - but not the same. To avoid confusion this PR renames the `actDims`instance to "something with rst" in the name.

While here the construction of the `AggregateActionxData` class rewritten slightly - mainly to reduce the visibility/lifetime of the `std::vector<int> action_rst_dims` instance. 

Not really important in any way - but a smell step to get better understanding/overview of the ACTIONX data in the restart file.