### PR TITLE
Handling connection aquifer mismatch

### DIFF
--- a/opm/input/eclipse/EclipseState/Aquifer/Aquancon.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/Aquancon.hpp
@@ -99,7 +99,8 @@ namespace Opm {
             bool operator==(const Aquancon& other) const;
             bool active() const;
 
-            const std::vector<Aquancon::AquancCell>& operator[](int aquiferID) const;
+            bool hasAquiferConnections(int aquiferID) const;
+            const std::vector<Aquancon::AquancCell>& getConnections(int aquiferID) const;
 
             template<class Serializer>
             void serializeOp(Serializer& serializer)

--- a/opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
@@ -61,6 +61,7 @@ public:
     const Aquancon& connections() const;
     bool operator==(const AquiferConfig& other) const;
     bool hasAquifer(const int aquID) const;
+    bool hasAnalyticalAquifer(const int aquID) const;
 
     bool hasNumericalAquifer() const;
     bool hasAnalyticalAquifer() const;

--- a/src/opm/input/eclipse/EclipseState/Aquifer/Aquancon.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/Aquancon.cpp
@@ -218,13 +218,18 @@ namespace Opm {
     }
 
 
-    const std::vector<Aquancon::AquancCell>& Aquancon::operator[](int aquiferID) const {
+    const std::vector<Aquancon::AquancCell>& Aquancon::getConnections(int aquiferID) const {
         const auto search = this->cells.find(aquiferID);
         if (search == this->cells.end()) {
             auto msg = fmt::format("There is no connection associated with analytical aquifer {}\n", aquiferID);
             throw std::runtime_error(msg);
         }
         return search->second;
+    }
+
+    bool Aquancon::hasAquiferConnections(const int aquiferID) const {
+        auto search = this->cells.find(aquiferID);
+        return (search != this->cells.end()) && !search->second.empty();
     }
 
     Aquancon::Aquancon(const std::unordered_map<int, std::vector<Aquancon::AquancCell>>& data) :

--- a/src/opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -100,9 +100,13 @@ const Aquancon& AquiferConfig::connections() const {
 }
 
 bool AquiferConfig::hasAquifer(const int aquID) const {
-    return aquifetp.hasAquifer(aquID) ||
-           aquiferct.hasAquifer(aquID) ||
+    return this->hasAnalyticalAquifer(aquID) ||
            numerical_aquifers.hasAquifer(aquID);
+}
+
+bool AquiferConfig::hasAnalyticalAquifer(const int aquID) const {
+    return aquifetp.hasAquifer(aquID) ||
+           aquiferct.hasAquifer(aquID);
 }
 
 bool AquiferConfig::hasNumericalAquifer() const {

--- a/src/opm/output/eclipse/AggregateAquiferData.cpp
+++ b/src/opm/output/eclipse/AggregateAquiferData.cpp
@@ -101,6 +101,10 @@ namespace {
                                        ConnectionCallBack&&      connectionOp)
     {
         for (const auto& [aquiferID, connections] : aqConfig.connections().data()) {
+            if ( !aqConfig.hasAnalyticalAquifer(int(aquiferID)) ) {
+                continue;
+            }
+
             const auto tot_influx =
                 std::accumulate(connections.begin(), connections.end(), 0.0,
                     [](const double t, const Opm::Aquancon::AquancCell& connection) -> double

--- a/tests/parser/AquiferTests.cpp
+++ b/tests/parser/AquiferTests.cpp
@@ -277,14 +277,14 @@ BOOST_AUTO_TEST_CASE(AquanconTest_DEFAULT_INFLUX)
     const auto& grid = makeGrid();
     Aquancon aqcon(grid, deck1);
 
-    const auto& cells_aq1 = aqcon[1];
+    const auto& cells_aq1 = aqcon.getConnections(1);
     /*
       The cells I = 0..2 are connected to aquifer 1; cell I==0 is inactive and
       not counted here ==> a total of 2 cells are connected to aquifer 1.
     */
     BOOST_CHECK_EQUAL(cells_aq1.size(), 2U);
 
-    const auto& cells_aq2 = aqcon[2];
+    const auto& cells_aq2 = aqcon.getConnections(2);
     BOOST_CHECK_EQUAL(cells_aq2.size(), 1U);
     BOOST_CHECK(aqcon.active());
 
@@ -352,8 +352,8 @@ BOOST_AUTO_TEST_CASE(AquanconTest_ALLOW_AQUIFER_INSIDE_OR_NOT)
     const Aquancon aq2(data);
 
     BOOST_CHECK(aqucon == aq2);
-    auto cells1 = aqucon[1];
-    auto cells2 = aqucon[2];
+    const auto cells1 = aqucon.getConnections(1);
+    const auto cells2 = aqucon.getConnections(2);
     BOOST_CHECK_EQUAL(cells1.size() , 2U);
     BOOST_CHECK_EQUAL(cells2.size() , 1U);
 }
@@ -639,6 +639,14 @@ END
     BOOST_CHECK_MESSAGE(  aquConfig.hasAquifer(7), "Configuration object must have Aquifer ID 7");
     BOOST_CHECK_MESSAGE(! aquConfig.hasAquifer(8), "Configuration object must NOT have Aquifer ID 8");
 
+    BOOST_CHECK_MESSAGE(  aquConfig.hasAnalyticalAquifer(1), "Configuration object must have Analytical Aquifer ID 1");
+    BOOST_CHECK_MESSAGE(  aquConfig.hasAnalyticalAquifer(2), "Configuration object must have Analytical Aquifer ID 2");
+    BOOST_CHECK_MESSAGE(  aquConfig.hasAnalyticalAquifer(3), "Configuration object must have Analytical Aquifer ID 3");
+    BOOST_CHECK_MESSAGE(  !aquConfig.hasAnalyticalAquifer(4), "Configuration object must NOT have Analytical Aquifer ID 4");
+    BOOST_CHECK_MESSAGE(  !aquConfig.hasAnalyticalAquifer(5), "Configuration object must NOT have Analytical Aquifer ID 5");
+    BOOST_CHECK_MESSAGE(  !aquConfig.hasAnalyticalAquifer(6), "Configuration object must NOT have Analytical Aquifer ID 6");
+    BOOST_CHECK_MESSAGE(  !aquConfig.hasAnalyticalAquifer(7), "Configuration object must NOT have Analytical Aquifer ID 7");
+
     {
         const auto expect = std::vector<int>{ 1, 2, 3 };
         const auto analytic = analyticAquiferIDs(aquConfig);
@@ -912,7 +920,7 @@ AQUANCON
 )";
        const auto& [aquconn, _] = load_aquifer(aq);
        (void)_;
-       auto cell1 = aquconn[1][0];
+       auto cell1 = aquconn.getConnections(1)[0];
        BOOST_CHECK_EQUAL(cell1.influx_coeff, 2.0);
    }
 
@@ -925,7 +933,7 @@ AQUANCON
 )";
        const auto& [aquconn, grid] = load_aquifer(aq);
        const auto& dims = grid.getCellDims(0,14,2);
-       auto cell1 = aquconn[1][0];
+       auto cell1 = aquconn.getConnections(1)[0];
        BOOST_CHECK_EQUAL(cell1.influx_coeff, 2.0 * dims[0]*dims[2]);
    }
 
@@ -937,7 +945,7 @@ AQUANCON
 )";
        const auto& [aquconn, grid] = load_aquifer(aq);
        const auto& dims = grid.getCellDims(0,14,2);
-       auto cell1 = aquconn[1][0];
+       auto cell1 = aquconn.getConnections(1)[0];
        BOOST_CHECK_EQUAL(cell1.influx_coeff, 3.0 * dims[1]*dims[2]);
    }
 
@@ -950,7 +958,7 @@ AQUANCON
 )";
        const auto& [aquconn, grid] = load_aquifer(aq);
        const auto& dims = grid.getCellDims(0,14,2);
-       auto cell1 = aquconn[1][0];
+       auto cell1 = aquconn.getConnections(1)[0];
        BOOST_CHECK_EQUAL(cell1.influx_coeff, 4 * ( 100 + 3.0 * dims[1]*dims[2]));
    }
 
@@ -963,7 +971,7 @@ AQUANCON
 /
 )";
        const auto& [aquconn, grid] = load_aquifer(aq);
-       auto cell1 = aquconn[1][0];
+       auto cell1 = aquconn.getConnections(1)[0];
        BOOST_CHECK_EQUAL(cell1.influx_coeff, 2*(77 + 3*(0 + 4*100)));
    }
 }


### PR DESCRIPTION
This is the upstream PR of  https://github.com/OPM/opm-simulators/pull/4015 . 

The following changes are introduced in this PR and https://github.com/OPM/opm-simulators/pull/4015 . 

1. For the situation that an defined analytical aquifer do not have valid connection, 
With the master branch, we will throw the following exception and terminate the running.

```
Program threw an exception: There is not connection associated with analztical aquifer 1
```

With this PR, we will give the following warning, and continue the simulation without terminating the running.
```
Warning: There is no valid connection associated with Carter-Tracy aquifer 1, this aquifer will be ignored in the simulation
```


2. For the situation that we define connections with undefined analytical aquifers, the running will crash due to segmentation fault in the RST writing code. 
With this PR, the simulator will give the following warning message and remove these connections and continue running. 
```
Warning: Keyword AQUANCON created 10 connections with analytical aquifer id 2, but analytical aquifer 2 is not defined. These connections will be removed
```


