### PR TITLE
[testing] update summary quantities even there is no wells associated with it

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2670,11 +2670,6 @@ namespace Evaluator {
                              static_cast<int>(sim_step), input.reg)
                 : std::vector<const Opm::Well*>{};
 
-            if (get_wells && wells.empty())
-                // Parameter depends on well information, but no active
-                // wells apply at this sim_step.  Nothing to do.
-                return;
-
             EfficiencyFactor efac{};
             efac.setFactors(this->node_, input.sched, wells, sim_step);
 


### PR DESCRIPTION
then it should get a zero. otherwise, the old values will be used.

this is part of the investigation for a reported issue with @bska .