### PR TITLE
Use std::shared_ptr as holder type for some Pybind11 classes

### DIFF
--- a/python/cxx/deck.cpp
+++ b/python/cxx/deck.cpp
@@ -45,7 +45,14 @@ namespace {
 
 void python::common::export_Deck(py::module &module) {
 
-    py::class_< Deck >(module, "Deck")
+    // Note: In the below class we std::shared_ptr as the holder type, see:
+    //
+    //  https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html
+    //
+    // this makes it possible to share the returned object with e.g. and
+    //   opm.simulators.BlackOilSimulator Python object
+    //
+    py::class_< Deck, std::shared_ptr<Deck> >(module, "Deck")
         .def( "__len__", &size )
         .def( "__contains__", &hasKeyword )
         .def("__iter__",

--- a/python/cxx/eclipse_config.cpp
+++ b/python/cxx/eclipse_config.cpp
@@ -17,7 +17,14 @@ void python::common::export_EclipseConfig(py::module& module)
     py::class_< EclipseConfig >( module, "EclipseConfig" )
         .def( "init",            py::overload_cast<>(&EclipseConfig::init, py::const_));
 
-    py::class_< SummaryConfig >( module, "SummaryConfig")
+    // Note: In the below class we std::shared_ptr as the holder type, see:
+    //
+    //  https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html
+    //
+    // this makes it possible to share the returned object with e.g. and
+    //   opm.simulators.BlackOilSimulator Python object
+    //
+    py::class_< SummaryConfig, std::shared_ptr<SummaryConfig> >( module, "SummaryConfig")
         .def(py::init([](const Deck& deck, const EclipseState& state, const Schedule& schedule) {
             return SummaryConfig( deck, schedule, state.fieldProps(), state.aquifer() );
          }  )  )

--- a/python/cxx/eclipse_state.cpp
+++ b/python/cxx/eclipse_state.cpp
@@ -93,7 +93,14 @@ namespace {
 
 void python::common::export_EclipseState(py::module& module) {
 
-    py::class_< EclipseState >( module, "EclipseState" )
+    // Note: In the below class we std::shared_ptr as the holder type, see:
+    //
+    //  https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html
+    //
+    // this makes it possible to share the returned object with e.g. and
+    //   opm.simulators.BlackOilSimulator Python object
+    //
+    py::class_< EclipseState, std::shared_ptr<EclipseState> >( module, "EclipseState" )
         .def(py::init<const Deck&>())
         .def_property_readonly( "title", &EclipseState::getTitle )
         .def( "field_props",    &get_field_props, ref_internal)

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -107,7 +107,14 @@ void python::common::export_Schedule(py::module& module) {
         .def("group", &get_group, ref_internal);
 
 
-    py::class_< Schedule >( module, "Schedule")
+    // Note: In the below class we std::shared_ptr as the holder type, see:
+    //
+    //  https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html
+    //
+    // this makes it possible to share the returned object with e.g. and
+    //   opm.simulators.BlackOilSimulator Python object
+    //
+    py::class_< Schedule, std::shared_ptr<Schedule> >( module, "Schedule")
     .def(py::init<const Deck&, const EclipseState& >())
     .def("_groups", &get_groups )
     .def_property_readonly( "start",  &get_start_time )


### PR DESCRIPTION
I am adding this PR as a preparation for some modifications of the Python interface in `opm-simulators`. The idea is to be able to do something like the following from Python:
```Python
from opm.io.parser import Parser
from opm.io.ecl_state import EclipseState
from opm.io.schedule import Schedule
from opm.io.summary import SummaryConfig
from opm.simulators import BlackOilSimulator

deck  = Parser().parse('SPE1CASE1.DATA')
state = EclipseState(deck)
schedule = Schedule( deck, state )
summary_config = SummaryConfig(deck, state, schedule)
sim = BlackOilSimulator( deck, state, schedule, summary_config  )
sim.step_init()
sim.step()
# ... 
sim.step_cleanup()
```
By using `std::shared_ptr` as the holder type for these classes they can be shared with `opm.simulators`. For example, after the `schedule` object has been handed over to the simulator it can be deleted (go out of scope) in Python without crashing the simulator.