### PR TITLE
Improves error messages on faults when additional chars are used.

### DIFF
--- a/src/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -22,6 +22,7 @@
 
 #include <fmt/format.h>
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/InfoLogger.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
@@ -349,9 +350,17 @@ AquiferConfig load_aquifers(const Deck& deck, const TableManager& tables, NNC& i
                 const auto& faultRecord = *iter;
                 const std::string& faultName = faultRecord.getItem(0).get< std::string >(0);
                 double multFlt = faultRecord.getItem(1).get< double >(0);
-                m_faults.setTransMult( faultName , multFlt );
-
-                logger(fmt::format("Setting fault transmissibility multiplier {} for fault {}", multFlt, faultName));
+                try
+                {
+                    m_faults.setTransMult( faultName , multFlt );
+                    logger(fmt::format("Setting fault transmissibility multiplier {} for fault {}", multFlt, faultName));
+                }
+                catch(const std::exception& e)
+                {
+                    auto msg = fmt::format("Could not set fault transmissibility multiplier {} for fault {}: {}",
+                                           multFlt, faultName, e.what());
+                    OPM_THROW(std::invalid_argument, msg);
+                }
             }
         }
     }


### PR DESCRIPTION
Faults are stored in an OrderedMap with the full string used during construction even if that is longer than 8 characters. When later these faults are e.g. modified whith MULTFLT using only the first 8 characters, the only message the user got was

```
An error occurred while creating the reservoir properties
Internal error: Key not found:

Unrecoverable errors while loading input: Key not found
```

With this patch we at least add some more context to the error
message:

```
Error:
An error occurred while creating the reservoir properties
Internal error: Could not set fault transmissibility multiplier 5.23166e-10 for fault CFN2_05t: Key ABCD_05q not found. Similar entries are ABCD_05q_extended_width, UABCD_05q_extended_width.
```