### PR TITLE
Add Unit for Pipeflow Velocity

### DIFF
--- a/opm/input/eclipse/Units/UnitSystem.hpp
+++ b/opm/input/eclipse/Units/UnitSystem.hpp
@@ -28,7 +28,6 @@
 #include <opm/input/eclipse/Units/Dimension.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 
-
 namespace Opm {
 
     class UnitSystem {
@@ -60,6 +59,7 @@ namespace Opm {
             gas_surface_rate,
             rate,
             geometric_volume_rate,
+            pipeflow_velocity,
             transmissibility,
             effective_Kh,
             mass,
@@ -171,8 +171,7 @@ namespace Opm {
         */
         mutable std::size_t m_use_count = 0;
     };
-}
 
+} // namespace Opm
 
-#endif
-
+#endif  // UNITSYSTEM_H

--- a/src/opm/input/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/input/eclipse/Units/UnitSystem.cpp
@@ -90,6 +90,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
     };
 
     static const double to_metric[] = {
@@ -111,6 +112,7 @@ namespace {
         1 / ( Metric::GasSurfaceVolume / Metric::Time ),
         1 / ( Metric::ReservoirVolume / Metric::Time ),
         1 / ( Metric::GeomVolume / Metric::Time ),
+        1 / Metric::Length,     // Pipeflow velocity: Length / Second.
         1 / Metric::Transmissibility,
         1 / (Metric::Permeability * Metric::Length),
         1 / Metric::Mass,
@@ -154,6 +156,7 @@ namespace {
         Metric::GasSurfaceVolume / Metric::Time,
         Metric::ReservoirVolume / Metric::Time,
         Metric::GeomVolume / Metric::Time,
+        Metric::Length,         // Pipeflow velocity: Length / Second.
         Metric::Transmissibility,
         Metric::Permeability * Metric::Length,
         Metric::Mass,
@@ -197,6 +200,7 @@ namespace {
         "SM3/DAY",
         "RM3/DAY",
         "SM3/DAY",  // Should possibly be RM3/DAY
+        "M/SEC",    // pipeflow velocity
         "CPR3/DAY/BARS",
         "MDM",
         "KG",
@@ -282,6 +286,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
     };
 
     static const double to_field[] = {
@@ -303,6 +308,7 @@ namespace {
         1 / ( Field::GasSurfaceVolume / Field::Time ),
         1 / ( Field::ReservoirVolume / Field::Time ),
         1 / ( Field::GeomVolume / Field::Time ),
+        1 / Field::Length,     // Pipeflow velocity: Length / Second.
         1 / Field::Transmissibility,
         1 / (Field::Permeability * Field::Length),
         1 / Field::Mass,
@@ -346,6 +352,7 @@ namespace {
          Field::GasSurfaceVolume / Field::Time,
          Field::ReservoirVolume / Field::Time,
          Field::GeomVolume / Field::Time,
+         Field::Length,         // Pipeflow velocity: Length / Second.
          Field::Transmissibility,
          Field::Permeability * Field::Length,
          Field::Mass,
@@ -389,6 +396,7 @@ namespace {
         "MSCF/DAY",
         "RB/DAY",
         "FT3/DAY",   // Should possibly be RFT3/DAY
+        "FT/SEC",    // Pipeflow velocity
         "CPRB/DAY/PSI",
         "MDFT",
         "LB",
@@ -474,6 +482,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
     };
 
     static const double to_lab[] = {
@@ -495,6 +504,7 @@ namespace {
         1 / ( Lab::GasSurfaceVolume / Lab::Time ),
         1 / ( Lab::ReservoirVolume / Lab::Time ),
         1 / ( Lab::GeomVolume / Lab::Time ),
+        1 / Lab::Length,        // Pipeflow velocity: Length / Second
         1 / Lab::Transmissibility,
         1 / (Lab::Permeability * Lab::Length),
         1 / Lab::Mass,
@@ -538,6 +548,7 @@ namespace {
         Lab::GasSurfaceVolume / Lab::Time,
         Lab::ReservoirVolume / Lab::Time,
         Lab::GeomVolume / Lab::Time,
+        Lab::Length,            // Pipeflow velocity: Length / Second
         Lab::Transmissibility,
         Lab::Permeability * Lab::Length,
         Lab::Mass,
@@ -581,6 +592,7 @@ namespace {
         "SCC/HR",
         "RCC/HR",
         "SCC/HR",   // Should possibly be RCC/HR
+        "CM/SEC",   // Pipeflow velocity
         "CPRCC/HR/ATM",
         "MDCC",
         "G",
@@ -666,6 +678,7 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
     };
 
     static const double to_pvt_m[] = {
@@ -687,6 +700,7 @@ namespace {
         1 / ( PVT_M::GasSurfaceVolume / PVT_M::Time ),
         1 / ( PVT_M::ReservoirVolume / PVT_M::Time ),
         1 / ( PVT_M::GeomVolume / PVT_M::Time ),
+        1 / PVT_M::Length,      // Pipeflow velocity: Length / Second
         1 / PVT_M::Transmissibility,
         1 / (PVT_M::Permeability * PVT_M::Length),
         1 / PVT_M::Mass,
@@ -730,6 +744,7 @@ namespace {
         PVT_M::GasSurfaceVolume / PVT_M::Time,
         PVT_M::ReservoirVolume / PVT_M::Time,
         PVT_M::GeomVolume / PVT_M::Time,
+        PVT_M::Length,          // Pipeflow velocity: Length / Second
         PVT_M::Transmissibility,
         PVT_M::Permeability * PVT_M::Length,
         PVT_M::Mass,
@@ -773,6 +788,7 @@ namespace {
         "SM3/DAY",
         "RM3/DAY",
         "SM3/DAY",     // Should possibly be SM3/DAY
+        "M/SEC",       // Pipeflow velocity
         "CPR3/DAY/ATM",
         "MDM",
         "KG",
@@ -858,9 +874,11 @@ namespace {
         0.0,
         0.0,
         0.0,
+        0.0,
     };
 
     static const double to_input[] = {
+        1,
         1,
         1,
         1,
@@ -944,6 +962,7 @@ namespace {
         1,
         1,
         1,
+        1,
     };
 
     static constexpr const char* input_names[static_cast<int>(UnitSystem::measure::_count)] = {
@@ -965,6 +984,7 @@ namespace {
         "SM3/DAY",
         "RM3/DAY",
         "SM3/DAY",
+        "M/SEC",                // Pipeflow velocity.
         "CPR3/DAY/BARS",
         "MDM",
         "KG",
@@ -1545,4 +1565,4 @@ namespace {
         };
     }
 
-}
+} // namespace Opm

--- a/tests/parser/UnitTests.cpp
+++ b/tests/parser/UnitTests.cpp
@@ -288,6 +288,7 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.to_si( Meas::gas_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::geometric_volume_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.to_si( Meas::pipeflow_velocity , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::transmissibility , 1.0 ) , 1.157407407407407e-13 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.to_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
@@ -326,6 +327,7 @@ BOOST_AUTO_TEST_CASE(METRIC_UNITS)
     BOOST_CHECK_CLOSE( metric.from_si( Meas::gas_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::geometric_volume_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( metric.from_si( Meas::pipeflow_velocity , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::transmissibility , 1.0 ) , 8.64e+12 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( metric.from_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
@@ -373,6 +375,7 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.to_si( Meas::gas_surface_rate , 1.0 ) , 3.277412800000001e-04 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::rate , 1.0 ) , 1.840130728333334e-06 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::geometric_volume_rate, 1.0 ) , 3.2774128e-07 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.to_si( Meas::pipeflow_velocity, 1.0 ) , 0.3048 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::transmissibility , 1.0 ) , 2.668883979653090e-13 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::effective_Kh , 1.0 ) , 3.008142116950407e-16 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.to_si( Meas::mass , 1.0 ) , 0.45359237 , 1.0e-10 );
@@ -412,6 +415,7 @@ BOOST_AUTO_TEST_CASE(FIELD_UNITS)
     BOOST_CHECK_CLOSE( field.from_si( Meas::gas_surface_rate , 1.0 ) , 3.051187204736614e+03 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::rate , 1.0 ) , 5.434396505653337e+05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::geometric_volume_rate, 3.2774128e-07 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( field.from_si( Meas::pipeflow_velocity, 1.0 ) , 3.280839895013123e+00 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::transmissibility , 1.0 ) , 3.746884494132199e+12 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::effective_Kh , 1.0 ) , 3.324311023622047e+15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( field.from_si( Meas::mass , 1.0 ) , 2.204622621848776e+00 , 1.0e-10 );
@@ -459,6 +463,7 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.to_si( Meas::gas_surface_rate , 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::rate , 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::geometric_volume_rate, 1.0 ) , 2.777777777777778e-10 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.to_si( Meas::pipeflow_velocity, 1.0 ) , 0.01 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::transmissibility , 1.0 ) , 2.741453518655592e-18 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160130e-18 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.to_si( Meas::mass , 1.0 ) , 1.0e-3 , 1.0e-10 );
@@ -498,6 +503,7 @@ BOOST_AUTO_TEST_CASE(LAB_UNITS)
     BOOST_CHECK_CLOSE( lab.from_si( Meas::gas_surface_rate , 1.0 ) , 3.6e9 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::rate , 1.0 ) , 3.6e9 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::geometric_volume_rate, 1.0 ) , 3.6e9 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( lab.from_si( Meas::pipeflow_velocity, 1.0 ) , 100.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::transmissibility , 1.0 ) , 3.647699999999999e+17 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+17 , 1.0e-10 );
     BOOST_CHECK_CLOSE( lab.from_si( Meas::mass , 1.0 ) , 1.0e3 , 1.0e-10 );
@@ -546,6 +552,7 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::gas_surface_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::geometric_volume_rate , 1.0 ) , 1.1574074074074073e-05 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::pipeflow_velocity , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::transmissibility , 1.0 ) , 1.142272299439830e-13 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::effective_Kh , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );
@@ -585,6 +592,7 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_surface_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::rate , 1.0 ) , 86.400e3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::geometric_volume_rate , 1.0 ) , 86.400e3 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::pipeflow_velocity , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::transmissibility , 1.0 ) , 8.75448e+12 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::effective_Kh , 1.0 ) , 1.01325e+15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::mass , 1.0 ) , 1.0 , 1.0e-10 );


### PR DESCRIPTION
Needed for summary and RFT file output of fluid flow velocity in well segments.

The velocity unit here is "length / second" rather than "length / time", so that's why we only need to convert the length unit when translating between input/output unit conventions and OPM's strict SI convention.