### PR TITLE
[backport] Do not hard-code shared-libs in package configuration if not needed.

### DIFF
--- a/cmake/Modules/OpmProject.cmake
+++ b/cmake/Modules/OpmProject.cmake
@@ -54,6 +54,12 @@ function (configure_cmake_file name variant version)
   foreach (suffix IN LISTS variable_suffices)
 	set (opm-project_${suffix} "${${name}_${suffix}}")
   endforeach (suffix)
+
+  if (BUILD_SHARED_LIBS)
+    # No need to list shared libraries as the linker information is alread
+    # in the shared lib
+    string(REGEX REPLACE ";?[^;]*.so" "" opm-project_LIBRARIES "${opm-project_LIBRARIES}")
+  endif()
   set (opm-project_NAME "${${name}_NAME}")
   set (opm-project_NAME_UC "${${name}_NAME}")
   string(TOUPPER "${opm-project_NAME}" opm-project_NAME_UC)


### PR DESCRIPTION
We usually list all libraries that might be needed for linking in the
CMake package configuration files. This is needed when building static
libraries as we do not yet use CMake targets (which would allow to
list them differently). As we are doing this unconditionally and
also including the ones listed in modules that we depend on, changing
a library (e.g. moving from Python 3.9 to 3.10) requires a complete
rebuild of all modules to get rid of the stale dependency on
libpython3.9.

At least when building shared libraries listing the dependencies is
not needed and this patch simply removes all shared libraries form the
list in the CMake package configuration file. Thus we only need to
recompile the modules that have direct dependency on a stale library.

Backport of #3023 to release