### PR TITLE
Cleanup when ESMRY renamle fails

### DIFF
--- a/opm/io/eclipse/ExtSmryOutput.hpp
+++ b/opm/io/eclipse/ExtSmryOutput.hpp
@@ -63,6 +63,7 @@ private:
 
     std::array<int, 3> ijk_from_global_index(const GridDims& dims, int globInd) const;
     std::vector<std::string> make_modified_keys(const std::vector<std::string>& valueKeys, const GridDims& dims);
+    bool rename_tmpfile(const std::string& tmp_fname);
 };
 
 


### PR DESCRIPTION
Delete temp esmry file when the rename temp ESMRY file to simulation ESMRY file.

With current master the following errors occurs from time to time. 

```
ERROR: Uncaught std::exception when running tasklet: filesystem error: cannot rename: No such file or directory [TMP_1667245070.ESMRY] [./TEST1_MASTER.ESMRY]. Trying to continue.
ERROR: Uncaught std::exception when running tasklet: filesystem error: cannot rename: No such file or directory [TMP_1667246438.ESMRY] [./TEST1_MASTER.ESMRY]. Trying to continue.
ERROR: Uncaught std::exception when running tasklet: filesystem error: cannot rename: No such file or directory [TMP_1667246626.ESMRY] [./TEST1_MASTER.ESMRY]. Trying to continue.
ERROR: Uncaught std::exception when running tasklet: filesystem error: cannot rename: No such file or directory [TMP_1667247125.ESMRY] [./TEST1_MASTER.ESMRY]. Trying to continue.
```
I have not understood why this happens, however this PR will catch the exeption and delete the temporary file. The PR has been tested on Equinor IT infrastructure and this works as expected. 