### PR TITLE
Incude binary package version in project-version.h and skip timestamp

### DIFF
--- a/cmake/Modules/UseVersion.cmake
+++ b/cmake/Modules/UseVersion.cmake
@@ -43,7 +43,6 @@ else ()
   # system, so there is "no" way we can update the SHA. notice
   # that this is a slightly different version of the label than
   # above.
-  if (NOT GIT_FOUND)
 	file (WRITE "${PROJECT_BINARY_DIR}/project-version.h"
               "#ifndef OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
               "#define OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
@@ -58,6 +57,7 @@ else ()
       "#define OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
       "#define BUILD_TIMESTAMP \"${build_timestamp}\"\n"
       "#endif // OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+  if (NOT GIT_FOUND OR NOT EXISTS ${PROJECT_SOURCE_DIR}/.git)
       )
   else ()
 	add_custom_target (update-version ALL

--- a/cmake/Modules/UseVersion.cmake
+++ b/cmake/Modules/UseVersion.cmake
@@ -17,6 +17,9 @@ message("-- Writing version information to local header project-version.h")
 string (TIMESTAMP build_timestamp "%Y-%m-%d at %H:%M:%S hrs")
 
 string (TOUPPER "${CMAKE_BUILD_TYPE}" cmake_build_type_upper_)
+set(OPM_BINARY_PACKAGE_VERSION "" CACHE STRING
+  "Version of the binary Linux package built (will be printed in PRT file of flow if not empty)")
+string(LENGTH "${OPM_BINARY_PACKAGE_VERSION}" _BINARY_PACKAGE_VERSION_LENGTH)
 if (cmake_build_type_upper_ MATCHES DEBUG)
   file (WRITE "${PROJECT_BINARY_DIR}/project-version.h"
         "#ifndef OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
@@ -43,22 +46,30 @@ else ()
   # system, so there is "no" way we can update the SHA. notice
   # that this is a slightly different version of the label than
   # above.
-	file (WRITE "${PROJECT_BINARY_DIR}/project-version.h"
-              "#ifndef OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
-              "#define OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
-              "#define PROJECT_VERSION_NAME \"${${project}_LABEL}\"\n"
-              "#define PROJECT_VERSION_HASH \"unknown git version\"\n"
-              "#define PROJECT_VERSION \"${${project}_LABEL} (unknown git version)\"\n"
-              "#endif // OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
-              )
-  # Write header file with build timestamp
-  file (WRITE "${PROJECT_BINARY_DIR}/project-timestamp.h"
-      "#ifndef OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
-      "#define OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
-      "#define BUILD_TIMESTAMP \"${build_timestamp}\"\n"
-      "#endif // OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
   if (NOT GIT_FOUND OR NOT EXISTS ${PROJECT_SOURCE_DIR}/.git)
+    if(_BINARY_PACKAGE_VERSION_LENGTH GREATER 0)
+      set(_PROJECT_VERSION_HASH "${OPM_BINARY_PACKAGE_VERSION}")
+    else()
+      set(_PROJECT_VERSION_HASH "unknown git version")
+    endif()
+    file (WRITE "${PROJECT_BINARY_DIR}/project-version.h"
+      "#ifndef OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+      "#define OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
+      "#define PROJECT_VERSION_NAME \"${${project}_LABEL}\"\n"
+      "#define PROJECT_VERSION_HASH \"${_PROJECT_VERSION_HASH}\"\n"
+      "#define PROJECT_VERSION \"${${project}_LABEL} (${_PROJECT_VERSION_HASH})\"\n"
+      "#endif // OPM_GENERATED_OPM_VERSION_HEADER_INCLUDED\n"
       )
+    # Write header file with build timestamp
+    file (WRITE "${PROJECT_BINARY_DIR}/project-timestamp.h"
+      "#ifndef OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n"
+      "#define OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n")
+    if (_BINARY_PACKAGE_VERSION_LENGTH EQUAL 0)
+      file(APPEND "${PROJECT_BINARY_DIR}/project-timestamp.h"
+	"#define BUILD_TIMESTAMP \"${build_timestamp}\"\n")
+    endif()
+    file(APPEND "${PROJECT_BINARY_DIR}/project-timestamp.h"
+      "#endif // OPM_GENERATED_OPM_TIMESTAMP_HEADER_INCLUDED\n")
   else ()
 	add_custom_target (update-version ALL
 	  COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
One can now set the variable OPM_BINARY_PACKAGE_VERSION to a meaningful version string (e.g. Debian 11.2: 2021.10-4). When building outside of git it will be used as the project hash. If the variable is non-empty there will also be no timestamp in project-timestamp.hh (as this would break reproducible builds).

Note that if building from git or not setting the variable then everything will be like before.

This is the opm-common part of fixing OPM/opm-simulators#3832