### PR TITLE
Rename EclipseState::apply_geo_keywords -> apply_schedule_keywords

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -102,7 +102,7 @@ namespace Opm {
 
         std::string getTitle() const;
 
-        void apply_geo_keywords(const std::vector<DeckKeyword>& keywords);
+        void apply_schedule_keywords(const std::vector<DeckKeyword>& keywords);
 
         const Runspec& runspec() const;
         const AquiferConfig& aquifer() const;

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -385,7 +385,7 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
         }
     }
 
-    void EclipseState::apply_geo_keywords(const std::vector<DeckKeyword>& keywords) {
+    void EclipseState::apply_schedule_keywords(const std::vector<DeckKeyword>& keywords) {
         using namespace ParserKeywords;
         for (const auto& keyword : keywords) {
 

--- a/tests/parser/integration/TransMultIntegrationTests.cpp
+++ b/tests/parser/integration/TransMultIntegrationTests.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(MULTFLT_IN_SCHEDULE) {
     BOOST_CHECK( schedule[3].events().hasEvent( ScheduleEvents::GEO_MODIFIER) );
     {
         const auto& keywords = schedule[3].geo_keywords();
-        state.apply_geo_keywords( keywords );
+        state.apply_schedule_keywords( keywords );
     }
     BOOST_CHECK_EQUAL( 2.00 , trans.getMultiplier( 2,2,0,FaceDir::XPlus ));
     BOOST_CHECK_EQUAL( 0.10 , trans.getMultiplier( 3,2,0,FaceDir::XPlus ));


### PR DESCRIPTION
Better name - first small PR in an effort to support MULTXYZ keywords in the ACTIONX section.

Downstream: https://github.com/OPM/opm-simulators/pull/3669