### PR TITLE
CO2: encapsulate CO2Tables

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -41,6 +41,7 @@ list (APPEND MAIN_SOURCE_FILES
       src/opm/common/utility/numeric/calculateCellVol.cpp
       src/opm/common/utility/shmatch.cpp
       src/opm/common/utility/TimeService.cpp
+      src/opm/material/components/CO2.cpp
       src/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.cpp
 )
 if(ENABLE_ECL_INPUT)
@@ -844,7 +845,6 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/common/Means.hpp
       opm/material/common/IntervalTabulated2DFunction.hpp
       opm/material/common/Tabulated1DFunction.hpp
-      opm/material/components/co2tables.inc
       opm/material/densead/Evaluation9.hpp
       opm/material/densead/Evaluation8.hpp
       opm/material/densead/Evaluation7.hpp

--- a/opm/material/components/CO2.hpp
+++ b/opm/material/components/CO2.hpp
@@ -32,6 +32,7 @@
 #include <opm/material/IdealGas.hpp>
 #include <opm/material/components/Component.hpp>
 #include <opm/material/common/MathToolbox.hpp>
+#include <opm/material/common/UniformTabulated2DFunction.hpp>
 
 #include <cmath>
 #include <iostream>
@@ -48,12 +49,16 @@ namespace Opm {
  * is not a top priority, the much simpler component \c Opm::SimpleCO2 can be
  * used instead
  */
-template <class Scalar, class CO2Tables>
-class CO2 : public Component<Scalar, CO2<Scalar, CO2Tables> >
+template <class Scalar>
+class CO2 : public Component<Scalar, CO2<Scalar>>
 {
     static constexpr Scalar R = Constants<Scalar>::R;
+    static const UniformTabulated2DFunction<double>& tabulatedEnthalpy;
+    static const UniformTabulated2DFunction<double>& tabulatedDensity;
 
 public:
+    static const Scalar brineSalinity;
+
     /*!
      * \brief A human readable name for the CO2.
      */
@@ -93,26 +98,26 @@ public:
     /*!
      * \brief Returns the pressure [Pa] at CO2's triple point.
      */
-    static Scalar minTabulatedPressure()
-    { return CO2Tables::tabulatedEnthalpy.minPress(); /* [N/m^2] */ }
+//    static Scalar minTabulatedPressure()
+//    { return tabulatedEnthalpy.minPress(); /* [N/m^2] */ }
 
     /*!
      * \brief Returns the pressure [Pa] at CO2's triple point.
      */
-    static Scalar maxTabulatedPressure()
-    { return CO2Tables::tabulatedEnthalpy.maxPress(); /* [N/m^2] */ }
+//    static Scalar maxTabulatedPressure()
+//    { return tabulatedEnthalpy.maxPress(); /* [N/m^2] */ }
 
     /*!
      * \brief Returns the pressure [Pa] at CO2's triple point.
      */
-    static Scalar minTabulatedTemperature()
-    { return CO2Tables::tabulatedEnthalpy.minTemp(); /* [N/m^2] */ }
+//    static Scalar minTabulatedTemperature()
+//    { return tabulatedEnthalpy.minTemp(); /* [N/m^2] */ }
 
     /*!
      * \brief Returns the pressure [Pa] at CO2's triple point.
      */
-    static Scalar maxTabulatedTemperature()
-    { return CO2Tables::tabulatedEnthalpy.maxTemp(); /* [N/m^2] */ }
+//    static Scalar maxTabulatedTemperature()
+//    { return tabulatedEnthalpy.maxTemp(); /* [N/m^2] */ }
 
     /*!
      * \brief The vapor pressure in [N/m^2] of pure CO2
@@ -165,7 +170,7 @@ public:
                                   const Evaluation& pressure,
                                   bool extrapolate = false)
     {
-        return CO2Tables::tabulatedEnthalpy.eval(temperature, pressure, extrapolate);
+        return tabulatedEnthalpy.eval(temperature, pressure, extrapolate);
     }
 
     /*!
@@ -190,7 +195,7 @@ public:
                                  const Evaluation& pressure,
                                  bool extrapolate = false)
     {
-        return CO2Tables::tabulatedDensity.eval(temperature, pressure, extrapolate);
+        return tabulatedDensity.eval(temperature, pressure, extrapolate);
     }
 
     /*!

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -56,9 +56,9 @@ namespace Opm {
  * high thermodynamic accuracy and thus requires the tables of the
  * sampling to be supplied as template argument.
  */
-template <class Scalar, class CO2Tables>
+template <class Scalar>
 class BrineCO2FluidSystem
-    : public BaseFluidSystem<Scalar, BrineCO2FluidSystem<Scalar, CO2Tables> >
+    : public BaseFluidSystem<Scalar, BrineCO2FluidSystem<Scalar> >
 {
     typedef ::Opm::H2O<Scalar> H2O_IAPWS;
     typedef ::Opm::Brine<Scalar, H2O_IAPWS> Brine_IAPWS;
@@ -75,7 +75,7 @@ public:
     //! The type of the component for brine used by the fluid system
     typedef Brine_Tabulated Brine;
     //! The type of the component for pure CO2 used by the fluid system
-    typedef ::Opm::CO2<Scalar, CO2Tables> CO2;
+    typedef ::Opm::CO2<Scalar> CO2;
 
     //! The binary coefficients for brine and CO2 used by this fluid system
     typedef BinaryCoeff::Brine_CO2<Scalar, H2O, CO2> BinaryCoeffBrineCO2;
@@ -217,7 +217,7 @@ public:
         }
 
         // set the salinity of brine to the one used by the CO2 tables
-        Brine_IAPWS::salinity = CO2Tables::brineSalinity;
+        Brine_IAPWS::salinity = CO2::brineSalinity;
 
         if (Brine::isTabulated) {
             Brine_Tabulated::init(tempMin, tempMax, nTemp,

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -38,7 +38,6 @@
 #include <opm/material/components/TabulatedComponent.hpp>
 #include <opm/material/binarycoefficients/H2O_CO2.hpp>
 #include <opm/material/binarycoefficients/Brine_CO2.hpp>
-#include <opm/material/components/co2tables.inc>
 
 #include <vector>
 
@@ -69,7 +68,7 @@ class BrineCo2Pvt
 public:
     using H2O = SimpleHuDuanH2O<Scalar>;
     using Brine = ::Opm::Brine<Scalar, H2O>;
-    using CO2 = ::Opm::CO2<Scalar, CO2Tables>;
+    using CO2 = ::Opm::CO2<Scalar>;
 
     //! The binary coefficients for brine and CO2 used by this fluid system
     using BinaryCoeffBrineCO2 = BinaryCoeff::Brine_CO2<Scalar, H2O, CO2>;

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -33,7 +33,6 @@
 #include <opm/material/components/SimpleHuDuanH2O.hpp>
 #include <opm/material/common/UniformTabulated2DFunction.hpp>
 #include <opm/material/binarycoefficients/Brine_CO2.hpp>
-#include <opm/material/components/co2tables.inc>
 
 #if HAVE_ECL_INPUT
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
@@ -51,7 +50,7 @@ namespace Opm {
 template <class Scalar>
 class Co2GasPvt
 {
-    using CO2 = ::Opm::CO2<Scalar, CO2Tables>;
+    using CO2 = ::Opm::CO2<Scalar>;
     using H2O = SimpleHuDuanH2O<Scalar>;
     static constexpr bool extrapolate = true;
 

--- a/src/opm/material/components/CO2.cpp
+++ b/src/opm/material/components/CO2.cpp
@@ -1,0 +1,48 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+#include <opm/material/components/CO2.hpp>
+
+#include "co2tables.inc"
+
+namespace Opm {
+
+template<>
+const UniformTabulated2DFunction<double>&
+CO2<double>::tabulatedEnthalpy = CO2Tables::tabulatedEnthalpy;
+template<>
+const UniformTabulated2DFunction<double>&
+CO2<double>::tabulatedDensity = CO2Tables::tabulatedDensity;
+template<>
+const double CO2<double>::brineSalinity = CO2Tables::brineSalinity;
+template<>
+const UniformTabulated2DFunction<double>&
+CO2<float>::tabulatedEnthalpy = CO2Tables::tabulatedEnthalpy;
+template<>
+const UniformTabulated2DFunction<double>&
+CO2<float>::tabulatedDensity = CO2Tables::tabulatedDensity;
+template<>
+const float CO2<float>::brineSalinity = CO2Tables::brineSalinity;
+
+} // namespace Opm

--- a/tests/test_components.cpp
+++ b/tests/test_components.cpp
@@ -59,11 +59,6 @@
 
 #include <opm/material/common/UniformTabulated2DFunction.hpp>
 
-namespace Opm {
-namespace ComponentsTest {
-#include <opm/material/components/co2tables.inc>
-}}
-
 #include <dune/common/parallel/mpihelper.hh>
 
 template <class Scalar, class Evaluation>
@@ -103,7 +98,7 @@ void testAllComponents()
 
     checkComponent<Opm::Air<Scalar>, Evaluation>();
     checkComponent<Opm::Brine<Scalar, H2O>, Evaluation>();
-    checkComponent<Opm::CO2<Scalar, Opm::ComponentsTest::CO2Tables>, Evaluation>();
+    checkComponent<Opm::CO2<Scalar>, Evaluation>();
     checkComponent<Opm::C1<Scalar>, Evaluation>();
     checkComponent<Opm::C10<Scalar>, Evaluation>();
     checkComponent<Opm::DNAPL<Scalar>, Evaluation>();

--- a/tests/test_fluidsystems.cpp
+++ b/tests/test_fluidsystems.cpp
@@ -245,7 +245,7 @@ void testAllFluidSystems()
     }
 
     // Brine -- CO2
-    {   typedef Opm::BrineCO2FluidSystem<Scalar, CO2Tables> FluidSystem;
+    {   typedef Opm::BrineCO2FluidSystem<Scalar> FluidSystem;
         checkFluidSystem<Scalar, FluidSystem, FluidStateEval, LhsEval>(); }
 
     // H2O -- N2


### PR DESCRIPTION
this way we don't have to drag 6MB of tables into multiple compile units. 
some flexibility is lost (ie the template parameter for the table), but this is unused in the current code.

comment out some templates that do not instance as they are referring to non-existent table members.

Waiting for https://github.com/OPM/opm-common/pull/3246