### PR TITLE
Always use MULTZ- as a global array.

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -140,7 +140,7 @@ static const std::unordered_map<std::string, keyword_info<double>> double_keywor
                                                                                       {"MULTY",   keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"MULTY-",  keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"MULTZ",   keyword_info<double>{}.init(1.0).mult(true).global_kw(true)},
-                                                                                      {"MULTZ-",  keyword_info<double>{}.init(1.0).mult(true)}};
+                                                                                      {"MULTZ-",  keyword_info<double>{}.init(1.0).mult(true).global_kw(true)}};
 
 static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {{"ACTNUM",  keyword_info<int>{}.init(1)},
                                                                                 {"FLUXNUM", keyword_info<int>{}},
@@ -167,7 +167,7 @@ static const std::unordered_map<std::string, keyword_info<double>> double_keywor
                                                                                       {"MULTY",   keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"MULTY-",  keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"MULTZ",   keyword_info<double>{}.init(1.0).mult(true).global_kw(true)},
-                                                                                      {"MULTZ-",  keyword_info<double>{}.init(1.0).mult(true)}};
+                                                                                      {"MULTZ-",  keyword_info<double>{}.init(1.0).mult(true).global_kw(true)}};
 
 static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {};
 }
@@ -280,7 +280,7 @@ static const std::unordered_map<std::string, keyword_info<double>> double_keywor
                                                                                       {"MULTY",   keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"MULTY-",  keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"MULTZ",   keyword_info<double>{}.init(1.0).mult(true).global_kw(true)},
-                                                                                      {"MULTZ-",  keyword_info<double>{}.init(1.0).mult(true)}};
+                                                                                      {"MULTZ-",  keyword_info<double>{}.init(1.0).mult(true).global_kw(true)}};
 
 static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {{"ROCKNUM",   keyword_info<int>{}}};
 


### PR DESCRIPTION
This is needed as it is used when calculating transmissibilities over pinched out cells. There it needs to behave the same way as MULTZ does.

Missing changes for OPM/opm-simulators#4320