### PR TITLE
New property

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -873,12 +873,9 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
       opm/material/fluidmatrixinteractions/TwoPhaseLETCurves.hpp
       opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
-<<<<<<< HEAD
       opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp
       opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp
-=======
       opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.hpp
->>>>>>> 376afbcc4 (addded new files to cmake system)
       opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
       opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
       opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -264,6 +264,7 @@ if(ENABLE_ECL_INPUT)
     src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
     src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
     src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+    src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.cpp
     src/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
     src/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
     src/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.cpp
@@ -872,8 +873,12 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp
       opm/material/fluidmatrixinteractions/TwoPhaseLETCurves.hpp
       opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+<<<<<<< HEAD
       opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp
       opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp
+=======
+      opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.hpp
+>>>>>>> 376afbcc4 (addded new files to cmake system)
       opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp
       opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
       opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -442,6 +442,9 @@ if(ENABLE_ECL_INPUT)
     tests/material/test_eclblackoilpvt.cpp
     tests/material/test_eclmateriallawmanager.cpp
     tests/material/test_propertyevaluation.cpp
+    tests/material/test_eclpropertyevaluation.cpp
+    tests/material/test_eclpropertyevaluation_lowlevel.cpp
+    tests/material/test_eclpropertyevaluation_lowlevel_spe9.cpp
     tests/parser/ACTIONX.cpp
     tests/parser/ADDREGTests.cpp
     tests/parser/AquiferTests.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -441,6 +441,7 @@ if(ENABLE_ECL_INPUT)
     tests/material/test_eclblackoilfluidsystem.cpp
     tests/material/test_eclblackoilpvt.cpp
     tests/material/test_eclmateriallawmanager.cpp
+    tests/material/test_propertyevaluation.cpp
     tests/parser/ACTIONX.cpp
     tests/parser/ADDREGTests.cpp
     tests/parser/AquiferTests.cpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -445,6 +445,9 @@ if(ENABLE_ECL_INPUT)
     tests/material/test_eclpropertyevaluation.cpp
     tests/material/test_eclpropertyevaluation_lowlevel.cpp
     tests/material/test_eclpropertyevaluation_lowlevel_spe9.cpp
+    tests/material/test_relpermevaluation.cpp
+    tests/material/test_eclrelpermevaluation.cpp
+    tests/material/test_eclrelpermevaluation_lowlevel.cpp   
     tests/parser/ACTIONX.cpp
     tests/parser/ADDREGTests.cpp
     tests/parser/AquiferTests.cpp

--- a/opm/material/common/Tabulated1DFunction.hpp
+++ b/opm/material/common/Tabulated1DFunction.hpp
@@ -268,6 +268,20 @@ public:
         return y0 + (y1 - y0)*(x - x0)/(x1 - x0);
     }
 
+    template <class Evaluation>
+    Evaluation eval(const Evaluation& x, size_t segIdx) const
+    {
+        Scalar x0 = xValues_[segIdx];
+        Scalar x1 = xValues_[segIdx + 1];
+
+        Scalar y0 = yValues_[segIdx];
+        Scalar y1 = yValues_[segIdx + 1];
+
+        return y0 + (y1 - y0)*(x - x0)/(x1 - x0);
+    }
+
+
+    
     /*!
      * \brief Evaluate the spline's derivative at a given position.
      *
@@ -421,7 +435,7 @@ public:
                yValues_ == data.yValues_;
     }
 
-private:
+//private:
     template <class Evaluation>
     size_t findSegmentIndex_(const Evaluation& x, bool extrapolate = false) const
     {
@@ -490,7 +504,7 @@ private:
             return lowerIdx;
         }
     }
-
+private:
     template <class Evaluation>
     Evaluation evalDerivative_(const Evaluation& x, size_t segIdx) const
     {

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -393,12 +393,18 @@ public:
     {
 #ifndef NDEBUG
         if (!extrapolate && !applies(x, y)) {
-            std::ostringstream oss;
-            oss << "Attempt to get undefined table value (" << x << ", " << y << ")";
-            throw NumericalIssue(oss.str());
+            if constexpr (std::is_floating_point_v<Evaluation>) {
+                throw NumericalProblem("Attempt to get undefined table value (" +
+                                       std::to_string(x) + ", " +
+                                       std::to_string(y) + ")");
+            } else {
+                throw NumericalProblem("Attempt to get undefined table value (" +
+                                       std::to_string(x.value()) + ", " +
+                                       std::to_string(y.value()) + ")");
+            }
         };
 #endif
-
+    
         // bi-linear interpolation: first, calculate the x and y indices in the lookup
         // table ...
         i = xSegmentIndex(x, extrapolate);

--- a/opm/material/common/UniformXTabulated2DFunction.hpp
+++ b/opm/material/common/UniformXTabulated2DFunction.hpp
@@ -387,6 +387,84 @@ public:
         return result;
     }
 
+        template <class Evaluation>
+    void findPoints(unsigned& i, unsigned& j1, unsigned& j2, Evaluation& alpha, Evaluation& beta1, Evaluation& beta2,
+               const Evaluation& x, const Evaluation& y, bool extrapolate=false) const
+    {
+#ifndef NDEBUG
+        if (!extrapolate && !applies(x, y)) {
+            std::ostringstream oss;
+            oss << "Attempt to get undefined table value (" << x << ", " << y << ")";
+            throw NumericalIssue(oss.str());
+        };
+#endif
+
+        // bi-linear interpolation: first, calculate the x and y indices in the lookup
+        // table ...
+        i = xSegmentIndex(x, extrapolate);
+        alpha = xToAlpha(x, i);
+        // The 'shift' is used to shift the points used to interpolate within
+        // the (i) and (i+1) sets of sample points, so that when approaching
+        // the boundary of the domain given by the samples, one gets the same
+        // value as one would get by interpolating along the boundary curve
+        // itself.
+        Evaluation shift = 0.0;
+        if (interpolationGuide_ == InterpolationPolicy::Vertical) {
+            // Shift is zero, no need to reset it.
+        } else {
+            // find upper and lower y value
+            if (interpolationGuide_ == InterpolationPolicy::LeftExtreme) {
+                // The domain is above the boundary curve, up to y = infinity.
+                // The shift is therefore the same for all values of y.
+                shift = yPos_[i+1] - yPos_[i];
+            } else {
+                assert(interpolationGuide_ == InterpolationPolicy::RightExtreme);
+                // The domain is below the boundary curve, down to y = 0.
+                // The shift is therefore no longer the the same for all
+                // values of y, since at y = 0 the shift must be zero.
+                // The shift is computed by linear interpolation between
+                // the maximal value at the domain boundary curve, and zero.
+                shift = yPos_[i+1] - yPos_[i];
+                auto yEnd = yPos_[i]*(1.0 - alpha) + yPos_[i+1]*alpha;
+                if (yEnd > 0.) {
+                    shift = shift * y / yEnd;
+                } else {
+                    shift = 0.;
+                }
+            }
+        }
+        auto yLower =  y - alpha*shift;
+        auto yUpper =  y + (1-alpha)*shift;
+
+        j1 = ySegmentIndex(yLower, i, extrapolate);
+        j2 = ySegmentIndex(yUpper, i + 1, extrapolate);
+        beta1 = yToBeta(yLower, i, j1);
+        beta2 = yToBeta(yUpper, i + 1, j2);
+
+    }
+
+    template <class Evaluation>
+    Evaluation eval(unsigned& i, unsigned& j1, unsigned& j2, Evaluation& alpha, Evaluation& beta1, Evaluation& beta2,
+         const Evaluation& x, const Evaluation& y, bool extrapolate=false) const
+    {
+        // evaluate the two function values for the same y value ...
+        const Evaluation& s1 = valueAt(i, j1)*(1.0 - beta1) + valueAt(i, j1 + 1)*beta1;
+        const Evaluation& s2 = valueAt(i + 1, j2)*(1.0 - beta2) + valueAt(i + 1, j2 + 1)*beta2;
+
+        Valgrind::CheckDefined(s1);
+        Valgrind::CheckDefined(s2);
+
+        // ... and combine them using the x position
+        const Evaluation& result = s1*(1.0 - alpha) + s2*alpha;
+        Valgrind::CheckDefined(result);
+
+        return result;
+    }
+
+
+
+
+    
     /*!
      * \brief Set the x-position of a vertical line.
      *

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -306,6 +306,102 @@ public:
      * oil relative permeability models" section of the ECLipse
      * technical description.
      */
+    //static void relativePermeabilitiesNew(ContainerT& values, const Params& params, const FluidState& fluidState)
+    template <class ContainerT, class FluidState,class ParamsOilWater, class ParamsGasOil>
+    static void relativePermeabilitiesNew(ContainerT& values,
+                                          const Scalar& Swco,
+                                          const ParamsOilWater& oilwaterparams,
+                                          const ParamsGasOil& gasoilparams, 
+                                          const FluidState& fluidState)
+    {
+        //const Evaluation SwUnscaled = scaledToUnscaledSatKrw(params, SwScaled);
+        //const Evaluation krwUnscaled = EffLaw::twoPhaseSatKrw(params.effectiveLawParams(), SwUnscaled);
+        //return unscaledToScaledKrw_(SwScaled, params, krwUnscaled);
+        using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
+        
+        
+        using PLTwoPhaseLawGasOil  = PiecewiseLinearTwoPhaseMaterial<typename GasOilMaterialLawT::Traits>;
+        using PLTwoPhaseLawOilWater  = PiecewiseLinearTwoPhaseMaterial<typename OilWaterMaterialLawT::Traits>;
+        
+        // values[waterPhaseIdx] = krw<FluidState, Evaluation>(params, fluidState);
+        
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        //const Evaluation krwv = OilWaterMaterialLaw::twoPhaseSatKrw(oilwaterparams, Sw);
+        //const auto& oilwaterparams =params.oilWaterParams().drainageParams().effectiveLawParams().template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+        //const Evaluation krwv = PLTwoPhaseLawOilWater::twoPhaseSatKrw(oilwaterparams, Sw);
+        size_t segIdx_ow = PLTwoPhaseLawOilWater::findSegmentIndex(oilwaterparams.SwKrwSamples(), Sw);
+        const Evaluation krwv = PLTwoPhaseLawOilWater::eval(oilwaterparams.SwKrwSamples(), oilwaterparams.krwSamples(), Sw, segIdx_ow);
+        
+        values[waterPhaseIdx] = krwv;
+        
+        //const Scalar Swco = params.Swl();
+        Evaluation krnv;
+        const Evaluation Sw_eff = max(Evaluation(Swco), decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
+
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        
+        const Evaluation Sw_ow = Sg + Sw_eff;
+        // const Evaluation kro_ow = relpermOilInOilWaterSystem<Evaluation>(params, fluidState);
+        //const Evaluation kro_ow = PLTwoPhaseLawOilWater::twoPhaseSatKrn(oilwaterparams, Sw_ow);
+        //size_t segIdx_ow = PLTwoPhaseLawOilWater::findSegmentIndex(oilwaterparams.SwKrwSamples(), Sw);
+        //NB assumes same index but probalby one should ahve used same x values also
+        //const Evaluation kro_ow = PLTwoPhaseLawOilWater::eval(oilwaterparams.SwKrnSamples(), oilwaterparams.krnSamples(), Sw_ow, segIdx_ow);
+        const Evaluation kro_ow = PLTwoPhaseLawOilWater::eval(oilwaterparams.SwKrwSamples(), oilwaterparams.krnSamples(), Sw_ow, segIdx_ow);
+
+// const Evaluation kro_go = relpermOilInOilGasSystem<Evaluation>(params, fluidState);
+        const Evaluation So_go = 1.0 - Sw_ow;
+        //const Evaluation kro_go = GasOilMaterialLaw::twoPhaseSatKrw(params.gasOilParams(), So_go);
+        //const auto& gasoilparams =params.gasOilParams().drainageParams().effectiveLawParams().template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+        //const Evaluation kro_go = PLTwoPhaseLawGasOil::twoPhaseSatKrw(gasoilparams, So_go);
+        size_t segIdx_go = PLTwoPhaseLawGasOil::findSegmentIndex(gasoilparams.SwKrwSamples(), So_go);
+        const Evaluation kro_go = PLTwoPhaseLawGasOil::eval(gasoilparams.SwKrwSamples(), gasoilparams.krwSamples(), So_go, segIdx_go);
+        // avoid the division by zero: chose a regularized kro which is used if Sw - Swco
+        // < epsilon/2 and interpolate between the oridinary and the regularized kro between
+        // epsilon and epsilon/2
+        constexpr const Scalar epsilon = 1e-5;
+        Scalar Sw_ow_wco = scalarValue(Sw_ow) - Swco;
+        if ( Sw_ow_wco < epsilon) {
+            const Evaluation kro2 = (kro_ow + kro_go) / 2;
+            if ( Sw_ow_wco > epsilon / 2) {
+                const Evaluation kro1 = (Sg * kro_go + (Sw - Swco) * kro_ow) / (Sw_ow - Swco);
+                const Evaluation alpha = (epsilon - (Sw_ow - Swco)) / (epsilon / 2);
+                
+                krnv = kro2 * alpha + kro1 * (1 - alpha);
+            }
+            
+            krnv = kro2;
+        } else {
+            krnv = (Sg * kro_go + (Sw - Swco) * kro_ow) / (Sw_ow - Swco);
+        }
+        
+        
+        values[oilPhaseIdx] = krnv;
+        //values[gasPhaseIdx] = krg<FluidState, Evaluation>(params, fluidState);
+        const Evaluation Sw_eff2 = 1.0 - Swco - Sg;
+        //Evaluation krgv = PLTwoPhaseLawGasOil::twoPhaseSatKrn(gasoilparams, Sw_eff2);
+        //size_t segIdx_go = PLTwoPhaseLawGasOil::findSegmentIndex(gasoilparams.SwKrnSamples(), Sw_eff2);
+        //const Evaluation krgv = PLTwoPhaseLawGasOil::eval(gasoilparams.SwKrnSamples(), gasoilparams.krnSamples(), Sw_eff2, segIdx_go);
+        const Evaluation krgv = PLTwoPhaseLawGasOil::eval(gasoilparams.SwKrwSamples(), gasoilparams.krnSamples(), Sw_eff2, segIdx_go);
+        values[gasPhaseIdx] = krgv;
+    }
+
+
+
+    /*!
+     * \brief The relative permeability of all phases.
+     *
+     * The relative permeability of the water phase it uses the same
+     * value as the relative permeability for water in the water-oil
+     * law with \f$S_o = 1 - S_w\f$. The gas relative permebility is
+     * taken from the gas-oil material law, but with \f$S_o = 1 -
+     * S_g\f$.  The relative permeability of the oil phase is
+     * calculated using the relative permeabilities of the oil phase
+     * in the two two-phase systems.
+     *
+     * A more detailed description can be found in the "Three phase
+     * oil relative permeability models" section of the ECLipse
+     * technical description.
+     */
     template <class ContainerT, class FluidState>
     static void relativePermeabilities(ContainerT& values,
                                        const Params& params,

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -337,19 +337,17 @@ public:
         const Evaluation krwv = OilWaterMaterialLaw::twoPhaseSatKrw(oilwaterparams, Sw);
                 
         values[waterPhaseIdx] = krwv;
-        
+
+        // const Evaluation kro_go = relpermOilInOilGasSystem<Evaluation>(params, fluidState);
         const Scalar Swco = params.Swl();
         Evaluation krnv;
         const Evaluation Sw_eff = max(Evaluation(Swco), decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
-
-        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
-        
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));       
         const Evaluation Sw_ow = Sg + Sw_eff;
         const Evaluation kro_ow = OilWaterMaterialLaw::twoPhaseSatKrn(oilwaterparams, Sw_ow);
    
        
-
-// const Evaluation kro_go = relpermOilInOilGasSystem<Evaluation>(params, fluidState);
+        //values[gasPhaseIdx] = krg<FluidState, Evaluation>(params, fluidState);
         const Evaluation So_go = 1.0 - Sw_ow;
         const Evaluation kro_go = GasOilMaterialLaw::twoPhaseSatKrw(gasoilparams , So_go);
         constexpr const Scalar epsilon = 1e-5;
@@ -367,125 +365,14 @@ public:
         } else {
             krnv = (Sg * kro_go + (Sw - Swco) * kro_ow) / (Sw_ow - Swco);
         }
-        
-        
+               
         values[oilPhaseIdx] = krnv;
-        //values[gasPhaseIdx] = krg<FluidState, Evaluation>(params, fluidState);
+        //Evaluation krgv = GasOilMaterialLaw::twoPhaseSatKrn(gasoilparams, Sw_eff2);
         const Evaluation Sw_eff2 = 1.0 - Swco - Sg;
         const Evaluation krgv = GasOilMaterialLaw::twoPhaseSatKrn(gasoilparams, Sw_eff2);
         
         values[gasPhaseIdx] = krgv;
     }
-
-
-
-
-/*!
-     * \brief The relative permeability of all phases.
-     *
-     * The relative permeability of the water phase it uses the same
-     * value as the relative permeability for water in the water-oil
-     * law with \f$S_o = 1 - S_w\f$. The gas relative permebility is
-     * taken from the gas-oil material law, but with \f$S_o = 1 -
-     * S_g\f$.  The relative permeability of the oil phase is
-     * calculated using the relative permeabilities of the oil phase
-     * in the two two-phase systems.
-     *
-     * A more detailed description can be found in the "Three phase
-     * oil relative permeability models" section of the ECLipse
-     * technical description.
-     */
-    //     template <class ContainerT, class FluidState,class ParamsOilWater, class ParamsGasOil>
-    // static void relativePermeabilitiesNew(ContainerT& values,
-    //                                       const Scalar& Swco,
-    //                                       const ParamsOilWater& oilwaterparams,
-    //                                       const ParamsGasOil& gasoilparams, 
-    //                                       const FluidState& fluidState)
-    template <class ContainerT, class FluidState>        
-    static void relativePermeabilitiesNew(ContainerT& values,
-                                          const Params& params,
-                                          const FluidState& fluidState)        
-    {
-        const auto& oilwaterparams = params.oilWaterParams();
-        const auto& gasoilparams = params.gasOilParams();
-        const auto& gasoilparams_tab =params.gasOilParams().drainageParams().effectiveLawParams().template getRealParams<Opm::SatCurveMultiplexerApproach::PiecewiseLinear>();
-        const auto& oilwaterparams_tab =params.oilWaterParams().drainageParams().effectiveLawParams().template getRealParams<Opm::SatCurveMultiplexerApproach::PiecewiseLinear>();
-        Scalar Swco = params.Swl();
-        //const Evaluation SwUnscaled = scaledToUnscaledSatKrw(params, SwScaled);
-        //const Evaluation krwUnscaled = EffLaw::twoPhaseSatKrw(params.effectiveLawParams(), SwUnscaled);
-        //return unscaledToScaledKrw_(SwScaled, params, krwUnscaled);
-        using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
-        
-        
-        using PLTwoPhaseLawGasOil  = PiecewiseLinearTwoPhaseMaterial<typename GasOilMaterialLawT::Traits>;
-        using PLTwoPhaseLawOilWater  = PiecewiseLinearTwoPhaseMaterial<typename OilWaterMaterialLawT::Traits>;
-        
-        // values[waterPhaseIdx] = krw<FluidState, Evaluation>(params, fluidState);
-        
-        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
-        //const Evaluation krwv = OilWaterMaterialLaw::twoPhaseSatKrw(oilwaterparams, Sw);
-        //const auto& oilwaterparams =params.oilWaterParams().drainageParams().effectiveLawParams().template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
-        //const Evaluation krwv = PLTwoPhaseLawOilWater::twoPhaseSatKrw(oilwaterparams, Sw);
-        size_t segIdx_ow = PLTwoPhaseLawOilWater::findSegmentIndex(oilwaterparams_tab.SwKrwSamples(), Sw);
-        const Evaluation krwv = PLTwoPhaseLawOilWater::eval(oilwaterparams_tab.SwKrwSamples(), oilwaterparams_tab.krwSamples(), Sw, segIdx_ow);
-        
-        values[waterPhaseIdx] = krwv;
-        
-        //const Scalar Swco = params.Swl();
-        Evaluation krnv;
-        const Evaluation Sw_eff = max(Evaluation(Swco), decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
-
-        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
-        
-        const Evaluation Sw_ow = Sg + Sw_eff;
-        // const Evaluation kro_ow = relpermOilInOilWaterSystem<Evaluation>(params, fluidState);
-        //const Evaluation kro_ow = OilWaterMaterialLaw::twoPhaseSatKrn(oilwaterparams, Sw_ow);
-        //const Evaluation kro_ow = PLTwoPhaseLawOilWater::twoPhaseSatKrn(oilwaterparams, Sw_ow);
-        //size_t segIdx_ow = PLTwoPhaseLawOilWater::findSegmentIndex(oilwaterparams.SwKrwSamples(), Sw);
-        //NB assumes same index but probalby one should ahve used same x values also
-        //const Evaluation kro_ow = PLTwoPhaseLawOilWater::eval(oilwaterparams.SwKrnSamples(), oilwaterparams.krnSamples(), Sw_ow, segIdx_ow);
-        size_t segIdx_ow_o = PLTwoPhaseLawOilWater::findSegmentIndex(oilwaterparams_tab.SwKrnSamples(), Sw_ow);
-        const Evaluation kro_ow = PLTwoPhaseLawOilWater::eval(oilwaterparams_tab.SwKrnSamples(), oilwaterparams_tab.krnSamples(), Sw_ow, segIdx_ow_o);
-
-// const Evaluation kro_go = relpermOilInOilGasSystem<Evaluation>(params, fluidState);
-        const Evaluation So_go = 1.0 - Sw_ow;
-        //const Evaluation kro_go = GasOilMaterialLaw::twoPhaseSatKrw(gasoilparams, So_go);
-        //const auto& gasoilparams =params.gasOilParams().drainageParams().effectiveLawParams().template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
-        //const Evaluation kro_go = PLTwoPhaseLawGasOil::twoPhaseSatKrw(gasoilparams, So_go);
-        size_t segIdx_go = PLTwoPhaseLawGasOil::findSegmentIndex(gasoilparams_tab.SwKrwSamples(), So_go);
-        const Evaluation kro_go = PLTwoPhaseLawGasOil::eval(gasoilparams_tab.SwKrwSamples(), gasoilparams_tab.krwSamples(), So_go, segIdx_go);
-        // avoid the division by zero: chose a regularized kro which is used if Sw - Swco
-        // < epsilon/2 and interpolate between the oridinary and the regularized kro between
-        // epsilon and epsilon/2
-        constexpr const Scalar epsilon = 1e-5;
-        Scalar Sw_ow_wco = scalarValue(Sw_ow) - Swco;
-        if ( Sw_ow_wco < epsilon) {
-            const Evaluation kro2 = (kro_ow + kro_go) / 2;
-            if ( Sw_ow_wco > epsilon / 2) {
-                const Evaluation kro1 = (Sg * kro_go + (Sw - Swco) * kro_ow) / (Sw_ow - Swco);
-                const Evaluation alpha = (epsilon - (Sw_ow - Swco)) / (epsilon / 2);
-                
-                krnv = kro2 * alpha + kro1 * (1 - alpha);
-            }
-            
-            krnv = kro2;
-        } else {
-            krnv = (Sg * kro_go + (Sw - Swco) * kro_ow) / (Sw_ow - Swco);
-        }
-        
-        
-        values[oilPhaseIdx] = krnv;
-        //values[gasPhaseIdx] = krg<FluidState, Evaluation>(params, fluidState);
-        const Evaluation Sw_eff2 = 1.0 - Swco - Sg;
-        //Evaluation krgv = GasOilMaterialLaw::twoPhaseSatKrn(gasoilparams, Sw_eff2);
-        //size_t segIdx_go = PLTwoPhaseLawGasOil::findSegmentIndex(gasoilparams.SwKrnSamples(), Sw_eff2);
-        //const Evaluation krgv = PLTwoPhaseLawGasOil::eval(gasoilparams.SwKrnSamples(), gasoilparams.krnSamples(), Sw_eff2, segIdx_go);
-        size_t segIdx_go_g = PLTwoPhaseLawGasOil::findSegmentIndexDescending(gasoilparams_tab.SwKrnSamples(), Sw_eff2);
-        const Evaluation krgv = PLTwoPhaseLawGasOil::eval(gasoilparams_tab.SwKrnSamples(), gasoilparams_tab.krnSamples(), Sw_eff2, segIdx_go_g);
-        values[gasPhaseIdx] = krgv;
-    }
-
-
 
     /*!
      * \brief The relative permeability of all phases.

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialExperimental.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialExperimental.hpp
@@ -1,0 +1,153 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclDefaultMaterial
+ */
+#ifndef OPM_ECL_DEFAULT_MATERIAL_EXPERIMENTAL_HPP
+#define OPM_ECL_DEFAULT_MATERIAL_EXPERIMENTAL_HPP
+
+#include "EclDefaultMaterialParams.hpp"
+
+#include <opm/material/common/MathToolbox.hpp>
+#include <opm/material/common/Valgrind.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <type_traits>
+
+
+namespace Opm {
+
+/*!
+ * \ingroup material
+ *
+ * \brief Expermimental evalutation of relperms by hardcoding static cast
+ *
+ */
+    template<class DefaultMaterial>    
+class EclDefaultMaterialExperimental 
+{    
+public:
+    static constexpr int waterPhaseIdx = DefaultMaterial::waterPhaseIdx;
+    static constexpr int gasPhaseIdx = DefaultMaterial::gasPhaseIdx;
+    static constexpr int oilPhaseIdx = DefaultMaterial::oilPhaseIdx;
+    using GasOilMaterialLaw = typename DefaultMaterial::GasOilMaterialLaw;
+    using OilWaterMaterialLaw = typename DefaultMaterial::OilWaterMaterialLaw;
+    using Scalar = typename GasOilMaterialLaw::Scalar;
+    template <class ContainerT, class FluidState,class ParamsOilWater, class ParamsGasOil>
+    static void relativePermeabilities(ContainerT& values,
+                                       const Scalar& Swco,
+                                       const ParamsOilWater& oilwaterparams_tab,
+                                       const ParamsGasOil& gasoilparams_tab, 
+                                       const FluidState& fluidState)
+    // template <class ContainerT, class FluidState>        
+    // static void relativePermeabilitiesNew(ContainerT& values,
+    //                                       const Params& params,
+    //                                       const FluidState& fluidState)        
+    {
+        // const auto& oilwaterparams = params.oilWaterParams();
+        // const auto& gasoilparams = params.gasOilParams();
+        // const auto& gasoilparams_tab =params.gasOilParams().drainageParams().effectiveLawParams().template getRealParams<Opm::SatCurveMultiplexerApproach::PiecewiseLinear>();
+        // const auto& oilwaterparams_tab =params.oilWaterParams().drainageParams().effectiveLawParams().template getRealParams<Opm::SatCurveMultiplexerApproach::PiecewiseLinear>();
+        //Scalar Swco = params.Swl();
+        //const Evaluation SwUnscaled = scaledToUnscaledSatKrw(params, SwScaled);
+        //const Evaluation krwUnscaled = EffLaw::twoPhaseSatKrw(params.effectiveLawParams(), SwUnscaled);
+        //return unscaledToScaledKrw_(SwScaled, params, krwUnscaled);
+        using Evaluation = typename std::remove_reference<decltype(values[0])>::type;
+        
+        
+        using PLTwoPhaseLawGasOil  = PiecewiseLinearTwoPhaseMaterial<typename GasOilMaterialLaw::Traits>;
+        using PLTwoPhaseLawOilWater  = PiecewiseLinearTwoPhaseMaterial<typename OilWaterMaterialLaw::Traits>;
+        
+        // values[waterPhaseIdx] = krw<FluidState, Evaluation>(params, fluidState);
+        
+        const Evaluation Sw = decay<Evaluation>(fluidState.saturation(waterPhaseIdx));
+        //const Evaluation krwv = OilWaterMaterialLaw::twoPhaseSatKrw(oilwaterparams, Sw);
+        //const auto& oilwaterparams =params.oilWaterParams().drainageParams().effectiveLawParams().template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+        //const Evaluation krwv = PLTwoPhaseLawOilWater::twoPhaseSatKrw(oilwaterparams, Sw);
+        size_t segIdx_ow = PLTwoPhaseLawOilWater::findSegmentIndex(oilwaterparams_tab.SwKrwSamples(), Sw);
+        const Evaluation krwv = PLTwoPhaseLawOilWater::eval(oilwaterparams_tab.SwKrwSamples(), oilwaterparams_tab.krwSamples(), Sw, segIdx_ow);
+        
+        values[waterPhaseIdx] = krwv;
+        
+        //const Scalar Swco = params.Swl();
+        Evaluation krnv;
+        const Evaluation Sw_eff = max(Evaluation(Swco), decay<Evaluation>(fluidState.saturation(waterPhaseIdx)));
+
+        const Evaluation Sg = decay<Evaluation>(fluidState.saturation(gasPhaseIdx));
+        
+        const Evaluation Sw_ow = Sg + Sw_eff;
+        // const Evaluation kro_ow = relpermOilInOilWaterSystem<Evaluation>(params, fluidState);
+        //const Evaluation kro_ow = OilWaterMaterialLaw::twoPhaseSatKrn(oilwaterparams, Sw_ow);
+        //const Evaluation kro_ow = PLTwoPhaseLawOilWater::twoPhaseSatKrn(oilwaterparams, Sw_ow);
+        //size_t segIdx_ow = PLTwoPhaseLawOilWater::findSegmentIndex(oilwaterparams.SwKrwSamples(), Sw);
+        //NB assumes same index but probalby one should ahve used same x values also
+        //const Evaluation kro_ow = PLTwoPhaseLawOilWater::eval(oilwaterparams.SwKrnSamples(), oilwaterparams.krnSamples(), Sw_ow, segIdx_ow);
+        size_t segIdx_ow_o = PLTwoPhaseLawOilWater::findSegmentIndex(oilwaterparams_tab.SwKrnSamples(), Sw_ow);
+        const Evaluation kro_ow = PLTwoPhaseLawOilWater::eval(oilwaterparams_tab.SwKrnSamples(), oilwaterparams_tab.krnSamples(), Sw_ow, segIdx_ow_o);
+
+// const Evaluation kro_go = relpermOilInOilGasSystem<Evaluation>(params, fluidState);
+        const Evaluation So_go = 1.0 - Sw_ow;
+        //const Evaluation kro_go = GasOilMaterialLaw::twoPhaseSatKrw(gasoilparams, So_go);
+        //const auto& gasoilparams =params.gasOilParams().drainageParams().effectiveLawParams().template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+        //const Evaluation kro_go = PLTwoPhaseLawGasOil::twoPhaseSatKrw(gasoilparams, So_go);
+        size_t segIdx_go = PLTwoPhaseLawGasOil::findSegmentIndex(gasoilparams_tab.SwKrwSamples(), So_go);
+        const Evaluation kro_go = PLTwoPhaseLawGasOil::eval(gasoilparams_tab.SwKrwSamples(), gasoilparams_tab.krwSamples(), So_go, segIdx_go);
+        // avoid the division by zero: chose a regularized kro which is used if Sw - Swco
+        // < epsilon/2 and interpolate between the oridinary and the regularized kro between
+        // epsilon and epsilon/2
+        constexpr const Scalar epsilon = 1e-5;
+        Scalar Sw_ow_wco = scalarValue(Sw_ow) - Swco;
+        if ( Sw_ow_wco < epsilon) {
+            const Evaluation kro2 = (kro_ow + kro_go) / 2;
+            if ( Sw_ow_wco > epsilon / 2) {
+                const Evaluation kro1 = (Sg * kro_go + (Sw - Swco) * kro_ow) / (Sw_ow - Swco);
+                const Evaluation alpha = (epsilon - (Sw_ow - Swco)) / (epsilon / 2);
+                
+                krnv = kro2 * alpha + kro1 * (1 - alpha);
+            }
+            
+            krnv = kro2;
+        } else {
+            krnv = (Sg * kro_go + (Sw - Swco) * kro_ow) / (Sw_ow - Swco);
+        }
+        
+        
+        values[oilPhaseIdx] = krnv;
+        //values[gasPhaseIdx] = krg<FluidState, Evaluation>(params, fluidState);
+        const Evaluation Sw_eff2 = 1.0 - Swco - Sg;
+        //Evaluation krgv = GasOilMaterialLaw::twoPhaseSatKrn(gasoilparams, Sw_eff2);
+        //size_t segIdx_go = PLTwoPhaseLawGasOil::findSegmentIndex(gasoilparams.SwKrnSamples(), Sw_eff2);
+        //const Evaluation krgv = PLTwoPhaseLawGasOil::eval(gasoilparams.SwKrnSamples(), gasoilparams.krnSamples(), Sw_eff2, segIdx_go);
+        size_t segIdx_go_g = PLTwoPhaseLawGasOil::findSegmentIndexDescending(gasoilparams_tab.SwKrnSamples(), Sw_eff2);
+        const Evaluation krgv = PLTwoPhaseLawGasOil::eval(gasoilparams_tab.SwKrnSamples(), gasoilparams_tab.krnSamples(), Sw_eff2, segIdx_go_g);
+        values[gasPhaseIdx] = krgv;
+    }
+};
+}
+
+#endif
+
+
+

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -63,37 +63,37 @@ public:
      * \brief The parameter object for the gas-oil twophase law.
      */
     const GasOilParams& gasOilParams() const
-    { EnsureFinalized::check(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return gasOilParams_; }
 
     /*!
      * \brief The parameter object for the gas-oil twophase law.
      */
     GasOilParams& gasOilParams()
-    { EnsureFinalized::check(); return *gasOilParams_; }
+    { EnsureFinalized::check(); return gasOilParams_; }
 
     /*!
      * \brief Set the parameter object for the gas-oil twophase law.
      */
     void setGasOilParams(std::shared_ptr<GasOilParams> val)
-    { gasOilParams_ = val; }
+    { gasOilParams_ = *val; }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
     const OilWaterParams& oilWaterParams() const
-    { EnsureFinalized::check(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return oilWaterParams_; }
 
     /*!
      * \brief The parameter object for the oil-water twophase law.
      */
     OilWaterParams& oilWaterParams()
-    { EnsureFinalized::check(); return *oilWaterParams_; }
+    { EnsureFinalized::check(); return oilWaterParams_; }
 
     /*!
      * \brief Set the parameter object for the oil-water twophase law.
      */
     void setOilWaterParams(std::shared_ptr<OilWaterParams> val)
-    { oilWaterParams_ = val; }
+    { oilWaterParams_ = *val; }
 
     /*!
      * \brief Set the saturation of "connate" water.
@@ -137,9 +137,10 @@ public:
     }
 
 private:
-    std::shared_ptr<GasOilParams> gasOilParams_;
-    std::shared_ptr<OilWaterParams> oilWaterParams_;
-
+    //std::shared_ptr<GasOilParams> gasOilParams_;
+    GasOilParams gasOilParams_;
+    //std::shared_ptr<OilWaterParams> oilWaterParams_;
+    OilWaterParams oilWaterParams_;
     Scalar Swl_;
 };
 } // namespace Opm

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -132,8 +132,8 @@ public:
     {
         // This is for restart serialization.
         // Only dynamic state in the parameters need to be stored.
-        serializer(*gasOilParams_);
-        serializer(*oilWaterParams_);
+        serializer(gasOilParams_);
+        serializer(oilWaterParams_);
     }
 
 private:

--- a/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLawParams.hpp
@@ -62,33 +62,33 @@ public:
      */
     void finalize()
     {
-#ifndef NDEBUG
-        assert(config_);
-        if (config_->enableSatScaling()) {
-            assert(unscaledPoints_);
-        }
-        assert(effectiveLawParams_);
-#endif
-        EnsureFinalized :: finalize();
+// #ifndef NDEBUG
+//         assert(config_);
+//         if (config_->enableSatScaling()) {
+//             assert(unscaledPoints_);
+//         }
+//         assert(effectiveLawParams_);
+// #endif
+//         EnsureFinalized :: finalize();
     }
 
     /*!
      * \brief Set the endpoint scaling configuration object.
      */
     void setConfig(std::shared_ptr<EclEpsConfig> value)
-    { config_ = value; }
+    { config_ = *value; }
 
     /*!
      * \brief Returns the endpoint scaling configuration object.
      */
     const EclEpsConfig& config() const
-    { return *config_; }
+    { return config_; }
 
     /*!
      * \brief Set the scaling points which are seen by the nested material law
      */
     void setUnscaledPoints(std::shared_ptr<ScalingPoints> value)
-    { unscaledPoints_ = value; }
+    { unscaledPoints_ = value.get(); }
 
     /*!
      * \brief Returns the scaling points which are seen by the nested material law
@@ -118,7 +118,7 @@ public:
      * \brief Sets the parameter object for the effective/nested material law.
      */
     void setEffectiveLawParams(std::shared_ptr<EffLawParams> value)
-    { effectiveLawParams_ = value; }
+    { effectiveLawParams_ = value.get(); }
 
     /*!
      * \brief Returns the parameter object for the effective/nested material law.
@@ -127,10 +127,12 @@ public:
     { return *effectiveLawParams_; }
 
 private:
-    std::shared_ptr<EffLawParams> effectiveLawParams_;
-
-    std::shared_ptr<EclEpsConfig> config_;
-    std::shared_ptr<ScalingPoints> unscaledPoints_;
+    //std::shared_ptr<EffLawParams> effectiveLawParams_;
+    EffLawParams* effectiveLawParams_;
+    //std::shared_ptr<EclEpsConfig> config_;
+    EclEpsConfig config_;
+    //std::shared_ptr<ScalingPoints> unscaledPoints_;
+    ScalingPoints* unscaledPoints_;
     ScalingPoints scaledPoints_;
 };
 

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -106,13 +106,13 @@ public:
      * \brief Set the endpoint scaling configuration object.
      */
     void setConfig(std::shared_ptr<EclHysteresisConfig> value)
-    { config_ = value; }
+    { config_ = *value; }
 
     /*!
      * \brief Returns the endpoint scaling configuration object.
      */
     const EclHysteresisConfig& config() const
-    { return *config_; }
+    { return config_; }
 
     /*!
      * \brief Sets the parameters used for the drainage curve
@@ -454,7 +454,8 @@ private:
         }
     }
 
-    std::shared_ptr<EclHysteresisConfig> config_;
+    //std::shared_ptr<EclHysteresisConfig> config_;
+    EclHysteresisConfig config_;
     EffLawParams imbibitionParams_;
     EffLawParams drainageParams_;
 

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.hpp
@@ -1,0 +1,342 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Opm::EclMaterialLawManager
+ */
+#if ! HAVE_ECL_INPUT
+#error "Eclipse input support in opm-common is required to use the ECL material manager!"
+#endif
+
+#ifndef OPM_ECL_MATERIAL_LAW_MANAGER_TABLE_HPP
+#define OPM_ECL_MATERIAL_LAW_MANAGER_TABLE_HPP
+
+#include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
+
+#include <opm/material/fluidmatrixinteractions/SatCurveMultiplexer.hpp>
+#include <opm/material/fluidmatrixinteractions/EclEpsTwoPhaseLaw.hpp>
+#include <opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp>
+#include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
+
+#include <cassert>
+#include <memory>
+#include <tuple>
+#include <vector>
+
+namespace Opm {
+
+class EclipseState;
+class EclEpsConfig;
+template<class Scalar> class EclEpsScalingPoints;
+template<class Scalar> struct EclEpsScalingPointsInfo;
+class EclHysteresisConfig;
+enum class EclTwoPhaseSystemType;
+class Runspec;
+class SgfnTable;
+class SgofTable;
+class SlgofTable;
+class Sof2Table;
+class Sof3Table;
+
+/*!
+ * \ingroup fluidmatrixinteractions
+ *
+ * \brief Provides an simple way to create and manage the material law objects
+ *        for a complete ECL deck.
+ */
+template <class TraitsT>
+class EclMaterialLawManagerTable
+{
+private:
+    using Traits = TraitsT;
+    using Scalar = typename Traits::Scalar;
+    enum { waterPhaseIdx = Traits::wettingPhaseIdx };
+    enum { oilPhaseIdx = Traits::nonWettingPhaseIdx };
+    enum { gasPhaseIdx = Traits::gasPhaseIdx };
+    enum { numPhases = Traits::numPhases };
+
+    using GasOilTraits = TwoPhaseMaterialTraits<Scalar, oilPhaseIdx, gasPhaseIdx>;
+    using OilWaterTraits = TwoPhaseMaterialTraits<Scalar, waterPhaseIdx, oilPhaseIdx>;
+    using GasWaterTraits = TwoPhaseMaterialTraits<Scalar, waterPhaseIdx, gasPhaseIdx>;
+
+    // the two-phase material law which is defined on effective (unscaled) saturations
+    //using GasOilEffectiveTwoPhaseLawMult = SatCurveMultiplexer<GasOilTraits>;
+    //using OilWaterEffectiveTwoPhaseLawMult = SatCurveMultiplexer<OilWaterTraits>;
+    //using GasWaterEffectiveTwoPhaseLawMult = SatCurveMultiplexer<GasWaterTraits>;
+    using GasOilEffectiveTwoPhaseLaw = PiecewiseLinearTwoPhaseMaterial<GasOilTraits>;
+    using OilWaterEffectiveTwoPhaseLaw = PiecewiseLinearTwoPhaseMaterial<OilWaterTraits>;
+    using GasWaterEffectiveTwoPhaseLaw = PiecewiseLinearTwoPhaseMaterial<GasWaterTraits>;
+
+
+    
+    using GasOilEffectiveTwoPhaseParams = typename GasOilEffectiveTwoPhaseLaw::Params;
+    using OilWaterEffectiveTwoPhaseParams = typename OilWaterEffectiveTwoPhaseLaw::Params;
+    using GasWaterEffectiveTwoPhaseParams = typename GasWaterEffectiveTwoPhaseLaw::Params;
+
+    // the two-phase material law which is defined on absolute (scaled) saturations
+    using GasOilEpsTwoPhaseLaw = EclEpsTwoPhaseLaw<GasOilEffectiveTwoPhaseLaw>;
+    using OilWaterEpsTwoPhaseLaw = EclEpsTwoPhaseLaw<OilWaterEffectiveTwoPhaseLaw>;
+    using GasWaterEpsTwoPhaseLaw = EclEpsTwoPhaseLaw<GasWaterEffectiveTwoPhaseLaw>;
+    using GasOilEpsTwoPhaseParams = typename GasOilEpsTwoPhaseLaw::Params;
+    using OilWaterEpsTwoPhaseParams = typename OilWaterEpsTwoPhaseLaw::Params;
+    using GasWaterEpsTwoPhaseParams = typename GasWaterEpsTwoPhaseLaw::Params;
+
+    // the scaled two-phase material laws with hystersis
+    using GasOilTwoPhaseLaw = EclHysteresisTwoPhaseLaw<GasOilEpsTwoPhaseLaw>;
+    using OilWaterTwoPhaseLaw = EclHysteresisTwoPhaseLaw<OilWaterEpsTwoPhaseLaw>;
+    using GasWaterTwoPhaseLaw = EclHysteresisTwoPhaseLaw<GasWaterEpsTwoPhaseLaw>;
+    using GasOilTwoPhaseHystParams = typename GasOilTwoPhaseLaw::Params;
+    using OilWaterTwoPhaseHystParams = typename OilWaterTwoPhaseLaw::Params;
+    using GasWaterTwoPhaseHystParams = typename GasWaterTwoPhaseLaw::Params;
+
+public:
+    // the three-phase material law used by the simulation
+    using MaterialLaw = EclMultiplexerMaterial<Traits, GasOilTwoPhaseLaw, OilWaterTwoPhaseLaw, GasWaterTwoPhaseLaw>;
+    using MaterialLawParams = typename MaterialLaw::Params;
+
+    EclMaterialLawManagerTable();
+    ~EclMaterialLawManagerTable();
+
+private:
+    // internal typedefs
+    using GasOilEffectiveParamVector = std::vector<std::shared_ptr<GasOilEffectiveTwoPhaseParams>>;
+    using OilWaterEffectiveParamVector = std::vector<std::shared_ptr<OilWaterEffectiveTwoPhaseParams>>;
+    using GasWaterEffectiveParamVector = std::vector<std::shared_ptr<GasWaterEffectiveTwoPhaseParams>>;
+
+    using GasOilScalingPointsVector = std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar>>>;
+    using OilWaterScalingPointsVector = std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar>>>;
+    using GasWaterScalingPointsVector = std::vector<std::shared_ptr<EclEpsScalingPoints<Scalar>>>;
+    using OilWaterScalingInfoVector = std::vector<EclEpsScalingPointsInfo<Scalar>>;
+    using GasOilParamVector = std::vector<std::shared_ptr<GasOilTwoPhaseHystParams>>;
+    using OilWaterParamVector = std::vector<std::shared_ptr<OilWaterTwoPhaseHystParams>>;
+    using GasWaterParamVector = std::vector<std::shared_ptr<GasWaterTwoPhaseHystParams>>;
+    using MaterialLawParamsVector = std::vector<std::shared_ptr<MaterialLawParams>>;
+
+public:
+    void initFromState(const EclipseState& eclState);
+
+    void initParamsForElements(const EclipseState& eclState, size_t numCompressedElems);
+
+    /*!
+     * \brief Modify the initial condition according to the SWATINIT keyword.
+     *
+     * The method returns the water saturation which yields a givenn capillary
+     * pressure. The reason this method is not folded directly into initFromState() is
+     * that the capillary pressure given depends on the particuars of how the simulator
+     * calculates its initial condition.
+     */
+    Scalar applySwatinit(unsigned elemIdx,
+                         Scalar pcow,
+                         Scalar Sw);
+
+    bool enableEndPointScaling() const
+    { return enableEndPointScaling_; }
+
+    bool enableHysteresis() const
+    { return hysteresisConfig_->enableHysteresis(); }
+
+    MaterialLawParams& materialLawParams(unsigned elemIdx)
+    {
+        assert(elemIdx <  materialLawParams_.size());
+        return materialLawParams_[elemIdx];
+    }
+
+    const MaterialLawParams& materialLawParams(unsigned elemIdx) const
+    {
+        assert(elemIdx <  materialLawParams_.size());
+        return materialLawParams_[elemIdx];
+    }
+
+    /*!
+     * \brief Returns a material parameter object for a given element and saturation region.
+     *
+     * This method changes the saturation table idx in the original material law parameter object.
+     * In the context of ECL reservoir simulators, this is required to properly handle
+     * wells with its own saturation table idx. In order to reset the saturation table idx
+     * in the materialLawparams_ call the method with the cells satRegionIdx
+     */
+    const MaterialLawParams& connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const;
+
+    int satnumRegionIdx(unsigned elemIdx) const
+    { return satnumRegionArray_[elemIdx]; }
+
+    int getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const;
+
+    bool hasDirectionalRelperms() const
+    {
+        return !krnumXArray_.empty() || !krnumYArray_.empty() || !krnumZArray_.empty();
+    }
+
+    int imbnumRegionIdx(unsigned elemIdx) const
+    { return imbnumRegionArray_[elemIdx]; }
+
+    template <class FluidState>
+    void updateHysteresis(const FluidState& fluidState, unsigned elemIdx)
+    {
+        if (!enableHysteresis())
+            return;
+
+        MaterialLaw::updateHysteresis(materialLawParams_[elemIdx], fluidState);
+    }
+
+    void oilWaterHysteresisParams(Scalar& pcSwMdc,
+                                  Scalar& krnSwMdc,
+                                  unsigned elemIdx) const;
+
+    void setOilWaterHysteresisParams(const Scalar& pcSwMdc,
+                                     const Scalar& krnSwMdc,
+                                     unsigned elemIdx);
+
+    void gasOilHysteresisParams(Scalar& pcSwMdc,
+                                Scalar& krnSwMdc,
+                                unsigned elemIdx) const;
+
+    void setGasOilHysteresisParams(const Scalar& pcSwMdc,
+                                   const Scalar& krnSwMdc,
+                                   unsigned elemIdx);
+
+    EclEpsScalingPoints<Scalar>& oilWaterScaledEpsPointsDrainage(unsigned elemIdx);
+
+    const EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(size_t elemIdx) const
+    { return oilWaterScaledEpsInfoDrainage_[elemIdx]; }
+
+private:
+    void readGlobalEpsOptions_(const EclipseState& eclState);
+
+    void readGlobalHysteresisOptions_(const EclipseState& state);
+
+    void readGlobalThreePhaseOptions_(const Runspec& runspec);
+
+    template <class Container>
+    void readGasOilEffectiveParameters_(Container& dest,
+                                        const EclipseState& eclState,
+                                        unsigned satRegionIdx);
+
+    void readGasOilEffectiveParametersSgof_(GasOilEffectiveTwoPhaseParams& effParams,
+                                            const Scalar Swco,
+                                            const double tolcrit,
+                                            const SgofTable& sgofTable);
+
+    void readGasOilEffectiveParametersSlgof_(GasOilEffectiveTwoPhaseParams& effParams,
+                                             const Scalar Swco,
+                                             const double tolcrit,
+                                             const SlgofTable& slgofTable);
+
+    void readGasOilEffectiveParametersFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
+                                               const Scalar Swco,
+                                               const double tolcrit,
+                                               const Sof3Table& sof3Table,
+                                               const SgfnTable& sgfnTable);
+
+    void readGasOilEffectiveParametersFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
+                                               const Scalar Swco,
+                                               const double tolcrit,
+                                               const Sof2Table& sof2Table,
+                                               const SgfnTable& sgfnTable);
+
+    template <class Container>
+    void readOilWaterEffectiveParameters_(Container& dest,
+                                          const EclipseState& eclState,
+                                          unsigned satRegionIdx);
+
+    template <class Container>
+    void readGasWaterEffectiveParameters_(Container& dest,
+                                        const EclipseState& eclState,
+                                        unsigned satRegionIdx);
+
+    template <class Container>
+    void readGasOilUnscaledPoints_(Container& dest,
+                                   std::shared_ptr<EclEpsConfig> config,
+                                   const EclipseState& /* eclState */,
+                                   unsigned satRegionIdx);
+
+    template <class Container>
+    void readOilWaterUnscaledPoints_(Container& dest,
+                                     std::shared_ptr<EclEpsConfig> config,
+                                     const EclipseState& /* eclState */,
+                                     unsigned satRegionIdx);
+
+    template <class Container>
+    void readGasWaterUnscaledPoints_(Container& dest,
+                                     std::shared_ptr<EclEpsConfig> config,
+                                     const EclipseState& /* eclState */,
+                                     unsigned satRegionIdx);
+
+    std::tuple<EclEpsScalingPointsInfo<Scalar>,
+               EclEpsScalingPoints<Scalar>>
+    readScaledPoints_(const EclEpsConfig& config,
+                      const EclipseState& eclState,
+                      const EclEpsGridProperties& epsGridProperties,
+                      unsigned elemIdx,
+                      EclTwoPhaseSystemType type);
+
+    void initThreePhaseParams_(const EclipseState& /* eclState */,
+                               MaterialLawParams& materialParams,
+                               unsigned satRegionIdx,
+                               const EclEpsScalingPointsInfo<Scalar>& epsInfo,
+                               std::shared_ptr<OilWaterTwoPhaseHystParams> oilWaterParams,
+                               std::shared_ptr<GasOilTwoPhaseHystParams> gasOilParams,
+                               std::shared_ptr<GasWaterTwoPhaseHystParams> gasWaterParams);
+
+    bool enableEndPointScaling_;
+    std::shared_ptr<EclHysteresisConfig> hysteresisConfig_;
+
+    std::shared_ptr<EclEpsConfig> oilWaterEclEpsConfig_;
+    std::vector<EclEpsScalingPointsInfo<Scalar>> unscaledEpsInfo_;
+    OilWaterScalingInfoVector oilWaterScaledEpsInfoDrainage_;
+
+    std::shared_ptr<EclEpsConfig> gasWaterEclEpsConfig_;
+
+    GasOilScalingPointsVector gasOilUnscaledPointsVector_;
+    OilWaterScalingPointsVector oilWaterUnscaledPointsVector_;
+    GasWaterScalingPointsVector gasWaterUnscaledPointsVector_;
+
+    GasOilEffectiveParamVector gasOilEffectiveParamVector_;
+    OilWaterEffectiveParamVector oilWaterEffectiveParamVector_;
+    GasWaterEffectiveParamVector gasWaterEffectiveParamVector_;
+
+    EclMultiplexerApproach threePhaseApproach_ = EclMultiplexerApproach::Default;
+    // this attribute only makes sense for twophase simulations!
+    enum EclTwoPhaseApproach twoPhaseApproach_ = EclTwoPhaseApproach::GasOil;
+
+    std::vector<MaterialLawParams> materialLawParams_;
+
+    std::vector<int> satnumRegionArray_;
+    std::vector<int> krnumXArray_;
+    std::vector<int> krnumYArray_;
+    std::vector<int> krnumZArray_;
+    std::vector<int> imbnumRegionArray_;
+    std::vector<Scalar> stoneEtas;
+
+    bool hasGas;
+    bool hasOil;
+    bool hasWater;
+
+    std::shared_ptr<EclEpsConfig> gasOilConfig;
+    std::shared_ptr<EclEpsConfig> oilWaterConfig;
+    std::shared_ptr<EclEpsConfig> gasWaterConfig;
+};
+} // namespace Opm
+
+#endif

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -217,6 +217,11 @@ public:
     }
 
     template <class Evaluation>
+    static size_t findSegmentIndexDescending(const ValueVector& xValues, const Evaluation& x){
+        return findSegmentIndexDescending_(xValues, scalarValue(x));
+    }
+    
+    template <class Evaluation>
     static Evaluation eval(const ValueVector& xValues, const ValueVector& yValues, const Evaluation& x, unsigned segIdx){
         Scalar x0 = xValues[segIdx];
         Scalar x1 = xValues[segIdx + 1];

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -210,6 +210,25 @@ public:
     static Evaluation twoPhaseSatKrnInv(const Params& params, const Evaluation& krn)
     { return eval_(params.krnSamples(), params.SwKrnSamples(), krn); }
 
+    template <class Evaluation>
+    static size_t findSegmentIndex(const ValueVector& xValues, const Evaluation& x){
+        return findSegmentIndex_(xValues, scalarValue(x));
+        //return findSegmentIndex_(xValues, x);
+    }
+
+    template <class Evaluation>
+    static Evaluation eval(const ValueVector& xValues, const ValueVector& yValues, const Evaluation& x, unsigned segIdx){
+        Scalar x0 = xValues[segIdx];
+        Scalar x1 = xValues[segIdx + 1];
+
+        Scalar y0 = yValues[segIdx];
+        Scalar y1 = yValues[segIdx + 1];
+
+        Scalar m = (y1 - y0)/(x1 - x0);
+
+        return y0 + (x - x0)*m;
+    }
+    
 private:
     template <class Evaluation>
     static Evaluation eval_(const ValueVector& xValues,
@@ -287,8 +306,8 @@ private:
 
         return (y1 - y0)/(x1 - x0);
     }
-
-    static size_t findSegmentIndex_(const ValueVector& xValues, Scalar x)
+    template<class ScalarT>
+    static size_t findSegmentIndex_(const ValueVector& xValues, const ScalarT& x)
     {
         assert(xValues.size() > 1); // we need at least two sampling points!
         size_t n = xValues.size() - 1;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -209,6 +209,31 @@ public:
         return (1.0 + X*(1.0 + X/2.0))/BwRef;
     }
 
+
+    template <class Evaluation>
+    void inverseBAndMu(Evaluation& bw, Evaluation& muW, unsigned regionIdx,
+                      // const Evaluation& /*temperature*/,
+                      const Evaluation& pressure) const
+                      // const Evaluation& /*Rsw*/,
+                      // const Evaluation& /*saltconcentration*/) const
+    {
+        // cf. ECLiPSE 2011 technical description, p. 116
+        Scalar pRef = waterReferencePressure_[regionIdx];
+        const Evaluation& X = waterCompressibility_[regionIdx]*(pressure - pRef);
+
+        Scalar BwRef = waterReferenceFormationVolumeFactor_[regionIdx];
+
+        // TODO (?): consider the salt concentration of the brine
+        bw = (1.0 + X*(1.0 + X/2.0))/BwRef;
+        
+        Scalar BwMuwRef = waterViscosity_[regionIdx]*BwRef;
+        
+        const Evaluation& Y =
+            (waterCompressibility_[regionIdx] - waterViscosibility_[regionIdx])
+            * (pressure - pRef);
+        muW =  BwMuwRef*bw/(1 + Y*(1 + Y/2));
+    }
+
     /*!
      * \brief Returns the saturation pressure of the water phase [Pa]
      *        depending on its mass fraction of the gas component

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -236,7 +236,7 @@ public:
     const std::vector<TabulatedOneDFunction>& gasMu() const
     { return gasMu_; }
 
-    const std::vector<TabulatedOneDFunction> inverseGasBMu() const
+    const std::vector<TabulatedOneDFunction>& inverseGasBMu() const
     { return inverseGasBMu_; }
 
 private:

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.cpp
@@ -752,7 +752,10 @@ readGasOilEffectiveParameters_(Container& dest,
         }
         break;
     }
-
+    case SatFuncControls::KeywordFamily::Family_III:
+    {
+        throw std::domain_error("Family III not handled");
+    }
     case SatFuncControls::KeywordFamily::Undefined:
         throw std::domain_error("No valid saturation keyword family specified");
     }
@@ -958,6 +961,10 @@ readOilWaterEffectiveParameters_(Container& dest,
         break;
     }
 
+    case SatFuncControls::KeywordFamily::Family_III:
+    {
+        throw std::domain_error("Family III not handled");
+    }
     case SatFuncControls::KeywordFamily::Undefined:
         throw std::domain_error("No valid saturation keyword family specified");
     }
@@ -1012,7 +1019,10 @@ readGasWaterEffectiveParameters_(Container& dest,
 
         break;
     }
-
+    case SatFuncControls::KeywordFamily::Family_III:
+    {
+        throw std::domain_error("Family III not handled");
+    }
     case SatFuncControls::KeywordFamily::Undefined:
         throw std::domain_error("No valid saturation keyword family specified");
     }

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.cpp
@@ -1,0 +1,1162 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#include <config.h>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManagerTable.hpp>
+
+#include <opm/common/OpmLog/OpmLog.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SgfnTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SgofTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SlgofTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Sof2Table.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Sof3Table.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SwfnTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/SwofTable.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableColumn.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+
+#include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
+#include <opm/material/fluidstates/SimpleModularFluidState.hpp>
+
+#include <algorithm>
+
+namespace {
+
+// Relative permeability values not strictly greater than 'tolcrit' treated as zero.
+std::vector<double> normalizeKrValues_(const double tolcrit,
+                                       const Opm::TableColumn& krValues)
+{
+    auto kr = krValues.vectorCopy();
+    std::transform(kr.begin(), kr.end(), kr.begin(),
+        [tolcrit](const double kri)
+    {
+        return (kri > tolcrit) ? kri : 0.0;
+    });
+
+    return kr;
+}
+
+}
+
+namespace Opm {
+
+template<class TraitsT>
+EclMaterialLawManagerTable<TraitsT>::EclMaterialLawManagerTable() = default;
+
+template<class TraitsT>
+EclMaterialLawManagerTable<TraitsT>::~EclMaterialLawManagerTable() = default;
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+initFromState(const EclipseState& eclState)
+{
+    // get the number of saturation regions and the number of cells in the deck
+    const auto&  runspec       = eclState.runspec();
+    const size_t numSatRegions = runspec.tabdims().getNumSatTables();
+
+    const auto& ph = runspec.phases();
+    this->hasGas = ph.active(Phase::GAS);
+    this->hasOil = ph.active(Phase::OIL);
+    this->hasWater = ph.active(Phase::WATER);
+
+    readGlobalEpsOptions_(eclState);
+    readGlobalHysteresisOptions_(eclState);
+    readGlobalThreePhaseOptions_(runspec);
+
+    // Read the end point scaling configuration (once per run).
+    gasOilConfig = std::make_shared<EclEpsConfig>();
+    oilWaterConfig = std::make_shared<EclEpsConfig>();
+    gasWaterConfig = std::make_shared<EclEpsConfig>();
+    gasOilConfig->initFromState(eclState, EclTwoPhaseSystemType::GasOil);
+    oilWaterConfig->initFromState(eclState, EclTwoPhaseSystemType::OilWater);
+    gasWaterConfig->initFromState(eclState, EclTwoPhaseSystemType::GasWater);
+
+
+    const auto& tables = eclState.getTableManager();
+
+    {
+        const auto& stone1exTables = tables.getStone1exTable();
+
+        if (! stone1exTables.empty()) {
+            stoneEtas.clear();
+            stoneEtas.reserve(numSatRegions);
+
+            for (const auto& table : stone1exTables) {
+                stoneEtas.push_back(table.eta);
+            }
+        }
+    }
+
+    this->unscaledEpsInfo_.resize(numSatRegions);
+
+    if (this->hasGas + this->hasOil + this->hasWater == 1) {
+        // Single-phase simulation.  Special case.  Nothing to do here.
+        return;
+    }
+
+    // Multiphase simulation.  Common case.
+    const auto tolcrit = runspec.saturationFunctionControls()
+        .minimumRelpermMobilityThreshold();
+
+    const auto rtep  = satfunc::getRawTableEndpoints(tables, ph, tolcrit);
+    const auto rfunc = satfunc::getRawFunctionValues(tables, ph, rtep);
+
+    for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
+        this->unscaledEpsInfo_[satRegionIdx]
+            .extractUnscaled(rtep, rfunc, satRegionIdx);
+    }
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+initParamsForElements(const EclipseState& eclState, size_t numCompressedElems)
+{
+    // get the number of saturation regions
+    const size_t numSatRegions = eclState.runspec().tabdims().getNumSatTables();
+
+    // setup the saturation region specific parameters
+    gasOilUnscaledPointsVector_.resize(numSatRegions);
+    oilWaterUnscaledPointsVector_.resize(numSatRegions);
+    gasWaterUnscaledPointsVector_.resize(numSatRegions);
+
+    gasOilEffectiveParamVector_.resize(numSatRegions);
+    oilWaterEffectiveParamVector_.resize(numSatRegions);
+    gasWaterEffectiveParamVector_.resize(numSatRegions);
+    for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++satRegionIdx) {
+        // unscaled points for end-point scaling
+        readGasOilUnscaledPoints_(gasOilUnscaledPointsVector_, gasOilConfig, eclState, satRegionIdx);
+        readOilWaterUnscaledPoints_(oilWaterUnscaledPointsVector_, oilWaterConfig, eclState, satRegionIdx);
+        readGasWaterUnscaledPoints_(gasWaterUnscaledPointsVector_, gasWaterConfig, eclState, satRegionIdx);
+
+        // the parameters for the effective two-phase matererial laws
+        readGasOilEffectiveParameters_(gasOilEffectiveParamVector_, eclState, satRegionIdx);
+        readOilWaterEffectiveParameters_(oilWaterEffectiveParamVector_, eclState, satRegionIdx);
+        readGasWaterEffectiveParameters_(gasWaterEffectiveParamVector_, eclState, satRegionIdx);
+    }
+
+    // copy the SATNUM grid property. in some cases this is not necessary, but it
+    // should not require much memory anyway...
+    satnumRegionArray_.resize(numCompressedElems);
+    if (eclState.fieldProps().has_int("SATNUM")) {
+        const auto& satnumRawData = eclState.fieldProps().get_int("SATNUM");
+        for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
+            satnumRegionArray_[elemIdx] = satnumRawData[elemIdx] - 1;
+        }
+    }
+    else {
+        std::fill(satnumRegionArray_.begin(), satnumRegionArray_.end(), 0);
+    }
+    auto copy_krnum = [&eclState, numCompressedElems](std::vector<int>& dest, const std::string keyword) {
+        if (eclState.fieldProps().has_int(keyword)) {
+            dest.resize(numCompressedElems);
+            const auto& satnumRawData = eclState.fieldProps().get_int(keyword);
+            for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
+                dest[elemIdx] = satnumRawData[elemIdx] - 1;
+            }
+        }
+    };
+    copy_krnum(krnumXArray_, "KRNUMX");
+    copy_krnum(krnumYArray_, "KRNUMY");
+    copy_krnum(krnumZArray_, "KRNUMZ");
+
+    // create the information for the imbibition region (IMBNUM). By default this is
+    // the same as the saturation region (SATNUM)
+    imbnumRegionArray_ = satnumRegionArray_;
+    if (eclState.fieldProps().has_int("IMBNUM")) {
+        const auto& imbnumRawData = eclState.fieldProps().get_int("IMBNUM");
+        for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
+            imbnumRegionArray_[elemIdx] = imbnumRawData[elemIdx] - 1;
+        }
+    }
+
+    assert(numCompressedElems == satnumRegionArray_.size());
+    assert(!enableHysteresis() || numCompressedElems == imbnumRegionArray_.size());
+
+    // read the scaled end point scaling parameters which are specific for each
+    // element
+    oilWaterScaledEpsInfoDrainage_.resize(numCompressedElems);
+
+    std::unique_ptr<EclEpsGridProperties> epsImbGridProperties;
+
+    if (enableHysteresis()) {
+        epsImbGridProperties = std::make_unique<EclEpsGridProperties>(eclState, true);
+    }
+
+    EclEpsGridProperties epsGridProperties(eclState, false);
+    materialLawParams_.resize(numCompressedElems);
+
+    for (unsigned elemIdx = 0; elemIdx < numCompressedElems; ++elemIdx) {
+        unsigned satRegionIdx = static_cast<unsigned>(satnumRegionArray_[elemIdx]);
+        auto gasOilParams = std::make_shared<GasOilTwoPhaseHystParams>();
+        auto oilWaterParams = std::make_shared<OilWaterTwoPhaseHystParams>();
+        auto gasWaterParams = std::make_shared<GasWaterTwoPhaseHystParams>();
+        gasOilParams->setConfig(hysteresisConfig_);
+        oilWaterParams->setConfig(hysteresisConfig_);
+        gasWaterParams->setConfig(hysteresisConfig_);
+
+        auto [gasOilScaledInfo, gasOilScaledPoint] =
+            readScaledPoints_(*gasOilConfig,
+                              eclState,
+                              epsGridProperties,
+                              elemIdx,
+                              EclTwoPhaseSystemType::GasOil);
+
+        auto [owinfo, oilWaterScaledEpsPointDrainage] =
+            readScaledPoints_(*oilWaterConfig,
+                              eclState,
+                              epsGridProperties,
+                              elemIdx,
+                              EclTwoPhaseSystemType::OilWater);
+        oilWaterScaledEpsInfoDrainage_[elemIdx] = owinfo;
+
+        auto [gasWaterScaledInfo, gasWaterScaledPoint] =
+            readScaledPoints_(*gasWaterConfig,
+                              eclState,
+                              epsGridProperties,
+                              elemIdx,
+                              EclTwoPhaseSystemType::GasWater);
+
+        if (hasGas && hasOil) {
+            GasOilEpsTwoPhaseParams gasOilDrainParams;
+            gasOilDrainParams.setConfig(gasOilConfig);
+            gasOilDrainParams.setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
+            gasOilDrainParams.setScaledPoints(gasOilScaledPoint);
+            gasOilDrainParams.setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
+            gasOilDrainParams.finalize();
+
+            gasOilParams->setDrainageParams(gasOilDrainParams,
+                                            gasOilScaledInfo,
+                                            EclTwoPhaseSystemType::GasOil);
+        }
+
+        if (hasOil && hasWater) {
+            OilWaterEpsTwoPhaseParams oilWaterDrainParams;
+            oilWaterDrainParams.setConfig(oilWaterConfig);
+            oilWaterDrainParams.setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
+            oilWaterDrainParams.setScaledPoints(oilWaterScaledEpsPointDrainage);
+            oilWaterDrainParams.setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
+            oilWaterDrainParams.finalize();
+
+            oilWaterParams->setDrainageParams(oilWaterDrainParams,
+                                              owinfo,
+                                              EclTwoPhaseSystemType::OilWater);
+        }
+
+        if (hasGas && hasWater && !hasOil) {
+            GasWaterEpsTwoPhaseParams gasWaterDrainParams;
+            gasWaterDrainParams.setConfig(gasWaterConfig);
+            gasWaterDrainParams.setUnscaledPoints(gasWaterUnscaledPointsVector_[satRegionIdx]);
+            gasWaterDrainParams.setScaledPoints(gasWaterScaledPoint);
+            gasWaterDrainParams.setEffectiveLawParams(gasWaterEffectiveParamVector_[satRegionIdx]);
+            gasWaterDrainParams.finalize();
+
+            gasWaterParams->setDrainageParams(gasWaterDrainParams,
+                                              gasWaterScaledInfo,
+                                              EclTwoPhaseSystemType::GasWater);
+        }
+
+        if (enableHysteresis()) {
+            auto [gasOilScaledImbInfo, gasOilScaledImbPoint] =
+                readScaledPoints_(*gasOilConfig,
+                                  eclState,
+                                  *epsImbGridProperties,
+                                  elemIdx,
+                                  EclTwoPhaseSystemType::GasOil);
+
+            auto [oilWaterScaledImbInfo, oilWaterScaledImbPoint] =
+                readScaledPoints_(*oilWaterConfig,
+                                  eclState,
+                                  *epsImbGridProperties,
+                                  elemIdx,
+                                  EclTwoPhaseSystemType::OilWater);
+
+            auto [gasWaterScaledImbInfo, gasWaterScaledImbPoint] =
+                readScaledPoints_(*gasWaterConfig,
+                                  eclState,
+                                  *epsImbGridProperties,
+                                  elemIdx,
+                                  EclTwoPhaseSystemType::GasWater);
+
+            unsigned imbRegionIdx = imbnumRegionArray_[elemIdx];
+            if (hasGas && hasOil) {
+                GasOilEpsTwoPhaseParams gasOilImbParamsHyst;
+                gasOilImbParamsHyst.setConfig(gasOilConfig);
+                gasOilImbParamsHyst.setUnscaledPoints(gasOilUnscaledPointsVector_[imbRegionIdx]);
+                gasOilImbParamsHyst.setScaledPoints(gasOilScaledImbPoint);
+                gasOilImbParamsHyst.setEffectiveLawParams(gasOilEffectiveParamVector_[imbRegionIdx]);
+                gasOilImbParamsHyst.finalize();
+
+                gasOilParams->setImbibitionParams(gasOilImbParamsHyst,
+                                                  gasOilScaledImbInfo,
+                                                  EclTwoPhaseSystemType::GasOil);
+            }
+
+            if (hasOil && hasWater) {
+                OilWaterEpsTwoPhaseParams oilWaterImbParamsHyst;
+                oilWaterImbParamsHyst.setConfig(oilWaterConfig);
+                oilWaterImbParamsHyst.setUnscaledPoints(oilWaterUnscaledPointsVector_[imbRegionIdx]);
+                oilWaterImbParamsHyst.setScaledPoints(oilWaterScaledImbPoint);
+                oilWaterImbParamsHyst.setEffectiveLawParams(oilWaterEffectiveParamVector_[imbRegionIdx]);
+                oilWaterImbParamsHyst.finalize();
+
+                oilWaterParams->setImbibitionParams(oilWaterImbParamsHyst,
+                                                    oilWaterScaledImbInfo,
+                                                    EclTwoPhaseSystemType::OilWater);
+            }
+
+            if (hasGas && hasWater && !hasOil) {
+                GasWaterEpsTwoPhaseParams gasWaterImbParamsHyst;
+                gasWaterImbParamsHyst.setConfig(gasWaterConfig);
+                gasWaterImbParamsHyst.setUnscaledPoints(gasWaterUnscaledPointsVector_[imbRegionIdx]);
+                gasWaterImbParamsHyst.setScaledPoints(gasWaterScaledImbPoint);
+                gasWaterImbParamsHyst.setEffectiveLawParams(gasWaterEffectiveParamVector_[imbRegionIdx]);
+                gasWaterImbParamsHyst.finalize();
+
+                gasWaterParams->setImbibitionParams(gasWaterImbParamsHyst,
+                                                    gasWaterScaledImbInfo,
+                                                    EclTwoPhaseSystemType::GasWater);
+            }
+        }
+
+        if (hasGas && hasOil)
+            gasOilParams->finalize();
+
+        if (hasOil && hasWater)
+            oilWaterParams->finalize();
+
+        if (hasGas && hasWater && !hasOil)
+            gasWaterParams->finalize();
+
+        initThreePhaseParams_(eclState,
+                              materialLawParams_[elemIdx],
+                              satRegionIdx,
+                              oilWaterScaledEpsInfoDrainage_[elemIdx],
+                              oilWaterParams,
+                              gasOilParams,
+                              gasWaterParams);
+
+        materialLawParams_[elemIdx].finalize();
+    }
+}
+
+template<class TraitsT>
+typename TraitsT::Scalar EclMaterialLawManagerTable<TraitsT>::
+applySwatinit(unsigned elemIdx,
+              Scalar pcow,
+              Scalar Sw)
+{
+    auto& elemScaledEpsInfo = oilWaterScaledEpsInfoDrainage_[elemIdx];
+
+    // TODO: Mixed wettability systems - see ecl kw OPTIONS switch 74
+
+    if (pcow < 0.0)
+        Sw = elemScaledEpsInfo.Swu;
+    else {
+
+        if (Sw <= elemScaledEpsInfo.Swl)
+            Sw = elemScaledEpsInfo.Swl;
+
+        // specify a fluid state which only stores the saturations
+        using FluidState = SimpleModularFluidState<Scalar,
+                                                   numPhases,
+                                                   /*numComponents=*/0,
+                                                   /*FluidSystem=*/void, /* -> don't care */
+                                                   /*storePressure=*/false,
+                                                   /*storeTemperature=*/false,
+                                                   /*storeComposition=*/false,
+                                                   /*storeFugacity=*/false,
+                                                   /*storeSaturation=*/true,
+                                                   /*storeDensity=*/false,
+                                                   /*storeViscosity=*/false,
+                                                   /*storeEnthalpy=*/false>;
+        FluidState fs;
+        fs.setSaturation(waterPhaseIdx, Sw);
+        fs.setSaturation(gasPhaseIdx, 0);
+        fs.setSaturation(oilPhaseIdx, 0);
+        std::array<Scalar, numPhases> pc = { 0 };
+        MaterialLaw::capillaryPressures(pc, materialLawParams(elemIdx), fs);
+
+        Scalar pcowAtSw = pc[oilPhaseIdx] - pc[waterPhaseIdx];
+        constexpr const Scalar pcowAtSwThreshold = 1.0; //Pascal
+        // avoid divison by very small number
+        if (std::abs(pcowAtSw) > pcowAtSwThreshold) {
+            elemScaledEpsInfo.maxPcow *= pcow/pcowAtSw;
+            auto& elemEclEpsScalingPoints = oilWaterScaledEpsPointsDrainage(elemIdx);
+            elemEclEpsScalingPoints.init(elemScaledEpsInfo,
+                                         *oilWaterEclEpsConfig_,
+                                         EclTwoPhaseSystemType::OilWater);
+        }
+    }
+
+    return Sw;
+}
+
+template<class TraitsT>
+const typename EclMaterialLawManagerTable<TraitsT>::MaterialLawParams&
+EclMaterialLawManagerTable<TraitsT>::
+connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const
+{
+    MaterialLawParams& mlp = const_cast<MaterialLawParams&>(materialLawParams_[elemIdx]);
+
+    if (enableHysteresis())
+        OpmLog::warning("Warning: Using non-default satnum regions for connection is not tested in combination with hysteresis");
+    // Currently we don't support COMPIMP. I.e. use the same table lookup for the hysteresis curves.
+    // unsigned impRegionIdx = satRegionIdx;
+
+    // change the sat table it points to.
+    switch (mlp.approach()) {
+    case EclMultiplexerApproach::Stone1: {
+        auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Stone1>();
+
+        realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
+        realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
+        realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
+        realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
+//            if (enableHysteresis()) {
+//                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
+//                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);
+//                realParams.gasOilParams().imbibitionParams().setUnscaledPoints(gasOilUnscaledPointsVector_[impRegionIdx]);
+//                realParams.gasOilParams().imbibitionParams().setEffectiveLawParams(gasOilEffectiveParamVector_[impRegionIdx]);
+//            }
+    }
+        break;
+
+    case EclMultiplexerApproach::Stone2: {
+        auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Stone2>();
+        realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
+        realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
+        realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
+        realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
+//            if (enableHysteresis()) {
+//                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
+//                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);
+//                realParams.gasOilParams().imbibitionParams().setUnscaledPoints(gasOilUnscaledPointsVector_[impRegionIdx]);
+//                realParams.gasOilParams().imbibitionParams().setEffectiveLawParams(gasOilEffectiveParamVector_[impRegionIdx]);
+//            }
+    }
+        break;
+
+    case EclMultiplexerApproach::Default: {
+        auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::Default>();
+        realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
+        realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
+        realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
+        realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
+//            if (enableHysteresis()) {
+//                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
+//                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);
+//                realParams.gasOilParams().imbibitionParams().setUnscaledPoints(gasOilUnscaledPointsVector_[impRegionIdx]);
+//                realParams.gasOilParams().imbibitionParams().setEffectiveLawParams(gasOilEffectiveParamVector_[impRegionIdx]);
+//            }
+    }
+        break;
+
+    case EclMultiplexerApproach::TwoPhase: {
+        auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::TwoPhase>();
+        realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
+        realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
+        realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
+        realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
+//            if (enableHysteresis()) {
+//                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
+//                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);
+//                realParams.gasOilParams().imbibitionParams().setUnscaledPoints(gasOilUnscaledPointsVector_[impRegionIdx]);
+//                realParams.gasOilParams().imbibitionParams().setEffectiveLawParams(gasOilEffectiveParamVector_[impRegionIdx]);
+//            }
+    }
+        break;
+
+    default:
+        throw std::logic_error("Enum value for material approach unknown!");
+    }
+
+    return mlp;
+}
+
+template<class TraitsT>
+int EclMaterialLawManagerTable<TraitsT>::
+getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const
+{
+    using Dir = FaceDir::DirEnum;
+    const std::vector<int>* array = nullptr;
+    switch(facedir) {
+    case Dir::XPlus:
+      array = &krnumXArray_;
+      break;
+    case Dir::YPlus:
+      array = &krnumYArray_;
+      break;
+    case Dir::ZPlus:
+      array = &krnumZArray_;
+      break;
+    default:
+      throw std::runtime_error("Unknown face direction");
+    }
+    if (array->size() > 0) {
+      return (*array)[elemIdx];
+    }
+    else {
+      return satnumRegionArray_[elemIdx];
+    }
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+oilWaterHysteresisParams(Scalar& pcSwMdc,
+                         Scalar& krnSwMdc,
+                         unsigned elemIdx) const
+{
+    if (!enableHysteresis())
+        throw std::runtime_error("Cannot get hysteresis parameters if hysteresis not enabled.");
+
+    const auto& params = materialLawParams(elemIdx);
+    MaterialLaw::oilWaterHysteresisParams(pcSwMdc, krnSwMdc, params);
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+setOilWaterHysteresisParams(const Scalar& pcSwMdc,
+                            const Scalar& krnSwMdc,
+                            unsigned elemIdx)
+{
+    if (!enableHysteresis())
+        throw std::runtime_error("Cannot set hysteresis parameters if hysteresis not enabled.");
+
+    auto& params = materialLawParams(elemIdx);
+    MaterialLaw::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc, params);
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+gasOilHysteresisParams(Scalar& pcSwMdc,
+                       Scalar& krnSwMdc,
+                       unsigned elemIdx) const
+{
+    if (!enableHysteresis())
+        throw std::runtime_error("Cannot get hysteresis parameters if hysteresis not enabled.");
+
+    const auto& params = materialLawParams(elemIdx);
+    MaterialLaw::gasOilHysteresisParams(pcSwMdc, krnSwMdc, params);
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+setGasOilHysteresisParams(const Scalar& pcSwMdc,
+                          const Scalar& krnSwMdc,
+                          unsigned elemIdx)
+{
+    if (!enableHysteresis())
+        throw std::runtime_error("Cannot set hysteresis parameters if hysteresis not enabled.");
+
+    auto& params = materialLawParams(elemIdx);
+    MaterialLaw::setGasOilHysteresisParams(pcSwMdc, krnSwMdc, params);
+}
+
+template<class TraitsT>
+EclEpsScalingPoints<typename TraitsT::Scalar>&
+EclMaterialLawManagerTable<TraitsT>::
+oilWaterScaledEpsPointsDrainage(unsigned elemIdx)
+{
+    auto& materialParams = materialLawParams_[elemIdx];
+    switch (materialParams.approach()) {
+    case EclMultiplexerApproach::Stone1: {
+        auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone1>();
+        return realParams.oilWaterParams().drainageParams().scaledPoints();
+    }
+
+    case EclMultiplexerApproach::Stone2: {
+        auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone2>();
+        return realParams.oilWaterParams().drainageParams().scaledPoints();
+    }
+
+    case EclMultiplexerApproach::Default: {
+        auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Default>();
+        return realParams.oilWaterParams().drainageParams().scaledPoints();
+    }
+
+    case EclMultiplexerApproach::TwoPhase: {
+        auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::TwoPhase>();
+        return realParams.oilWaterParams().drainageParams().scaledPoints();
+    }
+    default:
+        throw std::logic_error("Enum value for material approach unknown!");
+    }
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+readGlobalEpsOptions_(const EclipseState& eclState)
+{
+    oilWaterEclEpsConfig_ = std::make_shared<EclEpsConfig>();
+    oilWaterEclEpsConfig_->initFromState(eclState, EclTwoPhaseSystemType::OilWater);
+
+    enableEndPointScaling_ = eclState.getTableManager().hasTables("ENKRVD");
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+readGlobalHysteresisOptions_(const EclipseState& state)
+{
+    hysteresisConfig_ = std::make_shared<EclHysteresisConfig>();
+    hysteresisConfig_->initFromState(state.runspec());
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+readGlobalThreePhaseOptions_(const Runspec& runspec)
+{
+    bool gasEnabled = runspec.phases().active(Phase::GAS);
+    bool oilEnabled = runspec.phases().active(Phase::OIL);
+    bool waterEnabled = runspec.phases().active(Phase::WATER);
+
+    int numEnabled =
+        (gasEnabled?1:0)
+        + (oilEnabled?1:0)
+        + (waterEnabled?1:0);
+
+    if (numEnabled == 0) {
+        throw std::runtime_error("At least one fluid phase must be enabled. (Is: "+std::to_string(numEnabled)+")");
+    } else if (numEnabled == 1) {
+        threePhaseApproach_ = EclMultiplexerApproach::OnePhase;
+    } else if ( numEnabled == 2) {
+        threePhaseApproach_ = EclMultiplexerApproach::TwoPhase;
+        if (!gasEnabled)
+            twoPhaseApproach_ = EclTwoPhaseApproach::OilWater;
+        else if (!oilEnabled)
+            twoPhaseApproach_ = EclTwoPhaseApproach::GasWater;
+        else if (!waterEnabled)
+            twoPhaseApproach_ = EclTwoPhaseApproach::GasOil;
+    }
+    else {
+        assert(numEnabled == 3);
+
+        threePhaseApproach_ = EclMultiplexerApproach::Default;
+        const auto& satctrls = runspec.saturationFunctionControls();
+        if (satctrls.krModel() == SatFuncControls::ThreePhaseOilKrModel::Stone2)
+            threePhaseApproach_ = EclMultiplexerApproach::Stone2;
+        else if (satctrls.krModel() == SatFuncControls::ThreePhaseOilKrModel::Stone1)
+            threePhaseApproach_ = EclMultiplexerApproach::Stone1;
+    }
+}
+
+template<class TraitsT>
+template <class Container>
+void EclMaterialLawManagerTable<TraitsT>::
+readGasOilEffectiveParameters_(Container& dest,
+                               const EclipseState& eclState,
+                               unsigned satRegionIdx)
+{
+    if (!hasGas || !hasOil)
+        // we don't read anything if either the gas or the oil phase is not active
+        return;
+
+    dest[satRegionIdx] = std::make_shared<GasOilEffectiveTwoPhaseParams>();
+
+    auto& effParams = *dest[satRegionIdx];
+
+    // the situation for the gas phase is complicated that all saturations are
+    // shifted by the connate water saturation.
+    const Scalar Swco = unscaledEpsInfo_[satRegionIdx].Swl;
+    const auto tolcrit = eclState.runspec().saturationFunctionControls()
+        .minimumRelpermMobilityThreshold();
+
+    const auto& tableManager = eclState.getTableManager();
+
+    switch (eclState.runspec().saturationFunctionControls().family()) {
+    case SatFuncControls::KeywordFamily::Family_I:
+    {
+        const TableContainer& sgofTables = tableManager.getSgofTables();
+        const TableContainer& slgofTables = tableManager.getSlgofTables();
+        if (!sgofTables.empty())
+            readGasOilEffectiveParametersSgof_(effParams, Swco, tolcrit,
+                                               sgofTables.getTable<SgofTable>(satRegionIdx));
+        else if (!slgofTables.empty())
+            readGasOilEffectiveParametersSlgof_(effParams, Swco, tolcrit,
+                                                slgofTables.getTable<SlgofTable>(satRegionIdx));
+        else if ( !tableManager.getSgofletTable().empty() ) {
+            const auto& letSgofTab = tableManager.getSgofletTable()[satRegionIdx];
+            const std::vector<Scalar> dum; // dummy arg to comform with existing interface
+
+            //effParams.setApproach(SatCurveMultiplexerApproach::LET);
+            auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::LET>();
+
+            // S=(So-Sogcr)/(1-Sogcr-Sgcr-Swco),  krog = Krt*S^L/[S^L+E*(1.0-S)^T]
+            const Scalar s_min_w = letSgofTab.s2_critical;
+            const Scalar s_max_w = 1.0-letSgofTab.s1_critical-Swco;
+            const std::vector<Scalar>& letCoeffsOil = {s_min_w, s_max_w,
+                                                       static_cast<Scalar>(letSgofTab.l2_relperm),
+                                                       static_cast<Scalar>(letSgofTab.e2_relperm),
+                                                       static_cast<Scalar>(letSgofTab.t2_relperm),
+                                                       static_cast<Scalar>(letSgofTab.krt2_relperm)};
+            realParams.setKrwSamples(letCoeffsOil, dum);
+
+            // S=(1-So-Sgcr-Swco)/(1-Sogcr-Sgcr-Swco), krg = Krt*S^L/[S^L+E*(1.0-S)^T]
+            const Scalar s_min_nw = letSgofTab.s1_critical+Swco;
+            const Scalar s_max_nw = 1.0-letSgofTab.s2_critical;
+            const std::vector<Scalar>& letCoeffsGas = {s_min_nw, s_max_nw,
+                                                       static_cast<Scalar>(letSgofTab.l1_relperm),
+                                                       static_cast<Scalar>(letSgofTab.e1_relperm),
+                                                       static_cast<Scalar>(letSgofTab.t1_relperm),
+                                                       static_cast<Scalar>(letSgofTab.krt1_relperm)};
+            realParams.setKrnSamples(letCoeffsGas, dum);
+
+            // S=(So-Sorg)/(1-Sorg-Sgl-Swco), Pc = Pct + (pcir_pc-Pct)*(1-S)^L/[(1-S)^L+E*S^T]
+            const std::vector<Scalar>& letCoeffsPc = {static_cast<Scalar>(letSgofTab.s2_residual),
+                                                      static_cast<Scalar>(letSgofTab.s1_residual+Swco),
+                                                      static_cast<Scalar>(letSgofTab.l_pc),
+                                                      static_cast<Scalar>(letSgofTab.e_pc),
+                                                      static_cast<Scalar>(letSgofTab.t_pc),
+                                                      static_cast<Scalar>(letSgofTab.pcir_pc),
+                                                      static_cast<Scalar>(letSgofTab.pct_pc)};
+            realParams.setPcnwSamples(letCoeffsPc, dum);
+
+            realParams.finalize();
+        }
+        break;
+    }
+
+    case SatFuncControls::KeywordFamily::Family_II:
+    {
+        const SgfnTable& sgfnTable = tableManager.getSgfnTables().getTable<SgfnTable>( satRegionIdx );
+        if (!hasWater) {
+            // oil and gas case
+            const Sof2Table& sof2Table = tableManager.getSof2Tables().getTable<Sof2Table>( satRegionIdx );
+            readGasOilEffectiveParametersFamily2_(effParams, Swco, tolcrit, sof2Table, sgfnTable);
+        }
+        else {
+            const Sof3Table& sof3Table = tableManager.getSof3Tables().getTable<Sof3Table>( satRegionIdx );
+            readGasOilEffectiveParametersFamily2_(effParams, Swco, tolcrit, sof3Table, sgfnTable);
+        }
+        break;
+    }
+
+    case SatFuncControls::KeywordFamily::Undefined:
+        throw std::domain_error("No valid saturation keyword family specified");
+    }
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+readGasOilEffectiveParametersSgof_(GasOilEffectiveTwoPhaseParams& effParams,
+                                   const Scalar Swco,
+                                   const double tolcrit,
+                                   const SgofTable& sgofTable)
+{
+    // convert the saturations of the SGOF keyword from gas to oil saturations
+    std::vector<double> SoSamples(sgofTable.numRows());
+    for (size_t sampleIdx = 0; sampleIdx < sgofTable.numRows(); ++ sampleIdx) {
+        SoSamples[sampleIdx] = (1.0 - Swco) - sgofTable.get("SG", sampleIdx);
+    }
+
+    //effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+    auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+
+    realParams.setKrwSamples(SoSamples, normalizeKrValues_(tolcrit, sgofTable.getColumn("KROG")));
+    realParams.setKrnSamples(SoSamples, normalizeKrValues_(tolcrit, sgofTable.getColumn("KRG")));
+    realParams.setPcnwSamples(SoSamples, sgofTable.getColumn("PCOG").vectorCopy());
+    realParams.finalize();
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+readGasOilEffectiveParametersSlgof_(GasOilEffectiveTwoPhaseParams& effParams,
+                                    const Scalar Swco,
+                                    const double tolcrit,
+                                    const SlgofTable& slgofTable)
+{
+    // convert the saturations of the SLGOF keyword from "liquid" to oil saturations
+    std::vector<double> SoSamples(slgofTable.numRows());
+    for (size_t sampleIdx = 0; sampleIdx < slgofTable.numRows(); ++ sampleIdx) {
+        SoSamples[sampleIdx] = slgofTable.get("SL", sampleIdx) - Swco;
+    }
+
+    //effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+    auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+
+    realParams.setKrwSamples(SoSamples, normalizeKrValues_(tolcrit, slgofTable.getColumn("KROG")));
+    realParams.setKrnSamples(SoSamples, normalizeKrValues_(tolcrit, slgofTable.getColumn("KRG")));
+    realParams.setPcnwSamples(SoSamples, slgofTable.getColumn("PCOG").vectorCopy());
+    realParams.finalize();
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+readGasOilEffectiveParametersFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
+                                      const Scalar Swco,
+                                      const double tolcrit,
+                                      const Sof3Table& sof3Table,
+                                      const SgfnTable& sgfnTable)
+{
+    // convert the saturations of the SGFN keyword from gas to oil saturations
+    std::vector<double> SoSamples(sgfnTable.numRows());
+    std::vector<double> SoColumn = sof3Table.getColumn("SO").vectorCopy();
+    for (size_t sampleIdx = 0; sampleIdx < sgfnTable.numRows(); ++ sampleIdx) {
+        SoSamples[sampleIdx] = (1.0 - Swco) - sgfnTable.get("SG", sampleIdx);
+    }
+
+    //effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+    auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+
+    realParams.setKrwSamples(SoColumn, normalizeKrValues_(tolcrit, sof3Table.getColumn("KROG")));
+    realParams.setKrnSamples(SoSamples, normalizeKrValues_(tolcrit, sgfnTable.getColumn("KRG")));
+    realParams.setPcnwSamples(SoSamples, sgfnTable.getColumn("PCOG").vectorCopy());
+    realParams.finalize();
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+readGasOilEffectiveParametersFamily2_(GasOilEffectiveTwoPhaseParams& effParams,
+                                      const Scalar Swco,
+                                      const double tolcrit,
+                                      const Sof2Table& sof2Table,
+                                      const SgfnTable& sgfnTable)
+{
+    // convert the saturations of the SGFN keyword from gas to oil saturations
+    std::vector<double> SoSamples(sgfnTable.numRows());
+    std::vector<double> SoColumn = sof2Table.getColumn("SO").vectorCopy();
+    for (size_t sampleIdx = 0; sampleIdx < sgfnTable.numRows(); ++ sampleIdx) {
+        SoSamples[sampleIdx] = (1.0 - Swco) - sgfnTable.get("SG", sampleIdx);
+    }
+
+    //effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+    auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+
+    realParams.setKrwSamples(SoColumn, normalizeKrValues_(tolcrit, sof2Table.getColumn("KRO")));
+    realParams.setKrnSamples(SoSamples, normalizeKrValues_(tolcrit, sgfnTable.getColumn("KRG")));
+    realParams.setPcnwSamples(SoSamples, sgfnTable.getColumn("PCOG").vectorCopy());
+    realParams.finalize();
+}
+
+template<class TraitsT>
+template <class Container>
+void EclMaterialLawManagerTable<TraitsT>::
+readOilWaterEffectiveParameters_(Container& dest,
+                                 const EclipseState& eclState,
+                                 unsigned satRegionIdx)
+{
+    if (!hasOil || !hasWater)
+        // we don't read anything if either the water or the oil phase is not active
+        return;
+
+    dest[satRegionIdx] = std::make_shared<OilWaterEffectiveTwoPhaseParams>();
+
+    const auto tolcrit = eclState.runspec().saturationFunctionControls()
+        .minimumRelpermMobilityThreshold();
+
+    const auto& tableManager = eclState.getTableManager();
+    auto& effParams = *dest[satRegionIdx];
+
+    switch (eclState.runspec().saturationFunctionControls().family()) {
+    case SatFuncControls::KeywordFamily::Family_I:
+    {
+        if (tableManager.hasTables("SWOF")) {
+            const auto& swofTable = tableManager.getSwofTables().getTable<SwofTable>(satRegionIdx);
+            const std::vector<double> SwColumn = swofTable.getColumn("SW").vectorCopy();
+
+            //effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+            auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+
+            realParams.setKrwSamples(SwColumn, normalizeKrValues_(tolcrit, swofTable.getColumn("KRW")));
+            realParams.setKrnSamples(SwColumn, normalizeKrValues_(tolcrit, swofTable.getColumn("KROW")));
+            realParams.setPcnwSamples(SwColumn, swofTable.getColumn("PCOW").vectorCopy());
+            realParams.finalize();
+        }
+        else if ( !tableManager.getSwofletTable().empty() ) {
+            const auto& letTab = tableManager.getSwofletTable()[satRegionIdx];
+            const std::vector<Scalar> dum; // dummy arg to conform with existing interface
+
+            //effParams.setApproach(SatCurveMultiplexerApproach::LET);
+            auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::LET>();
+
+            // S=(Sw-Swcr)/(1-Sowcr-Swcr),  krw = Krt*S^L/[S^L+E*(1.0-S)^T]
+            const Scalar s_min_w = letTab.s1_critical;
+            const Scalar s_max_w = 1.0-letTab.s2_critical;
+            const std::vector<Scalar>& letCoeffsWat = {s_min_w, s_max_w,
+                                                       static_cast<Scalar>(letTab.l1_relperm),
+                                                       static_cast<Scalar>(letTab.e1_relperm),
+                                                       static_cast<Scalar>(letTab.t1_relperm),
+                                                       static_cast<Scalar>(letTab.krt1_relperm)};
+            realParams.setKrwSamples(letCoeffsWat, dum);
+
+            // S=(So-Sowcr)/(1-Sowcr-Swcr), krow = Krt*S^L/[S^L+E*(1.0-S)^T]
+            const Scalar s_min_nw = letTab.s2_critical;
+            const Scalar s_max_nw = 1.0-letTab.s1_critical;
+            const std::vector<Scalar>& letCoeffsOil = {s_min_nw, s_max_nw,
+                                                       static_cast<Scalar>(letTab.l2_relperm),
+                                                       static_cast<Scalar>(letTab.e2_relperm),
+                                                       static_cast<Scalar>(letTab.t2_relperm),
+                                                       static_cast<Scalar>(letTab.krt2_relperm)};
+            realParams.setKrnSamples(letCoeffsOil, dum);
+
+            // S=(Sw-Swco)/(1-Swco-Sorw), Pc = Pct + (Pcir-Pct)*(1-S)^L/[(1-S)^L+E*S^T]
+            const std::vector<Scalar>& letCoeffsPc = {static_cast<Scalar>(letTab.s1_residual),
+                                                      static_cast<Scalar>(letTab.s2_residual),
+                                                      static_cast<Scalar>(letTab.l_pc),
+                                                      static_cast<Scalar>(letTab.e_pc),
+                                                      static_cast<Scalar>(letTab.t_pc),
+                                                      static_cast<Scalar>(letTab.pcir_pc),
+                                                      static_cast<Scalar>(letTab.pct_pc)};
+            realParams.setPcnwSamples(letCoeffsPc, dum);
+
+            realParams.finalize();
+        }
+        break;
+    }
+
+    case SatFuncControls::KeywordFamily::Family_II:
+    {
+        const auto& swfnTable = tableManager.getSwfnTables().getTable<SwfnTable>(satRegionIdx);
+        const std::vector<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
+
+        //effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+        auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+
+        realParams.setKrwSamples(SwColumn, normalizeKrValues_(tolcrit, swfnTable.getColumn("KRW")));
+        realParams.setPcnwSamples(SwColumn, swfnTable.getColumn("PCOW").vectorCopy());
+
+        if (!hasGas) {
+            const auto& sof2Table = tableManager.getSof2Tables().getTable<Sof2Table>(satRegionIdx);
+            // convert the saturations of the SOF2 keyword from oil to water saturations
+            std::vector<double> SwSamples(sof2Table.numRows());
+            for (size_t sampleIdx = 0; sampleIdx < sof2Table.numRows(); ++ sampleIdx)
+                SwSamples[sampleIdx] = 1 - sof2Table.get("SO", sampleIdx);
+
+            realParams.setKrnSamples(SwSamples, normalizeKrValues_(tolcrit, sof2Table.getColumn("KRO")));
+        } else {
+            const auto& sof3Table = tableManager.getSof3Tables().getTable<Sof3Table>(satRegionIdx);
+            // convert the saturations of the SOF3 keyword from oil to water saturations
+            std::vector<double> SwSamples(sof3Table.numRows());
+            for (size_t sampleIdx = 0; sampleIdx < sof3Table.numRows(); ++ sampleIdx)
+                SwSamples[sampleIdx] = 1 - sof3Table.get("SO", sampleIdx);
+
+            realParams.setKrnSamples(SwSamples, normalizeKrValues_(tolcrit, sof3Table.getColumn("KROW")));
+        }
+        realParams.finalize();
+        break;
+    }
+
+    case SatFuncControls::KeywordFamily::Undefined:
+        throw std::domain_error("No valid saturation keyword family specified");
+    }
+}
+
+template<class TraitsT>
+template <class Container>
+void EclMaterialLawManagerTable<TraitsT>::
+readGasWaterEffectiveParameters_(Container& dest,
+                                 const EclipseState& eclState,
+                                 unsigned satRegionIdx)
+{
+    if (!hasGas || !hasWater || hasOil)
+        // we don't read anything if either the gas or the water phase is not active or if oil is present
+        return;
+
+    dest[satRegionIdx] = std::make_shared<GasWaterEffectiveTwoPhaseParams>();
+
+    auto& effParams = *dest[satRegionIdx];
+
+    const auto tolcrit = eclState.runspec().saturationFunctionControls()
+        .minimumRelpermMobilityThreshold();
+
+    const auto& tableManager = eclState.getTableManager();
+
+    switch (eclState.runspec().saturationFunctionControls().family()) {
+    case SatFuncControls::KeywordFamily::Family_I:
+    {
+        throw std::domain_error("Saturation keyword family I is not applicable for a gas-water system");
+    }
+
+    case SatFuncControls::KeywordFamily::Family_II:
+    {
+        //Todo: allow also for Sgwfn table input as alternative to Sgfn and Swfn table input
+        const SgfnTable& sgfnTable = tableManager.getSgfnTables().getTable<SgfnTable>( satRegionIdx );
+        const SwfnTable& swfnTable = tableManager.getSwfnTables().getTable<SwfnTable>( satRegionIdx );
+
+        //effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
+        auto& realParams = effParams;//.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();
+
+        std::vector<double> SwColumn = swfnTable.getColumn("SW").vectorCopy();
+
+        realParams.setKrwSamples(SwColumn, normalizeKrValues_(tolcrit, swfnTable.getColumn("KRW")));
+        std::vector<double> SwSamples(sgfnTable.numRows());
+        for (size_t sampleIdx = 0; sampleIdx < sgfnTable.numRows(); ++ sampleIdx)
+            SwSamples[sampleIdx] = 1 - sgfnTable.get("SG", sampleIdx);
+        realParams.setKrnSamples(SwSamples, normalizeKrValues_(tolcrit, sgfnTable.getColumn("KRG")));
+        //Capillary pressure is read from SWFN.
+        //For gas-water system the capillary pressure column values are set to 0 in SGFN
+        realParams.setPcnwSamples(SwColumn, swfnTable.getColumn("PCOW").vectorCopy());
+        realParams.finalize();
+
+        break;
+    }
+
+    case SatFuncControls::KeywordFamily::Undefined:
+        throw std::domain_error("No valid saturation keyword family specified");
+    }
+}
+
+template<class TraitsT>
+template <class Container>
+void EclMaterialLawManagerTable<TraitsT>::
+readGasOilUnscaledPoints_(Container& dest,
+                          std::shared_ptr<EclEpsConfig> config,
+                          const EclipseState& /* eclState */,
+                          unsigned satRegionIdx)
+{
+    if (!hasGas || !hasOil)
+        // we don't read anything if either the gas or the oil phase is not active
+        return;
+
+    dest[satRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
+    dest[satRegionIdx]->init(unscaledEpsInfo_[satRegionIdx],
+                             *config,
+                             EclTwoPhaseSystemType::GasOil);
+}
+
+template<class TraitsT>
+template <class Container>
+void EclMaterialLawManagerTable<TraitsT>::
+readOilWaterUnscaledPoints_(Container& dest,
+                            std::shared_ptr<EclEpsConfig> config,
+                            const EclipseState& /* eclState */,
+                            unsigned satRegionIdx)
+{
+    if (!hasOil || !hasWater)
+        // we don't read anything if either the water or the oil phase is not active
+        return;
+
+    dest[satRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
+    dest[satRegionIdx]->init(unscaledEpsInfo_[satRegionIdx],
+                             *config,
+                             EclTwoPhaseSystemType::OilWater);
+}
+
+template<class TraitsT>
+template <class Container>
+void EclMaterialLawManagerTable<TraitsT>::
+readGasWaterUnscaledPoints_(Container& dest,
+                            std::shared_ptr<EclEpsConfig> config,
+                            const EclipseState& /* eclState */,
+                            unsigned satRegionIdx)
+{
+    if (hasOil)
+        // we don't read anything if oil phase is active
+        return;
+
+    dest[satRegionIdx] = std::make_shared<EclEpsScalingPoints<Scalar> >();
+    dest[satRegionIdx]->init(unscaledEpsInfo_[satRegionIdx],
+                             *config,
+                             EclTwoPhaseSystemType::GasWater);
+}
+
+template<class TraitsT>
+std::tuple<EclEpsScalingPointsInfo<typename TraitsT::Scalar>,
+           EclEpsScalingPoints<typename TraitsT::Scalar>>
+EclMaterialLawManagerTable<TraitsT>::
+readScaledPoints_(const EclEpsConfig& config,
+                  const EclipseState& eclState,
+                  const EclEpsGridProperties& epsGridProperties,
+                  unsigned elemIdx,
+                  EclTwoPhaseSystemType type)
+{
+    unsigned satRegionIdx = epsGridProperties.satRegion( elemIdx );
+
+    EclEpsScalingPointsInfo<Scalar> destInfo(unscaledEpsInfo_[satRegionIdx]);
+    destInfo.extractScaled(eclState, epsGridProperties, elemIdx);
+
+    EclEpsScalingPoints<Scalar> destPoint;
+    destPoint.init(destInfo, config, type);
+
+    return {destInfo, destPoint};
+}
+
+template<class TraitsT>
+void EclMaterialLawManagerTable<TraitsT>::
+initThreePhaseParams_(const EclipseState& /* eclState */,
+                      MaterialLawParams& materialParams,
+                      unsigned satRegionIdx,
+                      const EclEpsScalingPointsInfo<Scalar>& epsInfo,
+                      std::shared_ptr<OilWaterTwoPhaseHystParams> oilWaterParams,
+                      std::shared_ptr<GasOilTwoPhaseHystParams> gasOilParams,
+                      std::shared_ptr<GasWaterTwoPhaseHystParams> gasWaterParams)
+{
+    materialParams.setApproach(threePhaseApproach_);
+
+    switch (materialParams.approach()) {
+    case EclMultiplexerApproach::Stone1: {
+        auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone1>();
+        realParams.setGasOilParams(gasOilParams);
+        realParams.setOilWaterParams(oilWaterParams);
+        realParams.setSwl(epsInfo.Swl);
+
+        if (!stoneEtas.empty()) {
+            realParams.setEta(stoneEtas[satRegionIdx]);
+        }
+        else
+            realParams.setEta(1.0);
+        realParams.finalize();
+        break;
+    }
+
+    case EclMultiplexerApproach::Stone2: {
+        auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Stone2>();
+        realParams.setGasOilParams(gasOilParams);
+        realParams.setOilWaterParams(oilWaterParams);
+        realParams.setSwl(epsInfo.Swl);
+        realParams.finalize();
+        break;
+    }
+
+    case EclMultiplexerApproach::Default: {
+        auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::Default>();
+        realParams.setGasOilParams(gasOilParams);
+        realParams.setOilWaterParams(oilWaterParams);
+        realParams.setSwl(epsInfo.Swl);
+        realParams.finalize();
+        break;
+    }
+
+    case EclMultiplexerApproach::TwoPhase: {
+        auto& realParams = materialParams.template getRealParams<EclMultiplexerApproach::TwoPhase>();
+        realParams.setGasOilParams(gasOilParams);
+        realParams.setOilWaterParams(oilWaterParams);
+        realParams.setGasWaterParams(gasWaterParams);
+        realParams.setApproach(twoPhaseApproach_);
+        realParams.finalize();
+        break;
+    }
+
+    case EclMultiplexerApproach::OnePhase: {
+        // Nothing to do, no parameters.
+        break;
+    }
+    }
+}
+
+template class EclMaterialLawManagerTable<ThreePhaseMaterialTraits<double,0,1,2>>;
+template class EclMaterialLawManagerTable<ThreePhaseMaterialTraits<float,0,1,2>>;
+
+} // namespace Opm

--- a/tests/material/test_eclpropertyevaluation.cpp
+++ b/tests/material/test_eclpropertyevaluation.cpp
@@ -122,23 +122,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     
      typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
     
-    // if (FluidSystem::numActivePhases() != 3)
-    // std::abort();
-
-    // if (!FluidSystem::enableDissolvedGas())
-    //     std::abort();
-    // if (!FluidSystem::enableVaporizedOil())
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
-    //     std::abort();
     std::vector<int> pvtnum(nc,0);
     const std::string& name("PVTNUM");
     if (eclState.fieldProps().has_int(name)){
@@ -162,6 +145,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     // const auto& waterpvt = FluidSystem::waterPvt();
     // const auto& oilpvt = FluidSystem::oilPvt();
     // const auto& gaspvt = FluidSystem::gasPvt();
+    // casting with the below give good speedup
     const auto& waterpvt = FluidSystem::waterPvt();//.template getRealPvt<Opm::WaterPvtApproach::ConstantCompressibilityWater>();
     const auto& oilpvt = FluidSystem::oilPvt();//.template getRealPvt<Opm::OilPvtApproach::LiveOil>();
     const auto& gaspvt = FluidSystem::gasPvt();//.template getRealPvt<Opm::GasPvtApproach::DryGas>();

--- a/tests/material/test_eclpropertyevaluation.cpp
+++ b/tests/material/test_eclpropertyevaluation.cpp
@@ -35,6 +35,8 @@
 
 #include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp>
+#include <opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/densead/Evaluation.hpp>
@@ -72,6 +74,7 @@
 // }
     
 
+
 template <class Evaluation>
 inline Opm::time_point::duration testAll(const char * deck_file)
 {
@@ -80,7 +83,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     
     typedef typename Opm::MathToolbox<Evaluation>::Scalar Scalar;
     //typedef typename Evaluation::ValueType simpletype;
-    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<Scalar> FluidSystem;
 
     static constexpr int numPhases = FluidSystem::numPhases;
 
@@ -155,9 +158,14 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     std::cout << "Doing evaluation " << num_total << " of nc " << nc << " total " << nc*num_total << std::endl;
     Opm::time_point start;
     start = Opm::TimeService::now();
+    const auto& materialParams = materialLawManager.materialLawParams(0).template getRealParams<Opm::EclMultiplexerApproach::Default>();
+    const auto& waterpvt = FluidSystem::waterPvt();
+    const auto& oilpvt = FluidSystem::oilPvt();
+    const auto& gaspvt = FluidSystem::gasPvt();
     for (unsigned step = 0; step < num_total; ++step) {
         for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
-            const auto& materialParams = materialLawManager.materialLawParams(elemIdx);
+            // const auto& materialParams =
+            //     materialLawManager.materialLawParams(elemIdx).template getRealParams<Opm::EclMultiplexerApproach::Default>();
             const auto& pvtRegionIdx = pvtnum[elemIdx];
             FluidState& fluidState = intQuant[elemIdx];
             Opm::Valgrind::SetUndefined(fluidState);
@@ -208,21 +216,32 @@ inline Opm::time_point::duration testAll(const char * deck_file)
             }
             paramCache.updateAll(fluidState);
 
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                // ensure that the black-oil specific variants of the methods to compute
-                // thermdynamic properties return the same value as the generic ones and that
-                // the generic methods return the same value as the ones for the saturated
-                // quantities (we specify the fluid state to be on the saturation line)
-                if (FluidSystem::phaseIsActive(phaseIdx)) {
-                    Evaluation b = FluidSystem::inverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
-                    //Evaluation bSat
-                    //    = FluidSystem::saturatedInverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
-                    fluidState.setInvB(phaseIdx, b);
-                }
-            }
-
             // calculate the phase densities
+            Evaluation T=278;
             Evaluation rho;
+            if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+                //const auto& waterpvt = FluidSystem::waterPvt();
+                Evaluation salt= 0.0;
+                Evaluation b = waterpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p, salt);//, Rsw, saltConcentration);
+                Evaluation mu = waterpvt.saturatedViscosity(pvtRegionIdx, T, p,salt);
+                fluidState.setInvB(waterPhaseIdx, b);
+            }
+            if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+                //const auto& gaspvt = FluidSystem::gasPvt();//.getRealPvt();
+                Evaluation b = gaspvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p);
+                //const auto& invmuBFunc = gaspvt.inverseSaturatedGasBMu();
+                //Evaluation invMuB = invmuBFunc[pvtRegionIdx].eval(p, /*extrapolate=*/true);
+                //Evaluation vic = b/invMuB;
+                Evaluation mu = gaspvt.saturatedViscosity(pvtRegionIdx, T, p);
+                fluidState.setInvB(gasPhaseIdx, b);
+            }
+            if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+                //const auto& oilpvt = FluidSystem::oilPvt();
+                Evaluation b = oilpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p);
+                Evaluation mu = oilpvt.saturatedViscosity(pvtRegionIdx, T, p);               
+                fluidState.setInvB(oilPhaseIdx, b);
+            }
+            
             if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
                 rho = fluidState.invB(waterPhaseIdx);
                 rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
@@ -232,7 +251,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
                 }
                 fluidState.setDensity(waterPhaseIdx, rho);
             }
-
+            
             if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
                 rho = fluidState.invB(gasPhaseIdx);
                 rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
@@ -247,7 +266,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
                 fluidState.setDensity(gasPhaseIdx, rho);
             }
 
-            if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+            if (FluidSystem::phaseIsActive(oilPhaseIdx)) {                
                 rho = fluidState.invB(oilPhaseIdx);
                 rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
                 if (FluidSystem::enableDissolvedGas()) {
@@ -258,17 +277,43 @@ inline Opm::time_point::duration testAll(const char * deck_file)
             }
 
             std::array<Evaluation, numPhases> mobility;
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
-                    // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
-                    const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
-                    mobility[phaseIdx] = mu;
-                }
-            }
+            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            //     if (FluidSystem::phaseIsActive(phaseIdx)) {
+            //         // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
+            //         const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
+            //         mobility[phaseIdx] = mu;
+            //     }
+            // }
 
             // std::array<Evaluation, numPhases> pC;
-            // MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
-            // MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+            // //MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
+            // //MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+            // MaterialLaw::DefaultMaterial::capillaryPressures(pC, materialParams, fluidState);
+            // MaterialLaw::DefaultMaterial::relativePermeabilities(mobility, materialParams, fluidState);
+            
+            // rocktabTables = eclState.getTableManager().getRocktabTables();
+            // const auto& rocktabTable = rocktabTables.template getTable<RocktabTable>(regionIdx);
+            // const auto& pressureColumn = rocktabTable.getPressureColumn();
+            // const auto& poroColumn = rocktabTable.getPoreVolumeMultiplierColumn();
+            // const auto& transColumn = rocktabTable.getTransmissibilityMultiplierColumn();
+           
+            // Evaluation porosity_;
+            // Evaluation rockCompTransMultiplier_;
+            // Scalar rockCompressibility = problem.rockCompressibility(globalSpaceIdx);
+            // if (rockCompressibility > 0.0) {
+            //     Scalar rockRefPressure = problem.rockReferencePressure(globalSpaceIdx);
+            //     Evaluation x;
+            //     if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+            //         x = rockCompressibility*(fluidState_.pressure(oilPhaseIdx) - rockRefPressure);
+            //     } else if (FluidSystem::phaseIsActive(waterPhaseIdx)){
+            //         x = rockCompressibility*(fluidState_.pressure(waterPhaseIdx) - rockRefPressure);
+            //     } else {
+            //         x = rockCompressibility*(fluidState_.pressure(gasPhaseIdx) - rockRefPressure);
+            //     }
+            //     porosity_ *= 1.0 + x + 0.5*x*x;
+            // }
+            // porosity_ *= problem.template rockCompPoroMultiplier<Evaluation>(*this, globalSpaceIdx);
+            // rockCompTransMultiplier_ = problem.template rockCompTransMultiplier<Evaluation>(*this, globalSpaceIdx);
         }
     }
     Opm::time_point::duration total_time = Opm::TimeService::now() - start;
@@ -285,7 +330,8 @@ int main(int argc, char **argv)
     Dune::MPIHelper::instance(argc, argv);
 
     typedef Opm::DenseAd::Evaluation<double, 3> TestEval;
-    typedef Opm::DenseAd::Evaluation<float, 3> TestEvalFloat;
+    //typedef Opm::DenseAd::Evaluation<float, 3> TestEvalFloat;
+    typedef Opm::DenseAd::Evaluation<double, 6> TestEval6;
 
     const char* deck_file = argv[1];
 
@@ -294,6 +340,7 @@ int main(int argc, char **argv)
     // auto evalfloat_time = testAll<TestEvalFloat>(deck_file);
     auto double_time = testAll<double>(deck_file);
     auto evaldouble_time = testAll<TestEval>(deck_file);
+    auto evaldouble6_time = testAll<TestEval6>(deck_file);
 
     std::cout << "complete." << std::endl << std::endl;
     std::cout << "Time: " << std::endl;
@@ -301,6 +348,7 @@ int main(int argc, char **argv)
     // std::cout << "   float.....: "  << std::chrono::duration<double>(float_time).count()  << " seconds" << std::endl;
     // std::cout << "   evalfloat.....: "  << std::chrono::duration<double>(evalfloat_time).count()  << " seconds" << std::endl;
     std::cout << "   double.....: "  << std::chrono::duration<double>(double_time).count()  << " seconds" << std::endl;
-    std::cout << "   eval double....: "  << std::chrono::duration<double>(evaldouble_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval3 double....: "  << std::chrono::duration<double>(evaldouble_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval6 double....: "  << std::chrono::duration<double>(evaldouble6_time).count()  << " seconds" << std::endl;
     return 0;
 }

--- a/tests/material/test_eclpropertyevaluation.cpp
+++ b/tests/material/test_eclpropertyevaluation.cpp
@@ -159,9 +159,12 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     Opm::time_point start;
     start = Opm::TimeService::now();
     const auto& materialParams = materialLawManager.materialLawParams(0).template getRealParams<Opm::EclMultiplexerApproach::Default>();
-    const auto& waterpvt = FluidSystem::waterPvt();
-    const auto& oilpvt = FluidSystem::oilPvt();
-    const auto& gaspvt = FluidSystem::gasPvt();
+    // const auto& waterpvt = FluidSystem::waterPvt();
+    // const auto& oilpvt = FluidSystem::oilPvt();
+    // const auto& gaspvt = FluidSystem::gasPvt();
+    const auto& waterpvt = FluidSystem::waterPvt();//.template getRealPvt<Opm::WaterPvtApproach::ConstantCompressibilityWater>();
+    const auto& oilpvt = FluidSystem::oilPvt();//.template getRealPvt<Opm::OilPvtApproach::LiveOil>();
+    const auto& gaspvt = FluidSystem::gasPvt();//.template getRealPvt<Opm::GasPvtApproach::DryGas>();
     for (unsigned step = 0; step < num_total; ++step) {
         for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
             // const auto& materialParams =

--- a/tests/material/test_eclpropertyevaluation_lowlevel.cpp
+++ b/tests/material/test_eclpropertyevaluation_lowlevel.cpp
@@ -122,23 +122,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     
      typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
     
-    // if (FluidSystem::numActivePhases() != 3)
-    // std::abort();
-
-    // if (!FluidSystem::enableDissolvedGas())
-    //     std::abort();
-    // if (!FluidSystem::enableVaporizedOil())
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
-    //     std::abort();
     std::vector<int> pvtnum(nc,0);
     const std::string& name("PVTNUM");
     if (eclState.fieldProps().has_int(name)){
@@ -200,26 +183,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
             if (FluidSystem::phaseIsActive(oilPhaseIdx))
                 fluidState.setSaturation(oilPhaseIdx, So);
 
-
-
-            // if (FluidSystem::enableDissolvedGas()) {
-            //     const Evaluation& RsSat
-            //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
-            //     fluidState.setRs(RsSat);
-            // }
-            // if (FluidSystem::enableVaporizedOil()) {
-            //     const Evaluation& RvSat
-            //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
-            //     fluidState.setRv(RvSat);
-            // }
-
-            // Evaluation SoMax = Opm::max(So, 0.5);
-            // ParamCache paramCache;
-            // paramCache.setRegionIndex(pvtRegionIdx);
-            // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-            //     paramCache.setMaxOilSat(SoMax);
-            // }
-            // paramCache.updateAll(fluidState);
 
             // calculate the phase densities
             Evaluation T=278;

--- a/tests/material/test_eclpropertyevaluation_lowlevel.cpp
+++ b/tests/material/test_eclpropertyevaluation_lowlevel.cpp
@@ -35,6 +35,8 @@
 
 #include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp>
+#include <opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/densead/Evaluation.hpp>
@@ -72,6 +74,7 @@
 // }
     
 
+
 template <class Evaluation>
 inline Opm::time_point::duration testAll(const char * deck_file)
 {
@@ -80,7 +83,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     
     typedef typename Opm::MathToolbox<Evaluation>::Scalar Scalar;
     //typedef typename Evaluation::ValueType simpletype;
-    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
+    typedef Opm::BlackOilFluidSystem<Scalar> FluidSystem;
 
     static constexpr int numPhases = FluidSystem::numPhases;
 
@@ -155,10 +158,20 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     std::cout << "Doing evaluation " << num_total << " of nc " << nc << " total " << nc*num_total << std::endl;
     Opm::time_point start;
     start = Opm::TimeService::now();
+    //const auto& materialParams = materialLawManager.materialLawParams(0).template getRealParams<Opm::EclMultiplexerApproach::Default>();
+    const auto& waterpvt = FluidSystem::waterPvt().template getRealPvt<Opm::WaterPvtApproach::ConstantCompressibilityWater>();
+    const auto& oilpvt = FluidSystem::oilPvt().template getRealPvt<Opm::OilPvtApproach::LiveOil>();
+    const auto& gaspvt = FluidSystem::gasPvt().template getRealPvt<Opm::GasPvtApproach::WetGas>();
+    // const auto& waterpvt = FluidSystem::waterPvt();
+    // const auto& oilpvt = FluidSystem::oilPvt();
+    // const auto& gaspvt = FluidSystem::gasPvt();
     for (unsigned step = 0; step < num_total; ++step) {
         for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
-            const auto& materialParams = materialLawManager.materialLawParams(elemIdx);
+            // const auto& materialParams =
+            //     materialLawManager.materialLawParams(elemIdx).template getRealParams<Opm::EclMultiplexerApproach::Default>();
+            std::array<Evaluation, numPhases> viscosity;
             const auto& pvtRegionIdx = pvtnum[elemIdx];
+            //const signed pvtRegionIdx = 0;
             FluidState& fluidState = intQuant[elemIdx];
             Opm::Valgrind::SetUndefined(fluidState);
             Evaluation p = Scalar(elemIdx + nc * step) / num_total * 350e5 + 100e5;
@@ -189,40 +202,68 @@ inline Opm::time_point::duration testAll(const char * deck_file)
 
 
 
-            if (FluidSystem::enableDissolvedGas()) {
-                const Evaluation& RsSat
-                    = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
-                fluidState.setRs(RsSat);
-            }
-            if (FluidSystem::enableVaporizedOil()) {
-                const Evaluation& RvSat
-                    = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
-                fluidState.setRv(RvSat);
-            }
+            // if (FluidSystem::enableDissolvedGas()) {
+            //     const Evaluation& RsSat
+            //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
+            //     fluidState.setRs(RsSat);
+            // }
+            // if (FluidSystem::enableVaporizedOil()) {
+            //     const Evaluation& RvSat
+            //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
+            //     fluidState.setRv(RvSat);
+            // }
 
-            Evaluation SoMax = Opm::max(So, 0.5);
-            ParamCache paramCache;
-            paramCache.setRegionIndex(pvtRegionIdx);
-            if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-                paramCache.setMaxOilSat(SoMax);
-            }
-            paramCache.updateAll(fluidState);
-
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                // ensure that the black-oil specific variants of the methods to compute
-                // thermdynamic properties return the same value as the generic ones and that
-                // the generic methods return the same value as the ones for the saturated
-                // quantities (we specify the fluid state to be on the saturation line)
-                if (FluidSystem::phaseIsActive(phaseIdx)) {
-                    Evaluation b = FluidSystem::inverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
-                    //Evaluation bSat
-                    //    = FluidSystem::saturatedInverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
-                    fluidState.setInvB(phaseIdx, b);
-                }
-            }
+            // Evaluation SoMax = Opm::max(So, 0.5);
+            // ParamCache paramCache;
+            // paramCache.setRegionIndex(pvtRegionIdx);
+            // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+            //     paramCache.setMaxOilSat(SoMax);
+            // }
+            // paramCache.updateAll(fluidState);
 
             // calculate the phase densities
+            Evaluation T=278;
             Evaluation rho;
+            if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+                //const auto& waterpvt = FluidSystem::waterPvt();
+                //Evaluation salt= 0.0;
+                //Evaluation b = waterpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p, salt);//, Rsw, saltConcentration);
+                //Evaluation mu = waterpvt.saturatedViscosity(pvtRegionIdx, T, p,salt);
+                Evaluation b;
+                Evaluation mu;
+                waterpvt.inverseBAndMu(b,mu,pvtRegionIdx, p);
+                fluidState.setInvB(waterPhaseIdx, b);
+                viscosity[waterPhaseIdx] = mu;
+            }
+            if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+//                if (FluidSystem::enableVaporizedOil()) {
+                size_t segIdx = gaspvt.saturatedOilVaporizationFactorTable()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
+                const Evaluation& RvSat = gaspvt.saturatedOilVaporizationFactorTable()[pvtRegionIdx].eval(p, segIdx);
+                fluidState.setRv(RvSat);
+//                }
+                //size_t segIdx = gaspvt.inverseSaturatedGasB()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
+                Evaluation b  =gaspvt.inverseSaturatedGasB()[pvtRegionIdx].eval(p, segIdx);
+                const Evaluation& invBMu = gaspvt.inverseSaturatedGasBMu()[pvtRegionIdx].eval(p, segIdx);
+                Evaluation mu = b/invBMu;
+                viscosity[oilPhaseIdx] =mu;          
+                fluidState.setInvB(gasPhaseIdx, b);
+            }
+            if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+                //if (FluidSystem::enableDissolvedGas()) {
+                // const Evaluation& RsSat
+                //     = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
+                size_t segIdx = oilpvt.saturatedGasDissolutionFactorTable()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
+                const Evaluation& RsSat = oilpvt.saturatedGasDissolutionFactorTable()[pvtRegionIdx].eval(p, segIdx);
+                fluidState.setRs(RsSat);
+                //}
+                
+                Evaluation b  =oilpvt.inverseSaturatedOilBTable()[pvtRegionIdx].eval(p, segIdx);
+                Evaluation invBMu = oilpvt.inverseSaturatedOilBMuTable()[pvtRegionIdx].eval(p,segIdx);
+                Evaluation mu = b/invBMu;
+                viscosity[oilPhaseIdx] =mu;          
+                fluidState.setInvB(oilPhaseIdx, b);
+            }
+            
             if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
                 rho = fluidState.invB(waterPhaseIdx);
                 rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
@@ -232,7 +273,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
                 }
                 fluidState.setDensity(waterPhaseIdx, rho);
             }
-
+            
             if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
                 rho = fluidState.invB(gasPhaseIdx);
                 rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
@@ -247,7 +288,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
                 fluidState.setDensity(gasPhaseIdx, rho);
             }
 
-            if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+            if (FluidSystem::phaseIsActive(oilPhaseIdx)) {                
                 rho = fluidState.invB(oilPhaseIdx);
                 rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
                 if (FluidSystem::enableDissolvedGas()) {
@@ -258,17 +299,43 @@ inline Opm::time_point::duration testAll(const char * deck_file)
             }
 
             std::array<Evaluation, numPhases> mobility;
-            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
-                    // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
-                    const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
-                    mobility[phaseIdx] = mu;
-                }
-            }
+            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            //     if (FluidSystem::phaseIsActive(phaseIdx)) {
+            //         // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
+            //         const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
+            //         mobility[phaseIdx] = mu;
+            //     }
+            // }
 
             // std::array<Evaluation, numPhases> pC;
-            // MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
-            // MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+            // //MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
+            // //MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+            // MaterialLaw::DefaultMaterial::capillaryPressures(pC, materialParams, fluidState);
+            // MaterialLaw::DefaultMaterial::relativePermeabilities(mobility, materialParams, fluidState);
+            
+            // rocktabTables = eclState.getTableManager().getRocktabTables();
+            // const auto& rocktabTable = rocktabTables.template getTable<RocktabTable>(regionIdx);
+            // const auto& pressureColumn = rocktabTable.getPressureColumn();
+            // const auto& poroColumn = rocktabTable.getPoreVolumeMultiplierColumn();
+            // const auto& transColumn = rocktabTable.getTransmissibilityMultiplierColumn();
+           
+            // Evaluation porosity_;
+            // Evaluation rockCompTransMultiplier_;
+            // Scalar rockCompressibility = problem.rockCompressibility(globalSpaceIdx);
+            // if (rockCompressibility > 0.0) {
+            //     Scalar rockRefPressure = problem.rockReferencePressure(globalSpaceIdx);
+            //     Evaluation x;
+            //     if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+            //         x = rockCompressibility*(fluidState_.pressure(oilPhaseIdx) - rockRefPressure);
+            //     } else if (FluidSystem::phaseIsActive(waterPhaseIdx)){
+            //         x = rockCompressibility*(fluidState_.pressure(waterPhaseIdx) - rockRefPressure);
+            //     } else {
+            //         x = rockCompressibility*(fluidState_.pressure(gasPhaseIdx) - rockRefPressure);
+            //     }
+            //     porosity_ *= 1.0 + x + 0.5*x*x;
+            // }
+            // porosity_ *= problem.template rockCompPoroMultiplier<Evaluation>(*this, globalSpaceIdx);
+            // rockCompTransMultiplier_ = problem.template rockCompTransMultiplier<Evaluation>(*this, globalSpaceIdx);
         }
     }
     Opm::time_point::duration total_time = Opm::TimeService::now() - start;
@@ -285,7 +352,8 @@ int main(int argc, char **argv)
     Dune::MPIHelper::instance(argc, argv);
 
     typedef Opm::DenseAd::Evaluation<double, 3> TestEval;
-    typedef Opm::DenseAd::Evaluation<float, 3> TestEvalFloat;
+    //typedef Opm::DenseAd::Evaluation<float, 3> TestEvalFloat;
+    typedef Opm::DenseAd::Evaluation<double, 6> TestEval6;
 
     const char* deck_file = argv[1];
 
@@ -294,6 +362,7 @@ int main(int argc, char **argv)
     // auto evalfloat_time = testAll<TestEvalFloat>(deck_file);
     auto double_time = testAll<double>(deck_file);
     auto evaldouble_time = testAll<TestEval>(deck_file);
+    auto evaldouble6_time = testAll<TestEval6>(deck_file);
 
     std::cout << "complete." << std::endl << std::endl;
     std::cout << "Time: " << std::endl;
@@ -301,6 +370,7 @@ int main(int argc, char **argv)
     // std::cout << "   float.....: "  << std::chrono::duration<double>(float_time).count()  << " seconds" << std::endl;
     // std::cout << "   evalfloat.....: "  << std::chrono::duration<double>(evalfloat_time).count()  << " seconds" << std::endl;
     std::cout << "   double.....: "  << std::chrono::duration<double>(double_time).count()  << " seconds" << std::endl;
-    std::cout << "   eval double....: "  << std::chrono::duration<double>(evaldouble_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval3 double....: "  << std::chrono::duration<double>(evaldouble_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval6 double....: "  << std::chrono::duration<double>(evaldouble6_time).count()  << " seconds" << std::endl;
     return 0;
 }

--- a/tests/material/test_eclpropertyevaluation_lowlevel_spe9.cpp
+++ b/tests/material/test_eclpropertyevaluation_lowlevel_spe9.cpp
@@ -122,23 +122,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     
      typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
     
-    // if (FluidSystem::numActivePhases() != 3)
-    // std::abort();
-
-    // if (!FluidSystem::enableDissolvedGas())
-    //     std::abort();
-    // if (!FluidSystem::enableVaporizedOil())
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
-    //     std::abort();
     std::vector<int> pvtnum(nc,0);
     const std::string& name("PVTNUM");
     if (eclState.fieldProps().has_int(name)){
@@ -202,24 +185,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
 
 
 
-            // if (FluidSystem::enableDissolvedGas()) {
-            //     const Evaluation& RsSat
-            //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
-            //     fluidState.setRs(RsSat);
-            // }
-            // if (FluidSystem::enableVaporizedOil()) {
-            //     const Evaluation& RvSat
-            //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
-            //     fluidState.setRv(RvSat);
-            // }
-
-            // Evaluation SoMax = Opm::max(So, 0.5);
-            // ParamCache paramCache;
-            // paramCache.setRegionIndex(pvtRegionIdx);
-            // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-            //     paramCache.setMaxOilSat(SoMax);
-            // }
-            // paramCache.updateAll(fluidState);
 
             // calculate the phase densities
             Evaluation T=278;
@@ -245,10 +210,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
                 //Evaluation b = gaspvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p);
                 size_t segIdx = gaspvt.inverseGasB()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
                 Evaluation b  =gaspvt.inverseGasB()[pvtRegionIdx].eval(p, segIdx);
-                //Evaluation b = gaspvt.inverseGasB()[pvtRegionIdx].eval(p, /*extrapolate=*/true);
-                //Evaluation mu = gaspvt.saturatedViscosity(pvtRegionIdx, T, p);
-                //const auto& table = gaspvt.inverseGasBMu()[pvtRegionIdx];
-                //const Evaluation& invBMu = gaspvt.inverseGasBMu()[pvtRegionIdx].eval(p, /*extrapolate=*/true);
                 const Evaluation& invBMu = gaspvt.inverseGasBMu()[pvtRegionIdx].eval(p, segIdx);
                 Evaluation mu = b/invBMu;
                 //viscosity[oilPhaseIdx] =mu;          

--- a/tests/material/test_eclpropertyevaluation_lowlevel_spe9.cpp
+++ b/tests/material/test_eclpropertyevaluation_lowlevel_spe9.cpp
@@ -243,8 +243,8 @@ inline Opm::time_point::duration testAll(const char * deck_file)
                 }
                 //const auto& gaspvt = FluidSystem::gasPvt();//.getRealPvt();
                 //Evaluation b = gaspvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p);
-                size_t segIdx = gaspvt.inverseSaturatedGasB()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
-                Evaluation b  =gaspvt.inverseSaturetedGasB()[pvtRegionIdx].eval(p, segIdx);
+                size_t segIdx = gaspvt.inverseGasB()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
+                Evaluation b  =gaspvt.inverseGasB()[pvtRegionIdx].eval(p, segIdx);
                 //Evaluation b = gaspvt.inverseGasB()[pvtRegionIdx].eval(p, /*extrapolate=*/true);
                 //Evaluation mu = gaspvt.saturatedViscosity(pvtRegionIdx, T, p);
                 //const auto& table = gaspvt.inverseGasBMu()[pvtRegionIdx];

--- a/tests/material/test_eclrelpermevaluation.cpp
+++ b/tests/material/test_eclrelpermevaluation.cpp
@@ -289,7 +289,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
             // //MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
             // //MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
             MaterialLaw::DefaultMaterial::capillaryPressures(pC, materialParams, fluidState);
-            MaterialLaw::DefaultMaterial::relativePermeabilities(mobility, materialParams, fluidState);
+            MaterialLaw::DefaultMaterial::relativePermeabilitiesSimple(mobility, materialParams, fluidState);
             
             // rocktabTables = eclState.getTableManager().getRocktabTables();
             // const auto& rocktabTable = rocktabTables.template getTable<RocktabTable>(regionIdx);

--- a/tests/material/test_eclrelpermevaluation.cpp
+++ b/tests/material/test_eclrelpermevaluation.cpp
@@ -122,23 +122,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     
      typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
     
-    // if (FluidSystem::numActivePhases() != 3)
-    // std::abort();
-
-    // if (!FluidSystem::enableDissolvedGas())
-    //     std::abort();
-    // if (!FluidSystem::enableVaporizedOil())
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
-    //     std::abort();
     std::vector<int> pvtnum(nc,0);
     const std::string& name("PVTNUM");
     if (eclState.fieldProps().has_int(name)){
@@ -196,94 +179,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
                 fluidState.setSaturation(oilPhaseIdx, So);
 
 
-
-            // if (FluidSystem::enableDissolvedGas()) {
-            //     const Evaluation& RsSat
-            //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
-            //     fluidState.setRs(RsSat);
-            // }
-            // if (FluidSystem::enableVaporizedOil()) {
-            //     const Evaluation& RvSat
-            //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
-            //     fluidState.setRv(RvSat);
-            // }
-
-            // Evaluation SoMax = Opm::max(So, 0.5);
-            // ParamCache paramCache;
-            // paramCache.setRegionIndex(pvtRegionIdx);
-            // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-            //     paramCache.setMaxOilSat(SoMax);
-            // }
-            // paramCache.updateAll(fluidState);
-
-            // // calculate the phase densities
-            // Evaluation T=278;
-            // Evaluation rho;
-            // if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
-            //     //const auto& waterpvt = FluidSystem::waterPvt();
-            //     Evaluation salt= 0.0;
-            //     Evaluation b = waterpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p, salt);//, Rsw, saltConcentration);
-            //     Evaluation mu = waterpvt.saturatedViscosity(pvtRegionIdx, T, p,salt);
-            //     fluidState.setInvB(waterPhaseIdx, b);
-            // }
-            // if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
-            //     //const auto& gaspvt = FluidSystem::gasPvt();//.getRealPvt();
-            //     Evaluation b = gaspvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p);
-            //     //const auto& invmuBFunc = gaspvt.inverseSaturatedGasBMu();
-            //     //Evaluation invMuB = invmuBFunc[pvtRegionIdx].eval(p, /*extrapolate=*/true);
-            //     //Evaluation vic = b/invMuB;
-            //     Evaluation mu = gaspvt.saturatedViscosity(pvtRegionIdx, T, p);
-            //     fluidState.setInvB(gasPhaseIdx, b);
-            // }
-            // if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
-            //     //const auto& oilpvt = FluidSystem::oilPvt();
-            //     Evaluation b = oilpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p);
-            //     Evaluation mu = oilpvt.saturatedViscosity(pvtRegionIdx, T, p);               
-            //     fluidState.setInvB(oilPhaseIdx, b);
-            // }
-            
-            // if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
-            //     rho = fluidState.invB(waterPhaseIdx);
-            //     rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
-            //     if (FluidSystem::enableDissolvedGasInWater()) {
-            //         rho += fluidState.invB(waterPhaseIdx) * fluidState.Rsw()
-            //             * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-            //     }
-            //     fluidState.setDensity(waterPhaseIdx, rho);
-            // }
-            
-            // if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
-            //     rho = fluidState.invB(gasPhaseIdx);
-            //     rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-            //     if (FluidSystem::enableVaporizedOil()) {
-            //         rho += fluidState.invB(gasPhaseIdx) * fluidState.Rv()
-            //             * FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
-            //     }
-            //     if (FluidSystem::enableVaporizedWater()) {
-            //         rho += fluidState.invB(gasPhaseIdx) * fluidState.Rvw()
-            //             * FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
-            //     }
-            //     fluidState.setDensity(gasPhaseIdx, rho);
-            // }
-
-            // if (FluidSystem::phaseIsActive(oilPhaseIdx)) {                
-            //     rho = fluidState.invB(oilPhaseIdx);
-            //     rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
-            //     if (FluidSystem::enableDissolvedGas()) {
-            //         rho += fluidState.invB(oilPhaseIdx) * fluidState.Rs()
-            //             * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-            //     }
-            //     fluidState.setDensity(oilPhaseIdx, rho);
-            // }
-
             std::array<Evaluation, numPhases> mobility;
-            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            //     if (FluidSystem::phaseIsActive(phaseIdx)) {
-            //         // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
-            //         const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
-            //         mobility[phaseIdx] = mu;
-            //     }
-            // }
 
             std::array<Evaluation, numPhases> pC;
             // //MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
@@ -291,29 +187,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
             MaterialLaw::DefaultMaterial::capillaryPressures(pC, materialParams, fluidState);
             MaterialLaw::DefaultMaterial::relativePermeabilitiesSimple(mobility, materialParams, fluidState);
             
-            // rocktabTables = eclState.getTableManager().getRocktabTables();
-            // const auto& rocktabTable = rocktabTables.template getTable<RocktabTable>(regionIdx);
-            // const auto& pressureColumn = rocktabTable.getPressureColumn();
-            // const auto& poroColumn = rocktabTable.getPoreVolumeMultiplierColumn();
-            // const auto& transColumn = rocktabTable.getTransmissibilityMultiplierColumn();
-           
-            // Evaluation porosity_;
-            // Evaluation rockCompTransMultiplier_;
-            // Scalar rockCompressibility = problem.rockCompressibility(globalSpaceIdx);
-            // if (rockCompressibility > 0.0) {
-            //     Scalar rockRefPressure = problem.rockReferencePressure(globalSpaceIdx);
-            //     Evaluation x;
-            //     if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
-            //         x = rockCompressibility*(fluidState_.pressure(oilPhaseIdx) - rockRefPressure);
-            //     } else if (FluidSystem::phaseIsActive(waterPhaseIdx)){
-            //         x = rockCompressibility*(fluidState_.pressure(waterPhaseIdx) - rockRefPressure);
-            //     } else {
-            //         x = rockCompressibility*(fluidState_.pressure(gasPhaseIdx) - rockRefPressure);
-            //     }
-            //     porosity_ *= 1.0 + x + 0.5*x*x;
-            // }
-            // porosity_ *= problem.template rockCompPoroMultiplier<Evaluation>(*this, globalSpaceIdx);
-            // rockCompTransMultiplier_ = problem.template rockCompTransMultiplier<Evaluation>(*this, globalSpaceIdx);
         }
     }
     Opm::time_point::duration total_time = Opm::TimeService::now() - start;

--- a/tests/material/test_eclrelpermevaluation.cpp
+++ b/tests/material/test_eclrelpermevaluation.cpp
@@ -1,0 +1,354 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief This is the unit test for the black oil fluid system
+ *
+ * This test requires the presence of opm-parser.
+ */
+#include "config.h"
+
+#if !HAVE_ECL_INPUT
+#error "The test for the black oil fluid system classes requires ecl input support in opm-common"
+#endif
+
+#include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp>
+#include <opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidstates/BlackOilFluidState.hpp>
+#include <opm/material/densead/Evaluation.hpp>
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/material/common/Valgrind.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/utility/TimeService.hpp>
+
+#include <type_traits>
+#include <cmath>
+
+// values of strings based on the SPE1 and NORNE cases of opm-data.
+// template<typename Evaluation,typename FluidSystem, int numPhases> class FluidAndRockState:
+//     public Opm::BlackOilFluidState<Evaluation, FluidSystem>
+// {
+// public:
+//     double referencePorosity_;
+//     Evaluation porosity_;
+//     Evaluation rockCompTransMultiplier_;
+//     std::array<Evaluation,numPhases> mobility_;
+// }
+    
+
+
+template <class Evaluation>
+inline Opm::time_point::duration testAll(const char * deck_file)
+{
+    // test the black-oil specific methods of BlackOilFluidSystem. The generic methods
+    // for fluid systems are already tested by the generic test for all fluidsystems.
+    
+    typedef typename Opm::MathToolbox<Evaluation>::Scalar Scalar;
+    //typedef typename Evaluation::ValueType simpletype;
+    typedef Opm::BlackOilFluidSystem<Scalar> FluidSystem;
+
+    static constexpr int numPhases = FluidSystem::numPhases;
+
+    static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
+    static constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
+    static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
+    typedef Opm::ThreePhaseMaterialTraits<Scalar,
+                                          /*wettingPhaseIdx=*/waterPhaseIdx,
+                                          /*nonWettingPhaseIdx=*/oilPhaseIdx,
+                                          /*gasPhaseIdx=*/gasPhaseIdx> MaterialTraits;
+
+    static constexpr int gasCompIdx = FluidSystem::gasCompIdx;
+    static constexpr int oilCompIdx = FluidSystem::oilCompIdx;
+    static constexpr int waterCompIdx = FluidSystem::waterCompIdx;
+
+    Opm::ParseContext parseContext;//(Opm::InputErrorAction::WARN);
+    Opm::ErrorGuard errors;
+    Opm::Parser parser;    
+
+    auto deck = parser.parseFile(deck_file, parseContext, errors);
+    auto python = std::make_shared<Opm::Python>();
+    Opm::EclipseState eclState(deck);
+    Opm::Schedule schedule(deck, eclState, python);
+
+    FluidSystem::initFromState(eclState, schedule);
+    const auto& eclGrid = eclState.getInputGrid();
+    //size_t nc = eclGrid.getCartesianSize();
+    size_t nc = eclGrid.getNumActive();
+    typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
+    MaterialLawManager  materialLawManager;
+    typedef typename MaterialLawManager::MaterialLaw MaterialLaw;
+    materialLawManager.initFromState(eclState);
+    materialLawManager.initParamsForElements(eclState, nc);
+    // create a parameter cache
+    typedef typename FluidSystem::template ParameterCache<Evaluation> ParamCache;
+    
+     typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
+    
+    // if (FluidSystem::numActivePhases() != 3)
+    // std::abort();
+
+    // if (!FluidSystem::enableDissolvedGas())
+    //     std::abort();
+    // if (!FluidSystem::enableVaporizedOil())
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
+    //     std::abort();
+    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
+    //     std::abort();
+    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
+    //     std::abort();
+    std::vector<int> pvtnum(nc,0);
+    const std::string& name("PVTNUM");
+    if (eclState.fieldProps().has_int(name)){
+        const auto& numData = eclState.fieldProps().get_int(name);
+    
+        for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
+            pvtnum[elemIdx] = static_cast<int>(numData[elemIdx]) - 1;
+        }
+    }
+    std::sort(pvtnum.begin(),pvtnum.end());
+    
+    static const Scalar eps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
+    unsigned numevals = 10000*100;
+    unsigned num_total = ceil(double(numevals)/double(nc));
+    //num_total=23;
+    std::vector<FluidState> intQuant(nc);
+    std::cout << "Doing evaluation " << num_total << " of nc " << nc << " total " << nc*num_total << std::endl;
+    Opm::time_point start;
+    start = Opm::TimeService::now();
+    //const auto& materialParams = materialLawManager.materialLawParams(0).template getRealParams<Opm::EclMultiplexerApproach::Default>();
+    const auto& waterpvt = FluidSystem::waterPvt();
+    const auto& oilpvt = FluidSystem::oilPvt();
+    const auto& gaspvt = FluidSystem::gasPvt();
+    for (unsigned step = 0; step < num_total; ++step) {
+        for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
+            const auto& materialParams =
+                materialLawManager.materialLawParams(elemIdx).template getRealParams<Opm::EclMultiplexerApproach::Default>();
+            // const auto& pvtRegionIdx = pvtnum[elemIdx];
+            FluidState& fluidState = intQuant[elemIdx];
+            Opm::Valgrind::SetUndefined(fluidState);
+            Evaluation p = Scalar(elemIdx + nc * step) / num_total * 350e5 + 100e5;
+
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (FluidSystem::phaseIsActive(phaseIdx)) {
+                    fluidState.setPressure(phaseIdx, p);
+                }
+            }
+            Evaluation Sw = 0.0;
+            if constexpr (true) {
+                Sw = Scalar(elemIdx + nc * step) / num_total;
+            }
+            Evaluation Sg = 0.0;
+            if constexpr (true) {
+                Sg = Scalar(elemIdx + nc * step) / num_total;
+            }
+            Evaluation So = 1 - Sw - Sg;
+
+            if (FluidSystem::phaseIsActive(waterPhaseIdx))
+                fluidState.setSaturation(waterPhaseIdx, Sw);
+            
+            if (FluidSystem::phaseIsActive(gasPhaseIdx))
+                fluidState.setSaturation(gasPhaseIdx, Sg);
+            
+            if (FluidSystem::phaseIsActive(oilPhaseIdx))
+                fluidState.setSaturation(oilPhaseIdx, So);
+
+
+
+            // if (FluidSystem::enableDissolvedGas()) {
+            //     const Evaluation& RsSat
+            //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
+            //     fluidState.setRs(RsSat);
+            // }
+            // if (FluidSystem::enableVaporizedOil()) {
+            //     const Evaluation& RvSat
+            //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
+            //     fluidState.setRv(RvSat);
+            // }
+
+            // Evaluation SoMax = Opm::max(So, 0.5);
+            // ParamCache paramCache;
+            // paramCache.setRegionIndex(pvtRegionIdx);
+            // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+            //     paramCache.setMaxOilSat(SoMax);
+            // }
+            // paramCache.updateAll(fluidState);
+
+            // // calculate the phase densities
+            // Evaluation T=278;
+            // Evaluation rho;
+            // if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+            //     //const auto& waterpvt = FluidSystem::waterPvt();
+            //     Evaluation salt= 0.0;
+            //     Evaluation b = waterpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p, salt);//, Rsw, saltConcentration);
+            //     Evaluation mu = waterpvt.saturatedViscosity(pvtRegionIdx, T, p,salt);
+            //     fluidState.setInvB(waterPhaseIdx, b);
+            // }
+            // if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+            //     //const auto& gaspvt = FluidSystem::gasPvt();//.getRealPvt();
+            //     Evaluation b = gaspvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p);
+            //     //const auto& invmuBFunc = gaspvt.inverseSaturatedGasBMu();
+            //     //Evaluation invMuB = invmuBFunc[pvtRegionIdx].eval(p, /*extrapolate=*/true);
+            //     //Evaluation vic = b/invMuB;
+            //     Evaluation mu = gaspvt.saturatedViscosity(pvtRegionIdx, T, p);
+            //     fluidState.setInvB(gasPhaseIdx, b);
+            // }
+            // if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+            //     //const auto& oilpvt = FluidSystem::oilPvt();
+            //     Evaluation b = oilpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p);
+            //     Evaluation mu = oilpvt.saturatedViscosity(pvtRegionIdx, T, p);               
+            //     fluidState.setInvB(oilPhaseIdx, b);
+            // }
+            
+            // if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+            //     rho = fluidState.invB(waterPhaseIdx);
+            //     rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+            //     if (FluidSystem::enableDissolvedGasInWater()) {
+            //         rho += fluidState.invB(waterPhaseIdx) * fluidState.Rsw()
+            //             * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+            //     }
+            //     fluidState.setDensity(waterPhaseIdx, rho);
+            // }
+            
+            // if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+            //     rho = fluidState.invB(gasPhaseIdx);
+            //     rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+            //     if (FluidSystem::enableVaporizedOil()) {
+            //         rho += fluidState.invB(gasPhaseIdx) * fluidState.Rv()
+            //             * FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+            //     }
+            //     if (FluidSystem::enableVaporizedWater()) {
+            //         rho += fluidState.invB(gasPhaseIdx) * fluidState.Rvw()
+            //             * FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+            //     }
+            //     fluidState.setDensity(gasPhaseIdx, rho);
+            // }
+
+            // if (FluidSystem::phaseIsActive(oilPhaseIdx)) {                
+            //     rho = fluidState.invB(oilPhaseIdx);
+            //     rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+            //     if (FluidSystem::enableDissolvedGas()) {
+            //         rho += fluidState.invB(oilPhaseIdx) * fluidState.Rs()
+            //             * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+            //     }
+            //     fluidState.setDensity(oilPhaseIdx, rho);
+            // }
+
+            std::array<Evaluation, numPhases> mobility;
+            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            //     if (FluidSystem::phaseIsActive(phaseIdx)) {
+            //         // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
+            //         const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
+            //         mobility[phaseIdx] = mu;
+            //     }
+            // }
+
+            std::array<Evaluation, numPhases> pC;
+            // //MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
+            // //MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+            MaterialLaw::DefaultMaterial::capillaryPressures(pC, materialParams, fluidState);
+            MaterialLaw::DefaultMaterial::relativePermeabilities(mobility, materialParams, fluidState);
+            
+            // rocktabTables = eclState.getTableManager().getRocktabTables();
+            // const auto& rocktabTable = rocktabTables.template getTable<RocktabTable>(regionIdx);
+            // const auto& pressureColumn = rocktabTable.getPressureColumn();
+            // const auto& poroColumn = rocktabTable.getPoreVolumeMultiplierColumn();
+            // const auto& transColumn = rocktabTable.getTransmissibilityMultiplierColumn();
+           
+            // Evaluation porosity_;
+            // Evaluation rockCompTransMultiplier_;
+            // Scalar rockCompressibility = problem.rockCompressibility(globalSpaceIdx);
+            // if (rockCompressibility > 0.0) {
+            //     Scalar rockRefPressure = problem.rockReferencePressure(globalSpaceIdx);
+            //     Evaluation x;
+            //     if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+            //         x = rockCompressibility*(fluidState_.pressure(oilPhaseIdx) - rockRefPressure);
+            //     } else if (FluidSystem::phaseIsActive(waterPhaseIdx)){
+            //         x = rockCompressibility*(fluidState_.pressure(waterPhaseIdx) - rockRefPressure);
+            //     } else {
+            //         x = rockCompressibility*(fluidState_.pressure(gasPhaseIdx) - rockRefPressure);
+            //     }
+            //     porosity_ *= 1.0 + x + 0.5*x*x;
+            // }
+            // porosity_ *= problem.template rockCompPoroMultiplier<Evaluation>(*this, globalSpaceIdx);
+            // rockCompTransMultiplier_ = problem.template rockCompTransMultiplier<Evaluation>(*this, globalSpaceIdx);
+        }
+    }
+    Opm::time_point::duration total_time = Opm::TimeService::now() - start;
+    return total_time;
+    // make sure that the {oil,gas,water}Pvt() methods are available
+    [[maybe_unused]] const auto& gPvt = FluidSystem::gasPvt();
+    [[maybe_unused]] const auto& oPvt = FluidSystem::oilPvt();
+    [[maybe_unused]] const auto& wPvt = FluidSystem::waterPvt();
+}
+
+int main(int argc, char **argv)
+{
+    
+    Dune::MPIHelper::instance(argc, argv);
+
+    typedef Opm::DenseAd::Evaluation<double, 3> TestEval;
+    //typedef Opm::DenseAd::Evaluation<float, 3> TestEvalFloat;
+    typedef Opm::DenseAd::Evaluation<double, 6> TestEval6;
+
+    const char* deck_file = argv[1];
+
+    
+    //auto float_time = testAll<float>(deck_file);
+    // auto evalfloat_time = testAll<TestEvalFloat>(deck_file);
+    auto double_time = testAll<double>(deck_file);
+    auto evaldouble_time = testAll<TestEval>(deck_file);
+    auto evaldouble6_time = testAll<TestEval6>(deck_file);
+
+    std::cout << "complete." << std::endl << std::endl;
+    std::cout << "Time: " << std::endl;
+    // float is slow here ?
+    // std::cout << "   float.....: "  << std::chrono::duration<double>(float_time).count()  << " seconds" << std::endl;
+    // std::cout << "   evalfloat.....: "  << std::chrono::duration<double>(evalfloat_time).count()  << " seconds" << std::endl;
+    std::cout << "   double.....: "  << std::chrono::duration<double>(double_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval3 double....: "  << std::chrono::duration<double>(evaldouble_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval6 double....: "  << std::chrono::duration<double>(evaldouble6_time).count()  << " seconds" << std::endl;
+    return 0;
+}

--- a/tests/material/test_eclrelpermevaluation_lowlevel.cpp
+++ b/tests/material/test_eclrelpermevaluation_lowlevel.cpp
@@ -1,0 +1,380 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief This is the unit test for the black oil fluid system
+ *
+ * This test requires the presence of opm-parser.
+ */
+#include "config.h"
+
+#if !HAVE_ECL_INPUT
+#error "The test for the black oil fluid system classes requires ecl input support in opm-common"
+#endif
+
+#include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp>
+#include <opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp>
+#include <opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp>
+#include <opm/material/fluidmatrixinteractions/SatCurveMultiplexer.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidstates/BlackOilFluidState.hpp>
+#include <opm/material/densead/Evaluation.hpp>
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/material/common/Valgrind.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/utility/TimeService.hpp>
+
+#include <type_traits>
+#include <cmath>
+
+// values of strings based on the SPE1 and NORNE cases of opm-data.
+// template<typename Evaluation,typename FluidSystem, int numPhases> class FluidAndRockState:
+//     public Opm::BlackOilFluidState<Evaluation, FluidSystem>
+// {
+// public:
+//     double referencePorosity_;
+//     Evaluation porosity_;
+//     Evaluation rockCompTransMultiplier_;
+//     std::array<Evaluation,numPhases> mobility_;
+// }
+    
+
+
+template <class Evaluation>
+inline Opm::time_point::duration testAll(const char * deck_file)
+{
+    // test the black-oil specific methods of BlackOilFluidSystem. The generic methods
+    // for fluid systems are already tested by the generic test for all fluidsystems.
+    
+    typedef typename Opm::MathToolbox<Evaluation>::Scalar Scalar;
+    //typedef typename Evaluation::ValueType simpletype;
+    typedef Opm::BlackOilFluidSystem<Scalar> FluidSystem;
+
+    static constexpr int numPhases = FluidSystem::numPhases;
+
+    static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
+    static constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
+    static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
+    typedef Opm::ThreePhaseMaterialTraits<Scalar,
+                                          /*wettingPhaseIdx=*/waterPhaseIdx,
+                                          /*nonWettingPhaseIdx=*/oilPhaseIdx,
+                                          /*gasPhaseIdx=*/gasPhaseIdx> MaterialTraits;
+
+    static constexpr int gasCompIdx = FluidSystem::gasCompIdx;
+    static constexpr int oilCompIdx = FluidSystem::oilCompIdx;
+    static constexpr int waterCompIdx = FluidSystem::waterCompIdx;
+
+    Opm::ParseContext parseContext;//(Opm::InputErrorAction::WARN);
+    Opm::ErrorGuard errors;
+    Opm::Parser parser;    
+
+    auto deck = parser.parseFile(deck_file, parseContext, errors);
+    auto python = std::make_shared<Opm::Python>();
+    Opm::EclipseState eclState(deck);
+    Opm::Schedule schedule(deck, eclState, python);
+
+    FluidSystem::initFromState(eclState, schedule);
+    const auto& eclGrid = eclState.getInputGrid();
+    //size_t nc = eclGrid.getCartesianSize();
+    size_t nc = eclGrid.getNumActive();
+    typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
+    MaterialLawManager  materialLawManager;
+    typedef typename MaterialLawManager::MaterialLaw MaterialLaw;
+    materialLawManager.initFromState(eclState);
+    materialLawManager.initParamsForElements(eclState, nc);
+    // create a parameter cache
+    typedef typename FluidSystem::template ParameterCache<Evaluation> ParamCache;
+    
+     typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
+    
+    // if (FluidSystem::numActivePhases() != 3)
+    // std::abort();
+
+    // if (!FluidSystem::enableDissolvedGas())
+    //     std::abort();
+    // if (!FluidSystem::enableVaporizedOil())
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
+    //     std::abort();
+    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
+    //     std::abort();
+    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
+    //     std::abort();
+    std::vector<int> pvtnum(nc,0);
+    const std::string& name("PVTNUM");
+    if (eclState.fieldProps().has_int(name)){
+        const auto& numData = eclState.fieldProps().get_int(name);
+    
+        for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
+            pvtnum[elemIdx] = static_cast<int>(numData[elemIdx]) - 1;
+        }
+    }
+    std::sort(pvtnum.begin(),pvtnum.end());
+    
+    static const Scalar eps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
+    unsigned numevals = 10000*100;
+    unsigned num_total = ceil(double(numevals)/double(nc));
+    //num_total=23;
+    std::vector<FluidState> intQuant(nc);
+    std::cout << "Doing evaluation " << num_total << " of nc " << nc << " total " << nc*num_total << std::endl;
+    Opm::time_point start;
+    start = Opm::TimeService::now();
+    const auto& materialParams = materialLawManager.materialLawParams(0).template getRealParams<Opm::EclMultiplexerApproach::Default>();
+    const auto& gasoilparams =materialParams.gasOilParams().drainageParams().effectiveLawParams().template getRealParams<Opm::SatCurveMultiplexerApproach::PiecewiseLinear>();
+    const auto& oilwaterparams =materialParams.oilWaterParams().drainageParams().effectiveLawParams().template getRealParams<Opm::SatCurveMultiplexerApproach::PiecewiseLinear>();
+    Scalar Swco = materialParams.Swl();
+    // const auto& waterpvt = FluidSystem::waterPvt().template getRealPvt<Opm::WaterPvtApproach::ConstantCompressibilityWater>();
+    // const auto& oilpvt = FluidSystem::oilPvt().template getRealPvt<Opm::OilPvtApproach::LiveOil>();
+    // const auto& gaspvt = FluidSystem::gasPvt().template getRealPvt<Opm::GasPvtApproach::WetGas>();
+    // const auto& waterpvt = FluidSystem::waterPvt();
+    // const auto& oilpvt = FluidSystem::oilPvt();
+    // const auto& gaspvt = FluidSystem::gasPvt();
+    for (unsigned step = 0; step < num_total; ++step) {
+        for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
+            //const auto& materialParams = materialLawManager.materialLawParams(elemIdx).template getRealParams<Opm::EclMultiplexerApproach::Default>();
+//             std::array<Evaluation, numPhases> viscosity;
+//             const auto& pvtRegionIdx = pvtnum[elemIdx];
+//             //const signed pvtRegionIdx = 0;
+            FluidState& fluidState = intQuant[elemIdx];
+            Opm::Valgrind::SetUndefined(fluidState);
+            Evaluation p = Scalar(elemIdx + nc * step) / num_total * 350e5 + 100e5;
+
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (FluidSystem::phaseIsActive(phaseIdx)) {
+                    fluidState.setPressure(phaseIdx, p);
+                }
+            }
+            Evaluation Sw = 0.0;
+            if constexpr (true) {
+                Sw = Scalar(elemIdx + nc * step) / num_total;
+            }
+            Evaluation Sg = 0.0;
+            if constexpr (true) {
+                Sg = Scalar(elemIdx + nc * step) / num_total;
+            }
+            Evaluation So = 1 - Sw - Sg;
+
+            if (FluidSystem::phaseIsActive(waterPhaseIdx))
+                fluidState.setSaturation(waterPhaseIdx, Sw);
+            
+            if (FluidSystem::phaseIsActive(gasPhaseIdx))
+                fluidState.setSaturation(gasPhaseIdx, Sg);
+            
+            if (FluidSystem::phaseIsActive(oilPhaseIdx))
+                fluidState.setSaturation(oilPhaseIdx, So);
+
+
+
+//             // if (FluidSystem::enableDissolvedGas()) {
+//             //     const Evaluation& RsSat
+//             //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
+//             //     fluidState.setRs(RsSat);
+//             // }
+//             // if (FluidSystem::enableVaporizedOil()) {
+//             //     const Evaluation& RvSat
+//             //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
+//             //     fluidState.setRv(RvSat);
+//             // }
+
+//             // Evaluation SoMax = Opm::max(So, 0.5);
+//             // ParamCache paramCache;
+//             // paramCache.setRegionIndex(pvtRegionIdx);
+//             // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+//             //     paramCache.setMaxOilSat(SoMax);
+//             // }
+//             // paramCache.updateAll(fluidState);
+
+//             // calculate the phase densities
+//             Evaluation T=278;
+//             Evaluation rho;
+//             if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+//                 //const auto& waterpvt = FluidSystem::waterPvt();
+//                 //Evaluation salt= 0.0;
+//                 //Evaluation b = waterpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p, salt);//, Rsw, saltConcentration);
+//                 //Evaluation mu = waterpvt.saturatedViscosity(pvtRegionIdx, T, p,salt);
+//                 Evaluation b;
+//                 Evaluation mu;
+//                 waterpvt.inverseBAndMu(b,mu,pvtRegionIdx, p);
+//                 fluidState.setInvB(waterPhaseIdx, b);
+//                 viscosity[waterPhaseIdx] = mu;
+//             }
+//             if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+// //                if (FluidSystem::enableVaporizedOil()) {
+//                 size_t segIdx = gaspvt.saturatedOilVaporizationFactorTable()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
+//                 const Evaluation& RvSat = gaspvt.saturatedOilVaporizationFactorTable()[pvtRegionIdx].eval(p, segIdx);
+//                 fluidState.setRv(RvSat);
+// //                }
+//                 //size_t segIdx = gaspvt.inverseSaturatedGasB()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
+//                 Evaluation b  =gaspvt.inverseSaturatedGasB()[pvtRegionIdx].eval(p, segIdx);
+//                 const Evaluation& invBMu = gaspvt.inverseSaturatedGasBMu()[pvtRegionIdx].eval(p, segIdx);
+//                 Evaluation mu = b/invBMu;
+//                 viscosity[oilPhaseIdx] =mu;          
+//                 fluidState.setInvB(gasPhaseIdx, b);
+//             }
+//             if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+//                 //if (FluidSystem::enableDissolvedGas()) {
+//                 // const Evaluation& RsSat
+//                 //     = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
+//                 size_t segIdx = oilpvt.saturatedGasDissolutionFactorTable()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
+//                 const Evaluation& RsSat = oilpvt.saturatedGasDissolutionFactorTable()[pvtRegionIdx].eval(p, segIdx);
+//                 fluidState.setRs(RsSat);
+//                 //}
+                
+//                 Evaluation b  =oilpvt.inverseSaturatedOilBTable()[pvtRegionIdx].eval(p, segIdx);
+//                 Evaluation invBMu = oilpvt.inverseSaturatedOilBMuTable()[pvtRegionIdx].eval(p,segIdx);
+//                 Evaluation mu = b/invBMu;
+//                 viscosity[oilPhaseIdx] =mu;          
+//                 fluidState.setInvB(oilPhaseIdx, b);
+//             }
+            
+//             if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+//                 rho = fluidState.invB(waterPhaseIdx);
+//                 rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+//                 if (FluidSystem::enableDissolvedGasInWater()) {
+//                     rho += fluidState.invB(waterPhaseIdx) * fluidState.Rsw()
+//                         * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+//                 }
+//                 fluidState.setDensity(waterPhaseIdx, rho);
+//             }
+            
+//             if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+//                 rho = fluidState.invB(gasPhaseIdx);
+//                 rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+//                 if (FluidSystem::enableVaporizedOil()) {
+//                     rho += fluidState.invB(gasPhaseIdx) * fluidState.Rv()
+//                         * FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+//                 }
+//                 if (FluidSystem::enableVaporizedWater()) {
+//                     rho += fluidState.invB(gasPhaseIdx) * fluidState.Rvw()
+//                         * FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+//                 }
+//                 fluidState.setDensity(gasPhaseIdx, rho);
+//             }
+
+//             if (FluidSystem::phaseIsActive(oilPhaseIdx)) {                
+//                 rho = fluidState.invB(oilPhaseIdx);
+//                 rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+//                 if (FluidSystem::enableDissolvedGas()) {
+//                     rho += fluidState.invB(oilPhaseIdx) * fluidState.Rs()
+//                         * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+//                 }
+//                 fluidState.setDensity(oilPhaseIdx, rho);
+//             }
+
+            std::array<Evaluation, numPhases> mobility;
+            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            //     if (FluidSystem::phaseIsActive(phaseIdx)) {
+            //         // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
+            //         const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
+            //         mobility[phaseIdx] = mu;
+            //     }
+            // }
+
+            std::array<Evaluation, numPhases> pC;
+            // //MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
+            // //MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+            //MaterialLaw::DefaultMaterial::capillaryPressures(pC, materialParams, fluidState);
+            //MaterialLaw::DefaultMaterial::relativePermeabilitiesNew(mobility, materialParams, fluidState);
+            MaterialLaw::DefaultMaterial::relativePermeabilitiesNew(mobility, Swco, oilwaterparams, gasoilparams, fluidState);
+            // rocktabTables = eclState.getTableManager().getRocktabTables();
+            // const auto& rocktabTable = rocktabTables.template getTable<RocktabTable>(regionIdx);
+            // const auto& pressureColumn = rocktabTable.getPressureColumn();
+            // const auto& poroColumn = rocktabTable.getPoreVolumeMultiplierColumn();
+            // const auto& transColumn = rocktabTable.getTransmissibilityMultiplierColumn();
+           
+            // Evaluation porosity_;
+            // Evaluation rockCompTransMultiplier_;
+            // Scalar rockCompressibility = problem.rockCompressibility(globalSpaceIdx);
+            // if (rockCompressibility > 0.0) {
+            //     Scalar rockRefPressure = problem.rockReferencePressure(globalSpaceIdx);
+            //     Evaluation x;
+            //     if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+            //         x = rockCompressibility*(fluidState_.pressure(oilPhaseIdx) - rockRefPressure);
+            //     } else if (FluidSystem::phaseIsActive(waterPhaseIdx)){
+            //         x = rockCompressibility*(fluidState_.pressure(waterPhaseIdx) - rockRefPressure);
+            //     } else {
+            //         x = rockCompressibility*(fluidState_.pressure(gasPhaseIdx) - rockRefPressure);
+            //     }
+            //     porosity_ *= 1.0 + x + 0.5*x*x;
+            // }
+            // porosity_ *= problem.template rockCompPoroMultiplier<Evaluation>(*this, globalSpaceIdx);
+            // rockCompTransMultiplier_ = problem.template rockCompTransMultiplier<Evaluation>(*this, globalSpaceIdx);
+        }
+    }
+    Opm::time_point::duration total_time = Opm::TimeService::now() - start;
+    return total_time;
+    // make sure that the {oil,gas,water}Pvt() methods are available
+    [[maybe_unused]] const auto& gPvt = FluidSystem::gasPvt();
+    [[maybe_unused]] const auto& oPvt = FluidSystem::oilPvt();
+    [[maybe_unused]] const auto& wPvt = FluidSystem::waterPvt();
+}
+
+int main(int argc, char **argv)
+{
+    
+    Dune::MPIHelper::instance(argc, argv);
+
+    typedef Opm::DenseAd::Evaluation<double, 3> TestEval;
+    //typedef Opm::DenseAd::Evaluation<float, 3> TestEvalFloat;
+    typedef Opm::DenseAd::Evaluation<double, 6> TestEval6;
+
+    const char* deck_file = argv[1];
+
+    
+    //auto float_time = testAll<float>(deck_file);
+    // auto evalfloat_time = testAll<TestEvalFloat>(deck_file);
+    auto double_time = testAll<double>(deck_file);
+    auto evaldouble_time = testAll<TestEval>(deck_file);
+    auto evaldouble6_time = testAll<TestEval6>(deck_file);
+
+    std::cout << "complete." << std::endl << std::endl;
+    std::cout << "Time: " << std::endl;
+    // float is slow here ?
+    // std::cout << "   float.....: "  << std::chrono::duration<double>(float_time).count()  << " seconds" << std::endl;
+    // std::cout << "   evalfloat.....: "  << std::chrono::duration<double>(evalfloat_time).count()  << " seconds" << std::endl;
+    std::cout << "   double.....: "  << std::chrono::duration<double>(double_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval3 double....: "  << std::chrono::duration<double>(evaldouble_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval6 double....: "  << std::chrono::duration<double>(evaldouble6_time).count()  << " seconds" << std::endl;
+    return 0;
+}

--- a/tests/material/test_eclrelpermevaluation_lowlevel.cpp
+++ b/tests/material/test_eclrelpermevaluation_lowlevel.cpp
@@ -39,6 +39,7 @@
 #include <opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/SatCurveMultiplexer.hpp>
+#include <opm/material/fluidmatrixinteractions/EclDefaultMaterialExperimental.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/densead/Evaluation.hpp>
@@ -123,25 +124,8 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     // create a parameter cache
     typedef typename FluidSystem::template ParameterCache<Evaluation> ParamCache;
     
-     typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
+    typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
     
-    // if (FluidSystem::numActivePhases() != 3)
-    // std::abort();
-
-    // if (!FluidSystem::enableDissolvedGas())
-    //     std::abort();
-    // if (!FluidSystem::enableVaporizedOil())
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
-    //     std::abort();
     std::vector<int> pvtnum(nc,0);
     const std::string& name("PVTNUM");
     if (eclState.fieldProps().has_int(name)){
@@ -179,10 +163,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     }
     for (unsigned step = 0; step < num_total; ++step) {
         for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
-            //const auto& materialParams = materialLawManager.materialLawParams(elemIdx).template getRealParams<Opm::EclMultiplexerApproach::Default>();
-//             std::array<Evaluation, numPhases> viscosity;
-//             const auto& pvtRegionIdx = pvtnum[elemIdx];
-//             //const signed pvtRegionIdx = 0;
             FluidState& fluidState = intQuant[elemIdx];
             Opm::Valgrind::SetUndefined(fluidState);
             
@@ -226,140 +206,16 @@ inline Opm::time_point::duration testAll(const char * deck_file)
 
 
 
-//             // if (FluidSystem::enableDissolvedGas()) {
-//             //     const Evaluation& RsSat
-//             //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
-//             //     fluidState.setRs(RsSat);
-//             // }
-//             // if (FluidSystem::enableVaporizedOil()) {
-//             //     const Evaluation& RvSat
-//             //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
-//             //     fluidState.setRv(RvSat);
-//             // }
-
-//             // Evaluation SoMax = Opm::max(So, 0.5);
-//             // ParamCache paramCache;
-//             // paramCache.setRegionIndex(pvtRegionIdx);
-//             // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-//             //     paramCache.setMaxOilSat(SoMax);
-//             // }
-//             // paramCache.updateAll(fluidState);
-
-//             // calculate the phase densities
-//             Evaluation T=278;
-//             Evaluation rho;
-//             if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
-//                 //const auto& waterpvt = FluidSystem::waterPvt();
-//                 //Evaluation salt= 0.0;
-//                 //Evaluation b = waterpvt.saturatedInverseFormationVolumeFactor(pvtRegionIdx, T, p, salt);//, Rsw, saltConcentration);
-//                 //Evaluation mu = waterpvt.saturatedViscosity(pvtRegionIdx, T, p,salt);
-//                 Evaluation b;
-//                 Evaluation mu;
-//                 waterpvt.inverseBAndMu(b,mu,pvtRegionIdx, p);
-//                 fluidState.setInvB(waterPhaseIdx, b);
-//                 viscosity[waterPhaseIdx] = mu;
-//             }
-//             if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
-// //                if (FluidSystem::enableVaporizedOil()) {
-//                 size_t segIdx = gaspvt.saturatedOilVaporizationFactorTable()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
-//                 const Evaluation& RvSat = gaspvt.saturatedOilVaporizationFactorTable()[pvtRegionIdx].eval(p, segIdx);
-//                 fluidState.setRv(RvSat);
-// //                }
-//                 //size_t segIdx = gaspvt.inverseSaturatedGasB()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
-//                 Evaluation b  =gaspvt.inverseSaturatedGasB()[pvtRegionIdx].eval(p, segIdx);
-//                 const Evaluation& invBMu = gaspvt.inverseSaturatedGasBMu()[pvtRegionIdx].eval(p, segIdx);
-//                 Evaluation mu = b/invBMu;
-//                 viscosity[oilPhaseIdx] =mu;          
-//                 fluidState.setInvB(gasPhaseIdx, b);
-//             }
-//             if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
-//                 //if (FluidSystem::enableDissolvedGas()) {
-//                 // const Evaluation& RsSat
-//                 //     = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
-//                 size_t segIdx = oilpvt.saturatedGasDissolutionFactorTable()[pvtRegionIdx].findSegmentIndex_(p,/*extrapolate=*/true);
-//                 const Evaluation& RsSat = oilpvt.saturatedGasDissolutionFactorTable()[pvtRegionIdx].eval(p, segIdx);
-//                 fluidState.setRs(RsSat);
-//                 //}
-                
-//                 Evaluation b  =oilpvt.inverseSaturatedOilBTable()[pvtRegionIdx].eval(p, segIdx);
-//                 Evaluation invBMu = oilpvt.inverseSaturatedOilBMuTable()[pvtRegionIdx].eval(p,segIdx);
-//                 Evaluation mu = b/invBMu;
-//                 viscosity[oilPhaseIdx] =mu;          
-//                 fluidState.setInvB(oilPhaseIdx, b);
-//             }
-            
-//             if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
-//                 rho = fluidState.invB(waterPhaseIdx);
-//                 rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
-//                 if (FluidSystem::enableDissolvedGasInWater()) {
-//                     rho += fluidState.invB(waterPhaseIdx) * fluidState.Rsw()
-//                         * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-//                 }
-//                 fluidState.setDensity(waterPhaseIdx, rho);
-//             }
-            
-//             if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
-//                 rho = fluidState.invB(gasPhaseIdx);
-//                 rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-//                 if (FluidSystem::enableVaporizedOil()) {
-//                     rho += fluidState.invB(gasPhaseIdx) * fluidState.Rv()
-//                         * FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
-//                 }
-//                 if (FluidSystem::enableVaporizedWater()) {
-//                     rho += fluidState.invB(gasPhaseIdx) * fluidState.Rvw()
-//                         * FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
-//                 }
-//                 fluidState.setDensity(gasPhaseIdx, rho);
-//             }
-
-//             if (FluidSystem::phaseIsActive(oilPhaseIdx)) {                
-//                 rho = fluidState.invB(oilPhaseIdx);
-//                 rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
-//                 if (FluidSystem::enableDissolvedGas()) {
-//                     rho += fluidState.invB(oilPhaseIdx) * fluidState.Rs()
-//                         * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-//                 }
-//                 fluidState.setDensity(oilPhaseIdx, rho);
-//             }
 
             std::array<Evaluation, numPhases> mobility;
-            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            //     if (FluidSystem::phaseIsActive(phaseIdx)) {
-            //         // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
-            //         const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
-            //         mobility[phaseIdx] = mu;
-            //     }
-            // }
 
             std::array<Evaluation, numPhases> pC;
-            // //MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
-            // //MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+            // MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
+            // MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
             //MaterialLaw::DefaultMaterial::capillaryPressures(pC, materialParams, fluidState);
-            MaterialLaw::DefaultMaterial::relativePermeabilitiesNew(mobility, materialParams, fluidState);
+            //MaterialLaw::DefaultMaterial::relativePermeabilitiesNew(mobility, materialParams, fluidState);
             //MaterialLaw::DefaultMaterial::relativePermeabilitiesNew(mobility, Swco, oilwaterparams, gasoilparams, fluidState);
-            // rocktabTables = eclState.getTableManager().getRocktabTables();
-            // const auto& rocktabTable = rocktabTables.template getTable<RocktabTable>(regionIdx);
-            // const auto& pressureColumn = rocktabTable.getPressureColumn();
-            // const auto& poroColumn = rocktabTable.getPoreVolumeMultiplierColumn();
-            // const auto& transColumn = rocktabTable.getTransmissibilityMultiplierColumn();
-           
-            // Evaluation porosity_;
-            // Evaluation rockCompTransMultiplier_;
-            // Scalar rockCompressibility = problem.rockCompressibility(globalSpaceIdx);
-            // if (rockCompressibility > 0.0) {
-            //     Scalar rockRefPressure = problem.rockReferencePressure(globalSpaceIdx);
-            //     Evaluation x;
-            //     if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
-            //         x = rockCompressibility*(fluidState_.pressure(oilPhaseIdx) - rockRefPressure);
-            //     } else if (FluidSystem::phaseIsActive(waterPhaseIdx)){
-            //         x = rockCompressibility*(fluidState_.pressure(waterPhaseIdx) - rockRefPressure);
-            //     } else {
-            //         x = rockCompressibility*(fluidState_.pressure(gasPhaseIdx) - rockRefPressure);
-            //     }
-            //     porosity_ *= 1.0 + x + 0.5*x*x;
-            // }
-            // porosity_ *= problem.template rockCompPoroMultiplier<Evaluation>(*this, globalSpaceIdx);
-            // rockCompTransMultiplier_ = problem.template rockCompTransMultiplier<Evaluation>(*this, globalSpaceIdx);
+            Opm::EclDefaultMaterialExperimental<MaterialLaw::DefaultMaterial>::relativePermeabilitiesNew(mobility, Swco, oilwaterparams, gasoilparams, fluidState);
         }
     }
     Opm::time_point::duration total_time = Opm::TimeService::now() - start;

--- a/tests/material/test_eclrelpermevaluation_lowlevel.cpp
+++ b/tests/material/test_eclrelpermevaluation_lowlevel.cpp
@@ -215,7 +215,7 @@ inline Opm::time_point::duration testAll(const char * deck_file)
             //MaterialLaw::DefaultMaterial::capillaryPressures(pC, materialParams, fluidState);
             //MaterialLaw::DefaultMaterial::relativePermeabilitiesNew(mobility, materialParams, fluidState);
             //MaterialLaw::DefaultMaterial::relativePermeabilitiesNew(mobility, Swco, oilwaterparams, gasoilparams, fluidState);
-            Opm::EclDefaultMaterialExperimental<MaterialLaw::DefaultMaterial>::relativePermeabilitiesNew(mobility, Swco, oilwaterparams, gasoilparams, fluidState);
+            Opm::EclDefaultMaterialExperimental<typename MaterialLaw::DefaultMaterial>::relativePermeabilities(mobility, Swco, oilwaterparams, gasoilparams, fluidState);
         }
     }
     Opm::time_point::duration total_time = Opm::TimeService::now() - start;

--- a/tests/material/test_propertyevaluation.cpp
+++ b/tests/material/test_propertyevaluation.cpp
@@ -119,23 +119,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     
      typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
     
-    // if (FluidSystem::numActivePhases() != 3)
-    // std::abort();
-
-    // if (!FluidSystem::enableDissolvedGas())
-    //     std::abort();
-    // if (!FluidSystem::enableVaporizedOil())
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
-    //     std::abort();
     std::vector<int> pvtnum(nc,0);
     const std::string& name("PVTNUM");
     if (eclState.fieldProps().has_int(name)){

--- a/tests/material/test_propertyevaluation.cpp
+++ b/tests/material/test_propertyevaluation.cpp
@@ -1,0 +1,308 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief This is the unit test for the black oil fluid system
+ *
+ * This test requires the presence of opm-parser.
+ */
+#include "config.h"
+
+#if !HAVE_ECL_INPUT
+#error "The test for the black oil fluid system classes requires ecl input support in opm-common"
+#endif
+
+#include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidstates/BlackOilFluidState.hpp>
+#include <opm/material/densead/Evaluation.hpp>
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/material/common/Valgrind.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/utility/TimeService.hpp>
+
+#include <type_traits>
+#include <cmath>
+
+// values of strings based on the SPE1 and NORNE cases of opm-data.
+// template<typename Evaluation,typename FluidSystem, int numPhases> class FluidAndRockState:
+//     public Opm::BlackOilFluidState<Evaluation, FluidSystem>
+// {
+// public:
+//     double referencePorosity_;
+//     Evaluation porosity_;
+//     Evaluation rockCompTransMultiplier_;
+//     std::array<Evaluation,numPhases> mobility_;
+// }
+    
+typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
+
+
+template <class Evaluation>
+inline Opm::time_point::duration testAll(const char * deck_file)
+{
+    // test the black-oil specific methods of BlackOilFluidSystem. The generic methods
+    // for fluid systems are already tested by the generic test for all fluidsystems.
+    
+    typedef typename Opm::MathToolbox<Evaluation>::Scalar Scalar;
+    //typedef typename Evaluation::ValueType simpletype;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
+
+    static constexpr int numPhases = FluidSystem::numPhases;
+
+    static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
+    static constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
+    static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
+    typedef Opm::ThreePhaseMaterialTraits<Scalar,
+                                          /*wettingPhaseIdx=*/waterPhaseIdx,
+                                          /*nonWettingPhaseIdx=*/oilPhaseIdx,
+                                          /*gasPhaseIdx=*/gasPhaseIdx> MaterialTraits;
+
+    static constexpr int gasCompIdx = FluidSystem::gasCompIdx;
+    static constexpr int oilCompIdx = FluidSystem::oilCompIdx;
+    static constexpr int waterCompIdx = FluidSystem::waterCompIdx;
+
+    Opm::ParseContext parseContext;//(Opm::InputErrorAction::WARN);
+    Opm::ErrorGuard errors;
+    Opm::Parser parser;    
+
+    auto deck = parser.parseFile(deck_file, parseContext, errors);
+    auto python = std::make_shared<Opm::Python>();
+    Opm::EclipseState eclState(deck);
+    Opm::Schedule schedule(deck, eclState, python);
+
+    FluidSystem::initFromState(eclState, schedule);
+    const auto& eclGrid = eclState.getInputGrid();
+    //size_t nc = eclGrid.getCartesianSize();
+    size_t nc = eclGrid.getNumActive();
+    typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
+    MaterialLawManager  materialLawManager;
+    typedef typename MaterialLawManager::MaterialLaw MaterialLaw;
+    materialLawManager.initFromState(eclState);
+    materialLawManager.initParamsForElements(eclState, nc);
+    // create a parameter cache
+    typedef typename FluidSystem::template ParameterCache<Evaluation> ParamCache;
+    
+     typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
+    
+    // if (FluidSystem::numActivePhases() != 3)
+    // std::abort();
+
+    // if (!FluidSystem::enableDissolvedGas())
+    //     std::abort();
+    // if (!FluidSystem::enableVaporizedOil())
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
+    //     std::abort();
+    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
+    //     std::abort();
+    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
+    //     std::abort();
+    std::vector<int> pvtnum(nc,0);
+    const std::string& name("PVTNUM");
+    if (eclState.fieldProps().has_int(name)){
+        const auto& numData = eclState.fieldProps().get_int(name);
+    
+        for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
+            pvtnum[elemIdx] = static_cast<int>(numData[elemIdx]) - 1;
+        }
+    }
+    std::sort(pvtnum.begin(),pvtnum.end());
+    
+    static const Scalar eps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
+    unsigned numevals = 10000*100;
+    unsigned num_total = ceil(double(numevals)/double(nc));
+    //num_total=23;
+    std::vector<FluidState> intQuant(nc);
+    std::cout << "Doing evaluation " << num_total << " of nc " << nc << " total " << nc*num_total << std::endl;
+    Opm::time_point start;
+    start = Opm::TimeService::now();
+    for (unsigned step = 0; step < num_total; ++step) {
+        for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
+            const auto& materialParams = materialLawManager.materialLawParams(elemIdx);
+            const auto& pvtRegionIdx = pvtnum[elemIdx];
+            FluidState& fluidState = intQuant[elemIdx];
+            Opm::Valgrind::SetUndefined(fluidState);
+            Evaluation p = Scalar(elemIdx + nc * step) / num_total * 350e5 + 100e5;
+
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (FluidSystem::phaseIsActive(phaseIdx)) {
+                    fluidState.setPressure(phaseIdx, p);
+                }
+            }
+            Evaluation Sw = 0.0;
+            if constexpr (true) {
+                Sw = Scalar(elemIdx + nc * step) / num_total;
+            }
+            Evaluation Sg = 0.0;
+            if constexpr (true) {
+                Sg = Scalar(elemIdx + nc * step) / num_total;
+            }
+            Evaluation So = 1 - Sw - Sg;
+
+            if (FluidSystem::phaseIsActive(waterPhaseIdx))
+                fluidState.setSaturation(waterPhaseIdx, Sw);
+            
+            if (FluidSystem::phaseIsActive(gasPhaseIdx))
+                fluidState.setSaturation(gasPhaseIdx, Sg);
+            
+            if (FluidSystem::phaseIsActive(oilPhaseIdx))
+                fluidState.setSaturation(oilPhaseIdx, So);
+
+
+
+            if (FluidSystem::enableDissolvedGas()) {
+                const Evaluation& RsSat
+                    = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
+                fluidState.setRs(RsSat);
+            }
+            if (FluidSystem::enableVaporizedOil()) {
+                const Evaluation& RvSat
+                    = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
+                fluidState.setRv(RvSat);
+            }
+
+            Evaluation SoMax = Opm::max(So, 0.5);
+            ParamCache paramCache;
+            paramCache.setRegionIndex(pvtRegionIdx);
+            if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+                paramCache.setMaxOilSat(SoMax);
+            }
+            paramCache.updateAll(fluidState);
+
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                // ensure that the black-oil specific variants of the methods to compute
+                // thermdynamic properties return the same value as the generic ones and that
+                // the generic methods return the same value as the ones for the saturated
+                // quantities (we specify the fluid state to be on the saturation line)
+                if (FluidSystem::phaseIsActive(phaseIdx)) {
+                    //Evaluation b = FluidSystem::inverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
+                    Evaluation bSat
+                        = FluidSystem::saturatedInverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
+                    fluidState.setInvB(phaseIdx, b);
+                }
+            }
+
+            // calculate the phase densities
+            Evaluation rho;
+            if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+                rho = fluidState.invB(waterPhaseIdx);
+                rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+                if (FluidSystem::enableDissolvedGasInWater()) {
+                    rho += fluidState.invB(waterPhaseIdx) * fluidState.Rsw()
+                        * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+                }
+                fluidState.setDensity(waterPhaseIdx, rho);
+            }
+
+            if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+                rho = fluidState.invB(gasPhaseIdx);
+                rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+                if (FluidSystem::enableVaporizedOil()) {
+                    rho += fluidState.invB(gasPhaseIdx) * fluidState.Rv()
+                        * FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+                }
+                if (FluidSystem::enableVaporizedWater()) {
+                    rho += fluidState.invB(gasPhaseIdx) * fluidState.Rvw()
+                        * FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+                }
+                fluidState.setDensity(gasPhaseIdx, rho);
+            }
+
+            if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+                rho = fluidState.invB(oilPhaseIdx);
+                rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+                if (FluidSystem::enableDissolvedGas()) {
+                    rho += fluidState.invB(oilPhaseIdx) * fluidState.Rs()
+                        * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+                }
+                fluidState.setDensity(oilPhaseIdx, rho);
+            }
+
+            std::array<Evaluation, numPhases> mobility;
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+                    // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
+                    const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
+                    mobility[phaseIdx] = mu;
+                }
+            }
+
+            std::array<Evaluation, numPhases> pC;
+            MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
+            MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+        }
+    }
+    Opm::time_point::duration total_time = Opm::TimeService::now() - start;
+    return total_time;
+    // make sure that the {oil,gas,water}Pvt() methods are available
+    [[maybe_unused]] const auto& gPvt = FluidSystem::gasPvt();
+    [[maybe_unused]] const auto& oPvt = FluidSystem::oilPvt();
+    [[maybe_unused]] const auto& wPvt = FluidSystem::waterPvt();
+}
+
+int main(int argc, char **argv)
+{
+    
+    Dune::MPIHelper::instance(argc, argv);
+
+    typedef Opm::DenseAd::Evaluation<double, 3> TestEval;
+    typedef Opm::DenseAd::Evaluation<float, 3> TestEvalFloat;
+
+    const char* deck_file = argv[1];
+
+    
+    //auto float_time = testAll<float>(deck_file);
+    // auto evalfloat_time = testAll<TestEvalFloat>(deck_file);
+    auto double_time = testAll<double>(deck_file);
+    auto evaldouble_time = testAll<TestEval>(deck_file);
+
+    std::cout << "complete." << std::endl << std::endl;
+    std::cout << "Time: " << std::endl;
+    // float is slow here ?
+    // std::cout << "   float.....: "  << std::chrono::duration<double>(float_time).count()  << " seconds" << std::endl;
+    // std::cout << "   evalfloat.....: "  << std::chrono::duration<double>(evalfloat_time).count()  << " seconds" << std::endl;
+    std::cout << "   double.....: "  << std::chrono::duration<double>(double_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval double....: "  << std::chrono::duration<double>(evaldouble_time).count()  << " seconds" << std::endl;
+    return 0;
+}

--- a/tests/material/test_relpermevaluation.cpp
+++ b/tests/material/test_relpermevaluation.cpp
@@ -1,0 +1,306 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief This is the unit test for the black oil fluid system
+ *
+ * This test requires the presence of opm-parser.
+ */
+#include "config.h"
+
+#if !HAVE_ECL_INPUT
+#error "The test for the black oil fluid system classes requires ecl input support in opm-common"
+#endif
+
+#include <opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp>
+#include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
+#include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
+#include <opm/material/fluidstates/BlackOilFluidState.hpp>
+#include <opm/material/densead/Evaluation.hpp>
+#include <opm/material/densead/Math.hpp>
+
+#include <opm/material/common/Valgrind.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParseContext.hpp>
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <dune/common/parallel/mpihelper.hh>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/OpmLog/StreamLog.hpp>
+#include <opm/common/OpmLog/LogUtil.hpp>
+#include <opm/common/utility/TimeService.hpp>
+
+#include <type_traits>
+#include <cmath>
+
+// values of strings based on the SPE1 and NORNE cases of opm-data.
+// template<typename Evaluation,typename FluidSystem, int numPhases> class FluidAndRockState:
+//     public Opm::BlackOilFluidState<Evaluation, FluidSystem>
+// {
+// public:
+//     double referencePorosity_;
+//     Evaluation porosity_;
+//     Evaluation rockCompTransMultiplier_;
+//     std::array<Evaluation,numPhases> mobility_;
+// }
+    
+
+template <class Evaluation>
+inline Opm::time_point::duration testAll(const char * deck_file)
+{
+    // test the black-oil specific methods of BlackOilFluidSystem. The generic methods
+    // for fluid systems are already tested by the generic test for all fluidsystems.
+    
+    typedef typename Opm::MathToolbox<Evaluation>::Scalar Scalar;
+    //typedef typename Evaluation::ValueType simpletype;
+    typedef Opm::BlackOilFluidSystem<double> FluidSystem;
+
+    static constexpr int numPhases = FluidSystem::numPhases;
+
+    static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
+    static constexpr int oilPhaseIdx = FluidSystem::oilPhaseIdx;
+    static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
+    typedef Opm::ThreePhaseMaterialTraits<Scalar,
+                                          /*wettingPhaseIdx=*/waterPhaseIdx,
+                                          /*nonWettingPhaseIdx=*/oilPhaseIdx,
+                                          /*gasPhaseIdx=*/gasPhaseIdx> MaterialTraits;
+
+    static constexpr int gasCompIdx = FluidSystem::gasCompIdx;
+    static constexpr int oilCompIdx = FluidSystem::oilCompIdx;
+    static constexpr int waterCompIdx = FluidSystem::waterCompIdx;
+
+    Opm::ParseContext parseContext;//(Opm::InputErrorAction::WARN);
+    Opm::ErrorGuard errors;
+    Opm::Parser parser;    
+
+    auto deck = parser.parseFile(deck_file, parseContext, errors);
+    auto python = std::make_shared<Opm::Python>();
+    Opm::EclipseState eclState(deck);
+    Opm::Schedule schedule(deck, eclState, python);
+
+    FluidSystem::initFromState(eclState, schedule);
+    const auto& eclGrid = eclState.getInputGrid();
+    //size_t nc = eclGrid.getCartesianSize();
+    size_t nc = eclGrid.getNumActive();
+    typedef Opm::EclMaterialLawManager<MaterialTraits> MaterialLawManager;
+    MaterialLawManager  materialLawManager;
+    typedef typename MaterialLawManager::MaterialLaw MaterialLaw;
+    materialLawManager.initFromState(eclState);
+    materialLawManager.initParamsForElements(eclState, nc);
+    // create a parameter cache
+    typedef typename FluidSystem::template ParameterCache<Evaluation> ParamCache;
+    
+     typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
+    
+    // if (FluidSystem::numActivePhases() != 3)
+    // std::abort();
+
+    // if (!FluidSystem::enableDissolvedGas())
+    //     std::abort();
+    // if (!FluidSystem::enableVaporizedOil())
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
+    //     std::abort();
+    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
+    //     std::abort();
+    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
+    //     std::abort();
+    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
+    //     std::abort();
+    std::vector<int> pvtnum(nc,0);
+    const std::string& name("PVTNUM");
+    if (eclState.fieldProps().has_int(name)){
+        const auto& numData = eclState.fieldProps().get_int(name);
+    
+        for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
+            pvtnum[elemIdx] = static_cast<int>(numData[elemIdx]) - 1;
+        }
+    }
+    std::sort(pvtnum.begin(),pvtnum.end());
+    
+    static const Scalar eps = std::sqrt(std::numeric_limits<Scalar>::epsilon());
+    unsigned numevals = 10000*100;
+    unsigned num_total = ceil(double(numevals)/double(nc));
+    //num_total=23;
+    std::vector<FluidState> intQuant(nc);
+    std::cout << "Doing evaluation " << num_total << " of nc " << nc << " total " << nc*num_total << std::endl;
+    Opm::time_point start;
+    start = Opm::TimeService::now();
+    for (unsigned step = 0; step < num_total; ++step) {
+        for (unsigned elemIdx = 0; elemIdx < nc; ++elemIdx) {
+            const auto& materialParams = materialLawManager.materialLawParams(elemIdx);
+            // const auto& pvtRegionIdx = pvtnum[elemIdx];
+            FluidState& fluidState = intQuant[elemIdx];
+            Opm::Valgrind::SetUndefined(fluidState);
+            Evaluation p = Scalar(elemIdx + nc * step) / num_total * 350e5 + 100e5;
+
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (FluidSystem::phaseIsActive(phaseIdx)) {
+                    fluidState.setPressure(phaseIdx, p);
+                }
+            }
+            Evaluation Sw = 0.0;
+            if constexpr (true) {
+                Sw = Scalar(elemIdx + nc * step) / num_total;
+            }
+            Evaluation Sg = 0.0;
+            if constexpr (true) {
+                Sg = Scalar(elemIdx + nc * step) / num_total;
+            }
+            Evaluation So = 1 - Sw - Sg;
+
+            if (FluidSystem::phaseIsActive(waterPhaseIdx))
+                fluidState.setSaturation(waterPhaseIdx, Sw);
+            
+            if (FluidSystem::phaseIsActive(gasPhaseIdx))
+                fluidState.setSaturation(gasPhaseIdx, Sg);
+            
+            if (FluidSystem::phaseIsActive(oilPhaseIdx))
+                fluidState.setSaturation(oilPhaseIdx, So);
+
+
+
+            // if (FluidSystem::enableDissolvedGas()) {
+            //     const Evaluation& RsSat
+            //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
+            //     fluidState.setRs(RsSat);
+            // }
+            // if (FluidSystem::enableVaporizedOil()) {
+            //     const Evaluation& RvSat
+            //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
+            //     fluidState.setRv(RvSat);
+            // }
+
+            // Evaluation SoMax = Opm::max(So, 0.5);
+            // ParamCache paramCache;
+            // paramCache.setRegionIndex(pvtRegionIdx);
+            // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
+            //     paramCache.setMaxOilSat(SoMax);
+            // }
+            // paramCache.updateAll(fluidState);
+
+            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            //     // ensure that the black-oil specific variants of the methods to compute
+            //     // thermdynamic properties return the same value as the generic ones and that
+            //     // the generic methods return the same value as the ones for the saturated
+            //     // quantities (we specify the fluid state to be on the saturation line)
+            //     if (FluidSystem::phaseIsActive(phaseIdx)) {
+            //         Evaluation b = FluidSystem::inverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
+            //         //Evaluation bSat
+            //         //    = FluidSystem::saturatedInverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
+            //         fluidState.setInvB(phaseIdx, b);
+            //     }
+            // }
+
+            // // calculate the phase densities
+            // Evaluation rho;
+            // if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+            //     rho = fluidState.invB(waterPhaseIdx);
+            //     rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+            //     if (FluidSystem::enableDissolvedGasInWater()) {
+            //         rho += fluidState.invB(waterPhaseIdx) * fluidState.Rsw()
+            //             * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+            //     }
+            //     fluidState.setDensity(waterPhaseIdx, rho);
+            // }
+
+            // if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
+            //     rho = fluidState.invB(gasPhaseIdx);
+            //     rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+            //     if (FluidSystem::enableVaporizedOil()) {
+            //         rho += fluidState.invB(gasPhaseIdx) * fluidState.Rv()
+            //             * FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+            //     }
+            //     if (FluidSystem::enableVaporizedWater()) {
+            //         rho += fluidState.invB(gasPhaseIdx) * fluidState.Rvw()
+            //             * FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+            //     }
+            //     fluidState.setDensity(gasPhaseIdx, rho);
+            // }
+
+            // if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
+            //     rho = fluidState.invB(oilPhaseIdx);
+            //     rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+            //     if (FluidSystem::enableDissolvedGas()) {
+            //         rho += fluidState.invB(oilPhaseIdx) * fluidState.Rs()
+            //             * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+            //     }
+            //     fluidState.setDensity(oilPhaseIdx, rho);
+            // }
+
+            std::array<Evaluation, numPhases> mobility;
+            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            //     if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
+            //         // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
+            //         const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
+            //         mobility[phaseIdx] = mu;
+            //     }
+            // }
+
+            std::array<Evaluation, numPhases> pC;
+            MaterialLaw::capillaryPressures(pC, materialParams, fluidState);
+            MaterialLaw::relativePermeabilities(mobility, materialParams, fluidState);
+        }
+    }
+    Opm::time_point::duration total_time = Opm::TimeService::now() - start;
+    return total_time;
+    // make sure that the {oil,gas,water}Pvt() methods are available
+    [[maybe_unused]] const auto& gPvt = FluidSystem::gasPvt();
+    [[maybe_unused]] const auto& oPvt = FluidSystem::oilPvt();
+    [[maybe_unused]] const auto& wPvt = FluidSystem::waterPvt();
+}
+
+int main(int argc, char **argv)
+{
+    
+    Dune::MPIHelper::instance(argc, argv);
+
+    typedef Opm::DenseAd::Evaluation<double, 3> TestEval;
+    typedef Opm::DenseAd::Evaluation<float, 3> TestEvalFloat;
+
+    const char* deck_file = argv[1];
+
+    
+    //auto float_time = testAll<float>(deck_file);
+    // auto evalfloat_time = testAll<TestEvalFloat>(deck_file);
+    auto double_time = testAll<double>(deck_file);
+    auto evaldouble_time = testAll<TestEval>(deck_file);
+
+    std::cout << "complete." << std::endl << std::endl;
+    std::cout << "Time: " << std::endl;
+    // float is slow here ?
+    // std::cout << "   float.....: "  << std::chrono::duration<double>(float_time).count()  << " seconds" << std::endl;
+    // std::cout << "   evalfloat.....: "  << std::chrono::duration<double>(evalfloat_time).count()  << " seconds" << std::endl;
+    std::cout << "   double.....: "  << std::chrono::duration<double>(double_time).count()  << " seconds" << std::endl;
+    std::cout << "   eval double....: "  << std::chrono::duration<double>(evaldouble_time).count()  << " seconds" << std::endl;
+    return 0;
+}

--- a/tests/material/test_relpermevaluation.cpp
+++ b/tests/material/test_relpermevaluation.cpp
@@ -119,23 +119,6 @@ inline Opm::time_point::duration testAll(const char * deck_file)
     
      typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
     
-    // if (FluidSystem::numActivePhases() != 3)
-    // std::abort();
-
-    // if (!FluidSystem::enableDissolvedGas())
-    //     std::abort();
-    // if (!FluidSystem::enableVaporizedOil())
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(oilPhaseIdx) != oilCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(gasPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::solventComponentIndex(waterPhaseIdx) != waterCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(oilPhaseIdx) != gasCompIdx)
-    //     std::abort();
-    // if (FluidSystem::soluteComponentIndex(gasPhaseIdx) != oilCompIdx)
-    //     std::abort();
     std::vector<int> pvtnum(nc,0);
     const std::string& name("PVTNUM");
     if (eclState.fieldProps().has_int(name)){
@@ -189,82 +172,8 @@ inline Opm::time_point::duration testAll(const char * deck_file)
 
 
 
-            // if (FluidSystem::enableDissolvedGas()) {
-            //     const Evaluation& RsSat
-            //         = FluidSystem::saturatedDissolutionFactor(fluidState, oilPhaseIdx, pvtRegionIdx);
-            //     fluidState.setRs(RsSat);
-            // }
-            // if (FluidSystem::enableVaporizedOil()) {
-            //     const Evaluation& RvSat
-            //         = FluidSystem::saturatedDissolutionFactor(fluidState, gasPhaseIdx, pvtRegionIdx);
-            //     fluidState.setRv(RvSat);
-            // }
-
-            // Evaluation SoMax = Opm::max(So, 0.5);
-            // ParamCache paramCache;
-            // paramCache.setRegionIndex(pvtRegionIdx);
-            // if (FluidSystem::phaseIsActive(FluidSystem::oilPhaseIdx)) {
-            //     paramCache.setMaxOilSat(SoMax);
-            // }
-            // paramCache.updateAll(fluidState);
-
-            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            //     // ensure that the black-oil specific variants of the methods to compute
-            //     // thermdynamic properties return the same value as the generic ones and that
-            //     // the generic methods return the same value as the ones for the saturated
-            //     // quantities (we specify the fluid state to be on the saturation line)
-            //     if (FluidSystem::phaseIsActive(phaseIdx)) {
-            //         Evaluation b = FluidSystem::inverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
-            //         //Evaluation bSat
-            //         //    = FluidSystem::saturatedInverseFormationVolumeFactor(fluidState, phaseIdx, pvtRegionIdx);
-            //         fluidState.setInvB(phaseIdx, b);
-            //     }
-            // }
-
-            // // calculate the phase densities
-            // Evaluation rho;
-            // if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
-            //     rho = fluidState.invB(waterPhaseIdx);
-            //     rho *= FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
-            //     if (FluidSystem::enableDissolvedGasInWater()) {
-            //         rho += fluidState.invB(waterPhaseIdx) * fluidState.Rsw()
-            //             * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-            //     }
-            //     fluidState.setDensity(waterPhaseIdx, rho);
-            // }
-
-            // if (FluidSystem::phaseIsActive(gasPhaseIdx)) {
-            //     rho = fluidState.invB(gasPhaseIdx);
-            //     rho *= FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-            //     if (FluidSystem::enableVaporizedOil()) {
-            //         rho += fluidState.invB(gasPhaseIdx) * fluidState.Rv()
-            //             * FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
-            //     }
-            //     if (FluidSystem::enableVaporizedWater()) {
-            //         rho += fluidState.invB(gasPhaseIdx) * fluidState.Rvw()
-            //             * FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
-            //     }
-            //     fluidState.setDensity(gasPhaseIdx, rho);
-            // }
-
-            // if (FluidSystem::phaseIsActive(oilPhaseIdx)) {
-            //     rho = fluidState.invB(oilPhaseIdx);
-            //     rho *= FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
-            //     if (FluidSystem::enableDissolvedGas()) {
-            //         rho += fluidState.invB(oilPhaseIdx) * fluidState.Rs()
-            //             * FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-            //     }
-            //     fluidState.setDensity(oilPhaseIdx, rho);
-            // }
 
             std::array<Evaluation, numPhases> mobility;
-            // for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            //     if (FluidSystem::phaseIsActive(waterPhaseIdx)) {
-            //         // const Evaluation mu = FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
-            //         const Evaluation mu = FluidSystem::viscosity(fluidState, phaseIdx, pvtRegionIdx);
-            //         mobility[phaseIdx] = mu;
-            //     }
-            // }
 
             std::array<Evaluation, numPhases> pC;
             MaterialLaw::capillaryPressures(pC, materialParams, fluidState);


### PR DESCRIPTION
New test exectutables for testing pvt and relperm on XXX.data files.
Changes and prototypes for faster pvt and relperm evaluation.
For pvt a factor >3 is likely possible without large changes in simulator.
For relperms >2 is possible. But for now It is only possible on simple models.  
Some sepeedup can be achived with simpler changes.
For more complicated models NORNE ++, refactoring is probably need for full speedup.
Summary of changes need to achive speedup:
- Concrete classes used in inner loop, (this is probably the most important)
- reuse of indices in table lookup between same tables.
- Using none saturation state when calling the pvt functions