### PR TITLE
Well.hpp: remove unnecessary Units.hpp include

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -37,7 +37,6 @@
 #include <opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
-#include <opm/input/eclipse/Units/Units.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/common/utility/ActiveGridCells.hpp>

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -37,6 +37,8 @@
 #include <opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 
+#include <opm/input/eclipse/Units/Units.hpp>
+
 #include <opm/common/utility/shmatch.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/S.hpp>


### PR DESCRIPTION
Reduces hotness of Units.hpp by 54% (183 files, 155 files instead of 338)