### PR TITLE
Identify Extended Network Model Node Name Item in ZNODE

### DIFF
--- a/opm/output/eclipse/VectorItems/network.hpp
+++ b/opm/output/eclipse/VectorItems/network.hpp
@@ -61,6 +61,12 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
     };
     }
 
+    namespace ZNode {
+        enum index : std::vector<const char*>::size_type {
+            NodeName = 0, // Node name
+        };
+    } // ZNode
+
 }}}} // Opm::RestartIO::Helpers::VectorItems
 
 #endif // OPM_OUTPUT_ECLIPSE_VECTOR_NETWORK_HPP

--- a/src/opm/output/eclipse/AggregateNetworkData.cpp
+++ b/src/opm/output/eclipse/AggregateNetworkData.cpp
@@ -541,7 +541,7 @@ template <class ZNodeArray>
 void staticContrib(const std::string&       nodeName,
                    ZNodeArray&               zNode)
 {
-    zNode[0] = nodeName;
+    zNode[VI::ZNode::index::NodeName] = nodeName;
 }
 } // Znode
 


### PR DESCRIPTION
In preparation of adding initial support for restarting simulations featuring the extended network model.