### PR TITLE
Ensure Continuous Cumulative Liquid Production On Restart

### DIFF
--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -1451,6 +1451,11 @@ namespace {
         smry.update_well_var(well, "WGPT", xwel[VI::XWell::index::GasPrTotal]);
         smry.update_well_var(well, "WVPT", xwel[VI::XWell::index::VoidPrTotal]);
 
+        // Cumulative liquid production = WOPT + WWPT
+        smry.update_well_var(well, "WLPT",
+                             xwel[VI::XWell::index::OilPrTotal] +
+                             xwel[VI::XWell::index::WatPrTotal]);
+
         smry.update_well_var(well, "WWIT", xwel[VI::XWell::index::WatInjTotal]);
         smry.update_well_var(well, "WGIT", xwel[VI::XWell::index::GasInjTotal]);
         smry.update_well_var(well, "WVIT", xwel[VI::XWell::index::VoidInjTotal]);
@@ -1493,6 +1498,11 @@ namespace {
         update("WPT", xgrp[VI::XGroup::index::WatPrTotal]);
         update("GPT", xgrp[VI::XGroup::index::GasPrTotal]);
         update("VPT", xgrp[VI::XGroup::index::VoidPrTotal]);
+
+        // Cumulative liquid production = xOPT + xWPT
+        update("LPT",
+               xgrp[VI::XGroup::index::OilPrTotal] +
+               xgrp[VI::XGroup::index::WatPrTotal]);
 
         update("WIT", xgrp[VI::XGroup::index::WatInjTotal]);
         update("GIT", xgrp[VI::XGroup::index::GasInjTotal]);


### PR DESCRIPTION
The `xLPT` curves should not start at zero in a restarted simulation run.  This commit initialises the cumulative liquid production volume using the value
```
xOPT + xWPT
```
with the individual terms taken from `XWEL` or `XGRP` as appropriate.

Thank you to @tskille for identifying the issue and suggesting the "OPT + WPT" solution.