### PR TITLE
Remove use of reserved identifier in OPM_THROW.

### DIFF
--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -49,22 +49,22 @@
 // std::runtime_error.
 //
 // Usage: OPM_THROW(ExceptionClass, "Error message " << value);
-#define OPM_THROW(Exception, message)                                   \
-    do {                                                                \
-        std::ostringstream oss__;                                       \
-        oss__ << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
-        ::Opm::OpmLog::error(oss__.str());                                \
-        throw Exception(oss__.str());                                   \
+#define OPM_THROW(Exception, message)                                                        \
+    do {                                                                                     \
+        std::ostringstream opmErrorMacroOStringStream;                                       \
+        opmErrorMacroOStringStream << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
+        ::Opm::OpmLog::error(opmErrorMacroOStringStream.str());                              \
+        throw Exception(opmErrorMacroOStringStream.str());                                   \
     } while (false)
 
 // Same as OPM_THROW, except for not making an OpmLog::error() call.
 //
 // Usage: OPM_THROW_NOLOG(ExceptionClass, "Error message " << value);
-#define OPM_THROW_NOLOG(Exception, message)                             \
-    do {                                                                \
-        std::ostringstream oss__;                                       \
-        oss__ << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
-        throw Exception(oss__.str());                                   \
+#define OPM_THROW_NOLOG(Exception, message)                                                  \
+    do {                                                                                     \
+        std::ostringstream opmErrorMacroOStringStream;                                       \
+        opmErrorMacroOStringStream << "[" << __FILE__ << ":" << __LINE__ << "] " << message; \
+        throw Exception(opmErrorMacroOStringStream.str());                                   \
     } while (false)
 
 // throw an exception if a condition is true


### PR DESCRIPTION
The use of double underscores (`__`) is reserved for the system (see eg. https://en.cppreference.com/w/cpp/language/identifiers ), hence this pull request renames the temporary variable `oss__` to the more verbose (but probably never shadowed) variable `opmErrorMacroOStringStream`.

This will also remove the constant warnings when running `clang-tidy` about reserved indentifiers on files that use any version of the `OPM_THROW` macros. 