### PR TITLE
Fixes bug that hit only for multiple find calls.

### DIFF
--- a/cmake/Modules/FindZOLTAN.cmake
+++ b/cmake/Modules/FindZOLTAN.cmake
@@ -24,7 +24,7 @@ find_package(PTScotch)
 #find_package(ParMETIS)
 
 # search for files which implements this module
-find_path (ZOLTAN_INCLUDE_DIRS
+find_path (ZOLTAN_INCLUDE_DIR
   NAMES "zoltan.h"
   PATHS ${ZOLTAN_SEARCH_PATH}
   PATH_SUFFIXES include trilinos
@@ -35,7 +35,7 @@ if (CMAKE_SIZEOF_VOID_P)
   math (EXPR _BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
 endif (CMAKE_SIZEOF_VOID_P)
 
-find_library(ZOLTAN_LIBRARIES
+find_library(ZOLTAN_LIBRARY
   NAMES zoltan trilinos_zoltan
   PATHS ${ZOLTAN_SEARCH_PATH}
   PATH_SUFFIXES "lib/.libs" "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
@@ -50,15 +50,20 @@ include (FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(ZOLTAN
   DEFAULT_MSG
-  ZOLTAN_LIBRARIES
-  ZOLTAN_INCLUDE_DIRS
+  ZOLTAN_LIBRARY
+  ZOLTAN_INCLUDE_DIR
   MPI_FOUND
   )
 
 if (ZOLTAN_FOUND)
   set(HAVE_ZOLTAN 1)
-  set(ZOLTAN_LIBRARIES ${ZOLTAN_LIBRARIES} ${PARMETIS_LIBRARIES} ${PTSCOTCH_LIBRARIES})
-  set(ZOLTAN_INCLUDE_DIRS ${ZOLTAN_INCLUDE_DIRS} ${PARMETIS_INCLUDE_DIRS}
+  set(ZOLTAN_LIBRARIES ${ZOLTAN_LIBRARY} ${PARMETIS_LIBRARIES} ${PTSCOTCH_LIBRARIES})
+  set(ZOLTAN_INCLUDE_DIRS ${ZOLTAN_INCLUDE_DIR} ${PARMETIS_INCLUDE_DIRS}
       ${PTSCOTCH_INCLUDE_DIRS})
+  # log result
+  file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+    "Determing location of ZOLTAN succeeded:\n"
+    "  Include directory: ${ZOLTAN_INCLUDE_DIRS}\n"
+    "  Library directory: ${ZOLTAN_LIBRARIES}\n\n")
 endif()
 

--- a/cmake/Modules/OpmPackage.cmake
+++ b/cmake/Modules/OpmPackage.cmake
@@ -124,7 +124,7 @@ macro (find_opm_package module deps header lib defs prog conf)
   # without config.h
   config_cmd_line (${module}_CMD_CONFIG ${module}_CONFIG_VARS)
 
-  if(prog)
+  if(NOT "${prog}" STREQUAL "")
     # check that we can compile a small test-program
     include (CMakePushCheckState)
     cmake_push_check_state ()
@@ -138,13 +138,16 @@ macro (find_opm_package module deps header lib defs prog conf)
     list (APPEND CMAKE_REQUIRED_DEFINITIONS ${${module}_CMD_CONFIG})
     check_cxx_source_compiles ("${prog}" HAVE_${MODULE})
     cmake_pop_check_state ()
-  else(prog)
+  else()
     if(${module}_FOUND)
       # No test code provided, mark compilation as successful
-      # if module was founf
-      set(HAVE_${MODULE} 1)
+      # if module was found
+      # Has to be cached because of scope. Otherwise it is not accessible
+      # where it is used.
+      set(HAVE_${MODULE} 1 CACHE BOOL "${module} found")
+      mark_as_advanced(HAVE_${MODULE})
     endif(${module}_FOUND)
-  endif(prog)
+  endif()
 
   # write status message in the same manner as everyone else
   include (FindPackageHandleStandardArgs)


### PR DESCRIPTION
Completes #3175 
Makes sure HAVE_${MODULE} is always defined in all scopes.

1. It was a normal variable if no test program was compiled before. That meant HAVE_DUNE_FEM was not defined even if dune-fem was found.
2. The if-statement checking whether there is something to compile was    wrong as this is macro and hence prog is not a variable. Resorted to comparison to empty string. (That is why 1 applied even thought we passed a program to the macro

