### PR TITLE
Direct Verbose Action Messages to Debug File

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -576,7 +576,8 @@ namespace Opm
                                     ErrorGuard& errors,
                                     const ScheduleGrid& grid,
                                     const std::unordered_map<std::string, double> * target_wellpi,
-                                    const std::string& prefix);
+                                    const std::string& prefix,
+                                    const bool log_to_debug = false);
         void addACTIONX(const Action::ActionX& action);
         void addGroupToGroup( const std::string& parent_group, const std::string& child_group);
         void addGroup(const std::string& groupName , std::size_t timeStep);


### PR DESCRIPTION
While useful for analysis in the case of failure, end users will typically not care that we "rerun" portions of the `SCHEDULE` section in response to triggering an action.  In the cases where we do need those messages they will be available in the `CASE.DBG` file instead.

---

As an example, with this PR and its downstream companion OPM/opm-simulators#4047, I get the following reduction in the number of lines&mdash;as reported by `wc -l`&mdash;in the `PRT` file of an [`ACTIONX_WPIMULT`](https://github.com/OPM/opm-tests/blob/b342b4e5f756d47d63f208490a50b9e948f9f8a1/actionx/ACTIONX_WPIMULT.DATA) run.
```
7649 ./master/ACTIONX_WPIMULT.PRT
6957 ./this-pr/ACTIONX_WPIMULT.PRT
```