### PR TITLE
Update NNC

### DIFF
--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/N/NNC
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/N/NNC
@@ -70,14 +70,12 @@
     {
       "item": 12,
       "name": "VE_FACE1",
-      "value_type": "STRING",
-      "default": ""
+      "value_type": "STRING"
     },
     {
       "item": 13,
       "name": "VE_FACE2",
-      "value_type": "STRING",
-      "default": ""
+      "value_type": "STRING"
     },
     {
       "item": 14,


### PR DESCRIPTION
Remove erroneous warning messages:

```
  NNC: invalid value '' in record 1 for item 12
  In file: RON-P50-A01-OPM.DATA, line 3387
  NNC(FACE1): not supported use 1* - will continue
```

For NNC(FACE1) and NNC(FACE2) by deleting the default "" value in the JSON file.

Client model had hundreds of these messages.