### PR TITLE
Add restart output type RESTART_TRACER_SOLUTION

### DIFF
--- a/opm/output/data/Cells.hpp
+++ b/opm/output/data/Cells.hpp
@@ -62,6 +62,7 @@ namespace data {
     enum class TargetType {
         RESTART_SOLUTION,
         RESTART_AUXILIARY,
+        RESTART_TRACER_SOLUTION,
         SUMMARY,
         INIT,
         RESTART_OPM_EXTENDED,

--- a/src/opm/output/eclipse/RestartIO.cpp
+++ b/src/opm/output/eclipse/RestartIO.cpp
@@ -566,7 +566,8 @@ namespace {
         vectors.reserve(value.solution.size());
 
         for (const auto& [name, vector] : value.solution) {
-            if (vector.target == data::TargetType::RESTART_SOLUTION) {
+            if ((vector.target == data::TargetType::RESTART_SOLUTION) ||
+                (vector.target == data::TargetType::RESTART_TRACER_SOLUTION)) {
                 vectors.push_back(name);
             }
         }


### PR DESCRIPTION
Tracer restart 3D vectors should have an addition header 'ZTRACER' with name and units for the tracer data coming in the next restart vector. This PR is a small preparation to output the 'ZTRACER' vector.


Add restart output type `RESTART_TRACER_SOLUTION`. With this PR there is absolutely no change, but when this and accompanying PR in opm-simulators is merged the remaining work can be done under the hood in opm-common.

Downstream: https://github.com/OPM/opm-simulators/pull/3702