### PR TITLE
Make SummaryConfig Nodes for Inter-Region Flows 

### DIFF
--- a/opm/io/eclipse/EclUtil.hpp
+++ b/opm/io/eclipse/EclUtil.hpp
@@ -37,6 +37,17 @@ namespace Opm { namespace EclIO {
     bool isFormatted(const std::string& filename);
     bool is_number(const std::string& numstr);
 
+    /// Compute the linearly combined summary vector ID number from two
+    /// constituents.
+    ///
+    /// Constituents are *typically* one-based region IDs, but at least one
+    /// of the two could be a component ID too.
+    int combineSummaryNumbers(const int n1, const int n2);
+
+    /// Split a combined summary vector ID ('NUMS' entry) into its original
+    /// two constituent IDs.
+    std::tuple<int,int> splitSummaryNumber(const int n);
+
     std::tuple<int, int> block_size_data_binary(eclArrType arrType);
     std::tuple<int, int, int> block_size_data_formatted(eclArrType arrType);
 

--- a/src/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -344,7 +344,7 @@ public:
             case FieldProps::GetStatus::MISSING_KEYWORD:
                 throw std::out_of_range("No such keyword in deck: " + keyword);
             case FieldProps::GetStatus::NOT_SUPPPORTED_KEYWORD:
-                throw std::logic_error("The kewyord  " + keyword + " is not supported");
+                throw std::logic_error("The keyword  " + keyword + " is not supported");
             }
         }
 

--- a/src/opm/input/eclipse/Schedule/SummaryState.cpp
+++ b/src/opm/input/eclipse/Schedule/SummaryState.cpp
@@ -31,10 +31,15 @@ namespace Opm{
 namespace {
 
     bool is_total(const std::string& key) {
-        static const std::vector<std::string> totals = {"OPT"  , "GPT"  , "WPT" , "GIT", "WIT", "OPTF" , "OPTS" , "OIT"  , "OVPT" , "OVIT" , "MWT" ,
-                                                        "WVPT" , "WVIT" , "GMT"  , "GPTF" , "SGT"  , "GST" , "FGT" , "GCT" , "GIMT" ,
-                                                        "WGPT" , "WGIT" , "EGT"  , "EXGT" , "GVPT" , "GVIT" , "LPT" , "VPT" , "VIT" , "NPT" , "NIT",
-                                                        "TPT", "TIT", "CPT", "CIT", "SPT", "SIT", "EPT", "EIT", "TPTHEA", "TITHEA"};
+        static const std::vector<std::string> totals = {
+            "OPT"  , "GPT"  , "WPT" , "GIT", "WIT", "OPTF" , "OPTS" , "OIT"  , "OVPT" , "OVIT" , "MWT" ,
+            "WVPT" , "WVIT" , "GMT"  , "GPTF" , "SGT"  , "GST" , "FGT" , "GCT" , "GIMT" ,
+            "WGPT" , "WGIT" , "EGT"  , "EXGT" , "GVPT" , "GVIT" , "LPT" , "VPT" , "VIT" , "NPT" , "NIT",
+            "TPT", "TIT", "CPT", "CIT", "SPT", "SIT", "EPT", "EIT", "TPTHEA", "TITHEA",
+            "OFT", "OFT+", "OFT-", "OFTG", "OFTL",
+            "GFT", "GFT+", "GFT-", "GFTG", "GFTL",
+            "WFT", "WFT+", "WFT-",
+        };
 
         auto sep_pos = key.find(':');
 

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -1220,8 +1220,7 @@ std::string ESmry::makeKeyString(const std::string& keywordArg, const std::strin
         if ((str34 == "FR") || (str34 == "FT") || (str45 == "FR") || (str45 == "FT")) {
 
             // NUMS = R1 + 32768*(R2 + 10)
-            const auto r1 =  num % (1UL << 15);
-            const auto r2 = (num / (1UL << 15)) - 10;
+            const auto& [r1, r2] = splitSummaryNumber(num);
 
             return fmt::format("{}:{}-{}", keywordArg, r1, r2);
         }

--- a/src/opm/io/eclipse/EclUtil.cpp
+++ b/src/opm/io/eclipse/EclUtil.cpp
@@ -103,6 +103,18 @@ bool Opm::EclIO::isEOF(std::fstream* fileH)
     }
 }
 
+int Opm::EclIO::combineSummaryNumbers(const int n1, const int n2)
+{
+    return n1 + (1 << 15)*(n2 + 10);
+}
+
+std::tuple<int, int> Opm::EclIO::splitSummaryNumber(const int n)
+{
+    const auto n1 =  n % (1 << 15);
+    const auto n2 = (n / (1 << 15)) - 10;
+
+    return { n1, n2 };
+}
 
 std::tuple<int, int> Opm::EclIO::block_size_data_binary(eclArrType arrType)
 {

--- a/tests/test_EclIO.cpp
+++ b/tests/test_EclIO.cpp
@@ -530,3 +530,20 @@ BOOST_AUTO_TEST_CASE(TestEcl_Write_CHAR) {
         BOOST_CHECK(std::get<1>(arrayList[0]) == Opm::EclIO::C0NN);
     }
 }
+
+BOOST_AUTO_TEST_CASE(CombinedVectorID) {
+    BOOST_CHECK_EQUAL(combineSummaryNumbers(1, 2), 393'217);
+    BOOST_CHECK_EQUAL(combineSummaryNumbers(10, 1), 360'458);
+
+    {
+        const auto [n1, n2] = splitSummaryNumber(393'217);
+        BOOST_CHECK_EQUAL(n1, 1);
+        BOOST_CHECK_EQUAL(n2, 2);
+    }
+
+    {
+        const auto [n1, n2] = splitSummaryNumber(360'458);
+        BOOST_CHECK_EQUAL(n1, 10);
+        BOOST_CHECK_EQUAL(n2,  1);
+    }
+}


### PR DESCRIPTION
This PR adds new nodes pertaining to the inter-region flows to the summary configuration keyword list.  We combine the pair of region IDs into a single `NUMS` value as part of creating the node. We also split inter-region nodes into a "supported" and an "unsupported" set, with the former containing the oil, gas, and water keywords.

To this end introduce new helper functions
```C++
int EclIO::combineSummaryNumbers(int, int);
std::tuple<int, int> EclIO::splitSummaryNumber(int);
```
that know about the relation
```
combined = n1 + 32768*(n2 + 10)
```
for one-based IDs `n1` and `n2` (typically region IDs).  Finally, register inter-region flow cumulatives for `SummaryState` as this is needed for correct accumulation.