### PR TITLE
Compute Segment Level UDQ Values

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -128,7 +128,12 @@ void msim::run_step(WellTestState& wtest_state, UDQState& udq_state, data::Solut
                           /* inplace = */ {});
 
         this->schedule.getUDQConfig(report_step - 1)
-            .eval(report_step, this->schedule, schedule.wellMatcher(report_step), this->st, udq_state);
+            .eval(report_step,
+                  this->schedule,
+                  this->schedule.wellMatcher(report_step),
+                  this->schedule.segmentMatcherFactory(report_step),
+                  this->st,
+                  udq_state);
 
         this->output(wtest_state,
                      udq_state,

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -65,6 +65,7 @@ namespace Opm
     class Python;
     class RPTConfig;
     class SCHEDULESection;
+    class SegmentMatcher;
     struct SimulatorUpdate;
     class SummaryState;
     class TracerConfig;
@@ -237,6 +238,7 @@ namespace Opm
         bool hasWell(const std::string& wellName, std::size_t timeStep) const;
 
         WellMatcher wellMatcher(std::size_t report_step) const;
+        std::function<std::unique_ptr<SegmentMatcher>()> segmentMatcherFactory(std::size_t report_step) const;
         std::vector<std::string> wellNames(const std::string& pattern, std::size_t timeStep, const std::vector<std::string>& matching_wells = {}) const;
         std::vector<std::string> wellNames(const std::string& pattern) const;
         std::vector<std::string> wellNames(std::size_t timeStep) const;

--- a/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
@@ -91,6 +91,9 @@ private:
     UDQSet eval_group_expression(const std::string& string_value,
                                  const UDQContext&  context) const;
 
+    UDQSet eval_segment_expression(const std::string& string_value,
+                                   const UDQContext&  context) const;
+
     UDQSet eval_scalar_function(const UDQVarType  target_type,
                                 const UDQContext& context) const;
 

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -72,7 +72,7 @@ namespace Opm {
         bool has_unit(const std::string& keyword) const;
         bool has_keyword(const std::string& keyword) const;
 
-        void add_record(SegmentMatcherFactory  segment_matcher_factory,
+        void add_record(SegmentMatcherFactory  create_segment_matcher,
                         const DeckRecord&      record,
                         const KeywordLocation& location,
                         std::size_t            report_step);
@@ -86,7 +86,7 @@ namespace Opm {
                         const std::vector<std::string>& data);
 
         void add_assign(const std::string&              quantity,
-                        SegmentMatcherFactory           segment_matcher_factory,
+                        SegmentMatcherFactory           create_segment_matcher,
                         const std::vector<std::string>& selector,
                         double                          value,
                         std::size_t                     report_step);
@@ -104,14 +104,14 @@ namespace Opm {
         void eval_assign(std::size_t           report_step,
                          const Schedule&       sched,
                          const WellMatcher&    wm,
-                         SegmentMatcherFactory segment_matcher_factory,
+                         SegmentMatcherFactory create_segment_matcher,
                          SummaryState&         st,
                          UDQState&             udq_state) const;
 
         void eval(std::size_t           report_step,
                   const Schedule&       sched,
                   const WellMatcher&    wm,
-                  SegmentMatcherFactory segment_matcher_factory,
+                  SegmentMatcherFactory create_segment_matcher,
                   SummaryState&         st,
                   UDQState&             udq_state) const;
 
@@ -192,7 +192,7 @@ namespace Opm {
                               std::size_t                     report_step);
 
         void add_enumerated_assign(const std::string&              quantity,
-                                   SegmentMatcherFactory           segment_matcher_factory,
+                                   SegmentMatcherFactory           create_segment_matcher,
                                    const std::vector<std::string>& selector,
                                    double                          value,
                                    std::size_t                     report_step);

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -31,7 +31,9 @@
 #include <opm/input/eclipse/EclipseState/Util/IOrderSet.hpp>
 
 #include <cstddef>
+#include <functional>
 #include <map>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -42,6 +44,7 @@ namespace Opm {
     class DeckRecord;
     class KeywordLocation;
     class Schedule;
+    class SegmentMatcher;
     class SummaryState;
     class UDQState;
     class WellMatcher;
@@ -57,6 +60,8 @@ namespace Opm {
     class UDQConfig
     {
     public:
+        using SegmentMatcherFactory = std::function<std::unique_ptr<SegmentMatcher>()>;
+
         UDQConfig() = default;
         explicit UDQConfig(const UDQParams& params);
         UDQConfig(const UDQParams& params, const RestartIO::RstState& rst_state);
@@ -66,18 +71,51 @@ namespace Opm {
         const std::string& unit(const std::string& key) const;
         bool has_unit(const std::string& keyword) const;
         bool has_keyword(const std::string& keyword) const;
-        void add_record(const DeckRecord& record, const KeywordLocation& location, std::size_t report_step);
 
-        void add_unit(const std::string& keyword, const std::string& unit);
-        void add_update(const std::string& keyword, std::size_t report_step, const KeywordLocation& location, const std::vector<std::string>& data);
-        void add_assign(const std::string& quantity, const std::vector<std::string>& selector, double value, std::size_t report_step);
-        void add_assign(const std::string& quantity, const std::unordered_set<std::string>& selector, double value, std::size_t report_step);
-        void add_define(const std::string& quantity, const KeywordLocation& location, const std::vector<std::string>& expression, std::size_t report_step);
+        void add_record(const DeckRecord&      record,
+                        const KeywordLocation& location,
+                        std::size_t            report_step);
 
-        void eval_assign(std::size_t report_step, const Schedule& sched, const WellMatcher& wm, SummaryState& st, UDQState& udq_state) const;
-        void eval(std::size_t report_step, const Schedule& sched, const WellMatcher& wm, SummaryState& st, UDQState& udq_state) const;
+        void add_unit(const std::string& keyword,
+                      const std::string& unit);
+
+        void add_update(const std::string&              keyword,
+                        std::size_t                     report_step,
+                        const KeywordLocation&          location,
+                        const std::vector<std::string>& data);
+
+        void add_assign(const std::string&              quantity,
+                        const std::vector<std::string>& selector,
+                        double                          value,
+                        std::size_t                     report_step);
+
+        void add_assign(const std::string&                     quantity,
+                        const std::unordered_set<std::string>& selector,
+                        double                                 value,
+                        std::size_t                            report_step);
+
+        void add_define(const std::string&              quantity,
+                        const KeywordLocation&          location,
+                        const std::vector<std::string>& expression,
+                        std::size_t                     report_step);
+
+        void eval_assign(std::size_t           report_step,
+                         const Schedule&       sched,
+                         const WellMatcher&    wm,
+                         SegmentMatcherFactory segment_matcher_factory,
+                         SummaryState&         st,
+                         UDQState&             udq_state) const;
+
+        void eval(std::size_t           report_step,
+                  const Schedule&       sched,
+                  const WellMatcher&    wm,
+                  SegmentMatcherFactory segment_matcher_factory,
+                  SummaryState&         st,
+                  UDQState&             udq_state) const;
+
         const UDQDefine& define(const std::string& key) const;
         const UDQAssign& assign(const std::string& key) const;
+
         std::vector<UDQDefine> definitions() const;
         std::vector<UDQDefine> definitions(UDQVarType var_type) const;
         std::vector<UDQInput> input() const;
@@ -85,7 +123,7 @@ namespace Opm {
         // The size() method will return the number of active DEFINE and ASSIGN
         // statements; this will correspond to the length of the vector returned
         // from input().
-        size_t size() const;
+        std::size_t size() const;
 
         UDQInput operator[](const std::string& keyword) const;
         UDQInput operator[](std::size_t insert_index) const;
@@ -107,17 +145,26 @@ namespace Opm {
             serializer(units);
             serializer(input_index);
             serializer(type_count);
-            // The UDQFunction table is constant up to udq_params.
-            // So we can just construct a new instance here.
-            if (!serializer.isSerializing())
+
+            // The UDQFunction table is constant up to udq_params, so we can
+            // just construct a new instance here.
+            if (!serializer.isSerializing()) {
                 udqft = UDQFunctionTable(udq_params);
+            }
         }
 
     private:
         void add_node(const std::string& quantity, UDQAction action);
         UDQAction action_type(const std::string& udq_key) const;
-        void eval_assign(std::size_t report_step, const Schedule& sched, UDQState& udq_state, UDQContext& context) const;
-        void eval_define(std::size_t report_step, UDQState& udq_state, UDQContext& context) const;
+
+        void eval_assign(std::size_t     report_step,
+                         const Schedule& sched,
+                         UDQState&       udq_state,
+                         UDQContext&     context) const;
+
+        void eval_define(std::size_t report_step,
+                         UDQState&   udq_state,
+                         UDQContext& context) const;
 
         UDQParams udq_params;
         UDQFunctionTable udqft;
@@ -137,8 +184,7 @@ namespace Opm {
         OrderedMap<UDQIndex> input_index;
         std::map<UDQVarType, std::size_t> type_count;
     };
-}
 
+} // namespace Opm
 
-
-#endif
+#endif // UDQINPUT_HPP_

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -72,7 +72,8 @@ namespace Opm {
         bool has_unit(const std::string& keyword) const;
         bool has_keyword(const std::string& keyword) const;
 
-        void add_record(const DeckRecord&      record,
+        void add_record(SegmentMatcherFactory  segment_matcher_factory,
+                        const DeckRecord&      record,
                         const KeywordLocation& location,
                         std::size_t            report_step);
 
@@ -85,6 +86,7 @@ namespace Opm {
                         const std::vector<std::string>& data);
 
         void add_assign(const std::string&              quantity,
+                        SegmentMatcherFactory           segment_matcher_factory,
                         const std::vector<std::string>& selector,
                         double                          value,
                         std::size_t                     report_step);
@@ -154,18 +156,6 @@ namespace Opm {
         }
 
     private:
-        void add_node(const std::string& quantity, UDQAction action);
-        UDQAction action_type(const std::string& udq_key) const;
-
-        void eval_assign(std::size_t     report_step,
-                         const Schedule& sched,
-                         UDQState&       udq_state,
-                         UDQContext&     context) const;
-
-        void eval_define(std::size_t report_step,
-                         UDQState&   udq_state,
-                         UDQContext& context) const;
-
         UDQParams udq_params;
         UDQFunctionTable udqft;
 
@@ -183,6 +173,29 @@ namespace Opm {
         IOrderSet<std::string> define_order;
         OrderedMap<UDQIndex> input_index;
         std::map<UDQVarType, std::size_t> type_count;
+
+        void add_node(const std::string& quantity, UDQAction action);
+        UDQAction action_type(const std::string& udq_key) const;
+
+        void eval_assign(std::size_t     report_step,
+                         const Schedule& sched,
+                         UDQState&       udq_state,
+                         UDQContext&     context) const;
+
+        void eval_define(std::size_t report_step,
+                         UDQState&   udq_state,
+                         UDQContext& context) const;
+
+        void add_named_assign(const std::string&              quantity,
+                              const std::vector<std::string>& selector,
+                              double                          value,
+                              std::size_t                     report_step);
+
+        void add_enumerated_assign(const std::string&              quantity,
+                                   SegmentMatcherFactory           segment_matcher_factory,
+                                   const std::vector<std::string>& selector,
+                                   double                          value,
+                                   std::size_t                     report_step);
     };
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQContext.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQContext.hpp
@@ -49,7 +49,7 @@ namespace Opm {
 
         UDQContext(const UDQFunctionTable& udqft,
                    const WellMatcher&      wm,
-                   SegmentMatcherFactory   segment_matcher_factory,
+                   SegmentMatcherFactory   create_segment_matcher,
                    SummaryState&           summary_state,
                    UDQState&               udq_state);
 
@@ -74,7 +74,7 @@ namespace Opm {
         const UDQFunctionTable& udqft;
         const WellMatcher& well_matcher;
 
-        SegmentMatcherFactory segment_matcher_factory;
+        SegmentMatcherFactory create_segment_matcher;
         mutable std::unique_ptr<SegmentMatcher> segment_matcher;
         SummaryState& summary_state;
         UDQState& udq_state;

--- a/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
@@ -116,6 +116,7 @@ private:
     UDQSet scatter_scalar_value(UDQSet&& res, const UDQContext& context) const;
     UDQSet scatter_scalar_well_value(const UDQContext& context, const std::optional<double>& value) const;
     UDQSet scatter_scalar_group_value(const UDQContext& context, const std::optional<double>& value) const;
+    UDQSet scatter_scalar_segment_value(const UDQContext& context, const std::optional<double>& value) const;
 };
 
 } // Namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
@@ -304,6 +304,11 @@ public:
     ///    this UDQ set.  Non-finite value leaves the UDQ set element
     ///    undefined.
     static UDQSet field(const std::string& name, double scalar_value);
+    static UDQSet segments(const std::string&                      name,
+                           const std::vector<EnumeratedWellItems>& segments);
+    static UDQSet segments(const std::string&                      name,
+                           const std::vector<EnumeratedWellItems>& segments,
+                           const double                            scalar_value);
 
     /// Assign value to every element of the UDQ set
     ///

--- a/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
@@ -30,6 +30,10 @@
 #include <vector>
 
 namespace Opm {
+    class SegmentSet;
+} // namespace Opm
+
+namespace Opm {
 
 class UDQScalar
 {
@@ -196,6 +200,9 @@ public:
             serializer(this->numbers);
         }
     };
+
+    static std::vector<EnumeratedWellItems>
+    getSegmentItems(const SegmentSet& segmentSet);
 
     /// Construct empty, named UDQ set of specific variable type
     ///

--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -29,8 +29,8 @@
 namespace Opm { namespace EclIO {
 
     struct lgr_info {
-        std::string name;
-        std::array<int, 3> ijk;
+        std::string name {};
+        std::array<int, 3> ijk {};
     };
 
 struct SummaryNode {
@@ -59,13 +59,13 @@ struct SummaryNode {
         Undefined,
     };
 
-    std::string keyword;
-    Category    category;
-    Type        type;
-    std::string wgname;
-    int         number;
-    std::optional<std::string> fip_region;
-    std::optional<lgr_info> lgr;
+    std::string                keyword {};
+    Category                   category { Category::Miscellaneous };
+    Type                       type { Type::Undefined };
+    std::string                wgname {};
+    int                        number {};
+    std::optional<std::string> fip_region {};
+    std::optional<lgr_info>    lgr {};
 
     constexpr static int default_number { std::numeric_limits<int>::min() };
 

--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1141,9 +1141,14 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
     {
         const auto& kw = keyword.name();
 
-        if (kw.size() > std::string::size_type{5}) {
-            // Easy check first--handles SUMMARY and SUMTHIN &c.
+        if ((kw == "SUMMARY") || (kw == "SUMTHIN")) {
             return false;
+        }
+
+        if (kw[1] == 'U') {
+            // User-defined quantity at segment level.  Unbounded set, so
+            // assume this is well defined.
+            return true;
         }
 
         const auto kw_whitelist = std::vector<const char*> {

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -44,6 +44,7 @@
 #include <opm/input/eclipse/Schedule/Group/GTNode.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
+#include <opm/input/eclipse/Schedule/MSW/SegmentMatcher.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
 #include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
@@ -1243,6 +1244,20 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return WellMatcher(sched_state->well_order.get(), sched_state->wlist_manager.get());
     }
 
+    std::function<std::unique_ptr<SegmentMatcher>()>
+    Schedule::segmentMatcherFactory(const std::size_t report_step) const
+    {
+        return {
+            [report_step, this]() -> std::unique_ptr<SegmentMatcher>
+            {
+                const auto ix = (report_step < this->snapshots.size())
+                    ? report_step
+                    : this->snapshots.size() - 1;
+
+                return std::make_unique<SegmentMatcher>(this->snapshots[ix]);
+            }
+        };
+    }
 
     std::vector<std::string> Schedule::wellNames(const std::string& pattern) const {
         return this->wellNames(pattern, this->size() - 1);

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1250,11 +1250,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return {
             [report_step, this]() -> std::unique_ptr<SegmentMatcher>
             {
-                const auto ix = (report_step < this->snapshots.size())
-                    ? report_step
-                    : this->snapshots.size() - 1;
-
-                return std::make_unique<SegmentMatcher>(this->snapshots[ix]);
+                return std::make_unique<SegmentMatcher>((*this)[report_step]);
             }
         };
     }

--- a/src/opm/input/eclipse/Schedule/SummaryState.cpp
+++ b/src/opm/input/eclipse/Schedule/SummaryState.cpp
@@ -266,6 +266,14 @@ namespace Opm
                 this->update_group_var(group, udq_set.name(), udq_value.value_or(undefined_value));
             }
         }
+        else if (var_type == UDQVarType::SEGMENT_VAR) {
+            for (const auto& udq_value : udq_set) {
+                this->update_segment_var(udq_value.wgname(),
+                                         udq_set.name(),
+                                         udq_value.number(),
+                                         udq_value.value().value_or(undefined_value));
+            }
+        }
         else {
             const auto& udq_var = udq_set[0].value();
             this->update(udq_set.name(), udq_var.value_or(undefined_value));

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQASTNode.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQASTNode.cpp
@@ -68,22 +68,6 @@ Opm::UDQVarType init_type(const Opm::UDQTokenType token_type)
     return Opm::UDQVarType::NONE;
 }
 
-std::vector<Opm::UDQSet::EnumeratedWellItems>
-make_segment_items(const Opm::SegmentSet& segSet)
-{
-    const auto numWells = segSet.numWells();
-
-    auto items = std::vector<Opm::UDQSet::EnumeratedWellItems>(numWells);
-    for (auto wellID = 0*numWells; wellID < numWells; ++wellID) {
-        auto segRange = segSet.segments(wellID);
-
-        items[wellID].well = segRange.well();
-        items[wellID].numbers.assign(segRange.begin(), segRange.end());
-    }
-
-    return items;
-}
-
 } // Anonymous namespace
 
 namespace Opm {
@@ -415,7 +399,7 @@ UDQSet
 UDQASTNode::eval_segment_expression(const std::string& string_value,
                                     const UDQContext&  context) const
 {
-    const auto all_msw_segments = make_segment_items(context.segments());
+    const auto all_msw_segments = UDQSet::getSegmentItems(context.segments());
     if (this->selector.empty()) {
         auto res = UDQSet::segments(string_value, all_msw_segments);
 
@@ -513,7 +497,7 @@ UDQASTNode::eval_number(const UDQVarType  target_type,
         return UDQSet::groups(dummy_name, context.groups(), numeric_value);
 
     case UDQVarType::SEGMENT_VAR:
-        return UDQSet::segments(dummy_name, make_segment_items(context.segments()), numeric_value);
+        return UDQSet::segments(dummy_name, UDQSet::getSegmentItems(context.segments()), numeric_value);
 
     case UDQVarType::SCALAR:
         return UDQSet::scalar(dummy_name, numeric_value);

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQASTNode.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQASTNode.cpp
@@ -19,9 +19,11 @@
 
 #include <opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/SegmentMatcher.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQFunction.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQSet.hpp>
 
 #include <memory>
 #include <set>
@@ -34,23 +36,52 @@
 
 namespace {
 
-bool is_udq(const std::string& key)
+bool is_udq_blacklist(const std::string& keyword)
 {
-    return (key.size() >= std::string::size_type{2})
-        && (key[1] == 'U');
+    static const auto udq_blacklistkw = std::unordered_set<std::string> {
+        "SUMTHIN", "SUMMARY", "RUNSUM",
+    };
+
+    return udq_blacklistkw.find(keyword) != udq_blacklistkw.end();
+}
+
+bool is_udq(const std::string& keyword)
+{
+    // Does 'keyword' match one of the patterns
+    //   AU*, BU*, CU*, FU*, GU*, RU*, SU*, or WU*?
+    using sz_t = std::string::size_type;
+
+    return (keyword.size() > sz_t{1})
+        && (keyword[1] == 'U')
+        && ! is_udq_blacklist(keyword)
+        && (keyword.find_first_of("WGFCRBSA") == sz_t{0});
 }
 
 Opm::UDQVarType init_type(const Opm::UDQTokenType token_type)
 {
-    if (token_type == Opm::UDQTokenType::number) {
-        return Opm::UDQVarType::SCALAR;
-    }
-
-    if (Opm::UDQ::scalarFunc(token_type)) {
+    if ((token_type == Opm::UDQTokenType::number) ||
+        Opm::UDQ::scalarFunc(token_type))
+    {
         return Opm::UDQVarType::SCALAR;
     }
 
     return Opm::UDQVarType::NONE;
+}
+
+std::vector<Opm::UDQSet::EnumeratedWellItems>
+make_segment_items(const Opm::SegmentSet& segSet)
+{
+    const auto numWells = segSet.numWells();
+
+    auto items = std::vector<Opm::UDQSet::EnumeratedWellItems>(numWells);
+    for (auto wellID = 0*numWells; wellID < numWells; ++wellID) {
+        auto segRange = segSet.segments(wellID);
+
+        items[wellID].well = segRange.well();
+        items[wellID].numbers.assign(segRange.begin(), segRange.end());
+    }
+
+    return items;
 }
 
 } // Anonymous namespace
@@ -132,7 +163,6 @@ UDQASTNode::UDQASTNode(const UDQTokenType                       type_arg,
 
     if ((this->var_type == UDQVarType::CONNECTION_VAR) ||
         (this->var_type == UDQVarType::REGION_VAR) ||
-        (this->var_type == UDQVarType::SEGMENT_VAR) ||
         (this->var_type == UDQVarType::AQUIFER_VAR) ||
         (this->var_type == UDQVarType::BLOCK_VAR))
     {
@@ -267,12 +297,13 @@ bool UDQASTNode::operator==(const UDQASTNode& data) const
 
 void UDQASTNode::required_summary(std::unordered_set<std::string>& summary_keys) const
 {
-    if (this->type == UDQTokenType::ecl_expr) {
-        if (std::holds_alternative<std::string>(this->value)) {
-            const auto& keyword = std::get<std::string>(this->value);
-            if (!is_udq(keyword)) {
-                summary_keys.insert(keyword);
-            }
+    if ((this->type == UDQTokenType::ecl_expr) &&
+        std::holds_alternative<std::string>(this->value))
+    {
+        if (const auto& keyword = std::get<std::string>(this->value);
+            !is_udq(keyword))
+        {
+            summary_keys.insert(keyword);
         }
     }
 
@@ -297,6 +328,10 @@ UDQASTNode::eval_expression(const UDQContext& context) const
 
     if (data_type == UDQVarType::GROUP_VAR) {
         return this->eval_group_expression(string_value, context);
+    }
+
+    if (data_type == UDQVarType::SEGMENT_VAR) {
+        return this->eval_segment_expression(string_value, context);
     }
 
     if (data_type == UDQVarType::FIELD_VAR) {
@@ -377,6 +412,54 @@ UDQASTNode::eval_group_expression(const std::string& string_value,
 }
 
 UDQSet
+UDQASTNode::eval_segment_expression(const std::string& string_value,
+                                    const UDQContext&  context) const
+{
+    const auto all_msw_segments = make_segment_items(context.segments());
+    if (this->selector.empty()) {
+        auto res = UDQSet::segments(string_value, all_msw_segments);
+
+        auto index = std::size_t{0};
+        for (const auto& ms_well : all_msw_segments) {
+            for (const auto& segment : ms_well.numbers) {
+                res.assign(index++, context.get_segment_var(ms_well.well, string_value, segment));
+            }
+        }
+
+        return res;
+    }
+
+    const auto selected_segments = context.segments(this->selector);
+    if (selected_segments.empty()) {
+        // No matching segments.  Could be because the 'selector' only
+        // applies to MS wells that are no yet online, or because the
+        // segments don't yet exist.
+        return UDQSet::empty(string_value);
+    }
+    else if (selected_segments.isScalar()) {
+        // Selector matches a single segment in a single MS well.
+        const auto segSet = selected_segments.segments(0);
+        const auto well = std::string { segSet.well() };
+        return UDQSet::scalar(string_value, context.get_segment_var(well, string_value, *segSet.begin()));
+    }
+
+    // If we get here, the selector matches at least one segment in at least
+    // one MS well.
+    auto res = UDQSet::segments(string_value, all_msw_segments);
+
+    const auto numWells = selected_segments.numWells();
+    for (auto wellID = 0*numWells; wellID < numWells; ++wellID) {
+        const auto segSet = selected_segments.segments(wellID);
+        const auto well = std::string { segSet.well() };
+        for (const auto& segment : segSet) {
+            res.assign(well, segment, context.get_segment_var(well, string_value, segment));
+        }
+    }
+
+    return res;
+}
+
+UDQSet
 UDQASTNode::eval_scalar_function(const UDQVarType  target_type,
                                  const UDQContext& context) const
 {
@@ -428,6 +511,9 @@ UDQASTNode::eval_number(const UDQVarType  target_type,
 
     case UDQVarType::GROUP_VAR:
         return UDQSet::groups(dummy_name, context.groups(), numeric_value);
+
+    case UDQVarType::SEGMENT_VAR:
+        return UDQSet::segments(dummy_name, make_segment_items(context.segments()), numeric_value);
 
     case UDQVarType::SCALAR:
         return UDQSet::scalar(dummy_name, numeric_value);

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -191,7 +191,7 @@ namespace Opm {
     }
 
     void UDQConfig::add_assign(const std::string&              quantity,
-                               SegmentMatcherFactory           segment_matcher_factory,
+                               SegmentMatcherFactory           create_segment_matcher,
                                const std::vector<std::string>& selector,
                                const double                    value,
                                const std::size_t               report_step)
@@ -201,7 +201,7 @@ namespace Opm {
         switch (UDQ::varType(quantity)) {
         case UDQVarType::SEGMENT_VAR:
             this->add_enumerated_assign(quantity,
-                                        std::move(segment_matcher_factory),
+                                        std::move(create_segment_matcher),
                                         selector, value, report_step);
             break;
 
@@ -289,7 +289,7 @@ namespace Opm {
         define.update_status(update_status, report_step);
     }
 
-    void UDQConfig::add_record(SegmentMatcherFactory  segment_matcher_factory,
+    void UDQConfig::add_record(SegmentMatcherFactory  create_segment_matcher,
                                const DeckRecord&      record,
                                const KeywordLocation& location,
                                const std::size_t      report_step)
@@ -310,7 +310,7 @@ namespace Opm {
             const auto selector = std::vector<std::string>(data.begin(), data.end() - 1);
             const auto value = std::stod(data.back());
             this->add_assign(quantity,
-                             std::move(segment_matcher_factory),
+                             std::move(create_segment_matcher),
                              selector, value, report_step);
         }
         else if (action == UDQAction::DEFINE) {
@@ -590,12 +590,12 @@ namespace Opm {
     void UDQConfig::eval(const std::size_t     report_step,
                          const Schedule&       sched,
                          const WellMatcher&    wm,
-                         SegmentMatcherFactory segment_matcher_factory,
+                         SegmentMatcherFactory create_segment_matcher,
                          SummaryState&         st,
                          UDQState&             udq_state) const
     {
         UDQContext context {
-            this->function_table(), wm, std::move(segment_matcher_factory), st, udq_state
+            this->function_table(), wm, std::move(create_segment_matcher), st, udq_state
         };
         this->eval_assign(report_step, sched, udq_state, context);
         this->eval_define(report_step, udq_state, context);
@@ -604,12 +604,12 @@ namespace Opm {
     void UDQConfig::eval_assign(const std::size_t     report_step,
                                 const Schedule&       sched,
                                 const WellMatcher&    wm,
-                                SegmentMatcherFactory segment_matcher_factory,
+                                SegmentMatcherFactory create_segment_matcher,
                                 SummaryState&         st,
                                 UDQState&             udq_state) const
     {
         UDQContext context {
-            this->function_table(), wm, std::move(segment_matcher_factory), st, udq_state
+            this->function_table(), wm, std::move(create_segment_matcher), st, udq_state
         };
         this->eval_assign(report_step, sched, udq_state, context);
     }
@@ -637,12 +637,12 @@ namespace Opm {
     }
 
     void UDQConfig::add_enumerated_assign(const std::string&              quantity,
-                                          SegmentMatcherFactory           segment_matcher_factory,
+                                          SegmentMatcherFactory           create_segment_matcher,
                                           const std::vector<std::string>& selector,
                                           const double                    value,
                                           const std::size_t               report_step)
     {
-        auto segmentMatcher = segment_matcher_factory();
+        auto segmentMatcher = create_segment_matcher();
 
         auto setDescriptor = SegmentMatcher::SetDescriptor{};
         if (! selector.empty()) {

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -24,6 +24,7 @@
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/SegmentMatcher.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
@@ -483,6 +484,7 @@ namespace Opm {
         select_var_type |= var_type_bit(UDQVarType::WELL_VAR);
         select_var_type |= var_type_bit(UDQVarType::GROUP_VAR);
         select_var_type |= var_type_bit(UDQVarType::FIELD_VAR);
+        select_var_type |= var_type_bit(UDQVarType::SEGMENT_VAR);
 
         for (const auto& [keyword, index] : this->input_index) {
             if (index.action != UDQAction::DEFINE) {
@@ -508,24 +510,30 @@ namespace Opm {
         }
     }
 
-    void UDQConfig::eval(const std::size_t  report_step,
-                         const Schedule&    sched,
-                         const WellMatcher& wm,
-                         SummaryState&      st,
-                         UDQState&          udq_state) const
+    void UDQConfig::eval(const std::size_t     report_step,
+                         const Schedule&       sched,
+                         const WellMatcher&    wm,
+                         SegmentMatcherFactory segment_matcher_factory,
+                         SummaryState&         st,
+                         UDQState&             udq_state) const
     {
-        UDQContext context(this->function_table(), wm, st, udq_state);
+        UDQContext context {
+            this->function_table(), wm, std::move(segment_matcher_factory), st, udq_state
+        };
         this->eval_assign(report_step, sched, udq_state, context);
         this->eval_define(report_step, udq_state, context);
     }
 
-    void UDQConfig::eval_assign(const std::size_t  report_step,
-                                const Schedule&    sched,
-                                const WellMatcher& wm,
-                                SummaryState&      st,
-                                UDQState&          udq_state) const
+    void UDQConfig::eval_assign(const std::size_t     report_step,
+                                const Schedule&       sched,
+                                const WellMatcher&    wm,
+                                SegmentMatcherFactory segment_matcher_factory,
+                                SummaryState&         st,
+                                UDQState&             udq_state) const
     {
-        UDQContext context(this->function_table(), wm, st, udq_state);
+        UDQContext context {
+            this->function_table(), wm, std::move(segment_matcher_factory), st, udq_state
+        };
         this->eval_assign(report_step, sched, udq_state, context);
     }
 

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -110,9 +110,19 @@ namespace {
         Opm::UDQSet operator()(const Opm::UDQAssign& assign) const
         {
             if (! this->eval_.has_value()) {
+                // First call to operator().
+                //
+                // Create evaluation function using whatever state was
+                // captured in the creation function, for instance a "const
+                // UDQContext&".
+                //
+                // Note: This is deferred initialisation.  The create_()
+                // call could be rather expensive so we don't incur the cost
+                // of calling the function until we know we that we have to.
                 this->eval_ = this->create_();
             }
 
+            // Evaluate type dependent UDQ ASSIGN statement.
             return (*this->eval_)(assign);
         }
 

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
@@ -16,45 +16,58 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <fmt/format.h>
 
-#include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQContext.hpp>
+
+#include <opm/input/eclipse/Schedule/MSW/SegmentMatcher.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
+
 #include <opm/common/utility/TimeService.hpp>
 
-namespace Opm {
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
 
 namespace {
 
-bool is_udq(const std::string& key) {
-    if (key.size() < 2)
-        return false;
-
-    if (key[1] != 'U')
-        return false;
-
-    return true;
+bool is_udq(const std::string& key)
+{
+    return (key.size() >= std::string::size_type{2})
+        && (key[1] == 'U');
 }
 
-}
+} // Anonymous namespace
 
+namespace Opm {
 
-    UDQContext::UDQContext(const UDQFunctionTable& udqft_arg, const WellMatcher& wm, SummaryState& summary_state_arg, UDQState& udq_state_arg) :
-        udqft(udqft_arg),
-        well_matcher(wm),
-        summary_state(summary_state_arg),
-        udq_state(udq_state_arg)
+    UDQContext::UDQContext(const UDQFunctionTable& udqft_arg,
+                           const WellMatcher&      wm,
+                           SegmentMatcherFactory   segment_matcher_factory_arg,
+                           SummaryState&           summary_state_arg,
+                           UDQState&               udq_state_arg)
+        : udqft                  (udqft_arg)
+        , well_matcher           (wm)
+        , segment_matcher_factory(std::move(segment_matcher_factory_arg))
+        , summary_state          (summary_state_arg)
+        , udq_state              (udq_state_arg)
     {
-        for (const auto& pair : TimeService::eclipseMonthIndices())
-            this->add(pair.first, pair.second);
+        for (const auto& [month, index] : TimeService::eclipseMonthIndices()) {
+            this->add(month, index);
+        }
 
-        /*
-          Simulator performance keywords which are expected to be available for
-          UDQ keywords; probably better to guarantee that they are present in
-          the underlying summary state object.
-        */
+        // Simulator performance keywords which are expected to be available
+        // for UDQ keywords; probably better to guarantee that they are
+        // present in the underlying summary state object.
 
         this->add("MSUMLINS", 0.0);
         this->add("MSUMNEWT", 0.0);
@@ -62,82 +75,169 @@ bool is_udq(const std::string& key) {
         this->add("TCPU", 0.0);
     }
 
-
-    void UDQContext::add(const std::string& key, double value) {
-        this->values[key] = value;
+    void UDQContext::add(const std::string& key, double value)
+    {
+        this->values.insert_or_assign(key, value);
     }
 
-    std::optional<double> UDQContext::get(const std::string& key) const {
+    std::optional<double>
+    UDQContext::get(const std::string& key) const
+    {
         if (is_udq(key)) {
-            if (this->udq_state.has(key))
+            if (this->udq_state.has(key)) {
                 return this->udq_state.get(key);
+            }
 
             return std::nullopt;
         }
 
-        const auto& pair_ptr = this->values.find(key);
-        if (pair_ptr != this->values.end())
+        auto pair_ptr = this->values.find(key);
+        if (pair_ptr != this->values.end()) {
             return pair_ptr->second;
+        }
 
         return this->summary_state.get(key);
     }
 
-    std::optional<double> UDQContext::get_well_var(const std::string& well, const std::string& var) const {
+    std::optional<double>
+    UDQContext::get_well_var(const std::string& well,
+                             const std::string& var) const
+    {
         if (is_udq(var)) {
-            if (this->udq_state.has_well_var(well, var))
+            if (this->udq_state.has_well_var(well, var)) {
                 return this->udq_state.get_well_var(well, var);
+            }
 
             return std::nullopt;
         }
+
         if (this->summary_state.has_well_var(var)) {
-            if (this->summary_state.has_well_var(well, var))
+            if (this->summary_state.has_well_var(well, var)) {
                 return this->summary_state.get_well_var(well, var);
-            else
-                return std::nullopt;
+            }
+
+            return std::nullopt;
         }
-        throw std::logic_error(fmt::format("Summary well variable: {} not registered", var));
+
+        throw std::logic_error {
+            fmt::format("Summary well variable: {} not registered", var)
+        };
     }
 
-    std::optional<double> UDQContext::get_group_var(const std::string& group, const std::string& var) const {
+    std::optional<double>
+    UDQContext::get_group_var(const std::string& group,
+                              const std::string& var) const
+    {
         if (is_udq(var)) {
-            if (this->udq_state.has_group_var(group, var))
+            if (this->udq_state.has_group_var(group, var)) {
                 return this->udq_state.get_group_var(group, var);
+            }
 
             return std::nullopt;
         }
 
         if (this->summary_state.has_group_var(var)) {
-            if (this->summary_state.has_group_var(group, var))
+            if (this->summary_state.has_group_var(group, var)) {
                 return this->summary_state.get_group_var(group, var);
-            else
-                return std::nullopt;
+            }
+
+            return std::nullopt;
         }
-        throw std::logic_error(fmt::format("Summary group variable: {} not registered", var));
+
+        throw std::logic_error {
+            fmt::format("Summary group variable: {} not registered", var)
+        };
     }
 
-    std::vector<std::string> UDQContext::wells() const {
+    std::optional<double>
+    UDQContext::get_segment_var(const std::string& well,
+                                const std::string& var,
+                                std::size_t        segment) const
+    {
+        if (is_udq(var)) {
+            if (this->udq_state.has_segment_var(well, var, segment)) {
+                return this->udq_state.get_segment_var(well, var, segment);
+            }
+
+            return std::nullopt;
+        }
+
+        if (this->summary_state.has_segment_var(well, var, segment)) {
+            return this->summary_state.get_segment_var(well, var, segment);
+        }
+
+        throw std::logic_error {
+            fmt::format("Segment summary variable {} not "
+                        "registered for segment {} in well {}",
+                        var, segment, well)
+        };
+    }
+
+    std::vector<std::string> UDQContext::wells() const
+    {
         return this->well_matcher.wells();
     }
 
-    std::vector<std::string> UDQContext::wells(const std::string& pattern) const {
+    std::vector<std::string> UDQContext::wells(const std::string& pattern) const
+    {
         return this->well_matcher.wells(pattern);
     }
 
-    std::vector<std::string> UDQContext::groups() const {
+    std::vector<std::string> UDQContext::groups() const
+    {
         return this->summary_state.groups();
     }
 
-    const UDQFunctionTable& UDQContext::function_table() const {
+    SegmentSet UDQContext::segments() const
+    {
+        // Empty descriptor matches all segments in all existing MS wells.
+
+        this->ensure_segment_matcher_exists();
+        return this->segment_matcher->findSegments(SegmentMatcher::SetDescriptor{});
+    }
+
+    SegmentSet UDQContext::segments(const std::vector<std::string>& set_descriptor) const
+    {
+        assert (! set_descriptor.empty() &&
+                "Internal error passing empty segment set "
+                "descriptor to filtered segment set query");
+
+        auto desc = SegmentMatcher::SetDescriptor{}
+            .wellNames(set_descriptor.front());
+
+        if (set_descriptor.size() > std::vector<std::string>::size_type{1}) {
+            desc.segmentNumber(set_descriptor[1]);
+        }
+
+        this->ensure_segment_matcher_exists();
+        return this->segment_matcher->findSegments(desc);
+    }
+
+    const UDQFunctionTable& UDQContext::function_table() const
+    {
         return this->udqft;
     }
 
-    void UDQContext::update_assign(std::size_t report_step, const std::string& keyword, const UDQSet& udq_result) {
+    void UDQContext::update_assign(const std::size_t  report_step,
+                                   const std::string& keyword,
+                                   const UDQSet&      udq_result)
+    {
         this->udq_state.add_assign(report_step, keyword, udq_result);
         this->summary_state.update_udq(udq_result, this->udq_state.undefined_value());
     }
 
-    void UDQContext::update_define(std::size_t report_step, const std::string& keyword, const UDQSet& udq_result) {
+    void UDQContext::update_define(const std::size_t  report_step,
+                                   const std::string& keyword,
+                                   const UDQSet&      udq_result)
+    {
         this->udq_state.add_define(report_step, keyword, udq_result);
         this->summary_state.update_udq(udq_result, this->udq_state.undefined_value());
+    }
+
+    void UDQContext::ensure_segment_matcher_exists() const
+    {
+        if (this->segment_matcher == nullptr) {
+            this->segment_matcher = this->segment_matcher_factory();
+        }
     }
 }

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
@@ -52,14 +52,14 @@ namespace Opm {
 
     UDQContext::UDQContext(const UDQFunctionTable& udqft_arg,
                            const WellMatcher&      wm,
-                           SegmentMatcherFactory   segment_matcher_factory_arg,
+                           SegmentMatcherFactory   create_segment_matcher_arg,
                            SummaryState&           summary_state_arg,
                            UDQState&               udq_state_arg)
-        : udqft                  (udqft_arg)
-        , well_matcher           (wm)
-        , segment_matcher_factory(std::move(segment_matcher_factory_arg))
-        , summary_state          (summary_state_arg)
-        , udq_state              (udq_state_arg)
+        : udqft                 (udqft_arg)
+        , well_matcher          (wm)
+        , create_segment_matcher(std::move(create_segment_matcher_arg))
+        , summary_state         (summary_state_arg)
+        , udq_state             (udq_state_arg)
     {
         for (const auto& [month, index] : TimeService::eclipseMonthIndices()) {
             this->add(month, index);
@@ -237,7 +237,7 @@ namespace Opm {
     void UDQContext::ensure_segment_matcher_exists() const
     {
         if (this->segment_matcher == nullptr) {
-            this->segment_matcher = this->segment_matcher_factory();
+            this->segment_matcher = this->create_segment_matcher();
         }
     }
 }

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
@@ -218,22 +218,6 @@ bool dynamic_type_check(const Opm::UDQVarType lhs,
     return true;
 }
 
-std::vector<Opm::UDQSet::EnumeratedWellItems>
-make_segment_items(const Opm::SegmentSet& segSet)
-{
-    const auto numWells = segSet.numWells();
-
-    auto items = std::vector<Opm::UDQSet::EnumeratedWellItems>(numWells);
-    for (auto wellID = 0*numWells; wellID < numWells; ++wellID) {
-        auto segRange = segSet.segments(wellID);
-
-        items[wellID].well = segRange.well();
-        items[wellID].numbers.assign(segRange.begin(), segRange.end());
-    }
-
-    return items;
-}
-
 } // Anonymous namespace
 
 namespace Opm {
@@ -487,10 +471,10 @@ UDQSet UDQDefine::scatter_scalar_segment_value(const UDQContext&            cont
                                                const std::optional<double>& value) const
 {
     if (! value.has_value()) {
-        return UDQSet::segments(this->m_keyword, make_segment_items(context.segments()));
+        return UDQSet::segments(this->m_keyword, UDQSet::getSegmentItems(context.segments()));
     }
 
-    return UDQSet::segments(this->m_keyword, make_segment_items(context.segments()), *value);
+    return UDQSet::segments(this->m_keyword, UDQSet::getSegmentItems(context.segments()), *value);
 }
 
 } // namespace Opm

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
@@ -270,6 +270,20 @@ UDQSet UDQSet::groups(const std::string&              name,
     return us;
 }
 
+UDQSet UDQSet::segments(const std::string&                      name,
+                        const std::vector<EnumeratedWellItems>& segments)
+{
+    return { name, UDQVarType::SEGMENT_VAR, segments };
+}
+
+UDQSet UDQSet::segments(const std::string&                      name,
+                        const std::vector<EnumeratedWellItems>& segments,
+                        const double                            scalar_value)
+{
+    auto us = UDQSet::segments(name, segments);
+    us.assign(scalar_value);
+    return us;
+}
 
 bool UDQSet::has(const std::string& name) const
 {

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
@@ -19,6 +19,8 @@
 
 #include <opm/input/eclipse/Schedule/UDQ/UDQSet.hpp>
 
+#include <opm/input/eclipse/Schedule/MSW/SegmentMatcher.hpp>
+
 #include <opm/common/utility/shmatch.hpp>
 
 #include <algorithm>
@@ -768,6 +770,22 @@ bool UDQSet::operator==(const UDQSet& other) const
     return (this->m_name == other.m_name)
         && (this->m_var_type == other.m_var_type)
         && (this->values == other.values);
+}
+
+std::vector<UDQSet::EnumeratedWellItems>
+UDQSet::getSegmentItems(const SegmentSet& segSet)
+{
+    const auto numWells = segSet.numWells();
+
+    auto items = std::vector<Opm::UDQSet::EnumeratedWellItems>(numWells);
+    for (auto wellID = 0*numWells; wellID < numWells; ++wellID) {
+        auto segRange = segSet.segments(wellID);
+
+        items[wellID].well = segRange.well();
+        items[wellID].numbers.assign(segRange.begin(), segRange.end());
+    }
+
+    return items;
 }
 
 } // namespace Opm

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/S/SEGMENT_PROBE
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/S/SEGMENT_PROBE
@@ -39,6 +39,7 @@
     "SWVIS"
   ],
   "comment": "This list is incomplete",
+  "deck_name_regex": "SU.+",
   "items": [
     {
       "name": "Well",


### PR DESCRIPTION
This commit adds support for calculating UDQs at the segment level, i.e., UDQs named 'SU*'.  This necessitates an API change for the UDQ context constructor and, transitively, every function that forms UDQ context objects.  We pass a factory function that will create segment matcher objects on demand, and provide a default implementation of this factory function in the Schedule class.

While here, also add support for outputting segment level UDQs to the summary file.  We calculate all segment level UDQs and add the values to the summary state for possible use in ACTIONXtoo.  The latter is not yet tested.