### PR TITLE
update the logic of whether a well is openable

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -191,6 +191,7 @@ public:
         bool updateUDQActive(const UDQConfig& udq_config, const WELTARGCMode cmode, UDQActive& active) const;
         void update_uda(const UDQConfig& udq_config, UDQActive& udq_active, UDAControl control, const UDAValue& value);
         void handleWTMULT(Well::WELTARGCMode cmode, double factor);
+        bool zeroRateConstraint() const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -278,6 +279,7 @@ public:
         void setBHPLimit(const double limit);
         int productionControls() const { return this->m_productionControls; }
         void handleWTMULT(Well::WELTARGCMode cmode, double factor);
+        bool zeroRateConstraint() const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1361,37 +1361,12 @@ bool Well::canOpen() const {
     if (this->allow_cross_flow)
         return true;
 
-    /*
-      If the UDAValue is in string mode we return true unconditionally, without
-      evaluating the internal UDA value.
-    */
     if (this->wtype.producer()) {
         const auto& prod = *this->production;
-        if (prod.OilRate.is<std::string>())
-            return true;
-
-        if (prod.GasRate.is<std::string>())
-          return true;
-
-        if (prod.WaterRate.is<std::string>())
-          return true;
-
-        if (!prod.OilRate.zero())
-            return true;
-
-        if (!prod.GasRate.zero())
-            return true;
-
-        if (!prod.WaterRate.zero())
-            return true;
-
-        return false;
+        return !prod.zeroRateConstraint();
     } else {
         const auto& inj = *this->injection;
-        if (inj.surfaceInjectionRate.is<std::string>())
-            return true;
-
-        return !inj.surfaceInjectionRate.zero();
+        return !inj.zeroRateConstraint();
     }
 }
 

--- a/src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -457,4 +457,23 @@ namespace Opm {
     }
 
 
+
+
+    bool Well::WellInjectionProperties::zeroRateConstraint() const {
+        if (this->hasInjectionControl(InjectorCMode::RATE)) {
+            if (!this->surfaceInjectionRate.is<std::string>() && this->surfaceInjectionRate.zero()) {
+                return true;
+            }
+        }
+
+        if (this->hasInjectionControl(InjectorCMode::RESV)) {
+            if (!this->reservoirInjectionRate.is<std::string>() && this->reservoirInjectionRate.zero()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
 }


### PR DESCRIPTION
if there is one zero rate constraint, we consider the well has zero rate constraint, because it is the strictest constraint matters. And if the well is banned from crossflow, we should not open this well through WELOPEN. 

It is something when working on the PR https://github.com/OPM/opm-common/pull/3197 . 

Not totally sure whether it will be needed eventually. But the original code in the master branch is not correct. 