### PR TITLE
Implement GASVISCT for black-oil [Bug fix]

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -24,15 +24,14 @@
 
 namespace Opm {
 
-    class Deck;
     class DeckItem;
 
     class GasvisctTable : public SimpleTable {
     public:
-        GasvisctTable( const Deck& deck, const DeckItem& deckItem );
+        GasvisctTable( const DeckItem& item, const int tableID  );
 
         const TableColumn& getTemperatureColumn() const;
-        const TableColumn& getGasViscosityColumn(size_t compIdx) const;
+        const TableColumn& getGasViscosityColumn() const;
     };
 }
 

--- a/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
@@ -289,7 +289,6 @@ namespace Opm {
         void initRTempTables(const Deck& deck);
         void initDims(const Deck& deck);
         void initRocktabTables(const Deck& deck);
-        void initGasvisctTables(const Deck& deck);
 
         void initPlymaxTables(const Deck& deck);
         void initPlyrockTables(const Deck& deck);

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -55,6 +55,7 @@ public:
     WaterPvtThermal()
     {
         enableThermalDensity_ = false;
+        enableJouleThomson_ = false;
         enableThermalViscosity_ = false;
         enableInternalEnergy_ = false;
         isothermalPvt_ = nullptr;

--- a/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -581,6 +581,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         initSimpleTableContainer<SpecheatTable>(deck, "SPECHEAT", m_tabdims.getNumPVTTables());
         initSimpleTableContainer<SpecrockTable>(deck, "SPECROCK", m_tabdims.getNumSatTables());
         initSimpleTableContainer<OilvisctTable>(deck, "OILVISCT", m_tabdims.getNumPVTTables());
+        initSimpleTableContainer<GasvisctTable>(deck, "GASVISCT", m_tabdims.getNumPVTTables());
         initSimpleTableContainer<WatvisctTable>(deck, "WATVISCT", m_tabdims.getNumPVTTables());
 
         initSimpleTableContainer<PlyadsTable>(deck, "PLYADS", m_tabdims.getNumSatTables());
@@ -592,7 +593,6 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         initPlyrockTables(deck);
         initPlymaxTables(deck);
-        initGasvisctTables(deck);
         initRTempTables(deck);
         initRocktabTables(deck);
         initPlyshlogTables(deck);
@@ -618,34 +618,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         } else if (hasRTEMPVD) {
             initSimpleTableContainer<RtempvdTable>(deck, "RTEMPVD", "RTEMPVD", m_eqldims.getNumEquilRegions());
         }
-    }
-
-
-    void TableManager::initGasvisctTables(const Deck& deck) {
-
-        const std::string keywordName = "GASVISCT";
-        size_t numTables = m_tabdims.getNumPVTTables();
-
-        if (!deck.hasKeyword(keywordName))
-            return; // the table is not featured by the deck...
-
-        auto& container = forceGetTables(keywordName , numTables);
-
-        if (deck.count(keywordName) > 1) {
-            complainAboutAmbiguousKeyword(deck, keywordName);
-            return;
-        }
-
-        const auto& tableKeyword = deck[keywordName].back();
-        for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
-            const auto& tableRecord = tableKeyword.getRecord( tableIdx );
-            const auto& dataItem = tableRecord.getItem( 0 );
-            if (dataItem.data_size() > 0) {
-                std::shared_ptr<GasvisctTable> table = std::make_shared<GasvisctTable>( deck , dataItem );
-                container.addTable( tableIdx , table );
-            }
-        }
-    }
+    }   
 
 
     void TableManager::initPlyshlogTables(const Deck& deck) {

--- a/src/opm/input/eclipse/EclipseState/Tables/Tables.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/Tables.cpp
@@ -1170,46 +1170,12 @@ WatvisctTable::getWaterViscosityColumn() const
     return SimpleTable::getColumn(1);
 }
 
-GasvisctTable::GasvisctTable(const Deck& deck, const DeckItem& deckItem)
+GasvisctTable::GasvisctTable(const DeckItem& item, const int tableID)
 {
-    int numComponents = deck.get<ParserKeywords::COMPS>().back().getRecord(0).getItem(0).get<int>(0);
-
-    auto temperatureDimension = deck.getActiveUnitSystem().getDimension("Temperature");
-    auto viscosityDimension = deck.getActiveUnitSystem().getDimension("Viscosity");
 
     m_schema.addColumn(ColumnSchema("Temperature", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
-    for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
-        std::string columnName = "Viscosity" + std::to_string(compIdx);
-        m_schema.addColumn(ColumnSchema(columnName, Table::INCREASING, Table::DEFAULT_NONE));
-    }
-
-    SimpleTable::addColumns();
-
-    if (deckItem.data_size() % numColumns() != 0)
-        throw std::runtime_error("Number of columns in the data file is inconsistent "
-                                 "with the expected number for keyword GASVISCT");
-
-    size_t rows = deckItem.data_size() / m_schema.size();
-    for (size_t columnIndex = 0; columnIndex < m_schema.size(); columnIndex++) {
-        auto& column = getColumn(columnIndex);
-        for (size_t rowIdx = 0; rowIdx < rows; rowIdx++) {
-            size_t deckIndex = rowIdx * m_schema.size() + columnIndex;
-
-            if (deckItem.defaultApplied(deckIndex))
-                column.addDefault("GASVISCT");
-            else {
-                double rawValue = deckItem.get<double>(deckIndex);
-                double SIValue;
-
-                if (columnIndex == 0)
-                    SIValue = temperatureDimension.convertRawToSi(rawValue);
-                else
-                    SIValue = viscosityDimension.convertRawToSi(rawValue);
-
-                column.addValue(SIValue, "GASVISCT");
-            }
-        }
-    }
+    m_schema.addColumn(ColumnSchema("Viscosity", Table::RANDOM, Table::DEFAULT_NONE));
+    SimpleTable::init("GASVISCT", item, tableID);
 }
 
 const TableColumn&
@@ -1219,17 +1185,16 @@ GasvisctTable::getTemperatureColumn() const
 }
 
 const TableColumn&
-GasvisctTable::getGasViscosityColumn(size_t compIdx) const
+GasvisctTable::getGasViscosityColumn() const
 {
-    return SimpleTable::getColumn(1 + compIdx);
+    return SimpleTable::getColumn(1);
 }
 
 RtempvdTable::RtempvdTable(const DeckItem& item, const int tableID)
 {
     m_schema.addColumn(ColumnSchema("Depth", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
     m_schema.addColumn(ColumnSchema("Temperature", Table::RANDOM, Table::DEFAULT_NONE));
-
-    SimpleTable::init("GASVISCT", item, tableID);
+    SimpleTable::init("RTEMPVD", item, tableID);
 }
 
 const TableColumn&

--- a/src/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
+++ b/src/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
@@ -85,8 +85,12 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 
             viscrefPress_[regionIdx] = viscrefTable[regionIdx].reference_pressure;
 
-            // temperature used to calculate the reference viscosity [K]. 
+            // Temperature used to calculate the reference viscosity [K]. 
+            // The value dooes not matter as the underlying PVT object is isothermal.
             constexpr const Scalar Tref = 273.15 + 20;
+            //TODO: For now I just assumed the default references RV and RVW = 0, 
+            // we could add these two parameters to a new item keyword VISCREF 
+            //or create a new keyword for gas. 
             constexpr const Scalar Rvref = 0.0;
             constexpr const Scalar Rvwref = 0.0;
             // compute the reference viscosity using the isothermal PVT object.

--- a/src/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
+++ b/src/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.cpp
@@ -52,6 +52,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
     const auto& tables = eclState.getTableManager();
 
     enableThermalDensity_ = tables.OilDenT().size() > 0;
+    enableJouleThomson_ = tables.OilJT().size() > 0;
     enableThermalViscosity_ = tables.hasTables("OILVISCT");
     enableInternalEnergy_ = tables.hasTables("SPECHEAT");
 


### PR DESCRIPTION
GASVISCT is a E300 keyword and requires COMPS keyword. OPM current implementation would simply give this error:
![image](https://user-images.githubusercontent.com/54812829/237048223-de9753ec-4ebd-4c10-9945-115e881d3e97.png)
That would happen because the implementation was trying to access the content of COMPS that was not there and there was no safeguard for that. 
I went ahead and implemented this keyword for a black-oil gas, considering we don't have support compositional formulation.  In the future it can be extended for compositional. 
Note, for now I just assumed references RV and RVW = 0, we could add these two parameters to the keyword VISCREF or create a new keyword for gas. What do you think @OPMUSER?
PS: I will add a test case in opm-tests today. 