### PR TITLE
Some janitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,14 @@ macro (install_hook)
           PATTERN *.hpp)
 endmacro (install_hook)
 
+# Used to append entries from one list to another.
+# The output list is suitable for use in setup.py subtitution
+macro(append_quoted OUT IN)
+  foreach(ENTRY ${${IN}})
+    list(APPEND ${OUT} "'${ARGN}${ENTRY}'")
+  endforeach()
+endmacro()
+
 # If opm-common is configured to embed the python interpreter we must make sure
 # that all downstream modules link libpython transitively. Due to the required
 # integration with Python+cmake machinery provided by pybind11 this is done by
@@ -385,33 +393,37 @@ if (OPM_ENABLE_PYTHON)
   endif()
 
   set(opm-common_PYTHON_PACKAGE_VERSION ${OPM_PYTHON_PACKAGE_VERSION_TAG})
+  set(SETUP_PY_FLAGS "'-std=c++17'")
 
   # Generate versioned setup.py
   if (pybind11_INCLUDE_DIRS)
-    string(REGEX REPLACE ";" "', '"  _tmp "${pybind11_INCLUDE_DIRS}")
-    set(SETUP_PY_PYBIND_INCLUDE_DIR "'${_tmp}'")
+    append_quoted(SETUP_PY_INCLUDE_DIRS pybind11_INCLUDE_DIRS)
   endif()
 
   if (TARGET fmt::fmt)
      get_target_property(SETUP_PY_FMT_LIBS fmt::fmt LOCATION)
      get_target_property(FMT_FLAGS fmt::fmt INTERFACE_COMPILE_DEFINITIONS)
-     foreach(flag ${FMT_FLAGS})
-       set(SETUP_PY_FMT_FLAGS "${SETUP_PY_FMT_FLAGS} '-D${flag}',")
-     endforeach()
-     list(APPEND opm-common_PYTHON_LINKAGE "'${SETUP_PY_FMT_LIBS}'")
+     append_quoted(SETUP_PY_FLAGS FMT_FLAGS "-D")
+     append_quoted(opm-common_PYTHON_LINKAGE SETUP_PY_FMT_LIBS)
   else()
-    set(SETUP_PY_FMT_FLAGS "'-DFMT_HEADER_ONLY'")
+    list(APPEND SETUP_PY_FLAGS "'-DFMT_HEADER_ONLY'")
   endif()
 
   if(cjson_FOUND)
-    list(APPEND opm-common_PYTHON_LINKAGE "'${cjson_LIBRARIES}'")
+    append_quoted(opm-common_PYTHON_LINKAGE cjson_LIBRARIES)
+    append_quoted(SETUP_PY_INCLUDE_DIRS cjson_INCLUDE_DIRS)
   endif()
 
-  # opm-common_PYTHON_LINKAGE is used verbatim in a listin python.
-  # Hence items need to be comma separated.
-  if (opm-common_PYTHON_LINKAGE)
-    string(REPLACE ";" "," SETUP_PY_LINKAGE "${opm-common_PYTHON_LINKAGE}")
+  if(OpenMP_FOUND)
+    append_quoted(opm-common_PYTHON_LINKAGE OpenMP_CXX_LIBRARIES)
+    append_quoted(SETUP_PY_FLAGS OpenMP_CXX_FLAGS)
+    append_quoted(SETUP_PY_INCLUDE_DIRS OpenMP_CXX_INCLUDE_DIRS)
   endif()
+
+  # Items need to be comma separated for setup.py generation
+  string(REPLACE ";" "," SETUP_PY_LINKAGE "${opm-common_PYTHON_LINKAGE}")
+  string(REPLACE ";" "," SETUP_PY_FLAGS "${SETUP_PY_FLAGS}")
+  string(REPLACE ";" "," SETUP_PY_INCLUDE_DIRS "${SETUP_PY_INCLUDE_DIRS}")
 
   configure_file (${PROJECT_SOURCE_DIR}/python/setup.py.in ${PROJECT_BINARY_DIR}/python/setup.py)
   file(COPY ${PROJECT_SOURCE_DIR}/python/README.md DESTINATION ${PROJECT_BINARY_DIR}/python)

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -60,7 +60,6 @@ namespace Opm {
           These constructors will make a copy of the src grid, with
           zcorn and or actnum have been adjustments.
         */
-        EclipseGrid(const EclipseGrid& src) = default;
         EclipseGrid(const EclipseGrid& src, const std::vector<int>& actnum);
         EclipseGrid(const EclipseGrid& src, const double* zcorn, const std::vector<int>& actnum);
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -43,6 +43,8 @@ public:
     // The default constructed fieldProps object is **NOT** usable
     FieldPropsManager() = default;
     FieldPropsManager(const Deck& deck, const Phases& ph, const EclipseGrid& grid, const TableManager& tables);
+    virtual ~FieldPropsManager() = default;
+
     virtual void reset_actnum(const std::vector<int>& actnum);
     const std::string& default_region() const;
     virtual std::vector<int> actnum() const;

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -74,9 +74,9 @@ ext_modules = [
         libraries=libs,
         language='c++',
         undef_macros=["NDEBUG"],
-        include_dirs=[@SETUP_PY_PYBIND_INCLUDE_DIR@],
-        extra_compile_args=['-std=c++17', '-fopenmp', @SETUP_PY_FMT_FLAGS@],
-        extra_link_args=['-fopenmp', @SETUP_PY_LINKAGE@]
+        include_dirs=[@SETUP_PY_INCLUDE_DIRS@],
+        extra_compile_args=[@SETUP_PY_FLAGS@],
+        extra_link_args=[@SETUP_PY_LINKAGE@]
     )
 ]
 

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(Python_Constructor) {
     BOOST_CHECK(python_on.enabled());
 
     //.enabled() Can only have one Python interpreter active at any time
-    BOOST_CHECK_THROW(Python(Python::Enable::ON), std::logic_error);
+    BOOST_CHECK_THROW(Python python_throw(Python::Enable::ON), std::logic_error);
 }
 
 BOOST_AUTO_TEST_CASE(Python_Constructor2) {


### PR DESCRIPTION
Found some stuff in a branch on my laptop.

- fix building python bindings on systems without openmp (e.g. clang when you forget to install libomp)
- add a missing virtual dtor
- respect rule-of-three
- workaround clang parsing issue in python test