### PR TITLE
Load Field-Wide Constraints From Restart File

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Group/Group.cpp
@@ -689,7 +689,10 @@ bool Group::hasGroup(const std::string& group_name) const  {
 void Group::delGroup(const std::string& group_name) {
     auto rm_count = this->m_groups.erase(group_name);
     if (rm_count == 0)
-        throw std::invalid_argument("Group does not have group: " + group_name);
+        throw std::invalid_argument {
+            fmt::format("Group '{}' is not a parent of group: {}",
+                        this->name(), group_name)
+        };
 }
 
 bool Group::update_gefac(double gf, bool transfer_gf) {


### PR DESCRIPTION
If constraints are applied at the field level, e.g., through the `GCONINJE` keyword, then we must incorporate those constraints into FIELD when restarting a simulation run.  This PR takes a step in this direction by explicitly loading the `*GRP` array entries pertaining to FIELD and special casing
```
Schedule::addGroup(rst_group, time)
```
to look for `rst_group.name == "FIELD"`.  In that case, we update the injection and production properties of the existing FIELD group as needed.

While here, also update the diagnostic message of `Group::delGroup()` to report the name of the purported parent group.  This is an aid to analysing rare conditions.