### PR TITLE
throw when there is no connection for analytical aquifer

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Aquifer/Aquancon.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/Aquancon.cpp
@@ -209,7 +209,12 @@ namespace Opm {
 
 
     const std::vector<Aquancon::AquancCell>& Aquancon::operator[](int aquiferID) const {
-        return this->cells.at( aquiferID );
+        const auto search = this->cells.find(aquiferID);
+        if (search == this->cells.end()) {
+            auto msg = fmt::format("There is no connection associated with analytical aquifer {}\n", aquiferID);
+            throw std::runtime_error(msg);
+        }
+        return search->second;
     }
 
     Aquancon::Aquancon(const std::unordered_map<int, std::vector<Aquancon::AquancCell>>& data) :


### PR DESCRIPTION
it gives slight more information than simple `_Map_base::at`. 

we can also just not handling this aquifer like it does not exist. 

The PR basically does not change the simulation behavoir of the master branch, which terminates running by throwing with `_Map_base::at`.  With this PR, it throws with a little more information. 