### PR TITLE
Use MPI_FOUND not MPI_Found.

### DIFF
--- a/cmake/Modules/UseDamaris.cmake
+++ b/cmake/Modules/UseDamaris.cmake
@@ -1,4 +1,4 @@
-if(USE_DAMARIS_LIB AND MPI_Found)
+if(USE_DAMARIS_LIB AND MPI_FOUND)
   if (Damaris_FOUND)
     set(HAVE_DAMARIS 1)
     message(STATUS "The Damaris library was found: ${Damaris_VERSION} ${Damaris_DIR}")


### PR DESCRIPTION
According to https://cmake.org/cmake/help/latest/module/FindMPI.html the capitalized version is what we should use.