### PR TITLE
Add item IGRP[NWGMAX + 39] to the Eclipse-compatible restart file

### DIFF
--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -74,6 +74,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         GroupLevel = 27,
         ParentGroup = 28,
         FlowingWells = 33,
+        NodeNumber = 39
     };
 
     namespace Value {

--- a/tests/MOD4_TEST_IGRP-DATA.DATA
+++ b/tests/MOD4_TEST_IGRP-DATA.DATA
@@ -75,6 +75,10 @@ REGDIMS
 -- ntfip  nmfipr  nrfreg
     1      1       1* /
 
+NETWORK
+ 3 2 /
+
+
 -- Well dimension data
 -- nwmaxz: max wells in the model
 -- ncwmax: max connections per well
@@ -9707,6 +9711,22 @@ GRUPTREE
  'SE'       'UPPER'  /
  'CENTRAL'  'LOWER'  /
 /
+
+
+
+BRANPROP
+--  Downtree  Uptree   #VFP    ALQ
+    LOWER       MOD4   9999       1* /
+    UPPER        MOD4   9999       1* /
+/
+
+NODEPROP
+--  Node_name  Press  autoChoke?  addGasLift?  Group_name
+     MOD4   21.0   NO          NO           1*  /
+     UPPER       1*     NO          NO           1*  /
+     LOWER      1*     NO          NO           1*  /
+/
+
 
 
 -- This reservoir simulation deck is made available under the Open Database

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -811,16 +811,19 @@ BOOST_AUTO_TEST_CASE (Declared_Group_Data_2)
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax +  5] ,   2); // group available for higher level production control
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 17] ,   1); // group available for higher level water injection control
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 22] ,  -1); // group available for higher level gas injection control
+        BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 39] ,   3); // groups sequence number in the external networt defined
 
         start = 1*ih[VI::intehead::NIGRPZ];
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax +  5] ,   0); // group available for higher level production control
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 17] ,  -1); // group available for higher level water injection control
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 22] ,  -1); // group available for higher level gas injection control
+        BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 39] ,   2); // groups sequence number in the external networt defined
 
         start = 2*ih[VI::intehead::NIGRPZ];
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax +  5] ,   2); // group available for higher level production control
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 17] ,   2); // group available for higher level water injection control
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 22] ,  -1); // group available for higher level gas injection control
+        BOOST_CHECK_EQUAL(iGrp[start + nwgmax + 39] ,   1); // groups sequence number in the external networt defined
 
         start = 3*ih[VI::intehead::NIGRPZ];
         BOOST_CHECK_EQUAL(iGrp[start + nwgmax +  5] ,  -1); // group available for higher level production control


### PR DESCRIPTION
This pull request contains code to output the sequence number of nodes according to the sequence entered with the BRANPROP keyword.  This sequence number is added for the groups that are nodes in the external network defined by the BRANPROP and NODEPROP keywords.

The pull request is ready for review and merge after corrections / improvements based on feedback from reviewers.

The pull request has been checked for unit test in opm-common (ctest) and make check in opm-simulators. The only error discovered is for test 131 (opm-simulators) and is related to IUAP - which should not be affected by this PR.