### PR TITLE
Add Guide Rate Value Accessor for SI Units

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -102,6 +102,7 @@ public:
     double getSI(const std::string& well, const Well::GuideRateTarget target, const RateVector& rates) const;
     double getSI(const std::string& group, const Group::GuideRateProdTarget target, const RateVector& rates) const;
     double getSI(const std::string& wgname, const GuideRateModel::Target target, const RateVector& rates) const;
+    double getSI(const std::string& group, const Phase& phase) const;
 
     bool has(const std::string& name) const;
     bool has(const std::string& name, const Phase& phase) const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -165,6 +165,29 @@ double GuideRate::getSI(const std::string&           wgname,
     };
 }
 
+double GuideRate::getSI(const std::string& group, const Phase& phase) const
+{
+    using M = UnitSystem::measure;
+
+    const auto gr = this->get(group, phase);
+
+    switch (phase) {
+    case Phase::OIL:
+    case Phase::WATER:
+        return this->schedule.getUnits().to_si(M::liquid_surface_rate, gr);
+
+    case Phase::GAS:
+        return this->schedule.getUnits().to_si(M::gas_surface_rate, gr);
+
+    default:
+        break;
+    }
+
+    throw std::invalid_argument {
+        fmt::format("Unsupported Injection Guiderate Phase '{}'", static_cast<int>(phase))
+    };
+}
+
 bool GuideRate::has(const std::string& name) const
 {
     return this->values.count(name) > 0;


### PR DESCRIPTION
Needed to properly report group-level injection guide rates in the summary file.

Forgotten in PR #2605 (commit 2a374fc53).