### PR TITLE
Revert "only using the AQUCT and AQUFETP in SOLUTION section"

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Aquifer/AquiferCT.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/AquiferCT.cpp
@@ -35,7 +35,6 @@
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/Deck/DeckSection.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
@@ -225,13 +224,10 @@ AquiferCT::AquiferCT(const TableManager& tables, const Deck& deck)
     if (!deck.hasKeyword<AQUCT>())
         return;
 
-    const auto& aquct_keywords = SOLUTIONSection(deck).getKeywordList("AQUCT");
-    for (const auto* keyword : aquct_keywords) {
-        OpmLog::info(OpmInputError::format("Initializing Fetkovich aquifers from {keyword} in {file} line {line}", keyword->location()));
-        for (const auto& record : *keyword) {
-            this->m_aquct.emplace_back(record, tables);
-        }
-    }
+    const auto& aquctKeyword = deck.get<AQUCT>().back();
+    OpmLog::info(OpmInputError::format("Initializing Carter Tracey aquifers from {keyword} in {file} line {line}", aquctKeyword.location()));
+    for (auto& record : aquctKeyword)
+        this->m_aquct.emplace_back(record, tables);
 }
 
 AquiferCT::AquiferCT(const std::vector<AquiferCT::AQUCT_data>& data) :

--- a/src/opm/input/eclipse/EclipseState/Aquifer/Aquifetp.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/Aquifetp.cpp
@@ -28,7 +28,6 @@
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/Deck/DeckSection.hpp>
 
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
@@ -149,13 +148,10 @@ Aquifetp::Aquifetp(const TableManager& tables, const Deck& deck)
     if (!deck.hasKeyword<AQUFETP>())
         return;
 
-    const auto& aqufetp_keywords = SOLUTIONSection(deck).getKeywordList("AQUFETP");
-    for (const auto* keyword : aqufetp_keywords) {
-        OpmLog::info(OpmInputError::format("Initializing Fetkovich aquifers from {keyword} in {file} line {line}", keyword->location()));
-        for (const auto& record : *keyword) {
-            this->m_aqufetp.emplace_back(record, tables);
-        }
-    }
+    const auto& aqufetpKeyword = deck.get<AQUFETP>().back();
+    OpmLog::info(OpmInputError::format("Initializing Fetkovich aquifers from {keyword} in {file} line {line}", aqufetpKeyword.location()));
+    for (auto& record : aqufetpKeyword)
+        this->m_aqufetp.emplace_back(record, tables);
 }
 
 


### PR DESCRIPTION
This reverts commit a89136f1f24c9886fb335b99b93dad23fc815628.

Partly to fix https://github.com/OPM/opm-tests/issues/938 .

The original commit did not consider that AQUCT and AQUFETP can be `GRID` and `PROPS` keywords also. 