### PR TITLE
OrderedMap: avoid sstream usage

### DIFF
--- a/opm/input/eclipse/EclipseState/Util/OrderedMap.hpp
+++ b/opm/input/eclipse/EclipseState/Util/OrderedMap.hpp
@@ -25,7 +25,6 @@
 #include <string>
 #include <stdexcept>
 #include <iterator>
-#include <sstream>
 #include <set>
 #include <cctype>
 #include <algorithm>
@@ -61,10 +60,11 @@ findSimilarStrings(std::string str,
         return {};
     }
 
-    std::stringstream concated;
-    std::copy(alternatives.begin(), alternatives.end(),
-              std::ostream_iterator<std::string>(concated, ", "));
-    auto concatedStr = concated.str();
+    std::string concatedStr;
+    for (const auto& alt : alternatives) {
+      concatedStr += alt;
+      concatedStr += ", ";
+    }
     return concatedStr.substr(0, concatedStr.size()-2);
 }
 

--- a/tests/parser/OrderedMapTests.cpp
+++ b/tests/parser/OrderedMapTests.cpp
@@ -37,6 +37,18 @@ BOOST_AUTO_TEST_CASE( check_empty) {
     BOOST_CHECK_EQUAL( map.count("NO_SUCH_KEY"), 0U);
 }
 
+BOOST_AUTO_TEST_CASE( check_similar) {
+    Opm::OrderedMap<std::string> map;
+    map.insert(std::make_pair("CKEY1" , "Value1"));
+    map.insert(std::make_pair("CKEY2" , "Value2"));
+    BOOST_CHECK_EXCEPTION(map.get("CKEY"), std::invalid_argument,
+                          [](const std::invalid_argument& e)
+                          {
+                              return std::string("Key CKEY not found. "
+                                                 "Similar entries are CKEY1, CKEY2.") == e.what();
+                          });
+}
+
 BOOST_AUTO_TEST_CASE( operator_square ) {
     Opm::OrderedMap<std::string> map;
     map.insert(std::make_pair("CKEY1" , "Value1"));


### PR DESCRIPTION
for a (small) reduction in amount of sources pulling stream classes.