### PR TITLE
fixed: initialize dimensions in serializeObject

### DIFF
--- a/opm/input/eclipse/Schedule/CompletedCells.hpp
+++ b/opm/input/eclipse/Schedule/CompletedCells.hpp
@@ -87,13 +87,14 @@ public:
                    this->j == other.j &&
                    this->k == other.k &&
                    this->depth == other.depth &&
-                   this->dimensions == other.dimensions && 
+                   this->dimensions == other.dimensions &&
                    this->props == other.props;
         }
 
         static Cell serializeObject() {
             Cell cell(0,1,1,1);
             cell.depth = 12345;
+            cell.dimensions = {1.0,2.0,3.0};
             return cell;
         }
 


### PR DESCRIPTION
the array is left uninitialized by the constructor.

the alternative is to add initialization, but I'm not sure if this was left undefined intentionally or not.