### PR TITLE
ScheduleState.hpp: forward UDQActive

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -49,7 +49,7 @@ namespace Opm
         class ActionX;
         class PyAction;
         class State;
-    };
+    }
     class ActiveGridCells;
     class Deck;
     class DeckKeyword;

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -60,7 +60,7 @@ namespace Opm {
 
     namespace Action {
         class Actions;
-    };
+    }
     class GasLiftOpt;
     class GConSale;
     class GConSump;

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -39,7 +39,6 @@
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/RFTConfig.hpp>
 #include <opm/input/eclipse/Schedule/RSTConfig.hpp>
@@ -73,6 +72,7 @@ namespace Opm {
         class ExtNetwork;
     }
     class RPTConfig;
+    class UDQActive;
     class WellTestConfig;
     class WListManager;
 

--- a/opm/output/eclipse/AggregateActionxData.hpp
+++ b/opm/output/eclipse/AggregateActionxData.hpp
@@ -25,7 +25,6 @@
 
 #include <opm/input/eclipse/Schedule/UDQ/UDQInput.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
@@ -39,7 +38,6 @@
 namespace Opm {
     class Schedule;
     class UDQInput;
-    class UDQActive;
     class Actdims;
 
     namespace Action {

--- a/src/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/src/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -27,6 +27,7 @@
 #include <opm/input/eclipse/Schedule/Network/Balance.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/RPTConfig.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>


### PR DESCRIPTION
Reduces hotness of UDQActive.hpp by 88% (148 files, 20 instead of 168)

Includes a fix for post-merge comments in #3339 