### PR TITLE
WIP: Install the `install.py` script such that it can be reused by opm-simulators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,9 @@ if (OPM_ENABLE_PYTHON)
     # Compatibility settings for PythonInterp and PythonLibs
     # used e.g. in FindCwrap, pybind11
     set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+    # Directory to install common (for opm modules) python scripts
+    include (GNUInstallDirs)
+    set(OPM_PYTHON_COMMON_DIR "${CMAKE_INSTALL_DATAROOTDIR}/opm/python")
   endif()
   # We always need the PYTHON_INCLUDE_DIR. Unfortunately
   # When we build pypi packages CMake will fail to determine
@@ -443,7 +446,7 @@ if (OPM_ENABLE_PYTHON)
     install( CODE "execute_process(COMMAND ${Python3_EXECUTABLE} ${PROJECT_BINARY_DIR}/python/install.py ${PROJECT_BINARY_DIR}/python/opm ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX} 1)")
     ## Need to install this Python script such that it can be used by opm-simulators when building against an installed
     ##  opm-common
-    install( PROGRAMS "python/install.py" DESTINATION "share/opm/python" )
+    install( PROGRAMS "python/install.py" DESTINATION "${OPM_PYTHON_COMMON_DIR}" )
   endif()
 
   # Observe that if the opmcommon library has been built as a shared library the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,9 @@ if (OPM_ENABLE_PYTHON)
   # setup-install.sh - and completely bypass cmake in the installation phase.
   if (OPM_INSTALL_PYTHON)
     install( CODE "execute_process(COMMAND ${Python3_EXECUTABLE} ${PROJECT_BINARY_DIR}/python/install.py ${PROJECT_BINARY_DIR}/python/opm ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX} 1)")
+    ## Need to install this Python script such that it can be used by opm-simulators when building against an installed
+    ##  opm-common
+    install( PROGRAMS "python/install.py" DESTINATION "share/opm/python" )
   endif()
 
   # Observe that if the opmcommon library has been built as a shared library the

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -35,6 +35,9 @@ if(NOT @opm-project_NAME@_FOUND)
   # actual code is self contained - and can be used downstream without awareness of this.
   set (@opm-project_NAME@_EMBEDDED_PYTHON @OPM_ENABLE_EMBEDDED_PYTHON@)
 
+  # Directory for common (across opm modules) Python scripts
+  set(@opm-project_NAME@_PYTHON_COMMON_DIR "${@opm-project_NAME@_PREFIX}/@OPM_PYTHON_COMMON_DIR@")
+
   # libraries come from the build tree where this file was generated
   set (@opm-project_NAME@_LIBRARY "@opm-project_LIBRARY@")
   set (@opm-project_NAME@_LIBRARIES ${@opm-project_NAME@_LIBRARY} "@opm-project_LIBRARIES@")
@@ -58,6 +61,7 @@ if(NOT @opm-project_NAME@_FOUND)
     string(REPLACE ${@opm-project_NAME@_PREFIX} ${DEST_PREFIX} @opm-project_NAME@_INCLUDE_DIRS "${@opm-project_NAME@_INCLUDE_DIRS}")
     string(REPLACE ${@opm-project_NAME@_PREFIX} ${DEST_PREFIX} @opm-project_NAME@_LIBRARY_DIRS "${@opm-project_NAME@_LIBRARY_DIRS}")
     string(REPLACE ${@opm-project_NAME@_PREFIX} ${DEST_PREFIX} @opm-project_NAME@_LIBRARY      "${@opm-project_NAME@_LIBRARY}")
+    string(REPLACE ${@opm-project_NAME@_PREFIX} ${DEST_PREFIX} @opm-project_NAME@_PYTHON_COMMON_DIR "${@opm-project_NAME@_PYTHON_COMMON_DIR}")
   endif()
 
 


### PR DESCRIPTION
See https://github.com/OPM/opm-simulators/pull/3918 for details.

Install the `install.py` python script such that it can be used by `opm-simulators` when building against an installed `opm-common`
