### PR TITLE
Load Constant Flux Aquifer Objects from Restart File

### DIFF
--- a/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.hpp
+++ b/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.hpp
@@ -30,9 +30,9 @@ namespace Opm {
     class DeckRecord;
 }
 
-namespace Opm::RestartIO {
-        class RstAquifer;
-} // Opm::RestartIO
+namespace Opm { namespace RestartIO {
+    class RstAquifer;
+}} // Opm::RestartIO
 
 namespace  Opm {
     struct SingleAquiferFlux

--- a/opm/io/eclipse/rst/aquifer.hpp
+++ b/opm/io/eclipse/rst/aquifer.hpp
@@ -77,6 +77,12 @@ namespace Opm { namespace RestartIO {
             double time_constant{};
         };
 
+        struct ConstantFlux {
+            int aquiferID{};
+
+            double flow_rate{};
+        };
+
         class Connections {
         public:
             struct Cell {
@@ -120,6 +126,7 @@ namespace Opm { namespace RestartIO {
         bool hasAnalyticAquifers() const;
 
         const std::vector<CarterTracy>&             carterTracy() const;
+        const std::vector<ConstantFlux>&            constantFlux() const;
         const std::vector<Fetkovich>&               fetkovich() const;
         const std::unordered_map<int, Connections>& connections() const;
 
@@ -127,6 +134,7 @@ namespace Opm { namespace RestartIO {
         class Implementation;
         std::unique_ptr<Implementation> pImpl_;
     };
+
 }} // Opm::RestartIO
 
 #endif  // OPM_RESTART_AQUIFER_HPP

--- a/opm/output/data/Aquifer.hpp
+++ b/opm/output/data/Aquifer.hpp
@@ -33,7 +33,7 @@ namespace Opm { namespace data {
 
     enum class AquiferType
     {
-        Fetkovich, CarterTracy, Numerical,
+        Fetkovich, CarterTracy, ConstantFlux, Numerical,
     };
 
     struct FetkovichData

--- a/src/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/AquiferFlux.cpp
@@ -116,7 +116,8 @@ namespace Opm {
     }
 
     void AquiferFlux::loadFromRestart(const RestartIO::RstAquifer&) {
-        // TODO: adding the restart functionality
+        // Constant flux aquifer objects loaded from restart file added to
+        // Schedule only.
     }
 
     AquiferFlux AquiferFlux::serializationTestObject() {

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1745,7 +1745,10 @@ namespace {
     }
 }
 
-    void Schedule::load_rst(const RestartIO::RstState& rst_state, const TracerConfig& tracer_config, const ScheduleGrid& grid, const FieldPropsManager& fp)
+    void Schedule::load_rst(const RestartIO::RstState& rst_state,
+                            const TracerConfig&        tracer_config,
+                            const ScheduleGrid&        grid,
+                            const FieldPropsManager&   fp)
     {
         const auto report_step = rst_state.header.report_step - 1;
         double udq_undefined = 0;
@@ -1916,6 +1919,15 @@ namespace {
         this->snapshots.back().wtest_config.update( WellTestConfig{rst_state, report_step});
 
         this->snapshots.back().network_balance.update(Network::Balance { rst_state.netbalan });
+
+        for (const auto& aquflux : rst_state.aquifers.constantFlux()) {
+            auto aqPos =  this->snapshots.back().aqufluxs
+                .insert_or_assign(aquflux.aquiferID,
+                                  SingleAquiferFlux { aquflux.aquiferID });
+
+            aqPos.first->second.flux = aquflux.flow_rate;
+            aqPos.first->second.active = true;
+        }
 
         if (!rst_state.wlists.empty())
             this->snapshots.back().wlist_manager.update( WListManager(rst_state) );

--- a/src/opm/output/eclipse/LoadRestart.cpp
+++ b/src/opm/output/eclipse/LoadRestart.cpp
@@ -1316,19 +1316,20 @@ namespace {
     Opm::data::AquiferType
     determineAquiferType(const AquiferVectors::Window<int>& iaaq)
     {
-        const auto t1 = iaaq[VI::IAnalyticAquifer::TypeRelated1];
+        using MType = Opm::RestartIO::Helpers::VectorItems::
+            IAnalyticAquifer::Value::ModelType;
 
-        if (t1 == 1) {
-            return Opm::data::AquiferType::CarterTracy;
-        }
+        using AType = Opm::data::AquiferType;
 
-        if (t1 == 0) {
-            return Opm::data::AquiferType::Fetkovich;
+        switch (iaaq[VI::IAnalyticAquifer::TypeRelated1]) {
+        case MType::Fetkovich:    return AType::Fetkovich;
+        case MType::CarterTracy:  return AType::CarterTracy;
+        case MType::ConstantFlux: return AType::ConstantFlux;
         }
 
         throw std::runtime_error {
-            "Unknown Aquifer Type:"
-            " T1 = "  + std::to_string(t1)
+            "Unknown Aquifer Type: T1 = " +
+            std::to_string(iaaq[VI::IAnalyticAquifer::TypeRelated1])
         };
     }
 


### PR DESCRIPTION
This PR adds logic and structures for bringing in constant flux aquifer objects&mdash;keyword `AQUFLUX`&mdash;from the restart file and forming the requisite dynamic objects in the `Schedule`.

In particular, the `RstAquifer` gets a new bare-bones representation of these aquifer types and we add new constant flux aquifer objects to the pertinent `ScheduleState` when these exist.  We also add this aquifer type to `data::Aquifers` in preparation of reinitialising the simulator's aquifer container from the restart file.  In particular, this needs the total produced volume from the aquifer so far.