### PR TITLE
Link Additional Targets to Dune Common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,8 +354,26 @@ target_compile_options(dunecommon INTERFACE ${dflags})
 target_compile_definitions(dunecommon INTERFACE DUNE_COMMON_VERSION_MAJOR=${DUNE_COMMON_VERSION_MAJOR})
 target_compile_definitions(dunecommon INTERFACE DUNE_COMMON_VERSION_MINOR=${DUNE_COMMON_VERSION_MINOR})
 target_compile_definitions(dunecommon INTERFACE DUNE_COMMON_VERSION_REVISION=${DUNE_COMMON_VERSION_REVISION})
-foreach(tgt test_co2brine_ptflash test_immiscibleflash test_ncpflash
-            test_pengrobinson test_threecomponents_ptflash)
+foreach(tgt
+    co2brinepvt
+    test_2dtables
+    test_blackoilfluidstate
+    test_co2brine_ptflash
+    test_co2brinepvt
+    test_components
+    test_densead
+    test_eclblackoilfluidsystem
+    test_eclblackoilpvt
+    test_eclmateriallawmanager
+    test_fluidmatrixinteractions
+    test_fluidsystems
+    test_immiscibleflash
+    test_ncpflash
+    test_pengrobinson
+    test_spline
+    test_tabulation
+    test_threecomponents_ptflash
+  )
   target_link_libraries(${tgt} dunecommon)
 endforeach()
 

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -635,7 +635,6 @@ if(ENABLE_ECL_INPUT)
     examples/rst_deck.cpp
     examples/make_esmry.cpp
     examples/co2brinepvt.cpp
-    examples/co2brinepvt.cpp
   )
 endif()
 


### PR DESCRIPTION
While here, also remove a duplicate entry for
```
examples/co2brinepvt.cpp
```