### PR TITLE
Pad XCON, XGRP and RSEG vectors with tracer zero

### DIFF
--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -31,7 +31,7 @@ namespace Opm {
 class EclipseGrid;
 class EclipseState;
 class UnitSystem;
-
+class Phases;
 }
 
 namespace Opm { namespace RestartIO {
@@ -228,6 +228,7 @@ namespace Opm { namespace RestartIO {
         InteHEAD& whistControlMode(int mode);
         InteHEAD& liftOptParam(int in_enc);
 
+        static int numRsegElem(const Opm::Phases& phase);
         const std::vector<int>& data() const
         {
             return this->data_;

--- a/opm/output/eclipse/VectorItems/connection.hpp
+++ b/opm/output/eclipse/VectorItems/connection.hpp
@@ -86,6 +86,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             ResVRate     = 49,  // Reservoir voidage rate
             VoidPrTotal  = 50,  // Total cumulative reservoir voidage volume production
             VoidInjTotal = 51,  // Total cumulative reservoir voidage volume injection
+
+            TracerOffset = 58,  // Tracer data starts after this index
         };
     } // XConn
 }}}} // Opm::RestartIO::Helpers::VectorItems

--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -158,6 +158,8 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
                                    // production (observed/historical rates)
             HistGasInjTotal = 144, // Group's total cumulative gas injection
                                    // (observed/historical rates)
+
+            TracerOffset = 180,    // Tracer data starts here
         };
     } // XGroup
 

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -295,6 +295,9 @@ namespace {
             xConn[Ix::OilRate_Copy] = xConn[Ix::OilRate];
             xConn[Ix::GasRate_Copy] = xConn[Ix::GasRate];
             xConn[Ix::WaterRate_Copy] = xConn[Ix::WaterRate];
+
+            // Pad the connection array with tracer values
+            std::fill(xConn.begin() + Ix::TracerOffset, xConn.end(), 0);
         }
     } // XConn
 } // Anonymous

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -975,6 +975,8 @@ void dynamicContrib(const std::vector<std::string>&      restart_group_keys,
     xGrp[Ix::VoidPrGuideRate_2] = xGrp[Ix::VoidPrGuideRate];
 
     xGrp[Ix::WatInjGuideRate_2] = xGrp[Ix::WatInjGuideRate];
+
+    std::fill(xGrp.begin() + Ix::TracerOffset, xGrp.end(), 0);
 }
 } // XGrp
 

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -367,24 +367,6 @@ namespace {
         };
     }
 
-    int numRsegElem(const ::Opm::Phases& phase)
-    {
-        const auto nact = phase.active(::Opm::Phase::OIL)
-            + phase.active(::Opm::Phase::GAS)
-            + phase.active(::Opm::Phase::WATER);
-
-        switch (nact) {
-        case 1: return 126;
-        case 2: return 134;
-        case 3: return 146;
-        }
-
-        throw std::invalid_argument {
-            "NRSEGZ is not supported for " +
-            std::to_string(nact) +
-            " active phases"
-        };
-    }
 
     Opm::RestartIO::InteHEAD::WellSegDims
     getWellSegDims(const int              num_water_tracer,
@@ -401,7 +383,7 @@ namespace {
             wsd.maxSegmentsPerWell(),
             wsd.maxLateralBranchesPerWell(),
             22,           // Number of entries per segment in ISEG (2017.2)
-            numRsegElem(rspec.phases()) + 8*num_water_tracer, // Number of entries per segment in RSEG
+            Opm::RestartIO::InteHEAD::numRsegElem(rspec.phases()) + 8*num_water_tracer, // Number of entries per segment in RSEG
             10            // Number of entries per segment in ILBR (2017.2)
         };
     }

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -27,6 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 
@@ -822,6 +823,24 @@ Opm::RestartIO::InteHEAD::netBalanceData(const NetBalanceDims& nwbaldim)
     return *this;
 }
 
+int Opm::RestartIO::InteHEAD::numRsegElem(const ::Opm::Phases& phase)
+{
+    const auto nact = phase.active(::Opm::Phase::OIL)
+        + phase.active(::Opm::Phase::GAS)
+        + phase.active(::Opm::Phase::WATER);
+
+    switch (nact) {
+    case 1: return 126;
+    case 2: return 134;
+    case 3: return 146;
+    }
+
+    throw std::invalid_argument {
+        "NRSEGZ is not supported for " +
+            std::to_string(nact) +
+            " active phases"
+            };
+}
 
 // =====================================================================
 


### PR DESCRIPTION
The important point is the resizing of the vectors - that is indirectly handled through the INTEHEAD updates (already merged). Personally I like mentioning this tracer data explicitly in the AggregateXXXX functions - but I agree it is not necessary and will not argue very hard.