### PR TITLE
Fixes parallel segfault for MULTFLT 

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -51,6 +51,9 @@ public:
 
     void apply_schedule_keywords(const std::vector<DeckKeyword>& keywords);
 
+    /// \brief Whether we can call methods on the manager
+    bool is_usable() const;
+
     /*
      The number of cells in the fields managed by this FieldPropsManager.
      Initially this will correspond to the number of active cells in the grid

--- a/src/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -395,8 +395,15 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
                 OpmLog::info(fmt::format("Apply transmissibility multiplier: {}", keyword.name()));
         }
 
-        this->field_props.apply_schedule_keywords(keywords);
-        this->applyMULTXYZ();
+        // After loadbalancing field_props is a nullptr on all processes except
+        // the one with rank zero. Currently, the simulator should to take care
+        // about communicating the field properties. I does not seem to do that,
+        // though. Only the transmissibility multipliers will get broadcasted.
+        if (this->field_props.is_usable())
+        {
+            this->field_props.apply_schedule_keywords(keywords);
+            this->applyMULTXYZ();
+        }
     }
 
 

--- a/src/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -47,6 +47,11 @@ void FieldPropsManager::reset_actnum(const std::vector<int>& actnum) {
     this->fp->reset_actnum(actnum);
 }
 
+bool FieldPropsManager::is_usable() const
+{
+    return static_cast<bool>(this->fp);
+}
+
 void FieldPropsManager::apply_schedule_keywords(const std::vector<DeckKeyword>& keywords) {
     this->fp->handle_schedule_keywords(keywords);
 }


### PR DESCRIPTION
This is a quick fix just fixing the immanent problem. 

The problem that occurs is the following. After loadbalancing the FieldPropsManager only has a non-nullptr to the FieldProperties on the process with rank=0. Therefore most of the calls to it will segfault. This has not been problem before changeset 2921838895. We did not make any calls to e.g. FieldProperties::apply_schedule_keywords during a simulation.
Now we do via  [eclproblem.hh#L1021-L1022](/OPM/opm-simulators/blob/3e4e62bc4f6f6f8a02eb2d2e4976dc2e2d956313/ebos/eclproblem.hh#L1021-L1022))

Closes #2922.

An open question is whether we are actually expecting field properties apart from the transmissibility multipliers to be changed 
during EclipseState::apply_schedule_keywords. Those will get lost! Only for the multipliers the simulator will broadcast the changed values. 

In the long term we might want to make that if `FieldPropertyManager::fp` is used and is a nullptr, we exit more gracefully. 
Maybe we can/should do that in another PR?