### PR TITLE
Damaris depends on MPI

### DIFF
--- a/cmake/Modules/UseDamaris.cmake
+++ b/cmake/Modules/UseDamaris.cmake
@@ -21,11 +21,6 @@ if(USE_DAMARIS_LIB)
     message(STATUS "The Damaris library was requested but NOT found")
   endif()
 else()  # User did not request Damaris support
-  if (Damaris_FOUND)
-    message(STATUS "The Damaris library was NOT requested but was found: ${Damaris_VERSION} ${Damaris_DIR}")
-  else()
-    message(STATUS "The Damaris library was NOT requested and was NOT found")
-  endif()
   unset(HAVE_DAMARIS)
 endif()
 

--- a/cmake/Modules/UseDamaris.cmake
+++ b/cmake/Modules/UseDamaris.cmake
@@ -1,4 +1,4 @@
-if(USE_DAMARIS_LIB)
+if(USE_DAMARIS_LIB AND MPI_Found)
   if (Damaris_FOUND)
     set(HAVE_DAMARIS 1)
     message(STATUS "The Damaris library was found: ${Damaris_VERSION} ${Damaris_DIR}")


### PR DESCRIPTION
Don't enable damaris if MPI was not enabled. Also reduce verbosity when damaris was not requested.