### PR TITLE
Corrections to output of network data to Eclipse compatible restart file

### DIFF
--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -123,6 +123,11 @@ namespace Opm { namespace RestartIO {
       int   nominated_phase;
      };
 
+
+     struct ActiveNetwork {
+         int actnetwrk;
+     };
+
      struct NetworkDims {
             int noactnod;
             int noactbr;
@@ -216,6 +221,7 @@ namespace Opm { namespace RestartIO {
         InteHEAD& tuningParam(const TuningPar& tunpar);
         InteHEAD& variousParam(const int version, const int iprog);
         InteHEAD& wellSegDimensions(const WellSegDims& wsdim);
+        InteHEAD& activeNetwork(const ActiveNetwork& actntwrk);
         InteHEAD& networkDimensions(const NetworkDims& nwdim);
         InteHEAD& netBalanceData(const NetBalanceDims& nwbaldim);
         InteHEAD& regionDimensions(const RegDims& rdim);

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -94,6 +94,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
         WHISTC = 71, //  Calendar year of report step
 
+        ACTNETWRK = 74, //  Indicator for active external network (= 0: no active network, = 2 Active network)
+
         NETBALAN_5 = 77, // NETBALAN, Item5
         NETBALAN_3 = 79, // NETBALAN, Item3
 

--- a/src/opm/output/eclipse/AggregateNetworkData.cpp
+++ b/src/opm/output/eclipse/AggregateNetworkData.cpp
@@ -599,7 +599,7 @@ allocate(const std::vector<int>& inteHead)
     using WV = Opm::RestartIO::Helpers::WindowedArray<double>;
 
     return WV {
-        WV::NumWindows{ nodmax(inteHead) },
+        WV::NumWindows{ nbrmax(inteHead) },
         WV::WindowSize{ entriesPerRbran(inteHead) }
     };
 }

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -123,7 +123,7 @@ enum index : std::vector<int>::size_type {
   NWHISTCTL    =       VI::intehead::WHISTC,   //       index for WHISTCTL keyword
   ih_072       =       72       ,              //       0       0
   ih_073       =       73       ,              //       0       0
-  ih_074       =       74       ,              //       0       0
+  ACTIVENETWRK =       VI::intehead::ACTNETWRK,  // Indicator for active external network (= 0: no active network, = 2 Active network)
   ih_075       =       75       ,              //       0       0
   ih_076       =       76       ,              //       0       0       2
   NETBALAN_5   =       VI::intehead::NETBALAN_5, // NETBALAN item 5 - Maximum number of iterations allowed in the calculation of the THP
@@ -793,6 +793,16 @@ liftOptParam(int in_enc)
 
     return *this;
 }
+
+Opm::RestartIO::InteHEAD&
+Opm::RestartIO::InteHEAD::activeNetwork(const ActiveNetwork& actntwrk)
+{
+    this->data_[ACTIVENETWRK] = actntwrk.actnetwrk;
+
+    return *this;
+}
+
+
 
 Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::networkDimensions(const NetworkDims& nwdim)

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/N/NETBALAN
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/N/NETBALAN
@@ -15,7 +15,7 @@
     {
       "name": "PRESSURE_CONVERGENCE_LIMIT",
       "value_type": "DOUBLE",
-      "default": 1e+04,
+      "default": 1.e-01,
       "dimension" : "Pressure"
     },
     {

--- a/src/opm/parser/eclipse/share/keywords/000_Eclipse100/N/NETBALAN
+++ b/src/opm/parser/eclipse/share/keywords/000_Eclipse100/N/NETBALAN
@@ -15,7 +15,7 @@
     {
       "name": "PRESSURE_CONVERGENCE_LIMIT",
       "value_type": "DOUBLE",
-      "default": 1e-01,
+      "default": 1e+04,
       "dimension" : "Pressure"
     },
     {

--- a/tests/test_AggregateNetworkData.cpp
+++ b/tests/test_AggregateNetworkData.cpp
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE (Constructor)
     BOOST_CHECK_EQUAL(static_cast<int>(networkData.getINobr().size()), ih[VI::NINOBR]);
     BOOST_CHECK_EQUAL(static_cast<int>(networkData.getZNode().size()), ih[VI::NZNODE] * ih[VI::NODMAX]);
     BOOST_CHECK_EQUAL(static_cast<int>(networkData.getRNode().size()), ih[VI::NRNODE] * ih[VI::NODMAX]);
-    BOOST_CHECK_EQUAL(static_cast<int>(networkData.getRBran().size()), ih[VI::NRBRAN] * ih[VI::NODMAX]);
+    BOOST_CHECK_EQUAL(static_cast<int>(networkData.getRBran().size()), ih[VI::NRBRAN] * ih[VI::NBRMAX]);
 
     //INode-parameters
     const auto& iNode = networkData.getINode();


### PR DESCRIPTION
This pull request contains corrections to the output of information for external networks to the Eclipse compatible restart file. 

1. An integer flag that indicates whether an active network is present in the model or not
2. Output of default NETBALAN vallues if an active network is present but the NETBALAN keyword is not used.
