### PR TITLE
List link dependencies as private.

### DIFF
--- a/cmake/Templates/opm-project.pc.in
+++ b/cmake/Templates/opm-project.pc.in
@@ -9,5 +9,6 @@ Name: @name@
 Description: @description@ @major@.@minor@
 Version: @major@.@minor@
 URL: http://opm-project.org
-Libs: @target@ @libs@
+Libs.private: @libs@
+Libs: @target@
 Cflags: @includes@ @defs@


### PR DESCRIPTION
This hides them for shared libraries that do not need them.
Should fix the following lintian warnings:
```
W: libopm-common-dev: pkg-config-references-unknown-shared-library usr/lib/x86_64-linux-gnu/pkgconfig/opm-common.pc -lpython3.7m (line 12)
W: libopm-common-dev: pkg-config-references-unknown-shared-library usr/lib/x86_64-linux-gnu/pkgconfig/opm-common.pc -lstdc++fs (line 12)
W: libopm-common-dev: pkg-config-references-unknown-shared-library usr/lib/x86_64-linux-gnu/pkgconfig/opm-common.pc -lgomp (line 12)
W: libopm-common-dev: pkg-config-references-unknown-shared-library usr/lib/x86_64-linux-gnu/pkgconfig/opm-common.pc -lboost_system (line 12)
W: libopm-common-dev: pkg-config-references-unknown-shared-library usr/lib/x86_64-linux-gnu/pkgconfig/opm-common.pc -lcjson (line 12)
```
Gbp-Pq: Name 0002-List-link-dependencies-as-private.patch

Patch is needed for Debian and seems like an improvement