### PR TITLE
Some small fixes in material classes

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -73,7 +73,7 @@ namespace Opm {
     }                                                                     \
     case GasPvtApproach::NoGas:                                           \
         throw std::logic_error("Not implemented: Gas PVT of this deck!"); \
-    } \
+    }
 
 enum class GasPvtApproach {
     NoGas,

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -237,7 +237,7 @@ public:
      /*!
      * \brief Returns true iff Joule-Thomson effect for the gas phase is active.
      */
-    bool enableJouleThomsony() const
+    bool enableJouleThomson() const
     { return enableJouleThomson_; }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -68,7 +68,7 @@ namespace Opm {
     }                                                                             \
     case OilPvtApproach::NoOil:                                                   \
         throw std::logic_error("Not implemented: Oil PVT of this deck!");         \
-    }                                                                             \
+    }
 
 enum class OilPvtApproach {
     NoOil,

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -255,7 +255,7 @@ public:
     /*!
      * \brief Returns true iff Joule-Thomson effect for the oil phase is active.
      */
-    bool enableJouleThomsony() const
+    bool enableJouleThomson() const
     { return enableJouleThomson_; }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -259,7 +259,7 @@ public:
      /*!
      * \brief Returns true iff Joule-Thomson effect for the water phase is active.
      */
-    bool enableJouleThomsony() const
+    bool enableJouleThomson() const
     { return enableJouleThomson_; }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -441,7 +441,6 @@ public:
                this->watdentCT2() == data.watdentCT2() &&
                this->watdentCT2() == data.watdentCT2() &&
                this->watJTRefPres() == data.watJTRefPres() &&
-               this->watJT() == data.watJT() &&
                this->watJTC() == data.watJTC() &&
                this->pvtwRefPress() == data.pvtwRefPress() &&
                this->pvtwRefB() == data.pvtwRefB() &&


### PR DESCRIPTION
- (harmless but potentially troublesome) \ at end of macros
- what looks like a copy-paste faulty method name
- a reference to nonexistent method

the two latter have been harmless since code using them has never been instanced, but i'm working on changes that does so.

Waiting for https://github.com/OPM/opm-common/pull/3246