### PR TITLE
EclipseGrid: make option 3 (MAX_EMPTY_GAP) of PINCH available

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -114,6 +114,7 @@ namespace Opm {
         PinchMode getPinchOption() const;
         PinchMode getMultzOption() const;
         PinchMode getPinchGapMode() const;
+        double getPinchMaxEmptyGap() const;
 
         MinpvMode getMinpvMode() const;
         const std::vector<double>& getMinpvVector( ) const;
@@ -227,6 +228,7 @@ namespace Opm {
         PinchMode m_pinchoutMode;
         PinchMode m_multzMode;
         PinchMode m_pinchGapMode;
+        double    m_pinchMaxEmptyGap = 1e20;
 
         mutable std::optional<std::vector<double>> active_volume;
 

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -53,7 +53,7 @@ namespace Opm {
 
     class EclipseGrid : public GridDims {
     public:
-        EclipseGrid() = default;
+        EclipseGrid();
         explicit EclipseGrid(const std::string& filename);
 
         /*
@@ -228,7 +228,7 @@ namespace Opm {
         PinchMode m_pinchoutMode;
         PinchMode m_multzMode;
         PinchMode m_pinchGapMode;
-        double    m_pinchMaxEmptyGap = 1e20;
+        double    m_pinchMaxEmptyGap;
 
         mutable std::optional<std::vector<double>> active_volume;
 
@@ -249,7 +249,7 @@ namespace Opm {
         std::optional<MapAxes> m_mapaxes;
 
         // Mapping to/from active cells.
-        int m_nactive;
+        int m_nactive {};
         std::vector<int> m_active_to_global;
         std::vector<int> m_global_to_active;
         // Numerical aquifer cells, needs to be active

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
@@ -43,6 +43,7 @@ namespace Opm {
     class FaultCollection;
     class DeckKeyword;
     class FieldPropsManager;
+    class Deck;
 
     class TransMult {
 

--- a/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -349,6 +349,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
             m_multzMode = PinchModeFromString(multzString);
             auto pinchGapString = record.getItem<ParserKeywords::PINCH::CONTROL_OPTION>().get< std::string >(0);
             m_pinchGapMode = PinchModeFromString(pinchGapString);
+            m_pinchMaxEmptyGap = record.getItem<ParserKeywords::PINCH::MAX_EMPTY_GAP>().getSIDouble(0);
         }
 
         if (deck.hasKeyword<ParserKeywords::MINPV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {
@@ -543,6 +544,11 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
     PinchMode EclipseGrid::getPinchGapMode() const {
         return m_pinchGapMode;
     }
+
+    double EclipseGrid::getPinchMaxEmptyGap() const {
+        return m_pinchMaxEmptyGap;
+    }
+
 
     const std::vector<double>& EclipseGrid::getMinpvVector( ) const {
         return m_minpvVector;

--- a/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -90,6 +90,14 @@ void apply_GRIDUNIT(const UnitSystem& deck_units, const UnitSystem& grid_units, 
 }
 
 }
+EclipseGrid::EclipseGrid()
+    : GridDims(),
+      m_minpvMode(MinpvMode::Inactive),
+      m_pinchoutMode(PinchMode::TOPBOT),
+      m_multzMode(PinchMode::TOP),
+      m_pinchGapMode(PinchMode::GAP),
+      m_pinchMaxEmptyGap(ParserKeywords::PINCH::MAX_EMPTY_GAP::defaultValue)
+{}
 
 EclipseGrid::EclipseGrid(const std::array<int, 3>& dims ,
                          const std::vector<double>& coord ,
@@ -99,7 +107,8 @@ EclipseGrid::EclipseGrid(const std::array<int, 3>& dims ,
       m_minpvMode(MinpvMode::Inactive),
       m_pinchoutMode(PinchMode::TOPBOT),
       m_multzMode(PinchMode::TOP),
-      m_pinchGapMode(PinchMode::GAP)
+      m_pinchGapMode(PinchMode::GAP),
+      m_pinchMaxEmptyGap(ParserKeywords::PINCH::MAX_EMPTY_GAP::defaultValue)
 {
     initCornerPointGrid( coord , zcorn , actnum );
 }
@@ -115,7 +124,8 @@ EclipseGrid::EclipseGrid(const std::string& fileName )
       m_minpvMode(MinpvMode::Inactive),
       m_pinchoutMode(PinchMode::TOPBOT),
       m_multzMode(PinchMode::TOP),
-      m_pinchGapMode(PinchMode::GAP)
+      m_pinchGapMode(PinchMode::GAP),
+      m_pinchMaxEmptyGap(ParserKeywords::PINCH::MAX_EMPTY_GAP::defaultValue)
 {
 
     Opm::EclIO::EclFile egridfile(fileName);
@@ -129,7 +139,8 @@ EclipseGrid::EclipseGrid(const GridDims& gd)
       m_minpvMode(MinpvMode::Inactive),
       m_pinchoutMode(PinchMode::TOPBOT),
       m_multzMode(PinchMode::TOP),
-      m_pinchGapMode(PinchMode::GAP)
+      m_pinchGapMode(PinchMode::GAP),
+      m_pinchMaxEmptyGap(ParserKeywords::PINCH::MAX_EMPTY_GAP::defaultValue)
 {
     this->m_nactive = this->getCartesianSize();
     this->active_volume = std::nullopt;
@@ -149,7 +160,8 @@ EclipseGrid::EclipseGrid(size_t nx, size_t ny , size_t nz,
       m_minpvMode(MinpvMode::Inactive),
       m_pinchoutMode(PinchMode::TOPBOT),
       m_multzMode(PinchMode::TOP),
-      m_pinchGapMode(PinchMode::GAP)
+      m_pinchGapMode(PinchMode::GAP),
+      m_pinchMaxEmptyGap(ParserKeywords::PINCH::MAX_EMPTY_GAP::defaultValue)
 {
 
     m_coord.reserve((nx+1)*(ny+1)*6);
@@ -257,7 +269,8 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
       m_minpvMode(MinpvMode::Inactive),
       m_pinchoutMode(PinchMode::TOPBOT),
       m_multzMode(PinchMode::TOP),
-      m_pinchGapMode(PinchMode::GAP)
+      m_pinchGapMode(PinchMode::GAP),
+      m_pinchMaxEmptyGap(ParserKeywords::PINCH::MAX_EMPTY_GAP::defaultValue)
 {
     if (deck.hasKeyword("GDFILE")){
 

--- a/tests/parser/EclipseGridTests.cpp
+++ b/tests/parser/EclipseGridTests.cpp
@@ -231,7 +231,7 @@ static Opm::Deck createPinchedNOGAPCPDeck() {
         "ACTNUM \n"
         "  1000*1 / \n"
         "PINCH \n"
-        "  0.2 NOGAP / \n"
+        "  0.2 NOGAP 5.0 / \n"
         "EDIT\n"
         "\n";
 
@@ -838,6 +838,8 @@ BOOST_AUTO_TEST_CASE(ConstructorNORUNSPEC_PINCH) {
     BOOST_CHECK_EQUAL(grid2.getPinchThresholdThickness(), 0.2);
     BOOST_CHECK_EQUAL(grid2.getPinchGapMode(), Opm::PinchMode::GAP);
     BOOST_CHECK_EQUAL(grid3.getPinchGapMode(), Opm::PinchMode::NOGAP);
+    BOOST_CHECK_EQUAL(grid2.getPinchMaxEmptyGap(), 1e20);
+    BOOST_CHECK_EQUAL(grid3.getPinchMaxEmptyGap(), 5.0);
 }
 
 BOOST_AUTO_TEST_CASE(ConstructorMINPV) {


### PR DESCRIPTION
This is needed to prevent creation of NNCs if  the empty gap created by pinched out cells is larger than this threshold.