### PR TITLE
Allow ALQ type to be updated if undefined

### DIFF
--- a/opm/input/eclipse/Schedule/VFPProdTable.hpp
+++ b/opm/input/eclipse/Schedule/VFPProdTable.hpp
@@ -137,6 +137,8 @@ public:
         return m_alq_data;
     }
 
+    void updateAlqType(const ALQ_TYPE& type, const UnitSystem& unit_system);
+
     /**
      * Returns the data of the table itself. For ordered access
      * use operator()(thp_idx, wfr_idx, gfr_idx, alq_idx, flo_idx)

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1662,7 +1662,6 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
 
             for (const auto& wname : well_names) {
                 auto well = GasLiftOpt::Well(wname, use_glo);
-
                 if (max_rate_item.hasValue(0))
                     well.max_rate( max_rate_item.getSIDouble(0) );
 
@@ -1670,8 +1669,21 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                 well.inc_weight_factor(inc_weight_factor);
                 well.min_rate(min_rate);
                 well.alloc_extra_gas(alloc_extra_gas);
-
                 glo.add_well(well);
+
+                auto well2 = this->snapshots.back().wells.get( wname );
+                auto prod_prop = well2.getProductionProperties();
+                auto table_no = prod_prop.VFPTableNumber;
+                auto& vfp_prod = this->snapshots.back().vfpprod;
+                if (vfp_prod.has(table_no)) {
+                    auto& table = vfp_prod.get(table_no);
+                    auto alq_type = table.getALQType();
+                    if (alq_type == VFPProdTable::ALQ_TYPE::ALQ_UNDEF) {
+                        table.updateAlqType(
+                            VFPProdTable::ALQ_TYPE::ALQ_GRAT,
+                            this->m_static.m_unit_system);
+                    }
+                }
             }
         }
 

--- a/src/opm/input/eclipse/Schedule/VFPProdTable.cpp
+++ b/src/opm/input/eclipse/Schedule/VFPProdTable.cpp
@@ -541,6 +541,14 @@ Dimension VFPProdTable::ALQDimension(const ALQ_TYPE& alq_type, const UnitSystem&
     return Dimension(scaling_factor);
 }
 
+void VFPProdTable::updateAlqType(const ALQ_TYPE& type, const UnitSystem& unit_system)
+{
+    if (this->m_alq_type != ALQ_TYPE::ALQ_UNDEF) {
+        throw std::logic_error("ALQ type already set. Cannot update.");
+    }
+    this->m_alq_type = type;
+    convertAlqToSI(type, this->m_alq_data, unit_system);
+}
 
 void VFPProdTable::convertAlqToSI(const ALQ_TYPE& type,
                                   std::vector<double>& values,


### PR DESCRIPTION
Refer to case [GASLIFT-02 line 723](https://github.com/OPM/opm-tests/blob/master/gaslift/GASLIFT-02.DATA#L723). Observe that item 7 in `VFPPROD` is defaulted. Currently, the manual is not clear what this means if gas lift optimization is used. However, after discussions with @OPMUSER and @totto82, it was clarified that in Eclipse this means that the item is set to `GRAT` (which it needs to be for gaslift optimization). In flow, it is currently not the case since a [default value is not defined](https://github.com/OPM/opm-common/blob/master/src/opm/input/eclipse/share/keywords/000_Eclipse100/V/VFPPROD#L36).

The approach taken here, is that if a `WLIFTOPT` keyword is encountered in the `SCHEDULE` section, after the corresponding `VFPPROD` table has been defined, item7 is reset to `GRAT` (this will however not work if `VFPPROD` is encountered after `WLIFTOPT` in the `SCHEDULE` section, any suggestions of how to handle this? Or if it should be handled at all?). 

