### PR TITLE
update list of blacklisted keywords

### DIFF
--- a/test_util/EclRegressionTest.hpp
+++ b/test_util/EclRegressionTest.hpp
@@ -163,7 +163,7 @@ private:
                                                         "TRANX", "TRANY", "TRANZ", "TRANNNC", "SGRP", "SCON", "DOUBHEAD"
                                                        };
     // keywords that should not be compared
-    const std::vector<std::string> keywordsBlackList = {"TCPU"};
+    const std::vector<std::string> keywordsBlackList = {"TCPU", "ELAPSED", "TCPUDAY", "TCPUTS", "TELAPLIN", "TCPUH", "TCPUHT", "TCPUSCH", "TCPUTSH", "TCPUTSHT", "TELAPDAY", "TELAPTS"};
 
     bool reportStepOnly = false;
 


### PR DESCRIPTION
When running the same data set twice it is unlikely that these keywords will give results that can be compared with the program compareECL. 

These keywords are not supported by Flow but some of these are commonly used by the commercial simulator Eclipse. 
In example the following keywords are requested with the NORNE_ATW2013 in opm-tests

```
"ELAPSED", "TCPUDAY", "TCPUTS", "TELAPLIN"
```
Description of added blacklisted keywords

```
ELAPSED - Elapsed time in seconds.
TCPUDAY - CPU time per day (or hour in lab units).
TCPUTS - CPU time per timestep in seconds.
TELAPLIN - Elapsed time per linear iteration in seconds.
TCPUH - Total CPU time for each gradient calculation (Gradient Option).
TCPUHT - Total CPU time for all gradient calculations (Gradient Option).
TCPUSCH - Total CPU time used in SCHEDULE section.
TCPUTSH - CPU time per timestep for each gradient calculation (Gradient Option).
TCPUTSHT - CPU time per timestep for all gradient calculations (Gradient Option).
TELAPDAY - Elapsed time per day (or hour in lab units).
TELAPTS - Elapsed time per timestep in seconds.

```


with this PR compareECL will be more robust when used with summary files generated by Eclipse. 


