### PR TITLE
changed: remove include of Math.hpp

### DIFF
--- a/opm/material/components/SimpleCO2.hpp
+++ b/opm/material/components/SimpleCO2.hpp
@@ -33,8 +33,6 @@
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/components/Component.hpp>
 
-#include <opm/material/densead/Math.hpp>
-
 #include <cmath>
 
 namespace Opm {


### PR DESCRIPTION
it should be up to instance sites to make every available for the templates to instance properly, even though we know we are instancing over Evaluations.

Waiting for https://github.com/OPM/opm-common/pull/3246