### PR TITLE
initialize variable to avoid compiler warnings

### DIFF
--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -135,7 +135,7 @@ std::tuple<T,int,int> PackUnpack(T& in)
     Opm::Serializer ser(packer);
     ser.pack(in);
     size_t pos1 = ser.position();
-    T out;
+    T out{};
     ser.unpack(out);
     size_t pos2 = ser.position();
 


### PR DESCRIPTION
Hopefully the end of the uninitialized-variable-in-serialization-warnings story..