### PR TITLE
Schedule: move more code to compile unit

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -32,7 +32,6 @@
 
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/Parser/InputErrorAction.hpp>
-#include <opm/input/eclipse/Python/Python.hpp>
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
@@ -60,6 +59,7 @@ namespace Opm
     class FieldPropsManager;
     class GTNode;
     class ParseContext;
+    class Python;
     class SCHEDULESection;
     class SummaryState;
     class ErrorGuard;
@@ -111,27 +111,9 @@ namespace Opm
         }
 
 
-        static ScheduleStatic serializationTestObject() {
-            auto python = std::make_shared<Python>(Python::Enable::OFF);
-            ScheduleStatic st(python);
-            st.m_deck_message_limits = MessageLimits::serializationTestObject();
-            st.m_runspec = Runspec::serializationTestObject();
-            st.m_unit_system = UnitSystem::newFIELD();
-            st.m_input_path = "Some/funny/path";
-            st.rst_config = RSTConfig::serializationTestObject();
-            st.rst_info = ScheduleRestartInfo::serializationTestObject();
-            return st;
-        }
+        static ScheduleStatic serializationTestObject();
 
-        bool operator==(const ScheduleStatic& other) const {
-            return this->m_input_path == other.m_input_path &&
-                   this->m_deck_message_limits == other.m_deck_message_limits &&
-                   this->m_unit_system == other.m_unit_system &&
-                   this->rst_config == other.rst_config &&
-                   this->rst_info == other.rst_info &&
-                   this->gaslift_opt_active == other.gaslift_opt_active &&
-                   this->m_runspec == other.m_runspec;
-        }
+        bool operator==(const ScheduleStatic& other) const;
     };
 
 

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -157,6 +157,30 @@ namespace Opm {
     {
     }
 
+    ScheduleStatic ScheduleStatic::serializationTestObject()
+    {
+        auto python = std::make_shared<Python>(Python::Enable::OFF);
+        ScheduleStatic st(python);
+        st.m_deck_message_limits = MessageLimits::serializationTestObject();
+        st.m_runspec = Runspec::serializationTestObject();
+        st.m_unit_system = UnitSystem::newFIELD();
+        st.m_input_path = "Some/funny/path";
+        st.rst_config = RSTConfig::serializationTestObject();
+        st.rst_info = ScheduleRestartInfo::serializationTestObject();
+        return st;
+    }
+
+    bool ScheduleStatic::operator==(const ScheduleStatic& other) const
+    {
+        return this->m_input_path == other.m_input_path &&
+               this->m_deck_message_limits == other.m_deck_message_limits &&
+               this->m_unit_system == other.m_unit_system &&
+               this->rst_config == other.rst_config &&
+               this->rst_info == other.rst_info &&
+               this->gaslift_opt_active == other.gaslift_opt_active &&
+               this->m_runspec == other.m_runspec;
+    }
+
     Schedule::Schedule( const Deck& deck,
                         const EclipseGrid& ecl_grid,
                         const FieldPropsManager& fp,

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -40,6 +40,8 @@
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 
+#include <opm/input/eclipse/Python/Python.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -31,6 +31,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/io/eclipse/rst/header.hpp>
 


### PR DESCRIPTION
we can now forward Opm::Python

micro optimization. reduce Python.hpp hotness by 31% (51 less compile units, 113 instead of 164).