### PR TITLE
ESmry and ExtESmry - Prevent loading data multiple times

### DIFF
--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -687,7 +687,9 @@ void ESmry::loadData(const std::vector<std::string>& vectList) const
             OPM_THROW(std::invalid_argument, "error loading key " + key );
 
         auto it = keyword_index.find(key);
-        keywIndVect.push_back(it->second);
+
+        if (!vectorLoaded[it->second])
+            keywIndVect.push_back(it->second);
     }
 
     for (auto ind : keywIndVect)

--- a/src/opm/io/eclipse/ExtESmry.cpp
+++ b/src/opm/io/eclipse/ExtESmry.cpp
@@ -367,10 +367,23 @@ void ExtESmry::loadData(const std::vector<std::string>& stringVect)
 {
     auto start = std::chrono::system_clock::now();
 
+    auto num_keys = stringVect.size();
     std::vector<int> keyIndexVect;
+    std::vector<int> loadKeyIndex;
 
-    for (const auto& key: stringVect)
-        keyIndexVect.push_back(m_keyword_index[0].at(key));
+    keyIndexVect.reserve(num_keys);
+    loadKeyIndex.reserve(num_keys);
+
+    int keyCounter = 0;
+
+    for (const auto& key: stringVect){
+        auto key_ind = m_keyword_index[0].at(key);
+        if (!m_vectorLoaded[key_ind]){
+            keyIndexVect.push_back(key_ind);
+            loadKeyIndex.push_back(keyCounter);
+        }
+        ++keyCounter;
+    }
 
     std::fstream fileH;
 
@@ -385,9 +398,10 @@ void ExtESmry::loadData(const std::vector<std::string>& stringVect)
         if (!fileH)
             throw std::runtime_error("Can not open file lodFile");
 
-        for (size_t n = 0 ; n < stringVect.size(); n++) {
+        for (size_t n = 0 ; n < loadKeyIndex.size(); n++) {
 
-            std::string key = stringVect[n];
+            //std::string key = loadKeyNames[n];
+            const auto& key = stringVect[loadKeyIndex[n]];
 
             std::string arrName;
             Opm::EclIO::eclArrType arrType;

--- a/tests/test_ESmry.cpp
+++ b/tests/test_ESmry.cpp
@@ -203,6 +203,29 @@ BOOST_AUTO_TEST_CASE(TestESmry_1) {
     for (unsigned int i=0;i< smryVect.size();i++){
         BOOST_REQUIRE_CLOSE (smryVect[i], bpr_10103_ref[i], 0.01);
     }
+
+    ESmry smry2("SPE1CASE1.SMSPEC");
+    auto fgor2a = smry2.get("FGOR");
+    smry2.loadData({"FGOR"});
+    auto fgor2b = smry2.get("FGOR");
+
+    BOOST_CHECK_EQUAL(fgor2a.size(), fgor2b.size());
+
+    ESmry smry3("SPE1CASE1.SMSPEC");
+    auto fgor3a = smry3.get("FGOR");
+    smry3.loadData();
+    auto fgor3b = smry3.get("FGOR");
+
+    BOOST_CHECK_EQUAL(fgor3a.size(), fgor3b.size());
+
+    ESmry smry4("SPE1CASE1.SMSPEC");
+    smry4.loadData();
+    auto fgor4a = smry4.get("FGOR");
+
+    smry4.loadData({"FGOR"});
+    auto fgor4b = smry4.get("FGOR");
+
+    BOOST_CHECK_EQUAL(fgor4a.size(), fgor4b.size());
 }
 
 BOOST_AUTO_TEST_CASE(TestESmry_2) {

--- a/tests/test_ExtESmry.cpp
+++ b/tests/test_ExtESmry.cpp
@@ -214,7 +214,19 @@ BOOST_AUTO_TEST_CASE(TestExtESmry_1) {
         BOOST_REQUIRE_CLOSE (smryVect[i], bpr_10103_ref[i], 0.01);
 
     ExtESmry esmry2("SPE1CASE1.ESMRY");
-    esmry2.loadData();
+    auto fopr2a = esmry2.get("FOPR");
+    esmry2.loadData({"FOPR"});
+    auto fopr2b = esmry2.get("FOPR");
+
+    BOOST_CHECK_EQUAL(fopr2a.size(), fopr2b.size());
+
+    ExtESmry esmry3("SPE1CASE1.ESMRY");
+    auto fopr3a = esmry3.get("FOPR");
+    esmry3.loadData();
+    auto fopr3b = esmry3.get("FOPR");
+
+    BOOST_CHECK_EQUAL(fopr3a.size(), fopr3b.size());
+
 }
 
 BOOST_AUTO_TEST_CASE(TestExtESmry_2) {


### PR DESCRIPTION
This PR is fixing a bug in load functions for both ESmry and ExtESmry. 

With current version of ESmry ( and similar with ExtESmry) the following code  

```c++
    ESmry smry2("SPE1CASE1.SMSPEC");
    auto fgor2a = smry2.get("FGOR");
    smry2.loadData({"FGOR"});
    auto fgor2b = smry2.get("FGOR");
```

will generate a vector fgor2b with double size compared with vector fgor2a since the vector FGOR is loaded twice from the disk. 
