### PR TITLE
WTEST - consecutive keywords overwrite instead of updating

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestConfig.hpp
@@ -21,14 +21,14 @@
 
 #include <cstddef>
 #include <string>
-#include <vector>
+#include <unordered_map>
 
 
 namespace Opm {
 
 class WellTestConfig {
 public:
-    enum Reason {
+    enum class Reason {
         PHYSICAL = 1,
         ECONOMIC = 2,
         GROUP = 4,
@@ -38,7 +38,7 @@ public:
 
     struct WTESTWell {
         std::string name;
-        Reason shut_reason;
+        int reasons;
         double test_interval;
         int num_test;
         double startup_time;
@@ -48,7 +48,7 @@ public:
 
         bool operator==(const WTESTWell& data) const {
             return name == data.name &&
-                   shut_reason == data.shut_reason &&
+                   reasons == data.reasons &&
                    test_interval == data.test_interval &&
                    num_test == data.num_test &&
                    startup_time == data.startup_time &&
@@ -56,7 +56,7 @@ public:
         }
 
         WTESTWell() = default;
-        WTESTWell(const std::string& name, Reason shut_reason, double test_interval, int num_test, double startup_time, int begin_report_step);
+        WTESTWell(const std::string& name, int reasons, double test_interval, int num_test, double startup_time, int begin_report_step);
         static WTESTWell serializeObject();
 
 
@@ -64,7 +64,7 @@ public:
         void serializeOp(Serializer& serializer)
         {
             serializer(name);
-            serializer(shut_reason);
+            serializer(reasons);
             serializer(test_interval);
             serializer(num_test);
             serializer(startup_time);
@@ -72,36 +72,29 @@ public:
         }
     };
 
-    WellTestConfig();
-
     static WellTestConfig serializeObject();
 
-    void add_well(const std::string& well, Reason reason, double test_interval, int num_test, double startup_time, int current_step);
     void add_well(const std::string& well, const std::string& reasons, double test_interval,
                   int num_test, double startup_time, int current_step);
     void drop_well(const std::string& well);
     bool has(const std::string& well) const;
     bool has(const std::string& well, Reason reason) const;
     const WTESTWell& get(const std::string& well, Reason reason) const;
-    size_t size() const;
 
     static std::string reasonToString(const Reason reason);
+    bool empty() const;
 
     bool operator==(const WellTestConfig& data) const;
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer.vector(wells);
+        serializer.map(wells);
     }
 
 private:
-    std::vector<WTESTWell> wells;
-
-    WTESTWell* getWell(const std::string& well_name, const Reason reason);
+    std::unordered_map<std::string, WTESTWell> wells;
 };
-
-
 }
 
 #endif

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2861,12 +2861,12 @@ WCONINJH
 
         {
             const auto& wtest_config = schedule[0].wtest_config.get();
-            BOOST_CHECK_EQUAL(wtest_config.size(), 0U);
+            BOOST_CHECK(wtest_config.empty());
         }
 
         {
             const auto& wtest_config = schedule[1].wtest_config.get();
-            BOOST_CHECK_EQUAL(wtest_config.size(), 0U);
+            BOOST_CHECK(wtest_config.empty());
         }
     }
 }
@@ -3158,12 +3158,12 @@ BOOST_AUTO_TEST_CASE(WTEST_CONFIG) {
     const auto& schedule = make_schedule(createDeckWTEST());
 
     const auto& wtest_config1 = schedule[0].wtest_config.get();
-    BOOST_CHECK_EQUAL(wtest_config1.size(), 2U);
+    BOOST_CHECK(!wtest_config1.empty());
     BOOST_CHECK(wtest_config1.has("ALLOW"));
     BOOST_CHECK(!wtest_config1.has("BAN"));
 
     const auto& wtest_config2 = schedule[1].wtest_config.get();
-    BOOST_CHECK_EQUAL(wtest_config2.size(), 3U);
+    BOOST_CHECK(!wtest_config2.empty());
     BOOST_CHECK(!wtest_config2.has("ALLOW"));
     BOOST_CHECK(wtest_config2.has("BAN"));
     BOOST_CHECK(wtest_config2.has("BAN", WellTestConfig::Reason::GROUP));

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -40,27 +40,24 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(CreateWellTestConfig) {
     WellTestConfig wc;
 
-    BOOST_CHECK_EQUAL(wc.size() , 0U);
+    BOOST_CHECK(wc.empty());
 
 
-    wc.add_well("NAME", WellTestConfig::Reason::PHYSICAL, 10, 10, 10, 1);
-    BOOST_CHECK_EQUAL(wc.size(), 1U);
-    BOOST_CHECK_THROW(wc.add_well("NAME2", "", 10.0,10,10.0, 1), std::invalid_argument);
-    BOOST_CHECK_THROW(wc.add_well("NAME3", "X", 1,2,3, 1), std::invalid_argument);
+    wc.add_well("NAME", "P", 10, 10, 10, 1);
+    BOOST_CHECK(!wc.empty());
+    BOOST_CHECK_THROW(wc.add_well("NAME2", "", 10.0,10,10.0, 1), std::exception);
+    BOOST_CHECK_THROW(wc.add_well("NAME3", "X", 1,2,3, 1), std::exception);
 
     wc.add_well("NAME", "PEGDC", 10, 10, 10, 1);
-    BOOST_CHECK_EQUAL(wc.size(), 5U);
     wc.add_well("NAMEX", "PGDC", 10, 10, 10, 1);
-    BOOST_CHECK_EQUAL(wc.size(), 9U);
     wc.drop_well("NAME");
-    BOOST_CHECK_EQUAL(wc.size(), 4U);
     BOOST_CHECK(wc.has("NAMEX"));
     BOOST_CHECK(wc.has("NAMEX", WellTestConfig::Reason::PHYSICAL));
     BOOST_CHECK(!wc.has("NAMEX", WellTestConfig::Reason::ECONOMIC));
     BOOST_CHECK(!wc.has("NAME"));
 
-    BOOST_CHECK_THROW(wc.get("NAMEX", WellTestConfig::Reason::ECONOMIC), std::invalid_argument);
-    BOOST_CHECK_THROW(wc.get("NO_NAME", WellTestConfig::Reason::ECONOMIC), std::invalid_argument);
+    BOOST_CHECK_THROW(wc.get("NAMEX", WellTestConfig::Reason::ECONOMIC), std::exception);
+    BOOST_CHECK_THROW(wc.get("NO_NAME", WellTestConfig::Reason::ECONOMIC), std::exception);
     const auto& wt = wc.get("NAMEX", WellTestConfig::Reason::PHYSICAL);
     BOOST_CHECK_EQUAL(wt.name, "NAMEX");
 }
@@ -69,7 +66,7 @@ BOOST_AUTO_TEST_CASE(CreateWellTestConfig) {
 BOOST_AUTO_TEST_CASE(WTEST_STATE2) {
     WellTestConfig wc;
     WellTestState st;
-    wc.add_well("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 0, 0, 0, 0);
+    wc.add_well("WELL_NAME", "P", 0, 0, 0, 0);
     st.closeWell("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 100);
     BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
 
@@ -124,7 +121,7 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
         BOOST_CHECK_EQUAL(shut_wells.size(), 0U);
     }
 
-    wc.add_well("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 1000. * day, 2, 0, 1);
+    wc.add_well("WELL_NAME", "P", 1000. * day, 2, 0, 1);
     // Not sufficient time has passed.
     BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 200. * day).size(), 0U);
 
@@ -147,7 +144,7 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
     // Too many attempts:
     BOOST_CHECK_EQUAL( st.updateWells(wc, wells, 4000. * day).size(), 0U);
 
-    wc.add_well("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 1000. * day, 3, 0, 5);
+    wc.add_well("WELL_NAME", "P", 1000. * day, 3, 0, 5);
 
 
     wells[0].updateStatus(Well::Status::SHUT);
@@ -188,7 +185,7 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
     auto closed_completions = st.updateWells(wc, wells, 5000);
     BOOST_CHECK_EQUAL( closed_completions.size(), 0U);
 
-    wc.add_well("WELL_NAME", WellTestConfig::Reason::COMPLETION, 1000, 2, 0, 0);
+    wc.add_well("WELL_NAME", "C", 1000, 2, 0, 0);
     // Not sufficient time has passed.
     BOOST_CHECK_EQUAL( st.updateCompletion(wc, 200).size(), 0U);
 


### PR DESCRIPTION
The WTEST keyword has ovewrite semantics - not update semantics.

Downstream: https://github.com/OPM/opm-simulators/pull/3559