### PR TITLE
Netbalan default

### DIFF
--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -223,6 +223,8 @@ public:
         return this->nMaxNoBranchesConToNode;
     }
 
+    bool active() const;
+
     bool operator==(const NetworkDims& data) const;
 
     template<class Serializer>

--- a/opm/parser/eclipse/EclipseState/Schedule/Network/Balance.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Network/Balance.hpp
@@ -40,6 +40,7 @@ enum class CalcMode {
 };
 
     Balance() = default;
+    Balance(bool network_active, const Tuning& tuning);
     Balance(const Tuning& tuning, const DeckKeyword& keyword);
 
     CalcMode mode() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Network/Balance.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Network/Balance.hpp
@@ -48,8 +48,8 @@ enum class CalcMode {
     std::size_t pressure_max_iter() const;
     double thp_tolerance() const;
     std::size_t thp_max_iter() const;
-    double target_balance_error() const;
-    double max_balance_error() const;
+    std::optional<double> target_balance_error() const;
+    std::optional<double> max_balance_error() const;
     double min_tstep() const;
 
     static Balance serializeObject();
@@ -79,8 +79,8 @@ private:
     double m_thp_tolerance;
     std::size_t m_thp_max_iter;
 
-    double target_branch_balance_error;
-    double max_branch_balance_error;
+    std::optional<double> target_branch_balance_error;
+    std::optional<double> max_branch_balance_error;
     double m_min_tstep;
 };
 

--- a/src/opm/output/eclipse/CreateDoubHead.cpp
+++ b/src/opm/output/eclipse/CreateDoubHead.cpp
@@ -25,7 +25,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group/GuideRateConfig.hpp>
-
+#include <opm/parser/eclipse/Parser/ParserKeywords/N.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/common/utility/TimeService.hpp>
@@ -142,8 +142,8 @@ namespace {
                 balancingInterval = units.from_si(M::time, sched[lookup_step].network_balance().interval());
                 convTolNodPres = units.from_si(M::pressure, sched[lookup_step].network_balance().pressure_tolerance());
                 convTolTHPCalc = sched[lookup_step].network_balance().thp_tolerance();
-                targBranchBalError = units.from_si(M::pressure, sched[lookup_step].network_balance().target_balance_error());
-                maxBranchBalError = units.from_si(M::pressure, sched[lookup_step].network_balance().max_balance_error());
+                targBranchBalError = units.from_si(M::pressure, sched[lookup_step].network_balance().target_balance_error().value_or(Opm::ParserKeywords::NETBALAN::TARGET_BALANCE_ERROR::defaultValue));
+                maxBranchBalError = units.from_si(M::pressure, sched[lookup_step].network_balance().max_balance_error().value_or(Opm::ParserKeywords::NETBALAN::MAX_BALANCE_ERROR::defaultValue));
                 minTimeStepSize = units.from_si(M::time, sched[lookup_step].network_balance().min_tstep());
             }
         }

--- a/src/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -284,6 +284,11 @@ NetworkDims::NetworkDims(const Deck& deck) : NetworkDims()
     }
 }
 
+bool NetworkDims::active() const {
+    return this->nMaxNoNodes > 0;
+}
+
+
 NetworkDims NetworkDims::serializeObject()
 {
     NetworkDims result;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Network/Balance.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Network/Balance.cpp
@@ -26,8 +26,9 @@
 namespace Opm {
 namespace Network {
 
+using NB = ParserKeywords::NETBALAN;
+
 Balance::Balance(const Tuning& tuning, const DeckKeyword& keyword) {
-    using NB = ParserKeywords::NETBALAN;
     const auto& record = keyword[0];
     double interval = record.getItem<NB::TIME_INTERVAL>().getSIDouble(0);
 
@@ -57,6 +58,24 @@ Balance::Balance(const Tuning& tuning, const DeckKeyword& keyword) {
         this->m_min_tstep = tuning.TSMINZ;
     else
         this->m_min_tstep = record.getItem<NB::MIN_TIME_STEP>().getSIDouble(0);
+}
+
+
+Balance::Balance(bool network_active, const Tuning& tuning)
+    : calc_mode(CalcMode::TimeStepStart)
+    , calc_interval(0)
+    , m_thp_tolerance( NB::THP_CONVERGENCE_LIMIT::defaultValue )
+    , m_thp_max_iter( NB::MAX_ITER_THP::defaultValue )
+{
+    if (network_active) {
+        this->ptol = NB::PRESSURE_CONVERGENCE_LIMIT::defaultValue;
+        this->m_pressure_max_iter = NB::MAX_ITER::defaultValue;
+        this->m_min_tstep = tuning.TSMINZ;
+    } else {
+        this->ptol = 0;
+        this->m_pressure_max_iter = 0;
+        this->m_min_tstep = 0;
+    }
 }
 
 Balance::CalcMode Balance::mode() const {

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Network/Balance.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Network/Balance.cpp
@@ -83,11 +83,11 @@ std::size_t Balance::pressure_max_iter() const {
     return this->m_pressure_max_iter;
 }
 
-double Balance::target_balance_error() const {
+std::optional<double> Balance::target_balance_error() const {
     return this->target_branch_balance_error;
 }
 
-double Balance::max_balance_error() const {
+std::optional<double> Balance::max_balance_error() const {
     return this->max_branch_balance_error;
 }
 

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1952,9 +1952,10 @@ void Schedule::create_first(const time_point& start_time, const std::optional<ti
     else
         this->snapshots.emplace_back(start_time);
 
+    const auto& runspec = this->m_static.m_runspec;
     auto& sched_state = snapshots.back();
-    sched_state.init_nupcol( this->m_static.m_runspec.nupcol() );
-    sched_state.update_oilvap( OilVaporizationProperties( this->m_static.m_runspec.tabdims().getNumPVTTables() ));
+    sched_state.init_nupcol( runspec.nupcol() );
+    sched_state.update_oilvap( OilVaporizationProperties( runspec.tabdims().getNumPVTTables() ));
     sched_state.update_message_limits( this->m_static.m_deck_message_limits );
     sched_state.pavg.update( PAvg() );
     sched_state.wtest_config.update( WellTestConfig() );
@@ -1966,13 +1967,13 @@ void Schedule::create_first(const time_point& start_time, const std::optional<ti
     sched_state.actions.update( Action::Actions() );
     sched_state.udq_active.update( UDQActive() );
     sched_state.well_order.update( NameOrder() );
-    sched_state.group_order.update( GroupOrder( this->m_static.m_runspec.wellDimensions().maxGroupsInField()) );
-    sched_state.udq.update( UDQConfig( this->m_static.m_runspec.udqParams() ));
+    sched_state.group_order.update( GroupOrder( runspec.wellDimensions().maxGroupsInField()) );
+    sched_state.udq.update( UDQConfig( runspec.udqParams() ));
     sched_state.glo.update( GasLiftOpt() );
     sched_state.guide_rate.update( GuideRateConfig() );
     sched_state.rft_config.update( RFTConfig() );
     sched_state.rst_config.update( RSTConfig::first( this->m_static.rst_config ) );
-    sched_state.network_balance.update( Network::Balance() );
+    sched_state.network_balance.update( Network::Balance(runspec.networkDimensions().active(), sched_state.tuning()) );
     sched_state.update_sumthin(this->m_static.sumthin);
     sched_state.rptonly(this->m_static.rptonly);
     //sched_state.update_date( start_time );

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -4613,7 +4613,7 @@ END
 
 
     auto netbalan0 = sched[0].network_balance();
-    BOOST_CHECK(netbalan0.mode() == Network::Balance::CalcMode::None);
+    BOOST_CHECK(netbalan0.mode() == Network::Balance::CalcMode::TimeStepStart);
 
     auto netbalan1 = sched[1].network_balance();
     BOOST_CHECK(netbalan1.mode() == Network::Balance::CalcMode::TimeInterval);


### PR DESCRIPTION
Create valid default NETBALAN object.

~~Data update is required because we now output real default values for NETBALAN - also in the case when it is not in use, compared to previously where we just output 0.~~

Update 2: For the NETBALAN keyword there are three different "states":

1. The keyword is entered in the deck - read values from deck, all good.
2. The network model is enabled, but no NETBLAN keyword in deck: One default initialization
3. The network model is not enabled: A second default initialization

The alternatives 2 & 3 are implemented in new function:
```C++
Balance::Balance(bool network_active, const Tuning& tuning)
    : calc_mode(CalcMode::TimeStepStart)
    , calc_interval(0)
    , m_thp_tolerance( NB::THP_CONVERGENCE_LIMIT::defaultValue )  
    , m_thp_max_iter( NB::MAX_ITER_THP::defaultValue )          <-- Create data update - was 0 previously
{
    if (network_active) {
        this->ptol = NB::PRESSURE_CONVERGENCE_LIMIT::defaultValue;
        this->m_pressure_max_iter = NB::MAX_ITER::defaultValue;
        this->m_min_tstep = tuning.TSMINZ;
    } else {
        this->ptol = 0;
        this->m_pressure_max_iter = 0;
        this->m_min_tstep = 0;
    }
}
```
and because of the update `thp_max_iter` value all(?) are regression tests get an updated INTEHEAD[77]



