### PR TITLE
Update Injected/Produced Flag When Processing WELOPEN

### DIFF
--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1245,23 +1245,39 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
             /* if all records are defaulted or just the status is set, only
              * well status is updated
              */
-            if (conn_defaulted( record )) {
-                const auto well_status = Well::StatusFromString( status_str );
+            if (conn_defaulted(record)) {
+                const auto new_well_status = Well::StatusFromString(status_str);
+
                 for (const auto& wname : well_names) {
-                    {
-                        const auto& well = this->getWell(wname, currentStep);
-                        if( well_status == open && !well.canOpen() ) {
-                            auto elapsed = this->snapshots[currentStep].start_time() - this->snapshots[0].start_time();
-                            auto days = std::chrono::duration_cast<std::chrono::hours>(elapsed).count() / 24;
-                            std::string msg = "Well " + wname
-                                + " where crossflow is banned has zero total rate."
-                                + " This well is prevented from opening at "
-                                + std::to_string( days ) + " days";
-                            OpmLog::note(msg);
-                        } else {
-                            this->updateWellStatus( wname, currentStep, well_status);
-                            if (handlerContext.sim_update)
-                                handlerContext.sim_update->affected_wells.insert(wname);
+                    if ((new_well_status == open) && !this->getWell(wname, currentStep).canOpen()) {
+                        auto elapsed = this->snapshots[currentStep].start_time() - this->snapshots[0].start_time();
+                        auto days = std::chrono::duration_cast<std::chrono::hours>(elapsed).count() / 24;
+                        std::string msg = "Well " + wname
+                            + " where crossflow is banned has zero total rate."
+                            + " This well is prevented from opening at "
+                            + std::to_string( days ) + " days";
+                        OpmLog::note(msg);
+                    }
+                    else {
+                        const auto did_update_well_status =
+                            this->updateWellStatus(wname, currentStep, new_well_status);
+
+                        if (handlerContext.sim_update) {
+                            handlerContext.sim_update->affected_wells.insert(wname);
+                        }
+
+                        if (did_update_well_status && (new_well_status == open)) {
+                            // Record possible well injection/production status change
+                            auto well2 = this->snapshots[currentStep].wells.get(wname);
+
+                            const auto did_flow_update =
+                                (well2.isProducer() && well2.updateHasProduced())
+                                ||
+                                (well2.isInjector() && well2.updateHasInjected());
+
+                            if (did_flow_update) {
+                                this->snapshots[currentStep].wells.update(std::move(well2));
+                            }
                         }
                     }
                 }

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1229,7 +1229,7 @@ inline quantity injection_history( const fn_args& args )
 }
 
 template< bool injection >
-inline quantity abondoned_well( const fn_args& args ) {
+inline quantity abandoned_well( const fn_args& args ) {
     std::size_t count = 0;
 
     for (const auto* sched_well : args.schedule_wells) {
@@ -2045,8 +2045,8 @@ static const std::unordered_map< std::string, ofun > funs = {
     { "FMWIN", flowing< injector > },
     { "FMWPR", flowing< producer > },
     { "FVPRT", res_vol_production_target },
-    { "FMWPA", abondoned_well< producer > },
-    { "FMWIA", abondoned_well< injector >},
+    { "FMWPA", abandoned_well< producer > },
+    { "FMWIA", abandoned_well< injector >},
 
     //Field control mode
     { "FMCTP", group_control< false, true,  false, false >},


### PR DESCRIPTION
If a well is entered in `WCON{INJE,PROD}` as status `'SHUT'` but later activated in `WELOPEN`, we must take care to record this status change in the well's internal `has_produced` or `has_injected` flags as appropriate.  Otherwise, the counts of "abandoned" wells (summary vectors `[FG]MW[IP]A`) will not be correct.

This PR fixes a problem that was identified in a client model.

While here, also correct a misspelling of "abandoned".