### PR TITLE
Internalize EDITNNCR keyword and make it available with the other NNC information.

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.hpp
@@ -109,8 +109,11 @@ public:
     static NNC serializationTestObject();
 
     bool addNNC(const size_t cell1, const size_t cell2, const double trans);
+    /// \brief Get the combined information from NNC
     const std::vector<NNCdata>& input() const { return m_input; }
+    /// \brief Get the information from EDITNNC keyword
     const std::vector<NNCdata>& edit() const { return m_edit; }
+    /// \brief Get the information from EDITNNCR keyword
     const std::vector<NNCdata>& editr() const { return m_editr; }
     KeywordLocation input_location(const NNCdata& nnc) const;
     KeywordLocation edit_location(const NNCdata& nnc) const;
@@ -137,8 +140,11 @@ private:
     void load_editr(const EclipseGrid& grid, const Deck& deck);
     void add_edit(const NNCdata& edit_node);
 
+    /// \brief Stores NNC not coinciding with entries in EDITNNCR
     std::vector<NNCdata> m_input;
+    /// \brief EDITNNC data not coinciding with entries in EDITNNCR.
     std::vector<NNCdata> m_edit;
+    /// \brief EDITNNCR data.
     std::vector<NNCdata> m_editr;
     std::optional<KeywordLocation> m_nnc_location;
     std::optional<KeywordLocation> m_edit_location;

--- a/opm/input/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.hpp
@@ -131,7 +131,6 @@ private:
     void load_input(const EclipseGrid& grid, const Deck& deck);
     void load_edit(const EclipseGrid& grid, const Deck& deck);
     void add_edit(const NNCdata& edit_node);
-    bool update_nnc(std::size_t global_index1, std::size_t global_index2, double tran_mult);
 
     std::vector<NNCdata> m_input;
     std::vector<NNCdata> m_edit;

--- a/opm/input/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/NNC.hpp
@@ -111,8 +111,10 @@ public:
     bool addNNC(const size_t cell1, const size_t cell2, const double trans);
     const std::vector<NNCdata>& input() const { return m_input; }
     const std::vector<NNCdata>& edit() const { return m_edit; }
+    const std::vector<NNCdata>& editr() const { return m_editr; }
     KeywordLocation input_location(const NNCdata& nnc) const;
     KeywordLocation edit_location(const NNCdata& nnc) const;
+    KeywordLocation editr_location(const NNCdata& nnc) const;
 
 
     bool operator==(const NNC& data) const;
@@ -122,20 +124,25 @@ public:
     {
         serializer(m_input);
         serializer(m_edit);
+        serializer(m_editr);
         serializer(m_nnc_location);
         serializer(m_edit_location);
+        serializer(m_editr_location);
     }
 
 private:
 
     void load_input(const EclipseGrid& grid, const Deck& deck);
     void load_edit(const EclipseGrid& grid, const Deck& deck);
+    void load_editr(const EclipseGrid& grid, const Deck& deck);
     void add_edit(const NNCdata& edit_node);
 
     std::vector<NNCdata> m_input;
     std::vector<NNCdata> m_edit;
+    std::vector<NNCdata> m_editr;
     std::optional<KeywordLocation> m_nnc_location;
     std::optional<KeywordLocation> m_edit_location;
+    std::optional<KeywordLocation> m_editr_location;
 };
 
 

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -19,6 +19,7 @@
 #include <array>
 #include <deque>
 #include <cstddef>
+#include <algorithm>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -90,6 +90,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
     NNC::NNC(const EclipseGrid& grid, const Deck& deck) {
         this->load_input(grid, deck);
         this->load_edit(grid, deck);
+        this->load_editr(grid, deck);
     }
 
 
@@ -138,6 +139,9 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
 
         std::sort(nnc_edit.begin(), nnc_edit.end());
 
+        // If we have a corresponding NNC already, then we apply
+        // the multiplier from  EDITNNC to it. Otherwise we internalize
+        // it into m_edit
         auto current_input = this->m_input.begin();
         for (const auto& current_edit : nnc_edit) {
             if (current_input == this->m_input.end()) {
@@ -171,14 +175,127 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
         }
     }
 
+    void NNC::load_editr(const EclipseGrid& grid, const Deck& deck) {
+        using NNCinsert = std::tuple<std::array<std::size_t,3>,double>;
+        std::vector<NNCinsert> nnc_editr;
+        std::size_t insertion_index = 0;
+
+        const auto& keyword_list = deck.getKeywordList<ParserKeywords::EDITNNCR>();
+
+        if (keyword_list.empty()) {
+            return;
+        }
+
+        for (const auto& keyword_ptr : deck.getKeywordList<ParserKeywords::EDITNNCR>()) {
+            const auto& records = *keyword_ptr;
+            if (records.empty()) {
+                continue;
+            }
+            for (const auto& record : records) {
+                auto index_pair = make_index_pair(grid, record);
+                if (!index_pair)
+                    continue;
+
+                auto [g1, g2] = index_pair.value();
+                if (is_neighbor(grid, g1, g2))
+                    continue;
+
+                double trans = record.getItem(6).getSIDouble(0);
+                nnc_editr.push_back( {{g1, g2, insertion_index }, trans});
+            }
+
+            if (!this->m_editr_location)
+                this->m_editr_location = keyword_ptr->location();
+        }
+
+        if (nnc_editr.empty()) {
+            return;
+        }
+
+        // Make the entries unique (i.e. only one entry for each index pair)
+        // the entry surviving should be last one (i.e. later enrtries overwrite previous entries)
+        std::sort(nnc_editr.begin(), nnc_editr.end(),
+                  [](const NNCinsert& d1, NNCinsert& d2) {
+                      return std::get<0>(d1) <  std::get<0>(d2);
+                  }
+                  );
+
+        std::size_t g1 = -1, g2 = -1;
+        auto target = nnc_editr.begin() - 1;
+
+        for(auto current =  nnc_editr.begin(); current != nnc_editr.end(); ++current)
+        {
+            const auto& indices = std::get<0>(*current);
+            if ( indices[0] == g1 && indices[1] == g2){
+                // overwrites previous entry
+                *target = std::move(*current);
+            }
+            else{
+                ++target;
+                if (target != current) {
+                    *target = std::move(*current);
+                }
+                g1 = indices[0];
+                g2 = indices[1];
+            }
+        }
+
+        nnc_editr.resize((++target) - nnc_editr.begin());
+
+        // Remove corresponding EDITNNC entries in m_edit as EDIT_NNCR
+        // will overwrite transmissibilities anyway
+        std::vector<NNCdata> slim_edit;
+        slim_edit.reserve(m_edit.size());
+        struct Comp
+        {
+            bool operator()(const NNCinsert& d1, NNCdata& d2){
+                return std::get<0>(d1)[0] < d2.cell1   && std::get<0>(d1)[1]  < d2.cell2 ;
+            }
+            bool operator()(const NNCdata& d1, NNCinsert& d2){
+                return d1.cell1 < std::get<0>(d2)[0] &&  d1.cell2 < std::get<0>(d2)[1];
+            }
+        };
+        std::set_difference(m_edit.begin(), m_edit.end(),
+                            nnc_editr.begin(), nnc_editr.end(),
+                            std::back_inserter(slim_edit),
+                            Comp());
+        m_edit = std::move(slim_edit);
+
+        // If we have a corresponding NNC already, then we overwrite
+        // its transmissibility from EDITNNCR. Otherwise we internalize it
+        // in m_editr
+        auto current_input = this->m_input.begin();
+        for (const auto& current_editr : nnc_editr) {
+            if (current_input == this->m_input.end()) {
+                m_editr.push_back({std::get<0>(current_editr)[0], std::get<0>(current_editr)[1], std::get<double>(current_editr)});
+                continue;
+            }
+            if (current_input->cell1 != std::get<0>(current_editr)[0] || current_input->cell2 != std::get<0>(current_editr)[1]) {
+                current_input = std::lower_bound(current_input,
+                                                 this->m_input.end(),
+                                                 NNCdata(std::get<0>(current_editr)[0], std::get<0>(current_editr)[1], 0));
+            }
+
+            if (current_input != this->m_input.end()
+                && current_input->cell1 == std::get<0>(current_editr)[0]
+                && current_input->cell2 == std::get<0>(current_editr)[1]) {
+                current_input->trans = std::get<double>(current_editr);
+            }
+            else {
+                m_editr.push_back({std::get<0>(current_editr)[0], std::get<0>(current_editr)[1], std::get<double>(current_editr)});
+            }
+        }
+    }
 
     NNC NNC::serializationTestObject()
     {
         NNC result;
         result.m_input= {{1,2,1.0},{2,3,2.0}};
         result.m_edit= {{1,2,1.0},{2,3,2.0}};
+        result.m_editr= {{1,2,1.0},{2,3,2.0}};
         result.m_nnc_location = {"NNC?", "File", 123};
         result.m_edit_location = {"EDITNNC?", "File", 123};
+        result.m_edit_location = {"EDITNNCR?", "File", 123};
         return result;
     }
 
@@ -237,5 +354,11 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
             return {};
     }
 
+    KeywordLocation NNC::editr_location([[maybe_unused]] const NNCdata& nnc) const {
+        if (this->m_editr_location)
+            return *this->m_editr_location;
+        else
+            return {};
+    }
 } // namespace Opm
 

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -180,7 +180,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
     void NNC::load_editr(const EclipseGrid& grid, const Deck& deck) {
         // Will contain EDITNNCR data in reverse order to be able
         // use unique to only keep the last one from the data file.
-        // For that we sort it later. This sort is stable and hence
+        // For that we stable_sort it later. This sort is stable and hence
         // entries for the cell pairs will be consecutive and the last
         // entry that was specified in the data file will come first and
         // will kept by std::unique.
@@ -221,11 +221,11 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
         // Sort the deck to make entries for the same cell pair consecutive.
         // Will keep the insertion order of entries for same cell pair as sort
         // is stable.
-        std::sort(nnc_editr.begin(), nnc_editr.end());
+        std::stable_sort(nnc_editr.begin(), nnc_editr.end());
 
         // remove duplicates (based on only cell1 and cell2 members)
         // recall that entries for the same cell pairs are consecutive after
-        // the sort above, and that the last entry specified in the data file
+        // the stable_sort above, and that the last entry specified in the data file
         // comes first in the deck (because we used emplace_front, and sort is stable)
         auto equality = [](const NNCdata& d1, const NNCdata& d2){
             return d1.cell1 == d2.cell1 && d1.cell2 == d2.cell2;

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -180,6 +180,10 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
     void NNC::load_editr(const EclipseGrid& grid, const Deck& deck) {
         // Will contain EDITNNCR data in reverse order to be able
         // use unique to only keep the last one from the data file.
+        // For that we sort it later. This sort is stable and hence
+        // entries for the cell pairs will be consecutive and the last
+        // entry that was specified in the data file will come first and
+        // will kept by std::unique.
         std::deque<NNCdata> nnc_editr;
 
         const auto& keyword_list = deck.getKeywordList<ParserKeywords::EDITNNCR>();
@@ -214,12 +218,15 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
             return;
         }
 
-        // Make the entries unique (i.e. only one entry for each index pair)
-        // the entry surviving should be last one (i.e. later enrtries overwrite previous entries)
-        // Will keep the insertion order of entries for same cell pair.
+        // Sort the deck to make entries for the same cell pair consecutive.
+        // Will keep the insertion order of entries for same cell pair as sort
+        // is stable.
         std::sort(nnc_editr.begin(), nnc_editr.end());
 
-        // remove duplicates (based on only cell1 and cell2 members
+        // remove duplicates (based on only cell1 and cell2 members)
+        // recall that entries for the same cell pairs are consecutive after
+        // the sort above, and that the last entry specified in the data file
+        // comes first in the deck (because we used emplace_front, and sort is stable)
         auto equality = [](const NNCdata& d1, const NNCdata& d2){
             return d1.cell1 == d2.cell1 && d1.cell2 == d2.cell2;
         };
@@ -237,9 +244,10 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
 
         // NNCs are left untouched as they are also needed for
         // grid construction. Transmissibilities are overwritten
-        // in the simulator by EDITNNCR
+        // in the simulator by EDITNNCR, anyway.
 
         // Create new container to not use excess memory
+        // and convert to std::vector
         m_editr = {nnc_editr.begin(), nnc_editr.end()};
     }
 

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -18,6 +18,7 @@
 */
 #include <array>
 #include <deque>
+#include <cstddef>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
@@ -141,7 +142,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
         std::sort(nnc_edit.begin(), nnc_edit.end());
 
         // If we have a corresponding NNC already, then we apply
-        // the multiplier from  EDITNNC to it. Otherwise we internalize
+        // the multiplier from EDITNNC to it. Otherwise we internalize
         // it into m_edit
         auto current_input = this->m_input.begin();
         for (const auto& current_edit : nnc_edit) {
@@ -296,7 +297,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
      keyword, but we should be ready for a more elaborate implementation without
      any API change.
     */
-    KeywordLocation NNC::input_location([[maybe_unused]] const NNCdata& nnc) const {
+    KeywordLocation NNC::input_location(const NNCdata& /* nnc */) const {
         if (this->m_nnc_location)
             return *this->m_nnc_location;
         else
@@ -304,14 +305,14 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
     }
 
 
-    KeywordLocation NNC::edit_location([[maybe_unused]] const NNCdata& nnc) const {
+    KeywordLocation NNC::edit_location(const NNCdata& /* nnc */) const {
         if (this->m_edit_location)
             return *this->m_edit_location;
         else
             return {};
     }
 
-    KeywordLocation NNC::editr_location([[maybe_unused]] const NNCdata& nnc) const {
+    KeywordLocation NNC::editr_location(const NNCdata& /* nnc */) const {
         if (this->m_editr_location)
             return *this->m_editr_location;
         else

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -248,7 +248,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
 
         // Create new container to not use excess memory
         // and convert to std::vector
-        m_editr = {nnc_editr.begin(), nnc_editr.end()};
+        m_editr.assign(nnc_editr.begin(), nnc_editr.end());
     }
 
     NNC NNC::serializationTestObject()

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -233,7 +233,7 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
             return d1.cell1 == d2.cell1 && d1.cell2 == d2.cell2;
         };
         auto new_end = std::unique(nnc_editr.begin(), nnc_editr.end(), equality);
-        nnc_editr.resize(new_end - nnc_editr.begin());
+        nnc_editr.erase(new_end, nnc_editr.end());
 
         // Remove corresponding EDITNNC entries in m_edit as EDITNNCR
         // will overwrite transmissibilities anyway

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -234,14 +234,11 @@ bool is_neighbor(const EclipseGrid& grid, std::size_t g1, std::size_t g2) {
                             std::back_inserter(slim_edit));
         m_edit = std::move(slim_edit);
 
-        // Remove corresponding NNC entries in m_input as EDITNNCR
-        // will overwrite transmissibilities anyway
-        std::vector<NNCdata> slim_input;
-        slim_edit.reserve(m_input.size());
-        std::set_difference(m_input.begin(), m_input.end(),
-                            nnc_editr.begin(), nnc_editr.end(),
-                            std::back_inserter(slim_input));
-        m_input = std::move(slim_input);
+        // NNCs are left untouched as they are also needed for
+        // grid construction. Transmissibilities are overwritten
+        // in the simulator by EDITNNCR
+
+        // Create new container to not use excess memory
         m_editr = {nnc_editr.begin(), nnc_editr.end()};
     }
 

--- a/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/NNC.cpp
@@ -1,5 +1,6 @@
 /*
   Copyright 2015 IRIS
+  Copyright 2018--2023 Equinor ASA
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/E/EDITNNCR
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/E/EDITNNCR
@@ -5,63 +5,81 @@
   ],
   "items": [
     {
+      "item": 1,
       "name": "I1",
       "value_type": "INT"
     },
     {
+      "item": 2,
       "name": "J1",
       "value_type": "INT"
     },
     {
+      "item": 3,
       "name": "K1",
       "value_type": "INT"
     },
     {
+      "item": 4,
       "name": "I2",
       "value_type": "INT"
     },
     {
+      "item": 5,
       "name": "J2",
       "value_type": "INT"
     },
     {
+      "item": 6,
       "name": "K2",
       "value_type": "INT"
     },
     {
+      "item": 7,
       "name": "TRANS",
       "value_type": "DOUBLE",
-      "default_value": 1
+      "dimension": "Transmissibility"
     },
     {
+      "item": 8,
       "name": "SAT_TABLE12",
       "value_type": "INT",
-      "default_value": 0
+      "default_value": 0,
+      "comment": "Not used"
     },
     {
+      "item": 9,
       "name": "SAT_TABLE21",
       "value_type": "INT",
-      "default_value": 0
+      "default_value": 0,
+      "comment": "Not used"
     },
     {
+      "item": 10,
       "name": "PRESS_TABLE12",
       "value_type": "INT",
-      "default_value": 0
+      "default_value": 0,
+      "comment": "Not used"
     },
     {
+      "item": 11,
       "name": "PRESS_TABLE21",
       "value_type": "INT",
-      "default_value": 0
+      "default_value": 0,
+      "comment": "Not used"
     },
     {
+      "item": 12,
       "name": "FACE_FLOW12",
       "value_type": "STRING"
     },
     {
+      "item": 13,
       "name": "FACE_FLOW21",
       "value_type": "STRING"
     },
     {
+      "item": 14,
       "name": "DIFF",
       "value_type": "DOUBLE",
       "dimension": "Length"

--- a/tests/parser/integration/NNCTests.cpp
+++ b/tests/parser/integration/NNCTests.cpp
@@ -268,7 +268,7 @@ EDITNNC
 
 EDITNNCR
 8 1 1 3 1 1 2.0 /
-1 1 1 1 2 1 0.01 / -- This is ignored because the two cells are not ijk neighbours
+1 1 1 1 2 1 0.01 / -- This is ignored because the two cells are ijk neighbours
 2 1 1 2 3 1 0.2 / -- Overwritten with 0.3 by next entry
 7 1 1 3 1 1 10 /
 /

--- a/tests/parser/integration/NNCTests.cpp
+++ b/tests/parser/integration/NNCTests.cpp
@@ -220,6 +220,65 @@ EDITNNC
 /
 )";
 
+const std::string editnncr_input = R"(
+RUNSPEC
+
+OIL
+GAS
+WATER
+
+
+DIMENS
+   10 10  1  /
+
+GRID
+
+NNC
+   7 1 1 3 1 1 0.1 / -- Transmissibility will be overwritten with 10 by EDITNNCR
+   3 1 1 5 1 1 0.1 /
+/
+
+
+DXV
+10*1000.0
+/
+
+DYV
+10*1000.0
+/
+
+DZ
+100*20.0
+/
+
+TOPS
+100*10
+/
+
+PORO
+   100*0.15 /
+
+EDIT
+
+EDITNNC
+5 1 1 3 1 1 2.0 / -- Will be removed after internalization as there is an NNC
+3 1 1 1 1 1 0.1 / -- stays internalized
+2 1 1 2 3 1 0.3 / -- Will be removed after internalization as there is an EDTNNCR
+/
+
+EDITNNCR
+8 1 1 3 1 1 2.0 /
+1 1 1 1 2 1 0.01 / -- This is ignored because the two cells are ijk neighbours
+2 1 1 2 3 1 0.2 / -- Overwritten with 0.3 by next entry
+7 1 1 3 1 1 10 / -- Will overwrite entry in NNC
+/
+
+EDITNNCR
+1 1 1 2 1 1 0.1 /  -- Ignored
+2 1 1 2 3 1 0.3 / -- Overwrites previous value
+/
+)";
+
 
 std::optional<NNCdata> find_nnc(const std::vector<NNCdata>& v, std::size_t c1, std::size_t c2) {
     if (c1 > c2)
@@ -270,6 +329,7 @@ void check_order(const std::vector<NNCdata>& d) {
 void check_order(const NNC& nnc) {
     check_order(nnc.input());
     check_order(nnc.edit());
+    check_order(nnc.editr());
 }
 
 
@@ -314,6 +374,7 @@ BOOST_AUTO_TEST_CASE(noNNC_EDIT)
     EclipseState eclipseState(deck);
     const auto& editnnc = eclipseState.getInputNNC();
     BOOST_CHECK(editnnc.edit().empty());
+    BOOST_CHECK(editnnc.editr().empty());
 }
 
 
@@ -339,6 +400,33 @@ BOOST_AUTO_TEST_CASE(readDeck_EDIT)
     check_nnc(input, grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(6,0,0), 0.10);
 }
 
+BOOST_AUTO_TEST_CASE(readDeck_EDITR)
+{
+    Parser parser;
+    auto deck = parser.parseString(editnncr_input);
+    EclipseGrid grid(10,10,10);
+
+    NNC nnc(grid, deck);
+    const std::vector<NNCdata>& input = nnc.input();
+    const std::vector<NNCdata>& edit = nnc.edit();
+    const std::vector<NNCdata>& editr = nnc.editr();
+    check_order(nnc);
+
+    BOOST_CHECK_EQUAL(input.size(), 2);
+    check_nnc(input, grid.getGlobalIndex(6,0,0), grid.getGlobalIndex(2,0,0), 10);
+    check_nnc(input, grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(4,0,0), 0.1*2.0);
+
+    BOOST_CHECK_EQUAL(edit.size(), 1);
+    BOOST_CHECK(!has_nnc(edit, grid.getGlobalIndex(4,0,0), grid.getGlobalIndex(2,0,0)));
+    check_edit_nnc(edit, grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(0,0,0), 0.1);
+
+    BOOST_CHECK_EQUAL(editr.size(), 2);
+    BOOST_CHECK(!has_nnc(editr, grid.getGlobalIndex(0,0,0), grid.getGlobalIndex(0,1,0)));
+    BOOST_CHECK(!has_nnc(editr, grid.getGlobalIndex(6,0,0), grid.getGlobalIndex(2,0,0)));
+    BOOST_CHECK(!has_nnc(editr, grid.getGlobalIndex(0,0,0), grid.getGlobalIndex(1,0,0)));
+    check_nnc(editr, grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(1,2,0), 0.3);
+    check_nnc(editr, grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(7,0,0), 2.0);
+}
 
 BOOST_AUTO_TEST_CASE(ACTNUM)
 {

--- a/tests/parser/integration/NNCTests.cpp
+++ b/tests/parser/integration/NNCTests.cpp
@@ -234,7 +234,7 @@ DIMENS
 GRID
 
 NNC
-   7 1 1 3 1 1 0.1 / -- Will not be represented internally, because there is a corresponding EDITNNCR
+   7 1 1 3 1 1 0.1 /
    3 1 1 5 1 1 0.1 / 
 /
 
@@ -270,7 +270,7 @@ EDITNNCR
 8 1 1 3 1 1 2.0 /
 1 1 1 1 2 1 0.01 / -- This is ignored because the two cells are not ijk neighbours
 2 1 1 2 3 1 0.2 / -- Overwritten with 0.3 by next entry
-7 1 1 3 1 1 10 / -- Will cause corresponding NNC to not be represented internally
+7 1 1 3 1 1 10 /
 /
 
 EDITNNCR
@@ -413,8 +413,10 @@ BOOST_AUTO_TEST_CASE(readDeck_EDITR)
     const std::vector<NNCdata>& editr = nnc.editr();
     check_order(nnc);
 
-    BOOST_CHECK_EQUAL(input.size(), 1);
+    BOOST_CHECK_EQUAL(input.size(), 2);
     check_nnc(input, grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(4,0,0), 0.1*2.0);
+    // Not checking value because of corresponding NNCR
+    BOOST_CHECK(has_nnc(input, grid.getGlobalIndex(6,0,0), grid.getGlobalIndex(2, 0, 0)));
 
     BOOST_CHECK_EQUAL(edit.size(), 1);
     BOOST_CHECK(!has_nnc(edit, grid.getGlobalIndex(4,0,0), grid.getGlobalIndex(2,0,0)));

--- a/tests/parser/integration/NNCTests.cpp
+++ b/tests/parser/integration/NNCTests.cpp
@@ -234,8 +234,8 @@ DIMENS
 GRID
 
 NNC
-   7 1 1 3 1 1 0.1 / -- Transmissibility will be overwritten with 10 by EDITNNCR
-   3 1 1 5 1 1 0.1 /
+   7 1 1 3 1 1 0.1 / -- Will not be represented internally, because there is a corresponding EDITNNCR
+   3 1 1 5 1 1 0.1 / 
 /
 
 
@@ -268,9 +268,9 @@ EDITNNC
 
 EDITNNCR
 8 1 1 3 1 1 2.0 /
-1 1 1 1 2 1 0.01 / -- This is ignored because the two cells are ijk neighbours
+1 1 1 1 2 1 0.01 / -- This is ignored because the two cells are not ijk neighbours
 2 1 1 2 3 1 0.2 / -- Overwritten with 0.3 by next entry
-7 1 1 3 1 1 10 / -- Will overwrite entry in NNC
+7 1 1 3 1 1 10 / -- Will cause corresponding NNC to not be represented internally
 /
 
 EDITNNCR
@@ -413,18 +413,17 @@ BOOST_AUTO_TEST_CASE(readDeck_EDITR)
     const std::vector<NNCdata>& editr = nnc.editr();
     check_order(nnc);
 
-    BOOST_CHECK_EQUAL(input.size(), 2);
-    check_nnc(input, grid.getGlobalIndex(6,0,0), grid.getGlobalIndex(2,0,0), 10);
+    BOOST_CHECK_EQUAL(input.size(), 1);
     check_nnc(input, grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(4,0,0), 0.1*2.0);
 
     BOOST_CHECK_EQUAL(edit.size(), 1);
     BOOST_CHECK(!has_nnc(edit, grid.getGlobalIndex(4,0,0), grid.getGlobalIndex(2,0,0)));
     check_edit_nnc(edit, grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(0,0,0), 0.1);
 
-    BOOST_CHECK_EQUAL(editr.size(), 2);
+    BOOST_CHECK_EQUAL(editr.size(), 3);
     BOOST_CHECK(!has_nnc(editr, grid.getGlobalIndex(0,0,0), grid.getGlobalIndex(0,1,0)));
-    BOOST_CHECK(!has_nnc(editr, grid.getGlobalIndex(6,0,0), grid.getGlobalIndex(2,0,0)));
     BOOST_CHECK(!has_nnc(editr, grid.getGlobalIndex(0,0,0), grid.getGlobalIndex(1,0,0)));
+    check_nnc(editr, grid.getGlobalIndex(6,0,0), grid.getGlobalIndex(2,0,0), 10);
     check_nnc(editr, grid.getGlobalIndex(1,0,0), grid.getGlobalIndex(1,2,0), 0.3);
     check_nnc(editr, grid.getGlobalIndex(2,0,0), grid.getGlobalIndex(7,0,0), 2.0);
 }

--- a/tests/parser/integration/NNCTests.cpp
+++ b/tests/parser/integration/NNCTests.cpp
@@ -385,6 +385,7 @@ BOOST_AUTO_TEST_CASE(readDeck_EDIT)
     EclipseGrid grid(10,10,10);
 
     NNC nnc(grid, deck);
+    BOOST_CHECK(nnc.editr().empty());
     const std::vector<NNCdata>& data = nnc.edit();
 
     BOOST_CHECK_EQUAL(data.size(), 2); //neighbouring connections in EDITNNC are ignored


### PR DESCRIPTION
If there is an EDITNNCR entry and a NNC entry for the same cell pair then the the corresponding NNC entry is removedas it will be overwritten anyway.

If there is an EDITNNC entry and an EDITNNCR entry for the same cell pair then the EDITNNC entry is removed while internalizing EDITNNCR.

Order matters for EDITNNCR entries in the sense that later specified values will overwrite previous entries when we internalize.

Note that similar to EDITNNC only the first 7 options are represented and the rest is ignored by OPM flow.

Note that EDITNNCR entries for neighboring cells are ignored (like for EDITNNC).

When actually storing the entries of EDITNNCR we treat them as NNCs internally. Hence we should be able to activate EDITNNCR in opm-simulators with out adding code actually handling EDITNNCR there.