### PR TITLE
SatCurveMultiplexer(Params): use visitors

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -378,6 +378,7 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_tabulation.cpp
       tests/test_threecomponents_ptflash.cpp
       tests/test_uniformtablelinear.cpp
+      tests/test_Visitor.cpp
 )
 if(ENABLE_ECL_INPUT)
   list(APPEND TEST_SOURCE_FILES
@@ -662,6 +663,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/utility/FileSystem.hpp
       opm/common/utility/OpmInputError.hpp
       opm/common/utility/Serializer.hpp
+      opm/common/utility/Visitor.hpp
       opm/common/utility/numeric/cmp.hpp
       opm/common/utility/platform_dependent/disable_warnings.h
       opm/common/utility/platform_dependent/reenable_warnings.h

--- a/opm/common/utility/Visitor.hpp
+++ b/opm/common/utility/Visitor.hpp
@@ -1,0 +1,64 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#ifndef VISITOR_HPP
+#define VISITOR_HPP
+
+#include <string>
+#include <variant>
+
+namespace Opm {
+
+//! \brief Helper struct for for generating visitor overload sets.
+template<class... Ts>
+struct VisitorOverloadSet : Ts...
+{
+    using Ts::operator()...;
+};
+
+//! \brief Deduction guide for visitor overload sets.
+template<class... Ts> VisitorOverloadSet(Ts...) -> VisitorOverloadSet<Ts...>;
+
+//! \brief A functor for handling a monostate in a visitor overload set.
+//! \details Throws an exception
+template<class Exception>
+struct MonoThrowHandler {
+    MonoThrowHandler(const std::string& message)
+        : message_(message)
+    {}
+
+    void operator()(std::monostate&)
+    {
+        throw Exception(message_);
+    }
+
+    void operator()(const std::monostate&) const
+    {
+        throw Exception(message_);
+    }
+
+private:
+    std::string message_;
+};
+
+}
+
+#endif

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -34,6 +34,9 @@
 #include <opm/material/common/EnsureFinalized.hpp>
 
 namespace Opm {
+
+template<class TraitsT, class ParamsT> class PiecewiseLinearTwoPhaseMaterial;
+
 /*!
  * \ingroup FluidMatrixInteractions
  *
@@ -46,6 +49,7 @@ class PiecewiseLinearTwoPhaseMaterialParams : public EnsureFinalized
     using Scalar = typename TraitsT::Scalar;
 
 public:
+    using Law = PiecewiseLinearTwoPhaseMaterial<TraitsT, PiecewiseLinearTwoPhaseMaterialParams<TraitsT>>;
     using ValueVector = std::vector<Scalar>;
 
     using Traits = TraitsT;

--- a/opm/material/fluidmatrixinteractions/TwoPhaseLETCurvesParams.hpp
+++ b/opm/material/fluidmatrixinteractions/TwoPhaseLETCurvesParams.hpp
@@ -40,12 +40,15 @@ namespace Opm {
  *
  *\see TwoPhaseLETCurves
  */
+
+template<class TraitsT, class ParamsT> class TwoPhaseLETCurves;
 template <class TraitsT>
 class TwoPhaseLETCurvesParams : public EnsureFinalized
 {
     using Scalar = typename TraitsT::Scalar;
 
 public:
+    using Law = TwoPhaseLETCurves<TraitsT, TwoPhaseLETCurvesParams<TraitsT>>;
     using Traits = TraitsT;
 
     static constexpr int wIdx = 0; //wetting phase index for two phase let

--- a/tests/test_Visitor.cpp
+++ b/tests/test_Visitor.cpp
@@ -1,0 +1,92 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE VISITOR_TESTS
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/utility/Visitor.hpp>
+
+#include <stdexcept>
+#include <variant>
+
+namespace {
+
+struct TestA {
+  void testThrow()
+  {
+      throw std::runtime_error("A");
+  }
+
+  char returnData()
+  {
+      return 'A';
+  }
+};
+
+struct TestB {
+  void testThrow()
+  {
+      throw std::range_error("B");
+  }
+
+  char returnData()
+  {
+      return 'B';
+  }
+};
+
+}
+
+using Variant = std::variant<std::monostate, TestA, TestB>;
+
+// Test overload set visitor on a simple list of classes
+BOOST_AUTO_TEST_CASE(VariantReturn)
+{
+    Variant v{};
+    char result = '\0';
+    Opm::MonoThrowHandler<std::logic_error> mh{"Mono state"};
+    auto rD = [&result](auto& param)
+              {
+                  result = param.returnData();
+              };
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::logic_error);
+    BOOST_CHECK(result == '\0');
+    v = TestA{};
+    BOOST_CHECK_NO_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v));
+    BOOST_CHECK(result == 'A');
+    v = TestB{};
+    BOOST_CHECK_NO_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v));
+    BOOST_CHECK(result == 'B');
+}
+
+// Test that overload set visitor throws expected exceptions
+BOOST_AUTO_TEST_CASE(VariantThrow)
+{
+    Variant v{};
+    Opm::MonoThrowHandler<std::logic_error> mh{"Mono state"};
+    auto rD = [](auto& param)
+              {
+                  param.testThrow();
+              };
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::logic_error);
+    v = TestA{};
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::runtime_error);
+    v = TestB{};
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::range_error);
+}


### PR DESCRIPTION
Replacing SFINAE, void ptr and repeated switch statements.

Sits on top of https://github.com/OPM/opm-common/pull/3278
Waiting for https://github.com/OPM/opm-common/pull/3246