### PR TITLE
Add Numbered Item to UDQ Scalars

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
@@ -35,125 +35,485 @@ class UDQScalar
 {
 public:
     UDQScalar() = default;
-    explicit UDQScalar(double value);
-    explicit UDQScalar(const std::string& wgname);
 
+    /// Constructor
+    ///
+    /// Forms a UDQ scalar defined by its numeric value and, possibly, a
+    /// particular numbered item.
+    ///
+    /// \param[in] value Numeric value
+    /// \param[in] num Item number.
+    explicit UDQScalar(const double value, const std::size_t num = 0);
+
+    /// Constructor
+    ///
+    /// Forms a UDQ scalar attached to a particular name and, possibly, a
+    /// particular numbered item.
+    ///
+    /// \param[in] wgname Named well or group to which this scalar is
+    ///    associated.
+    ///
+    /// \param[in] num Item number.
+    explicit UDQScalar(const std::string& wgname, const std::size_t num = 0);
+
+    /// Add other UDQ scalar to this
+    ///
+    /// Result is defined if both this and other scalar are defined, and the
+    /// sum is a finite value.
+    ///
+    /// \param[in] rhs Other UDQ scalar.
     void operator+=(const UDQScalar& rhs);
+
+    /// Add numeric value to this UDQ scalar.
+    ///
+    /// Result is defined if \c *this is defined and the sum is a finite
+    /// value.
+    ///
+    /// \param[in] rhs Numeric value.
     void operator+=(double rhs);
+
+    /// Multiply UDQ scalar into this
+    ///
+    /// Result is defined if both this and other scalar are defined, and if
+    /// the product is a finite value.
+    ///
+    /// \param[in] rhs Other UDQ scalar.
     void operator*=(const UDQScalar& rhs);
+
+    /// Multiply numeric value into this
+    ///
+    /// Result is defined if \c *this is defined and the product is a finite
+    /// value.
+    ///
+    /// \param[in] rhs Numeric value.
     void operator*=(double rhs);
+
+    /// Divide this UDQ scalar by other
+    ///
+    /// Result is defined if both this and other scalar are defined, and the
+    /// quotient is a finite value.
+    ///
+    /// \param[in] rhs Other UDQ scalar.
     void operator/=(const UDQScalar& rhs);
+
+    /// Divide this UDQ scalar by numeric value
+    ///
+    /// Result is defined if \c *this is defined and the quotient is a
+    /// finite value.
+    ///
+    /// \param[in] rhs Numeric value.
     void operator/=(double rhs);
+
+    /// Subtract other UDQ scalar from this.
+    ///
+    /// Result is defined if both this and other scalar are defined, and if
+    /// the difference is a finite value.
+    ///
+    /// \param[in] rhs Other UDQ scalar.
     void operator-=(const UDQScalar& rhs);
+
+    /// Add other UDQ scalar to this
+    ///
+    /// Result is defined if \c *this is defined and the difference is a
+    /// finite value.
+    ///
+    /// \param[in] rhs Numeric value.
     void operator-=(double rhs);
 
+    /// Predicate for whether or not this UDQ scalar has a defined value
+    ///
+    /// \returns \code this->defined() \endcode.
     operator bool() const;
+
+    /// Assign numeric value to this UDQ scalar.
+    ///
+    /// \param[in] value Numeric value.  Empty optional or non-finite value
+    ///    makes this UDQ scalar undefined.
     void assign(const std::optional<double>& value);
+
+    /// Assign numeric value to this UDQ scalar.
+    ///
+    /// \param[in] value Numeric value.  Non-finite value makes this UDQ
+    ///    scalar undefined.
     void assign(double value);
+
+    /// Predicate for whether or not this UDQ scalar has a defined value.
     bool defined() const;
+
+    /// Retrive contained numeric value.
+    ///
+    /// Throws an exception unless this UDQ scalar has a defined value.
     double get() const;
-    const std::optional<double>& value() const;
-    const std::string& wgname() const;
+
+    /// Retrive contained numeric value.
+    ///
+    /// Empty optional unless this scalar has a defined value.
+    const std::optional<double>& value() const { return this->m_value; }
+
+    /// Retrive named well/group to which this scalar is associated.
+    const std::string& wgname() const { return this->m_wgname; }
+
+    /// Retrive numbered item, typically segment or connection, to which
+    /// this scalar is associated.
+    ///
+    /// Always zero for non-numbered UDQ scalars.
+    std::size_t number() const { return this->m_num; }
+
+    /// Equality predicate
+    ///
+    /// \param[in] UDQ scalar to which this scalar will be compared for
+    ///    equality.
     bool operator==(const UDQScalar& other) const;
 
 public:
-    std::optional<double> m_value;
-    std::string m_wgname;
+    /// Scalar value.
+    std::optional<double> m_value{};
+
+    /// Associated well/group name
+    std::string m_wgname{};
+
+    /// Numbered item.  Typically segment or connection.  Zero for
+    /// non-numbered items.
+    std::size_t m_num = 0;
 };
 
 
 class UDQSet
 {
 public:
+    // Connections and segments.
+    struct EnumeratedWellItems {
+        std::string well{};
+        std::vector<std::size_t> numbers{};
+    };
+
+    /// Construct empty, named UDQ set of specific variable type
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] var_type UDQ set's variable type.
     UDQSet(const std::string& name, UDQVarType var_type);
+
+    /// Construct named UDQ set of specific variable type for particular set
+    /// of well/group names.
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] var_type UDQ set's variable type.
+    ///
+    /// \param[in] wgnames Well or group names.
     UDQSet(const std::string& name, UDQVarType var_type, const std::vector<std::string>& wgnames);
+
+    /// Construct named UDQ set of specific variable type for numbered well
+    /// items-typically segments or connections.
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] var_type UDQ set's variable type.
+    ///
+    /// \param[in] items Enumerated entities for which this UDQ set is
+    ///    defined.  Typically represents a set of segments in an MS well or
+    ///    a set of well/reservoir connections.
+    UDQSet(const std::string& name, UDQVarType var_type, const std::vector<EnumeratedWellItems>& items);
+
+    /// Construct empty, named UDQ set of specific variable type
+    ///
+    /// \param[in] name UDQ set name
+    /// \param[in] var_type UDQ set's variable type.
     UDQSet(const std::string& name, UDQVarType var_type, std::size_t size);
+
+    /// Construct empty, named UDQ set of specific variable type
+    ///
+    /// \param[in] name UDQ set name
+    /// \param[in] var_type UDQ set's variable type.
     UDQSet(const std::string& name, std::size_t size);
 
+    /// Form a UDQ set pertaining to a single scalar value.
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] scalar_value Initial numeric value of this scalar set.
+    ///    Empty optional or non-finite contained value leaves the UDQ set
+    ///    undefined.
     static UDQSet scalar(const std::string& name, const std::optional<double>& scalar_value);
+
+    /// Form a UDQ set pertaining to a single scalar value.
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] scalar_value Initial numeric value of this scalar set.
+    ///    Non-finite value leaves the UDQ set undefined.
     static UDQSet scalar(const std::string& name, double value);
+
+    /// Form an empty UDQ set.
+    ///
+    /// \param[in] name UDQ set name
     static UDQSet empty(const std::string& name);
+
+    /// Form a UDQ set pertaining to a set of named wells
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] wells Collection of named wells.
     static UDQSet wells(const std::string& name, const std::vector<std::string>& wells);
+
+    /// Form a UDQ set pertaining to a set of named wells
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] wells Collection of named wells.
+    ///
+    /// \param[in] scalar_value Initial numeric value of every element of
+    ///    this UDQ set.  Non-finite value leaves the UDQ set elements
+    ///    undefined.
     static UDQSet wells(const std::string& name, const std::vector<std::string>& wells, double scalar_value);
+
+    /// Form a UDQ set pertaining to a set of named groups
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] wells Collection of named groups.
     static UDQSet groups(const std::string& name, const std::vector<std::string>& groups);
+
+    /// Form a UDQ set pertaining to a set of named groups
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] groups Collection of named groups.
+    ///
+    /// \param[in] scalar_value Initial numeric value of every element of
+    ///    this UDQ set.  Non-finite value leaves the UDQ set elements
+    ///    undefined.
     static UDQSet groups(const std::string& name, const std::vector<std::string>& groups, double scalar_value);
+
+    /// Form a UDQ set at the field level
+    ///
+    /// \param[in] name UDQ set name
+    ///
+    /// \param[in] scalar_value Initial numeric value of every element of
+    ///    this UDQ set.  Non-finite value leaves the UDQ set element
+    ///    undefined.
     static UDQSet field(const std::string& name, double scalar_value);
 
+    /// Assign value to every element of the UDQ set
+    ///
+    /// \param[in] value Numeric value for each element.  Empty optional
+    ///    removes element from UDQ set.
     void assign(const std::optional<double>& value);
+
+    /// Assign value to specific element of the UDQ set
+    ///
+    /// \param[in] index Linear index into UDQ set.  Must be in the range
+    ///    0..size()-1 inclusive.
+    ///
+    /// \param[in] value Numeric value of specific UDQ set element.  Empty
+    ///    optional removes element from UDQ set.
+    void assign(std::size_t index, const std::optional<double>& value);
+
+    /// Assign value to specific element of the UDQ set
+    ///
+    /// \param[in] wgname Named element of UDQ set defined for wells/groups.
+    ///
+    /// \param[in] value Numeric value of specific UDQ set element.  Empty
+    ///    optional removes element from UDQ set.
     void assign(const std::string& wgname, const std::optional<double>& value);
 
+    /// Assign value to specific element of the UDQ set
+    ///
+    /// \param[in] wgname Named element of UDQ set defined for wells.
+    ///
+    /// \param[in] number Numbered sub-element of named UDQ set element
+    ///    referred to by \p wgname.
+    ///
+    /// \param[in] value Numeric value of specific UDQ set element.  Empty
+    ///    optional removes element from UDQ set.
+    void assign(const std::string& wgname, std::size_t number, const std::optional<double>& value);
+
+    /// Assign value to every element of the UDQ set
+    ///
+    /// \param[in] value Numeric value for each element.  Non-finite numeric
+    ///    value removes element from UDQ set.
     void assign(double value);
+
+    /// Assign value to specific element of the UDQ set
+    ///
+    /// \param[in] index Linear index into UDQ set.  Must be in the range
+    ///    0..size()-1 inclusive.
+    ///
+    /// \param[in] value Numeric value of specific UDQ set element.
+    ///    Non-finite numeric value removes element from UDQ set.
     void assign(std::size_t index, double value);
+
+    /// Assign value to specific element of the UDQ set
+    ///
+    /// \param[in] wgname Named element of UDQ set defined for wells/groups.
+    ///
+    /// \param[in] value Numeric value of specific UDQ set element.
+    ///    Non-finite numeric value removes element from UDQ set.
     void assign(const std::string& wgname, double value);
 
+    /// Predicate for whether or not named UDQ element exists.
     bool has(const std::string& name) const;
+
+    /// Number of elements in UDQ set.  Undefined elements counted the same
+    /// as defined elements.
     std::size_t size() const;
 
+    /// Add other UDQ set into this
+    ///
+    /// Defined elements in result is intersection of defined elements in \c
+    /// *this and \p rhs.
+    ///
+    /// \param[in] rhs Other UDQ set.
     void operator+=(const UDQSet& rhs);
+
+    /// Add numeric value to all defined elements of this UDQ set.
+    ///
+    /// \param[in] rhs Numeric value.
     void operator+=(double rhs);
+
+    /// Subtract UDQ set from this
+    ///
+    /// Defined elements in result is intersection of defined elements in \c
+    /// *this and \p rhs.
+    ///
+    /// \param[in] rhs Other UDQ set.
     void operator-=(const UDQSet& rhs);
+
+    /// Subtract numeric values from all defined elements of this UDQ set.
+    ///
+    /// \param[in] rhs Numeric value.
     void operator-=(double rhs);
+
+    /// Multiply other UDQ set into this.
+    ///
+    /// Defined elements in result is intersection of defined elements in \c
+    /// *this and \p rhs.  Multiplication is performed per element.
+    ///
+    /// \param[in] rhs Other UDQ set.
     void operator*=(const UDQSet& rhs);
+
+    /// Multiply every defined element with numeric element
+    ///
+    /// \param[in] rhs Numeric value.
     void operator*=(double rhs);
+
+    /// Divide this UDQ set by other UDQ set.
+    ///
+    /// Defined elements in result is intersection of defined elements in \c
+    /// *this and \p rhs.  Division is performed per element.
+    ///
+    /// \param[in] rhs Other UDQ set.
     void operator/=(const UDQSet& rhs);
+
+    /// Divide every defined element with numeric element
+    ///
+    /// \param[in] rhs Numeric value.
     void operator/=(double rhs);
 
+    /// Access individual UDQ scalar at particular index in UDQ set.
+    ///
+    /// \param[in] index Linear index into UDQ set.  Must be in the range
+    ///    0..size()-1 inclusive.  Indexing operator throws an exception if
+    ///    the index is out of bounds.
     const UDQScalar& operator[](std::size_t index) const;
+
+    /// Access individual UDQ scalar assiociated to particular named entity
+    /// (well or group).
+    ///
+    /// \param[in] wgname Named entity.  Indexing operator throws an
+    ///    exception if no element exists for this named entity.
     const UDQScalar& operator[](const std::string& wgname) const;
+
+    /// Access individual UDQ scalar assiociated to particular named well
+    /// and numbered sub-entity of that named well.
+    ///
+    /// \param[in] well Well name.  Indexing operator throws an
+    ///    exception if no element exists for this named well.
+    ///
+    /// \param[in] item Numbered sub-entity of named well.  Typically a
+    ///    segment or connection number.  Indexing operator throws an
+    ///    exception if no element exists for the numbered sub-entity of
+    ///    this well.
+    const UDQScalar& operator()(const std::string& well, const std::size_t item) const;
+
+    /// Range-for traversal support (beginning of range)
     std::vector<UDQScalar>::const_iterator begin() const;
+
+    /// Range-for traversal support (one past end of range)
     std::vector<UDQScalar>::const_iterator end() const;
 
+    /// Retrive names of entities associate to this UDQ set.
     std::vector<std::string> wgnames() const;
+
+    /// Retrive the UDQ set's defined values only
     std::vector<double> defined_values() const;
+
+    /// Retrive the UDQ set's number of defined values
     std::size_t defined_size() const;
+
+    /// Retrive the name of this UDQ set
     const std::string& name() const;
+
+    /// Assign the name of this UDQ set
     void name(const std::string& name);
+
+    /// Retrive the variable type of this UDQ set (e.g., well, group, field,
+    /// segment &c).
     UDQVarType var_type() const;
+
+    /// Equality comparison operator.
+    ///
+    /// \param[in] other UDQ set to which this set will be compared for equality.
     bool operator==(const UDQSet& other) const;
 
 private:
-    UDQSet() = default;
-
+    /// UDQ set name
     std::string m_name;
+
+    /// UDQ set's variable type
     UDQVarType m_var_type = UDQVarType::NONE;
+
+    /// UDQ set's element values.
     std::vector<UDQScalar> values;
+
+    /// Default constructor.  For implementing the named constructors only.
+    UDQSet() = default;
 };
 
 
-UDQScalar operator+(const UDQScalar&lhs, const UDQScalar& rhs);
-UDQScalar operator+(const UDQScalar&lhs, double rhs);
+UDQScalar operator+(const UDQScalar& lhs, const UDQScalar& rhs);
+UDQScalar operator+(const UDQScalar& lhs, double rhs);
 UDQScalar operator+(double lhs, const UDQScalar& rhs);
 
-UDQScalar operator-(const UDQScalar&lhs, const UDQScalar& rhs);
-UDQScalar operator-(const UDQScalar&lhs, double rhs);
+UDQScalar operator-(const UDQScalar& lhs, const UDQScalar& rhs);
+UDQScalar operator-(const UDQScalar& lhs, double rhs);
 UDQScalar operator-(double lhs, const UDQScalar& rhs);
 
-UDQScalar operator*(const UDQScalar&lhs, const UDQScalar& rhs);
-UDQScalar operator*(const UDQScalar&lhs, double rhs);
+UDQScalar operator*(const UDQScalar& lhs, const UDQScalar& rhs);
+UDQScalar operator*(const UDQScalar& lhs, double rhs);
 UDQScalar operator*(double lhs, const UDQScalar& rhs);
 
-UDQScalar operator/(const UDQScalar&lhs, const UDQScalar& rhs);
-UDQScalar operator/(const UDQScalar&lhs, double rhs);
+UDQScalar operator/(const UDQScalar& lhs, const UDQScalar& rhs);
+UDQScalar operator/(const UDQScalar& lhs, double rhs);
 UDQScalar operator/(double lhs, const UDQScalar& rhs);
 
-UDQSet operator+(const UDQSet&lhs, const UDQSet& rhs);
-UDQSet operator+(const UDQSet&lhs, double rhs);
+UDQSet operator+(const UDQSet& lhs, const UDQSet& rhs);
+UDQSet operator+(const UDQSet& lhs, double rhs);
 UDQSet operator+(double lhs, const UDQSet& rhs);
 
-UDQSet operator-(const UDQSet&lhs, const UDQSet& rhs);
-UDQSet operator-(const UDQSet&lhs, double rhs);
+UDQSet operator-(const UDQSet& lhs, const UDQSet& rhs);
+UDQSet operator-(const UDQSet& lhs, double rhs);
 UDQSet operator-(double lhs, const UDQSet& rhs);
 
-UDQSet operator*(const UDQSet&lhs, const UDQSet& rhs);
-UDQSet operator*(const UDQSet&lhs, double rhs);
+UDQSet operator*(const UDQSet& lhs, const UDQSet& rhs);
+UDQSet operator*(const UDQSet& lhs, double rhs);
 UDQSet operator*(double lhs, const UDQSet& rhs);
 
-UDQSet operator/(const UDQSet&lhs, const UDQSet& rhs);
-UDQSet operator/(const UDQSet&lhs, double rhs);
+UDQSet operator/(const UDQSet& lhs, const UDQSet& rhs);
+UDQSet operator/(const UDQSet& lhs, double rhs);
 UDQSet operator/(double lhs, const UDQSet&rhs);
 
-}
+} // namespace Opm
 
-
-
-#endif
+#endif  // UDQSET_HPP

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQState.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQState.cpp
@@ -17,201 +17,355 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-#include <stdexcept>
-
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
+
 #include <opm/io/eclipse/rst/state.hpp>
 
-namespace Opm {
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <unordered_map>
+
+#include <fmt/format.h>
 
 namespace {
 
-bool is_udq(const std::string& key) {
-    if (key.size() < 2)
-        return false;
+template <typename K, typename V>
+using UMap = std::unordered_map<K, V>;
 
-    if (key[1] != 'U')
-        return false;
+template <typename V>
+using SMap = UMap<std::string, V>;
 
-    return true;
+template <typename T>
+using S2Map = SMap<SMap<T>>;
+
+template <typename K, typename V>
+using SKMap = SMap<UMap<K, V>>;
+
+template <typename K, typename V>
+using S2KMap = S2Map<UMap<K, V>>;
+
+bool is_udq(const std::string& key)
+{
+    return (key.size() >= std::string::size_type{2})
+        && (key[1] == 'U');
 }
 
-bool has_var(const std::unordered_map<std::string, std::unordered_map<std::string, double>>& values,
-             const std::string& wgname,
-             const std::string udq_key) {
+bool has_var(const S2Map<double>& values,
+             const std::string&   wgname,
+             const std::string&   udq_key)
+{
     auto res_iter = values.find(udq_key);
-    if (res_iter == values.end())
-        return false;
-
-    return res_iter->second.count(wgname);
+    return (res_iter != values.end())
+        && (res_iter->second.count(wgname) > 0);
 }
 
-void add_results(std::unordered_map<std::string, std::unordered_map<std::string, double>>& values,
-                 const std::string& udq_key,
-                 const UDQSet& result) {
+void undefine_results(const Opm::UDQScalar& result,
+                      SMap<double>&         values)
+{
+    values.erase(result.wgname());
+}
 
+void undefine_results(const Opm::UDQScalar&       result,
+                      SKMap<std::size_t, double>& values)
+{
+    auto wellPos = values.find(result.wgname());
+    if (wellPos == values.end()) {
+        // No results for this well.  Nothing to do.
+        return;
+    }
+
+    wellPos->second.erase(result.number());
+}
+
+void add_defined_results(const Opm::UDQScalar& result,
+                         SMap<double>&         values)
+{
+    values.insert_or_assign(result.wgname(), result.get());
+}
+
+void add_defined_results(const Opm::UDQScalar&       result,
+                         SKMap<std::size_t, double>& values)
+{
+    auto wellPos = values.find(result.wgname());
+    if (wellPos == values.end()) {
+        values.insert_or_assign(result.wgname(), std::unordered_map<std::size_t, double>
+                                {{ result.number(), result.get() }});
+
+        return;
+    }
+
+    wellPos->second.insert_or_assign(result.number(), result.get());
+}
+
+void add_results(const std::string& udq_key,
+                 const Opm::UDQSet& result,
+                 S2Map<double>&     values)
+{
     auto& udq_values = values[udq_key];
     for (const auto& res1 : result) {
-        auto iter = udq_values.find(res1.wgname());
-        if (iter == udq_values.end()) {
-            if (res1.defined())
-                udq_values.emplace( res1.wgname(), res1.get() );
-        } else {
-            if (res1.defined())
-                iter->second = res1.get();
-            else
-                udq_values.erase(iter);
+        if (! res1.defined()) {
+            undefine_results(res1, udq_values);
+        }
+        else {
+            add_defined_results(res1, udq_values);
         }
     }
 }
 
-double get_scalar(const std::unordered_map<std::string, double>& values,
-                  const std::string& udq_key,
-                  double undef_value) {
+void add_results(const std::string&           udq_key,
+                 const Opm::UDQSet&           result,
+                 S2KMap<std::size_t, double>& values)
+{
+    auto& udq_values = values[udq_key];
+    for (const auto& res1 : result) {
+        if (! res1.defined()) {
+            undefine_results(res1, udq_values);
+        }
+        else {
+            add_defined_results(res1, udq_values);
+        }
+    }
+}
+
+double get_scalar(const SMap<double>& values,
+                  const std::string&  udq_key,
+                  const double        undef_value)
+{
     auto iter = values.find(udq_key);
-    if (iter == values.end())
+    if (iter == values.end()) {
         return undef_value;
+    }
+
     return iter->second;
 }
 
-
-double get_wg(const std::unordered_map<std::string, std::unordered_map<std::string, double>>& values,
-              const std::string& wgname,
-              const std::string& udq_key,
-              double undef_value) {
-
+double get_wg(const S2Map<double>& values,
+              const std::string&   wgname,
+              const std::string&   udq_key,
+              const double         undef_value)
+{
     auto res_iter = values.find(udq_key);
     if (res_iter == values.end()) {
-        if (is_udq(udq_key))
+        if (is_udq(udq_key)) {
             throw std::out_of_range("No such UDQ variable: " + udq_key);
-        else
+        }
+        else {
             throw std::logic_error("No such UDQ variable: " + udq_key);
+        }
     }
-    const auto& result_set = res_iter->second;
-    return get_scalar(result_set, wgname, undef_value);
+
+    return get_scalar(res_iter->second, wgname, undef_value);
 }
 
-}
+} // Anonymous namespace
 
-void UDQState::load_rst(const RestartIO::RstState& rst_state) {
+namespace Opm {
+
+void UDQState::load_rst(const RestartIO::RstState& rst_state)
+{
     for (const auto& udq : rst_state.udqs) {
         if (udq.is_define()) {
             if (udq.var_type == UDQVarType::WELL_VAR) {
-                for (const auto& [wname, value] : udq.values())
-                    this->well_values[udq.name][wname] = value;
+                auto& values = this->well_values[udq.name];
+                for (const auto& [wname, value] : udq.values()) {
+                    values.insert_or_assign(wname, value);
+                }
             }
 
             if (udq.var_type == UDQVarType::GROUP_VAR) {
-                for (const auto& [gname, value] : udq.values())
-                    this->group_values[udq.name][gname] = value;
+                auto& values = this->group_values[udq.name];
+                for (const auto& [gname, value] : udq.values()) {
+                    values.insert_or_assign(gname, value);
+                }
             }
 
-            const auto& field_value = udq.field_value();
-            if (field_value.has_value())
+            if (const auto& field_value = udq.field_value(); field_value.has_value()) {
                 this->scalar_values[udq.name] = field_value.value();
-        } else {
-            auto value = udq.assign_value();
-            if (udq.var_type == UDQVarType::WELL_VAR) {
-                for (const auto& wname : udq.assign_selector())
-                    this->well_values[udq.name][wname] = value;
+            }
+        }
+        else {
+            const auto value = udq.assign_value();
+
+            if ((udq.var_type == UDQVarType::WELL_VAR) &&
+                ! udq.assign_selector().empty())
+            {
+                auto& values = this->well_values[udq.name];
+                for (const auto& wname : udq.assign_selector()) {
+                    values.insert_or_assign(wname, value);
+                }
             }
 
             if (udq.var_type == UDQVarType::GROUP_VAR) {
-                for (const auto& gname : udq.assign_selector())
-                    this->group_values[udq.name][gname] = value;
+                auto& values = this->group_values[udq.name];
+                for (const auto& gname : udq.assign_selector()) {
+                    values.insert_or_assign(gname, value);
+                }
             }
 
-            if (udq.var_type == UDQVarType::FIELD_VAR)
+            if (udq.var_type == UDQVarType::FIELD_VAR) {
                 this->scalar_values[udq.name] = value;
+            }
         }
     }
 }
 
-double UDQState::undefined_value() const {
+double UDQState::undefined_value() const
+{
     return this->undef_value;
 }
 
-
-UDQState::UDQState(double undefined) :
-    undef_value(undefined)
+UDQState::UDQState(double undefined)
+    : undef_value(undefined)
 {}
 
-bool UDQState::has(const std::string& key)  const {
+bool UDQState::has(const std::string& key) const
+{
     return this->scalar_values.count(key);
 }
 
-
-
-bool UDQState::has_well_var(const std::string& well, const std::string& key) const {
-    return has_var( this->well_values, well, key);
+bool UDQState::has_well_var(const std::string& well, const std::string& key) const
+{
+    return has_var(this->well_values, well, key);
 }
 
-bool UDQState::has_group_var(const std::string& group, const std::string& key) const {
-    return has_var( this->group_values, group, key);
+bool UDQState::has_group_var(const std::string& group, const std::string& key) const
+{
+    return has_var(this->group_values, group, key);
 }
 
+bool UDQState::has_segment_var(const std::string& well,
+                               const std::string& key,
+                               const std::size_t  segment) const
+{
+    auto varPos = this->segment_values.find(key);
+    if (varPos == this->segment_values.end()) {
+        return false;
+    }
 
-void UDQState::add(const std::string& udq_key, const UDQSet& result) {
-    if (!is_udq(udq_key))
-        throw std::logic_error("Key is not a UDQ variable:" + udq_key);
+    auto wellPos = varPos->second.find(well);
+    if (wellPos == varPos->second.end()) {
+        return false;
+    }
 
-    auto var_type = result.var_type();
-    if (var_type == UDQVarType::WELL_VAR)
-        add_results(this->well_values, udq_key, result);
-    else if (var_type == UDQVarType::GROUP_VAR)
-        add_results(this->group_values, udq_key, result);
-    else {
-        auto scalar = result[0];
-        auto iter = this->scalar_values.find(udq_key);
-        if (iter == this->scalar_values.end()) {
-            if (scalar.defined())
-                this->scalar_values.emplace(udq_key, scalar.get());
-        } else {
-            if (scalar.defined())
-                iter->second = scalar.get();
-            else
-                this->scalar_values.erase(iter);
+    return wellPos->second.find(segment) != wellPos->second.end();
+}
+
+void UDQState::add(const std::string& udq_key, const UDQSet& result)
+{
+    if (!is_udq(udq_key)) {
+        throw std::logic_error {
+            fmt::format("{} is not a UDQ variable", udq_key)
+        };
+    }
+
+    switch (result.var_type()) {
+    case UDQVarType::WELL_VAR:
+        add_results(udq_key, result, this->well_values);
+        break;
+
+    case UDQVarType::GROUP_VAR:
+        add_results(udq_key, result, this->group_values);
+        break;
+
+    case UDQVarType::SEGMENT_VAR:
+        add_results(udq_key, result, this->segment_values);
+        break;
+
+    default:
+        // Scalar
+        if (const auto& scalar = result[0]; scalar.defined()) {
+            this->scalar_values.insert_or_assign(udq_key, scalar.get());
         }
+        else {
+            this->scalar_values.erase(udq_key);
+        }
+        break;
     }
 }
 
-
-void UDQState::add_define(std::size_t report_step, const std::string& udq_key, const UDQSet& result) {
+void UDQState::add_define(std::size_t report_step, const std::string& udq_key, const UDQSet& result)
+{
     this->defines[udq_key] = report_step;
     this->add(udq_key, result);
 }
 
-void UDQState::add_assign(std::size_t report_step, const std::string& udq_key, const UDQSet& result) {
+void UDQState::add_assign(std::size_t report_step, const std::string& udq_key, const UDQSet& result)
+{
     this->assignments[udq_key] = report_step;
     this->add(udq_key, result);
 }
 
-double UDQState::get(const std::string& key) const {
-    if (!is_udq(key))
+double UDQState::get(const std::string& key) const
+{
+    if (!is_udq(key)) {
         throw std::logic_error("Key is not a UDQ variable:" + key);
+    }
 
     auto iter = this->scalar_values.find(key);
     if (iter == this->scalar_values.end())
         throw std::out_of_range("Invalid key: " + key);
+
     return iter->second;
 }
 
-double UDQState::get_well_var(const std::string& well, const std::string& key) const {
-    return get_wg(this->well_values, well, key, this->undef_value);
-}
-
-double UDQState::get_group_var(const std::string& group, const std::string& key) const {
+double UDQState::get_group_var(const std::string& group, const std::string& key) const
+{
     return get_wg(this->group_values, group, key, this->undef_value);
 }
 
-bool UDQState::operator==(const UDQState& other) const {
-    return this->undef_value == other.undef_value &&
-           this->scalar_values == other.scalar_values &&
-           this->group_values == other.group_values &&
-           this->well_values == other.well_values &&
-           this->assignments == other.assignments &&
-           this->defines == other.defines;
+double UDQState::get_well_var(const std::string& well, const std::string& key) const
+{
+    return get_wg(this->well_values, well, key, this->undef_value);
+}
+
+double UDQState::get_segment_var(const std::string& well,
+                                 const std::string& var,
+                                 const std::size_t  segment) const
+{
+    if (! is_udq(var)) {
+        throw std::logic_error {
+            fmt::format("Cannot evaluate non-UDQ variable '{}'", var)
+        };
+    }
+
+    auto varPos = this->segment_values.find(var);
+    if (varPos == this->segment_values.end()) {
+        throw std::out_of_range {
+            fmt::format("'{}' is not a valid segment UDQ variable", var)
+        };
+    }
+
+    auto wellPos = varPos->second.find(well);
+    if (wellPos == varPos->second.end()) {
+        throw std::out_of_range {
+            fmt::format("'{}' is not a valid segment UDQ "
+                        "variable for well '{}'", var, well)
+        };
+    }
+
+    auto valPos = wellPos->second.find(segment);
+    if (valPos == wellPos->second.end()) {
+        throw std::invalid_argument {
+            fmt::format("'{}' is not a valid segment UDQ "
+                        "variable for segment {} in well '{}'",
+                        var, segment, well)
+        };
+    }
+
+    return valPos->second;
+}
+
+bool UDQState::operator==(const UDQState& other) const
+{
+    return (this->undef_value == other.undef_value)
+        && (this->scalar_values == other.scalar_values)
+        && (this->well_values == other.well_values)
+        && (this->group_values == other.group_values)
+        && (this->segment_values == other.segment_values)
+        && (this->assignments == other.assignments)
+        && (this->defines == other.defines);
 }
 
 UDQState UDQState::serializationTestObject()
@@ -227,29 +381,57 @@ UDQState UDQState::serializationTestObject()
 
     st.group_values.emplace("G1", std::unordered_map<std::string, double>{{"U1", 100}, {"U2", 200}});
     st.group_values.emplace("G2", std::unordered_map<std::string, double>{{"U1", 700}, {"32", 600}});
+
+    {
+        auto& sval = st.segment_values["SU1"];
+        sval.emplace("W1", std::unordered_map<std::size_t, double> {
+                { std::size_t{ 1},  123.456   },
+                { std::size_t{ 2},   17.29    },
+                { std::size_t{10}, -  2.71828 },
+            });
+
+        sval.emplace("W6", std::unordered_map<std::size_t, double> {
+                { std::size_t{ 7}, 3.1415926535 },
+            });
+    }
+
+    {
+        auto& sval = st.segment_values["SUVIS"];
+        sval.emplace("I2", std::unordered_map<std::size_t, double> {
+                { std::size_t{17},  29.0   },
+                { std::size_t{42}, - 1.618 },
+            });
+    }
+
+    // Deliberately creating an element with an empty value.  Not likely to
+    // occur in a real run, but we should be able to handle that case too.
+    st.segment_values["SUSPECT"];
+
     return st;
 }
 
-bool UDQState::assign(std::size_t report_step, const std::string& udq_key) const {
+bool UDQState::assign(std::size_t report_step, const std::string& udq_key) const
+{
     auto assign_iter = this->assignments.find(udq_key);
-    if (assign_iter == this->assignments.end())
-        return true;
-    else
-        return report_step > assign_iter->second;
+
+    return (assign_iter == this->assignments.end())
+        || (report_step > assign_iter->second);
 }
 
-bool UDQState::define(const std::string& udq_key, std::pair<UDQUpdate, std::size_t> update_status) const {
-    if (update_status.first == UDQUpdate::ON)
+bool UDQState::define(const std::string&                       udq_key,
+                      const std::pair<UDQUpdate, std::size_t>& update_status) const
+{
+    if (update_status.first == UDQUpdate::ON) {
         return true;
+    }
 
-    if (update_status.first == UDQUpdate::OFF)
+    if (update_status.first == UDQUpdate::OFF) {
         return false;
+    }
 
     auto define_iter = this->defines.find(udq_key);
-    if (define_iter == this->defines.end())
-        return true;
-
-    return define_iter->second < update_status.second;
+    return (define_iter == this->defines.end())
+        || (define_iter->second < update_status.second);
 }
 
 } // namespace Opm


### PR DESCRIPTION
This is in preparation of adding UDQs at the segment level.  We will probably need to rethink the UDQ scalars and UDQ sets at some point, since the lookup and assignment operations become more expensive from adding this piece of information.

While here, also add containers for segment level UDQs to the UDQ state object.  These are currently unused, but adding them here simplifies follow-up work.