### PR TITLE
Add types EclipseGrid::ActiveIndex and EclipseGrid::GlobalIndex for overload resolution

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -54,6 +54,16 @@ namespace Opm {
 
     class EclipseGrid : public GridDims {
     public:
+
+        struct ActiveIndex {
+            explicit std::size_t value;
+        };
+
+        struct GlobalIndex {
+            explicit std::size_t value;
+        };
+
+
         EclipseGrid() = default;
         explicit EclipseGrid(const std::string& filename);
 
@@ -154,6 +164,8 @@ namespace Opm {
         const std::vector<int>& getActiveMap() const;
         std::array<double, 3> getCellCenter(size_t i,size_t j, size_t k) const;
         std::array<double, 3> getCellCenter(size_t globalIndex) const;
+        std::array<double, 3> getCellCenter(const ActiveIndex& index) const;
+        std::array<double, 3> getCellCenter(const GlobalIndex& index) const;
         std::array<double, 3> getCornerPos(size_t i,size_t j, size_t k, size_t corner_index) const;
         const std::vector<double>& activeVolume() const;
         double getCellVolume(size_t globalIndex) const;

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -1549,6 +1549,17 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
     }
 
 
+    std::array<double, 3> EclipseGrid::getCellCenter(const EclipseGrid::ActiveIndex& index) const {
+        auto gi = this->getGlobalIndex( index.value );
+        return this->getCellCenter(gi);
+    }
+
+    std::array<double, 3> EclipseGrid::getCellCenter(const EclipseGrid::GlobalIndex& index) const {
+        auto gi = index.value;
+        return this->getCellCenter(gi);
+    }
+
+
     std::array<double, 3> EclipseGrid::getCellCenter(size_t i,size_t j, size_t k) const {
         assertIJK(i,j,k);
 

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -1104,6 +1104,11 @@ BOOST_AUTO_TEST_CASE(regularCartGrid) {
                 BOOST_CHECK_CLOSE(cc[0], ref_x, 1e-12);
                 BOOST_CHECK_CLOSE(cc[1], ref_y, 1e-12);
                 BOOST_CHECK_CLOSE(cc[2], ref_z, 1e-12);
+
+
+                const auto& ai = grid.activeIndex(i,j,k);
+                const auto& cc2 = grid.getCellCenter( Opm::EclipseGrid::ActiveIndex{ai} ));
+                BOOST_CHECK(cc == cc2);
             }
         }
     }
@@ -1401,6 +1406,9 @@ BOOST_AUTO_TEST_CASE(SpiderDetails) {
     BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 3 , 0 ) , sqrt(3.0)*0.25*( 4 - 1 ) , 0.0001);
     auto pos0 = grid.getCellCenter(0,0,0);
     auto pos2 = grid.getCellCenter(0,2,0);
+
+    auto pos00 = grid.getCellCenter( Opm::EclipseGrid::GlobalIndex{0} );
+    BOOST_CHECK(pos0 == pos00);
 
     BOOST_CHECK_CLOSE( std::get<0>(pos0) , 0.75 , 0.0001);
     BOOST_CHECK_CLOSE( std::get<1>(pos0) , 0.75 , 0.0001);


### PR DESCRIPTION
Just a small attempt which might have been benefical here: https://github.com/OPM/opm-simulators/pull/3565?