### PR TITLE
Support Block Level Solvent Saturation Summary Output

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2184,6 +2184,7 @@ static const std::unordered_map< std::string, Opm::UnitSystem::measure> block_un
   {"BGSAT"      , Opm::UnitSystem::measure::identity},
   {"BSOIL"      , Opm::UnitSystem::measure::identity},
   {"BOSAT"      , Opm::UnitSystem::measure::identity},
+  {"BNSAT"      , Opm::UnitSystem::measure::identity},
   {"BWKR"      , Opm::UnitSystem::measure::identity},
   {"BOKR"      , Opm::UnitSystem::measure::identity},
   {"BKRO"      , Opm::UnitSystem::measure::identity},


### PR DESCRIPTION
This commit recognises the summary vector `BNSAT` as a supported keyword.  This, in turn, enables retrieving the simulator's solvent saturation values at the block level as a time series.