### PR TITLE
[bugfix] Make opm-common_PYTHON_LINKAGE a comma separated list.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,12 @@ if (OPM_ENABLE_PYTHON)
     list(APPEND opm-common_PYTHON_LINKAGE "'${cjson_LIBRARIES}'")
   endif()
 
+  # opm-common_PYTHON_LINKAGE is used verbatim in a listin python.
+  # Hence items need to be comma separated.
+  if (opm-common_PYTHON_LINKAGE)
+    string(REPLACE ";" "," SETUP_PY_LINKAGE "${opm-common_PYTHON_LINKAGE}")
+  endif()
+
   configure_file (${PROJECT_SOURCE_DIR}/python/setup.py.in ${PROJECT_BINARY_DIR}/python/setup.py)
   file(COPY ${PROJECT_SOURCE_DIR}/python/README.md DESTINATION ${PROJECT_BINARY_DIR}/python)
   execute_process(COMMAND ${Python3_EXECUTABLE} target_name.py

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -69,7 +69,7 @@ ext_modules = [
         undef_macros=["NDEBUG"],
         include_dirs=[@SETUP_PY_PYBIND_INCLUDE_DIR@],
         extra_compile_args=['-std=c++17', '-fopenmp', @SETUP_PY_FMT_FLAGS@],
-        extra_link_args=['-fopenmp', @opm-common_PYTHON_LINKAGE@]
+        extra_link_args=['-fopenmp', @SETUP_PY_LINKAGE@]
     )
 ]
 


### PR DESCRIPTION
It is used verbatim in setup.py in the list that specifies the linker flage. Hence it needs to comma separted instead of using a   semicolon as separator.

Closes #2947