### PR TITLE
Improve error message for region operations on multz

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -311,7 +311,7 @@ Fieldprops::ScalarOperation fromString(const std::string& keyword) {
     if (keyword == ParserKeywords::MAXVALUE::keywordName)
         return Fieldprops::ScalarOperation::MAX;
 
-    throw std::invalid_argument("Keyword operation not recognized");
+    throw std::invalid_argument(fmt::format("Keyword operation ({}) not recognized", keyword));
 }
 
 

--- a/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -936,8 +936,11 @@ void FieldProps::handle_region_operation(const DeckKeyword& keyword) {
                 if (field_data.global_data)
                 {
                     const auto& location = keyword.location();
-                    throw std::logic_error(fmt::format("In file {} line {}: {} region operation on 3D field {} with global storage is not implemented!",
-                                                       location.filename, std::to_string(location.lineno), keyword.name(), target_kw));
+                    using namespace std::string_literals;
+                    throw OpmInputError(fmt::format("region operation on 3D field {} with "s +
+                                                    "global storage is not implemented!"s,
+                                                    target_kw),
+                                        location);
                 }
 
                 FieldProps::apply(fromString(keyword.name()), field_data.data, field_data.value_status, scalar_value, index_list);

--- a/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -26,6 +26,7 @@
 #include <set>
 #include <unordered_set>
 
+#include <fmt/format.h>
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/A.hpp>
@@ -933,7 +934,11 @@ void FieldProps::handle_region_operation(const DeckKeyword& keyword) {
                   with global storage.
                 */
                 if (field_data.global_data)
-                    throw std::logic_error("Region operations on 3D fields with global storage is not implemented");
+                {
+                    const auto& location = keyword.location();
+                    throw std::logic_error(fmt::format("In file {} line {}: {} region operation on 3D field {} with global storage is not implemented!",
+                                                       location.filename, std::to_string(location.lineno), keyword.name(), target_kw));
+                }
 
                 FieldProps::apply(fromString(keyword.name()), field_data.data, field_data.value_status, scalar_value, index_list);
             }


### PR DESCRIPTION
MULTZ is the only keyword that is stored in global representation
(i.e. with values for inactive cells, too) to allow the "PINCH ALL"
processing. This produced errors like:

```
Error:
An error occurred while creating the reservoir properties
Internal error: Region operations on 3D fields with global storage is
not implemented
```

With this change the error message has more information for the user
and might help to work around it:

```
Error:
An error occurred while creating the reservoir properties
Internal error: In file /path/to/file.inc line 3: MULTIREG region operation on 3D field MULTZ with global storage is not implemented!
```