### PR TITLE
[python] Use dist-packages if it is used for Python's sitepackages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,9 +334,13 @@ install(FILES cmake/OPM-CMake.md
 install(FILES etc/opm_bash_completion.sh.in DESTINATION share/opm/etc)
 
 if (OPM_ENABLE_PYTHON)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import site, sys; sys.stdout.write(site.getsitepackages()[-1]);" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_PATH)
   # -------------------------------------------------------------------------
   # 1: Wrap C++ functionality in Python
-  if (EXISTS "/etc/debian_version")
+  if (PYTHON_SITE_PACKAGES_PATH MATCHES ".*/dist-packages/?" AND
+      CMAKE_INSTALL_PREFIX MATCHES "^/usr.*")
+    # dist-packages is only used if we install below /usr and python's site packages
+    # path matches dist-packages
     set(PYTHON_PACKAGE_PATH "dist-packages")
   else()
     set(PYTHON_PACKAGE_PATH "site-packages")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,12 @@ install(FILES cmake/OPM-CMake.md
 install(FILES etc/opm_bash_completion.sh.in DESTINATION share/opm/etc)
 
 if (OPM_ENABLE_PYTHON)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import site, sys; sys.stdout.write(site.getsitepackages()[-1]);" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_PATH)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
+import site, sys
+try:
+    sys.stdout.write(site.getsitepackages()[-1])
+except e:
+    sys.stdout.write('')" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_PATH)
   # -------------------------------------------------------------------------
   # 1: Wrap C++ functionality in Python
   if (PYTHON_SITE_PACKAGES_PATH MATCHES ".*/dist-packages/?" AND

--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -226,7 +226,7 @@ function build_module_full {
   PY_MINOR=`python3 --version | awk -F ' ' '{print $2}' | awk -F '.' '{print $2}'`
   for configuration in ${!configurations[@]}
   do
-    export PYTHONPATH="$WORKSPACE/$configuration/install/lib/python$PY_MAJOR.$PY_MINOR/dist-packages"
+    export PYTHONPATH="$WORKSPACE/$configuration/install/lib/python$PY_MAJOR.$PY_MINOR/site-packages"
 
     # Build upstream modules
     build_upstreams


### PR DESCRIPTION
Instead of checking whether this is Debian system we query the sitepackages path from Python. If it matches dist-packages then
we use dist-packages if we install below /usr, otherwise site-packages is used.

This will work on Debian as before, but also on other system that decide to use the same approach.