### PR TITLE
Add missing <string> include.

### DIFF
--- a/opm/common/Exceptions.hpp
+++ b/opm/common/Exceptions.hpp
@@ -24,6 +24,7 @@
 #define OPM_EXCEPTIONS_HPP
 
 #include <stdexcept>
+#include <string>
 
 // the OPM-specific exception classes
 namespace Opm {


### PR DESCRIPTION
Used for constructing an exception object with a literal char array.