### PR TITLE
Don't Access an Empty Optional Object

### DIFF
--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -854,8 +854,22 @@ void staticContrib(const Opm::Group&        group,
 
     if (glo.has_group(group.name())) {
         const auto& glo_group = glo.group(group.name());
-        sGrp[Isp::GLOMaxSupply] = sgprop(M::gas_surface_rate, glo_group.max_lift_gas().value());
-        sGrp[Isp::GLOMaxRate]   = sgprop(M::gas_surface_rate, glo_group.max_total_gas().value());
+
+        const auto no_limit = -10.0f;
+
+        if (const auto& max_supply = glo_group.max_lift_gas(); max_supply.has_value()) {
+            sGrp[Isp::GLOMaxSupply] = sgprop(M::gas_surface_rate, max_supply.value());
+        }
+        else {
+            sGrp[Isp::GLOMaxSupply] = no_limit;
+        }
+
+        if (const auto& max_total = glo_group.max_total_gas(); max_total.has_value()) {
+            sGrp[Isp::GLOMaxRate] = sgprop(M::gas_surface_rate, max_total.value());
+        }
+        else {
+            sGrp[Isp::GLOMaxRate] = no_limit;
+        }
     }
 
     if ((group.name() == "FIELD") && (group.getGroupType() == Opm::Group::GroupType::NONE)) {


### PR DESCRIPTION
The maximum supply of lift gas and/or the maximum total gas flow rate of a group may be defaulted in the context of lift gas optimisation.  In that case, the `std::optional<>` objects will be empty and we must not access the contained object through the `value()` member function.