### PR TITLE
Don't Write RFT Records for Wells With No Connections

### DIFF
--- a/src/opm/output/eclipse/WriteRFT.cpp
+++ b/src/opm/output/eclipse/WriteRFT.cpp
@@ -375,9 +375,8 @@ namespace {
         const auto rft =
             createWellRFT(reportStep, wname, usys, grid, sched, xcon);
 
-        writeWellHeader(elapsed, wname, sched, usys, rftFile);
-
         if (rft.nConn() > std::size_t{0}) {
+            writeWellHeader(elapsed, wname, sched, usys, rftFile);
             write(rft, rftFile);
         }
     }


### PR DESCRIPTION
These render Flow's RFT files much more difficult to open in post-processing software such as ResInsight.