### PR TITLE
Recognize Non-Default FIP Arrays for Inter-Region Flow Summary Keywords

### DIFF
--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -198,6 +198,7 @@ namespace Opm {
             */
             bool require3DField( const std::string& keyword) const;
             std::set<std::string> fip_regions() const;
+            std::set<std::string> fip_regions_interreg_flow() const;
             std::unordered_set<std::string> wbp_wells() const;
 
             bool operator==(const SummaryConfig& data) const;

--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1808,6 +1808,22 @@ std::set<std::string> SummaryConfig::fip_regions() const {
     return reg_set;
 }
 
+std::set<std::string> SummaryConfig::fip_regions_interreg_flow() const
+{
+    using Category = EclIO::SummaryNode::Category;
+
+    auto reg_set = std::set<std::string>{};
+
+    for (const auto& node : this->m_keywords) {
+        if ((node.category() == Category::Region) &&
+            is_region_to_region(node.keyword()))
+        {
+            reg_set.insert(node.fip_region());
+        }
+    }
+
+    return reg_set;
+}
 
 bool SummaryConfig::operator==(const Opm::SummaryConfig& data) const {
     return this->m_keywords == data.m_keywords &&

--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -315,7 +315,9 @@ struct SummaryConfigContext {
 
     bool is_supported_region_to_region(const std::string& keyword)
     {
-        static const auto supported_kw = std::regex { R"(R[OGW]F[RT][-+GL]?)" };
+        static const auto supported_kw = std::regex {
+            R"~~(R[OGW]F[RT][-+GL_]?([A-Z0-9_]{3})?)~~"
+        };
 
         // R[OGW]F[RT][-+GL]? (e.g., "ROFTG", "RGFR+", or "RWFT")
         return std::regex_match(keyword, supported_kw);
@@ -323,7 +325,9 @@ struct SummaryConfigContext {
 
     bool is_unsupported_region_to_region(const std::string& keyword)
     {
-        static const auto unsupported_kw = std::regex { R"(R([EK]|NL)F[RT][-+]?)" };
+        static const auto unsupported_kw = std::regex {
+            R"~~(R([EK]|NL)F[RT][-+_]?([A-Z0-9_]{3})?)~~"
+        };
 
         // R[EK]F[RT][-+]? (e.g., "REFT" or "RKFR+")
         // RNLF[RT][-+]? (e.g., "RNLFR-" or "RNLFT")

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION2REGION_PROBE
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION2REGION_PROBE
@@ -3,15 +3,7 @@
   "sections": [
     "SUMMARY"
   ],
-  "deck_names": [
-    "ROFT",
-    "ROFTL",
-    "ROFTG",
-    "RGFT",
-    "RGFTL",
-    "RGFTG",
-    "RWFT"
-  ],
+  "deck_name_regex": "(R[OG]FT[GL]?|RWFT)(_?[A-Z0-9_]{3})?",
   "items": [
     {
       "name": "REGION1",

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/R/REGION2REGION_PROBE_E300
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/R/REGION2REGION_PROBE_E300
@@ -4,7 +4,7 @@
     "SUMMARY"
   ],
   "comment": "E300 only",
-  "deck_name_regex": "R[OGWEK]F(R[-+]?|T[-+])",
+  "deck_name_regex": "R[OGWEK]F(R[-+]?|T[-+])([A-Z0-9_]{3})?",
   "items": [
     {
       "name": "REGION1",

--- a/tests/parser/SummaryConfigTests.cpp
+++ b/tests/parser/SummaryConfigTests.cpp
@@ -81,7 +81,7 @@ RUNSPEC
 DIMENS
  10 10 10 /
 REGDIMS
-  3/
+  3 3 /
 AQUDIMS
 4 4 1* 1* 3 200 1* 1* /
 GRID
@@ -119,6 +119,8 @@ FIPNUM
 200*1 300*2 500*3 /
 FIPREG
 200*10 300*20 500*30 /
+FIPXYZ
+200*2 300*3 500*1 /
 SOLUTION
 AQUCT
 1    2040     1*    1000   .3    3.0e-5     1330     10     360.0   1   1* /
@@ -1484,6 +1486,55 @@ RHPV_REG
 
     // See comment on the roew() function in Summary.cpp for this uglyness.
     BOOST_CHECK(summary_config.hasKeyword("COPT"));
+}
+
+BOOST_AUTO_TEST_CASE(InterReg_Flows) {
+    const auto deck_string = std::string { R"(
+ROFT
+1 2 /
+/
+
+ROFTGXYZ
+1 2 /
+/
+
+RGFT_XYZ
+1 2 /
+/
+
+RWFR-XYZ
+1 3 /
+2 3 /
+/
+
+RGFR+XYZ
+1 3 /
+2 3 /
+/
+
+RGFTL
+2 3 /
+/
+)" };
+
+    const auto summary_config = createSummary(deck_string);
+
+    BOOST_CHECK_EQUAL(summary_config.size(), 8);
+    BOOST_CHECK(summary_config.hasKeyword("ROFT"));
+    BOOST_CHECK(summary_config.hasKeyword("ROFTGXYZ"));
+    BOOST_CHECK(summary_config.hasKeyword("RGFT_XYZ"));
+    BOOST_CHECK(summary_config.hasKeyword("RWFR-XYZ"));
+    BOOST_CHECK(summary_config.hasKeyword("RGFR+XYZ"));
+    BOOST_CHECK(summary_config.hasKeyword("RGFTL"));
+
+    const auto fip_regions_ireg = summary_config.fip_regions_interreg_flow();
+    const auto expect = std::vector<std::string> {
+        "FIPNUM", "FIPXYZ",
+    };
+
+    BOOST_CHECK_MESSAGE(std::is_permutation(fip_regions_ireg.begin(), fip_regions_ireg.end(),
+                                            expect.begin(), expect.end()),
+                        "Inter-regional arrays must match expected set");
 }
 
 BOOST_AUTO_TEST_CASE( WOPRL ) {


### PR DESCRIPTION
This PR adds a new query
```C++
std::set<std::string> SummaryConfig::fip_regions_interreg_flow() const;
```
that retrieves the set of FIP array names (e.g., `FIPNUM` and `FIPXYZ`) that are associated to any inter-region flow summary keywords.  This query method returns an empty set if there are no inter-region flow summary keywords.

We also extend the `SummaryConfig` support for inter-region flows to be aware of those user-provided FIP arrays.  In other words, we now recognize, e.g., that
```
ROFT_XYZ
```
is the cumulative inter-region oil flow volume corresponding to regions defined by the `FIPXYZ` region definition.