### PR TITLE
additional output from compareECL related to rsm files

### DIFF
--- a/src/opm/io/eclipse/ERsm.cpp
+++ b/src/opm/io/eclipse/ERsm.cpp
@@ -213,8 +213,17 @@ void ERsm::load_block(std::deque<std::string>& lines, std::size_t& vector_length
             double value;
             if (keyword == "WSTAT")
                 value = convert_wstat(data_row[data_index + 1]);
-            else
-                value = std::stod(data_row[data_index + 1]) * mult_list[data_index + 1];
+            else {
+
+                try {
+                    value = std::stod(data_row[data_index + 1]) * mult_list[data_index + 1];
+                } catch (...) {
+                    std::string message = "Error loading RSM file. Not able to convert '";
+                    message = message +  data_row[data_index + 1] + "' to a float value";
+                    throw std::runtime_error(message);
+                }
+            }
+
             block_data[data_index].data.push_back(value);
         }
 

--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -1002,9 +1002,16 @@ void ECLRegressionTest::results_smry()
         namespace fs = std::filesystem;
         std::string rsm_file = rootName2 + ".RSM";
         if (fs::is_regular_file(fs::path(rsm_file))) {
+            std::cout << "\nLoading RSM file " << rsm_file << "  .... " << std::flush;
             auto rsm = ERsm(rsm_file);
+            std::cout << " done " << std::endl << std::flush;;
+            
+            std::cout << "\nComparing RSM file against SMRY file  .... " << std::flush;
+        
             if (!cmp(smry2, rsm))
                 HANDLE_ERROR(std::runtime_error, "The RSM file did not compare equal to the summary file");
+            
+            std::cout << " done " << std::endl << std::flush;;
         }
 
     } else {

--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -889,7 +889,7 @@ void ECLRegressionTest::results_smry()
 
         ESmry smry2(fileName2, loadBaseRunData);
         smry2.loadData();
-        std::cout << "\nLoading summary file " << fileName2 << "  .... done" << std::endl;
+        std::cout << "Loading summary file " << fileName2 << "  .... done" << std::endl;
 
         deviations.clear();
 
@@ -999,25 +999,42 @@ void ECLRegressionTest::results_smry()
             }
         }
 
+    } else {
+        std::cout << "\n!Warning, summary files not found, hence not compared. \n" << std::endl;
+    }
+
+}
+
+void ECLRegressionTest::results_rsm()
+{
+    std::string fileName1,fileName2;
+    bool foundRsm2 = checkFileName(rootName2, "RSM", fileName2);
+    bool foundSmspec1 = checkFileName(rootName1, "SMSPEC", fileName1);
+
+    if ((foundRsm2) && (foundSmspec1)) {
+
+        ESmry smry2(fileName1, loadBaseRunData);
+        smry2.loadData();
+        std::cout << "\nLoading summary file " << fileName1 << "  .... done" << std::endl;
+
         namespace fs = std::filesystem;
         std::string rsm_file = rootName2 + ".RSM";
         if (fs::is_regular_file(fs::path(rsm_file))) {
             std::cout << "\nLoading RSM file " << rsm_file << "  .... " << std::flush;
             auto rsm = ERsm(rsm_file);
             std::cout << " done " << std::endl << std::flush;;
-            
+
             std::cout << "\nComparing RSM file against SMRY file  .... " << std::flush;
-        
+
             if (!cmp(smry2, rsm))
                 HANDLE_ERROR(std::runtime_error, "The RSM file did not compare equal to the summary file");
-            
+
             std::cout << " done " << std::endl << std::flush;;
         }
 
     } else {
-        std::cout << "\n!Warning, summary files not found, hence not compared. \n" << std::endl;
+        std::cout << "\n!Warning, summary and/or RSM - file not found, hence not compared. \n" << std::endl;
     }
-
 }
 
 

--- a/test_util/EclRegressionTest.hpp
+++ b/test_util/EclRegressionTest.hpp
@@ -98,6 +98,7 @@ public:
     void results_rst();
     void results_init();
     void results_smry();
+    void results_rsm();
     void results_rft();
 
 private:

--- a/test_util/compareECL.cpp
+++ b/test_util/compareECL.cpp
@@ -49,6 +49,7 @@ static void printHelp() {
               << "    -t INIT  \t Compare two initial files (.INIT).\n"
               << "    -t RFT   \t Compare two RFT files (.RFT).\n"
               << "    -t SMRY  \t Compare two cases consistent of (unified) summary files.\n"
+              << "    -t RSM   \t Compare RSM file agaist a summary file.\n"
               << "-x Allow extra keywords in case number 2. These additional keywords (not found in case number1) will be ignored in the comparison.\n"
               << "\nExample usage of the program: \n\n"
               << "compareECL -k PRESSURE <path to first casefile> <path to second casefile> 1e-3 1e-5\n"
@@ -229,6 +230,8 @@ int main(int argc, char** argv) {
                 comparator.results_rst();
             } else if (fileTypeString == "SMRY") {
                 comparator.results_smry();
+            } else if (fileTypeString == "RSM") {
+                comparator.results_rsm();
             } else if (fileTypeString == "RFT") {
                 comparator.results_rft();
             } else {
@@ -244,6 +247,7 @@ int main(int argc, char** argv) {
             comparator.results_init();
             comparator.results_rst();
             comparator.results_smry();
+            comparator.results_rsm();
             comparator.results_rft();
         }
 


### PR DESCRIPTION
This improves output from compareECL when comparing summary files. 

Notice that the RSM file generated by the commercial simulator, for test model [`opm-tests/wvfpexp/WVFPEXP-01.DATA`](https://github.com/OPM/opm-tests/blob/9c3555ab26aa9df6a5d23a99e3a4aef6620ac01a/wvfpexp/WVFPEXP-01.DATA), exposes a BUG in Eclipse.

```
tskille@melwood:~/prog/test_data$ ../opm-common/build/bin/compareECL TEST-0_ECL TEST-0_ECL 1e-5 1e-5 -t SMRY
Comparing 'TEST-0_ECL' to 'TEST-0_ECL'.

Loading EGrid TEST-0_ECL.EGRID  ....  done.
Loading EGrid TEST-0_ECL.EGRID  ....  done.

Loading summary file TEST-0_ECL.SMSPEC  .... done

Loading summary file TEST-0_ECL.SMSPEC  .... done

Comparing summary files 

Checking 223  vectors  ...  done.

Loading RSM file TEST-0_ECL.RSM  .... Program threw an exception: Error loading RSM file. Not able to convert 'SHUT/STP' to a float value
```

running `compareECL` with RSM files generated by flow will give the following output 

```
tskille@melwood:~/prog/test_data$ ../opm-common/build/bin/compareECL TEST-0 TEST-0 1e-5 1e-5 -t SMRY
Comparing 'TEST-0' to 'TEST-0'.

Loading EGrid TEST-0.EGRID  ....  done.
Loading EGrid TEST-0.EGRID  ....  done.

Loading summary file TEST-0.SMSPEC  .... done

Loading summary file TEST-0.SMSPEC  .... done

Comparing summary files 

Checking 221  vectors  ...  done.

Loading RSM file TEST-0.RSM  ....  done 

Comparing RSM file against SMRY file  ....  done 

Program finished 
```