### PR TITLE
Restore Builds With Dune in Non-Default Installed Locations

### DIFF
--- a/opm/material/common/quad.hpp
+++ b/opm/material/common/quad.hpp
@@ -336,6 +336,8 @@ inline bool isinf(quad val)
 
 } // namespace std
 
+#if HAVE_DUNE_COMMON
+
 // specialize Dune::className for __float128 since it former does not work properly with
 // __float128 (this is mainly the fault of GCC/libstdc++)
 #include <dune/common/classname.hh>
@@ -345,6 +347,8 @@ template <>
 inline std::string className<__float128>()
 { return "quad"; }
 } // namespace Dune
+
+#endif // HAVE_DUNE_COMMON
 
 #if HAVE_DUNE_FEM
 #include <dune/fem/io/streams/streams_inline.hh>


### PR DESCRIPTION
In general we'd need to link to dune-common (`target_link_library`) to get the appropriate include directories for Dune in that case, but in this specific instance we can get by with not specialising Dune's `className` function if Dune is not available.

Thanks to [at]akva2 for suggesting this workaround.