### PR TITLE
Fix driver, as POSIX or BSD getopt() stops on first non-option argument.

### DIFF
--- a/tests/rst_test_driver.sh
+++ b/tests/rst_test_driver.sh
@@ -7,16 +7,16 @@ deck=$3
 
 pushd $(mktemp -d)
 
-${rst_deck} ${deck} HISTORY:0 output/CASE_COPY.DATA -m copy -s
-${opmhash} ${deck} output/CASE_COPY.DATA -S
+${rst_deck} -m copy -s ${deck} HISTORY:0 output/CASE_COPY.DATA
+${opmhash} -S ${deck} output/CASE_COPY.DATA
 
-${rst_deck} ${deck} HISTORY:0 -m share -s > CASE_STDOUT.DATA
-${opmhash} ${deck} CASE_STDOUT.DATA -S
+${rst_deck} -m share -s ${deck} HISTORY:0 > CASE_STDOUT.DATA
+${opmhash} -S ${deck} CASE_STDOUT.DATA
 
 pushd output
 chmod -R a-w *
 popd
 
-${rst_deck} output/CASE_COPY.DATA HISTORY:0 output/CASE_SHARE.DATA -m copy -s
-${opmhash} ${deck} output/CASE_SHARE.DATA -S
+${rst_deck} -m copy -s output/CASE_COPY.DATA HISTORY:0 output/CASE_SHARE.DATA
+${opmhash} -S ${deck} output/CASE_SHARE.DATA
 popd

--- a/tests/rst_test_driver2.sh
+++ b/tests/rst_test_driver2.sh
@@ -11,11 +11,11 @@ single_rst_file=$6
 pushd $(mktemp -d)
 
 # Happy path using unified restart file from source location
-${rst_deck} ${unif_deck} ${unified_rst_file}:10 output/RESTART_UNIF.DATA -s
+${rst_deck} -s ${unif_deck} ${unified_rst_file}:10 output/RESTART_UNIF.DATA
 ${opmi} output/RESTART_UNIF.DATA
 
 # Happy path using single restart file with absolute path
-${rst_deck} ${single_deck} ${single_rst_file} output/RESTART_SINGLE_ABS.DATA -s
+${rst_deck} -s ${single_deck} ${single_rst_file} output/RESTART_SINGLE_ABS.DATA
 ${opmi} output/RESTART_SINGLE_ABS.DATA
 
 mkdir rst
@@ -23,7 +23,7 @@ cp ${single_rst_file} rst/.
 single_rst_file="$(basename -- ${single_rst_file})"
 
 # Happy path using single restart file wth relative path from rst/
-${rst_deck} ${single_deck} rst/${single_rst_file} output/RESTART_SINGLE_RELATIVE.DATA -s
+${rst_deck} -s ${single_deck} rst/${single_rst_file} output/RESTART_SINGLE_RELATIVE.DATA
 ${opmi} output/RESTART_SINGLE_RELATIVE.DATA
 
 
@@ -40,11 +40,11 @@ set +e
 # Test two error conditions
 
 # Deck with UNIFIN and pass a single .X0010 restart file
-${rst_deck} ${unif_deck} rst/${single_rst_file} output/RESTART_SINGLE_RELATIVE.DATA -s
+${rst_deck} -s ${unif_deck} rst/${single_rst_file} output/RESTART_SINGLE_RELATIVE.DATA
 assert_error
 
 # Ask for wrong restart number from unified restart file
-${rst_deck} ${unif_deck} ${unified_rst_file}:20 output/RESTART_ERROR.DATA -s
+${rst_deck} -s ${unif_deck} ${unified_rst_file}:20 output/RESTART_ERROR.DATA
 ${opmi} output/RESTART_ERROR.DATA
 assert_error
 


### PR DESCRIPTION
Putting options at the end of the command makes the rst_deck_* tests fail on BSD systems, such as macOS, since opmhash uses getopt().