### PR TITLE
Refactor RFT File Writing Code

### DIFF
--- a/opm/input/eclipse/Schedule/RFTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RFTConfig.hpp
@@ -27,36 +27,40 @@
 
 namespace Opm {
 
-class RFTConfig {
+class RFTConfig
+{
 public:
     enum class RFT {
-        YES = 1,
-        REPT = 2,
+        YES      = 1,
+        REPT     = 2,
         TIMESTEP = 3,
-        FOPN = 4,
-        NO = 5
+        FOPN     = 4,
+        NO       = 5,
     };
-    static std::string RFT2String(RFT enumValue);
+    static std::string RFT2String(const RFT enumValue);
     static RFT RFTFromString(const std::string &stringValue);
 
     enum class PLT {
         YES      = 1,
         REPT     = 2,
         TIMESTEP = 3,
-        NO       = 5
+        NO       = 5,
     };
-    static std::string PLT2String(PLT enumValue);
+    static std::string PLT2String(const PLT enumValue);
     static PLT PLTFromString( const std::string& stringValue);
 
-
     void first_open(bool on);
-    void update(const std::string& wname, PLT mode);
-    void update(const std::string& wname, RFT mode);
+    void update(const std::string& wname, const PLT mode);
+    void update(const std::string& wname, const RFT mode);
+
     bool active() const;
+
     bool rft() const;
     bool rft(const std::string& wname) const;
+
     bool plt() const;
     bool plt(const std::string& wname) const;
+
     std::optional<RFTConfig> next() const;
     std::optional<RFTConfig> well_open(const std::string& wname) const;
 
@@ -72,7 +76,6 @@ public:
         serializer.map(open_wells);
     }
 
-
 private:
     bool first_open_rft = false;
     std::unordered_map<std::string, RFT> rft_state;
@@ -80,6 +83,6 @@ private:
     std::unordered_map<std::string, bool> open_wells;
 };
 
-}
+} // namespace Opm
 
-#endif
+#endif // RFT_CONFIG2_HPP

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -17,7 +17,6 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef CONNECTIONSET_HPP_
 #define CONNECTIONSET_HPP_
 
@@ -25,6 +24,7 @@
 
 #include <cstddef>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <stddef.h>
@@ -36,55 +36,59 @@ namespace Opm {
     class KeywordLocation;
     class ScheduleGrid;
     class EclipseGrid;
+} // namespace Opm
 
-    class WellConnections {
+namespace Opm {
+
+    class WellConnections
+    {
     public:
+        using const_iterator = std::vector<Connection>::const_iterator;
 
-
-        WellConnections();
-        WellConnections(Connection::Order ordering, int headI, int headJ);
-        WellConnections(Connection::Order ordering, int headI, int headJ,
+        WellConnections() = default;
+        WellConnections(const Connection::Order ordering, const int headI, const int headJ);
+        WellConnections(const Connection::Order ordering, const int headI, const int headJ,
                         const std::vector<Connection>& connections);
 
         static WellConnections serializeObject();
 
         // cppcheck-suppress noExplicitConstructor
-        template<class Grid>
-        WellConnections(const WellConnections& src, const Grid& grid) :
-            m_ordering(src.ordering()),
-            headI(src.headI),
-            headJ(src.headJ)
+        template <class Grid>
+        WellConnections(const WellConnections& src, const Grid& grid)
+            : m_ordering(src.ordering())
+            , headI     (src.headI)
+            , headJ     (src.headJ)
         {
             for (const auto& c : src) {
-                if (grid.isCellActive(c.getI(), c.getJ(), c.getK()))
+                if (grid.isCellActive(c.getI(), c.getJ(), c.getK())) {
                     this->add(c);
+                }
             }
         }
 
-
-
-
-        void addConnection(int i, int j , int k ,
-                           std::size_t global_index,
-                           double depth,
-                           Connection::State state ,
-                           double CF,
-                           double Kh,
-                           double rw,
-                           double r0,
-                           double re,
-                           double connection_length,
-                           double skin_factor,
+        void addConnection(const int i, const int j, const int k,
+                           const std::size_t global_index,
+                           const double depth,
+                           const Connection::State state,
+                           const double CF,
+                           const double Kh,
+                           const double rw,
+                           const double r0,
+                           const double re,
+                           const double connection_length,
+                           const double skin_factor,
                            const int satTableId,
                            const Connection::Direction direction = Connection::Direction::Z,
                            const Connection::CTFKind ctf_kind = Connection::CTFKind::DeckValue,
                            const std::size_t seqIndex = 0,
                            const bool defaultSatTabId = true);
-        void loadCOMPDAT(const DeckRecord& record, const ScheduleGrid& grid, const std::string& wname, const KeywordLocation& location);
 
-        using const_iterator = std::vector< Connection >::const_iterator;
+        void loadCOMPDAT(const DeckRecord&      record,
+                         const ScheduleGrid&    grid,
+                         const std::string&     wname,
+                         const KeywordLocation& location);
 
-        void add( Connection );
+        void add(Connection);
         std::size_t size() const;
         bool empty() const;
         std::size_t num_open() const;
@@ -141,28 +145,33 @@ namespace Opm {
         void applyWellPIScaling(const double       scaleFactor,
                                 std::vector<bool>& scalingApplicable);
 
-        template<class Serializer>
+        template <class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            serializer(m_ordering);
-            serializer(headI);
-            serializer(headJ);
-            serializer.vector(m_connections);
+            serializer(this->m_ordering);
+            serializer(this->headI);
+            serializer(this->headJ);
+            serializer.vector(this->m_connections);
         }
 
     private:
-        void addConnection(int i, int j , int k ,
-                           std::size_t global_index,
-                           int complnum,
-                           double depth,
-                           Connection::State state ,
-                           double CF,
-                           double Kh,
-                           double rw,
-                           double r0,
-                           double re,
-                           double connection_length,
-                           double skin_factor,
+        Connection::Order m_ordering { Connection::Order::TRACK };
+        int headI{0};
+        int headJ{0};
+        std::vector<Connection> m_connections{};
+
+        void addConnection(const int i, const int j, const int k,
+                           const std::size_t global_index,
+                           const int complnum,
+                           const double depth,
+                           const Connection::State state,
+                           const double CF,
+                           const double Kh,
+                           const double rw,
+                           const double r0,
+                           const double re,
+                           const double connection_length,
+                           const double skin_factor,
                            const int satTableId,
                            const Connection::Direction direction = Connection::Direction::Z,
                            const Connection::CTFKind ctf_kind = Connection::CTFKind::DeckValue,
@@ -173,17 +182,11 @@ namespace Opm {
         void orderTRACK();
         void orderMSW();
         void orderDEPTH();
-
-        Connection::Order m_ordering = Connection::Order::TRACK;
-        int headI, headJ;
-        std::vector< Connection > m_connections;
     };
 
     std::optional<int>
     getCompletionNumberFromGlobalConnectionIndex(const WellConnections& connections,
                                                  const std::size_t      global_index);
-}
+} // namespace Opm
 
-
-
-#endif
+#endif // CONNECTIONSET_HPP_

--- a/src/opm/input/eclipse/Schedule/RFTConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/RFTConfig.cpp
@@ -21,196 +21,290 @@
 
 #include <algorithm>
 #include <cassert>
+#include <optional>
 #include <stdexcept>
+#include <string>
 #include <utility>
+
+namespace {
+
+template <typename Map, typename Predicate>
+bool mapContains(const Map& map, Predicate&& p)
+{
+    return std::any_of(map.begin(), map.end(), std::forward<Predicate>(p));
+}
+
+template <typename Map, typename Predicate>
+void pruneFromMapIf(Map& map, Predicate prune)
+{
+    for (auto begin = map.begin(); begin != map.end(); ) {
+        if (prune(*begin)) {
+            begin = map.erase(begin);
+        }
+        else {
+            ++begin;
+        }
+    }
+}
+
+} // Anonymous namespace
 
 namespace Opm {
 
-std::string RFTConfig::RFT2String(RFT enumValue) {
+std::string RFTConfig::RFT2String(const RFT enumValue)
+{
     switch (enumValue) {
-    case RFT::YES:
-        return "YES";
-    case RFT::REPT:
-        return "REPT";
-    case RFT::TIMESTEP:
-        return "TIMESTEP";
-    case RFT::FOPN:
-        return "FOPN";
-    case RFT::NO:
-        return "NO";
-    default:
-        throw std::invalid_argument("unhandled enum value");
+    case RFT::YES:      return "YES";
+    case RFT::REPT:     return "REPT";
+    case RFT::TIMESTEP: return "TIMESTEP";
+    case RFT::FOPN:     return "FOPN";
+    case RFT::NO:       return "NO";
     }
+
+    throw std::invalid_argument {
+        "unhandled enum value " + std::to_string(static_cast<int>(enumValue))
+    };
 }
 
-RFTConfig::RFT RFTConfig::RFTFromString(const std::string& stringValue) {
-    if (stringValue == "YES")
+RFTConfig::RFT RFTConfig::RFTFromString(const std::string& stringValue)
+{
+    if (stringValue == "YES") {
         return RFT::YES;
-    else if (stringValue == "REPT")
+    }
+
+    if (stringValue == "REPT") {
         return RFT::REPT;
-    else if (stringValue == "TIMESTEP")
+    }
+
+    if (stringValue == "TIMESTEP") {
         return RFT::TIMESTEP;
-    else if (stringValue == "FOPN")
+    }
+
+    if (stringValue == "FOPN") {
         return RFT::FOPN;
-    else if (stringValue == "NO")
+    }
+
+    if (stringValue == "NO") {
         return RFT::NO;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue);
+    }
+
+    throw std::invalid_argument {
+        "Unknown enum state string: " + stringValue
+    };
 }
 
-std::string RFTConfig::PLT2String(PLT enumValue) {
+std::string RFTConfig::PLT2String(const PLT enumValue)
+{
     switch (enumValue) {
-    case PLT::YES:
-        return "YES";
-    case PLT::REPT:
-        return "REPT";
-    case PLT::TIMESTEP:
-        return "TIMESTEP";
-    case PLT::NO:
-        return "NO";
-    default:
-        throw std::invalid_argument("unhandled enum value");
+    case PLT::YES:      return "YES";
+    case PLT::REPT:     return "REPT";
+    case PLT::TIMESTEP: return "TIMESTEP";
+    case PLT::NO:       return "NO";
     }
+
+    throw std::invalid_argument {
+        "unhandled enum value " + std::to_string(static_cast<int>(enumValue))
+    };
 }
 
-RFTConfig::PLT RFTConfig::PLTFromString( const std::string& stringValue ){
-    if (stringValue == "YES")
+RFTConfig::PLT RFTConfig::PLTFromString(const std::string& stringValue)
+{
+    if (stringValue == "YES") {
         return PLT::YES;
-    else if (stringValue == "REPT")
-        return PLT::REPT;
-    else if (stringValue == "TIMESTEP")
-        return PLT::TIMESTEP;
-    else if (stringValue == "NO")
-        return PLT::NO;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue );
-}
-
-bool RFTConfig::operator==(const RFTConfig& data) const {
-    return this->first_open_rft == data.first_open_rft &&
-           this->rft_state == data.rft_state &&
-           this->plt_state == data.plt_state &&
-           this->open_wells == data.open_wells;
-}
-
-
-RFTConfig RFTConfig::serializeObject() {
-    RFTConfig rft_config;
-    rft_config.first_open( true );
-    return rft_config;
-}
-
-
-std::optional<RFTConfig> RFTConfig::well_open(const std::string& wname) const {
-    auto iter = this->open_wells.find(wname);
-
-    if (iter == this->open_wells.end()) {
-        if (this->first_open_rft) {
-            auto new_rft = *this;
-            new_rft.open_wells[wname] = true;
-            new_rft.update(wname, RFT::YES);
-            return new_rft;
-        } else {
-            auto new_rft = *this;
-            auto rft_fopn = std::find_if( new_rft.rft_state.begin(), new_rft.rft_state.end(), [&wname](const auto& rft_pair) -> bool { return (rft_pair.second == RFT::FOPN && rft_pair.first == wname); });
-            if (rft_fopn != new_rft.rft_state.end())
-                rft_fopn->second = RFT::YES;
-
-            new_rft.open_wells[wname] = true;
-            return new_rft;
-        }
     }
 
-    return {};
+    if (stringValue == "REPT") {
+        return PLT::REPT;
+    }
+
+    if (stringValue == "TIMESTEP") {
+        return PLT::TIMESTEP;
+    }
+
+    if (stringValue == "NO") {
+        return PLT::NO;
+    }
+
+    throw std::invalid_argument {
+        "Unknown enum state string: '" + stringValue + '\''
+    };
 }
 
-void RFTConfig::first_open(bool on) {
+void RFTConfig::first_open(const bool on)
+{
     this->first_open_rft = on;
 }
 
-void RFTConfig::update(const std::string& wname, RFT mode) {
+// Note: 'mode' intentionally accepted as mutable to simplify
+// implementation of 'FOPN' case.
+void RFTConfig::update(const std::string& wname, RFT mode)
+{
     if (mode == RFT::NO) {
         auto iter = this->rft_state.find(wname);
-        if (iter != this->rft_state.end())
-            this->rft_state.erase( iter );
+        if (iter != this->rft_state.end()) {
+            this->rft_state.erase(iter);
+        }
+
         return;
     }
+
     if (mode == RFT::FOPN) {
-        if (this->open_wells.count(wname) > 0) {
-            this->open_wells[wname] = true;
+        // Treat FOPN as YES for wells that are already open.
+        auto pos = this->open_wells.find(wname);
+        if (pos != this->open_wells.end()) {
+            pos->second = true;
             mode = RFT::YES;
         }
     }
-    this->rft_state[wname] = mode;
+
+    this->rft_state.insert_or_assign(wname, mode);
 }
 
-bool RFTConfig::rft() const {
-    for (const auto& [_, mode] : this->rft_state) {
-        (void)_;
-        if (mode != RFT::FOPN)
-            return true;
-    }
-    return false;
-}
-
-bool RFTConfig::plt() const {
-    return (this->plt_state.size() > 0);
-}
-
-void RFTConfig::update(const std::string& wname, PLT mode) {
+void RFTConfig::update(const std::string& wname, const PLT mode)
+{
     if (mode == PLT::NO) {
         auto iter = this->plt_state.find(wname);
-        if (iter != this->plt_state.end())
-            this->plt_state.erase( iter );
+        if (iter != this->plt_state.end()) {
+            this->plt_state.erase(iter);
+        }
+
         return;
     }
 
     this->plt_state[wname] = mode;
 }
 
-bool RFTConfig::active() const {
+bool RFTConfig::active() const
+{
     return this->rft() || this->plt();
 }
 
-bool RFTConfig::rft(const std::string& wname) const {
+bool RFTConfig::rft() const
+{
+    return std::any_of(this->rft_state.begin(), this->rft_state.end(),
+                       [](const auto& rft_pair)
+                       {
+                           return rft_pair.second != RFT::FOPN;
+                       });
+}
+
+bool RFTConfig::rft(const std::string& wname) const
+{
     auto well_iter = this->rft_state.find(wname);
-    if (well_iter == this->rft_state.end())
-        return false;
-    auto mode = well_iter->second;
-    if (mode == RFT::FOPN)
-        return false;
-    return true;
+
+    return (well_iter != this->rft_state.end())
+        && (well_iter->second != RFT::FOPN);
 }
 
-bool RFTConfig::plt(const std::string& wname) const {
-    auto well_iter = this->plt_state.find(wname);
-    if (well_iter == this->plt_state.end())
-        return false;
-    return true;
+bool RFTConfig::plt() const
+{
+    return ! this->plt_state.empty();
 }
 
-std::optional<RFTConfig> RFTConfig::next() const {
-    auto yes_iter_rft = std::find_if( this->rft_state.begin(), this->rft_state.end(), [](const auto& rft_pair) { return rft_pair.second == RFT::YES; });
-    auto yes_iter_plt = std::find_if( this->plt_state.begin(), this->plt_state.end(), [](const auto& plt_pair) { return plt_pair.second == PLT::YES; });
-    if (yes_iter_rft == this->rft_state.end() && yes_iter_plt == this->plt_state.end())
+bool RFTConfig::plt(const std::string& wname) const
+{
+    return this->plt_state.find(wname) != this->plt_state.end();
+}
+
+std::optional<RFTConfig>
+RFTConfig::well_open(const std::string& wname) const
+{
+    auto iter = this->open_wells.find(wname);
+    if (iter != this->open_wells.end()) {
+        // RFT data at well open is already recorded.  Don't trigger new RFT
+        // output event.
         return {};
-
-    auto new_rft = *this;
-    for (auto iter = new_rft.rft_state.begin(); iter != new_rft.rft_state.end(); ) {
-        if (iter->second == RFT::YES)
-            iter = new_rft.rft_state.erase(iter);
-        else
-            iter++;
     }
 
-    for (auto iter = new_rft.plt_state.begin(); iter != new_rft.plt_state.end(); ) {
-        if (iter->second == PLT::YES)
-            iter = new_rft.plt_state.erase(iter);
-        else
-            iter++;
+    auto new_rft = *this;
+
+    if (this->first_open_rft) {
+        // Well opens at this time and user requests RFT data on well open
+        // for all new wells.  Trigger RFT output.
+        new_rft.update(wname, RFT::YES);
+        new_rft.open_wells.insert_or_assign(wname, true);
+
+        return new_rft;
+    }
+
+    auto rft_fopn = new_rft.rft_state.find(wname);
+    if ((rft_fopn != new_rft.rft_state.end()) &&
+        (rft_fopn->second == RFT::FOPN))
+    {
+        // Well opens at this time and user requests RFT data on well open
+        // for this particular well.  Trigger RFT output.
+        rft_fopn->second = RFT::YES;
+    }
+
+    new_rft.open_wells.insert_or_assign(wname, true);
+
+    return new_rft;
+}
+
+std::optional<RFTConfig> RFTConfig::next() const
+{
+    // Next block configured by removing all 'YES' nodes from *this.  We do
+    // this because the 'YES' nodes have already triggered by the time the
+    // next block runs.
+    const auto rft_is_yes = [](const auto& rft_pair) {
+        return rft_pair.second == RFT::YES;
+    };
+
+    const auto plt_is_yes = [](const auto& plt_pair) {
+        return plt_pair.second == PLT::YES;
+    };
+
+    const auto rft_has_yes = mapContains(this->rft_state, rft_is_yes);
+    const auto plt_has_yes = mapContains(this->plt_state, plt_is_yes);
+
+    if (! (rft_has_yes || plt_has_yes)) {
+        // No 'YES' node in either the RFT or the PLT states.  Return
+        // nullopt to signify that next block is unchanged from current.
+        return {};
+    }
+
+    // Prune 'YES' nodes from both RFT and PLT states to form next block.
+    auto new_rft = std::optional<RFTConfig>{*this};
+
+    if (rft_has_yes) {
+        pruneFromMapIf(new_rft->rft_state, rft_is_yes);
+    }
+
+    if (plt_has_yes) {
+        pruneFromMapIf(new_rft->plt_state, plt_is_yes);
     }
 
     return new_rft;
 }
 
+bool RFTConfig::operator==(const RFTConfig& data) const
+{
+    return (this->first_open_rft == data.first_open_rft)
+        && (this->rft_state == data.rft_state)
+        && (this->plt_state == data.plt_state)
+        && (this->open_wells == data.open_wells);
 }
+
+RFTConfig RFTConfig::serializeObject()
+{
+    // Establish an object in a non-default state to enable testing the
+    // serialization code.  These statements "simply" record a number of
+    // requests to populate every internal table.  That way we get the best
+    // test coverage.
+
+    RFTConfig rft_config;
+    rft_config.first_open(true);
+
+    // Trigger RFT output for P-1 when well opens.
+    rft_config.update("P-1", RFT::FOPN);
+
+    // Trigger PLT output for P-2 at every timestep.
+    rft_config.update("P-2", PLT::TIMESTEP);
+
+    // I-1 is an open well at this time.
+    rft_config.open_wells.emplace("I-1", true);
+
+    return rft_config;
+}
+
+} // namespace Opm

--- a/src/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -373,6 +373,10 @@ std::string Connection::Direction2String(const Direction enumValue)
     case Direction::Z:
         stringValue = "Z";
         break;
+
+    default:
+        stringValue = std::to_string(static_cast<int>(enumValue));
+        break;
     }
 
     return stringValue;

--- a/tests/parser/RFTConfigTests.cpp
+++ b/tests/parser/RFTConfigTests.cpp
@@ -22,16 +22,18 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/input/eclipse/Schedule/RFTConfig.hpp>
-#include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+
 #include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <cstddef>
+#include <memory>
 #include <string>
 
 namespace {
@@ -40,14 +42,12 @@ namespace {
         Setup(const ::Opm::Deck& deck);
 
         ::Opm::EclipseState es;
-        std::shared_ptr<::Opm::Python> python;
         ::Opm::Schedule     sched;
     };
 
     Setup::Setup(const ::Opm::Deck& deck)
         : es   (deck)
-        , python(std::make_shared<::Opm::Python>() )
-        , sched(deck, es, python)
+        , sched(deck, es, std::make_shared<Opm::Python>())
     {}
 
     Setup parseDeckString(const std::string& input)
@@ -165,7 +165,6 @@ TSTEP
     }
 }
 
-
 BOOST_AUTO_TEST_CASE(Simple)
 {
     const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_all_open());
@@ -193,7 +192,6 @@ BOOST_AUTO_TEST_CASE(Simple_Deferred_Open)
 }
 
 BOOST_AUTO_TEST_SUITE_END() // No_RFT_Keywords
-
 
 // =====================================================================
 
@@ -320,9 +318,6 @@ BOOST_AUTO_TEST_CASE(Simple)
     BOOST_CHECK_MESSAGE(!sched[9].rft_config().active(), "RFT Config must be Inactive at Step 9");
 }
 
-
-
-
 BOOST_AUTO_TEST_CASE(Deferred_Open)
 {
     const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_deferred_open());
@@ -374,6 +369,7 @@ BOOST_AUTO_TEST_CASE(Deferred_Open)
 }
 
 BOOST_AUTO_TEST_SUITE_END() // WRFT
+
 // =====================================================================
 
 BOOST_AUTO_TEST_SUITE(WRFTPLT)
@@ -507,8 +503,6 @@ TSTEP
     }
 }
 
-
-
 BOOST_AUTO_TEST_CASE(All_Open)
 {
     const auto cse = parseDeckString(basesetup_5x5x5() + simple_tstep_all_open());
@@ -600,8 +594,6 @@ BOOST_AUTO_TEST_CASE(All_Open)
     BOOST_CHECK_MESSAGE( sched[14].rft_config().active(), R"(RFT Config must be Active at Step 14)");
     BOOST_CHECK_MESSAGE( sched[15].rft_config().active(), R"(RFT Config must be Active at Step 15)");
 }
-
-
 
 BOOST_AUTO_TEST_CASE(Deferred_Open)
 {
@@ -715,7 +707,7 @@ BOOST_AUTO_TEST_CASE(Deferred_Open)
     BOOST_CHECK_MESSAGE(!sched[14].rft_config().rft("P2"), R"(Should NOT Output RFT Data for "P2" at Step 14)");
     BOOST_CHECK_MESSAGE(!sched[15].rft_config().rft("P2"), R"(Should NOT Output RFT Data for "P2" at Step 15)");
 
-    // NOTE: Not at FOPN becaus17e P2 was not declared at WRFTPLT:FOPN time.
+    // NOTE: Not at FOPN because P2 was not declared at WRFTPLT:FOPN time.
     BOOST_CHECK_MESSAGE(!sched[16].rft_config().rft("P2"), R"(Should NOT Output RFT Data for "P2" at Step 16)");
 
     BOOST_CHECK_MESSAGE(!sched[17].rft_config().rft("P2"), R"(Should NOT Output RFT Data for "P2" at Step 17)");
@@ -768,7 +760,4 @@ BOOST_AUTO_TEST_CASE(Deferred_Open)
     BOOST_CHECK_MESSAGE( sched[20].rft_config().active(), R"(RFT Config must be Active at Step 15)");
 }
 
-
-
 BOOST_AUTO_TEST_SUITE_END() // WRFTPLT
-


### PR DESCRIPTION
In preparation of supporting new data types (PLT and segment). Introduce a wrapper class, `WellRFTOutputData`, which knows about all supported data types and how to emit the RFT record header.  Defer specialised data type handling to dedicated record types and, to this end, rename the existing `WellRFT` class to `RFTRecord`.

While here, also apply `const` and sundry whitespace adjustments in the `WellConnections` code and the `WRFT*` keyword handlers.