### PR TITLE
EclMultiplexerMaterial(Params): use visitors

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -378,6 +378,7 @@ list (APPEND TEST_SOURCE_FILES
       tests/test_tabulation.cpp
       tests/test_threecomponents_ptflash.cpp
       tests/test_uniformtablelinear.cpp
+      tests/test_Visitor.cpp
 )
 if(ENABLE_ECL_INPUT)
   list(APPEND TEST_SOURCE_FILES
@@ -662,6 +663,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/utility/FileSystem.hpp
       opm/common/utility/OpmInputError.hpp
       opm/common/utility/Serializer.hpp
+      opm/common/utility/Visitor.hpp
       opm/common/utility/numeric/cmp.hpp
       opm/common/utility/platform_dependent/disable_warnings.h
       opm/common/utility/platform_dependent/reenable_warnings.h

--- a/opm/common/utility/Visitor.hpp
+++ b/opm/common/utility/Visitor.hpp
@@ -1,0 +1,64 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#ifndef VISITOR_HPP
+#define VISITOR_HPP
+
+#include <string>
+#include <variant>
+
+namespace Opm {
+
+//! \brief Helper struct for for generating visitor overload sets.
+template<class... Ts>
+struct VisitorOverloadSet : Ts...
+{
+    using Ts::operator()...;
+};
+
+//! \brief Deduction guide for visitor overload sets.
+template<class... Ts> VisitorOverloadSet(Ts...) -> VisitorOverloadSet<Ts...>;
+
+//! \brief A functor for handling a monostate in a visitor overload set.
+//! \details Throws an exception
+template<class Exception>
+struct MonoThrowHandler {
+    MonoThrowHandler(const std::string& message)
+        : message_(message)
+    {}
+
+    void operator()(std::monostate&)
+    {
+        throw Exception(message_);
+    }
+
+    void operator()(const std::monostate&) const
+    {
+        throw Exception(message_);
+    }
+
+private:
+    std::string message_;
+};
+
+}
+
+#endif

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -55,8 +55,8 @@ template <class TraitsT,
           class GasOilMaterialLawT,
           class OilWaterMaterialLawT,
           class ParamsT = EclDefaultMaterialParams<TraitsT,
-                                                   typename GasOilMaterialLawT::Params,
-                                                   typename OilWaterMaterialLawT::Params> >
+                                                   GasOilMaterialLawT,
+                                                   OilWaterMaterialLawT>>
 class EclDefaultMaterial : public TraitsT
 {
 public:

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -41,7 +41,7 @@ namespace Opm {
  * Essentially, this class just stores the two parameter objects for
  * the twophase capillary pressure laws.
  */
-template<class Traits, class GasOilParamsT, class OilWaterParamsT>
+template<class Traits, class GasOilLawT, class OilWaterLawT>
 class EclDefaultMaterialParams : public EnsureFinalized
 {
     using Scalar = typename Traits::Scalar;
@@ -49,8 +49,8 @@ class EclDefaultMaterialParams : public EnsureFinalized
 public:
     using EnsureFinalized :: finalize;
 
-    using GasOilParams = GasOilParamsT;
-    using OilWaterParams = OilWaterParamsT;
+    using GasOilParams = typename GasOilLawT::Params;
+    using OilWaterParams = typename OilWaterLawT::Params;
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -53,13 +53,6 @@ public:
     using OilWaterParams = OilWaterParamsT;
 
     /*!
-     * \brief The default constructor.
-     */
-    EclDefaultMaterialParams()
-    {
-    }
-
-    /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     const GasOilParams& gasOilParams() const
@@ -131,7 +124,7 @@ private:
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;
 
-    Scalar Swl_;
+    Scalar Swl_{};
 };
 } // namespace Opm
 

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -33,6 +33,11 @@
 
 namespace Opm {
 
+template<class Traits,
+         class GasOilLawT,
+         class OilWaterLawT,
+         class Params> class EclDefaultMaterial;
+
 /*!
  * \brief Default implementation for the parameters required by the
  *        default three-phase capillary pressure model used by
@@ -51,6 +56,8 @@ public:
 
     using GasOilParams = typename GasOilLawT::Params;
     using OilWaterParams = typename OilWaterLawT::Params;
+    using Material = EclDefaultMaterial<Traits,GasOilLawT,OilWaterLawT,
+                                        EclDefaultMaterialParams<Traits,GasOilLawT,OilWaterLawT>>;
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -520,72 +520,16 @@ public:
         // unsigned impRegionIdx = satRegionIdx;
 
         // change the sat table it points to.
-        switch (mlp.approach()) {
-        case EclMultiplexerApproach::Stone1: {
-            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Stone1>();
-
-            realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
-            realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
-            realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
-            realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
-//            if (enableHysteresis()) {
-//                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
-//                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);
-//                realParams.gasOilParams().imbibitionParams().setUnscaledPoints(gasOilUnscaledPointsVector_[impRegionIdx]);
-//                realParams.gasOilParams().imbibitionParams().setEffectiveLawParams(gasOilEffectiveParamVector_[impRegionIdx]);
-//            }
-        }
-            break;
-
-        case EclMultiplexerApproach::Stone2: {
-            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Stone2>();
-            realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
-            realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
-            realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
-            realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
-//            if (enableHysteresis()) {
-//                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
-//                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);
-//                realParams.gasOilParams().imbibitionParams().setUnscaledPoints(gasOilUnscaledPointsVector_[impRegionIdx]);
-//                realParams.gasOilParams().imbibitionParams().setEffectiveLawParams(gasOilEffectiveParamVector_[impRegionIdx]);
-//            }
-        }
-            break;
-
-        case EclMultiplexerApproach::Default: {
-            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Default>();
-            realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
-            realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
-            realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
-            realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
-//            if (enableHysteresis()) {
-//                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
-//                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);
-//                realParams.gasOilParams().imbibitionParams().setUnscaledPoints(gasOilUnscaledPointsVector_[impRegionIdx]);
-//                realParams.gasOilParams().imbibitionParams().setEffectiveLawParams(gasOilEffectiveParamVector_[impRegionIdx]);
-//            }
-        }
-            break;
-
-        case EclMultiplexerApproach::TwoPhase: {
-            auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::TwoPhase>();
-            realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
-            realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
-            realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
-            realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
-//            if (enableHysteresis()) {
-//                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
-//                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);
-//                realParams.gasOilParams().imbibitionParams().setUnscaledPoints(gasOilUnscaledPointsVector_[impRegionIdx]);
-//                realParams.gasOilParams().imbibitionParams().setEffectiveLawParams(gasOilEffectiveParamVector_[impRegionIdx]);
-//            }
-        }
-            break;
-
-        default:
-            throw std::logic_error("Enum value for material approach unknown!");
-        }
-
+        mlp.visit(VisitorOverloadSet{[&](auto& realParams)
+                                     {
+                                         realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
+                                         realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
+                                         realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
+                                         realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
+                                     },
+                                     [](std::monostate&)
+                                     {
+                                     }});
         return mlp;
     }
 
@@ -686,29 +630,16 @@ public:
     EclEpsScalingPoints<Scalar>& oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
     {
         auto& materialParams = materialLawParams_[elemIdx];
-        switch (materialParams.approach()) {
-        case EclMultiplexerApproach::Stone1: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone1>();
-            return realParams.oilWaterParams().drainageParams().scaledPoints();
-        }
-
-        case EclMultiplexerApproach::Stone2: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone2>();
-            return realParams.oilWaterParams().drainageParams().scaledPoints();
-        }
-
-        case EclMultiplexerApproach::Default: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Default>();
-            return realParams.oilWaterParams().drainageParams().scaledPoints();
-        }
-
-        case EclMultiplexerApproach::TwoPhase: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::TwoPhase>();
-            return realParams.oilWaterParams().drainageParams().scaledPoints();
-        }
-        default:
-            throw std::logic_error("Enum value for material approach unknown!");
-        }
+        EclEpsScalingPoints<Scalar>* result;
+        materialParams.visit(VisitorOverloadSet{[&](auto& realParams)
+                                                {
+                                                    result = &realParams.oilWaterParams().drainageParams().scaledPoints();;
+                                                },
+                                                [](std::monostate&)
+                                                {
+                                                    throw std::logic_error("Enum value for material approach unknown!");
+                                                }});
+        return *result;
     }
 
     const EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(size_t elemIdx) const
@@ -1184,55 +1115,36 @@ private:
     {
         materialParams.setApproach(threePhaseApproach_);
 
-        switch (materialParams.approach()) {
-        case EclMultiplexerApproach::Stone1: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone1>();
-            realParams.setGasOilParams(gasOilParams);
-            realParams.setOilWaterParams(oilWaterParams);
-            realParams.setSwl(epsInfo.Swl);
+        materialParams.visit(VisitorOverloadSet{[&](typename MaterialLaw::Stone1Material::Params& realParams)
+                                                {
+                                                    realParams.setGasOilParams(gasOilParams);
+                                                    realParams.setOilWaterParams(oilWaterParams);
+                                                    realParams.setSwl(epsInfo.Swl);
 
-            if (!stoneEtas.empty()) {
-                realParams.setEta(stoneEtas[satRegionIdx]);
-            }
-            else
-                realParams.setEta(1.0);
-            realParams.finalize();
-            break;
-        }
-
-        case EclMultiplexerApproach::Stone2: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone2>();
-            realParams.setGasOilParams(gasOilParams);
-            realParams.setOilWaterParams(oilWaterParams);
-            realParams.setSwl(epsInfo.Swl);
-            realParams.finalize();
-            break;
-        }
-
-        case EclMultiplexerApproach::Default: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Default>();
-            realParams.setGasOilParams(gasOilParams);
-            realParams.setOilWaterParams(oilWaterParams);
-            realParams.setSwl(epsInfo.Swl);
-            realParams.finalize();
-            break;
-        }
-
-        case EclMultiplexerApproach::TwoPhase: {
-            auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::TwoPhase>();
-            realParams.setGasOilParams(gasOilParams);
-            realParams.setOilWaterParams(oilWaterParams);
-            realParams.setGasWaterParams(gasWaterParams);
-            realParams.setApproach(twoPhaseApproach_);
-            realParams.finalize();
-            break;
-        }
-
-        case EclMultiplexerApproach::OnePhase: {
-            // Nothing to do, no parameters.
-            break;
-        }
-        }
+                                                    if (!stoneEtas.empty())
+                                                        realParams.setEta(stoneEtas[satRegionIdx]);
+                                                    else
+                                                        realParams.setEta(1.0);
+                                                    realParams.finalize();
+                                                },
+                                                [&](typename MaterialLaw::TwoPhaseMaterial::Params& realParams)
+                                                {
+                                                    realParams.setGasOilParams(gasOilParams);
+                                                    realParams.setOilWaterParams(oilWaterParams);
+                                                    realParams.setGasWaterParams(gasWaterParams);
+                                                    realParams.setApproach(twoPhaseApproach_);
+                                                    realParams.finalize();
+                                                },
+                                                [&](auto& realParams)
+                                                {
+                                                    realParams.setGasOilParams(gasOilParams);
+                                                    realParams.setOilWaterParams(oilWaterParams);
+                                                    realParams.setSwl(epsInfo.Swl);
+                                                    realParams.finalize();
+                                                },
+                                                [](std::monostate&)
+                                                {
+                                                }});
     }
 
     // Relative permeability values not strictly greater than 'tolcrit' treated as zero.

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -217,7 +217,7 @@ private:
         return *(static_cast<const ParamT *> (realParams_.operator->()));
     }
 
-    EclMultiplexerApproach approach_;
+    EclMultiplexerApproach approach_ = EclMultiplexerApproach::OnePhase;
     ParamPointerType realParams_;
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1Material.hpp
@@ -55,7 +55,9 @@ namespace Opm {
 template <class TraitsT,
           class GasOilMaterialLawT,
           class OilWaterMaterialLawT,
-          class ParamsT = EclStone1MaterialParams<TraitsT, GasOilMaterialLawT, OilWaterMaterialLawT> >
+          class ParamsT = EclStone1MaterialParams<TraitsT,
+                                                  GasOilMaterialLawT,
+                                                  OilWaterMaterialLawT>>
 class EclStone1Material : public TraitsT
 {
 public:

--- a/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
@@ -52,13 +52,6 @@ public:
     using OilWaterParams = typename OilWaterLawT::Params;
 
     /*!
-     * \brief The default constructor.
-     */
-    EclStone1MaterialParams()
-    {
-    }
-
-    /*!
      * \brief Finish the initialization of the parameter object.
      */
     void finalize()
@@ -147,9 +140,9 @@ private:
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;
 
-    Scalar Swl_;
-    Scalar eta_;
-    Scalar krocw_;
+    Scalar Swl_{};
+    Scalar eta_{};
+    Scalar krocw_{};
 };
 
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
@@ -33,6 +33,10 @@
 
 namespace Opm {
 
+template <class TraitsT,
+          class GasOilMaterialLawT,
+          class OilWaterMaterialLawT,
+          class ParamsT> class EclStone1Material;
 /*!
  * \brief Default implementation for the parameters required by the
  *        three-phase capillary pressure/relperm Stone 2 model used by
@@ -50,6 +54,8 @@ class EclStone1MaterialParams : public EnsureFinalized
 public:
     using GasOilParams = typename GasOilLawT::Params;
     using OilWaterParams = typename OilWaterLawT::Params;
+    using Material = EclStone1Material<Traits,GasOilLawT,OilWaterLawT,
+                                       EclStone1MaterialParams<Traits,GasOilLawT,OilWaterLawT>>;
 
     /*!
      * \brief Finish the initialization of the parameter object.

--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -55,8 +55,8 @@ template <class TraitsT,
           class GasOilMaterialLawT,
           class OilWaterMaterialLawT,
           class ParamsT = EclStone2MaterialParams<TraitsT,
-                                                   typename GasOilMaterialLawT::Params,
-                                                   typename OilWaterMaterialLawT::Params> >
+                                                  GasOilMaterialLawT,
+                                                  OilWaterMaterialLawT>>
 class EclStone2Material : public TraitsT
 {
 public:

--- a/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
@@ -41,7 +41,7 @@ namespace Opm {
  * Essentially, this class just stores the two parameter objects for
  * the twophase capillary pressure laws.
  */
-template<class Traits, class GasOilParamsT, class OilWaterParamsT>
+template<class Traits, class GasOilLawT, class OilWaterLawT>
 class EclStone2MaterialParams : public EnsureFinalized
 {
     using Scalar = typename Traits::Scalar;
@@ -49,8 +49,8 @@ class EclStone2MaterialParams : public EnsureFinalized
 public:
     using EnsureFinalized :: finalize;
 
-    using GasOilParams = GasOilParamsT;
-    using OilWaterParams = OilWaterParamsT;
+    using GasOilParams = typename GasOilLawT::Params;
+    using OilWaterParams = typename OilWaterLawT::Params;
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.

--- a/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
@@ -33,6 +33,11 @@
 
 namespace Opm {
 
+template <class TraitsT,
+          class GasOilMaterialLawT,
+          class OilWaterMaterialLawT,
+          class ParamsT> class EclStone2Material;
+
 /*!
  * \brief Default implementation for the parameters required by the
  *        three-phase capillary pressure/relperm Stone 2 model used by
@@ -51,6 +56,8 @@ public:
 
     using GasOilParams = typename GasOilLawT::Params;
     using OilWaterParams = typename OilWaterLawT::Params;
+    using Material = EclStone2Material<Traits,GasOilLawT,OilWaterLawT,
+                                       EclStone2MaterialParams<Traits,GasOilLawT,OilWaterLawT>>;
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.

--- a/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
@@ -53,13 +53,6 @@ public:
     using OilWaterParams = OilWaterParamsT;
 
     /*!
-     * \brief The default constructor.
-     */
-    EclStone2MaterialParams()
-    {
-    }
-
-    /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     const GasOilParams& gasOilParams() const
@@ -119,7 +112,7 @@ private:
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;
 
-    Scalar Swl_;
+    Scalar Swl_{};
 };
 } // namespace Opm
 

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -50,9 +50,9 @@ template <class TraitsT,
           class OilWaterMaterialLawT,
           class GasWaterMaterialLawT,
           class ParamsT = EclTwoPhaseMaterialParams<TraitsT,
-                                                    typename GasOilMaterialLawT::Params,
-                                                    typename OilWaterMaterialLawT::Params,
-                                                    typename GasWaterMaterialLawT::Params> >
+                                                    GasOilMaterialLawT,
+                                                    OilWaterMaterialLawT,
+                                                    GasWaterMaterialLawT>>
 class EclTwoPhaseMaterial : public TraitsT
 {
 public:

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -46,7 +46,7 @@ enum class EclTwoPhaseApproach {
  * Essentially, this class just stores the two parameter objects for
  * the twophase capillary pressure laws.
  */
-template<class Traits, class GasOilParamsT, class OilWaterParamsT, class GasWaterParamsT>
+template<class Traits, class GasOilLawT, class OilWaterLawT, class GasWaterLawT>
 class EclTwoPhaseMaterialParams : public EnsureFinalized
 {
     using Scalar = typename Traits::Scalar;
@@ -54,9 +54,9 @@ class EclTwoPhaseMaterialParams : public EnsureFinalized
 public:
     using EnsureFinalized :: finalize;
 
-    using GasOilParams = GasOilParamsT;
-    using OilWaterParams = OilWaterParamsT;
-    using GasWaterParams = GasWaterParamsT;
+    using GasOilParams = typename GasOilLawT::Params;
+    using OilWaterParams = typename OilWaterLawT::Params;
+    using GasWaterParams = typename GasWaterLawT::Params;
 
     void setApproach(EclTwoPhaseApproach newApproach)
     { approach_ = newApproach; }

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -58,13 +58,6 @@ public:
     using OilWaterParams = OilWaterParamsT;
     using GasWaterParams = GasWaterParamsT;
 
-    /*!
-     * \brief The default constructor.
-     */
-    EclTwoPhaseMaterialParams()
-    {
-    }
-
     void setApproach(EclTwoPhaseApproach newApproach)
     { approach_ = newApproach; }
 

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -33,6 +33,12 @@
 
 namespace Opm {
 
+template <class TraitsT,
+          class GasOilMaterialLawT,
+          class OilWaterMaterialLawT,
+          class GasWaterMaterialLawT,
+          class ParamsT> class EclTwoPhaseMaterial;
+
 enum class EclTwoPhaseApproach {
     GasOil,
     OilWater,
@@ -57,6 +63,9 @@ public:
     using GasOilParams = typename GasOilLawT::Params;
     using OilWaterParams = typename OilWaterLawT::Params;
     using GasWaterParams = typename GasWaterLawT::Params;
+    using Material = EclTwoPhaseMaterial<Traits,GasOilLawT,OilWaterLawT,GasWaterLawT,
+                                         EclTwoPhaseMaterialParams<Traits,GasOilLawT,
+                                                                   OilWaterLawT,GasWaterLawT>>;
 
     void setApproach(EclTwoPhaseApproach newApproach)
     { approach_ = newApproach; }
@@ -119,7 +128,7 @@ public:
     { gasWaterParams_ = val; }
     
 private:
-    EclTwoPhaseApproach approach_;
+    EclTwoPhaseApproach approach_ = EclTwoPhaseApproach::GasOil;
 
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;

--- a/tests/test_Visitor.cpp
+++ b/tests/test_Visitor.cpp
@@ -1,0 +1,92 @@
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#define BOOST_TEST_MODULE VISITOR_TESTS
+#include <boost/test/unit_test.hpp>
+
+#include <opm/common/utility/Visitor.hpp>
+
+#include <stdexcept>
+#include <variant>
+
+namespace {
+
+struct TestA {
+  void testThrow()
+  {
+      throw std::runtime_error("A");
+  }
+
+  char returnData()
+  {
+      return 'A';
+  }
+};
+
+struct TestB {
+  void testThrow()
+  {
+      throw std::range_error("B");
+  }
+
+  char returnData()
+  {
+      return 'B';
+  }
+};
+
+}
+
+using Variant = std::variant<std::monostate, TestA, TestB>;
+
+// Test overload set visitor on a simple list of classes
+BOOST_AUTO_TEST_CASE(VariantReturn)
+{
+    Variant v{};
+    char result = '\0';
+    Opm::MonoThrowHandler<std::logic_error> mh{"Mono state"};
+    auto rD = [&result](auto& param)
+              {
+                  result = param.returnData();
+              };
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::logic_error);
+    BOOST_CHECK(result == '\0');
+    v = TestA{};
+    BOOST_CHECK_NO_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v));
+    BOOST_CHECK(result == 'A');
+    v = TestB{};
+    BOOST_CHECK_NO_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v));
+    BOOST_CHECK(result == 'B');
+}
+
+// Test that overload set visitor throws expected exceptions
+BOOST_AUTO_TEST_CASE(VariantThrow)
+{
+    Variant v{};
+    Opm::MonoThrowHandler<std::logic_error> mh{"Mono state"};
+    auto rD = [](auto& param)
+              {
+                  param.testThrow();
+              };
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::logic_error);
+    v = TestA{};
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::runtime_error);
+    v = TestB{};
+    BOOST_CHECK_THROW(std::visit(Opm::VisitorOverloadSet{mh, rD}, v), std::range_error);
+}

--- a/tests/test_fluidmatrixinteractions.cpp
+++ b/tests/test_fluidmatrixinteractions.cpp
@@ -229,7 +229,7 @@ void testThreePhaseApi()
 
         // make sure the two-phase specific methods are present
         const FluidState fs;
-        const typename MaterialLaw::Params params;
+        const typename MaterialLaw::Params params{};
 
         [[maybe_unused]] Scalar v;
         v = MaterialLaw::template pcnw<FluidState, Scalar>(params, fs);


### PR DESCRIPTION
Replacing SFINAE, void ptr and repeated switch statements.

Sits on top of https://github.com/OPM/opm-common/pull/3278
Waiting for https://github.com/OPM/opm-common/pull/3246