### PR TITLE
fixing bug in IO class ESmry

### DIFF
--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -426,13 +426,13 @@ ESmry::ESmry(const std::string &filename, bool loadBaseRunData) :
             for (size_t i=0; i < keywords.size(); i++) {
                 Opm::EclIO::lgr_info lgr { lgrs[i], {numlx[i], numly[i], numlz[i]}};
                 const std::string keyw = makeKeyString(keywords[i], wgnames[i], nums[i], lgr);
-                if (keywList.find(keyw) != keywList.end())
+                if ((!keyw.empty()) && (keywList.find(keyw) != keywList.end()))
                     arrayPos[specInd][keyIndex[keyw]]=i;
             }
         } else {
             for (size_t i=0; i < keywords.size(); i++) {
                 const std::string keyw = makeKeyString(keywords[i], wgnames[i], nums[i], {});
-                if (keywList.find(keyw) != keywList.end())
+                if ((!keyw.empty()) && (keywList.find(keyw) != keywList.end()))
                     arrayPos[specInd][keyIndex[keyw]]=i;
             }
         }


### PR DESCRIPTION
Summary files generated by the Eclipse simulator creates a lot of time vectors which are not real data. These should be ignored by ESmry. The member function ESmry::makeKeyString will return an empty string for this entries and importantly the map arrayPos should not be updated with this vectors.