### PR TITLE
added: getInputDir in IOConfig

### DIFF
--- a/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -182,6 +182,8 @@ namespace Opm {
         /// i.e. /path/to/sim/CASE
         std::string fullBasePath( ) const;
 
+        std::string getInputDir() const;
+
         bool initOnly() const;
 
         bool operator==(const IOConfig& data) const;

--- a/src/opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -239,12 +239,21 @@ namespace Opm {
         return m_output_enabled;
     }
 
-    void IOConfig::setOutputEnabled(bool enabled){
+    void IOConfig::setOutputEnabled(bool enabled) {
         m_output_enabled = enabled;
     }
 
     std::string IOConfig::getOutputDir() const {
         return m_output_dir;
+    }
+
+    std::string IOConfig::getInputDir() const {
+        std::filesystem::path path(m_deck_filename);
+        if (path.has_parent_path()) {
+            return path.parent_path();
+        } else {
+            return std::filesystem::current_path();
+        }
     }
 
     void IOConfig::setOutputDir(const std::string& outputDir) {


### PR DESCRIPTION
returns the input directory

I couldn't find this recorded anywhere else (only in the deck). Please feel free to correct me if I missed something.