### PR TITLE
Add Restart Support for Known Well Level Economic Limits

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp
@@ -22,6 +22,10 @@
 
 #include <string>
 
+namespace Opm { namespace RestartIO {
+    struct RstWell;
+}} // namespace Opm::RestartIO
+
 namespace Opm {
 
     class DeckRecord;
@@ -52,9 +56,9 @@ namespace Opm {
         static std::string EconWorkover2String(EconWorkover enumValue);
         static EconWorkover EconWorkoverFromString(const std::string& stringValue);
 
-
-        explicit WellEconProductionLimits(const DeckRecord& record);
         WellEconProductionLimits();
+        explicit WellEconProductionLimits(const DeckRecord& record);
+        explicit WellEconProductionLimits(const RestartIO::RstWell& rstWell);
 
         static WellEconProductionLimits serializeObject();
 

--- a/opm/io/eclipse/rst/well.hpp
+++ b/opm/io/eclipse/rst/well.hpp
@@ -28,6 +28,7 @@
 #include <array>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace Opm {
@@ -72,8 +73,10 @@ struct RstWell
     int well_status;
     int active_control;
     int vfp_table;
+    int econ_workover_procedure;
     int preferred_phase;
     bool allow_xflow;
+    int econ_limit_end_run;
     int hist_requested_control;
     int msw_index;
     int completion_ordering;
@@ -82,6 +85,8 @@ struct RstWell
     int wtest_config_reasons;
     int wtest_close_reason;
     int wtest_remaining;
+    int econ_limit_quantity;
+    int econ_workover_procedure_2;
     bool glift_active;
     bool glift_alloc_extra_gas;
 
@@ -99,6 +104,13 @@ struct RstWell
     float drainage_radius;
     float efficiency_factor;
     float alq_value;
+    float econ_limit_min_oil;
+    float econ_limit_min_gas;
+    float econ_limit_max_wct;
+    float econ_limit_max_gor;
+    float econ_limit_max_wgr;
+    float econ_limit_max_wct_2;
+    float econ_limit_min_liq;
     float wtest_interval;
     float wtest_startup;
     float glift_max_rate;

--- a/opm/io/eclipse/rst/well.hpp
+++ b/opm/io/eclipse/rst/well.hpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
@@ -19,24 +20,26 @@
 #ifndef RST_WELL
 #define RST_WELL
 
-#include <array>
-#include <vector>
-#include <string>
-#include <unordered_map>
-
-
 #include <opm/io/eclipse/rst/connection.hpp>
 #include <opm/io/eclipse/rst/segment.hpp>
+
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
+
+#include <array>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace Opm {
 class UnitSystem;
+} // namespace Opm
 
-namespace RestartIO {
+namespace Opm { namespace RestartIO {
 
 struct RstHeader;
 
-struct RstWell {
+struct RstWell
+{
     RstWell(const ::Opm::UnitSystem& unit_system,
             const RstHeader& header,
             const std::string& group_arg,
@@ -69,8 +72,8 @@ struct RstWell {
     int well_status;
     int active_control;
     int vfp_table;
-    bool allow_xflow;
     int preferred_phase;
+    bool allow_xflow;
     int hist_requested_control;
     int msw_index;
     int completion_ordering;
@@ -130,16 +133,11 @@ struct RstWell {
     double water_void_rate;
     double gas_void_rate;
 
-    const RstSegment segment(int segment_number) const;
+    const RstSegment& segment(int segment_number) const;
     std::vector<RstConnection> connections;
     std::vector<RstSegment> segments;
 };
 
+}} // namespace Opm::RestartIO
 
-}
-}
-
-
-
-
-#endif
+#endif // RST_WELL

--- a/src/opm/io/eclipse/rst/well.cpp
+++ b/src/opm/io/eclipse/rst/well.cpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
@@ -76,8 +77,8 @@ RstWell::RstWell(const ::Opm::UnitSystem& unit_system,
     well_status(                                                     iwel[VI::IWell::Status]),
     active_control(                                                  iwel[VI::IWell::ActWCtrl]),
     vfp_table(                                                       iwel[VI::IWell::VFPTab]),
-    allow_xflow(                                                     iwel[VI::IWell::XFlow] == 1),
     preferred_phase(                                                 iwel[VI::IWell::PreferredPhase]),
+    allow_xflow(                                                     iwel[VI::IWell::XFlow] == 1),
     hist_requested_control(                                          iwel[VI::IWell::HistReqWCtrl]),
     msw_index(                                                       iwel[VI::IWell::MsWID]),
     completion_ordering(                                             iwel[VI::IWell::CompOrd]),
@@ -190,13 +191,15 @@ RstWell::RstWell(const ::Opm::UnitSystem& unit_system,
     }
 }
 
-const RstSegment RstWell::segment(int segment_number) const {
+const RstSegment&
+RstWell::segment(int segment_number) const
+{
     const auto& iter = std::find_if(this->segments.begin(), this->segments.end(), [segment_number](const RstSegment& segment) { return segment.segment == segment_number; });
+
     if (iter == this->segments.end())
         throw std::invalid_argument("No such segment");
 
     return *iter;
 }
 
-}
-}
+}} // namepace Opm::RestartIO

--- a/src/opm/io/eclipse/rst/well.cpp
+++ b/src/opm/io/eclipse/rst/well.cpp
@@ -28,7 +28,14 @@
 #include <opm/output/eclipse/VectorItems/well.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <algorithm>
 #include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace {
     bool is_sentinel(const float raw_value)
@@ -77,8 +84,10 @@ RstWell::RstWell(const ::Opm::UnitSystem& unit_system,
     well_status(                                                     iwel[VI::IWell::Status]),
     active_control(                                                  iwel[VI::IWell::ActWCtrl]),
     vfp_table(                                                       iwel[VI::IWell::VFPTab]),
+    econ_workover_procedure(                                         iwel[VI::IWell::EconWorkoverProcedure]),
     preferred_phase(                                                 iwel[VI::IWell::PreferredPhase]),
     allow_xflow(                                                     iwel[VI::IWell::XFlow] == 1),
+    econ_limit_end_run(                                              iwel[VI::IWell::EconLimitEndRun]),
     hist_requested_control(                                          iwel[VI::IWell::HistReqWCtrl]),
     msw_index(                                                       iwel[VI::IWell::MsWID]),
     completion_ordering(                                             iwel[VI::IWell::CompOrd]),
@@ -87,6 +96,8 @@ RstWell::RstWell(const ::Opm::UnitSystem& unit_system,
     wtest_config_reasons(                                            iwel[VI::IWell::WTestConfigReason]),
     wtest_close_reason(                                              iwel[VI::IWell::WTestCloseReason]),
     wtest_remaining(                                                 iwel[VI::IWell::WTestRemaining] -1),
+    econ_limit_quantity(                                             iwel[VI::IWell::EconLimitQuantity]),
+    econ_workover_procedure_2(                                       iwel[VI::IWell::EconWorkoverProcedure_2]),
     glift_active(                                                    iwel[VI::IWell::LiftOpt] == 1),
     glift_alloc_extra_gas(                                           iwel[VI::IWell::LiftOptAllocExtra] == 1),
     // The values orat_target -> bhp_target_float will be used in UDA values. The
@@ -106,6 +117,13 @@ RstWell::RstWell(const ::Opm::UnitSystem& unit_system,
     drainage_radius(     unit_system.to_si(M::length,                swel_value(swel[VI::SWell::DrainageRadius]))),
     efficiency_factor(   unit_system.to_si(M::identity,              swel[VI::SWell::EfficiencyFactor1])),
     alq_value(                                                       swel[VI::SWell::Alq_value]),
+    econ_limit_min_oil(  unit_system.to_si(M::liquid_surface_rate,   swel[VI::SWell::EconLimitMinOil])),
+    econ_limit_min_gas(  unit_system.to_si(M::gas_surface_rate,      swel[VI::SWell::EconLimitMinGas])),
+    econ_limit_max_wct(  keep_sentinel(swel[VI::SWell::EconLimitMaxWct], [](const double wct_) { return wct_; })),
+    econ_limit_max_gor(  keep_sentinel(swel[VI::SWell::EconLimitMaxGor], [&unit_system](const double gor_) { return unit_system.to_si(M::gas_oil_ratio, gor_); })),
+    econ_limit_max_wgr(  keep_sentinel(swel[VI::SWell::EconLimitMaxWgr], [&unit_system](const double wgr_) { return unit_system.to_si(M::oil_gas_ratio, wgr_); })),
+    econ_limit_max_wct_2(keep_sentinel(swel[VI::SWell::EconLimitMaxWct_2], [](const double wct_) { return wct_; })),
+    econ_limit_min_liq(  unit_system.to_si(M::liquid_surface_rate,   swel[VI::SWell::EconLimitMinLiq])),
     wtest_interval(      unit_system.to_si(M::time,                  swel[VI::SWell::WTestInterval])),
     wtest_startup(       unit_system.to_si(M::time,                  swel[VI::SWell::WTestStartupTime])),
     glift_max_rate(      unit_system.to_si(M::gas_surface_rate,      swel[VI::SWell::LOmaxRate])),


### PR DESCRIPTION
Notably missing are

  - Maximum gas-liquid ratio
  - Maximum temperature
  - Minimum reservoir fluid flow rate
  - Follow-on well

We do not currently write those items to the restart file but will extend the support as need arises.