### PR TITLE
Pyaction applyaction

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -86,7 +86,7 @@ void msim::post_step(Schedule& schedule, SummaryState& st, data::Solution& /* so
     for (const auto& action : actions.pending(this->action_state, std::chrono::system_clock::to_time_t(sim_time))) {
         auto result = action->eval(context);
         if (result)
-            schedule.applyAction(report_step, *action, result, {});
+            schedule.applyAction(report_step, *action, result.wells(), {});
     }
 
     for (const auto& pyaction : actions.pending_python())

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -86,7 +86,7 @@ void msim::post_step(Schedule& schedule, SummaryState& st, data::Solution& /* so
     for (const auto& action : actions.pending(this->action_state, std::chrono::system_clock::to_time_t(sim_time))) {
         auto result = action->eval(context);
         if (result)
-            schedule.applyAction(report_step, sim_time, *action, result, {});
+            schedule.applyAction(report_step, *action, result, {});
     }
 
     for (const auto& pyaction : actions.pending_python())

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -280,6 +280,7 @@ namespace Opm
         const std::map< std::string, int >& rst_keywords( size_t timestep ) const;
 
         SimulatorUpdate applyAction(std::size_t reportStep, const Action::ActionX& action, const std::vector<std::string>& matching_wells, const std::unordered_map<std::string, double>& wellpi);
+        SimulatorUpdate runPyAction(std::size_t reportStep, const Action::PyAction& pyaction, EclipseState& ecl_state, SummaryState& summary_state);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -279,7 +279,7 @@ namespace Opm
         bool write_rst_file(std::size_t report_step) const;
         const std::map< std::string, int >& rst_keywords( size_t timestep ) const;
 
-        SimulatorUpdate applyAction(std::size_t reportStep, const time_point& sim_time, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& wellpi);
+        SimulatorUpdate applyAction(std::size_t reportStep, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& wellpi);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -279,7 +279,7 @@ namespace Opm
         bool write_rst_file(std::size_t report_step) const;
         const std::map< std::string, int >& rst_keywords( size_t timestep ) const;
 
-        SimulatorUpdate applyAction(std::size_t reportStep, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& wellpi);
+        SimulatorUpdate applyAction(std::size_t reportStep, const Action::ActionX& action, const std::vector<std::string>& matching_wells, const std::unordered_map<std::string, double>& wellpi);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
 

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1290,7 +1290,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
     }
 
 
-    SimulatorUpdate Schedule::applyAction(std::size_t reportStep, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& target_wellpi) {
+    SimulatorUpdate Schedule::applyAction(std::size_t reportStep, const Action::ActionX& action, const std::vector<std::string>& matching_wells, const std::unordered_map<std::string, double>& target_wellpi) {
         const std::string prefix = "| ";
         ParseContext parseContext;
         ErrorGuard errors;
@@ -1311,7 +1311,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
                                 parseContext,
                                 errors,
                                 grid,
-                                result.wells(),
+                                matching_wells,
                                 true,
                                 &sim_update,
                                 &target_wellpi);

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1332,6 +1332,12 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
 
 
 
+    SimulatorUpdate Schedule::runPyAction(std::size_t reportStep, const Action::PyAction& pyaction, EclipseState& ecl_state, SummaryState& summary_state) {
+        SimulatorUpdate sim_update;
+        pyaction.run(ecl_state, *this, reportStep, summary_state);
+        return sim_update;
+    }
+
     void Schedule::applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double newWellPI) {
         if (reportStep >= this->snapshots.size())
             return;

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1290,7 +1290,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
     }
 
 
-    SimulatorUpdate Schedule::applyAction(std::size_t reportStep, const time_point&, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& target_wellpi) {
+    SimulatorUpdate Schedule::applyAction(std::size_t reportStep, const Action::ActionX& action, const Action::Result& result, const std::unordered_map<std::string, double>& target_wellpi) {
         const std::string prefix = "| ";
         ParseContext parseContext;
         ErrorGuard errors;

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -158,7 +158,7 @@ TSTEP
 
     Action::Result action_result(true);
     const auto& action1 = sched[0].actions.get()["ACTION"];
-    auto sim_update = sched.applyAction(0, action1, action_result, {});
+    auto sim_update = sched.applyAction(0, action1, action_result.wells(), {});
     const auto& affected_wells = sim_update.affected_wells;
     std::vector<std::string> expected_wells{"W0", "W1", "W3"};
     BOOST_CHECK( std::is_permutation(affected_wells.begin(), affected_wells.end(),
@@ -224,7 +224,7 @@ COMPDAT
     Schedule sched = make_schedule(TRAILING_COMPDAT);
     Action::Result action_result(true);
     const auto& action1 = sched[0].actions.get()["ACTION"];
-    BOOST_CHECK_NO_THROW( sched.applyAction(0, action1, Action::Result{true}, {}));
+    BOOST_CHECK_NO_THROW( sched.applyAction(0, action1, {}, {}));
 }
 
 
@@ -1137,7 +1137,7 @@ TSTEP
 
 
     Action::Result action_result(true);
-    sched.applyAction(0, action1, action_result, {});
+    sched.applyAction(0, action1, action_result.wells(), {});
 
     {
         const auto& group = sched.getGroup("G1", 1);
@@ -1252,7 +1252,7 @@ TSTEP
 
 
     Action::Result action_result(true);
-    const auto& sim_update = sched.applyAction(0, action1, action_result, {});
+    const auto& sim_update = sched.applyAction(0, action1, action_result.wells(), {});
     BOOST_CHECK( sim_update.affected_wells.empty() );
     {
         const auto& glo = sched.glo(0);
@@ -1326,7 +1326,7 @@ TSTEP
     BOOST_CHECK(!sched.hasWell("PROD1"));
 
     Action::Result action_result(true);
-    sched.applyAction(0, action1, action_result, {});
+    sched.applyAction(0, action1, action_result.wells(), {});
 
     const auto& well = sched.getWell("PROD1", 1);
     const auto& connections = well.getConnections();
@@ -1388,10 +1388,10 @@ TSTEP
 
 
     Action::Result action_result(true);
-    BOOST_CHECK_THROW( sched.applyAction(0, action1, action_result, {}), std::exception);
+    BOOST_CHECK_THROW( sched.applyAction(0, action1, action_result.wells(), {}), std::exception);
     {
         const auto& well = sched.getWell("PROD1", 0);
-        const auto& sim_update = sched.applyAction(0, action1, action_result, {{"PROD1", well.convertDeckPI(500)}});
+        const auto& sim_update = sched.applyAction(0, action1, action_result.wells(), {{"PROD1", well.convertDeckPI(500)}});
         BOOST_CHECK_EQUAL( sim_update.affected_wells.count("PROD1"), 1);
         BOOST_CHECK_EQUAL( sim_update.affected_wells.size(), 1);
     }
@@ -1461,7 +1461,7 @@ TSTEP
     BOOST_CHECK(sched[0].geo_keywords().empty());
 
     Action::Result action_result(true);
-    auto sim_update = sched.applyAction(0, action1, action_result, {});
+    auto sim_update = sched.applyAction(0, action1, action_result.wells(), {});
     BOOST_CHECK( sim_update.tran_update );
     BOOST_CHECK_EQUAL(sched[0].geo_keywords().size(), 3);
 }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -157,9 +157,8 @@ TSTEP
     BOOST_CHECK( sched.hasWell("W2"));
 
     Action::Result action_result(true);
-    auto sim_time = TimeService::now();
     const auto& action1 = sched[0].actions.get()["ACTION"];
-    auto sim_update = sched.applyAction(0, sim_time, action1, action_result, {});
+    auto sim_update = sched.applyAction(0, action1, action_result, {});
     const auto& affected_wells = sim_update.affected_wells;
     std::vector<std::string> expected_wells{"W0", "W1", "W3"};
     BOOST_CHECK( std::is_permutation(affected_wells.begin(), affected_wells.end(),
@@ -224,9 +223,8 @@ COMPDAT
 
     Schedule sched = make_schedule(TRAILING_COMPDAT);
     Action::Result action_result(true);
-    auto sim_time = TimeService::now();
     const auto& action1 = sched[0].actions.get()["ACTION"];
-    BOOST_CHECK_NO_THROW( sched.applyAction(0, sim_time, action1, Action::Result{true}, {}));
+    BOOST_CHECK_NO_THROW( sched.applyAction(0, action1, Action::Result{true}, {}));
 }
 
 
@@ -1139,8 +1137,7 @@ TSTEP
 
 
     Action::Result action_result(true);
-    auto sim_time = TimeService::now();
-    sched.applyAction(0, sim_time, action1, action_result, {});
+    sched.applyAction(0, action1, action_result, {});
 
     {
         const auto& group = sched.getGroup("G1", 1);
@@ -1255,7 +1252,7 @@ TSTEP
 
 
     Action::Result action_result(true);
-    const auto& sim_update = sched.applyAction(0, TimeService::now(), action1, action_result, {});
+    const auto& sim_update = sched.applyAction(0, action1, action_result, {});
     BOOST_CHECK( sim_update.affected_wells.empty() );
     {
         const auto& glo = sched.glo(0);
@@ -1329,7 +1326,7 @@ TSTEP
     BOOST_CHECK(!sched.hasWell("PROD1"));
 
     Action::Result action_result(true);
-    sched.applyAction(0, TimeService::now(), action1, action_result, {});
+    sched.applyAction(0, action1, action_result, {});
 
     const auto& well = sched.getWell("PROD1", 1);
     const auto& connections = well.getConnections();
@@ -1391,10 +1388,10 @@ TSTEP
 
 
     Action::Result action_result(true);
-    BOOST_CHECK_THROW( sched.applyAction(0, TimeService::now(), action1, action_result, {}), std::exception);
+    BOOST_CHECK_THROW( sched.applyAction(0, action1, action_result, {}), std::exception);
     {
         const auto& well = sched.getWell("PROD1", 0);
-        const auto& sim_update = sched.applyAction(0, TimeService::now(), action1, action_result, {{"PROD1", well.convertDeckPI(500)}});
+        const auto& sim_update = sched.applyAction(0, action1, action_result, {{"PROD1", well.convertDeckPI(500)}});
         BOOST_CHECK_EQUAL( sim_update.affected_wells.count("PROD1"), 1);
         BOOST_CHECK_EQUAL( sim_update.affected_wells.size(), 1);
     }
@@ -1464,7 +1461,7 @@ TSTEP
     BOOST_CHECK(sched[0].geo_keywords().empty());
 
     Action::Result action_result(true);
-    auto sim_update = sched.applyAction(0, TimeService::now(), action1, action_result, {});
+    auto sim_update = sched.applyAction(0, action1, action_result, {});
     BOOST_CHECK( sim_update.tran_update );
     BOOST_CHECK_EQUAL(sched[0].geo_keywords().size(), 3);
 }


### PR DESCRIPTION
This PR is just a small preparation for some more PYACTION related updates.

At some stage the `Schedule` implementation was heavily rewritten in order to better support ACTIONX. The plan now is to update the execution of PYACTION to use the same mechanism - i.e. apply a bunch keywords and not call methods on the `Schedule`object when something should be changed.

Yes - I know it is but ugly; but the execution model of flow/eclipse is so complex that I think this is the only viable solution. That said - there is nothing here preventing a more elegant approach when/if that is possible. 

Downstream: https://github.com/OPM/opm-simulators/pull/3782