### PR TITLE
Improve error message for unsupported ACTIONX keyword

### DIFF
--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -498,8 +498,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
                             this->prefetch_cell_properties(grid, action_keyword);
                         }
                         else {
-                            std::string msg_fmt = "The keyword {keyword} is not supported in the ACTIONX block\n"
-                                "In {file} line {line}.";
+                            std::string msg_fmt = fmt::format("The keyword {} is not supported in the ACTIONX block", action_keyword.name());
                             parseContext.handleError( ParseContext::ACTIONX_ILLEGAL_KEYWORD, msg_fmt, action_keyword.location(), errors);
                         }
                     }

--- a/src/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -168,7 +168,7 @@ namespace Opm {
             // when it goes out of scope.
             errors.clear();
 
-            throw OpmInputError(msg_fmt, location.value_or(KeywordLocation{}));
+            throw OpmInputError(msg, location.value_or(KeywordLocation{}));
         }
 
         if (action == InputError::EXIT1) {


### PR DESCRIPTION
Produces:
```
Error: The keyword GRID is not supported in the ACTIONX block

Error: Problem with keyword GRID
In opm-tests/actionx/ACTIONX_COMPLUMP.DATA line 355
The keyword GRID is not supported in the ACTIONX block
```
which is at least an improvement on: https://github.com/OPM/opm-common/issues/2893
