### PR TITLE
fixed: depend on the copy_python target

### DIFF
--- a/GenerateKeywords.cmake
+++ b/GenerateKeywords.cmake
@@ -67,10 +67,12 @@ endforeach()
 list(APPEND _target_output ${PROJECT_BINARY_DIR}/include/opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp)
 list(APPEND _tmp_output ${PROJECT_BINARY_DIR}/tmp_gen/include/opm/input/eclipse/Parser/ParserKeywords/Builtin.hpp)
 
+set(GEN_DEPS ${_tmp_output})
 if (OPM_ENABLE_PYTHON)
   list(APPEND genkw_argv ${PROJECT_BINARY_DIR}/tmp_gen/builtin_pybind11.cpp)
   list(APPEND _tmp_output ${PROJECT_BINARY_DIR}/tmp_gen/builtin_pybind11.cpp)
   list(APPEND _target_output ${PROJECT_BINARY_DIR}/python/cxx/builtin_pybind11.cpp)
+  list(APPEND GEN_DEPS copy_python)
 endif()
 
 add_custom_command( OUTPUT
@@ -81,5 +83,5 @@ add_custom_command( OUTPUT
 # To avoid some rebuilds
 add_custom_command(OUTPUT
   ${_target_output}
-  DEPENDS ${_tmp_output}
+  DEPENDS ${GEN_DEPS}
   COMMAND ${CMAKE_COMMAND} -DBASE_DIR=${PROJECT_BINARY_DIR} -P ${PROJECT_SOURCE_DIR}/CopyHeaders.cmake)


### PR DESCRIPTION
the generated python code requires the copy_python target to setup the directory structure. without this, builds failed when building a specific target (ie not 'all') in a clean build tree