### PR TITLE
split out timing macros to separate header

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -691,6 +691,7 @@ endif()
 list( APPEND PUBLIC_HEADER_FILES
       opm/common/ErrorMacros.hpp
       opm/common/Exceptions.hpp
+      opm/common/TimingMacros.hpp
       opm/common/OpmLog/CounterLog.hpp
       opm/common/OpmLog/EclipsePRTLog.hpp
       opm/common/OpmLog/LogBackend.hpp

--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -40,20 +40,6 @@
 # define OPM_MESSAGE_IF(cond, m) do {} while (false)
 #endif
 
-// macros used to time blocks for example with tracy
-// time block of main part of codes which do not effect performance
-#ifndef OPM_TIMEBLOCK
-#define OPM_TIMEBLOCK(x)\
-    do { /* nothing */ } while (false)
-#endif
-
-// detailed timing which may effect performance
-#ifndef OPM_TIMEBLOCK_LOCAL
-#define OPM_TIMEBLOCK_LOCAL(x)\
-    do { /* nothing */ } while (false)
-#endif
-
-
 // Macro to throw an exception. NOTE: For this macro to work, the
 // exception class must exhibit a constructor with the signature
 // (const std::string &message). Since this condition is not fulfilled

--- a/opm/common/TimingMacros.hpp
+++ b/opm/common/TimingMacros.hpp
@@ -1,0 +1,35 @@
+/*
+  Copyright 2023 SINTEF Digital
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef OPM_TIMINGMACROS_HPP
+#define OPM_TIMINGMACROS_HPP
+
+// macros used to time blocks for example with tracy
+// time block of main part of codes which do not effect performance
+#ifndef OPM_TIMEBLOCK
+#define OPM_TIMEBLOCK(x)\
+    do { /* nothing */ } while (false)
+#endif
+
+// detailed timing which may effect performance
+#ifndef OPM_TIMEBLOCK_LOCAL
+#define OPM_TIMEBLOCK_LOCAL(x)\
+    do { /* nothing */ } while (false)
+#endif
+
+#endif // OPM_TIMINGMACROS_HPP

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -26,12 +26,14 @@
  */
 #ifndef OPM_ECL_MULTIPLEXER_MATERIAL_HPP
 #define OPM_ECL_MULTIPLEXER_MATERIAL_HPP
-#include <opm/common/ErrorMacros.hpp>
+
 #include "EclMultiplexerMaterialParams.hpp"
 #include "EclDefaultMaterial.hpp"
 #include "EclStone1Material.hpp"
 #include "EclStone2Material.hpp"
 #include "EclTwoPhaseMaterial.hpp"
+
+#include <opm/common/TimingMacros.hpp>
 
 #include <algorithm>
 #include <stdexcept>

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -26,12 +26,14 @@
  */
 #ifndef OPM_BLACK_OIL_FLUID_SYSTEM_HPP
 #define OPM_BLACK_OIL_FLUID_SYSTEM_HPP
-#include <opm/common/ErrorMacros.hpp>
+
 #include "BlackOilDefaultIndexTraits.hpp"
 #include "blackoilpvt/OilPvtMultiplexer.hpp"
 #include "blackoilpvt/GasPvtMultiplexer.hpp"
 #include "blackoilpvt/WaterPvtMultiplexer.hpp"
 #include "blackoilpvt/BrineCo2Pvt.hpp"
+
+#include <opm/common/TimingMacros.hpp>
 
 #include <opm/material/fluidsystems/BaseFluidSystem.hpp>
 #include <opm/material/Constants.hpp>

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -24,6 +24,7 @@
 #include <config.h>
 #include <opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp>
 
+#include <opm/common/TimingMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>

--- a/tests/material/test_fluidmatrixinteractions.cpp
+++ b/tests/material/test_fluidmatrixinteractions.cpp
@@ -29,6 +29,8 @@
  */
 #include "config.h"
 
+#include <opm/common/TimingMacros.hpp>
+
 // include the local AD framwork
 #include <opm/material/densead/Math.hpp>
 


### PR DESCRIPTION
My OCD twitched. Separation of concerns, no reason to pull in strings, exceptions, logging.