### PR TITLE
Cast enum classes to int when used in fmt::format.

### DIFF
--- a/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
@@ -519,8 +519,8 @@ std::pair<UDQSet, UDQSet> udq_cast(const UDQSet& lhs, const UDQSet& rhs)
     }
 
     auto msg = fmt::format("Type/size mismatch when combining UDQs {}(size={}, type={}) and {}(size={}, type={})",
-                           lhs.name(), lhs.size(), lhs.var_type(),
-                           rhs.name(), rhs.size(), rhs.var_type());
+                           lhs.name(), lhs.size(), static_cast<int>(lhs.var_type()),
+                           rhs.name(), rhs.size(), static_cast<int>(rhs.var_type()));
     throw std::logic_error(msg);
 }
 

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -91,7 +91,8 @@ int nwgmax(const std::vector<int>& inteHead)
             return value::GuideRateMode::None;
 
         default:
-            throw std::logic_error(fmt::format("Not recognized value: {} for GuideRateProdTarget", grpt));
+            throw std::logic_error(fmt::format("Not recognized value: {} for GuideRateProdTarget",
+                                               static_cast<int>(grpt)));
     }
 }
 


### PR DESCRIPTION
This is needed for libfmt >= 8.1.0 as in that version the
cast to int was removed from inside the fmt::format call and an
assertion will fail:
```
In file included from /usr/include/fmt/format.h:48,
                 from /build/opm-common-2021.10/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp:22:
/usr/include/fmt/core.h: In instantiation of 'constexpr fmt::v8::detail::value<Context> fmt::v8::detail::make_arg(T&&) [with bool IS_PACKED = true; Context = fmt::v8::basic_format_context<fmt::v8::appender, char>; fmt::v8::detail::type <anonymous> = fmt::v8::detail::type::custom_type; T = Opm::UDQVarType&; typename std::enable_if<IS_PACKED, int>::type <anonymous> = 0]':
/usr/include/fmt/core.h:1855:77:   required from 'constexpr fmt::v8::format_arg_store<Context, Args>::format_arg_store(T&& ...) [with T = {const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, long unsigned int&, Opm::UDQVarType&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, long unsigned int&, Opm::UDQVarType&}; Context = fmt::v8::basic_format_context<fmt::v8::appender, char>; Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long unsigned int, Opm::UDQVarType, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long unsigned int, Opm::UDQVarType}]'
/usr/include/fmt/core.h:1872:38:   required from 'constexpr fmt::v8::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<Args>::type>::type ...> fmt::v8::make_format_args(Args&& ...) [with Context = fmt::v8::basic_format_context<fmt::v8::appender, char>; Args = {const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, long unsigned int&, Opm::UDQVarType&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, long unsigned int&, Opm::UDQVarType&}]'
/usr/include/fmt/core.h:3119:44:   required from 'std::string fmt::v8::format(fmt::v8::format_string<T ...>, T&& ...) [with T = {const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, long unsigned int, Opm::UDQVarType, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, long unsigned int, Opm::UDQVarType}; std::string = std::__cxx11::basic_string<char>; fmt::v8::format_string<T ...> = fmt::v8::basic_format_string<char, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, long unsigned int, Opm::UDQVarType, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, long unsigned int, Opm::UDQVarType>]'
/build/opm-common-2021.10/src/opm/parser/eclipse/EclipseState/Schedule/UDQ/UDQSet.cpp:523:27:   required from here
/usr/include/fmt/core.h:1728:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1728 |       formattable,
      |       ^~~~~~~~~~~
/usr/include/fmt/core.h:1728:7: note: 'formattable' evaluates to false
```

Closes #2935 