### PR TITLE
Prepare for fixing packing of Rates, fix bug in Connection comparison operator

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -163,7 +163,8 @@ namespace Opm {
                    cell_pressure == conn2.cell_pressure &&
                    cell_saturation_water == conn2.cell_saturation_water &&
                    cell_saturation_gas == conn2.cell_saturation_gas &&
-                   effective_Kh == conn2.effective_Kh;
+                   effective_Kh == conn2.effective_Kh &&
+                   trans_factor == conn2.trans_factor;
         }
 
         template <class MessageBufferType>

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -36,6 +36,8 @@
 
 namespace Opm {
 
+    namespace Mpi { template <class T> struct Packing; }
+
     namespace data {
 
     class Rates {
@@ -100,6 +102,8 @@ namespace Opm {
             void write(MessageBufferType& buffer) const;
             template <class MessageBufferType>
             void read(MessageBufferType& buffer);
+
+            friend struct Mpi::Packing<Rates>;
 
             bool operator==(const Rates& rat2) const;
 
@@ -167,6 +171,8 @@ namespace Opm {
         template <class MessageBufferType>
         void read(MessageBufferType& buffer);
 
+        friend struct Mpi::Packing<Connection>;
+
         inline void init_json(Json::JsonObject& json_data) const;
     };
 
@@ -207,6 +213,8 @@ namespace Opm {
             }
         }
 
+        friend struct Mpi::Packing<SegmentPressures>;
+
     private:
         constexpr static std::size_t numvals = 5;
 
@@ -235,6 +243,8 @@ namespace Opm {
 
         template <class MessageBufferType>
         void read(MessageBufferType& buffer);
+
+        friend struct Mpi::Packing<Segment>;
     };
 
     struct CurrentControl {

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -455,8 +455,6 @@ void compare( const RestartValue& fst,
         for( ; first != fst.solution.data( key).end(); ++first, ++second )
             BOOST_CHECK_CLOSE( *first, *second, tol );
     }
-
-    BOOST_CHECK_EQUAL( fst.wells, snd.wells );
 }
 
 
@@ -596,9 +594,6 @@ void compare_equal( const RestartValue& fst,
         for( ; first != fst.solution.data( key ).end(); ++first, ++second )
           BOOST_CHECK_EQUAL( *first, *second);
     }
-
-    BOOST_CHECK_EQUAL( fst.wells, snd.wells );
-    //BOOST_CHECK_EQUAL( fst.extra, snd.extra );
 }
 
 BOOST_AUTO_TEST_CASE(EclipseReadWriteWellStateData_double) {


### PR DESCRIPTION
After adding the `tracer` member the data::Rates class, it is no longer a POD. The same applies to data::Connection and data::Segment, since these contain data::Rates subobjects. In the serialization used for communicating these objects to other MPI ranks, this means they now need specific packSize(), pack() and unpack() methods. These must be implemented in opm-simulators (in ParallelRestart.cpp), but need access to the members. I have therefore added a friend declaration that enables this.

The second commit is a drive-by fix in the same file, operator== of Connection was not updated when adding the `trans_factor` member. This fix then caused a test failure, it turns out that the restart I/O does not treat the Connection objects completely. However, the data::Wells objects compared are never used in actual restarting, so it is not something we need to test! (Thanks to @bska for explanation.) I have therefore removed these comparisons from the test, this is the third commit of the PR.

A final note on serialization. We **really** should implement unified serialization in-class using the serializeOp approach. That would result in less code and fewer bugs.