### PR TITLE
Make sure USE_SUPERLU is defined when calling FindSuperLU.cmake

### DIFF
--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -148,3 +148,8 @@ option (USE_QUADMATH "Search for high precision floating point library (normally
 if (NOT USE_QUADMATH)
   set (CMAKE_DISABLE_FIND_PACKAGE_QuadMath TRUE)
 endif ()
+
+option (USE_SUPERLU "Use SuperLU direct solvers for AMG (if umfpack is not found)" ON)
+if (NOT USE_SUPERLU)
+  set (CMAKE_DISABLE_FIND_PACKAGE_SuperLU TRUE)
+endif ()

--- a/cmake/Modules/OpmLibMain.cmake
+++ b/cmake/Modules/OpmLibMain.cmake
@@ -63,9 +63,6 @@ find_openmp (${project})
 include (UseThreads)
 find_threads (${project})
 
-# SuperLU is optional
-option (USE_SUPERLU "Use SuperLU direct solvers for AMG (if umfpack is not found)" ON)
-
 # PETSc is optional
 option (USE_PETSC "Use PETSc iterative solvers" OFF)
 


### PR DESCRIPTION
Previously, touching CMakeLists.txt after a first compilation would trigger compile errors as the two CMake runs were done with
inconsistent parameters (first one without USE_SUPERLU defined and second one with -DUSE_SUPERLU=ON). Of course that meant that the options would also differ from module to module, which seems like a recipe for desaster.

This patch fixes this by moving the definition of the USE_SUPERLU option to OpmInit.cmake which is included very early in the top most CMakeLists.txt of each module.

Closes OPM/opm-simulators#3908