### PR TITLE
we need to update the nodal pressure when a new NODEPROP is specified in the schedule

### DIFF
--- a/src/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
+++ b/src/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
@@ -161,7 +161,7 @@ void ExtNetwork::add_node(Node node)
     }
 
 
-    this->m_nodes.insert({ name, std::move(node) });
+    this->m_nodes.insert_or_assign(name, std::move(node) );
 }
 
 void ExtNetwork::add_indexed_node_name(std::string name)


### PR DESCRIPTION
 Master branch uses std::map::insert(), the new value will not be used if the node exists already.
