### PR TITLE
Disallow Wells Parented Directly to FIELD

### DIFF
--- a/tests/parser/data/integration_tests/IOConfig/RPT_TEST2.DATA
+++ b/tests/parser/data/integration_tests/IOConfig/RPT_TEST2.DATA
@@ -43,7 +43,7 @@ RPTRST
 --NORST=1  --> output for visualization only 
 
 WELSPECS
-     'F-14A'    'FIELD'   12   85  99.00       'OIL'  7* /
+     'F-14A'    'G'   12   85  99.00       'OIL'  7* /
 /
 
 DATES


### PR DESCRIPTION
The commercial simulator does not support parenting a well directly to the `FIELD` group and Flow in multiple locations implicitly assumes that no well is parented directly to `FIELD` either.

With this PR we detect this situation at the parser stage and stop reading the input file.  In this case, we issue a diagnostic message of the form
```
Error: Problem with keyword WELSPECS
In SPE1CASE1.DATA line 384
Wells cannot be parented directly to 'FIELD'.
Wells entered with disallowed 'FIELD' parent group:
 * PROD
 * INJ

Error: Unrecoverable errors were encountered while loading input
```