### PR TITLE
Prepare for Handling UDQ ASSIGN for Segments

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp
@@ -17,89 +17,127 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef UDQASSIGN_HPP_
 #define UDQASSIGN_HPP_
 
+#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQSet.hpp>
+
+#include <cstddef>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
-
-#include <opm/input/eclipse/Schedule/UDQ/UDQSet.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
 
 namespace Opm {
 
-
-class UDQAssign{
+class UDQAssign
+{
 public:
-
-    /*
-      If the same keyword is assigned several times the different assignment
-      records are assembled in one UDQAssign instance. This is an attempt to
-      support restart in a situation where a full UDQ ASSIGN statement can be
-      swapped with a UDQ DEFINE statement.
-    */
-    struct AssignRecord {
-        std::vector<std::string> input_selector;
-        std::unordered_set<std::string> rst_selector;
-        double value;
-        std::size_t report_step;
+    // If the same keyword is assigned several times the different
+    // assignment records are assembled in one UDQAssign instance.  This is
+    // an attempt to support restart in a situation where a full UDQ ASSIGN
+    // statement can be swapped with a UDQ DEFINE statement.
+    struct AssignRecord
+    {
+        std::vector<std::string> input_selector{};
+        std::unordered_set<std::string> rst_selector{};
+        std::vector<UDQSet::EnumeratedWellItems> numbered_selector{};
+        double value{};
+        std::size_t report_step{};
 
         AssignRecord() = default;
 
-        AssignRecord(const std::vector<std::string>& selector, double value_arg, std::size_t report_step_arg)
+        AssignRecord(const std::vector<std::string>& selector,
+                     const double                    value_arg,
+                     const std::size_t               report_step_arg)
             : input_selector(selector)
-            , value(value_arg)
-            , report_step(report_step_arg)
+            , value         (value_arg)
+            , report_step   (report_step_arg)
         {}
 
-        AssignRecord(const std::unordered_set<std::string>& selector, double value_arg, std::size_t report_step_arg)
+        AssignRecord(const std::unordered_set<std::string>& selector,
+                     const double                           value_arg,
+                     const std::size_t                      report_step_arg)
             : rst_selector(selector)
-            , value(value_arg)
-            , report_step(report_step_arg)
+            , value       (value_arg)
+            , report_step (report_step_arg)
         {}
 
-        void eval(UDQSet& values) const {
-            if (this->input_selector.empty() && this->rst_selector.empty())
-                values.assign( this->value );
-            else {
-                if (this->rst_selector.empty())
-                    values.assign(this->input_selector[0], this->value);
-                else {
-                    for (const auto& wgname : this->rst_selector)
-                        values.assign(wgname, this->value);
-                }
-            }
-        }
+        AssignRecord(const std::vector<UDQSet::EnumeratedWellItems>& selector,
+                     const double                                    value_arg,
+                     const std::size_t                               report_step_arg)
+            : numbered_selector(selector)
+            , value            (value_arg)
+            , report_step      (report_step_arg)
+        {}
 
-        bool operator==(const AssignRecord& data) const {
-            return input_selector == data.input_selector &&
-                   rst_selector == data.rst_selector &&
-                   report_step == data.report_step &&
-                   value == data.value;
-        }
+        AssignRecord(std::vector<UDQSet::EnumeratedWellItems>&& selector,
+                     const double                               value_arg,
+                     const std::size_t                          report_step_arg)
+            : numbered_selector(std::move(selector))
+            , value            (value_arg)
+            , report_step      (report_step_arg)
+        {}
+
+        void eval(UDQSet& values) const;
+
+        bool operator==(const AssignRecord& data) const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            serializer(input_selector);
-            serializer(rst_selector);
-            serializer(value);
-            serializer(report_step);
+            serializer(this->input_selector);
+            serializer(this->rst_selector);
+            serializer(this->numbered_selector);
+            serializer(this->value);
+            serializer(this->report_step);
         }
     };
 
-    UDQAssign();
-    UDQAssign(const std::string& keyword, const std::vector<std::string>& selector, double value, std::size_t report_step);
-    UDQAssign(const std::string& keyword, const std::unordered_set<std::string>& selector, double value, std::size_t report_step);
+    UDQAssign() = default;
+    UDQAssign(const std::string&              keyword,
+              const std::vector<std::string>& selector,
+              double                          value,
+              std::size_t                     report_step);
+
+    UDQAssign(const std::string&                     keyword,
+              const std::unordered_set<std::string>& selector,
+              double                                 value,
+              std::size_t                            report_step);
+
+    UDQAssign(const std::string&                              keyword,
+              const std::vector<UDQSet::EnumeratedWellItems>& selector,
+              double                                          value,
+              std::size_t                                     report_step);
+
+    UDQAssign(const std::string&                         keyword,
+              std::vector<UDQSet::EnumeratedWellItems>&& selector,
+              double                                     value,
+              std::size_t                                report_step);
 
     static UDQAssign serializationTestObject();
 
     const std::string& keyword() const;
     UDQVarType var_type() const;
-    void add_record(const std::vector<std::string>& selector, double value, std::size_t report_step);
-    void add_record(const std::unordered_set<std::string>& rst_selector, double value, std::size_t report_step);
+
+    void add_record(const std::vector<std::string>& selector,
+                    double                          value,
+                    std::size_t                     report_step);
+
+    void add_record(const std::unordered_set<std::string>& rst_selector,
+                    double                                 value,
+                    std::size_t                            report_step);
+
+    void add_record(const std::vector<UDQSet::EnumeratedWellItems>& selector,
+                    double                                          value,
+                    std::size_t                                     report_step);
+
+    void add_record(std::vector<UDQSet::EnumeratedWellItems>&& selector,
+                    double                                     value,
+                    std::size_t                                report_step);
+
+    UDQSet eval(const std::vector<UDQSet::EnumeratedWellItems>& items) const;
     UDQSet eval(const std::vector<std::string>& wells) const;
     UDQSet eval() const;
     std::size_t report_step() const;
@@ -115,12 +153,11 @@ public:
     }
 
 private:
-    std::string m_keyword;
-    UDQVarType m_var_type;
-    std::vector<AssignRecord> records;
+    std::string m_keyword{};
+    UDQVarType m_var_type{UDQVarType::NONE};
+    std::vector<AssignRecord> records{};
 };
-}
 
+} // namespace Opm
 
-
-#endif
+#endif // UDQASSIGN_HPP_

--- a/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
@@ -185,6 +185,16 @@ public:
     struct EnumeratedWellItems {
         std::string well{};
         std::vector<std::size_t> numbers{};
+
+        bool operator==(const EnumeratedWellItems& rhs) const;
+        static EnumeratedWellItems serializationTestObject();
+
+        template <class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(this->well);
+            serializer(this->numbers);
+        }
     };
 
     /// Construct empty, named UDQ set of specific variable type

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQAssign.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQAssign.cpp
@@ -18,27 +18,93 @@
  */
 
 #include <opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp>
+
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQSet.hpp>
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
 
 namespace Opm {
 
-UDQAssign::UDQAssign() :
-    m_var_type(UDQVarType::NONE)
+void UDQAssign::AssignRecord::eval(UDQSet& values) const
 {
+    if (this->input_selector.empty() &&
+        this->rst_selector.empty() &&
+        this->numbered_selector.empty())
+    {
+        values.assign(this->value);
+    }
+    else if (! this->input_selector.empty()) {
+        values.assign(this->input_selector[0], this->value);
+    }
+    else if (! this->rst_selector.empty()) {
+        for (const auto& wgname : this->rst_selector) {
+            values.assign(wgname, this->value);
+        }
+    }
+    else {
+        for (const auto& item : this->numbered_selector) {
+            for (const auto& number : item.numbers) {
+                values.assign(item.well, number, this->value);
+            }
+        }
+    }
 }
 
-UDQAssign::UDQAssign(const std::string& keyword, const std::vector<std::string>& input_selector, double value, std::size_t report_step) :
-    m_keyword(keyword),
-    m_var_type(UDQ::varType(keyword))
+bool UDQAssign::AssignRecord::operator==(const AssignRecord& data) const
+{
+    return (this->input_selector == data.input_selector)
+        && (this->rst_selector == data.rst_selector)
+        && (this->numbered_selector == data.numbered_selector)
+        && (this->report_step == data.report_step)
+        && (this->value == data.value);
+}
+
+UDQAssign::UDQAssign(const std::string&              keyword,
+                     const std::vector<std::string>& input_selector,
+                     const double                    value,
+                     const std::size_t               report_step)
+    : m_keyword (keyword)
+    , m_var_type(UDQ::varType(keyword))
 {
     this->add_record(input_selector, value, report_step);
 }
 
-UDQAssign::UDQAssign(const std::string& keyword, const std::unordered_set<std::string>& rst_selector, double value, std::size_t report_step) :
-    m_keyword(keyword),
-    m_var_type(UDQ::varType(keyword))
+UDQAssign::UDQAssign(const std::string&                     keyword,
+                     const std::unordered_set<std::string>& rst_selector,
+                     const double                           value,
+                     const std::size_t                      report_step)
+    : m_keyword (keyword)
+    , m_var_type(UDQ::varType(keyword))
 {
     this->add_record(rst_selector, value, report_step);
+}
+
+UDQAssign::UDQAssign(const std::string&                              keyword,
+                     const std::vector<UDQSet::EnumeratedWellItems>& selector,
+                     double                                          value,
+                     std::size_t                                     report_step)
+    : m_keyword(keyword)
+    , m_var_type(UDQ::varType(keyword))
+{
+    this->add_record(selector, value, report_step);
+}
+
+UDQAssign::UDQAssign(const std::string&                         keyword,
+                     std::vector<UDQSet::EnumeratedWellItems>&& selector,
+                     double                                     value,
+                     std::size_t                                report_step)
+    : m_keyword(keyword)
+    , m_var_type(UDQ::varType(keyword))
+{
+    this->add_record(std::move(selector), value, report_step);
 }
 
 UDQAssign UDQAssign::serializationTestObject()
@@ -46,58 +112,117 @@ UDQAssign UDQAssign::serializationTestObject()
     UDQAssign result;
     result.m_keyword = "test";
     result.m_var_type = UDQVarType::CONNECTION_VAR;
-    result.records = {{std::vector<std::string>{"test1"}, 1.0, 0}};
+    result.records.emplace_back(std::vector<std::string>{"test1"}, 1.0, 0);
+
+    result.records.emplace_back(std::unordered_set<std::string>{ "I-45" }, 3.1415, 3);
+
+    // Class-template argument deduction for the vector element type.
+    result.records.emplace_back(std::vector { UDQSet::EnumeratedWellItems::serializationTestObject() }, 2.71828, 42);
 
     return result;
 }
 
-void UDQAssign::add_record(const std::vector<std::string>& input_selector, double value, std::size_t report_step) {
-    this->records.push_back({input_selector, value, report_step});
+void UDQAssign::add_record(const std::vector<std::string>& input_selector,
+                           const double                    value,
+                           const std::size_t               report_step)
+{
+    this->records.emplace_back(input_selector, value, report_step);
 }
 
-void UDQAssign::add_record(const std::unordered_set<std::string>& rst_selector, double value, std::size_t report_step) {
-    this->records.push_back({rst_selector, value, report_step});
+void UDQAssign::add_record(const std::unordered_set<std::string>& rst_selector,
+                           const double                           value,
+                           const std::size_t                      report_step)
+{
+    this->records.emplace_back(rst_selector, value, report_step);
 }
 
-const std::string& UDQAssign::keyword() const {
+void UDQAssign::add_record(const std::vector<UDQSet::EnumeratedWellItems>& selector,
+                           const double                                    value,
+                           const std::size_t                               report_step)
+{
+    this->records.emplace_back(selector, value, report_step);
+}
+
+void UDQAssign::add_record(std::vector<UDQSet::EnumeratedWellItems>&& selector,
+                           const double                               value,
+                           const std::size_t                          report_step)
+{
+    this->records.emplace_back(std::move(selector), value, report_step);
+}
+
+const std::string& UDQAssign::keyword() const
+{
     return this->m_keyword;
 }
 
-UDQVarType UDQAssign::var_type() const {
+UDQVarType UDQAssign::var_type() const
+{
     return this->m_var_type;
 }
 
-
-std::size_t UDQAssign::report_step() const {
+std::size_t UDQAssign::report_step() const
+{
     return this->records.back().report_step;
 }
 
-
-UDQSet UDQAssign::eval(const std::vector<std::string>& wells) const {
+UDQSet UDQAssign::eval(const std::vector<std::string>& wgnames) const
+{
     if (this->m_var_type == UDQVarType::WELL_VAR) {
-        UDQSet ws = UDQSet::wells(this->m_keyword, wells);
+        auto ws = UDQSet::wells(this->m_keyword, wgnames);
 
-        for (const auto& record : this->records)
+        for (const auto& record : this->records) {
             record.eval(ws);
+        }
 
         return ws;
     }
-    throw std::invalid_argument("Not yet implemented");
+
+    throw std::invalid_argument {
+        fmt::format("ASSIGN UDQ '{}': eval(vector<string>) not "
+                    "yet implemented for variables of type {}",
+                    this->m_keyword, UDQ::typeName(this->m_var_type))
+    };
 }
 
-UDQSet UDQAssign::eval() const {
-    if (this->m_var_type == UDQVarType::FIELD_VAR || this->m_var_type == UDQVarType::SCALAR ) {
-        const auto& record = this->records.back();
-        return UDQSet::scalar(this->m_keyword, record.value);
+UDQSet UDQAssign::eval(const std::vector<UDQSet::EnumeratedWellItems>& items) const
+{
+    if (this->m_var_type == UDQVarType::SEGMENT_VAR) {
+        auto us = UDQSet { this->m_keyword, this->m_var_type, items };
+
+        for (const auto& record : this->records) {
+            record.eval(us);
+        }
+
+        return us;
     }
-    throw std::invalid_argument("Not yet implemented");
+
+    throw std::invalid_argument {
+        fmt::format("ASSIGN UDQ '{}': eval(vector<Enumerated Items>) not "
+                    "yet implemented for variables of type {}",
+                    this->m_keyword, UDQ::typeName(this->m_var_type))
+    };
 }
 
+UDQSet UDQAssign::eval() const
+{
+    if ((this->m_var_type == UDQVarType::FIELD_VAR) ||
+        (this->m_var_type == UDQVarType::SCALAR))
+    {
+        return UDQSet::scalar(this->m_keyword, this->records.back().value);
+    }
 
-bool UDQAssign::operator==(const UDQAssign& data) const {
-    return this->keyword() == data.keyword() &&
-           this->var_type() == data.var_type() &&
-           this->records == data.records;
+    throw std::invalid_argument {
+        fmt::format("ASSIGN UDQ '{}': eval() not yet "
+                    "implemented for variables of type {}",
+                    this->m_keyword, UDQ::typeName(this->m_var_type))
+    };
 }
 
+bool UDQAssign::operator==(const UDQAssign& data) const
+{
+    return (this->keyword() == data.keyword())
+        && (this->var_type() == data.var_type())
+        && (this->records == data.records);
 }
+
+} // namespace Opm

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
@@ -146,6 +146,18 @@ bool UDQScalar::operator==(const UDQScalar& other) const
 // UDQSet Implementation Below Separator
 // ------------------------------------------------------------------------
 
+bool UDQSet::EnumeratedWellItems::operator==(const EnumeratedWellItems& that) const
+{
+    return (this->well == that.well)
+        && (this->numbers == that.numbers);
+}
+
+UDQSet::EnumeratedWellItems
+UDQSet::EnumeratedWellItems::serializationTestObject()
+{
+    return { "PROD01", std::vector<std::size_t>{ 17, 29 } };
+}
+
 const std::string& UDQSet::name() const
 {
     return this->m_name;

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1009,6 +1009,59 @@ BOOST_AUTO_TEST_CASE(UDQASSIGN_TEST) {
     BOOST_CHECK(!res3["I2"].defined());
 }
 
+BOOST_AUTO_TEST_CASE(UDQASSIGN_NUMBERED_ITEMS_TEST) {
+    using Vsz = std::vector<std::size_t>;
+
+    const auto selector = UDQSet::EnumeratedWellItems {
+        "PROD01", Vsz { 1, 3, 5, 7 }
+    };
+
+    const auto as = UDQAssign {
+        "SUVTRIG", std::vector { selector }, 0.123, 42
+    };
+
+    const auto segments = std::vector {
+        UDQSet::EnumeratedWellItems { "PROD01", Vsz { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, } },
+        UDQSet::EnumeratedWellItems { "PROD02", Vsz { 1, 2, 3, 4, 5, } },
+        UDQSet::EnumeratedWellItems { "PROD06", Vsz { 2, 4, 6, 8, 10, } },
+        UDQSet::EnumeratedWellItems { "I-45", Vsz { 1, 2, 3, } },
+    };
+
+    const auto us = as.eval(segments);
+
+    BOOST_CHECK_EQUAL(us.size(), std::size_t{23});
+    BOOST_CHECK_CLOSE(us("PROD01", 1).get(), 0.123, 1.0e-8);
+    BOOST_CHECK_MESSAGE(!us("PROD01", 2).defined(), R"(SUVTRIG("PROD01", 2) must not be defined)");
+    BOOST_CHECK_CLOSE(us("PROD01", 3).get(), 0.123, 1.0e-8);
+    BOOST_CHECK_MESSAGE(!us("PROD01", 4).defined(), R"(SUVTRIG("PROD01", 4) must not be defined)");
+    BOOST_CHECK_CLOSE(us("PROD01", 5).get(), 0.123, 1.0e-8);
+    BOOST_CHECK_MESSAGE(!us("PROD01", 6).defined(), R"(SUVTRIG("PROD01", 6) must not be defined)");
+    BOOST_CHECK_CLOSE(us("PROD01", 7).get(), 0.123, 1.0e-8);
+    BOOST_CHECK_MESSAGE(!us("PROD01",  8).defined(), R"(SUVTRIG("PROD01", 8) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD01",  9).defined(), R"(SUVTRIG("PROD01", 9) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD01", 10).defined(), R"(SUVTRIG("PROD01", 10) must not be defined)");
+
+    BOOST_CHECK_MESSAGE(!us("PROD02", 1).defined(), R"(SUVTRIG("PROD02", 1) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD02", 2).defined(), R"(SUVTRIG("PROD02", 2) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD02", 3).defined(), R"(SUVTRIG("PROD02", 3) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD02", 4).defined(), R"(SUVTRIG("PROD02", 4) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD02", 5).defined(), R"(SUVTRIG("PROD02", 5) must not be defined)");
+
+    BOOST_CHECK_MESSAGE(!us("PROD06",  2).defined(), R"(SUVTRIG("PROD06", 2) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD06",  4).defined(), R"(SUVTRIG("PROD06", 4) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD06",  6).defined(), R"(SUVTRIG("PROD06", 6) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD06",  8).defined(), R"(SUVTRIG("PROD06", 8) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("PROD06", 10).defined(), R"(SUVTRIG("PROD06", 10) must not be defined)");
+
+    BOOST_CHECK_THROW(!us("PROD06", 3).defined(), std::out_of_range);
+
+    BOOST_CHECK_MESSAGE(!us("I-45", 1).defined(), R"(SUVTRIG("I-45", 1) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("I-45", 2).defined(), R"(SUVTRIG("I-45", 2) must not be defined)");
+    BOOST_CHECK_MESSAGE(!us("I-45", 3).defined(), R"(SUVTRIG("I-45", 3) must not be defined)");
+
+    BOOST_CHECK_THROW(!us("Hello", 42).defined(), std::out_of_range);
+}
+
 BOOST_AUTO_TEST_CASE(UDQ_POW_TEST) {
     KeywordLocation location;
     UDQFunctionTable udqft;


### PR DESCRIPTION
This PR adds support for constructing UDQ `ASSIGN` records for enumerated well items such as those encountered in UDQs at the segment level, e.g.,
```
ASSIGN SUSPECT PROD01    123.456 /
ASSIGN SUSPECT PROD02 17 654.321 /
```
We do not support this syntax quite yet, but this is a step on the way there.