### PR TITLE
changed: use STRING type

### DIFF
--- a/cmake/Modules/FindSuiteSparse.cmake
+++ b/cmake/Modules/FindSuiteSparse.cmake
@@ -259,9 +259,9 @@ foreach (module IN LISTS SuiteSparse_FIND_COMPONENTS)
 	set (SuiteSparse_FOUND FALSE)
 	# use empty string instead of zero, so it can be tested with #ifdef
 	# as well as #if in the source code
-	set (HAVE_SUITESPARSE_${MODULE}_H "" CACHE INT "Is ${module} header present?")
+    set (HAVE_SUITESPARSE_${MODULE}_H "" CACHE STRING "Is ${module} header present?")
   else (NOT SuiteSparse_${MODULE}_FOUND)
-	set (HAVE_SUITESPARSE_${MODULE}_H 1 CACHE INT "Is ${module} header present?")
+    set (HAVE_SUITESPARSE_${MODULE}_H 1 CACHE STRING "Is ${module} header present?")
 	list (APPEND SuiteSparse_LIBRARIES "${${MODULE}_LIBRARIES}")
 	list (APPEND SuiteSparse_LINKER_FLAGS "${${MODULE}_LINKER_FLAGS}")
 	list (APPEND SuiteSparse_INCLUDE_DIRS "${${MODULE}_INCLUDE_DIRS}")


### PR DESCRIPTION
there is no such thing as INT type in cmake

```
CMake Warning (dev) at /var/lib/jenkins/workspace/opm-common-PR-builder@2/mpi/install/share/opm/cmake/Modules/FindSuiteSparse.cmake:264 (set):
  implicitly converting 'INT' to 'STRING' type.
Call Stack (most recent call first):
  /var/lib/jenkins/workspace/opm-common-PR-builder@2/mpi/install/share/opm/cmake/Modules/OpmFind.cmake:144 (find_package)
  /var/lib/jenkins/workspace/opm-common-PR-builder@2/mpi/install/share/opm/cmake/Modules/OpmFind.cmake:236 (find_and_append_package_to)
  /var/lib/jenkins/workspace/opm-common-PR-builder@2/mpi/install/share/opm/cmake/Modules/OpmLibMain.cmake:83 (find_and_append_package_list_to)
  CMakeLists.txt:280 (include)
```