### PR TITLE
Switch to Using Named Items For Extracting EQUIL Keyword Data

### DIFF
--- a/src/opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
+++ b/src/opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
@@ -1,23 +1,38 @@
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/Equil.hpp>
+
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
+
+#include <vector>
+
+#include <stddef.h>
 
 namespace Opm {
 
-    EquilRecord::EquilRecord() :
-        EquilRecord(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false, 0.0)
-  {
-  }
+    EquilRecord::EquilRecord()
+        : EquilRecord(0.0, 0.0,
+                      0.0, 0.0,
+                      0.0, 0.0,
+                      false,
+                      false,
+                      0)
+    {}
 
-   EquilRecord::EquilRecord( double datum_depth_arg, double datum_depth_pc_arg, double woc_depth, double woc_pc, double goc_depth, double goc_pc, bool live_oil_init, bool wet_gas_init, int target_accuracy) :
-       datum_depth(datum_depth_arg),
-       datum_depth_ps(datum_depth_pc_arg),
-       water_oil_contact_depth(woc_depth),
-       water_oil_contact_capillary_pressure(woc_pc),
-       gas_oil_contact_depth(goc_depth),
-       gas_oil_contact_capillary_pressure(goc_pc),
-       live_oil_init_proc(live_oil_init),
-       wet_gas_init_proc(wet_gas_init),
-       init_target_accuracy(target_accuracy)
+    EquilRecord::EquilRecord(const double datum_depth_arg, const double datum_depth_pc_arg,
+                             const double woc_depth      , const double woc_pc,
+                             const double goc_depth      , const double goc_pc,
+                             const bool   live_oil_init  ,
+                             const bool   wet_gas_init   ,
+                             const int    target_accuracy)
+        : datum_depth(datum_depth_arg)
+        , datum_depth_ps(datum_depth_pc_arg)
+        , water_oil_contact_depth(woc_depth)
+        , water_oil_contact_capillary_pressure(woc_pc)
+        , gas_oil_contact_depth(goc_depth)
+        , gas_oil_contact_capillary_pressure(goc_pc)
+        , live_oil_init_proc(live_oil_init)
+        , wet_gas_init_proc(wet_gas_init)
+        , init_target_accuracy(target_accuracy)
     {}
 
     double EquilRecord::datumDepth() const {
@@ -70,22 +85,27 @@ namespace Opm {
                init_target_accuracy == data.init_target_accuracy;
     }
 
-    /* */
+    /* ----------------------------------------------------------------- */
 
     Equil::Equil( const DeckKeyword& keyword )
     {
-        for (const auto& record : keyword) {
-            auto datum_depth_arg = record.getItem( 0 ).getSIDouble( 0 );
-            auto datum_depth_pc_arg = record.getItem( 1 ).getSIDouble( 0 );
-            auto woc_depth = record.getItem(2).getSIDouble(0);
-            auto woc_pc = record.getItem(3).getSIDouble(0);
-            auto goc_depth = record.getItem(4).getSIDouble(0);
-            auto goc_pc = record.getItem(5).getSIDouble(0);
-            auto live_oil_init = record.getItem(6).get<int>(0) <= 0;
-            auto wet_gas_init = record.getItem(7).get<int>(0) <= 0;
-            auto target_accuracy = record.getItem(8).get<int>(0);
+        using ParserKeywords::EQUIL;
 
-            this->m_records.push_back( EquilRecord(datum_depth_arg, datum_depth_pc_arg, woc_depth, woc_pc, goc_depth, goc_pc, live_oil_init, wet_gas_init, target_accuracy) );
+        for (const auto& record : keyword) {
+            const auto datum_depth_arg = record.getItem<EQUIL::DATUM_DEPTH>().getSIDouble(0);
+            const auto datum_depth_pc_arg = record.getItem<EQUIL::DATUM_PRESSURE>().getSIDouble(0);
+            const auto woc_depth = record.getItem<EQUIL::OWC>().getSIDouble(0);
+            const auto woc_pc = record.getItem<EQUIL::PC_OWC>().getSIDouble(0);
+            const auto goc_depth = record.getItem<EQUIL::GOC>().getSIDouble(0);
+            const auto goc_pc = record.getItem<EQUIL::PC_GOC>().getSIDouble(0);
+            const auto live_oil_init = record.getItem<EQUIL::BLACK_OIL_INIT>().get<int>(0) <= 0;
+            const auto wet_gas_init = record.getItem<EQUIL::BLACK_OIL_INIT_WG>().get<int>(0) <= 0;
+            const auto target_accuracy = record.getItem<EQUIL::OIP_INIT>().get<int>(0);
+
+            this->m_records.emplace_back(datum_depth_arg, datum_depth_pc_arg,
+                                         woc_depth      , woc_pc,
+                                         goc_depth      , goc_pc,
+                                         live_oil_init, wet_gas_init, target_accuracy);
         }
     }
 


### PR DESCRIPTION
This is more self-documenting than  numeric item indices.  While here, also switch to constructing the `EQUIL` record in place instead of forming a temporary and moving it into the vector.