### PR TITLE
[backport] fixed: avoid direct floating point comparisons in tests

### DIFF
--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -23,6 +23,7 @@
 #define BOOST_TEST_MODULE ACTIONX
 
 #include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
@@ -1268,7 +1269,7 @@ TSTEP
         const auto& glo = sched.glo(0);
         BOOST_CHECK(glo.has_group("PLAT-A"));
         const auto& plat_group = glo.group("PLAT-A");
-        BOOST_CHECK_EQUAL( *plat_group.max_lift_gas(), unitSystem.to_si( UnitSystem::measure::gas_surface_rate, 200000));
+        BOOST_CHECK_CLOSE( *plat_group.max_lift_gas(), unitSystem.to_si( UnitSystem::measure::gas_surface_rate, 200000), 1e-13);
         BOOST_CHECK(!plat_group.max_total_gas().has_value());
     }
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -29,6 +29,7 @@
 #define BOOST_TEST_MODULE FieldPropsTests
 
 #include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Parser/Parser.hpp>
@@ -346,7 +347,7 @@ ENDBOX
 
     // k = 0: poro * V
     for (std::size_t g = 0; g < 100; g++) {
-        BOOST_CHECK_EQUAL(porv[g], grid.getCellVolume(g) * poro[g]);
+        BOOST_CHECK_CLOSE(porv[g], grid.getCellVolume(g) * poro[g], 1e-13);
         BOOST_CHECK_EQUAL(porv[g], 0.10);
         BOOST_CHECK_EQUAL(poro[g], 0.10);
         BOOST_CHECK_EQUAL(ntg[g], 1.0);
@@ -355,7 +356,7 @@ ENDBOX
 
     // k = 1: poro * NTG * V
     for (std::size_t g = 100; g < 200; g++) {
-        BOOST_CHECK_EQUAL(porv[g], grid.getCellVolume(g) * poro[g] * ntg[g]);
+        BOOST_CHECK_CLOSE(porv[g], grid.getCellVolume(g) * poro[g] * ntg[g], 1e-13);
         BOOST_CHECK_EQUAL(porv[g], 0.20);
         BOOST_CHECK_EQUAL(poro[g], 0.10);
         BOOST_CHECK_EQUAL(ntg[g], 2.0);
@@ -372,7 +373,7 @@ ENDBOX
 
     // k = 3: poro * V * multpv
     for (std::size_t g = 300; g < 400; g++) {
-        BOOST_CHECK_EQUAL(porv[g], multpv[g] * grid.getCellVolume(g) * poro[g] * ntg[g]);
+        BOOST_CHECK_CLOSE(porv[g], multpv[g] * grid.getCellVolume(g) * poro[g] * ntg[g], 1e-13);
         BOOST_CHECK_EQUAL(porv[g], 0.40);
         BOOST_CHECK_EQUAL(poro[g], 0.10);
         BOOST_CHECK_EQUAL(ntg[g], 1.0);
@@ -381,7 +382,7 @@ ENDBOX
 
     // k = 4: poro * V * MULTREGP
     for (std::size_t g = 400; g < 500; g++) {
-        BOOST_CHECK_EQUAL(porv[g], grid.getCellVolume(g) * poro[g] * 5.0);
+        BOOST_CHECK_CLOSE(porv[g], grid.getCellVolume(g) * poro[g] * 5.0, 1e-13);
         BOOST_CHECK_EQUAL(porv[g], 0.50);
         BOOST_CHECK_EQUAL(poro[g], 0.10);
     }
@@ -671,8 +672,8 @@ OPERATE
 
     const auto& permz = fpm.get_double("PERMZ");
     for (std::size_t i = 0; i < 3; i++) {
-        BOOST_CHECK_EQUAL(permz[i]  , 2*permy[i]   + to_si(1000));
-        BOOST_CHECK_EQUAL(permz[i+3], 3*permx[i+3] + to_si(300));
+        BOOST_CHECK_CLOSE(permz[i]  , 2*permy[i]   + to_si(1000), 1e-13);
+        BOOST_CHECK_CLOSE(permz[i+3], 3*permx[i+3] + to_si(300), 1e-13);
     }
 }
 
@@ -2061,23 +2062,23 @@ MINVALUE
                     auto a = grid.activeIndex(i,j,k);
 
                     if (k==0)
-                        BOOST_CHECK_EQUAL(tranx[a], to_si(0.20));
+                        BOOST_CHECK_CLOSE(tranx[a], to_si(0.20), 1e-13);
                     else
-                        BOOST_CHECK_EQUAL(tranx[a], to_si(0.10));
+                        BOOST_CHECK_CLOSE(tranx[a], to_si(0.10), 1e-13);
 
                     if (k == 0)
-                        BOOST_CHECK_EQUAL(trany[a], to_si(2.0));
+                        BOOST_CHECK_CLOSE(trany[a], to_si(2.0), 1e-13);
                     else if (k == 1)
-                        BOOST_CHECK_EQUAL(trany[a], to_si(5.0));
+                        BOOST_CHECK_CLOSE(trany[a], to_si(5.0), 1e-13);
                     else if (k == 2)
-                        BOOST_CHECK_EQUAL(trany[a], to_si(2.0));
+                        BOOST_CHECK_CLOSE(trany[a], to_si(2.0), 1e-13);
 
                     if (k==0)
                         BOOST_CHECK(tranz[a] <= to_si(0));
                     else if (k == 1)
                         BOOST_CHECK(tranz[a] >= to_si(3.0));
                     else if (k == 2)
-                        BOOST_CHECK_EQUAL(tranz[a], to_si(1.0));
+                        BOOST_CHECK_CLOSE(tranz[a], to_si(1.0), 1e-13);
                 }
             }
         }
@@ -2473,8 +2474,8 @@ OPERATE
 
     const auto& permz = fpm.get_double("PERMZ");
     for (std::size_t i = 0; i < 3; i++) {
-        BOOST_CHECK_EQUAL(permz[i]  , 2*permy[i]   + to_si(1000));
-        BOOST_CHECK_EQUAL(permz[i+3], 3*permx[i+3] + to_si(300));
+        BOOST_CHECK_CLOSE(permz[i]  , 2*permy[i]   + to_si(1000), 1e-13);
+        BOOST_CHECK_CLOSE(permz[i+3], 3*permx[i+3] + to_si(300), 1e-13);
     }
 
     BOOST_CHECK(permx == fpm.get_double("PERMR"));

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -30,6 +30,7 @@
 #define BOOST_TEST_MODULE ScheduleTests
 
 #include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/common/utility/TimeService.hpp>
@@ -991,14 +992,14 @@ I1 THP 4 /
     const auto wpp_2 = well_2.getProductionProperties();
     const auto prod_controls = wpp_2.controls(st, 0);
 
-    BOOST_CHECK_EQUAL(prod_controls.oil_rate, 1300 * siFactorL);
-    BOOST_CHECK_EQUAL(prod_controls.water_rate, 1400 * siFactorL);
-    BOOST_CHECK_EQUAL(prod_controls.gas_rate, 1500.52 * siFactorG);
-    BOOST_CHECK_EQUAL(prod_controls.liquid_rate, 1600.58 * siFactorL);
-    BOOST_CHECK_EQUAL(prod_controls.resv_rate, 1801.05 * siFactorL);
-    BOOST_CHECK_EQUAL(prod_controls.bhp_limit, 1900 * siFactorP);
-    BOOST_CHECK_EQUAL(prod_controls.thp_limit, 2000 * siFactorP);
-    BOOST_CHECK_EQUAL(wpp_2.ALQValue.get<double>(), 1234);
+    BOOST_CHECK_CLOSE(prod_controls.oil_rate, 1300 * siFactorL, 1e-13);
+    BOOST_CHECK_CLOSE(prod_controls.water_rate, 1400 * siFactorL, 1e-13);
+    BOOST_CHECK_CLOSE(prod_controls.gas_rate, 1500.52 * siFactorG, 1e-13);
+    BOOST_CHECK_CLOSE(prod_controls.liquid_rate, 1600.58 * siFactorL, 1e-13);
+    BOOST_CHECK_CLOSE(prod_controls.resv_rate, 1801.05 * siFactorL, 1e-13);
+    BOOST_CHECK_CLOSE(prod_controls.bhp_limit, 1900 * siFactorP, 1e-13);
+    BOOST_CHECK_CLOSE(prod_controls.thp_limit, 2000 * siFactorP, 1e-13);
+    BOOST_CHECK_CLOSE(wpp_2.ALQValue.get<double>(), 1234, 1e-13);
 
     BOOST_CHECK (wpp_2.hasProductionControl( Opm::Well::ProducerCMode::ORAT) );
     BOOST_CHECK (wpp_2.hasProductionControl( Opm::Well::ProducerCMode::RESV) );
@@ -1008,9 +1009,9 @@ I1 THP 4 /
     const auto wpp_3 = well_3.getProductionProperties();
     const auto prod_controls3 = wpp_3.controls(st, 0);
 
-    BOOST_CHECK_EQUAL(prod_controls3.oil_rate, 2 * 1300 * siFactorL);
-    BOOST_CHECK_EQUAL(prod_controls3.water_rate, 4 * 1400 * siFactorL);
-    BOOST_CHECK_EQUAL(prod_controls3.gas_rate, 3 * 1500.52 * siFactorG);
+    BOOST_CHECK_CLOSE(prod_controls3.oil_rate, 2 * 1300 * siFactorL, 1e-13);
+    BOOST_CHECK_CLOSE(prod_controls3.water_rate, 4 * 1400 * siFactorL, 1e-13);
+    BOOST_CHECK_CLOSE(prod_controls3.gas_rate, 3 * 1500.52 * siFactorG, 1e-13);
 
 
     const auto& inj_controls2 = schedule.getWell("I1", 2).getInjectionProperties().controls(unitSystem, st, 0);
@@ -1212,13 +1213,13 @@ COMPDAT
     const auto& cs3 = schedule.getWell("OP_1", 3).getConnections();
     const auto& cs4 = schedule.getWell("OP_1", 4).getConnections();
     for(size_t i = 0; i < cs2.size(); i++)
-        BOOST_CHECK_EQUAL(cs2.get( i ).CF() / cs1.get(i).CF(), 1.3);
+        BOOST_CHECK_CLOSE(cs2.get( i ).CF() / cs1.get(i).CF(), 1.3, 1e-13);
 
     for(size_t i = 0; i < cs3.size(); i++ )
-        BOOST_CHECK_EQUAL(cs3.get( i ).CF() / cs1.get(i).CF(), (1.3*1.3));
+        BOOST_CHECK_CLOSE(cs3.get( i ).CF() / cs1.get(i).CF(), (1.3*1.3), 1e-13);
 
     for(size_t i = 0; i < cs4.size(); i++ )
-        BOOST_CHECK_EQUAL(cs4.get( i ).CF(), cs1.get(i).CF());
+        BOOST_CHECK_CLOSE(cs4.get( i ).CF(), cs1.get(i).CF(), 1e-13);
 
     auto sim_time1 = TimeStampUTC{ schedule.simTime(1) };
     BOOST_CHECK_EQUAL(sim_time1.day(), 10);
@@ -1328,20 +1329,20 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
 
         {
             auto g = schedule.getGroup("G1", 1);
-            BOOST_CHECK_EQUAL(g.productionControls(st).oil_target, 1000 * siFactorL);
+            BOOST_CHECK_CLOSE(g.productionControls(st).oil_target, 1000 * siFactorL, 1e-13);
             BOOST_CHECK(g.has_control(Group::ProductionCMode::ORAT));
             BOOST_CHECK(!g.has_control(Group::ProductionCMode::WRAT));
             BOOST_CHECK_EQUAL(g.productionControls(st).guide_rate, 0);
         }
         {
             auto g = schedule.getGroup("G1", 2);
-            BOOST_CHECK_EQUAL(g.productionControls(st).oil_target, 2000 * siFactorL);
+            BOOST_CHECK_CLOSE(g.productionControls(st).oil_target, 2000 * siFactorL, 1e-13);
             BOOST_CHECK_EQUAL(g.productionControls(st).guide_rate, 148);
             BOOST_CHECK_EQUAL(true, g.productionControls(st).guide_rate_def == Group::GuideRateProdTarget::OIL);
         }
 
         auto g2 = schedule.getGroup("G2", 2);
-        BOOST_CHECK_EQUAL(g2.productionControls(st).oil_target, 2000 * siFactorL);
+        BOOST_CHECK_CLOSE(g2.productionControls(st).oil_target, 2000 * siFactorL, 1e-13);
 
         auto gh = schedule.getGroup("H1", 1);
 
@@ -4807,7 +4808,7 @@ WCONPROD
 
     auto dim = sched.getUnits().getDimension(UnitSystem::measure::gas_surface_rate);
     const auto& controls2 = well2.productionControls(st);
-    BOOST_CHECK_EQUAL(controls2.alq_value, dim.convertRawToSi(123));
+    BOOST_CHECK_CLOSE(controls2.alq_value, dim.convertRawToSi(123), 1e-13);
 
     BOOST_CHECK(!sched[0].has_gpmaint());
 }

--- a/tests/test_nonuniformtablelinear.cpp
+++ b/tests/test_nonuniformtablelinear.cpp
@@ -24,6 +24,7 @@
 
 #define BOOST_TEST_MODULE NonuniformTableLinearTests
 #include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <opm/common/utility/numeric/NonuniformTableLinear.hpp>
 
@@ -63,9 +64,9 @@ BOOST_AUTO_TEST_CASE(table_operations)
     for (int i = 0; i < numvals; ++i) {
         BOOST_CHECK_EQUAL(t1(xv[i]), yv[i]);
     }
-    BOOST_CHECK_EQUAL(t1(2.6), 3.5);
-    BOOST_CHECK_EQUAL(t1(4.0), 3.0);
-    BOOST_CHECK_EQUAL(t1.derivative(4.0), -1.0);
+    BOOST_CHECK_CLOSE(t1(2.6), 3.5, 1e-13);
+    BOOST_CHECK_CLOSE(t1(4.0), 3.0, 1e-13);
+    BOOST_CHECK_CLOSE(t1.derivative(4.0), -1.0, 1e-13);
     // Derivatives at endpoints.
     BOOST_CHECK_CLOSE(t1.derivative(-1.0), 1.0/3.0, 1e-13);
     BOOST_CHECK_CLOSE(t1.derivative(5.0), -1.0, 1e-13);
@@ -83,6 +84,6 @@ BOOST_AUTO_TEST_CASE(table_operations)
     for (int i = 0; i < numvals; ++i) {
         BOOST_CHECK_EQUAL(t1((xv[i] + 1.0)*20.0 - 100.0), yv[i]);
     }
-    BOOST_CHECK_EQUAL(t1(0.0), 3.0);
+    BOOST_CHECK_CLOSE(t1(0.0), 3.0, 1e-13);
     BOOST_CHECK(std::fabs(t1.derivative(0.0)  + 1.0/20.0) < 1e-11);
 }

--- a/tests/test_uniformtablelinear.cpp
+++ b/tests/test_uniformtablelinear.cpp
@@ -23,6 +23,7 @@
 
 #define BOOST_TEST_MODULE UniformTableLinearTests
 #include <boost/test/unit_test.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <opm/common/utility/numeric/UniformTableLinear.hpp>
 
 
@@ -50,7 +51,7 @@ BOOST_AUTO_TEST_CASE(table_operations)
     }
     BOOST_CHECK_EQUAL(t1(2.25), 0.0);
     BOOST_CHECK_EQUAL(t1(9.75), 3.0);
-    BOOST_CHECK_EQUAL(t1.derivative(9.75), -2.0/xdelta);
+    BOOST_CHECK_CLOSE(t1.derivative(9.75), -2.0/xdelta, 1e-13);
     // Until we implement anything but the ClosestValue end policy, we only test that.
     BOOST_CHECK_EQUAL(t1(xmin - 1.0), yv[0]);
     BOOST_CHECK_EQUAL(t1(xmax + 1.0), yv.back());


### PR DESCRIPTION
we want to compare with an epsilon since these have gone
through calculations

Backport of #3007 