### PR TITLE
change default name from FIPNUM to NUM in GPMAINT

### DIFF
--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/G/GPMAINT
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/G/GPMAINT
@@ -19,7 +19,7 @@
     {
       "name": "FIP_FAMILY",
       "value_type": "STRING",
-      "default": "FIPNUM"
+      "default": "NUM"
     },
     {
       "name": "PRESSURE_TARGET",

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -722,7 +722,7 @@ GCONPROD
 
         auto [name, number] = *gpm_prod->region();
         BOOST_CHECK_EQUAL(number, 2);
-        BOOST_CHECK_EQUAL(name, "FIPNUM");
+        BOOST_CHECK_EQUAL(name, "NUM");
 
         const auto& gpm_c1 = c1_group.gpmaint();
         BOOST_CHECK(!gpm_c1->region());


### PR DESCRIPTION
This make it consistent with the other names. i.e. FIP is always added as s prefix.  