### PR TITLE
adjust for array serializer API change

### DIFF
--- a/opm/input/eclipse/Schedule/CompletedCells.hpp
+++ b/opm/input/eclipse/Schedule/CompletedCells.hpp
@@ -107,7 +107,7 @@ public:
             serializer(this->k);
             serializer(this->depth);
             serializer(this->props);
-            serializer.template array<std::array<double,3>, false>(this->dimensions);
+            serializer.array(this->dimensions);
         }
 
         Cell(std::size_t g, std::size_t i_, std::size_t j_, std::size_t k_)


### PR DESCRIPTION
The existence of serializeOp in the data type is now detected at compile time.

Down/upstream of https://github.com/OPM/opm-simulators/pull/4051