### PR TITLE
Install python bindings as default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(ENABLE_ECL_INPUT "Enable eclipse input support?" ON)
 option(ENABLE_ECL_OUTPUT "Enable eclipse output support?" ON)
 option(ENABLE_MOCKSIM "Build the mock simulator for io testing" ON)
 option(OPM_ENABLE_PYTHON "Enable python bindings?" OFF)
-option(OPM_INSTALL_PYTHON "Enable python bindings?" OFF)
+option(OPM_INSTALL_PYTHON "Install python bindings?" ON)
 option(OPM_ENABLE_EMBEDDED_PYTHON "Enable embedded python?" OFF)
 
 # Output implies input


### PR DESCRIPTION
This is for consistency with opm-simulators, which (always) installs them if they are built.

Closes #2976