### PR TITLE
TimerLog: avoid sstream in header

### DIFF
--- a/opm/common/OpmLog/TimerLog.hpp
+++ b/opm/common/OpmLog/TimerLog.hpp
@@ -22,7 +22,7 @@
 #include <time.h>
 
 #include <memory>
-#include <sstream>
+#include <iosfwd>
 #include <string>
 
 #include <opm/common/OpmLog/StreamLog.hpp>
@@ -50,7 +50,6 @@ protected:
                                    const std::string& message) override;
 private:
     clock_t m_start;
-    std::ostringstream m_work;
 };
 
 typedef std::shared_ptr<TimerLog> TimerLogPtr;

--- a/src/opm/common/OpmLog/TimerLog.cpp
+++ b/src/opm/common/OpmLog/TimerLog.cpp
@@ -16,28 +16,28 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <stdexcept>
-#include <cassert>
-#include <iomanip>
 
-#include <opm/common/OpmLog/OpmLog.hpp>
-#include <opm/common/OpmLog/LogUtil.hpp>
+#include <config.h>
 #include <opm/common/OpmLog/TimerLog.hpp>
+
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>
 
-
+#include <cassert>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
 
 namespace Opm {
 
 TimerLog::TimerLog(const std::string& logFile) : StreamLog( logFile , StopTimer | StartTimer )
 {
-    m_work.precision(8);
     m_start = 0;
 }
 
 TimerLog::TimerLog(std::ostream& os) : StreamLog( os , StopTimer | StartTimer )
 {
-    m_work.precision(8);
     m_start = 0;
 }
 
@@ -48,9 +48,10 @@ void TimerLog::addMessageUnconditionally(int64_t messageType, const std::string&
         clock_t stop = clock();
         double secondsElapsed = 1.0 * (m_start - stop) / CLOCKS_PER_SEC ;
 
-        m_work.str("");
-        m_work << std::fixed << msg << ": " << secondsElapsed << " seconds ";
-        StreamLog::addMessageUnconditionally( messageType, m_work.str());
+        std::ostringstream work;
+        work.precision(8);
+        work << std::fixed << msg << ": " << secondsElapsed << " seconds ";
+        StreamLog::addMessageUnconditionally( messageType, work.str());
     } else {
         if (messageType == StartTimer)
             m_start = clock();


### PR DESCRIPTION
minor minor, but still better.