### PR TITLE
Welltest state rename

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
@@ -160,11 +160,11 @@ public:
                                          double sim_time);
 
     /*
-      If the simulator decides that a constraint is no longer met the dropCompletion()
+      If the simulator decides that a constraint is no longer met the open_completion()
       method should be called to indicate that this reason for keeping the well
       closed is no longer active.
     */
-    void dropCompletion(const std::string& well_name, int complnum);
+    void open_completion(const std::string& well_name, int complnum);
 
     bool well_is_closed(const std::string& well_name, WellTestConfig::Reason reason) const;
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
@@ -160,7 +160,7 @@ namespace Opm {
     }
 
 
-    void WellTestState::dropCompletion(const std::string& well_name, int complnum) {
+    void WellTestState::open_completion(const std::string& well_name, int complnum) {
         completions.erase(std::remove_if(completions.begin(),
                                          completions.end(),
                                          [&well_name, complnum](const ClosedCompletion& completion) { return (completion.wellName == well_name && completion.complnum == complnum); }),

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -187,9 +187,13 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
     auto num_closed_completions = st.updateWells(wc, wells, 5000);
     BOOST_CHECK_EQUAL( num_closed_completions.size(), 0U);
 
-    st.dropCompletion("WELL_NAME", 2);
-    st.dropCompletion("WELLX", 3);
+    BOOST_CHECK_NO_THROW( st.open_completion("WELL_NAME", 20000));
+
+    st.open_completion("WELL_NAME", 2);
+    st.open_completion("WELLX", 3);
     BOOST_CHECK_EQUAL(st.num_closed_completions(), 1U);
+
+    BOOST_CHECK_NO_THROW( st.open_completion("NO_SUCH_WELL", 3) );
 }
 
 


### PR DESCRIPTION
Rename functions in WellTestState: some functions get more descriptive names, others just get the `snake_case_style` 

Downstream: https://github.com/OPM/opm-simulators/pull/3591