### PR TITLE
Allow FIELD group as parent for wells

### DIFF
--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -339,6 +339,7 @@ class KeywordLocation;
 
         const static std::string SCHEDULE_GROUP_ERROR;
         const static std::string SCHEDULE_IGNORED_GUIDE_RATE;
+        const static std::string SCHEDULE_WELL_IN_FIELD_GROUP;
 
         const static std::string SCHEDULE_COMPSEGS_INVALID;
         const static std::string SCHEDULE_COMPSEGS_NOT_SUPPORTED;

--- a/src/opm/common/utility/OpmInputError.cpp
+++ b/src/opm/common/utility/OpmInputError.cpp
@@ -43,7 +43,7 @@ std::string formatImpl(const std::string& msg_format, const KeywordLocation& loc
 std::string OpmInputError::formatException(const std::exception& e, const KeywordLocation& loc) {
     const std::string defaultMessage { R"(Problem with keyword {keyword}
 In {file} line {line}.
-Internal error: {})" } ;
+{})" } ;
 
     return formatImpl(defaultMessage, loc, e.what());
 }

--- a/src/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/input/eclipse/Parser/ParseContext.cpp
@@ -121,6 +121,7 @@ namespace Opm {
         this->addKey(UDQ_TYPE_ERROR, InputErrorAction::THROW_EXCEPTION);
         this->addKey(SCHEDULE_GROUP_ERROR, InputErrorAction::THROW_EXCEPTION);
         this->addKey(SCHEDULE_IGNORED_GUIDE_RATE, InputErrorAction::WARN);
+        this->addKey(SCHEDULE_WELL_IN_FIELD_GROUP, InputErrorAction::WARN);
         this->addKey(SCHEDULE_COMPSEGS_INVALID, InputErrorAction::THROW_EXCEPTION);
         this->addKey(SCHEDULE_COMPSEGS_NOT_SUPPORTED, InputErrorAction::THROW_EXCEPTION);
         addKey(SCHEDULE_INVALID_NAME, InputErrorAction::THROW_EXCEPTION);
@@ -368,6 +369,7 @@ namespace Opm {
     const std::string ParseContext::UDQ_TYPE_ERROR = "UDQ_TYPE_ERROR";
     const std::string ParseContext::SCHEDULE_GROUP_ERROR = "SCHEDULE_GROUP_ERROR";
     const std::string ParseContext::SCHEDULE_IGNORED_GUIDE_RATE = "SCHEDULE_IGNORED_GUIDE_RATE";
+    const std::string ParseContext::SCHEDULE_WELL_IN_FIELD_GROUP = "SCHEDULE_WELL_IN_FIELD_GROUP";
 
     const std::string ParseContext::SCHEDULE_COMPSEGS_INVALID = "SCHEDULE_COMPSEG_INVALID";
     const std::string ParseContext::SCHEDULE_COMPSEGS_NOT_SUPPORTED = "SCHEDULE_COMPSEGS_NOT_SUPPORTED";

--- a/src/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -656,7 +656,7 @@ bool Group::wellgroup() const {
 
 bool Group::addWell(const std::string& well_name) {
     if (!this->m_groups.empty())
-        throw std::logic_error("Groups can not mix group and well children. Trying to add well: " + well_name + " to group: " + this->name());
+        throw std::runtime_error("Groups can not mix group and well children. Trying to add well: " + well_name + " to group: " + this->name());
 
     if (this->m_wells.count(well_name) == 0) {
         this->m_wells.insert(well_name);
@@ -677,7 +677,7 @@ void Group::delWell(const std::string& well_name) {
 
 bool Group::addGroup(const std::string& group_name) {
     if (!this->m_wells.empty())
-        throw std::logic_error("Groups can not mix group and well children. Trying to add group: " + group_name + " to group: " + this->name());
+        throw std::runtime_error("Groups can not mix group and well children. Trying to add group: " + group_name + " to group: " + this->name());
 
     if (this->m_groups.count(group_name) == 0) {
         this->m_groups.insert(group_name);

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1496,7 +1496,6 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
 
             if (groupName == "FIELD") {
                 fieldWells.push_back(wellName);
-                continue;
             }
 
             const auto fip_region_number = record.getItem<ParserKeywords::WELSPECS::FIP_REGION>().get<int>(0);
@@ -1565,12 +1564,13 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
 
         if (! fieldWells.empty()) {
             const auto* plural = (fieldWells.size() == 1) ? "" : "s";
-
-            throw OpmInputError {
-                fmt::format(R"(Well{0} cannot be parented directly to 'FIELD'.
-Well{0} entered with disallowed 'FIELD' parent group:
- * {1})", plural, fmt::join(fieldWells, "\n * ")), handlerContext.keyword.location()
-            };
+            const auto msg_fmt = fmt::format(R"(Well{0} is parented directly to 'FIELD', this is allowed but discouraged.
+Well{0} entered with 'FIELD' parent group:
+ * {1})", plural, fmt::join(fieldWells, "\n * "));
+            handlerContext.parseContext.handleError( ParseContext::SCHEDULE_WELL_IN_FIELD_GROUP,
+                                                     msg_fmt,
+                                                     handlerContext.keyword.location(),
+                                                     handlerContext.errors );
         }
     }
 

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -2420,11 +2420,17 @@ Well{0} entered with disallowed 'FIELD' parent group:
             std::invoke(function_iterator->second, this, handlerContext);
         } catch (const OpmInputError&) {
             throw;
-        } catch (const std::exception& e) {
-            const OpmInputError opm_error { e, handlerContext.keyword.location() } ;
-
+        } catch (const std::logic_error& e) {
+            // Rethrow as OpmInputError to provide more context,
+            // but add "Internal error: " to the string, as that
+            // is what logic_error signifies.
+            const OpmInputError opm_error { std::string("Internal error: ") + e.what(), handlerContext.keyword.location() } ;
             OpmLog::error(opm_error.what());
-
+            std::throw_with_nested(opm_error);
+        } catch (const std::exception& e) {
+            // Rethrow as OpmInputError to provide more context.
+            const OpmInputError opm_error { e, handlerContext.keyword.location() } ;
+            OpmLog::error(opm_error.what());
             std::throw_with_nested(opm_error);
         }
 

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -246,8 +246,8 @@ BOOST_AUTO_TEST_CASE(GroupCreate) {
     BOOST_CHECK( g2.addGroup("G2") );
 
     // The children must be either all wells - or all groups.
-    BOOST_CHECK_THROW(g1.addGroup("G1"), std::logic_error);
-    BOOST_CHECK_THROW(g2.addWell("W1"), std::logic_error);
+    BOOST_CHECK_THROW(g1.addGroup("G1"), std::runtime_error);
+    BOOST_CHECK_THROW(g2.addWell("W1"), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(createDeckWithGCONPROD) {

--- a/tests/test_OpmInputError_format.cpp
+++ b/tests/test_OpmInputError_format.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(positional) {
 BOOST_AUTO_TEST_CASE(exception_init) {
     const std::string expected { R"(Problem with keyword MXUNSUPP
 In FILENAME.DAT line 42.
-Internal error: Runtime Error)" };
+Runtime Error)" };
 
     const std::string formatted { Opm::OpmInputError(std::runtime_error("Runtime Error"), location).what() } ;
 
@@ -66,7 +66,7 @@ Internal error: Runtime Error)" };
 BOOST_AUTO_TEST_CASE(exception_nest) {
     const std::string expected { R"(Problem with keyword MXUNSUPP
 In FILENAME.DAT line 42.
-Internal error: Runtime Error)" };
+Runtime Error)" };
 
     try {
         try {


### PR DESCRIPTION
This relaxes the restriction on parents. Also moves the handling of this to the ParseContext system, and (only somewhat related) makes it clear that mixing wells and groups as children of a single group (which is still forbidden) is a user input error, not an internal error.


Requires https://github.com/OPM/opm-simulators/pull/4608 downstream.