### PR TITLE
Add and use portable_timegm().

### DIFF
--- a/opm/common/utility/TimeService.hpp
+++ b/opm/common/utility/TimeService.hpp
@@ -45,6 +45,7 @@ namespace Opm {
 
     std::time_t mkdatetime(int in_year, int in_month, int in_day, int hour, int minute, int second);
     std::time_t mkdate(int in_year, int in_month, int in_day);
+    std::time_t portable_timegm(const std::tm* t);
     std::time_t timeFromEclipse(const DeckRecord &dateRecord);
     }
 


### PR DESCRIPTION
This function converts a std::tm to a std::time_t, assuming UTC and not local timezone. This is used instead of relying on
repeated calls to mktime(), which can fail on some system (BSD) for dates before 1900.

This was discovered by running a case with START date 1 JAN 1900, which when run in the CET zone is in 1899 (UTC).