### PR TITLE
WIP: Insert keywords into schedule section from Python.

### DIFF
--- a/opm/parser/eclipse/Deck/DeckValue.hpp
+++ b/opm/parser/eclipse/Deck/DeckValue.hpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <opm/parser/eclipse/Utility/Typetools.hpp>
+#include <opm/parser/eclipse/Deck/UDAValue.hpp>
 
 namespace Opm {
 
@@ -33,7 +34,8 @@ class DeckValue {
         explicit DeckValue(int);
         explicit DeckValue(double);
         explicit DeckValue(const std::string&);
-        
+        explicit DeckValue(const UDAValue&);
+
         bool is_default() const;
 
         template<typename T>
@@ -48,7 +50,8 @@ class DeckValue {
         type_tag value_enum;
         int int_value;
         double double_value;
-        std::string string_value;    
+        std::string string_value;
+        UDAValue uda_value;
 
 };
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -297,7 +297,7 @@ namespace Opm
           for the schedule instances created by loading a restart file.
         */
         static bool cmp(const Schedule& sched1, const Schedule& sched2, std::size_t report_step);
-        void applyKeywords(const Deck &deck, std::size_t timeStep);
+        void applyKeywords(std::vector<DeckKeyword*>& keywords, std::size_t timeStep);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -297,6 +297,7 @@ namespace Opm
           for the schedule instances created by loading a restart file.
         */
         static bool cmp(const Schedule& sched1, const Schedule& sched2, std::size_t report_step);
+        void applyKeywords(const Deck &deck, std::size_t timeStep);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -509,7 +510,6 @@ namespace Opm
         void addGroup(Group group);
         void addGroup(const RestartIO::RstGroup& rst_group, std::size_t timeStep);
         void addWell(const std::string& wellName, const DeckRecord& record, std::size_t timeStep, Connection::Order connection_order);
-        void applyKeywords(const DeckView &deck, std::size_t timeStep);
         void checkIfAllConnectionsIsShut(std::size_t currentStep);
         void end_report(std::size_t report_step);
         void handleKeyword(std::size_t currentStep,

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -509,6 +509,7 @@ namespace Opm
         void addGroup(Group group);
         void addGroup(const RestartIO::RstGroup& rst_group, std::size_t timeStep);
         void addWell(const std::string& wellName, const DeckRecord& record, std::size_t timeStep, Connection::Order connection_order);
+        void applyKeywords(const DeckView &deck, std::size_t timeStep);
         void checkIfAllConnectionsIsShut(std::size_t currentStep);
         void end_report(std::size_t report_step);
         void handleKeyword(std::size_t currentStep,

--- a/python/cxx/deck.cpp
+++ b/python/cxx/deck.cpp
@@ -45,7 +45,7 @@ namespace {
 
 void python::common::export_Deck(py::module &module) {
 
-    // Note: In the below class we std::shared_ptr as the holder type, see:
+    // Note: In the below class we use std::shared_ptr as the holder type, see:
     //
     //  https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html
     //

--- a/python/cxx/deck_keyword.cpp
+++ b/python/cxx/deck_keyword.cpp
@@ -62,7 +62,11 @@ bool is_int(const std::string& s)
 }
 
 
-void push_string_as_deck_value(std::vector<DeckValue>& record, const std::string str) {
+void push_string_as_deck_value(
+    const ParserItem& parser_item,
+    std::vector<DeckValue>& record,
+    const std::string str)
+{
 
     std::size_t star_pos = str.find('*');
     if (star_pos != std::string::npos) {
@@ -79,12 +83,25 @@ void push_string_as_deck_value(std::vector<DeckValue>& record, const std::string
 
         std::string value_str = str.substr(star_pos + 1, str.length());
         DeckValue value;
-
-        if (value_str.length() > 0) {
-            if (is_int(value_str))
-                value = DeckValue( stoi(value_str) );
-            else
-                value = DeckValue( stod(value_str) );
+        if (parser_item.dataType() == type_tag::uda) {
+            std::cout << "  processing uda item for " << parser_item.name() << '\n';
+            if (value_str.length() > 0) {
+                if (is_int(value_str))
+                    value = DeckValue( UDAValue(stoi(value_str)) );
+                else
+                    value = DeckValue( UDAValue(stod(value_str)) );
+            }
+            else {
+                value = DeckValue( UDAValue( parser_item.getDefault<UDAValue>() ) );
+            }
+        }
+        else {
+            if (value_str.length() > 0) {
+                if (is_int(value_str))
+                    value = DeckValue( stoi(value_str) );
+                else
+                    value = DeckValue( stod(value_str) );
+            }
         }
 
         for (int i = 0; i < multiplier; i++)
@@ -140,35 +157,47 @@ void python::common::export_DeckKeyword(py::module& module) {
         .def(py::init([](const ParserKeyword& parser_keyword, py::list record_list, UnitSystem& active_system, UnitSystem& default_system) {
 
             std::vector< std::vector<DeckValue> > value_record_list;
-
+            int i = 0;
             for (py::handle record_obj : record_list) {
                  py::list record = record_obj.cast<py::list>();
                  std::vector<DeckValue> value_record;
-
+                 const ParserRecord& parser_record = parser_keyword.getRecord(i++);
+                 int j = 0;
                  for (const py::handle& value_obj : record) {
+                     const ParserItem& parser_item = parser_record.get(j++);
+                     try {
+                         int val_int = value_obj.cast<int>();
+                         if (parser_item.dataType() == type_tag::uda) {
+                             value_record.push_back( DeckValue(UDAValue(val_int)) );
+                         }
+                         else {
+                             value_record.push_back( DeckValue( val_int) );
+                         }
+                         continue;
+                     }
+                     catch (const std::exception& e_int) {}
 
-                      try {
-                          int val_int = value_obj.cast<int>();
-                          value_record.push_back( DeckValue(val_int) );
-                          continue;
-                      }
-                      catch (const std::exception& e_int) {}
+                     try {
+                         double val_double = value_obj.cast<double>();
+                         if (parser_item.dataType() == type_tag::uda) {
+                             value_record.push_back( DeckValue(UDAValue(val_double)));
+                         }
+                         else {
+                             value_record.push_back( DeckValue(val_double) );
+                         }
+                         continue;
+                     }
+                     catch (const std::exception& e_double) {}
 
-                      try {
-                           double val_double = value_obj.cast<double>();
-                           value_record.push_back( DeckValue(val_double) );
-                           continue;
-                      }
-                      catch (const std::exception& e_double) {}
+                     try {
+                         std::string val_string = value_obj.cast<std::string>();
+                         push_string_as_deck_value(
+                             parser_item, value_record, val_string);
+                         continue;
+                     }
+                     catch (const std::exception& e_string) {}
 
-                      try {
-                           std::string val_string = value_obj.cast<std::string>();
-                           push_string_as_deck_value(value_record, val_string);
-                           continue;
-                      }
-                      catch (const std::exception& e_string) {}
-
-                      throw py::type_error("DeckKeyword: tried to add unknown type to record.");
+                     throw py::type_error("DeckKeyword: tried to add unknown type to record.");
 
                  }
                  value_record_list.push_back( value_record );

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -1,6 +1,7 @@
 #include <ctime>
 #include <chrono>
 
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
@@ -92,6 +93,16 @@ namespace {
         return sch[index];
     }
 
+    void insert_keywords(
+        Schedule& sch,
+        const std::string& deck_string,
+        std::size_t index
+    )
+    {
+        Parser parser;
+        auto deck = parser.parseString(deck_string);
+        //sch.applyKeywords(deck, index);
+    }
 }
 
 
@@ -128,6 +139,7 @@ void python::common::export_Schedule(py::module& module) {
     .def( "get_wells", &Schedule::getWells)
     .def("well_names", py::overload_cast<const std::string&>(&Schedule::wellNames, py::const_))
     .def( "get_well", &get_well)
+        .def( "insert_keywords", &insert_keywords, py::arg("data"), py::arg("step"))
     .def( "__contains__", &has_well );
 
 }

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -3,6 +3,7 @@
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
@@ -96,12 +97,30 @@ namespace {
     void insert_keywords(
         Schedule& sch,
         const std::string& deck_string,
-        std::size_t index
+        std::size_t index,
+        const UnitSystem& unit_system
     )
     {
         Parser parser;
-        auto deck = parser.parseString(deck_string);
-        sch.applyKeywords(deck, index);
+        std::string str {unit_system.deck_name() + "\n\n" + deck_string};
+        auto deck = parser.parseString(str);
+        std::vector<DeckKeyword*> keywords;
+        for (auto &keyword : deck) {
+            keywords.push_back(&keyword);
+        }
+        sch.applyKeywords(keywords, index);
+    }
+
+    void insert_keywords(
+        Schedule& sch, py::list& deck_keywords, std::size_t index)
+    {
+        Parser parser;
+        std::vector<DeckKeyword*> keywords;
+        for (py::handle item : deck_keywords) {
+            DeckKeyword &keyword = item.cast<DeckKeyword&>();
+            keywords.push_back(&keyword);
+        }
+        sch.applyKeywords(keywords, index);
     }
 }
 
@@ -118,7 +137,7 @@ void python::common::export_Schedule(py::module& module) {
         .def("group", &get_group, ref_internal);
 
 
-    // Note: In the below class we std::shared_ptr as the holder type, see:
+    // Note: In the below class we use std::shared_ptr as the holder type, see:
     //
     //  https://pybind11.readthedocs.io/en/stable/advanced/smart_ptrs.html
     //
@@ -139,7 +158,13 @@ void python::common::export_Schedule(py::module& module) {
     .def( "get_wells", &Schedule::getWells)
     .def("well_names", py::overload_cast<const std::string&>(&Schedule::wellNames, py::const_))
     .def( "get_well", &get_well)
-        .def( "insert_keywords", &insert_keywords, py::arg("data"), py::arg("step"))
+    .def( "insert_keywords",
+         py::overload_cast<Schedule&, py::list&, std::size_t>(&insert_keywords),
+         py::arg("keywords"), py::arg("step"))
+    .def( "insert_keywords",
+        py::overload_cast<
+               Schedule&, const std::string&, std::size_t, const UnitSystem&
+           >(&insert_keywords),
+        py::arg("data"), py::arg("step"), py::arg("unit_system"))
     .def( "__contains__", &has_well );
-
 }

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -101,7 +101,7 @@ namespace {
     {
         Parser parser;
         auto deck = parser.parseString(deck_string);
-        //sch.applyKeywords(deck, index);
+        sch.applyKeywords(deck, index);
     }
 }
 

--- a/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -128,7 +128,23 @@ namespace Opm {
                               add_deckvalue<std::string>(std::move(deck_item), deck_record, parser_item, input_record, j);
                           }
                           break;
-
+                      case type_tag::uda:
+                         {
+                             auto& dimensions = parser_item.dimensions();
+                             std::vector<Dimension> active_dimensions;
+                             std::vector<Dimension> default_dimensions;
+                             for (const auto& dim_string : dimensions) {
+                                 active_dimensions.push_back(
+                                     system_active.parse(dim_string));
+                                 default_dimensions.push_back(
+                                     system_default.parse(dim_string));
+                             }
+                             DeckItem deck_item(parser_item.name(), UDAValue(),
+                                 active_dimensions, default_dimensions);
+                             add_deckvalue<UDAValue>(std::move(deck_item),
+                                 deck_record, parser_item, input_record, j);
+                         }
+                         break;
                       default: throw std::invalid_argument("For input to DeckKeyword '" + name() + ": unsupported type. (only support for string, double and int.)");
                   }
              }

--- a/src/opm/parser/eclipse/Deck/DeckValue.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckValue.cpp
@@ -47,6 +47,12 @@ DeckValue::DeckValue(const std::string& value):
     string_value(value)
 {}
 
+DeckValue::DeckValue(const UDAValue& value):
+    default_value(false),
+    value_enum(type_tag::uda),
+    uda_value(value)
+{}
+
 bool DeckValue::is_default() const {
     return default_value;
 }
@@ -79,6 +85,15 @@ std::string DeckValue::get() const {
 }
 
 template<>
+UDAValue DeckValue::get() const {
+    if (value_enum == type_tag::uda)
+        return this->uda_value;
+
+    throw std::invalid_argument("DeckValue does not hold an UDAValue");
+}
+
+
+template<>
 bool DeckValue::is_compatible<int>() const {
     return (value_enum == type_tag::integer);
 }
@@ -94,6 +109,10 @@ bool DeckValue::is_compatible<std::string>() const {
     return (value_enum == type_tag::string);
 }
 
+template<>
+bool DeckValue::is_compatible<UDAValue>() const {
+    return (value_enum == type_tag::uda);
+}
 
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1221,6 +1221,42 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         return std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
     }
 
+    void Schedule::applyKeywords(const DeckView& deck, std::size_t reportStep) {
+        ParseContext parseContext;
+        ErrorGuard errors;
+        std::unordered_set<std::string> affected_wells;
+        std::unordered_map<std::string, double> target_wellpi;
+        std::vector<std::string> matching_wells;
+        const std::string prefix = "| "; /* logger prefix string */
+        this->snapshots.resize(reportStep + 1);
+        auto& input_block = this->m_sched_deck[reportStep];
+        for (const auto& keyword : deck) {
+            input_block.push_back(keyword);
+            this->handleKeyword(reportStep,
+                                input_block,
+                                keyword,
+                                parseContext,
+                                errors,
+                                /*EclipseGrid *grid=*/nullptr,
+                                /*FieldPropsManager *fp=*/nullptr,
+                                matching_wells,
+                                /*actionx_mode=*/false,
+                                &affected_wells,
+                                &target_wellpi);
+        }
+        this->end_report(reportStep);
+        if (reportStep < this->m_sched_deck.size() - 1) {
+            iterateScheduleSection(
+                reportStep + 1,
+                this->m_sched_deck.size(),
+                parseContext,
+                errors,
+                &target_wellpi,
+                /*EclipseGrid *grid=*/nullptr,
+                /*FieldPropsManager *fp=*/nullptr,
+                prefix);
+        }
+    }
 
     std::unordered_set<std::string> Schedule::applyAction(std::size_t reportStep, const time_point&, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& target_wellpi) {
         const std::string prefix = "| ";

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1221,7 +1221,8 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         return std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
     }
 
-    void Schedule::applyKeywords(const Deck& deck, std::size_t reportStep) {
+    void Schedule::applyKeywords(
+             std::vector<DeckKeyword*>& keywords, std::size_t reportStep) {
         ParseContext parseContext;
         ErrorGuard errors;
         std::unordered_set<std::string> affected_wells;
@@ -1230,11 +1231,11 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         const std::string prefix = "| "; /* logger prefix string */
         this->snapshots.resize(reportStep + 1);
         auto& input_block = this->m_sched_deck[reportStep];
-        for (const auto& keyword : deck) {
-            input_block.push_back(keyword);
+        for (auto keyword : keywords) {
+            input_block.push_back(*keyword);
             this->handleKeyword(reportStep,
                                 input_block,
-                                keyword,
+                                *keyword,
                                 parseContext,
                                 errors,
                                 /*EclipseGrid *grid=*/nullptr,

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1221,7 +1221,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         return std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
     }
 
-    void Schedule::applyKeywords(const DeckView& deck, std::size_t reportStep) {
+    void Schedule::applyKeywords(const Deck& deck, std::size_t reportStep) {
         ParseContext parseContext;
         ErrorGuard errors;
         std::unordered_set<std::string> affected_wells;


### PR DESCRIPTION
Adds support for adding keywords to the SCHEDULE section from Python. This is currently work in progress, the plan is to be able to update/change the SCHEDULE from Python by adding a keyword block at a certain report step. For example:

```python
from opm.io.parser import Parser
from opm.io.ecl_state import EclipseState
from opm.io.schedule import Schedule
from opm.io.summary import SummaryConfig
from opm2.simulators import BlackOilSimulator

deck  = Parser().parse('SPE1CASE1.DATA')
state = EclipseState(deck)
schedule = Schedule( deck, state )

report_step = 3
oil_target = 30000  # stb/day
well_name = "PROD"
well_status = "OPEN"
control_mode = "ORAT"
bhp_limit = 1000  # psia
data = """
WCONPROD
	'{}' '{}' '{}' {} 4* {} /
/
""".format(well_name, well_status, control_mode, oil_target, bhp_limit)
schedule.insert_keywords(data, step=report_step)
summary_config = SummaryConfig(deck, state, schedule)
sim = BlackOilSimulator( deck, state, schedule, summary_config  )
sim.step_init()
sim.step()
sim.step()
sim.step()
sim.step()
sim.step()
sim.step()
sim.step_cleanup()
```

Note that in the above example, the input file [`SPE1CASE1.DATA`](https://github.com/OPM/opm-tests/blob/master/spe1/SPE1CASE1.DATA) has initially an oil rate target of 20000 stb/day, see [line 405](https://github.com/OPM/opm-tests/blob/master/spe1/SPE1CASE1.DATA#L405) and we are trying to change that to 30000 at report step #3 in the above Python example. Currently this does not seem to work, as the generated summary output file shows no change in the oil production rate for well `PROD`. Any ideas what can be the issue?
