### PR TITLE
Remove double printing of OpmInputError messages

### DIFF
--- a/src/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -151,7 +151,6 @@ namespace Opm {
         }
     }
     catch (const OpmInputError& opm_error) {
-        OpmLog::error(opm_error.what());
         throw;
     } 
     catch (const std::exception& std_error) {


### PR DESCRIPTION
This PR removes a `OpmLog::error` call in `EclipseState.cpp` since that led to duplicate printing of `OpmInputError` exceptions when running `flow`.

However, it is unclear to me if that log call is needed in any other context, hence feedback if this change is safe is welcome.
