### PR TITLE
Fix SALTVD unit

### DIFF
--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/S/SALTVD
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/S/SALTVD
@@ -15,7 +15,7 @@
       "size_type": "ALL",
       "dimension": [
         "Length",
-        "Density"
+        "Salinity"
       ]
     }
   ]


### PR DESCRIPTION
According to eclipse/flow manuals, saltvd input should be lb/stb (Salinity in Units.hpp), not Density (lb/ft3).