### PR TITLE
Round numerical month values to integer before comparison

### DIFF
--- a/opm/common/utility/TimeService.hpp
+++ b/opm/common/utility/TimeService.hpp
@@ -40,6 +40,7 @@ namespace Opm {
     std::time_t makeUTCTime(std::tm timePoint);
     const std::unordered_map<std::string , int>& eclipseMonthIndices();
     const std::unordered_map<int, std::string>& eclipseMonthNames();
+    int eclipseMonth(const std::string& name);
     bool valid_month(const std::string& month_name);
 
     std::time_t mkdatetime(int in_year, int in_month, int in_day, int hour, int minute, int second);

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/ActionValue.hpp
@@ -23,6 +23,7 @@ enum TokenType {
 enum class FuncType {
   none,
   time,
+  time_month,
   region,
   field,
   group,

--- a/src/opm/common/utility/TimeService.cpp
+++ b/src/opm/common/utility/TimeService.cpp
@@ -107,6 +107,15 @@ const std::unordered_map<std::string , int>& eclipseMonthIndices() {
     return month_indices;
 }
 
+int eclipseMonth(const std::string& name) {
+    auto iter = month_indices.find(name);
+    if (iter != month_indices.end())
+        return iter->second;
+
+    return std::stod(name);
+}
+
+
 const std::unordered_map<int, std::string>& eclipseMonthNames() {
     return month_names;
 }

--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -454,17 +454,8 @@ const std::map<logic_enum, int> logicalToIndex_17 = {
                 if (it_rhsq == rhsQuantityToIndex.end()) {
                     //come here if constant value condition
                     double t_val = 0.;
-                    if (lhsQtype == "M") {
-                       const auto& monthToNo = Opm::TimeService::eclipseMonthIndices();
-                       const auto& it_mnth = monthToNo.find(condition.rhs.quantity);
-                       if (it_mnth != monthToNo.end()) {
-                           t_val = it_mnth->second;
-                       }
-                       else {
-                            std::cout << "Unknown Month: " << condition.rhs.quantity << std::endl;
-                            throw std::invalid_argument("Actionx: " + action.name() + "  Condition: " + condition.lhs.quantity );
-                        }
-                    }
+                    if (lhsQtype == "M")
+                        t_val = Opm::TimeService::eclipseMonth(condition.rhs.quantity);
                     else {
                         t_val = std::stod(condition.rhs.quantity);
                     }

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/ActionParser.cpp
@@ -88,7 +88,7 @@ TokenType Parser::get_type(const std::string& arg) {
 FuncType Parser::get_func(const std::string& arg) {
 
     if (arg == "YEAR") return FuncType::time;
-    if (arg == "MNTH") return FuncType::time;
+    if (arg == "MNTH") return FuncType::time_month;
     if (arg == "DAY")  return FuncType::time;
 
     using Cat = SummaryConfigNode::Category;

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -355,6 +355,19 @@ BOOST_AUTO_TEST_CASE(DATE) {
     BOOST_CHECK( !ast.eval(context));
 }
 
+BOOST_AUTO_TEST_CASE(MNTH_NUMERIC) {
+    Action::AST ast(std::vector<std::string>{"MNTH", ">=", "6.3"});
+    SummaryState st(TimeService::now());
+    WListManager wlm;
+    Action::Context context(st, wlm);
+
+    context.add("MNTH", 5);
+    BOOST_CHECK( !ast.eval(context));
+
+    context.add("MNTH", 6);
+    BOOST_CHECK( ast.eval(context) );
+}
+
 
 BOOST_AUTO_TEST_CASE(MANUAL1) {
     Action::AST ast({"GGPR", "FIELD", ">", "50000", "AND", "WGOR", "PR", ">" ,"GGOR", "FIELD"});


### PR DESCRIPTION
[New math](https://www.youtube.com/watch?v=UIKGV2cTgqA):

When evaluating numerical month arguments in ACTIONX statements the values should be rounded before comparison - i.e.
```
   MNTH = 4.25 
```
should evaluate to `true` for the month of April.