### PR TITLE
Include header to compile with g++-8.4.0

### DIFF
--- a/opm/input/eclipse/Utility/Functional.hpp
+++ b/opm/input/eclipse/Utility/Functional.hpp
@@ -24,6 +24,7 @@
 #include <iterator>
 #include <vector>
 #include <numeric>
+#include <functional>
 
 namespace Opm {
 


### PR DESCRIPTION
`opm-common/opm/input/eclipse/Utility/Functional.hpp` did not compile for g++-8.4.0, without this header.

Resolves https://github.com/OPM/opm-common/issues/3050.