### PR TITLE
Move well enums and controls to separate classes

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1098,6 +1098,7 @@ if(ENABLE_ECL_INPUT)
        opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.hpp
        opm/input/eclipse/Schedule/Well/Well.hpp
        opm/input/eclipse/Schedule/Well/WellEnums.hpp
+       opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp
        opm/input/eclipse/Schedule/Well/WList.hpp
        opm/input/eclipse/Schedule/Well/NameOrder.hpp
        opm/input/eclipse/Schedule/Well/WellMatcher.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1096,6 +1096,7 @@ if(ENABLE_ECL_INPUT)
        opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp
        opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.hpp
        opm/input/eclipse/Schedule/Well/Well.hpp
+       opm/input/eclipse/Schedule/Well/WellEnums.hpp
        opm/input/eclipse/Schedule/Well/WList.hpp
        opm/input/eclipse/Schedule/Well/NameOrder.hpp
        opm/input/eclipse/Schedule/Well/WellMatcher.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1099,6 +1099,7 @@ if(ENABLE_ECL_INPUT)
        opm/input/eclipse/Schedule/Well/Well.hpp
        opm/input/eclipse/Schedule/Well/WellEnums.hpp
        opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp
+       opm/input/eclipse/Schedule/Well/WellProductionControls.hpp
        opm/input/eclipse/Schedule/Well/WList.hpp
        opm/input/eclipse/Schedule/Well/NameOrder.hpp
        opm/input/eclipse/Schedule/Well/WellMatcher.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -174,26 +174,27 @@ if(ENABLE_ECL_INPUT)
     src/opm/input/eclipse/Schedule/WriteRestartFileEvents.cpp
     src/opm/input/eclipse/Schedule/Well/Connection.cpp
     src/opm/input/eclipse/Schedule/Well/injection.cpp
+    src/opm/input/eclipse/Schedule/Well/NameOrder.cpp
     src/opm/input/eclipse/Schedule/Well/PAvg.cpp
     src/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
     src/opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.cpp
     src/opm/input/eclipse/Schedule/Well/Well.cpp
     src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
-    src/opm/input/eclipse/Schedule/Well/NameOrder.cpp
     src/opm/input/eclipse/Schedule/Well/WellMatcher.cpp
-    src/opm/input/eclipse/Schedule/Well/WList.cpp
-    src/opm/input/eclipse/Schedule/Well/WListManager.cpp
+    src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
+    src/opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
     src/opm/input/eclipse/Schedule/Well/WellEconProductionLimits.cpp
     src/opm/input/eclipse/Schedule/Well/WellFoamProperties.cpp
     src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
     src/opm/input/eclipse/Schedule/Well/WellMICPProperties.cpp
     src/opm/input/eclipse/Schedule/Well/WellPolymerProperties.cpp
-    src/opm/input/eclipse/Schedule/Well/WellBrineProperties.cpp
-    src/opm/input/eclipse/Schedule/Well/WellTracerProperties.cpp
-    src/opm/input/eclipse/Schedule/Well/WVFPEXP.cpp
     src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
     src/opm/input/eclipse/Schedule/Well/WellTestConfig.cpp
     src/opm/input/eclipse/Schedule/Well/WellTestState.cpp
+    src/opm/input/eclipse/Schedule/Well/WellTracerProperties.cpp
+    src/opm/input/eclipse/Schedule/Well/WList.cpp
+    src/opm/input/eclipse/Schedule/Well/WListManager.cpp
+    src/opm/input/eclipse/Schedule/Well/WVFPEXP.cpp
     src/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
     src/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
     src/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp

--- a/examples/wellgraph.cpp
+++ b/examples/wellgraph.cpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/StreamLog.hpp>

--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -33,6 +33,7 @@
 #include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>

--- a/opm/input/eclipse/Schedule/Group/GuideRate.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.hpp
@@ -22,7 +22,6 @@
 
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateModel.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <cstddef>
 #include <ctime>
@@ -35,6 +34,7 @@
 namespace Opm {
 
 class Schedule;
+enum class WellGuideRateTarget;
 
 } // namespace Opm
 
@@ -52,7 +52,7 @@ public:
             , wat_rat(wrat)
         {}
 
-        double eval(const Well::GuideRateTarget target) const;
+        double eval(const WellGuideRateTarget target) const;
         double eval(const Group::GuideRateProdTarget target) const;
         double eval(const GuideRateModel::Target target) const;
 
@@ -103,12 +103,12 @@ public:
     bool hasPotentials(const std::string& name) const;
     bool has(const std::string& name, const Phase& phase) const;
 
-    double get(const std::string& well, const Well::GuideRateTarget target, const RateVector& rates) const;
+    double get(const std::string& well, const WellGuideRateTarget target, const RateVector& rates) const;
     double get(const std::string& group, const Group::GuideRateProdTarget target, const RateVector& rates) const;
     double get(const std::string& name, const GuideRateModel::Target model_target, const RateVector& rates) const;
     double get(const std::string& group, const Phase& phase) const;
 
-    double getSI(const std::string& well, const Well::GuideRateTarget target, const RateVector& rates) const;
+    double getSI(const std::string& well, const WellGuideRateTarget target, const RateVector& rates) const;
     double getSI(const std::string& group, const Group::GuideRateProdTarget target, const RateVector& rates) const;
     double getSI(const std::string& wgname, const GuideRateModel::Target target, const RateVector& rates) const;
     double getSI(const std::string& group, const Phase& phase) const;

--- a/opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp
@@ -27,7 +27,7 @@
 
 #include <opm/input/eclipse/Schedule/Group/GuideRateModel.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 
 namespace Opm {
 
@@ -37,7 +37,7 @@ public:
 
  struct WellTarget {
     double guide_rate;
-    Well::GuideRateTarget target;
+    WellGuideRateTarget target;
     double scaling_factor;
 
     bool operator==(const WellTarget& data) const {

--- a/opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp
@@ -31,6 +31,7 @@
 
 namespace Opm {
 
+class Well;
 
 class GuideRateConfig {
 public:

--- a/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRateModel.hpp
@@ -22,9 +22,10 @@
 
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 namespace Opm {
+
+enum class WellGuideRateTarget;
 
 class GuideRateModel {
 public:
@@ -82,7 +83,7 @@ public:
     double getE() const;
     double getF() const;
 
-    static Target convert_target(Well::GuideRateTarget well_target);
+    static Target convert_target(WellGuideRateTarget well_target);
     static Target convert_target(Group::GuideRateProdTarget group_target);
     static Target convert_target(Phase injection_phase);
     static double pot(Target target, double oil_pot, double gas_pot, double wat_pot);

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -37,7 +37,6 @@
 #include <opm/input/eclipse/Schedule/ScheduleDeck.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
 #include <opm/input/eclipse/Schedule/CompletedCells.hpp>
 #include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
@@ -68,8 +67,13 @@ namespace Opm
     class SCHEDULESection;
     struct SimulatorUpdate;
     class SummaryState;
+    class TracerConfig;
     class UDQConfig;
+    class Well;
+    enum class WellGasInflowEquation;
     class WellMatcher;
+    enum class WellProducerCMode;
+    enum class WellStatus;
     class WellTestConfig;
 
     namespace RestartIO { struct RstState; }
@@ -266,7 +270,7 @@ namespace Opm
 
         std::vector<const Group*> getChildGroups2(const std::string& group_name, std::size_t timeStep) const;
         std::vector<Well> getChildWells2(const std::string& group_name, std::size_t timeStep) const;
-        Well::ProducerCMode getGlobalWhistctlMmode(std::size_t timestep) const;
+        WellProducerCMode getGlobalWhistctlMmode(std::size_t timestep) const;
 
         const UDQConfig& getUDQConfig(std::size_t timeStep) const;
         void evalAction(const SummaryState& summary_state, std::size_t timeStep);
@@ -590,7 +594,7 @@ namespace Opm
                      bool allowCrossFlow,
                      bool automaticShutIn,
                      int pvt_table,
-                     Well::GasInflowEquation gas_inflow,
+                     WellGasInflowEquation gas_inflow,
                      std::size_t timeStep,
                      Connection::Order wellConnectionOrder);
         bool updateWPAVE(const std::string& wname, std::size_t report_step, const PAvg& pavg);
@@ -598,7 +602,7 @@ namespace Opm
         void updateGuideRateModel(const GuideRateModel& new_model, std::size_t report_step);
         GTNode groupTree(const std::string& root_node, std::size_t report_step, std::size_t level, const std::optional<std::string>& parent_name) const;
         bool checkGroups(const ParseContext& parseContext, ErrorGuard& errors);
-        bool updateWellStatus( const std::string& well, std::size_t reportStep, Well::Status status, std::optional<KeywordLocation> = {});
+        bool updateWellStatus( const std::string& well, std::size_t reportStep, WellStatus status, std::optional<KeywordLocation> = {});
         void addWellToGroup( const std::string& group_name, const std::string& well_name , std::size_t timeStep);
         void iterateScheduleSection(std::size_t load_start,
                                     std::size_t load_end,

--- a/opm/input/eclipse/Schedule/ScheduleState.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.hpp
@@ -35,7 +35,7 @@
 #include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
 #include <opm/input/eclipse/Schedule/Events.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 #include <opm/input/eclipse/Schedule/MessageLimits.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
@@ -73,6 +73,7 @@ namespace Opm {
     class RPTConfig;
     class UDQActive;
     class UDQConfig;
+    class Well;
     class WellTestConfig;
     class WListManager;
 
@@ -331,8 +332,8 @@ namespace Opm {
         MessageLimits& message_limits();
         const MessageLimits& message_limits() const;
 
-        Well::ProducerCMode whistctl() const;
-        void update_whistctl(Well::ProducerCMode whistctl);
+        WellProducerCMode whistctl() const;
+        void update_whistctl(WellProducerCMode whistctl);
 
         bool rst_file(const RSTConfig& rst_config, const time_point& previous_restart_output_time) const;
         void update_date(const time_point& prev_time);
@@ -521,7 +522,7 @@ namespace Opm {
         WellGroupEvents m_wellgroup_events;
         std::vector<DeckKeyword> m_geo_keywords;
         MessageLimits m_message_limits;
-        Well::ProducerCMode m_whistctl_mode = Well::ProducerCMode::CMODE_UNDEFINED;
+        WellProducerCMode m_whistctl_mode = WellProducerCMode::CMODE_UNDEFINED;
         std::optional<double> m_sumthin;
         bool m_rptonly{false};
     };

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -92,8 +92,6 @@ public:
     using GuideRateTarget = WellGuideRateTarget;
 
     using GasInflowEquation = WellGasInflowEquation;
-    static const std::string GasInflowEquation2String(GasInflowEquation enumValue);
-    static GasInflowEquation GasInflowEquationFromString(const std::string& stringValue);
 
     struct WellGuideRate {
         bool available;

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -86,8 +86,6 @@ public:
       that; and it is not part of the string conversion routines.
     */
     using ProducerCMode = WellProducerCMode;
-    static const std::string ProducerCMode2String(ProducerCMode enumValue);
-    static ProducerCMode ProducerCModeFromString(const std::string& stringValue);
 
     using WELTARGCMode = WellWELTARGCMode;
     static WELTARGCMode WELTARGCModeFromString(const std::string& stringValue);
@@ -660,8 +658,6 @@ private:
 
 std::ostream& operator<<( std::ostream&, const Well::WellInjectionProperties& );
 std::ostream& operator<<( std::ostream&, const Well::WellProductionProperties& );
-
-std::ostream& operator<<(std::ostream& os, const Well::ProducerCMode& cm);
 
 }
 #endif

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -79,8 +79,6 @@ public:
       be intact.
     */
     using InjectorCMode = WellInjectorCMode;
-    static const std::string InjectorCMode2String(InjectorCMode enumValue);
-    static InjectorCMode InjectorCModeFromString(const std::string& stringValue);
 
     /*
       The properties are initialized with the CMODE_UNDEFINED
@@ -664,7 +662,6 @@ std::ostream& operator<<( std::ostream&, const Well::WellInjectionProperties& );
 std::ostream& operator<<( std::ostream&, const Well::WellProductionProperties& );
 
 std::ostream& operator<<(std::ostream& os, const Well::ProducerCMode& cm);
-std::ostream& operator<<(std::ostream& os, const Well::InjectorCMode& cm);
 
 }
 #endif

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -88,7 +88,6 @@ public:
     using ProducerCMode = WellProducerCMode;
 
     using WELTARGCMode = WellWELTARGCMode;
-    static WELTARGCMode WELTARGCModeFromString(const std::string& stringValue);
 
     using GuideRateTarget = WellGuideRateTarget;
     static const std::string GuideRateTarget2String(GuideRateTarget enumValue);

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -35,6 +35,7 @@
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
@@ -68,110 +69,40 @@ namespace RestartIO {
 struct RstWell;
 }
 
-
 class Well {
 public:
-
-    enum class Status {
-        OPEN = 1,
-        STOP = 2,
-        SHUT = 3,
-        AUTO = 4
-    };
+    using Status = WellStatus;
     static std::string Status2String(Status enumValue);
     static Status StatusFromString(const std::string& stringValue);
-
-
 
     /*
       The elements in this enum are used as bitmasks to keep track
       of which controls are present, i.e. the 2^n structure must
       be intact.
     */
-    enum class InjectorCMode : int{
-        RATE =  1 ,
-        RESV =  2 ,
-        BHP  =  4 ,
-        THP  =  8 ,
-        GRUP = 16 ,
-        CMODE_UNDEFINED = 512
-    };
-    static const std::string InjectorCMode2String( InjectorCMode enumValue );
-    static InjectorCMode InjectorCModeFromString( const std::string& stringValue );
-
+    using InjectorCMode = WellInjectorCMode;
+    static const std::string InjectorCMode2String(InjectorCMode enumValue);
+    static InjectorCMode InjectorCModeFromString(const std::string& stringValue);
 
     /*
-      The items BHP, THP and GRUP only apply in prediction mode:
-      WCONPROD. The elements in this enum are used as bitmasks to
-      keep track of which controls are present, i.e. the 2^n
-      structure must be intact.The NONE item is only used in WHISTCTL
-      to cancel its effect.
-
       The properties are initialized with the CMODE_UNDEFINED
       value, but the undefined value is never assigned apart from
       that; and it is not part of the string conversion routines.
     */
-    enum class ProducerCMode : int {
-        NONE =     0,
-        ORAT =     1,
-        WRAT =     2,
-        GRAT =     4,
-        LRAT =     8,
-        CRAT =    16,
-        RESV =    32,
-        BHP  =    64,
-        THP  =   128,
-        GRUP =   256,
-        CMODE_UNDEFINED = 1024
-    };
-    static const std::string ProducerCMode2String( ProducerCMode enumValue );
-    static ProducerCMode ProducerCModeFromString( const std::string& stringValue );
+    using ProducerCMode = WellProducerCMode;
+    static const std::string ProducerCMode2String(ProducerCMode enumValue);
+    static ProducerCMode ProducerCModeFromString(const std::string& stringValue);
 
-
-
-    enum class WELTARGCMode {
-        ORAT =  1,
-        WRAT =  2,
-        GRAT =  3,
-        LRAT =  4,
-        CRAT =  5,   // Not supported
-        RESV =  6,
-        BHP  =  7,
-        THP  =  8,
-        VFP  =  9,
-        LIFT = 10,   // Not supported
-        GUID = 11
-    };
-
+    using WELTARGCMode = WellWELTARGCMode;
     static WELTARGCMode WELTARGCModeFromString(const std::string& stringValue);
 
+    using GuideRateTarget = WellGuideRateTarget;
+    static const std::string GuideRateTarget2String(GuideRateTarget enumValue);
+    static GuideRateTarget GuideRateTargetFromString(const std::string& stringValue);
 
-    enum class GuideRateTarget {
-        OIL = 0,
-        WAT = 1,
-        GAS = 2,
-        LIQ = 3,
-        COMB = 4,
-        WGA = 5,
-        CVAL = 6,
-        RAT = 7,
-        RES = 8,
-        UNDEFINED = 9
-    };
-    static const std::string GuideRateTarget2String( GuideRateTarget enumValue );
-    static GuideRateTarget GuideRateTargetFromString( const std::string& stringValue );
-
-
-    enum class GasInflowEquation {
-        STD = 0,
-        R_G = 1,
-        P_P = 2,
-        GPP = 3
-    };
+    using GasInflowEquation = WellGasInflowEquation;
     static const std::string GasInflowEquation2String(GasInflowEquation enumValue);
     static GasInflowEquation GasInflowEquationFromString(const std::string& stringValue);
-
-
 
     struct WellGuideRate {
         bool available;

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -33,11 +33,12 @@
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
+#include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp>
-#include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellProductionControls.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 namespace Opm {
@@ -212,52 +213,7 @@ public:
         }
     };
 
-    struct ProductionControls {
-    public:
-        ProductionControls(int controls_arg) :
-            controls(controls_arg)
-        {
-        }
-
-        ProducerCMode cmode = ProducerCMode::NONE;
-        double oil_rate{0};
-        double water_rate{0};
-        double gas_rate{0};
-        double liquid_rate{0};
-        double resv_rate{0};
-        double bhp_history{0};
-        double thp_history{0};
-        double bhp_limit{0};
-        double thp_limit{0};
-        double alq_value{0};
-        int    vfp_table_number{0};
-        bool   prediction_mode{0};
-
-        bool hasControl(ProducerCMode cmode_arg) const {
-            return (this->controls & static_cast<int>(cmode_arg)) != 0;
-        }
-
-        bool operator==(const ProductionControls& other) const {
-            return this->cmode == other.cmode &&
-                   this->oil_rate == other.oil_rate &&
-                   this->water_rate == other.water_rate &&
-                   this->gas_rate == other.gas_rate &&
-                   this->liquid_rate == other.liquid_rate &&
-                   this->resv_rate == other.resv_rate &&
-                   this->bhp_history == other.bhp_history &&
-                   this->thp_history == other.thp_history &&
-                   this->bhp_limit == other.bhp_limit &&
-                   this->thp_limit == other.thp_limit &&
-                   this->alq_value == other.alq_value &&
-                   this->vfp_table_number == other.vfp_table_number &&
-                   this->prediction_mode == other.prediction_mode;
-        }
-
-
-    private:
-        int controls;
-    };
-
+    using ProductionControls = WellProductionControls;
 
     class WellProductionProperties {
     public:

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -72,8 +72,6 @@ struct RstWell;
 class Well {
 public:
     using Status = WellStatus;
-    static std::string Status2String(Status enumValue);
-    static Status StatusFromString(const std::string& stringValue);
 
     /*
       The elements in this enum are used as bitmasks to keep track
@@ -665,8 +663,6 @@ private:
 std::ostream& operator<<( std::ostream&, const Well::WellInjectionProperties& );
 std::ostream& operator<<( std::ostream&, const Well::WellProductionProperties& );
 
-
-std::ostream& operator<<(std::ostream& os, const Well::Status& st);
 std::ostream& operator<<(std::ostream& os, const Well::ProducerCMode& cm);
 std::ostream& operator<<(std::ostream& os, const Well::InjectorCMode& cm);
 

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
@@ -127,34 +128,7 @@ public:
         }
     };
 
-
-    struct InjectionControls {
-    public:
-        InjectionControls(int controls_arg) :
-            controls(controls_arg)
-        {}
-
-        double bhp_limit;
-        double thp_limit;
-
-
-        InjectorType injector_type;
-        InjectorCMode cmode = InjectorCMode::CMODE_UNDEFINED;
-        double surface_rate;
-        double reservoir_rate;
-        int    vfp_table_number;
-        bool   prediction_mode;
-        double rs_rv_inj;
-
-        bool hasControl(InjectorCMode cmode_arg) const {
-            return (this->controls & static_cast<int>(cmode_arg)) != 0;
-        }
-
-    private:
-        int controls;
-    };
-
-
+    using InjectionControls = WellInjectionControls;
 
     struct WellInjectionProperties {
         std::string name;

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -90,8 +90,6 @@ public:
     using WELTARGCMode = WellWELTARGCMode;
 
     using GuideRateTarget = WellGuideRateTarget;
-    static const std::string GuideRateTarget2String(GuideRateTarget enumValue);
-    static GuideRateTarget GuideRateTargetFromString(const std::string& stringValue);
 
     using GasInflowEquation = WellGasInflowEquation;
     static const std::string GasInflowEquation2String(GasInflowEquation enumValue);

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -110,6 +110,10 @@ std::string WellInjectorCMode2String(WellInjectorCMode enumValue);
 WellInjectorCMode WellInjectorCModeFromString(const std::string& stringValue);
 std::ostream& operator<<(std::ostream& os, const WellInjectorCMode& cm);
 
+std::string WellProducerCMode2String(WellProducerCMode enumValue);
+WellProducerCMode WellProducerCModeFromString(const std::string& stringValue);
+std::ostream& operator<<(std::ostream& os, const WellProducerCMode& cm);
+
 }
 
 #endif

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -20,6 +20,9 @@
 #ifndef WELL_ENUMS_HPP
 #define WELL_ENUMS_HPP
 
+#include <iosfwd>
+#include <string>
+
 namespace Opm {
 
 enum class WellStatus {
@@ -98,6 +101,10 @@ enum class WellGasInflowEquation {
     P_P = 2,
     GPP = 3
 };
+
+std::string WellStatus2String(WellStatus enumValue);
+WellStatus WellStatusFromString(const std::string& stringValue);
+std::ostream& operator<<(std::ostream& os, const WellStatus& st);
 
 }
 

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -119,6 +119,9 @@ WellWELTARGCMode WellWELTARGCModeFromString(const std::string& stringValue);
 std::string WellGuideRateTarget2String(WellGuideRateTarget enumValue);
 WellGuideRateTarget WellGuideRateTargetFromString(const std::string& stringValue);
 
+std::string WellGasInflowEquation2String(WellGasInflowEquation enumValue);
+WellGasInflowEquation WellGasInflowEquationFromString(const std::string& stringValue);
+
 }
 
 #endif

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -106,6 +106,10 @@ std::string WellStatus2String(WellStatus enumValue);
 WellStatus WellStatusFromString(const std::string& stringValue);
 std::ostream& operator<<(std::ostream& os, const WellStatus& st);
 
+std::string WellInjectorCMode2String(WellInjectorCMode enumValue);
+WellInjectorCMode WellInjectorCModeFromString(const std::string& stringValue);
+std::ostream& operator<<(std::ostream& os, const WellInjectorCMode& cm);
+
 }
 
 #endif

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -116,6 +116,9 @@ std::ostream& operator<<(std::ostream& os, const WellProducerCMode& cm);
 
 WellWELTARGCMode WellWELTARGCModeFromString(const std::string& stringValue);
 
+std::string WellGuideRateTarget2String(WellGuideRateTarget enumValue);
+WellGuideRateTarget WellGuideRateTargetFromString(const std::string& stringValue);
+
 }
 
 #endif

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -1,0 +1,104 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef WELL_ENUMS_HPP
+#define WELL_ENUMS_HPP
+
+namespace Opm {
+
+enum class WellStatus {
+    OPEN = 1,
+    STOP = 2,
+    SHUT = 3,
+    AUTO = 4
+};
+
+/*
+  The elements in this enum are used as bitmasks to keep track
+  of which controls are present, i.e. the 2^n structure must
+  be intact.
+*/
+enum class WellInjectorCMode : int{
+    RATE =  1 ,
+    RESV =  2 ,
+    BHP  =  4 ,
+    THP  =  8 ,
+    GRUP = 16 ,
+    CMODE_UNDEFINED = 512
+};
+
+/*
+  The items BHP, THP and GRUP only apply in prediction mode:
+  WCONPROD. The elements in this enum are used as bitmasks to
+  keep track of which controls are present, i.e. the 2^n
+  structure must be intact. The NONE item is only used in
+  WHISTCTL to cancel its effect.
+*/
+
+enum class WellProducerCMode : int {
+    NONE =     0,
+    ORAT =     1,
+    WRAT =     2,
+    GRAT =     4,
+    LRAT =     8,
+    CRAT =    16,
+    RESV =    32,
+    BHP  =    64,
+    THP  =   128,
+    GRUP =   256,
+    CMODE_UNDEFINED = 1024
+};
+
+enum class WellWELTARGCMode {
+    ORAT =  1,
+    WRAT =  2,
+    GRAT =  3,
+    LRAT =  4,
+    CRAT =  5,   // Not supported
+    RESV =  6,
+    BHP  =  7,
+    THP  =  8,
+    VFP  =  9,
+    LIFT = 10,   // Not supported
+    GUID = 11
+};
+
+enum class WellGuideRateTarget {
+    OIL = 0,
+    WAT = 1,
+    GAS = 2,
+    LIQ = 3,
+    COMB = 4,
+    WGA = 5,
+    CVAL = 6,
+    RAT = 7,
+    RES = 8,
+    UNDEFINED = 9
+};
+
+enum class WellGasInflowEquation {
+    STD = 0,
+    R_G = 1,
+    P_P = 2,
+    GPP = 3
+};
+
+}
+
+#endif

--- a/opm/input/eclipse/Schedule/Well/WellEnums.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellEnums.hpp
@@ -114,6 +114,8 @@ std::string WellProducerCMode2String(WellProducerCMode enumValue);
 WellProducerCMode WellProducerCModeFromString(const std::string& stringValue);
 std::ostream& operator<<(std::ostream& os, const WellProducerCMode& cm);
 
+WellWELTARGCMode WellWELTARGCModeFromString(const std::string& stringValue);
+
 }
 
 #endif

--- a/opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp
@@ -1,0 +1,57 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef WELL_INJECTION_CONTROLS_HPP
+#define WELL_INJECTION_CONTROLS_HPP
+
+#include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
+
+namespace Opm {
+
+struct WellInjectionControls {
+public:
+    WellInjectionControls(int controls_arg) :
+        controls(controls_arg)
+    {}
+
+    bool hasControl(WellInjectorCMode cmode_arg) const
+    {
+        return (this->controls & static_cast<int>(cmode_arg)) != 0;
+    }
+
+    double bhp_limit;
+    double thp_limit;
+
+    InjectorType injector_type;
+    WellInjectorCMode cmode = WellInjectorCMode::CMODE_UNDEFINED;
+    double surface_rate;
+    double reservoir_rate;
+    int    vfp_table_number;
+    bool   prediction_mode;
+    double rs_rv_inj;
+
+private:
+    int controls;
+};
+
+}
+
+#endif

--- a/opm/input/eclipse/Schedule/Well/WellProductionControls.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionControls.hpp
@@ -1,0 +1,78 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef WELL_PRODUCTION_CONTROLS_HPP
+#define WELL_PRODUCTION_CONTROLS_HPP
+
+#include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
+
+namespace Opm {
+
+struct WellProductionControls {
+public:
+    WellProductionControls(int controls_arg) :
+        controls(controls_arg)
+    {
+    }
+
+    bool hasControl(WellProducerCMode cmode_arg) const
+    {
+        return (this->controls & static_cast<int>(cmode_arg)) != 0;
+    }
+
+    bool operator==(const WellProductionControls& other) const
+    {
+        return this->cmode == other.cmode &&
+               this->oil_rate == other.oil_rate &&
+               this->water_rate == other.water_rate &&
+               this->gas_rate == other.gas_rate &&
+               this->liquid_rate == other.liquid_rate &&
+               this->resv_rate == other.resv_rate &&
+               this->bhp_history == other.bhp_history &&
+               this->thp_history == other.thp_history &&
+               this->bhp_limit == other.bhp_limit &&
+               this->thp_limit == other.thp_limit &&
+               this->alq_value == other.alq_value &&
+               this->vfp_table_number == other.vfp_table_number &&
+               this->prediction_mode == other.prediction_mode;
+    }
+
+    WellProducerCMode cmode = WellProducerCMode::NONE;
+    double oil_rate{0};
+    double water_rate{0};
+    double gas_rate{0};
+    double liquid_rate{0};
+    double resv_rate{0};
+    double bhp_history{0};
+    double thp_history{0};
+    double bhp_limit{0};
+    double thp_limit{0};
+    double alq_value{0};
+    int    vfp_table_number{0};
+    bool   prediction_mode{0};
+
+private:
+    int controls;
+};
+
+}
+
+#endif

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -518,7 +518,7 @@ namespace Opm {
             if (this->inj == ::Opm::Well::InjectorCMode::CMODE_UNDEFINED)
                 json_data.add_item("inj", "CMODE_UNDEFINED");
             else
-                json_data.add_item("inj", ::Opm::Well::InjectorCMode2String(this->inj));
+                json_data.add_item("inj", ::Opm::WellInjectorCMode2String(this->inj));
 
             if (this->prod == ::Opm::Well::ProducerCMode::CMODE_UNDEFINED)
                 json_data.add_item("prod", "CMODE_UNDEFINED");

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -523,7 +523,7 @@ namespace Opm {
             if (this->prod == ::Opm::Well::ProducerCMode::CMODE_UNDEFINED)
                 json_data.add_item("prod", "CMODE_UNDEFINED");
             else
-                json_data.add_item("prod", ::Opm::Well::ProducerCMode2String(this->prod));
+                json_data.add_item("prod", ::Opm::WellProducerCMode2String(this->prod));
         }
 
         template <class MessageBufferType>

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -21,7 +21,7 @@
 #define OPM_OUTPUT_WELLS_HPP
 
 #include <opm/output/data/GuideRateValue.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 
 #include <opm/json/JsonObject.hpp>
 
@@ -498,12 +498,12 @@ namespace Opm {
     struct CurrentControl {
         bool isProducer{true};
 
-        ::Opm::Well::ProducerCMode prod {
-            ::Opm::Well::ProducerCMode::CMODE_UNDEFINED
+        ::Opm::WellProducerCMode prod {
+            ::Opm::WellProducerCMode::CMODE_UNDEFINED
         };
 
-        ::Opm::Well::InjectorCMode inj {
-            ::Opm::Well::InjectorCMode::CMODE_UNDEFINED
+        ::Opm::WellInjectorCMode inj {
+            ::Opm::WellInjectorCMode::CMODE_UNDEFINED
         };
 
         bool operator==(const CurrentControl& rhs) const
@@ -515,12 +515,12 @@ namespace Opm {
 
         void init_json(Json::JsonObject& json_data) const
         {
-            if (this->inj == ::Opm::Well::InjectorCMode::CMODE_UNDEFINED)
+            if (this->inj == ::Opm::WellInjectorCMode::CMODE_UNDEFINED)
                 json_data.add_item("inj", "CMODE_UNDEFINED");
             else
                 json_data.add_item("inj", ::Opm::WellInjectorCMode2String(this->inj));
 
-            if (this->prod == ::Opm::Well::ProducerCMode::CMODE_UNDEFINED)
+            if (this->prod == ::Opm::WellProducerCMode::CMODE_UNDEFINED)
                 json_data.add_item("prod", "CMODE_UNDEFINED");
             else
                 json_data.add_item("prod", ::Opm::WellProducerCMode2String(this->prod));
@@ -543,8 +543,8 @@ namespace Opm {
         static CurrentControl serializationTestObject()
         {
           return CurrentControl{false,
-                                ::Opm::Well::ProducerCMode::BHP,
-                                ::Opm::Well::InjectorCMode::GRUP
+                                ::Opm::WellProducerCMode::BHP,
+                                ::Opm::WellInjectorCMode::GRUP
                  };
         }
     };
@@ -556,7 +556,7 @@ namespace Opm {
         double temperature{0.0};
         int control{0};
 
-        ::Opm::Well::Status dynamicStatus { Opm::Well::Status::OPEN };
+        ::Opm::WellStatus dynamicStatus { Opm::WellStatus::OPEN };
 
         std::vector< Connection > connections{};
         std::unordered_map<std::size_t, Segment> segments{};
@@ -631,7 +631,7 @@ namespace Opm {
                         2.0,
                         3.0,
                         4,
-                        ::Opm::Well::Status::SHUT,
+                        ::Opm::WellStatus::SHUT,
                         {Connection::serializationTestObject()},
                         {{0, Segment::serializationTestObject()}},
                         CurrentControl::serializationTestObject(),

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -987,7 +987,7 @@ namespace Opm {
         buffer.write(this->control);
 
         {
-            const auto status = ::Opm::Well::Status2String(this->dynamicStatus);
+            const auto status = ::Opm::WellStatus2String(this->dynamicStatus);
             buffer.write(status);
         }
 
@@ -1093,7 +1093,7 @@ namespace Opm {
         {
             auto status = std::string{};
             buffer.read(status);
-            this->dynamicStatus = ::Opm::Well::StatusFromString(status);
+            this->dynamicStatus = ::Opm::WellStatusFromString(status);
         }
 
         // Connection information
@@ -1139,7 +1139,7 @@ namespace Opm {
         json_data.add_item("bhp", this->bhp);
         json_data.add_item("thp", this->thp);
         json_data.add_item("temperature", this->temperature);
-        json_data.add_item("status", ::Opm::Well::Status2String(this->dynamicStatus));
+        json_data.add_item("status", ::Opm::WellStatus2String(this->dynamicStatus));
 
         auto json_control = json_data.add_object("control");
         this->current_control.init_json(json_control);

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -9,6 +9,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <fmt/format.h>
 #include <pybind11/stl.h>

--- a/python/cxx/well.cpp
+++ b/python/cxx/well.cpp
@@ -14,7 +14,7 @@ namespace {
     }
 
     std::string status( const Well& w )  {
-        return Well::Status2String( w.getStatus() );
+        return WellStatus2String( w.getStatus() );
     }
 
     std::string preferred_phase( const Well& w ) {

--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -33,6 +33,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>

--- a/src/opm/input/eclipse/Schedule/ArrayDimChecker.cpp
+++ b/src/opm/input/eclipse/Schedule/ArrayDimChecker.cpp
@@ -16,22 +16,27 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <algorithm>
-#include <cstddef>
-#include <iterator>
 
-#include <fmt/format.h>
+#include <config.h>
+#include <opm/input/eclipse/Schedule/ArrayDimChecker.hpp>
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
+
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/Schedule/Group/Group.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
-#include <opm/input/eclipse/Schedule/ArrayDimChecker.hpp>
 
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Group/Group.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
 
 namespace {
     namespace WellDims {

--- a/src/opm/input/eclipse/Schedule/Group/GuideRate.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GuideRate.cpp
@@ -22,6 +22,7 @@
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <opm/input/eclipse/Units/Units.hpp>
 

--- a/src/opm/input/eclipse/Schedule/Group/GuideRateConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GuideRateConfig.cpp
@@ -17,9 +17,9 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 namespace Opm {
 

--- a/src/opm/input/eclipse/Schedule/Group/GuideRateModel.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GuideRateModel.cpp
@@ -23,6 +23,7 @@
 
 #include <opm/input/eclipse/Parser/ParserKeywords/L.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateModel.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 
 namespace Opm {
 
@@ -312,20 +313,20 @@ bool GuideRateModel::updateLINCOM(const UDAValue& , const UDAValue& , const UDAV
 }
 
 
-GuideRateModel::Target GuideRateModel::convert_target(Well::GuideRateTarget well_target) {
-    if (well_target == Well::GuideRateTarget::OIL)
+GuideRateModel::Target GuideRateModel::convert_target(WellGuideRateTarget well_target) {
+    if (well_target == WellGuideRateTarget::OIL)
         return Target::OIL;
 
-    if (well_target == Well::GuideRateTarget::GAS)
+    if (well_target == WellGuideRateTarget::GAS)
         return Target::GAS;
 
-    if (well_target == Well::GuideRateTarget::LIQ)
+    if (well_target == WellGuideRateTarget::LIQ)
         return Target::LIQ;
 
-    if (well_target == Well::GuideRateTarget::WAT)
+    if (well_target == WellGuideRateTarget::WAT)
         return Target::WAT;
 
-    if (well_target == Well::GuideRateTarget::RES)
+    if (well_target == WellGuideRateTarget::RES)
         return Target::RES;
 
     throw std::logic_error("Can not convert this .... ");

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1607,7 +1607,7 @@ Well{0} entered with disallowed 'FIELD' parent group:
                 auto phase = Well::GuideRateTarget::UNDEFINED;
                 if (!record.getItem("PHASE").defaultApplied(0)) {
                     std::string guideRatePhase = record.getItem("PHASE").getTrimmedString(0);
-                    phase = Well::GuideRateTargetFromString(guideRatePhase);
+                    phase = WellGuideRateTargetFromString(guideRatePhase);
                 }
 
                 auto well = this->snapshots.back().wells.get(well_name);

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1624,7 +1624,7 @@ Well{0} entered with disallowed 'FIELD' parent group:
     void Schedule::handleWHISTCTL(HandlerContext& handlerContext) {
         const auto& record = handlerContext.keyword.getRecord(0);
         const std::string& cmodeString = record.getItem("CMODE").getTrimmedString(0);
-        const auto controlMode = Well::ProducerCModeFromString( cmodeString );
+        const auto controlMode = WellProducerCModeFromString(cmodeString);
 
         if (controlMode != Well::ProducerCMode::NONE) {
             if (!Well::WellProductionProperties::effectiveHistoryProductionControl(controlMode) ) {

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -69,6 +69,7 @@
 #include <opm/input/eclipse/Schedule/Network/Balance.hpp>
 #include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
 #include <opm/input/eclipse/Schedule/RFTConfig.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
 
 #include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -955,7 +955,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const auto well_names = this->wellNames(wellNamePattern, handlerContext);
 
-            const Well::Status status = Well::StatusFromString(record.getItem("STATUS").getTrimmedString(0));
+            const Well::Status status = WellStatusFromString(record.getItem("STATUS").getTrimmedString(0));
 
             for (const auto& well_name : well_names) {
                 this->updateWellStatus( well_name , handlerContext.currentStep , status, handlerContext.keyword.location() );
@@ -1029,7 +1029,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const auto well_names = this->wellNames(wellNamePattern, handlerContext);
 
-            const Well::Status status = Well::StatusFromString(record.getItem("STATUS").getTrimmedString(0));
+            const Well::Status status = WellStatusFromString(record.getItem("STATUS").getTrimmedString(0));
 
             for (const auto& well_name : well_names) {
                 bool update_well = this->updateWellStatus(well_name, handlerContext.currentStep, status, handlerContext.keyword.location());
@@ -1091,7 +1091,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const auto well_names = wellNames(wellNamePattern, handlerContext);
 
-            const Well::Status status = Well::StatusFromString(record.getItem("STATUS").getTrimmedString(0));
+            const Well::Status status = WellStatusFromString(record.getItem("STATUS").getTrimmedString(0));
 
             for (const auto& well_name : well_names) {
                 this->updateWellStatus(well_name, handlerContext.currentStep, status, handlerContext.keyword.location());
@@ -1158,7 +1158,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
         for (const auto& record : handlerContext.keyword) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const auto well_names = wellNames(wellNamePattern, handlerContext);
-            const Well::Status status = Well::StatusFromString( record.getItem("STATUS").getTrimmedString(0));
+            const Well::Status status = WellStatusFromString( record.getItem("STATUS").getTrimmedString(0));
 
             for (const auto& well_name : well_names) {
                 this->updateWellStatus(well_name, handlerContext.currentStep, status, handlerContext.keyword.location());
@@ -1255,7 +1255,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
              * well status is updated
              */
             if (conn_defaulted(record)) {
-                const auto new_well_status = Well::StatusFromString(status_str);
+                const auto new_well_status = WellStatusFromString(status_str);
 
                 for (const auto& wname : well_names) {
                     if ((new_well_status == open) && !this->getWell(wname, currentStep).canOpen()) {

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1533,7 +1533,7 @@ Well{0} entered with disallowed 'FIELD' parent group:
             if (well_names.empty())
                 this->invalidNamePattern( wellNamePattern, handlerContext);
 
-            const auto cmode = Well::WELTARGCModeFromString(record.getItem("CMODE").getTrimmedString(0));
+            const auto cmode = WellWELTARGCModeFromString(record.getItem("CMODE").getTrimmedString(0));
             const auto new_arg = record.getItem("NEW_VALUE").get<UDAValue>(0);
 
             for (const auto& well_name : well_names) {
@@ -2205,7 +2205,7 @@ Well{0} entered with disallowed 'FIELD' parent group:
                 throw OpmInputError(reason, handlerContext.keyword.location());
             }
 
-            const auto cmode = Well::WELTARGCModeFromString(control);
+            const auto cmode = WellWELTARGCModeFromString(control);
             if (cmode == Well::WELTARGCMode::GUID)
                 throw std::logic_error("Multiplying guide rate is not implemented");
 

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -954,7 +954,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
 
         const std::string& group = record.getItem<ParserKeywords::WELSPECS::GROUP>().getTrimmedString(0);
         auto pvt_table = record.getItem<ParserKeywords::WELSPECS::P_TABLE>().get<int>(0);
-        auto gas_inflow = Well::GasInflowEquationFromString( record.getItem<ParserKeywords::WELSPECS::INFLOW_EQ>().get<std::string>(0) );
+        auto gas_inflow = WellGasInflowEquationFromString(record.getItem<ParserKeywords::WELSPECS::INFLOW_EQ>().get<std::string>(0));
 
         this->addWell(wellName,
                       group,

--- a/src/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/src/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -32,6 +32,7 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
 

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1557,43 +1557,6 @@ void Well::setWellTemperature(const double temp) {
     this->well_temperature = temp;
 }
 
-std::ostream& operator<<(std::ostream& os, const Well::Status& st) {
-    os << Well::Status2String(st);
-    return os;
-}
-
-std::string Well::Status2String(Well::Status enumValue) {
-    switch( enumValue ) {
-    case Status::OPEN:
-        return "OPEN";
-    case Status::SHUT:
-        return "SHUT";
-    case Status::AUTO:
-        return "AUTO";
-    case Status::STOP:
-        return "STOP";
-    default:
-        throw std::invalid_argument("unhandled enum value");
-    }
-}
-
-
-Well::Status Well::StatusFromString(const std::string& stringValue) {
-    if (stringValue == "OPEN")
-        return Status::OPEN;
-    else if (stringValue == "SHUT")
-        return Status::SHUT;
-    else if (stringValue == "STOP")
-        return Status::STOP;
-    else if (stringValue == "AUTO")
-        return Status::AUTO;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue );
-}
-
-
-
-
 const std::string Well::InjectorCMode2String( InjectorCMode enumValue ) {
     switch( enumValue ) {
     case InjectorCMode::RESV:

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1357,38 +1357,6 @@ Well::GasInflowEquation Well::gas_inflow_equation() const {
     return this->gas_inflow;
 }
 
-const std::string Well::GasInflowEquation2String(GasInflowEquation enumValue) {
-    switch(enumValue) {
-    case GasInflowEquation::STD:
-        return "STD";
-    case GasInflowEquation::R_G:
-        return "R-G";
-    case GasInflowEquation::P_P:
-        return "P-P";
-    case GasInflowEquation::GPP:
-        return "GPP";
-    default:
-        throw std::invalid_argument("Unhandled enum value");
-    }
-}
-
-Well::GasInflowEquation Well::GasInflowEquationFromString(const std::string& stringValue) {
-    if (stringValue == "STD" || stringValue == "NO")
-        return GasInflowEquation::STD;
-
-    if (stringValue == "R-G" || stringValue == "YES")
-        return GasInflowEquation::R_G;
-
-    if (stringValue == "P-P")
-        return GasInflowEquation::P_P;
-
-    if (stringValue == "GPP")
-        return GasInflowEquation::GPP;
-
-    throw std::invalid_argument("Gas inflow equation type: " + stringValue + " not recognized");
-}
-
-
 bool Well::canOpen() const {
     if (this->allow_cross_flow)
         return true;

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1557,43 +1557,6 @@ void Well::setWellTemperature(const double temp) {
     this->well_temperature = temp;
 }
 
-Well::WELTARGCMode Well::WELTARGCModeFromString(const std::string& string_value) {
-    if (string_value == "ORAT")
-        return WELTARGCMode::ORAT;
-
-    if (string_value == "WRAT")
-        return WELTARGCMode::WRAT;
-
-    if (string_value == "GRAT")
-        return WELTARGCMode::GRAT;
-
-    if (string_value == "LRAT")
-        return WELTARGCMode::LRAT;
-
-    if (string_value == "CRAT")
-        return WELTARGCMode::CRAT;
-
-    if (string_value == "RESV")
-        return WELTARGCMode::RESV;
-
-    if (string_value == "BHP")
-        return WELTARGCMode::BHP;
-
-    if (string_value == "THP")
-        return WELTARGCMode::THP;
-
-    if (string_value == "VFP")
-        return WELTARGCMode::VFP;
-
-    if (string_value == "LIFT")
-        return WELTARGCMode::LIFT;
-
-    if (string_value == "GUID")
-        return WELTARGCMode::GUID;
-
-    throw std::invalid_argument("WELTARG control mode: " + string_value + " not recognized.");
-}
-
 const std::string Well::GuideRateTarget2String( GuideRateTarget enumValue ) {
     switch( enumValue ) {
     case GuideRateTarget::OIL:

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1594,66 +1594,6 @@ Well::WELTARGCMode Well::WELTARGCModeFromString(const std::string& string_value)
     throw std::invalid_argument("WELTARG control mode: " + string_value + " not recognized.");
 }
 
-
-std::ostream& operator<<(std::ostream& os, const Well::ProducerCMode& cm) {
-    if (cm == Well::ProducerCMode::CMODE_UNDEFINED)
-        os << "UNDEFINED";
-    else
-        os << Well::ProducerCMode2String(cm);
-    return os;
-}
-
-const std::string Well::ProducerCMode2String( ProducerCMode enumValue ) {
-    switch( enumValue ) {
-    case ProducerCMode::ORAT:
-        return "ORAT";
-    case ProducerCMode::WRAT:
-        return "WRAT";
-    case ProducerCMode::GRAT:
-        return "GRAT";
-    case ProducerCMode::LRAT:
-        return "LRAT";
-    case ProducerCMode::CRAT:
-        return "CRAT";
-    case ProducerCMode::RESV:
-        return "RESV";
-    case ProducerCMode::BHP:
-        return "BHP";
-    case ProducerCMode::THP:
-        return "THP";
-    case ProducerCMode::GRUP:
-        return "GRUP";
-    default:
-        throw std::invalid_argument("Unhandled enum value: " + std::to_string(static_cast<int>(enumValue)) + " in ProducerCMode2String");
-    }
-}
-
-Well::ProducerCMode Well::ProducerCModeFromString( const std::string& stringValue ) {
-    if (stringValue == "ORAT")
-        return ProducerCMode::ORAT;
-    else if (stringValue == "WRAT")
-        return ProducerCMode::WRAT;
-    else if (stringValue == "GRAT")
-        return ProducerCMode::GRAT;
-    else if (stringValue == "LRAT")
-        return ProducerCMode::LRAT;
-    else if (stringValue == "CRAT")
-        return ProducerCMode::CRAT;
-    else if (stringValue == "RESV")
-        return ProducerCMode::RESV;
-    else if (stringValue == "BHP")
-        return ProducerCMode::BHP;
-    else if (stringValue == "THP")
-        return ProducerCMode::THP;
-    else if (stringValue == "GRUP")
-        return ProducerCMode::GRUP;
-    else if (stringValue == "NONE")
-        return ProducerCMode::NONE;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue );
-}
-
-
 const std::string Well::GuideRateTarget2String( GuideRateTarget enumValue ) {
     switch( enumValue ) {
     case GuideRateTarget::OIL:

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1557,59 +1557,6 @@ void Well::setWellTemperature(const double temp) {
     this->well_temperature = temp;
 }
 
-const std::string Well::GuideRateTarget2String( GuideRateTarget enumValue ) {
-    switch( enumValue ) {
-    case GuideRateTarget::OIL:
-        return "OIL";
-    case GuideRateTarget::WAT:
-        return "WAT";
-    case GuideRateTarget::GAS:
-        return "GAS";
-    case GuideRateTarget::LIQ:
-        return "LIQ";
-    case GuideRateTarget::COMB:
-        return "COMB";
-    case GuideRateTarget::WGA:
-        return "WGA";
-    case GuideRateTarget::CVAL:
-        return "CVAL";
-    case GuideRateTarget::RAT:
-        return "RAT";
-    case GuideRateTarget::RES:
-        return "RES";
-    case GuideRateTarget::UNDEFINED:
-        return "UNDEFINED";
-    default:
-        throw std::invalid_argument("unhandled enum value");
-    }
-}
-
-Well::GuideRateTarget Well::GuideRateTargetFromString( const std::string& stringValue ) {
-    if (stringValue == "OIL")
-        return GuideRateTarget::OIL;
-    else if (stringValue == "WAT")
-        return GuideRateTarget::WAT;
-    else if (stringValue == "GAS")
-        return GuideRateTarget::GAS;
-    else if (stringValue == "LIQ")
-        return GuideRateTarget::LIQ;
-    else if (stringValue == "COMB")
-        return GuideRateTarget::COMB;
-    else if (stringValue == "WGA")
-        return GuideRateTarget::WGA;
-    else if (stringValue == "CVAL")
-        return GuideRateTarget::CVAL;
-    else if (stringValue == "RAT")
-        return GuideRateTarget::RAT;
-    else if (stringValue == "RES")
-        return GuideRateTarget::RES;
-    else if (stringValue == "UNDEFINED")
-        return GuideRateTarget::UNDEFINED;
-    else
-        throw std::invalid_argument("Unknown enum state string: " + stringValue );
-}
-
-
 bool Well::cmp_structure(const Well& other) const {
     if ((this->segments && !other.segments) ||
         (!this->segments && other.segments))

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -404,7 +404,7 @@ Well::Well(const RestartIO::RstWell& rst_well,
                 throw std::invalid_argument {
                     fmt::format("Unsupported control mode '{}' for "
                                 "history controlled injection well '{}'",
-                                Well::InjectorCMode2String(active_control), this->name())
+                                WellInjectorCMode2String(active_control), this->name())
                 };
             }
         }
@@ -1555,44 +1555,6 @@ double Well::temperature() const {
 }
 void Well::setWellTemperature(const double temp) {
     this->well_temperature = temp;
-}
-
-const std::string Well::InjectorCMode2String( InjectorCMode enumValue ) {
-    switch( enumValue ) {
-    case InjectorCMode::RESV:
-        return "RESV";
-    case InjectorCMode::RATE:
-        return "RATE";
-    case InjectorCMode::BHP:
-        return "BHP";
-    case InjectorCMode::THP:
-        return "THP";
-    case InjectorCMode::GRUP:
-        return "GRUP";
-    default:
-        throw std::invalid_argument("Unhandled enum value: " + std::to_string(static_cast<int>(enumValue)) + " in InjectorCMode2String");
-    }
-}
-
-
-Well::InjectorCMode Well::InjectorCModeFromString(const std::string &stringValue) {
-    if (stringValue == "RATE")
-        return InjectorCMode::RATE;
-    else if (stringValue == "RESV")
-        return InjectorCMode::RESV;
-    else if (stringValue == "BHP")
-        return InjectorCMode::BHP;
-    else if (stringValue == "THP")
-        return InjectorCMode::THP;
-    else if (stringValue == "GRUP")
-        return InjectorCMode::GRUP;
-    else
-        throw std::invalid_argument("Unknown control mode string: " + stringValue);
-}
-
-std::ostream& operator<<(std::ostream& os, const Well::InjectorCMode& cm) {
-    os << Well::InjectorCMode2String(cm);
-    return os;
 }
 
 Well::WELTARGCMode Well::WELTARGCModeFromString(const std::string& string_value) {

--- a/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
@@ -27,7 +27,7 @@ namespace Opm {
 
 std::string WellStatus2String(WellStatus enumValue)
 {
-    switch(enumValue) {
+    switch (enumValue) {
     case WellStatus::OPEN:
         return "OPEN";
     case WellStatus::SHUT:
@@ -58,6 +58,48 @@ WellStatus WellStatusFromString(const std::string& stringValue)
 std::ostream& operator<<(std::ostream& os, const WellStatus& st)
 {
     os << WellStatus2String(st);
+    return os;
+}
+
+std::string WellInjectorCMode2String(WellInjectorCMode enumValue)
+{
+    switch (enumValue) {
+    case WellInjectorCMode::RESV:
+        return "RESV";
+    case WellInjectorCMode::RATE:
+        return "RATE";
+    case WellInjectorCMode::BHP:
+        return "BHP";
+    case WellInjectorCMode::THP:
+        return "THP";
+    case WellInjectorCMode::GRUP:
+        return "GRUP";
+    default:
+        throw std::invalid_argument("Unhandled enum value: " +
+                                    std::to_string(static_cast<int>(enumValue))
+                                    + " in WellInjectorCMode2String");
+    }
+}
+
+WellInjectorCMode WellInjectorCModeFromString(const std::string &stringValue)
+{
+    if (stringValue == "RATE")
+        return WellInjectorCMode::RATE;
+    else if (stringValue == "RESV")
+        return WellInjectorCMode::RESV;
+    else if (stringValue == "BHP")
+        return WellInjectorCMode::BHP;
+    else if (stringValue == "THP")
+        return WellInjectorCMode::THP;
+    else if (stringValue == "GRUP")
+        return WellInjectorCMode::GRUP;
+    else
+        throw std::invalid_argument("Unknown control mode string: " + stringValue);
+}
+
+std::ostream& operator<<(std::ostream& os, const WellInjectorCMode& cm)
+{
+    os << WellInjectorCMode2String(cm);
     return os;
 }
 

--- a/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
@@ -204,4 +204,58 @@ WellWELTARGCMode WellWELTARGCModeFromString(const std::string& string_value)
     throw std::invalid_argument("WELTARG control mode: " + string_value + " not recognized.");
 }
 
+std::string WellGuideRateTarget2String(WellGuideRateTarget enumValue)
+{
+    switch (enumValue) {
+    case WellGuideRateTarget::OIL:
+        return "OIL";
+    case WellGuideRateTarget::WAT:
+        return "WAT";
+    case WellGuideRateTarget::GAS:
+        return "GAS";
+    case WellGuideRateTarget::LIQ:
+        return "LIQ";
+    case WellGuideRateTarget::COMB:
+        return "COMB";
+    case WellGuideRateTarget::WGA:
+        return "WGA";
+    case WellGuideRateTarget::CVAL:
+        return "CVAL";
+    case WellGuideRateTarget::RAT:
+        return "RAT";
+    case WellGuideRateTarget::RES:
+        return "RES";
+    case WellGuideRateTarget::UNDEFINED:
+        return "UNDEFINED";
+    default:
+        throw std::invalid_argument("unhandled enum value");
+    }
+}
+
+WellGuideRateTarget WellGuideRateTargetFromString(const std::string& stringValue)
+{
+    if (stringValue == "OIL")
+        return WellGuideRateTarget::OIL;
+    else if (stringValue == "WAT")
+        return WellGuideRateTarget::WAT;
+    else if (stringValue == "GAS")
+        return WellGuideRateTarget::GAS;
+    else if (stringValue == "LIQ")
+        return WellGuideRateTarget::LIQ;
+    else if (stringValue == "COMB")
+        return WellGuideRateTarget::COMB;
+    else if (stringValue == "WGA")
+        return WellGuideRateTarget::WGA;
+    else if (stringValue == "CVAL")
+        return WellGuideRateTarget::CVAL;
+    else if (stringValue == "RAT")
+        return WellGuideRateTarget::RAT;
+    else if (stringValue == "RES")
+        return WellGuideRateTarget::RES;
+    else if (stringValue == "UNDEFINED")
+        return WellGuideRateTarget::UNDEFINED;
+    else
+        throw std::invalid_argument("Unknown enum state string: " + stringValue );
+}
+
 }

--- a/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
@@ -76,8 +76,8 @@ std::string WellInjectorCMode2String(WellInjectorCMode enumValue)
         return "GRUP";
     default:
         throw std::invalid_argument("Unhandled enum value: " +
-                                    std::to_string(static_cast<int>(enumValue))
-                                    + " in WellInjectorCMode2String");
+                                    std::to_string(static_cast<int>(enumValue)) +
+                                    " in WellInjectorCMode2String");
     }
 }
 
@@ -100,6 +100,69 @@ WellInjectorCMode WellInjectorCModeFromString(const std::string &stringValue)
 std::ostream& operator<<(std::ostream& os, const WellInjectorCMode& cm)
 {
     os << WellInjectorCMode2String(cm);
+    return os;
+}
+
+std::string WellProducerCMode2String(WellProducerCMode enumValue)
+{
+    switch (enumValue) {
+    case WellProducerCMode::ORAT:
+        return "ORAT";
+    case WellProducerCMode::WRAT:
+        return "WRAT";
+    case WellProducerCMode::GRAT:
+        return "GRAT";
+    case WellProducerCMode::LRAT:
+        return "LRAT";
+    case WellProducerCMode::CRAT:
+        return "CRAT";
+    case WellProducerCMode::RESV:
+        return "RESV";
+    case WellProducerCMode::BHP:
+        return "BHP";
+    case WellProducerCMode::THP:
+        return "THP";
+    case WellProducerCMode::GRUP:
+        return "GRUP";
+    default:
+        throw std::invalid_argument("Unhandled enum value: " +
+                                    std::to_string(static_cast<int>(enumValue)) +
+                                    " in ProducerCMode2String");
+    }
+}
+
+WellProducerCMode WellProducerCModeFromString(const std::string& stringValue)
+{
+    if (stringValue == "ORAT")
+        return WellProducerCMode::ORAT;
+    else if (stringValue == "WRAT")
+        return WellProducerCMode::WRAT;
+    else if (stringValue == "GRAT")
+        return WellProducerCMode::GRAT;
+    else if (stringValue == "LRAT")
+        return WellProducerCMode::LRAT;
+    else if (stringValue == "CRAT")
+        return WellProducerCMode::CRAT;
+    else if (stringValue == "RESV")
+        return WellProducerCMode::RESV;
+    else if (stringValue == "BHP")
+        return WellProducerCMode::BHP;
+    else if (stringValue == "THP")
+        return WellProducerCMode::THP;
+    else if (stringValue == "GRUP")
+        return WellProducerCMode::GRUP;
+    else if (stringValue == "NONE")
+        return WellProducerCMode::NONE;
+    else
+        throw std::invalid_argument("Unknown enum state string: " + stringValue);
+}
+
+std::ostream& operator<<(std::ostream& os, const WellProducerCMode& cm)
+{
+    if (cm == WellProducerCMode::CMODE_UNDEFINED)
+        os << "UNDEFINED";
+    else
+        os << WellProducerCMode2String(cm);
     return os;
 }
 

--- a/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
@@ -166,4 +166,42 @@ std::ostream& operator<<(std::ostream& os, const WellProducerCMode& cm)
     return os;
 }
 
+WellWELTARGCMode WellWELTARGCModeFromString(const std::string& string_value)
+{
+    if (string_value == "ORAT")
+        return WellWELTARGCMode::ORAT;
+
+    if (string_value == "WRAT")
+        return WellWELTARGCMode::WRAT;
+
+    if (string_value == "GRAT")
+        return WellWELTARGCMode::GRAT;
+
+    if (string_value == "LRAT")
+        return WellWELTARGCMode::LRAT;
+
+    if (string_value == "CRAT")
+        return WellWELTARGCMode::CRAT;
+
+    if (string_value == "RESV")
+        return WellWELTARGCMode::RESV;
+
+    if (string_value == "BHP")
+        return WellWELTARGCMode::BHP;
+
+    if (string_value == "THP")
+        return WellWELTARGCMode::THP;
+
+    if (string_value == "VFP")
+        return WellWELTARGCMode::VFP;
+
+    if (string_value == "LIFT")
+        return WellWELTARGCMode::LIFT;
+
+    if (string_value == "GUID")
+        return WellWELTARGCMode::GUID;
+
+    throw std::invalid_argument("WELTARG control mode: " + string_value + " not recognized.");
+}
+
 }

--- a/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
@@ -1,0 +1,64 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
+
+#include <ostream>
+#include <stdexcept>
+
+namespace Opm {
+
+std::string WellStatus2String(WellStatus enumValue)
+{
+    switch(enumValue) {
+    case WellStatus::OPEN:
+        return "OPEN";
+    case WellStatus::SHUT:
+        return "SHUT";
+    case WellStatus::AUTO:
+        return "AUTO";
+    case WellStatus::STOP:
+        return "STOP";
+    default:
+        throw std::invalid_argument("unhandled enum value");
+    }
+}
+
+WellStatus WellStatusFromString(const std::string& stringValue)
+{
+    if (stringValue == "OPEN")
+        return WellStatus::OPEN;
+    else if (stringValue == "SHUT")
+        return WellStatus::SHUT;
+    else if (stringValue == "STOP")
+        return WellStatus::STOP;
+    else if (stringValue == "AUTO")
+        return WellStatus::AUTO;
+    else
+        throw std::invalid_argument("Unknown enum state string: " + stringValue );
+}
+
+std::ostream& operator<<(std::ostream& os, const WellStatus& st)
+{
+    os << WellStatus2String(st);
+    return os;
+}
+
+}

--- a/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellEnums.cpp
@@ -258,4 +258,37 @@ WellGuideRateTarget WellGuideRateTargetFromString(const std::string& stringValue
         throw std::invalid_argument("Unknown enum state string: " + stringValue );
 }
 
+std::string WellGasInflowEquation2String(WellGasInflowEquation enumValue)
+{
+    switch (enumValue) {
+    case WellGasInflowEquation::STD:
+        return "STD";
+    case WellGasInflowEquation::R_G:
+        return "R-G";
+    case WellGasInflowEquation::P_P:
+        return "P-P";
+    case WellGasInflowEquation::GPP:
+        return "GPP";
+    default:
+        throw std::invalid_argument("Unhandled enum value");
+    }
+}
+
+WellGasInflowEquation WellGasInflowEquationFromString(const std::string& stringValue)
+{
+    if (stringValue == "STD" || stringValue == "NO")
+        return WellGasInflowEquation::STD;
+
+    if (stringValue == "R-G" || stringValue == "YES")
+        return WellGasInflowEquation::R_G;
+
+    if (stringValue == "P-P")
+        return WellGasInflowEquation::P_P;
+
+    if (stringValue == "GPP")
+        return WellGasInflowEquation::GPP;
+
+    throw std::invalid_argument("Gas inflow equation type: " + stringValue + " not recognized");
+}
+
 }

--- a/src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -124,7 +124,7 @@ namespace Opm {
             this->dropInjectionControl(InjectorCMode::GRUP);
         {
             const std::string& cmodeString = record.getItem("CMODE").getTrimmedString(0);
-            InjectorCMode controlModeArg = InjectorCModeFromString( cmodeString );
+            InjectorCMode controlModeArg = WellInjectorCModeFromString(cmodeString);
             if (this->hasInjectionControl( controlModeArg))
                 this->controlMode = controlModeArg;
             else {
@@ -196,7 +196,7 @@ namespace Opm {
             this->THPH = record.getItem("THP").getSIDouble(0);
 
         const std::string& cmodeString = record.getItem("CMODE").getTrimmedString(0);
-        const InjectorCMode newControlMode = InjectorCModeFromString( cmodeString );
+        const InjectorCMode newControlMode = WellInjectorCModeFromString(cmodeString);
 
         if ( !(newControlMode == InjectorCMode::RATE || newControlMode == InjectorCMode::BHP) ) {
             const std::string msg = "Only RATE and BHP control are allowed for WCONINJH for well " + well_name;
@@ -287,7 +287,7 @@ namespace Opm {
             << "prediction mode: "  << wp.predictionMode << ", "
             << "injection ctrl: "   << wp.injectionControls << ", "
             << "injector type: "    << InjectorType2String(wp.injectorType) << ", "
-            << "control mode: "     << Well::InjectorCMode2String(wp.controlMode) << " , "
+            << "control mode: "     << WellInjectorCMode2String(wp.controlMode) << " , "
             << "rs/rv concentration: " << wp.rsRvInj << " }";
     }
 

--- a/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -133,7 +133,7 @@ namespace Opm {
         if (effectiveHistoryProductionControl(this->whistctl_cmode) )
             cmode = this->whistctl_cmode;
         else
-            cmode = ProducerCModeFromString( cmodeItem.getTrimmedString( 0 ) );
+            cmode = WellProducerCModeFromString(cmodeItem.getTrimmedString(0));
 
         // clearing the existing targets/limits
         clearControls();
@@ -159,7 +159,7 @@ namespace Opm {
 
 
 
-void Well::WellProductionProperties::handleWCONPROD(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type, const UnitSystem& unit_system_arg, const std::string& /* well */, const DeckRecord& record)
+    void Well::WellProductionProperties::handleWCONPROD(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type, const UnitSystem& unit_system_arg, const std::string& /* well */, const DeckRecord& record)
     {
         this->predictionMode = true;
         this->init_vfp(alq_type, unit_system_arg, record);
@@ -193,7 +193,7 @@ void Well::WellProductionProperties::handleWCONPROD(const std::optional<VFPProdT
         {
             const auto& cmodeItem = record.getItem("CMODE");
             if (cmodeItem.hasValue(0)) {
-                auto cmode = Well::ProducerCModeFromString( cmodeItem.getTrimmedString(0) );
+                auto cmode = WellProducerCModeFromString(cmodeItem.getTrimmedString(0));
 
                 if (this->hasProductionControl( cmode ))
                     this->controlMode = cmode;
@@ -345,7 +345,7 @@ void Well::WellProductionProperties::handleWCONHIST(const std::optional<VFPProdT
             << "THPH: "         << wp.THPH              << ", "
             << "VFP table: "    << wp.VFPTableNumber    << ", "
             << "ALQ: "          << wp.ALQValue          << ", "
-            << "WHISTCTL: "     << Well::ProducerCMode2String(wp.whistctl_cmode)    << ", "
+            << "WHISTCTL: "     << WellProducerCMode2String(wp.whistctl_cmode)    << ", "
             << "prediction: "   << wp.predictionMode    << " }";
     }
 

--- a/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -30,6 +30,7 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include "../eval_uda.hpp"
 

--- a/src/opm/input/eclipse/Schedule/eval_uda.hpp
+++ b/src/opm/input/eclipse/Schedule/eval_uda.hpp
@@ -22,21 +22,37 @@
 
 #include <string>
 
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
-#include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
-
 namespace Opm {
-class UDAvalue;
+
+enum class InjectorType;
+class UDAValue;
+enum class Phase;
 class SummaryState;
 class UnitSystem;
 
 namespace UDA {
 
-    double eval_well_uda(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined);
-    double eval_well_uda_rate(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined, InjectorType wellType, const UnitSystem& unitSystem);
+    double eval_well_uda(const UDAValue& value,
+                         const std::string& name,
+                         const SummaryState& st,
+                         double udq_undefined);
+    double eval_well_uda_rate(const UDAValue& value,
+                              const std::string& name,
+                              const SummaryState& st,
+                              double udq_undefined,
+                              InjectorType wellType,
+                              const UnitSystem& unitSystem);
 
-    double eval_group_uda(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined);
-    double eval_group_uda_rate(const UDAValue& value, const std::string& name, const SummaryState& st, double udq_undefined, Phase phase, const UnitSystem& unitSystem);
+    double eval_group_uda(const UDAValue& value,
+                          const std::string& name,
+                          const SummaryState& st,
+                          double udq_undefined);
+    double eval_group_uda_rate(const UDAValue& value,
+                               const std::string& name,
+                               const SummaryState& st,
+                               double udq_undefined,
+                               Phase phase,
+                               const UnitSystem& unitSystem);
 }
 
 }

--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -39,6 +39,7 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/output/eclipse/VectorItems/action.hpp>
 
 #include <algorithm>

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -27,6 +27,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>

--- a/src/opm/output/eclipse/AggregateGroupData.cpp
+++ b/src/opm/output/eclipse/AggregateGroupData.cpp
@@ -29,6 +29,7 @@
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -28,6 +28,7 @@
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Segment.hpp>
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>

--- a/src/opm/output/eclipse/AggregateUDQData.cpp
+++ b/src/opm/output/eclipse/AggregateUDQData.cpp
@@ -37,6 +37,8 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
 
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstring>

--- a/src/opm/output/eclipse/AggregateWellData.cpp
+++ b/src/opm/output/eclipse/AggregateWellData.cpp
@@ -354,7 +354,7 @@ namespace {
             default:
                 throw std::invalid_argument {
                     fmt::format("Unsupported guiderate phase '{}' for restart",
-                                Opm::Well::GuideRateTarget2String(grTarget))
+                                Opm::WellGuideRateTarget2String(grTarget))
                 };
             }
         }

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -36,6 +36,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>

--- a/src/opm/output/eclipse/RegionCache.cpp
+++ b/src/opm/output/eclipse/RegionCache.cpp
@@ -22,6 +22,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -322,7 +322,7 @@ namespace {
         }
 
         std::string shut_status(const context&, std::size_t, std::size_t) const {
-            return Opm::Well::Status2String(well.getStatus());
+            return Opm::WellStatus2String(well.getStatus());
         }
 
         std::string region_number(const context&, std::size_t, std::size_t) const {

--- a/src/opm/output/eclipse/report/WELSPECS.cpp
+++ b/src/opm/output/eclipse/report/WELSPECS.cpp
@@ -350,7 +350,7 @@ namespace {
         }
 
         std::string gas_inflow(const context&, std::size_t, std::size_t) const {
-            return Opm::Well::GasInflowEquation2String( well.gas_inflow_equation() );
+            return Opm::WellGasInflowEquation2String(well.gas_inflow_equation());
         }
     };
 

--- a/tests/msim/test_msim.cpp
+++ b/tests/msim/test_msim.cpp
@@ -43,6 +43,7 @@
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <tests/WorkArea.hpp>

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -37,6 +37,7 @@
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -45,6 +45,7 @@
 #include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Action/WGNames.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Schedule/Well/WList.hpp>

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -30,6 +30,7 @@
 #include <opm/input/eclipse/Deck/Deck.hpp>
 
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -34,6 +34,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 using namespace Opm;
 

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -30,13 +30,14 @@
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
+#include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateModel.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRate.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
-#include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -35,6 +35,7 @@
 #include <opm/input/eclipse/Schedule/CompletedCells.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleGrid.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 
 #include <opm/input/eclipse/Parser/Parser.hpp>

--- a/tests/parser/PAvgTests.cpp
+++ b/tests/parser/PAvgTests.cpp
@@ -25,6 +25,7 @@
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3055,57 +3055,57 @@ BOOST_AUTO_TEST_CASE(ProducerControlModeEnumLoop) {
 /*****************************************************************/
 
 BOOST_AUTO_TEST_CASE(GuideRatePhaseEnum2String) {
-    BOOST_CHECK_EQUAL( "OIL"  ,        Well::GuideRateTarget2String(Well::GuideRateTarget::OIL));
-    BOOST_CHECK_EQUAL( "WAT"  ,        Well::GuideRateTarget2String(Well::GuideRateTarget::WAT));
-    BOOST_CHECK_EQUAL( "GAS"  ,        Well::GuideRateTarget2String(Well::GuideRateTarget::GAS));
-    BOOST_CHECK_EQUAL( "LIQ"  ,        Well::GuideRateTarget2String(Well::GuideRateTarget::LIQ));
-    BOOST_CHECK_EQUAL( "COMB" ,        Well::GuideRateTarget2String(Well::GuideRateTarget::COMB));
-    BOOST_CHECK_EQUAL( "WGA"  ,        Well::GuideRateTarget2String(Well::GuideRateTarget::WGA));
-    BOOST_CHECK_EQUAL( "CVAL" ,        Well::GuideRateTarget2String(Well::GuideRateTarget::CVAL));
-    BOOST_CHECK_EQUAL( "RAT"  ,        Well::GuideRateTarget2String(Well::GuideRateTarget::RAT));
-    BOOST_CHECK_EQUAL( "RES"  ,        Well::GuideRateTarget2String(Well::GuideRateTarget::RES));
-    BOOST_CHECK_EQUAL( "UNDEFINED"  ,  Well::GuideRateTarget2String(Well::GuideRateTarget::UNDEFINED));
+    BOOST_CHECK_EQUAL( "OIL"  ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::OIL));
+    BOOST_CHECK_EQUAL( "WAT"  ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::WAT));
+    BOOST_CHECK_EQUAL( "GAS"  ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::GAS));
+    BOOST_CHECK_EQUAL( "LIQ"  ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::LIQ));
+    BOOST_CHECK_EQUAL( "COMB" ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::COMB));
+    BOOST_CHECK_EQUAL( "WGA"  ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::WGA));
+    BOOST_CHECK_EQUAL( "CVAL" ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::CVAL));
+    BOOST_CHECK_EQUAL( "RAT"  ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::RAT));
+    BOOST_CHECK_EQUAL( "RES"  ,        Opm::WellGuideRateTarget2String(Well::GuideRateTarget::RES));
+    BOOST_CHECK_EQUAL( "UNDEFINED"  ,  Opm::WellGuideRateTarget2String(Well::GuideRateTarget::UNDEFINED));
 }
 
 
 BOOST_AUTO_TEST_CASE(GuideRatePhaseEnumFromString) {
-    BOOST_CHECK_THROW( Well::GuideRateTargetFromString("XRAT") , std::invalid_argument );
-    BOOST_CHECK( Well::GuideRateTarget::OIL       == Well::GuideRateTargetFromString("OIL"));
-    BOOST_CHECK( Well::GuideRateTarget::WAT       == Well::GuideRateTargetFromString("WAT"));
-    BOOST_CHECK( Well::GuideRateTarget::GAS       == Well::GuideRateTargetFromString("GAS"));
-    BOOST_CHECK( Well::GuideRateTarget::LIQ       == Well::GuideRateTargetFromString("LIQ"));
-    BOOST_CHECK( Well::GuideRateTarget::COMB      == Well::GuideRateTargetFromString("COMB"));
-    BOOST_CHECK( Well::GuideRateTarget::WGA       == Well::GuideRateTargetFromString("WGA"));
-    BOOST_CHECK( Well::GuideRateTarget::CVAL      == Well::GuideRateTargetFromString("CVAL"));
-    BOOST_CHECK( Well::GuideRateTarget::RAT       == Well::GuideRateTargetFromString("RAT"));
-    BOOST_CHECK( Well::GuideRateTarget::RES       == Well::GuideRateTargetFromString("RES"));
-    BOOST_CHECK( Well::GuideRateTarget::UNDEFINED == Well::GuideRateTargetFromString("UNDEFINED"));
+    BOOST_CHECK_THROW( Opm::WellGuideRateTargetFromString("XRAT") , std::invalid_argument );
+    BOOST_CHECK( Well::GuideRateTarget::OIL       == Opm::WellGuideRateTargetFromString("OIL"));
+    BOOST_CHECK( Well::GuideRateTarget::WAT       == Opm::WellGuideRateTargetFromString("WAT"));
+    BOOST_CHECK( Well::GuideRateTarget::GAS       == Opm::WellGuideRateTargetFromString("GAS"));
+    BOOST_CHECK( Well::GuideRateTarget::LIQ       == Opm::WellGuideRateTargetFromString("LIQ"));
+    BOOST_CHECK( Well::GuideRateTarget::COMB      == Opm::WellGuideRateTargetFromString("COMB"));
+    BOOST_CHECK( Well::GuideRateTarget::WGA       == Opm::WellGuideRateTargetFromString("WGA"));
+    BOOST_CHECK( Well::GuideRateTarget::CVAL      == Opm::WellGuideRateTargetFromString("CVAL"));
+    BOOST_CHECK( Well::GuideRateTarget::RAT       == Opm::WellGuideRateTargetFromString("RAT"));
+    BOOST_CHECK( Well::GuideRateTarget::RES       == Opm::WellGuideRateTargetFromString("RES"));
+    BOOST_CHECK( Well::GuideRateTarget::UNDEFINED == Opm::WellGuideRateTargetFromString("UNDEFINED"));
 }
 
 
 
 BOOST_AUTO_TEST_CASE(GuideRatePhaseEnum2Loop) {
-    BOOST_CHECK( Well::GuideRateTarget::OIL        == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::OIL ) ));
-    BOOST_CHECK( Well::GuideRateTarget::WAT        == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::WAT ) ));
-    BOOST_CHECK( Well::GuideRateTarget::GAS        == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::GAS ) ));
-    BOOST_CHECK( Well::GuideRateTarget::LIQ        == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::LIQ ) ));
-    BOOST_CHECK( Well::GuideRateTarget::COMB       == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::COMB ) ));
-    BOOST_CHECK( Well::GuideRateTarget::WGA        == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::WGA ) ));
-    BOOST_CHECK( Well::GuideRateTarget::CVAL       == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::CVAL ) ));
-    BOOST_CHECK( Well::GuideRateTarget::RAT        == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::RAT ) ));
-    BOOST_CHECK( Well::GuideRateTarget::RES        == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::RES ) ));
-    BOOST_CHECK( Well::GuideRateTarget::UNDEFINED  == Well::GuideRateTargetFromString( Well::GuideRateTarget2String( Well::GuideRateTarget::UNDEFINED ) ));
+    BOOST_CHECK( Well::GuideRateTarget::OIL        == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::OIL ) ));
+    BOOST_CHECK( Well::GuideRateTarget::WAT        == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::WAT ) ));
+    BOOST_CHECK( Well::GuideRateTarget::GAS        == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::GAS ) ));
+    BOOST_CHECK( Well::GuideRateTarget::LIQ        == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::LIQ ) ));
+    BOOST_CHECK( Well::GuideRateTarget::COMB       == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::COMB ) ));
+    BOOST_CHECK( Well::GuideRateTarget::WGA        == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::WGA ) ));
+    BOOST_CHECK( Well::GuideRateTarget::CVAL       == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::CVAL ) ));
+    BOOST_CHECK( Well::GuideRateTarget::RAT        == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::RAT ) ));
+    BOOST_CHECK( Well::GuideRateTarget::RES        == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::RES ) ));
+    BOOST_CHECK( Well::GuideRateTarget::UNDEFINED  == Opm::WellGuideRateTargetFromString( Opm::WellGuideRateTarget2String( Well::GuideRateTarget::UNDEFINED ) ));
 
-    BOOST_CHECK_EQUAL( "OIL"        , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "OIL"  ) ));
-    BOOST_CHECK_EQUAL( "WAT"        , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "WAT"  ) ));
-    BOOST_CHECK_EQUAL( "GAS"        , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "GAS"  ) ));
-    BOOST_CHECK_EQUAL( "LIQ"        , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "LIQ"  ) ));
-    BOOST_CHECK_EQUAL( "COMB"       , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "COMB"  ) ));
-    BOOST_CHECK_EQUAL( "WGA"        , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "WGA"  ) ));
-    BOOST_CHECK_EQUAL( "CVAL"       , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "CVAL"  ) ));
-    BOOST_CHECK_EQUAL( "RAT"        , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "RAT"  ) ));
-    BOOST_CHECK_EQUAL( "RES"        , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "RES"  ) ));
-    BOOST_CHECK_EQUAL( "UNDEFINED"  , Well::GuideRateTarget2String(Well::GuideRateTargetFromString( "UNDEFINED"  ) ));
+    BOOST_CHECK_EQUAL( "OIL"        , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "OIL"  ) ));
+    BOOST_CHECK_EQUAL( "WAT"        , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "WAT"  ) ));
+    BOOST_CHECK_EQUAL( "GAS"        , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "GAS"  ) ));
+    BOOST_CHECK_EQUAL( "LIQ"        , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "LIQ"  ) ));
+    BOOST_CHECK_EQUAL( "COMB"       , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "COMB"  ) ));
+    BOOST_CHECK_EQUAL( "WGA"        , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "WGA"  ) ));
+    BOOST_CHECK_EQUAL( "CVAL"       , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "CVAL"  ) ));
+    BOOST_CHECK_EQUAL( "RAT"        , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "RAT"  ) ));
+    BOOST_CHECK_EQUAL( "RES"        , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "RES"  ) ));
+    BOOST_CHECK_EQUAL( "UNDEFINED"  , Opm::WellGuideRateTarget2String(Opm::WellGuideRateTargetFromString( "UNDEFINED"  ) ));
 
 }
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2968,33 +2968,33 @@ BOOST_AUTO_TEST_CASE(InjectorControlModeEnumLoop) {
 /*****************************************************************/
 
 BOOST_AUTO_TEST_CASE(InjectorStatusEnum2String) {
-    BOOST_CHECK_EQUAL( "OPEN",  Well::Status2String(Well::Status::OPEN));
-    BOOST_CHECK_EQUAL( "SHUT",  Well::Status2String(Well::Status::SHUT));
-    BOOST_CHECK_EQUAL( "AUTO",  Well::Status2String(Well::Status::AUTO));
-    BOOST_CHECK_EQUAL( "STOP",  Well::Status2String(Well::Status::STOP));
+    BOOST_CHECK_EQUAL( "OPEN",  Opm::WellStatus2String(Well::Status::OPEN));
+    BOOST_CHECK_EQUAL( "SHUT",  Opm::WellStatus2String(Well::Status::SHUT));
+    BOOST_CHECK_EQUAL( "AUTO",  Opm::WellStatus2String(Well::Status::AUTO));
+    BOOST_CHECK_EQUAL( "STOP",  Opm::WellStatus2String(Well::Status::STOP));
 }
 
 
 BOOST_AUTO_TEST_CASE(InjectorStatusEnumFromString) {
-    BOOST_CHECK_THROW( Well::StatusFromString("XXX") , std::invalid_argument );
-    BOOST_CHECK( Well::Status::OPEN == Well::StatusFromString("OPEN"));
-    BOOST_CHECK( Well::Status::AUTO == Well::StatusFromString("AUTO"));
-    BOOST_CHECK( Well::Status::SHUT == Well::StatusFromString("SHUT"));
-    BOOST_CHECK( Well::Status::STOP == Well::StatusFromString("STOP"));
+    BOOST_CHECK_THROW( Opm::WellStatusFromString("XXX") , std::invalid_argument );
+    BOOST_CHECK( Well::Status::OPEN == Opm::WellStatusFromString("OPEN"));
+    BOOST_CHECK( Well::Status::AUTO == Opm::WellStatusFromString("AUTO"));
+    BOOST_CHECK( Well::Status::SHUT == Opm::WellStatusFromString("SHUT"));
+    BOOST_CHECK( Well::Status::STOP == Opm::WellStatusFromString("STOP"));
 }
 
 
 
 BOOST_AUTO_TEST_CASE(InjectorStatusEnumLoop) {
-    BOOST_CHECK( Well::Status::OPEN == Well::StatusFromString( Well::Status2String( Well::Status::OPEN ) ));
-    BOOST_CHECK( Well::Status::AUTO == Well::StatusFromString( Well::Status2String( Well::Status::AUTO ) ));
-    BOOST_CHECK( Well::Status::SHUT == Well::StatusFromString( Well::Status2String( Well::Status::SHUT ) ));
-    BOOST_CHECK( Well::Status::STOP == Well::StatusFromString( Well::Status2String( Well::Status::STOP ) ));
+    BOOST_CHECK( Well::Status::OPEN == Opm::WellStatusFromString( Opm::WellStatus2String( Well::Status::OPEN ) ));
+    BOOST_CHECK( Well::Status::AUTO == Opm::WellStatusFromString( Opm::WellStatus2String( Well::Status::AUTO ) ));
+    BOOST_CHECK( Well::Status::SHUT == Opm::WellStatusFromString( Opm::WellStatus2String( Well::Status::SHUT ) ));
+    BOOST_CHECK( Well::Status::STOP == Opm::WellStatusFromString( Opm::WellStatus2String( Well::Status::STOP ) ));
 
-    BOOST_CHECK_EQUAL( "STOP", Well::Status2String(Well::StatusFromString(  "STOP" ) ));
-    BOOST_CHECK_EQUAL( "OPEN", Well::Status2String(Well::StatusFromString(  "OPEN" ) ));
-    BOOST_CHECK_EQUAL( "SHUT", Well::Status2String(Well::StatusFromString(  "SHUT" ) ));
-    BOOST_CHECK_EQUAL( "AUTO", Well::Status2String(Well::StatusFromString(  "AUTO" ) ));
+    BOOST_CHECK_EQUAL( "STOP", Opm::WellStatus2String(Opm::WellStatusFromString(  "STOP" ) ));
+    BOOST_CHECK_EQUAL( "OPEN", Opm::WellStatus2String(Opm::WellStatusFromString(  "OPEN" ) ));
+    BOOST_CHECK_EQUAL( "SHUT", Opm::WellStatus2String(Opm::WellStatusFromString(  "SHUT" ) ));
+    BOOST_CHECK_EQUAL( "AUTO", Opm::WellStatus2String(Opm::WellStatusFromString(  "AUTO" ) ));
 }
 
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2930,37 +2930,37 @@ BOOST_AUTO_TEST_CASE(TestInjectorEnumLoop) {
 /*****************************************************************/
 
 BOOST_AUTO_TEST_CASE(InjectorCOntrolMopdeEnum2String) {
-    BOOST_CHECK_EQUAL( "RATE"  , Well::InjectorCMode2String(Well::InjectorCMode::RATE));
-    BOOST_CHECK_EQUAL( "RESV"  , Well::InjectorCMode2String(Well::InjectorCMode::RESV));
-    BOOST_CHECK_EQUAL( "BHP"   , Well::InjectorCMode2String(Well::InjectorCMode::BHP));
-    BOOST_CHECK_EQUAL( "THP"   , Well::InjectorCMode2String(Well::InjectorCMode::THP));
-    BOOST_CHECK_EQUAL( "GRUP"  , Well::InjectorCMode2String(Well::InjectorCMode::GRUP));
+    BOOST_CHECK_EQUAL( "RATE"  , Opm::WellInjectorCMode2String(Well::InjectorCMode::RATE));
+    BOOST_CHECK_EQUAL( "RESV"  , Opm::WellInjectorCMode2String(Well::InjectorCMode::RESV));
+    BOOST_CHECK_EQUAL( "BHP"   , Opm::WellInjectorCMode2String(Well::InjectorCMode::BHP));
+    BOOST_CHECK_EQUAL( "THP"   , Opm::WellInjectorCMode2String(Well::InjectorCMode::THP));
+    BOOST_CHECK_EQUAL( "GRUP"  , Opm::WellInjectorCMode2String(Well::InjectorCMode::GRUP));
 }
 
 
 BOOST_AUTO_TEST_CASE(InjectorControlModeEnumFromString) {
-    BOOST_CHECK_THROW( Well::InjectorCModeFromString("XXX") , std::invalid_argument );
-    BOOST_CHECK( Well::InjectorCMode::RATE == Well::InjectorCModeFromString("RATE"));
-    BOOST_CHECK( Well::InjectorCMode::BHP  == Well::InjectorCModeFromString("BHP"));
-    BOOST_CHECK( Well::InjectorCMode::RESV == Well::InjectorCModeFromString("RESV"));
-    BOOST_CHECK( Well::InjectorCMode::THP  == Well::InjectorCModeFromString("THP"));
-    BOOST_CHECK( Well::InjectorCMode::GRUP == Well::InjectorCModeFromString("GRUP"));
+    BOOST_CHECK_THROW( Opm::WellInjectorCModeFromString("XXX") , std::invalid_argument );
+    BOOST_CHECK( Well::InjectorCMode::RATE == Opm::WellInjectorCModeFromString("RATE"));
+    BOOST_CHECK( Well::InjectorCMode::BHP  == Opm::WellInjectorCModeFromString("BHP"));
+    BOOST_CHECK( Well::InjectorCMode::RESV == Opm::WellInjectorCModeFromString("RESV"));
+    BOOST_CHECK( Well::InjectorCMode::THP  == Opm::WellInjectorCModeFromString("THP"));
+    BOOST_CHECK( Well::InjectorCMode::GRUP == Opm::WellInjectorCModeFromString("GRUP"));
 }
 
 
 
 BOOST_AUTO_TEST_CASE(InjectorControlModeEnumLoop) {
-    BOOST_CHECK( Well::InjectorCMode::RATE == Well::InjectorCModeFromString( Well::InjectorCMode2String( Well::InjectorCMode::RATE ) ));
-    BOOST_CHECK( Well::InjectorCMode::BHP  == Well::InjectorCModeFromString( Well::InjectorCMode2String( Well::InjectorCMode::BHP ) ));
-    BOOST_CHECK( Well::InjectorCMode::RESV == Well::InjectorCModeFromString( Well::InjectorCMode2String( Well::InjectorCMode::RESV ) ));
-    BOOST_CHECK( Well::InjectorCMode::THP  == Well::InjectorCModeFromString( Well::InjectorCMode2String( Well::InjectorCMode::THP ) ));
-    BOOST_CHECK( Well::InjectorCMode::GRUP == Well::InjectorCModeFromString( Well::InjectorCMode2String( Well::InjectorCMode::GRUP ) ));
+    BOOST_CHECK( Well::InjectorCMode::RATE == Opm::WellInjectorCModeFromString( Opm::WellInjectorCMode2String( Well::InjectorCMode::RATE ) ));
+    BOOST_CHECK( Well::InjectorCMode::BHP  == Opm::WellInjectorCModeFromString( Opm::WellInjectorCMode2String( Well::InjectorCMode::BHP ) ));
+    BOOST_CHECK( Well::InjectorCMode::RESV == Opm::WellInjectorCModeFromString( Opm::WellInjectorCMode2String( Well::InjectorCMode::RESV ) ));
+    BOOST_CHECK( Well::InjectorCMode::THP  == Opm::WellInjectorCModeFromString( Opm::WellInjectorCMode2String( Well::InjectorCMode::THP ) ));
+    BOOST_CHECK( Well::InjectorCMode::GRUP == Opm::WellInjectorCModeFromString( Opm::WellInjectorCMode2String( Well::InjectorCMode::GRUP ) ));
 
-    BOOST_CHECK_EQUAL( "THP"  , Well::InjectorCMode2String(Well::InjectorCModeFromString(  "THP" ) ));
-    BOOST_CHECK_EQUAL( "RATE" , Well::InjectorCMode2String(Well::InjectorCModeFromString(  "RATE" ) ));
-    BOOST_CHECK_EQUAL( "RESV" , Well::InjectorCMode2String(Well::InjectorCModeFromString(  "RESV" ) ));
-    BOOST_CHECK_EQUAL( "BHP"  , Well::InjectorCMode2String(Well::InjectorCModeFromString(  "BHP" ) ));
-    BOOST_CHECK_EQUAL( "GRUP" , Well::InjectorCMode2String(Well::InjectorCModeFromString(  "GRUP" ) ));
+    BOOST_CHECK_EQUAL( "THP"  , Opm::WellInjectorCMode2String(Opm::WellInjectorCModeFromString(  "THP" ) ));
+    BOOST_CHECK_EQUAL( "RATE" , Opm::WellInjectorCMode2String(Opm::WellInjectorCModeFromString(  "RATE" ) ));
+    BOOST_CHECK_EQUAL( "RESV" , Opm::WellInjectorCMode2String(Opm::WellInjectorCModeFromString(  "RESV" ) ));
+    BOOST_CHECK_EQUAL( "BHP"  , Opm::WellInjectorCMode2String(Opm::WellInjectorCModeFromString(  "BHP" ) ));
+    BOOST_CHECK_EQUAL( "GRUP" , Opm::WellInjectorCMode2String(Opm::WellInjectorCModeFromString(  "GRUP" ) ));
 }
 
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3002,53 +3002,53 @@ BOOST_AUTO_TEST_CASE(InjectorStatusEnumLoop) {
 /*****************************************************************/
 
 BOOST_AUTO_TEST_CASE(ProducerCOntrolMopdeEnum2String) {
-    BOOST_CHECK_EQUAL( "ORAT"  ,  Well::ProducerCMode2String(Well::ProducerCMode::ORAT));
-    BOOST_CHECK_EQUAL( "WRAT"  ,  Well::ProducerCMode2String(Well::ProducerCMode::WRAT));
-    BOOST_CHECK_EQUAL( "GRAT"  ,  Well::ProducerCMode2String(Well::ProducerCMode::GRAT));
-    BOOST_CHECK_EQUAL( "LRAT"  ,  Well::ProducerCMode2String(Well::ProducerCMode::LRAT));
-    BOOST_CHECK_EQUAL( "CRAT"  ,  Well::ProducerCMode2String(Well::ProducerCMode::CRAT));
-    BOOST_CHECK_EQUAL( "RESV"  ,  Well::ProducerCMode2String(Well::ProducerCMode::RESV));
-    BOOST_CHECK_EQUAL( "BHP"   ,  Well::ProducerCMode2String(Well::ProducerCMode::BHP));
-    BOOST_CHECK_EQUAL( "THP"   ,  Well::ProducerCMode2String(Well::ProducerCMode::THP));
-    BOOST_CHECK_EQUAL( "GRUP"  ,  Well::ProducerCMode2String(Well::ProducerCMode::GRUP));
+    BOOST_CHECK_EQUAL( "ORAT"  ,  Opm::WellProducerCMode2String(Well::ProducerCMode::ORAT));
+    BOOST_CHECK_EQUAL( "WRAT"  ,  Opm::WellProducerCMode2String(Well::ProducerCMode::WRAT));
+    BOOST_CHECK_EQUAL( "GRAT"  ,  Opm::WellProducerCMode2String(Well::ProducerCMode::GRAT));
+    BOOST_CHECK_EQUAL( "LRAT"  ,  Opm::WellProducerCMode2String(Well::ProducerCMode::LRAT));
+    BOOST_CHECK_EQUAL( "CRAT"  ,  Opm::WellProducerCMode2String(Well::ProducerCMode::CRAT));
+    BOOST_CHECK_EQUAL( "RESV"  ,  Opm::WellProducerCMode2String(Well::ProducerCMode::RESV));
+    BOOST_CHECK_EQUAL( "BHP"   ,  Opm::WellProducerCMode2String(Well::ProducerCMode::BHP));
+    BOOST_CHECK_EQUAL( "THP"   ,  Opm::WellProducerCMode2String(Well::ProducerCMode::THP));
+    BOOST_CHECK_EQUAL( "GRUP"  ,  Opm::WellProducerCMode2String(Well::ProducerCMode::GRUP));
 }
 
 
 BOOST_AUTO_TEST_CASE(ProducerControlModeEnumFromString) {
-    BOOST_CHECK_THROW( Well::ProducerCModeFromString("XRAT") , std::invalid_argument );
-    BOOST_CHECK( Well::ProducerCMode::ORAT   == Well::ProducerCModeFromString("ORAT"));
-    BOOST_CHECK( Well::ProducerCMode::WRAT   == Well::ProducerCModeFromString("WRAT"));
-    BOOST_CHECK( Well::ProducerCMode::GRAT   == Well::ProducerCModeFromString("GRAT"));
-    BOOST_CHECK( Well::ProducerCMode::LRAT   == Well::ProducerCModeFromString("LRAT"));
-    BOOST_CHECK( Well::ProducerCMode::CRAT   == Well::ProducerCModeFromString("CRAT"));
-    BOOST_CHECK( Well::ProducerCMode::RESV   == Well::ProducerCModeFromString("RESV"));
-    BOOST_CHECK( Well::ProducerCMode::BHP    == Well::ProducerCModeFromString("BHP" ));
-    BOOST_CHECK( Well::ProducerCMode::THP    == Well::ProducerCModeFromString("THP" ));
-    BOOST_CHECK( Well::ProducerCMode::GRUP   == Well::ProducerCModeFromString("GRUP"));
+    BOOST_CHECK_THROW( Opm::WellProducerCModeFromString("XRAT") , std::invalid_argument );
+    BOOST_CHECK( Well::ProducerCMode::ORAT   == Opm::WellProducerCModeFromString("ORAT"));
+    BOOST_CHECK( Well::ProducerCMode::WRAT   == Opm::WellProducerCModeFromString("WRAT"));
+    BOOST_CHECK( Well::ProducerCMode::GRAT   == Opm::WellProducerCModeFromString("GRAT"));
+    BOOST_CHECK( Well::ProducerCMode::LRAT   == Opm::WellProducerCModeFromString("LRAT"));
+    BOOST_CHECK( Well::ProducerCMode::CRAT   == Opm::WellProducerCModeFromString("CRAT"));
+    BOOST_CHECK( Well::ProducerCMode::RESV   == Opm::WellProducerCModeFromString("RESV"));
+    BOOST_CHECK( Well::ProducerCMode::BHP    == Opm::WellProducerCModeFromString("BHP" ));
+    BOOST_CHECK( Well::ProducerCMode::THP    == Opm::WellProducerCModeFromString("THP" ));
+    BOOST_CHECK( Well::ProducerCMode::GRUP   == Opm::WellProducerCModeFromString("GRUP"));
 }
 
 
 
 BOOST_AUTO_TEST_CASE(ProducerControlModeEnumLoop) {
-    BOOST_CHECK( Well::ProducerCMode::ORAT == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::ORAT ) ));
-    BOOST_CHECK( Well::ProducerCMode::WRAT == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::WRAT ) ));
-    BOOST_CHECK( Well::ProducerCMode::GRAT == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::GRAT ) ));
-    BOOST_CHECK( Well::ProducerCMode::LRAT == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::LRAT ) ));
-    BOOST_CHECK( Well::ProducerCMode::CRAT == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::CRAT ) ));
-    BOOST_CHECK( Well::ProducerCMode::RESV == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::RESV ) ));
-    BOOST_CHECK( Well::ProducerCMode::BHP  == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::BHP  ) ));
-    BOOST_CHECK( Well::ProducerCMode::THP  == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::THP  ) ));
-    BOOST_CHECK( Well::ProducerCMode::GRUP == Well::ProducerCModeFromString( Well::ProducerCMode2String( Well::ProducerCMode::GRUP ) ));
+    BOOST_CHECK( Well::ProducerCMode::ORAT == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::ORAT ) ));
+    BOOST_CHECK( Well::ProducerCMode::WRAT == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::WRAT ) ));
+    BOOST_CHECK( Well::ProducerCMode::GRAT == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::GRAT ) ));
+    BOOST_CHECK( Well::ProducerCMode::LRAT == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::LRAT ) ));
+    BOOST_CHECK( Well::ProducerCMode::CRAT == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::CRAT ) ));
+    BOOST_CHECK( Well::ProducerCMode::RESV == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::RESV ) ));
+    BOOST_CHECK( Well::ProducerCMode::BHP  == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::BHP  ) ));
+    BOOST_CHECK( Well::ProducerCMode::THP  == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::THP  ) ));
+    BOOST_CHECK( Well::ProducerCMode::GRUP == Opm::WellProducerCModeFromString( Opm::WellProducerCMode2String( Well::ProducerCMode::GRUP ) ));
 
-    BOOST_CHECK_EQUAL( "ORAT"      , Well::ProducerCMode2String(Well::ProducerCModeFromString( "ORAT"  ) ));
-    BOOST_CHECK_EQUAL( "WRAT"      , Well::ProducerCMode2String(Well::ProducerCModeFromString( "WRAT"  ) ));
-    BOOST_CHECK_EQUAL( "GRAT"      , Well::ProducerCMode2String(Well::ProducerCModeFromString( "GRAT"  ) ));
-    BOOST_CHECK_EQUAL( "LRAT"      , Well::ProducerCMode2String(Well::ProducerCModeFromString( "LRAT"  ) ));
-    BOOST_CHECK_EQUAL( "CRAT"      , Well::ProducerCMode2String(Well::ProducerCModeFromString( "CRAT"  ) ));
-    BOOST_CHECK_EQUAL( "RESV"      , Well::ProducerCMode2String(Well::ProducerCModeFromString( "RESV"  ) ));
-    BOOST_CHECK_EQUAL( "BHP"       , Well::ProducerCMode2String(Well::ProducerCModeFromString( "BHP"   ) ));
-    BOOST_CHECK_EQUAL( "THP"       , Well::ProducerCMode2String(Well::ProducerCModeFromString( "THP"   ) ));
-    BOOST_CHECK_EQUAL( "GRUP"      , Well::ProducerCMode2String(Well::ProducerCModeFromString( "GRUP"  ) ));
+    BOOST_CHECK_EQUAL( "ORAT"      , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "ORAT"  ) ));
+    BOOST_CHECK_EQUAL( "WRAT"      , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "WRAT"  ) ));
+    BOOST_CHECK_EQUAL( "GRAT"      , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "GRAT"  ) ));
+    BOOST_CHECK_EQUAL( "LRAT"      , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "LRAT"  ) ));
+    BOOST_CHECK_EQUAL( "CRAT"      , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "CRAT"  ) ));
+    BOOST_CHECK_EQUAL( "RESV"      , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "RESV"  ) ));
+    BOOST_CHECK_EQUAL( "BHP"       , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "BHP"   ) ));
+    BOOST_CHECK_EQUAL( "THP"       , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "THP"   ) ));
+    BOOST_CHECK_EQUAL( "GRUP"      , Opm::WellProducerCMode2String(Opm::WellProducerCModeFromString( "GRUP"  ) ));
 }
 
 /*******************************************************************/

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -27,6 +27,7 @@
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -40,6 +40,7 @@
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Parser/ErrorGuard.hpp>

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -28,6 +28,7 @@
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -29,6 +29,7 @@
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/SlgofTable.hpp>

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -31,6 +31,7 @@
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp>

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -39,6 +39,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
 

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -37,6 +37,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/common/utility/TimeService.hpp>
 
 #include <cstddef>

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -47,6 +47,7 @@
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -42,6 +42,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 
 #include <opm/input/eclipse/Units/Units.hpp>

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -45,6 +45,7 @@
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -48,6 +48,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -46,6 +46,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/common/utility/TimeService.hpp>

--- a/tests/test_restartwellinfo.cpp
+++ b/tests/test_restartwellinfo.cpp
@@ -32,6 +32,7 @@
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -45,6 +45,7 @@
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>


### PR DESCRIPTION
This enables forwarding in various places.

Reduce hotness of Well.hpp by 31% (64 files, 144 files instead of 208)