### PR TITLE
Serialize All Schedule Data Members

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -321,35 +321,35 @@ namespace Opm
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            m_sched_deck.serializeOp(serializer);
-            serializer.vector(snapshots);
-            m_static.serializeOp(serializer);
-            restart_output.serializeOp(serializer);
+            this->m_sched_deck.serializeOp(serializer);
+            serializer.vector(this->snapshots);
+            this->m_static.serializeOp(serializer);
+            this->restart_output.serializeOp(serializer);
             this->completed_cells.serializeOp(serializer);
             this->action_wgnames.serializeOp(serializer);
 
-            pack_unpack<PAvg, Serializer>(serializer);
-            pack_unpack<WellTestConfig, Serializer>(serializer);
-            pack_unpack<GConSale, Serializer>(serializer);
-            pack_unpack<GConSump, Serializer>(serializer);
-            pack_unpack<WListManager, Serializer>(serializer);
-            pack_unpack<Network::ExtNetwork, Serializer>(serializer);
-            pack_unpack<Network::Balance, Serializer>(serializer);
-            pack_unpack<RPTConfig, Serializer>(serializer);
-            pack_unpack<Action::Actions, Serializer>(serializer);
-            pack_unpack<UDQActive, Serializer>(serializer);
-            pack_unpack<UDQConfig, Serializer>(serializer);
-            pack_unpack<NameOrder, Serializer>(serializer);
-            pack_unpack<GroupOrder, Serializer>(serializer);
-            pack_unpack<GuideRateConfig, Serializer>(serializer);
-            pack_unpack<GasLiftOpt, Serializer>(serializer);
-            pack_unpack<RFTConfig, Serializer>(serializer);
-            pack_unpack<RSTConfig, Serializer>(serializer);
+            this->template pack_unpack<PAvg>(serializer);
+            this->template pack_unpack<WellTestConfig>(serializer);
+            this->template pack_unpack<GConSale>(serializer);
+            this->template pack_unpack<GConSump>(serializer);
+            this->template pack_unpack<WListManager>(serializer);
+            this->template pack_unpack<Network::ExtNetwork>(serializer);
+            this->template pack_unpack<Network::Balance>(serializer);
+            this->template pack_unpack<RPTConfig>(serializer);
+            this->template pack_unpack<Action::Actions>(serializer);
+            this->template pack_unpack<UDQActive>(serializer);
+            this->template pack_unpack<UDQConfig>(serializer);
+            this->template pack_unpack<NameOrder>(serializer);
+            this->template pack_unpack<GroupOrder>(serializer);
+            this->template pack_unpack<GuideRateConfig>(serializer);
+            this->template pack_unpack<GasLiftOpt>(serializer);
+            this->template pack_unpack<RFTConfig>(serializer);
+            this->template pack_unpack<RSTConfig>(serializer);
 
-            pack_unpack_map<int, VFPProdTable, Serializer>(serializer);
-            pack_unpack_map<int, VFPInjTable, Serializer>(serializer);
-            pack_unpack_map<std::string, Group, Serializer>(serializer);
-            pack_unpack_map<std::string, Well, Serializer>(serializer);
+            this->template pack_unpack_map<int, VFPProdTable>(serializer);
+            this->template pack_unpack_map<int, VFPInjTable>(serializer);
+            this->template pack_unpack_map<std::string, Group>(serializer);
+            this->template pack_unpack_map<std::string, Well>(serializer);
         }
 
         template <typename T, class Serializer>
@@ -358,13 +358,13 @@ namespace Opm
             std::vector<std::size_t> index_list;
 
             if (serializer.isSerializing())
-                pack_state<T>(value_list, index_list);
+                this->template pack_state<T>(value_list, index_list);
 
             serializer.vector(value_list);
             serializer.template vector<std::size_t, false>(index_list);
 
             if (!serializer.isSerializing())
-                unpack_state<T>(value_list, index_list);
+                this->template unpack_state<T>(value_list, index_list);
         }
 
         template <typename T>
@@ -382,7 +382,7 @@ namespace Opm
 
         template <typename T>
         void pack_state(std::vector<T>& value_list, std::vector<std::size_t>& index_list) const {
-            auto unique_values = this->unique<T>();
+            auto unique_values = this->template unique<T>();
             for (auto& [index, value] : unique_values) {
                 value_list.push_back( std::move(value) );
                 index_list.push_back( index );

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -321,12 +321,12 @@ namespace Opm
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            this->m_sched_deck.serializeOp(serializer);
-            serializer.vector(this->snapshots);
             this->m_static.serializeOp(serializer);
+            this->m_sched_deck.serializeOp(serializer);
+            this->action_wgnames.serializeOp(serializer);
+            serializer.vector(this->snapshots);
             this->restart_output.serializeOp(serializer);
             this->completed_cells.serializeOp(serializer);
-            this->action_wgnames.serializeOp(serializer);
 
             this->template pack_unpack<PAvg>(serializer);
             this->template pack_unpack<WellTestConfig>(serializer);

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -324,6 +324,7 @@ namespace Opm
             this->m_static.serializeOp(serializer);
             this->m_sched_deck.serializeOp(serializer);
             this->action_wgnames.serializeOp(serializer);
+            serializer(this->exit_status);
             serializer.vector(this->snapshots);
             this->restart_output.serializeOp(serializer);
             this->completed_cells.serializeOp(serializer);
@@ -531,6 +532,11 @@ namespace Opm
 
         };
 
+        // Please update the member functions
+        //   - operator==(const Schedule&) const
+        //   - serializeObject()
+        //   - serializeOp(Serializer&)
+        // when you update/change this list of data members.
         ScheduleStatic m_static;
         ScheduleDeck m_sched_deck;
         Action::WGNames action_wgnames;

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -282,8 +282,8 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const std::optional
         Schedule result;
 
         result.m_static = ScheduleStatic::serializeObject();
-        result.snapshots = { ScheduleState::serializeObject() };
         result.m_sched_deck = ScheduleDeck::serializeObject();
+        result.snapshots = { ScheduleState::serializeObject() };
         result.restart_output = WriteRestartFileEvents::serializeObject();
 
         return result;
@@ -1531,9 +1531,9 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
     bool Schedule::operator==(const Schedule& data) const {
         return this->m_static == data.m_static &&
                this->m_sched_deck == data.m_sched_deck &&
+               this->action_wgnames == data.action_wgnames &&
                this->snapshots == data.snapshots &&
                this->restart_output == data.restart_output &&
-               this->action_wgnames == data.action_wgnames &&
                this->completed_cells == data.completed_cells;
      }
 

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -283,8 +283,11 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const std::optional
 
         result.m_static = ScheduleStatic::serializeObject();
         result.m_sched_deck = ScheduleDeck::serializeObject();
+        result.action_wgnames = Action::WGNames::serializeObject();
+        result.exit_status = EXIT_FAILURE;
         result.snapshots = { ScheduleState::serializeObject() };
         result.restart_output = WriteRestartFileEvents::serializeObject();
+        result.completed_cells = CompletedCells::serializeObject();
 
         return result;
     }
@@ -1532,6 +1535,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return this->m_static == data.m_static &&
                this->m_sched_deck == data.m_sched_deck &&
                this->action_wgnames == data.action_wgnames &&
+               this->exit_status == data.exit_status &&
                this->snapshots == data.snapshots &&
                this->restart_output == data.restart_output &&
                this->completed_cells == data.completed_cells;


### PR DESCRIPTION
PR #3104 made me realize that we're not serializing all data members of the `Schedule` object.  It **probably** not a big deal, but this PR nevertheless adds serialization support for the `exit_status` member too.  While here, add proper testing of the `action_wgnames` and `completed_cells` too.

Finally, prefer template argument deduction to explicit template arguments when calling the `pack_unpack<>` helper.