### PR TITLE
changed: put EclHysteresisConfig initFromState in separate compile unit

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -233,6 +233,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/input/eclipse/Utility/Functional.cpp
     src/opm/material/fluidmatrixinteractions/EclEpsConfig.cpp
     src/opm/material/fluidmatrixinteractions/EclEpsGridProperties.cpp
+    src/opm/material/fluidmatrixinteractions/EclHysteresisConfig.cpp
   )
 
 

--- a/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp
@@ -27,11 +27,12 @@
 #ifndef OPM_ECL_HYSTERESIS_CONFIG_HPP
 #define OPM_ECL_HYSTERESIS_CONFIG_HPP
 
+namespace Opm {
+
 #if HAVE_ECL_INPUT
-#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+class Runspec;
 #endif
 
-namespace Opm {
 /*!
  * \ingroup FluidMatrixInteractions
  *
@@ -40,13 +41,6 @@ namespace Opm {
 class EclHysteresisConfig
 {
 public:
-    EclHysteresisConfig()
-    {
-        enableHysteresis_ = false;
-        pcHysteresisModel_ = -1;
-        krHysteresisModel_ = -1;
-    }
-
     /*!
      * \brief Specify whether hysteresis is enabled or not.
      */
@@ -125,31 +119,18 @@ public:
      *
      * This requires that the opm-parser module is available.
      */
-    void initFromState(const Runspec& runspec)
-    {
-        enableHysteresis_ = false;
-
-        enableHysteresis_ = runspec.hysterPar().active();
-
-        if (!enableHysteresis_)
-            return;
-
-        krHysteresisModel_ = runspec.hysterPar().krHysteresisModel();
-        pcHysteresisModel_ = runspec.hysterPar().pcHysteresisModel();
-        modParamTrapped_ = runspec.hysterPar().modParamTrapped();
-        curvatureCapPrs_ = runspec.hysterPar().curvatureCapPrs();
-    }
+    void initFromState(const Runspec& runspec);
 #endif
 
 private:
     // enable hysteresis at all
-    bool enableHysteresis_;
+    bool enableHysteresis_{false};
 
     // the capillary pressure and the relperm hysteresis models to be used
-    int pcHysteresisModel_;
-    int krHysteresisModel_;
-    double modParamTrapped_;
-    double curvatureCapPrs_;
+    int pcHysteresisModel_{-1};
+    int krHysteresisModel_{-1};
+    double modParamTrapped_{};
+    double curvatureCapPrs_{};
 };
 
 } // namespace Opm

--- a/src/opm/material/fluidmatrixinteractions/EclHysteresisConfig.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclHysteresisConfig.cpp
@@ -1,0 +1,46 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+#include <opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp>
+
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+
+namespace Opm {
+
+void EclHysteresisConfig::initFromState(const Runspec& runspec)
+{
+    enableHysteresis_ = false;
+
+    enableHysteresis_ = runspec.hysterPar().active();
+
+    if (!enableHysteresis_)
+        return;
+
+    krHysteresisModel_ = runspec.hysterPar().krHysteresisModel();
+    pcHysteresisModel_ = runspec.hysterPar().pcHysteresisModel();
+    modParamTrapped_ = runspec.hysterPar().modParamTrapped();
+    curvatureCapPrs_ = runspec.hysterPar().curvatureCapPrs();
+}
+
+} // namespace Opm


### PR DESCRIPTION
in particular this allows to encapsulate the Runspec class usage. also use class member initialization instead of constructor.