### PR TITLE
changed: rename the packer used in test_Serialization to MemPacker

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -34,6 +34,7 @@ list (APPEND MAIN_SOURCE_FILES
       src/opm/common/utility/ActiveGridCells.cpp
       src/opm/common/utility/Demangle.cpp
       src/opm/common/utility/FileSystem.cpp
+      src/opm/common/utility/MemPacker.cpp
       src/opm/common/utility/numeric/MonotCubicInterpolator.cpp
       src/opm/common/utility/OpmInputError.cpp
       src/opm/common/utility/parameters/Parameter.cpp
@@ -706,6 +707,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/common/utility/FileSystem.hpp
       opm/common/utility/OpmInputError.hpp
       opm/common/utility/Serializer.hpp
+      opm/common/utility/MemPacker.hpp
       opm/common/utility/numeric/cmp.hpp
       opm/common/utility/platform_dependent/disable_warnings.h
       opm/common/utility/platform_dependent/reenable_warnings.h

--- a/opm/common/utility/MemPacker.hpp
+++ b/opm/common/utility/MemPacker.hpp
@@ -16,8 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef SIMPLE_PACKER_HPP
-#define SIMPLE_PACKER_HPP
+#ifndef MEM_PACKER_HPP
+#define MEM_PACKER_HPP
 
 #include <opm/common/utility/TimeService.hpp>
 
@@ -27,7 +27,7 @@
 #include <string>
 
 namespace Opm {
-namespace TestUtil {
+namespace Serialization {
 namespace detail {
 
 //! \brief Abstract struct for packing which is (partially) specialized for specific types.
@@ -134,79 +134,41 @@ struct Packing<false,T>
 template <std::size_t Size>
 struct Packing<false,std::bitset<Size>>
 {
-    static std::size_t packSize(const std::bitset<Size>& data)
-    {
-        return Packing<true,unsigned long long>::packSize(data.to_ullong());
-    }
+    static std::size_t packSize(const std::bitset<Size>& data);
 
     static void pack(const std::bitset<Size>& data,
-                     std::vector<char>& buffer, int& position)
-    {
-        Packing<true,unsigned long long>::pack(data.to_ullong(), buffer, position);
-    }
+                     std::vector<char>& buffer, int& position);
 
     static void unpack(std::bitset<Size>& data,
-                       std::vector<char>& buffer, int& position)
-    {
-        unsigned long long d;
-        Packing<true,unsigned long long>::unpack(d, buffer, position);
-        data = std::bitset<Size>(d);
-    }
+                       std::vector<char>& buffer, int& position);
 };
 
 template<>
 struct Packing<false,std::string>
 {
-    static std::size_t packSize(const std::string& data)
-    {
-        return sizeof(std::size_t) + data.size();
-    }
+    static std::size_t packSize(const std::string& data);
 
     static void pack(const std::string& data,
-                     std::vector<char>& buffer, int& position)
-    {
-        Packing<true,std::size_t>::pack(data.size(), buffer, position);
-        Packing<true,char>::pack(data.data(), data.size(), buffer, position);
-    }
+                     std::vector<char>& buffer, int& position);
 
-    static void unpack(std::string& data, std::vector<char>& buffer, int& position)
-    {
-        std::size_t length = 0;
-        Packing<true,std::size_t>::unpack(length, buffer, position);
-        std::vector<char> cStr(length+1, '\0');
-        Packing<true,char>::unpack(cStr.data(), length, buffer, position);
-        data.clear();
-        data.append(cStr.data(), length);
-    }
+    static void unpack(std::string& data, std::vector<char>& buffer, int& position);
 };
 
 template<>
 struct Packing<false,time_point>
 {
-    static std::size_t packSize(const time_point&)
-    {
-        return Packing<true,std::time_t>::packSize(std::time_t());
-    }
+    static std::size_t packSize(const time_point&);
 
     static void pack(const time_point& data,
-                     std::vector<char>& buffer, int& position)
-    {
-        Packing<true,std::time_t>::pack(TimeService::to_time_t(data),
-                                        buffer, position);
-    }
+                     std::vector<char>& buffer, int& position);
 
-    static void unpack(time_point& data, std::vector<char>& buffer, int& position)
-    {
-        std::time_t res;
-        Packing<true,std::time_t>::unpack(res, buffer, position);
-        data = TimeService::from_time_t(res);
-    }
+    static void unpack(time_point& data, std::vector<char>& buffer, int& position);
 };
 
 }
 
-//! \brief Struct handling packing of serialization for test purposes.
-struct Packer {
+//! \brief Struct handling packing of serialization to a memory buffer.
+struct MemPacker {
     //! \brief Calculates the pack size for a variable.
     //! \tparam T The type of the data to be packed
     //! \param data The data to pack
@@ -286,7 +248,7 @@ struct Packer {
     }
 };
 
-} // end namespace TestUtil
+} // end namespace Serialization
 } // end namespace Opm
 
-#endif // SIMPLE_PACKER_HPP
+#endif // MEM_PACKER_HPP

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -39,6 +39,10 @@
 namespace Dune { template<typename,int> class FieldVector; }
 #endif
 
+#if HAVE_DUNE_ISTL
+namespace Dune { template<typename,typename> class BlockVector; }
+#endif
+
 namespace Opm {
 namespace detail {
 
@@ -390,6 +394,13 @@ protected:
     struct is_vector<std::vector<T1,Allocator>> {
         constexpr static bool value = true;
     };
+
+#if HAVE_DUNE_ISTL
+    template<class T1, class Allocator>
+    struct is_vector<Dune::BlockVector<T1,Allocator>> {
+        constexpr static bool value = true;
+    };
+#endif
 
     //! \brief Predicate for detecting variants.
     template<class T>

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -35,6 +35,10 @@
 #include <variant>
 #include <vector>
 
+#if HAVE_DUNE_COMMON
+namespace Dune { template<typename,int> class FieldVector; }
+#endif
+
 namespace Opm {
 namespace detail {
 
@@ -483,6 +487,13 @@ protected:
     struct is_array<std::array<T,N>> {
         constexpr static bool value = true;
     };
+
+#if HAVE_DUNE_COMMON
+    template<class T, int N>
+    struct is_array<Dune::FieldVector<T,N>> {
+        constexpr static bool value = true;
+    };
+#endif
 
     //! Detect existence of \c serializeOp member function
     //!

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 #include <unordered_map>

--- a/opm/common/utility/Serializer.hpp
+++ b/opm/common/utility/Serializer.hpp
@@ -185,10 +185,10 @@ protected:
     //! \brief Handler for vectors.
     //! \tparam T Type for vector elements
     //! \param data The vector to (de-)serialize
-    template <typename T>
-    void vector(const std::vector<T>& data)
+    template <typename Vector>
+    void vector(const Vector& data)
     {
-        if constexpr (std::is_pod_v<T>) {
+        if constexpr (std::is_pod_v<typename Vector::value_type>) {
           if (m_op == Operation::PACKSIZE) {
               (*this)(data.size());
               m_packSize += m_packer.packSize(data.data(), data.size());
@@ -198,7 +198,7 @@ protected:
           } else if (m_op == Operation::UNPACK) {
               std::size_t size = 0;
               (*this)(size);
-              auto& data_mut = const_cast<std::vector<T>&>(data);
+              auto& data_mut = const_cast<Vector&>(data);
               data_mut.resize(size);
               m_packer.unpack(data_mut.data(), size, m_buffer, m_position);
           }
@@ -206,7 +206,7 @@ protected:
             if (m_op == Operation::UNPACK) {
                 std::size_t size = 0;
                 (*this)(size);
-                auto& data_mut = const_cast<std::vector<T>&>(data);
+                auto& data_mut = const_cast<Vector&>(data);
                 data_mut.resize(size);
                 std::for_each(data_mut.begin(), data_mut.end(), std::ref(*this));
             } else {

--- a/src/opm/common/utility/MemPacker.cpp
+++ b/src/opm/common/utility/MemPacker.cpp
@@ -1,0 +1,107 @@
+/*
+  Copyright 2019 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <config.h>
+#include <opm/common/utility/MemPacker.hpp>
+
+namespace Opm {
+namespace Serialization {
+namespace detail {
+
+//! \brief Specialization for std::bitset
+template <std::size_t Size>
+std::size_t Packing<false,std::bitset<Size>>::
+packSize(const std::bitset<Size>& data)
+{
+    return Packing<true,unsigned long long>::packSize(data.to_ullong());
+}
+
+template <std::size_t Size>
+void Packing<false,std::bitset<Size>>::
+pack(const std::bitset<Size>& data,
+     std::vector<char>& buffer, int& position)
+{
+    Packing<true,unsigned long long>::pack(data.to_ullong(), buffer, position);
+}
+
+template <std::size_t Size>
+void Packing<false,std::bitset<Size>>::
+unpack(std::bitset<Size>& data,
+       std::vector<char>& buffer, int& position)
+{
+    unsigned long long d;
+    Packing<true,unsigned long long>::unpack(d, buffer, position);
+    data = std::bitset<Size>(d);
+}
+
+std::size_t Packing<false,std::string>::
+packSize(const std::string& data)
+{
+    return sizeof(std::size_t) + data.size();
+}
+
+void Packing<false,std::string>::
+pack(const std::string& data,
+     std::vector<char>& buffer, int& position)
+{
+    Packing<true,std::size_t>::pack(data.size(), buffer, position);
+    Packing<true,char>::pack(data.data(), data.size(), buffer, position);
+}
+
+void Packing<false,std::string>::
+unpack(std::string& data, std::vector<char>& buffer, int& position)
+{
+    std::size_t length = 0;
+    Packing<true,std::size_t>::unpack(length, buffer, position);
+    std::vector<char> cStr(length+1, '\0');
+    Packing<true,char>::unpack(cStr.data(), length, buffer, position);
+    data.clear();
+    data.append(cStr.data(), length);
+}
+
+std::size_t Packing<false,time_point>::
+packSize(const time_point&)
+{
+    return Packing<true,std::time_t>::packSize(std::time_t());
+}
+
+void Packing<false,time_point>::
+pack(const time_point& data,
+     std::vector<char>& buffer, int& position)
+{
+    Packing<true,std::time_t>::pack(TimeService::to_time_t(data),
+                                    buffer, position);
+}
+
+void Packing<false,time_point>::
+unpack(time_point& data, std::vector<char>& buffer, int& position)
+{
+    std::time_t res;
+    Packing<true,std::time_t>::unpack(res, buffer, position);
+    data = TimeService::from_time_t(res);
+}
+
+template struct Packing<false,std::bitset<3>>;
+template struct Packing<false,std::bitset<4>>;
+template struct Packing<false,std::bitset<10>>;
+
+}
+
+} // end namespace Serialization
+} // end namespace Opm

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -140,12 +140,12 @@
 #include <opm/output/data/Aquifer.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
 #include <opm/common/utility/Serializer.hpp>
-#include "SimplePacker.hpp"
+#include <opm/common/utility/MemPacker.hpp>
 
 template<class T>
 std::tuple<T,int,int> PackUnpack(T& in)
 {
-    Opm::TestUtil::Packer packer;
+    Opm::Serialization::MemPacker packer;
     Opm::Serializer ser(packer);
     ser.pack(in);
     size_t pos1 = ser.position();


### PR DESCRIPTION
Make it a public header so it can be reused elsewhere.

This is a the start of a PR series enabling "perfect restart" of simulators. 