### PR TITLE
Ensure Proper Initialisation of All TableManager Member

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
@@ -381,8 +381,8 @@ namespace Opm {
         DenT watDenT;
         StandardCond stcond;
         std::size_t m_gas_comp_index = 77;
-        double m_rtemp;
-        double m_salinity;
+        double m_rtemp {288.7056}; // 60 Fahrenheit in Kelvin
+        double m_salinity {0.0};
 
         struct SplitSimpleTables {
           size_t plyshMax = 0;


### PR DESCRIPTION
Otherwise, the equality operators for a default-constructed `TableManager` object, mostly used in unit tests, will depend on uninitialised values.

Thanks to [at]akva2 for the initial clue to the underlying cause.