### PR TITLE
Added empty macro which can be used for timing with for example Tracy

### DIFF
--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -40,6 +40,18 @@
 # define OPM_MESSAGE_IF(cond, m) do {} while (false)
 #endif
 
+// macros used to time blocks for example with tracy
+// time block of main part of codes which do not effect performance
+#ifndef OPM_TIMEBLOCK
+#define OPM_TIMEBLOCK(x) /* nothing */
+#endif
+
+// detailed timing which may effect performance
+#ifndef OPM_TIMEBLOCK_LOCAL
+#define OPM_TIMEBLOCK_LOCAL(x) /* nothing */
+#endif
+
+
 // Macro to throw an exception. NOTE: For this macro to work, the
 // exception class must exhibit a constructor with the signature
 // (const std::string &message). Since this condition is not fulfilled

--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -43,12 +43,14 @@
 // macros used to time blocks for example with tracy
 // time block of main part of codes which do not effect performance
 #ifndef OPM_TIMEBLOCK
-#define OPM_TIMEBLOCK(x) /* nothing */
+#define OPM_TIMEBLOCK(x)\
+    do { /* nothing */ } while (false)
 #endif
 
 // detailed timing which may effect performance
 #ifndef OPM_TIMEBLOCK_LOCAL
-#define OPM_TIMEBLOCK_LOCAL(x) /* nothing */
+#define OPM_TIMEBLOCK_LOCAL(x)\
+    do { /* nothing */ } while (false)
 #endif
 
 


### PR DESCRIPTION
The intend to define a marco which can be used for timing blocks in OPM.
- if successfully merged one can add  OPM_TIMEBLOCK for full coverage of main functions and OPM_TIMEBLOCK_LOCAL for small portions of code.
-  The consent has been used to time intensivequantities and linearsolvers in the experimental for flow_blackoil_fast
