### PR TITLE
EclEpsConfig: put initFromState in separate compile unit

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -231,6 +231,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/input/eclipse/Units/Dimension.cpp
     src/opm/input/eclipse/Units/UnitSystem.cpp
     src/opm/input/eclipse/Utility/Functional.cpp
+    src/opm/material/fluidmatrixinteractions/EclEpsConfig.cpp
   )
 
 

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -27,15 +27,14 @@
 #ifndef OPM_ECL_EPS_CONFIG_HPP
 #define OPM_ECL_EPS_CONFIG_HPP
 
-#if HAVE_ECL_INPUT
-#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <stdexcept>
-#endif
-
-#include <cassert>
 #include <string>
 
 namespace Opm {
+
+#if HAVE_ECL_INPUT
+class EclipseState;
+#endif
+
 /*!
  * \brief Specified which fluids are involved in a given twophase material law for
  *        endpoint scaling.
@@ -56,17 +55,6 @@ enum EclTwoPhaseSystemType {
 class EclEpsConfig
 {
 public:
-    EclEpsConfig()
-    {
-        // by default, do not scale anything
-        enableSatScaling_ = false;
-        enablePcScaling_ = false;
-        enableLeverettScaling_ = false;
-        enableKrwScaling_ = false;
-        enableKrnScaling_ = false;
-        enableThreePointKrSatScaling_ = false;
-    }
-
     /*!
      * \brief Specify whether saturation scaling is enabled.
      */
@@ -186,95 +174,26 @@ public:
     void initFromState(const EclipseState& eclState,
                        EclTwoPhaseSystemType twoPhaseSystemType,
                        const std::string& prefix = "",
-                       const std::string& suffix = "")
-    {
-        const auto& endscale = eclState.runspec().endpointScaling();
-        // find out if endpoint scaling is used in the first place
-        if (!endscale) {
-            // it is not used, i.e., just set all enable$Foo attributes to 0 and be done
-            // with it.
-            enableSatScaling_ = false;
-            enableThreePointKrSatScaling_ = false;
-            enablePcScaling_ = false;
-            enableLeverettScaling_ = false;
-            enableKrwScaling_ = false;
-            enableKrnScaling_ = false;
-            return;
-        }
-
-        // endpoint scaling is used, i.e., at least saturation scaling needs to be enabled
-        enableSatScaling_ = true;
-        enableThreePointKrSatScaling_ = endscale.threepoint();
-
-        if (eclState.getTableManager().useJFunc()) {
-            const auto flag = eclState.getTableManager().getJFunc().flag();
-
-            enableLeverettScaling_ = (flag == JFunc::Flag::BOTH)
-                || ((twoPhaseSystemType == EclOilWaterSystem) &&
-                    (flag == JFunc::Flag::WATER))
-                || ((twoPhaseSystemType == EclGasOilSystem) &&
-                    (flag == JFunc::Flag::GAS));
-        }
-
-        const auto& fp = eclState.fieldProps();
-        auto hasKR = [&fp, &prefix, &suffix](const std::string& scaling)
-        {
-            return fp.has_double(prefix + "KR" + scaling + suffix);
-        };
-        auto hasPC = [&fp, &prefix](const std::string& scaling)
-        {
-            return fp.has_double(prefix + "PC" + scaling);
-        };
-
-        // check if we are supposed to scale the Y axis of the capillary pressure
-        if (twoPhaseSystemType == EclOilWaterSystem) {
-            this->setEnableThreePointKrwScaling(hasKR("WR"));
-            this->setEnableThreePointKrnScaling(hasKR("ORW"));
-
-            this->enableKrnScaling_ = hasKR("O") || this->enableThreePointKrnScaling();
-            this->enableKrwScaling_ = hasKR("W") || this->enableThreePointKrwScaling();
-            this->enablePcScaling_  = hasPC("W") || fp.has_double("SWATINIT");
-        }
-        else if (twoPhaseSystemType == EclGasOilSystem) {
-            this->setEnableThreePointKrwScaling(hasKR("ORG"));
-            this->setEnableThreePointKrnScaling(hasKR("GR"));
-
-            this->enableKrnScaling_ = hasKR("G") || this->enableThreePointKrnScaling();
-            this->enableKrwScaling_ = hasKR("O") || this->enableThreePointKrwScaling();
-            this->enablePcScaling_  = hasPC("G");
-        }
-        else {
-            assert(twoPhaseSystemType == EclGasWaterSystem);
-            //TODO enable endpoint scaling for gaswater system
-        }
-
-        if (enablePcScaling_ && enableLeverettScaling_) {
-            throw std::runtime_error {
-                "Capillary pressure scaling and the Leverett scaling function "
-                "are mutually exclusive. The deck contains the PCW/PCG property "
-                "and the JFUNC keyword applies to the water phase."
-            };
-        }
-    }
+                       const std::string& suffix = "");
 #endif
 
 private:
     // enable scaling of the input saturations (i.e., rescale the x-Axis)
-    bool enableSatScaling_;
+    bool enableSatScaling_{false};
 
     // use three (instead of two) points to scale the saturations for the relative
     // permeabilities.
     //
     // This means that two piecewise linear functions are used for saturation scaling
     // instead of a single linear one
-    bool enableThreePointKrSatScaling_;
+    bool enableThreePointKrSatScaling_{false};
 
     // enable the scaling of the capillary pressure and relative permeability outputs
     // (i.e., rescale the y-Axis)
-    bool enablePcScaling_;
-    bool enableLeverettScaling_;
-    bool enableKrwScaling_;
-    bool enableKrnScaling_;
+    bool enablePcScaling_{false};
+    bool enableLeverettScaling_{false};
+    bool enableKrwScaling_{false};
+    bool enableKrnScaling_{false};
 
     // Employ three-point vertical scaling (e.g., KRWR and KRW).
     bool enableThreePointKrwScaling_{false};

--- a/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsConfig.hpp
@@ -39,10 +39,10 @@ class EclipseState;
  * \brief Specified which fluids are involved in a given twophase material law for
  *        endpoint scaling.
  */
-enum EclTwoPhaseSystemType {
-    EclGasOilSystem,
-    EclOilWaterSystem,
-    EclGasWaterSystem
+enum class EclTwoPhaseSystemType {
+    GasOil,
+    OilWater,
+    GasWater
 };
 
 /*!

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -312,7 +312,7 @@ public:
               const EclEpsConfig& config,
               EclTwoPhaseSystemType epsSystemType)
     {
-        if (epsSystemType == EclOilWaterSystem) {
+        if (epsSystemType == EclTwoPhaseSystemType::OilWater) {
             // saturation scaling for capillary pressure
             saturationPcPoints_[0] = epsInfo.Swl;
             saturationPcPoints_[2] = saturationPcPoints_[1] = epsInfo.Swu;
@@ -342,7 +342,8 @@ public:
             maxKrn_ = epsInfo.maxKrow;
         }
         else {
-            assert((epsSystemType == EclGasOilSystem) ||(epsSystemType == EclGasWaterSystem) );
+            assert(epsSystemType == EclTwoPhaseSystemType::GasOil ||
+                   epsSystemType == EclTwoPhaseSystemType::GasWater);
 
             // saturation scaling for capillary pressure
             saturationPcPoints_[0] = 1.0 - epsInfo.Swl - epsInfo.Sgu;

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -114,19 +114,19 @@ public:
     {
         drainageParams_ = value;
 
-        oilWaterSystem_ = (twoPhaseSystem == EclOilWaterSystem);
+        oilWaterSystem_ = (twoPhaseSystem == EclTwoPhaseSystemType::OilWater);
 
         if (!config().enableHysteresis())
             return;
 
         if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().pcHysteresisModel() == 0) {
-            if (twoPhaseSystem == EclGasOilSystem) {
+            if (twoPhaseSystem == EclTwoPhaseSystemType::GasOil) {
                 Sncrd_ = info.Sgcr+info.Swl;
                 Snmaxd_ = info.Sgu+info.Swl;
                 KrndMax_ = EffLawT::twoPhaseSatKrn(drainageParams(), 1.0-Snmaxd_);
             }
             else {
-                assert(twoPhaseSystem == EclOilWaterSystem);
+                assert(twoPhaseSystem == EclTwoPhaseSystemType::OilWater);
                 Sncrd_ = info.Sowcr;
                 Snmaxd_ = 1.0 - info.Swl - info.Sgl;
                 KrndMax_ = EffLawT::twoPhaseSatKrn(drainageParams(), 1.0-Snmaxd_);
@@ -135,12 +135,12 @@ public:
 
         // Additional Killough hysteresis model for pc
         if (config().pcHysteresisModel() == 0) {
-            if (twoPhaseSystem == EclGasOilSystem) {
+            if (twoPhaseSystem == EclTwoPhaseSystemType::GasOil) {
                 Swcrd_ = info.Sogcr;
                 pcmaxd_ = info.maxPcgo;
             }
             else {
-                assert(twoPhaseSystem == EclOilWaterSystem);
+                assert(twoPhaseSystem == EclTwoPhaseSystemType::OilWater);
                 Swcrd_ = info.Swcr;
                 pcmaxd_ = -17.0; // At this point 'info.maxPcow' holds pre-swatinit value ...;
             }
@@ -170,24 +170,24 @@ public:
 
         // Killough hysteresis model for nonw kr
         if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().pcHysteresisModel() == 0) {
-            if (twoPhaseSystem == EclGasOilSystem) {
+            if (twoPhaseSystem == EclTwoPhaseSystemType::GasOil) {
                 Sncri_ = info.Sgcr+info.Swl;
             }
             else {
-                assert(twoPhaseSystem == EclOilWaterSystem);
+                assert(twoPhaseSystem == EclTwoPhaseSystemType::OilWater);
                 Sncri_ = info.Sowcr;
             }
         }
 
         // Killough hysteresis model for pc
         if (config().pcHysteresisModel() == 0) {
-            if (twoPhaseSystem == EclGasOilSystem) {
+            if (twoPhaseSystem == EclTwoPhaseSystemType::GasOil) {
                 Swcri_ = info.Sogcr;
                 Swmaxi_ = 1.0 - info.Sgl - info.Swl;
                 pcmaxi_ = info.maxPcgo;
             }
             else {
-                assert(twoPhaseSystem == EclOilWaterSystem);
+                assert(twoPhaseSystem == EclTwoPhaseSystemType::OilWater);
                 Swcri_ = info.Swcr;
                 Swmaxi_ = info.Swu;
                 pcmaxi_ = info.maxPcow;

--- a/src/opm/material/fluidmatrixinteractions/EclEpsConfig.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclEpsConfig.cpp
@@ -1,0 +1,112 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclEpsConfig
+ */
+
+#include <config.h>
+#include <opm/material/fluidmatrixinteractions/EclEpsConfig.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <stdexcept>
+
+#include <cassert>
+
+namespace Opm {
+
+void EclEpsConfig::initFromState(const EclipseState& eclState,
+                                 EclTwoPhaseSystemType twoPhaseSystemType,
+                                const std::string& prefix,
+                                const std::string& suffix)
+{
+    const auto& endscale = eclState.runspec().endpointScaling();
+    // find out if endpoint scaling is used in the first place
+    if (!endscale) {
+        // it is not used, i.e., just set all enable$Foo attributes to 0 and be done
+        // with it.
+        enableSatScaling_ = false;
+        enableThreePointKrSatScaling_ = false;
+        enablePcScaling_ = false;
+        enableLeverettScaling_ = false;
+        enableKrwScaling_ = false;
+        enableKrnScaling_ = false;
+        return;
+    }
+
+    // endpoint scaling is used, i.e., at least saturation scaling needs to be enabled
+    enableSatScaling_ = true;
+    enableThreePointKrSatScaling_ = endscale.threepoint();
+
+    if (eclState.getTableManager().useJFunc()) {
+        const auto flag = eclState.getTableManager().getJFunc().flag();
+
+        enableLeverettScaling_ = (flag == JFunc::Flag::BOTH)
+            || ((twoPhaseSystemType == EclOilWaterSystem) &&
+                (flag == JFunc::Flag::WATER))
+            || ((twoPhaseSystemType == EclGasOilSystem) &&
+                (flag == JFunc::Flag::GAS));
+    }
+
+    const auto& fp = eclState.fieldProps();
+    auto hasKR = [&fp, &prefix, &suffix](const std::string& scaling)
+    {
+        return fp.has_double(prefix + "KR" + scaling + suffix);
+    };
+    auto hasPC = [&fp, &prefix](const std::string& scaling)
+    {
+        return fp.has_double(prefix + "PC" + scaling);
+    };
+
+    // check if we are supposed to scale the Y axis of the capillary pressure
+    if (twoPhaseSystemType == EclOilWaterSystem) {
+        this->setEnableThreePointKrwScaling(hasKR("WR"));
+        this->setEnableThreePointKrnScaling(hasKR("ORW"));
+
+        this->enableKrnScaling_ = hasKR("O") || this->enableThreePointKrnScaling();
+        this->enableKrwScaling_ = hasKR("W") || this->enableThreePointKrwScaling();
+        this->enablePcScaling_  = hasPC("W") || fp.has_double("SWATINIT");
+    }
+    else if (twoPhaseSystemType == EclGasOilSystem) {
+        this->setEnableThreePointKrwScaling(hasKR("ORG"));
+        this->setEnableThreePointKrnScaling(hasKR("GR"));
+
+        this->enableKrnScaling_ = hasKR("G") || this->enableThreePointKrnScaling();
+        this->enableKrwScaling_ = hasKR("O") || this->enableThreePointKrwScaling();
+        this->enablePcScaling_  = hasPC("G");
+    }
+    else {
+        assert(twoPhaseSystemType == EclGasWaterSystem);
+        //TODO enable endpoint scaling for gaswater system
+    }
+
+    if (enablePcScaling_ && enableLeverettScaling_) {
+        throw std::runtime_error {
+            "Capillary pressure scaling and the Leverett scaling function "
+            "are mutually exclusive. The deck contains the PCW/PCG property "
+            "and the JFUNC keyword applies to the water phase."
+        };
+    }
+}
+
+} // namespace Opm

--- a/src/opm/material/fluidmatrixinteractions/EclEpsConfig.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclEpsConfig.cpp
@@ -62,9 +62,9 @@ void EclEpsConfig::initFromState(const EclipseState& eclState,
         const auto flag = eclState.getTableManager().getJFunc().flag();
 
         enableLeverettScaling_ = (flag == JFunc::Flag::BOTH)
-            || ((twoPhaseSystemType == EclOilWaterSystem) &&
+            || ((twoPhaseSystemType == EclTwoPhaseSystemType::OilWater) &&
                 (flag == JFunc::Flag::WATER))
-            || ((twoPhaseSystemType == EclGasOilSystem) &&
+            || ((twoPhaseSystemType == EclTwoPhaseSystemType::GasOil) &&
                 (flag == JFunc::Flag::GAS));
     }
 
@@ -79,7 +79,7 @@ void EclEpsConfig::initFromState(const EclipseState& eclState,
     };
 
     // check if we are supposed to scale the Y axis of the capillary pressure
-    if (twoPhaseSystemType == EclOilWaterSystem) {
+    if (twoPhaseSystemType == EclTwoPhaseSystemType::OilWater) {
         this->setEnableThreePointKrwScaling(hasKR("WR"));
         this->setEnableThreePointKrnScaling(hasKR("ORW"));
 
@@ -87,7 +87,7 @@ void EclEpsConfig::initFromState(const EclipseState& eclState,
         this->enableKrwScaling_ = hasKR("W") || this->enableThreePointKrwScaling();
         this->enablePcScaling_  = hasPC("W") || fp.has_double("SWATINIT");
     }
-    else if (twoPhaseSystemType == EclGasOilSystem) {
+    else if (twoPhaseSystemType == EclTwoPhaseSystemType::GasOil) {
         this->setEnableThreePointKrwScaling(hasKR("ORG"));
         this->setEnableThreePointKrnScaling(hasKR("GR"));
 
@@ -96,7 +96,7 @@ void EclEpsConfig::initFromState(const EclipseState& eclState,
         this->enablePcScaling_  = hasPC("G");
     }
     else {
-        assert(twoPhaseSystemType == EclGasWaterSystem);
+        assert(twoPhaseSystemType == EclTwoPhaseSystemType::GasWater);
         //TODO enable endpoint scaling for gaswater system
     }
 


### PR DESCRIPTION
This to encapsulate EclipseState and some other headers.  While here, use class member initialization to avoid the need for a trivial constructor.

Also convert an enum to an enum class, cleaner in itself and allows for forwarding which is useful to avoid pulling in this header elsewhere.