### PR TITLE
Parse compositional summary keywords

### DIFF
--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -384,6 +384,15 @@ struct SummaryConfigContext {
         return std::regex_match(keyword, well_compl_kw);
     }
 
+    bool is_well_comp(const std::string& keyword)
+    {
+        static const auto well_comp_kw = keyword_set {
+             "WXMF", "WYMF", "WZMF", "WCGMR", "WCOMR"
+        };
+
+        return is_in_set(well_comp_kw, keyword);
+    }
+
     bool is_node_keyword(const std::string& keyword)
     {
         static const auto nodekw = keyword_set {
@@ -1362,6 +1371,12 @@ inline void handleKW( SummaryConfig::keyword_list& list,
     const auto cat = parseKeywordCategory(name);
     switch (cat) {
     case Cat::Well:
+        if (is_well_comp(keyword.name())) {
+            Opm::OpmLog::warning(Opm::OpmInputError::format("Unhandled summary keyword {keyword}\n"
+                                                        "In {file} line {line}", keyword.location()));
+        return;
+        }
+
         keywordW(list, parseContext, errors, keyword, schedule);
         break;
 

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/W/WELL_PROBE_COMP
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/W/WELL_PROBE_COMP
@@ -1,0 +1,24 @@
+{
+  "name": "WELL_PROBE_COMP",
+  "sections": [
+    "SUMMARY"
+  ],
+  "deck_names": [
+    "WXMF",
+    "WYMF",
+    "WZMF",
+    "WCGMR",
+    "WCOMR"
+],
+"items": [
+  {
+    "name": "WELLS",
+    "value_type": "STRING",
+    "size_type": "ALL"
+  },
+  {
+    "name": "COMP_NUM",
+    "value_type": "INT"
+  }
+]
+}

--- a/src/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1090,6 +1090,7 @@ set( keywords
      001_Eclipse300/T/TREF
      001_Eclipse300/T/TREFS
      001_Eclipse300/W/WELLSTRE
+     001_Eclipse300/W/WELL_PROBE_COMP
      001_Eclipse300/W/WINJGAS
      001_Eclipse300/W/WINJTEMP
      001_Eclipse300/W/WATDENT


### PR DESCRIPTION
I can run https://github.com/OPM/opm-tests/pull/959 using this implementation. 
It parses: "WXMF", "WYMF", "WZMF", "WCGMR", "WCOMR" , but does not output anything. 