### PR TITLE
Fixing the broken build in macOS

### DIFF
--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
@@ -300,8 +300,8 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
 
     case SatFuncControls::KeywordFamily::Family_III:
     {
-        const GsfTable& gsfTable = tableManager.getGsfTables().getTable<GsfTable>( satRegionIdx );
-        const WsfTable& wsfTable = tableManager.getWsfTables().getTable<WsfTable>( satRegionIdx );
+        const GsfTable& gsfTable = tableManager.getGsfTables().template getTable<GsfTable>( satRegionIdx );
+        const WsfTable& wsfTable = tableManager.getWsfTables().template getTable<WsfTable>( satRegionIdx );
 
         effParams.setApproach(SatCurveMultiplexerApproach::PiecewiseLinear);
         auto& realParams = effParams.template getRealParams<SatCurveMultiplexerApproach::PiecewiseLinear>();


### PR DESCRIPTION
```
/Users/dmar/Github/opm/opm-common/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp:303:64: error: use 'template' keyword to treat 'getTable' as a dependent template name
        const GsfTable& gsfTable = tableManager.getGsfTables().getTable<GsfTable>( satRegionIdx );
                                                               ^
                                                               template 
/Users/dmar/Github/opm/opm-common/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp:304:64: error: use 'template' keyword to treat 'getTable' as a dependent template name
        const WsfTable& wsfTable = tableManager.getWsfTables().getTable<WsfTable>( satRegionIdx );
                                                               ^
                                                               template
```