### PR TITLE
Remove WellTestState::xxx_is_open() predicates

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.hpp
@@ -166,22 +166,23 @@ public:
     std::vector<std::string> test_wells(const WellTestConfig& config, double sim_time);
 
     /*
-      As mentioned the purpose of this class is to manage *closed wells*; i.e.
-      the default state of a well/completion in this container is closed. This
-      has some consequences for the behavior of well_is_closed() and
-      well_is_open() which are *not* perfectly opposite.
+      The purpose of this container is to manage explicitly *closed wells*,
+      since the class has no relation to the set of of wells defined in the
+      Schedule section the concept of open wells and totally unknown wells is
+      slightly murky:
 
-          well_is_closed("UNKNOWN_WELL") -> false
-          well_is_open("UNKNOWN_WELL")   -> throw std::exception
+         well_is_closed("UNKOWN_WELL") -> false
 
-          completion_is_closed("UNKNOWN_WELL", *)       -> false
-          completion_is_closed("W1", $unknown_complnum) -> false
-          completion_is_open("UNKNOWN_WELL", *)         -> throw std::exception
-          completion_is_closed("W1", $unknown_complnum) -> false
+      This implies that we have not explicitly closed a well with name
+      'UNKNOWN_WELL', but since we do not know whether the well is at all
+      defined it does not make sense to extrapolate to:
+
+         well_is_open("UNKNOWN_WELL") -> true.
+
+      That is the reason we do not have any xxx_is_open() predicates.
     */
     void close_well(const std::string& well_name, WellTestConfig::Reason reason, double sim_time);
     bool well_is_closed(const std::string& well_name) const;
-    bool well_is_open(const std::string& well_name) const;
     void open_well(const std::string& well_name);
     std::size_t num_closed_wells() const;
     double lastTestTime(const std::string& well_name) const;
@@ -190,7 +191,6 @@ public:
     void open_completion(const std::string& well_name, int complnum);
     void open_completions(const std::string& well_name);
     bool completion_is_closed(const std::string& well_name, const int complnum) const;
-    bool completion_is_open(const std::string& well_name, const int complnum) const;
     std::size_t num_closed_completions() const;
 
     void clear();

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Well/WellTestState.cpp
@@ -79,11 +79,6 @@ namespace Opm {
     }
 
 
-    bool WellTestState::well_is_open(const std::string& well_name) const {
-        const auto& well = this->wells.at(well_name);
-        return !well.closed;
-    }
-
 
     size_t WellTestState::num_closed_wells() const {
         return std::count_if(this->wells.begin(), this->wells.end(), [](const auto& well_pair) { return well_pair.second.closed; });
@@ -154,16 +149,6 @@ namespace Opm {
 
         return true;
     }
-
-    bool WellTestState::completion_is_open(const std::string& well_name, const int complnum) const {
-        const auto& well = this->completions.at(well_name);
-        const auto& completion_iter = well.find(complnum);
-        if (completion_iter == well.end())
-            return true;
-
-        return false;
-    }
-
 
     size_t WellTestState::num_closed_completions() const {
         std::size_t count = 0;

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -167,10 +167,6 @@ BOOST_AUTO_TEST_CASE(WTEST_STATE_COMPLETIONS) {
 
     BOOST_CHECK_NO_THROW(st.open_completion("NO_SUCH_WELL", 1000));
     BOOST_CHECK_NO_THROW(st.open_completion("NO_SUCH_WELL", 1000));
-
-    BOOST_CHECK_THROW(st.completion_is_open("NO_SUCH_WELL", 1000), std::exception);
-    BOOST_CHECK_EQUAL(st.completion_is_open("WELL_NAME", 2), true);
-    BOOST_CHECK_THROW(st.well_is_open("NO_SUCH_WELL"), std::exception);
 }
 
 


### PR DESCRIPTION
Updated comment:
```C++
/*
      The purpose of this container is to manage explicitly *closed wells*,
      since the class has no relation to the set of of wells defined in the
      Schedule section the concept of open wells and totally unknown wells is
      slightly murky:

         well_is_closed("UNKOWN_WELL") -> false

      This implies that we have not explicitly closed a well with name
      'UNKNOWN_WELL', but since we do not know whether the well is at all
      defined it does not make sense to extrapolate to:

         well_is_open("UNKNOWN_WELL") -> true.

      That is the reason we do not have any xxx_is_open() predicates.
*/
```