### PR TITLE
Add missing <string> include for std::to_string().

### DIFF
--- a/src/opm/output/data/InterRegFlowMap.cpp
+++ b/src/opm/output/data/InterRegFlowMap.cpp
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Necessary to compile with clang.