### PR TITLE
Support DIFFCGAS and DIFFCWAT for the CO2STORE module

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -191,6 +191,63 @@ struct DiffCoeffTable : public FlatTable< DiffCoeffRecord > {
     }
 };
 
+
+struct DiffCoeffWatRecord {
+    static constexpr std::size_t size = 2;
+
+    // hardcoded to 2 components
+    double co2_in_water;
+    double h2o_in_water;
+
+    bool operator==(const DiffCoeffWatRecord& data) const {
+        return co2_in_water == data.co2_in_water &&
+               h2o_in_water == data.h2o_in_water;}
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(co2_in_water);
+        serializer(h2o_in_water);
+    }
+};
+
+struct DiffCoeffWatTable : public FlatTable< DiffCoeffWatRecord > {
+    using FlatTable< DiffCoeffWatRecord >::FlatTable;
+
+    static DiffCoeffWatTable serializationTestObject()
+    {
+        return DiffCoeffWatTable({{1.0, 2.0}});
+    }
+};
+
+struct DiffCoeffGasRecord {
+    static constexpr std::size_t size = 2;
+
+    // hardcoded to 2 components
+    double co2_in_gas;
+    double h2o_in_gas;
+
+    bool operator==(const DiffCoeffGasRecord& data) const {
+        return co2_in_gas == data.co2_in_gas &&
+               h2o_in_gas == data.h2o_in_gas;}
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(co2_in_gas);
+        serializer(h2o_in_gas);
+    }
+};
+
+struct DiffCoeffGasTable : public FlatTable< DiffCoeffGasRecord > {
+    using FlatTable< DiffCoeffGasRecord >::FlatTable;
+
+    static DiffCoeffGasTable serializationTestObject()
+    {
+        return DiffCoeffGasTable({{1.0, 2.0}});
+    }
+};
+
 struct PVTWRecord {
     static constexpr std::size_t size = 5;
 

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
@@ -164,6 +164,8 @@ namespace Opm {
         const PvcdoTable& getPvcdoTable() const;
         const DensityTable& getDensityTable() const;
         const DiffCoeffTable& getDiffusionCoefficientTable() const;
+        const DiffCoeffWatTable& getDiffusionCoefficientWaterTable() const;
+        const DiffCoeffGasTable& getDiffusionCoefficientGasTable() const;
         const PlyvmhTable& getPlyvmhTable() const;
         const RockTable& getRockTable() const;
         const ViscrefTable& getViscrefTable() const;
@@ -220,6 +222,8 @@ namespace Opm {
             serializer(m_pvcdoTable);
             serializer(m_densityTable);
             serializer(m_diffCoeffTable);
+            serializer(m_diffCoeffWatTable);
+            serializer(m_diffCoeffGasTable);
             serializer(m_plyvmhTable);
             serializer(m_rockTable);
             serializer(m_plmixparTable);
@@ -364,6 +368,8 @@ namespace Opm {
         PvcdoTable m_pvcdoTable;
         DensityTable m_densityTable;
         DiffCoeffTable m_diffCoeffTable;
+        DiffCoeffWatTable m_diffCoeffWatTable;
+        DiffCoeffGasTable m_diffCoeffGasTable;
         PlyvmhTable m_plyvmhTable;
         RockTable m_rockTable;
         PlmixparTable m_plmixparTable;

--- a/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -175,6 +175,12 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         if( deck.hasKeyword( "DIFFC" ) )
             this->m_diffCoeffTable = DiffCoeffTable( deck["DIFFC"].back() );
 
+        if( deck.hasKeyword( "DIFFCWAT" ) )
+            this->m_diffCoeffWatTable = DiffCoeffWatTable( deck["DIFFCWAT"].back() );
+
+        if( deck.hasKeyword( "DIFFCGAS" ) )
+            this->m_diffCoeffGasTable = DiffCoeffGasTable( deck["DIFFCGAS"].back() );
+
         if( deck.hasKeyword( "ROCK" ) )
             this->m_rockTable = RockTable( deck["ROCK"].back() );
 
@@ -279,6 +285,8 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         result.m_pvcdoTable = PvcdoTable::serializationTestObject();
         result.m_densityTable = DensityTable::serializationTestObject();
         result.m_diffCoeffTable = DiffCoeffTable::serializationTestObject();
+        result.m_diffCoeffWatTable = DiffCoeffWatTable::serializationTestObject();
+        result.m_diffCoeffGasTable = DiffCoeffGasTable::serializationTestObject();
         result.m_plyvmhTable = PlyvmhTable::serializationTestObject();
         result.m_rockTable = RockTable::serializationTestObject();
         result.m_plmixparTable = PlmixparTable::serializationTestObject();
@@ -1130,6 +1138,14 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         return this->m_diffCoeffTable;
     }
 
+    const DiffCoeffWatTable& TableManager::getDiffusionCoefficientWaterTable() const {
+        return this->m_diffCoeffWatTable;
+    }
+
+    const DiffCoeffGasTable& TableManager::getDiffusionCoefficientGasTable() const {
+        return this->m_diffCoeffGasTable;
+    }
+
     const RockTable& TableManager::getRockTable() const {
         return this->m_rockTable;
     }
@@ -1268,6 +1284,8 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
                m_pvcdoTable == data.m_pvcdoTable &&
                m_densityTable == data.m_densityTable &&
                m_diffCoeffTable == data.m_diffCoeffTable &&
+               m_diffCoeffWatTable == data.m_diffCoeffWatTable &&
+               m_diffCoeffGasTable == data.m_diffCoeffGasTable &&
                m_plmixparTable == data.m_plmixparTable &&
                m_plyvmhTable == data.m_plyvmhTable &&
                m_shrateTable == data.m_shrateTable &&

--- a/src/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -2198,6 +2198,8 @@ FlatTable<T>::FlatTable(const DeckKeyword& kw)
 }
 
 template FlatTable<DiffCoeffRecord>::FlatTable(const DeckKeyword&);
+template FlatTable<DiffCoeffWatRecord>::FlatTable(const DeckKeyword&);
+template FlatTable<DiffCoeffGasRecord>::FlatTable(const DeckKeyword&);
 template FlatTable<PVCDORecord>::FlatTable(const DeckKeyword&);
 template FlatTable<ROCKRecord>::FlatTable(const DeckKeyword&);
 template FlatTable<PlyvmhRecord>::FlatTable(const DeckKeyword&);

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFCGAS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFCGAS
@@ -1,0 +1,23 @@
+{
+  "name": "DIFFCGAS",
+  "comment": "Hardcoded two components.",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NTPVT"
+  },
+  "items": [
+  {
+    "name": "CO2_IN_GAS",
+    "value_type": "DOUBLE",
+    "dimension": "Length*Length/Time"
+  },
+  {
+    "name": "H20_IN_GAS",
+    "value_type": "DOUBLE",
+    "dimension": "Length*Length/Time"
+  }
+]
+}

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFCWAT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFCWAT
@@ -1,0 +1,23 @@
+{
+  "name": "DIFFCWAT",
+  "comment": "Hardcoded two components.",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NTPVT"
+  },
+  "items": [
+  {
+    "name": "CO2_IN_WATER",
+    "value_type": "DOUBLE",
+    "dimension": "Length*Length/Time"
+  },
+  {
+    "name": "H20_IN_WATER",
+    "value_type": "DOUBLE",
+    "dimension": "Length*Length/Time"
+  }
+  ]
+}

--- a/src/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1052,6 +1052,8 @@ set( keywords
      001_Eclipse300/C/CO2STORE
      001_Eclipse300/C/CREF
      001_Eclipse300/C/CREFS
+     001_Eclipse300/D/DIFFCGAS
+     001_Eclipse300/D/DIFFCWAT
      001_Eclipse300/D/DREF
      001_Eclipse300/D/DREFS
      001_Eclipse300/D/DZV

--- a/src/opm/material/fluidsystems/BlackOilFluidSystem.cpp
+++ b/src/opm/material/fluidsystems/BlackOilFluidSystem.cpp
@@ -159,6 +159,29 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
                               "or set it to zero.");
                 }
             }
+        } else if ( eclState.runspec().co2Storage()
+                && eclState.runspec().phases().active(Phase::GAS)
+                && eclState.runspec().phases().active(Phase::WATER))
+        {
+            diffusionCoefficients_.resize(numRegions,{0,0,0,0,0,0,0,0,0});
+            // diffusion coefficients can be set using DIFFCGAS and DIFFCWAT
+            // for CO2STORE cases with gas + water
+            const auto& diffCoeffWatTables = eclState.getTableManager().getDiffusionCoefficientWaterTable();
+            if (!diffCoeffWatTables.empty()) {
+                for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+                    const auto& diffCoeffWatTable = diffCoeffWatTables[regionIdx];
+                    setDiffusionCoefficient(diffCoeffWatTable.co2_in_water, gasCompIdx, waterPhaseIdx, regionIdx);
+                    setDiffusionCoefficient(diffCoeffWatTable.h2o_in_water, waterCompIdx, waterPhaseIdx, regionIdx);
+                }
+            }
+            const auto& diffCoeffGasTables = eclState.getTableManager().getDiffusionCoefficientGasTable();
+            if (!diffCoeffGasTables.empty()) {
+                for (unsigned regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+                    const auto& diffCoeffGasTable = diffCoeffGasTables[regionIdx];
+                    setDiffusionCoefficient(diffCoeffGasTable.co2_in_gas, gasCompIdx, gasPhaseIdx, regionIdx);
+                    setDiffusionCoefficient(diffCoeffGasTable.h2o_in_gas, waterCompIdx, gasPhaseIdx, regionIdx);
+                }
+            }
         }
     }
 }

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -2346,6 +2346,34 @@ BOOST_AUTO_TEST_CASE( TestParseDIFFC ) {
     BOOST_CHECK_CLOSE( 1.8, diffc[0].oil_in_oil_cross_phase*conversion_factor, epsilon() );
 }
 
+
+BOOST_AUTO_TEST_CASE( TestParseDIFFCWATGAS ) {
+    const std::string data = R"(
+      TABDIMS
+        1* 1 /
+
+      DIFFCWAT
+        1.1 1.2 /
+
+      DIFFCGAS
+        1.3 1.4 /
+    )";
+
+    Opm::Parser parser;
+    auto deck = parser.parseString(data);
+    Opm::TableManager tables( deck );
+    double conversion_factor = (60*60*24);
+
+    const auto& diffcwat = tables.getDiffusionCoefficientWaterTable();
+    BOOST_CHECK_CLOSE( 1.1, diffcwat[0].co2_in_water*conversion_factor, epsilon() );
+    BOOST_CHECK_CLOSE( 1.2, diffcwat[0].h2o_in_water*conversion_factor, epsilon());
+
+    const auto& diffcgas = tables.getDiffusionCoefficientGasTable();
+    BOOST_CHECK_CLOSE( 1.3, diffcgas[0].co2_in_gas*conversion_factor, epsilon() );
+    BOOST_CHECK_CLOSE( 1.4, diffcgas[0].h2o_in_gas*conversion_factor, epsilon() );
+}
+
+
 BOOST_AUTO_TEST_CASE( TestParseROCK ) {
     const std::string data = R"(
       TABDIMS


### PR DESCRIPTION
This make it possible to specify diffusion coefficients for CO2STORE cases using the DIFFCGAS and DIFFCWAT keywords for gas-water cases. For gas-oil + co2store you will still need to use the DIFFC keywords. Note that if neither of these keywords are used by DIFFUSE is active the simulator will use default values computed based on temperature and pressure in the reservoir using correlation in the literature. 