### PR TITLE
Added EclipseGrid method to check whether PINCH item 3 is defaulted.

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -115,6 +115,7 @@ namespace Opm {
         PinchMode getMultzOption() const;
         PinchMode getPinchGapMode() const;
         double getPinchMaxEmptyGap() const;
+        bool maxEmptyGapDefaulted()const;
 
         MinpvMode getMinpvMode() const;
         const std::vector<double>& getMinpvVector( ) const;

--- a/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -556,6 +556,10 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         return m_pinchMaxEmptyGap;
     }
 
+    bool EclipseGrid::maxEmptyGapDefaulted() const {
+        return m_pinchMaxEmptyGap ==
+            ParserKeywords::PINCH::MAX_EMPTY_GAP::defaultValue;
+    }
 
     const std::vector<double>& EclipseGrid::getMinpvVector( ) const {
         return m_minpvVector;


### PR DESCRIPTION
This is needed for correctly generating or not generating NNCs across vertical gaps.