### PR TITLE
Support Resetting ACTNUM At EclipseState Level

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -106,6 +106,7 @@ namespace Opm {
         const AquiferConfig& aquifer() const;
         const TracerConfig& tracer() const;
 
+        void reset_actnum(const std::vector<int>& new_actnum);
         void pruneDeactivatedAquiferConnections(const std::vector<std::size_t>& deactivated_cells);
         void loadRestartAquifers(const RestartIO::RstAquifer& aquifers);
 

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -267,6 +267,10 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
         return this->tracer_config;
     }
 
+    void EclipseState::reset_actnum(const std::vector<int>& new_actnum) {
+        this->field_props.reset_actnum(new_actnum);
+    }
+
     void EclipseState::pruneDeactivatedAquiferConnections(const std::vector<std::size_t>& deactivated_cells) {
         if (this->aquifer_config.hasAnalyticalAquifer())
             this->aquifer_config.pruneDeactivatedAquiferConnections(deactivated_cells);


### PR DESCRIPTION
Mostly a convenience method that avoids resorting to ugly `const_cast<>` expressions in client code.