### PR TITLE
In WCONHIST, use STOP status when all rates are zero.

### DIFF
--- a/opm/input/eclipse/Deck/UDAValue.hpp
+++ b/opm/input/eclipse/Deck/UDAValue.hpp
@@ -65,7 +65,11 @@ public:
       The getSI() can only be called for numerical values.
     */
     double getSI() const;
-    bool zero() const;
+
+    /*
+      Return true if and only if the type is numeric, and that numeric value is 0.0.
+    */
+    bool isZero() const;
 
     //epsilon limit  = 1.E-20  (~= 0.)
     double epsilonLimit() const;

--- a/src/opm/input/eclipse/Deck/UDAValue.cpp
+++ b/src/opm/input/eclipse/Deck/UDAValue.cpp
@@ -135,9 +135,8 @@ std::string UDAValue::get() const {
     throw std::invalid_argument("UDAValue does not hold a string value");
 }
 
-bool UDAValue::zero() const {
-    this->assert_numeric();
-    return (this->double_value == 0.0);
+bool UDAValue::isZero() const {
+    return this->numeric_value && this->double_value == 0.0;
 }
 
 const Dimension& UDAValue::get_dim() const {

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1376,13 +1376,13 @@ bool Well::canOpen() const {
         if (prod.WaterRate.is<std::string>())
           return true;
 
-        if (!prod.OilRate.zero())
+        if (!prod.OilRate.isZero())
             return true;
 
-        if (!prod.GasRate.zero())
+        if (!prod.GasRate.isZero())
             return true;
 
-        if (!prod.WaterRate.zero())
+        if (!prod.WaterRate.isZero())
             return true;
 
         return false;
@@ -1391,7 +1391,7 @@ bool Well::canOpen() const {
         if (inj.surfaceInjectionRate.is<std::string>())
             return true;
 
-        return !inj.surfaceInjectionRate.zero();
+        return !inj.surfaceInjectionRate.isZero();
     }
 }
 

--- a/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -182,7 +182,7 @@ namespace Opm {
             if( !record.getItem( cmode.first ).defaultApplied( 0 ) ) {
 
                 // a zero value THP limit will not be handled as a THP limit
-                if (cmode.first == "THP" && this->THPTarget.is<double>() && this->THPTarget.zero())
+                if (cmode.first == "THP" && this->THPTarget.isZero())
                     continue;
 
                 this->addProductionControl( cmode.second );


### PR DESCRIPTION
This makes the simulator behave better and stabler when encountering things like this in the Norne deck:
```
WCONHIST
     'C-4H'      'OPEN'      'ORAT'      0.000      0.000      0.000  5* /
```
by treating it as 'STOP' rather than 'OPEN'.

The modification of `UDAValue::zero()` should be fine, as it does not change the semantics for the `true` case. Without the modification, you cannot call zero() and expect it to not throw, as the UDAValue could be a user defined variable (name stored in a string, instead of value stored in a double).

@GitPaean @vkip I think you have cases where this could help.