### PR TITLE
Add Parser argument to restart loader

### DIFF
--- a/opm/io/eclipse/rst/state.hpp
+++ b/opm/io/eclipse/rst/state.hpp
@@ -36,6 +36,7 @@
 
 namespace Opm {
     class EclipseGrid;
+    class Parser;
 } // namespace Opm
 
 namespace Opm { namespace EclIO {
@@ -50,6 +51,7 @@ struct RstState {
 
     static RstState load(std::shared_ptr<EclIO::RestartFileView> rstView,
                          const Runspec& runspec,
+                         const Parser& parser,
                          const ::Opm::EclipseGrid*               grid = nullptr);
 
     const RstWell& get_well(const std::string& wname) const;

--- a/src/opm/io/eclipse/rst/state.cpp
+++ b/src/opm/io/eclipse/rst/state.cpp
@@ -29,6 +29,7 @@
 #include <opm/io/eclipse/rst/well.hpp>
 #include <opm/io/eclipse/rst/state.hpp>
 
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/output/eclipse/UDQDims.hpp>
 #include <opm/output/eclipse/VectorItems/connection.hpp>
 #include <opm/output/eclipse/VectorItems/well.hpp>
@@ -275,6 +276,7 @@ const RstWell& RstState::get_well(const std::string& wname) const {
 
 RstState RstState::load(std::shared_ptr<EclIO::RestartFileView> rstView,
                         const Runspec&,
+                        const Parser&,
                         const ::Opm::EclipseGrid*               grid)
 {
     RstState state(rstView, grid);

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(RUN) {
 
             const int report_step = 50;
             auto rst_view = std::make_shared<EclIO::RestartFileView>(std::move(rst), report_step);
-            const auto rst_state = Opm::RestartIO::RstState::load(std::move(rst_view), state.runspec());
+            const auto rst_state = Opm::RestartIO::RstState::load(std::move(rst_view), state.runspec(), parser);
             Schedule sched_rst(deck, state, python, {}, &rst_state);
             const auto& rfti_well = sched_rst.getWell("RFTI", report_step);
             const auto& rftp_well = sched_rst.getWell("RFTP", report_step);

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(LoadRST) {
     auto deck = parser.parseFile("SPE1CASE2.DATA");
     auto rst_file = std::make_shared<EclIO::ERst>("SPE1CASE2.X0060");
     auto rst_view = std::make_shared<EclIO::RestartFileView>(std::move(rst_file), 60);
-    auto rst_state = RestartIO::RstState::load(std::move(rst_view), Runspec{});
+    auto rst_state = RestartIO::RstState::load(std::move(rst_view), Runspec{}, parser);
     BOOST_REQUIRE_THROW( rst_state.get_well("NO_SUCH_WELL"), std::out_of_range);
     auto python = std::make_shared<Python>();
     EclipseState ecl_state(deck);
@@ -107,7 +107,7 @@ std::pair<Schedule, Schedule> load_schedule_pair(const std::string& base_deck,
     auto restart_deck = parser.parseFile(rst_deck);
     auto rst_file = std::make_shared<EclIO::ERst>(rst_fname);
     auto rst_view = std::make_shared<EclIO::RestartFileView>(std::move(rst_file), restart_step);
-    auto rst_state = RestartIO::RstState::load(std::move(rst_view), ecl_state.runspec());
+    auto rst_state = RestartIO::RstState::load(std::move(rst_view), ecl_state.runspec(), parser);
     EclipseState ecl_state_restart(restart_deck);
     Schedule restart_sched(restart_deck, ecl_state_restart, python, {}, &rst_state);
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3618,7 +3618,7 @@ BOOST_AUTO_TEST_CASE(SKIPREST_VFP) {
     const auto& rst_filename = es.getIOConfig().getRestartFileName( init_config.getRestartRootName(), report_step, false );
     auto rst_file = std::make_shared<Opm::EclIO::ERst>(rst_filename);
     auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>(std::move(rst_file), report_step);
-    const auto rst = Opm::RestartIO::RstState::load(std::move(rst_view), es.runspec());
+    const auto rst = Opm::RestartIO::RstState::load(std::move(rst_view), es.runspec(), parser);
     const auto sched = Schedule{ deck, es, python , {}, &rst };
     BOOST_CHECK_NO_THROW( sched[3].vfpprod(5) );
 

--- a/tests/rst_test.cpp
+++ b/tests/rst_test.cpp
@@ -79,7 +79,7 @@ std::pair<Opm::EclipseState, Opm::Schedule> load_schedule(std::shared_ptr<const 
         auto rst_file = std::make_shared<Opm::EclIO::ERst>(rst_filename);
         auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>(std::move(rst_file), report_step);
 
-        const auto rst = Opm::RestartIO::RstState::load(std::move(rst_view), state.runspec());
+        const auto rst = Opm::RestartIO::RstState::load(std::move(rst_view), state.runspec(), parser);
         return {
             std::piecewise_construct,
             std::forward_as_tuple(state),

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -182,7 +182,7 @@ struct SimulationCase
     Opm::EclipseGrid  grid;
     std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
-
+    Opm::Parser       parser;
 };
 
 BOOST_AUTO_TEST_SUITE(Aggregate_UDQ)
@@ -749,7 +749,7 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
     {
         auto rst_file = std::make_shared<Opm::EclIO::ERst>("TEST_UDQRST.UNRST");
         auto rst_view = std::make_shared<Opm::EclIO::RestartFileView>(std::move(rst_file), 1);
-        auto rst_state = Opm::RestartIO::RstState::load(std::move(rst_view), es.runspec());
+        auto rst_state = Opm::RestartIO::RstState::load(std::move(rst_view), es.runspec(), simCase.parser);
         BOOST_CHECK_EQUAL(rst_state.header.nwell_udq, 4);
         BOOST_CHECK_EQUAL(rst_state.header.ngroup_udq, 1);
         BOOST_CHECK_EQUAL(rst_state.header.nfield_udq, 39);

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -205,6 +205,7 @@ struct SimulationCase
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
     Opm::Schedule     sched;
+    Opm::Parser       parser;
 };
 
 // =====================================================================
@@ -348,7 +349,7 @@ BOOST_AUTO_TEST_CASE(State_test) {
         auto rst_file = std::make_shared<Opm::EclIO::ERst>("TEST_UDQRST.UNRST");
         auto rstView = std::make_shared<Opm::EclIO::RestartFileView>(std::move(rst_file), rptStep);
 
-        auto state = Opm::RestartIO::RstState::load(std::move(rstView), simCase.es.runspec());
+        auto state = Opm::RestartIO::RstState::load(std::move(rstView), simCase.es.runspec(), simCase.parser);
 
         const auto& well = state.get_well("OP_3");
         BOOST_CHECK_THROW(well.segment(10), std::invalid_argument);


### PR DESCRIPTION
Preparation to parse keyword strings read from the restart file.

Downstream: https://github.com/OPM/opm-simulators/pull/3515