### PR TITLE
Initialize values used for overloading in ParserItem

### DIFF
--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -103,11 +103,11 @@ namespace Opm {
                                     const std::string* defaultValue = nullptr ) const;
 
     private:
-        double dval;
-        int ival;
-        std::string sval;
-        RawString rsval;
-        UDAValue uval;
+        double dval{0};
+        int ival{0};
+        std::string sval{};
+        RawString rsval{};
+        UDAValue uval{};
         std::vector< std::string > m_dimensions;
 
         std::string m_name;


### PR DESCRIPTION
This should cut down quite significantly on coverity warnings