### PR TITLE
Support Lower Case COMPDAT Direction Strings

### DIFF
--- a/src/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -387,9 +387,9 @@ Connection::Direction Connection::DirectionFromString(const std::string& s )
 {
     Direction direction;
 
-    if      (s == "X") { direction = Direction::X; }
-    else if (s == "Y") { direction = Direction::Y; }
-    else if (s == "Z") { direction = Direction::Z; }
+    if      ((s == "X") || (s == "x")) { direction = Direction::X; }
+    else if ((s == "Y") || (s == "y")) { direction = Direction::Y; }
+    else if ((s == "Z") || (s == "z")) { direction = Direction::Z; }
     else {
         std::string msg = "Unsupported completion direction " + s;
         throw std::invalid_argument(msg);

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -126,7 +126,25 @@ BOOST_AUTO_TEST_CASE(WellConnectionsGetOutOfRangeThrows) {
 }
 
 
+BOOST_AUTO_TEST_CASE(Compdat_Direction) {
+    BOOST_CHECK_MESSAGE(Opm::Connection::DirectionFromString("X") == Opm::Connection::Direction::X,
+                        R"(Direction "X" must be Direction::X)");
+    BOOST_CHECK_MESSAGE(Opm::Connection::DirectionFromString("x") == Opm::Connection::Direction::X,
+                        R"(Direction "x" must be Direction::X)");
+    BOOST_CHECK_MESSAGE(Opm::Connection::DirectionFromString("Y") == Opm::Connection::Direction::Y,
+                        R"(Direction "Y" must be Direction::Y)");
+    BOOST_CHECK_MESSAGE(Opm::Connection::DirectionFromString("y") == Opm::Connection::Direction::Y,
+                        R"(Direction "y" must be Direction::Y)");
+    BOOST_CHECK_MESSAGE(Opm::Connection::DirectionFromString("Z") == Opm::Connection::Direction::Z,
+                        R"(Direction "Z" must be Direction::Z)");
+    BOOST_CHECK_MESSAGE(Opm::Connection::DirectionFromString("z") == Opm::Connection::Direction::Z,
+                        R"(Direction "z" must be Direction::Z)");
 
+    BOOST_CHECK_THROW(Opm::Connection::DirectionFromString(""), std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::Connection::DirectionFromString("XX"), std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::Connection::DirectionFromString("X-"), std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::Connection::DirectionFromString("HeLlo"), std::invalid_argument);
+}
 
 
 BOOST_AUTO_TEST_CASE(AddCompletionCopy) {


### PR DESCRIPTION
Some models will use lower-case strings to input the direction of penetration, e.g., `'x'` or `'z'`.  This PR extends our direction parser to support such strings.

This PR addresses Issue #3164.