### PR TITLE
Use std::optional<> for tracer details

### DIFF
--- a/opm/parser/eclipse/EclipseState/TracerConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/TracerConfig.hpp
@@ -34,10 +34,10 @@ public:
         std::string name;
         std::string unit_string;
         Phase phase = Phase::OIL;
-        std::vector<double> free_concentration;
-        std::vector<double> solution_concentration;
-        TracerVdTable free_tvdp;
-        TracerVdTable solution_tvdp;
+        std::optional<std::vector<double>> free_concentration;
+        std::optional<std::vector<double>> solution_concentration;
+        std::optional<TracerVdTable> free_tvdp;
+        std::optional<TracerVdTable> solution_tvdp;
 
         TracerEntry() = default;
         TracerEntry(const std::string& name_, const std::string& unit_string_,
@@ -92,8 +92,8 @@ public:
             serializer(phase);
             serializer(free_concentration);
             serializer(solution_concentration);
-            free_tvdp.serializeOp(serializer);
-            solution_tvdp.serializeOp(serializer);
+            serializer(this->free_tvdp);
+            serializer(this->solution_tvdp);
         }
     };
 

--- a/tests/parser/TracerTests.cpp
+++ b/tests/parser/TracerTests.cpp
@@ -80,12 +80,12 @@ BOOST_AUTO_TEST_CASE(TracerConfigTest) {
     auto it = tc.begin();
     BOOST_CHECK_EQUAL(it->name, "SEA");
     BOOST_CHECK_EQUAL(it->phase, Phase::WATER);
-    BOOST_CHECK(it->free_concentration.empty());
-    BOOST_CHECK_EQUAL(it->free_tvdp.numColumns(), 2U);
+    BOOST_CHECK(!it->free_concentration.has_value());
+    BOOST_CHECK_EQUAL(it->free_tvdp.value().numColumns(), 2U);
 
     ++it;
     BOOST_CHECK_EQUAL(it->name, "OCE");
     BOOST_CHECK_EQUAL(it->phase, Phase::GAS);
-    BOOST_CHECK_EQUAL(it->free_concentration.size(), 3U);
-    BOOST_CHECK_EQUAL(it->free_tvdp.numColumns(), 0U);
+    BOOST_CHECK_EQUAL(it->free_concentration.value().size(), 3U);
+    BOOST_CHECK(!it->free_tvdp.has_value());
 }


### PR DESCRIPTION
Tracers can be initialized in many ways - use `std::optional<>` to ensure that we do not continue with invalid input

Downstream: https://github.com/OPM/opm-simulators/pull/3707