### PR TITLE
Add Predicate for Potential Rates of W/G Name

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.hpp
@@ -100,6 +100,7 @@ public:
                  const double       guide_rate);
 
     bool has(const std::string& name) const;
+    bool hasPotentials(const std::string& name) const;
     bool has(const std::string& name, const Phase& phase) const;
 
     double get(const std::string& well, const Well::GuideRateTarget target, const RateVector& rates) const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/GuideRate.cpp
@@ -195,6 +195,11 @@ bool Opm::GuideRate::has(const std::string& name) const
     return this->values.count(name) > 0;
 }
 
+bool Opm::GuideRate::hasPotentials(const std::string& name) const
+{
+    return this->potentials.find(name) != this->potentials.end();
+}
+
 bool Opm::GuideRate::has(const std::string& name, const Phase& phase) const
 {
     return this->injection_group_values.count(std::pair(phase, name)) > 0;


### PR DESCRIPTION
This PR adds a new predicate, `GuideRate::hasPotentials()`, that checks whether or not rates exist in the `potentials` array for a particular well or group name.  If neither explicit guide rate values nor potential rates exist for a particular "wgname", then it is an error to call `GuideRate::get()` and that member function will throw an exception.  This new predicate provides a way of avoiding that exception.

This PR closes #2785.