### PR TITLE
Actionx welspecs

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -110,6 +110,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/parser/eclipse/EclipseState/Schedule/Action/Condition.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Action/Enums.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/Action/State.cpp
+    src/opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/CompletedCells.cpp
     src/opm/parser/eclipse/EclipseState/Schedule/eval_uda.cpp
@@ -800,6 +801,7 @@ if(ENABLE_ECL_INPUT)
        opm/parser/eclipse/EclipseState/Schedule/Action/PyAction.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/SimulatorUpdate.hpp
        opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp
+       opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.hpp
        opm/parser/eclipse/EclipseState/Schedule/ArrayDimChecker.hpp
        opm/parser/eclipse/EclipseState/Schedule/GasLiftOpt.hpp
        opm/parser/eclipse/EclipseState/Schedule/Network/Balance.hpp

--- a/opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.hpp
@@ -1,0 +1,55 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WGNAMES_HPP
+#define WGNAMES_HPP
+
+#include <string>
+#include <unordered_set>
+
+namespace Opm {
+namespace Action {
+
+class WGNames {
+public:
+    WGNames() = default;
+    void add_well(const std::string& wname);
+    void add_group(const std::string& gname);
+
+    bool has_well(const std::string& wname) const;
+    bool has_group(const std::string& gname) const;
+    static WGNames serializeObject();
+    bool operator==(const WGNames& other) const;
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->wells);
+        serializer(this->groups);
+    }
+
+private:
+    std::unordered_set<std::string> wells;
+    std::unordered_set<std::string> groups;
+};
+
+}
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Network/ExtNetwork.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/RPTConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/PAvg.hpp>
@@ -314,6 +315,7 @@ namespace Opm
             m_static.serializeOp(serializer);
             restart_output.serializeOp(serializer);
             this->completed_cells.serializeOp(serializer);
+            this->action_wgnames.serializeOp(serializer);
 
             pack_unpack<PAvg, Serializer>(serializer);
             pack_unpack<WellTestConfig, Serializer>(serializer);
@@ -517,6 +519,7 @@ namespace Opm
 
         ScheduleStatic m_static;
         ScheduleDeck m_sched_deck;
+        Action::WGNames action_wgnames;
         std::optional<int> exit_status;
         std::vector<ScheduleState> snapshots;
         WriteRestartFileEvents restart_output;
@@ -573,6 +576,7 @@ namespace Opm
                            const std::unordered_map<std::string, double> * target_wellpi);
 
         void prefetch_cell_properties(const ScheduleGrid& grid, const DeckKeyword& keyword);
+        void store_wgnames(const DeckKeyword& keyword);
         std::vector<std::string> wellNames(const std::string& pattern, const HandlerContext& context);
         std::vector<std::string> wellNames(const std::string& pattern, std::size_t timeStep, const std::vector<std::string>& matching_wells, InputError::Action error_action, ErrorGuard& errors, const KeywordLocation& location) const;
         void invalidNamePattern( const std::string& namePattern, const HandlerContext& context) const;

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2021 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.hpp>
+
+
+namespace Opm {
+namespace Action {
+
+void WGNames::add_well(const std::string& wname) {
+    this->wells.insert(wname);
+}
+
+void WGNames::add_group(const std::string& gname) {
+    this->groups.insert(gname);
+}
+
+bool WGNames::has_well(const std::string& wname) const {
+    return (this->wells.count(wname) == 1);
+}
+
+bool WGNames::has_group(const std::string& gname) const {
+    return (this->groups.count(gname) == 1);
+}
+
+WGNames WGNames::serializeObject() {
+    WGNames wgn;
+    wgn.add_well("W1");
+    wgn.add_group("G1");
+    return wgn;
+}
+
+bool WGNames::operator==(const WGNames& other) const {
+    return this->wells == other.wells && this->groups == other.groups;
+}
+
+}
+}

--- a/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/src/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1381,6 +1381,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
                this->m_sched_deck == data.m_sched_deck &&
                this->snapshots == data.snapshots &&
                this->restart_output == data.restart_output &&
+               this->action_wgnames == data.action_wgnames &&
                this->completed_cells == data.completed_cells;
      }
 

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/State.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionX.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Action/ActionResult.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Action/WGNames.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WList.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well/WListManager.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -1264,6 +1265,18 @@ TSTEP
         BOOST_CHECK(!plat_group.max_total_gas().has_value());
     }
 
+}
+
+BOOST_AUTO_TEST_CASE(ACTIONX_WGNAME) {
+    Action::WGNames wgnames;
+
+    wgnames.add_well("W1");
+    BOOST_CHECK(wgnames.has_well("W1"));
+    BOOST_CHECK(!wgnames.has_well("W2"));
+
+    wgnames.add_group("G1");
+    BOOST_CHECK(wgnames.has_group("G1"));
+    BOOST_CHECK(!wgnames.has_group("G2"));
 }
 
 BOOST_AUTO_TEST_CASE(Action_COMPDAT_ACTION) {

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -1312,6 +1312,14 @@ ENDACTIO
 TSTEP
 10 /
 
+WELOPEN
+  'PROD1' 'OPEN' 5* /
+/
+
+TSTEP
+10/
+
+
         )"};
 
     const auto st = SummaryState{ TimeService::now() };


### PR DESCRIPTION
This PR addresses the situation where a well is introduced/defined in ACTIONX and then manipulated with e.g. `WCONPROD` in the normal SCHEDULE section:
```
ACTIONX
...
/

WELSPECS
   'NEW_WELL' .... /
/

ENDACTIO

TSTEP     --The ACTIONX must trigger True at some point here in order to define the well. 
   100*30 /

WCONPROD
    'NEW_WELL' .... /
/
```
In current master this fail with an exception when reaching `WCONPROD` in the Schedule construction. With this PR it will register that `NEW_WELL` will (hopefully ...) come with ACTIONX and only give a warning at the first pass of `WCONPROD`.
