### PR TITLE
return unique vector of names and not a map with wells and reason

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
@@ -82,9 +82,9 @@ public:
       update method will update the internal state of the object by counting up
       the openiing attempts, and also set the time for the last attempt to open.
     */
-    std::vector<std::pair<std::string, WellTestConfig::Reason>> updateWells(const WellTestConfig& config,
-                                                                            const std::vector<Well>& wells_ecl,
-                                                                            double sim_time);
+    std::vector<std::string> updateWells(const WellTestConfig& config,
+                                         const std::vector<Well>& wells_ecl,
+                                         double sim_time);
 
     /*
       The update will consult the WellTestConfig object and return a list of

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
@@ -100,11 +100,11 @@ namespace Opm {
         return this->wells.size();
     }
 
-    std::vector<std::pair<std::string, WellTestConfig::Reason>>
+    std::vector<std::string>
     WellTestState::updateWells(const WellTestConfig& config,
                                const std::vector<Well>& wells_ecl,
                                double sim_time) {
-        std::vector<std::pair<std::string, WellTestConfig::Reason>> output;
+        std::vector<std::string> output;
 
         updateForNewWTEST(config);
 
@@ -130,7 +130,7 @@ namespace Opm {
                     if (well_config.num_test == 0 || (well.num_attempt < well_config.num_test)) {
                         well.last_test = sim_time;
                         well.num_attempt ++;
-                        output.emplace_back(std::make_pair(well.name, well.reason));
+                        output.emplace_back(well.name);
                         if ( (well_config.num_test != 0) && (well.num_attempt >= well_config.num_test) ) {
                             OpmLog::info(well.name + " will be tested for " + WellTestConfig::reasonToString(well.reason)
                                         + " reason for the last time! " );
@@ -138,6 +138,9 @@ namespace Opm {
                     }
             }
         }
+        std::sort(output.begin(), output.end());
+        auto last = std::unique(output.begin(), output.end());
+        output.erase(last, output.end());
         return output;
     }
 


### PR DESCRIPTION
We don't need the reason to test the well since it should be operable under both E and P condition to open up again. 