### PR TITLE
fixed: use curly-braces

### DIFF
--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -2981,7 +2981,7 @@ EDIT
 BOOST_AUTO_TEST_CASE(GDFILE_NO_ACTNUM) {
     Opm::Parser parser;
     auto deck = parser.parseFile("GDFILE_NO_ACTNUM.DATA");
-    BOOST_CHECK_NO_THROW( Opm::EclipseState(deck));
+    BOOST_CHECK_NO_THROW( Opm::EclipseState{deck} );
 }
 
 


### PR DESCRIPTION
the parantheses confused the preprocessor and the wanted code did not execute at all.

quells the warnings that clearly spelled this out.