### PR TITLE
changed: flag an error if just one case has a rft file

### DIFF
--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -1044,9 +1044,9 @@ void ECLRegressionTest::results_rft()
     bool foundRft1 = checkFileName(rootName1, "RFT", fileName1);
     bool foundRft2 = checkFileName(rootName2, "RFT", fileName2);
 
-    if ((foundRft1) && (not foundRft2)){
-        std::string message ="test case rft file " + rootName2 + ".RFT not found";
-	std::cout << message << std::endl;
+    if ((!foundRft1 && foundRft2) || (foundRft1 && !foundRft2)) {
+        std::string message ="test case rft file " + (foundRft1 ? rootName1 : rootName2) + ".RFT not found";
+        std::cout << message << std::endl;
         OPM_THROW(std::runtime_error, message);
     }
 


### PR DESCRIPTION
We should not be silently ignoring if reference case has no rft file, but new run has.
ref https://github.com/OPM/opm-tests/pull/853