### PR TITLE
added: FaceDir::FromIntersectionIndex

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FaceDir.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FaceDir.hpp
@@ -44,6 +44,8 @@ namespace Opm {
 
         DirEnum FromString(const std::string& stringValue);
         int     FromMULTREGTString(const std::string& stringValue);
+        DirEnum FromIntersectionIndex(int idx);
+
         const std::string toString(DirEnum dir);
     }
 }

--- a/src/opm/input/eclipse/EclipseState/Grid/FaceDir.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FaceDir.cpp
@@ -96,5 +96,16 @@ namespace Opm {
                 throw std::runtime_error("This should not happen");
             return fmt::format("{}",fmt::join(ret, "|"));
         }
+
+        DirEnum FromIntersectionIndex(int idx)
+        {
+            const std::vector<FaceDir::DirEnum> mapping =
+                {XMinus, XPlus, YMinus, YPlus, ZMinus, ZPlus};
+
+            if (idx < 0 || idx > 5)
+                throw std::invalid_argument("Wrong face direction");
+
+            return mapping[idx];
+        }
     }
 }

--- a/tests/parser/FaceDirTests.cpp
+++ b/tests/parser/FaceDirTests.cpp
@@ -73,6 +73,18 @@ BOOST_AUTO_TEST_CASE(CheckComposite) {
     BOOST_CHECK_THROW( FaceDir::FromString("YX") , std::invalid_argument);
 }
 
+BOOST_AUTO_TEST_CASE(CheckIntersection) {
+    BOOST_CHECK_EQUAL(FaceDir::FromIntersectionIndex(0), FaceDir::XMinus);
+    BOOST_CHECK_EQUAL(FaceDir::FromIntersectionIndex(1), FaceDir::XPlus);
+    BOOST_CHECK_EQUAL(FaceDir::FromIntersectionIndex(2), FaceDir::YMinus);
+    BOOST_CHECK_EQUAL(FaceDir::FromIntersectionIndex(3), FaceDir::YPlus);
+    BOOST_CHECK_EQUAL(FaceDir::FromIntersectionIndex(4), FaceDir::ZMinus);
+    BOOST_CHECK_EQUAL(FaceDir::FromIntersectionIndex(5), FaceDir::ZPlus);
+
+    BOOST_CHECK_THROW(FaceDir::FromIntersectionIndex(-1), std::invalid_argument);
+    BOOST_CHECK_THROW(FaceDir::FromIntersectionIndex(6), std::invalid_argument);
+}
+
 
 }
 


### PR DESCRIPTION
this translates from a dune intersection id to a FaceDir::DirEnum.

Upstream of https://github.com/OPM/opm-simulators/pull/4171