### PR TITLE
Add mutable EclipseState::getTransMult()

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -77,6 +77,7 @@ namespace Opm {
         const FaultCollection& getFaults() const;
         const MICPpara& getMicppara() const;
         const TransMult& getTransMult() const;
+        TransMult& getTransMult();
 
         /// non-neighboring connections
         /// the non-standard adjacencies as specified in input deck

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -261,6 +261,10 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
         return m_transMult;
     }
 
+    TransMult& EclipseState::getTransMult() {
+        return m_transMult;
+    }
+
     const NNC& EclipseState::getInputNNC() const {
         return m_inputNnc;
     }


### PR DESCRIPTION
This is required in order to broadcast runtime updated transmissibility multipliers.