### PR TITLE
[backport] Make not finding Quadmath non-fatal (e.g. not available on arm64)

### DIFF
--- a/cmake/Modules/FindQuadmath.cmake
+++ b/cmake/Modules/FindQuadmath.cmake
@@ -43,7 +43,7 @@ int main(void){
 endif()
 
 if (USE_QUADMATH AND NOT QUADMATH_FOUND)
-  message(FATAL_ERROR "Quadruple precision math support was explicitly requested but is unavailable!")
+  message(STATUS "Quadruple precision math support is unavailable! Skipping it.")
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -144,7 +144,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # quadmath must be explicitly enabled
 # This needs to be in OpmInit as prereqs is called before OpmLibMain is included.
-option (USE_QUADMATH "Use high precision floating point library (slow)" ON)
+option (USE_QUADMATH "Search for high precision floating point library (normally not used)" ON)
 if (NOT USE_QUADMATH)
   set (CMAKE_DISABLE_FIND_PACKAGE_QuadMath TRUE)
 endif ()


### PR DESCRIPTION
Quadmath is usually unused except when a dependency uses it and explicitly puts QuadMath::QuadMath into their CMake package configuration file.

On most platforms the compiler has Quadmath available by default. But on those that don't we should not stop CMake and fail. Hence now we only print a message that Quadmath is not available.

Backport of #3012 