### PR TITLE
fix cap-press GSF

### DIFF
--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerReadEffectiveParams.cpp
@@ -314,9 +314,7 @@ readGasWaterParameters_(GasWaterEffectiveParamVector& dest, unsigned satRegionId
             SwSamples[sampleIdx] = 1 - gsfTable.get("SG", sampleIdx);
         realParams.setKrnSamples(SwSamples, normalizeKrValues_(tolcrit, gsfTable.getColumn("KRG")));
         //Capillary pressure is read from GSF.
-        // TODO need to check if gas/water sg
-        std::vector<double> SgColumn = gsfTable.getColumn("SG").vectorCopy();
-        realParams.setPcnwSamples(SgColumn, gsfTable.getColumn("PCGW").vectorCopy());
+        realParams.setPcnwSamples(SwSamples, gsfTable.getColumn("PCGW").vectorCopy());
         realParams.finalize();
 
         break;


### PR DESCRIPTION
```C++
// TODO need to check if gas/water sg
```
I have done the check and indeed the first implementation was wrong...