### PR TITLE
Add Separate SummaryState Data Member for Segment Level Values

### DIFF
--- a/opm/input/eclipse/Schedule/SummaryState.hpp
+++ b/opm/input/eclipse/Schedule/SummaryState.hpp
@@ -20,53 +20,52 @@
 #ifndef SUMMARY_STATE_H
 #define SUMMARY_STATE_H
 
+#include <opm/common/utility/TimeService.hpp>
+
 #include <chrono>
 #include <iosfwd>
 #include <optional>
+#include <set>
 #include <string>
 #include <unordered_map>
-#include <set>
 #include <vector>
-
-#include <opm/common/utility/TimeService.hpp>
 
 namespace Opm {
 
 class UDQSet;
 
-/*
-  The purpose of this class is to serve as a small container object for
-  computed, ready to use summary values. The values will typically be used by
-  the UDQ, WTEST and ACTIONX calculations. Observe that all value *have been
-  converted to the correct output units*.
+// The purpose of this class is to serve as a small container object for
+// computed, ready to use summary values. The values will typically be used
+// by the UDQ, WTEST and ACTIONX calculations. Observe that all value *have
+// been converted to the correct output units*.
+//
+// The main key used to access the content of this container is the eclipse
+// style colon separated string - i.e. 'WWCT:OPX' to get the watercut in
+// well 'OPX'.  The main usage of the SummaryState class is a temporary
+// holding ground while assembling data for the summary output, but it is
+// also used as a context object when evaulating the condition in ACTIONX
+// keywords. For that reason some of the data is duplicated both in the
+// general structure and a specialized structure:
+//
+//     SummaryState st;
+//
+//     st.add_well_var("OPX", "WWCT", 0.75);
+//     st.add("WGOR:OPY", 120);
+//
+//     // The WWCT:OPX key has been added with the specialized add_well_var()
+//     // method and this data is available both with the general
+//     // st.has("WWCT:OPX") and the specialized st.has_well_var("OPX", "WWCT");
+//     st.has("WWCT:OPX") => True
+//     st.has_well_var("OPX", "WWCT") => True
+//
+//
+//     // The WGOR:OPY key is added with the general add("WGOR:OPY") and is *not*
+//     // accessible through the specialized st.has_well_var("OPY", "WGOR").
+//     st.has("WGOR:OPY") => True
+//     st.has_well_var("OPY", "WGOR") => False
 
-  The main key used to access the content of this container is the eclipse style
-  colon separated string - i.e. 'WWCT:OPX' to get the watercut in well 'OPX'.
-  The main usage of the SummaryState class is a temporary holding ground while
-  assembling data for the summary output, but it is also used as a context
-  object when evaulating the condition in ACTIONX keywords. For that reason some
-  of the data is duplicated both in the general structure and a specialized
-  structure:
-
-      SummaryState st;
-
-      st.add_well_var("OPX", "WWCT", 0.75);
-      st.add("WGOR:OPY", 120);
-
-      // The WWCT:OPX key has been added with the specialized add_well_var()
-      // method and this data is available both with the general
-      // st.has("WWCT:OPX") and the specialized st.has_well_var("OPX", "WWCT");
-      st.has("WWCT:OPX") => True
-      st.has_well_var("OPX", "WWCT") => True
-
-
-      // The WGOR:OPY key is added with the general add("WGOR:OPY") and is *not*
-      // accessible through the specialized st.has_well_var("OPY", "WGOR").
-      st.has("WGOR:OPY") => True
-      st.has_well_var("OPY", "WGOR") => False
-*/
-
-class SummaryState {
+class SummaryState
+{
 public:
     typedef std::unordered_map<std::string, double>::const_iterator const_iterator;
     explicit SummaryState(time_point sim_start_arg);
@@ -77,12 +76,11 @@ public:
     // Only used for testing purposes.
     SummaryState() : SummaryState(std::time_t{0}) {}
 
-    /*
-      The canonical way to update the SummaryState is through the update_xxx()
-      methods which will inspect the variable and either accumulate or just
-      assign, depending on whether it represents a total or not. The set()
-      method is low level and unconditionally do an assignment. 
-    */
+    // The canonical way to update the SummaryState is through the
+    // update_xxx() methods which will inspect the variable and either
+    // accumulate or just assign, depending on whether it represents a total
+    // or not. The set() method is low level and unconditionally do an
+    // assignment.
     void set(const std::string& key, double value);
 
     bool erase(const std::string& key);
@@ -180,5 +178,6 @@ private:
 
 std::ostream& operator<<(std::ostream& stream, const SummaryState& st);
 
-}
-#endif
+} // namespace Opm
+
+#endif  // SUMMARY_STATE_H

--- a/opm/input/eclipse/Schedule/SummaryState.hpp
+++ b/opm/input/eclipse/Schedule/SummaryState.hpp
@@ -93,7 +93,7 @@ public:
     bool has_group_var(const std::string& group, const std::string& var) const;
     bool has_group_var(const std::string& var) const;
     bool has_conn_var(const std::string& well, const std::string& var, std::size_t global_index) const;
-
+    bool has_segment_var(const std::string& well, const std::string& var, std::size_t segment) const;
 
     void update(const std::string& key, double value);
     void update_well_var(const std::string& well, const std::string& var, double value);
@@ -101,6 +101,7 @@ public:
     void update_elapsed(double delta);
     void update_udq(const UDQSet& udq_set, double undefined_value);
     void update_conn_var(const std::string& well, const std::string& var, std::size_t global_index, double value);
+    void update_segment_var(const std::string& well, const std::string& var, std::size_t segment, double value);
 
     double get(const std::string&) const;
     double get(const std::string&, double) const;
@@ -108,9 +109,11 @@ public:
     double get_well_var(const std::string& well, const std::string& var) const;
     double get_group_var(const std::string& group, const std::string& var) const;
     double get_conn_var(const std::string& conn, const std::string& var, std::size_t global_index) const;
+    double get_segment_var(const std::string& well, const std::string& var, std::size_t segment) const;
     double get_well_var(const std::string& well, const std::string& var, double) const;
     double get_group_var(const std::string& group, const std::string& var, double) const;
     double get_conn_var(const std::string& conn, const std::string& var, std::size_t global_index, double) const;
+    double get_segment_var(const std::string& well, const std::string& var, std::size_t segment, double) const;
 
     const std::vector<std::string>& wells() const;
     std::vector<std::string> wells(const std::string& var) const;
@@ -136,24 +139,10 @@ public:
       serializer(m_groups);
       serializer(group_names);
       serializer(conn_values);
+      serializer(segment_values);
     }
 
-    static SummaryState serializationTestObject()
-    {
-        auto st = SummaryState{TimeService::from_time_t(101)};
-
-        st.elapsed = 1.0;
-        st.values = {{"test1", 2.0}};
-        st.well_values = {{"test2", {{"test3", 3.0}}}};
-        st.m_wells = {"test4"};
-        st.well_names = {"test5"};
-        st.group_values = {{"test6", {{"test7", 4.0}}}},
-        st.m_groups = {"test7"};
-        st.group_names = {"test8"},
-        st.conn_values = {{"test9", {{"test10", {{5, 6.0}}}}}};
-
-        return st;
-    }
+    static SummaryState serializationTestObject();
 
 private:
     time_point sim_start;
@@ -173,8 +162,11 @@ private:
     // The first key is the variable and the second key is the well and the
     // third is the global index. NB: The global_index has offset 1!
     std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::size_t, double>>> conn_values;
-};
 
+    // The first key is the variable and the second key is the well and the
+    // third is the one-based segment number.
+    std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::size_t, double>>> segment_values;
+};
 
 std::ostream& operator<<(std::ostream& stream, const SummaryState& st);
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2521,6 +2521,10 @@ void updateValue(const Opm::EclIO::SummaryNode& node, const double value, Opm::S
         st.update_conn_var(node.wgname, node.keyword, node.number, value);
         break;
 
+    case Cat::Segment:
+        st.update_segment_var(node.wgname, node.keyword, node.number, value);
+        break;
+
     default:
         st.update(node.unique_key(), value);
         break;


### PR DESCRIPTION
Enables easier access for UDQ/ACTIONX purposes.

While here, also move the `serializationTestObject()` member function's implementation to the .cpp file and reorder the member function implementations to match the declaration order in the header.