### PR TITLE
Convert default ALQ type to GRAT when gaslift optimization is active

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -87,6 +87,7 @@ namespace Opm
         std::optional<int> output_interval;
         double sumthin{-1.0};
         bool rptonly{false};
+        bool gaslift_opt_active{false};
 
         ScheduleStatic() = default;
 
@@ -113,6 +114,7 @@ namespace Opm
             rst_info.serializeOp(serializer);
             rst_config.serializeOp(serializer);
             serializer(this->output_interval);
+            serializer(this->gaslift_opt_active);
         }
 
 
@@ -134,6 +136,7 @@ namespace Opm
                    this->m_unit_system == other.m_unit_system &&
                    this->rst_config == other.rst_config &&
                    this->rst_info == other.rst_info &&
+                   this->gaslift_opt_active == other.gaslift_opt_active &&
                    this->m_runspec == other.m_runspec;
         }
     };

--- a/opm/input/eclipse/Schedule/VFPProdTable.hpp
+++ b/opm/input/eclipse/Schedule/VFPProdTable.hpp
@@ -67,7 +67,7 @@ public:
     };
 
     VFPProdTable();
-    VFPProdTable( const DeckKeyword& table, const UnitSystem& deck_unit_system);
+    VFPProdTable( const DeckKeyword& table, bool gaslift_opt_active, const UnitSystem& deck_unit_system);
     VFPProdTable(int table_num,
                  double datum_depth,
                  FLO_TYPE flo_type,

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -936,7 +936,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
     }
 
     void Schedule::handleVFPPROD(HandlerContext& handlerContext) {
-        auto table = VFPProdTable(handlerContext.keyword, this->m_static.m_unit_system);
+        auto table = VFPProdTable(handlerContext.keyword, this->m_static.gaslift_opt_active, this->m_static.m_unit_system);
         this->snapshots.back().events().addEvent( ScheduleEvents::VFPPROD_UPDATE );
         this->snapshots.back().vfpprod.update( std::move(table) );
     }

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -51,6 +51,7 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/B.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/L.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>
@@ -144,7 +145,8 @@ namespace Opm {
         rst_config( SOLUTIONSection(deck), parseContext, errors ),
         output_interval(output_interval_),
         sumthin(sumthin_summary_section(SUMMARYSection{ deck })),
-        rptonly(rptonly_summary_section(SUMMARYSection{ deck }))
+        rptonly(rptonly_summary_section(SUMMARYSection{ deck })),
+        gaslift_opt_active(deck.hasKeyword<ParserKeywords::LIFTOPT>())
     {
     }
 

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -698,7 +698,7 @@ VFPPROD \n\
 
     BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
-    Opm::VFPProdTable vfpprodTable(vfpprodKeyword, units);
+    Opm::VFPProdTable vfpprodTable(vfpprodKeyword, false, units);
 
 
     BOOST_CHECK_EQUAL(vfpprodTable.getTableNum(), 5);
@@ -822,14 +822,14 @@ VFPPROD \n\
 
     BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
-    Opm::VFPProdTable vfpprodTable(vfpprodKeyword, units);
+    Opm::VFPProdTable vfpprodTable(vfpprodKeyword, true , units);
 
     BOOST_CHECK_EQUAL(vfpprodTable.getTableNum(), 5);
     BOOST_CHECK_EQUAL(vfpprodTable.getDatumDepth(), 32.9);
     BOOST_CHECK(vfpprodTable.getFloType() == Opm::VFPProdTable::FLO_TYPE::FLO_LIQ);
     BOOST_CHECK(vfpprodTable.getWFRType() == Opm::VFPProdTable::WFR_TYPE::WFR_WCT);
     BOOST_CHECK(vfpprodTable.getGFRType() == Opm::VFPProdTable::GFR_TYPE::GFR_GOR);
-    BOOST_CHECK(vfpprodTable.getALQType() == Opm::VFPProdTable::ALQ_TYPE::ALQ_UNDEF);
+    BOOST_CHECK(vfpprodTable.getALQType() == Opm::VFPProdTable::ALQ_TYPE::ALQ_GRAT);
 
     //Flo axis
     {
@@ -869,13 +869,18 @@ VFPPROD \n\
         BOOST_CHECK_EQUAL(gfr[0], 19);
     }
 
-    //ALQ axis
+    //ALQ axis. The table has been instantiated with gaslift_opt == true, which
+    //implies that the ALQ_TYPE has been converted from ALQ_UNDEF to GRAT during
+    //construction.
     {
         const std::vector<double>& alq = vfpprodTable.getALQAxis();
         BOOST_REQUIRE_EQUAL(alq.size(), 1U);
 
-        //Unit of ALQ undefined
-        BOOST_CHECK_EQUAL(alq[0], 29);
+        const auto gas_surface_volume    = units.getDimension(UnitSystem::measure::gas_surface_volume).getSIScaling();
+        const auto time                  = units.getDimension(UnitSystem::measure::time).getSIScaling();
+
+        auto scaling_factor = gas_surface_volume / time;
+        BOOST_CHECK_EQUAL(alq[0], 29 * scaling_factor);
     }
 
     //The data itself
@@ -967,7 +972,7 @@ VFPPROD \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, false, units), std::invalid_argument);
     }
 
 
@@ -1001,7 +1006,7 @@ VFPPROD \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, false, units), std::invalid_argument);
     }
 
 
@@ -1033,7 +1038,7 @@ VFPPROD \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, false, units), std::invalid_argument);
     }
 
 
@@ -1066,7 +1071,7 @@ VFPPROD \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, false, units), std::invalid_argument);
     }
 
 
@@ -1099,7 +1104,7 @@ VFPPROD \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPPROD"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpprodKeyword, false, units), std::invalid_argument);
     }
 }
 
@@ -1228,7 +1233,7 @@ VFPINJ \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, false, units), std::invalid_argument);
     }
 
 
@@ -1256,7 +1261,7 @@ VFPINJ \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, false, units), std::invalid_argument);
     }
 
 
@@ -1283,7 +1288,7 @@ VFPINJ \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, false, units), std::invalid_argument);
     }
 
 
@@ -1311,7 +1316,7 @@ VFPINJ \n\
         auto units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, false, units), std::invalid_argument);
     }
 
 
@@ -1339,7 +1344,7 @@ VFPINJ \n\
         auto units = Opm::UnitSystem::newMETRIC();
         BOOST_CHECK_EQUAL(deck.count("VFPINJ"), 1U);
 
-        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, units), std::invalid_argument);
+        BOOST_CHECK_THROW(Opm::VFPProdTable(vfpinjKeyword, false, units), std::invalid_argument);
     }
 }
 


### PR DESCRIPTION
A possible alternative to: #2966 

Downstream: https://github.com/OPM/opm-simulators/pull/3831