### PR TITLE
Register ecl io tests using the file list in CMakeLists_files.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,11 +300,6 @@ if(ENABLE_ECL_INPUT)
       ${PROJECT_BINARY_DIR}/tests
     )
 
-  foreach(test test_EclIO test_EGrid test_ERft test_ERst test_ESmry test_EInit test_ExtESmry)
-    opm_add_test(${test} CONDITION ENABLE_ECL_INPUT AND Boost_UNIT_TEST_FRAMEWORK_FOUND
-                         LIBRARIES ${_libs}
-                         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
-  endforeach()
 endif()
 
 # Install build system files and documentation

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -354,6 +354,13 @@ if(ENABLE_ECL_INPUT)
     tests/test_ERsm.cpp
     tests/test_GuideRate.cpp
     tests/test_RestartFileView.cpp
+    tests/test_EclIO.cpp
+    tests/test_EGrid.cpp
+    tests/test_ERft.cpp
+    tests/test_ERst.cpp
+    tests/test_ESmry.cpp
+    tests/test_EInit.cpp
+    tests/test_ExtESmry.cpp
     tests/parser/ACTIONX.cpp
     tests/parser/ADDREGTests.cpp
     tests/parser/AquiferTests.cpp


### PR DESCRIPTION
Small change: register a lists of tests the "normal" way.