### PR TITLE
Save and Reload Free/Solution Gas/Oil Cumulatives in Restart

### DIFF
--- a/opm/output/eclipse/AggregateGroupData.hpp
+++ b/opm/output/eclipse/AggregateGroupData.hpp
@@ -71,8 +71,9 @@ public:
 
     const std::vector<std::string> restart_group_keys = {"GOPP", "GWPP", "GOPR", "GWPR", "GGPR",
                                                          "GVPR", "GWIR", "GGIR", "GWCT", "GGOR",
-                                                         "GOPT", "GWPT", "GGPT", "GVPT", "GWIT",
-                                                         "GGIT", "GVIT",
+                                                         "GOPT", "GWPT", "GGPT", "GVPT",
+                                                         "GOPTS", "GGPTS",
+                                                         "GWIT" , "GGIT" , "GVIT",
                                                          "GOPTH", "GWPTH", "GGPTH",
                                                          "GWITH", "GGITH",
                                                          "GOPGR", "GWPGR", "GGPGR", "GVPGR",
@@ -82,8 +83,9 @@ public:
     // Note: guide rates don't exist at the FIELD level.
     const std::vector<std::string> restart_field_keys = {"FOPP", "FWPP", "FOPR", "FWPR", "FGPR",
                                                          "FVPR", "FWIR", "FGIR", "FWCT", "FGOR",
-                                                         "FOPT", "FWPT", "FGPT", "FVPT", "FWIT",
-                                                         "FGIT", "FVIT",
+                                                         "FOPT", "FWPT", "FGPT", "FVPT",
+                                                         "FOPTS", "FGPTS",
+                                                         "FWIT" , "FGIT" , "FVIT",
                                                          "FOPTH", "FWPTH", "FGPTH",
                                                          "FWITH", "FGITH"};
 
@@ -105,6 +107,8 @@ public:
                                                            {"GVIT", 17},
                                                            {"GOPP", 22},
                                                            {"GWPP", 23},
+                                                           {"GOPTS", 73},
+                                                           {"GGPTS", 74},
                                                            {"GOPGR", 85},
                                                            {"GWPGR", 86},
                                                            {"GGPGR", 87},
@@ -137,6 +141,8 @@ public:
                                                            {"FVIT", 17},
                                                            {"FOPP", 22},
                                                            {"FWPP", 23},
+                                                           {"FOPTS", 73},
+                                                           {"FGPTS", 74},
                                                            {"FOPTH", 135},
                                                            {"FWPTH", 139},
                                                            {"FWITH", 140},

--- a/opm/output/eclipse/VectorItems/group.hpp
+++ b/opm/output/eclipse/VectorItems/group.hpp
@@ -132,6 +132,9 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             OilPrPot = 22, // Group's oil production potential
             WatPrPot = 23, // Group's water production potential
 
+            OilPrTotalSolution = 73, // Group's total cumulative oil production in solution
+            GasPrTotalSolution = 74, // Group's total cumulative gas production in solution
+
             OilPrGuideRate  = 85, // Group's producer guide rate for oil.
             WatPrGuideRate  = 86, // Group's producer guide rate for water.
             GasPrGuideRate  = 87, // Group's producer guide rate for gas.

--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -224,6 +224,9 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             GasPrGuideRate  = 50, // Well's producer guide rate for gas
             VoidPrGuideRate = 68, // Well's producer guide rate for reservoir voidag volume
 
+            OilPrTotalSolution = 73, // Well's total cumulative oil production in solution
+            GasPrTotalSolution = 74, // Well's total cumulative gas production in solution
+
             HistOilPrTotal  = 75, // Well's total cumulative oil production
                                   // (observed/historical rates)
             HistWatPrTotal  = 76, // Well's total cumulative water

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -781,19 +781,20 @@ namespace {
 
             auto get = [&smry, &well](const std::string& vector)
             {
-                return smry.get_well_var(well, vector, 0);
+                return smry.get_well_var(well, vector, 0.0);
             };
 
-            /*
-              Since a well can change between producer and injector in the
-              lifetime of the field we output both production and injection
-              cumulatives.
-            */
+            // Since a well can change between producer and injector in the
+            // lifetime of the field we output both production and injection
+            // cumulatives.
 
             xWell[Ix::OilPrTotal]  = get("WOPT");
             xWell[Ix::WatPrTotal]  = get("WWPT");
             xWell[Ix::GasPrTotal]  = get("WGPT");
             xWell[Ix::VoidPrTotal] = get("WVPT");
+
+            xWell[Ix::OilPrTotalSolution] = get("WOPTS");
+            xWell[Ix::GasPrTotalSolution] = get("WGPTS");
 
             xWell[Ix::HistOilPrTotal] = get("WOPTH");
             xWell[Ix::HistWatPrTotal] = get("WWPTH");

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -1464,6 +1464,19 @@ namespace {
         smry.update_well_var(well, "WGIT", xwel[VI::XWell::index::GasInjTotal]);
         smry.update_well_var(well, "WVIT", xwel[VI::XWell::index::VoidInjTotal]);
 
+        smry.update_well_var(well, "WOPTS", xwel[VI::XWell::index::OilPrTotalSolution]);
+        smry.update_well_var(well, "WGPTS", xwel[VI::XWell::index::GasPrTotalSolution]);
+
+        // Free oil cumulative production = WOPT - WOPTS
+        smry.update_well_var(well, "WOPTF",
+                             xwel[VI::XWell::index::OilPrTotal] -
+                             xwel[VI::XWell::index::OilPrTotalSolution]);
+
+        // Free gas cumulative production = WGPT - WGPTS
+        smry.update_well_var(well, "WGPTF",
+                             xwel[VI::XWell::index::GasPrTotal] -
+                             xwel[VI::XWell::index::GasPrTotalSolution]);
+
         smry.update_well_var(well, "WOPTH", xwel[VI::XWell::index::HistOilPrTotal]);
         smry.update_well_var(well, "WWPTH", xwel[VI::XWell::index::HistWatPrTotal]);
         smry.update_well_var(well, "WGPTH", xwel[VI::XWell::index::HistGasPrTotal]);
@@ -1520,6 +1533,19 @@ namespace {
         update("WIT", xgrp[VI::XGroup::index::WatInjTotal]);
         update("GIT", xgrp[VI::XGroup::index::GasInjTotal]);
         update("VIT", xgrp[VI::XGroup::index::VoidInjTotal]);
+
+        update("OPTS", xgrp[VI::XGroup::index::OilPrTotalSolution]);
+        update("GPTS", xgrp[VI::XGroup::index::GasPrTotalSolution]);
+
+        // Free oil cumulative production = xOPT - xOPTS
+        update("OPTF",
+               xgrp[VI::XGroup::index::OilPrTotal] -
+               xgrp[VI::XGroup::index::OilPrTotalSolution]);
+
+        // Free gas cumulative production = xGPT - xGPTS
+        update("GPTF",
+               xgrp[VI::XGroup::index::GasPrTotal] -
+               xgrp[VI::XGroup::index::GasPrTotalSolution]);
 
         update("OPTH", xgrp[VI::XGroup::index::HistOilPrTotal]);
         update("WPTH", xgrp[VI::XGroup::index::HistWatPrTotal]);

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -111,6 +111,8 @@ namespace {
             ParamCTorArgs{ "WPT" , Type::Total },
             ParamCTorArgs{ "GPT" , Type::Total },
             ParamCTorArgs{ "VPT" , Type::Total },
+            ParamCTorArgs{ "OPTS", Type::Total },
+            ParamCTorArgs{ "GPTS", Type::Total },
             ParamCTorArgs{ "OPTH", Type::Total },
             ParamCTorArgs{ "WPTH", Type::Total },
             ParamCTorArgs{ "GPTH", Type::Total },


### PR DESCRIPTION
This commit ensures that the field, group, and well level cumulative production curves of solution/free oil and gas are continuous in a restarted simulation run.

Thanks to Torbjørn Skille for identifying the appropriate locations in `XGRP`/`XWEL` for outputting these items.