### PR TITLE
Add <cstddef> include for std::size_t.

### DIFF
--- a/opm/output/eclipse/WriteRPT.hpp
+++ b/opm/output/eclipse/WriteRPT.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_WRITE_RPT_HPP
 #define OPM_WRITE_RPT_HPP
 
+#include <cstddef>
 #include <iosfwd>
 
 namespace Opm {


### PR DESCRIPTION
Needed to compile with recent clang and libc++.