### PR TITLE
Link New Test to Dune Common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ foreach(tgt
     test_eclblackoilfluidsystem
     test_eclblackoilpvt
     test_eclmateriallawmanager
+    test_EvaluationFormat
     test_fluidmatrixinteractions
     test_fluidsystems
     test_immiscibleflash


### PR DESCRIPTION
Otherwise, we get build failures if the Dune libraries and headers are outside of the system directories.