### PR TITLE
Support MINPORV

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -344,14 +344,6 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
             m_pinchGapMode = PinchMode::PinchModeFromString(pinchGapString);
         }
 
-        if (deck.hasKeyword<ParserKeywords::MINPV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {
-            throw std::invalid_argument("Can not have both MINPV and MINPVFIL in the deck.");
-        } else if(deck.hasKeyword<ParserKeywords::MINPV>() && deck.hasKeyword<ParserKeywords::MINPORV>()) {   
-            throw std::invalid_argument("Can not have both MINPV and MINPORV in the deck.");
-        } else if(deck.hasKeyword<ParserKeywords::MINPORV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {   
-            throw std::invalid_argument("Can not have both MINPORV and MINPVFIL in the deck.");
-        }
-
         m_minpvVector.resize(getCartesianSize(), 0.0);
         if (deck.hasKeyword<ParserKeywords::MINPV>()) {
             const auto& record = deck.get<ParserKeywords::MINPV>( ).back().getRecord(0);

--- a/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -344,6 +344,12 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
             m_pinchGapMode = PinchMode::PinchModeFromString(pinchGapString);
         }
 
+        if (deck.hasKeyword<ParserKeywords::MINPV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {
+            throw std::invalid_argument("Can not have both MINPV and MINPVFIL in the deck.");
+        } else if(deck.hasKeyword<ParserKeywords::MINPORV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {   
+            throw std::invalid_argument("Can not have both MINPORV and MINPVFIL in the deck.");
+        }
+        
         m_minpvVector.resize(getCartesianSize(), 0.0);
         if (deck.hasKeyword<ParserKeywords::MINPV>()) {
             const auto& record = deck.get<ParserKeywords::MINPV>( ).back().getRecord(0);

--- a/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -345,13 +345,22 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         }
 
         if (deck.hasKeyword<ParserKeywords::MINPV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {
-            throw std::invalid_argument("Can not have both MINPV and MINPVFIL in deck.");
+            throw std::invalid_argument("Can not have both MINPV and MINPVFIL in the deck.");
+        } else if(deck.hasKeyword<ParserKeywords::MINPV>() && deck.hasKeyword<ParserKeywords::MINPORV>()) {   
+            throw std::invalid_argument("Can not have both MINPV and MINPORV in the deck.");
+        } else if(deck.hasKeyword<ParserKeywords::MINPORV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {   
+            throw std::invalid_argument("Can not have both MINPORV and MINPVFIL in the deck.");
         }
 
         m_minpvVector.resize(getCartesianSize(), 0.0);
         if (deck.hasKeyword<ParserKeywords::MINPV>()) {
             const auto& record = deck.get<ParserKeywords::MINPV>( ).back().getRecord(0);
             const auto& item = record.getItem<ParserKeywords::MINPV::VALUE>( );
+            std::fill(m_minpvVector.begin(), m_minpvVector.end(), item.getSIDouble(0));
+            m_minpvMode = MinpvMode::ModeEnum::EclSTD;
+        } else if (deck.hasKeyword<ParserKeywords::MINPORV>()) {
+            const auto& record = deck.get<ParserKeywords::MINPORV>( ).back().getRecord(0);
+            const auto& item = record.getItem<ParserKeywords::MINPORV::VALUE>( );
             std::fill(m_minpvVector.begin(), m_minpvVector.end(), item.getSIDouble(0));
             m_minpvMode = MinpvMode::ModeEnum::EclSTD;
         } else if(deck.hasKeyword<ParserKeywords::MINPVV>()) {

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPORV
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPORV
@@ -3,7 +3,7 @@
   "sections": [
     "GRID"
   ],
-  "prohibits" : ["MINPV", "MINPVFIL"],
+  "prohibits" : ["MINPV"],
   "size": 1,
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPORV
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPORV
@@ -6,8 +6,8 @@
   "size": 1,
   "items": [
     {
-      "name": "MIN_PORE_VOL",
-      "value_type": "DOUBLE",
+     "name": "VALUE",
+       "value_type": "DOUBLE",
       "dimension": "ReservoirVolume",
       "default": 1e-06
     }

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPORV
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPORV
@@ -3,6 +3,7 @@
   "sections": [
     "GRID"
   ],
+  "prohibits" : ["MINPV", "MINPVFIL"],
   "size": 1,
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPV
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPV
@@ -3,6 +3,7 @@
   "sections": [
     "GRID"
   ],
+  "prohibits" : ["MINPORV", "MINPVFIL"],
   "size": 1,
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPV
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MINPV
@@ -3,7 +3,7 @@
   "sections": [
     "GRID"
   ],
-  "prohibits" : ["MINPORV", "MINPVFIL"],
+  "prohibits" : ["MINPORV"],
   "size": 1,
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/900_OPM/M/MINPVFIL
+++ b/src/opm/input/eclipse/share/keywords/900_OPM/M/MINPVFIL
@@ -3,6 +3,7 @@
   "sections": [
     "GRID"
   ],
+  "prohibits" : ["MINPV", "MINPORV"],
   "size": 1,
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/900_OPM/M/MINPVFIL
+++ b/src/opm/input/eclipse/share/keywords/900_OPM/M/MINPVFIL
@@ -3,7 +3,6 @@
   "sections": [
     "GRID"
   ],
-  "prohibits" : ["MINPV", "MINPORV"],
   "size": 1,
   "items": [
     {


### PR DESCRIPTION
Add support for MINPORV, which is an alias for MINPV. Also added additional checks, such that only one of MINPV, MINPORV and MINPVFIL can be active in the deck