### PR TITLE
Increase Compatibility of NETBALAN Restart Output

### DIFF
--- a/opm/input/eclipse/Schedule/Network/Balance.hpp
+++ b/opm/input/eclipse/Schedule/Network/Balance.hpp
@@ -17,33 +17,34 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef NETWORK_BALANCE_HPP
 #define NETWORK_BALANCE_HPP
-#include <optional>
-#include <cstddef>
 
+#include <cstddef>
+#include <optional>
 
 namespace Opm {
-class DeckKeyword;
-struct Tuning;
-class UnitSystem;
+    class DeckKeyword;
+    class UnitSystem;
+} // namespace Opm
 
-namespace Network {
+namespace Opm { namespace Network {
 
-class Balance {
+class Balance
+{
 public:
+    enum class CalcMode {
+        None = 0,
+        TimeInterval = 1,
+        TimeStepStart = 2,
+        NUPCOL = 3,
+    };
 
-enum class CalcMode {
-    None = 0,
-    TimeInterval = 1,
-    TimeStepStart = 2,
-    NUPCOL = 3
-};
+    Balance();
+    explicit Balance(const DeckKeyword& keyword);
+    explicit Balance(bool network_active);
 
-    Balance() = default;
-    Balance(bool network_active, const Tuning& tuning);
-    Balance(const Tuning& tuning, const DeckKeyword& keyword);
+    static Balance serializeObject();
 
     CalcMode mode() const;
     double interval() const;
@@ -51,11 +52,10 @@ enum class CalcMode {
     std::size_t pressure_max_iter() const;
     double thp_tolerance() const;
     std::size_t thp_max_iter() const;
-    std::optional<double> target_balance_error() const;
-    std::optional<double> max_balance_error() const;
-    double min_tstep() const;
+    const std::optional<double>& target_balance_error() const;
+    const std::optional<double>& max_balance_error() const;
+    const std::optional<double>& min_tstep() const;
 
-    static Balance serializeObject();
     bool operator==(const Balance& other) const;
 
     template<class Serializer>
@@ -72,7 +72,6 @@ enum class CalcMode {
         serializer(this->m_min_tstep);
     }
 
-
 private:
     CalcMode calc_mode{CalcMode::None};
     double calc_interval;
@@ -82,11 +81,11 @@ private:
     double m_thp_tolerance;
     std::size_t m_thp_max_iter;
 
-    std::optional<double> target_branch_balance_error;
-    std::optional<double> max_branch_balance_error;
-    double m_min_tstep;
+    std::optional<double> target_branch_balance_error{};
+    std::optional<double> max_branch_balance_error{};
+    std::optional<double> m_min_tstep{};
 };
 
-}
-}
-#endif
+}} // Opm::Network
+
+#endif  // NETWORK_BALANCE_HPP

--- a/opm/output/eclipse/DoubHEAD.hpp
+++ b/opm/output/eclipse/DoubHEAD.hpp
@@ -28,6 +28,7 @@ namespace Opm {
     struct Tuning;
     class Schedule;
     class UDQParams;
+    class UnitSystem;
 }
 
 namespace Opm { namespace RestartIO {
@@ -57,7 +58,9 @@ namespace Opm { namespace RestartIO {
             double min_ec_grad;
         };
 
-       struct NetBalanceParams {
+        struct NetBalanceParams {
+            explicit NetBalanceParams(const UnitSystem& usys);
+
             double balancingInterval;
             double convTolNodPres;
             double convTolTHPCalc;

--- a/opm/output/eclipse/VectorItems/doubhead.hpp
+++ b/opm/output/eclipse/VectorItems/doubhead.hpp
@@ -43,12 +43,21 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         XxxMBE  = 18,
         XxxLCV  = 19,
         XxxWFL  = 20,
-        Netbalint  = 51,    //  balancingInterval
-        Netbalnpre  = 53,    //  convTolNodPres
-        Netbalthpc  = 50,    //  convTolTHPCalc
-        Netbaltarerr  = 63,    //  targBranchBalError
-        Netbalmaxerr  = 64,    //  maxBranchBalError
-        Netbalstepsz  = 66,    //  minTimeStepSize
+
+        Netbalthpc    = 50,    //  Network balancing THP convergence limit (NETBALAN(4))
+        Netbalint     = 51,    //  Network balancing interval (NETBALAN(1))
+        Netbalnpre    = 53,    //  Network balancing nodal pressure
+                               //  convergence limit (NETBALAN(2))
+
+        Netbaltarerr  = 63,    //  Target largest branch network balancing
+                               //  error at end of timestep (NETBALAN(6))
+
+        Netbalmaxerr  = 64,    //  Maximum permitted network balancing error
+                               //  at end of timestep (NETBALAN(7))
+
+        Netbalstepsz  = 66,    //  Minimum stepsize for steps limited by
+                               //  network balancing errors (NETBALAN(8))
+
         TrgDPR  = 82,
         TfDiff  = 83,
         DdpLim  = 84,
@@ -74,6 +83,14 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         UdqPar_3 = 213,		// UDQPARAM item number 3 (Value given to undefined elements when outputting data)
         UdqPar_4 = 214,		// UDQPARAM item number 4 (fractional equality tolerance used in ==, <= etc. functions)
     };
+
+    namespace DoubHeadValue {
+        // Default if no active network (BRANPROP/NODEPROP)
+        constexpr auto NetBalNodPressDefault = 0.0; // Barsa
+
+        // Default => Use TSMINZ from TUNING
+        constexpr auto NetBalMinTSDefault = 0.0;
+    }
 
 }}}} // Opm::RestartIO::Helpers::VectorItems
 

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -738,8 +738,8 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
     }
 
     void Schedule::handleNETBALAN(HandlerContext& handlerContext) {
-        Network::Balance new_balance(this->snapshots.back().tuning(), handlerContext.keyword);
-        this->snapshots.back().network_balance.update( std::move(new_balance) );
+        this->snapshots.back().network_balance
+            .update(Network::Balance{ handlerContext.keyword });
     }
 
     void Schedule::handleNEXTSTEP(HandlerContext& handlerContext) {

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -2051,7 +2051,7 @@ void Schedule::create_first(const time_point& start_time, const std::optional<ti
     sched_state.guide_rate.update( GuideRateConfig() );
     sched_state.rft_config.update( RFTConfig() );
     sched_state.rst_config.update( RSTConfig::first( this->m_static.rst_config ) );
-    sched_state.network_balance.update( Network::Balance(runspec.networkDimensions().active(), sched_state.tuning()) );
+    sched_state.network_balance.update(Network::Balance{ runspec.networkDimensions().active() });
     sched_state.update_sumthin(this->m_static.sumthin);
     sched_state.rptonly(this->m_static.rptonly);
     //sched_state.update_date( start_time );


### PR DESCRIPTION
The current `Network::Balance` class applies default values a little too eagerly and this leads to problems for restarted simulation.  We must take care to preserve the "did this item have a value" state also in the restart file lest interactions with `TUNING` be lost there.

To this end, make the minimum timestep size for network balancing be an `std::optional<>` and use `std::nullopt` to represent "no value set" in the input file.  While here, also preserve negative balancing intervals exactly instead of replacing these values by zero.