### PR TITLE
Check that backend exists before logging.

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -1402,10 +1402,12 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
             }
         }
 
-        if (auto prtLog = OpmLog::getBackend<EclipsePRTLog>("ECLIPSEPRTLOG")) {
+        if (OpmLog::hasBackend("ECLIPSEPRTLOG")) {
+            auto prtLog = OpmLog::getBackend<EclipsePRTLog>("ECLIPSEPRTLOG");
             prtLog->addMessage(Log::MessageType::Warning, prt.str());
         }
-        if (auto consoleLog = OpmLog::getBackend<StreamLog>("STDOUT_LOGGER")) {
+        if (OpmLog::hasBackend("STDOUT_LOGGER")) {
+            auto consoleLog = OpmLog::getBackend<StreamLog>("STDOUT_LOGGER");
             consoleLog->addMessage(Log::MessageType::Warning, console.str());
         }
     }


### PR DESCRIPTION
Lack of checking triggered an exception for programs not setting up logging exactly like OPM Flow (using the exact same backend name strings) when ran on cases where this condition (a warning about a fluid table) was triggered. In particular this includes the `wellgraph` tool.