### PR TITLE
Added default values for I, J, K1 and K2 in COMPLUMP

### DIFF
--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/C/COMPLUMP
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/C/COMPLUMP
@@ -10,19 +10,23 @@
     },
     {
       "name": "I",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": 0
     },
     {
       "name": "J",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": 0
     },
     {
       "name": "K1",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": 0
     },
     {
       "name": "K2",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": 0
     },
     {
       "name": "N",


### PR DESCRIPTION
The defaults of I, J, K1 and K2 in Eclipse keyword COMPLUMP should be zero according to the Eclipse manual. The text below is cut of from the manual:

```
Each record contains the following items:
1.
Well name, well name template, well list or well list template
A template enclosed in quotes can be used to refer to multiple wells or well lists. See "Well name and
well list template matching" in the ECLIPSE Technical Description for further details. Well list names
should be enclosed in quotes and begin with an asterisk (*). Well lists are constructed with the
keyword WLIST.
2.
I - location of connecting grid block(s)
DEFAULT: 0 (allows any I-value)
3.
J - location of connecting grid block(s)
DEFAULT: 0 (allows any J-value)
4.
K - location of upper connecting block in this completion
DEFAULT: 0
5.
K - location of lower connecting block in this completion
DEFAULT: 0
```
