### PR TITLE
Dimension Segment Related Restart Arrays According to Dynamic Size

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -77,6 +77,8 @@ namespace Opm {
 
         std::size_t size() const;
         bool empty() const;
+        int maxSegmentID() const;
+        int maxBranchID() const;
         double depthTopSegment() const;
         double lengthTopSegment() const;
         double volumeTopSegment() const;

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -387,6 +387,8 @@ public:
     const std::vector<const Connection *> getConnections(int completion) const;
     const WellConnections& getConnections() const;
     const WellSegments& getSegments() const;
+    int maxSegmentID() const;
+    int maxBranchID() const;
 
     const WellProductionProperties& getProductionProperties() const;
     const WellInjectionProperties& getInjectionProperties() const;

--- a/src/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -28,11 +28,19 @@
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <map>
+#include <cstddef>
 #include <iterator>
+#include <map>
+#include <numeric>
+#include <set>
+#include <stdexcept>
+#include <string>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 #ifdef _WIN32
 #define _USE_MATH_DEFINES
@@ -74,6 +82,26 @@ namespace Opm {
 
     bool WellSegments::empty() const {
         return this->m_segments.empty();
+    }
+
+    int WellSegments::maxSegmentID() const
+    {
+        return std::accumulate(this->m_segments.begin(),
+                               this->m_segments.end(), 0,
+            [](const int maxID, const Segment& seg)
+        {
+            return std::max(maxID, seg.segmentNumber());
+        });
+    }
+
+    int WellSegments::maxBranchID() const
+    {
+        return std::accumulate(this->m_segments.begin(),
+                               this->m_segments.end(), 0,
+            [](const int maxID, const Segment& seg)
+        {
+            return std::max(maxID, seg.branchNumber());
+        });
     }
 
     const Segment& WellSegments::topSegment() const {

--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1122,6 +1122,20 @@ const WellSegments& Well::getSegments() const {
         throw std::logic_error("Asked for segment information in not MSW well: " + this->name());
 }
 
+int Well::maxSegmentID() const
+{
+    return (this->segments == nullptr)
+        ? 0
+        : this->segments->maxSegmentID();
+}
+
+int Well::maxBranchID() const
+{
+    return (this->segments == nullptr)
+        ? 0
+        : this->segments->maxBranchID();
+}
+
 const Well::WellInjectionProperties& Well::getInjectionProperties() const {
     return *this->injection;
 }


### PR DESCRIPTION
The `[IR]SEG` and `ILB[RS]` arrays must be able to accommodate the maximum number of segments and branches used in the run.  This PR incorporates the dynamic maximum sizes.  If those sizes exceed the maximum values entered in `WSEGDIMS`, then the resulting restart file will not be fully compatible with other simulation software.