### PR TITLE
Python: avoid searching from Development.Embed unless required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,8 +218,10 @@ if (OPM_ENABLE_PYTHON)
     endif()
     # We always need to search for Development as we use
     # pybind11_add_module even if don't embed Python
-    find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
-    if (OPM_ENABLE_EMBEDDED_PYTHON)
+    if (NOT OPM_ENABLE_EMBEDDED_PYTHON)
+      find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+    else()
+      find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Embed Development.Module)
       get_target_property(_lib_path Python3::Python IMPORTED_LOCATION)
       set(PYTHON_LIBRARY ${_lib_path})
       set(PYTHON_LIBRARIES {PYTHON_LIBRARY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,17 +228,6 @@ if (OPM_ENABLE_PYTHON)
       list(APPEND opm-common_LIBRARIES ${PYTHON_LIBRARY})
       set(PYTHON_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
     endif()
-    # Make sure we fail gracefully here without setuptool
-    execute_process(COMMAND ${Python3_EXECUTABLE} -c "import setuptools"
-      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-      ERROR_VARIABLE SETUPTOOL_ERROR OUTPUT_VARIABLE SETUPTOOL_OUT
-      RESULT_VARIABLE SETUPTOOL_RESULT)
-    if(SETUPTOOL_RESULT GREATER 0)
-      message(WARNING "Trying to test setuptools resulted in error message: ${SETUPTOOL_ERROR}")
-      message(SEND_ERROR "To build the python bindings you need to install setuptool. "
-        "Either use \"apt-get install python3-setuptools\" (on Debian/Ubuntu) "
-        "or \"pip install setuptools\"")
-    endif()
     if(Python3_VERSION_MINOR LESS 3)
       # Python native namespace packages requires python >= 3.3
       message(SEND_ERROR "OPM requires python >= 3.3 but only version ${Python3_VERSION} was found")


### PR DESCRIPTION
The change to unconditionally search for Development broke the pypi builders. The reason is that the manylinux2014 docker images used to build does not contain the embedding headers.

Since this is more correct in general, I opted to fix it like this instead of hackery in the pypi builder.

Also remove outdated check for setuptools. No longer required, only used for the pypi builder and that checks this thoroughly on its own.