### PR TITLE
Well.hpp: forward WellTracerProperties

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -35,7 +35,6 @@
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
@@ -66,6 +65,7 @@ class WellConnections;
 class WellBrineProperties;
 class WellFoamProperties;
 class WellSegments;
+class WellTracerProperties;
 
 namespace RestartIO {
 struct RstWell;

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -83,6 +83,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Units/Dimension.hpp>

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -32,6 +32,7 @@
 #include <opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 
 #include <opm/common/utility/shmatch.hpp>
 

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -28,6 +28,7 @@
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>


### PR DESCRIPTION
Reduces hotness of WellTracerProperties.hpp by 97% (276 files, 8 files instead of 284)