### PR TITLE
not forbidding WELOPEN wells with zero rate and disallowing crossflow

### DIFF
--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1273,41 +1273,28 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
              */
             if (conn_defaulted(record)) {
                 const auto new_well_status = WellStatusFromString(status_str);
-
                 for (const auto& wname : well_names) {
-                    if ((new_well_status == open) && !this->getWell(wname, currentStep).canOpen()) {
-                        auto elapsed = this->snapshots[currentStep].start_time() - this->snapshots[0].start_time();
-                        auto days = std::chrono::duration_cast<std::chrono::hours>(elapsed).count() / 24;
-                        std::string msg = "Well " + wname
-                            + " where crossflow is banned has zero total rate."
-                            + " This well is prevented from opening at "
-                            + std::to_string( days ) + " days";
-                        OpmLog::note(msg);
+                    const auto did_update_well_status =
+                        this->updateWellStatus(wname, currentStep, new_well_status);
+
+                    if (handlerContext.sim_update) {
+                        handlerContext.sim_update->affected_wells.insert(wname);
                     }
-                    else {
-                        const auto did_update_well_status =
-                            this->updateWellStatus(wname, currentStep, new_well_status);
 
-                        if (handlerContext.sim_update) {
-                            handlerContext.sim_update->affected_wells.insert(wname);
-                        }
+                    if (did_update_well_status && (new_well_status == open)) {
+                        // Record possible well injection/production status change
+                        auto well2 = this->snapshots[currentStep].wells.get(wname);
 
-                        if (did_update_well_status && (new_well_status == open)) {
-                            // Record possible well injection/production status change
-                            auto well2 = this->snapshots[currentStep].wells.get(wname);
+                        const auto did_flow_update =
+                            (well2.isProducer() && well2.updateHasProduced())
+                            ||
+                            (well2.isInjector() && well2.updateHasInjected());
 
-                            const auto did_flow_update =
-                                (well2.isProducer() && well2.updateHasProduced())
-                                ||
-                                (well2.isInjector() && well2.updateHasInjected());
-
-                            if (did_flow_update) {
-                                this->snapshots[currentStep].wells.update(std::move(well2));
-                            }
+                        if (did_flow_update) {
+                            this->snapshots[currentStep].wells.update(std::move(well2));
                         }
                     }
                 }
-
                 continue;
             }
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -672,7 +672,7 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
     BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 1).getStatus());
     BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 2).getStatus());
     BOOST_CHECK(Well::Status::SHUT == schedule.getWell("BAN", 3).getStatus());
-    BOOST_CHECK(Well::Status::SHUT == schedule.getWell("BAN", 4).getStatus()); // not allow to open
+    BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 4).getStatus());
     BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 5).getStatus());
 }
 


### PR DESCRIPTION
The PR aims at solving a issue reported by @vkip . 

In the case,  the well setup related to the issue is as follows, 
```
WCONPROD
  'PROD-2'   'SHUT'  'RESV'  4*  0.0 1.0 1* 0 1.0 5* /
/

DATES
 1 'FEB' 2000 /
/

WELOPEN
  'PROD-2' 'OPEN'  5* /
/

WELTARG
   'PROD-2' 'RESV'  2000.0 /
/

-- 31.000000 days from start of simulation ( 1 'JAN' 2000 )
DATES
 1 'JUN' 2000 /
/
```
With the master branch, FLOW will not be able to open the well `PROD-2` with WELOPEN, since the well `PROD-2` disallows crossflow and also has a zero rate constraint. And WELOPEN does not consider the later `WELTARG` is changing the rate constraint to be non-zero. 

In this PR, we let us WELOPEN open the well without checking the rate constraint and crossflow specification.  Then we have two options to go after this. 

1.  the current PR is the final form of the solution. The running results are good. And the argument for this is that we did not check the rate constraint and crossflow setup when we process other WCON*** keywords. Checking those only with `WELOPEN` is introducing inconsistency.  The testing failure in `ScheduleTests` is one example to show this inconsistency (a well OPEN with
    ```
    WCONHIST
    'BAN'      'OPEN'      'RESV'      0.000      0.000      0.000  5* /
    /
    ```
    ).
    Furthermore, with UDQ, the rate constraints are not determined during the parsing stage (not totally sure this is a relevant argument, while from the code, it looks like relevant)

2. Or we still check the rate constraint and crossflow and SHUT some of the wells during the parsing stage. If you think it is necessary, please suggest.  Then I will update the code to do this in a more consistent way. (But some discussion will necessary with the final approach)