### PR TITLE
fixed: do not compare index 2 twice

### DIFF
--- a/external/resinsight/LibCore/cvfVector4.inl
+++ b/external/resinsight/LibCore/cvfVector4.inl
@@ -491,7 +491,7 @@ inline void Vector4<S>::setZero()
 template<typename S>
 inline bool Vector4<S>::isZero() const
 {
-    return (m_v[0] == 0) && (m_v[1] == 0) && (m_v[2] == 0) && (m_v[2] == 0);
+    return (m_v[0] == 0) && (m_v[1] == 0) && (m_v[2] == 0) && (m_v[3] == 0);
 }
 
 


### PR DESCRIPTION
Found while analyzing output from static analyzers. Also sent upstream, https://github.com/OPM/ResInsight/pull/10256