### PR TITLE
Support GRAVITY As Fallback for DENSITY

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -51,6 +51,37 @@ struct DensityTable : public FlatTable< DENSITYRecord > {
     }
 };
 
+struct GRAVITYRecord {
+    static constexpr std::size_t size = 3;
+
+    double oil_api;
+    double water_sg;
+    double gas_sg;
+
+    bool operator==(const GRAVITYRecord& data) const {
+        return this->oil_api == data.oil_api &&
+               this->water_sg == data.water_sg &&
+               this->gas_sg == data.gas_sg;
+    }
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->oil_api);
+        serializer(this->water_sg);
+        serializer(this->gas_sg);
+    }
+};
+
+struct GravityTable : public FlatTable< GRAVITYRecord > {
+    using FlatTable< GRAVITYRecord >::FlatTable;
+
+    static GravityTable serializeObject()
+    {
+        return GravityTable({{1.0, 2.0, 3.0}});
+    }
+};
+
 struct DiffCoeffRecord {
     static constexpr std::size_t size = 8;
 

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -1526,6 +1526,7 @@ FlatTable< T >::FlatTable( const DeckKeyword& kw ) :
 {}
 
 template FlatTable< DENSITYRecord >::FlatTable( const DeckKeyword& );
+template FlatTable< GRAVITYRecord >::FlatTable( const DeckKeyword& );
 template FlatTable< DiffCoeffRecord >::FlatTable( const DeckKeyword& );
 template FlatTable< PVTWRecord >::FlatTable( const DeckKeyword& );
 template FlatTable< PVCDORecord >::FlatTable( const DeckKeyword& );

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GRAVITY
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/G/GRAVITY
@@ -17,11 +17,13 @@
     {
       "name": "WATER_SP_GRAVITY",
       "value_type": "DOUBLE",
+      "dimension": "1",
       "default": 1
     },
     {
       "name": "GAS_SP_GRAVITY",
       "value_type": "DOUBLE",
+      "dimension": "1",
       "default": 0.7773
     }
   ]

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -1665,6 +1665,25 @@ BOOST_AUTO_TEST_CASE( TestParseDENSITY ) {
     BOOST_CHECK_EQUAL( 1.3, density[0].gas );
 }
 
+BOOST_AUTO_TEST_CASE( TestParseGRAVITY ) {
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+TABDIMS
+  1* 1 /
+
+GRAVITY
+  12.34 1.2 1.21 /
+
+END
+)");
+
+    const auto tables = Opm::TableManager { deck };
+    const auto& density = tables.getDensityTable();
+
+    BOOST_CHECK_CLOSE(  983.731924360, density[0].oil  , 1.0e-8 );
+    BOOST_CHECK_CLOSE( 1200.0        , density[0].water, 1.0e-8 );
+    BOOST_CHECK_CLOSE(    1.4762     , density[0].gas  , 1.0e-8 );
+}
+
 BOOST_AUTO_TEST_CASE( TestParseDIFFC ) {
     const std::string data = R"(
       TABDIMS


### PR DESCRIPTION
This commit activates support for the `GRAVITY` keyword.  We treat this as a fallback alternative to the `DENSITY` keyword and simply convert `GRAVITY` data to `DENSITY` data on input.  This means that fluid densities at surface conditions will be reported to the `.INIT` file as if they were entered using the `DENSITY` keyword.