### PR TITLE
GasPvtMultiplexer: Replace unholy trinity with visitor overload sets

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -388,6 +388,7 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_SegmentMatcher.cpp
       tests/test_sparsevector.cpp
       tests/test_uniformtablelinear.cpp
+      tests/test_Visitor.cpp
 )
 
 # tests that need to be linked to dune-common
@@ -697,6 +698,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/utility/FileSystem.hpp
       opm/common/utility/OpmInputError.hpp
       opm/common/utility/Serializer.hpp
+      opm/common/utility/Visitor.hpp
       opm/common/utility/numeric/cmp.hpp
       opm/common/utility/platform_dependent/disable_warnings.h
       opm/common/utility/platform_dependent/reenable_warnings.h

--- a/opm/common/utility/Visitor.hpp
+++ b/opm/common/utility/Visitor.hpp
@@ -1,0 +1,64 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#ifndef VISITOR_HPP
+#define VISITOR_HPP
+
+#include <string>
+#include <variant>
+
+namespace Opm {
+
+//! \brief Helper struct for for generating visitor overload sets.
+template<class... Ts>
+struct VisitorOverloadSet : Ts...
+{
+    using Ts::operator()...;
+};
+
+//! \brief Deduction guide for visitor overload sets.
+template<class... Ts> VisitorOverloadSet(Ts...) -> VisitorOverloadSet<Ts...>;
+
+//! \brief A functor for handling a monostate in a visitor overload set.
+//! \details Throws an exception
+template<class Exception>
+struct MonoThrowHandler {
+    MonoThrowHandler(const std::string& message)
+        : message_(message)
+    {}
+
+    void operator()(std::monostate&)
+    {
+        throw Exception(message_);
+    }
+
+    void operator()(const std::monostate&) const
+    {
+        throw Exception(message_);
+    }
+
+private:
+    std::string message_;
+};
+
+}
+
+#endif

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -27,6 +27,8 @@
 #ifndef OPM_GAS_PVT_MULTIPLEXER_HPP
 #define OPM_GAS_PVT_MULTIPLEXER_HPP
 
+#include <opm/common/utility/Visitor.hpp>
+
 #include "DryGasPvt.hpp"
 #include "DryHumidGasPvt.hpp"
 #include "WetHumidGasPvt.hpp"
@@ -40,42 +42,6 @@ namespace Opm {
 class EclipseState;
 class Schedule;
 #endif
-
-#define OPM_GAS_PVT_MULTIPLEXER_CALL(codeToCall)                          \
-    switch (gasPvtApproach_) {                                            \
-    case GasPvtApproach::DryGas: {                                        \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::DryGas>();             \
-        codeToCall;                                                       \
-        break;                                                            \
-    }                                                                     \
-    case GasPvtApproach::DryHumidGas: {                                   \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::DryHumidGas>();        \
-        codeToCall;                                                       \
-        break;                                                            \
-    }                                                                     \
-    case GasPvtApproach::WetHumidGas: {                                   \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::WetHumidGas>();        \
-        codeToCall;                                                       \
-        break;                                                            \
-    }                                                                     \
-    case GasPvtApproach::WetGas: {                                        \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::WetGas>();             \
-        codeToCall;                                                       \
-        break;                                                            \
-    }                                                                     \
-    case GasPvtApproach::ThermalGas: {                                    \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::ThermalGas>();         \
-        codeToCall;                                                       \
-        break;                                                            \
-    }                                                                     \
-    case GasPvtApproach::Co2Gas: {                                        \
-        auto& pvtImpl = getRealPvt<GasPvtApproach::Co2Gas>();             \
-        codeToCall;                                                       \
-        break;                                                            \
-    }                                                                     \
-    case GasPvtApproach::NoGas:                                           \
-        throw std::logic_error("Not implemented: Gas PVT of this deck!"); \
-    }
 
 enum class GasPvtApproach {
     NoGas,
@@ -101,54 +67,6 @@ template <class Scalar, bool enableThermal = true>
 class GasPvtMultiplexer
 {
 public:
-    GasPvtMultiplexer()
-    {
-        gasPvtApproach_ = GasPvtApproach::NoGas;
-        realGasPvt_ = nullptr;
-    }
-
-    GasPvtMultiplexer(GasPvtApproach approach, void* realGasPvt)
-        : gasPvtApproach_(approach)
-        , realGasPvt_(realGasPvt)
-    { }
-
-    GasPvtMultiplexer(const GasPvtMultiplexer<Scalar,enableThermal>& data)
-    {
-        *this = data;
-    }
-
-    ~GasPvtMultiplexer()
-    {
-        switch (gasPvtApproach_) {
-        case GasPvtApproach::DryGas: {
-            delete &getRealPvt<GasPvtApproach::DryGas>();
-            break;
-        }
-        case GasPvtApproach::DryHumidGas: {
-            delete &getRealPvt<GasPvtApproach::DryHumidGas>();
-            break;
-        }
-        case GasPvtApproach::WetHumidGas: {
-            delete &getRealPvt<GasPvtApproach::WetHumidGas>();
-            break;
-        }
-        case GasPvtApproach::WetGas: {
-            delete &getRealPvt<GasPvtApproach::WetGas>();
-            break;
-        }
-        case GasPvtApproach::ThermalGas: {
-            delete &getRealPvt<GasPvtApproach::ThermalGas>();
-            break;
-        }
-        case GasPvtApproach::Co2Gas: {
-            delete &getRealPvt<GasPvtApproach::Co2Gas>();
-            break;
-        }
-        case GasPvtApproach::NoGas:
-            break;
-        }
-    }
-
 #if HAVE_ECL_INPUT
     /*!
      * \brief Initialize the parameters for gas using an ECL deck.
@@ -162,27 +80,27 @@ public:
     {
         switch (gasPvtAppr) {
         case GasPvtApproach::DryGas:
-            realGasPvt_ = new DryGasPvt<Scalar>;
+            gasPvt_ = DryGasPvt<Scalar>{};
             break;
 
         case GasPvtApproach::DryHumidGas:
-            realGasPvt_ = new DryHumidGasPvt<Scalar>;
+            gasPvt_ = DryHumidGasPvt<Scalar>{};
             break;
         
         case GasPvtApproach::WetHumidGas:
-            realGasPvt_ = new WetHumidGasPvt<Scalar>;
+            gasPvt_ = WetHumidGasPvt<Scalar>{};
             break;
 
         case GasPvtApproach::WetGas:
-            realGasPvt_ = new WetGasPvt<Scalar>;
+            gasPvt_ = WetGasPvt<Scalar>{};
             break;
 
         case GasPvtApproach::ThermalGas:
-            realGasPvt_ = new GasPvtThermal<Scalar>;
+            gasPvt_ = GasPvtThermal<Scalar>{};
             break;
 
         case GasPvtApproach::Co2Gas:
-            realGasPvt_ = new Co2GasPvt<Scalar>;
+            gasPvt_ = Co2GasPvt<Scalar>{};
             break;
 
         case GasPvtApproach::NoGas:
@@ -193,108 +111,211 @@ public:
     }
 
     void initEnd()
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(pvtImpl.initEnd()); }
+    {
+        std::visit(VisitorOverloadSet{[](auto& pvt) { pvt.initEnd(); }, monoHandler_}, gasPvt_);
+    }
 
     /*!
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
     unsigned numRegions() const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); return 1; }
+    {
+        unsigned result;
+        std::visit(VisitorOverloadSet{[&result](const auto& pvt)
+                                      {
+                                          result = pvt.numRegions();
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Return the reference density which are considered by this PVT-object.
      */
-    const Scalar gasReferenceDensity(unsigned regionIdx)
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.gasReferenceDensity(regionIdx)); return 2.; }
+    Scalar gasReferenceDensity(unsigned regionIdx) const
+    {
+        Scalar result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.gasReferenceDensity(regionIdx);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
      */
     template <class Evaluation>
     Evaluation internalEnergy(unsigned regionIdx,
-                        const Evaluation& temperature,
-                        const Evaluation& pressure,
-                        const Evaluation& Rv) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.internalEnergy(regionIdx, temperature, pressure, Rv)); return 0; }
+                              const Evaluation& temperature,
+                              const Evaluation& pressure,
+                              const Evaluation& Rv) const
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.internalEnergy(regionIdx,
+                                                                      temperature,
+                                                                      pressure,
+                                                                      Rv);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation viscosity(unsigned regionIdx,
                          const Evaluation& temperature,
                          const Evaluation& pressure,
                          const Evaluation& Rv,
-                         const Evaluation& Rvw ) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, Rv, Rvw)); return 0; }
+                         const Evaluation& Rvw) const
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.viscosity(regionIdx,
+                                                                 temperature,
+                                                                 pressure,
+                                                                 Rv, Rvw);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of oil saturated gas given a set of parameters.
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation saturatedViscosity(unsigned regionIdx,
                                   const Evaluation& temperature,
                                   const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedViscosity(regionIdx, temperature, pressure)); return 0; }
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.saturatedViscosity(regionIdx,
+                                                                          temperature,
+                                                                          pressure);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the formation volume factor [-] of the fluid phase.
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation inverseFormationVolumeFactor(unsigned regionIdx,
                                             const Evaluation& temperature,
                                             const Evaluation& pressure,
                                             const Evaluation& Rv,
                                             const Evaluation& Rvw) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rv, Rvw)); return 0; }
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.inverseFormationVolumeFactor(regionIdx,
+                                                                                    temperature,
+                                                                                    pressure,
+                                                                                    Rv, Rvw);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the formation volume factor [-] of oil saturated gas given a set of parameters.
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation saturatedInverseFormationVolumeFactor(unsigned regionIdx,
                                                      const Evaluation& temperature,
                                                      const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure)); return 0; }
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.saturatedInverseFormationVolumeFactor(regionIdx,
+                                                                                             temperature,
+                                                                                             pressure);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of oil saturated gas.
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& temperature,
                                               const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilVaporizationFactor(regionIdx, temperature, pressure)); return 0; }
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.saturatedOilVaporizationFactor(regionIdx,
+                                                                                      temperature,
+                                                                                      pressure);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of oil saturated gas.
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& temperature,
                                               const Evaluation& pressure,
                                               const Evaluation& oilSaturation,
                                               const Evaluation& maxOilSaturation) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedOilVaporizationFactor(regionIdx, temperature, pressure, oilSaturation, maxOilSaturation)); return 0; }
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.saturatedOilVaporizationFactor(regionIdx,
+                                                                                      temperature,
+                                                                                      pressure,
+                                                                                      oilSaturation,
+                                                                                      maxOilSaturation);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the water vaporization factor \f$R_vw\f$ [m^3/m^3] of water saturated gas.
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
-                                              const Evaluation& temperature,
-                                              const Evaluation& pressure) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedWaterVaporizationFactor(regionIdx, temperature, pressure)); return 0; }
-    
+                                                const Evaluation& temperature,
+                                                const Evaluation& pressure) const
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.saturatedWaterVaporizationFactor(regionIdx,
+                                                                                        temperature,
+                                                                                        pressure);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
+
     /*!
      * \brief Returns the water vaporization factor \f$R_vw\f$ [m^3/m^3] of water saturated gas.
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
-                                              const Evaluation& temperature,
-                                              const Evaluation& pressure, 
-                                              const Evaluation& saltConcentration) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedWaterVaporizationFactor(regionIdx, temperature, pressure, saltConcentration)); return 0; }
+                                                const Evaluation& temperature,
+                                                const Evaluation& pressure,
+                                                const Evaluation& saltConcentration) const
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.saturatedWaterVaporizationFactor(regionIdx,
+                                                                                        temperature,
+                                                                                        pressure,
+                                                                                        saltConcentration);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the saturation pressure of the gas phase [Pa]
@@ -302,11 +323,20 @@ public:
      *
      * \param Rv The surface volume of oil component dissolved in what will yield one cubic meter of gas at the surface [-]
      */
-    template <class Evaluation = Scalar>
+    template <class Evaluation>
     Evaluation saturationPressure(unsigned regionIdx,
                                   const Evaluation& temperature,
                                   const Evaluation& Rv) const
-    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturationPressure(regionIdx, temperature, Rv)); return 0; }
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.saturationPressure(regionIdx,
+                                                                          temperature,
+                                                                          Rv);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
+    }
 
     /*!
      * \copydoc BaseFluidSystem::diffusionCoefficient
@@ -316,7 +346,14 @@ public:
                                     const Evaluation& pressure,
                                     unsigned compIdx) const
     {
-      OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.diffusionCoefficient(temperature, pressure, compIdx)); return 0;
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.diffusionCoefficient(temperature,
+                                                                            pressure,
+                                                                            compIdx);
+                                      }, monoHandler_}, gasPvt_);
+        return result;
     }
 
     /*!
@@ -327,128 +364,25 @@ public:
     GasPvtApproach gasPvtApproach() const
     { return gasPvtApproach_; }
 
-    // get the parameter object for the dry gas case
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryGas, DryGasPvt<Scalar> >::type& getRealPvt()
+    //! \brief Apply a visitor to the concrete pvt implementation.
+    template<class Function>
+    void visit(Function f)
     {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<DryGasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryGas, const DryGasPvt<Scalar> >::type& getRealPvt() const
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<const DryGasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    // get the parameter object for the dry humid gas case
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryHumidGas, DryHumidGasPvt<Scalar> >::type& getRealPvt()
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<DryHumidGasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::DryHumidGas, const DryHumidGasPvt<Scalar> >::type& getRealPvt() const
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<const DryHumidGasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    // get the parameter object for the wet humid gas case
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetHumidGas, WetHumidGasPvt<Scalar> >::type& getRealPvt()
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<WetHumidGasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetHumidGas, const WetHumidGasPvt<Scalar> >::type& getRealPvt() const
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<const WetHumidGasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    // get the parameter object for the wet gas case
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetGas, WetGasPvt<Scalar> >::type& getRealPvt()
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<WetGasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::WetGas, const WetGasPvt<Scalar> >::type& getRealPvt() const
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<const WetGasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    // get the parameter object for the thermal gas case
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::ThermalGas, GasPvtThermal<Scalar> >::type& getRealPvt()
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<GasPvtThermal<Scalar>* >(realGasPvt_);
-    }
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::ThermalGas, const GasPvtThermal<Scalar> >::type& getRealPvt() const
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<const GasPvtThermal<Scalar>* >(realGasPvt_);
-    }
-
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::Co2Gas, Co2GasPvt<Scalar> >::type& getRealPvt()
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<Co2GasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    template <GasPvtApproach approachV>
-    typename std::enable_if<approachV == GasPvtApproach::Co2Gas, const Co2GasPvt<Scalar> >::type& getRealPvt() const
-    {
-        assert(gasPvtApproach() == approachV);
-        return *static_cast<const Co2GasPvt<Scalar>* >(realGasPvt_);
-    }
-
-    const void* realGasPvt() const { return realGasPvt_; }
-
-    GasPvtMultiplexer<Scalar,enableThermal>& operator=(const GasPvtMultiplexer<Scalar,enableThermal>& data)
-    {
-        gasPvtApproach_ = data.gasPvtApproach_;
-        switch (gasPvtApproach_) {
-        case GasPvtApproach::DryGas:
-            realGasPvt_ = new DryGasPvt<Scalar>(*static_cast<const DryGasPvt<Scalar>*>(data.realGasPvt_));
-            break;
-        case GasPvtApproach::DryHumidGas:
-            realGasPvt_ = new DryHumidGasPvt<Scalar>(*static_cast<const DryHumidGasPvt<Scalar>*>(data.realGasPvt_));
-            break;
-        case GasPvtApproach::WetHumidGas:
-            realGasPvt_ = new WetHumidGasPvt<Scalar>(*static_cast<const WetHumidGasPvt<Scalar>*>(data.realGasPvt_));
-            break;
-        case GasPvtApproach::WetGas:
-            realGasPvt_ = new WetGasPvt<Scalar>(*static_cast<const WetGasPvt<Scalar>*>(data.realGasPvt_));
-            break;
-        case GasPvtApproach::ThermalGas:
-            realGasPvt_ = new GasPvtThermal<Scalar>(*static_cast<const GasPvtThermal<Scalar>*>(data.realGasPvt_));
-            break;
-        case GasPvtApproach::Co2Gas:
-            realGasPvt_ = new Co2GasPvt<Scalar>(*static_cast<const Co2GasPvt<Scalar>*>(data.realGasPvt_));
-            break;
-        default:
-            break;
-        }
-
-        return *this;
+        std::visit(VisitorOverloadSet{f, monoHandler_, [](auto&) {}}, gasPvt_);
     }
 
 private:
-    GasPvtApproach gasPvtApproach_;
-    void* realGasPvt_;
+    GasPvtApproach gasPvtApproach_ = GasPvtApproach::NoGas;
+    std::variant<std::monostate,
+                 DryGasPvt<Scalar>,
+                 DryHumidGasPvt<Scalar>,
+                 WetHumidGasPvt<Scalar>,
+                 WetGasPvt<Scalar>,
+                 GasPvtThermal<Scalar>,
+                 Co2GasPvt<Scalar>> gasPvt_;
+
+    MonoThrowHandler<std::logic_error>
+    monoHandler_{"Not implemented: Gas PVT of this deck!"}; // mono state handler
 };
 
 } // namespace Opm

--- a/src/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.cpp
+++ b/src/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.cpp
@@ -48,8 +48,10 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     else if (!eclState.getTableManager().getPvtgwTables().empty())
         setApproach(GasPvtApproach::DryHumidGas);
 
-
-    OPM_GAS_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule));
+    std::visit(VisitorOverloadSet{[&](auto& pvt)
+                                  {
+                                      pvt.initFromState(eclState, schedule);
+                                  }, monoHandler_}, gasPvt_);
 }
 
 template class GasPvtMultiplexer<double,false>;

--- a/tests/test_Visitor.cpp
+++ b/tests/test_Visitor.cpp
@@ -1,0 +1,92 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE VISITOR_TESTS
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/utility/Visitor.hpp>
+
+#include <stdexcept>
+#include <variant>
+
+namespace {
+
+struct TestA {
+  void testThrow()
+  {
+      throw std::runtime_error("A");
+  }
+
+  char returnData()
+  {
+      return 'A';
+  }
+};
+
+struct TestB {
+  void testThrow()
+  {
+      throw std::range_error("B");
+  }
+
+  char returnData()
+  {
+      return 'B';
+  }
+};
+
+}
+
+using Variant = std::variant<std::monostate, TestA, TestB>;
+
+// Test overload set visitor on a simple list of classes
+BOOST_AUTO_TEST_CASE(VariantReturn)
+{
+    Variant v{};
+    char result = '\0';
+    Opm::MonoThrowHandler<std::logic_error> mh{"Mono state"};
+    auto rD = [&result](auto& param)
+              {
+                  result = param.returnData();
+              };
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::logic_error);
+    BOOST_CHECK(result == '\0');
+    v = TestA{};
+    BOOST_CHECK_NO_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v));
+    BOOST_CHECK(result == 'A');
+    v = TestB{};
+    BOOST_CHECK_NO_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v));
+    BOOST_CHECK(result == 'B');
+}
+
+// Test that overload set visitor throws expected exceptions
+BOOST_AUTO_TEST_CASE(VariantThrow)
+{
+    Variant v{};
+    Opm::MonoThrowHandler<std::logic_error> mh{"Mono state"};
+    auto rD = [](auto& param)
+              {
+                  param.testThrow();
+              };
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::logic_error);
+    v = TestA{};
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::runtime_error);
+    v = TestB{};
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::range_error);
+}


### PR DESCRIPTION
Sits on top of https://github.com/OPM/opm-common/pull/3278
Waiting for https://github.com/OPM/opm-common/pull/3246

I realize this may be controversial, and that it might have runtime implications (which we need to benchmark) but;
This replaces what I consider the unholy trinity (void pointers, macros and SFINAE) with the visitor overload set idiom in the gas multiplexer.

As a bonus we avoid the need to have explicit ctors, copy ctors, assignment and comparison operators.