### PR TITLE
Use dune buildsystem defaults for MPI SuperLU, and Quadmath

### DIFF
--- a/cmake/Modules/Finddune-istl.cmake
+++ b/cmake/Modules/Finddune-istl.cmake
@@ -19,7 +19,7 @@ find_opm_package (
   "dune-common REQUIRED;
   ParMETIS;
   SuperLU;
-  SuiteSparse COMPONENTS umfpack
+  SuiteSparse COMPONENTS umfpack REQUIRED
   "
   # header to search for
   "dune/istl/bcrsmatrix.hh"

--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -130,7 +130,7 @@ endif ()
 
 # parallel computing must be explicitly enabled
 # This needs to be in OpmInit as prereqs is called before OpmLibMain is included.
-option (USE_MPI "Use Message Passing Interface for parallel computing" OFF)
+option (USE_MPI "Use Message Passing Interface for parallel computing" ON)
 if (NOT USE_MPI)
   set (CMAKE_DISABLE_FIND_PACKAGE_MPI TRUE)
 endif ()
@@ -144,7 +144,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # quadmath must be explicitly enabled
 # This needs to be in OpmInit as prereqs is called before OpmLibMain is included.
-option (USE_QUADMATH "Use high precision floating point library (slow)" OFF)
+option (USE_QUADMATH "Use high precision floating point library (slow)" ON)
 if (NOT USE_QUADMATH)
   set (CMAKE_DISABLE_FIND_PACKAGE_QuadMath TRUE)
 endif ()

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -64,7 +64,7 @@ include (UseThreads)
 find_threads (${project})
 
 # SuperLU is optional
-option (USE_SUPERLU "Use SuperLU direct solvers" OFF)
+option (USE_SUPERLU "Use SuperLU direct solvers for AMG (if umfpack is not found)" ON)
 
 # PETSc is optional
 option (USE_PETSC "Use PETSc iterative solvers" OFF)


### PR DESCRIPTION
As DUNE 2.8 uses CMake targets and always searches for these by default, the targets will be in the cmake configuration files and used for linking. Unfortunately, CMake package configuration files do not yet search for dependencies but rely on the DUNE build system (which we don't use). Hence our current approach will fail if we did not search for them and the targets are not defined.

In addition we make UMFPack mandatory (which I actually thought was the case already, but I obviously was wrong here.

Closes #2897 