### PR TITLE
WellTestState: will only count actually closed wells

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
@@ -190,8 +190,8 @@ public:
 
     bool hasCompletion(const std::string& well_name, const int complnum) const;
 
-    size_t sizeWells() const;
-    size_t sizeCompletions() const;
+    std::size_t num_closed_wells() const;
+    std::size_t num_closed_completions() const;
 
     /*
       Return the last tested time for the well, or throw if no such well.

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
@@ -103,8 +103,8 @@ namespace Opm {
     }
 
 
-    size_t WellTestState::sizeWells() const {
-        return this->wells.size();
+    size_t WellTestState::num_closed_wells() const {
+        return std::count_if(this->wells.begin(), this->wells.end(), [](const WTestWell& well) { return well.closed; });
     }
 
     std::vector<std::string>
@@ -178,7 +178,7 @@ namespace Opm {
         return (completion_iter != completions.end());
     }
 
-    size_t WellTestState::sizeCompletions() const {
+    size_t WellTestState::num_closed_completions() const {
         return this->completions.size();
     }
 

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE2) {
     WellTestState st;
     wc.add_well("WELL_NAME", "P", 0, 0, 0, 0);
     st.closeWell("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 100);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
+    BOOST_CHECK_EQUAL(st.num_closed_wells(), 1U);
 
     const UnitSystem us{};
     std::vector<Well> wells;
@@ -92,19 +92,19 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE) {
     const double day = 86400.;
     WellTestState st;
     st.closeWell("WELL_NAME", WellTestConfig::Reason::ECONOMIC, 100. * day);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
+    BOOST_CHECK_EQUAL(st.num_closed_wells(), 1U);
 
     st.openWell("WELL_NAME", WellTestConfig::Reason::ECONOMIC);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
+    BOOST_CHECK_EQUAL(st.num_closed_wells(), 0);
 
     st.closeWell("WELL_NAME", WellTestConfig::Reason::ECONOMIC, 100. * day);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 1U);
+    BOOST_CHECK_EQUAL(st.num_closed_wells(), 1U);
 
     st.closeWell("WELL_NAME", WellTestConfig::Reason::PHYSICAL, 100. * day);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 2U);
+    BOOST_CHECK_EQUAL(st.num_closed_wells(), 2U);
 
     st.closeWell("WELLX", WellTestConfig::Reason::PHYSICAL, 100. * day);
-    BOOST_CHECK_EQUAL(st.sizeWells(), 3U);
+    BOOST_CHECK_EQUAL(st.num_closed_wells(), 3U);
 
     const UnitSystem us{};
     std::vector<Well> wells;
@@ -166,16 +166,16 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
     WellTestConfig wc;
     WellTestState st;
     st.addClosedCompletion("WELL_NAME", 2, 100);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1U);
+    BOOST_CHECK_EQUAL(st.num_closed_completions(), 1U);
 
     st.addClosedCompletion("WELL_NAME", 2, 100);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1U);
+    BOOST_CHECK_EQUAL(st.num_closed_completions(), 1U);
 
     st.addClosedCompletion("WELL_NAME", 3, 100);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 2U);
+    BOOST_CHECK_EQUAL(st.num_closed_completions(), 2U);
 
     st.addClosedCompletion("WELLX", 3, 100);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 3U);
+    BOOST_CHECK_EQUAL(st.num_closed_completions(), 3U);
 
     const UnitSystem us{};
     std::vector<Well> wells;
@@ -184,8 +184,8 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
     wells.emplace_back("WELLX", "A", 0, 0, 2, 2, 200., WellType(Phase::OIL), Well::ProducerCMode::NONE, Connection::Order::TRACK, us, 0., 1.0, true, true, 0, Well::GasInflowEquation::STD);
     wells[1].updateStatus(Well::Status::OPEN);
 
-    auto closed_completions = st.updateWells(wc, wells, 5000);
-    BOOST_CHECK_EQUAL( closed_completions.size(), 0U);
+    auto num_closed_completions = st.updateWells(wc, wells, 5000);
+    BOOST_CHECK_EQUAL( num_closed_completions.size(), 0U);
 
     wc.add_well("WELL_NAME", "C", 1000, 2, 0, 0);
     // Not sufficient time has passed.
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
 
     st.dropCompletion("WELL_NAME", 2);
     st.dropCompletion("WELLX", 3);
-    BOOST_CHECK_EQUAL(st.sizeCompletions(), 1U);
+    BOOST_CHECK_EQUAL(st.num_closed_completions(), 1U);
 }
 
 


### PR DESCRIPTION
This PR changes the semantics of opening wells which are managed by WTEST. The data structure used to manage the state of wells closed due to WTEST manages a bool flag closed, which is set to false when the well is opened. This affects how the method counts the number of wells in the container. Assuming the chain of events is as follows:

1. Well "W1" is closed with WTEST: A new entry for well "W1" is added to the `WellTestState` container with the `closed` flag set to `true`.
2. Well "W1" is reopened: We find the "W1" well in the container and flip the `closed` flag to `false`.

Now - the point is that the method counting wells does not differentiate between closed and open wells, so in this we will get one well even after the well has been opened again. With this PR the count method actually inspects the `closed` flag.

The downstream PR is only a rename; but I thought that made sense due to change in semantic behavior.


Downstream: https://github.com/OPM/opm-simulators/pull/3579