### PR TITLE
Restore Group Level Controls if Limits Exist

### DIFF
--- a/opm/io/eclipse/rst/group.hpp
+++ b/opm/io/eclipse/rst/group.hpp
@@ -45,6 +45,7 @@ struct RstGroup {
     int winj_cmode;
     int ginj_cmode;
     int guide_rate_def;
+    int exceed_action;
 
     float oil_rate_limit;
     float water_rate_limit;

--- a/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/Group.hpp
@@ -65,7 +65,7 @@ enum class ExceedAction {
 };
 static const std::string ExceedAction2String( ExceedAction enumValue );
 static ExceedAction ExceedActionFromString( const std::string& stringValue );
-
+static ExceedAction ExceedActionFromInt(const int value);
 
 enum class InjectionCMode  : int {
     NONE = 0,

--- a/src/opm/io/eclipse/rst/group.cpp
+++ b/src/opm/io/eclipse/rst/group.cpp
@@ -53,6 +53,7 @@ RstGroup::RstGroup(const ::Opm::UnitSystem& unit_system,
     winj_cmode(igrp[header.nwgmax + VI::IGroup::GConInjeWInjCMode]),
     ginj_cmode(igrp[header.nwgmax + VI::IGroup::GConInjeGInjCMode]),
     guide_rate_def(igrp[header.nwgmax + VI::IGroup::GuideRateDef]),
+    exceed_action(igrp[header.nwgmax + VI::IGroup::ExceedAction]),
     // The values oil_rate_limit -> gas_voidage_limit will be used in UDA
     // values. The UDA values are responsible for unit conversion and raw values
     // are internalized here.

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -772,6 +772,13 @@ Group::ExceedAction Group::ExceedActionFromString( const std::string& stringValu
         throw std::invalid_argument("Unknown enum state string: " + stringValue );
 }
 
+Group::ExceedAction Group::ExceedActionFromInt( const int value ) {
+
+    if (value < 0) return ExceedAction::NONE;
+    if (value == 4) return ExceedAction::RATE;
+
+    throw std::invalid_argument(fmt::format("Unknown ExceedAction state integer: {}", value));
+}
 
 const std::string Group::InjectionCMode2String( InjectionCMode enumValue ) {
     switch( enumValue ) {


### PR DESCRIPTION
A group may have limits but no active control at the time of restart.

While here, also support restoring a limited `ExceedAction` value from the restart file.