### PR TITLE
Ensure At Least One Well List per Well

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -37,9 +37,11 @@
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 
+#include <algorithm>
 #include <ostream>
 #include <stdexcept>
 #include <type_traits>
+
 #include <fmt/format.h>
 
 namespace {
@@ -204,7 +206,7 @@ Welldims::Welldims(const Deck& deck)
         this->nCWMax = wd.getItem<WD::MAXCONN>().get<int>(0);
         this->nWGMax = wd.getItem<WD::MAX_GROUPSIZE>().get<int>(0);
 
-        // This is the E100 definition.  E300 instead uses
+        // Note: nGMax uses the E100 definition.  E300 instead uses
         //
         //   Max{ "MAXGROUPS", "MAXWELLS" }
         //
@@ -212,11 +214,13 @@ Welldims::Welldims(const Deck& deck)
         this->nGMax = wd.getItem<WD::MAXGROUPS>().get<int>(0);
         this->nWMax = wd.getItem<WD::MAXWELLS>().get<int>(0);
 
-        // maximum number of well lists pr well
-        this->nWlistPrWellMax = wd.getItem<WD::MAX_WELLIST_PR_WELL>().get<int>(0);
-        //maximum number of dynamic well lists
-        this->nDynWlistMax = wd.getItem<WD::MAX_DYNAMIC_WELLIST>().get<int>(0);
+        // Maximum number of well lists pr well.  Always at least 1.
+        this->nWlistPrWellMax =
+            std::max(WD::MAX_WELLIST_PR_WELL::defaultValue,
+                     wd.getItem<WD::MAX_WELLIST_PR_WELL>().get<int>(0));
 
+        // Maximum number of dynamic well lists
+        this->nDynWlistMax = wd.getItem<WD::MAX_DYNAMIC_WELLIST>().get<int>(0);
 
         this->m_location = keyword.location();
     }

--- a/tests/parser/RunspecTests.cpp
+++ b/tests/parser/RunspecTests.cpp
@@ -434,6 +434,55 @@ WELLDIMS
     BOOST_CHECK_EQUAL(wd.maxGroupsInField(), 0);  // WELLDIMS(3), defaulted
 }
 
+BOOST_AUTO_TEST_CASE(WELLDIMS_MaxWList_Dflt)
+{
+    const auto input = std::string { R"(
+RUNSPEC
+
+WELLDIMS
+/
+)" };
+
+    const auto wd = Welldims {
+        Parser{}.parseString(input)
+    };
+
+    BOOST_CHECK_EQUAL(wd.maxWellListsPrWell(), 1); // WELLDIMS(11), defaulted
+}
+
+BOOST_AUTO_TEST_CASE(WELLDIMS_MaxWList_Assigned)
+{
+    const auto input = std::string { R"(
+RUNSPEC
+
+WELLDIMS
+10* 5 /
+)" };
+
+    const auto wd = Welldims {
+        Parser{}.parseString(input)
+    };
+
+    BOOST_CHECK_EQUAL(wd.maxWellListsPrWell(), 5); // WELLDIMS(11), assigned
+}
+
+BOOST_AUTO_TEST_CASE(WELLDIMS_MaxWList_Zero)
+{
+    const auto input = std::string { R"(
+RUNSPEC
+
+WELLDIMS
+10* 0 /
+)" };
+
+    const auto wd = Welldims {
+        Parser{}.parseString(input)
+    };
+
+    // WELLDIMS(11) assigned but reset to at least 1.
+    BOOST_CHECK_EQUAL(wd.maxWellListsPrWell(), 1);
+}
+
 BOOST_AUTO_TEST_CASE(WSEGDIMS_NotSpecified)
 {
     const auto input = std::string {


### PR DESCRIPTION
If the input model sets the maximum number of well lists per well to zero (or negative), then treat this as if the limit is defaulted and reset the value to the default (one).


This backports #3195