### PR TITLE
GuideRate: avoid pointer semantics

### DIFF
--- a/opm/input/eclipse/Schedule/Group/GuideRate.hpp
+++ b/opm/input/eclipse/Schedule/Group/GuideRate.hpp
@@ -135,7 +135,6 @@ private:
         }
     };
 
-    using GRValPtr = std::unique_ptr<GRValState>;
     using pair = std::pair<Phase, std::string>;
 
     void well_compute(const std::string& wgname,
@@ -166,7 +165,7 @@ private:
 
     const Schedule& schedule;
 
-    std::unordered_map<std::string, GRValPtr> values{};
+    std::unordered_map<std::string, GRValState> values{};
     std::unordered_map<pair, double, pair_hash> injection_group_values{};
     std::unordered_map<std::string, RateVector> potentials{};
     bool guide_rates_expired {false};


### PR DESCRIPTION
As far as I can tell there is no reason to use pointer semantics here. Since it causes grief for my serialization efforts, I chose to simply remove them. If I missed something, do make fun of me..