### PR TITLE
fixed: zero initialize to avoid compiler warnings

### DIFF
--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -283,7 +283,7 @@ protected:
             bool has = false;
             (*this)(has);
             if (has) {
-                T res;
+                T res{};
                 (*this)(res);
                 const_cast<std::optional<T>&>(data) = res;
             }


### PR DESCRIPTION
In particular gcc11 is noisy..