### PR TITLE
Remove debug output from parser keyword generation

### DIFF
--- a/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/src/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -994,9 +994,6 @@ void set_dimensions( ParserItem& item,
         }
         ss << '\n';
 
-        const auto& kw_size = this->getKeywordSize();
-        std::cout << kw_size.construct() << std::endl;
-
         return ss.str();
     }
 


### PR DESCRIPTION
Fixes: https://github.com/OPM/opm-common/issues/2637