### PR TITLE
Reduce redundancy in some enums

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -801,8 +801,8 @@ private:
                 const auto& letSgofTab = tableManager.getSgofletTable()[satRegionIdx];
                 const std::vector<Scalar> dum; // dummy arg to comform with existing interface
 
-                effParams.setApproach(SatCurveMultiplexerApproach::LETApproach);
-                auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::LETApproach>();
+                effParams.setApproach(SatCurveMultiplexerApproach::LET);
+                auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::LET>();
 
                 // S=(So-Sogcr)/(1-Sogcr-Sgcr-Swco),  krog = Krt*S^L/[S^L+E*(1.0-S)^T]
                 const Scalar s_min_w = letSgofTab.s2_critical;
@@ -870,8 +870,8 @@ private:
             SoSamples[sampleIdx] = (1.0 - Swco) - sgofTable.get("SG", sampleIdx);
         }
 
-        effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinearApproach);
-        auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>();
+        effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+        auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
 
         realParams.setKrwSamples(SoSamples, normalizeKrValues_(tolcrit, sgofTable.getColumn("KROG")));
         realParams.setKrnSamples(SoSamples, normalizeKrValues_(tolcrit, sgofTable.getColumn("KRG")));
@@ -890,8 +890,8 @@ private:
             SoSamples[sampleIdx] = slgofTable.get("SL", sampleIdx) - Swco;
         }
 
-        effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinearApproach);
-        auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>();
+        effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+        auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
 
         realParams.setKrwSamples(SoSamples, normalizeKrValues_(tolcrit, slgofTable.getColumn("KROG")));
         realParams.setKrnSamples(SoSamples, normalizeKrValues_(tolcrit, slgofTable.getColumn("KRG")));
@@ -912,8 +912,8 @@ private:
             SoSamples[sampleIdx] = (1.0 - Swco) - sgfnTable.get("SG", sampleIdx);
         }
 
-        effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinearApproach);
-        auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>();
+        effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+        auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
 
         realParams.setKrwSamples(SoColumn, normalizeKrValues_(tolcrit, sof3Table.getColumn("KROG")));
         realParams.setKrnSamples(SoSamples, normalizeKrValues_(tolcrit, sgfnTable.getColumn("KRG")));
@@ -934,8 +934,8 @@ private:
             SoSamples[sampleIdx] = (1.0 - Swco) - sgfnTable.get("SG", sampleIdx);
         }
 
-        effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinearApproach);
-        auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>();
+        effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+        auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
 
         realParams.setKrwSamples(SoColumn, normalizeKrValues_(tolcrit, sof2Table.getColumn("KRO")));
         realParams.setKrnSamples(SoSamples, normalizeKrValues_(tolcrit, sgfnTable.getColumn("KRG")));
@@ -967,8 +967,8 @@ private:
                 const auto& swofTable = tableManager.getSwofTables().getTable<SwofTable>(satRegionIdx);
                 const std::vector<double> SwColumn = swofTable.getColumn("SW").vectorCopy();
 
-                effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinearApproach);
-                auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>();
+                effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+                auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
 
                 realParams.setKrwSamples(SwColumn, normalizeKrValues_(tolcrit, swofTable.getColumn("KRW")));
                 realParams.setKrnSamples(SwColumn, normalizeKrValues_(tolcrit, swofTable.getColumn("KROW")));
@@ -979,8 +979,8 @@ private:
                 const auto& letTab = tableManager.getSwofletTable()[satRegionIdx];
                 const std::vector<Scalar> dum; // dummy arg to conform with existing interface
 
-                effParams.setApproach(SatCurveMultiplexerApproach::LETApproach);
-                auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::LETApproach>();
+                effParams.setApproach(SatCurveMultiplexerApproach::LET);
+                auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::LET>();
 
                 // S=(Sw-Swcr)/(1-Sowcr-Swcr),  krw = Krt*S^L/[S^L+E*(1.0-S)^T]
                 const Scalar s_min_w = letTab.s1_critical;
@@ -1022,8 +1022,8 @@ private:
             const auto& swfnTable = tableManager.getSwfnTables().getTable<SwfnTable>(satRegionIdx);
             const std::vector<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
 
-            effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinearApproach);
-            auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>();
+            effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+            auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
 
             realParams.setKrwSamples(SwColumn, normalizeKrValues_(tolcrit, swfnTable.getColumn("KRW")));
             realParams.setPcnwSamples(SwColumn, swfnTable.getColumn("PCOW").vectorCopy());
@@ -1084,8 +1084,8 @@ private:
             const SgfnTable& sgfnTable = tableManager.getSgfnTables().getTable<SgfnTable>( satRegionIdx );
             const SwfnTable& swfnTable = tableManager.getSwfnTables().getTable<SwfnTable>( satRegionIdx );
 
-            effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinearApproach);
-            auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>();
+            effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+            auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
 
             std::vector<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -521,8 +521,8 @@ public:
 
         // change the sat table it points to.
         switch (mlp.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach: {
-            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::EclStone1Approach>();
+        case EclMultiplexerApproach::Stone1: {
+            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Stone1>();
 
             realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
             realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
@@ -537,8 +537,8 @@ public:
         }
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach: {
-            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::EclStone2Approach>();
+        case EclMultiplexerApproach::Stone2: {
+            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Stone2>();
             realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
             realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
             realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
@@ -552,8 +552,8 @@ public:
         }
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach: {
-            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>();
+        case EclMultiplexerApproach::Default: {
+            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Default>();
             realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
             realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
             realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
@@ -567,8 +567,8 @@ public:
         }
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach: {
-            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>();
+        case EclMultiplexerApproach::TwoPhase: {
+            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::TwoPhase>();
             realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
             realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
             realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
@@ -687,23 +687,23 @@ public:
     {
         auto& materialParams = materialLawParams_[elemIdx];
         switch (materialParams.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclStone1Approach>();
+        case EclMultiplexerApproach::Stone1: {
+            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone1>();
             return realParams.oilWaterParams().drainageParams().scaledPoints();
         }
 
-        case EclMultiplexerApproach::EclStone2Approach: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclStone2Approach>();
+        case EclMultiplexerApproach::Stone2: {
+            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone2>();
             return realParams.oilWaterParams().drainageParams().scaledPoints();
         }
 
-        case EclMultiplexerApproach::EclDefaultApproach: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>();
+        case EclMultiplexerApproach::Default: {
+            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Default>();
             return realParams.oilWaterParams().drainageParams().scaledPoints();
         }
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>();
+        case EclMultiplexerApproach::TwoPhase: {
+            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::TwoPhase>();
             return realParams.oilWaterParams().drainageParams().scaledPoints();
         }
         default:
@@ -743,9 +743,9 @@ private:
         if (numEnabled == 0) {
             throw std::runtime_error("At least one fluid phase must be enabled. (Is: "+std::to_string(numEnabled)+")");
         } else if (numEnabled == 1) {
-            threePhaseApproach_ = EclMultiplexerApproach::EclOnePhaseApproach;
+            threePhaseApproach_ = EclMultiplexerApproach::OnePhase;
         } else if ( numEnabled == 2) {
-            threePhaseApproach_ = EclMultiplexerApproach::EclTwoPhaseApproach;
+            threePhaseApproach_ = EclMultiplexerApproach::TwoPhase;
             if (!gasEnabled)
                 twoPhaseApproach_ = EclTwoPhaseApproach::EclTwoPhaseOilWater;
             else if (!oilEnabled)
@@ -756,12 +756,12 @@ private:
         else {
             assert(numEnabled == 3);
 
-            threePhaseApproach_ = EclMultiplexerApproach::EclDefaultApproach;
+            threePhaseApproach_ = EclMultiplexerApproach::Default;
             const auto& satctrls = runspec.saturationFunctionControls();
             if (satctrls.krModel() == SatFuncControls::ThreePhaseOilKrModel::Stone2)
-                threePhaseApproach_ = EclMultiplexerApproach::EclStone2Approach;
+                threePhaseApproach_ = EclMultiplexerApproach::Stone2;
             else if (satctrls.krModel() == SatFuncControls::ThreePhaseOilKrModel::Stone1)
-                threePhaseApproach_ = EclMultiplexerApproach::EclStone1Approach;
+                threePhaseApproach_ = EclMultiplexerApproach::Stone1;
         }
     }
 
@@ -1185,8 +1185,8 @@ private:
         materialParams.setApproach(threePhaseApproach_);
 
         switch (materialParams.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclStone1Approach>();
+        case EclMultiplexerApproach::Stone1: {
+            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone1>();
             realParams.setGasOilParams(gasOilParams);
             realParams.setOilWaterParams(oilWaterParams);
             realParams.setSwl(epsInfo.Swl);
@@ -1200,8 +1200,8 @@ private:
             break;
         }
 
-        case EclMultiplexerApproach::EclStone2Approach: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclStone2Approach>();
+        case EclMultiplexerApproach::Stone2: {
+            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone2>();
             realParams.setGasOilParams(gasOilParams);
             realParams.setOilWaterParams(oilWaterParams);
             realParams.setSwl(epsInfo.Swl);
@@ -1209,8 +1209,8 @@ private:
             break;
         }
 
-        case EclMultiplexerApproach::EclDefaultApproach: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>();
+        case EclMultiplexerApproach::Default: {
+            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Default>();
             realParams.setGasOilParams(gasOilParams);
             realParams.setOilWaterParams(oilWaterParams);
             realParams.setSwl(epsInfo.Swl);
@@ -1218,8 +1218,8 @@ private:
             break;
         }
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>();
+        case EclMultiplexerApproach::TwoPhase: {
+            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::TwoPhase>();
             realParams.setGasOilParams(gasOilParams);
             realParams.setOilWaterParams(oilWaterParams);
             realParams.setGasWaterParams(gasWaterParams);
@@ -1228,7 +1228,7 @@ private:
             break;
         }
 
-        case EclMultiplexerApproach::EclOnePhaseApproach: {
+        case EclMultiplexerApproach::OnePhase: {
             // Nothing to do, no parameters.
             break;
         }
@@ -1266,7 +1266,7 @@ private:
     OilWaterEffectiveParamVector oilWaterEffectiveParamVector_;
     GasWaterEffectiveParamVector gasWaterEffectiveParamVector_;
 
-    EclMultiplexerApproach threePhaseApproach_ = EclMultiplexerApproach::EclDefaultApproach;
+    EclMultiplexerApproach threePhaseApproach_ = EclMultiplexerApproach::Default;
     // this attribute only makes sense for twophase simulations!
     enum EclTwoPhaseApproach twoPhaseApproach_ = EclTwoPhaseApproach::EclTwoPhaseGasOil;
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -747,11 +747,11 @@ private:
         } else if ( numEnabled == 2) {
             threePhaseApproach_ = EclMultiplexerApproach::TwoPhase;
             if (!gasEnabled)
-                twoPhaseApproach_ = EclTwoPhaseApproach::EclTwoPhaseOilWater;
+                twoPhaseApproach_ = EclTwoPhaseApproach::OilWater;
             else if (!oilEnabled)
-                twoPhaseApproach_ = EclTwoPhaseApproach::EclTwoPhaseGasWater;
+                twoPhaseApproach_ = EclTwoPhaseApproach::GasWater;
             else if (!waterEnabled)
-                twoPhaseApproach_ = EclTwoPhaseApproach::EclTwoPhaseGasOil;
+                twoPhaseApproach_ = EclTwoPhaseApproach::GasOil;
         }
         else {
             assert(numEnabled == 3);
@@ -1268,7 +1268,7 @@ private:
 
     EclMultiplexerApproach threePhaseApproach_ = EclMultiplexerApproach::Default;
     // this attribute only makes sense for twophase simulations!
-    enum EclTwoPhaseApproach twoPhaseApproach_ = EclTwoPhaseApproach::EclTwoPhaseGasOil;
+    enum EclTwoPhaseApproach twoPhaseApproach_ = EclTwoPhaseApproach::GasOil;
 
     std::vector<MaterialLawParams> materialLawParams_;
 

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -135,31 +135,31 @@ public:
                                    const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             Stone1Material::capillaryPressures(values,
-                                               params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>(),
+                                               params.template getRealParams<EclMultiplexerApproach::Stone1>(),
                                                fluidState);
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             Stone2Material::capillaryPressures(values,
-                                               params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>(),
+                                               params.template getRealParams<EclMultiplexerApproach::Stone2>(),
                                                fluidState);
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             DefaultMaterial::capillaryPressures(values,
-                                                params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>(),
+                                                params.template getRealParams<EclMultiplexerApproach::Default>(),
                                                 fluidState);
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach:
+        case EclMultiplexerApproach::TwoPhase:
             TwoPhaseMaterial::capillaryPressures(values,
-                                                 params.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>(),
+                                                 params.template getRealParams<EclMultiplexerApproach::TwoPhase>(),
                                                  fluidState);
             break;
 
-        case EclMultiplexerApproach::EclOnePhaseApproach:
+        case EclMultiplexerApproach::OnePhase:
             values[0] = 0.0;
             break;
         }
@@ -176,27 +176,27 @@ public:
                                          const Params& params)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             Stone1Material::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Stone1>());
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             Stone2Material::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Stone2>());
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             DefaultMaterial::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Default>());
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach:
+        case EclMultiplexerApproach::TwoPhase:
             TwoPhaseMaterial::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>());
+                                     params.template getRealParams<EclMultiplexerApproach::TwoPhase>());
             break;
 
-        case EclMultiplexerApproach::EclOnePhaseApproach:
+        case EclMultiplexerApproach::OnePhase:
             // Do nothing.
             break;
         }
@@ -213,27 +213,27 @@ public:
                                             Params& params)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             Stone1Material::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Stone1>());
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             Stone2Material::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Stone2>());
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             DefaultMaterial::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Default>());
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach:
+        case EclMultiplexerApproach::TwoPhase:
             TwoPhaseMaterial::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>());
+                                     params.template getRealParams<EclMultiplexerApproach::TwoPhase>());
             break;
 
-        case EclMultiplexerApproach::EclOnePhaseApproach:
+        case EclMultiplexerApproach::OnePhase:
             // Do nothing.
             break;
         }
@@ -250,27 +250,27 @@ public:
                                        const Params& params)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             Stone1Material::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Stone1>());
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             Stone2Material::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Stone2>());
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             DefaultMaterial::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Default>());
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach:
+        case EclMultiplexerApproach::TwoPhase:
             TwoPhaseMaterial::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>());
+                                     params.template getRealParams<EclMultiplexerApproach::TwoPhase>());
             break;
 
-        case EclMultiplexerApproach::EclOnePhaseApproach:
+        case EclMultiplexerApproach::OnePhase:
             // Do nothing.
             break;
         }
@@ -287,27 +287,27 @@ public:
                                           Params& params)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             Stone1Material::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Stone1>());
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             Stone2Material::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Stone2>());
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             DefaultMaterial::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>());
+                                     params.template getRealParams<EclMultiplexerApproach::Default>());
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach:
+        case EclMultiplexerApproach::TwoPhase:
             TwoPhaseMaterial::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
-                                     params.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>());
+                                     params.template getRealParams<EclMultiplexerApproach::TwoPhase>());
             break;
 
-        case EclMultiplexerApproach::EclOnePhaseApproach:
+        case EclMultiplexerApproach::OnePhase:
             // Do nothing.
             break;
         }
@@ -407,31 +407,31 @@ public:
                                        const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             Stone1Material::relativePermeabilities(values,
-                                                   params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>(),
+                                                   params.template getRealParams<EclMultiplexerApproach::Stone1>(),
                                                    fluidState);
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             Stone2Material::relativePermeabilities(values,
-                                                   params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>(),
+                                                   params.template getRealParams<EclMultiplexerApproach::Stone2>(),
                                                    fluidState);
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             DefaultMaterial::relativePermeabilities(values,
-                                                    params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>(),
+                                                    params.template getRealParams<EclMultiplexerApproach::Default>(),
                                                     fluidState);
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach:
+        case EclMultiplexerApproach::TwoPhase:
             TwoPhaseMaterial::relativePermeabilities(values,
-                                                     params.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>(),
+                                                     params.template getRealParams<EclMultiplexerApproach::TwoPhase>(),
                                                      fluidState);
             break;
 
-        case EclMultiplexerApproach::EclOnePhaseApproach:
+        case EclMultiplexerApproach::OnePhase:
             values[0] = 1.0;
             break;
 
@@ -449,19 +449,19 @@ public:
                                                const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             return Stone1Material::template relpermOilInOilGasSystem<Evaluation>
-                (params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>(),
+                (params.template getRealParams<EclMultiplexerApproach::Stone1>(),
                  fluidState);
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             return Stone2Material::template relpermOilInOilGasSystem<Evaluation>
-                (params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>(),
+                (params.template getRealParams<EclMultiplexerApproach::Stone2>(),
                  fluidState);
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             return DefaultMaterial::template relpermOilInOilGasSystem<Evaluation>
-                (params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>(),
+                (params.template getRealParams<EclMultiplexerApproach::Default>(),
                  fluidState);
 
         default:
@@ -479,19 +479,19 @@ public:
                                                  const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             return Stone1Material::template relpermOilInOilWaterSystem<Evaluation>
-                (params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>(),
+                (params.template getRealParams<EclMultiplexerApproach::Stone1>(),
                  fluidState);
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             return Stone2Material::template relpermOilInOilWaterSystem<Evaluation>
-                (params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>(),
+                (params.template getRealParams<EclMultiplexerApproach::Stone2>(),
                  fluidState);
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             return DefaultMaterial::template relpermOilInOilWaterSystem<Evaluation>
-                (params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>(),
+                (params.template getRealParams<EclMultiplexerApproach::Default>(),
                  fluidState);
 
         default:
@@ -543,26 +543,26 @@ public:
     static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
-            Stone1Material::updateHysteresis(params.template getRealParams<EclMultiplexerApproach::EclStone1Approach>(),
+        case EclMultiplexerApproach::Stone1:
+            Stone1Material::updateHysteresis(params.template getRealParams<EclMultiplexerApproach::Stone1>(),
                                              fluidState);
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach:
-            Stone2Material::updateHysteresis(params.template getRealParams<EclMultiplexerApproach::EclStone2Approach>(),
+        case EclMultiplexerApproach::Stone2:
+            Stone2Material::updateHysteresis(params.template getRealParams<EclMultiplexerApproach::Stone2>(),
                                              fluidState);
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach:
-            DefaultMaterial::updateHysteresis(params.template getRealParams<EclMultiplexerApproach::EclDefaultApproach>(),
+        case EclMultiplexerApproach::Default:
+            DefaultMaterial::updateHysteresis(params.template getRealParams<EclMultiplexerApproach::Default>(),
                                               fluidState);
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach:
-            TwoPhaseMaterial::updateHysteresis(params.template getRealParams<EclMultiplexerApproach::EclTwoPhaseApproach>(),
+        case EclMultiplexerApproach::TwoPhase:
+            TwoPhaseMaterial::updateHysteresis(params.template getRealParams<EclMultiplexerApproach::TwoPhase>(),
                                                fluidState);
             break;
-        case EclMultiplexerApproach::EclOnePhaseApproach:
+        case EclMultiplexerApproach::OnePhase:
             break;
         }
     }

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -41,11 +41,11 @@
 namespace Opm {
 
 enum class EclMultiplexerApproach {
-    EclDefaultApproach,
-    EclStone1Approach,
-    EclStone2Approach,
-    EclTwoPhaseApproach,
-    EclOnePhaseApproach
+    Default,
+    Stone1,
+    Stone2,
+    TwoPhase,
+    OnePhase
 };
 
 /*!
@@ -111,23 +111,23 @@ public:
         approach_ = newApproach;
 
         switch (approach()) {
-        case EclMultiplexerApproach::EclStone1Approach:
+        case EclMultiplexerApproach::Stone1:
             realParams_ = ParamPointerType(new Stone1Params, Deleter< Stone1Params > () );
             break;
 
-        case EclMultiplexerApproach::EclStone2Approach:
+        case EclMultiplexerApproach::Stone2:
             realParams_ = ParamPointerType(new Stone2Params, Deleter< Stone2Params > () );
             break;
 
-        case EclMultiplexerApproach::EclDefaultApproach:
+        case EclMultiplexerApproach::Default:
             realParams_ = ParamPointerType(new DefaultParams, Deleter< DefaultParams > () );
             break;
 
-        case EclMultiplexerApproach::EclTwoPhaseApproach:
+        case EclMultiplexerApproach::TwoPhase:
             realParams_ = ParamPointerType(new TwoPhaseParams, Deleter< TwoPhaseParams > () );
             break;
 
-        case EclMultiplexerApproach::EclOnePhaseApproach:
+        case EclMultiplexerApproach::OnePhase:
             // Do nothing, no parameters.
             break;
         }
@@ -138,7 +138,7 @@ public:
 
     // get the parameter object for the Stone1 case
     template <EclMultiplexerApproach approachV>
-    typename std::enable_if<approachV == EclMultiplexerApproach::EclStone1Approach, Stone1Params>::type&
+    typename std::enable_if<approachV == EclMultiplexerApproach::Stone1, Stone1Params>::type&
     getRealParams()
     {
         assert(approach() == approachV);
@@ -146,7 +146,7 @@ public:
     }
 
     template <EclMultiplexerApproach approachV>
-    typename std::enable_if<approachV == EclMultiplexerApproach::EclStone1Approach, const Stone1Params>::type&
+    typename std::enable_if<approachV == EclMultiplexerApproach::Stone1, const Stone1Params>::type&
     getRealParams() const
     {
         assert(approach() == approachV);
@@ -155,7 +155,7 @@ public:
 
     // get the parameter object for the Stone2 case
     template <EclMultiplexerApproach approachV>
-    typename std::enable_if<approachV == EclMultiplexerApproach::EclStone2Approach, Stone2Params>::type&
+    typename std::enable_if<approachV == EclMultiplexerApproach::Stone2, Stone2Params>::type&
     getRealParams()
     {
         assert(approach() == approachV);
@@ -163,7 +163,7 @@ public:
     }
 
     template <EclMultiplexerApproach approachV>
-    typename std::enable_if<approachV == EclMultiplexerApproach::EclStone2Approach, const Stone2Params>::type&
+    typename std::enable_if<approachV == EclMultiplexerApproach::Stone2, const Stone2Params>::type&
     getRealParams() const
     {
         assert(approach() == approachV);
@@ -172,7 +172,7 @@ public:
 
     // get the parameter object for the default case
     template <EclMultiplexerApproach approachV>
-    typename std::enable_if<approachV == EclMultiplexerApproach::EclDefaultApproach, DefaultParams>::type&
+    typename std::enable_if<approachV == EclMultiplexerApproach::Default, DefaultParams>::type&
     getRealParams()
     {
         assert(approach() == approachV);
@@ -180,7 +180,7 @@ public:
     }
 
     template <EclMultiplexerApproach approachV>
-    typename std::enable_if<approachV == EclMultiplexerApproach::EclDefaultApproach, const DefaultParams>::type&
+    typename std::enable_if<approachV == EclMultiplexerApproach::Default, const DefaultParams>::type&
     getRealParams() const
     {
         assert(approach() == approachV);
@@ -189,7 +189,7 @@ public:
 
     // get the parameter object for the twophase case
     template <EclMultiplexerApproach approachV>
-    typename std::enable_if<approachV == EclMultiplexerApproach::EclTwoPhaseApproach, TwoPhaseParams>::type&
+    typename std::enable_if<approachV == EclMultiplexerApproach::TwoPhase, TwoPhaseParams>::type&
     getRealParams()
     {
         assert(approach() == approachV);
@@ -197,7 +197,7 @@ public:
     }
 
     template <EclMultiplexerApproach approachV>
-    typename std::enable_if<approachV == EclMultiplexerApproach::EclTwoPhaseApproach, const TwoPhaseParams>::type&
+    typename std::enable_if<approachV == EclMultiplexerApproach::TwoPhase, const TwoPhaseParams>::type&
     getRealParams() const
     {
         assert(approach() == approachV);

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -133,7 +133,7 @@ public:
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
 
         switch (params.approach()) {
-        case EclTwoPhaseApproach::EclTwoPhaseGasOil: {
+        case EclTwoPhaseApproach::GasOil: {
             const Evaluation& So =
                 decay<Evaluation>(fluidState.saturation(oilPhaseIdx));
 
@@ -142,7 +142,7 @@ public:
             break;
         }
 
-        case EclTwoPhaseApproach::EclTwoPhaseOilWater: {
+        case EclTwoPhaseApproach::OilWater: {
             const Evaluation& Sw =
                 decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
 
@@ -151,7 +151,7 @@ public:
             break;
         }
 
-        case EclTwoPhaseApproach::EclTwoPhaseGasWater: {
+        case EclTwoPhaseApproach::GasWater: {
             const Evaluation& Sw =
                 decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
 
@@ -321,7 +321,7 @@ public:
         using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
 
         switch (params.approach()) {
-        case EclTwoPhaseApproach::EclTwoPhaseGasOil: {
+        case EclTwoPhaseApproach::GasOil: {
             const Evaluation& So =
                 decay<Evaluation>(fluidState.saturation(oilPhaseIdx));
 
@@ -330,7 +330,7 @@ public:
             break;
         }
 
-        case EclTwoPhaseApproach::EclTwoPhaseOilWater: {
+        case EclTwoPhaseApproach::OilWater: {
             const Evaluation& Sw =
                 decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
 
@@ -339,7 +339,7 @@ public:
             break;
         }
 
-        case EclTwoPhaseApproach::EclTwoPhaseGasWater: {
+        case EclTwoPhaseApproach::GasWater: {
             const Evaluation& Sw =
                 decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
             
@@ -393,21 +393,21 @@ public:
     static void updateHysteresis(Params& params, const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case EclTwoPhaseApproach::EclTwoPhaseGasOil: {
+        case EclTwoPhaseApproach::GasOil: {
             Scalar So = scalarValue(fluidState.saturation(oilPhaseIdx));
 
             params.gasOilParams().update(/*pcSw=*/So, /*krwSw=*/So, /*krnSw=*/So);
             break;
         }
 
-        case EclTwoPhaseApproach::EclTwoPhaseOilWater: {
+        case EclTwoPhaseApproach::OilWater: {
             Scalar Sw = scalarValue(fluidState.saturation(waterPhaseIdx));
 
             params.oilWaterParams().update(/*pcSw=*/Sw, /*krwSw=*/Sw, /*krnSw=*/Sw);
             break;
         }
 
-        case EclTwoPhaseApproach::EclTwoPhaseGasWater: {
+        case EclTwoPhaseApproach::GasWater: {
             Scalar Sw = scalarValue(fluidState.saturation(waterPhaseIdx));
            
             params.gasWaterParams().update(/*pcSw=*/1.0, /*krwSw=*/0.0, /*krnSw=*/Sw);

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -34,9 +34,9 @@
 namespace Opm {
 
 enum class EclTwoPhaseApproach {
-    EclTwoPhaseGasOil,
-    EclTwoPhaseOilWater,
-    EclTwoPhaseGasWater
+    GasOil,
+    OilWater,
+    GasWater
 };
 
 /*!

--- a/opm/material/fluidmatrixinteractions/SatCurveMultiplexer.hpp
+++ b/opm/material/fluidmatrixinteractions/SatCurveMultiplexer.hpp
@@ -91,15 +91,15 @@ public:
     static void capillaryPressures(Container& values, const Params& params, const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
+        case SatCurveMultiplexerApproach::LET:
             LETTwoPhaseLaw::capillaryPressures(values,
-                                               params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+                                               params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                                fluidState);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
             PLTwoPhaseLaw::capillaryPressures(values,
-                                              params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+                                              params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                               fluidState);
             break;
         }
@@ -113,15 +113,15 @@ public:
     static void saturations(Container& values, const Params& params, const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
+        case SatCurveMultiplexerApproach::LET:
             LETTwoPhaseLaw::saturations(values,
-                                        params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+                                        params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                         fluidState);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
             PLTwoPhaseLaw::saturations(values,
-                                       params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+                                       params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                        fluidState);
             break;
         }
@@ -141,15 +141,15 @@ public:
     static void relativePermeabilities(Container& values, const Params& params, const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
+        case SatCurveMultiplexerApproach::LET:
             LETTwoPhaseLaw::relativePermeabilities(values,
-                                                   params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+                                                   params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                                    fluidState);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
             PLTwoPhaseLaw::relativePermeabilities(values,
-                                                  params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+                                                  params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                                   fluidState);
             break;
         }
@@ -162,13 +162,13 @@ public:
     static Evaluation pcnw(const Params& params, const FluidState& fluidState)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::pcnw(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::pcnw(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                         fluidState);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::pcnw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::pcnw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                        fluidState);
             break;
         }
@@ -180,13 +180,13 @@ public:
     static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::twoPhaseSatPcnw(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::twoPhaseSatPcnw(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                                    Sw);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::twoPhaseSatPcnw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::twoPhaseSatPcnw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                                   Sw);
             break;
         }
@@ -208,13 +208,13 @@ public:
     static Evaluation Sw(const Params& params, const FluidState& fluidstate)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::Sw(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::Sw(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                       fluidstate);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::Sw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::Sw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                      fluidstate);
             break;
         }
@@ -237,13 +237,13 @@ public:
     static Evaluation Sn(const Params& params, const FluidState& fluidstate)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::Sn(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::Sn(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                       fluidstate);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::Sn(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::Sn(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                      fluidstate);
             break;
         }
@@ -255,13 +255,13 @@ public:
     static Evaluation twoPhaseSatSn(const Params& params, const Evaluation& pc)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::twoPhaseSatSn(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::twoPhaseSatSn(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                                  pc);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::twoPhaseSatSn(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::twoPhaseSatSn(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                                 pc);
             break;
         }
@@ -277,13 +277,13 @@ public:
     static Evaluation krw(const Params& params, const FluidState& fluidstate)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::krw(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::krw(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                        fluidstate);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::krw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::krw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                       fluidstate);
             break;
         }
@@ -295,13 +295,13 @@ public:
     static Evaluation twoPhaseSatKrw(const Params& params, const Evaluation& Sw)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::twoPhaseSatKrw(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::twoPhaseSatKrw(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                                   Sw);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::twoPhaseSatKrw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::twoPhaseSatKrw(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                                  Sw);
             break;
         }
@@ -323,13 +323,13 @@ public:
     static Evaluation krn(const Params& params, const FluidState& fluidstate)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::krn(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::krn(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                        fluidstate);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::krn(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::krn(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                       fluidstate);
             break;
         }
@@ -341,13 +341,13 @@ public:
     static Evaluation twoPhaseSatKrn(const Params& params, const Evaluation& Sw)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::twoPhaseSatKrn(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::twoPhaseSatKrn(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                                   Sw);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::twoPhaseSatKrn(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::twoPhaseSatKrn(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                                  Sw);
             break;
         }
@@ -359,13 +359,13 @@ public:
     static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krn)
     {
         switch (params.approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
-            return LETTwoPhaseLaw::twoPhaseSatKrnInv(params.template getRealParams<SatCurveMultiplexerApproach::LETApproach>(),
+        case SatCurveMultiplexerApproach::LET:
+            return LETTwoPhaseLaw::twoPhaseSatKrnInv(params.template getRealParams<SatCurveMultiplexerApproach::LET>(),
                                                      krn);
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
-            return PLTwoPhaseLaw::twoPhaseSatKrnInv(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinearApproach>(),
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            return PLTwoPhaseLaw::twoPhaseSatKrnInv(params.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>(),
                                                     krn);
             break;
         }

--- a/opm/material/fluidmatrixinteractions/SatCurveMultiplexerParams.hpp
+++ b/opm/material/fluidmatrixinteractions/SatCurveMultiplexerParams.hpp
@@ -39,11 +39,11 @@
 #include <cassert>
 #include <memory>
 
-namespace Opm
+namespace Opm {
 
-{enum class SatCurveMultiplexerApproach {
-    PiecewiseLinearApproach,
-    LETApproach
+enum class SatCurveMultiplexerApproach {
+    PiecewiseLinear,
+    LET
 };
 
 /*!
@@ -108,11 +108,11 @@ public:
         approach_ = newApproach;
 
         switch (approach()) {
-        case SatCurveMultiplexerApproach::LETApproach:
+        case SatCurveMultiplexerApproach::LET:
             realParams_ = ParamPointerType(new LETParams, Deleter< LETParams > () );
             break;
 
-        case SatCurveMultiplexerApproach::PiecewiseLinearApproach:
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
             realParams_ = ParamPointerType(new PLParams, Deleter< PLParams > () );
             break;
         }
@@ -123,7 +123,7 @@ public:
 
     // get the parameter object for the LET curve
     template <SatCurveMultiplexerApproach approachV>
-    typename std::enable_if<approachV == SatCurveMultiplexerApproach::LETApproach, LETParams>::type&
+    typename std::enable_if<approachV == SatCurveMultiplexerApproach::LET, LETParams>::type&
     getRealParams()
     {
         assert(approach() == approachV);
@@ -131,7 +131,7 @@ public:
     }
 
     template <SatCurveMultiplexerApproach approachV>
-    typename std::enable_if<approachV == SatCurveMultiplexerApproach::LETApproach, const LETParams>::type&
+    typename std::enable_if<approachV == SatCurveMultiplexerApproach::LET, const LETParams>::type&
     getRealParams() const
     {
         assert(approach() == approachV);
@@ -140,7 +140,7 @@ public:
 
     // get the parameter object for the PL curve
     template <SatCurveMultiplexerApproach approachV>
-    typename std::enable_if<approachV == SatCurveMultiplexerApproach::PiecewiseLinearApproach, PLParams>::type&
+    typename std::enable_if<approachV == SatCurveMultiplexerApproach::PiecewiseLinear, PLParams>::type&
     getRealParams()
     {
         assert(approach() == approachV);
@@ -148,7 +148,7 @@ public:
     }
 
     template <SatCurveMultiplexerApproach approachV>
-    typename std::enable_if<approachV == SatCurveMultiplexerApproach::PiecewiseLinearApproach, const PLParams>::type&
+    typename std::enable_if<approachV == SatCurveMultiplexerApproach::PiecewiseLinear, const PLParams>::type&
     getRealParams() const
     {
         assert(approach() == approachV);

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -41,48 +41,48 @@
 namespace Opm {
 #define OPM_GAS_PVT_MULTIPLEXER_CALL(codeToCall)                          \
     switch (gasPvtApproach_) {                                            \
-    case GasPvtApproach::DryGasPvt: {                                     \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::DryGasPvt>();          \
+    case GasPvtApproach::DryGas: {                                        \
+        auto& pvtImpl = getRealPvt<GasPvtApproach::DryGas>();             \
         codeToCall;                                                       \
         break;                                                            \
     }                                                                     \
-    case GasPvtApproach::DryHumidGasPvt: {                                \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::DryHumidGasPvt>();     \
+    case GasPvtApproach::DryHumidGas: {                                   \
+        auto& pvtImpl = getRealPvt<GasPvtApproach::DryHumidGas>();        \
         codeToCall;                                                       \
         break;                                                            \
     }                                                                     \
-    case GasPvtApproach::WetHumidGasPvt: {                                \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::WetHumidGasPvt>();     \
+    case GasPvtApproach::WetHumidGas: {                                   \
+        auto& pvtImpl = getRealPvt<GasPvtApproach::WetHumidGas>();        \
         codeToCall;                                                       \
         break;                                                            \
     }                                                                     \
-    case GasPvtApproach::WetGasPvt: {                                     \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::WetGasPvt>();          \
+    case GasPvtApproach::WetGas: {                                        \
+        auto& pvtImpl = getRealPvt<GasPvtApproach::WetGas>();             \
         codeToCall;                                                       \
         break;                                                            \
     }                                                                     \
-    case GasPvtApproach::ThermalGasPvt: {                                 \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::ThermalGasPvt>();      \
+    case GasPvtApproach::ThermalGas: {                                    \
+        auto& pvtImpl = getRealPvt<GasPvtApproach::ThermalGas>();         \
         codeToCall;                                                       \
         break;                                                            \
     }                                                                     \
-    case GasPvtApproach::Co2GasPvt: {                                     \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::Co2GasPvt>();          \
+    case GasPvtApproach::Co2Gas: {                                        \
+        auto& pvtImpl = getRealPvt<GasPvtApproach::Co2Gas>();             \
         codeToCall;                                                       \
         break;                                                            \
     }                                                                     \
-    case GasPvtApproach::NoGasPvt:                                        \
+    case GasPvtApproach::NoGas:                                           \
         throw std::logic_error("Not implemented: Gas PVT of this deck!"); \
     } \
 
 enum class GasPvtApproach {
-    NoGasPvt,
-    DryGasPvt,
-    DryHumidGasPvt,
-    WetHumidGasPvt,
-    WetGasPvt,
-    ThermalGasPvt,
-    Co2GasPvt
+    NoGas,
+    DryGas,
+    DryHumidGas,
+    WetHumidGas,
+    WetGas,
+    ThermalGas,
+    Co2Gas
 };
 
 /*!
@@ -101,7 +101,7 @@ class GasPvtMultiplexer
 public:
     GasPvtMultiplexer()
     {
-        gasPvtApproach_ = GasPvtApproach::NoGasPvt;
+        gasPvtApproach_ = GasPvtApproach::NoGas;
         realGasPvt_ = nullptr;
     }
 
@@ -118,31 +118,31 @@ public:
     ~GasPvtMultiplexer()
     {
         switch (gasPvtApproach_) {
-        case GasPvtApproach::DryGasPvt: {
-            delete &getRealPvt<GasPvtApproach::DryGasPvt>();
+        case GasPvtApproach::DryGas: {
+            delete &getRealPvt<GasPvtApproach::DryGas>();
             break;
         }
-        case GasPvtApproach::DryHumidGasPvt: {
-            delete &getRealPvt<GasPvtApproach::DryHumidGasPvt>();
+        case GasPvtApproach::DryHumidGas: {
+            delete &getRealPvt<GasPvtApproach::DryHumidGas>();
             break;
         }
-        case GasPvtApproach::WetHumidGasPvt: {
-            delete &getRealPvt<GasPvtApproach::WetHumidGasPvt>();
+        case GasPvtApproach::WetHumidGas: {
+            delete &getRealPvt<GasPvtApproach::WetHumidGas>();
             break;
         }
-        case GasPvtApproach::WetGasPvt: {
-            delete &getRealPvt<GasPvtApproach::WetGasPvt>();
+        case GasPvtApproach::WetGas: {
+            delete &getRealPvt<GasPvtApproach::WetGas>();
             break;
         }
-        case GasPvtApproach::ThermalGasPvt: {
-            delete &getRealPvt<GasPvtApproach::ThermalGasPvt>();
+        case GasPvtApproach::ThermalGas: {
+            delete &getRealPvt<GasPvtApproach::ThermalGas>();
             break;
         }
-        case GasPvtApproach::Co2GasPvt: {
-            delete &getRealPvt<GasPvtApproach::Co2GasPvt>();
+        case GasPvtApproach::Co2Gas: {
+            delete &getRealPvt<GasPvtApproach::Co2Gas>();
             break;
         }
-        case GasPvtApproach::NoGasPvt:
+        case GasPvtApproach::NoGas:
             break;
         }
     }
@@ -158,17 +158,17 @@ public:
         if (!eclState.runspec().phases().active(Phase::GAS))
             return;
         if (eclState.runspec().co2Storage())
-            setApproach(GasPvtApproach::Co2GasPvt);
+            setApproach(GasPvtApproach::Co2Gas);
         else if (enableThermal && eclState.getSimulationConfig().isThermal())
-            setApproach(GasPvtApproach::ThermalGasPvt);
+            setApproach(GasPvtApproach::ThermalGas);
         else if (!eclState.getTableManager().getPvtgwTables().empty() && !eclState.getTableManager().getPvtgTables().empty())
-            setApproach(GasPvtApproach::WetHumidGasPvt);
+            setApproach(GasPvtApproach::WetHumidGas);
         else if (!eclState.getTableManager().getPvtgTables().empty())
-            setApproach(GasPvtApproach::WetGasPvt);
+            setApproach(GasPvtApproach::WetGas);
         else if (eclState.getTableManager().hasTables("PVDG"))
-            setApproach(GasPvtApproach::DryGasPvt);
+            setApproach(GasPvtApproach::DryGas);
         else if (!eclState.getTableManager().getPvtgwTables().empty())
-            setApproach(GasPvtApproach::DryHumidGasPvt);
+            setApproach(GasPvtApproach::DryHumidGas);
        
 
         OPM_GAS_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule));
@@ -178,31 +178,31 @@ public:
     void setApproach(GasPvtApproach gasPvtAppr)
     {
         switch (gasPvtAppr) {
-        case GasPvtApproach::DryGasPvt:
+        case GasPvtApproach::DryGas:
             realGasPvt_ = new DryGasPvt<Scalar>;
             break;
 
-        case GasPvtApproach::DryHumidGasPvt:
+        case GasPvtApproach::DryHumidGas:
             realGasPvt_ = new DryHumidGasPvt<Scalar>;
             break;
         
-        case GasPvtApproach::WetHumidGasPvt:
+        case GasPvtApproach::WetHumidGas:
             realGasPvt_ = new WetHumidGasPvt<Scalar>;
             break;
 
-        case GasPvtApproach::WetGasPvt:
+        case GasPvtApproach::WetGas:
             realGasPvt_ = new WetGasPvt<Scalar>;
             break;
 
-        case GasPvtApproach::ThermalGasPvt:
+        case GasPvtApproach::ThermalGas:
             realGasPvt_ = new GasPvtThermal<Scalar>;
             break;
 
-        case GasPvtApproach::Co2GasPvt:
+        case GasPvtApproach::Co2Gas:
             realGasPvt_ = new Co2GasPvt<Scalar>;
             break;
 
-        case GasPvtApproach::NoGasPvt:
+        case GasPvtApproach::NoGas:
             throw std::logic_error("Not implemented: Gas PVT of this deck!");
         }
 
@@ -346,14 +346,14 @@ public:
 
     // get the parameter object for the dry gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryGasPvt, DryGasPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::DryGas, DryGasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<DryGasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryGasPvt, const DryGasPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::DryGas, const DryGasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<const DryGasPvt<Scalar>* >(realGasPvt_);
@@ -361,14 +361,14 @@ public:
 
     // get the parameter object for the dry humid gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryHumidGasPvt, DryHumidGasPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::DryHumidGas, DryHumidGasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<DryHumidGasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryHumidGasPvt, const DryHumidGasPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::DryHumidGas, const DryHumidGasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<const DryHumidGasPvt<Scalar>* >(realGasPvt_);
@@ -376,14 +376,14 @@ public:
 
     // get the parameter object for the wet humid gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetHumidGasPvt, WetHumidGasPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::WetHumidGas, WetHumidGasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<WetHumidGasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetHumidGasPvt, const WetHumidGasPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::WetHumidGas, const WetHumidGasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<const WetHumidGasPvt<Scalar>* >(realGasPvt_);
@@ -391,14 +391,14 @@ public:
 
     // get the parameter object for the wet gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetGasPvt, WetGasPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::WetGas, WetGasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<WetGasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetGasPvt, const WetGasPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::WetGas, const WetGasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<const WetGasPvt<Scalar>* >(realGasPvt_);
@@ -406,27 +406,27 @@ public:
 
     // get the parameter object for the thermal gas case
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::ThermalGasPvt, GasPvtThermal<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::ThermalGas, GasPvtThermal<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<GasPvtThermal<Scalar>* >(realGasPvt_);
     }
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::ThermalGasPvt, const GasPvtThermal<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::ThermalGas, const GasPvtThermal<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<const GasPvtThermal<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::Co2GasPvt, Co2GasPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == GasPvtApproach::Co2Gas, Co2GasPvt<Scalar> >::type& getRealPvt()
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<Co2GasPvt<Scalar>* >(realGasPvt_);
     }
 
     template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::Co2GasPvt, const Co2GasPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == GasPvtApproach::Co2Gas, const Co2GasPvt<Scalar> >::type& getRealPvt() const
     {
         assert(gasPvtApproach() == approachV);
         return *static_cast<const Co2GasPvt<Scalar>* >(realGasPvt_);
@@ -440,22 +440,22 @@ public:
             return false;
 
         switch (gasPvtApproach_) {
-        case GasPvtApproach::DryGasPvt:
+        case GasPvtApproach::DryGas:
             return *static_cast<const DryGasPvt<Scalar>*>(realGasPvt_) ==
                    *static_cast<const DryGasPvt<Scalar>*>(data.realGasPvt_);
-        case GasPvtApproach::DryHumidGasPvt:
+        case GasPvtApproach::DryHumidGas:
             return *static_cast<const DryHumidGasPvt<Scalar>*>(realGasPvt_) ==
                    *static_cast<const DryHumidGasPvt<Scalar>*>(data.realGasPvt_);
-        case GasPvtApproach::WetHumidGasPvt:
+        case GasPvtApproach::WetHumidGas:
             return *static_cast<const WetHumidGasPvt<Scalar>*>(realGasPvt_) ==
                    *static_cast<const WetHumidGasPvt<Scalar>*>(data.realGasPvt_);
-        case GasPvtApproach::WetGasPvt:
+        case GasPvtApproach::WetGas:
             return *static_cast<const WetGasPvt<Scalar>*>(realGasPvt_) ==
                    *static_cast<const WetGasPvt<Scalar>*>(data.realGasPvt_);
-        case GasPvtApproach::ThermalGasPvt:
+        case GasPvtApproach::ThermalGas:
             return *static_cast<const GasPvtThermal<Scalar>*>(realGasPvt_) ==
                    *static_cast<const GasPvtThermal<Scalar>*>(data.realGasPvt_);
-        case GasPvtApproach::Co2GasPvt:
+        case GasPvtApproach::Co2Gas:
             return *static_cast<const Co2GasPvt<Scalar>*>(realGasPvt_) ==
                     *static_cast<const Co2GasPvt<Scalar>*>(data.realGasPvt_);
         default:
@@ -467,22 +467,22 @@ public:
     {
         gasPvtApproach_ = data.gasPvtApproach_;
         switch (gasPvtApproach_) {
-        case GasPvtApproach::DryGasPvt:
+        case GasPvtApproach::DryGas:
             realGasPvt_ = new DryGasPvt<Scalar>(*static_cast<const DryGasPvt<Scalar>*>(data.realGasPvt_));
             break;
-        case GasPvtApproach::DryHumidGasPvt:
+        case GasPvtApproach::DryHumidGas:
             realGasPvt_ = new DryHumidGasPvt<Scalar>(*static_cast<const DryHumidGasPvt<Scalar>*>(data.realGasPvt_));
             break;
-        case GasPvtApproach::WetHumidGasPvt:
+        case GasPvtApproach::WetHumidGas:
             realGasPvt_ = new WetHumidGasPvt<Scalar>(*static_cast<const WetHumidGasPvt<Scalar>*>(data.realGasPvt_));
             break;
-        case GasPvtApproach::WetGasPvt:
+        case GasPvtApproach::WetGas:
             realGasPvt_ = new WetGasPvt<Scalar>(*static_cast<const WetGasPvt<Scalar>*>(data.realGasPvt_));
             break;
-        case GasPvtApproach::ThermalGasPvt:
+        case GasPvtApproach::ThermalGas:
             realGasPvt_ = new GasPvtThermal<Scalar>(*static_cast<const GasPvtThermal<Scalar>*>(data.realGasPvt_));
             break;
-        case GasPvtApproach::Co2GasPvt:
+        case GasPvtApproach::Co2Gas:
             realGasPvt_ = new Co2GasPvt<Scalar>(*static_cast<const Co2GasPvt<Scalar>*>(data.realGasPvt_));
             break;
         default:

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -39,44 +39,44 @@
 #endif
 
 namespace Opm {
-#define OPM_OIL_PVT_MULTIPLEXER_CALL(codeToCall)                                     \
-    switch (approach_) {                                                             \
-    case OilPvtApproach::ConstantCompressibilityOilPvt: {                            \
-        auto& pvtImpl = getRealPvt<OilPvtApproach::ConstantCompressibilityOilPvt>(); \
-        codeToCall;                                                                  \
-        break;                                                                       \
-    }                                                                                \
-    case OilPvtApproach::DeadOilPvt: {                                               \
-        auto& pvtImpl = getRealPvt<OilPvtApproach::DeadOilPvt>();                    \
-        codeToCall;                                                                  \
-        break;                                                                       \
-    }                                                                                \
-    case OilPvtApproach::LiveOilPvt: {                                               \
-        auto& pvtImpl = getRealPvt<OilPvtApproach::LiveOilPvt>();                    \
-        codeToCall;                                                                  \
-        break;                                                                       \
-    }                                                                                \
-    case OilPvtApproach::ThermalOilPvt: {                                            \
-        auto& pvtImpl = getRealPvt<OilPvtApproach::ThermalOilPvt>();                 \
-        codeToCall;                                                                  \
-        break;                                                                       \
-    }                                                                                \
-    case OilPvtApproach::BrineCo2Pvt: {                                              \
-        auto& pvtImpl = getRealPvt<OilPvtApproach::BrineCo2Pvt>();                   \
-        codeToCall;                                                                  \
-        break;                                                                       \
-    }                                                                                \
-    case OilPvtApproach::NoOilPvt:                                                   \
-        throw std::logic_error("Not implemented: Oil PVT of this deck!");            \
-    }                                                                                \
+#define OPM_OIL_PVT_MULTIPLEXER_CALL(codeToCall)                                  \
+    switch (approach_) {                                                          \
+    case OilPvtApproach::ConstantCompressibilityOil: {                            \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::ConstantCompressibilityOil>(); \
+        codeToCall;                                                               \
+        break;                                                                    \
+    }                                                                             \
+    case OilPvtApproach::DeadOil: {                                               \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::DeadOil>();                    \
+        codeToCall;                                                               \
+        break;                                                                    \
+    }                                                                             \
+    case OilPvtApproach::LiveOil: {                                               \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::LiveOil>();                    \
+        codeToCall;                                                               \
+        break;                                                                    \
+    }                                                                             \
+    case OilPvtApproach::ThermalOil: {                                            \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::ThermalOil>();                 \
+        codeToCall;                                                               \
+        break;                                                                    \
+    }                                                                             \
+    case OilPvtApproach::BrineCo2: {                                              \
+        auto& pvtImpl = getRealPvt<OilPvtApproach::BrineCo2>();                   \
+        codeToCall;                                                               \
+        break;                                                                    \
+    }                                                                             \
+    case OilPvtApproach::NoOil:                                                   \
+        throw std::logic_error("Not implemented: Oil PVT of this deck!");         \
+    }                                                                             \
 
 enum class OilPvtApproach {
-    NoOilPvt,
-    LiveOilPvt,
-    DeadOilPvt,
-    ConstantCompressibilityOilPvt,
-    ThermalOilPvt,
-    BrineCo2Pvt
+    NoOil,
+    LiveOil,
+    DeadOil,
+    ConstantCompressibilityOil,
+    ThermalOil,
+    BrineCo2
 };
 
 /*!
@@ -97,7 +97,7 @@ class OilPvtMultiplexer
 public:
     OilPvtMultiplexer()
     {
-        approach_ = OilPvtApproach::NoOilPvt;
+        approach_ = OilPvtApproach::NoOil;
         realOilPvt_ = nullptr;
     }
 
@@ -114,28 +114,28 @@ public:
     ~OilPvtMultiplexer()
     {
         switch (approach_) {
-        case OilPvtApproach::LiveOilPvt: {
-            delete &getRealPvt<OilPvtApproach::LiveOilPvt>();
+        case OilPvtApproach::LiveOil: {
+            delete &getRealPvt<OilPvtApproach::LiveOil>();
             break;
         }
-        case OilPvtApproach::DeadOilPvt: {
-            delete &getRealPvt<OilPvtApproach::DeadOilPvt>();
+        case OilPvtApproach::DeadOil: {
+            delete &getRealPvt<OilPvtApproach::DeadOil>();
             break;
         }
-        case OilPvtApproach::ConstantCompressibilityOilPvt: {
-            delete &getRealPvt<OilPvtApproach::ConstantCompressibilityOilPvt>();
+        case OilPvtApproach::ConstantCompressibilityOil: {
+            delete &getRealPvt<OilPvtApproach::ConstantCompressibilityOil>();
             break;
         }
-        case OilPvtApproach::ThermalOilPvt: {
-            delete &getRealPvt<OilPvtApproach::ThermalOilPvt>();
+        case OilPvtApproach::ThermalOil: {
+            delete &getRealPvt<OilPvtApproach::ThermalOil>();
             break;
         }
-        case OilPvtApproach::BrineCo2Pvt: {
-            delete &getRealPvt<OilPvtApproach::BrineCo2Pvt>();
+        case OilPvtApproach::BrineCo2: {
+            delete &getRealPvt<OilPvtApproach::BrineCo2>();
             break;
         }
 
-        case OilPvtApproach::NoOilPvt:
+        case OilPvtApproach::NoOil:
             break;
         }
     }
@@ -153,15 +153,15 @@ public:
         // TODO move the BrineCo2 approach to the waterPvtMultiplexer
         // when a proper gas-water simulator is supported
         if (eclState.runspec().co2Storage())
-            setApproach(OilPvtApproach::BrineCo2Pvt);
+            setApproach(OilPvtApproach::BrineCo2);
         else if (enableThermal && eclState.getSimulationConfig().isThermal())
-            setApproach(OilPvtApproach::ThermalOilPvt);
+            setApproach(OilPvtApproach::ThermalOil);
         else if (!eclState.getTableManager().getPvcdoTable().empty())
-            setApproach(OilPvtApproach::ConstantCompressibilityOilPvt);
+            setApproach(OilPvtApproach::ConstantCompressibilityOil);
         else if (eclState.getTableManager().hasTables("PVDO"))
-            setApproach(OilPvtApproach::DeadOilPvt);
+            setApproach(OilPvtApproach::DeadOil);
         else if (!eclState.getTableManager().getPvtoTables().empty())
-            setApproach(OilPvtApproach::LiveOilPvt);
+            setApproach(OilPvtApproach::LiveOil);
 
         OPM_OIL_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule));
     }
@@ -278,27 +278,27 @@ public:
     void setApproach(OilPvtApproach appr)
     {
         switch (appr) {
-        case OilPvtApproach::LiveOilPvt:
+        case OilPvtApproach::LiveOil:
             realOilPvt_ = new LiveOilPvt<Scalar>;
             break;
 
-        case OilPvtApproach::DeadOilPvt:
+        case OilPvtApproach::DeadOil:
             realOilPvt_ = new DeadOilPvt<Scalar>;
             break;
 
-        case OilPvtApproach::ConstantCompressibilityOilPvt:
+        case OilPvtApproach::ConstantCompressibilityOil:
             realOilPvt_ = new ConstantCompressibilityOilPvt<Scalar>;
             break;
 
-        case OilPvtApproach::ThermalOilPvt:
+        case OilPvtApproach::ThermalOil:
             realOilPvt_ = new OilPvtThermal<Scalar>;
             break;
 
-        case OilPvtApproach::BrineCo2Pvt:
+        case OilPvtApproach::BrineCo2:
             realOilPvt_ = new BrineCo2Pvt<Scalar>;
             break;
 
-        case OilPvtApproach::NoOilPvt:
+        case OilPvtApproach::NoOil:
             throw std::logic_error("Not implemented: Oil PVT of this deck!");
         }
 
@@ -315,70 +315,70 @@ public:
 
     // get the concrete parameter object for the oil phase
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::LiveOilPvt, LiveOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::LiveOil, LiveOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<LiveOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::LiveOilPvt, const LiveOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::LiveOil, const LiveOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<LiveOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::DeadOilPvt, DeadOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::DeadOil, DeadOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<DeadOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::DeadOilPvt, const DeadOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::DeadOil, const DeadOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<DeadOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOilPvt, ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOil, ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<ConstantCompressibilityOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOilPvt, const ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::ConstantCompressibilityOil, const ConstantCompressibilityOilPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<ConstantCompressibilityOilPvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::ThermalOilPvt, OilPvtThermal<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::ThermalOil, OilPvtThermal<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<OilPvtThermal<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::ThermalOilPvt, const OilPvtThermal<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::ThermalOil, const OilPvtThermal<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<const OilPvtThermal<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::BrineCo2Pvt, BrineCo2Pvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == OilPvtApproach::BrineCo2, BrineCo2Pvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<BrineCo2Pvt<Scalar>* >(realOilPvt_);
     }
 
     template <OilPvtApproach approachV>
-    typename std::enable_if<approachV == OilPvtApproach::BrineCo2Pvt, const BrineCo2Pvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == OilPvtApproach::BrineCo2, const BrineCo2Pvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<const BrineCo2Pvt<Scalar>* >(realOilPvt_);
@@ -392,19 +392,19 @@ public:
             return false;
 
         switch (approach_) {
-        case OilPvtApproach::ConstantCompressibilityOilPvt:
+        case OilPvtApproach::ConstantCompressibilityOil:
             return *static_cast<const ConstantCompressibilityOilPvt<Scalar>*>(realOilPvt_) ==
                    *static_cast<const ConstantCompressibilityOilPvt<Scalar>*>(data.realOilPvt_);
-        case OilPvtApproach::DeadOilPvt:
+        case OilPvtApproach::DeadOil:
             return *static_cast<const DeadOilPvt<Scalar>*>(realOilPvt_) ==
                    *static_cast<const DeadOilPvt<Scalar>*>(data.realOilPvt_);
-        case OilPvtApproach::LiveOilPvt:
+        case OilPvtApproach::LiveOil:
             return *static_cast<const LiveOilPvt<Scalar>*>(realOilPvt_) ==
                    *static_cast<const LiveOilPvt<Scalar>*>(data.realOilPvt_);
-        case OilPvtApproach::ThermalOilPvt:
+        case OilPvtApproach::ThermalOil:
             return *static_cast<const OilPvtThermal<Scalar>*>(realOilPvt_) ==
                    *static_cast<const OilPvtThermal<Scalar>*>(data.realOilPvt_);
-        case OilPvtApproach::BrineCo2Pvt:
+        case OilPvtApproach::BrineCo2:
             return *static_cast<const BrineCo2Pvt<Scalar>*>(realOilPvt_) ==
                     *static_cast<const BrineCo2Pvt<Scalar>*>(data.realOilPvt_);
         default:
@@ -416,19 +416,19 @@ public:
     {
         approach_ = data.approach_;
         switch (approach_) {
-        case OilPvtApproach::ConstantCompressibilityOilPvt:
+        case OilPvtApproach::ConstantCompressibilityOil:
             realOilPvt_ = new ConstantCompressibilityOilPvt<Scalar>(*static_cast<const ConstantCompressibilityOilPvt<Scalar>*>(data.realOilPvt_));
             break;
-        case OilPvtApproach::DeadOilPvt:
+        case OilPvtApproach::DeadOil:
             realOilPvt_ = new DeadOilPvt<Scalar>(*static_cast<const DeadOilPvt<Scalar>*>(data.realOilPvt_));
             break;
-        case OilPvtApproach::LiveOilPvt:
+        case OilPvtApproach::LiveOil:
             realOilPvt_ = new LiveOilPvt<Scalar>(*static_cast<const LiveOilPvt<Scalar>*>(data.realOilPvt_));
             break;
-        case OilPvtApproach::ThermalOilPvt:
+        case OilPvtApproach::ThermalOil:
             realOilPvt_ = new OilPvtThermal<Scalar>(*static_cast<const OilPvtThermal<Scalar>*>(data.realOilPvt_));
             break;
-        case OilPvtApproach::BrineCo2Pvt:
+        case OilPvtApproach::BrineCo2:
             realOilPvt_ = new BrineCo2Pvt<Scalar>(*static_cast<const BrineCo2Pvt<Scalar>*>(data.realOilPvt_));
             break;
         default:

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -38,32 +38,32 @@
 
 #define OPM_WATER_PVT_MULTIPLEXER_CALL(codeToCall)                      \
     switch (approach_) {                                                \
-    case WaterPvtApproach::ConstantCompressibilityWaterPvt: {           \
-        auto& pvtImpl = getRealPvt<WaterPvtApproach::ConstantCompressibilityWaterPvt>();  \
+    case WaterPvtApproach::ConstantCompressibilityWater: {           \
+        auto& pvtImpl = getRealPvt<WaterPvtApproach::ConstantCompressibilityWater>();  \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
-    case WaterPvtApproach::ConstantCompressibilityBrinePvt: {           \
-        auto& pvtImpl = getRealPvt<WaterPvtApproach::ConstantCompressibilityBrinePvt>();  \
+    case WaterPvtApproach::ConstantCompressibilityBrine: {           \
+        auto& pvtImpl = getRealPvt<WaterPvtApproach::ConstantCompressibilityBrine>();  \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
-    case WaterPvtApproach::ThermalWaterPvt: {                           \
-        auto& pvtImpl = getRealPvt<WaterPvtApproach::ThermalWaterPvt>();                  \
+    case WaterPvtApproach::ThermalWater: {                           \
+        auto& pvtImpl = getRealPvt<WaterPvtApproach::ThermalWater>();   \
         codeToCall;                                                     \
         break;                                                          \
     }                                                                   \
-    case WaterPvtApproach::NoWaterPvt:                                  \
+    case WaterPvtApproach::NoWater:                                     \
         throw std::logic_error("Not implemented: Water PVT of this deck!"); \
     }
 
 namespace Opm {
 
 enum class WaterPvtApproach {
-    NoWaterPvt,
-    ConstantCompressibilityBrinePvt,
-    ConstantCompressibilityWaterPvt,
-    ThermalWaterPvt
+    NoWater,
+    ConstantCompressibilityBrine,
+    ConstantCompressibilityWater,
+    ThermalWater
 };
 
 /*!
@@ -76,7 +76,7 @@ class WaterPvtMultiplexer
 public:
     WaterPvtMultiplexer()
     {
-        approach_ = WaterPvtApproach::NoWaterPvt;
+        approach_ = WaterPvtApproach::NoWater;
         realWaterPvt_ = nullptr;
     }
 
@@ -93,19 +93,19 @@ public:
     ~WaterPvtMultiplexer()
     {
         switch (approach_) {
-        case WaterPvtApproach::ConstantCompressibilityWaterPvt: {
-            delete &getRealPvt<WaterPvtApproach::ConstantCompressibilityWaterPvt>();
+        case WaterPvtApproach::ConstantCompressibilityWater: {
+            delete &getRealPvt<WaterPvtApproach::ConstantCompressibilityWater>();
             break;
         }
-        case WaterPvtApproach::ConstantCompressibilityBrinePvt: {
-            delete &getRealPvt<WaterPvtApproach::ConstantCompressibilityBrinePvt>();
+        case WaterPvtApproach::ConstantCompressibilityBrine: {
+            delete &getRealPvt<WaterPvtApproach::ConstantCompressibilityBrine>();
             break;
         }
-        case WaterPvtApproach::ThermalWaterPvt: {
-            delete &getRealPvt<WaterPvtApproach::ThermalWaterPvt>();
+        case WaterPvtApproach::ThermalWater: {
+            delete &getRealPvt<WaterPvtApproach::ThermalWater>();
             break;
         }
-        case WaterPvtApproach::NoWaterPvt:
+        case WaterPvtApproach::NoWater:
             break;
         }
     }
@@ -122,11 +122,11 @@ public:
             return;
 
         if (enableThermal && eclState.getSimulationConfig().isThermal())
-            setApproach(WaterPvtApproach::ThermalWaterPvt);
+            setApproach(WaterPvtApproach::ThermalWater);
         else if (!eclState.getTableManager().getPvtwTable().empty())
-            setApproach(WaterPvtApproach::ConstantCompressibilityWaterPvt);
+            setApproach(WaterPvtApproach::ConstantCompressibilityWater);
         else if (enableBrine && !eclState.getTableManager().getPvtwSaltTables().empty())
-            setApproach(WaterPvtApproach::ConstantCompressibilityBrinePvt);
+            setApproach(WaterPvtApproach::ConstantCompressibilityBrine);
 
         OPM_WATER_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule));
     }
@@ -185,19 +185,19 @@ public:
     void setApproach(WaterPvtApproach appr)
     {
         switch (appr) {
-        case WaterPvtApproach::ConstantCompressibilityWaterPvt:
+        case WaterPvtApproach::ConstantCompressibilityWater:
             realWaterPvt_ = new ConstantCompressibilityWaterPvt<Scalar>;
             break;
 
-        case WaterPvtApproach::ConstantCompressibilityBrinePvt:
+        case WaterPvtApproach::ConstantCompressibilityBrine:
             realWaterPvt_ = new ConstantCompressibilityBrinePvt<Scalar>;
             break;
 
-        case WaterPvtApproach::ThermalWaterPvt:
+        case WaterPvtApproach::ThermalWater:
             realWaterPvt_ = new WaterPvtThermal<Scalar, enableBrine>;
             break;
 
-        case WaterPvtApproach::NoWaterPvt:
+        case WaterPvtApproach::NoWater:
             throw std::logic_error("Not implemented: Water PVT of this deck!");
         }
 
@@ -214,42 +214,42 @@ public:
 
     // get the concrete parameter object for the water phase
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWaterPvt, ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWater, ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWaterPvt, const ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWater, const ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrinePvt, ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt()
+    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrine, ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<ConstantCompressibilityBrinePvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrinePvt, const ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt() const
+    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrine, const ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<ConstantCompressibilityBrinePvt<Scalar>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ThermalWaterPvt, WaterPvtThermal<Scalar, enableBrine> >::type& getRealPvt()
+    typename std::enable_if<approachV == WaterPvtApproach::ThermalWater, WaterPvtThermal<Scalar, enableBrine> >::type& getRealPvt()
     {
         assert(approach() == approachV);
         return *static_cast<WaterPvtThermal<Scalar, enableBrine>* >(realWaterPvt_);
     }
 
     template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ThermalWaterPvt, const WaterPvtThermal<Scalar, enableBrine> >::type& getRealPvt() const
+    typename std::enable_if<approachV == WaterPvtApproach::ThermalWater, const WaterPvtThermal<Scalar, enableBrine> >::type& getRealPvt() const
     {
         assert(approach() == approachV);
         return *static_cast<WaterPvtThermal<Scalar, enableBrine>* >(realWaterPvt_);
@@ -263,13 +263,13 @@ public:
             return false;
 
         switch (approach_) {
-        case WaterPvtApproach::ConstantCompressibilityWaterPvt:
+        case WaterPvtApproach::ConstantCompressibilityWater:
             return *static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(realWaterPvt_) ==
                    *static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(data.realWaterPvt_);
-        case WaterPvtApproach::ConstantCompressibilityBrinePvt:
+        case WaterPvtApproach::ConstantCompressibilityBrine:
             return *static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(realWaterPvt_) ==
                    *static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(data.realWaterPvt_);
-        case WaterPvtApproach::ThermalWaterPvt:
+        case WaterPvtApproach::ThermalWater:
             return *static_cast<const WaterPvtThermal<Scalar, enableBrine>*>(realWaterPvt_) ==
                    *static_cast<const WaterPvtThermal<Scalar, enableBrine>*>(data.realWaterPvt_);
         default:
@@ -281,13 +281,13 @@ public:
     {
         approach_ = data.approach_;
         switch (approach_) {
-        case WaterPvtApproach::ConstantCompressibilityWaterPvt:
+        case WaterPvtApproach::ConstantCompressibilityWater:
             realWaterPvt_ = new ConstantCompressibilityWaterPvt<Scalar>(*static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(data.realWaterPvt_));
             break;
-        case WaterPvtApproach::ConstantCompressibilityBrinePvt:
+        case WaterPvtApproach::ConstantCompressibilityBrine:
             realWaterPvt_ = new ConstantCompressibilityBrinePvt<Scalar>(*static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(data.realWaterPvt_));
             break;
-        case WaterPvtApproach::ThermalWaterPvt:
+        case WaterPvtApproach::ThermalWater:
             realWaterPvt_ = new WaterPvtThermal<Scalar, enableBrine>(*static_cast<const WaterPvtThermal<Scalar, enableBrine>*>(data.realWaterPvt_));
             break;
         default:


### PR DESCRIPTION
The name of the entries in these enums contains redundancies now that they have been converted to enum class. Remedy this to tidy code a little.