### PR TITLE
Backport #3484: fixed: missing serialization of tokens in UDQDefine

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp
@@ -94,6 +94,7 @@ public:
     void serializeOp(Serializer& serializer)
     {
         serializer(m_keyword);
+        serializer(m_tokens);
         serializer(ast);
         serializer(m_var_type);
         serializer(m_location);

--- a/opm/input/eclipse/Schedule/UDQ/UDQToken.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQToken.hpp
@@ -30,15 +30,29 @@ namespace Opm {
 
 class UDQToken {
 public:
+    UDQToken() = default;
     UDQToken(const std::string& string_token, UDQTokenType token_type);
     UDQToken(const std::string& string_token, const std::vector<std::string>& selector);
+
+    static UDQToken serializationTestObject();
 
     const std::vector<std::string>& selector() const;
     const std::variant<std::string, double>& value() const;
     UDQTokenType type() const;
     std::string str() const;
+
+    bool operator==(const UDQToken&) const;
+
+    template<class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(token_type);
+        serializer(m_value);
+        serializer(m_selector);
+    }
+
 private:
-    UDQTokenType token_type;
+    UDQTokenType token_type{UDQTokenType::error};
     std::variant<std::string,double> m_value;
     std::vector<std::string> m_selector;
 };

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
@@ -279,6 +279,7 @@ UDQDefine UDQDefine::serializationTestObject()
 {
     UDQDefine result;
     result.m_keyword = "test1";
+    result.m_tokens = {UDQToken::serializationTestObject()};
     result.ast = std::make_shared<UDQASTNode>(UDQASTNode::serializationTestObject());
     result.m_var_type = UDQVarType::SEGMENT_VAR;
     result.string_data = "test2";
@@ -404,6 +405,7 @@ bool UDQDefine::operator==(const UDQDefine& data) const
     }
 
     return (this->keyword() == data.keyword())
+        && (this->m_tokens == data.m_tokens)
         && (this->m_location == data.location())
         && (this->var_type() == data.var_type())
         && (this->status() == data.status())

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQToken.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQToken.cpp
@@ -89,4 +89,16 @@ std::string UDQToken::str() const
     }
 }
 
+UDQToken UDQToken::serializationTestObject()
+{
+    return UDQToken{"test1", {"test2", "test3"}};
+}
+
+bool UDQToken::operator==(const UDQToken& rhs) const
+{
+    return this->token_type == rhs.token_type &&
+           this->m_value == rhs.m_value &&
+           this->m_selector == rhs.m_selector;
+}
+
 } // namespace Opm


### PR DESCRIPTION
this went unnoticed since there are no UDQDefines in the pre-simulation Schedule broadcast for parallel. however it causes issues for serialized restarts