### PR TITLE
Implement Proper Record Copying Behaviour for ROCK

### DIFF
--- a/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_ROCK_CONFIG_HPP
 #define OPM_ROCK_CONFIG_HPP
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -28,36 +29,36 @@ namespace Opm {
 class Deck;
 class FieldPropsManager;
 
-class RockConfig {
+class RockConfig
+{
 public:
-
-enum class Hysteresis {
-    REVERS = 1,
-    IRREVERS = 2,
-    HYSTER = 3,
-    BOBERG = 4,
-    REVLIMIT = 5,
-    PALM_MAN = 6,
-    NONE = 7
-};
-
-
-struct RockComp {
-    double pref;
-    double compressibility;
-
-    RockComp() = default;
-    RockComp(double pref_arg, double comp_arg);
-    bool operator==(const RockComp& other) const;
-
-    template<class Serializer>
-    void serializeOp(Serializer& serializer)
+    enum class Hysteresis
     {
-        serializer(pref);
-        serializer(compressibility);
-    }
-};
+        REVERS = 1,
+        IRREVERS = 2,
+        HYSTER = 3,
+        BOBERG = 4,
+        REVLIMIT = 5,
+        PALM_MAN = 6,
+        NONE = 7,
+    };
 
+    struct RockComp
+    {
+        double pref{};
+        double compressibility{};
+
+        RockComp() = default;
+        RockComp(double pref_arg, double comp_arg);
+        bool operator==(const RockComp& other) const;
+
+        template<class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(pref);
+            serializer(compressibility);
+        }
+    };
 
     RockConfig();
     RockConfig(const Deck& deck, const FieldPropsManager& fp);
@@ -95,4 +96,4 @@ private:
 
 } //namespace Opm
 
-#endif
+#endif // OPM_ROCK_CONFIG_HPP

--- a/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -96,12 +96,6 @@ struct GravityTable : public FlatTableWithCopy<GRAVITYRecord>
     {
         return GravityTable({{1.0, 2.0, 3.0}});
     }
-
-    template <class Serializer>
-    void serializeOp(Serializer& serializer)
-    {
-        FlatTableWithCopy::serializeOp(serializer);
-    }
 };
 
 struct DENSITYRecord {
@@ -136,12 +130,6 @@ struct DensityTable : public FlatTableWithCopy<DENSITYRecord>
     static DensityTable serializationTestObject()
     {
         return DensityTable({{1.0, 2.0, 3.0}});
-    }
-
-    template <class Serializer>
-    void serializeOp(Serializer& serializer)
-    {
-        FlatTableWithCopy::serializeOp(serializer);
     }
 };
 
@@ -286,12 +274,6 @@ struct PvtwTable : public FlatTableWithCopy<PVTWRecord>
     {
         return PvtwTable({{1.0, 2.0, 3.0, 4.0, 5.0}});
     }
-
-    template <class Serializer>
-    void serializeOp(Serializer& serializer)
-    {
-        FlatTableWithCopy::serializeOp(serializer);
-    }
 };
 
 struct ROCKRecord {
@@ -322,12 +304,6 @@ struct RockTable : public FlatTableWithCopy<ROCKRecord>
     static RockTable serializationTestObject()
     {
         return RockTable({{1.0, 2.0}});
-    }
-
-    template <class Serializer>
-    void serializeOp(Serializer& serializer)
-    {
-        FlatTableWithCopy::serializeOp(serializer);
     }
 };
 

--- a/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/FlatTable.hpp
@@ -313,12 +313,21 @@ struct ROCKRecord {
     }
 };
 
-struct RockTable : public FlatTable< ROCKRecord > {
-    using FlatTable< ROCKRecord >::FlatTable;
+struct RockTable : public FlatTableWithCopy<ROCKRecord>
+{
+    RockTable() = default;
+    explicit RockTable(const DeckKeyword& kw);
+    explicit RockTable(std::initializer_list<ROCKRecord> records);
 
     static RockTable serializationTestObject()
     {
         return RockTable({{1.0, 2.0}});
+    }
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        FlatTableWithCopy::serializeOp(serializer);
     }
 };
 

--- a/src/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
@@ -15,72 +15,118 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
-#include <unordered_set>
+#include <opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
 
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 
-namespace Opm {
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
 
 namespace {
 
-
-
-std::string num_prop(const std::string& prop_name) {
+std::string num_prop(const std::string& prop_name)
+{
     static const std::unordered_set<std::string> prop_names = {"PVTNUM", "SATNUM", "ROCKNUM"};
-    if (prop_names.count(prop_name) == 1)
+    if (prop_names.count(prop_name) == 1) {
         return prop_name;
+    }
 
     throw std::invalid_argument("The rocknum propertype: " + prop_name + " is not valid");
 }
 
-
-RockConfig::Hysteresis hysteresis(const std::string& s) {
+Opm::RockConfig::Hysteresis hysteresis(const std::string& s)
+{
     if (s == "REVERS")
-        return RockConfig::Hysteresis::REVERS;
+        return Opm::RockConfig::Hysteresis::REVERS;
 
     if (s == "IRREVERS")
-        return RockConfig::Hysteresis::IRREVERS;
+        return Opm::RockConfig::Hysteresis::IRREVERS;
 
     if (s == "HYSTER")
-        return RockConfig::Hysteresis::HYSTER;
+        return Opm::RockConfig::Hysteresis::HYSTER;
 
     if (s == "BOBERG")
-        return RockConfig::Hysteresis::BOBERG;
+        return Opm::RockConfig::Hysteresis::BOBERG;
 
     if (s == "REVLIMIT")
-        return RockConfig::Hysteresis::REVLIMIT;
+        return Opm::RockConfig::Hysteresis::REVLIMIT;
 
     if (s == "PALM-MAN")
-        return RockConfig::Hysteresis::PALM_MAN;
+        return Opm::RockConfig::Hysteresis::PALM_MAN;
 
     if (s == "NONE")
-        return RockConfig::Hysteresis::NONE;
+        return Opm::RockConfig::Hysteresis::NONE;
 
     throw std::invalid_argument("Not recognized hysteresis option: " + s);
 }
 
-}
+} // Anonymous namespace
 
-RockConfig::RockConfig() :
-    num_property(ParserKeywords::ROCKOPTS::TABLE_TYPE::defaultValue),
-    num_tables(ParserKeywords::ROCKCOMP::NTROCC::defaultValue)
-{
-}
+// ===========================================================================
 
-bool RockConfig::RockComp::operator==(const RockConfig::RockComp& other) const {
-    return this->pref == other.pref &&
-           this->compressibility == other.compressibility;
-}
+namespace Opm {
 
-RockConfig::RockComp::RockComp(double pref_arg, double comp_arg) :
-    pref(pref_arg),
-    compressibility(comp_arg)
+RockConfig::RockComp::RockComp(double pref_arg, double comp_arg)
+    : pref(pref_arg)
+    , compressibility(comp_arg)
 {}
+
+bool RockConfig::RockComp::operator==(const RockConfig::RockComp& other) const
+{
+    return (this->pref == other.pref)
+        && (this->compressibility == other.compressibility);
+}
+
+// ---------------------------------------------------------------------------
+
+RockConfig::RockConfig()
+    : num_property(ParserKeywords::ROCKOPTS::TABLE_TYPE::defaultValue)
+    , num_tables  (ParserKeywords::ROCKCOMP::NTROCC::defaultValue)
+{}
+
+RockConfig::RockConfig(const Deck& deck, const FieldPropsManager& fp)
+    : RockConfig {}
+{
+    using rock = ParserKeywords::ROCK;
+    using rockopts = ParserKeywords::ROCKOPTS;
+    using rockcomp = ParserKeywords::ROCKCOMP;
+
+    if (deck.hasKeyword<rock>()) {
+        for (const auto& table : RockTable { deck.get<rock>().back() }) {
+            this->m_comp.emplace_back(table.reference_pressure,
+                                      table.compressibility);
+        }
+    }
+
+    if (deck.hasKeyword<rockopts>()) {
+        const auto& record = deck.get<rockopts>().back().getRecord(0);
+        this->num_property = num_prop( record.getItem<rockopts::TABLE_TYPE>().getTrimmedString(0) );
+    }
+
+    if (deck.hasKeyword<rockcomp>()) {
+        const auto& record = deck.get<rockcomp>().back().getRecord(0);
+        if (fp.has_int("ROCKNUM")) {
+            this->num_property = "ROCKNUM";
+        }
+
+        this->num_tables = record.getItem<rockcomp::NTROCC>().get<int>(0);
+        this->hyst_mode = hysteresis(record.getItem<rockcomp::HYSTERESIS>().getTrimmedString(0));
+        this->m_water_compaction = DeckItem::to_bool(record.getItem<rockcomp::WATER_COMPACTION>().getTrimmedString(0));
+
+        this->m_active = true;
+        if ((this->hyst_mode == Hysteresis::NONE) && !this->m_water_compaction) {
+            this->m_active = false;
+        }
+    }
+}
 
 RockConfig RockConfig::serializationTestObject()
 {
@@ -95,71 +141,44 @@ RockConfig RockConfig::serializationTestObject()
     return result;
 }
 
-bool RockConfig::water_compaction() const {
-    return this->m_water_compaction;
-}
-
-const std::vector<RockConfig::RockComp>& RockConfig::comp() const {
-    return this->m_comp;
-}
-
-std::size_t RockConfig::num_rock_tables() const {
-    return this->num_tables;
-}
-
-const std::string& RockConfig::rocknum_property() const {
-    return this->num_property;
-}
-
-RockConfig::Hysteresis RockConfig::hysteresis_mode() const {
-    return this->hyst_mode;
-}
-
-bool RockConfig::active() const {
+bool RockConfig::active() const
+{
     return this->m_active;
 }
 
-RockConfig::RockConfig(const Deck& deck, const FieldPropsManager& fp)
-		: RockConfig {}
+const std::vector<RockConfig::RockComp>& RockConfig::comp() const
 {
-    using rock = ParserKeywords::ROCK;
-    using rockopts = ParserKeywords::ROCKOPTS;
-    using rockcomp = ParserKeywords::ROCKCOMP;
-    if (deck.hasKeyword<rock>()) {
-        const auto& rock_kw = deck.get<rock>().back();
-        for (const auto& record : rock_kw)
-            this->m_comp.emplace_back( record.getItem<rock::PREF>().getSIDouble(0),
-                                       record.getItem<rock::COMPRESSIBILITY>().getSIDouble(0));
-    }
-
-    if (deck.hasKeyword<rockopts>()) {
-        const auto& record = deck.get<rockopts>().back().getRecord(0);
-        this->num_property = num_prop( record.getItem<rockopts::TABLE_TYPE>().getTrimmedString(0) );
-    }
-
-    if (deck.hasKeyword<rockcomp>()) {
-        const auto& record = deck.get<rockcomp>().back().getRecord(0);
-        if (fp.has_int("ROCKNUM"))
-            this->num_property = "ROCKNUM";
-
-        this->num_tables = record.getItem<rockcomp::NTROCC>().get<int>(0);
-        this->hyst_mode = hysteresis(record.getItem<rockcomp::HYSTERESIS>().getTrimmedString(0));
-        this->m_water_compaction = DeckItem::to_bool(record.getItem<rockcomp::WATER_COMPACTION>().getTrimmedString(0));
-
-        this->m_active = true;
-        if (this->hyst_mode == Hysteresis::NONE && !this->m_water_compaction)
-            this->m_active = false;
-    }
+    return this->m_comp;
 }
 
+const std::string& RockConfig::rocknum_property() const
+{
+    return this->num_property;
+}
 
-bool RockConfig::operator==(const RockConfig& other) const {
-    return this->num_property == other.num_property &&
-           this->m_comp == other.m_comp &&
-           this->num_tables == other.num_tables &&
-           this->m_active == other.m_active &&
-           this->m_water_compaction == other.m_water_compaction &&
-           this->hyst_mode == other.hyst_mode;
+std::size_t RockConfig::num_rock_tables() const
+{
+    return this->num_tables;
+}
+
+RockConfig::Hysteresis RockConfig::hysteresis_mode() const
+{
+    return this->hyst_mode;
+}
+
+bool RockConfig::water_compaction() const
+{
+    return this->m_water_compaction;
+}
+
+bool RockConfig::operator==(const RockConfig& other) const
+{
+    return (this->num_property == other.num_property)
+        && (this->m_comp == other.m_comp)
+        && (this->num_tables == other.num_tables)
+        && (this->m_active == other.m_active)
+        && (this->m_water_compaction == other.m_water_compaction)
+        && (this->hyst_mode == other.hyst_mode);
 }
 
 } //namespace Opm

--- a/tests/parser/TableManagerTests.cpp
+++ b/tests/parser/TableManagerTests.cpp
@@ -2398,6 +2398,28 @@ BOOST_AUTO_TEST_CASE( TestParseROCK ) {
     BOOST_CHECK_EQUAL( 8U , tables.numFIPRegions( ));
 }
 
+BOOST_AUTO_TEST_CASE( TestParseROCK_WithDefault )
+{
+    const auto deck = Opm::Parser{}.parseString(R"(RUNSPEC
+TABDIMS
+  1* 2 /
+PROPS
+ROCK
+  1.1 1.2 /
+/ -- Copy from region 1
+)");
+
+    const auto tables = Opm::TableManager { deck };
+    const auto& rock = tables.getRockTable();
+    BOOST_CHECK_EQUAL(rock.size(), std::size_t{2});
+
+    BOOST_CHECK_CLOSE(1.1e5,  rock[0].reference_pressure, 1.0e-8);
+    BOOST_CHECK_CLOSE(1.2e-5, rock[0].compressibility, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(1.1e5,  rock[1].reference_pressure, 1.0e-8);
+    BOOST_CHECK_CLOSE(1.2e-5, rock[1].compressibility, 1.0e-8);
+}
+
 BOOST_AUTO_TEST_CASE( TestParsePVCDO ) {
     const std::string data = R"(
       TABDIMS


### PR DESCRIPTION
This PR adds the expected behaviour for all-defaulted records in `ROCK`, provided the all-defaulted records are not the first of the keyword.  Similarly to, e.g. `PVTW`, all-defaulted records are treated as copies of the immediately preceding record.

In other words, given
```
ROCK
-- REF. PRES   COMPRESSIBILITY
  280.000        5.6E-5 /
/
```
the second record is supposed to be a copy of the first.