### PR TITLE
adding defaults to json files

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -95,7 +95,7 @@ namespace Opm {
 
         int getHeadI() const;
         int getHeadJ() const;
-        std::vector<double> getMD() const;
+        const std::vector<double>& getMD() const;
         void add(Connection);
         std::size_t size() const;
         bool empty() const;

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -95,6 +95,7 @@ namespace Opm {
 
         int getHeadI() const;
         int getHeadJ() const;
+        std::vector<double> getMD() const;
         void add(Connection);
         std::size_t size() const;
         bool empty() const;

--- a/opm/input/eclipse/Schedule/Well/WellConnections.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellConnections.hpp
@@ -93,6 +93,8 @@ namespace Opm {
 
         void loadWELTRAJ(const DeckRecord& record, const ScheduleGrid& grid, const std::string& wname, const KeywordLocation& location);
 
+        int getHeadI() const;
+        int getHeadJ() const;
         void add(Connection);
         std::size_t size() const;
         bool empty() const;

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -238,6 +238,8 @@ namespace {
                 auto connections = std::make_shared<WellConnections>(WellConnections(well2.getConnections()));
                 // cellsearchTree is calculated only once and is used to calculated cell intersections of the perforations specified in COMPTRAJ 
                 connections->loadCOMPTRAJ(record, handlerContext.grid, name, handlerContext.keyword.location(), cellSearchTree);
+                // In the case that defaults are used in WELSPECS for headI/J the headI/J are calculated based on the well trajectory data
+                well2.updateHead(connections->getHeadI(), connections->getHeadJ());
                 if (well2.updateConnections(connections, handlerContext.grid)) {
                     this->snapshots.back().wells.update( well2 );
                     wells.insert( name );

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -220,6 +220,11 @@ namespace {
                     this->snapshots.back().wells.update( well2 );
                 }
                 this->snapshots.back().wellgroup_events().addEvent( name, ScheduleEvents::COMPLETION_CHANGE);
+                const auto& md = connections->getMD();
+                if (!std::is_sorted(std::begin(md), std::end(md))) {
+                    auto msg = fmt::format("Well {} has no increasing measured depth column", name);
+                    throw OpmInputError(msg, handlerContext.keyword.location());
+                }
             }
         }
         this->snapshots.back().events().addEvent(ScheduleEvents::COMPLETION_CHANGE);

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -222,7 +222,7 @@ namespace {
                 this->snapshots.back().wellgroup_events().addEvent( name, ScheduleEvents::COMPLETION_CHANGE);
                 const auto& md = connections->getMD();
                 if (!std::is_sorted(std::begin(md), std::end(md))) {
-                    auto msg = fmt::format("Well {} has no increasing measured depth column", name);
+                    auto msg = fmt::format("Well {} measured depth column is not strictly increasing", name);
                     throw OpmInputError(msg, handlerContext.keyword.location());
                 }
             }

--- a/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -937,7 +937,7 @@ namespace Opm {
         return this->headJ;
     }
 
-    std::vector<double> WellConnections::getMD() const {
+    const std::vector<double>& WellConnections::getMD() const {
         return this->md;
     }
 

--- a/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -937,6 +937,10 @@ namespace Opm {
         return this->headJ;
     }
 
+    std::vector<double> WellConnections::getMD() const {
+        return this->md;
+    }
+
     std::optional<int>
     getCompletionNumberFromGlobalConnectionIndex(const WellConnections& connections,
                                                  const std::size_t      global_index)

--- a/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -577,9 +577,18 @@ namespace Opm {
             I = ijk[0];
             J = ijk[1];
             k = ijk[2];
-            // std::cout<< "I: " << I << " J: " << J << " K: " << k << std::endl;
-            external::cvf::Vec3d connection_vector = intersections[is].intersectionLengthsInCellCS;
 
+            // When using WELTRAJ & COMPTRAJ one may use default settings in WELSPECS for headI/J and let the 
+            // headI/J be calculated by the trajectory data.
+            // If these defaults are used the headI/J are set to the first intersection.
+            if (is == 0) {
+                if (this->headI == -1)
+                    this->headI = I;
+                if (this->headJ == -1)
+                    this->headJ = J;
+            }
+
+            external::cvf::Vec3d connection_vector = intersections[is].intersectionLengthsInCellCS;
 
             const CompletedCells::Cell& cell = grid.get_cell(I, J, k);
 
@@ -918,6 +927,14 @@ namespace Opm {
             }
         }
         return perf_length;
+    }
+
+    int WellConnections::getHeadI() const {
+        return this->headI;
+    }
+
+    int WellConnections::getHeadJ() const {
+        return this->headJ;
     }
 
     std::optional<int>

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/W/WELSPECS
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/W/WELSPECS
@@ -17,12 +17,14 @@
     {
       "item": 3,
       "name": "HEAD_I",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": 0
     },
     {
       "item": 4,
       "name": "HEAD_J",
-      "value_type": "INT"
+      "value_type": "INT",
+      "default": 0
     },
     {
       "item": 5,

--- a/src/opm/input/eclipse/share/keywords/900_OPM/C/COMPTRAJ
+++ b/src/opm/input/eclipse/share/keywords/900_OPM/C/COMPTRAJ
@@ -3,6 +3,7 @@
   "sections": [
     "SCHEDULE"
   ],
+  "requires": ["WELTRAJ"],
   "items": [
     {
       "item": 1,

--- a/src/opm/input/eclipse/share/keywords/900_OPM/C/COMPTRAJ
+++ b/src/opm/input/eclipse/share/keywords/900_OPM/C/COMPTRAJ
@@ -13,6 +13,7 @@
       "item": 2,
       "name": "BRANCH_NUMBER",
       "value_type": "INT",
+      "default": 1,
       "comment": "Not used"
     },
     {
@@ -31,12 +32,14 @@
       "item": 5,
       "name": "PERF_REF",
       "value_type": "STRING",
+      "default": "TVD",
       "comment": "Not used"
     },
     {
       "item": 6,
       "name": "COMPLETION_NUMBER",
       "value_type": "INT",
+      "default": 1,
       "comment": "Not used"
     },
     {

--- a/src/opm/input/eclipse/share/keywords/900_OPM/W/WELTRAJ
+++ b/src/opm/input/eclipse/share/keywords/900_OPM/W/WELTRAJ
@@ -13,6 +13,7 @@
       "item": 2,
       "name": "BRANCH_NUMBER",
       "value_type": "INT",
+      "default": 1,
       "comment": "Not used"
     },
     {


### PR DESCRIPTION
In this PR some defaults have been aded to the json files `COMPTRAJ` and `WELTRAJ`.

Furthermore `WELSPECS` json file is adjusted to allow defaults (`1*`) for `HEAD_I` and `HEAD_J`. With this change  of `WELSPECS` the (standard) well can fully be specified grid independent together with `WELTRAJ` and `COMPTRAJ` keywords.