### PR TITLE
Forward declare structs as struct, not class, to silence warnings.

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -66,7 +66,7 @@ namespace Opm
     class Python;
     class RPTConfig;
     class SCHEDULESection;
-    class SimulatorUpdate;
+    struct SimulatorUpdate;
     class SummaryState;
     class UDQConfig;
     class WellMatcher;

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -59,11 +59,11 @@ class UDQConfig;
 class Valve;
 class TracerConfig;
 class WellConnections;
-class WellBrineProperties;
+struct WellBrineProperties;
 class WellEconProductionLimits;
-class WellFoamProperties;
-class WellMICPProperties;
-class WellPolymerProperties;
+struct WellFoamProperties;
+struct WellMICPProperties;
+struct WellPolymerProperties;
 class WellSegments;
 class WellTracerProperties;
 


### PR DESCRIPTION
Clang complains about these.