### PR TITLE
Preserve SCHEDULE Section AQUFLUX Objects Across Report Steps

### DIFF
--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -137,8 +137,8 @@ namespace {
         // auto& aqufluxs = this->snapshots.back().aqufluxs;
         auto& aqufluxs = this->snapshots.back().aqufluxs;
         for (const auto& record : handlerContext.keyword) {
-            SingleAquiferFlux aquifer(record);
-            aqufluxs.insert({aquifer.id, aquifer});
+            const auto aquifer = SingleAquiferFlux { record };
+            aqufluxs.insert_or_assign(aquifer.id, aquifer);
         }
     }
 

--- a/src/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/src/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -115,7 +115,6 @@ ScheduleState::ScheduleState(const ScheduleState& src, const time_point& start_t
     this->m_wellgroup_events.reset();
     this->m_geo_keywords.clear();
     this->target_wellpi.clear();
-    this->aqufluxs.clear();
     this->m_save_step = false;
 
     auto next_rft = this->rft_config().next();


### PR DESCRIPTION
This is in preparation of adding support for writing those objects to the restart file.  We need a consistent view of active aquifers for that purpose.