### PR TITLE
[backport] added: ability to use jenkins build scripts for release test building

### DIFF
--- a/jenkins/build-opm-module.sh
+++ b/jenkins/build-opm-module.sh
@@ -16,7 +16,12 @@ function parseRevisions {
   do
     if grep -qi "$upstream=" <<< $ghprbCommentBody
     then
-      upstreamRev[$upstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*${upstream,,}=([0-9]+).*/\1/g"`/merge
+      if test -n "$absolute_revisions"
+      then
+        upstreamRev[$upstream]=`echo $ghprbCommentBody | sed -r "s/.*${upstream,,}=([^ ]+).*/\1/g"`
+      else
+        upstreamRev[$upstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*${upstream,,}=([0-9]+).*/\1/g"`/merge
+      fi
     fi
   done
   if grep -q "with downstreams" <<< $ghprbCommentBody
@@ -25,8 +30,13 @@ function parseRevisions {
     do
       if grep -qi "$downstream=" <<< $ghprbCommentBody
       then
-        downstreamRev[$downstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*${downstream,,}=([0-9]+).*/\1/g"`/merge
-      fi
+        if test -n "$absolute_revisions"
+        then
+          downstreamRev[$downstream]=`echo $ghprbCommentBody | sed -r "s/.*${downstream,,}=([^ ]+).*/\1/g"`
+        else
+          downstreamRev[$downstream]=pull/`echo $ghprbCommentBody | sed -r "s/.*${downstream,,}=([0-9]+).*/\1/g"`/merge
+       fi
+     fi
     done
   fi
 


### PR DESCRIPTION
we need to be able to specify absolute refs to use for the repos
rather than a pull request number.

Backport of #2998