### PR TITLE
Fix metis-related warnings

### DIFF
--- a/cmake/Modules/FindMETIS.cmake
+++ b/cmake/Modules/FindMETIS.cmake
@@ -46,8 +46,8 @@ if (METIS_INCLUDE_DIRS OR METIS_LIBRARIES)
   file(READ "${METIS_INCLUDE_DIRS}/metis.h" metisheader)
   string(REGEX MATCH "#define METIS_VER_MAJOR[ ]+([0-9]+)" METIS_MAJOR_VERSION ${metisheader})
   if(NOT METIS_API_VERSION AND METIS_MAJOR_VERSION)
-#    string(REGEX REPLACE ".*#define METIS_VER_MAJOR[ ]+([0-9]+).*" "\\1"
-#    METIS_MAJOR_VERSION "${metisheader}")
+    string(REGEX REPLACE ".*#define METIS_VER_MAJOR[ ]+([0-9]+).*" "\\1"
+    METIS_MAJOR_VERSION "${metisheader}")
     if(METIS_MAJOR_VERSION GREATER_EQUAL 3 AND METIS_MAJOR_VERSION LESS 5)
       set(METIS_API_VERSION "3")
     else()


### PR DESCRIPTION
With master, I get lots of
```
WARNING: Preprocessor definitions containing '#' may not be passed on the compiler command line because many compilers do not support it.
CMake is dropping a preprocessor definition: METIS_API_VERSION=#define METIS_VER_MAJOR         5
Consider defining the macro in a (configured) header file.
```

The commented-out part seems to be necessary to avoid this.