### PR TITLE
Forward SimulatorUpdate in Schedule

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -29,6 +29,7 @@
 #include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
+#include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>

--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -20,8 +20,8 @@
 #ifndef SIMULATOR_UPDATE_HPP
 #define SIMULATOR_UPDATE_HPP
 
+#include <string>
 #include <unordered_set>
-
 
 namespace Opm {
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -539,10 +539,7 @@ namespace Opm
             , grid(grid_)
             {}
 
-            void affected_well(const std::string& well_name) {
-                if (this->sim_update)
-                    this->sim_update->affected_wells.insert(well_name);
-            }
+            void affected_well(const std::string& well_name);
 
             /// \brief Mark that the well occured in a  WELSEGS keyword
             void welsegs_handled(const std::string& well_name)

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -44,7 +44,6 @@
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
 #include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
 #include <opm/input/eclipse/Schedule/CompletedCells.hpp>
-#include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
@@ -55,6 +54,7 @@ namespace Opm
     class DeckKeyword;
     class DeckRecord;
     class EclipseState;
+    class ErrorGuard;
     class FieldPropsManager;
     class GuideRateConfig;
     class GuideRateModel;
@@ -62,8 +62,8 @@ namespace Opm
     class ParseContext;
     class Python;
     class SCHEDULESection;
+    class SimulatorUpdate;
     class SummaryState;
-    class ErrorGuard;
     class UDQConfig;
     class WellMatcher;
 

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -56,6 +56,7 @@
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
+#include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/Events.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/GTNode.hpp>

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -2273,4 +2273,10 @@ std::ostream& operator<<(std::ostream& os, const Schedule& sched)
     return os;
 }
 
+void Schedule::HandlerContext::affected_well(const std::string& well_name)
+{
+    if (this->sim_update)
+        this->sim_update->affected_wells.insert(well_name);
+}
+
 }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -39,10 +39,11 @@
 #include <opm/input/eclipse/Schedule/Action/ActionAST.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
-#include <opm/input/eclipse/Schedule/Action/State.hpp>
-#include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
+#include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
+#include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
 #include <opm/input/eclipse/Schedule/Well/WList.hpp>
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>


### PR DESCRIPTION
reduce hotness of SimulatorUpdate.hpp by 96% (154 files, 6 files instead of 160).