### PR TITLE
Fix bug in ExtESmry

### DIFF
--- a/opm/io/eclipse/ESmry.hpp
+++ b/opm/io/eclipse/ESmry.hpp
@@ -61,7 +61,8 @@ public:
 
     bool make_esmry_file();
 
-    time_point startdate() const { return startdat; }
+    time_point startdate() const { return tp_startdat; }
+    std::vector<int> start_v() const { return start_vect; }
 
     const std::vector<std::string>& keywordList() const;
     std::vector<std::string> keywordList(const std::string& pattern) const;
@@ -110,7 +111,8 @@ private:
     std::vector<SummaryNode> summaryNodes;
     std::unordered_map<std::string, std::string> kwunits;
 
-    time_point startdat;
+    time_point tp_startdat;
+    std::vector<int> start_vect;
 
     mutable double m_io_opening;
     mutable double m_io_loading;

--- a/opm/io/eclipse/ExtESmry.hpp
+++ b/opm/io/eclipse/ExtESmry.hpp
@@ -54,6 +54,7 @@ public:
     void loadData(const std::vector<std::string>& stringVect);
 
     time_point startdate() const { return m_startdat; }
+    std::vector<int> start_v() const { return m_start_vect; }
 
     bool hasKey(const std::string& key) const;
 
@@ -93,6 +94,7 @@ private:
     std::vector<uint64_t> m_rstep_offset;
 
     time_point m_startdat;
+    std::vector<int> m_start_vect;
 
     double m_io_opening;
     double m_io_loading;

--- a/src/opm/io/eclipse/ExtESmry.cpp
+++ b/src/opm/io/eclipse/ExtESmry.cpp
@@ -51,7 +51,7 @@ Opm::time_point make_date(const std::vector<int>& datetime) {
     auto minute = 0;
     auto second = 0;
 
-    if (datetime.size() == 6) {
+    if (datetime.size() == 7) {
         hour = datetime[3];
         minute = datetime[4];
         auto total_usec = datetime[5];
@@ -293,15 +293,15 @@ bool ExtESmry::open_esmry(const std::filesystem::path& inputFileName, ExtSmryHea
     if ((arrName != "START   ") or (arrType != Opm::EclIO::INTE))
         OPM_THROW(std::invalid_argument, "reading start, invalid esmry file " + inputFileName.string() );
 
-    std::vector<int> start_vect;
+
     try {
-        start_vect = Opm::EclIO::readBinaryInteArray(fileH, arr_size);
+        m_start_vect = Opm::EclIO::readBinaryInteArray(fileH, arr_size);
     } catch (const std::runtime_error& error)
     {
         return false;
     }
 
-    auto startdat = make_date(start_vect);
+    auto startdat = make_date(m_start_vect);
 
     try {
        Opm::EclIO::readBinaryHeader(fileH, arrName, arr_size, arrType, sizeOfElement);


### PR DESCRIPTION
Start date in ESMRY file (format) have 7 elements, last element is milliseconds.