### PR TITLE
Restart serialization: add hysteresis parameters

### DIFF
--- a/opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/DirectionalMaterialLawParams.hpp
@@ -25,16 +25,28 @@
 #define OPM_DIRECTIONAL_MATERIAL_LAW_PARAMS_HH
 
 #include <cstddef>
+#include <stdexcept>
 #include <vector>
 
 namespace Opm {
+
 template <class MaterialLawParams>
 struct DirectionalMaterialLawParams {
     using vector_type = std::vector<MaterialLawParams>;
-    DirectionalMaterialLawParams() : materialLawParamsX_{}, materialLawParamsY_{}, materialLawParamsZ_{} {}
-    DirectionalMaterialLawParams(std::size_t size) :
-        materialLawParamsX_(size), materialLawParamsY_(size), materialLawParamsZ_(size) {}
-    vector_type& getArray(int index) {
+    DirectionalMaterialLawParams()
+        : materialLawParamsX_{}
+        , materialLawParamsY_{}
+        , materialLawParamsZ_{}
+    {}
+
+    DirectionalMaterialLawParams(std::size_t size)
+        : materialLawParamsX_(size)
+        , materialLawParamsY_(size)
+        , materialLawParamsZ_(size)
+    {}
+
+    vector_type& getArray(int index)
+    {
         switch(index) {
             case 0:
                 return materialLawParamsX_;
@@ -46,9 +58,12 @@ struct DirectionalMaterialLawParams {
                 throw std::runtime_error("Unexpected mobility array index");
         }
     }
+
     vector_type materialLawParamsX_;
     vector_type materialLawParamsY_;
     vector_type materialLawParamsZ_;
 };
+
 } // namespace Opm
+
 #endif

--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterialParams.hpp
@@ -127,6 +127,15 @@ public:
     bool inconsistentHysteresisUpdate() const
     { return true; }
 
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        // This is for restart serialization.
+        // Only dynamic state in the parameters need to be stored.
+        serializer(*gasOilParams_);
+        serializer(*oilWaterParams_);
+    }
+
 private:
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -71,6 +71,19 @@ public:
         // deltaSwImbKrw_ = 0.0;
     }
 
+    static EclHysteresisTwoPhaseLawParams serializationTestObject()
+    {
+        EclHysteresisTwoPhaseLawParams<EffLawT> result;
+        result.deltaSwImbKrn_ = 1.0;
+        result.Sncrt_ = 2.0;
+        result.initialImb_ = true;
+        result.pcSwMic_ = 3.0;
+        result.krnSwMdc_ = 4.0;
+        result.KrndHy_ = 5.0;
+
+        return result;
+    }
+
     /*!
      * \brief Calculate all dependent quantities once the independent
      *        quantities of the parameter object have been set.
@@ -376,6 +389,28 @@ public:
 
         if (updateParams)
             updateDynamicParams_();
+    }
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        // only serializes dynamic state - see update() and updateDynamic_()
+        serializer(deltaSwImbKrn_);
+        serializer(Sncrt_);
+        serializer(initialImb_);
+        serializer(pcSwMic_);
+        serializer(krnSwMdc_);
+        serializer(KrndHy_);
+    }
+
+    bool operator==(const EclHysteresisTwoPhaseLawParams& rhs) const
+    {
+        return this->deltaSwImbKrn_ == rhs.deltaSwImbKrn_ &&
+               this->Sncrt_ == rhs.Sncrt_ &&
+               this->initialImb_ == rhs.initialImb_ &&
+               this->pcSwMic_ == rhs.pcSwMic_ &&
+               this->krnSwMdc_ == rhs.krnSwMdc_ &&
+               this->KrndHy_ == rhs.KrndHy_;
     }
 
 private:

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -27,14 +27,14 @@
 #ifndef OPM_ECL_HYSTERESIS_TWO_PHASE_LAW_PARAMS_HPP
 #define OPM_ECL_HYSTERESIS_TWO_PHASE_LAW_PARAMS_HPP
 
-#include "EclHysteresisConfig.hpp"
-#include "EclEpsScalingPoints.hpp"
+#include <opm/material/common/EnsureFinalized.hpp>
+#include <opm/material/fluidmatrixinteractions/EclEpsConfig.hpp>
+#include <opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp>
+#include <opm/material/fluidmatrixinteractions/EclHysteresisConfig.hpp>
 
 #include <cassert>
 #include <cmath>
 #include <memory>
-
-#include <opm/material/common/EnsureFinalized.hpp>
 
 namespace Opm {
 /*!

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -51,6 +51,7 @@ namespace Opm {
 
 class EclipseState;
 class EclEpsConfig;
+class EclEpsGridProperties;
 template<class Scalar> class EclEpsScalingPoints;
 template<class Scalar> struct EclEpsScalingPointsInfo;
 class EclHysteresisConfig;
@@ -349,6 +350,18 @@ public:
 
     const EclEpsScalingPointsInfo<Scalar>& oilWaterScaledEpsInfoDrainage(size_t elemIdx) const
     { return oilWaterScaledEpsInfoDrainage_[elemIdx]; }
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        // This is for restart serialization.
+        // Only dynamic state in the parameters need to be stored.
+        // For that reason we do not serialize the vector
+        // as that would recreate the objects inside.
+        for (auto& mat : materialLawParams_) {
+            serializer(mat);
+        }
+    }
 
 private:
     const MaterialLawParams& materialLawParamsFunc_(unsigned elemIdx, FaceDir::DirEnum facedir) const;

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterialParams.hpp
@@ -204,6 +204,32 @@ public:
         return this->template castTo<TwoPhaseParams>();
     }
 
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        switch (approach()) {
+        case EclMultiplexerApproach::Stone1:
+            serializer(castTo<Stone1Params>());
+            break;
+
+        case EclMultiplexerApproach::Stone2:
+            serializer(castTo<Stone2Params>());
+            break;
+
+        case EclMultiplexerApproach::Default:
+            serializer(castTo<DefaultParams>());
+            break;
+
+        case EclMultiplexerApproach::TwoPhase:
+            serializer(castTo<TwoPhaseParams>());
+            break;
+
+        case EclMultiplexerApproach::OnePhase:
+            // Do nothing, no parameters.
+            break;
+        }
+    }
+
 private:
     template <class ParamT>
     ParamT& castTo()

--- a/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone1MaterialParams.hpp
@@ -143,6 +143,13 @@ public:
     Scalar eta() const
     { EnsureFinalized::check(); return eta_; }
 
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(*gasOilParams_);
+        serializer(*oilWaterParams_);
+    }
+
 private:
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;

--- a/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2MaterialParams.hpp
@@ -115,6 +115,15 @@ public:
     Scalar Swl() const
     { EnsureFinalized::check(); return Swl_; }
 
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        // This is for restart serialization.
+        // Only dynamic state in the parameters need to be stored.
+        serializer(*gasOilParams_);
+        serializer(*oilWaterParams_);
+    }
+
 private:
     std::shared_ptr<GasOilParams> gasOilParams_;
     std::shared_ptr<OilWaterParams> oilWaterParams_;

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -124,6 +124,16 @@ public:
      */
     void setGasWaterParams(std::shared_ptr<GasWaterParams> val)
     { gasWaterParams_ = val; }
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        // This is for restart serialization.
+        // Only dynamic state in the parameters need to be stored.
+        serializer(*gasOilParams_);
+        serializer(*oilWaterParams_);
+        serializer(*gasWaterParams_);
+    }
     
 private:
     EclTwoPhaseApproach approach_;

--- a/opm/material/fluidmatrixinteractions/SatCurveMultiplexerParams.hpp
+++ b/opm/material/fluidmatrixinteractions/SatCurveMultiplexerParams.hpp
@@ -155,6 +155,20 @@ public:
         return this->template castTo<PLParams>();
     }
 
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        switch (approach()) {
+        case SatCurveMultiplexerApproach::LET:
+            serializer(castTo<LETParams>());
+            break;
+
+        case SatCurveMultiplexerApproach::PiecewiseLinear:
+            serializer(castTo<PLParams>());
+            break;
+        }
+    }
+
 private:
     template <class ParamT>
     ParamT& castTo()


### PR DESCRIPTION
These need to be stored or restart won't be 'perfect'.