### PR TITLE
fixed: forward struct as struct

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp
@@ -28,7 +28,7 @@
 namespace Opm {
 
 namespace RestartIO {
-class RstState;
+struct RstState;
 }
 
 class WListManager {


### PR DESCRIPTION
Causes warnings using clang.