### PR TITLE
Allow NONE for item 7 in GCONPROD

### DIFF
--- a/src/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -130,6 +130,7 @@ namespace {
         production.exceed_action = Opm::Group::ExceedActionFromInt(rst_group.exceed_action);
         production.guide_rate_def = Opm::Group::GuideRateProdTargetFromInt(rst_group.prod_guide_rate_def);
 
+        //TODO allow also for ExceedAction::NONE (item 7 of GCONPROD)
         if ((production.cmode == Opm::Group::ProductionCMode::ORAT) ||
             (production.cmode == Opm::Group::ProductionCMode::WRAT) ||
             (production.cmode == Opm::Group::ProductionCMode::GRAT) ||

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -564,32 +564,69 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                     production.resv_target = resv_target;
                     production.available_group_control = availableForGroupControl;
 
-                    // if ((production.cmode == Group::ProductionCMode::ORAT) ||
-                    //     (production.cmode == Group::ProductionCMode::WRAT) ||
-                    //     (production.cmode == Group::ProductionCMode::GRAT) ||
-                    //     (production.cmode == Group::ProductionCMode::LRAT))
-                    //     production.exceed_action = Group::ExceedAction::RATE;
-                    // else
-                    //     production.exceed_action = exceedAction;
-
                     production.exceed_action = exceedAction;
                     production.production_controls = 0;
-
-                    if (!apply_default_oil_target)
-                        if (exceedAction == Group::ExceedAction::RATE)
-                            production.production_controls += static_cast<int>(Group::ProductionCMode::ORAT);
-
-                    if (!apply_default_gas_target)
-                        if (exceedAction == Group::ExceedAction::RATE)
-                            production.production_controls += static_cast<int>(Group::ProductionCMode::GRAT);
-
-                    if (!apply_default_water_target)
-                        if (exceedAction == Group::ExceedAction::RATE)
-                            production.production_controls += static_cast<int>(Group::ProductionCMode::WRAT);
-
-                    if (!apply_default_liquid_target)
-                        if (exceedAction == Group::ExceedAction::RATE)
-                            production.production_controls += static_cast<int>(Group::ProductionCMode::LRAT);
+                    // GCONPROD
+                    // 'G1' 'ORAT' 1000 100 200 300 NONE =>  constraints 100,200,300 should be ignored
+                    //
+                    // GCONPROD
+                    // 'G1' 'ORAT' 1000 100 200 300 RATE =>  constraints 100,200,300 should be honored
+                    if (production.cmode == Group::ProductionCMode::ORAT){
+                        production.production_controls += static_cast<int>(Group::ProductionCMode::ORAT);
+                        if (exceedAction == Group::ExceedAction::RATE) {
+                            if (!apply_default_gas_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::GRAT);
+                            if (!apply_default_water_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::WRAT);
+                            if (!apply_default_liquid_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::LRAT);
+                        }
+                    }
+                    else if (production.cmode == Group::ProductionCMode::GRAT){
+                        production.production_controls += static_cast<int>(Group::ProductionCMode::GRAT);
+                        if (exceedAction == Group::ExceedAction::RATE) {
+                            if (!apply_default_oil_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::ORAT);
+                            if (!apply_default_water_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::WRAT);
+                            if (!apply_default_liquid_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::LRAT);
+                        }
+                    }
+                    else if (production.cmode == Group::ProductionCMode::WRAT){
+                        production.production_controls += static_cast<int>(Group::ProductionCMode::WRAT);
+                        if (exceedAction == Group::ExceedAction::RATE) {
+                            if (!apply_default_oil_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::ORAT);
+                            if (!apply_default_gas_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::GRAT);
+                            if (!apply_default_liquid_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::LRAT);
+                        }
+                    }
+                    else if (production.cmode == Group::ProductionCMode::LRAT){
+                        production.production_controls += static_cast<int>(Group::ProductionCMode::LRAT);
+                        if (exceedAction == Group::ExceedAction::RATE) {
+                            if (!apply_default_oil_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::ORAT);
+                            if (!apply_default_gas_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::GRAT);
+                            if (!apply_default_water_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::WRAT);
+                        }
+                    }
+                    else {
+                        if (exceedAction == Group::ExceedAction::RATE) {
+                            if (!apply_default_oil_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::ORAT);
+                            if (!apply_default_water_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::WRAT);
+                            if (!apply_default_gas_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::GRAT);
+                            if (!apply_default_liquid_target)
+                                 production.production_controls += static_cast<int>(Group::ProductionCMode::LRAT);
+                        }
+                    }
 
                     if (!apply_default_resv_target)
                         production.production_controls += static_cast<int>(Group::ProductionCMode::RESV);

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -564,27 +564,32 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                     production.resv_target = resv_target;
                     production.available_group_control = availableForGroupControl;
 
-                    if ((production.cmode == Group::ProductionCMode::ORAT) ||
-                        (production.cmode == Group::ProductionCMode::WRAT) ||
-                        (production.cmode == Group::ProductionCMode::GRAT) ||
-                        (production.cmode == Group::ProductionCMode::LRAT))
-                        production.exceed_action = Group::ExceedAction::RATE;
-                    else
-                        production.exceed_action = exceedAction;
+                    // if ((production.cmode == Group::ProductionCMode::ORAT) ||
+                    //     (production.cmode == Group::ProductionCMode::WRAT) ||
+                    //     (production.cmode == Group::ProductionCMode::GRAT) ||
+                    //     (production.cmode == Group::ProductionCMode::LRAT))
+                    //     production.exceed_action = Group::ExceedAction::RATE;
+                    // else
+                    //     production.exceed_action = exceedAction;
 
+                    production.exceed_action = exceedAction;
                     production.production_controls = 0;
 
                     if (!apply_default_oil_target)
-                        production.production_controls += static_cast<int>(Group::ProductionCMode::ORAT);
+                        if (exceedAction == Group::ExceedAction::RATE)
+                            production.production_controls += static_cast<int>(Group::ProductionCMode::ORAT);
 
                     if (!apply_default_gas_target)
-                        production.production_controls += static_cast<int>(Group::ProductionCMode::GRAT);
+                        if (exceedAction == Group::ExceedAction::RATE)
+                            production.production_controls += static_cast<int>(Group::ProductionCMode::GRAT);
 
                     if (!apply_default_water_target)
-                        production.production_controls += static_cast<int>(Group::ProductionCMode::WRAT);
+                        if (exceedAction == Group::ExceedAction::RATE)
+                            production.production_controls += static_cast<int>(Group::ProductionCMode::WRAT);
 
                     if (!apply_default_liquid_target)
-                        production.production_controls += static_cast<int>(Group::ProductionCMode::LRAT);
+                        if (exceedAction == Group::ExceedAction::RATE)
+                            production.production_controls += static_cast<int>(Group::ProductionCMode::LRAT);
 
                     if (!apply_default_resv_target)
                         production.production_controls += static_cast<int>(Group::ProductionCMode::RESV);

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -264,6 +264,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGCONPROD) {
         GCONPROD
             'G1' 'ORAT' 10000 3* 'CON' /
             'G2' 'RESV' 10000 3* 'CON' /
+            'G3' 'ORAT' 10000 3*  1* /
         /)";
 
     auto schedule = create_schedule(input);
@@ -271,12 +272,15 @@ BOOST_AUTO_TEST_CASE(createDeckWithGCONPROD) {
 
     const auto& group1 = schedule.getGroup("G1", 0);
     const auto& group2 = schedule.getGroup("G2", 0);
+    const auto& group3 = schedule.getGroup("G3", 0);
 
     auto ctrl1 = group1.productionControls(st);
     auto ctrl2 = group2.productionControls(st);
+    auto ctrl3 = group3.productionControls(st);
 
     BOOST_CHECK(ctrl1.exceed_action == Group::ExceedAction::RATE);
     BOOST_CHECK(ctrl2.exceed_action == Group::ExceedAction::CON);
+    BOOST_CHECK(ctrl3.exceed_action == Group::ExceedAction::NONE);
 }
 
 

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -259,10 +259,11 @@ BOOST_AUTO_TEST_CASE(createDeckWithGCONPROD) {
         GRUPTREE
            'G1'  'FIELD' /
            'G2'  'FIELD' /
+           'G3'  'FIELD' /
         /
 
         GCONPROD
-            'G1' 'ORAT' 10000 3* 'CON' /
+            'G1' 'ORAT' 10000 3* 'RATE' /
             'G2' 'RESV' 10000 3* 'CON' /
             'G3' 'ORAT' 10000 3*  1* /
         /)";

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1509,6 +1509,18 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
         GCONPROD
         'G*' 'ORAT' 2000 0 0 0 'NONE' 'YES' 148 'OIL'/
         /
+        DATES             -- 3
+         10  DEC 2008 /
+        /
+        GCONPROD
+        'G*' 'ORAT' 2000 1000 0 0 'NONE' 'YES' 148 'OIL'/
+        /
+        DATES             -- 4
+         10  JAN 2009 /
+        /
+        GCONPROD
+        'G*' 'ORAT' 2000 1000 0 0 'RATE' 'YES' 148 'OIL'/
+        /
         )";
 
         const auto& schedule = make_schedule(input);
@@ -1529,6 +1541,19 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
             BOOST_CHECK_CLOSE(g.productionControls(st).oil_target, 2000 * siFactorL, 1e-13);
             BOOST_CHECK_EQUAL(g.productionControls(st).guide_rate, 148);
             BOOST_CHECK_EQUAL(true, g.productionControls(st).guide_rate_def == Group::GuideRateProdTarget::OIL);
+        }
+        {
+            auto g = schedule.getGroup("G1", 3);
+            BOOST_CHECK_CLOSE(g.productionControls(st).oil_target, 2000 * siFactorL, 1e-13);
+            BOOST_CHECK(g.has_control(Group::ProductionCMode::ORAT));
+            BOOST_CHECK(!g.has_control(Group::ProductionCMode::WRAT));
+        }
+        {
+            auto g = schedule.getGroup("G1", 4);
+            BOOST_CHECK_CLOSE(g.productionControls(st).oil_target, 2000 * siFactorL, 1e-13);
+            BOOST_CHECK(g.has_control(Group::ProductionCMode::ORAT));
+            BOOST_CHECK_CLOSE(g.productionControls(st).water_target, 1000 * siFactorL, 1e-13);
+            BOOST_CHECK(g.has_control(Group::ProductionCMode::WRAT));
         }
 
         auto g2 = schedule.getGroup("G2", 2);


### PR DESCRIPTION
This PR is to allow for default value `NONE` of item 7 of `GCONPROD`. So far only `RATE` was allowed for item 7 (see https://github.com/OPM/opm-simulators/pull/4593)