### PR TITLE
Ensure That Keyword Name Matches Filename

### DIFF
--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/S/SURFCAPD
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/S/SURFCAPD
@@ -1,5 +1,5 @@
 {
-  "name": "SURFADS",
+  "name": "SURFCAPD",
   "sections": [
     "PROPS"
   ],


### PR DESCRIPTION
Otherwise, we get "missing keyword" errors at the parsing stage.