### PR TITLE
Using PVTNUM as the default ROCKNUM

### DIFF
--- a/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
@@ -87,7 +87,7 @@ struct RockComp {
 private:
     bool m_active = false;
     std::vector<RockComp> m_comp;
-    std::string num_property;
+    std::string num_property = "PVTNUM";
     std::size_t num_tables = 0;
     bool m_water_compaction = false;
     Hysteresis hyst_mode = Hysteresis::REVERS;


### PR DESCRIPTION
This change ensures that PVTNUM is used as the default for lookup of properties from the ROCK keyword (i.e., in case there is no other region specified in ROCKOPTS item 3). 

A test case is added here: https://github.com/OPM/opm-tests/pull/916 (results vs. reference tool shown below).

![image](https://user-images.githubusercontent.com/2436155/223183243-5e3d7049-2c83-4ec4-a389-39e8fc32943e.png)
