### PR TITLE
Cleanup Schedule.hpp usage

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -20,22 +20,21 @@
 #define SCHEDULE_HPP
 
 #include <cstddef>
+#include <ctime>
 #include <map>
 #include <memory>
 #include <optional>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include <time.h>
-
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
+#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
-#include <opm/input/eclipse/Schedule/Group/GTNode.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
@@ -45,18 +44,10 @@
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
 #include <opm/input/eclipse/Schedule/CompletedCells.hpp>
-#include <opm/input/eclipse/Schedule/ScheduleDeck.hpp>
-#include <opm/input/eclipse/Schedule/ScheduleState.hpp>
-#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
 #include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
-#include <opm/input/eclipse/Parser/ParseContext.hpp>
-
-#include <opm/input/eclipse/Python/Python.hpp>
-
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 namespace Opm
@@ -67,11 +58,13 @@ namespace Opm
     class DeckRecord;
     class EclipseState;
     class FieldPropsManager;
+    class GTNode;
     class ParseContext;
     class SCHEDULESection;
     class SummaryState;
     class ErrorGuard;
     class UDQConfig;
+    class WellMatcher;
 
     namespace RestartIO { struct RstState; }
 
@@ -213,10 +206,10 @@ namespace Opm
          * If the input deck does not specify a start time, Eclipse's 1. Jan
          * 1983 is defaulted
          */
-        time_t getStartTime() const;
-        time_t posixStartTime() const;
-        time_t posixEndTime() const;
-        time_t simTime(std::size_t timeStep) const;
+        std::time_t getStartTime() const;
+        std::time_t posixStartTime() const;
+        std::time_t posixEndTime() const;
+        std::time_t simTime(std::size_t timeStep) const;
         double seconds(std::size_t timeStep) const;
         double stepLength(std::size_t timeStep) const;
         std::optional<int> exitStatus() const;

--- a/opm/output/eclipse/AggregateActionxData.hpp
+++ b/opm/output/eclipse/AggregateActionxData.hpp
@@ -30,7 +30,6 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 
 #include <cstddef>
 #include <string>

--- a/src/opm/input/eclipse/Python/Python.cpp
+++ b/src/opm/input/eclipse/Python/Python.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
 #include "PythonInterp.hpp"
 

--- a/src/opm/input/eclipse/Python/PythonInterp.hpp
+++ b/src/opm/input/eclipse/Python/PythonInterp.hpp
@@ -26,7 +26,6 @@
 #include <memory>
 
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Action/PyAction.hpp>
 
 
@@ -41,8 +40,8 @@ namespace py = pybind11;
 namespace Opm {
 
 #ifdef EMBEDDED_PYTHON
-class Parser;
 class Deck;
+class Parser;
 
 
 class __attribute__ ((visibility("hidden"))) PythonInterp {
@@ -63,6 +62,7 @@ private:
 #else
 
 class EclipseState;
+class Schedule;
 
 class PythonInterp {
 public:

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -68,6 +68,7 @@
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
+#include <opm/input/eclipse/Schedule/Group/GTNode.hpp>
 
 #include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
@@ -294,11 +295,11 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const std::optional
         return this->posixStartTime( );
     }
 
-    time_t Schedule::posixStartTime() const {
+    std::time_t Schedule::posixStartTime() const {
         return std::chrono::system_clock::to_time_t(this->m_sched_deck[0].start_time());
     }
 
-    time_t Schedule::posixEndTime() const {
+    std::time_t Schedule::posixEndTime() const {
         // This should indeed access the start_time() property of the last
         // snapshot.
         return std::chrono::system_clock::to_time_t(this->snapshots.back().start_time());
@@ -1257,7 +1258,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
     }
 
-    time_t Schedule::simTime(std::size_t timeStep) const {
+    std::time_t Schedule::simTime(std::size_t timeStep) const {
         return std::chrono::system_clock::to_time_t( this->snapshots[timeStep].start_time() );
     }
 

--- a/src/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -32,7 +32,6 @@
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 
 namespace Opm {

--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -37,7 +37,6 @@
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -71,6 +71,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellInjectionProperties.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>
+#include <opm/input/eclipse/Schedule/Group/GTNode.hpp>
 #include <opm/input/eclipse/Schedule/CompletedCells.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 

--- a/tests/parser/WTEST.cpp
+++ b/tests/parser/WTEST.cpp
@@ -24,7 +24,6 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>

--- a/tests/test_AggregateAquiferData.cpp
+++ b/tests/test_AggregateAquiferData.cpp
@@ -36,7 +36,6 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp>
 


### PR DESCRIPTION
Remove include in header and deal with consequences.
And clean list of includes in Schedule.hpp

Not really a big impact, from 532 build steps to 523 build steps according to ninja.