### PR TITLE
Also install co2brinepvt as we install the manpage.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,7 @@ if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
 endif()
 if(BUILD_EXAMPLES)
   target_link_libraries(co2brinepvt dunecommon)
+  install(TARGETS co2brinepvt DESTINATION bin)
 endif()
 
 # Install build system files and documentation


### PR DESCRIPTION
Mmh. That binary is from opm-material. While it was never installed there, we did install its man page (:flushed: Was me of course :grimacing:)

Closes #3474