### PR TITLE
Adds a method get_injection_properties() to the Python interface to Opm::Schedule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,34 +334,7 @@ install(FILES cmake/OPM-CMake.md
 install(FILES etc/opm_bash_completion.sh.in DESTINATION share/opm/etc)
 
 if (OPM_ENABLE_PYTHON)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
-import site, sys
-try:
-    sys.stdout.write(site.getsitepackages()[-1])
-except e:
-    sys.stdout.write('')" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_PATH)
-  # -------------------------------------------------------------------------
-  # 1: Wrap C++ functionality in Python
-  if (PYTHON_SITE_PACKAGES_PATH MATCHES ".*/dist-packages/?" AND
-      CMAKE_INSTALL_PREFIX MATCHES "^/usr.*")
-    # dist-packages is only used if we install below /usr and python's site packages
-    # path matches dist-packages
-    set(PYTHON_PACKAGE_PATH "dist-packages")
-  else()
-    set(PYTHON_PACKAGE_PATH "site-packages")
-  endif()
-  if(PYTHON_VERSION_MAJOR)
-    set(PY_MAJOR ${PYTHON_VERSION_MAJOR})
-  else()
-    set(PY_MAJOR ${Python3_VERSION_MAJOR})
-  endif()
-  if(PYTHON_VERSION_MINOR)
-    set(PY_MINOR ${PYTHON_VERSION_MINOR})
-  else()
-    set(PY_MINOR ${Python3_VERSION_MINOR})
-  endif()
-  set(PYTHON_INSTALL_PREFIX "lib/python${PY_MAJOR}.${PY_MINOR}/${PYTHON_PACKAGE_PATH}" CACHE STRING "Subdirectory to install Python modules in")
-
+  include(PyInstallPrefix)
   make_directory(${PROJECT_BINARY_DIR}/python)
   get_target_property(_opmcommon_include_dirs opmcommon INCLUDE_DIRECTORIES)
   list(APPEND _opmcommon_include_dirs ${_ecl_include_dirs})

--- a/cmake/Modules/PyInstallPrefix.cmake
+++ b/cmake/Modules/PyInstallPrefix.cmake
@@ -1,0 +1,28 @@
+# We make this a cmake module so it can be used from opm-simulators' CMakeLists.txt also
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
+import site, sys
+try:
+    sys.stdout.write(site.getsitepackages()[-1])
+except e:
+    sys.stdout.write('')" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES_PATH)
+  # -------------------------------------------------------------------------
+  # 1: Wrap C++ functionality in Python
+if (PYTHON_SITE_PACKAGES_PATH MATCHES ".*/dist-packages/?" AND
+    CMAKE_INSTALL_PREFIX MATCHES "^/usr.*")
+  # dist-packages is only used if we install below /usr and python's site packages
+  # path matches dist-packages
+  set(PYTHON_PACKAGE_PATH "dist-packages")
+else()
+  set(PYTHON_PACKAGE_PATH "site-packages")
+endif()
+if(PYTHON_VERSION_MAJOR)
+  set(PY_MAJOR ${PYTHON_VERSION_MAJOR})
+else()
+  set(PY_MAJOR ${Python3_VERSION_MAJOR})
+endif()
+if(PYTHON_VERSION_MINOR)
+  set(PY_MINOR ${PYTHON_VERSION_MINOR})
+else()
+  set(PY_MINOR ${Python3_VERSION_MINOR})
+endif()
+set(PYTHON_INSTALL_PREFIX "lib/python${PY_MAJOR}.${PY_MINOR}/${PYTHON_PACKAGE_PATH}" CACHE STRING "Subdirectory to install Python modules in")

--- a/python/tests/test_schedule.py
+++ b/python/tests/test_schedule.py
@@ -57,6 +57,22 @@ class TestSchedule(unittest.TestCase):
         with self.assertRaises(Exception):
             self.sch[0].group('foo')
 
+    def test_injection_properties(self):
+        deck  = Parser().parse(test_path('spe3/SPE3CASE1.DATA'))
+        state = EclipseState(deck)
+        sch = Schedule( deck, state )
+        report_step = 4
+        well_name = 'INJ'
+        prop = sch.get_injection_properties(well_name, report_step)
+        self.assertEqual(prop['surf_inj_rate'], 4700.0) # Mscf/day
+        self.assertEqual(prop['resv_inj_rate'], 0.0) # rb/day
+        self.assertEqual(prop['bhp_target'], 4000.0) # psi
+        self.assertEqual(prop['thp_target'], 0.0)
+        with self.assertRaises(IndexError):
+            prop = sch.get_injection_properties("UNDEF", report_step)
+        with self.assertRaises(KeyError):
+            prop = sch.get_injection_properties("PROD", report_step)
+
     def test_production_properties(self):
         deck  = Parser().parse(test_path('spe3/SPE3CASE1.DATA'))
         state = EclipseState(deck)
@@ -67,11 +83,15 @@ class TestSchedule(unittest.TestCase):
         self.assertEqual(prop['alq_value'], 0.0)
         self.assertEqual(prop['bhp_target'], 500.0)
         self.assertEqual(prop['gas_rate'], 6200.0)
-        self.assertEqual(prop['liquid_rate'], 0.0)
         self.assertEqual(prop['oil_rate'], 0.0)
+        self.assertEqual(prop['water_rate'], 0.0)
+        self.assertEqual(prop['liquid_rate'], 0.0)
         self.assertEqual(prop['resv_rate'], 0.0)
         self.assertEqual(prop['thp_target'], 0.0)
-        self.assertEqual(prop['water_rate'], 0.0)
+        with self.assertRaises(IndexError):
+            prop = sch.get_production_properties("UNDEF", report_step)
+        with self.assertRaises(KeyError):
+            prop = sch.get_production_properties("INJ", report_step)
 
     def test_well_names(self):
         deck  = Parser().parse(test_path('spe3/SPE3CASE1.DATA'))


### PR DESCRIPTION
See use case downstream: https://github.com/OPM/opm-simulators/pull/3918

Adds a method `get_injection_properties()` to the Python interface to `Opm::Schedule` This method can be used to get information about `Well::WellInjectionProperties` for a given report step.

In order to avoid code duplication between `opm-simulators` and `opm-common`, logic in `CMakeLists.txt` was refactored out into `cmake/Modules/PyInstallPrefix.cmake`
