### PR TITLE
add THERMAL option to BC

### DIFF
--- a/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
@@ -36,7 +36,8 @@ class DeckRecord;
 enum class BCType {
      RATE,
      FREE,
-     DIRICHLET
+     DIRICHLET,
+     THERMAL
 };
 
 enum class BCComponent {

--- a/src/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
@@ -38,6 +38,9 @@ BCType bctype(const std::string& s) {
     if (s == "DIRICHLET")
         return BCType::DIRICHLET;
 
+    if (s == "THERMAL")
+        return BCType::THERMAL;
+
     throw std::invalid_argument("Not recognized boundary condition type: " + s);
 }
 


### PR DESCRIPTION
With the THERMAL option the temperature is kept constant at the given boundary by allowing for heat conduction only. In other words no fluid flow only heat. 