### PR TITLE
Require ENDSCALE When JFUNC Entered

### DIFF
--- a/python/tests/data/JFUNC.DATA
+++ b/python/tests/data/JFUNC.DATA
@@ -5,6 +5,10 @@ TITLE
 
 DIMENS
  10 10 10 /
+
+ENDSCALE
+/
+
 GRID
 DX
 1000*0.25 /

--- a/python/tests/test_state.py
+++ b/python/tests/test_state.py
@@ -156,6 +156,8 @@ SATNUM
         jfunc_gas = """
 DIMENS
  10 10 10 /
+ENDSCALE
+/
 GRID
 DX
 1000*0.25 /

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/J/JFUNC
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/J/JFUNC
@@ -4,6 +4,7 @@
     "GRID"
   ],
   "size": 1,
+  "requires": ["ENDSCALE"],
   "items": [
     {
       "name": "FLAG",

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/J/JFUNCR
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/J/JFUNCR
@@ -7,6 +7,7 @@
     "keyword": "TABDIMS",
     "item": "NTSFUN"
   },
+  "requires": ["ENDSCALE"],
   "items": [
     {
       "name": "J_FUNCTION",


### PR DESCRIPTION
We effectively ignore `JFUNC` data unless end-point scaling is activated through the `ENDSCALE` keyword in the `RUNSPEC` section. Alert the user to this fact by terminating the simulation run if the case uses `JFUNC` without `ENDSCALE` present in `RUNSPEC`.  In this case, issue a diagnostic message of the form
```
Error: Unrecoverable errors while loading input: Problem with keyword JFUNC
In CASE.DATA line 125
Incompatible keyword combination: JFUNC declared, but ENDSCALE is missing.
```