### PR TITLE
Adding support for LGR related summary vectors

### DIFF
--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -119,8 +119,9 @@ private:
 
     void updatePathAndRootName(filesystem::path& dir, filesystem::path& rootN) const;
 
+
     std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num,
-                              const std::string& lgr = "none", int numlx = -1, int numly = -1, int numlz = -1) const;
+                              const std::optional<Opm::EclIO::lgr_info> lgr_info) const;
 
     std::string unpackNumber(const SummaryNode&) const;
     std::string lookupKey(const SummaryNode&) const;

--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -119,7 +119,8 @@ private:
 
     void updatePathAndRootName(filesystem::path& dir, filesystem::path& rootN) const;
 
-    std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num) const;
+    std::string makeKeyString(const std::string& keyword, const std::string& wgname, int num,
+                              const std::string& lgr = "none", int numlx = -1, int numly = -1, int numlz = -1) const;
 
     std::string unpackNumber(const SummaryNode&) const;
     std::string lookupKey(const SummaryNode&) const;

--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -24,8 +24,14 @@
 #include <optional>
 #include <string>
 #include <unordered_set>
+#include <array>
 
 namespace Opm { namespace EclIO {
+
+    struct lgr_info {
+        std::string name;
+        std::array<int, 3> ijk;
+    };
 
 struct SummaryNode {
     enum class Category {
@@ -52,13 +58,14 @@ struct SummaryNode {
         Undefined,
     };
 
+
     std::string keyword;
     Category    category;
     Type        type;
     std::string wgname;
     int         number;
-
     std::optional<std::string> fip_region;
+    std::optional<lgr_info> lgr;
 
     constexpr static int default_number { std::numeric_limits<int>::min() };
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -68,7 +68,7 @@ namespace Opm {
         const KeywordLocation& location( ) const { return this->loc; }
 
         operator Opm::EclIO::SummaryNode() const {
-            return { keyword_, category_, type_, name_, number_, fip_region_ };
+            return { keyword_, category_, type_, name_, number_, fip_region_, {}};
         }
 
         template<class Serializer>

--- a/src/opm/io/eclipse/ERsm.cpp
+++ b/src/opm/io/eclipse/ERsm.cpp
@@ -177,7 +177,9 @@ void ERsm::load_block(std::deque<std::string>& lines, std::size_t& vector_length
                                  SummaryNode::Type::Undefined,
                                  wgnames[kw_index],
                                  make_num(nums_list[kw_index]),
-                                 ""};
+                                 "",
+                                 {}
+        };
         block_data.emplace_back( node, vector_length );
     }
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -197,12 +197,12 @@ namespace {
             // Recall: Cannot use emplace_back() for PODs.
             for (const auto& vector : vectors) {
                 entities.push_back({ kwpref + vector.kw, cat,
-                                     vector.type, name, dflt_num, {} });
+                                     vector.type, name, dflt_num, {}, {} });
             }
 
             for (const auto& extra_vector : extra_vectors) {
                 entities.push_back({ extra_vector.kw, cat,
-                                     extra_vector.type, name, dflt_num, {} });
+                                     extra_vector.type, name, dflt_num, {}, {} });
             }
         };
 
@@ -212,7 +212,7 @@ namespace {
             const auto& well = sched.getWellatEnd(well_name);
             for (const auto& conn : well.getConnections()) {
                 for (const auto& conn_vector : extra_connection_vectors)
-                    entities.push_back( {conn_vector.kw, Cat::Connection, conn_vector.type, well.name(), static_cast<int>(conn.global_index() + 1), {}} );
+                    entities.push_back( {conn_vector.kw, Cat::Connection, conn_vector.type, well.name(), static_cast<int>(conn.global_index() + 1), {}, {}} );
             }
         }
 
@@ -249,7 +249,7 @@ namespace {
             for (auto segID = 0*nSeg + 1; segID <= nSeg; ++segID) {
                 for (const auto& vector : vectors) {
                     entities.push_back({ vector.kw, Cat::Segment,
-                                         vector.type, wname, segID, {} });
+                                         vector.type, wname, segID, {}, {} });
                 }
             }
         };
@@ -286,7 +286,7 @@ namespace {
         for (const auto& aquiferID : aquiferIDs) {
             for (const auto& vector : vectors) {
                 entities.push_back({ vector.kw, Cat::Aquifer,
-                                     vector.type, "", aquiferID, {} });
+                                     vector.type, "", aquiferID, {}, {} });
             }
         }
 
@@ -309,7 +309,7 @@ namespace {
         for (const auto& aquiferID : aquiferIDs) {
             for (const auto& vector : vectors) {
                 entities.push_back({ vector.kw, Cat::Aquifer,
-                                     vector.type, "", aquiferID, {} });
+                                     vector.type, "", aquiferID, {}, {} });
             }
         }
 


### PR DESCRIPTION
Update of class Opn::EclIO::ESmry, now supporting LGR related summary vectors
 - local block data starting with 'LB'
 - local well connections starting with 'LC'
 - local well data starting with 'LW'

This PR is also fixing a bug related to inter-regions summary data. 