### PR TITLE
ScheduleState.hpp: forward GConSump

### DIFF
--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -37,7 +37,6 @@
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
-#include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/Network/Balance.hpp>
@@ -65,6 +64,7 @@ namespace {
 namespace Opm {
 
     class GasLiftOpt;
+    class GConSump;
     class GroupOrder;
     class GuideRateConfig;
     class NameOrder;

--- a/tests/parser/ScheduleSerializeTest.cpp
+++ b/tests/parser/ScheduleSerializeTest.cpp
@@ -51,6 +51,7 @@
 #include <opm/input/eclipse/Units/Dimension.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>
 

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -62,6 +62,7 @@
 #include <opm/input/eclipse/Schedule/Action/Condition.hpp>
 #include <opm/input/eclipse/Schedule/Events.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
+#include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateModel.hpp>


### PR DESCRIPTION
reduce hotness of GConSump.hpp by 92% (152 files, 13 files instead of 165)