### PR TITLE
fixed: handle dynamically sized evaluations in {fmt} formatter

### DIFF
--- a/opm/material/densead/EvaluationFormat.hpp
+++ b/opm/material/densead/EvaluationFormat.hpp
@@ -47,10 +47,11 @@ struct fmt::formatter<Opm::DenseAd::Evaluation<ValueT,numDerivs,staticSize>>
     auto format(const Opm::DenseAd::Evaluation<ValueT,numDerivs,staticSize>& e,
                 FormatContext& ctx)
     {
-        std::array<ValueT,numDerivs> tmp;
-        for (int i = 0; i < numDerivs; ++i)
+        std::vector<ValueT> tmp(e.size());
+        for (int i = 0; i < e.size(); ++i)
             tmp[i] = e.derivative(i);
-        return fmt::format_to(ctx.out(), "v: "+ spec +" / d: [" + spec +"]", e.value(), fmt::join(tmp, ", "));
+        return fmt::format_to(ctx.out(), "v: "+ spec +" / d: [" + spec +"]",
+                              e.value(), fmt::join(tmp, ", "));
     }
 };
 


### PR DESCRIPTION
formatting should not be time critical. use the method instead of the template param. the template param is -1 for dynamically sized evaluations which means the formatter tries to allocate a very large array..