### PR TITLE
Add rpath to libopmcommon.so in the build directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,7 +357,12 @@ if (OPM_ENABLE_PYTHON)
     endif()
 
     if (BUILD_SHARED_LIBS)
-      list(APPEND _python_rpath_list "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+      if (OPM_INSTALL_PYTHON)
+        list(APPEND _python_rpath_list "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+        list(APPEND _python_rpath_list "${PROJECT_BINARY_DIR}/lib")
+      else()
+        list(APPEND _python_rpath_list "${PROJECT_BINARY_DIR}/lib")
+      endif()
     endif()
 
     if (_python_rpath_list)


### PR DESCRIPTION
Currently, an rpath to the install directory of `libopmcommon.so` is generated for `libopmcommon_python.so`, but a similar rpath is not added to the `libopmcommon.so` in the build directory. It is useful to be able to use the build directory libraries when not compiling with `-DOPM_INSTALL_PYTHON` or when developing.

This PR fixes issue #2843 for me.