### PR TITLE
WaterPvtMultiplexer: Replace unholy trinity with visitor overload sets

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -378,6 +378,7 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_tabulation.cpp
       tests/test_threecomponents_ptflash.cpp
       tests/test_uniformtablelinear.cpp
+      tests/test_Visitor.cpp
 )
 if(ENABLE_ECL_INPUT)
   list(APPEND TEST_SOURCE_FILES
@@ -662,6 +663,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/utility/FileSystem.hpp
       opm/common/utility/OpmInputError.hpp
       opm/common/utility/Serializer.hpp
+      opm/common/utility/Visitor.hpp
       opm/common/utility/numeric/cmp.hpp
       opm/common/utility/platform_dependent/disable_warnings.h
       opm/common/utility/platform_dependent/reenable_warnings.h

--- a/opm/common/utility/Visitor.hpp
+++ b/opm/common/utility/Visitor.hpp
@@ -1,0 +1,64 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#ifndef VISITOR_HPP
+#define VISITOR_HPP
+
+#include <string>
+#include <variant>
+
+namespace Opm {
+
+//! \brief Helper struct for for generating visitor overload sets.
+template<class... Ts>
+struct VisitorOverloadSet : Ts...
+{
+    using Ts::operator()...;
+};
+
+//! \brief Deduction guide for visitor overload sets.
+template<class... Ts> VisitorOverloadSet(Ts...) -> VisitorOverloadSet<Ts...>;
+
+//! \brief A functor for handling a monostate in a visitor overload set.
+//! \details Throws an exception
+template<class Exception>
+struct MonoThrowHandler {
+    MonoThrowHandler(const std::string& message)
+        : message_(message)
+    {}
+
+    void operator()(std::monostate&)
+    {
+        throw Exception(message_);
+    }
+
+    void operator()(const std::monostate&) const
+    {
+        throw Exception(message_);
+    }
+
+private:
+    std::string message_;
+};
+
+}
+
+#endif

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -27,6 +27,8 @@
 #ifndef OPM_WATER_PVT_MULTIPLEXER_HPP
 #define OPM_WATER_PVT_MULTIPLEXER_HPP
 
+#include <opm/common/utility/Visitor.hpp>
+
 #include "ConstantCompressibilityWaterPvt.hpp"
 #include "ConstantCompressibilityBrinePvt.hpp"
 #include "WaterPvtThermal.hpp"
@@ -36,26 +38,7 @@
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #endif
 
-#define OPM_WATER_PVT_MULTIPLEXER_CALL(codeToCall)                      \
-    switch (approach_) {                                                \
-    case WaterPvtApproach::ConstantCompressibilityWater: {           \
-        auto& pvtImpl = getRealPvt<WaterPvtApproach::ConstantCompressibilityWater>();  \
-        codeToCall;                                                     \
-        break;                                                          \
-    }                                                                   \
-    case WaterPvtApproach::ConstantCompressibilityBrine: {           \
-        auto& pvtImpl = getRealPvt<WaterPvtApproach::ConstantCompressibilityBrine>();  \
-        codeToCall;                                                     \
-        break;                                                          \
-    }                                                                   \
-    case WaterPvtApproach::ThermalWater: {                           \
-        auto& pvtImpl = getRealPvt<WaterPvtApproach::ThermalWater>();   \
-        codeToCall;                                                     \
-        break;                                                          \
-    }                                                                   \
-    case WaterPvtApproach::NoWater:                                     \
-        throw std::logic_error("Not implemented: Water PVT of this deck!"); \
-    }
+#include <variant>
 
 namespace Opm {
 
@@ -74,42 +57,6 @@ template <class Scalar, bool enableThermal = true, bool enableBrine = true>
 class WaterPvtMultiplexer
 {
 public:
-    WaterPvtMultiplexer()
-    {
-        approach_ = WaterPvtApproach::NoWater;
-        realWaterPvt_ = nullptr;
-    }
-
-    WaterPvtMultiplexer(WaterPvtApproach approach, void* realWaterPvt)
-        : approach_(approach)
-        , realWaterPvt_(realWaterPvt)
-    { }
-
-    WaterPvtMultiplexer(const WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>& data)
-    {
-        *this = data;
-    }
-
-    ~WaterPvtMultiplexer()
-    {
-        switch (approach_) {
-        case WaterPvtApproach::ConstantCompressibilityWater: {
-            delete &getRealPvt<WaterPvtApproach::ConstantCompressibilityWater>();
-            break;
-        }
-        case WaterPvtApproach::ConstantCompressibilityBrine: {
-            delete &getRealPvt<WaterPvtApproach::ConstantCompressibilityBrine>();
-            break;
-        }
-        case WaterPvtApproach::ThermalWater: {
-            delete &getRealPvt<WaterPvtApproach::ThermalWater>();
-            break;
-        }
-        case WaterPvtApproach::NoWater:
-            break;
-        }
-    }
-
 #if HAVE_ECL_INPUT
     /*!
      * \brief Initialize the parameters for water using an ECL deck.
@@ -128,24 +75,46 @@ public:
         else if (enableBrine && !eclState.getTableManager().getPvtwSaltTables().empty())
             setApproach(WaterPvtApproach::ConstantCompressibilityBrine);
 
-        OPM_WATER_PVT_MULTIPLEXER_CALL(pvtImpl.initFromState(eclState, schedule));
+        std::visit(VisitorOverloadSet{[&](auto& pvt)
+                                      {
+                                          pvt.initFromState(eclState, schedule);
+                                      }, monoHandler_}, waterPvt_);
     }
 #endif // HAVE_ECL_INPUT
 
     void initEnd()
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(pvtImpl.initEnd()); }
+    {
+        std::visit(VisitorOverloadSet{[](auto& pvt)
+                                        {
+                                            pvt.initEnd();
+                                        }, monoHandler_}, waterPvt_);
+    }
 
     /*!
      * \brief Return the number of PVT regions which are considered by this PVT-object.
      */
     unsigned numRegions() const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.numRegions()); return 1; }
+    {
+        unsigned result;
+        std::visit(VisitorOverloadSet{[&result](const auto& pvt)
+                                      {
+                                          result = pvt.numRegions();
+                                      }, monoHandler_}, waterPvt_);
+        return result;
+    }
 
     /*!
      * \brief Return the reference density which are considered by this PVT-object.
      */
-    const Scalar waterReferenceDensity(unsigned regionIdx)
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.waterReferenceDensity(regionIdx)); return 1000.; }
+    Scalar waterReferenceDensity(unsigned regionIdx) const
+    {
+        Scalar result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                         {
+                                             result = pvt.waterReferenceDensity(regionIdx);
+                                         }, monoHandler_}, waterPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
@@ -155,7 +124,17 @@ public:
                         const Evaluation& temperature,
                         const Evaluation& pressure,
                         const Evaluation& saltconcentration) const
-    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.internalEnergy(regionIdx, temperature, pressure, saltconcentration)); return 0; }
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.internalEnergy(regionIdx,
+                                                                      temperature,
+                                                                      pressure,
+                                                                      saltconcentration);
+                                      }, monoHandler_}, waterPvt_);
+        return result;
+    }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
@@ -166,8 +145,15 @@ public:
                          const Evaluation& pressure,
                          const Evaluation& saltconcentration) const
     {
-        OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.viscosity(regionIdx, temperature, pressure, saltconcentration));
-        return 0;
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.viscosity(regionIdx,
+                                                                 temperature,
+                                                                 pressure,
+                                                                 saltconcentration);
+                                      }, monoHandler_}, waterPvt_);
+        return result;
     }
 
     /*!
@@ -178,23 +164,31 @@ public:
                                             const Evaluation& temperature,
                                             const Evaluation& pressure,
                                             const Evaluation& saltconcentration) const
-    {   OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactor(regionIdx, temperature, pressure, saltconcentration));
-        return 0;
+    {
+        Evaluation result;
+        std::visit(VisitorOverloadSet{[&](const auto& pvt)
+                                      {
+                                          result = pvt.viscosity(regionIdx,
+                                                                 temperature,
+                                                                 pressure,
+                                                                 saltconcentration);
+                                      }, monoHandler_}, waterPvt_);
+        return result;
     }
 
     void setApproach(WaterPvtApproach appr)
     {
         switch (appr) {
         case WaterPvtApproach::ConstantCompressibilityWater:
-            realWaterPvt_ = new ConstantCompressibilityWaterPvt<Scalar>;
+            waterPvt_ = ConstantCompressibilityWaterPvt<Scalar>{};
             break;
 
         case WaterPvtApproach::ConstantCompressibilityBrine:
-            realWaterPvt_ = new ConstantCompressibilityBrinePvt<Scalar>;
+            waterPvt_ = ConstantCompressibilityBrinePvt<Scalar>{};
             break;
 
         case WaterPvtApproach::ThermalWater:
-            realWaterPvt_ = new WaterPvtThermal<Scalar, enableBrine>;
+            waterPvt_ = WaterPvtThermal<Scalar, enableBrine>{};
             break;
 
         case WaterPvtApproach::NoWater:
@@ -212,97 +206,23 @@ public:
     WaterPvtApproach approach() const
     { return approach_; }
 
-    // get the concrete parameter object for the water phase
-    template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWater, ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt()
+    //! \brief Apply a visitor to the concrete pvt implementation.
+    template<class Function>
+    void visit(Function f)
     {
-        assert(approach() == approachV);
-        return *static_cast<ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
-    }
-
-    template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityWater, const ConstantCompressibilityWaterPvt<Scalar> >::type& getRealPvt() const
-    {
-        assert(approach() == approachV);
-        return *static_cast<ConstantCompressibilityWaterPvt<Scalar>* >(realWaterPvt_);
-    }
-
-    template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrine, ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt()
-    {
-        assert(approach() == approachV);
-        return *static_cast<ConstantCompressibilityBrinePvt<Scalar>* >(realWaterPvt_);
-    }
-
-    template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ConstantCompressibilityBrine, const ConstantCompressibilityBrinePvt<Scalar> >::type& getRealPvt() const
-    {
-        assert(approach() == approachV);
-        return *static_cast<ConstantCompressibilityBrinePvt<Scalar>* >(realWaterPvt_);
-    }
-
-    template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ThermalWater, WaterPvtThermal<Scalar, enableBrine> >::type& getRealPvt()
-    {
-        assert(approach() == approachV);
-        return *static_cast<WaterPvtThermal<Scalar, enableBrine>* >(realWaterPvt_);
-    }
-
-    template <WaterPvtApproach approachV>
-    typename std::enable_if<approachV == WaterPvtApproach::ThermalWater, const WaterPvtThermal<Scalar, enableBrine> >::type& getRealPvt() const
-    {
-        assert(approach() == approachV);
-        return *static_cast<WaterPvtThermal<Scalar, enableBrine>* >(realWaterPvt_);
-    }
-
-    const void* realWaterPvt() const { return realWaterPvt_; }
-
-    bool operator==(const WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>& data) const
-    {
-        if (this->approach() != data.approach())
-            return false;
-
-        switch (approach_) {
-        case WaterPvtApproach::ConstantCompressibilityWater:
-            return *static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(realWaterPvt_) ==
-                   *static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(data.realWaterPvt_);
-        case WaterPvtApproach::ConstantCompressibilityBrine:
-            return *static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(realWaterPvt_) ==
-                   *static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(data.realWaterPvt_);
-        case WaterPvtApproach::ThermalWater:
-            return *static_cast<const WaterPvtThermal<Scalar, enableBrine>*>(realWaterPvt_) ==
-                   *static_cast<const WaterPvtThermal<Scalar, enableBrine>*>(data.realWaterPvt_);
-        default:
-            return true;
-        }
-    }
-
-    WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>& operator=(const WaterPvtMultiplexer<Scalar,enableThermal,enableBrine>& data)
-    {
-        approach_ = data.approach_;
-        switch (approach_) {
-        case WaterPvtApproach::ConstantCompressibilityWater:
-            realWaterPvt_ = new ConstantCompressibilityWaterPvt<Scalar>(*static_cast<const ConstantCompressibilityWaterPvt<Scalar>*>(data.realWaterPvt_));
-            break;
-        case WaterPvtApproach::ConstantCompressibilityBrine:
-            realWaterPvt_ = new ConstantCompressibilityBrinePvt<Scalar>(*static_cast<const ConstantCompressibilityBrinePvt<Scalar>*>(data.realWaterPvt_));
-            break;
-        case WaterPvtApproach::ThermalWater:
-            realWaterPvt_ = new WaterPvtThermal<Scalar, enableBrine>(*static_cast<const WaterPvtThermal<Scalar, enableBrine>*>(data.realWaterPvt_));
-            break;
-        default:
-            break;
-        }
-
-        return *this;
+        std::visit(VisitorOverloadSet{f, monoHandler_, [](auto&) {}}, waterPvt_);
     }
 
 private:
-    WaterPvtApproach approach_;
-    void* realWaterPvt_;
-};
+    WaterPvtApproach approach_ = WaterPvtApproach::NoWater;
+    std::variant<std::monostate,
+                 ConstantCompressibilityBrinePvt<Scalar>,
+                 ConstantCompressibilityWaterPvt<Scalar>,
+                 WaterPvtThermal<Scalar,enableBrine>> waterPvt_;
 
-#undef OPM_WATER_PVT_MULTIPLEXER_CALL
+    MonoThrowHandler<std::logic_error>
+    monoHandler_{"Not implemented: Water PVT of this deck!"}; // mono state handler
+};
 
 } // namespace Opm
 

--- a/tests/test_Visitor.cpp
+++ b/tests/test_Visitor.cpp
@@ -1,0 +1,92 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE VISITOR_TESTS
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/utility/Visitor.hpp>
+
+#include <stdexcept>
+#include <variant>
+
+namespace {
+
+struct TestA {
+  void testThrow()
+  {
+      throw std::runtime_error("A");
+  }
+
+  char returnData()
+  {
+      return 'A';
+  }
+};
+
+struct TestB {
+  void testThrow()
+  {
+      throw std::range_error("B");
+  }
+
+  char returnData()
+  {
+      return 'B';
+  }
+};
+
+}
+
+using Variant = std::variant<std::monostate, TestA, TestB>;
+
+// Test overload set visitor on a simple list of classes
+BOOST_AUTO_TEST_CASE(VariantReturn)
+{
+    Variant v{};
+    char result = '\0';
+    Opm::MonoThrowHandler<std::logic_error> mh{"Mono state"};
+    auto rD = [&result](auto& param)
+              {
+                  result = param.returnData();
+              };
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::logic_error);
+    BOOST_CHECK(result == '\0');
+    v = TestA{};
+    BOOST_CHECK_NO_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v));
+    BOOST_CHECK(result == 'A');
+    v = TestB{};
+    BOOST_CHECK_NO_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v));
+    BOOST_CHECK(result == 'B');
+}
+
+// Test that overload set visitor throws expected exceptions
+BOOST_AUTO_TEST_CASE(VariantThrow)
+{
+    Variant v{};
+    Opm::MonoThrowHandler<std::logic_error> mh{"Mono state"};
+    auto rD = [](auto& param)
+              {
+                  param.testThrow();
+              };
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::logic_error);
+    v = TestA{};
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::runtime_error);
+    v = TestB{};
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::range_error);
+}


### PR DESCRIPTION
Sits on top of https://github.com/OPM/opm-common/pull/3278
Waiting for https://github.com/OPM/opm-common/pull/3246

I realize this may be controversial, and that it might have runtime implications (which we need to benchmark) but;
This replaces what I consider the unholy trinity (void pointers, macros and SFINAE) with the visitor overload set idiom in the gas multiplexer.

As a bonus we avoid the need to have explicit ctors, copy ctors, assignment and comparison operators.