### PR TITLE
changed: build python wheels using skbuild

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(install_python_binding)
+
+cmake_minimum_required(VERSION 3.15)
+
+install(CODE "message(\"Dummy install\")")

--- a/python/generate-pypi-package.sh
+++ b/python/generate-pypi-package.sh
@@ -25,7 +25,7 @@ do
       rm -rf $tag
     fi
     mkdir $tag && pushd $tag
-    cmake3 -DPYTHON_EXECUTABLE=${python_versions[$tag]} -DBOOST_INCLUDEDIR=/usr/include/boost169 -DBOOST_LIBRARYDIR=/usr/lib64/boost169 -DWITH_NATIVE=0 \
+    cmake -DPYTHON_EXECUTABLE=${python_versions[$tag]} -DBOOST_INCLUDEDIR=/usr/include/boost169 -DBOOST_LIBRARYDIR=/usr/lib64/boost169 -DWITH_NATIVE=0 \
     -DOPM_ENABLE_PYTHON=ON -DOPM_PYTHON_PACKAGE_VERSION_TAG=${VERSION_TAG} ..
 
     # make step is necessary until the generated ParserKeywords/*.hpp are generated in the Python step

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires= [
+  "setuptools>=42",
+  "scikit-build>=0.13",
+  "cmake>=3.15",
+  "ninja"
+]

--- a/python/setup-docker-image.sh
+++ b/python/setup-docker-image.sh
@@ -8,11 +8,11 @@
 
 yum-config-manager --add-repo \
 https://www.opm-project.org/package/opm.repo
-yum install -y cmake3 ccache boost169-devel boost169-static tbb-devel
+yum install -y ccache boost169-devel boost169-static tbb-devel
 yum install -y blas-devel suitesparse-devel dune-common-devel
 
 for python_bin in ${python_versions[*]}
 do
   ${python_bin} -m pip install pip --upgrade
-  ${python_bin} -m pip install wheel setuptools twine pytest-runner auditwheel
+  ${python_bin} -m pip install wheel setuptools twine pytest-runner auditwheel scikit-build cmake
 done

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,4 +1,4 @@
-from setuptools import setup
+from skbuild import setup
 
 import os
 
@@ -32,7 +32,6 @@ setup(
     package_data={'opm' : ['$<TARGET_FILE_NAME:opmcommon_python>']},
     include_package_data=True,
     license='Open Source',
-    zip_safe=False,
     test_suite='tests',
     setup_requires=["pytest-runner", 'setuptools_scm'],
     python_requires='>=3.6',


### PR DESCRIPTION
the vanilla setup-tools doesn't get the triplet correctly for some reason. also use cmake from pip as cmake 3.16 in the image has a bug in the python find rule.

after exhaustive searching i gave up beating setuptools into behaving and just went for skbuild. it's a bit naughty since it needs a dummy cmakelists but this works at least.