### PR TITLE
remove not need throw in non PYTHON build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ endmacro()
 # OpmLibMain function. Here only the library dependency is implemented, the
 # bulk of the python configuration is further down in the file.
 if (OPM_ENABLE_PYTHON)
+  set(HAVE_PYTHON 1)
   # We need to be compatible with older CMake versions
   # that do not offer FindPython3
   # e.g. Ubuntu LTS 18.04 uses cmake 3.10

--- a/opm-common-prereqs.cmake
+++ b/opm-common-prereqs.cmake
@@ -9,6 +9,7 @@ set (opm-common_CONFIG_VAR
 	HAVE_FINAL
 	HAVE_ECL_INPUT
 	HAVE_CXA_DEMANGLE
+	HAVE_PYTHON
 	)
 
 # dependencies

--- a/opm/input/eclipse/Python/Python.hpp
+++ b/opm/input/eclipse/Python/Python.hpp
@@ -121,8 +121,11 @@ public:
         TRY,   /* Try to enable Python extensions*/
         OFF    /* Do not enable Python */
     };
-
+#ifdef HAVE_PYTHON
     explicit Python(Enable enable = Enable::TRY);
+#else
+    explicit Python(Enable enable = Enable::OFF);
+#endif    
     bool exec(const std::string& python_code) const;
     bool exec(const std::string& python_code, const Parser& parser, Deck& deck) const;
     bool exec(const Action::PyAction& py_action, EclipseState& ecl_state, Schedule& schedule, std::size_t report_step, SummaryState& st) const;


### PR DESCRIPTION
Remove throw when running flow when it is compiles without python.  This saves time when debugging the code.