### PR TITLE
fixed: disable python SIGINT signal handler for the embedded interpreter

### DIFF
--- a/src/opm/input/eclipse/Python/PythonInterp.cpp
+++ b/src/opm/input/eclipse/Python/PythonInterp.cpp
@@ -82,6 +82,8 @@ PythonInterp::PythonInterp(bool enable) {
             throw std::logic_error("An instance of the Python interpreter is already running");
 
         this->guard = std::make_unique<py::scoped_interpreter>();
+        py::exec(R"~~(import signal
+signal.signal(signal.SIGINT, signal.SIG_DFL))~~");
     }
 }
 


### PR DESCRIPTION
This restores the ability to stop the simulator using ctrl-c when compiled with PyAction support.