### PR TITLE
Refactor Deck to use a call to operator[] instead of method getKeyword()

### DIFF
--- a/examples/opmpack.cpp
+++ b/examples/opmpack.cpp
@@ -171,7 +171,7 @@ int main(int argc, char** argv) {
 
             using GDFILE = Opm::ParserKeywords::GDFILE;
             if (deck.hasKeyword<GDFILE>()) {
-                const auto& gdfile_keyword = deck.getKeyword<GDFILE>();
+                const auto& gdfile_keyword = deck.getKeyword<GDFILE>().back();
                 const auto& fname = gdfile_keyword.getRecord(0).getItem<GDFILE::filename>().get<std::string>(0);
                 copy_file(input_arg.parent_path(), fname, output_dir);
             }

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -101,8 +101,6 @@ namespace Opm {
 
             const DeckKeyword& getKeyword( const std::string& keyword, size_t index ) const;
             const DeckKeyword& getKeyword( const std::string& keyword ) const;
-            const DeckKeyword& getKeyword( size_t index ) const;
-            DeckKeyword& getKeyword( size_t index );
 
             const DeckKeyword& operator[](std::size_t index) const;
 

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -99,8 +99,6 @@ namespace Opm {
             const_iterator begin() const;
             const_iterator end() const;
 
-            const DeckKeyword& getKeyword( const std::string& keyword, size_t index ) const;
-
             Opm::DeckView operator[](const std::string& keyword) const;
             const DeckKeyword& operator[](std::size_t index) const;
 
@@ -110,7 +108,7 @@ namespace Opm {
             }
             template< class Keyword >
             const DeckKeyword& getKeyword( size_t index ) const {
-                return getKeyword( Keyword::keywordName, index );
+                return this->operator[](Keyword::keywordName)[index];
             }
 
             std::vector< const DeckKeyword* > getKeywordList( const std::string& keyword ) const;

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -100,13 +100,13 @@ namespace Opm {
             const_iterator end() const;
 
             const DeckKeyword& getKeyword( const std::string& keyword, size_t index ) const;
-            const DeckKeyword& getKeyword( const std::string& keyword ) const;
 
+            Opm::DeckView operator[](const std::string& keyword) const;
             const DeckKeyword& operator[](std::size_t index) const;
 
             template< class Keyword >
-            const DeckKeyword& getKeyword() const {
-                return getKeyword( Keyword::keywordName );
+            Opm::DeckView getKeyword() const {
+                return this->operator[](Keyword::keywordName);
             }
             template< class Keyword >
             const DeckKeyword& getKeyword( size_t index ) const {

--- a/python/cxx/deck.cpp
+++ b/python/cxx/deck.cpp
@@ -24,7 +24,7 @@ namespace {
     const DeckKeyword& getKeyword_tuple( const Deck& deck, py::tuple kw_index ) {
         const std::string kw = py::cast<const std::string>(kw_index[0]);
         const size_t index = py::cast<size_t>(kw_index[1]);
-        return deck.getKeyword(kw, index);
+        return deck[kw][index];
     }
 
     const DeckKeyword& getKeyword_string( const Deck& deck, const std::string& kw ) {

--- a/python/cxx/deck.cpp
+++ b/python/cxx/deck.cpp
@@ -28,11 +28,11 @@ namespace {
     }
 
     const DeckKeyword& getKeyword_string( const Deck& deck, const std::string& kw ) {
-        return deck.getKeyword(kw);
+        return deck[kw].back();
     }
 
     const DeckKeyword& getKeyword_int( const Deck& deck, size_t index ) {
-        return deck.getKeyword(index);
+        return deck[index];
     }
 
     //This adds a keyword by copy

--- a/src/opm/output/eclipse/EclipseGridInspector.cpp
+++ b/src/opm/output/eclipse/EclipseGridInspector.cpp
@@ -71,13 +71,13 @@ void EclipseGridInspector::init_()
 
     if (deck_.hasKeyword("SPECGRID")) {
         const auto& specgridRecord =
-            deck_.getKeyword("SPECGRID").getRecord(0);
+            deck_["SPECGRID"].back().getRecord(0);
         logical_gridsize_[0] = specgridRecord.getItem("NX").get< int >(0);
         logical_gridsize_[1] = specgridRecord.getItem("NY").get< int >(0);
         logical_gridsize_[2] = specgridRecord.getItem("NZ").get< int >(0);
     } else if (deck_.hasKeyword("DIMENS")) {
         const auto& dimensRecord =
-            deck_.getKeyword("DIMENS").getRecord(0);
+            deck_["DIMENS"].back().getRecord(0);
         logical_gridsize_[0] = dimensRecord.getItem("NX").get< int >(0);
         logical_gridsize_[1] = dimensRecord.getItem("NY").get< int >(0);
         logical_gridsize_[2] = dimensRecord.getItem("NZ").get< int >(0);
@@ -100,13 +100,13 @@ std::pair<double,double> EclipseGridInspector::cellDips(int i, int j, int k) con
 {
     checkLogicalCoords(i, j, k);
     const std::vector<double>& pillc =
-        deck_.getKeyword("COORD").getSIDoubleData();
+        deck_["COORD"].back().getSIDoubleData();
     int num_pillars = (logical_gridsize_[0] + 1)*(logical_gridsize_[1] + 1);
         if (6*num_pillars != int(pillc.size())) {
         throw std::runtime_error("Wrong size of COORD field.");
     }
     const std::vector<double>& z =
-        deck_.getKeyword("ZCORN").getSIDoubleData();
+        deck_["ZCORN"].back().getSIDoubleData();
     int num_cells = logical_gridsize_[0]*logical_gridsize_[1]*logical_gridsize_[2];
     if (8*num_cells != int(z.size())) {
         throw std::runtime_error("Wrong size of ZCORN field");
@@ -210,13 +210,13 @@ double EclipseGridInspector::cellVolumeVerticalPillars(int i, int j, int k) cons
     // Checking parameters and obtaining values from parser.
     checkLogicalCoords(i, j, k);
     const std::vector<double>& pillc =
-        deck_.getKeyword("COORD").getSIDoubleData();
+        deck_["COORD"].back().getSIDoubleData();
     int num_pillars = (logical_gridsize_[0] + 1)*(logical_gridsize_[1] + 1);
     if (6*num_pillars != int(pillc.size())) {
 	throw std::runtime_error("Wrong size of COORD field.");
     }
     const std::vector<double>& z =
-        deck_.getKeyword("ZCORN").getSIDoubleData();
+        deck_["ZCORN"].back().getSIDoubleData();
     int num_cells = logical_gridsize_[0]*logical_gridsize_[1]*logical_gridsize_[2];
     if (8*num_cells != int(z.size())) {
 	throw std::runtime_error("Wrong size of ZCORN field");
@@ -278,8 +278,8 @@ std::array<double, 6> EclipseGridInspector::getGridLimits() const
         throw std::runtime_error("EclipseGridInspector: Grid does not have SPECGRID, COORD, and ZCORN, can't find dimensions.");
     }
 
-    std::vector<double> coord = deck_.getKeyword("COORD").getSIDoubleData();
-    std::vector<double> zcorn = deck_.getKeyword("ZCORN").getSIDoubleData();
+    std::vector<double> coord = deck_["COORD"].back().getSIDoubleData();
+    std::vector<double> zcorn = deck_["ZCORN"].back().getSIDoubleData();
 
     double xmin = +DBL_MAX;
     double xmax = -DBL_MAX;
@@ -328,7 +328,7 @@ std::array<int, 3> EclipseGridInspector::gridSize() const
 std::array<double, 8> EclipseGridInspector::cellZvals(int i, int j, int k) const
 {
     // Get the zcorn field.
-    const std::vector<double>& z = deck_.getKeyword("ZCORN").getSIDoubleData();
+    const std::vector<double>& z = deck_["ZCORN"].back().getSIDoubleData();
     int num_cells = logical_gridsize_[0]*logical_gridsize_[1]*logical_gridsize_[2];
     if (8*num_cells != int(z.size())) {
 	throw std::runtime_error("Wrong size of ZCORN field");

--- a/src/opm/parser/eclipse/Deck/Deck.cpp
+++ b/src/opm/parser/eclipse/Deck/Deck.cpp
@@ -66,14 +66,13 @@ const DeckView& Deck::global_view() const {
         return this->global_view().operator[](keyword)[index];
     }
 
-    const DeckKeyword& Deck::getKeyword( const std::string& keyword ) const {
-        return this->global_view().operator[](keyword).back();
-    }
-
     const DeckKeyword& Deck::operator[](std::size_t index) const {
         return this->keywordList.at(index);
     }
 
+    Opm::DeckView Deck::operator[](const std::string& keyword) const {
+        return this->global_view()[keyword];
+    } 
 
     Deck::Deck( const Deck& d )
         : keywordList( d.keywordList )

--- a/src/opm/parser/eclipse/Deck/Deck.cpp
+++ b/src/opm/parser/eclipse/Deck/Deck.cpp
@@ -60,19 +60,14 @@ const DeckView& Deck::global_view() const {
     return *this->m_global_view;
 }
 
-
-
-    const DeckKeyword& Deck::getKeyword( const std::string& keyword, size_t index ) const {
-        return this->global_view().operator[](keyword)[index];
-    }
+    Opm::DeckView Deck::operator[](const std::string& keyword) const {
+        return this->global_view()[keyword];
+    } 
 
     const DeckKeyword& Deck::operator[](std::size_t index) const {
         return this->keywordList.at(index);
     }
 
-    Opm::DeckView Deck::operator[](const std::string& keyword) const {
-        return this->global_view()[keyword];
-    } 
 
     Deck::Deck( const Deck& d )
         : keywordList( d.keywordList )

--- a/src/opm/parser/eclipse/Deck/Deck.cpp
+++ b/src/opm/parser/eclipse/Deck/Deck.cpp
@@ -70,14 +70,9 @@ const DeckView& Deck::global_view() const {
         return this->global_view().operator[](keyword).back();
     }
 
-    const DeckKeyword& Deck::getKeyword( size_t index ) const {
-        return this->operator[](index);
-    }
-
     const DeckKeyword& Deck::operator[](std::size_t index) const {
         return this->keywordList.at(index);
     }
-
 
 
     Deck::Deck( const Deck& d )
@@ -132,11 +127,6 @@ const DeckView& Deck::global_view() const {
     void Deck::addKeyword( const DeckKeyword& keyword ) {
         DeckKeyword kw = keyword;
         this->addKeyword( std::move( kw ) );
-    }
-
-
-    DeckKeyword& Deck::getKeyword( size_t index ) {
-        return this->keywordList.at( index );
     }
 
     UnitSystem& Deck::getDefaultUnitSystem() {

--- a/src/opm/parser/eclipse/Deck/DeckSection.cpp
+++ b/src/opm/parser/eclipse/Deck/DeckSection.cpp
@@ -88,7 +88,7 @@ const std::unordered_map<std::string, std::size_t> section_index = {
     {
         auto [start_index, end_index] = index_pair(deck, section);
         for (std::size_t index = start_index; index < end_index; index++)
-            this->add_keyword(deck.getKeyword(index));
+            this->add_keyword(deck[index]);
     }
 
 

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/Aquancon.cpp
@@ -145,7 +145,7 @@ namespace Opm {
         std::map<std::size_t, Aquancon::AquancCell> work;
         const std::vector<int>& actnum = grid.getACTNUM();
         for (std::size_t iaq = 0; iaq < deck.count("AQUANCON"); iaq++) {
-            const auto& aquanconKeyword = deck.getKeyword("AQUANCON", iaq);
+            const auto& aquanconKeyword = deck["AQUANCON"][iaq];
             OpmLog::info(OpmInputError::format("Initializing aquifer connections from {keyword} in {file} line {line}", aquanconKeyword.location()));
             for (const auto& aquanconRecord : aquanconKeyword) {
                 const int aquiferID = aquanconRecord.getItem("AQUIFER_ID").get<int>(0);

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/AquiferCT.cpp
@@ -220,7 +220,7 @@ AquiferCT::AquiferCT(const TableManager& tables, const Deck& deck)
     if (!deck.hasKeyword<AQUCT>())
         return;
 
-    const auto& aquctKeyword = deck.getKeyword<AQUCT>();
+    const auto& aquctKeyword = deck.getKeyword<AQUCT>().back();
     OpmLog::info(OpmInputError::format("Initializing Carter Tracey aquifers from {keyword} in {file} line {line}", aquctKeyword.location()));
     for (auto& record : aquctKeyword)
         this->m_aquct.emplace_back(record, tables);

--- a/src/opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Aquifer/Aquifetp.cpp
@@ -141,7 +141,7 @@ Aquifetp::Aquifetp(const TableManager& tables, const Deck& deck)
     if (!deck.hasKeyword<AQUFETP>())
         return;
 
-    const auto& aqufetpKeyword = deck.getKeyword<AQUFETP>();
+    const auto& aqufetpKeyword = deck.getKeyword<AQUFETP>().back();
     OpmLog::info(OpmInputError::format("Initializing Fetkovich aquifers from {keyword} in {file} line {line}", aqufetpKeyword.location()));
     for (auto& record : aqufetpKeyword)
         this->m_aqufetp.emplace_back(record, tables);

--- a/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -142,7 +142,7 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
             OpmLog::info(fmt::format("Only {} fluid phases are enabled",  this->runspec().phases().size() ));
 
         if (deck.hasKeyword( "TITLE" )) {
-            const auto& titleKeyword = deck.getKeyword( "TITLE" );
+            const auto& titleKeyword = deck["TITLE"].back();
             const auto& item = titleKeyword.getRecord( 0 ).getItem( 0 );
             std::vector<std::string> itemValue = item.getData<std::string>();
             for (const auto& entry : itemValue)
@@ -155,7 +155,7 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
 
         const auto& init_config = this->getInitConfig();
         if (init_config.restartRequested()) {
-            const auto& restart_keyword = deck.getKeyword<ParserKeywords::RESTART>();
+            const auto& restart_keyword = deck.getKeyword<ParserKeywords::RESTART>().back();
             const auto& io_config = this->getIOConfig();
             const int report_step = init_config.getRestartStep();
             const auto& restart_file = io_config.getRestartFileName( init_config.getRestartRootName(), report_step, false);

--- a/src/opm/parser/eclipse/EclipseState/EndpointScaling.cpp
+++ b/src/opm/parser/eclipse/EclipseState/EndpointScaling.cpp
@@ -151,6 +151,7 @@ bool threepoint_scaling( const Deck& deck ) {
      */
     const auto value = std::toupper(
         deck.getKeyword<ScaleCRS>()
+            .back()
             .getRecord(0)
             .getItem<ScaleCRS::VALUE>()
             .get<std::string>(0).front());
@@ -217,7 +218,7 @@ EndpointScaling::EndpointScaling( const Deck& deck ) {
         bool reversible_ = true;
 
         if (has_endscale) {
-            const auto& endscale = deck.getKeyword<ParserKeywords::ENDSCALE>();
+            const auto& endscale = deck.getKeyword<ParserKeywords::ENDSCALE>().back();
             direct_ = !endscale_nodir( endscale );
             reversible_ = endscale_revers( endscale );
         }

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -265,7 +265,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
             // actnum already reset in initBinaryGrid
         } else {
             if (deck.hasKeyword<ParserKeywords::ACTNUM>()) {
-                const auto& actnumData = deck.getKeyword<ParserKeywords::ACTNUM>().getIntData();
+                const auto& actnumData = deck.getKeyword<ParserKeywords::ACTNUM>().back().getIntData();
                 /*
                   Would have liked to fail hard in the case where the size of the
                   ACTNUM array disagrees with nx*ny*nz; but it is possible to embed
@@ -338,7 +338,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         }
 
         if (deck.hasKeyword<ParserKeywords::PINCH>()) {
-            const auto& record = deck.getKeyword<ParserKeywords::PINCH>( ).getRecord(0);
+            const auto& record = deck.getKeyword<ParserKeywords::PINCH>( ).back().getRecord(0);
             const auto& item = record.getItem<ParserKeywords::PINCH::THRESHOLD_THICKNESS>( );
             m_pinch = item.getSIDouble(0);
 
@@ -357,13 +357,13 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
         m_minpvVector.resize(getCartesianSize(), 0.0);
         if (deck.hasKeyword<ParserKeywords::MINPV>()) {
-            const auto& record = deck.getKeyword<ParserKeywords::MINPV>( ).getRecord(0);
+            const auto& record = deck.getKeyword<ParserKeywords::MINPV>( ).back().getRecord(0);
             const auto& item = record.getItem<ParserKeywords::MINPV::VALUE>( );
             std::fill(m_minpvVector.begin(), m_minpvVector.end(), item.getSIDouble(0));
             m_minpvMode = MinpvMode::ModeEnum::EclSTD;
         } else if(deck.hasKeyword<ParserKeywords::MINPVV>()) {
             // We should use the grid properties to support BOX, but then we need the eclipseState
-            const auto& record = deck.getKeyword<ParserKeywords::MINPVV>( ).getRecord(0);
+            const auto& record = deck.getKeyword<ParserKeywords::MINPVV>( ).back().getRecord(0);
             m_minpvVector =record.getItem(0).getSIDoubleData();
             m_minpvMode = MinpvMode::ModeEnum::EclSTD;
         }
@@ -530,7 +530,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
     void EclipseGrid::initBinaryGrid(const Deck& deck) {
 
-        const DeckKeyword& gdfile_kw = deck.getKeyword("GDFILE");
+        const DeckKeyword& gdfile_kw = deck["GDFILE"].back();
         const std::string& gdfile_arg = gdfile_kw.getRecord(0).getItem("filename").get<std::string>(0);
         std::string filename = deck.makeDeckPath(gdfile_arg);
 
@@ -561,10 +561,10 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
     void EclipseGrid::initDVDEPTHZGrid(const Deck& deck) {
       OpmLog::info(fmt::format("\nCreating grid from keywords DXV, DYV, DZV and DEPTHZ"));
-        const std::vector<double>& DXV = deck.getKeyword<ParserKeywords::DXV>().getSIDoubleData();
-        const std::vector<double>& DYV = deck.getKeyword<ParserKeywords::DYV>().getSIDoubleData();
-        const std::vector<double>& DZV = deck.getKeyword<ParserKeywords::DZV>().getSIDoubleData();
-        const std::vector<double>& DEPTHZ = deck.getKeyword<ParserKeywords::DEPTHZ>().getSIDoubleData();
+        const std::vector<double>& DXV = deck.getKeyword<ParserKeywords::DXV>().back().getSIDoubleData();
+        const std::vector<double>& DYV = deck.getKeyword<ParserKeywords::DYV>().back().getSIDoubleData();
+        const std::vector<double>& DZV = deck.getKeyword<ParserKeywords::DZV>().back().getSIDoubleData();
+        const std::vector<double>& DEPTHZ = deck.getKeyword<ParserKeywords::DEPTHZ>().back().getSIDoubleData();
         auto nx = this->getNX();
         auto ny = this->getNY();
         auto nz = this->getNZ();
@@ -1003,9 +1003,9 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         if (!(deck.hasKeyword<ParserKeywords::DZ>() || deck.hasKeyword<ParserKeywords::DZV>()) || !deck.hasKeyword<ParserKeywords::TOPS>())
             throw std::logic_error("The vertical cell size must be specified using the DZ or DZV, and the TOPS keywords");
 
-        const std::vector<double>& drv     = deck.getKeyword<ParserKeywords::DRV>().getSIDoubleData();
-        const std::vector<double>& dthetav = deck.getKeyword<ParserKeywords::DTHETAV>().getSIDoubleData();
-        const std::vector<double>& tops    = deck.getKeyword<ParserKeywords::TOPS>().getSIDoubleData();
+        const std::vector<double>& drv     = deck.getKeyword<ParserKeywords::DRV>().back().getSIDoubleData();
+        const std::vector<double>& dthetav = deck.getKeyword<ParserKeywords::DTHETAV>().back().getSIDoubleData();
+        const std::vector<double>& tops    = deck.getKeyword<ParserKeywords::TOPS>().back().getSIDoubleData();
         OpmLog::info(fmt::format("\nCreating {} grid from keywords DRV, DTHETAV, DZV and TOPS", kind));
 
         if (drv.size() != this->getNX())
@@ -1019,12 +1019,12 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
 
         std::vector<double> dz(volume);
         if (deck.hasKeyword<ParserKeywords::DZ>()) {
-            const std::vector<double>& dz_deck = deck.getKeyword<ParserKeywords::DZ>().getSIDoubleData();
+            const std::vector<double>& dz_deck = deck.getKeyword<ParserKeywords::DZ>().back().getSIDoubleData();
             if (dz_deck.size() != volume)
                 throw std::invalid_argument("DZ keyword should have exactly " + std::to_string( volume ) + " elements");
             dz = dz_deck;
         } else {
-            const std::vector<double>& dzv = deck.getKeyword<ParserKeywords::DZV>().getSIDoubleData();
+            const std::vector<double>& dzv = deck.getKeyword<ParserKeywords::DZV>().back().getSIDoubleData();
             if (dzv.size() != this->getNZ())
                 throw std::invalid_argument("DZV keyword should have exactly " + std::to_string( this->getNZ() ) + " elements");
             for (std::size_t k= 0; k < this->getNZ(); k++)
@@ -1077,7 +1077,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
                 std::vector<double> tj(this->getNY() + 1);
                 double z1 = *std::min_element( zcorn.begin() , zcorn.end());
                 double z2 = *std::max_element( zcorn.begin() , zcorn.end());
-                ri[0] = deck.getKeyword<ParserKeywords::INRAD>().getRecord(0).getItem(0).getSIDouble( 0 );
+                ri[0] = deck.getKeyword<ParserKeywords::INRAD>().back().getRecord(0).getItem(0).getSIDouble( 0 );
                 for (std::size_t i = 1; i <= this->getNX(); i++)
                     ri[i] = ri[i - 1] + drv[i - 1];
 
@@ -1138,8 +1138,8 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
     void EclipseGrid::initCornerPointGrid(const Deck& deck) {
         assertCornerPointKeywords(deck);
         {
-            const auto& ZCORNKeyWord = deck.getKeyword<ParserKeywords::ZCORN>();
-            const auto& COORDKeyWord = deck.getKeyword<ParserKeywords::COORD>();
+            const auto& ZCORNKeyWord = deck.getKeyword<ParserKeywords::ZCORN>().back();
+            const auto& COORDKeyWord = deck.getKeyword<ParserKeywords::COORD>().back();
 
             const std::vector<double>& zcorn = ZCORNKeyWord.getSIDoubleData();
             const std::vector<double>& coord = COORDKeyWord.getSIDoubleData();
@@ -1148,7 +1148,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
             std::vector<int> actnumVector;
 
             if (deck.hasKeyword<ParserKeywords::ACTNUM>()) {
-                 const auto& actnumKeyword = deck.getKeyword<ParserKeywords::ACTNUM>();
+                 const auto& actnumKeyword = deck.getKeyword<ParserKeywords::ACTNUM>().back();
                 actnumVector = actnumKeyword.getIntData();
 
                 if (actnumVector.size() != this->getCartesianSize())
@@ -1178,7 +1178,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         const int ny = this->getNY();
         const int nz = this->getNZ();
         {
-            const auto& ZCORNKeyWord = deck.getKeyword<ParserKeywords::ZCORN>();
+            const auto& ZCORNKeyWord = deck.getKeyword<ParserKeywords::ZCORN>().back();
 
             if (ZCORNKeyWord.getDataSize() != static_cast<size_t>(8*nx*ny*nz)) {
                 const std::string msg =
@@ -1191,7 +1191,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         }
 
         {
-            const auto& COORDKeyWord = deck.getKeyword<ParserKeywords::COORD>();
+            const auto& COORDKeyWord = deck.getKeyword<ParserKeywords::COORD>().back();
             if (COORDKeyWord.getDataSize() != static_cast<size_t>(6*(nx + 1)*(ny + 1))) {
                 const std::string msg =
                     "Wrong size of the COORD keyword: Expected 6*(nx + 1)*(ny + 1) = "
@@ -1292,7 +1292,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         double z_tolerance = 1e-6;
         size_t volume = dims[0] * dims[1] * dims[2];
         size_t area = dims[0] * dims[1];
-        const auto& TOPSKeyWord = deck.getKeyword<ParserKeywords::TOPS>();
+        const auto& TOPSKeyWord = deck.getKeyword<ParserKeywords::TOPS>().back();
         std::vector<double> TOPS = TOPSKeyWord.getSIDoubleData();
 
         if (TOPS.size() >= area) {
@@ -1326,7 +1326,7 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         size_t area = dims[0] * dims[1];
         std::vector<double> D;
         if (deck.hasKeyword(DKey)) {
-            D = deck.getKeyword( DKey ).getSIDoubleData();
+            D = deck[DKey].back().getSIDoubleData();
 
 
             if (D.size() >= area && D.size() < volume) {
@@ -1345,7 +1345,7 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
             if (D.size() != volume)
                 throw std::invalid_argument(DKey + " size mismatch");
         } else {
-            const auto& DVKeyWord = deck.getKeyword(DVKey);
+            const auto& DVKeyWord = deck[DVKey].back();
             const std::vector<double>& DV = DVKeyWord.getSIDoubleData();
             if (DV.size() != static_cast<std::size_t>(dims[dim]))
                 throw std::invalid_argument(DVKey + " size mismatch");

--- a/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -442,7 +442,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         keywordList.reserve(deck.size());
 
         for (size_t n=0;n<deck.size();n++){
-            DeckKeyword kw = deck.getKeyword( n );
+            DeckKeyword kw = deck[n];
             keywordList.push_back(kw.name());
         }
 

--- a/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -154,7 +154,7 @@ namespace {
  */
 std::string default_region_keyword(const Deck& deck) {
     if (deck.hasKeyword("GRIDOPTS")) {
-        const auto& gridOpts = deck.getKeyword("GRIDOPTS");
+        const auto& gridOpts = deck["GRIDOPTS"].back();
         const auto& record = gridOpts.getRecord(0);
         const auto& nrmult_item = record.getItem("NRMULT");
 
@@ -451,7 +451,7 @@ FieldProps::FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid
     this->tran.emplace( "TRANZ", Fieldprops::TranCalculator("TRANZ") );
 
     if (deck.hasKeyword<ParserKeywords::MULTREGP>()) {
-        const DeckKeyword& multregpKeyword = deck.getKeyword("MULTREGP");
+        const DeckKeyword& multregpKeyword = deck["MULTREGP"].back();
         for (const auto& record : multregpKeyword) {
             int region_value = record.getItem("REGION").get<int>(0);
             if (region_value <= 0)

--- a/src/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
@@ -55,9 +55,9 @@ namespace Opm {
 
     GridDims::GridDims(const Deck& deck) {
         if (deck.hasKeyword("SPECGRID"))
-            init(deck.getKeyword("SPECGRID"));
+            init(deck["SPECGRID"].back());
         else if (deck.hasKeyword("DIMENS"))
-            init(deck.getKeyword("DIMENS"));
+            init(deck["DIMENS"].back());
         else if (deck.hasKeyword("GDFILE"))
             binary_init(deck);
         else
@@ -148,7 +148,7 @@ namespace Opm {
     }
 
     void GridDims::binary_init(const Deck& deck) {
-        const DeckKeyword& gdfile_kw = deck.getKeyword("GDFILE");
+        const DeckKeyword& gdfile_kw = deck["GDFILE"].back();
         const std::string& gdfile_arg = gdfile_kw.getRecord(0).getItem("filename").get<std::string>(0);
         const EclIO::EGrid egrid( deck.makeDeckPath(gdfile_arg) );
         const auto& dimens = egrid.dimension();

--- a/src/opm/parser/eclipse/EclipseState/Grid/MapAxes.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Grid/MapAxes.cpp
@@ -107,11 +107,11 @@ MapAxes::MapAxes(const Deck& deck)
     if (!deck.hasKeyword<ParserKeywords::MAPAXES>())
         throw std::logic_error("Can not instantiate MapAxes object without MAPAXES keyword in deck");
 
-    const auto& mapaxes_kw = deck.getKeyword<ParserKeywords::MAPAXES>();
+    const auto& mapaxes_kw = deck.getKeyword<ParserKeywords::MAPAXES>().back();
     const auto& mapaxes_data = mapaxes_kw.getRawDoubleData();
     double lf = 1.0;
     if (deck.hasKeyword<ParserKeywords::MAPUNITS>()) {
-        this->map_units = deck.getKeyword<ParserKeywords::MAPUNITS>().getRecord(0).getItem(0).get<std::string>(0);
+        this->map_units = deck.getKeyword<ParserKeywords::MAPUNITS>().back().getRecord(0).getItem(0).get<std::string>(0);
         lf = length_factor(this->map_units.value());
     }
 

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/FoamConfig.cpp
@@ -132,7 +132,7 @@ FoamConfig::FoamConfig(const Deck& deck)
         // We only support the default (GAS transport phase, TAB mobility reduction model)
         // setup for foam at this point, so we detect and deal with it here even though we
         // do not store any data related to it.
-        const auto& kw_foamopts = deck.getKeyword<ParserKeywords::FOAMOPTS>();
+        const auto& kw_foamopts = deck.getKeyword<ParserKeywords::FOAMOPTS>().back();
         this->transport_phase_ = get_phase(kw_foamopts.getRecord(0).getItem(0).get<std::string>(0));
         if (!(this->transport_phase_ == Phase::GAS || this->transport_phase_ == Phase::WATER))
             throw OpmInputError("Only WATER and GAS phases are allowed for foam transport", kw_foamopts.location());
@@ -146,8 +146,8 @@ FoamConfig::FoamConfig(const Deck& deck)
     }
 
     if (deck.hasKeyword<ParserKeywords::FOAMFSC>()) {
-        const auto& kw_foamfsc = deck.getKeyword<ParserKeywords::FOAMFSC>();
-        const auto& kw_foamrock = deck.getKeyword<ParserKeywords::FOAMROCK>();
+        const auto& kw_foamfsc = deck.getKeyword<ParserKeywords::FOAMFSC>().back();
+        const auto& kw_foamrock = deck.getKeyword<ParserKeywords::FOAMROCK>().back();
         if (kw_foamfsc.size() != kw_foamrock.size()) {
             throw std::runtime_error("FOAMFSC and FOAMROCK keywords have different number of records.");
         }
@@ -157,7 +157,7 @@ FoamConfig::FoamConfig(const Deck& deck)
         }
     } else if (deck.hasKeyword<ParserKeywords::FOAMROCK>()) {
         // We have FOAMROCK, but not FOAMFSC.
-        const auto& kw_foamrock = deck.getKeyword<ParserKeywords::FOAMROCK>();
+        const auto& kw_foamrock = deck.getKeyword<ParserKeywords::FOAMROCK>().back();
         for (const auto& record : kw_foamrock) {
             this->data_.emplace_back(record);
         }

--- a/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -35,7 +35,7 @@ namespace Opm {
 
     static inline Equil equils( const Deck& deck ) {
         if( !deck.hasKeyword<ParserKeywords::EQUIL>( ) ) return {};
-        return Equil( deck.getKeyword<ParserKeywords::EQUIL>(  ) );
+        return Equil( deck.getKeyword<ParserKeywords::EQUIL>( ).back() );
     }
 
     InitConfig::InitConfig()
@@ -59,7 +59,7 @@ namespace Opm {
 
         m_gravity = !deck.hasKeyword("NOGRAV");
 
-        const auto& record = deck.getKeyword( "RESTART" ).getRecord(0);
+        const auto& record = deck["RESTART"].back().getRecord(0);
         const auto& save_item = record.getItem(2);
 
         if( save_item.hasValue( 0 ) ) {

--- a/src/opm/parser/eclipse/EclipseState/MICPpara.cpp
+++ b/src/opm/parser/eclipse/EclipseState/MICPpara.cpp
@@ -51,7 +51,7 @@ Opm::MICPpara::MICPpara( const Opm::Deck& deck)
     if (!deck.hasKeyword<MICPPARA>())
         return;
 
-    const auto& keyword = deck.getKeyword<MICPPARA>();
+    const auto& keyword = deck.getKeyword<MICPPARA>().back();
     const auto& record = keyword.getRecord(0);
     this->m_density_biofilm = record.getItem<MICPPARA::DENSITY_BIOFILM>().getSIDouble(0);
     this->m_density_calcite = record.getItem<MICPPARA::DENSITY_CALCITE>().getSIDouble(0);

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -242,7 +242,7 @@ WellSegmentDims::WellSegmentDims() :
 WellSegmentDims::WellSegmentDims(const Deck& deck) : WellSegmentDims()
 {
     if (deck.hasKeyword("WSEGDIMS")) {
-        const auto& wsd = deck.getKeyword("WSEGDIMS", 0).getRecord(0);
+        const auto& wsd = deck["WSEGDIMS"][0].getRecord(0);
 
         this->nSegWellMax   = wsd.getItem("NSWLMX").get<int>(0);
         this->nSegmentMax   = wsd.getItem("NSEGMX").get<int>(0);
@@ -276,7 +276,7 @@ NetworkDims::NetworkDims() :
 NetworkDims::NetworkDims(const Deck& deck) : NetworkDims()
 {
     if (deck.hasKeyword("NETWORK")) {
-        const auto& wsd = deck.getKeyword("NETWORK", 0).getRecord(0);
+        const auto& wsd = deck["NETWORK"][0].getRecord(0);
 
         this->nMaxNoNodes   = wsd.getItem("NODMAX").get<int>(0);
         this->nMaxNoBranches   = wsd.getItem("NBRMAX").get<int>(0);

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -111,7 +111,7 @@ namespace {
 
 std::time_t create_start_time(const Opm::Deck& deck) {
     if (deck.hasKeyword("START")) {
-        const auto& keyword = deck.getKeyword("START");
+        const auto& keyword = deck["START"].back();
         return Opm::TimeService::timeFromEclipse(keyword.getRecord(0));
     } else
         // The default start date is not specified in the Eclipse
@@ -342,7 +342,7 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
         if (!deck.hasKeyword("SATOPTS"))
             return;
 
-        const auto& satoptsItem = deck.getKeyword("SATOPTS").getRecord(0).getItem(0);
+        const auto& satoptsItem = deck["SATOPTS"].back().getRecord(0).getItem(0);
         for (unsigned i = 0; i < satoptsItem.data_size(); ++i) {
             std::string satoptsValue = satoptsItem.get< std::string >(0);
             std::transform(satoptsValue.begin(),
@@ -373,7 +373,7 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
 	* 1: use the Carlson model for relative permeability hysteresis of the non-wetting
 	*    phase and the imbibition curve for the relperm of the wetting phase
 	*/
-        const auto& ehystrKeyword = deck.getKeyword("EHYSTR");
+        const auto& ehystrKeyword = deck["EHYSTR"].back();
         if (deck.hasKeyword("NOHYKR"))
             krHystMod = -1;
         else {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/Actdims.cpp
@@ -36,7 +36,7 @@ Actdims::Actdims(const Deck& deck)
     : Actdims()
 {
     if (deck.hasKeyword<ParserKeywords::ACTDIMS>()) {
-        const auto& keyword = deck.getKeyword<ParserKeywords::ACTDIMS>();
+        const auto& keyword = deck.getKeyword<ParserKeywords::ACTDIMS>().back();
         const auto& record = keyword.getRecord(0);
 
         this->keywords   = record.getItem<ParserKeywords::ACTDIMS::MAX_ACTION>().get<int>(0);

--- a/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQParams.cpp
@@ -59,7 +59,7 @@ namespace Opm {
         UDQParams()
     {
         if (deck.hasKeyword("UDQDIMS")) {
-            const auto& record = deck.getKeyword("UDQDIMS").getRecord(0);
+            const auto& record = deck["UDQDIMS"].back().getRecord(0);
             const auto& item = record.getItem("RESTART_NEW_SEED");
             const auto& bool_string = item.get<std::string>(0);
 
@@ -67,7 +67,7 @@ namespace Opm {
         }
 
         if (deck.hasKeyword("UDQPARAM")) {
-            const auto& record = deck.getKeyword("UDQPARAM").getRecord(0);
+            const auto& record = deck["UDQPARAM"].back().getRecord(0);
             random_seed = record.getItem("RANDOM_SEED").get<int>(0);
             value_range = record.getItem("RANGE").get<double>(0);
             undefined_value = record.getItem("UNDEFINED_VALUE").get<double>(0);

--- a/src/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
@@ -125,19 +125,19 @@ RockConfig::RockConfig(const Deck& deck, const FieldPropsManager& fp)
     using rockopts = ParserKeywords::ROCKOPTS;
     using rockcomp = ParserKeywords::ROCKCOMP;
     if (deck.hasKeyword<rock>()) {
-        const auto& rock_kw = deck.getKeyword<rock>();
+        const auto& rock_kw = deck.getKeyword<rock>().back();
         for (const auto& record : rock_kw)
             this->m_comp.emplace_back( record.getItem<rock::PREF>().getSIDouble(0),
                                        record.getItem<rock::COMPRESSIBILITY>().getSIDouble(0));
     }
 
     if (deck.hasKeyword<rockopts>()) {
-        const auto& record = deck.getKeyword<rockopts>().getRecord(0);
+        const auto& record = deck.getKeyword<rockopts>().back().getRecord(0);
         this->num_property = num_prop( record.getItem<rockopts::TABLE_TYPE>().getTrimmedString(0) );
     }
 
     if (deck.hasKeyword<rockcomp>()) {
-        const auto& record = deck.getKeyword<rockcomp>().getRecord(0);
+        const auto& record = deck.getKeyword<rockcomp>().back().getRecord(0);
         if (fp.has_int("ROCKNUM"))
             this->num_property = "ROCKNUM";
 

--- a/src/opm/parser/eclipse/EclipseState/Tables/Aqudims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Aqudims.cpp
@@ -42,7 +42,7 @@ Aqudims::Aqudims(const Deck& deck) :
     Aqudims()
 {
     if (deck.hasKeyword("AQUDIMS")) {
-        const auto& record = deck.getKeyword( "AQUDIMS" , 0 ).getRecord( 0 );
+        const auto& record = deck[ "AQUDIMS" ][0].getRecord( 0 );
         m_mxnaqn  = record.getItem("MXNAQN").get<int>(0);
         m_mxnaqc  = record.getItem("MXNAQC").get<int>(0);
         m_niftbl  = record.getItem("NIFTBL").get<int>(0);

--- a/src/opm/parser/eclipse/EclipseState/Tables/Regdims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Regdims.cpp
@@ -38,7 +38,7 @@ Regdims::Regdims(const Deck& deck) :
     Regdims()
 {
     if (deck.hasKeyword("REGDIMS")) {
-        const auto& record = deck.getKeyword( "REGDIMS" , 0 ).getRecord( 0 );
+        const auto& record = deck["REGDIMS"][0].getRecord( 0 );
         m_NTFIP   = record.getItem("NTFIP").get<int>(0);
         m_NMFIPR  = record.getItem("NMFIPR").get<int>(0);
         m_NRFREG  = record.getItem("NRFREG").get<int>(0);

--- a/src/opm/parser/eclipse/EclipseState/Tables/TLMixpar.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TLMixpar.cpp
@@ -29,7 +29,7 @@ TLMixpar::TLMixpar(const Deck& deck) {
     if (!deck.hasKeyword<TLM>())
         return;
 
-    const auto& keyword = deck.getKeyword<TLM>();
+    const auto& keyword = deck.getKeyword<TLM>().back();
     for (const auto& record : keyword) {
         const double viscosity_parameter = record.getItem<TLM::TL_VISCOSITY_PARAMETER>().getSIDouble(0);
         double density_parameter = viscosity_parameter;

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tabdims.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tabdims.cpp
@@ -40,7 +40,7 @@ Tabdims::Tabdims(const Deck& deck) :
     Tabdims()
 {
     if (deck.hasKeyword("TABDIMS")) {
-        const auto& record = deck.getKeyword( "TABDIMS" , 0 ).getRecord( 0 );
+        const auto& record = deck["TABDIMS"][0].getRecord(0);
         m_ntsfun = record.getItem("NTSFUN").get<int>(0);
         m_ntpvt  = record.getItem("NTPVT").get<int>(0);
         m_nssfun = record.getItem("NSSFUN").get<int>(0);

--- a/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -187,36 +187,36 @@ DensityTable make_density_table(const GravityTable& gravity) {
            initFullTables(deck, "PVTSOL", m_pvtsolTables);
 
         if( deck.hasKeyword( "PVTW" ) )
-            this->m_pvtwTable = PvtwTable( deck.getKeyword( "PVTW" ) );
+            this->m_pvtwTable = PvtwTable( deck["PVTW"].back() );
 
         if( deck.hasKeyword( "PVCDO" ) )
-            this->m_pvcdoTable = PvcdoTable( deck.getKeyword( "PVCDO" ) );
+            this->m_pvcdoTable = PvcdoTable( deck["PVCDO"].back() );
 
         if( deck.hasKeyword( "DENSITY" ) )
-            this->m_densityTable = DensityTable( deck.getKeyword( "DENSITY" ) );
+            this->m_densityTable = DensityTable( deck["DENSITY"].back() );
 
         else if( deck.hasKeyword( "GRAVITY" ) )
-            this->m_densityTable = make_density_table( GravityTable ( deck.getKeyword( "GRAVITY" ) ) );
+            this->m_densityTable = make_density_table( GravityTable ( deck["GRAVITY"].back() ) );
 
         if( deck.hasKeyword( "DIFFC" ) )
-            this->m_diffCoeffTable = DiffCoeffTable( deck.getKeyword( "DIFFC" ) );
+            this->m_diffCoeffTable = DiffCoeffTable( deck["DIFFC"].back() );
 
         if( deck.hasKeyword( "ROCK" ) )
-            this->m_rockTable = RockTable( deck.getKeyword( "ROCK" ) );
+            this->m_rockTable = RockTable( deck["ROCK"].back() );
 
         if( deck.hasKeyword( "VISCREF" ) )
-            this->m_viscrefTable = ViscrefTable( deck.getKeyword( "VISCREF" ) );
+            this->m_viscrefTable = ViscrefTable( deck["VISCREF"].back() );
 
         if( deck.hasKeyword( "WATDENT" ) )
-            this->m_watdentTable = WatdentTable( deck.getKeyword( "WATDENT" ) );
+            this->m_watdentTable = WatdentTable( deck["WATDENT"].back() );
 
         if( deck.hasKeyword( "RTEMP" ) )
-            m_rtemp = deck.getKeyword("RTEMP").getRecord(0).getItem("TEMP").getSIDouble( 0 );
+            m_rtemp = deck["RTEMP"].back().getRecord(0).getItem("TEMP").getSIDouble( 0 );
         else if (deck.hasKeyword( "RTEMPA" ) )
-            m_rtemp = deck.getKeyword("RTEMPA").getRecord(0).getItem("TEMP").getSIDouble( 0 );
+            m_rtemp = deck["RTEMPA"].back().getRecord(0).getItem("TEMP").getSIDouble( 0 );
 
         if( deck.hasKeyword( "SALINITY" ) )
-            m_salinity = deck.getKeyword("SALINITY").getRecord(0).getItem("MOLALITY").get<double>( 0 ); //unit independent of unit systems
+            m_salinity = deck["SALINITY"].back().getRecord(0).getItem("MOLALITY").get<double>( 0 ); //unit independent of unit systems
 
         if ( deck.hasKeyword( "ROCK2D") )
             initRockTables(deck, "ROCK2D", m_rock2dTables );
@@ -237,41 +237,41 @@ DensityTable make_density_table(const GravityTable& gravity) {
             initSolventTables(deck, m_sdensityTables );
 
         if (deck.hasKeyword<ParserKeywords::GASDENT>())
-            this->gasDenT = DenT( deck.getKeyword<ParserKeywords::GASDENT>());
+            this->gasDenT = DenT( deck.getKeyword<ParserKeywords::GASDENT>().back());
 
         if (deck.hasKeyword<ParserKeywords::OILDENT>())
-            this->oilDenT = DenT( deck.getKeyword<ParserKeywords::OILDENT>());
+            this->oilDenT = DenT( deck.getKeyword<ParserKeywords::OILDENT>().back());
 
         if (deck.hasKeyword<ParserKeywords::WATDENT>())
-            this->watDenT = DenT( deck.getKeyword<ParserKeywords::WATDENT>());
+            this->watDenT = DenT( deck.getKeyword<ParserKeywords::WATDENT>().back());
 
         if (deck.hasKeyword<ParserKeywords::STCOND>()) {
-            auto stcondKeyword = deck.getKeyword("STCOND");
+            auto stcondKeyword = deck["STCOND"].back();
             this->stcond.temperature = stcondKeyword.getRecord(0).getItem("TEMPERATURE").getSIDouble(0);
             this->stcond.pressure = stcondKeyword.getRecord(0).getItem("PRESSURE").getSIDouble(0);
         }
 
         if (deck.hasKeyword<ParserKeywords::PLMIXPAR>()) {
-            this->m_plmixparTable = PlmixparTable(deck.getKeyword("PLMIXPAR"));
+            this->m_plmixparTable = PlmixparTable(deck["PLMIXPAR"].back());
         }
 
         if (deck.hasKeyword<ParserKeywords::SHRATE>()) {
-            this->m_shrateTable = ShrateTable(deck.getKeyword("SHRATE"));
+            this->m_shrateTable = ShrateTable(deck["SHRATE"].back());
             hasShrate = true;
         }
 
         if (deck.hasKeyword<ParserKeywords::STONE1EX>()) {
-            this->m_stone1exTable = Stone1exTable(deck.getKeyword("STONE1EX"));
+            this->m_stone1exTable = Stone1exTable(deck["STONE1EX"].back());
             hasShrate = true;
         }
 
         if (deck.hasKeyword<ParserKeywords::PLYVMH>()) {
-            this->m_plyvmhTable = PlyvmhTable(deck.getKeyword("PLYVMH"));
+            this->m_plyvmhTable = PlyvmhTable(deck["PLYVMH"].back());
         }
 
         using GC = ParserKeywords::GCOMPIDX;
         if (deck.hasKeyword<GC>())
-            this->m_gas_comp_index = deck.getKeyword<GC>().getRecord(0).getItem<GC::GAS_COMPONENT_INDEX>().get<int>(0);
+            this->m_gas_comp_index = deck.getKeyword<GC>().back().getRecord(0).getItem<GC::GAS_COMPONENT_INDEX>().get<int>(0);
     }
 
 
@@ -326,7 +326,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         using namespace Opm::ParserKeywords;
 
         if (deck.hasKeyword<EQLDIMS>()) {
-            const auto& keyword = deck.getKeyword<EQLDIMS>();
+            const auto& keyword = deck.getKeyword<EQLDIMS>().back();
             const auto& record = keyword.getRecord(0);
             int ntsequl   = record.getItem<EQLDIMS::NTEQUL>().get< int >(0);
             int nodes_p   = record.getItem<EQLDIMS::DEPTH_NODES_P>().get< int >(0);
@@ -338,7 +338,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         }
 
         if (deck.hasKeyword<REGDIMS>()) {
-            const auto& keyword = deck.getKeyword<REGDIMS>();
+            const auto& keyword = deck.getKeyword<REGDIMS>().back();
             const auto& record = keyword.getRecord(0);
             int ntfip  = record.getItem<REGDIMS::NTFIP>().get< int >(0);
             int nmfipr = record.getItem<REGDIMS::NMFIPR>().get< int >(0);
@@ -448,7 +448,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         {
             size_t numMiscibleTables = ParserKeywords::MISCIBLE::NTMISC::defaultValue;
             if (deck.hasKeyword<ParserKeywords::MISCIBLE>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::MISCIBLE>();
+                const auto& keyword = deck.getKeyword<ParserKeywords::MISCIBLE>().back();
                 const auto& record = keyword.getRecord(0);
                 numMiscibleTables =  static_cast<size_t>(record.getItem<ParserKeywords::MISCIBLE::NTMISC>().get< int >(0));
             }
@@ -463,7 +463,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             size_t numEndScaleTables = ParserKeywords::ENDSCALE::NTENDP::defaultValue;
 
             if (deck.hasKeyword<ParserKeywords::ENDSCALE>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::ENDSCALE>();
+                const auto& keyword = deck.getKeyword<ParserKeywords::ENDSCALE>().back();
                 const auto& record = keyword.getRecord(0);
                 numEndScaleTables = static_cast<size_t>(record.getItem<ParserKeywords::ENDSCALE::NTENDP>().get< int >(0));
             }
@@ -477,7 +477,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             size_t numRocktabTables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
 
             if (deck.hasKeyword<ParserKeywords::ROCKCOMP>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::ROCKCOMP>();
+                const auto& keyword = deck.getKeyword<ParserKeywords::ROCKCOMP>().back();
                 const auto& record = keyword.getRecord(0);
                 numRocktabTables = static_cast<size_t>(record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0));
             }
@@ -513,7 +513,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             size_t numEndScaleTables = ParserKeywords::ENDSCALE::NTENDP::defaultValue;
 
             if (deck.hasKeyword<ParserKeywords::ENDSCALE>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::ENDSCALE>();
+                const auto& keyword = deck.getKeyword<ParserKeywords::ENDSCALE>().back();
                 const auto& record = keyword.getRecord(0);
                 numEndScaleTables = static_cast<size_t>(record.getItem<ParserKeywords::ENDSCALE::NTENDP>().get< int >(0));
             }
@@ -527,7 +527,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         {
             size_t numMiscibleTables = ParserKeywords::MISCIBLE::NTMISC::defaultValue;
             if (deck.hasKeyword<ParserKeywords::MISCIBLE>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::MISCIBLE>();
+                const auto& keyword = deck.getKeyword<ParserKeywords::MISCIBLE>().back();
                 const auto& record = keyword.getRecord(0);
                 numMiscibleTables =  static_cast<size_t>(record.getItem<ParserKeywords::MISCIBLE::NTMISC>().get< int >(0));
             }
@@ -542,7 +542,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             size_t numRocktabTables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
 
             if (deck.hasKeyword<ParserKeywords::ROCKCOMP>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::ROCKCOMP>();
+                const auto& keyword = deck.getKeyword<ParserKeywords::ROCKCOMP>().back();
                 const auto& record = keyword.getRecord(0);
                 numRocktabTables = static_cast<size_t>(record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0));
             }
@@ -587,7 +587,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             hasRTEMPVD { deck.hasKeyword<ParserKeywords::RTEMPVD>() } ;
 
         if (hasTEMPVD && hasRTEMPVD) {
-            throw OpmInputError("The TEMPVD and RTEMPVD tables are mutually exclusive.", deck.getKeyword<ParserKeywords::TEMPVD>().location(), deck.getKeyword<ParserKeywords::RTEMPVD>().location());
+            throw OpmInputError("The TEMPVD and RTEMPVD tables are mutually exclusive.", deck.getKeyword<ParserKeywords::TEMPVD>().back().location(), deck.getKeyword<ParserKeywords::RTEMPVD>().back().location());
         } else if (hasTEMPVD) {
             initSimpleTableContainer<RtempvdTable>(deck,  "TEMPVD", "RTEMPVD", m_eqldims.getNumEquilRegions());
         } else if (hasRTEMPVD) {
@@ -611,7 +611,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             return;
         }
 
-        const auto& tableKeyword = deck.getKeyword(keywordName);
+        const auto& tableKeyword = deck[keywordName].back();
         for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& tableRecord = tableKeyword.getRecord( tableIdx );
             const auto& dataItem = tableRecord.getItem( 0 );
@@ -636,7 +636,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         }
         size_t numTables = m_tabdims.getNumPVTTables();
         auto& container = forceGetTables(keywordName , numTables);
-        const auto& tableKeyword = deck.getKeyword(keywordName);
+        const auto& tableKeyword = deck[keywordName].back();
 
         if (tableKeyword.size() > 2) {
             const std::string reason {
@@ -759,7 +759,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             return;
         }
 
-        const auto& keyword = deck.getKeyword<ParserKeywords::PLYROCK>();
+        const auto& keyword = deck.getKeyword<ParserKeywords::PLYROCK>().back();
         auto& container = forceGetTables(keywordName , numTables);
         for (size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord( tableIdx );
@@ -781,7 +781,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             return;
         }
 
-        const auto& keyword = deck.getKeyword<ParserKeywords::PLYMAX>();
+        const auto& keyword = deck.getKeyword<ParserKeywords::PLYMAX>().back();
         auto& container = forceGetTables(keywordName , numTables);
         for (size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord( tableIdx );
@@ -800,15 +800,15 @@ DensityTable make_density_table(const GravityTable& gravity) {
             complainAboutAmbiguousKeyword(deck, "ROCKTAB");
             return;
         }
-        const auto& rockcompKeyword = deck.getKeyword<ParserKeywords::ROCKCOMP>();
+        const auto& rockcompKeyword = deck.getKeyword<ParserKeywords::ROCKCOMP>().back();
         const auto& record = rockcompKeyword.getRecord( 0 );
         size_t numTables = record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0);
         auto& container = forceGetTables("ROCKTAB" , numTables);
-        const auto rocktabKeyword = deck.getKeyword("ROCKTAB");
+        const auto rocktabKeyword = deck["ROCKTAB"].back();
 
         bool isDirectional = deck.hasKeyword<ParserKeywords::RKTRMDIR>();
         if (isDirectional) {
-            const auto& keyword = deck.getKeyword<ParserKeywords::RKTRMDIR>();
+            const auto& keyword = deck.getKeyword<ParserKeywords::RKTRMDIR>().back();
             const std::string reason {
                 "RKTRMDIR is in the deck. Flow does not support directional rock compaction mulipliers.\n"
                 "Make sure that your ROCKTAB table only has 3 columns)"
@@ -819,7 +819,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
 
         bool useStressOption = false;
         if (deck.hasKeyword<ParserKeywords::ROCKOPTS>()) {
-            const auto rockoptsKeyword = deck.getKeyword<ParserKeywords::ROCKOPTS>();
+            const auto rockoptsKeyword = deck.getKeyword<ParserKeywords::ROCKOPTS>().back();
             const auto& rockoptsRecord = rockoptsKeyword.getRecord(0);
             const auto& item = rockoptsRecord.getItem<ParserKeywords::ROCKOPTS::METHOD>();
             useStressOption = (item.getTrimmedString(0) == "STRESS");
@@ -1264,7 +1264,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         size_t numTables = m_tabdims.getNumPVTTables();
         solventtables.resize(numTables);
 
-        const auto& keyword = deck.getKeyword("SDENSITY");
+        const auto& keyword = deck["SDENSITY"].back();
         size_t numEntries = keyword.size();
         assert(numEntries == numTables);
         for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
@@ -1424,12 +1424,12 @@ DensityTable make_density_table(const GravityTable& gravity) {
             OpmLog::error("ROCKWNOD must be present if ROCK2DTR is used");
         }
 
-        const auto& rockcompKeyword = deck.getKeyword("ROCKCOMP");
+        const auto& rockcompKeyword = deck["ROCKCOMP"].back();
         const auto& record = rockcompKeyword.getRecord( 0 );
         size_t numTables = record.getItem("NTROCC").get< int >(0);
         rocktable.resize(numTables);
 
-        const auto& keyword = deck.getKeyword(keywordName);
+        const auto& keyword = deck[keywordName].back();
         size_t numEntries = keyword.size();
         size_t regionIdx = 0;
         size_t tableIdx = 0;
@@ -1451,7 +1451,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         size_t numTables = m_tabdims.getNumPVTTables();
         pvtwtables.resize(numTables);
 
-        const auto& keyword = deck.getKeyword("PVTWSALT");
+        const auto& keyword = deck["PVTWSALT"].back();
         size_t numEntries = keyword.size();
         size_t regionIdx = 0;
         for (unsigned lineIdx = 0; lineIdx < numEntries; lineIdx += 2) {
@@ -1467,7 +1467,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         size_t numTables = m_tabdims.getNumPVTTables();
         rwgtables.resize(numTables);
 
-        const auto& keyword = deck.getKeyword("RWGSALT");
+        const auto& keyword = deck["RWGSALT"].back();
         size_t regionIdx = 0;
         for (const auto& record : keyword) {
             rwgtables[regionIdx].init(record);
@@ -1483,7 +1483,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
         size_t numTables = m_tabdims.getNumPVTTables();
         brinetables.resize(numTables);
 
-        const auto& keyword = deck.getKeyword("BDENSITY");
+        const auto& keyword = deck["BDENSITY"].back();
         size_t numEntries = keyword.size();
         assert(numEntries == numTables);
         for (unsigned lineIdx = 0; lineIdx < numEntries; ++lineIdx) {
@@ -1506,7 +1506,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             return;
         }
 
-        const auto& tableKeyword = deck.getKeyword(keywordName);
+        const auto& tableKeyword = deck[keywordName].back();
         for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
             if (dataItem.data_size() > 0) {
@@ -1531,7 +1531,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             return;
         }
 
-        const auto& tableKeyword = deck.getKeyword(keywordName);
+        const auto& tableKeyword = deck[keywordName].back();
         for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
             if (dataItem.data_size() > 0) {
@@ -1568,7 +1568,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             return;
         }
 
-        const auto& tableKeyword = deck.getKeyword(keywordName);
+        const auto& tableKeyword = deck[keywordName].back();
         for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
             if (dataItem.data_size() == 0) {
@@ -1601,7 +1601,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             return;
         }
 
-        const auto& tableKeyword = deck.getKeyword(keywordName);
+        const auto& tableKeyword = deck[keywordName].back();
 
         int numTables = TableType::numTables( tableKeyword );
         for (int tableIdx = 0; tableIdx < numTables; ++tableIdx)

--- a/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -856,7 +856,7 @@ const TableColumn& WatvisctTable::getWaterViscosityColumn() const {
 }
 
 GasvisctTable::GasvisctTable( const Deck& deck, const DeckItem& deckItem ) {
-    int numComponents = deck.getKeyword<ParserKeywords::COMPS>().getRecord(0).getItem(0).get< int >(0);
+    int numComponents = deck.getKeyword<ParserKeywords::COMPS>().back().getRecord(0).getItem(0).get< int >(0);
 
     auto temperatureDimension = deck.getActiveUnitSystem().getDimension("Temperature");
     auto viscosityDimension = deck.getActiveUnitSystem().getDimension("Viscosity");

--- a/src/opm/parser/eclipse/EclipseState/TracerConfig.cpp
+++ b/src/opm/parser/eclipse/EclipseState/TracerConfig.cpp
@@ -50,7 +50,7 @@ TracerConfig::TracerConfig(const UnitSystem& unit_system, const Deck& deck)
 {
     using TR = ParserKeywords::TRACER;
     if (deck.hasKeyword<TR>()) {
-        const auto& keyword = deck.getKeyword<TR>();
+        const auto& keyword = deck.getKeyword<TR>().back();
         OpmLog::info( keyword.location().format("\nInitializing tracers from {keyword} in {file} line {line}") );
         InfoLogger logger("Tracer tables", 3);
         for (const auto& record : keyword) {
@@ -86,7 +86,7 @@ TracerConfig::TracerConfig(const UnitSystem& unit_system, const Deck& deck)
 
             std::string tracer_field = "TBLKF" + name;
             if (deck.hasKeyword(tracer_field)) {
-                const auto& tracer_keyword = deck.getKeyword(tracer_field);
+                const auto& tracer_keyword = deck[tracer_field].back();
                 auto free_concentration = tracer_keyword.getRecord(0).getItem(0).getData<double>();
                 logger(tracer_keyword.location().format("Loading tracer concentration from {keyword} in {file} line {line}"));
 
@@ -95,7 +95,7 @@ TracerConfig::TracerConfig(const UnitSystem& unit_system, const Deck& deck)
 
                 std::string tracer_field_solution = "TBLKS" + name;
                 if (deck.hasKeyword(tracer_field_solution)) {
-                    const auto& tracer_keyword_solution = deck.getKeyword(tracer_field_solution);
+                    const auto& tracer_keyword_solution = deck[tracer_field_solution].back();
                     auto solution_concentration = tracer_keyword_solution.getRecord(0).getItem(0).getData<double>();
                     logger(tracer_keyword_solution.location().format("Loading tracer concentration from {keyword} in {file} line {line}"));
 
@@ -112,13 +112,13 @@ TracerConfig::TracerConfig(const UnitSystem& unit_system, const Deck& deck)
 
             std::string tracer_table = "TVDPF" + name;
             if (deck.hasKeyword(tracer_table)) {
-                const auto& tracer_keyword = deck.getKeyword(tracer_table);
+                const auto& tracer_keyword = deck[tracer_table].back();
                 const auto& deck_item = tracer_keyword.getRecord(0).getItem(0);
                 logger(tracer_keyword.location().format("Loading tracer concentration from {keyword} in {file} line {line}"));
 
                 std::string tracer_table_solution = "TVDPS" + name;
                 if (deck.hasKeyword(tracer_table_solution)) {
-                    const auto& tracer_keyword_solution = deck.getKeyword(tracer_table_solution);
+                    const auto& tracer_keyword_solution = deck[tracer_table_solution].back();
                     const auto& deck_item_solution = tracer_keyword_solution.getRecord(0).getItem(0);
                     logger(tracer_keyword_solution.location().format("Loading tracer concentration from {keyword} in {file} line {line}"));
 

--- a/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -36,7 +36,7 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
     if (enabledChecks & UnknownKeywords) {
         size_t keywordIdx = 0;
         for (; keywordIdx < deck.size(); keywordIdx++) {
-            const auto& keyword = deck.getKeyword(keywordIdx);
+            const auto& keyword = deck[keywordIdx];
             if (!parser.isRecognizedKeyword( keyword.name() ) ) {
                 std::string msg("Keyword '" + keyword.name() + "' is unknown.");
                 const auto& location = keyword.location();

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -1414,17 +1414,17 @@ std::vector<std::string> Parser::getAllDeckNames () const {
 
         bool deckValid = true;
 
-        if( deck.getKeyword(0).name() != "RUNSPEC" ) {
+        if( deck[0].name() != "RUNSPEC" ) {
             std::string msg = "The first keyword of a valid deck must be RUNSPEC\n";
-            auto curKeyword = deck.getKeyword(0);
+            auto curKeyword = deck[0];
             OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
             deckValid = false;
         }
 
-        std::string curSectionName = deck.getKeyword(0).name();
+        std::string curSectionName = deck[0].name();
         size_t curKwIdx = 1;
         for (; curKwIdx < deck.size(); ++curKwIdx) {
-            const auto& curKeyword = deck.getKeyword(curKwIdx);
+            const auto& curKeyword = deck[curKwIdx];
             const std::string& curKeywordName = curKeyword.name();
 
             if (!isSectionDelimiter( curKeyword )) {
@@ -1526,7 +1526,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
 
         // SCHEDULE is the last section and it is mandatory, so make sure it is there
         if (curSectionName != "SCHEDULE") {
-            const auto& curKeyword = deck.getKeyword(deck.size() - 1);
+            const auto& curKeyword = deck[deck.size() - 1];
             std::string msg =
                 "The last section of a valid deck must be SCHEDULE (is "+curSectionName+")";
             OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );

--- a/src/opm/parser/eclipse/Parser/Parser.cpp
+++ b/src/opm/parser/eclipse/Parser/Parser.cpp
@@ -696,7 +696,7 @@ RawKeyword * newRawKeyword(const ParserKeyword& parserKeyword, const std::string
     auto size_type = parserKeyword.isTableCollection() ? Raw::TABLE_COLLECTION : Raw::FIXED;
 
     if( deck.hasKeyword(keyword_size.keyword() ) ) {
-        const auto& sizeDefinitionKeyword = deck.getKeyword(keyword_size.keyword());
+        const auto& sizeDefinitionKeyword = deck[keyword_size.keyword()].back();
         const auto& record = sizeDefinitionKeyword.getRecord(0);
         auto targetSize = record.getItem( keyword_size.item() ).get< int >( 0 ) + keyword_size.size_shift();
         if (parserKeyword.isAlternatingKeyword())

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -76,7 +76,7 @@ ACTIONX
     BOOST_CHECK_EQUAL(action1.name(), "NAME");
 
     const auto deck = Parser{}.parseString( action_kw );
-    const auto& kw = deck.getKeyword("ACTIONX");
+    const auto& kw = deck["ACTIONX"].back();
 
     Action::ActionX action2(kw, {}, 0);
     BOOST_CHECK_EQUAL(action2.name(), "ACTION");
@@ -870,7 +870,7 @@ TSTEP
         rdeck_string += strings[i] + "\n";
 
     auto deck2 = parser.parseString(rdeck_string);
-    BOOST_CHECK(deck2.getKeyword("WELSPECS") == deck.getKeyword("WELSPECS"));
+    BOOST_CHECK(deck2["WELSPECS"].back() == deck["WELSPECS"].back());
 
 
     const auto& conditions = act1.conditions();

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -1179,14 +1179,14 @@ WELPI
     Action::ActionX action("NAME", 1, 1, 0);
     NameOrder well_order({"W1", "W2", "P1", "P2", "P3"});
     WellMatcher well_matcher( well_order );
-    action.addKeyword(deck.getKeyword("WELPI", 0));
+    action.addKeyword(deck["WELPI"][0]);
     {
         auto wells = action.wellpi_wells(well_matcher, {});
         BOOST_CHECK_EQUAL( wells.size(), 2 );
         has_well(wells, "W1");
         has_well(wells, "W2");
     }
-    action.addKeyword(deck.getKeyword("WELPI", 1));
+    action.addKeyword(deck["WELPI"][1]);
     {
         auto wells = action.wellpi_wells(well_matcher, {});
         BOOST_CHECK_EQUAL( wells.size(), 5 );

--- a/tests/parser/COMPSEGUnits.cpp
+++ b/tests/parser/COMPSEGUnits.cpp
@@ -45,7 +45,7 @@ inline Deck createCOMPSEGSDeck() {
 
 BOOST_AUTO_TEST_CASE(CreateDimension) {
     auto deck = createCOMPSEGSDeck();
-    const auto& keyword = deck.getKeyword<ParserKeywords::COMPSEGS>();
+    const auto& keyword = deck.getKeyword<ParserKeywords::COMPSEGS>().back();
     const auto& record = keyword.getRecord(1);
     BOOST_CHECK_NO_THROW( record.getItem<ParserKeywords::COMPSEGS::DISTANCE_START>().getSIDouble(0) );
 }

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -55,7 +55,7 @@ Opm::WellConnections loadCOMPDAT(const std::string& compdat_keyword) {
     Opm::Parser parser;
     const auto deck = parser.parseString(compdat_keyword);
     Opm::FieldPropsManager field_props(deck, Opm::Phases{true, true, true}, grid, Opm::TableManager());
-    const auto& keyword = deck.getKeyword("COMPDAT", 0);
+    const auto& keyword = deck["COMPDAT"][0];
     Opm::WellConnections connections(Opm::Connection::Order::TRACK, 10,10);
     Opm::CompletedCells cells(grid);
     for (const auto& rec : keyword)

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -46,7 +46,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(hasKeyword_empty_returnFalse) {
     Deck deck;
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("Bjarne"));
-    BOOST_CHECK_THROW( deck.getKeyword("Bjarne") , std::exception);
+    BOOST_CHECK_THROW( deck["Bjarne"].back() , std::exception);
 }
 
 std::pair<std::vector<Dimension>, std::vector<Dimension>> make_dims() {

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(getKeyword_indexok_returnskeyword) {
     Deck deck;
     Parser parser;
     deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
-    BOOST_CHECK_NO_THROW(deck.getKeyword(0));
+    BOOST_CHECK_NO_THROW(deck[0]);
 }
 
 BOOST_AUTO_TEST_CASE(numKeyword_singlekeyword_return1) {
@@ -129,12 +129,12 @@ BOOST_AUTO_TEST_CASE(getKeywordList_OK) {
 BOOST_AUTO_TEST_CASE(keywordList_getbyindexoutofbounds_exceptionthrown) {
     Parser parser;
     Deck deck;
-    BOOST_CHECK_THROW(deck.getKeyword(0), std::exception);
+    BOOST_CHECK_THROW(deck[0], std::exception);
     deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     deck.addKeyword( DeckKeyword( parser.getKeyword("INIT")));
-    BOOST_CHECK_NO_THROW(deck.getKeyword(2));
-    BOOST_CHECK_THROW(deck.getKeyword(3), std::exception);
+    BOOST_CHECK_NO_THROW(deck[2]);
+    BOOST_CHECK_THROW(deck[3], std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(keywordList_getbyindex_correctkeywordreturned) {
@@ -143,9 +143,9 @@ BOOST_AUTO_TEST_CASE(keywordList_getbyindex_correctkeywordreturned) {
     deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
     deck.addKeyword( DeckKeyword( parser.getKeyword("INIT")));
-    BOOST_CHECK_EQUAL("GRID",  deck.getKeyword(0).name());
-    BOOST_CHECK_EQUAL("GRID",  deck.getKeyword(1).name());
-    BOOST_CHECK_EQUAL("INIT", deck.getKeyword(2).name());
+    BOOST_CHECK_EQUAL("GRID",  deck[0].name());
+    BOOST_CHECK_EQUAL("GRID",  deck[1].name());
+    BOOST_CHECK_EQUAL("INIT", deck[2].name());
 }
 
 BOOST_AUTO_TEST_CASE(set_and_get_data_file) {

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(getKeyword_singlekeyword_outRange_throws) {
     Deck deck;
     Parser parser;
     deck.addKeyword( DeckKeyword( parser.getKeyword("GRID")));
-    BOOST_CHECK_THROW(deck.getKeyword("GRID" , 10) , std::exception);
+    BOOST_CHECK_THROW(deck["GRID"][10], std::exception);
 }
 
 
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(size_twokeyword_return2) {
     deck.addKeyword(keyword);
     BOOST_CHECK_EQUAL(2U , deck.size());
 
-    BOOST_CHECK_THROW( deck.getKeyword("GRID" , 3) , std::exception);
+    BOOST_CHECK_THROW( deck["GRID"][3], std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(getKeywordList_OK) {

--- a/tests/parser/DeckValueTests.cpp
+++ b/tests/parser/DeckValueTests.cpp
@@ -201,7 +201,7 @@ PERMX
 
     Parser parser;
     Deck deck = parser.parseString(deck_string);
-    const auto& permx = deck.getKeyword("PERMX");
+    const auto& permx = deck["PERMX"].back();
     const auto& status = permx.getValueStatus();
     BOOST_CHECK_EQUAL(status.size(), 100U);
     for (const auto& vs : status) {

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -607,7 +607,7 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchCOORD) {
 
     Opm::Parser parser;
     auto deck = parser.parseString( deckData) ;
-    const auto& zcorn = deck.getKeyword("ZCORN");
+    const auto& zcorn = deck["ZCORN"].back();
     BOOST_CHECK_EQUAL( 8000U , zcorn.getDataSize( ));
 
     BOOST_CHECK_THROW(Opm::EclipseGrid{ deck }, std::invalid_argument);

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(PYINPUT_BASIC) {
     BOOST_CHECK( deck.hasKeyword("FIELD") );
     BOOST_CHECK( deck.hasKeyword("DIMENS") );
     BOOST_CHECK( deck.hasKeyword("DX") );
-    auto DX = deck.getKeyword("DX");
+    auto DX = deck["DX"].back();
     std::vector<double> dx_data = DX.getSIDoubleData();
     BOOST_CHECK_EQUAL( dx_data.size(), 4 );
     BOOST_CHECK_EQUAL( dx_data[2], 0.25 * 0.3048 );

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -111,19 +111,19 @@ BOOST_AUTO_TEST_CASE(InvalidInput) {
 
     // Invalid direction
     std::vector<const Opm::DeckKeyword*> keywords0;
-    const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
+    const auto& multregtKeyword0 = deck["MULTREGT"][0];
     keywords0.push_back( &multregtKeyword0 );
     BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( grid, &fp, keywords0 ); , std::invalid_argument );
 
     // Not supported region
     std::vector<const Opm::DeckKeyword*> keywords1;
-    const auto& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
+    const auto& multregtKeyword1 = deck["MULTREGT"][1];
     keywords1.push_back( &multregtKeyword1 );
     BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( grid, &fp, keywords1 ); , std::invalid_argument );
 
     // The keyword is ok; but it refers to a region which is not in the deck.
     std::vector<const Opm::DeckKeyword*> keywords2;
-    const auto& multregtKeyword2 = deck.getKeyword( "MULTREGT", 2 );
+    const auto& multregtKeyword2 = deck["MULTREGT"][2];
     keywords2.push_back( &multregtKeyword2 );
     BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( grid, &fp, keywords2 ); , std::logic_error );
 }
@@ -178,13 +178,13 @@ BOOST_AUTO_TEST_CASE(NotSupported) {
 
     // Not support NOAQUNNC behaviour
     std::vector<const Opm::DeckKeyword*> keywords0;
-    const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
+    const auto& multregtKeyword0 = deck["MULTREGT"][0];
     keywords0.push_back( &multregtKeyword0 );
     BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( grid, &fp, keywords0 ); , std::invalid_argument );
 
     // srcValue == targetValue - not supported
     std::vector<const Opm::DeckKeyword*> keywords1;
-    const Opm::DeckKeyword& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
+    const Opm::DeckKeyword& multregtKeyword1 = deck["MULTREGT"][1];
     keywords1.push_back( &multregtKeyword1 );
     BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( grid, &fp, keywords1 ); , std::invalid_argument );
 }
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
 
 
   std::vector<const Opm::DeckKeyword*> keywords0;
-  const auto& multregtKeyword0 = deck.getKeyword( "MULTREGT", 0 );
+  const auto& multregtKeyword0 = deck["MULTREGT"][0];
   keywords0.push_back( &multregtKeyword0 );
   Opm::MULTREGTScanner scanner0(grid, &fp, keywords0);
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(0,0,1), grid.getGlobalIndex(1,0,1), Opm::FaceDir::XPlus ), 1.25);
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(DefaultedRegions) {
   BOOST_CHECK_EQUAL( scanner0.getRegionMultiplier(grid.getGlobalIndex(2,0,1), grid.getGlobalIndex(2,0,0), Opm::FaceDir::ZMinus ), 0.0);
 
   std::vector<const Opm::DeckKeyword*> keywords1;
-  const Opm::DeckKeyword& multregtKeyword1 = deck.getKeyword( "MULTREGT", 1 );
+  const Opm::DeckKeyword& multregtKeyword1 = deck["MULTREGT"][1];
   keywords1.push_back( &multregtKeyword1 );
   Opm::MULTREGTScanner scanner1(grid, &fp, keywords1 );
   BOOST_CHECK_EQUAL( scanner1.getRegionMultiplier(grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(1,0,0), Opm::FaceDir::XMinus ), 0.75);

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -109,10 +109,10 @@ WSEGAICD
     Opm::Parser parser;
     Opm::Deck deck = parser.parseString(compsegs_string);
 
-    const Opm::DeckKeyword compsegs = deck.getKeyword("COMPSEGS");
+    const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::DeckKeyword welsegs = deck.getKeyword("WELSEGS");
+    const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set(welsegs);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
@@ -126,7 +126,7 @@ WSEGAICD
     const auto& [new_connection_set, new_segment_set] = Opm::Compsegs::processCOMPSEGS(compsegs, connection_set, segment_set, Opm::ScheduleGrid(grid, fp, cells), parseContext, errorGuard);
 
     // checking the ICD segment
-    const Opm::DeckKeyword wsegaicd = deck.getKeyword("WSEGAICD");
+    const Opm::DeckKeyword wsegaicd = deck["WSEGAICD"].back();
     const auto aicd_map = Opm::AutoICD::fromWSEGAICD(wsegaicd);
     BOOST_CHECK_EQUAL(1U, aicd_map.size());
 
@@ -268,10 +268,10 @@ WSEGSICD
     Opm::Parser parser;
     Opm::Deck deck = parser.parseString(compsegs_string);
 
-    const Opm::DeckKeyword compsegs = deck.getKeyword("COMPSEGS");
+    const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::DeckKeyword welsegs = deck.getKeyword("WELSEGS");
+    const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set(welsegs);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
@@ -285,7 +285,7 @@ WSEGSICD
     const auto& [new_connection_set, new_segment_set] = Opm::Compsegs::processCOMPSEGS(compsegs, connection_set, segment_set, Opm::ScheduleGrid(grid, fp, cells), parseContext, errorGuard);
 
     // checking the ICD segment
-    const Opm::DeckKeyword wsegsicd = deck.getKeyword("WSEGSICD");
+    const Opm::DeckKeyword wsegsicd = deck["WSEGSICD"].back();
     BOOST_CHECK_EQUAL(1U, wsegsicd.size());
     const Opm::DeckRecord& record = wsegsicd.getRecord(0);
     const int start_segment = record.getItem("SEGMENT1").get< int >(0);
@@ -427,10 +427,10 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS) {
     Opm::Parser parser;
     Opm::Deck deck = parser.parseString(compsegs_string);
 
-    const Opm::DeckKeyword compsegs = deck.getKeyword("COMPSEGS");
+    const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::DeckKeyword welsegs = deck.getKeyword("WELSEGS");
+    const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set(welsegs);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
@@ -496,10 +496,10 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS) {
     Opm::Parser parser;
     Opm::Deck deck = parser.parseString(compsegs_string);
 
-    const Opm::DeckKeyword compsegs = deck.getKeyword("COMPSEGS");
+    const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::DeckKeyword welsegs = deck.getKeyword("WELSEGS");
+    const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set(welsegs);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
@@ -571,10 +571,10 @@ BOOST_AUTO_TEST_CASE(testwsegvalv) {
     Opm::Parser parser;
     Opm::Deck deck = parser.parseString(compsegs_string);
 
-    const Opm::DeckKeyword compsegs = deck.getKeyword("COMPSEGS");
+    const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::DeckKeyword welsegs = deck.getKeyword("WELSEGS");
+    const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
     Opm::WellSegments segment_set(welsegs);
 
     BOOST_CHECK_EQUAL(8U, segment_set.size());
@@ -588,7 +588,7 @@ BOOST_AUTO_TEST_CASE(testwsegvalv) {
     BOOST_CHECK_NO_THROW( Opm::Compsegs::processCOMPSEGS(compsegs, connection_set, segment_set, Opm::ScheduleGrid(grid, fp, cells), parseContext, errorGuard));
 
     // checking the WSEGVALV segment
-    const Opm::DeckKeyword wsegvalv = deck.getKeyword("WSEGVALV");
+    const Opm::DeckKeyword wsegvalv = deck["WSEGVALV"].back();
     BOOST_CHECK_EQUAL(2U, wsegvalv.size());
 
     const Opm::DeckRecord& record1 = wsegvalv.getRecord(0);

--- a/tests/parser/PAvgTests.cpp
+++ b/tests/parser/PAvgTests.cpp
@@ -47,13 +47,13 @@ BOOST_AUTO_TEST_CASE(DEFAULT_PAVG) {
 void invalid_deck(const std::string& deck_string, const std::string& kw) {
     Parser parser;
     auto deck = parser.parseString(deck_string);
-    BOOST_CHECK_THROW( PAvg(deck.getKeyword(kw).getRecord(0)), std::exception );
+    BOOST_CHECK_THROW( PAvg(deck[kw].back().getRecord(0)), std::exception );
 }
 
 void valid_deck(const std::string& deck_string, const std::string& kw) {
     Parser parser;
     auto deck = parser.parseString(deck_string);
-    BOOST_CHECK_NO_THROW( PAvg(deck.getKeyword(kw).getRecord(0)));
+    BOOST_CHECK_NO_THROW( PAvg(deck[kw].back().getRecord(0)));
 }
 
 
@@ -94,7 +94,7 @@ WWPAVE
     valid_deck(valid_input, "WWPAVE");
 
     Parser parser;
-    PAvg pavg( parser.parseString(valid_input).getKeyword("WPAVE").getRecord(0) );
+    PAvg pavg( parser.parseString(valid_input)["WPAVE"].back().getRecord(0) );
     BOOST_CHECK_EQUAL( pavg.inner_weight(), 0.25);
     BOOST_CHECK_EQUAL( pavg.conn_weight(), 0.5);
     BOOST_CHECK( pavg.use_porv() );

--- a/tests/parser/ParseDATAWithDefault.cpp
+++ b/tests/parser/ParseDATAWithDefault.cpp
@@ -70,7 +70,7 @@ ENKRVD\n\
 BOOST_AUTO_TEST_CASE( parse_DATAWithDefult_OK ) {
     Parser parser;
     auto deck = parser.parseString( data );
-    const auto& keyword = deck.getKeyword( "ENKRVD" );
+    const auto& keyword = deck["ENKRVD"].back();
     const auto& rec0 = keyword.getRecord(0);
     const auto& rec1 = keyword.getRecord(1);
     const auto& rec2 = keyword.getRecord(2);

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -344,8 +344,8 @@ BOOST_AUTO_TEST_CASE( handle_empty_title ) {
 
     Parser parser;
     const auto deck = parser.parseString( input_deck);
-    BOOST_CHECK_EQUAL( "opm/flow", deck.getKeyword( "TITLE" ).getStringData().front() );
-    BOOST_CHECK_EQUAL( "simulation", deck.getKeyword( "TITLE" ).getStringData().back() );
+    BOOST_CHECK_EQUAL( "opm/flow", deck["TITLE"].back().getStringData().front() );
+    BOOST_CHECK_EQUAL( "simulation", deck[ "TITLE" ].back().getStringData().back() );
  }
 
 BOOST_AUTO_TEST_CASE( deck_comma_separated_fields ) {
@@ -1902,7 +1902,7 @@ AQUTAB
 
   Parser parser;
   const auto deck = parser.parseString( deck_string);
-  const auto& aqutab = deck.getKeyword("AQUTAB");
+  const auto& aqutab = deck["AQUTAB"].back();
   BOOST_CHECK_EQUAL( 1, aqutab.size());
 }
 
@@ -1915,7 +1915,7 @@ BOOST_AUTO_TEST_CASE(ParseRAW_STRING) {
 )";
     Parser parser;
     const auto deck = parser.parseString( deck_string);
-    const auto& udq = deck.getKeyword("UDQ");
+    const auto& udq = deck["UDQ"].back();
     const std::vector<std::string> expected0 = {"'P*X*'"};
     const std::vector<std::string> expected1 = {"'P*X*'", "5*(1", "+", "LOG(WBHP))"};
     const auto& data0 = RawString::strings( udq.getRecord(0).getItem("DATA").getData<RawString>() );
@@ -2007,7 +2007,7 @@ DENSITY
 
     BOOST_CHECK( deck.hasKeyword( "RSCONST" ) );
 
-    const auto& rsconst = deck.getKeyword("RSCONST");
+    const auto& rsconst = deck["RSCONST"].back();
     BOOST_CHECK_EQUAL( rsconst.size( ), 1 );
 
     const auto& rec = rsconst.getRecord( 0 );
@@ -2054,7 +2054,7 @@ DENSITY
 
     BOOST_CHECK( deck.hasKeyword( "RSCONST" ) );
 
-    const auto& rsconst = deck.getKeyword("RSCONST");
+    const auto& rsconst = deck["RSCONST"].back();
     BOOST_CHECK_EQUAL( rsconst.size( ), 1 );
 
     const auto& rec = rsconst.getRecord( 0 );
@@ -2136,7 +2136,7 @@ DENSITY
 
     BOOST_CHECK( deck.hasKeyword( "RSCONSTT" ) );
 
-    const auto& rsconstt = deck.getKeyword( "RSCONSTT" );
+    const auto& rsconstt = deck[ "RSCONSTT" ].back();
     BOOST_CHECK_EQUAL( rsconstt.size( ), 2 );
 
     // First Record (ID = 0)
@@ -2224,9 +2224,9 @@ PLAT-B 15 /
     BOOST_CHECK( deck.hasKeyword("CECONT") );
     BOOST_CHECK( deck.hasKeyword("GCONSUMP") );
 
-    auto kw_density = deck.getKeyword("DENSITY");
+    auto kw_density = deck["DENSITY"].back();
 
-    auto kw = deck.getKeyword("CECONT");
+    auto kw = deck["CECONT"].back();
     BOOST_CHECK( kw.isDoubleRecordKeyword() );
 
     auto record00 = kw.getRecord(0);
@@ -2316,12 +2316,12 @@ This keyword will not be finished
 Parser parser;
 auto deck = parser.parseString(deck_string);
 BOOST_CHECK( deck.hasKeyword("GCUTBACK") );
-auto kw = deck.getKeyword("GCUTBACK");
+auto kw = deck["GCUTBACK"].back();
 BOOST_CHECK_EQUAL( kw.size(), 2 );
 auto record = kw.getRecord(1);
 BOOST_CHECK_EQUAL( record.getItem(5).get<double>(0), 0.9 );
 BOOST_CHECK( !deck.hasKeyword("LANGMUIR") );
- const auto& tracerkm = deck.getKeyword<ParserKeywords::TRACERKM>();
+ const auto& tracerkm = deck.getKeyword<ParserKeywords::TRACERKM>().back();
 BOOST_CHECK_EQUAL(tracerkm.size(), 5);
  BOOST_CHECK_EQUAL(deck.count<ParserKeywords::SAVE>(), 2);
 }

--- a/tests/parser/PvtxTableTests.cpp
+++ b/tests/parser/PvtxTableTests.cpp
@@ -55,9 +55,9 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables1 ) {
     Parser parser;
     std::filesystem::path deckFile(prefix() + "TABLES/PVTX1.DATA");
     auto deck =  parser.parseFile(deckFile.string());
-    BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword<ParserKeywords::PVTO>()) , 1);
+    BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword<ParserKeywords::PVTO>().back()) , 1);
 
-    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
+    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>().back() );
     auto range = ranges[0];
     BOOST_CHECK_EQUAL( range.first , 0 );
     BOOST_CHECK_EQUAL( range.second , 2 );
@@ -68,9 +68,9 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables2 ) {
     Parser parser;
     std::filesystem::path deckFile(prefix() + "TABLES/PVTO2.DATA");
     auto deck =  parser.parseFile(deckFile.string());
-    BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword<ParserKeywords::PVTO>()) , 3);
+    BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword<ParserKeywords::PVTO>().back()) , 3);
 
-    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
+    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>().back() );
     auto range1 = ranges[0];
     BOOST_CHECK_EQUAL( range1.first , 0 );
     BOOST_CHECK_EQUAL( range1.second , 41 );
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables3 ) {
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
 
-    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
+    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>().back() );
     BOOST_CHECK_EQUAL( 2 ,ranges.size() );
 
     auto range1 = ranges[0];

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -4469,10 +4469,10 @@ END
     auto       sched = Schedule{ deck, es };
 
     PAvg pavg0;
-    PAvg pavg1( deck.getKeyword("WPAVE", 0).getRecord(0) );
-    PAvg pavg2( deck.getKeyword("WWPAVE", 0).getRecord(0) );
-    PAvg pavg3( deck.getKeyword("WWPAVE", 0).getRecord(1) );
-    PAvg pavg4( deck.getKeyword("WPAVE", 1).getRecord(0) );
+    PAvg pavg1( deck["WPAVE"][0].getRecord(0) );
+    PAvg pavg2( deck["WWPAVE"][0].getRecord(0) );
+    PAvg pavg3( deck["WWPAVE"][0].getRecord(1) );
+    PAvg pavg4( deck["WPAVE"][1].getRecord(0) );
 
     {
         const auto& w1 = sched.getWell("P1", 0);

--- a/tests/parser/TableContainerTests.cpp
+++ b/tests/parser/TableContainerTests.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE( CreateContainer ) {
     BOOST_CHECK_EQUAL( 0U , container.size() );
     BOOST_CHECK_EQUAL( false , container.hasTable( 1 ));
 
-    std::shared_ptr<Opm::SimpleTable> table = std::make_shared<Opm::SwofTable>( deck.getKeyword("SWOF").getRecord(0).getItem(0), false );
+    std::shared_ptr<Opm::SimpleTable> table = std::make_shared<Opm::SwofTable>( deck["SWOF"].back().getRecord(0).getItem(0), false );
     BOOST_CHECK_THROW( container.addTable( 10 , table ), std::invalid_argument );
     container.addTable( 6 , table );
     BOOST_CHECK_EQUAL( 1U , container.size() );

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -271,8 +271,8 @@ SWOF
 END
 )");
 
-    Opm::SwofTable swof1Table(deck.getKeyword("SWOF").getRecord(0).getItem(0), false);
-    Opm::SwofTable swof2Table(deck.getKeyword("SWOF").getRecord(1).getItem(0), false);
+    Opm::SwofTable swof1Table(deck["SWOF"].back().getRecord(0).getItem(0), false);
+    Opm::SwofTable swof2Table(deck["SWOF"].back().getRecord(1).getItem(0), false);
 
     BOOST_CHECK_EQUAL(swof1Table.numRows(), 2U);
     BOOST_CHECK_EQUAL(swof2Table.numRows(), 3U);
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(PbvdTable_Tests) {
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
 
-    Opm::PbvdTable pbvdTable1(deck.getKeyword("PBVD").getRecord(0).getItem(0));
+    Opm::PbvdTable pbvdTable1(deck["PBVD"].back().getRecord(0).getItem(0));
 
     BOOST_CHECK_EQUAL(pbvdTable1.numRows(), 2U);
     BOOST_CHECK_EQUAL(pbvdTable1.numColumns(), 2U);
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(PbvdTable_Tests) {
     BOOST_CHECK_EQUAL(pbvdTable1.getPbubColumn().front(), 100000); // 1 barsa
 
     // depth must be increasing down the column.
-    BOOST_CHECK_THROW(Opm::PbvdTable pbvdTable2(deck.getKeyword("PBVD").getRecord(1).getItem(0)), std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::PbvdTable pbvdTable2(deck["PBVD"].back().getRecord(1).getItem(0)), std::invalid_argument);
 }
 
 
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(PdvdTable_Tests) {
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
 
-    Opm::PdvdTable pdvdTable1(deck.getKeyword("PDVD").getRecord(0).getItem(0));
+    Opm::PdvdTable pdvdTable1(deck["PDVD"].back().getRecord(0).getItem(0));
 
     BOOST_CHECK_EQUAL(pdvdTable1.numRows(), 2U);
     BOOST_CHECK_EQUAL(pdvdTable1.numColumns(), 2U);
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(PdvdTable_Tests) {
     BOOST_CHECK_EQUAL(pdvdTable1.getPdewColumn().front(), 100000); // 1 barsa
 
     // depth must be increasing down the column.
-    BOOST_CHECK_THROW(Opm::PdvdTable pdvdTable2(deck.getKeyword("PDVD").getRecord(1).getItem(0)), std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::PdvdTable pdvdTable2(deck["PDVD"].back().getRecord(1).getItem(0)), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(SgwfnTable_Tests) {
@@ -369,8 +369,8 @@ BOOST_AUTO_TEST_CASE(SgwfnTable_Tests) {
     auto deck = parser.parseString(deckData);
 
 
-    Opm::SgwfnTable sgwfn1Table(deck.getKeyword("SGWFN").getRecord(0).getItem(0));
-    Opm::SgwfnTable sgwfn2Table(deck.getKeyword("SGWFN").getRecord(1).getItem(0));
+    Opm::SgwfnTable sgwfn1Table(deck["SGWFN"].back().getRecord(0).getItem(0));
+    Opm::SgwfnTable sgwfn2Table(deck["SGWFN"].back().getRecord(1).getItem(0));
 
     BOOST_CHECK_EQUAL(sgwfn1Table.numRows(), 2U);
     BOOST_CHECK_EQUAL(sgwfn2Table.numRows(), 3U);
@@ -414,8 +414,8 @@ SGOF
 END
 )");
 
-    Opm::SgofTable sgof1Table(deck.getKeyword("SGOF").getRecord(0).getItem(0), false);
-    Opm::SgofTable sgof2Table(deck.getKeyword("SGOF").getRecord(1).getItem(0), false);
+    Opm::SgofTable sgof1Table(deck["SGOF"].back().getRecord(0).getItem(0), false);
+    Opm::SgofTable sgof2Table(deck["SGOF"].back().getRecord(1).getItem(0), false);
 
     BOOST_CHECK_EQUAL(sgof1Table.numRows(), 2U);
     BOOST_CHECK_EQUAL(sgof2Table.numRows(), 3U);
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "3.00    0.000030 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(correctDeckData);
-        const auto& plyadsKeyword = deck.getKeyword("PLYADS");
+        const auto& plyadsKeyword = deck["PLYADS"].back();
         Opm::PlyadsTable plyadsTable(plyadsKeyword.getRecord(0).getItem(0));
 
 
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "3.00    0.000030 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(incorrectDeckData);
-        const auto& plyadsKeyword = deck.getKeyword("PLYADS");
+        const auto& plyadsKeyword = deck["PLYADS"].back();
 
         BOOST_CHECK_THROW(Opm::PlyadsTable(plyadsKeyword.getRecord(0).getItem(0)), std::invalid_argument);
     }
@@ -511,7 +511,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "3.00    0.000029 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(incorrectDeckData);
-        const auto& plyadsKeyword = deck.getKeyword("PLYADS");
+        const auto& plyadsKeyword = deck["PLYADS"].back();
 
         BOOST_CHECK_THROW(Opm::PlyadsTable(plyadsKeyword.getRecord(0).getItem(0)), std::invalid_argument);
     }
@@ -535,7 +535,7 @@ BOOST_AUTO_TEST_CASE(FoamadsTable_Tests) {
             "3.00    0.000030 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(correctDeckData);
-        const auto& foamadsKeyword = deck.getKeyword("FOAMADS");
+        const auto& foamadsKeyword = deck["FOAMADS"].back();
         Opm::FoamadsTable foamadsTable(foamadsKeyword.getRecord(0).getItem(0));
 
 
@@ -564,7 +564,7 @@ BOOST_AUTO_TEST_CASE(FoamadsTable_Tests) {
             "3.00    0.000030 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(incorrectDeckData);
-        const auto& foamadsKeyword = deck.getKeyword("FOAMADS");
+        const auto& foamadsKeyword = deck["FOAMADS"].back();
 
         BOOST_CHECK_THROW(Opm::FoamadsTable(foamadsKeyword.getRecord(0).getItem(0)), std::invalid_argument);
     }
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE(FoamadsTable_Tests) {
             "3.00    0.000029 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(incorrectDeckData);
-        const auto& foamadsKeyword = deck.getKeyword("FOAMADS");
+        const auto& foamadsKeyword = deck["FOAMADS"].back();
 
         BOOST_CHECK_THROW(Opm::FoamadsTable(foamadsKeyword.getRecord(0).getItem(0)), std::invalid_argument);
     }
@@ -605,7 +605,7 @@ BOOST_AUTO_TEST_CASE(FoammobTable_Tests) {
             "0.03    0.1 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(correctDeckData);
-        const auto& foammobKeyword = deck.getKeyword("FOAMMOB");
+        const auto& foammobKeyword = deck["FOAMMOB"].back();
         Opm::FoammobTable foammobTable(foammobKeyword.getRecord(0).getItem(0));
 
 
@@ -628,7 +628,7 @@ BOOST_AUTO_TEST_CASE(FoammobTable_Tests) {
             "0.02    0.1 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(incorrectDeckData);
-        const auto& foammobKeyword = deck.getKeyword("FOAMMOB");
+        const auto& foammobKeyword = deck["FOAMMOB"].back();
 
         BOOST_CHECK_THROW(Opm::FoammobTable(foammobKeyword.getRecord(0).getItem(0)), std::invalid_argument);
     }
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE(FoammobTable_Tests) {
             "0.03    0.11 /\n";
         Opm::Parser parser;
         auto deck = parser.parseString(incorrectDeckData);
-        const auto& foammobKeyword = deck.getKeyword("FOAMMOB");
+        const auto& foammobKeyword = deck["FOAMMOB"].back();
 
         BOOST_CHECK_THROW(Opm::FoammobTable(foammobKeyword.getRecord(0).getItem(0)), std::invalid_argument);
     }
@@ -694,7 +694,7 @@ VFPPROD \n\
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
     auto units = Opm::UnitSystem::newMETRIC();
-    const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
+    const auto& vfpprodKeyword = deck["VFPPROD"].back();
 
     BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
@@ -817,7 +817,7 @@ VFPPROD \n\
 
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
-    const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
+    const auto& vfpprodKeyword = deck["VFPPROD"].back();
     auto units = Opm::UnitSystem::newMETRIC();
 
     BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
@@ -963,7 +963,7 @@ VFPPROD \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(missing_values);
-        const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
+        const auto& vfpprodKeyword = deck["VFPPROD"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
@@ -997,7 +997,7 @@ VFPPROD \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(missing_values);
-        const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
+        const auto& vfpprodKeyword = deck["VFPPROD"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
@@ -1029,7 +1029,7 @@ VFPPROD \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(missing_metadata);
-        const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
+        const auto& vfpprodKeyword = deck["VFPPROD"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
@@ -1062,7 +1062,7 @@ VFPPROD \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(wrong_metadata);
-        const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
+        const auto& vfpprodKeyword = deck["VFPPROD"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
@@ -1095,7 +1095,7 @@ VFPPROD \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(missing_axes);
-        const auto& vfpprodKeyword = deck.getKeyword("VFPPROD");
+        const auto& vfpprodKeyword = deck["VFPPROD"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
@@ -1126,7 +1126,7 @@ VFPINJ \n\
 
     Opm::Parser parser;
     auto deck = parser.parseString(deckData);
-    const auto& vfpprodKeyword = deck.getKeyword("VFPINJ");
+    const auto& vfpprodKeyword = deck["VFPINJ"].back();
     auto units = Opm::UnitSystem::newMETRIC();
 
     BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
@@ -1224,7 +1224,7 @@ VFPINJ \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(missing_values);
-        const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
+        const auto& vfpinjKeyword = deck["VFPINJ"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
@@ -1252,7 +1252,7 @@ VFPINJ \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(missing_values);
-        const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
+        const auto& vfpinjKeyword = deck["VFPINJ"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
@@ -1279,7 +1279,7 @@ VFPINJ \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(missing_metadata);
-        const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
+        const auto& vfpinjKeyword = deck["VFPINJ"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
@@ -1307,7 +1307,7 @@ VFPINJ \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(wrong_metadata);
-        const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
+        const auto& vfpinjKeyword = deck["VFPINJ"].back();
         auto units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
@@ -1335,7 +1335,7 @@ VFPINJ \n\
 
         Opm::Parser parser;
         auto deck = parser.parseString(missing_axes);
-        const auto& vfpinjKeyword = deck.getKeyword("VFPINJ");
+        const auto& vfpinjKeyword = deck["VFPINJ"].back();
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
@@ -1850,8 +1850,8 @@ OILDENT
     Opm::Parser parser;
     const auto& deck = parser.parseString(deck_string);
     Opm::TableManager tables(deck);
-    Opm::DenT gd(deck.getKeyword("GASDENT"));
-    Opm::DenT od(deck.getKeyword("OILDENT"));
+    Opm::DenT gd(deck["GASDENT"].back());
+    Opm::DenT od(deck["OILDENT"].back());
     const auto& wd = tables.WatDenT();
 
     BOOST_CHECK_EQUAL(gd.size(), 3U);

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -535,7 +535,7 @@ UDQ
 )";
     Parser parser;
     auto deck = parser.parseString(input);
-    const auto& udq = deck.getKeyword("UDQ");
+    const auto& udq = deck["UDQ"].back();
     const auto& record = udq.getRecord(0);
     const auto& data_item = record.getItem("DATA");
     const auto& data = RawString::strings( data_item.getData<RawString>() );

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
     Runspec runspec(deck);
     Schedule schedule(deck, grid , fp, runspec, python);
     BOOST_CHECK(deck.hasKeyword("WSOLVENT"));
-    const auto& keyword = deck.getKeyword("WSOLVENT");
+    const auto& keyword = deck["WSOLVENT"].back();
     BOOST_CHECK_EQUAL(keyword.size(),1U);
     const auto& record = keyword.getRecord(0);
     const std::string& well_name = record.getItem("WELL").getTrimmedString(0);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -590,7 +590,7 @@ namespace {
             Opm::Parser parser;
             Opm::UnitSystem unit_system(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC);
             auto deck = parser.parseString(input);
-            const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
+            const auto& record = deck["WCONHIST"].back().getRecord(0);
             Opm::Well::WellProductionProperties hist(unit_system, "W");
             hist.handleWCONHIST(alq_type, unit_system, record);
 
@@ -642,7 +642,7 @@ namespace {
         {
             Opm::Parser parser;
             auto deck = parser.parseString(input);
-            const auto& kwd     = deck.getKeyword("WCONPROD");
+            const auto& kwd     = deck["WCONPROD"].back();
             const auto&  record = kwd.getRecord(0);
             Opm::Well::WellProductionProperties pred(unit_system, "W");
             pred.handleWCONPROD(alq_type, unit_system, "WELL", record);

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER) {
     Runspec runspec ( deck );
     Schedule schedule(deck, grid , fp, runspec, python);
     BOOST_CHECK(deck.hasKeyword("WTRACER"));
-    const auto& keyword = deck.getKeyword("WTRACER");
+    const auto& keyword = deck["WTRACER"].back();
     BOOST_CHECK_EQUAL(keyword.size(),1U);
     const auto& record = keyword.getRecord(0);
     const std::string& well_name = record.getItem("WELL").getTrimmedString(0);

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE( CONSTRUCTOR_AND_UPDATE ) {
     auto deck = makeDeck( prefix() + "BOX/BOXTEST1" );
     EclipseGrid grid(deck);
     const auto& box_keyword = deck.getKeyword("BOX", 0);
-    const auto& operate_keyword = deck.getKeyword("OPERATE");
+    const auto& operate_keyword = deck["OPERATE"].back();
     Box box(grid);
     box.update(box_keyword.getRecord(0));
     BOOST_CHECK_EQUAL(box.size(), 8);

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE( OPERATE ) {
 BOOST_AUTO_TEST_CASE( CONSTRUCTOR_AND_UPDATE ) {
     auto deck = makeDeck( prefix() + "BOX/BOXTEST1" );
     EclipseGrid grid(deck);
-    const auto& box_keyword = deck.getKeyword("BOX", 0);
+    const auto& box_keyword = deck["BOX"][0];
     const auto& operate_keyword = deck["OPERATE"].back();
     Box box(grid);
     box.update(box_keyword.getRecord(0));

--- a/tests/parser/integration/EclipseGridCreateFromDeck.cpp
+++ b/tests/parser/integration/EclipseGridCreateFromDeck.cpp
@@ -103,8 +103,8 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     BOOST_CHECK_EQUAL( actnum.size() , volume );
 
     {
-        const std::vector<int>& deckActnum = deck.getKeyword("ACTNUM").getIntData();
-        const std::vector<double>& deckZCORN = deck.getKeyword("ZCORN").getSIDoubleData();
+        const std::vector<int>& deckActnum = deck["ACTNUM"].back().getIntData();
+        const std::vector<double>& deckZCORN = deck["ZCORN"].back().getSIDoubleData();
 
         for (size_t i = 0; i < volume; i++) {
             BOOST_CHECK_EQUAL( deckActnum[i] , actnum[i]);

--- a/tests/parser/integration/IntegrationTests.cpp
+++ b/tests/parser/integration/IntegrationTests.cpp
@@ -119,8 +119,8 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_dataIsCorrect) {
     std::filesystem::path singleKeywordFile(pathprefix() + "wwct.data");
     auto parser = createWWCTParser();
     auto deck = parser.parseFile(singleKeywordFile.string());
-    BOOST_CHECK_EQUAL("WELL-1", deck.getKeyword("WWCT" , 0).getRecord(0).getItem(0).get< std::string >(0));
-    BOOST_CHECK_EQUAL("WELL-2", deck.getKeyword("WWCT" , 0).getRecord(0).getItem(0).get< std::string >(1));
+    BOOST_CHECK_EQUAL("WELL-1", deck["WWCT"][0].getRecord(0).getItem(0).get< std::string >(0));
+    BOOST_CHECK_EQUAL("WELL-2", deck["WWCT"][0].getRecord(0).getItem(0).get< std::string >(1));
 }
 
 BOOST_AUTO_TEST_CASE(parser_internal_name_vs_deck_name) {
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
     auto parser = createBPRParser();
     auto deck =  parser.parseFile(singleKeywordFile.string());
 
-    const auto& keyword = deck.getKeyword("BPR" , 0);
+    const auto& keyword = deck["BPR"][0];
     BOOST_CHECK_EQUAL(2U, keyword.size());
 
     const auto& record1 = keyword.getRecord(0);
@@ -237,8 +237,8 @@ RADFIN4
 
     auto deck =  parser.parseString(deck_string);
     BOOST_CHECK_EQUAL(3U, deck.size());
-    const auto& radfin4_0_full= deck.getKeyword("RADFIN4", 0);
-    const auto& radfin4_1_partial= deck.getKeyword("RADFIN4", 1);
+    const auto& radfin4_0_full= deck["RADFIN4"][0];
+    const auto& radfin4_1_partial= deck["RADFIN4"][1];
 
     // Specified in datafile
     BOOST_CHECK_EQUAL("NAME", radfin4_0_full.getRecord(0).getItem(0).get< std::string >(0));

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -81,7 +81,7 @@ COORDSYS
 )";
     const auto& deck = Parser().parseString( input );
 
-    const auto& brine = deck.getKeyword("BRINE");
+    const auto& brine = deck["BRINE"].back();
     BOOST_CHECK_EQUAL(brine.size(), 0);
 }
 
@@ -227,8 +227,8 @@ BOOST_AUTO_TEST_CASE( SORWMIS ) {
 
     auto deck1 =  parser.parseString(miscibleData + sorwmisData);
 
-    const auto& sorwmis = deck1.getKeyword("SORWMIS");
-    const auto& miscible = deck1.getKeyword("MISCIBLE");
+    const auto& sorwmis = deck1["SORWMIS"].back();
+    const auto& miscible = deck1["MISCIBLE"].back();
 
     const auto& miscible0 = miscible.getRecord(0);
     const auto& sorwmis0 = sorwmis.getRecord(0);
@@ -257,8 +257,8 @@ BOOST_AUTO_TEST_CASE( SGCWMIS ) {
     Parser parser;
     auto deck1 =  parser.parseString(miscibleData + sgcwmisData);
 
-    const auto& sgcwmis = deck1.getKeyword("SGCWMIS");
-    const auto& miscible = deck1.getKeyword("MISCIBLE");
+    const auto& sgcwmis = deck1["SGCWMIS"].back();
+    const auto& miscible = deck1["MISCIBLE"].back();
 
     const auto& miscible0 = miscible.getRecord(0);
     const auto& sgcwmis0 = sgcwmis.getRecord(0);
@@ -317,17 +317,17 @@ BOOST_AUTO_TEST_CASE( MISC ) {
 
     // out of range MISC keyword
     auto deck1 = parser.parseString(miscOutOfRangeData);
-    const auto& item = deck1.getKeyword("MISC").getRecord(0).getItem(0);
+    const auto& item = deck1["MISC"].back().getRecord(0).getItem(0);
     Opm::MiscTable miscTable1(item);
 
     // too litle range of MISC keyword
     auto deck2 = parser.parseString(miscTooSmallRangeData);
-    const auto& item2 = deck2.getKeyword("MISC").getRecord(0).getItem(0);
+    const auto& item2 = deck2["MISC"].back().getRecord(0).getItem(0);
     Opm::MiscTable miscTable2(item2);
 
     // test table input
     auto deck3 =  parser.parseString(miscData);
-    const auto& item3 = deck3.getKeyword("MISC").getRecord(0).getItem(0);
+    const auto& item3 = deck3["MISC"].back().getRecord(0).getItem(0);
     Opm::MiscTable miscTable3(item3);
     BOOST_CHECK_EQUAL(3U, miscTable3.getSolventFractionColumn().size());
     BOOST_CHECK_EQUAL(0.1, miscTable3.getSolventFractionColumn()[1]);
@@ -347,7 +347,7 @@ PMISC
 BOOST_AUTO_TEST_CASE( PMISC ) {
     Parser parser;
     auto deck =  parser.parseString(pmiscData);
-    Opm::PmiscTable pmiscTable(deck.getKeyword("PMISC").getRecord(0).getItem(0));
+    Opm::PmiscTable pmiscTable(deck["PMISC"].back().getRecord(0).getItem(0));
     BOOST_CHECK_EQUAL(3U, pmiscTable.getOilPhasePressureColumn().size());
     BOOST_CHECK_EQUAL(200*1e5, pmiscTable.getOilPhasePressureColumn()[1]);
     BOOST_CHECK_EQUAL(0.5, pmiscTable.getMiscibilityColumn()[1]);
@@ -369,13 +369,13 @@ BOOST_AUTO_TEST_CASE( MSFN ) {
     Parser parser;
     auto deck =  parser.parseString(msfnData);
 
-    Opm::MsfnTable msfnTable1(deck.getKeyword("MSFN").getRecord(0).getItem(0));
+    Opm::MsfnTable msfnTable1(deck["MSFN"].back().getRecord(0).getItem(0));
     BOOST_CHECK_EQUAL(2U, msfnTable1.getGasPhaseFractionColumn().size());
     BOOST_CHECK_EQUAL(1.0, msfnTable1.getGasPhaseFractionColumn()[1]);
     BOOST_CHECK_EQUAL(1.0, msfnTable1.getGasSolventRelpermMultiplierColumn()[1]);
     BOOST_CHECK_EQUAL(0.0, msfnTable1.getOilRelpermMultiplierColumn()[1]);
 
-    Opm::MsfnTable msfnTable2(deck.getKeyword("MSFN").getRecord(1).getItem(0));
+    Opm::MsfnTable msfnTable2(deck["MSFN"].back().getRecord(1).getItem(0));
     BOOST_CHECK_EQUAL(3U, msfnTable2.getGasPhaseFractionColumn().size());
     BOOST_CHECK_EQUAL(0.5, msfnTable2.getGasPhaseFractionColumn()[1]);
     BOOST_CHECK_EQUAL(0.3, msfnTable2.getGasSolventRelpermMultiplierColumn()[1]);
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE( TLPMIXPA ) {
 
     Parser parser;
     auto deck =  parser.parseString(tlpmixpa);
-    Opm::TlpmixpaTable tlpmixpaTable(deck.getKeyword("TLPMIXPA").getRecord(0).getItem(0));
+    Opm::TlpmixpaTable tlpmixpaTable(deck["TLPMIXPA"].back().getRecord(0).getItem(0));
     BOOST_CHECK_EQUAL(3U, tlpmixpaTable.getOilPhasePressureColumn().size());
     BOOST_CHECK_EQUAL(200*1e5, tlpmixpaTable.getOilPhasePressureColumn()[1]);
     BOOST_CHECK_EQUAL(0.5, tlpmixpaTable.getMiscibilityColumn()[1]);
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
     const auto deck =  parser.parseFile(deckFile);
 
     // for WELSEGS keyword
-    const auto& kw = deck.getKeyword("WELSEGS");
+    const auto& kw = deck["WELSEGS"].back();
 
     BOOST_CHECK_EQUAL( 7, kw.size() );
 
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
     }
 
     // for COMPSEG keyword
-    const auto& kw1 = deck.getKeyword("COMPSEGS");
+    const auto& kw1 = deck["COMPSEGS"].back();
     // check the size of the keywords
     BOOST_CHECK_EQUAL( 8, kw1.size() );
     // first record only contains the well name
@@ -638,7 +638,7 @@ BOOST_AUTO_TEST_CASE( MULTISEGMENT_ABS ) {
 BOOST_AUTO_TEST_CASE( PLYADS ) {
     Parser parser;
     auto deck =  parser.parseFile(pathprefix() + "POLYMER/plyads.data");
-    const auto& kw   = deck.getKeyword("PLYADS");
+    const auto& kw   = deck["PLYADS"].back();
     const auto& rec  = kw.getRecord(0);
     const auto& item = rec.getItem(0);
 
@@ -650,7 +650,7 @@ BOOST_AUTO_TEST_CASE( PLYADSS ) {
     Parser parser;
     std::string deckFile(pathprefix() + "POLYMER/plyadss.data");
     auto deck =  parser.parseFile(deckFile);
-    const auto& kw = deck.getKeyword("PLYADSS");
+    const auto& kw = deck["PLYADSS"].back();
     BOOST_CHECK_EQUAL( kw.size() , 11U );
 }
 
@@ -658,7 +658,7 @@ BOOST_AUTO_TEST_CASE( PLYDHFLF ) {
     Parser parser;
     std::string deckFile(pathprefix() + "POLYMER/plydhflf.data");
     auto deck =  parser.parseFile(deckFile);
-    const auto& kw = deck.getKeyword("PLYDHFLF");
+    const auto& kw = deck["PLYDHFLF"].back();
     const auto& rec = kw.getRecord(0);
     const auto& item = rec.getItem(0);
 
@@ -671,7 +671,7 @@ BOOST_AUTO_TEST_CASE( PLYSHLOG ) {
     Parser parser;
     std::string deckFile(pathprefix() + "POLYMER/plyshlog.data");
     auto deck =  parser.parseFile(deckFile);
-    const auto& kw = deck.getKeyword("PLYSHLOG");
+    const auto& kw = deck["PLYSHLOG"].back();
     const auto& rec1 = kw.getRecord(0); // reference conditions
 
     const auto& itemRefPolyConc = rec1.getItem("REF_POLYMER_CONCENTRATION");
@@ -700,7 +700,7 @@ BOOST_AUTO_TEST_CASE( PLYVISC ) {
     Parser parser;
     std::string deckFile(pathprefix() + "POLYMER/plyvisc.data");
     auto deck =  parser.parseFile(deckFile);
-    const auto& kw = deck.getKeyword("PLYVISC");
+    const auto& kw = deck["PLYVISC"].back();
     const auto& rec = kw.getRecord(0);
     const auto& item = rec.getItem(0);
 
@@ -965,14 +965,14 @@ SGOF
     Parser parser;
     auto deck =  parser.parseString(parserData);
 
-    const auto& kw1 = deck.getKeyword("SGOF");
+    const auto& kw1 = deck["SGOF"].back();
     BOOST_CHECK_EQUAL(1U , kw1.size());
     const auto& record0 = kw1.getRecord(0);
     BOOST_CHECK_EQUAL(1U , record0.size());
     const auto& item0 = record0.getItem(0);
     BOOST_CHECK_EQUAL(10U * 4, item0.data_size());
 
-    Opm::SgofTable sgofTable(deck.getKeyword("SGOF").getRecord(0).getItem(0), false);
+    Opm::SgofTable sgofTable(deck["SGOF"].back().getRecord(0).getItem(0), false);
     BOOST_CHECK_EQUAL(10U, sgofTable.getSgColumn().size());
     BOOST_CHECK_EQUAL(0.1, sgofTable.getSgColumn()[0]);
     BOOST_CHECK_EQUAL(0.0, sgofTable.getKrgColumn()[0]);
@@ -1006,14 +1006,14 @@ SWOF
     Parser parser;
     auto deck =  parser.parseString(parserData);
 
-    const auto& kw1 = deck.getKeyword("SWOF");
+    const auto& kw1 = deck["SWOF"].back();
     const auto& record0 = kw1.getRecord(0);
     const auto& item0 = record0.getItem(0);
     BOOST_CHECK_EQUAL(1U , kw1.size());
     BOOST_CHECK_EQUAL(1U , record0.size());
     BOOST_CHECK_EQUAL(10U * 4, item0.data_size());
 
-    Opm::SwofTable swofTable(deck.getKeyword("SWOF").getRecord(0).getItem(0), false);
+    Opm::SwofTable swofTable(deck["SWOF"].back().getRecord(0).getItem(0), false);
     BOOST_CHECK_EQUAL(10U, swofTable.getSwColumn().size());
     BOOST_CHECK_CLOSE(0.1, swofTable.getSwColumn()[0], 1e-8);
     BOOST_CHECK_CLOSE(1.0, swofTable.getSwColumn().back(), 1e-8);
@@ -1064,14 +1064,14 @@ SLGOF
     Parser parser;
     auto deck =  parser.parseString(parserData);
 
-    const auto& kw1 = deck.getKeyword("SLGOF");
+    const auto& kw1 = deck["SLGOF"].back();
     const auto& record0 = kw1.getRecord(0);
     const auto& item0 = record0.getItem(0);
     BOOST_CHECK_EQUAL(1U , kw1.size());
     BOOST_CHECK_EQUAL(1U , record0.size());
     BOOST_CHECK_EQUAL(10U * 4, item0.data_size());
 
-    Opm::SlgofTable slgofTable( deck.getKeyword("SLGOF").getRecord(0).getItem(0), false );
+    Opm::SlgofTable slgofTable( deck["SLGOF"].back().getRecord(0).getItem(0), false );
     BOOST_CHECK_EQUAL(10U, slgofTable.getSlColumn().size());
     BOOST_CHECK_EQUAL(0.1, slgofTable.getSlColumn()[0]);
     BOOST_CHECK_EQUAL(1.0, slgofTable.getSlColumn()[9]);
@@ -1089,7 +1089,7 @@ BOOST_AUTO_TEST_CASE( TITLE ) {
     BOOST_CHECK_EQUAL(size_t(2), deck.size());
     BOOST_CHECK_EQUAL (true, deck.hasKeyword("TITLE"));
 
-    const auto& titleKeyword = deck.getKeyword("TITLE");
+    const auto& titleKeyword = deck["TITLE"].back();
     const auto& record = titleKeyword.getRecord(0);
     const auto& item = record.getItem(0);
 
@@ -1520,13 +1520,13 @@ SGOF
 
 
     auto deck = parser.parseString(input);
-    const auto& pvtwsalt = deck.getKeyword("PVTWSALT");
+    const auto& pvtwsalt = deck["PVTWSALT"].back();
     BOOST_CHECK_EQUAL(pvtwsalt.size(), 4);
 
-    const auto& sgof = deck.getKeyword("SGOF");
+    const auto& sgof = deck["SGOF"].back();
     BOOST_CHECK_EQUAL(sgof.size(), 1);
 
-    const auto& brine = deck.getKeyword("BRINE");
+    const auto& brine = deck["BRINE"].back();
     const auto& salts = brine.getRecord(0).getItem(0);
     BOOST_CHECK_EQUAL( salts.data_size(), 2);
 }

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE( DENSITY ) {
     Parser parser;
     std::string file(pathprefix() + "DENSITY/DENSITY1");
     auto deck =  parser.parseFile(file);
-    const auto& densityKw = deck.getKeyword("DENSITY" , 0);
+    const auto& densityKw = deck["DENSITY"][0];
 
 
     BOOST_CHECK_EQUAL( 2U , densityKw.size());
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE( EQUIL_MISSING_DIMS ) {
     const std::string equil = "EQUIL\n"
         "2469   382.4   1705.0  0.0    500    0.0     1     1      20 /";
     auto deck = parser.parseString(equil, parseContext, errors);
-    const auto& kw1 = deck.getKeyword("EQUIL" , 0);
+    const auto& kw1 = deck["EQUIL"][0];
     BOOST_CHECK_EQUAL( 1U , kw1.size() );
 
     const auto& rec1 = kw1.getRecord(0);
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE( EQUIL ) {
     Parser parser;
     std::string pvtgFile(pathprefix() + "EQUIL/EQUIL1");
     auto deck =  parser.parseFile(pvtgFile);
-    const auto& kw1 = deck.getKeyword("EQUIL" , 0);
+    const auto& kw1 = deck["EQUIL"][0];
     BOOST_CHECK_EQUAL( 3U , kw1.size() );
 
     const auto& rec1 = kw1.getRecord(0);
@@ -712,8 +712,8 @@ BOOST_AUTO_TEST_CASE( PORO_PERMX ) {
     Parser parser;
     std::string poroFile(pathprefix() + "PORO/PORO1");
     auto deck =  parser.parseFile(poroFile);
-    const auto& kw1 = deck.getKeyword("PORO" , 0);
-    const auto& kw2 = deck.getKeyword("PERMX" , 0);
+    const auto& kw1 = deck["PORO"][0];
+    const auto& kw2 = deck["PERMX"][0];
 
     BOOST_CHECK_THROW( kw1.getIntData() , std::logic_error );
     BOOST_CHECK_THROW( kw1.getStringData() , std::logic_error );
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE( RSVD ) {
     Parser parser;
     std::string pvtgFile(pathprefix() + "RSVD/RSVD.txt");
     auto deck =  parser.parseFile(pvtgFile);
-    const auto& kw1 = deck.getKeyword("RSVD" , 0);
+    const auto& kw1 = deck["RSVD"][0];
     BOOST_CHECK_EQUAL( 6U , kw1.size() );
 
     const auto& rec1 = kw1.getRecord(0);
@@ -791,7 +791,7 @@ PVTG
 
     Parser parser;
     auto deck =  parser.parseString(pvtgData);
-    const auto& kw1 = deck.getKeyword("PVTG" , 0);
+    const auto& kw1 = deck["PVTG"][0];
     BOOST_CHECK_EQUAL(5U , kw1.size());
 
     const auto& record0 = kw1.getRecord(0);
@@ -883,7 +883,7 @@ PVTO
 
     Parser parser;
     auto deck =  parser.parseString(pvtoData);
-    const auto& kw1 = deck.getKeyword("PVTO" , 0);
+    const auto& kw1 = deck["PVTO"][0];
     BOOST_CHECK_EQUAL(5U , kw1.size());
 
     const auto& record0 = kw1.getRecord(0);
@@ -1176,9 +1176,9 @@ BOOST_AUTO_TEST_CASE( VFPPROD ) {
     BOOST_CHECK( parser.isRecognizedKeyword("VFPPROD"));
 
     auto deck =  parser.parseFile(file);
-    const auto& VFPPROD1 = deck.getKeyword("VFPPROD" , 0);
-    const auto& BPR = deck.getKeyword("BPR" , 0);
-    const auto& VFPPROD2 = deck.getKeyword("VFPPROD" , 1);
+    const auto& VFPPROD1 = deck["VFPPROD"][0];
+    const auto& BPR = deck["BPR"][0];
+    const auto& VFPPROD2 = deck["VFPPROD"][1];
 
     BOOST_CHECK_EQUAL( 573U  , VFPPROD1.size() );
     BOOST_CHECK_EQUAL( 1U    , BPR.size());
@@ -1305,7 +1305,7 @@ BOOST_AUTO_TEST_CASE( WCHONHIST ) {
     Parser parser;
     std::string wconhistFile(pathprefix() + "WCONHIST/WCONHIST1");
     auto deck =  parser.parseFile(wconhistFile);
-    const auto& kw1 = deck.getKeyword("WCONHIST" , 0);
+    const auto& kw1 = deck["WCONHIST"][0];
     BOOST_CHECK_EQUAL( 3U , kw1.size() );
 
     const auto& rec1 = kw1.getRecord(0);
@@ -1320,7 +1320,7 @@ BOOST_AUTO_TEST_CASE( WCHONHIST ) {
     BOOST_CHECK_EQUAL( &item1  , &item1_index );
     BOOST_CHECK_EQUAL( "OP_1" , item1.get< std::string >(0));
 
-    const auto& kw2 = deck.getKeyword( "WCONHIST", 1 );
+    const auto& kw2 = deck["WCONHIST"][1];
     BOOST_CHECK_EQUAL( "OP_3" , rec3.getItem("WELL").get< std::string >(0));
     BOOST_CHECK_EQUAL( 2U , deck.count("WCONHIST"));
     BOOST_CHECK_EQUAL( "OP_3_B" , kw2.getRecord( 2 ).getItem("WELL").get< std::string >(0));

--- a/tests/parser/integration/parse_write.cpp
+++ b/tests/parser/integration/parse_write.cpp
@@ -46,8 +46,8 @@ inline void loadDeck( const char * deck_file) {
         }
 
         for (size_t index=0; index < deck.size(); index++) {
-            const auto& kw1 = deck.getKeyword( index );
-            const auto& kw2 = deck2.getKeyword( index );
+            const auto& kw1 = deck[index];
+            const auto& kw2 = deck2[index];
 
             if (!kw1.equal( kw2 , true , true)) {
                 std::cerr << "Keyword " << index << " different " << kw1.name() << " " << kw2.name() << std::endl;

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -157,13 +157,13 @@ void checkInitFile( const Deck& deck, const data::Solution& simProps) {
 
     if (initFile.hasKey("PORO")) {
         const auto& poro   = initFile.get<float>("PORO");
-        const auto& expect = deck.getKeyword("PORO").getSIDoubleData();
+        const auto& expect = deck["PORO"].back().getSIDoubleData();
 
         compareErtData(expect, poro, 1e-4);
     }
 
     if (initFile.hasKey("PERMX")) {
-        const auto& expect = deck.getKeyword("PERMX").getSIDoubleData();
+        const auto& expect = deck["PERMX"].back().getSIDoubleData();
         auto        permx  = initFile.get<float>("PERMX");
 
         for (auto& kx : permx) {


### PR DESCRIPTION
Call to `operator[std::string].back()` replaces `Deck::getKeyword(std::string)`, 
`operator[size_t]` replaces  `Deck::getKeyword(size_t)` and  
`deck[std::string][size_t]` replaces  `deck.getKeyword(std::string, size_t)`