### PR TITLE
fixed: process all MULTREGP entries in the deck

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -470,24 +470,25 @@ FieldProps::FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid
     this->tran.emplace( "TRANZ", Fieldprops::TranCalculator("TRANZ") );
 
     if (deck.hasKeyword<ParserKeywords::MULTREGP>()) {
-        const DeckKeyword& multregpKeyword = deck["MULTREGP"].back();
-        for (const auto& record : multregpKeyword) {
-            int region_value = record.getItem("REGION").get<int>(0);
-            if (region_value <= 0)
-                continue;
+        for (const auto& keyword : deck["MULTREGP"]) {
+            for (const auto& record : keyword) {
+                int region_value = record.getItem("REGION").get<int>(0);
+                if (region_value <= 0)
+                    continue;
 
-            std::string region_name = make_region_name( record.getItem("REGION_TYPE").get<std::string>(0) );
-            double multiplier = record.getItem("MULTIPLIER").get<double>(0);
-            auto iter = std::find_if(this->multregp.begin(), this->multregp.end(), [region_value](const MultregpRecord& mregp) { return mregp.region_value == region_value; });
-            /*
-              There is some weirdness if the same region value is entered in several records,
-              then only the last applies.
-            */
-            if (iter != this->multregp.end()) {
-                iter->region_name = region_name;
-                iter->multiplier = multiplier;
-            } else
-                this->multregp.emplace_back( region_value, multiplier, region_name );
+                std::string region_name = make_region_name( record.getItem("REGION_TYPE").get<std::string>(0) );
+                double multiplier = record.getItem("MULTIPLIER").get<double>(0);
+                auto iter = std::find_if(this->multregp.begin(), this->multregp.end(), [region_value](const MultregpRecord& mregp) { return mregp.region_value == region_value; });
+                /*
+                  There is some weirdness if the same region value is entered in several records,
+                  then only the last applies.
+                */
+                if (iter != this->multregp.end()) {
+                    iter->region_name = region_name;
+                    iter->multiplier = multiplier;
+                } else
+                    this->multregp.emplace_back( region_value, multiplier, region_name );
+            }
         }
     }
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -379,6 +379,9 @@ ENDBOX
 
 MULTREGP
   2 8 F /  -- This should be ignored
+/
+
+MULTREGP
   2 5 M /
 /
 
@@ -421,7 +424,7 @@ ENDBOX
         BOOST_CHECK_EQUAL(poro[g], 0.10);
         BOOST_CHECK_EQUAL(ntg[g], 1.0);
         BOOST_CHECK_EQUAL(multpv[g], 1.0);
-        BOOST_CHECK_EQUAL(porv[g],3.0);
+        BOOST_CHECK_EQUAL(porv[g], 3.0);
     }
 
     // k = 3: poro * V * multpv


### PR DESCRIPTION
Not only the last keyword.

Note I'm rather blind on the details here, but it seems like a logical fix if multiple copies of the keyword is actually allowed in the spec.