### PR TITLE
fixed: properly export opm-common_PYTHON_COMMON_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,10 @@ if (OPM_ENABLE_PYTHON)
     # Directory to install common (for opm modules) python scripts
     include (GNUInstallDirs)
     set(OPM_PYTHON_COMMON_DIR "${CMAKE_INSTALL_DATAROOTDIR}/opm/python")
+    set(OPM_PROJECT_EXTRA_CODE_INTREE "${OPM_PROJECT_EXTRA_CODE_INTREE}
+                                       set(opm-common_PYTHON_COMMON_DIR ${PROJECT_SOURCE_DIR}/python)")
+    set(OPM_PROJECT_EXTRA_CODE_INSTALLED "${OPM_PROJECT_EXTRA_CODE_INSTALLED}
+                                         set(opm-common_PYTHON_COMMON_DIR ${CMAKE_INSTALL_PREFIX}/${OPM_PYTHON_COMMON_DIR})")
   endif()
   # We always need the PYTHON_INCLUDE_DIR. Unfortunately
   # When we build pypi packages CMake will fail to determine

--- a/cmake/Templates/opm-project-config.cmake.in
+++ b/cmake/Templates/opm-project-config.cmake.in
@@ -35,9 +35,6 @@ if(NOT @opm-project_NAME@_FOUND)
   # actual code is self contained - and can be used downstream without awareness of this.
   set (@opm-project_NAME@_EMBEDDED_PYTHON @OPM_ENABLE_EMBEDDED_PYTHON@)
 
-  # Directory for common (across opm modules) Python scripts
-  set(@opm-project_NAME@_PYTHON_COMMON_DIR "${@opm-project_NAME@_PREFIX}/@OPM_PYTHON_COMMON_DIR@")
-
   # libraries come from the build tree where this file was generated
   set (@opm-project_NAME@_LIBRARY "@opm-project_LIBRARY@")
   set (@opm-project_NAME@_LIBRARIES ${@opm-project_NAME@_LIBRARY} "@opm-project_LIBRARIES@")


### PR DESCRIPTION
this needs to be different for the in-tree and installed config files.

i found the issue you were struggling with @blattms
this fixes it properly.