### PR TITLE
Set Appropriate Restart BHP Limit for History Wells

### DIFF
--- a/src/opm/io/eclipse/rst/well.cpp
+++ b/src/opm/io/eclipse/rst/well.cpp
@@ -71,7 +71,7 @@ RstWell::RstWell(const ::Opm::UnitSystem& unit_system,
     completion_ordering(                                             iwel[VI::IWell::CompOrd]),
     pvt_table(                                                       def_pvt_table),
     msw_pressure_drop_model(                                         iwel[VI::IWell::MSW_PlossMod]),
-    // The values orat_target -> bhp_target_flow will be used in UDA values. The
+    // The values orat_target -> bhp_target_float will be used in UDA values. The
     // UDA values are responsible for unit conversion and raw values are
     // internalized here.
     orat_target(                                                     swel_value(swel[VI::SWell::OilRateTarget])),

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/Well.cpp
@@ -230,6 +230,11 @@ Well::Well(const RestartIO::RstWell& rst_well,
         }
 
         p->addProductionControl(Well::ProducerCMode::BHP);
+        if (! p->predictionMode) {
+            p->BHPTarget.update(0.0);
+            p->setBHPLimit(rst_well.bhp_target_double);
+        }
+
         if (this->isAvailableForGroupControl())
             p->addProductionControl(Well::ProducerCMode::GRUP);
         this->updateProduction(std::move(p));
@@ -290,6 +295,13 @@ Well::Well(const RestartIO::RstWell& rst_well,
 
         i->addInjectionControl(Well::InjectorCMode::BHP);
         i->BHPTarget.update(rst_well.bhp_target_float);
+        if (! i->predictionMode) {
+            if (i->controlMode == Well::InjectorCMode::BHP)
+                i->bhp_hist_limit = rst_well.hist_bhp_target;
+            else
+                i->resetDefaultHistoricalBHPLimit();
+        }
+
         if (this->isAvailableForGroupControl())
             i->addInjectionControl(Well::InjectorCMode::GRUP);
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellProductionProperties.cpp
@@ -112,7 +112,7 @@ namespace Opm {
     void Well::WellProductionProperties::init_history(const DeckRecord& record)
     {
         this->predictionMode = false;
-        // update LiquidRate. The funnny constrction with explicitly making a new
+        // update LiquidRate. The funny construction with explicitly making a new
         // UDAValue is to ensure that the UDAValue has the correct dimension.
         this->LiquidRate = UDAValue(this->WaterRate.get<double>() + this->OilRate.get<double>(), this->OilRate.get_dim());
 


### PR DESCRIPTION
Without this we would end up with very wrong BHP limits for this case&mdash;e.g., upper BHP limit of 1 ATM for injectors&mdash;and this would obviously mean that restarted runs do not converge.

While here, also correct a couple of misprints.

Thanks to @tskille for providing a test case based on [opm-tests/model1/BASE_MODEL_1.DATA](https://github.com/OPM/opm-tests/blob/563b9d2a529e6258f1f2091953615aa681e49a16/model1/BASE_MODEL_1.DATA).