### PR TITLE
Add New Summary Node Category of Completion

### DIFF
--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -20,12 +20,11 @@
 #ifndef OPM_IO_SUMMARYNODE_HPP
 #define OPM_IO_SUMMARYNODE_HPP
 
+#include <array>
 #include <functional>
+#include <limits>
 #include <optional>
 #include <string>
-#include <unordered_set>
-#include <array>
-#include <limits>
 
 namespace Opm { namespace EclIO {
 
@@ -42,6 +41,7 @@ struct SummaryNode {
         Region,
         Block,
         Connection,
+        Completion,
         Segment,
         Aquifer,
         Node,
@@ -58,7 +58,6 @@ struct SummaryNode {
         ProdIndex,
         Undefined,
     };
-
 
     std::string keyword;
     Category    category;
@@ -78,6 +77,14 @@ struct SummaryNode {
     bool is_user_defined() const;
 
     static Category category_from_keyword(const std::string&);
+
+    static std::string normalise_keyword(const Category     category,
+                                         const std::string& keyword);
+
+    static inline std::string normalise_keyword(const std::string& keyword)
+    {
+        return normalise_keyword(category_from_keyword(keyword), keyword);
+    }
 
     // Return true for keywords which should be Miscellaneous, although the
     // naive first-character-based classification suggests something else.

--- a/tests/test_SummaryNode.cpp
+++ b/tests/test_SummaryNode.cpp
@@ -23,11 +23,16 @@
 
 #include <opm/io/eclipse/SummaryNode.hpp>
 
+#include <initializer_list>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
 namespace {
     void expect_key(const Opm::EclIO::SummaryNode& node, const std::string& unique_key) {
         BOOST_CHECK_EQUAL(node.unique_key(), unique_key);
     }
-}
+} // Anonymous namespace
 
 BOOST_AUTO_TEST_SUITE(UniqueKey)
 
@@ -86,3 +91,100 @@ BOOST_AUTO_TEST_CASE(user_defined) {
 }
 
 BOOST_AUTO_TEST_SUITE_END() // UniqueKey
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Category)
+
+namespace {
+    std::string to_string(const Opm::EclIO::SummaryNode::Category cat)
+    {
+        using Cat = Opm::EclIO::SummaryNode::Category;
+
+        switch (cat) {
+        case Cat::Aquifer:       return "Aquifer";
+        case Cat::Well:          return "Well";
+        case Cat::Group:         return "Group";
+        case Cat::Field:         return "Field";
+        case Cat::Region:        return "Region";
+        case Cat::Block:         return "Block";
+        case Cat::Connection:    return "Connection";
+        case Cat::Completion:    return "Completion";
+        case Cat::Segment:       return "Segment";
+        case Cat::Node:          return "Node";
+        case Cat::Miscellaneous: return "Miscellaneous";
+        }
+
+        throw std::invalid_argument {
+            "Unhandled Summary Parameter Category '"
+            + std::to_string(static_cast<int>(cat)) + '\''
+        };
+    }
+
+    Opm::EclIO::SummaryNode::Category category(const std::string& kw)
+    {
+        return Opm::EclIO::SummaryNode::category_from_keyword(kw);
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_CASE(Well)
+{
+    const auto well_kw = std::vector<std::string> {
+        "WOPR", "WOPT", "WGIR", "WWIR",
+    };
+
+    for (const auto& kw : well_kw) {
+        BOOST_CHECK_MESSAGE(category(kw) == Opm::EclIO::SummaryNode::Category::Well,
+                            "Keyword '" << kw << "' must be category 'Well'. Got '" <<
+                            to_string(category(kw)) << "' instead");
+    }
+
+    BOOST_CHECK_MESSAGE(category("WOPRL") != Opm::EclIO::SummaryNode::Category::Well,
+                        "Keyword 'WOPRL' must NOT be category 'Well'");
+}
+
+BOOST_AUTO_TEST_CASE(Connection)
+{
+    const auto connection_kw = std::vector<std::string> {
+        "COPR", "COPT", "CGIR", "CWIR",
+    };
+
+    for (const auto& kw : connection_kw) {
+        BOOST_CHECK_MESSAGE(category(kw) == Opm::EclIO::SummaryNode::Category::Connection,
+                            "Keyword '" << kw << "' must be category 'Connection'. Got '" <<
+                            to_string(category(kw)) << "' instead");
+    }
+
+    BOOST_CHECK_MESSAGE(category("COPRL") != Opm::EclIO::SummaryNode::Category::Connection,
+                        "Keyword 'COPRL' must NOT be category 'Connection'");
+}
+
+BOOST_AUTO_TEST_CASE(Completion)
+{
+    const auto compl_kw = std::vector<std::string> {
+        "OPRL", "OPTL", "GIRL", "WIRL",
+    };
+
+    for (const auto& kw_base : compl_kw) {
+        const auto kw = 'C' + kw_base;
+        BOOST_CHECK_MESSAGE(category(kw) == Opm::EclIO::SummaryNode::Category::Completion,
+                            "Keyword '" << kw << "' must be category 'Completion'. Got '" <<
+                            to_string(category(kw)) << "' instead");
+    }
+
+    for (const auto* suffix : { "", "__1", "_12", "123" }) {
+        for (const auto& kw_base : compl_kw) {
+            const auto kw = 'W' + kw_base + suffix;
+            BOOST_CHECK_MESSAGE(category(kw) == Opm::EclIO::SummaryNode::Category::Completion,
+                                "Keyword '" << kw << "' must be category 'Completion'. Got '" <<
+                                to_string(category(kw)) << "' instead");
+        }
+    }
+
+    for (const auto* kw : { "WOPRLK", "CGIR", "WKITL__8", "WOOOOPRL", "WHIRL" }) {
+        BOOST_CHECK_MESSAGE(category(kw) != Opm::EclIO::SummaryNode::Category::Completion,
+                            "Keyword '" << kw << "' must NOT be category 'Completion'");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Category


### PR DESCRIPTION
This enables not using the non-standard node names
```
WOPRL__1
```
&c which increases post-processor compatibility of our `SMSPEC` files and enables detecting situations where we need to supply completion numbers for nodes that would otherwise be treated as pertaining to wells instead.