### PR TITLE
changed: rename serializeObject to serializationTestObject

### DIFF
--- a/opm/common/OpmLog/KeywordLocation.hpp
+++ b/opm/common/OpmLog/KeywordLocation.hpp
@@ -53,7 +53,7 @@ public:
 
     std::string format(const std::string& msg_fmt) const;
 
-    static KeywordLocation serializeObject()
+    static KeywordLocation serializationTestObject()
     {
         KeywordLocation result;
         result.keyword = "KW";

--- a/opm/input/eclipse/Deck/Deck.hpp
+++ b/opm/input/eclipse/Deck/Deck.hpp
@@ -69,7 +69,7 @@ namespace Opm {
             Deck( const Deck& );
             Deck( Deck&& );
 
-            static Deck serializeObject();
+            static Deck serializationTestObject();
 
             Deck& operator=(const Deck& rhs);
             bool operator==(const Deck& data) const;

--- a/opm/input/eclipse/Deck/DeckItem.hpp
+++ b/opm/input/eclipse/Deck/DeckItem.hpp
@@ -46,7 +46,7 @@ namespace Opm {
         DeckItem( const std::string&, UDAValue, const std::vector<Dimension>& active_dim, const std::vector<Dimension>& default_dim);
         DeckItem( const std::string&, double, const std::vector<Dimension>& active_dim, const std::vector<Dimension>& default_dim);
 
-        static DeckItem serializeObject();
+        static DeckItem serializationTestObject();
 
         const std::string& name() const;
 

--- a/opm/input/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/input/eclipse/Deck/DeckKeyword.hpp
@@ -46,7 +46,7 @@ namespace Opm {
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<int>& data);
         DeckKeyword(const ParserKeyword& parserKeyword, const std::vector<double>& data, const UnitSystem& system_active, const UnitSystem& system_default);
 
-        static DeckKeyword serializeObject();
+        static DeckKeyword serializationTestObject();
 
         const std::string& name() const;
         void setFixedSize();

--- a/opm/input/eclipse/Deck/DeckRecord.hpp
+++ b/opm/input/eclipse/Deck/DeckRecord.hpp
@@ -36,7 +36,7 @@ namespace Opm {
         DeckRecord() = default;
         DeckRecord( std::vector< DeckItem >&& items, const bool check_for_duplicate_names = true );
 
-        static DeckRecord serializeObject();
+        static DeckRecord serializationTestObject();
 
         size_t size() const;
         void addItem( DeckItem deckItem );

--- a/opm/input/eclipse/Deck/UDAValue.hpp
+++ b/opm/input/eclipse/Deck/UDAValue.hpp
@@ -51,7 +51,7 @@ public:
     void update(const std::string& s);
     void update_value(const UDAValue& other);
 
-    static UDAValue serializeObject();
+    static UDAValue serializationTestObject();
 
     /*
       The get<double>() and get<std::string>() methods will throw an

--- a/opm/input/eclipse/EclipseState/Aquifer/Aquancon.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/Aquancon.hpp
@@ -93,7 +93,7 @@ namespace Opm {
             void pruneDeactivatedAquiferConnections(const std::vector<std::size_t>& deactivated_cells);
             void loadFromRestart(const RestartIO::RstAquifer& rst_aquifers);
 
-            static Aquancon serializeObject();
+            static Aquancon serializationTestObject();
 
             const std::unordered_map<int, std::vector<Aquancon::AquancCell>>& data() const;
             bool operator==(const Aquancon& other) const;

--- a/opm/input/eclipse/EclipseState/Aquifer/AquiferCT.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/AquiferCT.hpp
@@ -81,7 +81,7 @@ namespace Opm {
             std::vector<double> dimensionless_time{};
             std::vector<double> dimensionless_pressure{};
 
-            static AQUCT_data serializeObject();
+            static AQUCT_data serializationTestObject();
 
             double timeConstant() const { return this->time_constant_; }
             double influxConstant() const { return this->influx_constant_; }
@@ -129,7 +129,7 @@ namespace Opm {
         void loadFromRestart(const RestartIO::RstAquifer& rst,
                              const TableManager&          tables);
 
-        static AquiferCT serializeObject();
+        static AquiferCT serializationTestObject();
 
         std::size_t size() const;
         std::vector<AquiferCT::AQUCT_data>::const_iterator begin() const;

--- a/opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp
@@ -53,7 +53,7 @@ public:
     void loadFromRestart(const RestartIO::RstAquifer& aquifers,
                          const TableManager&          tables);
 
-    static AquiferConfig serializeObject();
+    static AquiferConfig serializationTestObject();
 
     bool active() const;
     const AquiferCT& ct() const;

--- a/opm/input/eclipse/EclipseState/Aquifer/Aquifetp.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/Aquifetp.hpp
@@ -71,7 +71,7 @@ class Aquifetp {
         std::optional<double> initial_pressure{};
         std::optional<double> initial_temperature{};
 
-        static AQUFETP_data serializeObject();
+        static AQUFETP_data serializationTestObject();
 
         double timeConstant() const { return this->time_constant_; }
         double waterDensity() const { return this->water_density_; }
@@ -110,7 +110,7 @@ class Aquifetp {
     void loadFromRestart(const RestartIO::RstAquifer& rst,
                          const TableManager&          tables);
 
-    static Aquifetp serializeObject();
+    static Aquifetp serializationTestObject();
 
     const std::vector<Aquifetp::AQUFETP_data>& data() const;
 

--- a/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp
@@ -57,7 +57,7 @@ namespace Opm {
         void initConnections(const Deck& deck, const EclipseGrid& grid);
         void postProcessConnections(const EclipseGrid& grid, const std::vector<int>& actnum);
 
-        static NumericalAquifers serializeObject();
+        static NumericalAquifers serializationTestObject();
         template <class Serializer>
         void serializeOp(Serializer& serializer)
         {

--- a/opm/input/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseConfig.hpp
@@ -34,7 +34,7 @@ namespace Opm {
         explicit EclipseConfig(const Deck& deck);
         EclipseConfig(const InitConfig& initConfig, const IOConfig& io_conf);
 
-        static EclipseConfig serializeObject();
+        static EclipseConfig serializationTestObject();
 
         InitConfig& init();
         IOConfig& io();

--- a/opm/input/eclipse/EclipseState/EndpointScaling.hpp
+++ b/opm/input/eclipse/EclipseState/EndpointScaling.hpp
@@ -30,7 +30,7 @@ class EndpointScaling {
         EndpointScaling() noexcept = default;
         explicit EndpointScaling( const Deck& );
 
-        static EndpointScaling serializeObject();
+        static EndpointScaling serializationTestObject();
 
         /* true if endpoint scaling is enabled, otherwise false */
         operator bool() const noexcept;

--- a/opm/input/eclipse/EclipseState/Grid/Fault.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/Fault.hpp
@@ -35,7 +35,7 @@ public:
     Fault() = default;
     explicit Fault(const std::string& faultName);
 
-    static Fault serializeObject();
+    static Fault serializationTestObject();
 
     const  std::string& getName() const;
     void   setTransMult(double transMult);

--- a/opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp
@@ -37,7 +37,7 @@ public:
     FaultCollection();
     FaultCollection(const GRIDSection& gridSection, const GridDims& grid);
 
-    static FaultCollection serializeObject();
+    static FaultCollection serializationTestObject();
 
     size_t size() const;
     bool hasFault(const std::string& faultName) const;

--- a/opm/input/eclipse/EclipseState/Grid/FaultFace.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FaultFace.hpp
@@ -36,7 +36,7 @@ public:
               size_t K1 , size_t K2,
               FaceDir::DirEnum faceDir);
 
-    static FaultFace serializeObject();
+    static FaultFace serializationTestObject();
 
     std::vector<size_t>::const_iterator begin() const;
     std::vector<size_t>::const_iterator end() const;

--- a/opm/input/eclipse/EclipseState/Grid/GridDims.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/GridDims.hpp
@@ -34,7 +34,7 @@ namespace Opm {
         explicit GridDims(const std::array<int, 3>& xyz);
         GridDims(std::size_t nx, std::size_t ny, std::size_t nz);
 
-        static GridDims serializeObject();
+        static GridDims serializationTestObject();
 
         explicit GridDims(const Deck& deck);
 

--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -92,7 +92,7 @@ namespace Opm {
                         const FieldPropsManager* fp_arg,
                         const std::vector< const DeckKeyword* >& keywords);
 
-        static MULTREGTScanner serializeObject();
+        static MULTREGTScanner serializationTestObject();
 
         double getRegionMultiplier(size_t globalCellIdx1, size_t globalCellIdx2, FaceDir::DirEnum faceDir) const;
 

--- a/opm/input/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.hpp
@@ -106,7 +106,7 @@ public:
     /// Construct from input deck.
     NNC(const EclipseGrid& grid, const Deck& deck);
 
-    static NNC serializeObject();
+    static NNC serializationTestObject();
 
     bool addNNC(const size_t cell1, const size_t cell2, const double trans);
     const std::vector<NNCdata>& input() const { return m_input; }

--- a/opm/input/eclipse/EclipseState/Grid/TranCalculator.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/TranCalculator.hpp
@@ -105,7 +105,7 @@ public:
         serializer(actions);
     }
 
-    static TranCalculator serializeObject()
+    static TranCalculator serializationTestObject()
     {
         TranCalculator tran("test");
         tran.add_action(ScalarOperation::MIN, "FGOP");

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
@@ -50,7 +50,7 @@ namespace Opm {
         TransMult() = default;
         TransMult(const GridDims& dims, const Deck& deck, const FieldPropsManager& fp);
 
-        static TransMult serializeObject();
+        static TransMult serializationTestObject();
 
         double getMultiplier(size_t globalIndex, FaceDir::DirEnum faceDir) const;
         double getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const;

--- a/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -152,7 +152,7 @@ namespace Opm {
         explicit IOConfig( const Deck& );
         explicit IOConfig( const std::string& input_path );
 
-        static IOConfig serializeObject();
+        static IOConfig serializationTestObject();
 
         void setEclCompatibleRST(bool ecl_rst);
         bool getEclCompatibleRST() const;

--- a/opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/Equil.hpp
@@ -62,7 +62,7 @@ namespace Opm {
             Equil() = default;
             explicit Equil( const DeckKeyword& );
 
-            static Equil serializeObject();
+            static Equil serializationTestObject();
 
             const EquilRecord& getRecord( size_t id ) const;
 

--- a/opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp
@@ -39,7 +39,7 @@ public:
     FoamData(const DeckRecord& FOAMFSC_record, const DeckRecord& FOAMROCK_record);
     explicit FoamData(const DeckRecord& FOAMROCK_record);
 
-    static FoamData serializeObject();
+    static FoamData serializationTestObject();
 
     double referenceSurfactantConcentration() const;
     double exponent() const;
@@ -80,7 +80,7 @@ public:
     FoamConfig() = default;
     explicit FoamConfig(const Deck&);
 
-    static FoamConfig serializeObject();
+    static FoamConfig serializationTestObject();
 
     const FoamData& getRecord(std::size_t index) const;
 

--- a/opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -35,7 +35,7 @@ namespace Opm {
         InitConfig();
         explicit InitConfig(const Deck& deck);
 
-        static InitConfig serializeObject();
+        static InitConfig serializationTestObject();
 
         void setRestart( const std::string& root, int step);
         bool restartRequested() const;

--- a/opm/input/eclipse/EclipseState/MICPpara.hpp
+++ b/opm/input/eclipse/EclipseState/MICPpara.hpp
@@ -31,7 +31,7 @@ class Deck;
       explicit MICPpara(const Deck& deck);
 
 
-      static MICPpara serializeObject()
+      static MICPpara serializationTestObject()
       {
           MICPpara mp;
           mp.m_density_biofilm = 100;

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -60,7 +60,7 @@ class Phases {
         Phases( bool oil, bool gas, bool wat, bool solvent = false, bool polymer = false, bool energy = false,
                 bool polymw = false, bool foam = false, bool brine = false, bool zfraction = false ) noexcept;
 
-        static Phases serializeObject();
+        static Phases serializationTestObject();
 
         bool active( Phase ) const noexcept;
         size_t size() const noexcept;
@@ -83,7 +83,7 @@ public:
     Welldims() = default;
     explicit Welldims(const Deck& deck);
 
-    static Welldims serializeObject();
+    static Welldims serializationTestObject();
 
     int maxConnPerWell() const
     {
@@ -161,7 +161,7 @@ public:
     WellSegmentDims();
     explicit WellSegmentDims(const Deck& deck);
 
-    static WellSegmentDims serializeObject();
+    static WellSegmentDims serializationTestObject();
 
 
     int maxSegmentedWells() const
@@ -200,7 +200,7 @@ public:
     NetworkDims();
     explicit NetworkDims(const Deck& deck);
 
-    static NetworkDims serializeObject();
+    static NetworkDims serializationTestObject();
 
     int maxNONodes() const
     {
@@ -240,7 +240,7 @@ public:
     AquiferDimensions();
     explicit AquiferDimensions(const Deck& deck);
 
-    static AquiferDimensions serializeObject();
+    static AquiferDimensions serializationTestObject();
 
     int maxAnalyticAquifers() const
     {
@@ -272,7 +272,7 @@ public:
     EclHysterConfig() = default;
     explicit EclHysterConfig(const Deck& deck);
 
-    static EclHysterConfig serializeObject();
+    static EclHysterConfig serializationTestObject();
 
     /*!
      * \brief Specify whether hysteresis is enabled or not.
@@ -339,7 +339,7 @@ public:
                              const ThreePhaseOilKrModel model,
                              const KeywordFamily family);
 
-    static SatFuncControls serializeObject();
+    static SatFuncControls serializationTestObject();
 
     double minimumRelpermMobilityThreshold() const
     {
@@ -380,7 +380,7 @@ public:
     void update(int value);
     int value() const;
 
-    static Nupcol serializeObject();
+    static Nupcol serializationTestObject();
     bool operator==(const Nupcol& data) const;
 
     template<class Serializer>
@@ -414,7 +414,7 @@ public:
         serializer(this->min_iter);
     }
 
-    static Tracers serializeObject();
+    static Tracers serializationTestObject();
     bool operator==(const Tracers& data) const;
 
 private:
@@ -435,7 +435,7 @@ public:
     Runspec() = default;
     explicit Runspec( const Deck& );
 
-    static Runspec serializeObject();
+    static Runspec serializationTestObject();
 
     std::time_t start_time() const noexcept;
     const UDQParams& udqParams() const noexcept;

--- a/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
@@ -61,7 +61,7 @@ public:
         BCFace() = default;
         explicit BCFace(const DeckRecord& record);
 
-        static BCFace serializeObject();
+        static BCFace serializationTestObject();
 
         bool operator==(const BCFace& other) const;
 
@@ -85,7 +85,7 @@ public:
     BCConfig() = default;
     explicit BCConfig(const Deck& deck);
 
-    static BCConfig serializeObject();
+    static BCConfig serializationTestObject();
 
     std::size_t size() const;
     std::vector<BCFace>::const_iterator begin() const;

--- a/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
@@ -61,7 +61,7 @@ struct RockComp {
     RockConfig();
     RockConfig(const Deck& deck, const FieldPropsManager& fp);
 
-    static RockConfig serializeObject();
+    static RockConfig serializationTestObject();
 
     bool active() const;
     const std::vector<RockConfig::RockComp>& comp() const;

--- a/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -38,7 +38,7 @@ namespace Opm {
                          const Deck& deck,
                          const FieldPropsManager& fp);
 
-        static SimulationConfig serializeObject();
+        static SimulationConfig serializationTestObject();
 
         const RockConfig& rock_config() const;
         const ThresholdPressure& getThresholdPressure() const;

--- a/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -46,7 +46,7 @@ namespace Opm {
         {}
 
         //! \brief Returns an instance for serialization tests.
-        static ThresholdPressure serializeObject();
+        static ThresholdPressure serializationTestObject();
 
         /*
           The hasRegionBarrier() method checks if a threshold pressure

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -48,7 +48,7 @@ namespace Opm {
         SummaryConfigNode() = default;
         explicit SummaryConfigNode(std::string keyword, const Category cat, KeywordLocation loc_arg);
 
-        static SummaryConfigNode serializeObject();
+        static SummaryConfigNode serializationTestObject();
 
         SummaryConfigNode& parameterType(const Type type);
         SummaryConfigNode& namedEntity(std::string name);
@@ -160,7 +160,7 @@ namespace Opm {
                           const std::set<std::string>& shortKwds,
                           const std::set<std::string>& smryKwds);
 
-            static SummaryConfig serializeObject();
+            static SummaryConfig serializationTestObject();
 
             const_iterator begin() const;
             const_iterator end() const;

--- a/opm/input/eclipse/EclipseState/Tables/Aqudims.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Aqudims.hpp
@@ -38,7 +38,7 @@ namespace Opm {
 
         explicit Aqudims(const Deck& deck);
 
-        static Aqudims serializeObject()
+        static Aqudims serializationTestObject()
         {
             Aqudims result;
             result.m_mxnaqn = 1;

--- a/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
 
     class BrineDensityTable {
     public:
-        static BrineDensityTable serializeObject();
+        static BrineDensityTable serializationTestObject();
 
         void init(const Opm::DeckRecord& record);
         const std::vector<double>& getBrineDensityColumn() const;

--- a/opm/input/eclipse/EclipseState/Tables/ColumnSchema.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/ColumnSchema.hpp
@@ -34,7 +34,7 @@ namespace Opm {
         ColumnSchema(const std::string& name , Table::ColumnOrderEnum order, Table::DefaultAction defaultAction);
         ColumnSchema(const std::string& name , Table::ColumnOrderEnum order, double defaultValue);
 
-        static ColumnSchema serializeObject();
+        static ColumnSchema serializationTestObject();
 
         const std::string& name() const;
         bool validOrder( double value1 , double value2) const;

--- a/opm/input/eclipse/EclipseState/Tables/DenT.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/DenT.hpp
@@ -52,7 +52,7 @@ namespace Opm {
         DenT() = default;
         explicit DenT(const DeckKeyword& keyword);
 
-        static DenT serializeObject();
+        static DenT serializationTestObject();
 
         const entry& operator[](const std::size_t index) const;
         bool operator==(const DenT& other) const;

--- a/opm/input/eclipse/EclipseState/Tables/Eqldims.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Eqldims.hpp
@@ -42,7 +42,7 @@ namespace Opm {
             m_nstrvd( nstrvd )
         { }
 
-        static Eqldims serializeObject()
+        static Eqldims serializationTestObject()
         {
             return Eqldims(1, 2, 3, 4, 5);
         }

--- a/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -92,7 +92,7 @@ struct GravityTable : public FlatTableWithCopy<GRAVITYRecord>
     explicit GravityTable(const DeckKeyword& kw);
     explicit GravityTable(std::initializer_list<GRAVITYRecord> records);
 
-    static GravityTable serializeObject()
+    static GravityTable serializationTestObject()
     {
         return GravityTable({{1.0, 2.0, 3.0}});
     }
@@ -133,7 +133,7 @@ struct DensityTable : public FlatTableWithCopy<DENSITYRecord>
     explicit DensityTable(const GravityTable& gravity);
     explicit DensityTable(std::initializer_list<DENSITYRecord> records);
 
-    static DensityTable serializeObject()
+    static DensityTable serializationTestObject()
     {
         return DensityTable({{1.0, 2.0, 3.0}});
     }
@@ -185,7 +185,7 @@ struct DiffCoeffRecord {
 struct DiffCoeffTable : public FlatTable< DiffCoeffRecord > {
     using FlatTable< DiffCoeffRecord >::FlatTable;
 
-    static DiffCoeffTable serializeObject()
+    static DiffCoeffTable serializationTestObject()
     {
         return DiffCoeffTable({{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0}});
     }
@@ -225,7 +225,7 @@ struct PvtwTable : public FlatTableWithCopy<PVTWRecord>
     explicit PvtwTable(const DeckKeyword& kw);
     explicit PvtwTable(std::initializer_list<PVTWRecord> records);
 
-    static PvtwTable serializeObject()
+    static PvtwTable serializationTestObject()
     {
         return PvtwTable({{1.0, 2.0, 3.0, 4.0, 5.0}});
     }
@@ -259,7 +259,7 @@ struct ROCKRecord {
 struct RockTable : public FlatTable< ROCKRecord > {
     using FlatTable< ROCKRecord >::FlatTable;
 
-    static RockTable serializeObject()
+    static RockTable serializationTestObject()
     {
         return RockTable({{1.0, 2.0}});
     }
@@ -296,7 +296,7 @@ struct PVCDORecord {
 struct PvcdoTable : public FlatTable< PVCDORecord > {
     using FlatTable< PVCDORecord >::FlatTable;
 
-    static PvcdoTable serializeObject()
+    static PvcdoTable serializationTestObject()
     {
         return PvcdoTable({{1.0, 2.0, 3.0, 4.0, 5.0}});
     }
@@ -321,7 +321,7 @@ struct PlmixparRecord {
 struct PlmixparTable : public FlatTable< PlmixparRecord> {
     using FlatTable< PlmixparRecord >::FlatTable;
 
-    static PlmixparTable serializeObject()
+    static PlmixparTable serializationTestObject()
     {
         return PlmixparTable({PlmixparRecord{1.0}});
     }
@@ -355,7 +355,7 @@ struct PlyvmhRecord {
 struct PlyvmhTable : public FlatTable<PlyvmhRecord> {
     using FlatTable< PlyvmhRecord >::FlatTable;
 
-    static PlyvmhTable serializeObject()
+    static PlyvmhTable serializationTestObject()
     {
         return PlyvmhTable({{1.0, 2.0, 3.0, 4.0}});
     }
@@ -380,7 +380,7 @@ struct ShrateRecord {
 struct ShrateTable : public FlatTable<ShrateRecord> {
     using FlatTable< ShrateRecord >::FlatTable;
 
-    static ShrateTable serializeObject()
+    static ShrateTable serializationTestObject()
     {
         return ShrateTable({ShrateRecord{1.0}});
     }
@@ -405,7 +405,7 @@ struct Stone1exRecord {
 struct Stone1exTable : public FlatTable<Stone1exRecord> {
     using FlatTable< Stone1exRecord >::FlatTable;
 
-    static Stone1exTable serializeObject()
+    static Stone1exTable serializationTestObject()
     {
         return Stone1exTable({Stone1exRecord{1.0}});
     }
@@ -433,7 +433,7 @@ struct TlmixparRecord {
 struct TlmixparTable : public FlatTable< TlmixparRecord> {
     using FlatTable< TlmixparRecord >::FlatTable;
 
-    static TlmixparTable serializeObject()
+    static TlmixparTable serializationTestObject()
     {
         return TlmixparTable({{1.0, 2.0}});
     }
@@ -461,7 +461,7 @@ struct VISCREFRecord {
 struct ViscrefTable : public FlatTable< VISCREFRecord > {
     using FlatTable< VISCREFRecord >::FlatTable;
 
-    static ViscrefTable serializeObject()
+    static ViscrefTable serializationTestObject()
     {
         return ViscrefTable({{1.0, 2.0}});
     }
@@ -492,7 +492,7 @@ struct WATDENTRecord {
 struct WatdentTable : public FlatTable< WATDENTRecord > {
     using FlatTable< WATDENTRecord >::FlatTable;
 
-    static WatdentTable serializeObject()
+    static WatdentTable serializationTestObject()
     {
         return WatdentTable({{1.0, 2.0, 3.0}});
     }
@@ -565,7 +565,7 @@ struct SatFuncLETRecord {
 struct SwofletTable : public FlatTable< SatFuncLETRecord > {
     using FlatTable< SatFuncLETRecord >::FlatTable;
 
-    static SwofletTable serializeObject()
+    static SwofletTable serializationTestObject()
     {
         return SwofletTable({{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0}});
     }
@@ -575,7 +575,7 @@ struct SwofletTable : public FlatTable< SatFuncLETRecord > {
 struct SgofletTable : public FlatTable< SatFuncLETRecord > {
     using FlatTable< SatFuncLETRecord >::FlatTable;
 
-    static SgofletTable serializeObject()
+    static SgofletTable serializationTestObject()
     {
         return SgofletTable({{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0}});
     }

--- a/opm/input/eclipse/EclipseState/Tables/JFunc.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/JFunc.hpp
@@ -34,7 +34,7 @@ public:
     JFunc();
     explicit JFunc(const Deck& deck);
 
-    static JFunc serializeObject();
+    static JFunc serializationTestObject();
 
     double alphaFactor() const;
     double betaFactor() const;

--- a/opm/input/eclipse/EclipseState/Tables/JouleThomson.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/JouleThomson.hpp
@@ -50,7 +50,7 @@ namespace Opm {
         JouleThomson() = default;
         explicit JouleThomson(const DeckKeyword& keyword);
 
-        static JouleThomson serializeObject();
+        static JouleThomson serializationTestObject();
 
         const entry& operator[](const std::size_t index) const;
         bool operator==(const JouleThomson& other) const;

--- a/opm/input/eclipse/EclipseState/Tables/PlymwinjTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PlymwinjTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
         PlymwinjTable() = default;
         explicit PlymwinjTable(const DeckKeyword& table);
 
-        static PlymwinjTable serializeObject();
+        static PlymwinjTable serializationTestObject();
 
         const std::vector<std::vector<double>>& getMoleWeights() const;
         bool operator==(const PlymwinjTable& data) const;

--- a/opm/input/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -34,7 +34,7 @@ namespace Opm {
         PlyshlogTable() = default;
         PlyshlogTable(const DeckRecord& indexRecord, const DeckRecord& dataRecord);
 
-        static PlyshlogTable serializeObject();
+        static PlyshlogTable serializationTestObject();
 
         double getRefPolymerConcentration() const;
         double getRefSalinity() const;

--- a/opm/input/eclipse/EclipseState/Tables/PolyInjTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PolyInjTable.hpp
@@ -43,7 +43,7 @@ namespace Opm {
 
     class PolyInjTable {
     public:
-        static PolyInjTable serializeObject();
+        static PolyInjTable serializationTestObject();
 
         int getTableNumber() const;
 

--- a/opm/input/eclipse/EclipseState/Tables/PvtgTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtgTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
         PvtgTable() = default;
         PvtgTable( const DeckKeyword& keyword, size_t tableIdx);
 
-        static PvtgTable serializeObject();
+        static PvtgTable serializationTestObject();
 
         bool operator==(const PvtgTable& data) const;
     };

--- a/opm/input/eclipse/EclipseState/Tables/PvtgwTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtgwTable.hpp
@@ -31,7 +31,7 @@ namespace Opm {
         PvtgwTable() = default;
         PvtgwTable( const DeckKeyword& keyword, size_t tableIdx);
         
-        static PvtgwTable serializeObject();
+        static PvtgwTable serializationTestObject();
 
         bool operator==(const PvtgwTable& data) const;
     };

--- a/opm/input/eclipse/EclipseState/Tables/PvtgwoTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtgwoTable.hpp
@@ -31,7 +31,7 @@ namespace Opm {
         PvtgwoTable() = default;
         PvtgwoTable( const DeckKeyword& keyword, size_t tableIdx);
 
-        static PvtgwoTable serializeObject();
+        static PvtgwoTable serializationTestObject();
 
         bool operator==(const PvtgwoTable& data) const;
     };

--- a/opm/input/eclipse/EclipseState/Tables/PvtoTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtoTable.hpp
@@ -40,7 +40,7 @@ namespace Opm {
         PvtoTable() = default;
         PvtoTable(const DeckKeyword& keyword, size_t tableIdx);
 
-        static PvtoTable serializeObject();
+        static PvtoTable serializationTestObject();
 
         bool operator==(const PvtoTable& data) const;
 

--- a/opm/input/eclipse/EclipseState/Tables/PvtsolTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtsolTable.hpp
@@ -29,7 +29,7 @@ namespace Opm {
     public:
         PvtsolTable() = default;
         PvtsolTable(const DeckKeyword& keyword, size_t tableIdx);
-        static PvtsolTable serializeObject();
+        static PvtsolTable serializationTestObject();
         bool operator==(const PvtsolTable& data) const;
     };
 }

--- a/opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.hpp
@@ -29,7 +29,7 @@ namespace Opm {
     public:
         PvtwsaltTable();
 
-        static PvtwsaltTable serializeObject();
+        static PvtwsaltTable serializationTestObject();
 
         void init(const Opm::DeckRecord& record0, const Opm::DeckRecord& record1);
         size_t size() const;

--- a/opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/PvtxTable.hpp
@@ -118,7 +118,7 @@ The first row actually corresponds to saturated values.
         PvtxTable() = default;
         explicit PvtxTable(const std::string& columnName);
 
-        static PvtxTable serializeObject();
+        static PvtxTable serializationTestObject();
 
         const SimpleTable& getUnderSaturatedTable(size_t tableNumber) const;
         void init(const DeckKeyword& keyword, size_t tableIdx);

--- a/opm/input/eclipse/EclipseState/Tables/Regdims.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Regdims.hpp
@@ -48,7 +48,7 @@ namespace Opm {
             m_NPLMIX( nplmix )
         {}
 
-        static Regdims serializeObject()
+        static Regdims serializationTestObject()
         {
             return Regdims(1, 2, 3, 4, 5);
         }

--- a/opm/input/eclipse/EclipseState/Tables/Rock2dTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Rock2dTable.hpp
@@ -29,7 +29,7 @@ namespace Opm {
     public:
         Rock2dTable();
 
-        static Rock2dTable serializeObject();
+        static Rock2dTable serializationTestObject();
 
         void init(const Opm::DeckRecord& record, size_t tableIdx);
         size_t size() const;

--- a/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.hpp
@@ -29,7 +29,7 @@ namespace Opm {
     public:
         Rock2dtrTable();
 
-        static Rock2dtrTable serializeObject();
+        static Rock2dtrTable serializationTestObject();
 
         void init(const Opm::DeckRecord& record, size_t tableIdx);
         size_t size() const;

--- a/opm/input/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -33,7 +33,7 @@ namespace Opm {
                      bool hasStressOption,
                      const int tableID);
 
-        static RocktabTable serializeObject();
+        static RocktabTable serializationTestObject();
 
         const TableColumn& getPressureColumn() const;
         const TableColumn& getPoreVolumeMultiplierColumn() const;

--- a/opm/input/eclipse/EclipseState/Tables/RwgsaltTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/RwgsaltTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
     public:
         RwgsaltTable();
 
-        static RwgsaltTable serializeObject();
+        static RwgsaltTable serializationTestObject();
 
         void init(const Opm::DeckRecord& record1);
         size_t size() const;

--- a/opm/input/eclipse/EclipseState/Tables/SimpleTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/SimpleTable.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         SimpleTable(TableSchema, const DeckItem& deckItem, const int tableID);
         explicit SimpleTable( TableSchema );
 
-        static SimpleTable serializeObject();
+        static SimpleTable serializationTestObject();
 
         void addColumns();
         //! \brief Initialize deck item.

--- a/opm/input/eclipse/EclipseState/Tables/SkprpolyTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/SkprpolyTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
         SkprpolyTable() = default;
         explicit SkprpolyTable(const DeckKeyword& table);
 
-        static SkprpolyTable serializeObject();
+        static SkprpolyTable serializationTestObject();
 
         double referenceConcentration() const;
 

--- a/opm/input/eclipse/EclipseState/Tables/SkprwatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/SkprwatTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
         SkprwatTable() = default;
         explicit SkprwatTable(const DeckKeyword& table);
 
-        static SkprwatTable serializeObject();
+        static SkprwatTable serializationTestObject();
 
         const std::vector<std::vector<double>>& getSkinPressures() const;
 

--- a/opm/input/eclipse/EclipseState/Tables/SolventDensityTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/SolventDensityTable.hpp
@@ -25,7 +25,7 @@ namespace Opm {
 
     class SolventDensityTable {
     public:
-        static SolventDensityTable serializeObject();
+        static SolventDensityTable serializationTestObject();
 
         void init(const Opm::DeckRecord& record);
         const std::vector<double>& getSolventDensityColumn() const;

--- a/opm/input/eclipse/EclipseState/Tables/StandardCond.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/StandardCond.hpp
@@ -24,7 +24,7 @@ namespace Opm {
     struct StandardCond {
         StandardCond();
 
-        static StandardCond serializeObject();
+        static StandardCond serializationTestObject();
 
         bool operator==(const StandardCond& data) const {
             return temperature == data.temperature &&

--- a/opm/input/eclipse/EclipseState/Tables/TLMixpar.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TLMixpar.hpp
@@ -57,7 +57,7 @@ public:
 
     TLMixpar() = default;
     explicit TLMixpar(const Deck& deck);
-    static TLMixpar serializeObject();
+    static TLMixpar serializationTestObject();
     std::size_t size() const;
     bool empty() const;
     const TLMixRecord& operator[](const std::size_t index) const;

--- a/opm/input/eclipse/EclipseState/Tables/Tabdims.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/Tabdims.hpp
@@ -45,7 +45,7 @@ namespace Opm {
 
         explicit Tabdims(const Deck& deck);
 
-        static Tabdims serializeObject()
+        static Tabdims serializationTestObject()
         {
             Tabdims result;
             result.m_ntsfun = 1;

--- a/opm/input/eclipse/EclipseState/Tables/TableColumn.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableColumn.hpp
@@ -36,7 +36,7 @@ namespace Opm {
 
         TableColumn(const TableColumn& c2) { *this = c2; }
 
-        static TableColumn serializeObject();
+        static TableColumn serializationTestObject();
 
         size_t size( ) const;
         const std::string& name() const;

--- a/opm/input/eclipse/EclipseState/Tables/TableContainer.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableContainer.hpp
@@ -64,7 +64,7 @@ namespace Opm {
         TableContainer();
         explicit TableContainer( size_t maxTables );
 
-        static TableContainer serializeObject();
+        static TableContainer serializationTestObject();
 
         bool empty() const;
 

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
@@ -67,7 +67,7 @@ namespace Opm {
         explicit TableManager( const Deck& deck );
         TableManager() = default;
 
-        static TableManager serializeObject();
+        static TableManager serializationTestObject();
 
         const TableContainer& getTables( const std::string& tableName ) const;
         const TableContainer& operator[](const std::string& tableName) const;

--- a/opm/input/eclipse/EclipseState/Tables/TableSchema.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableSchema.hpp
@@ -30,7 +30,7 @@ namespace Opm {
 
     class TableSchema {
     public:
-        static TableSchema serializeObject();
+        static TableSchema serializationTestObject();
 
         void addColumn( ColumnSchema );
         const ColumnSchema& getColumn( const std::string& name ) const;

--- a/opm/input/eclipse/EclipseState/TracerConfig.hpp
+++ b/opm/input/eclipse/EclipseState/TracerConfig.hpp
@@ -110,7 +110,7 @@ public:
     TracerConfig() = default;
     TracerConfig(const UnitSystem& unit_system, const Deck& deck);
 
-    static TracerConfig serializeObject();
+    static TracerConfig serializationTestObject();
 
     size_t size() const;
     bool empty() const;

--- a/opm/input/eclipse/Schedule/Action/ASTNode.hpp
+++ b/opm/input/eclipse/Schedule/Action/ASTNode.hpp
@@ -20,7 +20,7 @@ public:
     ASTNode(double value);
     ASTNode(TokenType type_arg, FuncType func_type_arg, const std::string& func_arg, const std::vector<std::string>& arg_list_arg);
 
-    static ASTNode serializeObject();
+    static ASTNode serializationTestObject();
 
     Action::Result eval(const Action::Context& context) const;
     Action::Value value(const Action::Context& context) const;

--- a/opm/input/eclipse/Schedule/Action/Actdims.hpp
+++ b/opm/input/eclipse/Schedule/Action/Actdims.hpp
@@ -32,7 +32,7 @@ public:
     Actdims();
     explicit Actdims(const Deck& deck);
 
-    static Actdims serializeObject();
+    static Actdims serializationTestObject();
 
     std::size_t max_keywords() const;
     std::size_t max_line_count() const;

--- a/opm/input/eclipse/Schedule/Action/ActionAST.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionAST.hpp
@@ -46,7 +46,7 @@ public:
     AST() = default;
     explicit AST(const std::vector<std::string>& tokens);
 
-    static AST serializeObject();
+    static AST serializationTestObject();
 
     Result eval(const Context& context) const;
 

--- a/opm/input/eclipse/Schedule/Action/ActionResult.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionResult.hpp
@@ -88,7 +88,7 @@ public:
         serializer(this->well_set);
     }
 
-    static WellSet serializeObject();
+    static WellSet serializationTestObject();
 
 private:
     std::unordered_set<std::string> well_set;
@@ -121,7 +121,7 @@ public:
         serializer(this->matching_wells);
     }
 
-    static Result serializeObject();
+    static Result serializationTestObject();
 
 private:
     void assign(bool value);

--- a/opm/input/eclipse/Schedule/Action/ActionX.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.hpp
@@ -79,7 +79,7 @@ public:
     ActionX(const DeckRecord& record, std::time_t start_time);
     explicit ActionX(const RestartIO::RstAction& rst_action);
 
-    static ActionX serializeObject();
+    static ActionX serializationTestObject();
 
     void addKeyword(const DeckKeyword& kw);
     bool ready(const State& state, std::time_t sim_time) const;

--- a/opm/input/eclipse/Schedule/Action/Actions.hpp
+++ b/opm/input/eclipse/Schedule/Action/Actions.hpp
@@ -43,7 +43,7 @@ public:
     Actions() = default;
     Actions(const std::vector<ActionX>& action, const std::vector<PyAction>& pyactions);
 
-    static Actions serializeObject();
+    static Actions serializationTestObject();
 
     std::size_t py_size() const;
     std::size_t ecl_size() const;

--- a/opm/input/eclipse/Schedule/Action/PyAction.hpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.hpp
@@ -48,7 +48,7 @@ public:
 
 
     static RunCount from_string(std::string run_count);
-    static PyAction serializeObject();
+    static PyAction serializationTestObject();
     PyAction() = default;
     PyAction(std::shared_ptr<const Python> python, const std::string& name, RunCount run_count, const std::string& module_file);
     bool run(EclipseState& ecl_state, Schedule& schedule, std::size_t report_step, SummaryState& st,

--- a/opm/input/eclipse/Schedule/Action/State.hpp
+++ b/opm/input/eclipse/Schedule/Action/State.hpp
@@ -52,7 +52,7 @@ struct RunState {
         this->run_count += 1;
     }
 
-    static RunState serializeObject()
+    static RunState serializationTestObject()
     {
         RunState rs;
         rs.run_count = 100;
@@ -97,7 +97,7 @@ public:
     }
 
 
-    static State serializeObject();
+    static State serializationTestObject();
     bool operator==(const State& other) const;
 
 private:

--- a/opm/input/eclipse/Schedule/Action/WGNames.hpp
+++ b/opm/input/eclipse/Schedule/Action/WGNames.hpp
@@ -34,7 +34,7 @@ public:
 
     bool has_well(const std::string& wname) const;
     bool has_group(const std::string& gname) const;
-    static WGNames serializeObject();
+    static WGNames serializationTestObject();
     bool operator==(const WGNames& other) const;
 
     template<class Serializer>

--- a/opm/input/eclipse/Schedule/CompletedCells.hpp
+++ b/opm/input/eclipse/Schedule/CompletedCells.hpp
@@ -62,7 +62,7 @@ public:
                 serializer(this->ntg);
             }
 
-            static Props serializeObject(){
+            static Props serializationTestObject(){
                 Props props;
                 props.permx = 10.0;
                 props.permy = 78.0;
@@ -91,7 +91,7 @@ public:
                    this->props == other.props;
         }
 
-        static Cell serializeObject() {
+        static Cell serializationTestObject() {
             Cell cell(0,1,1,1);
             cell.depth = 12345;
             cell.dimensions = {1.0,2.0,3.0};
@@ -127,7 +127,7 @@ public:
     std::pair<bool, Cell&> try_get(std::size_t i, std::size_t j, std::size_t k);
 
     bool operator==(const CompletedCells& other) const;
-    static CompletedCells serializeObject();
+    static CompletedCells serializationTestObject();
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/input/eclipse/Schedule/Events.hpp
+++ b/opm/input/eclipse/Schedule/Events.hpp
@@ -146,7 +146,7 @@ namespace Opm
 
     class Events {
     public:
-        static Events serializeObject();
+        static Events serializationTestObject();
 
         void addEvent(ScheduleEvents::Events event);
         bool hasEvent(uint64_t eventMask) const;
@@ -168,7 +168,7 @@ namespace Opm
 
     class WellGroupEvents {
     public:
-        static WellGroupEvents serializeObject();
+        static WellGroupEvents serializationTestObject();
 
         void addWell(const std::string& wname);
         void addGroup(const std::string& gname);

--- a/opm/input/eclipse/Schedule/GasLiftOpt.hpp
+++ b/opm/input/eclipse/Schedule/GasLiftOpt.hpp
@@ -82,7 +82,7 @@ public:
         }
 
 
-        static Group serializeObject() {
+        static Group serializationTestObject() {
             Group group;
             group.m_name = "GR";
             group.m_max_lift_gas  = 100;
@@ -217,7 +217,7 @@ public:
             serializer(m_alloc_extra_gas);
         }
 
-        static Well serializeObject() {
+        static Well serializationTestObject() {
             Well well;
             well.m_name = "WELL";
             well.m_max_rate = 2000;
@@ -269,7 +269,7 @@ public:
     bool has_group(const std::string& group) const;
     std::size_t num_wells() const;
 
-    static GasLiftOpt serializeObject();
+    static GasLiftOpt serializationTestObject();
     bool operator==(const GasLiftOpt& other) const;
 
     template<class Serializer>

--- a/opm/input/eclipse/Schedule/Group/GConSale.hpp
+++ b/opm/input/eclipse/Schedule/Group/GConSale.hpp
@@ -73,7 +73,7 @@ namespace Opm {
             MaxProcedure max_proc;
         };
 
-        static GConSale serializeObject();
+        static GConSale serializationTestObject();
         
         bool has(const std::string& name) const;
         const GCONSALEGroup& get(const std::string& name) const;

--- a/opm/input/eclipse/Schedule/Group/GConSump.hpp
+++ b/opm/input/eclipse/Schedule/Group/GConSump.hpp
@@ -64,7 +64,7 @@ namespace Opm {
             std::string network_node;
         };
 
-        static GConSump serializeObject();
+        static GConSump serializationTestObject();
 
         bool has(const std::string& name) const;
         const GCONSUMPGroup& get(const std::string& name) const;

--- a/opm/input/eclipse/Schedule/Group/GPMaint.hpp
+++ b/opm/input/eclipse/Schedule/Group/GPMaint.hpp
@@ -51,7 +51,7 @@ friend class GPMaint;
 
     GPMaint() = default;
     GPMaint(std::size_t report_step, const DeckRecord& record);
-    static GPMaint serializeObject();
+    static GPMaint serializationTestObject();
 
     double pressure_target() const;
     double prop_constant() const;

--- a/opm/input/eclipse/Schedule/Group/Group.hpp
+++ b/opm/input/eclipse/Schedule/Group/Group.hpp
@@ -146,7 +146,7 @@ struct GroupInjectionProperties {
     double guide_rate = 0;
     GuideRateInjTarget guide_rate_def = GuideRateInjTarget::NO_GUIDE_RATE;
 
-    static GroupInjectionProperties serializeObject();
+    static GroupInjectionProperties serializationTestObject();
 
     int injection_controls = 0;
     bool operator==(const GroupInjectionProperties& other) const;
@@ -203,7 +203,7 @@ struct GroupProductionProperties {
     GuideRateProdTarget guide_rate_def = GuideRateProdTarget::NO_GUIDE_RATE;
     double resv_target = 0;
     bool available_group_control = true;
-    static GroupProductionProperties serializeObject();
+    static GroupProductionProperties serializationTestObject();
 
     int production_controls = 0;
     bool operator==(const GroupProductionProperties& other) const;
@@ -248,7 +248,7 @@ struct ProductionControls {
     Group(const std::string& group_name, std::size_t insert_index_arg, double udq_undefined_arg, const UnitSystem& unit_system);
     Group(const RestartIO::RstGroup& rst_group, std::size_t insert_index_arg, double udq_undefined_arg, const UnitSystem& unit_system);
 
-    static Group serializeObject();
+    static Group serializationTestObject();
 
     std::size_t insert_index() const;
     const std::string& name() const;

--- a/opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp
@@ -89,7 +89,7 @@ struct GroupInjTarget {
     }
 };
 
-    static GuideRateConfig serializeObject();
+    static GuideRateConfig serializationTestObject();
 
     const GuideRateModel& model() const;
     bool has_model() const;

--- a/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
@@ -65,7 +65,7 @@ public:
                           double damping_factor);
 
 
-    static GuideRateModel serializeObject();
+    static GuideRateModel serializationTestObject();
 
     double eval(double oil_pot, double gas_pot, double wat_pot) const;
     bool updateLINCOM(const UDAValue& alpha, const UDAValue& beta, const UDAValue& gamma) const;

--- a/opm/input/eclipse/Schedule/MSW/AICD.hpp
+++ b/opm/input/eclipse/Schedule/MSW/AICD.hpp
@@ -37,7 +37,7 @@ namespace Opm {
         AutoICD() = default;
         AutoICD(const DeckRecord& record);
 
-        static AutoICD serializeObject();
+        static AutoICD serializationTestObject();
 
         // the function will return a map
         // [

--- a/opm/input/eclipse/Schedule/MSW/SICD.hpp
+++ b/opm/input/eclipse/Schedule/MSW/SICD.hpp
@@ -51,7 +51,7 @@ namespace Opm {
              ICDStatus status,
              double scalingFactor);
 
-        static SICD serializeObject();
+        static SICD serializationTestObject();
 
         // the function will return a map
         // [

--- a/opm/input/eclipse/Schedule/MSW/Segment.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.hpp
@@ -49,7 +49,7 @@ namespace Opm {
         void serializeOp(Serializer&) {
         }
 
-        static RegularSegment serializeObject() {
+        static RegularSegment serializationTestObject() {
             return RegularSegment();
         }
 
@@ -79,7 +79,7 @@ namespace Opm {
                 double internal_diameter_in, double roughness_in, double cross_area_in, double volume_in, bool data_ready_in);
         Segment(const RestartIO::RstSegment& rst_segment);
 
-        static Segment serializeObject();
+        static Segment serializationTestObject();
 
         int segmentNumber() const;
         int branchNumber() const;

--- a/opm/input/eclipse/Schedule/MSW/Valve.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Valve.hpp
@@ -48,7 +48,7 @@ namespace Opm {
               double pipeCrossA,
               ICDStatus stat);
 
-        static Valve serializeObject();
+        static Valve serializationTestObject();
 
         // the function will return a map
         // [

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -71,7 +71,7 @@ namespace Opm {
         explicit WellSegments(const DeckKeyword& keyword);
         void loadWELSEGS( const DeckKeyword& welsegsKeyword);
 
-        static WellSegments serializeObject();
+        static WellSegments serializationTestObject();
 
         std::size_t size() const;
         double depthTopSegment() const;

--- a/opm/input/eclipse/Schedule/MessageLimits.hpp
+++ b/opm/input/eclipse/Schedule/MessageLimits.hpp
@@ -30,7 +30,7 @@ namespace Opm {
         MessageLimits();
         explicit MessageLimits(const Deck& deck);
 
-        static MessageLimits serializeObject();
+        static MessageLimits serializationTestObject();
 
         ///Get all the value from MESSAGES keyword.
         int getMessagePrintLimit() const;

--- a/opm/input/eclipse/Schedule/Network/Balance.hpp
+++ b/opm/input/eclipse/Schedule/Network/Balance.hpp
@@ -49,7 +49,7 @@ public:
     explicit Balance(bool network_active);
     explicit Balance(const RestartIO::RstNetbalan& netbalan);
 
-    static Balance serializeObject();
+    static Balance serializationTestObject();
 
     CalcMode mode() const;
     double interval() const;

--- a/opm/input/eclipse/Schedule/Network/Branch.hpp
+++ b/opm/input/eclipse/Schedule/Network/Branch.hpp
@@ -49,7 +49,7 @@ public:
     AlqEQ alq_eq() const;
     std::optional<double> alq_value() const;
 
-    static Branch serializeObject();
+    static Branch serializationTestObject();
     bool operator==(const Branch& other) const;
 
     template<class Serializer>

--- a/opm/input/eclipse/Schedule/Network/ExtNetwork.hpp
+++ b/opm/input/eclipse/Schedule/Network/ExtNetwork.hpp
@@ -50,7 +50,7 @@ public:
     int NoOfBranches() const;
 
     bool operator==(const ExtNetwork& other) const;
-    static ExtNetwork serializeObject();
+    static ExtNetwork serializationTestObject();
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/input/eclipse/Schedule/Network/Node.hpp
+++ b/opm/input/eclipse/Schedule/Network/Node.hpp
@@ -42,7 +42,7 @@ public:
     void add_gas_lift_gas(bool add_gas);
     void as_choke(const std::string& target_group);
 
-    static Node serializeObject();
+    static Node serializationTestObject();
     bool operator==(const Node& other) const;
 
     template<class Serializer>

--- a/opm/input/eclipse/Schedule/OilVaporizationProperties.hpp
+++ b/opm/input/eclipse/Schedule/OilVaporizationProperties.hpp
@@ -44,7 +44,7 @@ namespace Opm
         OilVaporizationProperties();
         explicit OilVaporizationProperties(const size_t numPvtReginIdx);
 
-        static OilVaporizationProperties serializeObject();
+        static OilVaporizationProperties serializationTestObject();
 
         static void updateDRSDT(Opm::OilVaporizationProperties& ovp, const std::vector<double>& maxDRSDT, const std::vector<std::string>& option);
         static void updateDRSDTCON(Opm::OilVaporizationProperties& ovp, const std::vector<double>& maxDRSDT, const std::vector<std::string>& option);

--- a/opm/input/eclipse/Schedule/RFTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RFTConfig.hpp
@@ -68,7 +68,7 @@ public:
     std::optional<RFTConfig> next() const;
     std::optional<RFTConfig> well_open(const std::string& wname) const;
 
-    static RFTConfig serializeObject();
+    static RFTConfig serializationTestObject();
     bool operator==(const RFTConfig& data) const;
 
     template <class Serializer>
@@ -86,7 +86,7 @@ private:
     using StateMap = std::unordered_map<std::string, Kind>;
 
     // Please make sure that member functions serializeOp(), operator==(),
-    // and serializeObject() are also up to date when changing this list of
+    // and serializationTestObject() are also up to date when changing this list of
     // data members.
     bool first_open_rft = false;
     StateMap<RFT> rft_state{};

--- a/opm/input/eclipse/Schedule/RPTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RPTConfig.hpp
@@ -44,7 +44,7 @@ public:
     std::size_t size() const { return this->m_mnemonics.size(); };
     unsigned& at(const std::string& key) { return this->m_mnemonics.at(key); };
 
-    static RPTConfig serializeObject();
+    static RPTConfig serializationTestObject();
     bool operator==(const RPTConfig& other) const;
 
 private:

--- a/opm/input/eclipse/Schedule/RSTConfig.hpp
+++ b/opm/input/eclipse/Schedule/RSTConfig.hpp
@@ -200,7 +200,7 @@ public:
     void update(const DeckKeyword& keyword, const ParseContext& parseContext, ErrorGuard& errors);
     void init_next();
     static RSTConfig first(const RSTConfig& src);
-    static RSTConfig serializeObject();
+    static RSTConfig serializationTestObject();
 
     template<class Serializer>
     void serializeOp(Serializer& serializer) {

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -111,15 +111,15 @@ namespace Opm
         }
 
 
-        static ScheduleStatic serializeObject() {
+        static ScheduleStatic serializationTestObject() {
             auto python = std::make_shared<Python>(Python::Enable::OFF);
             ScheduleStatic st(python);
-            st.m_deck_message_limits = MessageLimits::serializeObject();
-            st.m_runspec = Runspec::serializeObject();
+            st.m_deck_message_limits = MessageLimits::serializationTestObject();
+            st.m_runspec = Runspec::serializationTestObject();
             st.m_unit_system = UnitSystem::newFIELD();
             st.m_input_path = "Some/funny/path";
-            st.rst_config = RSTConfig::serializeObject();
-            st.rst_info = ScheduleRestartInfo::serializeObject();
+            st.rst_config = RSTConfig::serializationTestObject();
+            st.rst_info = ScheduleRestartInfo::serializationTestObject();
             return st;
         }
 
@@ -200,7 +200,7 @@ namespace Opm
                  const std::optional<int>& output_interval = {},
                  const RestartIO::RstState* rst = nullptr);
 
-        static Schedule serializeObject();
+        static Schedule serializationTestObject();
 
         /*
          * If the input deck does not specify a start time, Eclipse's 1. Jan
@@ -534,7 +534,7 @@ namespace Opm
 
         // Please update the member functions
         //   - operator==(const Schedule&) const
-        //   - serializeObject()
+        //   - serializationTestObject()
         //   - serializeOp(Serializer&)
         // when you update/change this list of data members.
         ScheduleStatic m_static;

--- a/opm/input/eclipse/Schedule/ScheduleDeck.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleDeck.hpp
@@ -68,7 +68,7 @@ namespace Opm {
         std::vector<DeckKeyword>::const_iterator end() const;
 
         bool operator==(const ScheduleBlock& other) const;
-        static ScheduleBlock serializeObject();
+        static ScheduleBlock serializationTestObject();
         template<class Serializer>
         void serializeOp(Serializer& serializer) {
             serializer(m_time_type);
@@ -98,7 +98,7 @@ namespace Opm {
 
         ScheduleRestartInfo(const RestartIO::RstState * rst, const Deck& deck);
         bool operator==(const ScheduleRestartInfo& other) const;
-        static ScheduleRestartInfo serializeObject();
+        static ScheduleRestartInfo serializationTestObject();
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -137,7 +137,7 @@ namespace Opm {
         double seconds(std::size_t timeStep) const;
 
         bool operator==(const ScheduleDeck& other) const;
-        static ScheduleDeck serializeObject();
+        static ScheduleDeck serializationTestObject();
         template<class Serializer>
         void serializeOp(Serializer& serializer) {
             serializer(m_restart_time);

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -256,9 +256,9 @@ namespace Opm {
             }
 
 
-            static map_member<K,T> serializeObject() {
+            static map_member<K,T> serializationTestObject() {
                 map_member<K,T> map_object;
-                T value_object = T::serializeObject();
+                T value_object = T::serializationTestObject();
                 K key = value_object.name();
                 map_object.m_data.emplace( key, std::make_shared<T>( std::move(value_object) ));
                 return map_object;
@@ -295,7 +295,7 @@ namespace Opm {
         bool first_in_year() const;
 
         bool operator==(const ScheduleState& other) const;
-        static ScheduleState serializeObject();
+        static ScheduleState serializationTestObject();
 
         void update_tuning(Tuning tuning);
         Tuning& tuning();

--- a/opm/input/eclipse/Schedule/ScheduleTypes.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleTypes.hpp
@@ -42,7 +42,7 @@ public:
     explicit WellType(Phase welspecs_phase);
     WellType() = default;
 
-    static WellType serializeObject();
+    static WellType serializationTestObject();
 
     bool injector() const;
     bool producer() const;

--- a/opm/input/eclipse/Schedule/SummaryState.hpp
+++ b/opm/input/eclipse/Schedule/SummaryState.hpp
@@ -140,7 +140,7 @@ public:
       serializer(conn_values);
     }
 
-    static SummaryState serializeObject()
+    static SummaryState serializationTestObject()
     {
         auto st = SummaryState{TimeService::from_time_t(101)};
 

--- a/opm/input/eclipse/Schedule/Tuning.hpp
+++ b/opm/input/eclipse/Schedule/Tuning.hpp
@@ -29,7 +29,7 @@ namespace Opm {
         double value() const;
         bool every_report() const;
         bool operator==(const NextStep& other) const;
-        static NextStep serializeObject();
+        static NextStep serializationTestObject();
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -46,7 +46,7 @@ namespace Opm {
     struct Tuning {
         Tuning();
 
-        static Tuning serializeObject();
+        static Tuning serializationTestObject();
 
         // Record1
         double TSINIT;

--- a/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
@@ -45,7 +45,7 @@ public:
     UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg);
     UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg, const std::vector<std::string>& selector);
 
-    static UDQASTNode serializeObject();
+    static UDQASTNode serializationTestObject();
 
     UDQSet eval(UDQVarType eval_target, const UDQContext& context) const;
 

--- a/opm/input/eclipse/Schedule/UDQ/UDQActive.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQActive.hpp
@@ -161,7 +161,7 @@ public:
         UDAControl control;
     };
 
-    static UDQActive serializeObject();
+    static UDQActive serializationTestObject();
     UDQActive() = default;
     static std::vector<RstRecord> load_rst(const UnitSystem& units,
                                            const UDQConfig& udq_config,

--- a/opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp
@@ -94,7 +94,7 @@ public:
     UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value, std::size_t report_step);
     UDQAssign(const std::string& keyword, const std::unordered_set<std::string>& selector, double value, std::size_t report_step);
 
-    static UDQAssign serializeObject();
+    static UDQAssign serializationTestObject();
 
     const std::string& keyword() const;
     UDQVarType var_type() const;

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -54,7 +54,7 @@ namespace Opm {
         explicit UDQConfig(const UDQParams& params);
         UDQConfig(const UDQParams& params, const RestartIO::RstState& rst_state);
 
-        static UDQConfig serializeObject();
+        static UDQConfig serializationTestObject();
 
         const std::string& unit(const std::string& key) const;
         bool has_unit(const std::string& keyword) const;

--- a/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
@@ -67,7 +67,7 @@ public:
               const ParseContext& parseContext,
               T&& errors);
 
-    static UDQDefine serializeObject();
+    static UDQDefine serializationTestObject();
 
     UDQSet eval(const UDQContext& context) const;
     const std::string& keyword() const;

--- a/opm/input/eclipse/Schedule/UDQ/UDQInput.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQInput.hpp
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    static UDQIndex serializeObject()
+    static UDQIndex serializationTestObject()
     {
         UDQIndex result;
         result.insert_index = 1;

--- a/opm/input/eclipse/Schedule/UDQ/UDQParams.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQParams.hpp
@@ -33,7 +33,7 @@ namespace Opm {
         explicit UDQParams(const Deck& deck);
         UDQParams();
 
-        static UDQParams serializeObject();
+        static UDQParams serializationTestObject();
 
         bool reseed() const;
         int rand_seed() const noexcept;

--- a/opm/input/eclipse/Schedule/UDQ/UDQState.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQState.hpp
@@ -55,7 +55,7 @@ public:
 
     bool operator==(const UDQState& other) const;
 
-    static UDQState serializeObject() {
+    static UDQState serializationTestObject() {
         UDQState st;
         st.undef_value = 78;
         st.scalar_values = {{"FU1", 100}, {"FU2", 200}};

--- a/opm/input/eclipse/Schedule/VFPInjTable.hpp
+++ b/opm/input/eclipse/Schedule/VFPInjTable.hpp
@@ -46,7 +46,7 @@ public:
     VFPInjTable();
     VFPInjTable(const DeckKeyword& table, const UnitSystem& deck_unit_system);
 
-    static VFPInjTable serializeObject();
+    static VFPInjTable serializationTestObject();
 
     inline const KeywordLocation& location() const {
         return this->m_location;

--- a/opm/input/eclipse/Schedule/VFPProdTable.hpp
+++ b/opm/input/eclipse/Schedule/VFPProdTable.hpp
@@ -82,7 +82,7 @@ public:
                  const std::vector<double>& data);
     static Dimension ALQDimension(const ALQ_TYPE& alq_type, const UnitSystem& unit_system);
 
-    static VFPProdTable serializeObject();
+    static VFPProdTable serializationTestObject();
 
     inline int getTableNum() const {
         return m_table_num;

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -98,7 +98,7 @@ namespace RestartIO {
 
         Connection(const RestartIO::RstConnection& rst_connection, const ScheduleGrid& grid, const FieldPropsManager& fp);
 
-        static Connection serializeObject();
+        static Connection serializationTestObject();
 
         bool attachedToSegment() const;
         bool sameCoordinate(const int i, const int j, const int k) const;

--- a/opm/input/eclipse/Schedule/Well/NameOrder.hpp
+++ b/opm/input/eclipse/Schedule/Well/NameOrder.hpp
@@ -52,7 +52,7 @@ public:
         serializer(m_name_list);
     }
 
-    static NameOrder serializeObject();
+    static NameOrder serializationTestObject();
 
     const std::string& operator[](std::size_t index) const;
     bool operator==(const NameOrder& other) const;
@@ -79,7 +79,7 @@ public:
         serializer(m_name_list);
         serializer(m_max_groups);
     }
-    static GroupOrder serializeObject();
+    static GroupOrder serializationTestObject();
 
     bool operator==(const GroupOrder& other) const;
     std::vector<std::string>::const_iterator begin() const;

--- a/opm/input/eclipse/Schedule/Well/PAvg.hpp
+++ b/opm/input/eclipse/Schedule/Well/PAvg.hpp
@@ -52,7 +52,7 @@ public:
         serializer(m_open_connections);
     }
 
-    static PAvg serializeObject();
+    static PAvg serializationTestObject();
 
     bool operator==(const PAvg& other) const;
     bool operator!=(const PAvg& other) const;

--- a/opm/input/eclipse/Schedule/Well/WListManager.hpp
+++ b/opm/input/eclipse/Schedule/Well/WListManager.hpp
@@ -35,7 +35,7 @@ class WListManager {
 public:
     WListManager() = default;
     explicit WListManager(const RestartIO::RstState& rst_state);
-    static WListManager serializeObject();
+    static WListManager serializationTestObject();
 
     std::size_t WListSize() const;
     bool hasList(const std::string&) const;

--- a/opm/input/eclipse/Schedule/Well/WVFPEXP.hpp
+++ b/opm/input/eclipse/Schedule/Well/WVFPEXP.hpp
@@ -29,7 +29,7 @@ namespace Opm {
     class WVFPEXP
     {
     public:
-        static WVFPEXP serializeObject();
+        static WVFPEXP serializationTestObject();
 
         void update(const DeckRecord& record);
 

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -185,7 +185,7 @@ public:
         GuideRateTarget guide_phase;
         double scale_factor;
 
-        static WellGuideRate serializeObject()
+        static WellGuideRate serializationTestObject()
         {
             WellGuideRate result;
             result.available = true;
@@ -270,7 +270,7 @@ public:
         WellInjectionProperties();
         WellInjectionProperties(const UnitSystem& units, const std::string& wname);
 
-        static WellInjectionProperties serializeObject();
+        static WellInjectionProperties serializationTestObject();
 
         void handleWELTARG(WELTARGCMode cmode, const UDAValue& new_arg, double SIFactorP);
         void handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name);
@@ -406,7 +406,7 @@ public:
         WellProductionProperties();
         WellProductionProperties(const UnitSystem& units, const std::string& name_arg);
 
-        static WellProductionProperties serializeObject();
+        static WellProductionProperties serializationTestObject();
 
         bool hasProductionControl(ProducerCMode controlModeArg) const {
             return (m_productionControls & static_cast<int>(controlModeArg)) != 0;
@@ -507,7 +507,7 @@ public:
          const UnitSystem& unit_system,
          double udq_undefined);
 
-    static Well serializeObject();
+    static Well serializationTestObject();
 
     bool isMultiSegment() const;
     bool isAvailableForGroupControl() const;

--- a/opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp
@@ -33,7 +33,7 @@ struct WellBrineProperties
     bool operator!=(const WellBrineProperties& other) const;
     bool operator==(const WellBrineProperties& other) const;
 
-    static WellBrineProperties serializeObject();
+    static WellBrineProperties serializationTestObject();
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -50,7 +50,7 @@ namespace Opm {
         WellConnections(const Connection::Order ordering, const int headI, const int headJ,
                         const std::vector<Connection>& connections);
 
-        static WellConnections serializeObject();
+        static WellConnections serializationTestObject();
 
         // cppcheck-suppress noExplicitConstructor
         template <class Grid>

--- a/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp
@@ -60,7 +60,7 @@ namespace Opm {
         explicit WellEconProductionLimits(const DeckRecord& record);
         explicit WellEconProductionLimits(const RestartIO::RstWell& rstWell);
 
-        static WellEconProductionLimits serializeObject();
+        static WellEconProductionLimits serializationTestObject();
 
         // TODO: not handling things related to m_secondary_max_water_cut
         // for the moment.

--- a/opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp
@@ -27,7 +27,7 @@ class DeckRecord;
 
 struct WellFoamProperties
 {
-    static WellFoamProperties serializeObject();
+    static WellFoamProperties serializationTestObject();
 
     double m_foamConcentration = 0.0;
     void handleWFOAM(const DeckRecord& rec);

--- a/opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp
@@ -27,7 +27,7 @@ class DeckRecord;
 
 struct WellMICPProperties
 {
-    static WellMICPProperties serializeObject();
+    static WellMICPProperties serializationTestObject();
 
     double m_microbialConcentration = 0.0;
     double m_oxygenConcentration = 0.0;

--- a/opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp
@@ -32,7 +32,7 @@ namespace Opm {
         int m_skprwattable = -1;
         int m_skprpolytable = -1;
 
-        static WellPolymerProperties serializeObject();
+        static WellPolymerProperties serializationTestObject();
 
         bool operator==(const WellPolymerProperties& other) const;
         bool operator!=(const WellPolymerProperties& other) const;

--- a/opm/input/eclipse/Schedule/Well/WellTestConfig.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestConfig.hpp
@@ -88,7 +88,7 @@ public:
         bool test_well(int num_attempt, double elapsed) const;
 
         static int inverse_ecl_reasons(int ecl_reasons);
-        static WTESTWell serializeObject();
+        static WTESTWell serializationTestObject();
         int ecl_reasons() const;
 
         template<class Serializer>
@@ -103,7 +103,7 @@ public:
         }
     };
 
-    static WellTestConfig serializeObject();
+    static WellTestConfig serializationTestObject();
 
     WellTestConfig() = default;
     WellTestConfig(const RestartIO::RstState& rst_state, int report_step);

--- a/opm/input/eclipse/Schedule/Well/WellTestState.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.hpp
@@ -114,7 +114,7 @@ public:
                    this->wtest_report_step == other.wtest_report_step;
         }
 
-        static WTestWell serializeObject();
+        static WTestWell serializationTestObject();
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -162,7 +162,7 @@ public:
                    this->num_attempt == other.num_attempt;
         }
 
-        static ClosedCompletion serializeObject();
+        static ClosedCompletion serializationTestObject();
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -279,7 +279,7 @@ public:
     }
 
 
-    static WellTestState serializeObject();
+    static WellTestState serializationTestObject();
     bool operator==(const WellTestState& other) const;
 
     std::optional<WellTestState::RestartWell> restart_well(const Opm::WellTestConfig& config, const std::string& wname) const;

--- a/opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp
@@ -28,7 +28,7 @@ namespace Opm {
     class WellTracerProperties {
 
     public:
-        static WellTracerProperties serializeObject();
+        static WellTracerProperties serializationTestObject();
 
         void setConcentration(const std::string& name, const double& concentration);
         double getConcentration(const std::string& name) const;

--- a/opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp
+++ b/opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp
@@ -41,7 +41,7 @@ public:
 
     bool operator==(const WriteRestartFileEvents& that) const;
 
-    static WriteRestartFileEvents serializeObject();
+    static WriteRestartFileEvents serializationTestObject();
 
     template <class Serializer>
     void serializeOp(Serializer& serializer)

--- a/opm/input/eclipse/Units/Dimension.hpp
+++ b/opm/input/eclipse/Units/Dimension.hpp
@@ -30,7 +30,7 @@ namespace Opm {
         Dimension(double SIfactor,
                   double SIoffset = 0.0);
 
-        static Dimension serializeObject();
+        static Dimension serializationTestObject();
 
         double getSIScaling() const;
         double getSIOffset() const;

--- a/opm/input/eclipse/Units/UnitSystem.hpp
+++ b/opm/input/eclipse/Units/UnitSystem.hpp
@@ -89,7 +89,7 @@ namespace Opm {
         explicit UnitSystem(UnitType unit = UnitType::UNIT_TYPE_METRIC);
         explicit UnitSystem(const std::string& deck_name);
 
-        static UnitSystem serializeObject();
+        static UnitSystem serializationTestObject();
 
         const std::string& getName() const;
         UnitType getType() const;

--- a/opm/output/data/Aquifer.hpp
+++ b/opm/output/data/Aquifer.hpp
@@ -60,7 +60,7 @@ namespace Opm { namespace data {
             serializer(timeConstant);
         }
 
-        static FetkovichData serializeObject()
+        static FetkovichData serializationTestObject()
         {
           return FetkovichData{1.0, 2.0, 3.0};
         }
@@ -97,7 +97,7 @@ namespace Opm { namespace data {
             serializer(dimensionless_pressure);
         }
 
-        static CarterTracyData serializeObject()
+        static CarterTracyData serializationTestObject()
         {
             return CarterTracyData{1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
         }
@@ -123,7 +123,7 @@ namespace Opm { namespace data {
             serializer(initPressure);
         }
 
-        static NumericAquiferData serializeObject()
+        static NumericAquiferData serializationTestObject()
         {
             return NumericAquiferData{{1.0, 2.0, 3.0}};
         }
@@ -350,7 +350,7 @@ namespace Opm { namespace data {
             serializer(typeData);
         }
 
-        static AquiferData serializeObjectF()
+        static AquiferData serializationTestObjectF()
         {
             auto aquifer = AquiferData {1, 123.456, 56.78, 9.0e10, 290.0, 2515.5};
             auto* aquFet = aquifer.typeData.create<AquiferType::Fetkovich>();
@@ -361,7 +361,7 @@ namespace Opm { namespace data {
             return aquifer;
         }
 
-        static AquiferData serializeObjectC()
+        static AquiferData serializationTestObjectC()
         {
             auto aquifer = AquiferData {2, 123.456, 56.78, 9.0e10, 290.0, 2515.5};
             auto* aquCT = aquifer.typeData.create<AquiferType::CarterTracy>();
@@ -376,7 +376,7 @@ namespace Opm { namespace data {
             return aquifer;
         }
 
-        static AquiferData serializeObjectN()
+        static AquiferData serializationTestObjectN()
         {
           auto aquifer = AquiferData {3, 123.456, 56.78, 9.0e10, 290.0, 2515.5};
           auto* aquNum = aquifer.typeData.create<AquiferType::Numerical>();

--- a/opm/output/data/Cells.hpp
+++ b/opm/output/data/Cells.hpp
@@ -91,7 +91,7 @@ namespace data {
             serializer(target);
         }
 
-        static CellData serializeObject()
+        static CellData serializationTestObject()
         {
             return CellData{UnitSystem::measure::runtime,
                             {1.0, 2.0, 3.0},

--- a/opm/output/data/Groups.hpp
+++ b/opm/output/data/Groups.hpp
@@ -69,7 +69,7 @@ namespace Opm { namespace data {
             serializer(currentWaterInjectionConstraint);
         }
 
-        static GroupConstraints serializeObject()
+        static GroupConstraints serializationTestObject()
         {
             return GroupConstraints{Group::ProductionCMode::GRAT,
                                     Group::InjectionCMode::RATE,
@@ -116,10 +116,10 @@ namespace Opm { namespace data {
             serializer(injection);
         }
 
-        static GroupGuideRates serializeObject()
+        static GroupGuideRates serializationTestObject()
         {
-            return GroupGuideRates{GuideRateValue::serializeObject(),
-                                   GuideRateValue::serializeObject()};
+            return GroupGuideRates{GuideRateValue::serializationTestObject(),
+                                   GuideRateValue::serializationTestObject()};
         }
     };
 
@@ -163,10 +163,10 @@ namespace Opm { namespace data {
             serializer(guideRates);
         }
 
-        static GroupData serializeObject()
+        static GroupData serializationTestObject()
         {
-          return GroupData{GroupConstraints::serializeObject(),
-                           GroupGuideRates::serializeObject()};
+          return GroupData{GroupConstraints::serializationTestObject(),
+                           GroupGuideRates::serializationTestObject()};
         }
     };
 
@@ -200,7 +200,7 @@ namespace Opm { namespace data {
             serializer(pressure);
         }
 
-        static NodeData serializeObject()
+        static NodeData serializationTestObject()
         {
             return NodeData{10.0};
         }
@@ -264,11 +264,11 @@ namespace Opm { namespace data {
             serializer(nodeData);
         }
 
-        static GroupAndNetworkValues serializeObject()
+        static GroupAndNetworkValues serializationTestObject()
         {
             return GroupAndNetworkValues{
-                        {{"test_data", GroupData::serializeObject()}},
-                        {{"test_node", NodeData::serializeObject()}}
+                        {{"test_data", GroupData::serializationTestObject()}},
+                        {{"test_node", NodeData::serializationTestObject()}}
                    };
         }
 

--- a/opm/output/data/GuideRateValue.hpp
+++ b/opm/output/data/GuideRateValue.hpp
@@ -139,7 +139,7 @@ namespace Opm { namespace data {
            serializer(value_);
         }
 
-        static GuideRateValue serializeObject()
+        static GuideRateValue serializationTestObject()
         {
             GuideRateValue val;
             val.mask_ = std::bitset<Size>(1234);

--- a/opm/output/data/Solution.hpp
+++ b/opm/output/data/Solution.hpp
@@ -62,11 +62,11 @@ class Solution : public std::map< std::string, data::CellData > {
           serializer(si);
         }
 
-        static Solution serializeObject()
+        static Solution serializationTestObject()
         {
             Solution sol;
             sol.si = false;
-            sol.insert({"test_data", CellData::serializeObject()});
+            sol.insert({"test_data", CellData::serializationTestObject()});
 
             return sol;
         }

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -133,7 +133,7 @@ namespace Opm {
                 serializer(vaporized_water);
             }
 
-            static Rates serializeObject()
+            static Rates serializationTestObject()
             {
                 Rates rat1;
                 rat1.set(opt::wat, 1.0);
@@ -242,9 +242,9 @@ namespace Opm {
             serializer(trans_factor);
         }
 
-        static Connection serializeObject()
+        static Connection serializationTestObject()
         {
-            return Connection{1, Rates::serializeObject(),
+            return Connection{1, Rates::serializationTestObject(),
                               2.0, 3.0, 4.0, 5.0,
                               6.0, 7.0, 8.0};
         }
@@ -293,7 +293,7 @@ namespace Opm {
             serializer(values_);
         }
 
-        static SegmentPressures serializeObject()
+        static SegmentPressures serializationTestObject()
         {
             SegmentPressures spres;
             spres[Value::Pressure] = 1.0;
@@ -342,10 +342,10 @@ namespace Opm {
             serializer(segNumber);
         }
 
-        static Segment serializeObject()
+        static Segment serializationTestObject()
         {
-            return Segment{Rates::serializeObject(),
-                           SegmentPressures::serializeObject(),
+            return Segment{Rates::serializationTestObject(),
+                           SegmentPressures::serializationTestObject(),
                            10
                    };
         }
@@ -396,7 +396,7 @@ namespace Opm {
             serializer(inj);
         }
 
-        static CurrentControl serializeObject()
+        static CurrentControl serializationTestObject()
         {
           return CurrentControl{false,
                                 ::Opm::Well::ProducerCMode::BHP,
@@ -480,18 +480,18 @@ namespace Opm {
             serializer(guide_rates);
         }
 
-        static Well serializeObject()
+        static Well serializationTestObject()
         {
-            return Well{Rates::serializeObject(),
+            return Well{Rates::serializationTestObject(),
                         1.0,
                         2.0,
                         3.0,
                         4,
                         ::Opm::Well::Status::SHUT,
-                        {Connection::serializeObject()},
-                        {{0, Segment::serializeObject()}},
-                        CurrentControl::serializeObject(),
-                        GuideRateValue::serializeObject()
+                        {Connection::serializationTestObject()},
+                        {{0, Segment::serializationTestObject()}},
+                        CurrentControl::serializationTestObject(),
+                        GuideRateValue::serializationTestObject()
                    };
         }
     };
@@ -575,10 +575,10 @@ namespace Opm {
             serializer(static_cast<std::map<std::string,Well>&>(*this));
         }
 
-        static Wells serializeObject()
+        static Wells serializationTestObject()
         {
             Wells w;
-            w.insert({"test_well", Well::serializeObject()});
+            w.insert({"test_well", Well::serializationTestObject()});
 
             return w;
         }

--- a/opm/output/eclipse/RestartValue.hpp
+++ b/opm/output/eclipse/RestartValue.hpp
@@ -69,7 +69,7 @@ namespace Opm {
             serializer(required);
         }
 
-        static RestartKey serializeObject()
+        static RestartKey serializationTestObject()
         {
             return RestartKey{"test_key", UnitSystem::measure::effective_Kh, true};
         }
@@ -123,17 +123,17 @@ namespace Opm {
           serializer(extra);
         }
 
-        static RestartValue serializeObject()
+        static RestartValue serializationTestObject()
         {
             auto res = RestartValue {
-                           data::Solution::serializeObject(),
-                           data::Wells::serializeObject(),
-                           data::GroupAndNetworkValues::serializeObject(),
-                           {{1, data::AquiferData::serializeObjectF()},
-                            {2, data::AquiferData::serializeObjectC()},
-                            {3, data::AquiferData::serializeObjectN()}}
+                           data::Solution::serializationTestObject(),
+                           data::Wells::serializationTestObject(),
+                           data::GroupAndNetworkValues::serializationTestObject(),
+                           {{1, data::AquiferData::serializationTestObjectF()},
+                            {2, data::AquiferData::serializationTestObjectC()},
+                            {3, data::AquiferData::serializationTestObjectN()}}
                        };
-            res.extra = {{RestartKey::serializeObject(), {1.0, 2.0}}};
+            res.extra = {{RestartKey::serializationTestObject(), {1.0, 2.0}}};
 
             return res;
         }

--- a/src/opm/input/eclipse/Deck/Deck.cpp
+++ b/src/opm/input/eclipse/Deck/Deck.cpp
@@ -91,12 +91,12 @@ const DeckView& Deck::global_view() const {
     {
     }
 
-    Deck Deck::serializeObject()
+    Deck Deck::serializationTestObject()
     {
         Deck result;
-        result.keywordList = {DeckKeyword::serializeObject()};
-        result.defaultUnits = UnitSystem::serializeObject();
-        result.activeUnits = UnitSystem::serializeObject();
+        result.keywordList = {DeckKeyword::serializationTestObject()};
+        result.defaultUnits = UnitSystem::serializationTestObject();
+        result.activeUnits = UnitSystem::serializationTestObject();
         result.m_dataFile = "test1";
         result.input_path = "test2";
         result.unit_system_access_count = 1;

--- a/src/opm/input/eclipse/Deck/DeckItem.cpp
+++ b/src/opm/input/eclipse/Deck/DeckItem.cpp
@@ -113,7 +113,7 @@ DeckItem::DeckItem( const std::string& nm, UDAValue, const std::vector<Dimension
 {
 }
 
-DeckItem DeckItem::serializeObject()
+DeckItem DeckItem::serializationTestObject()
 {
     DeckItem result;
     result.dval = {1.0};
@@ -124,8 +124,8 @@ DeckItem DeckItem::serializeObject()
     result.item_name = "test2";
     result.value_status = {value::status::deck_value};
     result.raw_data = false;
-    result.active_dimensions = {Dimension::serializeObject()};
-    result.default_dimensions = {Dimension::serializeObject()};
+    result.active_dimensions = {Dimension::serializationTestObject()};
+    result.default_dimensions = {Dimension::serializationTestObject()};
 
     return result;
 }

--- a/src/opm/input/eclipse/Deck/DeckKeyword.cpp
+++ b/src/opm/input/eclipse/Deck/DeckKeyword.cpp
@@ -52,12 +52,12 @@ namespace Opm {
     {
     }
 
-    DeckKeyword DeckKeyword::serializeObject()
+    DeckKeyword DeckKeyword::serializationTestObject()
     {
         DeckKeyword result;
         result.m_keywordName = "test";
-        result.m_location = KeywordLocation::serializeObject();
-        result.m_recordList = {DeckRecord::serializeObject()};
+        result.m_location = KeywordLocation::serializationTestObject();
+        result.m_recordList = {DeckRecord::serializationTestObject()};
         result.m_isDataKeyword = true;
         result.m_slashTerminated = true;
         result.m_isDoubleRecordKeyword = true;

--- a/src/opm/input/eclipse/Deck/DeckRecord.cpp
+++ b/src/opm/input/eclipse/Deck/DeckRecord.cpp
@@ -55,10 +55,10 @@ namespace Opm {
         }
     }
 
-    DeckRecord DeckRecord::serializeObject()
+    DeckRecord DeckRecord::serializationTestObject()
     {
         DeckRecord result;
-        result.m_items = {DeckItem::serializeObject()};
+        result.m_items = {DeckItem::serializationTestObject()};
 
         return result;
     }

--- a/src/opm/input/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/input/eclipse/Deck/UDAValue.cpp
@@ -60,13 +60,13 @@ UDAValue::UDAValue(const std::string& value, const Dimension& dim_):
 {
 }
 
-UDAValue UDAValue::serializeObject()
+UDAValue UDAValue::serializationTestObject()
 {
     UDAValue result;
     result.numeric_value = true;
     result.double_value = 1.0;
     result.string_value = "test";
-    result.dim = Dimension::serializeObject();
+    result.dim = Dimension::serializationTestObject();
 
     return result;
 }

--- a/src/opm/input/eclipse/EclipseState/Aquifer/Aquancon.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/Aquancon.cpp
@@ -209,7 +209,7 @@ namespace Opm {
     }
 
 
-    Aquancon Aquancon::serializeObject()
+    Aquancon Aquancon::serializationTestObject()
     {
         Aquancon result;
         result.cells = {{1, {{2, 3, 4.0, 5.0, FaceDir::XPlus}}}};

--- a/src/opm/input/eclipse/EclipseState/Aquifer/AquiferCT.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/AquiferCT.cpp
@@ -166,7 +166,7 @@ AquiferCT::AQUCT_data::AQUCT_data(const int aqID,
     , initial_temperature(T0_)
 {}
 
-AquiferCT::AQUCT_data AquiferCT::AQUCT_data::serializeObject()
+AquiferCT::AQUCT_data AquiferCT::AQUCT_data::serializationTestObject()
 {
     auto ret = AQUCT_data {
         1, 2, 3, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0
@@ -258,9 +258,9 @@ void AquiferCT::loadFromRestart(const RestartIO::RstAquifer& rst,
     }
 }
 
-AquiferCT AquiferCT::serializeObject()
+AquiferCT AquiferCT::serializationTestObject()
 {
-    return { { AQUCT_data::serializeObject() } };
+    return { { AQUCT_data::serializationTestObject() } };
 }
 
 std::size_t AquiferCT::size() const {

--- a/src/opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.cpp
@@ -64,13 +64,13 @@ void AquiferConfig::loadFromRestart(const RestartIO::RstAquifer& aquifers,
     this->aqconn.loadFromRestart(aquifers);
 }
 
-AquiferConfig AquiferConfig::serializeObject()
+AquiferConfig AquiferConfig::serializationTestObject()
 {
     AquiferConfig result;
-    result.aquifetp = Aquifetp::serializeObject();
-    result.aquiferct = AquiferCT::serializeObject();
-    result.aqconn = Aquancon::serializeObject();
-    result.numerical_aquifers = NumericalAquifers::serializeObject();
+    result.aquifetp = Aquifetp::serializationTestObject();
+    result.aquiferct = AquiferCT::serializationTestObject();
+    result.aqconn = Aquancon::serializationTestObject();
+    result.numerical_aquifers = NumericalAquifers::serializationTestObject();
 
     return result;
 }

--- a/src/opm/input/eclipse/EclipseState/Aquifer/Aquifetp.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/Aquifetp.cpp
@@ -109,7 +109,7 @@ Aquifetp::AQUFETP_data::AQUFETP_data(const int aquiferID_,
     , initial_temperature (t0_)
 {}
 
-Aquifetp::AQUFETP_data Aquifetp::AQUFETP_data::serializeObject()
+Aquifetp::AQUFETP_data Aquifetp::AQUFETP_data::serializationTestObject()
 {
     auto ret = AQUFETP_data {
         1, 2, 3.0, 4.0, 5.0, 6.0, 7.0, 11.0
@@ -180,10 +180,10 @@ void Aquifetp::loadFromRestart(const RestartIO::RstAquifer& rst,
     }
 }
 
-Aquifetp Aquifetp::serializeObject()
+Aquifetp Aquifetp::serializationTestObject()
 {
     Aquifetp result;
-    result.m_aqufetp = { AQUFETP_data::serializeObject() };
+    result.m_aqufetp = { AQUFETP_data::serializationTestObject() };
 
     return result;
 }

--- a/src/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.cpp
@@ -127,7 +127,7 @@ namespace Opm {
         return this->m_aquifers.size();
     }
 
-    NumericalAquifers NumericalAquifers::serializeObject() {
+    NumericalAquifers NumericalAquifers::serializationTestObject() {
         NumericalAquifers result;
         result.m_aquifers  = {{1, SingleNumericalAquifer{1}}};
         return result;

--- a/src/opm/input/eclipse/EclipseState/EclipseConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/EclipseConfig.cpp
@@ -40,11 +40,11 @@ namespace Opm {
     }
 
 
-    EclipseConfig EclipseConfig::serializeObject()
+    EclipseConfig EclipseConfig::serializationTestObject()
     {
         EclipseConfig result;
-        result.m_initConfig = InitConfig::serializeObject();
-        result.io_config = IOConfig::serializeObject();
+        result.m_initConfig = InitConfig::serializationTestObject();
+        result.io_config = IOConfig::serializationTestObject();
 
         return result;
     }

--- a/src/opm/input/eclipse/EclipseState/EndpointScaling.cpp
+++ b/src/opm/input/eclipse/EclipseState/EndpointScaling.cpp
@@ -94,7 +94,7 @@ namespace {
 
 namespace Opm {
 
-EndpointScaling EndpointScaling::serializeObject()
+EndpointScaling EndpointScaling::serializationTestObject()
 {
     EndpointScaling result;
     result.options = std::bitset<4>{13};

--- a/src/opm/input/eclipse/EclipseState/Grid/Fault.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/Fault.cpp
@@ -27,12 +27,12 @@ namespace Opm {
     {
     }
 
-    Fault Fault::serializeObject()
+    Fault Fault::serializationTestObject()
     {
         Fault result;
         result.m_name = "test";
         result.m_transMult = 1.0;
-        result.m_faceList = {FaultFace::serializeObject()};
+        result.m_faceList = {FaultFace::serializationTestObject()};
 
         return result;
     }

--- a/src/opm/input/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -57,10 +57,10 @@ namespace Opm {
         }
     }
 
-    FaultCollection FaultCollection::serializeObject()
+    FaultCollection FaultCollection::serializationTestObject()
     {
         FaultCollection result;
-        result.m_faults.insert({"test", Fault::serializeObject()});
+        result.m_faults.insert({"test", Fault::serializationTestObject()});
 
         return result;
     }

--- a/src/opm/input/eclipse/EclipseState/Grid/FaultFace.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FaultFace.cpp
@@ -55,7 +55,7 @@ namespace Opm {
                 }
     }
 
-    FaultFace FaultFace::serializeObject()
+    FaultFace FaultFace::serializationTestObject()
     {
         FaultFace result;
         result.m_faceDir = FaceDir::YPlus;

--- a/src/opm/input/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/GridDims.cpp
@@ -49,7 +49,7 @@ namespace Opm {
         : m_nx(nx), m_ny(ny), m_nz(nz)
     {}
 
-    GridDims GridDims::serializeObject()
+    GridDims GridDims::serializationTestObject()
     {
         return { 1, 2, 3 };
     }

--- a/src/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -155,7 +155,7 @@ std::vector<int> unique(const std::vector<int>& data) {
         }
     }
 
-    MULTREGTScanner MULTREGTScanner::serializeObject()
+    MULTREGTScanner MULTREGTScanner::serializationTestObject()
     {
         MULTREGTScanner result;
         result.nx = 1;

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -172,7 +172,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
     }
 
 
-    NNC NNC::serializeObject()
+    NNC NNC::serializationTestObject()
     {
         NNC result;
         result.m_input= {{1,2,1.0},{2,3,2.0}};

--- a/src/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
@@ -62,7 +62,7 @@ namespace Opm {
         }
     }
 
-    TransMult TransMult::serializeObject()
+    TransMult TransMult::serializationTestObject()
     {
         TransMult result;
         result.m_nx = 1;
@@ -70,7 +70,7 @@ namespace Opm {
         result.m_nz = 3;
         result.m_trans = {{FaceDir::YPlus, {4.0, 5.0}}};
         result.m_names = {{FaceDir::ZPlus, "test1"}};
-        result.m_multregtScanner = MULTREGTScanner::serializeObject();
+        result.m_multregtScanner = MULTREGTScanner::serializationTestObject();
 
         return result;
     }

--- a/src/opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -86,7 +86,7 @@ namespace Opm {
         this->setBaseName(basename(input_path));
     }
 
-    IOConfig IOConfig::serializeObject()
+    IOConfig IOConfig::serializationTestObject()
     {
         IOConfig result;
         result.m_write_INIT_file = true;

--- a/src/opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
+++ b/src/opm/input/eclipse/EclipseState/InitConfig/Equil.cpp
@@ -118,7 +118,7 @@ namespace Opm {
         }
     }
 
-    Equil Equil::serializeObject()
+    Equil Equil::serializationTestObject()
     {
         Equil result;
         result.m_records = {{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, true, false, 1, false}};

--- a/src/opm/input/eclipse/EclipseState/InitConfig/FoamConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/InitConfig/FoamConfig.cpp
@@ -70,7 +70,7 @@ FoamData::FoamData(const DeckRecord& FOAMROCK_record)
 }
 
 FoamData
-FoamData::serializeObject()
+FoamData::serializationTestObject()
 {
     FoamData result;
     result.reference_surfactant_concentration_ = 1.0;
@@ -165,10 +165,10 @@ FoamConfig::FoamConfig(const Deck& deck)
 }
 
 FoamConfig
-FoamConfig::serializeObject()
+FoamConfig::serializationTestObject()
 {
     FoamConfig result;
-    result.data_ = {Opm::FoamData::serializeObject()};
+    result.data_ = {Opm::FoamData::serializationTestObject()};
     result.transport_phase_ = Phase::GAS;
     result.mobility_model_ = MobilityModel::TAB;
 

--- a/src/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -78,11 +78,11 @@ namespace Opm {
             this->setRestart( input_path + "/" + root, step );
     }
 
-    InitConfig InitConfig::serializeObject()
+    InitConfig InitConfig::serializationTestObject()
     {
         InitConfig result;
-        result.equil = Equil::serializeObject();
-        result.foamconfig = FoamConfig::serializeObject();
+        result.equil = Equil::serializationTestObject();
+        result.foamconfig = FoamConfig::serializationTestObject();
         result.m_filleps = true;
         result.m_gravity = false;
         result.m_restartRequested = true;

--- a/src/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -177,7 +177,7 @@ Phases::Phases( bool oil, bool gas, bool wat, bool sol, bool pol, bool energy, b
 
 {}
 
-Phases Phases::serializeObject()
+Phases Phases::serializationTestObject()
 {
     return Phases(true, true, true, false, true, false, true, false);
 }
@@ -222,7 +222,7 @@ Welldims::Welldims(const Deck& deck)
     }
 }
 
-Welldims Welldims::serializeObject()
+Welldims Welldims::serializationTestObject()
 {
     Welldims result;
     result.nWMax = 1;
@@ -231,7 +231,7 @@ Welldims Welldims::serializeObject()
     result.nGMax = 4;
     result.nWlistPrWellMax = 5;
     result.nDynWlistMax = 6;
-    result.m_location = KeywordLocation::serializeObject();
+    result.m_location = KeywordLocation::serializationTestObject();
     return result;
 }
 
@@ -252,7 +252,7 @@ WellSegmentDims::WellSegmentDims(const Deck& deck) : WellSegmentDims()
     }
 }
 
-WellSegmentDims WellSegmentDims::serializeObject()
+WellSegmentDims WellSegmentDims::serializationTestObject()
 {
     WellSegmentDims result;
     result.nSegWellMax = 1;
@@ -291,7 +291,7 @@ bool NetworkDims::active() const {
 }
 
 
-NetworkDims NetworkDims::serializeObject()
+NetworkDims NetworkDims::serializationTestObject()
 {
     NetworkDims result;
     result.nMaxNoNodes = 1;
@@ -327,7 +327,7 @@ AquiferDimensions::AquiferDimensions(const Deck& deck)
     }
 }
 
-AquiferDimensions AquiferDimensions::serializeObject()
+AquiferDimensions AquiferDimensions::serializationTestObject()
 {
     auto dim = AquiferDimensions{};
 
@@ -414,7 +414,7 @@ EclHysterConfig::EclHysterConfig(const Opm::Deck& deck)
         }
     }
 
-EclHysterConfig EclHysterConfig::serializeObject()
+EclHysterConfig EclHysterConfig::serializationTestObject()
 {
     EclHysterConfig result;
     result.activeHyst = true;
@@ -467,7 +467,7 @@ SatFuncControls::SatFuncControls(const double tolcritArg,
     , satfunc_family(family)
 {}
 
-SatFuncControls SatFuncControls::serializeObject()
+SatFuncControls SatFuncControls::serializationTestObject()
 {
     return SatFuncControls {
         1.0, ThreePhaseOilKrModel::Stone2, KeywordFamily::Family_I
@@ -498,7 +498,7 @@ void Nupcol::update(int value) {
     this->nupcol_value = std::max(value, this->min_nupcol);
 }
 
-Nupcol Nupcol::serializeObject() {
+Nupcol Nupcol::serializationTestObject() {
     Nupcol nc;
     nc.update(123);
     return nc;
@@ -525,7 +525,7 @@ bool Tracers::operator==(const Tracers& other) const {
         this->min_iter == other.min_iter;
 }
 
-Tracers Tracers::serializeObject() {
+Tracers Tracers::serializationTestObject() {
     Tracers tracers;
     tracers.m_oil_tracers = 123;
     tracers.m_gas_tracers = 77;
@@ -624,21 +624,21 @@ Runspec::Runspec( const Deck& deck )
     }
 }
 
-Runspec Runspec::serializeObject()
+Runspec Runspec::serializationTestObject()
 {
     Runspec result;
-    result.active_phases = Phases::serializeObject();
-    result.m_tabdims = Tabdims::serializeObject();
-    result.m_regdims = Regdims::serializeObject();
-    result.endscale = EndpointScaling::serializeObject();
-    result.welldims = Welldims::serializeObject();
-    result.wsegdims = WellSegmentDims::serializeObject();
-    result.aquiferdims = AquiferDimensions::serializeObject();
-    result.udq_params = UDQParams::serializeObject();
-    result.hystpar = EclHysterConfig::serializeObject();
-    result.m_actdims = Actdims::serializeObject();
-    result.m_sfuncctrl = SatFuncControls::serializeObject();
-    result.m_nupcol = Nupcol::serializeObject();
+    result.active_phases = Phases::serializationTestObject();
+    result.m_tabdims = Tabdims::serializationTestObject();
+    result.m_regdims = Regdims::serializationTestObject();
+    result.endscale = EndpointScaling::serializationTestObject();
+    result.welldims = Welldims::serializationTestObject();
+    result.wsegdims = WellSegmentDims::serializationTestObject();
+    result.aquiferdims = AquiferDimensions::serializationTestObject();
+    result.udq_params = UDQParams::serializationTestObject();
+    result.hystpar = EclHysterConfig::serializationTestObject();
+    result.m_actdims = Actdims::serializationTestObject();
+    result.m_sfuncctrl = SatFuncControls::serializationTestObject();
+    result.m_nupcol = Nupcol::serializationTestObject();
     result.m_co2storage = true;
     result.m_micp = true;
 

--- a/src/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
@@ -78,7 +78,7 @@ BCConfig::BCFace::BCFace(const DeckRecord& record) :
 {
 }
 
-BCConfig::BCFace BCConfig::BCFace::serializeObject()
+BCConfig::BCFace BCConfig::BCFace::serializationTestObject()
 {
     BCFace result;
     result.i1 = 10;
@@ -119,10 +119,10 @@ BCConfig::BCConfig(const Deck& deck) {
 }
 
 
-BCConfig BCConfig::serializeObject()
+BCConfig BCConfig::serializationTestObject()
 {
     BCConfig result;
-    result.m_faces = {BCFace::serializeObject()};
+    result.m_faces = {BCFace::serializationTestObject()};
 
     return result;
 }

--- a/src/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
@@ -82,7 +82,7 @@ RockConfig::RockComp::RockComp(double pref_arg, double comp_arg) :
     compressibility(comp_arg)
 {}
 
-RockConfig RockConfig::serializeObject()
+RockConfig RockConfig::serializationTestObject()
 {
     RockConfig result;
     result.m_active = true;

--- a/src/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -100,12 +100,12 @@ namespace Opm {
         }
     }
 
-    SimulationConfig SimulationConfig::serializeObject()
+    SimulationConfig SimulationConfig::serializationTestObject()
     {
         SimulationConfig result;
-        result.m_ThresholdPressure = ThresholdPressure::serializeObject();
-        result.m_bcconfig = BCConfig::serializeObject();
-        result.m_rock_config = RockConfig::serializeObject();
+        result.m_ThresholdPressure = ThresholdPressure::serializationTestObject();
+        result.m_bcconfig = BCConfig::serializationTestObject();
+        result.m_rock_config = RockConfig::serializationTestObject();
         result.m_useCPR = false;
         result.m_DISGAS = true;
         result.m_VAPOIL = false;

--- a/src/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/src/opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -127,7 +127,7 @@ namespace Opm {
         }
     }
 
-    ThresholdPressure ThresholdPressure::serializeObject()
+    ThresholdPressure ThresholdPressure::serializationTestObject()
     {
         ThresholdPressure result;
         result.m_active = false;

--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1515,12 +1515,12 @@ SummaryConfigNode::SummaryConfigNode(std::string keyword, const Category cat, Ke
     , loc      (std::move(loc_arg))
 {}
 
-SummaryConfigNode SummaryConfigNode::serializeObject()
+SummaryConfigNode SummaryConfigNode::serializationTestObject()
 {
     SummaryConfigNode result;
     result.keyword_ = "test1";
     result.category_ = Category::Region;
-    result.loc = KeywordLocation::serializeObject();
+    result.loc = KeywordLocation::serializationTestObject();
     result.type_ = Type::Pressure;
     result.name_ = "test2";
     result.number_ = 2;
@@ -1771,10 +1771,10 @@ SummaryConfig::SummaryConfig(const keyword_list& kwds,
     m_keywords(kwds), short_keywords(shortKwds), summary_keywords(smryKwds)
 {}
 
-SummaryConfig SummaryConfig::serializeObject()
+SummaryConfig SummaryConfig::serializationTestObject()
 {
     SummaryConfig result;
-    result.m_keywords = {SummaryConfigNode::serializeObject()};
+    result.m_keywords = {SummaryConfigNode::serializationTestObject()};
     result.short_keywords = {"test1"};
     result.summary_keywords = {"test2"};
 

--- a/src/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/BrineDensityTable.cpp
@@ -24,7 +24,7 @@
 #include <opm/input/eclipse/EclipseState/Tables/BrineDensityTable.hpp>
 
 namespace Opm {
-        BrineDensityTable BrineDensityTable::serializeObject()
+        BrineDensityTable BrineDensityTable::serializationTestObject()
         {
             BrineDensityTable result;
             result.m_tableValues = {1.0, 2.0, 3.0};

--- a/src/opm/input/eclipse/EclipseState/Tables/ColumnSchema.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/ColumnSchema.cpp
@@ -48,7 +48,7 @@ namespace Opm {
     {
     }
 
-    ColumnSchema ColumnSchema::serializeObject()
+    ColumnSchema ColumnSchema::serializationTestObject()
     {
         ColumnSchema result;
         result.m_name = "test1";

--- a/src/opm/input/eclipse/EclipseState/Tables/DenT.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/DenT.cpp
@@ -34,7 +34,7 @@ DenT::entry::entry(const DeckRecord& record) :
 {
 }
 
-DenT DenT::serializeObject()
+DenT DenT::serializationTestObject()
 {
     DenT result;
     result.m_records = {{1,2,3}, {4,5,6}};

--- a/src/opm/input/eclipse/EclipseState/Tables/JFunc.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/JFunc.cpp
@@ -69,7 +69,7 @@ namespace Opm {
             throw std::invalid_argument("Illegal JFUNC DIRECTION, must be XY, X, Y, or Z.  Was \"" + kw_dir + "\".");
     }
 
-    JFunc JFunc::serializeObject()
+    JFunc JFunc::serializationTestObject()
     {
         JFunc result;
         result.m_flag = Flag::BOTH;

--- a/src/opm/input/eclipse/EclipseState/Tables/JouleThomson.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/JouleThomson.cpp
@@ -33,7 +33,7 @@ JouleThomson::entry::entry(const DeckRecord& record) :
 {
 }
 
-JouleThomson JouleThomson::serializeObject()
+JouleThomson JouleThomson::serializationTestObject()
 {
    JouleThomson result;
     result.m_records = {{1,2}, {3,4}};

--- a/src/opm/input/eclipse/EclipseState/Tables/PolyInjTables.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/PolyInjTables.cpp
@@ -37,7 +37,7 @@
 namespace Opm{
 
     // PolyInjTable
-    PolyInjTable PolyInjTable::serializeObject()
+    PolyInjTable PolyInjTable::serializationTestObject()
     {
         PolyInjTable result;
         result.m_throughputs = {1.0};
@@ -79,10 +79,10 @@ namespace Opm{
 
 
     // PlymwinjTable
-    PlymwinjTable PlymwinjTable::serializeObject()
+    PlymwinjTable PlymwinjTable::serializationTestObject()
     {
         PlymwinjTable result;
-        static_cast<PolyInjTable&>(result) = PolyInjTable::serializeObject();
+        static_cast<PolyInjTable&>(result) = PolyInjTable::serializationTestObject();
 
         return result;
     }
@@ -137,10 +137,10 @@ namespace Opm{
 
 
     // SkprwatTable
-    SkprwatTable SkprwatTable::serializeObject()
+    SkprwatTable SkprwatTable::serializationTestObject()
     {
         SkprwatTable result;
-        static_cast<PolyInjTable&>(result) = PolyInjTable::serializeObject();
+        static_cast<PolyInjTable&>(result) = PolyInjTable::serializationTestObject();
 
         return result;
     }
@@ -194,10 +194,10 @@ namespace Opm{
     }
 
     // SkprpolyTable
-    SkprpolyTable SkprpolyTable::serializeObject()
+    SkprpolyTable SkprpolyTable::serializationTestObject()
     {
         SkprpolyTable result;
-        static_cast<PolyInjTable&>(result) = PolyInjTable::serializeObject();
+        static_cast<PolyInjTable&>(result) = PolyInjTable::serializationTestObject();
         result.m_ref_polymer_concentration = 3.0;
 
         return result;

--- a/src/opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/PvtwsaltTable.cpp
@@ -30,7 +30,7 @@ namespace Opm {
         {
         }
 
-        PvtwsaltTable PvtwsaltTable::serializeObject()
+        PvtwsaltTable PvtwsaltTable::serializationTestObject()
         {
             PvtwsaltTable result;
             result.m_pRefValues = 1.0;

--- a/src/opm/input/eclipse/EclipseState/Tables/PvtxTable.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/PvtxTable.cpp
@@ -46,15 +46,15 @@ namespace Opm {
 
     }
 
-    PvtxTable PvtxTable::serializeObject()
+    PvtxTable PvtxTable::serializationTestObject()
     {
         PvtxTable result;
-        result.m_outerColumnSchema = ColumnSchema::serializeObject();
-        result.m_outerColumn = TableColumn::serializeObject();
-        result.m_underSaturatedSchema = TableSchema::serializeObject();
-        result.m_saturatedSchema = TableSchema::serializeObject();
-        result.m_underSaturatedTables = {SimpleTable::serializeObject()};
-        result.m_saturatedTable = SimpleTable::serializeObject();
+        result.m_outerColumnSchema = ColumnSchema::serializationTestObject();
+        result.m_outerColumn = TableColumn::serializationTestObject();
+        result.m_underSaturatedSchema = TableSchema::serializationTestObject();
+        result.m_saturatedSchema = TableSchema::serializationTestObject();
+        result.m_underSaturatedTables = {SimpleTable::serializationTestObject()};
+        result.m_saturatedTable = SimpleTable::serializationTestObject();
 
         return result;
     }

--- a/src/opm/input/eclipse/EclipseState/Tables/Rock2dTable.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/Rock2dTable.cpp
@@ -29,7 +29,7 @@ namespace Opm {
         {
         }
 
-        Rock2dTable Rock2dTable::serializeObject()
+        Rock2dTable Rock2dTable::serializationTestObject()
         {
             Rock2dTable result;
             result.m_pvmultValues = {{1.0,2.0},{3.0,4.0}};

--- a/src/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/Rock2dtrTable.cpp
@@ -29,7 +29,7 @@ namespace Opm {
         {
         }
 
-        Rock2dtrTable  Rock2dtrTable::serializeObject()
+        Rock2dtrTable  Rock2dtrTable::serializationTestObject()
         {
             Rock2dtrTable result;
 

--- a/src/opm/input/eclipse/EclipseState/Tables/RwgsaltTable.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/RwgsaltTable.cpp
@@ -31,7 +31,7 @@ namespace Opm {
         {
         }
 
-        RwgsaltTable RwgsaltTable::serializeObject()
+        RwgsaltTable RwgsaltTable::serializationTestObject()
         {
             RwgsaltTable result;
             result.m_tableValues = {1.0, 2.0, 3.0};

--- a/src/opm/input/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -44,11 +44,11 @@ namespace Opm {
     }
 
 
-    SimpleTable SimpleTable::serializeObject()
+    SimpleTable SimpleTable::serializationTestObject()
     {
         SimpleTable result;
-        result.m_schema = Opm::TableSchema::serializeObject();
-        result.m_columns.insert({"test3", Opm::TableColumn::serializeObject()});
+        result.m_schema = Opm::TableSchema::serializationTestObject();
+        result.m_columns.insert({"test3", Opm::TableColumn::serializationTestObject()});
         result.m_jfunc = true;
 
         return result;

--- a/src/opm/input/eclipse/EclipseState/Tables/SolventDensityTable.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/SolventDensityTable.cpp
@@ -24,7 +24,7 @@
 #include <opm/input/eclipse/EclipseState/Tables/SolventDensityTable.hpp>
 
 namespace Opm {
-        SolventDensityTable SolventDensityTable::serializeObject()
+        SolventDensityTable SolventDensityTable::serializationTestObject()
         {
             SolventDensityTable result;
             result.m_tableValues = {1.0, 2.0, 3.0};

--- a/src/opm/input/eclipse/EclipseState/Tables/StandardCond.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/StandardCond.cpp
@@ -34,7 +34,7 @@ StandardCond::StandardCond() {
 }
 
 
-StandardCond StandardCond::serializeObject()
+StandardCond StandardCond::serializationTestObject()
 {
     StandardCond result;
     result.temperature = 1.0;

--- a/src/opm/input/eclipse/EclipseState/Tables/TLMixpar.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TLMixpar.cpp
@@ -50,7 +50,7 @@ std::size_t TLMixpar::size() const {
     return this->data.size();
 }
 
-TLMixpar TLMixpar::serializeObject() {
+TLMixpar TLMixpar::serializationTestObject() {
     TLMixpar tlm;
     return tlm;
 }

--- a/src/opm/input/eclipse/EclipseState/Tables/TableColumn.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableColumn.cpp
@@ -38,10 +38,10 @@ namespace Opm {
     }
 
 
-    TableColumn TableColumn::serializeObject()
+    TableColumn TableColumn::serializationTestObject()
     {
         TableColumn result;
-        result.m_schema = Opm::ColumnSchema::serializeObject();
+        result.m_schema = Opm::ColumnSchema::serializationTestObject();
         result.m_name = "test2";
         result.m_values = {1.0, 2.0};
         result.m_default = {false, true};

--- a/src/opm/input/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -35,12 +35,12 @@ namespace Opm {
     {
     }
 
-    TableContainer TableContainer::serializeObject()
+    TableContainer TableContainer::serializationTestObject()
     {
         TableContainer result;
         result.m_maxTables = 2;
-        result.addTable(0, std::make_shared<Opm::SimpleTable>(Opm::SimpleTable::serializeObject()));
-        result.addTable(1, std::make_shared<Opm::SimpleTable>(Opm::SimpleTable::serializeObject()));
+        result.addTable(0, std::make_shared<Opm::SimpleTable>(Opm::SimpleTable::serializationTestObject()));
+        result.addTable(1, std::make_shared<Opm::SimpleTable>(Opm::SimpleTable::serializationTestObject()));
 
         return result;
     }

--- a/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -263,55 +263,55 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
     }
 
 
-    TableManager TableManager::serializeObject()
+    TableManager TableManager::serializationTestObject()
     {
         TableManager result;
-        result.m_simpleTables = {{"test", TableContainer::serializeObject()}};
-        result.m_pvtgTables = {PvtgTable::serializeObject()};
-        result.m_pvtgwTables = {PvtgwTable::serializeObject()};
-        result.m_pvtgwoTables = {PvtgwoTable::serializeObject()};
-        result.m_pvtoTables = {PvtoTable::serializeObject()};
-        result.m_rock2dTables = {Rock2dTable::serializeObject()};
-        result.m_rock2dtrTables = {Rock2dtrTable::serializeObject()};
-        result.m_pvtwTable = PvtwTable::serializeObject();
-        result.m_pvcdoTable = PvcdoTable::serializeObject();
-        result.m_densityTable = DensityTable::serializeObject();
-        result.m_diffCoeffTable = DiffCoeffTable::serializeObject();
-        result.m_plyvmhTable = PlyvmhTable::serializeObject();
-        result.m_rockTable = RockTable::serializeObject();
-        result.m_plmixparTable = PlmixparTable::serializeObject();
-        result.m_shrateTable = ShrateTable::serializeObject();
-        result.m_stone1exTable = Stone1exTable::serializeObject();
-        result.m_viscrefTable = ViscrefTable::serializeObject();
-        result.m_watdentTable = WatdentTable::serializeObject();
-        result.m_sgofletTable = SgofletTable::serializeObject();
-        result.m_swofletTable = SwofletTable::serializeObject();
-        result.m_pvtwsaltTables = {PvtwsaltTable::serializeObject()};
-        result.m_rwgsaltTables = {RwgsaltTable::serializeObject()};
-        result.m_bdensityTables = {BrineDensityTable::serializeObject()};
-        result.m_sdensityTables = {SolventDensityTable::serializeObject()};
-        result.m_plymwinjTables = {{1, Opm::PlymwinjTable::serializeObject()}};
-        result.m_skprwatTables =  {{2, Opm::SkprwatTable::serializeObject()}};
-        result.m_skprpolyTables = {{3, Opm::SkprpolyTable::serializeObject()}};
-        result.m_tabdims = Tabdims::serializeObject();
-        result.m_regdims = Regdims::serializeObject();
-        result.m_eqldims = Eqldims::serializeObject();
+        result.m_simpleTables = {{"test", TableContainer::serializationTestObject()}};
+        result.m_pvtgTables = {PvtgTable::serializationTestObject()};
+        result.m_pvtgwTables = {PvtgwTable::serializationTestObject()};
+        result.m_pvtgwoTables = {PvtgwoTable::serializationTestObject()};
+        result.m_pvtoTables = {PvtoTable::serializationTestObject()};
+        result.m_rock2dTables = {Rock2dTable::serializationTestObject()};
+        result.m_rock2dtrTables = {Rock2dtrTable::serializationTestObject()};
+        result.m_pvtwTable = PvtwTable::serializationTestObject();
+        result.m_pvcdoTable = PvcdoTable::serializationTestObject();
+        result.m_densityTable = DensityTable::serializationTestObject();
+        result.m_diffCoeffTable = DiffCoeffTable::serializationTestObject();
+        result.m_plyvmhTable = PlyvmhTable::serializationTestObject();
+        result.m_rockTable = RockTable::serializationTestObject();
+        result.m_plmixparTable = PlmixparTable::serializationTestObject();
+        result.m_shrateTable = ShrateTable::serializationTestObject();
+        result.m_stone1exTable = Stone1exTable::serializationTestObject();
+        result.m_viscrefTable = ViscrefTable::serializationTestObject();
+        result.m_watdentTable = WatdentTable::serializationTestObject();
+        result.m_sgofletTable = SgofletTable::serializationTestObject();
+        result.m_swofletTable = SwofletTable::serializationTestObject();
+        result.m_pvtwsaltTables = {PvtwsaltTable::serializationTestObject()};
+        result.m_rwgsaltTables = {RwgsaltTable::serializationTestObject()};
+        result.m_bdensityTables = {BrineDensityTable::serializationTestObject()};
+        result.m_sdensityTables = {SolventDensityTable::serializationTestObject()};
+        result.m_plymwinjTables = {{1, Opm::PlymwinjTable::serializationTestObject()}};
+        result.m_skprwatTables =  {{2, Opm::SkprwatTable::serializationTestObject()}};
+        result.m_skprpolyTables = {{3, Opm::SkprpolyTable::serializationTestObject()}};
+        result.m_tabdims = Tabdims::serializationTestObject();
+        result.m_regdims = Regdims::serializationTestObject();
+        result.m_eqldims = Eqldims::serializationTestObject();
         result.hasImptvd = true;
         result.hasEnptvd = true;
         result.hasEqlnum = true;
         result.hasShrate = true;
-        result.jfunc = Opm::JFunc::serializeObject();
-        result.oilDenT = DenT::serializeObject();
-        result.gasDenT = DenT::serializeObject();
-        result.watDenT = DenT::serializeObject();
-        result.oilJT = JouleThomson::serializeObject();
-        result.gasJT = JouleThomson::serializeObject();
-        result.watJT = JouleThomson::serializeObject();
-        result.stcond = StandardCond::serializeObject();
+        result.jfunc = Opm::JFunc::serializationTestObject();
+        result.oilDenT = DenT::serializationTestObject();
+        result.gasDenT = DenT::serializationTestObject();
+        result.watDenT = DenT::serializationTestObject();
+        result.oilJT = JouleThomson::serializationTestObject();
+        result.gasJT = JouleThomson::serializationTestObject();
+        result.watJT = JouleThomson::serializationTestObject();
+        result.stcond = StandardCond::serializationTestObject();
         result.m_gas_comp_index = 77;
         result.m_rtemp = 1.0;
         result.m_salinity = 1.0;
-        result.m_tlmixpar = TLMixpar::serializeObject();
+        result.m_tlmixpar = TLMixpar::serializationTestObject();
         return result;
     }
 

--- a/src/opm/input/eclipse/EclipseState/Tables/TableSchema.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableSchema.cpp
@@ -22,10 +22,10 @@
 
 namespace Opm {
 
-    TableSchema TableSchema::serializeObject()
+    TableSchema TableSchema::serializationTestObject()
     {
         TableSchema result;
-        result.m_columns.insert({"test1", ColumnSchema::serializeObject()});
+        result.m_columns.insert({"test1", ColumnSchema::serializationTestObject()});
 
         return result;
     }

--- a/src/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -118,9 +118,9 @@ PvtgTable::PvtgTable( const DeckKeyword& keyword, size_t tableIdx ) :
         PvtxTable::init(keyword, tableIdx);
     }
 
-PvtgTable PvtgTable::serializeObject() {
+PvtgTable PvtgTable::serializationTestObject() {
     PvtgTable result;
-    static_cast<PvtxTable&>(result) = PvtxTable::serializeObject();
+    static_cast<PvtxTable&>(result) = PvtxTable::serializationTestObject();
 
     return result;
 }
@@ -144,9 +144,9 @@ PvtgwTable::PvtgwTable( const DeckKeyword& keyword, size_t tableIdx ) :
         PvtxTable::init(keyword, tableIdx);
     }
 
-PvtgwTable PvtgwTable::serializeObject() {
+PvtgwTable PvtgwTable::serializationTestObject() {
     PvtgwTable result;
-    static_cast<PvtxTable&>(result) = PvtxTable::serializeObject();
+    static_cast<PvtxTable&>(result) = PvtxTable::serializationTestObject();
 
     return result;
 }
@@ -172,9 +172,9 @@ PvtgwoTable::PvtgwoTable( const DeckKeyword& keyword, size_t tableIdx ) :
         PvtxTable::init(keyword, tableIdx);
     }
 
-PvtgwoTable PvtgwoTable::serializeObject() {
+PvtgwoTable PvtgwoTable::serializationTestObject() {
     PvtgwoTable result;
-    static_cast<PvtxTable&>(result) = PvtxTable::serializeObject();
+    static_cast<PvtxTable&>(result) = PvtxTable::serializationTestObject();
 
     return result;
 }
@@ -197,9 +197,9 @@ PvtoTable::PvtoTable( const DeckKeyword& keyword, size_t tableIdx) :
         PvtxTable::init(keyword , tableIdx);
     }
 
-PvtoTable PvtoTable::serializeObject() {
+PvtoTable PvtoTable::serializationTestObject() {
     PvtoTable result;
-    static_cast<PvtxTable&>(result) = PvtxTable::serializeObject();
+    static_cast<PvtxTable&>(result) = PvtxTable::serializationTestObject();
 
     return result;
 }
@@ -259,9 +259,9 @@ PvtsolTable::PvtsolTable( const DeckKeyword& keyword, size_t tableIdx) :
         PvtxTable::init(keyword , tableIdx);
     }
 
-PvtsolTable PvtsolTable::serializeObject() {
+PvtsolTable PvtsolTable::serializationTestObject() {
     PvtsolTable result;
-    static_cast<PvtxTable&>(result) = PvtxTable::serializeObject();
+    static_cast<PvtxTable&>(result) = PvtxTable::serializationTestObject();
 
     return result;
 }
@@ -772,10 +772,10 @@ PlyshlogTable::PlyshlogTable(
     SimpleTable::init( dataRecord.getItem<ParserKeywords::PLYSHLOG::DATA>(), 1 );
 }
 
-PlyshlogTable PlyshlogTable::serializeObject()
+PlyshlogTable PlyshlogTable::serializationTestObject()
 {
     PlyshlogTable result;
-    static_cast<SimpleTable&>(result) = SimpleTable::serializeObject();
+    static_cast<SimpleTable&>(result) = SimpleTable::serializationTestObject();
     result.m_refPolymerConcentration = 1.0;
     result.m_refSalinity = 2.0;
     result.m_refTemperature = 3.0;
@@ -964,10 +964,10 @@ RocktabTable::RocktabTable(
     SimpleTable::init(item, tableID);
 }
 
-RocktabTable RocktabTable::serializeObject()
+RocktabTable RocktabTable::serializationTestObject()
 {
     RocktabTable result;
-    static_cast<SimpleTable&>(result) = Opm::SimpleTable::serializeObject();
+    static_cast<SimpleTable&>(result) = Opm::SimpleTable::serializationTestObject();
     result.m_isDirectional = true;
 
     return result;

--- a/src/opm/input/eclipse/EclipseState/TracerConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/TracerConfig.cpp
@@ -157,7 +157,7 @@ TracerConfig::TracerConfig(const UnitSystem& unit_system, const Deck& deck)
     }
 }
 
-TracerConfig TracerConfig::serializeObject()
+TracerConfig TracerConfig::serializationTestObject()
 {
     TracerConfig result;
     result.tracers = {{"test", "", Phase::OIL, {1.0}}};

--- a/src/opm/input/eclipse/Schedule/Action/ASTNode.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ASTNode.cpp
@@ -71,7 +71,7 @@ ASTNode::ASTNode(TokenType type_arg, FuncType func_type_arg, const std::string& 
     arg_list(strip_quotes(arg_list_arg))
 {}
 
-ASTNode ASTNode::serializeObject()
+ASTNode ASTNode::serializationTestObject()
 {
     ASTNode result;
     result.type = ::number;

--- a/src/opm/input/eclipse/Schedule/Action/Actdims.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/Actdims.cpp
@@ -46,7 +46,7 @@ Actdims::Actdims(const Deck& deck)
     }
 }
 
-Actdims Actdims::serializeObject()
+Actdims Actdims::serializationTestObject()
 {
     Actdims result;
     result.keywords = 1;

--- a/src/opm/input/eclipse/Schedule/Action/ActionAST.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionAST.cpp
@@ -38,10 +38,10 @@ AST::AST(const std::vector<std::string>& tokens) {
     this->condition.reset( new Action::ASTNode(condition_node) );
 }
 
-AST AST::serializeObject()
+AST AST::serializationTestObject()
 {
     AST result;
-    result.condition = std::make_shared<ASTNode>(ASTNode::serializeObject());
+    result.condition = std::make_shared<ASTNode>(ASTNode::serializationTestObject());
 
     return result;
 }

--- a/src/opm/input/eclipse/Schedule/Action/ActionResult.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionResult.cpp
@@ -155,17 +155,17 @@ bool WellSet::operator==(const WellSet& other) const {
     return this->well_set == other.well_set;
 }
 
-WellSet WellSet::serializeObject() {
+WellSet WellSet::serializationTestObject() {
     WellSet ws;
     ws.well_set = {"W1", "W2", "W3"};
     return ws;
 }
 
 
-Result Result::serializeObject() {
+Result Result::serializationTestObject() {
     Result rs;
     rs.result = false;
-    rs.matching_wells = WellSet::serializeObject();
+    rs.matching_wells = WellSet::serializationTestObject();
     return rs;
 }
 

--- a/src/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -139,15 +139,15 @@ ActionX::ActionX(const DeckKeyword& kw, const Actdims& actdims, std::time_t star
 }
 
 
-ActionX ActionX::serializeObject()
+ActionX ActionX::serializationTestObject()
 {
     ActionX result;
     result.m_name = "test";
     result.m_max_run = 1;
     result.m_min_wait = 2;
     result.m_start_time = 3;
-    result.keywords = {DeckKeyword::serializeObject()};
-    result.condition = Action::AST::serializeObject();
+    result.keywords = {DeckKeyword::serializationTestObject()};
+    result.condition = Action::AST::serializationTestObject();
     Quantity quant;
     quant.quantity = "test1";
     quant.args = {"test2"};

--- a/src/opm/input/eclipse/Schedule/Action/Actions.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/Actions.cpp
@@ -31,11 +31,11 @@ Actions::Actions(const std::vector<ActionX>& action, const std::vector<PyAction>
 {}
 
 
-Actions Actions::serializeObject()
+Actions Actions::serializationTestObject()
 {
     Actions result;
-    result.actions = {ActionX::serializeObject()};
-    result.pyactions = {PyAction::serializeObject()};
+    result.actions = {ActionX::serializationTestObject()};
+    result.pyactions = {PyAction::serializationTestObject()};
 
     return result;
 }

--- a/src/opm/input/eclipse/Schedule/Action/PyAction.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/PyAction.cpp
@@ -53,7 +53,7 @@ PyAction::RunCount PyAction::from_string(std::string run_count) {
     throw std::invalid_argument("RunCount string: " + run_count + " not recognized ");
 }
 
-PyAction PyAction::serializeObject()
+PyAction PyAction::serializationTestObject()
 {
     PyAction result;
 

--- a/src/opm/input/eclipse/Schedule/Action/State.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/State.cpp
@@ -105,10 +105,10 @@ bool State::operator==(const State& other) const {
 }
 
 
-State State::serializeObject() {
+State State::serializationTestObject() {
     State st;
-    st.run_state.insert(std::make_pair( std::make_pair("ACTION", 100), RunState::serializeObject()));
-    st.last_result.insert( std::make_pair("ACTION", Result::serializeObject()));
+    st.run_state.insert(std::make_pair( std::make_pair("ACTION", 100), RunState::serializationTestObject()));
+    st.last_result.insert( std::make_pair("ACTION", Result::serializationTestObject()));
     st.m_python_result.insert( std::make_pair("PYACTION", false) );
     return st;
 }

--- a/src/opm/input/eclipse/Schedule/Action/WGNames.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/WGNames.cpp
@@ -39,7 +39,7 @@ bool WGNames::has_group(const std::string& gname) const {
     return (this->groups.count(gname) == 1);
 }
 
-WGNames WGNames::serializeObject() {
+WGNames WGNames::serializationTestObject() {
     WGNames wgn;
     wgn.add_well("W1");
     wgn.add_group("G1");

--- a/src/opm/input/eclipse/Schedule/CompletedCells.cpp
+++ b/src/opm/input/eclipse/Schedule/CompletedCells.cpp
@@ -53,9 +53,9 @@ bool Opm::CompletedCells::operator==(const Opm::CompletedCells& other) const {
 }
 
 
-Opm::CompletedCells Opm::CompletedCells::serializeObject() {
+Opm::CompletedCells Opm::CompletedCells::serializationTestObject() {
     Opm::CompletedCells cells(2,3,4);
-    cells.cells.emplace(7, Opm::CompletedCells::Cell::serializeObject());
+    cells.cells.emplace(7, Opm::CompletedCells::Cell::serializationTestObject());
     return cells;
 }
 

--- a/src/opm/input/eclipse/Schedule/Events.cpp
+++ b/src/opm/input/eclipse/Schedule/Events.cpp
@@ -23,7 +23,7 @@
 namespace Opm {
 
 
-    Events Events::serializeObject()
+    Events Events::serializationTestObject()
     {
         Events result;
         result.m_events = 12345;
@@ -52,7 +52,7 @@ namespace Opm {
     }
 
 
-    WellGroupEvents WellGroupEvents::serializeObject() {
+    WellGroupEvents WellGroupEvents::serializationTestObject() {
         WellGroupEvents wg;
         wg.addWell("WG1");
         wg.addGroup("GG1");

--- a/src/opm/input/eclipse/Schedule/GasLiftOpt.cpp
+++ b/src/opm/input/eclipse/Schedule/GasLiftOpt.cpp
@@ -100,7 +100,7 @@ const GasLiftOpt::Well& GasLiftOpt::well(const std::string& wname) const {
     return iter->second;
 }
 
-GasLiftOpt GasLiftOpt::serializeObject() {
+GasLiftOpt GasLiftOpt::serializationTestObject() {
     GasLiftOpt glo;
     glo.m_increment = 0;
     glo.m_min_eco_gradient = 100;

--- a/src/opm/input/eclipse/Schedule/Group/GConSale.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GConSale.cpp
@@ -25,11 +25,11 @@
 
 namespace Opm {
 
-GConSale GConSale::serializeObject()
+GConSale GConSale::serializationTestObject()
 {
     GConSale result;
     result.groups = {{"test1", {UDAValue(1.0), UDAValue(2.0), UDAValue(3.0),
-                                MaxProcedure::PLUG, 4.0, UnitSystem::serializeObject()}}};
+                                MaxProcedure::PLUG, 4.0, UnitSystem::serializationTestObject()}}};
 
     return result;
 }

--- a/src/opm/input/eclipse/Schedule/Group/GConSump.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GConSump.cpp
@@ -23,11 +23,11 @@
 
 namespace Opm {
 
-GConSump GConSump::serializeObject()
+GConSump GConSump::serializationTestObject()
 {
     GConSump result;
     result.groups = {{"test1", {UDAValue(1.0), UDAValue(2.0), "test2", 3.0,
-                                UnitSystem::serializeObject()}}};
+                                UnitSystem::serializationTestObject()}}};
 
     return result;
 }

--- a/src/opm/input/eclipse/Schedule/Group/GPMaint.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GPMaint.cpp
@@ -53,7 +53,7 @@ double GPMaint::time_constant() const {
     return this->m_time_constant;
 }
 
-GPMaint GPMaint::serializeObject() {
+GPMaint GPMaint::serializationTestObject() {
     GPMaint gpm;
     gpm.m_flow_target = FlowTarget::SURF_GINJ;
     gpm.m_region_name = "FIPNUM";

--- a/src/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -246,13 +246,13 @@ Group::Group(const RestartIO::RstGroup& rst_group, std::size_t insert_index_arg,
 }
 
 
-Group Group::serializeObject()
+Group Group::serializationTestObject()
 {
     Group result;
     result.m_name = "test1";
     result.m_insert_index = 1;
     result.udq_undefined = 3.0;
-    result.unit_system = UnitSystem::serializeObject();
+    result.unit_system = UnitSystem::serializationTestObject();
     result.group_type = GroupType::PRODUCTION;
     result.gefac = 4.0;
     result.transfer_gefac = true;
@@ -260,10 +260,10 @@ Group Group::serializeObject()
     result.parent_group = "test2";
     result.m_wells = {{"test3", "test4"}, {"test5", "test6"}};
     result.m_groups = {{"test7", "test8"}, {"test9", "test10"}};
-    result.injection_properties = {{Opm::Phase::OIL, GroupInjectionProperties::serializeObject()}};
-    result.production_properties = GroupProductionProperties::serializeObject();
+    result.injection_properties = {{Opm::Phase::OIL, GroupInjectionProperties::serializationTestObject()}};
+    result.production_properties = GroupProductionProperties::serializationTestObject();
     result.m_topup_phase = Phase::OIL;
-    result.m_gpmaint = GPMaint::serializeObject();
+    result.m_gpmaint = GPMaint::serializationTestObject();
 
     return result;
 }
@@ -385,7 +385,7 @@ Group::GroupInjectionProperties::GroupInjectionProperties(std::string group_name
     , target_void_fraction { unit_system.getDimension(UnitSystem::measure::identity) }
 {}
 
-Group::GroupInjectionProperties Group::GroupInjectionProperties::serializeObject()
+Group::GroupInjectionProperties Group::GroupInjectionProperties::serializationTestObject()
 {
     Group::GroupInjectionProperties result{"G"};
     result.phase = Phase::OIL;
@@ -493,7 +493,7 @@ Group::GroupProductionProperties::GroupProductionProperties(const UnitSystem& un
 {
 }
 
-Group::GroupProductionProperties Group::GroupProductionProperties::serializeObject()
+Group::GroupProductionProperties Group::GroupProductionProperties::serializationTestObject()
 {
     Group::GroupProductionProperties result(UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC), "Group123");
     result.name = "Group123";

--- a/src/opm/input/eclipse/Schedule/Group/GuideRateConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GuideRateConfig.cpp
@@ -23,10 +23,10 @@
 
 namespace Opm {
 
-GuideRateConfig GuideRateConfig::serializeObject()
+GuideRateConfig GuideRateConfig::serializationTestObject()
 {
     GuideRateConfig result;
-    result.m_model = GuideRateModel::serializeObject();
+    result.m_model = GuideRateModel::serializationTestObject();
     result.wells = {{"test1", WellTarget{1.0, Well::GuideRateTarget::COMB, 2.0}}};
     result.production_groups = {{"test2", GroupProdTarget{1.0, Group::GuideRateProdTarget::COMB}}};
     result.injection_groups = {{{Phase::OIL, "test3"}, GroupInjTarget{1.0, Group::GuideRateInjTarget::NETV}}};

--- a/src/opm/input/eclipse/Schedule/Group/GuideRateModel.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GuideRateModel.cpp
@@ -66,7 +66,7 @@ GuideRateModel::GuideRateModel(double time_interval_arg,
         throw std::invalid_argument("Invalid value for F must be in interval [-3,3]");
 }
 
-GuideRateModel GuideRateModel::serializeObject()
+GuideRateModel GuideRateModel::serializationTestObject()
 {
     GuideRateModel result;
     result.time_interval = 1.0;

--- a/src/opm/input/eclipse/Schedule/MSW/AICD.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/AICD.cpp
@@ -28,9 +28,9 @@
 
 namespace Opm {
 
-AutoICD AutoICD::serializeObject() {
+AutoICD AutoICD::serializationTestObject() {
     AutoICD aicd;
-    static_cast<SICD&>(aicd) = SICD::serializeObject();
+    static_cast<SICD&>(aicd) = SICD::serializationTestObject();
     aicd.m_flow_rate_exponent = 1.0;
     aicd.m_visc_exponent = 2.0;
     aicd.m_oil_density_exponent = 3.0;

--- a/src/opm/input/eclipse/Schedule/MSW/SICD.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/SICD.cpp
@@ -85,7 +85,7 @@ namespace Opm {
     }
 
 
-    SICD SICD::serializeObject()
+    SICD SICD::serializationTestObject()
     {
         SICD result;
         result.m_strength = 1.0;

--- a/src/opm/input/eclipse/Schedule/MSW/Segment.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/Segment.cpp
@@ -154,7 +154,7 @@ namespace {
       this->m_volume = new_volume;
   }
 
-  Segment Segment::serializeObject()
+  Segment Segment::serializationTestObject()
   {
       Segment result;
       result.m_segment_number = 1;
@@ -168,7 +168,7 @@ namespace {
       result.m_cross_area = 10.0;
       result.m_volume = 11.0;
       result.m_data_ready = true;
-      result.m_icd = SICD::serializeObject();
+      result.m_icd = SICD::serializationTestObject();
       return result;
   }
 

--- a/src/opm/input/eclipse/Schedule/MSW/Valve.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/Valve.cpp
@@ -96,7 +96,7 @@ namespace Opm {
         }
     }
 
-    Valve Valve::serializeObject()
+    Valve Valve::serializationTestObject()
     {
         Valve result;
         result.m_con_flow_coeff = 1.0;

--- a/src/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -55,11 +55,11 @@ namespace Opm {
     }
 
 
-    WellSegments WellSegments::serializeObject()
+    WellSegments WellSegments::serializationTestObject()
     {
         WellSegments result;
         result.m_comp_pressure_drop = CompPressureDrop::HF_;
-        result.m_segments = {Opm::Segment::serializeObject()};
+        result.m_segments = {Opm::Segment::serializationTestObject()};
         result.segment_number_to_index = {{1, 2}};
 
         return result;

--- a/src/opm/input/eclipse/Schedule/MessageLimits.cpp
+++ b/src/opm/input/eclipse/Schedule/MessageLimits.cpp
@@ -56,7 +56,7 @@ namespace Opm {
     }
 
 
-    MessageLimits MessageLimits::serializeObject()
+    MessageLimits MessageLimits::serializationTestObject()
     {
        MessageLimits result;
        result.message_print_limit = 12345;

--- a/src/opm/input/eclipse/Schedule/Network/Balance.cpp
+++ b/src/opm/input/eclipse/Schedule/Network/Balance.cpp
@@ -169,7 +169,7 @@ const std::optional<double>& Balance::min_tstep() const {
     return this->m_min_tstep;
 }
 
-Balance Balance::serializeObject() {
+Balance Balance::serializationTestObject() {
     Balance balance;
     balance.calc_interval = 0.;
     balance.calc_mode = Balance::CalcMode::NUPCOL;

--- a/src/opm/input/eclipse/Schedule/Network/Branch.cpp
+++ b/src/opm/input/eclipse/Schedule/Network/Branch.cpp
@@ -32,7 +32,7 @@ constexpr int invalid_vfp_table = 9999;
 }
 
 
-Branch Branch::serializeObject() {
+Branch Branch::serializationTestObject() {
     Branch object;
     return object;
 }

--- a/src/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
+++ b/src/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
@@ -25,7 +25,7 @@
 namespace Opm {
 namespace Network {
 
-ExtNetwork ExtNetwork::serializeObject() {
+ExtNetwork ExtNetwork::serializationTestObject() {
     ExtNetwork object;
     return object;
 }

--- a/src/opm/input/eclipse/Schedule/Network/Node.cpp
+++ b/src/opm/input/eclipse/Schedule/Network/Node.cpp
@@ -68,7 +68,7 @@ bool Node::operator==(const Node& other) const {
 }
 
 
-Node Node::serializeObject()
+Node Node::serializationTestObject()
 {
   Node result;
   result.m_name = "test";

--- a/src/opm/input/eclipse/Schedule/OilVaporizationProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/OilVaporizationProperties.cpp
@@ -36,7 +36,7 @@ namespace Opm {
          m_maxDRVDT(numPvtRegionIdx, -1.0)
     {  }
 
-    OilVaporizationProperties OilVaporizationProperties::serializeObject()
+    OilVaporizationProperties OilVaporizationProperties::serializationTestObject()
     {
         OilVaporizationProperties result;
         result.m_type = OilVaporization::VAPPARS;

--- a/src/opm/input/eclipse/Schedule/RFTConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/RFTConfig.cpp
@@ -307,7 +307,7 @@ bool RFTConfig::operator==(const RFTConfig& data) const
         && (this->open_wells == data.open_wells);
 }
 
-RFTConfig RFTConfig::serializeObject()
+RFTConfig RFTConfig::serializationTestObject()
 {
     // Establish an object in a non-default state to enable testing the
     // serialization code.  These statements "simply" record a number of

--- a/src/opm/input/eclipse/Schedule/RPTConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/RPTConfig.cpp
@@ -44,7 +44,7 @@ namespace {
 
 namespace Opm {
 
-RPTConfig RPTConfig::serializeObject() {
+RPTConfig RPTConfig::serializationTestObject() {
     RPTConfig rptc;
     rptc.m_mnemonics.emplace( "KEY", 100 );
     return rptc;

--- a/src/opm/input/eclipse/Schedule/RSTConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/RSTConfig.cpp
@@ -495,7 +495,7 @@ void RSTConfig::update(const DeckKeyword& keyword, const ParseContext& parseCont
 }
 
 
-RSTConfig RSTConfig::serializeObject() {
+RSTConfig RSTConfig::serializationTestObject() {
     RSTConfig rst_config;
     rst_config.basic = 10;
     rst_config.freq = {};

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -278,23 +278,23 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const std::optional
     }
 
     /*
-      In general the serializeObject() instances are used as targets for
+      In general the serializationTestObject() instances are used as targets for
       deserialization, i.e. the serialized buffer is unpacked into this
       instance. However the Schedule object is a top level object, and the
       simulator will instantiate and manage a Schedule object to unpack into, so
       the instance created here is only for testing.
     */
-    Schedule Schedule::serializeObject()
+    Schedule Schedule::serializationTestObject()
     {
         Schedule result;
 
-        result.m_static = ScheduleStatic::serializeObject();
-        result.m_sched_deck = ScheduleDeck::serializeObject();
-        result.action_wgnames = Action::WGNames::serializeObject();
+        result.m_static = ScheduleStatic::serializationTestObject();
+        result.m_sched_deck = ScheduleDeck::serializationTestObject();
+        result.action_wgnames = Action::WGNames::serializationTestObject();
         result.exit_status = EXIT_FAILURE;
-        result.snapshots = { ScheduleState::serializeObject() };
-        result.restart_output = WriteRestartFileEvents::serializeObject();
-        result.completed_cells = CompletedCells::serializeObject();
+        result.snapshots = { ScheduleState::serializationTestObject() };
+        result.restart_output = WriteRestartFileEvents::serializationTestObject();
+        result.completed_cells = CompletedCells::serializationTestObject();
 
         return result;
     }

--- a/src/opm/input/eclipse/Schedule/ScheduleDeck.cpp
+++ b/src/opm/input/eclipse/Schedule/ScheduleDeck.cpp
@@ -58,7 +58,7 @@ bool ScheduleRestartInfo::operator==(const ScheduleRestartInfo& other) const {
 }
 
 
-ScheduleRestartInfo ScheduleRestartInfo::serializeObject() {
+ScheduleRestartInfo ScheduleRestartInfo::serializationTestObject() {
     ScheduleRestartInfo rst_info;
     rst_info.report_step = 12345;
     rst_info.skiprest = false;
@@ -161,13 +161,13 @@ const KeywordLocation& ScheduleBlock::location() const {
 }
 
 
-ScheduleBlock ScheduleBlock::serializeObject() {
+ScheduleBlock ScheduleBlock::serializationTestObject() {
     ScheduleBlock block;
     block.m_time_type = ScheduleTimeType::TSTEP;
     block.m_start_time = TimeService::from_time_t( asTimeT( TimeStampUTC( 2003, 10, 10 )));
     block.m_end_time = TimeService::from_time_t( asTimeT( TimeStampUTC( 1993, 07, 06 )));
-    block.m_location = KeywordLocation::serializeObject();
-    block.m_keywords = {DeckKeyword::serializeObject()};
+    block.m_location = KeywordLocation::serializationTestObject();
+    block.m_keywords = {DeckKeyword::serializationTestObject()};
     return block;
 }
 
@@ -400,12 +400,12 @@ bool ScheduleDeck::operator==(const ScheduleDeck& other) const {
            this->m_blocks == other.m_blocks;
 }
 
-ScheduleDeck ScheduleDeck::serializeObject() {
+ScheduleDeck ScheduleDeck::serializationTestObject() {
     ScheduleDeck deck;
     deck.m_restart_time = TimeService::from_time_t( asTimeT( TimeStampUTC( 2013, 12, 12 )));
     deck.m_restart_offset = 123;
-    deck.m_location = KeywordLocation::serializeObject();
-    deck.m_blocks = { ScheduleBlock::serializeObject(), ScheduleBlock::serializeObject() };
+    deck.m_location = KeywordLocation::serializationTestObject();
+    deck.m_blocks = { ScheduleBlock::serializationTestObject(), ScheduleBlock::serializationTestObject() };
     return deck;
 }
 

--- a/src/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/src/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -281,43 +281,43 @@ bool ScheduleState::operator==(const ScheduleState& other) const {
 
 
 
-ScheduleState ScheduleState::serializeObject() {
+ScheduleState ScheduleState::serializationTestObject() {
     auto t1 = TimeService::now();
     auto t2 = t1 + std::chrono::hours(48);
     ScheduleState ts(t1, t2);
     ts.m_sim_step = 123;
     ts.m_month_num = 12;
     ts.m_year_num = 66;
-    ts.vfpprod = map_member<int, VFPProdTable>::serializeObject();
-    ts.vfpinj = map_member<int, VFPInjTable>::serializeObject();
-    ts.groups = map_member<std::string, Group>::serializeObject();
-    ts.m_events = Events::serializeObject();
-    ts.m_nupcol = Nupcol::serializeObject();
-    ts.update_oilvap( Opm::OilVaporizationProperties::serializeObject() );
-    ts.m_message_limits = MessageLimits::serializeObject();
+    ts.vfpprod = map_member<int, VFPProdTable>::serializationTestObject();
+    ts.vfpinj = map_member<int, VFPInjTable>::serializationTestObject();
+    ts.groups = map_member<std::string, Group>::serializationTestObject();
+    ts.m_events = Events::serializationTestObject();
+    ts.m_nupcol = Nupcol::serializationTestObject();
+    ts.update_oilvap( Opm::OilVaporizationProperties::serializationTestObject() );
+    ts.m_message_limits = MessageLimits::serializationTestObject();
     ts.m_whistctl_mode = Well::ProducerCMode::THP;
     ts.target_wellpi = {{"WELL1", 1000}, {"WELL2", 2000}};
 
     ts.m_sumthin = 12.345;
     ts.m_rptonly = true;
 
-    ts.pavg.update( PAvg::serializeObject() );
-    ts.wtest_config.update( WellTestConfig::serializeObject() );
-    ts.gconsump.update( GConSump::serializeObject() );
-    ts.gconsale.update( GConSale::serializeObject() );
-    ts.wlist_manager.update( WListManager::serializeObject() );
-    ts.rpt_config.update( RPTConfig::serializeObject() );
-    ts.actions.update( Action::Actions::serializeObject() );
-    ts.udq_active.update( UDQActive::serializeObject() );
-    ts.network.update( Network::ExtNetwork::serializeObject() );
-    ts.network_balance.update( Network::Balance::serializeObject() );
-    ts.well_order.update( NameOrder::serializeObject() );
-    ts.group_order.update( GroupOrder::serializeObject() );
-    ts.udq.update( UDQConfig::serializeObject() );
-    ts.guide_rate.update( GuideRateConfig::serializeObject() );
-    ts.glo.update( GasLiftOpt::serializeObject() );
-    ts.rft_config.update( RFTConfig::serializeObject() );
-    ts.rst_config.update( RSTConfig::serializeObject() );
+    ts.pavg.update( PAvg::serializationTestObject() );
+    ts.wtest_config.update( WellTestConfig::serializationTestObject() );
+    ts.gconsump.update( GConSump::serializationTestObject() );
+    ts.gconsale.update( GConSale::serializationTestObject() );
+    ts.wlist_manager.update( WListManager::serializationTestObject() );
+    ts.rpt_config.update( RPTConfig::serializationTestObject() );
+    ts.actions.update( Action::Actions::serializationTestObject() );
+    ts.udq_active.update( UDQActive::serializationTestObject() );
+    ts.network.update( Network::ExtNetwork::serializationTestObject() );
+    ts.network_balance.update( Network::Balance::serializationTestObject() );
+    ts.well_order.update( NameOrder::serializationTestObject() );
+    ts.group_order.update( GroupOrder::serializationTestObject() );
+    ts.udq.update( UDQConfig::serializationTestObject() );
+    ts.guide_rate.update( GuideRateConfig::serializationTestObject() );
+    ts.glo.update( GasLiftOpt::serializationTestObject() );
+    ts.rft_config.update( RFTConfig::serializationTestObject() );
+    ts.rst_config.update( RSTConfig::serializationTestObject() );
 
     return ts;
 }

--- a/src/opm/input/eclipse/Schedule/ScheduleTypes.cpp
+++ b/src/opm/input/eclipse/Schedule/ScheduleTypes.cpp
@@ -130,7 +130,7 @@ WellType::WellType(Phase phase) :
     WellType(true, phase)
 {}
 
-WellType WellType::serializeObject()
+WellType WellType::serializationTestObject()
 {
     WellType result;
     result.m_producer = true;

--- a/src/opm/input/eclipse/Schedule/Tuning.cpp
+++ b/src/opm/input/eclipse/Schedule/Tuning.cpp
@@ -95,7 +95,7 @@ Tuning::Tuning() {
 }
 
 
-Tuning Tuning::serializeObject() {
+Tuning Tuning::serializationTestObject() {
     Tuning result;
     result.TSINIT = 1.0;
     result.TSMAXZ = 2.0;

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQASTNode.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQASTNode.cpp
@@ -102,7 +102,7 @@ UDQASTNode::UDQASTNode(UDQTokenType type_arg,
 }
 
 
-UDQASTNode UDQASTNode::serializeObject()
+UDQASTNode UDQASTNode::serializationTestObject()
 {
     UDQASTNode result;
     result.var_type = UDQVarType::REGION_VAR;

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQActive.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQActive.cpp
@@ -56,7 +56,7 @@ std::vector<UDQActive::RstRecord> UDQActive::load_rst(const UnitSystem& units,
     return records;
 }
 
-UDQActive UDQActive::serializeObject()
+UDQActive UDQActive::serializationTestObject()
 {
     UDQActive result;
     result.input_data = {{1, "test1", "test2", UDAControl::WCONPROD_ORAT}};

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQAssign.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQAssign.cpp
@@ -41,7 +41,7 @@ UDQAssign::UDQAssign(const std::string& keyword, const std::unordered_set<std::s
     this->add_record(rst_selector, value, report_step);
 }
 
-UDQAssign UDQAssign::serializeObject()
+UDQAssign UDQAssign::serializationTestObject()
 {
     UDQAssign result;
     result.m_keyword = "test";

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -60,15 +60,15 @@ namespace Opm {
         }
     }
 
-    UDQConfig UDQConfig::serializeObject()
+    UDQConfig UDQConfig::serializationTestObject()
     {
         UDQConfig result;
-        result.udq_params = UDQParams::serializeObject();
+        result.udq_params = UDQParams::serializationTestObject();
         result.udqft = UDQFunctionTable(result.udq_params);
-        result.m_definitions = {{"test1", UDQDefine::serializeObject()}};
-        result.m_assignments = {{"test2", UDQAssign::serializeObject()}};
+        result.m_definitions = {{"test1", UDQDefine::serializationTestObject()}};
+        result.m_assignments = {{"test2", UDQAssign::serializationTestObject()}};
         result.units = {{"test3", "test4"}};
-        result.input_index.insert({"test5", UDQIndex::serializeObject()});
+        result.input_index.insert({"test5", UDQIndex::serializationTestObject()});
         result.type_count = {{UDQVarType::SCALAR, 5}};
 
         return result;

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
@@ -206,11 +206,11 @@ void UDQDefine::update_status(UDQUpdate update, std::size_t report_step) {
 
 
 
-UDQDefine UDQDefine::serializeObject()
+UDQDefine UDQDefine::serializationTestObject()
 {
     UDQDefine result;
     result.m_keyword = "test1";
-    result.ast = std::make_shared<UDQASTNode>(UDQASTNode::serializeObject());
+    result.ast = std::make_shared<UDQASTNode>(UDQASTNode::serializationTestObject());
     result.m_var_type = UDQVarType::SEGMENT_VAR;
     result.string_data = "test2";
     result.m_location = KeywordLocation{"KEYWOR", "file", 100};

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQParams.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQParams.cpp
@@ -76,7 +76,7 @@ namespace Opm {
         this->m_sim_rng.seed( this->random_seed );
     }
 
-    UDQParams UDQParams::serializeObject()
+    UDQParams UDQParams::serializationTestObject()
     {
         UDQParams result;
         result.reseed_rng = true;

--- a/src/opm/input/eclipse/Schedule/VFPInjTable.cpp
+++ b/src/opm/input/eclipse/Schedule/VFPInjTable.cpp
@@ -178,7 +178,7 @@ VFPInjTable::VFPInjTable( const DeckKeyword& table, const UnitSystem& deck_unit_
 }
 
 
-VFPInjTable VFPInjTable::serializeObject()
+VFPInjTable VFPInjTable::serializationTestObject()
 {
     VFPInjTable result;
     result.m_table_num = 1;
@@ -187,7 +187,7 @@ VFPInjTable VFPInjTable::serializeObject()
     result.m_flo_data = {3.0, 4.0};
     result.m_thp_data = {5.0, 6.0};
     result.m_data = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
-    result.m_location = KeywordLocation::serializeObject();
+    result.m_location = KeywordLocation::serializationTestObject();
 
     return result;
 }

--- a/src/opm/input/eclipse/Schedule/VFPProdTable.cpp
+++ b/src/opm/input/eclipse/Schedule/VFPProdTable.cpp
@@ -158,7 +158,7 @@ VFPProdTable::VFPProdTable(int table_num,
 }
 
 
-VFPProdTable VFPProdTable::serializeObject()
+VFPProdTable VFPProdTable::serializationTestObject()
 {
     VFPProdTable result;
     result.m_table_num = 1;
@@ -173,7 +173,7 @@ VFPProdTable VFPProdTable::serializeObject()
     result.m_gfr_data = {8.0};
     result.m_alq_data = {9.0, 10.0, 11.0};
     result.m_data = {12.0, 13.0, 14.0, 15.0, 16.0};
-    result.m_location = KeywordLocation::serializeObject();
+    result.m_location = KeywordLocation::serializationTestObject();
 
     return result;
 }

--- a/src/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -114,7 +114,7 @@ Connection::Connection(const RestartIO::RstConnection& rst_connection, const Sch
                        0, Direction::X, CTFKind::DeckValue, 0, false)
     {}
 
-    Connection Connection::serializeObject()
+    Connection Connection::serializationTestObject()
     {
         Connection result;
         result.direction = Direction::Y;

--- a/src/opm/input/eclipse/Schedule/Well/NameOrder.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/NameOrder.cpp
@@ -54,7 +54,7 @@ std::vector<std::string> NameOrder::sort(std::vector<std::string> names) const {
     return names;
 }
 
-NameOrder NameOrder::serializeObject() {
+NameOrder NameOrder::serializationTestObject() {
     NameOrder wo;
     wo.add("W1");
     wo.add("W2");
@@ -112,7 +112,7 @@ const std::vector<std::string>& GroupOrder::names() const {
 }
 
 
-GroupOrder GroupOrder::serializeObject() {
+GroupOrder GroupOrder::serializationTestObject() {
     GroupOrder go(123);
     go.add("G1");
     go.add("G2");

--- a/src/opm/input/eclipse/Schedule/Well/PAvg.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/PAvg.cpp
@@ -69,7 +69,7 @@ PAvg::PAvg(double inner_weight, double conn_weight, DepthCorrection depth_correc
     m_open_connections(use_open_connections)
 {}
 
-PAvg PAvg::serializeObject() {
+PAvg PAvg::serializationTestObject() {
     return PAvg(0.10, 0.30, PAvg::DepthCorrection::NONE, false);
 }
 

--- a/src/opm/input/eclipse/Schedule/Well/WListManager.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WListManager.cpp
@@ -27,7 +27,7 @@
 
 namespace Opm {
 
-    WListManager WListManager::serializeObject()
+    WListManager WListManager::serializationTestObject()
     {
         WListManager result;
         result.wlists = {{"test1", WList({"test2", "test3"}, "test1")}};

--- a/src/opm/input/eclipse/Schedule/Well/WVFPEXP.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WVFPEXP.cpp
@@ -28,7 +28,7 @@
 
 namespace Opm {
 
-    WVFPEXP WVFPEXP::serializeObject()
+    WVFPEXP WVFPEXP::serializationTestObject()
     {
         WVFPEXP result;
         result.m_explicit = true;

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -469,7 +469,7 @@ Well::Well(const std::string& wname_arg,
     this->updateProduction(p);
 }
 
-Well Well::serializeObject()
+Well Well::serializationTestObject()
 {
     Well result;
     result.wname = "test1";
@@ -479,7 +479,7 @@ Well Well::serializeObject()
     result.headI = 3;
     result.headJ = 4;
     result.ref_depth = 5;
-    result.unit_system = UnitSystem::serializeObject();
+    result.unit_system = UnitSystem::serializationTestObject();
     result.udq_undefined = 6.0;
     result.status = Status::AUTO;
     result.drainage_radius = 7.0;
@@ -488,21 +488,21 @@ Well Well::serializeObject()
     result.pvt_table = 77;
     result.gas_inflow = GasInflowEquation::GPP;
     result.wtype = WellType(Phase::WATER);
-    result.guide_rate = WellGuideRate::serializeObject();
+    result.guide_rate = WellGuideRate::serializationTestObject();
     result.efficiency_factor = 8.0;
     result.solvent_fraction = 9.0;
     result.prediction_mode = false;
-    result.econ_limits = std::make_shared<Opm::WellEconProductionLimits>(Opm::WellEconProductionLimits::serializeObject());
-    result.foam_properties = std::make_shared<WellFoamProperties>(WellFoamProperties::serializeObject());
-    result.polymer_properties =  std::make_shared<WellPolymerProperties>(WellPolymerProperties::serializeObject());
-    result.micp_properties =  std::make_shared<WellMICPProperties>(WellMICPProperties::serializeObject());
-    result.brine_properties = std::make_shared<WellBrineProperties>(WellBrineProperties::serializeObject());
-    result.tracer_properties = std::make_shared<WellTracerProperties>(WellTracerProperties::serializeObject());
-    result.connections = std::make_shared<WellConnections>(WellConnections::serializeObject());
-    result.production = std::make_shared<Well::WellProductionProperties>(Well::WellProductionProperties::serializeObject());
-    result.injection = std::make_shared<Well::WellInjectionProperties>(Well::WellInjectionProperties::serializeObject());
-    result.segments = std::make_shared<WellSegments>(WellSegments::serializeObject());
-    result.wvfpexp = std::make_shared<WVFPEXP>(WVFPEXP::serializeObject());
+    result.econ_limits = std::make_shared<Opm::WellEconProductionLimits>(Opm::WellEconProductionLimits::serializationTestObject());
+    result.foam_properties = std::make_shared<WellFoamProperties>(WellFoamProperties::serializationTestObject());
+    result.polymer_properties =  std::make_shared<WellPolymerProperties>(WellPolymerProperties::serializationTestObject());
+    result.micp_properties =  std::make_shared<WellMICPProperties>(WellMICPProperties::serializationTestObject());
+    result.brine_properties = std::make_shared<WellBrineProperties>(WellBrineProperties::serializationTestObject());
+    result.tracer_properties = std::make_shared<WellTracerProperties>(WellTracerProperties::serializationTestObject());
+    result.connections = std::make_shared<WellConnections>(WellConnections::serializationTestObject());
+    result.production = std::make_shared<Well::WellProductionProperties>(Well::WellProductionProperties::serializationTestObject());
+    result.injection = std::make_shared<Well::WellInjectionProperties>(Well::WellInjectionProperties::serializationTestObject());
+    result.segments = std::make_shared<WellSegments>(WellSegments::serializationTestObject());
+    result.wvfpexp = std::make_shared<WVFPEXP>(WVFPEXP::serializationTestObject());
     result.m_pavg = PAvg();
 
     return result;

--- a/src/opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
@@ -22,7 +22,7 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 
-Opm::WellBrineProperties Opm::WellBrineProperties::serializeObject()
+Opm::WellBrineProperties Opm::WellBrineProperties::serializationTestObject()
 {
     Opm::WellBrineProperties result;
     result.m_saltConcentration = 1.0;

--- a/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -152,13 +152,13 @@ namespace Opm {
         , m_connections(connections)
     {}
 
-    WellConnections WellConnections::serializeObject()
+    WellConnections WellConnections::serializationTestObject()
     {
         WellConnections result;
         result.m_ordering = Connection::Order::DEPTH;
         result.headI = 1;
         result.headJ = 2;
-        result.m_connections = {Connection::serializeObject()};
+        result.m_connections = {Connection::serializationTestObject()};
 
         return result;
     }

--- a/src/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.cpp
@@ -178,7 +178,7 @@ namespace Opm {
         assign_if_finite(rstWell.econ_limit_min_liq,   this->m_min_liquid_rate);
     }
 
-    WellEconProductionLimits WellEconProductionLimits::serializeObject()
+    WellEconProductionLimits WellEconProductionLimits::serializationTestObject()
     {
         WellEconProductionLimits result;
         result.m_min_oil_rate = 1.0;

--- a/src/opm/input/eclipse/Schedule/Well/WellFoamProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellFoamProperties.cpp
@@ -22,7 +22,7 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 
-Opm::WellFoamProperties Opm::WellFoamProperties::serializeObject()
+Opm::WellFoamProperties Opm::WellFoamProperties::serializationTestObject()
 {
     Opm::WellFoamProperties result;
     result.m_foamConcentration = 1.0;

--- a/src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -59,7 +59,7 @@ namespace Opm {
     {
     }
 
-    Well::WellInjectionProperties Well::WellInjectionProperties::serializeObject()
+    Well::WellInjectionProperties Well::WellInjectionProperties::serializationTestObject()
     {
         Well::WellInjectionProperties result;
         result.name = "test";

--- a/src/opm/input/eclipse/Schedule/Well/WellMICPProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellMICPProperties.cpp
@@ -22,7 +22,7 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 
-Opm::WellMICPProperties Opm::WellMICPProperties::serializeObject()
+Opm::WellMICPProperties Opm::WellMICPProperties::serializationTestObject()
 {
     Opm::WellMICPProperties result;
     result.m_microbialConcentration = 1.0;

--- a/src/opm/input/eclipse/Schedule/Well/WellPolymerProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellPolymerProperties.cpp
@@ -26,7 +26,7 @@
 
 namespace Opm {
 
-    WellPolymerProperties WellPolymerProperties::serializeObject()
+    WellPolymerProperties WellPolymerProperties::serializationTestObject()
     {
         WellPolymerProperties result;
         result.m_polymerConcentration = 1.0;

--- a/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -59,7 +59,7 @@ namespace Opm {
     {}
 
 
-    Well::WellProductionProperties Well::WellProductionProperties::serializeObject()
+    Well::WellProductionProperties Well::WellProductionProperties::serializationTestObject()
     {
         Well::WellProductionProperties result;
         result.name = "test";

--- a/src/opm/input/eclipse/Schedule/Well/WellTestConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellTestConfig.cpp
@@ -33,7 +33,7 @@ WellTestConfig::WTESTWell::WTESTWell(const std::string& name_arg, int shut_reaso
     begin_report_step(begin_report_step_arg)
 {}
 
-WellTestConfig::WTESTWell WellTestConfig::WTESTWell::serializeObject() {
+WellTestConfig::WTESTWell WellTestConfig::WTESTWell::serializationTestObject() {
     return WellTestConfig::WTESTWell("name", static_cast<int>(Reason::PHYSICAL), 100, 1, 674, 56);
 }
 
@@ -93,10 +93,10 @@ int WellTestConfig::WTESTWell::inverse_ecl_reasons(int ecl_reasons) {
 
 
 
-WellTestConfig WellTestConfig::serializeObject()
+WellTestConfig WellTestConfig::serializationTestObject()
 {
     WellTestConfig result;
-    result.wells.emplace(  "W1", WellTestConfig::WTESTWell::serializeObject() );
+    result.wells.emplace(  "W1", WellTestConfig::WTESTWell::serializationTestObject() );
     return result;
 }
 

--- a/src/opm/input/eclipse/Schedule/Well/WellTestState.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellTestState.cpp
@@ -74,7 +74,7 @@ namespace Opm {
     }
 
 
-    WellTestState::WTestWell WellTestState::WTestWell::serializeObject() {
+    WellTestState::WTestWell WellTestState::WTestWell::serializationTestObject() {
         return WTestWell("Name", WellTestConfig::Reason::GROUP, 123.45);
     }
 
@@ -154,7 +154,7 @@ namespace Opm {
         return output;
     }
 
-    WellTestState::ClosedCompletion WellTestState::ClosedCompletion::serializeObject() {
+    WellTestState::ClosedCompletion WellTestState::ClosedCompletion::serializationTestObject() {
         ClosedCompletion c;
         c.wellName = "ABC";
         c.last_test = 0.781;
@@ -242,7 +242,7 @@ namespace Opm {
     }
 
 
-    WellTestState WellTestState::serializeObject() {
+    WellTestState WellTestState::serializationTestObject() {
         WellTestState ws;
         ws.close_well("W1", WellTestConfig::Reason::PHYSICAL, 100);
         ws.close_completion("W1", 3, 200);

--- a/src/opm/input/eclipse/Schedule/Well/WellTracerProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellTracerProperties.cpp
@@ -24,7 +24,7 @@
 
 namespace Opm {
 
-    WellTracerProperties WellTracerProperties::serializeObject()
+    WellTracerProperties WellTracerProperties::serializationTestObject()
     {
         WellTracerProperties result;
         result.m_tracerConcentrations = {{"test", 1.0}, {"test2", 2.0}};

--- a/src/opm/input/eclipse/Schedule/WriteRestartFileEvents.cpp
+++ b/src/opm/input/eclipse/Schedule/WriteRestartFileEvents.cpp
@@ -180,7 +180,7 @@ bool Opm::WriteRestartFileEvents::operator==(const WriteRestartFileEvents& that)
 }
 
 Opm::WriteRestartFileEvents
-Opm::WriteRestartFileEvents::serializeObject()
+Opm::WriteRestartFileEvents::serializationTestObject()
 {
     auto events = WriteRestartFileEvents{};
 

--- a/src/opm/input/eclipse/Units/Dimension.cpp
+++ b/src/opm/input/eclipse/Units/Dimension.cpp
@@ -39,7 +39,7 @@ namespace Opm {
         m_SIoffset = SIoffset;
     }
 
-    Dimension Dimension::serializeObject()
+    Dimension Dimension::serializationTestObject()
     {
         return Dimension(1.0, 2.0);
     }

--- a/src/opm/input/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/input/eclipse/Units/UnitSystem.cpp
@@ -1014,7 +1014,7 @@ namespace {
         init();
     }
 
-    UnitSystem UnitSystem::serializeObject()
+    UnitSystem UnitSystem::serializationTestObject()
     {
         return UnitSystem(UnitType::UNIT_TYPE_METRIC);
     }

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(NAME) \
 }
 
 #define TEST_FOR_TYPE_NAMED(TYPE, NAME) \
-    TEST_FOR_TYPE_NAMED_OBJ(TYPE, NAME, serializeObject)
+    TEST_FOR_TYPE_NAMED_OBJ(TYPE, NAME, serializationTestObject)
 
 #define TEST_FOR_TYPE(TYPE) \
     TEST_FOR_TYPE_NAMED(TYPE, TYPE)
@@ -175,9 +175,9 @@ TEST_FOR_TYPE(BCConfig)
 TEST_FOR_TYPE(BrineDensityTable)
 TEST_FOR_TYPE(ColumnSchema)
 TEST_FOR_TYPE(Connection)
-TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_CarterTracy, serializeObjectC)
-TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_Fetkovich, serializeObjectF)
-TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_Numeric, serializeObjectN)
+TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_CarterTracy, serializationTestObjectC)
+TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_Fetkovich, serializationTestObjectF)
+TEST_FOR_TYPE_NAMED_OBJ(data::AquiferData, AquiferData_Numeric, serializationTestObjectN)
 TEST_FOR_TYPE_NAMED(data::CarterTracyData, CarterTracyData)
 TEST_FOR_TYPE_NAMED(data::CellData, CellData)
 TEST_FOR_TYPE_NAMED(data::Connection, dataConnection)


### PR DESCRIPTION
makes it more clear what these members are used for.