### PR TITLE
Add tracer config function fname() == name + "F"

### DIFF
--- a/opm/parser/eclipse/EclipseState/TracerConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/TracerConfig.hpp
@@ -38,6 +38,10 @@ public:
         std::optional<std::vector<double>> solution_concentration;
         std::optional<TracerVdTable> free_tvdp;
         std::optional<TracerVdTable> solution_tvdp;
+        std::string fname() const {
+            return this->name + "F";
+        }
+
 
         TracerEntry() = default;
         TracerEntry(const std::string& name_, const std::string& unit_string_,


### PR DESCRIPTION
The restart solution field tracer arrays have a trailing 'F' in the name - i.e. if a tracer is registered with name "S61" it will be "S61F" in the restart file. Don't know the full domain model here - so current implementation is just to append an 'F' - with this PR that is made very explicit. 