### PR TITLE
throw when AQUCT and AQUFETP are used as SCHEDULE keywords

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -673,6 +673,8 @@ namespace Opm
 
         // Normal keyword handlers -- in KeywordHandlers.cpp
 
+        void handleAQUCT     (HandlerContext&);
+        void handleAQUFETP   (HandlerContext&);
         void handleBRANPROP  (HandlerContext&);
         void handleCOMPDAT   (HandlerContext&);
         void handleCOMPLUMP  (HandlerContext&);

--- a/src/opm/input/eclipse/EclipseState/Aquifer/AquiferCT.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/AquiferCT.cpp
@@ -35,6 +35,7 @@
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
@@ -224,10 +225,13 @@ AquiferCT::AquiferCT(const TableManager& tables, const Deck& deck)
     if (!deck.hasKeyword<AQUCT>())
         return;
 
-    const auto& aquctKeyword = deck.get<AQUCT>().back();
-    OpmLog::info(OpmInputError::format("Initializing Carter Tracey aquifers from {keyword} in {file} line {line}", aquctKeyword.location()));
-    for (auto& record : aquctKeyword)
-        this->m_aquct.emplace_back(record, tables);
+    const auto& aquct_keywords = SOLUTIONSection(deck).getKeywordList("AQUCT");
+    for (const auto* keyword : aquct_keywords) {
+        OpmLog::info(OpmInputError::format("Initializing Fetkovich aquifers from {keyword} in {file} line {line}", keyword->location()));
+        for (const auto& record : *keyword) {
+            this->m_aquct.emplace_back(record, tables);
+        }
+    }
 }
 
 AquiferCT::AquiferCT(const std::vector<AquiferCT::AQUCT_data>& data) :

--- a/src/opm/input/eclipse/EclipseState/Aquifer/Aquifetp.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/Aquifetp.cpp
@@ -28,6 +28,7 @@
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
 
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
@@ -148,10 +149,13 @@ Aquifetp::Aquifetp(const TableManager& tables, const Deck& deck)
     if (!deck.hasKeyword<AQUFETP>())
         return;
 
-    const auto& aqufetpKeyword = deck.get<AQUFETP>().back();
-    OpmLog::info(OpmInputError::format("Initializing Fetkovich aquifers from {keyword} in {file} line {line}", aqufetpKeyword.location()));
-    for (auto& record : aqufetpKeyword)
-        this->m_aqufetp.emplace_back(record, tables);
+    const auto& aqufetp_keywords = SOLUTIONSection(deck).getKeywordList("AQUFETP");
+    for (const auto* keyword : aqufetp_keywords) {
+        OpmLog::info(OpmInputError::format("Initializing Fetkovich aquifers from {keyword} in {file} line {line}", keyword->location()));
+        for (const auto& record : *keyword) {
+            this->m_aqufetp.emplace_back(record, tables);
+        }
+    }
 }
 
 

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -124,7 +124,13 @@ namespace {
     }
 
 }
+    void Schedule::handleAQUCT(HandlerContext& handlerContext) {
+        throw OpmInputError("AQUCT is not supported as SCHEDULE keyword", handlerContext.keyword.location());
+    }
 
+    void Schedule::handleAQUFETP(HandlerContext& handlerContext) {
+        throw OpmInputError("AQUFETP is not supported as SCHEDULE keyword", handlerContext.keyword.location());
+    }
 
     void Schedule::handleBRANPROP(HandlerContext& handlerContext) {
         auto ext_network = this->snapshots.back().network.get();
@@ -2245,6 +2251,8 @@ Well{0} entered with disallowed 'FIELD' parent group:
     bool Schedule::handleNormalKeyword(HandlerContext& handlerContext) {
         using handler_function = void (Schedule::*) (HandlerContext&);
         static const std::unordered_map<std::string,handler_function> handler_functions = {
+            { "AQUCT",    &Schedule::handleAQUCT     },
+            { "AQUFETP",  &Schedule::handleAQUFETP   },
             { "BOX",      &Schedule::handleGEOKeyword},
             { "BRANPROP", &Schedule::handleBRANPROP  },
             { "COMPDAT" , &Schedule::handleCOMPDAT   },


### PR DESCRIPTION
We are not supporting AQUCT and AQUFETP as SCHEDULE keywords yet. They are only supported as keywords in SOLUTION section. 

But if in the DATA file, there are AQUCT and AQUFETP keywords in the SCHEDULE section, with the master branch, there will be unexpected effects in the results. 

In the master branch, we use the last keyword (`const auto& aqufetpKeyword = deck.get<AQUFETP>().back();`) in the DATA file to generate the AQUCT and AQUFETP aquifers.  If there are AQUCT and AQUFETP keywords in the SCHEDULE section, they will use the last one in the SCHEDULE and not considering the one in the SOLUTION section at all.

At the same time, the implementation in the master branch does not consider that multiple AQUCT or AQUFETP keywords can be input, and also only uses the last one, which is also problematic. 

In this PR, we make sure we use the AQUCT and AQUFETP keywords (can be multiple) in the SOLUTION section to generate the `AquiferConfig`. And also we throw for the AQUCT and AQUFETP keywrods in the SCHEDULE section. 

With this PR, it is generally reflecting what OPM-flow is actually supporting in a more correct manner, hopefully, it reduces potential confusion. 
