### PR TITLE
Move actionx enums to separate compilation unit

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -104,6 +104,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/Action/Enums.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/eval_uda.cpp
@@ -760,6 +761,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/Action/Actions.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
+       opm/parser/eclipse/EclipseState/Schedule/Action/Enums.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/ASTNode.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/PyAction.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/Enums.hpp>
 
 namespace Opm {
 
@@ -60,22 +61,6 @@ public:
 
 class Condition {
 public:
-
-enum class Logical {
-    AND,
-    OR,
-    END
-};
-
-enum class Comparator {
-    EQUAL,
-    GREATER,
-    LESS,
-    GREATER_EQUAL,
-    LESS_EQUAL,
-    INVALID
-};
-
 
     Condition() = default;
     Condition(const std::vector<std::string>& tokens, const KeywordLocation& location);

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/Enums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/Enums.hpp
@@ -1,0 +1,45 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ACTION_ENUMS_HPP
+#define ACTION_ENUMS_HPP
+
+namespace Opm {
+namespace Action {
+
+enum class Logical {
+    AND,
+    OR,
+    END
+};
+
+enum class Comparator {
+    EQUAL,
+    GREATER,
+    LESS,
+    GREATER_EQUAL,
+    LESS_EQUAL,
+    INVALID
+};
+
+
+}
+}
+
+#endif

--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -70,7 +70,7 @@ namespace {
                                                            {"Y",   0},
     };*/
 
-    using cmp_enum = Opm::Action::Condition::Comparator;
+    using cmp_enum = Opm::Action::Comparator;
     const std::map<cmp_enum, int> cmpToIacn_12 = {
                                                     {cmp_enum::GREATER,       0},
                                                     {cmp_enum::LESS,          1},
@@ -87,7 +87,7 @@ const std::map<std::string, int> rhsQuantityToIndex = {
                                                 {"G",   3},
 };
 
-using logic_enum = Opm::Action::Condition::Logical;
+using logic_enum = Opm::Action::Logical;
 
 const std::map<logic_enum, int> logicalToIndex_17 = {
                                                     {logic_enum::AND,   1},
@@ -425,7 +425,7 @@ const std::map<logic_enum, int> logicalToIndex_17 = {
                         parenFirstCond = true;
                         insideParen = true;
                     }
-                    if (cond_it->logic == Opm::Action::Condition::Logical::AND) {
+                    if (cond_it->logic == Opm::Action::Logical::AND) {
                         allPrevLogicOp_AND = true;
                     }
                 } else {
@@ -449,9 +449,9 @@ const std::map<logic_enum, int> logicalToIndex_17 = {
                     }
 
                     // update the previous logic-sequence
-                    if (parenFirstCond && cond_it->logic == Opm::Action::Condition::Logical::OR) {
+                    if (parenFirstCond && cond_it->logic == Opm::Action::Logical::OR) {
                         allPrevLogicOp_AND = false;
-                    } else if (!insideParen && cond_it->logic == Opm::Action::Condition::Logical::OR) {
+                    } else if (!insideParen && cond_it->logic == Opm::Action::Logical::OR) {
                         allPrevLogicOp_AND = false;
                     }
                 }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.cpp
@@ -102,8 +102,8 @@ ActionX ActionX::serializeObject()
     Condition cond;
     cond.lhs = quant;
     cond.rhs = quant;
-    cond.logic = Condition::Logical::AND;
-    cond.cmp = Condition::Comparator::GREATER_EQUAL;
+    cond.logic = Logical::AND;
+    cond.cmp = Comparator::GREATER_EQUAL;
     cond.cmp_string = "test3";
     result.m_conditions = {cond};
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
@@ -22,6 +22,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/Condition.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/Enums.hpp>
 
 #include "ActionParser.hpp"
 
@@ -32,40 +33,40 @@ namespace Action {
 
 namespace {
 
-Condition::Comparator comparator(TokenType tt) {
+Comparator comparator(TokenType tt) {
     if (tt == TokenType::op_eq)
-        return Condition::Comparator::EQUAL;
+        return Comparator::EQUAL;
 
     if (tt == TokenType::op_gt)
-        return Condition::Comparator::GREATER;
+        return Comparator::GREATER;
 
     if (tt == TokenType::op_lt)
-        return Condition::Comparator::LESS;
+        return Comparator::LESS;
 
     if (tt == TokenType::op_le)
-        return Condition::Comparator::LESS_EQUAL;
+        return Comparator::LESS_EQUAL;
 
     if (tt == TokenType::op_ge)
-        return Condition::Comparator::GREATER_EQUAL;
+        return Comparator::GREATER_EQUAL;
 
-    return Condition::Comparator::INVALID;
+    return Comparator::INVALID;
 }
 
 
-std::string cmp2string(Condition::Comparator cmp) {
-    if (cmp == Condition::Comparator::EQUAL)
+std::string cmp2string(Comparator cmp) {
+    if (cmp == Comparator::EQUAL)
         return "=";
 
-    if (cmp == Condition::Comparator::GREATER)
+    if (cmp == Comparator::GREATER)
         return ">";
 
-    if (cmp == Condition::Comparator::LESS)
+    if (cmp == Comparator::LESS)
         return "<";
 
-    if (cmp == Condition::Comparator::LESS_EQUAL)
+    if (cmp == Comparator::LESS_EQUAL)
         return "<=";
 
-    if (cmp == Condition::Comparator::GREATER_EQUAL)
+    if (cmp == Comparator::GREATER_EQUAL)
         return ">=";
 
     throw std::logic_error("Bug in opm/flow - should not be here");
@@ -139,9 +140,9 @@ Condition::Condition(const std::vector<std::string>& tokens, const KeywordLocati
 
         auto token_type = Parser::get_type(tokens[token_index]);
         if (token_type == TokenType::op_and)
-            this->logic = Condition::Logical::AND;
+            this->logic = Logical::AND;
         else if (token_type == TokenType::op_or)
-            this->logic = Condition::Logical::OR;
+            this->logic = Logical::OR;
         else if (token_type == TokenType::close_paren)
             this->right_paren = true;
         else
@@ -170,7 +171,7 @@ bool Condition::close_paren() const {
     return !this->left_paren && this->right_paren;
 }
 
-Condition::Logical Condition::logic_from_int(int int_logic) {
+Logical Condition::logic_from_int(int int_logic) {
     if (int_logic == 0)
         return Logical::END;
 
@@ -196,18 +197,18 @@ int Condition::logic_as_int() const {
     }
 }
 
-Condition::Comparator Condition::comparator_from_int(int cmp_int) {
+Comparator Condition::comparator_from_int(int cmp_int) {
     switch (cmp_int) {
     case 1:
-        return Condition::Comparator::GREATER;
+        return Comparator::GREATER;
     case 2:
-        return Condition::Comparator::LESS;
+        return Comparator::LESS;
     case 3:
-        return Condition::Comparator::GREATER_EQUAL;
+        return Comparator::GREATER_EQUAL;
     case 4:
-        return Condition::Comparator::LESS_EQUAL;
+        return Comparator::LESS_EQUAL;
     case 5:
-        return Condition::Comparator::EQUAL;
+        return Comparator::EQUAL;
     default:
         throw std::logic_error("What the f...?");
     }
@@ -215,15 +216,15 @@ Condition::Comparator Condition::comparator_from_int(int cmp_int) {
 
 int Condition::comparator_as_int() const {
     switch (this->cmp) {
-    case Condition::Comparator::GREATER:
+    case Comparator::GREATER:
         return 1;
-    case Condition::Comparator::LESS:
+    case Comparator::LESS:
         return 2;
-    case Condition::Comparator::GREATER_EQUAL:
+    case Comparator::GREATER_EQUAL:
         return 3;
-    case Condition::Comparator::LESS_EQUAL:
+    case Comparator::LESS_EQUAL:
         return 4;
-    case Condition::Comparator::EQUAL:
+    case Comparator::EQUAL:
         return 5;
     default:
         throw std::logic_error("What the f...?");

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Enums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Enums.cpp
@@ -1,0 +1,26 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+namespace Opm {
+namespace Action {
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/Enums.hpp>
+
+}
+}

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -702,7 +702,7 @@ BOOST_AUTO_TEST_CASE(Conditions) {
     BOOST_CHECK_THROW(Action::Condition cond({"WWCT", "OPX", ">"}, location), std::invalid_argument);
 
     Action::Condition cond({"WWCT", "OPX", ">", "0.75",  "AND"}, location);
-    BOOST_CHECK(cond.cmp == Action::Condition::Comparator::GREATER);
+    BOOST_CHECK(cond.cmp == Action::Comparator::GREATER);
     BOOST_CHECK(cond.cmp_string == ">" );
     BOOST_CHECK_EQUAL(cond.lhs.quantity, "WWCT");
     BOOST_CHECK_EQUAL(cond.lhs.args.size(), 1U);
@@ -712,10 +712,10 @@ BOOST_AUTO_TEST_CASE(Conditions) {
 
     BOOST_CHECK_EQUAL(cond.rhs.quantity, "0.75");
     BOOST_CHECK_EQUAL(cond.rhs.args.size(), 0U);
-    BOOST_CHECK(cond.logic == Action::Condition::Logical::AND);
+    BOOST_CHECK(cond.logic == Action::Logical::AND);
 
     Action::Condition cond2({"WWCT", "OPX", "<=", "WSOPR", "OPX", "235"}, location);
-    BOOST_CHECK(cond2.cmp == Action::Condition::Comparator::LESS_EQUAL);
+    BOOST_CHECK(cond2.cmp == Action::Comparator::LESS_EQUAL);
     BOOST_CHECK(cond2.cmp_string == "<=" );
     BOOST_CHECK_EQUAL(cond2.lhs.quantity, "WWCT");
     BOOST_CHECK_EQUAL(cond2.lhs.args.size(), 1U);
@@ -725,7 +725,7 @@ BOOST_AUTO_TEST_CASE(Conditions) {
     BOOST_CHECK_EQUAL(cond2.rhs.args.size(), 2U);
     BOOST_CHECK_EQUAL(cond2.rhs.args[0], "OPX");
     BOOST_CHECK_EQUAL(cond2.rhs.args[1], "235");
-    BOOST_CHECK(cond2.logic == Action::Condition::Logical::END);
+    BOOST_CHECK(cond2.logic == Action::Logical::END);
 }
 
 
@@ -808,8 +808,8 @@ TSTEP
 
     const auto& cond0 = conditions[0];
     BOOST_CHECK_EQUAL(cond0.lhs.quantity, "WWCT");
-    BOOST_CHECK(cond0.cmp == Action::Condition::Comparator::GREATER);
-    BOOST_CHECK(cond0.logic == Action::Condition::Logical::AND);
+    BOOST_CHECK(cond0.cmp == Action::Comparator::GREATER);
+    BOOST_CHECK(cond0.logic == Action::Logical::AND);
     BOOST_CHECK_EQUAL(cond0.lhs.args.size(), 1U);
     BOOST_CHECK_EQUAL(cond0.lhs.args[0], "OPX");
     BOOST_CHECK_EQUAL(cond0.rhs.args.size(), 0U);
@@ -817,8 +817,8 @@ TSTEP
 
     const auto& cond1 = conditions[1];
     BOOST_CHECK_EQUAL(cond1.lhs.quantity, "FPR");
-    BOOST_CHECK(cond1.cmp == Action::Condition::Comparator::LESS);
-    BOOST_CHECK(cond1.logic == Action::Condition::Logical::END);
+    BOOST_CHECK(cond1.cmp == Action::Comparator::LESS);
+    BOOST_CHECK(cond1.logic == Action::Logical::END);
 
     /*****************************************************************/
 
@@ -829,16 +829,16 @@ TSTEP
     const auto& condB = actB.conditions();
     BOOST_CHECK_EQUAL(condB.size() , 1U);
     BOOST_CHECK_EQUAL(condB[0].lhs.quantity, "FWCT");
-    BOOST_CHECK(condB[0].cmp == Action::Condition::Comparator::LESS_EQUAL);
-    BOOST_CHECK(condB[0].logic == Action::Condition::Logical::END);
+    BOOST_CHECK(condB[0].cmp == Action::Comparator::LESS_EQUAL);
+    BOOST_CHECK(condB[0].logic == Action::Logical::END);
     BOOST_CHECK_EQUAL(condB[0].cmp_string, "<=");
 
     const auto& actA = actions2.get("A");
     const auto& condA = actA.conditions();
     BOOST_CHECK_EQUAL(condA.size() , 1U);
     BOOST_CHECK_EQUAL(condA[0].lhs.quantity, "WOPR");
-    BOOST_CHECK(condA[0].cmp == Action::Condition::Comparator::EQUAL);
-    BOOST_CHECK(condA[0].logic == Action::Condition::Logical::END);
+    BOOST_CHECK(condA[0].cmp == Action::Comparator::EQUAL);
+    BOOST_CHECK(condA[0].logic == Action::Logical::END);
     BOOST_CHECK_EQUAL(condA[0].cmp_string , "=");
 
     std::size_t index = 0;


### PR DESCRIPTION
IN order to avoid circular references in the actionx restart code