### PR TITLE
Split udq eval in eval_assign() and eval_define()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQConfig.hpp
@@ -67,6 +67,7 @@ namespace Opm {
         void add_assign(const std::string& quantity, const std::unordered_set<std::string>& selector, double value, std::size_t report_step);
         void add_define(const std::string& quantity, const KeywordLocation& location, const std::vector<std::string>& expression, std::size_t report_step);
 
+        void eval_assign(std::size_t report_step, const WellMatcher& wm, SummaryState& st, UDQState& udq_state) const;
         void eval(std::size_t report_step, const WellMatcher& wm, SummaryState& st, UDQState& udq_state) const;
         const UDQDefine& define(const std::string& key) const;
         const UDQAssign& assign(const std::string& key) const;
@@ -109,6 +110,8 @@ namespace Opm {
     private:
         void add_node(const std::string& quantity, UDQAction action);
         UDQAction action_type(const std::string& udq_key) const;
+        void eval_assign(std::size_t report_step, SummaryState& st, UDQState& udq_state, UDQContext& context) const;
+        void eval_define(std::size_t report_step, UDQState& udq_state, UDQContext& context) const;
 
 
         UDQParams udq_params;

--- a/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.hpp
@@ -195,6 +195,7 @@ namespace UDQ {
     bool production_control(UDAControl control);
 
     std::string typeName(UDQVarType var_type);
+    std::string controlName(UDAControl control);
     UDAKeyword keyword(UDAControl control);
     int udaCode(UDAControl control);
     UDAControl udaControl(int uda_code);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQActive.cpp
@@ -16,6 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <fmt/format.h>
 #include <iostream>
 
 #include <opm/io/eclipse/rst/state.hpp>
@@ -109,6 +110,11 @@ int UDQActive::update(const UDQConfig& udq_config, const UDAValue& uda, const st
     // Alternative 1
     if (uda.is<double>() && this->input_data.empty())
         return 0;
+
+    if (uda.is<std::string>()) {
+        if (!udq_config.has_keyword(uda.get<std::string>()))
+            throw std::logic_error(fmt::format("Missing ASSIGN/DEFINE for UDQ {} can not be used as UDA for {} for {}", uda.get<std::string>(), UDQ::controlName(control), wgname));
+    }
 
     for (auto iter = this->input_data.begin(); iter != this->input_data.end(); ++iter) {
         auto& record = *iter;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQEnums.cpp
@@ -560,4 +560,70 @@ UDAControl udaControl(int uda_code) {
 }
 
 
+std::string controlName(UDAControl control) {
+    switch (control) {
+    case UDAControl::GCONPROD_OIL_TARGET:
+        return "GCONPROD_ORAT";
+
+    case UDAControl::GCONPROD_WATER_TARGET:
+        return "GCONPROD_WRAT";
+
+    case UDAControl::GCONPROD_GAS_TARGET:
+        return "GCONPROD_GRAT";
+
+    case UDAControl::GCONPROD_LIQUID_TARGET:
+        return "GCONPROD_LRAT";
+
+    case UDAControl::GCONINJE_SURFACE_MAX_RATE:
+        return "GCONINJE_SURFACE_RATE";
+
+    case UDAControl::GCONINJE_RESV_MAX_RATE:
+        return "GCONINJE_RESERVOIR_RATE";
+
+    case UDAControl::GCONINJE_TARGET_REINJ_FRACTION:
+        return "GCONINJE_REINJ_FRACTION";
+
+    case UDAControl::GCONINJE_TARGET_VOID_FRACTION:
+        return "GCONINJE_VOID_FRACTION";
+
+    case UDAControl::WCONPROD_ORAT:
+        return "WCONPROD_ORAT";
+
+    case UDAControl::WCONPROD_GRAT:
+        return "WCONPROD_GRAT";
+
+    case UDAControl::WCONPROD_WRAT:
+        return "WCONPROD_WRAT";
+
+    case UDAControl::WCONPROD_LRAT:
+        return "WCONPROD_LRAT";
+
+    case UDAControl::WCONPROD_RESV:
+        return "WCONPROD_RESV";
+
+    case UDAControl::WCONPROD_BHP:
+        return "WCONPROD_BHP";
+
+    case UDAControl::WCONPROD_THP:
+        return "WCONPROD_THP";
+
+    case UDAControl::WCONINJE_RATE:
+        return "WCONINJE_RATE";
+
+    case UDAControl::WCONINJE_RESV:
+        return "WCONINJE_RESV";
+
+    case UDAControl::WCONINJE_BHP:
+        return "WCONINJE_BHP";
+
+    case UDAControl::WCONINJE_THP:
+        return "WCONINJE_THP";
+
+    default:
+        throw std::logic_error("What the ??");
+    }
+}
+
+
+
 }} // Opm::UDQ

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -977,6 +977,41 @@ WELTARG
     BOOST_CHECK (wpp_2.hasProductionControl( Opm::Well::ProducerCMode::WRAT) );
 }
 
+BOOST_AUTO_TEST_CASE(createDeckWithWeltArg_UDA_Exception) {
+    std::string input = R"(
+START             -- 0
+19 JUN 2007 /
+SCHEDULE
+DATES             -- 1
+ 10  OKT 2008 /
+/
+
+
+
+WELSPECS
+    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  /
+/
+COMPDAT
+ 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+ 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 /
+ 'OP_1'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 /
+/
+WCONPROD
+ 'OP_1'      'OPEN'      'ORAT'      0.000      0.000      0.000  5* /
+/
+DATES             -- 2
+ 20  JAN 2010 /
+/
+WELTARG
+ OP_1     ORAT        WUORAT /
+ OP_1     WRAT        WUWRAT /
+/
+)";
+
+    BOOST_CHECK_THROW(make_schedule(input), std::exception);
+}
+
+
 
 BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException) {
     std::string input = R"(


### PR DESCRIPTION
This to enable calling `UDQ::eval_assign()` at the start of each report step - and use the new assignments as UDA values.

Downstream:  https://github.com/OPM/opm-simulators/pull/3513