### PR TITLE
Treat All-Defaulted PVTW Record as Copy of Previous

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <initializer_list>
+#include <string_view>
 #include <vector>
 
 namespace Opm {
@@ -22,6 +23,45 @@ struct FlatTable : public std::vector< T > {
     {
         serializer.vector(*this);
     }
+};
+
+template <typename RecordType>
+class FlatTableWithCopy
+{
+public:
+    FlatTableWithCopy() = default;
+    explicit FlatTableWithCopy(const DeckKeyword& kw,
+                               std::string_view   expect = "");
+    explicit FlatTableWithCopy(std::initializer_list<RecordType> records);
+
+    auto size()  const { return this->table_.size(); }
+    bool empty() const { return this->table_.empty(); }
+    auto begin() const { return this->table_.begin(); }
+    auto end()   const { return this->table_.end(); }
+
+    const RecordType& operator[](const std::size_t tableID) const
+    {
+        return this->table_[tableID];
+    }
+
+    const RecordType& at(const std::size_t tableID) const
+    {
+        return this->table_.at(tableID);
+    }
+
+    bool operator==(const FlatTableWithCopy& other) const
+    {
+        return this->table_ == other.table_;
+    }
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer.vector(this->table_);
+    }
+
+protected:
+    std::vector<RecordType> table_{};
 };
 
 struct GRAVITYRecord {
@@ -46,32 +86,11 @@ struct GRAVITYRecord {
     }
 };
 
-class GravityTable
+struct GravityTable : public FlatTableWithCopy<GRAVITYRecord>
 {
-public:
     GravityTable() = default;
     explicit GravityTable(const DeckKeyword& kw);
     explicit GravityTable(std::initializer_list<GRAVITYRecord> records);
-
-    auto size()  const { return this->table_.size(); }
-    bool empty() const { return this->table_.empty(); }
-    auto begin() const { return this->table_.begin(); }
-    auto end()   const { return this->table_.end(); }
-
-    const GRAVITYRecord& operator[](const std::size_t tableID) const
-    {
-        return this->table_[tableID];
-    }
-
-    const GRAVITYRecord& at(const std::size_t tableID) const
-    {
-        return this->table_.at(tableID);
-    }
-
-    bool operator==(const GravityTable& other) const
-    {
-        return this->table_ == other.table_;
-    }
 
     static GravityTable serializeObject()
     {
@@ -81,11 +100,8 @@ public:
     template <class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer.vector(this->table_);
+        FlatTableWithCopy::serializeOp(serializer);
     }
-
-private:
-    std::vector<GRAVITYRecord> table_{};
 };
 
 struct DENSITYRecord {
@@ -110,33 +126,12 @@ struct DENSITYRecord {
     }
 };
 
-class DensityTable
+struct DensityTable : public FlatTableWithCopy<DENSITYRecord>
 {
-public:
     DensityTable() = default;
     explicit DensityTable(const DeckKeyword& kw);
-    explicit DensityTable(std::initializer_list<DENSITYRecord> records);
     explicit DensityTable(const GravityTable& gravity);
-
-    auto size()  const { return this->table_.size(); }
-    bool empty() const { return this->table_.empty(); }
-    auto begin() const { return this->table_.begin(); }
-    auto end()   const { return this->table_.end(); }
-
-    const DENSITYRecord& operator[](const std::size_t tableID) const
-    {
-        return this->table_[tableID];
-    }
-
-    const DENSITYRecord& at(const std::size_t tableID) const
-    {
-        return this->table_.at(tableID);
-    }
-
-    bool operator==(const DensityTable& other) const
-    {
-        return this->table_ == other.table_;
-    }
+    explicit DensityTable(std::initializer_list<DENSITYRecord> records);
 
     static DensityTable serializeObject()
     {
@@ -146,11 +141,8 @@ public:
     template <class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer.vector(this->table_);
+        FlatTableWithCopy::serializeOp(serializer);
     }
-
-private:
-    std::vector<DENSITYRecord> table_{};
 };
 
 struct DiffCoeffRecord {
@@ -227,30 +219,11 @@ struct PVTWRecord {
     }
 };
 
-class PvtwTable
+struct PvtwTable : public FlatTableWithCopy<PVTWRecord>
 {
-public:
     PvtwTable() = default;
     explicit PvtwTable(const DeckKeyword& kw);
     explicit PvtwTable(std::initializer_list<PVTWRecord> records);
-
-    auto size()  const { return this->table_.size(); }
-    bool empty() const { return this->table_.empty(); }
-
-    const PVTWRecord& operator[](const std::size_t tableID) const
-    {
-        return this->table_[tableID];
-    }
-
-    const PVTWRecord& at(const std::size_t tableID) const
-    {
-        return this->table_.at(tableID);
-    }
-
-    bool operator==(const PvtwTable& other) const
-    {
-        return this->table_ == other.table_;
-    }
 
     static PvtwTable serializeObject()
     {
@@ -260,11 +233,8 @@ public:
     template <class Serializer>
     void serializeOp(Serializer& serializer)
     {
-        serializer.vector(this->table_);
+        FlatTableWithCopy::serializeOp(serializer);
     }
-
-private:
-    std::vector<PVTWRecord> table_{};
 };
 
 struct ROCKRecord {

--- a/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -24,37 +24,6 @@ struct FlatTable : public std::vector< T > {
     }
 };
 
-struct DENSITYRecord {
-    static constexpr std::size_t size = 3;
-
-    double oil;
-    double water;
-    double gas;
-
-    bool operator==(const DENSITYRecord& data) const {
-        return oil == data.oil &&
-               water == data.water &&
-               gas == data.gas;
-    }
-
-    template<class Serializer>
-    void serializeOp(Serializer& serializer)
-    {
-        serializer(oil);
-        serializer(water);
-        serializer(gas);
-    }
-};
-
-struct DensityTable : public FlatTable< DENSITYRecord > {
-    using FlatTable< DENSITYRecord >::FlatTable;
-
-    static DensityTable serializeObject()
-    {
-        return DensityTable({{1.0, 2.0, 3.0}});
-    }
-};
-
 struct GRAVITYRecord {
     static constexpr std::size_t size = 3;
 
@@ -77,13 +46,111 @@ struct GRAVITYRecord {
     }
 };
 
-struct GravityTable : public FlatTable< GRAVITYRecord > {
-    using FlatTable< GRAVITYRecord >::FlatTable;
+class GravityTable
+{
+public:
+    GravityTable() = default;
+    explicit GravityTable(const DeckKeyword& kw);
+    explicit GravityTable(std::initializer_list<GRAVITYRecord> records);
+
+    auto size()  const { return this->table_.size(); }
+    bool empty() const { return this->table_.empty(); }
+    auto begin() const { return this->table_.begin(); }
+    auto end()   const { return this->table_.end(); }
+
+    const GRAVITYRecord& operator[](const std::size_t tableID) const
+    {
+        return this->table_[tableID];
+    }
+
+    const GRAVITYRecord& at(const std::size_t tableID) const
+    {
+        return this->table_.at(tableID);
+    }
+
+    bool operator==(const GravityTable& other) const
+    {
+        return this->table_ == other.table_;
+    }
 
     static GravityTable serializeObject()
     {
         return GravityTable({{1.0, 2.0, 3.0}});
     }
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer.vector(this->table_);
+    }
+
+private:
+    std::vector<GRAVITYRecord> table_{};
+};
+
+struct DENSITYRecord {
+    static constexpr std::size_t size = 3;
+
+    double oil;
+    double water;
+    double gas;
+
+    bool operator==(const DENSITYRecord& data) const {
+        return oil == data.oil &&
+               water == data.water &&
+               gas == data.gas;
+    }
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(oil);
+        serializer(water);
+        serializer(gas);
+    }
+};
+
+class DensityTable
+{
+public:
+    DensityTable() = default;
+    explicit DensityTable(const DeckKeyword& kw);
+    explicit DensityTable(std::initializer_list<DENSITYRecord> records);
+    explicit DensityTable(const GravityTable& gravity);
+
+    auto size()  const { return this->table_.size(); }
+    bool empty() const { return this->table_.empty(); }
+    auto begin() const { return this->table_.begin(); }
+    auto end()   const { return this->table_.end(); }
+
+    const DENSITYRecord& operator[](const std::size_t tableID) const
+    {
+        return this->table_[tableID];
+    }
+
+    const DENSITYRecord& at(const std::size_t tableID) const
+    {
+        return this->table_.at(tableID);
+    }
+
+    bool operator==(const DensityTable& other) const
+    {
+        return this->table_ == other.table_;
+    }
+
+    static DensityTable serializeObject()
+    {
+        return DensityTable({{1.0, 2.0, 3.0}});
+    }
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer.vector(this->table_);
+    }
+
+private:
+    std::vector<DENSITYRecord> table_{};
 };
 
 struct DiffCoeffRecord {

--- a/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -1,6 +1,10 @@
 #ifndef OPM_FLAT_TABLE_HPP
 #define OPM_FLAT_TABLE_HPP
 
+#include <cstddef>
+#include <initializer_list>
+#include <vector>
+
 namespace Opm {
 
 class DeckKeyword;
@@ -156,13 +160,44 @@ struct PVTWRecord {
     }
 };
 
-struct PvtwTable : public FlatTable< PVTWRecord > {
-    using FlatTable< PVTWRecord >::FlatTable;
+class PvtwTable
+{
+public:
+    PvtwTable() = default;
+    explicit PvtwTable(const DeckKeyword& kw);
+    explicit PvtwTable(std::initializer_list<PVTWRecord> records);
+
+    auto size()  const { return this->table_.size(); }
+    bool empty() const { return this->table_.empty(); }
+
+    const PVTWRecord& operator[](const std::size_t tableID) const
+    {
+        return this->table_[tableID];
+    }
+
+    const PVTWRecord& at(const std::size_t tableID) const
+    {
+        return this->table_.at(tableID);
+    }
+
+    bool operator==(const PvtwTable& other) const
+    {
+        return this->table_ == other.table_;
+    }
 
     static PvtwTable serializeObject()
     {
         return PvtwTable({{1.0, 2.0, 3.0, 4.0, 5.0}});
     }
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer.vector(this->table_);
+    }
+
+private:
+    std::vector<PVTWRecord> table_{};
 };
 
 struct ROCKRecord {

--- a/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -1587,12 +1587,24 @@ DensityTable make_density_table(const GravityTable& gravity) {
             return;
         }
 
+        auto lastComplete = 0 * numTables;
         const auto& tableKeyword = deck[keywordName].back();
         for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
             if (dataItem.data_size() > 0) {
                 std::shared_ptr<TableType> table = std::make_shared<TableType>( dataItem, tableIdx );
                 container.addTable( tableIdx , table );
+                lastComplete = tableIdx;
+            }
+            else if (tableIdx > static_cast<size_t>(0)) {
+                const auto& item = tableKeyword.getRecord(lastComplete).getItem("DATA");
+                container.addTable(tableIdx, std::make_shared<TableType>(item, tableIdx));
+            }
+            else {
+                throw OpmInputError {
+                    fmt::format("Cannot default region {}'s table data", tableIdx + 1),
+                    tableKeyword.location()
+                };
             }
         }
     }

--- a/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -123,36 +123,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     return JFunc(deck);
 }
 
-DensityTable make_density_table(const GravityTable& gravity) {
-    auto rho = DensityTable{};
-    rho.reserve(gravity.size());
-
-    constexpr auto default_air_density =
-        1.22 * unit::kilogram / unit::cubic(unit::meter);
-
-    constexpr auto default_water_density =
-        1000.0 * unit::kilogram / unit::cubic(unit::meter);
-
-    // Degrees API defined as
-    //
-    //   API = (141.5 / SG) - 131.5
-    //
-    // with SG being the specific gravity of oil relative to pure water.
-
-    std::transform(gravity.begin(), gravity.end(),
-                   std::back_inserter(rho),
-                   [](const GRAVITYRecord& record)
-    {
-        return DENSITYRecord {
-            (141.5 / (record.oil_api + 131.5)) * default_water_density,
-            record.water_sg * default_water_density,
-            record.gas_sg * default_air_density
-        };
-    });
-
-    return rho;
-}
-
 }
 
 
@@ -197,7 +167,7 @@ DensityTable make_density_table(const GravityTable& gravity) {
             this->m_densityTable = DensityTable( deck["DENSITY"].back() );
 
         else if( deck.hasKeyword( "GRAVITY" ) )
-            this->m_densityTable = make_density_table( GravityTable ( deck["GRAVITY"].back() ) );
+            this->m_densityTable = DensityTable( GravityTable ( deck["GRAVITY"].back() ) );
 
         if( deck.hasKeyword( "DIFFC" ) )
             this->m_diffCoeffTable = DiffCoeffTable( deck["DIFFC"].back() );

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -43,6 +43,8 @@
 #include <opm/input/eclipse/EclipseState/Tables/FoammobTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PbvdTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PdvdTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PvdgTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/PvdoTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/DenT.hpp>
 
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
@@ -652,6 +654,150 @@ BOOST_AUTO_TEST_CASE(FoammobTable_Tests) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(PvdoTable_Tests) {
+    // PVDO tables from opm-tests/model6/0_BASE_MODEL6.DATA .
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
+TABDIMS
+1 2 /
+PROPS
+DENSITY
+   924.1      1026.0      1.03446 /
+   924.1      1026.0      1.03446 /
+PVDO
+ 23.0  1.10770  52.630
+ 27.5  1.08610  53.660
+ 32.1  1.06460  54.730
+ 50.0  1.06350  58.940
+/
+/ -- Copied from table 1
+END
+)");
+
+    const auto tmgr = Opm::TableManager { deck };
+    const auto& pvdo = tmgr.getPvdoTables();
+    BOOST_REQUIRE_EQUAL(pvdo.size(), std::size_t{2});
+
+    {
+        const auto& t1 = pvdo.getTable<PvdoTable>(0);
+
+        const auto& p = t1.getPressureColumn();
+        BOOST_REQUIRE_EQUAL(p.size(), std::size_t{4});
+        BOOST_CHECK_CLOSE(p[0], 2.3e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[1], 2.75e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[2], 3.21e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[3], 5.0e6, 1.0e-8);
+
+        const auto& B = t1.getFormationFactorColumn();
+        BOOST_REQUIRE_EQUAL(B.size(), std::size_t{4});
+        BOOST_CHECK_CLOSE(B[0], 1.10770, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[1], 1.08610, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[2], 1.06460, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[3], 1.06350, 1.0e-8);
+
+        const auto& mu = t1.getViscosityColumn();
+        BOOST_REQUIRE_EQUAL(mu.size(), std::size_t{4});
+        BOOST_CHECK_CLOSE(mu[0], 52.630e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[1], 53.660e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[2], 54.730e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[3], 58.940e-3, 1.0e-8);
+    }
+
+    {
+        const auto& t2 = pvdo.getTable<PvdoTable>(1);
+
+        const auto& p = t2.getPressureColumn();
+        BOOST_REQUIRE_EQUAL(p.size(), std::size_t{4});
+        BOOST_CHECK_CLOSE(p[0], 2.3e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[1], 2.75e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[2], 3.21e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[3], 5.0e6, 1.0e-8);
+
+        const auto& B = t2.getFormationFactorColumn();
+        BOOST_REQUIRE_EQUAL(B.size(), std::size_t{4});
+        BOOST_CHECK_CLOSE(B[0], 1.10770, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[1], 1.08610, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[2], 1.06460, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[3], 1.06350, 1.0e-8);
+
+        const auto& mu = t2.getViscosityColumn();
+        BOOST_REQUIRE_EQUAL(mu.size(), std::size_t{4});
+        BOOST_CHECK_CLOSE(mu[0], 52.630e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[1], 53.660e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[2], 54.730e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[3], 58.940e-3, 1.0e-8);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(PvdgTable_Tests) {
+    // PVT tables from opm-tests/model5/include/pvt_live_oil_dgas.ecl .
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
+TABDIMS
+1 2 /
+PROPS
+DENSITY
+   924.1      1026.0      1.03446 /
+   924.1      1026.0      1.03446 /
+PVDG
+-- Table number: 1
+    10.0000    0.266161     0.0108
+    15.0000    0.127259     0.0116
+    25.0000    0.062022     0.0123 /
+/ -- Copied from table 1
+END
+)");
+
+    const auto tmgr = Opm::TableManager { deck };
+    const auto& pvdg = tmgr.getPvdgTables();
+    BOOST_REQUIRE_EQUAL(pvdg.size(), std::size_t{2});
+
+    {
+        const auto& t1 = pvdg.getTable<PvdgTable>(0);
+
+        const auto& p = t1.getPressureColumn();
+        BOOST_REQUIRE_EQUAL(p.size(), std::size_t{3});
+        BOOST_CHECK_CLOSE(p[0], 1.0e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[1], 1.5e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[2], 2.5e6, 1.0e-8);
+
+        const auto& B = t1.getFormationFactorColumn();
+        BOOST_REQUIRE_EQUAL(B.size(), std::size_t{3});
+        BOOST_CHECK_CLOSE(B[0], 0.266161, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[1], 0.127259, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[2], 0.062022, 1.0e-8);
+
+        const auto& mu = t1.getViscosityColumn();
+        BOOST_REQUIRE_EQUAL(mu.size(), std::size_t{3});
+        BOOST_CHECK_CLOSE(mu[0], 0.0108e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[1], 0.0116e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[2], 0.0123e-3, 1.0e-8);
+    }
+
+    {
+        const auto& t2 = pvdg.getTable<PvdgTable>(1);
+
+        const auto& p = t2.getPressureColumn();
+        BOOST_REQUIRE_EQUAL(p.size(), std::size_t{3});
+        BOOST_CHECK_CLOSE(p[0], 1.0e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[1], 1.5e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(p[2], 2.5e6, 1.0e-8);
+
+        const auto& B = t2.getFormationFactorColumn();
+        BOOST_REQUIRE_EQUAL(B.size(), std::size_t{3});
+        BOOST_CHECK_CLOSE(B[0], 0.266161, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[1], 0.127259, 1.0e-8);
+        BOOST_CHECK_CLOSE(B[2], 0.062022, 1.0e-8);
+
+        const auto& mu = t2.getViscosityColumn();
+        BOOST_REQUIRE_EQUAL(mu.size(), std::size_t{3});
+        BOOST_CHECK_CLOSE(mu[0], 0.0108e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[1], 0.0116e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(mu[2], 0.0123e-3, 1.0e-8);
+    }
+}
 
 
 BOOST_AUTO_TEST_CASE(PvtwTable_Tests) {

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -1223,6 +1223,70 @@ END
     }
 }
 
+BOOST_AUTO_TEST_CASE(DensityTable_Tests) {
+    // PVT tables from opm-tests/model5/include/pvt_live_oil_dgas.ecl .
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
+TABDIMS
+1 2 /
+PROPS
+DENSITY
+   924.1  1026.0  1.03446 /
+/ -- Copied from region 1
+END
+)");
+
+    const auto tmgr = Opm::TableManager { deck };
+    const auto& dens = tmgr.getDensityTable();
+    BOOST_REQUIRE_EQUAL(dens.size(), std::size_t{2});
+
+    {
+        const auto& t1 = dens[0];
+        BOOST_CHECK_CLOSE(t1.oil, 924.1, 1.0e-8);
+        BOOST_CHECK_CLOSE(t1.gas, 1.03446, 1.0e-8);
+        BOOST_CHECK_CLOSE(t1.water, 1026.0, 1.0e-8);
+    }
+
+    {
+        const auto& t2 = dens[1];
+        BOOST_CHECK_CLOSE(t2.oil, 924.1, 1.0e-8);
+        BOOST_CHECK_CLOSE(t2.gas, 1.03446, 1.0e-8);
+        BOOST_CHECK_CLOSE(t2.water, 1026.0, 1.0e-8);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(GravityTable_Tests) {
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
+TABDIMS
+1 2 /
+GRAVITY
+  12.34 1.2 1.21 /
+/ -- Copied from region 1
+END
+)");
+
+    const auto tmgr = Opm::TableManager { deck };
+    const auto& dens = tmgr.getDensityTable();
+    BOOST_REQUIRE_EQUAL(dens.size(), std::size_t{2});
+
+    {
+        const auto& t1 = dens[0];
+        BOOST_CHECK_CLOSE(  983.731924360, t1.oil  , 1.0e-8 );
+        BOOST_CHECK_CLOSE( 1200.0        , t1.water, 1.0e-8 );
+        BOOST_CHECK_CLOSE(    1.4762     , t1.gas  , 1.0e-8 );
+    }
+
+    {
+        const auto& t2 = dens[1];
+        BOOST_CHECK_CLOSE(  983.731924360, t2.oil  , 1.0e-8 );
+        BOOST_CHECK_CLOSE( 1200.0        , t2.water, 1.0e-8 );
+        BOOST_CHECK_CLOSE(    1.4762     , t2.gas  , 1.0e-8 );
+    }
+}
+
 /**
  * Tests "happy path" for a VFPPROD table, i.e., when everything goes well
  */

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -38,6 +38,7 @@
 #include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PlyadsTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PlymaxTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/FoamadsTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/FoammobTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PbvdTable.hpp>
@@ -653,6 +654,62 @@ BOOST_AUTO_TEST_CASE(FoammobTable_Tests) {
 
 
 
+BOOST_AUTO_TEST_CASE(PvtwTable_Tests) {
+    // PVT tables from opm-tests/model5/include/pvt_live_oil_dgas.ecl .
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+OIL
+WATER
+TABDIMS
+1 2 /
+PROPS
+DENSITY
+   924.1      1026.0      1.03446 /
+   924.1      1026.0      1.03446 /
+PVTW
+   79.0  1.02643  0.37876E-04  0.39831  0.74714E-04 /
+/
+END
+)");
+
+    const auto tmgr = Opm::TableManager { deck };
+    const auto& pvtw = tmgr.getPvtwTable();
+    BOOST_REQUIRE_EQUAL(pvtw.size(), std::size_t{2});
+
+    {
+        const auto& t1 = pvtw[0];
+        BOOST_CHECK_CLOSE(t1.reference_pressure, 7.9e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(t1.volume_factor, 1.02643, 1.0e-8);
+        BOOST_CHECK_CLOSE(t1.compressibility, 0.37876e-9, 1.0e-8);
+        BOOST_CHECK_CLOSE(t1.viscosity, 0.39831e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(t1.viscosibility, 0.74714e-9, 1.0e-9);
+    }
+
+    {
+        const auto& t2 = pvtw[1];
+        BOOST_CHECK_CLOSE(t2.reference_pressure, 7.9e6, 1.0e-8);
+        BOOST_CHECK_CLOSE(t2.volume_factor, 1.02643, 1.0e-8);
+        BOOST_CHECK_CLOSE(t2.compressibility, 0.37876e-9, 1.0e-8);
+        BOOST_CHECK_CLOSE(t2.viscosity, 0.39831e-3, 1.0e-8);
+        BOOST_CHECK_CLOSE(t2.viscosibility, 0.74714e-9, 1.0e-9);
+    }
+
+    const auto& dens = tmgr.getDensityTable();
+    BOOST_REQUIRE_EQUAL(dens.size(), std::size_t{2});
+
+    {
+        const auto& t1 = dens[0];
+        BOOST_CHECK_CLOSE(t1.oil, 924.1, 1.0e-8);
+        BOOST_CHECK_CLOSE(t1.gas, 1.03446, 1.0e-8);
+        BOOST_CHECK_CLOSE(t1.water, 1026.0, 1.0e-8);
+    }
+
+    {
+        const auto& t2 = dens[1];
+        BOOST_CHECK_CLOSE(t2.oil, 924.1, 1.0e-8);
+        BOOST_CHECK_CLOSE(t2.gas, 1.03446, 1.0e-8);
+        BOOST_CHECK_CLOSE(t2.water, 1026.0, 1.0e-8);
+    }
+}
 
 /**
  * Tests "happy path" for a VFPPROD table, i.e., when everything goes well


### PR DESCRIPTION
A simulation model may choose to give PVTW data as
```
PVTW
  1.0 1.0 1.0e-5 0.2 0.0 /
  /  -- record 2 (copied from record 1)
```
if, for instance, the oil and/or gas tables are different in regions 1 and 2, but the water is the same.  In this case we must properly copy record 1 into record 2 and essentially recreate the table.

To this end, decouple the `PvtwTable` from the `FlatTable` machinery and make the former into an independent type containing `vector<>` instead of inheriting from `vector<>`.  Implement the default->copy behaviour in the new constructor
```C++
PvtwTable::PvtwTable(const DeckKeyword&)
```

---

Update: I have now added similar behaviour for `PVDO`, `PVDG`, `PVTO`, `PVTG`, `DENSITY`, and `GRAVITY` too.  The latter two keywords use the same approach as `PVTW`, while the others go through the existing constructors.