### PR TITLE
fix to broken built with clang

### DIFF
--- a/src/opm/output/eclipse/ActiveIndexByColumns.cpp
+++ b/src/opm/output/eclipse/ActiveIndexByColumns.cpp
@@ -82,10 +82,10 @@ namespace {
     {
         auto colGlobIx = activeCells;
 
-        const auto [outer, middle] = inferOuterLoopOrdering(cartDims);
+        const auto& [outer, middle] = inferOuterLoopOrdering(cartDims);
 
         std::transform(colGlobIx.begin(), colGlobIx.end(), colGlobIx.begin(),
-                       [&cartDims, &getIJK, outer, middle]
+                       [&cartDims, &getIJK, outer=outer, middle=middle]
             (const std::size_t cell)
         {
             return columnarGlobalIdx(cartDims, getIJK(cell), outer, middle);


### PR DESCRIPTION
This commit fixes the current broken built in clang
```
[ 15%] Building CXX object CMakeFiles/opmcommon.dir/src/opm/output/eclipse/AggregateGroupData.cpp.o
/Users/dmar/Github/opm/opm-common/src/opm/output/eclipse/ActiveIndexByColumns.cpp:88:45: error: 'outer' in capture list does not name a variable
                       [&cartDims, &getIJK, outer, middle]
                                            ^
```