### PR TITLE
Empty actionx

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ASTNode.hpp
+++ b/opm/input/eclipse/Schedule/Action/ASTNode.hpp
@@ -28,6 +28,8 @@ public:
     FuncType func_type;
     void add_child(const ASTNode& child);
     size_t size() const;
+    bool empty() const;
+
     std::string func;
     void required_summary(std::unordered_set<std::string>& required_summary) const;
 

--- a/src/opm/input/eclipse/Schedule/Action/ASTNode.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ASTNode.cpp
@@ -89,6 +89,9 @@ size_t ASTNode::size() const {
     return this->children.size();
 }
 
+bool ASTNode::empty() const {
+    return this->size() == 0;
+}
 
 void ASTNode::add_child(const ASTNode& child) {
     this->children.push_back(child);

--- a/src/opm/input/eclipse/Schedule/Action/ActionAST.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionAST.cpp
@@ -47,10 +47,10 @@ AST AST::serializeObject()
 }
 
 Action::Result AST::eval(const Action::Context& context) const {
-    if (this->condition)
-        return this->condition->eval(context);
-    else
+    if (!this->condition || this->condition->empty())
         return Action::Result(false);
+    else
+        return this->condition->eval(context);
 }
 
 

--- a/src/opm/input/eclipse/Schedule/Action/ActionParser.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionParser.cpp
@@ -265,7 +265,9 @@ Action::ASTNode Parser::parse_or() {
 
 Action::ASTNode Parser::parse(const std::vector<std::string>& tokens) {
     Parser parser(tokens);
-    parser.next();
+    auto start_node = parser.next();
+    if (start_node.type == TokenType::end)
+        return ASTNode( start_node.type );
 
     auto tree = parser.parse_or();
     auto current = parser.current();

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -303,29 +303,6 @@ BOOST_AUTO_TEST_CASE(TestContext) {
 
 
 
-Opm::Schedule make_action(const std::string& action_string) {
-    std::string start = std::string{ R"(
-SCHEDULE
-)"};
-    std::string end = std::string{ R"(
-ENDACTIO
-
-TSTEP
-   10 /
-)"};
-
-    std::string deck_string = start + action_string + end;
-    Opm::Parser parser;
-    auto deck = parser.parseString(deck_string);
-    auto python = std::make_shared<Python>();
-    EclipseGrid grid1(10,10,10);
-    TableManager table ( deck );
-    FieldPropsManager fp( deck, Phases{true, true, true}, grid1, table);
-    Runspec runspec(deck);
-
-    return Schedule(deck, grid1, fp, runspec, python);
-}
-
 
 BOOST_AUTO_TEST_CASE(TestAction_AST_BASIC) {
     // Missing comparator

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -227,6 +227,38 @@ COMPDAT
     BOOST_CHECK_NO_THROW( sched.applyAction(0, action1, {}, {}));
 }
 
+BOOST_AUTO_TEST_CASE(EMPTY) {
+
+    const auto EMPTY_ACTION = std::string{ R"(
+GRID
+
+PORO
+    1000*0.1 /
+PERMX
+    1000*1 /
+PERMY
+    1000*0.1 /
+PERMZ
+    1000*0.01 /
+
+SCHEDULE
+
+ACTIONX
+   'ACTION' /
+/
+
+ENDACTIO
+)"};
+
+    Schedule sched = make_schedule(EMPTY_ACTION);
+    Action::Result action_result(true);
+    const auto& action1 = sched[0].actions.get()["ACTION"];
+    Opm::SummaryState st(TimeService::now());
+    Opm::WListManager wlm;
+    Opm::Action::Context context(st, wlm);
+    BOOST_CHECK( !action1.eval(context) );
+}
+
 
 BOOST_AUTO_TEST_CASE(TestActions) {
     Opm::SummaryState st(TimeService::now());


### PR DESCRIPTION
 Allow ACTIONX keywords with empty conditions, these ACTIONX keywords will always
evaluate to false. Main motivation is to facilitate dummy keywords for PYACTION.