### PR TITLE
ScheduleState.hpp: forward GConSale

### DIFF
--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -37,7 +37,6 @@
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
-#include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/Network/Balance.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
@@ -64,6 +63,7 @@ namespace {
 namespace Opm {
 
     class GasLiftOpt;
+    class GConSale;
     class GConSump;
     class GroupOrder;
     class GuideRateConfig;

--- a/tests/parser/ScheduleSerializeTest.cpp
+++ b/tests/parser/ScheduleSerializeTest.cpp
@@ -51,6 +51,7 @@
 #include <opm/input/eclipse/Units/Dimension.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
 #include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>


### PR DESCRIPTION
reduces hotness of GConSale.hpp by 92% (151 files, 13 instead of 164)