### PR TITLE
Reimplement WBPn Calculation Procedure

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -469,6 +469,7 @@ if(ENABLE_ECL_INPUT)
     tests/test_ERst.cpp
     tests/test_ESmry.cpp
     tests/test_ExtESmry.cpp
+    tests/test_PAvgCalculator.cpp
     tests/test_PAvgDynamicSourceData.cpp
     tests/test_Serialization.cpp
     tests/material/test_co2brinepvt.cpp

--- a/opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp
+++ b/opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2020 Equinor ASA.
+  Copyright 2020, 2023 Equinor ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -17,93 +17,787 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef PAVG_CALCULATOR_HPP
+#define PAVG_CALCULATOR_HPP
 
-#ifndef PAVE_CALC_HPP
-#define PAVE_CALC_HPP
-
+#include <array>
+#include <cstddef>
 #include <functional>
-#include <map>
+#include <memory>
 #include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
-
-#include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
-#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
 
 namespace Opm {
 
+class Connection;
+class GridDims;
+class PAvg;
+class PAvgDynamicSourceData;
 class WellConnections;
-class EclipseGrid;
 
-class PAvgCalculator {
+} // namespace Opm
+
+namespace Opm {
+
+/// Facility for deriving well-level pressure values from selected
+/// block-averaging procedures.  Applicable to stopped wells which don't
+/// have a flowing bottom-hole pressure.  Mainly useful for reporting.
+class PAvgCalculator
+{
+protected:
+    class Accumulator;
+
 public:
+    /// Result of block-averaging well pressure procedure
+    class Result
+    {
+    private:
+        /// Enclosing type's accumulator object can access internal data
+        /// members.
+        friend class Accumulator;
 
-    PAvgCalculator(const std::string& well, double well_ref_depth, const EclipseGrid& grid, const std::vector<double>& porv, const WellConnections& connections, const PAvg& pavg);
+        /// Grant internal data member access to combination function.
+        friend Result
+        linearCombination(const double alpha, Result x,
+                          const double beta , const Result& y);
 
-    enum class WBPMode {
-        WBP,
-        WBP4,
-        WBP5,
-        WBP9
-    };
-
-
-    struct Neighbour {
-        Neighbour(double porv_arg, std::size_t index_arg) :
-            porv(porv_arg),
-            global_index(index_arg)
-        {}
-
-        double porv;
-        std::size_t global_index;
-    };
-
-
-    struct Connection {
-        Connection(double porv_arg, double cf, ::Opm::Connection::Direction dir_arg, std::size_t index_arg) :
-            porv(porv_arg),
-            cfactor(cf),
-            dir(dir_arg),
-            global_index(index_arg)
+    public:
+        /// Kind of block-averaged well pressure
+        enum class WBPMode
         {
+            WBP,  //< Connecting cells
+            WBP4, //< Immediate neighbours
+            WBP5, //< Connecting cells and immediate neighbours
+            WBP9, //< Connecting cells, immediate, and diagonal neighbours
+        };
+
+        /// Retrieve numerical value of specific block-averaged well pressure.
+        ///
+        /// \param[in] type Block-averaged pressure kind.
+        /// \return Block-averaged pressure.
+        double value(const WBPMode type) const
+        {
+            return this->wbp_[this->index(type)];
         }
 
-        double porv;
-        double cfactor;
-        ::Opm::Connection::Direction dir;
-        std::size_t global_index;
-        std::vector<Neighbour> rect_neighbours;
-        std::vector<Neighbour> diag_neighbours;
+    private:
+        /// Number of block-averaged pressure kinds/modes.
+        static constexpr auto NumModes =
+            static_cast<std::size_t>(WBPMode::WBP9) + 1;
+
+        /// Storage type for block-averaged well pressure results.
+        using WBPStore = std::array<double, NumModes>;
+
+        /// Block-averaged well pressure results.
+        WBPStore wbp_{};
+
+        /// Assign single block-averaged pressure result.
+        ///
+        /// \param[in] type Block-averaged pressure kind.
+        /// \param[in] wbp Block-averaged pressure value.
+        /// \return \code *this \endcode.
+        Result& set(const WBPMode type, const double wbp)
+        {
+            this->wbp_[this->index(type)] = wbp;
+
+            return *this;
+        }
+
+        /// Convert block-averaged pressure kind to linear index
+        ///
+        /// \param[in] mode Block-averaged pressure kind.
+        /// \return Linear index corresponding to \p mode.
+        constexpr WBPStore::size_type index(const WBPMode mode) const
+        {
+            return static_cast<WBPStore::size_type>(mode);
+        }
     };
 
+    /// References to source contributions owned by other party
+    class Sources
+    {
+    public:
+        /// Provide reference to cell-level contributions (pressure,
+        /// pore-volume, mixture density) owned by other party.
+        ///
+        /// \param[in] wbSrc Cell-level contributions
+        /// \return \code *this \endcode.
+        Sources& wellBlocks(const PAvgDynamicSourceData& wbSrc)
+        {
+            this->wb_ = &wbSrc;
+            return *this;
+        }
 
-    const std::string& wname() const;
-    double wbp() const;
-    double wbp4() const;
-    double wbp5() const;
-    double wbp9() const;
-    double wbp(WBPMode mode) const;
-    bool add_pressure(std::size_t global_index, double pressure);
-    const std::vector< std::size_t >& index_list() const;
-    std::pair< std::reference_wrapper<const std::vector<double>>, std::reference_wrapper<const std::vector<bool>> > data() const;
+        /// Provide reference to connection-level contributions (pressure,
+        /// pore-volume, mixture density) owned by other party.
+        ///
+        /// \param[in] wcSrc Connection-level contributions
+        /// \return \code *this \endcode.
+        Sources& wellConns(const PAvgDynamicSourceData& wcSrc)
+        {
+            this->wc_ = &wcSrc;
+            return *this;
+        }
+
+        /// Get read-only access to cell-level contributions.
+        const PAvgDynamicSourceData& wellBlocks() const
+        {
+            return *this->wb_;
+        }
+
+        /// Get read-only access to connection-level contributions.
+        const PAvgDynamicSourceData& wellConns() const
+        {
+            return *this->wc_;
+        }
+
+    private:
+        /// Cell-level contributions.
+        const PAvgDynamicSourceData* wb_{nullptr};
+
+        /// Connection-level contributions.
+        const PAvgDynamicSourceData* wc_{nullptr};
+    };
+
+    /// Constructor
+    ///
+    /// \param[in] cellIndexMap Cell index triple map ((I,J,K) <-> global).
+    ///
+    /// \param[in] connections List of reservoir connections for single
+    ///   well.
+    PAvgCalculator(const GridDims&        cellIndexMap,
+                   const WellConnections& connections);
+
+    /// Destructor.
+    virtual ~PAvgCalculator();
+
+    /// Finish construction by pruning inactive cells.
+    ///
+    /// \param[in] isActive Linearised predicate for whether or not given
+    ///   cell amongst \code allWBPCells() \endcode is actually active in
+    ///   the model.
+    ///
+    ///   Assumed to have the same size--number of elements--as the return
+    ///   value from member function \code allWBPCells() \endcode, and
+    ///   organise its elements such that \code isActive[i] \endcode holds
+    ///   the active status of \code allWBPCells()[i] \endcode.
+    void pruneInactiveWBPCells(const std::vector<bool>& isActive);
+
+    /// Compute block-average well-level pressure values from collection of
+    /// source contributions and user-defined averaging procedure controls.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] controls Averaging procedure controls.
+    ///
+    /// \param[in] gravity Strength of gravity in SI units [m/s^2].
+    ///
+    /// \param[in] refDepth Well's reference depth for block-average
+    ///   pressure calculation.  Often, but not always, equal to the well's
+    ///   bottom-hole pressure reference depth.
+    void inferBlockAveragePressures(const Sources& sources,
+                                    const PAvg&    controls,
+                                    const double   gravity,
+                                    const double   refDepth);
+
+    /// List of all cells, global indices in natural ordering, that
+    /// contribute to the block-average pressures in this well.
+    const std::vector<std::size_t>& allWBPCells() const
+    {
+        return this->contributingCells_;
+    }
+
+    /// List all reservoir connections that potentially contribute to this
+    /// block-averaging pressure calculation.
+    ///
+    /// Convenience method only.  Mainly intended to aid in constructing
+    /// PAvgDynamicSourceData objects for the current well's reservoir
+    /// connections.
+    ///
+    /// \return Vector of the numbers 0 .. n-1 in increasing order with n
+    ///   being the number of connections in the input set provided to the
+    ///   object constructor.
+    std::vector<std::size_t> allWellConnections() const;
+
+    /// Block-average pressure derived from selection of source cells.
+    ///
+    /// \param[in] mode Source cell selection.
+    ///
+    /// \return Block-average pressure
+    const Result& averagePressures() const
+    {
+        return this->averagePressures_;
+    }
+
+protected:
+    /// Accumulate weighted running averages of cell contributions to WBP
+    class Accumulator
+    {
+    public:
+        /// Collection of running averages and their associate weights.
+        ///
+        /// Intended primarily as a means of exchanging intermediate results
+        /// in a parallel run.
+        using LocalRunningAverages = std::array<double, 8>;
+
+        /// Constructor
+        Accumulator();
+
+        /// Destructor
+        ~Accumulator();
+
+        /// Copy constructor
+        ///
+        /// \param[in] rhs Source object
+        Accumulator(const Accumulator& rhs);
+
+        /// Move constructor
+        ///
+        /// \param[inout] rhs Source object.  Nullified on exit.
+        Accumulator(Accumulator&& rhs);
+
+        /// Assignment operator
+        ///
+        /// \param[in] rhs Source object
+        Accumulator& operator=(const Accumulator& rhs);
+
+        /// Move assignment operator
+        ///
+        /// \param[inout] rhs Source object.  Nullified on exit.
+        Accumulator& operator=(Accumulator&& rhs);
+
+        /// Add contribution from centre/connecting cell
+        ///
+        /// \param[in] weight Pressure weighting factor
+        /// \param[in] press Pressure value
+        /// \return \code *this \endcode
+        Accumulator& addCentre(const double weight,
+                               const double press);
+
+        /// Add contribution from direct, rectangular, level 1 neighbouring
+        /// cell
+        ///
+        /// \param[in] weight Pressure weighting factor
+        /// \param[in] press Pressure value
+        /// \return \code *this \endcode
+        Accumulator& addRectangular(const double weight,
+                                    const double press);
+
+        /// Add contribution from diagonal, level 2 neighbouring cell
+        ///
+        /// \param[in] weight Pressure weighting factor
+        /// \param[in] press Pressure value
+        /// \return \code *this \endcode
+        Accumulator& addDiagonal(const double weight,
+                                 const double press);
+
+        /// Add contribution from other accumulator
+        ///
+        /// This typically incorporates a set of results from a single
+        /// reservoir connection into a larger sum across all connections.
+        ///
+        /// \param[in] weight Pressure weighting factor
+        /// \param[in] other Contribution from other accumulation process.
+        /// \return \code *this \endcode
+        Accumulator& add(const double       weight,
+                         const Accumulator& other);
+
+        /// Zero out/clear WBP result buffer
+        void prepareAccumulation();
+
+        /// Zero out/clear WBP term buffer
+        void prepareContribution();
+
+        /// Accumulate current source term into result buffer whilst
+        /// applying any user-prescribed term weighting.
+        ///
+        /// \param[in] innerWeight Weighting factor for inner/connecting
+        ///   cell contributions.  Outer cells weighted by 1-innerWeight
+        ///   where applicable.  If inner weight factor is negative, no
+        ///   weighting is applied.  Typically the F1 weighting factor from
+        ///   the WPAVE keyword.  Default value (-1) mainly applicable to
+        ///   PV-weighted accumulations.
+        void commitContribution(const double innerWeight = -1.0);
+
+        // Please note that member functions \c getRunningAverages() and \c
+        // assignRunningAverages() are concessions to parallel/MPI runs, and
+        // especially for simulation runs with distributed wells.  In this
+        // situation we need a way to access, communicate/collect/sum, and
+        // assign partial results.  Moreover, the \c LocalRunningAverages
+        // should be treated opaquely apart from applying a global reduction
+        // operation.  In other words, the intended/expected use case is
+        //
+        //   Accumulator a{}
+        //   ...
+        //   auto avg = a.getRunningAverages()
+        //   MPI_Allreduce(avg, MPI_SUM)
+        //   a.assignRunningAverages(avg)
+        //
+        // Any other use is probably a bug and the above is the canonical
+        // implementation of member function collectGlobalContributions() in
+        // MPI aware sub classes of PAvgCalculator.
+
+        /// Get buffer of intermediate, local results.
+        LocalRunningAverages getRunningAverages() const;
+
+        /// Assign coalesced/global contributions
+        ///
+        /// \param[in] avg Buffer of coalesced global contributions.
+        void assignRunningAverages(const LocalRunningAverages& avg);
+
+        /// Calculate final WBP results from individual contributions
+        ///
+        /// \return New result object.
+        Result getFinalResult() const;
+
+    private:
+        /// Implementation class
+        class Impl;
+
+        /// Pointer to implementation object.
+        std::unique_ptr<Impl> pImpl_;
+    };
+
+    /// Average pressures weighted by connection transmissibility factor.
+    Accumulator accumCTF_{};
+
+    /// Average pressures weighted by pore-volume
+    Accumulator accumPV_{};
 
 private:
-    void update(const std::vector<double>& p, const std::vector<char>& m);
-    void add_connection(const PAvgCalculator::Connection& conn);
-    void add_neighbour(std::size_t global_index, std::optional<PAvgCalculator::Neighbour> neighbour, bool rect_neighbour);
-    double get_pressure(std::size_t global_index) const;
-    double cf_avg(const std::vector<std::optional<double>>& block_pressure) const;
-    std::pair<double,double> porv_pressure(std::size_t global_index) const;
-    std::vector<std::optional<double>> block_pressures(PAvgCalculator::WBPMode mode) const;
+    /// Type representing enumeration of locally contributing cells.
+    using ContrIndexType = std::vector<std::size_t>::size_type;
 
-    std::string well_name;
-    PAvg m_pavg;
-    std::vector<Connection> m_connections;
-    std::map<std::size_t, std::size_t> m_index_map;
-    std::vector<std::size_t> m_index_list;
-    std::vector<double> pressure;
-    std::vector<char> valid_pressure;
-    double ref_depth;
+    /// Type for translating (linearised) global cell indices to enumerated
+    /// local, contributing cells.
+    ///
+    /// Only used during construction/setup.
+    using SetupMap = std::unordered_map<std::size_t, ContrIndexType>;
+
+    /// Type of neighbour of connection's connecting cell.
+    enum class NeighbourKind
+    {
+        /// Neighbour is of the direct, rectangular, level 1 kind.
+        Rectangular,
+
+        /// Neighbour is of the diagonal level 2 kind.
+        Diagonal,
+    };
+
+    /// Well's reservoir connection, stripped to hold only information
+    /// necessary to infer block-averaged pressures.
+    struct PAvgConnection
+    {
+        /// Constructor.
+        ///
+        /// \param[in] ctf_arg Connection's transmissiblity factor
+        ///
+        /// \param[in] depth_arg Connection's depth
+        ///
+        /// \param[in] cell_arg Connection's connecting cell.  Enumerated
+        ///   local contributing cell.
+        PAvgConnection(const double         ctf_arg,
+                       const double         depth_arg,
+                       const ContrIndexType cell_arg)
+            : ctf  (ctf_arg)
+            , depth(depth_arg)
+            , cell (cell_arg)
+        {}
+
+        /// Connection transmissiblity factor.
+        double ctf{};
+
+        /// Connection's depth.
+        double depth{};
+
+        /// Index into \c contributingCells_ of connection's cell.
+        ContrIndexType cell{};
+
+        /// Connecting cell's immediate (level-1) neighbours
+        ///   ((i-1,j), (i+1,j), (i,j-1), and (i,j+1))
+        /// Indices into \c contributingCells_.
+        std::vector<ContrIndexType> rectNeighbours{};
+
+        /// Connecting cell's diagnoal (level-2) neighbours
+        ///   ((i-1,j-1), (i+1,j-1), (i-1,j+1), and (i+1,j+1))
+        /// Indices into \c contributingCells_.
+        std::vector<ContrIndexType> diagNeighbours{};
+    };
+
+    /// Set of well/reservoir connections from which the block-average
+    /// pressures derive.
+    std::vector<PAvgConnection> connections_{};
+
+    /// List of indices into \c connections_ that represent open connections.
+    std::vector<std::vector<PAvgConnection>::size_type> openConns_{};
+
+    /// Collection of all (global) cell indices that potentially contribute
+    /// to this block-average well pressure calculation.
+    std::vector<std::size_t> contributingCells_{};
+
+    /// Well level pressure values derived from block-averaging procedures.
+    ///
+    /// Cached end result from \code inferBlockAveragePressures() \endcode.
+    Result averagePressures_{};
+
+    /// Include reservoir connection and all direction-dependent level 1 and
+    /// level 2 neighbours of connection's connecting cell into known cell
+    /// set.
+    ///
+    /// Writes to \c connections_, \c openConns_, and \c contributingCells_.
+    ///
+    /// \param[in] grid Collection of active cells.
+    ///
+    /// \param[in] conn Specific reservoir connection
+    ///
+    /// \param[inout] setupHelperMap Translation between linearised global
+    ///   cell indices and enumerated local contributing cells.  Updated as
+    ///   new contributing cells are discovered.
+    void addConnection(const GridDims&   cellIndexMap,
+                       const Connection& conn,
+                       SetupMap&         setupHelperMap);
+
+    /// Top-level entry point for accumulating local WBP contributions.
+    ///
+    /// Will dispatch to lower-level entry points depending on control's
+    /// flag for whether to average over the set of open or the set of all
+    /// reservoir connections.  Writes to \c accumCTF_ and \c accumPV_.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] controls Averaging procedure controls.
+    ///
+    /// \param[in] gravity Strength of gravity in SI units [m/s^2].
+    ///
+    /// \param[in] refDepth Well's reference depth for block-average
+    ///   pressure calculation.  Often, but not always, equal to the well's
+    ///   bottom-hole pressure reference depth.
+    void accumulateLocalContributions(const Sources& sources,
+                                      const PAvg&    controls,
+                                      const double   gravity,
+                                      const double   refDepth);
+
+    /// Communicate local contributions and collect global (off-rank)
+    /// contributions.
+    ///
+    /// Intended as an MPI-aware customisation point.  Typically a no-op in
+    /// a sequential run.
+    ///
+    /// Reads from and writes to data members \c accumCTF_ and \c accumPV_.
+    virtual void collectGlobalContributions();
+
+    /// Form final result object from all accumulated contributions.
+    ///
+    /// Writes to \c averagePressures_.
+    ///
+    /// \param[in] controls Averaging procedure controls.  Needed for
+    ///   weighting factor F2 (== conn_weight()) between CTF-weighted
+    ///   average (\c accumCTF_) and PV-weighted average (\c accumPV_).
+    void assignResults(const PAvg& controls);
+
+    /// Include individual neighbour of currently latest connection's
+    /// connecting cell into known cell set.
+    ///
+    /// Writes to \code connections_.back() \endcode and \c
+    /// contributingCells_.
+    ///
+    /// \param[in] neighbour Global, linearised cell index.  Nullopt if
+    ///    neighbour happens to be in an inactive cell or outside the
+    ///    model's Cartesian dimensions.  In that case, no change is made to
+    ///    any data member.
+    ///
+    /// \param[in] neighbourKind Classification for \p neighbour.
+    ///
+    /// \param[inout] setupHelperMap Translation between linearised global
+    ///   cell indices and enumerated local contributing cells.  Updated as
+    ///   new contributing cells are discovered.
+    void addNeighbour(std::optional<std::size_t> neighbour,
+                      NeighbourKind              neighbourKind,
+                      SetupMap&                  setupHelperMap);
+
+    /// Global index of currently latest connection's connecting cell.
+    ///
+    /// Convenience function for inferring connecting cell's IJK index.
+    std::size_t lastConnsCell() const;
+
+    /// Include all level 1 and level 2 neighbours orthogonal to X axis of
+    /// currently latest connection's connecting cell into known cell set.
+    ///
+    /// Writes to \code connections_.back() \endcode and \c
+    /// contributingCells_.
+    ///
+    /// \param[in] grid Collection of active cells.
+    ///
+    /// \param[inout] setupHelperMap Translation between linearised global
+    ///   cell indices and enumerated local contributing cells.  Updated as
+    ///   new contributing cells are discovered.
+    void addNeighbours_X(const GridDims& grid, SetupMap& setupHelperMap);
+
+    /// Include all level 1 and level 2 neighbours orthogonal to Y axis of
+    /// currently latest connection's connecting cell into known cell set.
+    ///
+    /// Writes to \code connections_.back() \endcode and \c
+    /// contributingCells_.
+    ///
+    /// \param[in] grid Collection of active cells.
+    ///
+    /// \param[inout] setupHelperMap Translation between linearised global
+    ///   cell indices and enumerated local contributing cells.  Updated as
+    ///   new contributing cells are discovered.
+    void addNeighbours_Y(const GridDims& grid, SetupMap& setupHelperMap);
+
+    /// Include all level 1 and level 2 neighbours orthogonal to Z axis of
+    /// currently latest connection's connecting cell into known cell set.
+    ///
+    /// Writes to \code connections_.back() \endcode and \c
+    /// contributingCells_.
+    ///
+    /// \param[in] grid Collection of active cells.
+    ///
+    /// \param[inout] setupHelperMap Translation between linearised global
+    ///   cell indices and enumerated local contributing cells.  Updated as
+    ///   new contributing cells are discovered.
+    void addNeighbours_Z(const GridDims& grid, SetupMap& setupHelperMap);
+
+    /// Calculation routine for accumulating local WBP contributions.
+    ///
+    /// \tparam ConnIndexMap Callable type translating from requested set of
+    ///   connections to linear index into all known reservoir connections.
+    ///   Must provide a call operator such that
+    /// \code
+    ///   connections_[ix(i)]
+    /// \endcode
+    ///   is well formed for an object \c ix of type \p ConnIndexMap and an
+    ///   index \c i in 0 .. n-1, with 'n' being the number of connections
+    ///   in the current connection subset.  Will typically just be the
+    ///   identity mapping \code [](i){return i} \endcode or the open
+    ///   connection mapping \code [](i){return openConns_[i]} \endcode.
+    ///
+    /// \tparam CTFPressureWeightFunction Callable type generating term
+    ///   weighting values for the CTF-weighted connection contributions.
+    ///   Must provide a call operator such that
+    /// \code
+    ///   double w = weight(src)
+    /// \endcode
+    ///   is well formed for an object \c weight of type \p
+    ///   CTFPressureWeightFunction and a \c src object of type \code
+    ///   PAvgDynamicSourceData::SourceDataSpan<const double> \endcode.
+    ///   Will typically be a lambda that returns the pore volume in \c src
+    ///   if the weighting factor F1 in WPAVE is negative, or a lambda that
+    ///   just returns the number one (1.0) otherwise.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] controls Averaging procedure controls.
+    ///
+    /// \param[in] connDP Pressure correction term for each reservoir
+    ///   connection.
+    ///
+    /// \param[in] connIndex Translation method from active connection index
+    ///   to index into all known reservoir connections.
+    ///
+    /// \param[in] ctfPressWeight Pressure weighting method for CTF term's
+    ///   individual contributions.
+    template <typename ConnIndexMap, typename CTFPressureWeightFunction>
+    void accumulateLocalContributions(const Sources&             sources,
+                                      const PAvg&                controls,
+                                      const std::vector<double>& connDP,
+                                      ConnIndexMap               connIndex,
+                                      CTFPressureWeightFunction  ctfPressWeight);
+
+    /// Final dispatch level before going to calculation routine which
+    /// accumulates the local WBP contributions.
+    ///
+    /// Dispatches based on sign of averaging procedure's F1 weighting term
+    /// (== inner_weight()).  If F1 < 0, then invoke calculation routine
+    /// with a pore-volume based weighting of the individual cell
+    /// contributions.  Otherwise, use unit weighting of the individual cell
+    /// contributions and weight the accumulated CTF contributions for a
+    /// single reservoir connection according to F1.
+    ///
+    /// \tparam ConnIndexMap Callable type translating from requested set of
+    ///   connections to linear index into all known reservoir connections.
+    ///   Must provide a call operator such that
+    /// \code
+    ///   connections_[ix(i)]
+    /// \endcode
+    ///   is well formed for an object \c ix of type \p ConnIndexMap and an
+    ///   index \c i in 0 .. n-1, with 'n' being the number of connections
+    ///   in the current connection subset.  Will typically just be the
+    ///   identity mapping \code [](i){return i} \endcode or the open
+    ///   connection mapping \code [](i){return openConns_[i]} \endcode.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] controls Averaging procedure controls.
+    ///
+    /// \param[in] connDP Pressure correction term for each reservoir
+    ///   connection.
+    ///
+    /// \param[in] connIndex Translation method from active connection index
+    ///   to index into all known reservoir connections.
+    template <typename ConnIndexMap>
+    void accumulateLocalContributions(const Sources&             sources,
+                                      const PAvg&                controls,
+                                      const std::vector<double>& connDP,
+                                      ConnIndexMap&&             connIndex);
+
+    /// First dispatch level before going to calculation routine which
+    /// accumulates the local WBP contributions.
+    ///
+    /// Invokes final dispatch level on set of open connections only.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] controls Averaging procedure controls.
+    ///
+    /// \param[in] connDP Pressure correction term for each reservoir
+    ///   connection.
+    void accumulateLocalContribOpen(const Sources&             sources,
+                                    const PAvg&                controls,
+                                    const std::vector<double>& connDP);
+
+    /// First dispatch level before going to calculation routine which
+    /// accumulates the local WBP contributions.
+    ///
+    /// Invokes final dispatch level on set of all known connections.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] controls Averaging procedure controls.
+    ///
+    /// \param[in] connDP Pressure correction term for each reservoir
+    ///   connection.
+    void accumulateLocalContribAll(const Sources&             sources,
+                                   const PAvg&                controls,
+                                   const std::vector<double>& connDP);
+
+    /// Compute pressure correction term/offset using Well method
+    ///
+    /// Uses mixture density from well bore.
+    ///
+    /// \tparam ConnIndexMap Callable type translating from requested set of
+    ///   connections to linear index into all known reservoir connections.
+    ///   Must provide a call operator such that
+    /// \code
+    ///   connections_[ix(i)]
+    /// \endcode
+    ///   is well formed for an object \c ix of type \p ConnIndexMap and an
+    ///   index \c i in 0 .. n-1, with 'n' being the number of connections
+    ///   in the current connection subset.  Will typically just be the
+    ///   identity mapping \code [](i){return i} \endcode or the open
+    ///   connection mapping \code [](i){return openConns_[i]} \endcode.
+    ///
+    /// \param[in] nconn Number of elements in active connection subset.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] gravity Strength of gravity in SI units [m/s^2].
+    ///
+    /// \param[in] refDepth Well's reference depth for block-average
+    ///   pressure calculation.  Often, but not always, equal to the well's
+    ///   bottom-hole pressure reference depth.
+    ///
+    /// \param[in] connIndex Translation method from active connection index
+    ///   to index into all known reservoir connections.
+    ///
+    /// \return Pressure correction term for each active connection.
+    template <typename ConnIndexMap>
+    std::vector<double>
+    connectionPressureOffsetWell(const std::size_t nconn,
+                                 const Sources&    sources,
+                                 const double      gravity,
+                                 const double      refDepth,
+                                 ConnIndexMap      connIndex) const;
+
+    /// Compute pressure correction term/offset using Reservoir method
+    ///
+    /// Uses pore-volume weighted mixture density from connecting cell and
+    /// its level 1 and level 2 neighbours.
+    ///
+    /// \tparam ConnIndexMap Callable type translating from requested set of
+    ///   connections to linear index into all known reservoir connections.
+    ///   Must provide a call operator such that
+    /// \code
+    ///   connections_[ix(i)]
+    /// \endcode
+    ///   is well formed for an object \c ix of type \p ConnIndexMap and an
+    ///   index \c i in 0 .. n-1, with 'n' being the number of connections
+    ///   in the current connection subset.  Will typically just be the
+    ///   identity mapping \code [](i){return i} \endcode or the open
+    ///   connection mapping \code [](i){return openConns_[i]} \endcode.
+    ///
+    /// \param[in] nconn Number of elements in active connection subset.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] gravity Strength of gravity in SI units [m/s^2].
+    ///
+    /// \param[in] refDepth Well's reference depth for block-average
+    ///   pressure calculation.  Often, but not always, equal to the well's
+    ///   bottom-hole pressure reference depth.
+    ///
+    /// \param[in] connIndex Translation method from active connection index
+    ///   to index into all known reservoir connections.
+    ///
+    /// \return Pressure correction term for each active connection.
+    template <typename ConnIndexMap>
+    std::vector<double>
+    connectionPressureOffsetRes(const std::size_t nconn,
+                                const Sources&    sources,
+                                const double      gravity,
+                                const double      refDepth,
+                                ConnIndexMap      connIndex) const;
+
+    /// Top-level entry point for computing the pressure correction
+    /// term/offset of each active reservoir connection
+    ///
+    /// Will dispatch to lower level calculation routines based on algorithm
+    /// selection parameter in procedure controls.
+    ///
+    /// \param[in] sources Connection and cell-level raw data.
+    ///
+    /// \param[in] controls Averaging procedure controls.  This function uses
+    ///   the depth correction and open connections flags.
+    ///
+    /// \param[in] gravity Strength of gravity in SI units [m/s^2].
+    ///
+    /// \param[in] refDepth Well's reference depth for block-average
+    ///   pressure calculation.  Often, but not always, equal to the well's
+    ///   bottom-hole pressure reference depth.
+    ///
+    /// \return Pressure correction term for each active connection.
+    std::vector<double>
+    connectionPressureOffset(const Sources& sources,
+                             const PAvg&    controls,
+                             const double   gravity,
+                             const double   refDepth) const;
 };
 
-}
-#endif
+/// Form linear combination of WBP result objects.
+///
+/// Typically the very last step of computing the block-averaged well
+/// pressure values; namely a weighted averaged of the CTF-weighted and the
+/// PV-weighted contributions.
+///
+/// \param[in] alpha Coefficient in linear combination.  Typically the F2
+///    weighting factor from the WPAVE (or WWPAVE) keyword.
+///
+/// \param[in] x First WBP result.  Typically the CTF-weighted WBP result.
+///
+/// \param[in] beta Coefficient in linear combination.  Typically 1-F2, with
+///    F2 from WPAVE.
+///
+/// \param[in] y Second WBP result.  Typically the PV-weighted WBP result.
+///
+/// \return \code alpha*x + beta*y \endcode.
+PAvgCalculator::Result
+linearCombination(const double alpha, PAvgCalculator::Result        x,
+                  const double beta , const PAvgCalculator::Result& y);
+
+} // namespace Opm
+
+#endif // PAVG_CALCULATOR_HPP

--- a/opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.hpp
+++ b/opm/input/eclipse/Schedule/Well/PAvgCalculatorCollection.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2020 Equinor ASA.
+  Copyright 2020, 2023 Equinor ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -17,33 +17,125 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef PAVE_CALC_COLLECTIONHPP
 #define PAVE_CALC_COLLECTIONHPP
 
-#include <optional>
+#include <cstddef>
+#include <functional>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-#include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
-#include <opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp>
-
+namespace Opm {
+    class PAvgCalculator;
+} // namespace Opm
 
 namespace Opm {
 
-class PAvgCalculatorCollection {
+/// Collection of WBPn calculation objects, one for each well.
+class PAvgCalculatorCollection
+{
 public:
+    /// Wrapper for a WBPn calclation object.
+    ///
+    /// We use a pointer here to enable polymorphic behaviour at runtime,
+    /// e.g., parallel calculation in an MPI-enabled simulation run.
+    using CalculatorPtr = std::unique_ptr<PAvgCalculator>;
+
+    /// Predicate for whether or not a particular source location is active.
+    ///
+    /// One typical use case is determining whether or not a particular cell
+    /// defined by its Cartesian (I,J,K) index triple is actually amongst
+    /// the model's active cells.
+    ///
+    /// This predicate will be called with a vector of source location
+    /// indices and must return a vector of the same size that holds the
+    /// value 'true' if the corresponding source location is active and
+    /// 'false' otherwise.
+    using ActivePredicate = std::function<
+        std::vector<bool>(const std::vector<std::size_t>&)>;
+
+    /// Default constructor.
+    PAvgCalculatorCollection() = default;
+
+    /// Destructor.
+    ~PAvgCalculatorCollection() = default;
+
+    /// Copy constructor.
+    PAvgCalculatorCollection(const PAvgCalculatorCollection&) = delete;
+
+    /// Move constructor.
+    PAvgCalculatorCollection(PAvgCalculatorCollection&&) = default;
+
+    /// Assignment operator.
+    PAvgCalculatorCollection& operator=(const PAvgCalculatorCollection&) = delete;
+
+    /// Move-assignment operator.
+    PAvgCalculatorCollection& operator=(PAvgCalculatorCollection&&) = default;
+
+    /// Assign/register a WBPn calculation object for a single well.
+    ///
+    /// \param[in] wellID Unique numeric ID representing a single well.
+    ///   Typically the \code seqIndex() \endcode of a \c Well object.
+    ///
+    /// \param[in] calculator Calculation object specific to a single well.
+    ///
+    /// \return Index by which to refer to the calculation object later,
+    ///   e.g., when calculating the WBPn values for a single well.  No
+    ///   relation to \p wellID.
+    std::size_t setCalculator(const std::size_t wellID, CalculatorPtr calculator);
+
+    /// Discard inactive source locations from all WBPn calculation objects.
+    ///
+    /// At the end of this call, no source location deemed to be "inactive"
+    /// will be amongst those later used for collection of source term
+    /// contributions.
+    ///
+    /// \param[in] isActive Predicate for whether or not a source location
+    ///   is "active".  The caller determines what "active" means.  Must
+    ///   abide by the protocol outlined above.
+    void pruneInactiveWBPCells(ActivePredicate isActive);
+
+    /// Access mutable WBPn calculation object.
+    ///
+    /// \param[in] i WBPn calculation object index.  Must be one returned
+    ///   from a previous call to \c setCalculator.
+    ///
+    /// \return Mutable WBPn calculation object.
+    PAvgCalculator& operator[](const std::size_t i);
+
+    /// Access immutable WBPn calculation object.
+    ///
+    /// \param[in] i WBPn calculation object index.  Must be one returned
+    ///   from a previous call to \c setCalculator.
+    ///
+    /// \return Immutable WBPn calculation object.
+    const PAvgCalculator& operator[](const std::size_t i) const;
+
+    /// Whether or not this collection has any WBPn calculation objects.
     bool empty() const;
-    void add(const PAvgCalculator& calculator);
-    bool has(const std::string& wname) const;
-    const PAvgCalculator& get(const std::string& wname) const;
-    const std::vector<std::size_t>& index_list() const;
-    void add_pressure(std::size_t index, double pressure);
+
+    /// Number of WBPn calculation objects owned by this collection.
+    std::size_t numCalculators() const;
+
+    /// Union of all distinct/unique cells/source locations contributing to
+    /// this complete collection of WBPn calculation objects.
+    ///
+    /// Mainly intended to configure \c PAvgDynamicSourceData objects.
+    std::vector<std::size_t> allWBPCells() const;
+
 private:
-    std::unordered_map<std::string, PAvgCalculator> calculators;
-    mutable std::optional<std::vector<std::size_t>> indexlist;
+    /// Representation of calculator indices.
+    using CalcIndex = std::vector<CalculatorPtr>::size_type;
+
+    /// Translation table for mapping Well IDs to calculator indices.
+    std::unordered_map<std::size_t, CalcIndex> index_{};
+
+    /// Collection of WBPn calculation objects.
+    std::vector<CalculatorPtr> calculators_{};
 };
 
-}
-#endif
+} // namespace Opm
+
+#endif // PAVE_CALC_COLLECTIONHPP

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -2195,6 +2195,32 @@ Well{0} entered with 'FIELD' parent group:
 
     void Schedule::handleWPAVE(HandlerContext& handlerContext) {
         auto wpave = PAvg( handlerContext.keyword.getRecord(0) );
+
+        if (wpave.inner_weight() > 1.0) {
+            const auto reason =
+                fmt::format("Inner block weighting F1 "
+                            "must not exceed 1.0. Got {}",
+                            wpave.inner_weight());
+
+            throw OpmInputError {
+                reason, handlerContext.keyword.location()
+            };
+        }
+
+        if ((wpave.conn_weight() < 0.0) ||
+            (wpave.conn_weight() > 1.0))
+        {
+            const auto reason =
+                fmt::format("Connection weighting factor F2 "
+                            "must be between zero and one "
+                            "inclusive. Got {} instead.",
+                            wpave.conn_weight());
+
+            throw OpmInputError {
+                reason, handlerContext.keyword.location()
+            };
+        }
+
         for (const auto& wname : this->wellNames(handlerContext.currentStep))
             this->updateWPAVE(wname, handlerContext.currentStep, wpave );
 
@@ -2245,6 +2271,32 @@ Well{0} entered with 'FIELD' parent group:
                 this->invalidNamePattern(wellNamePattern, handlerContext);
 
             auto wpave = PAvg(record);
+
+            if (wpave.inner_weight() > 1.0) {
+                const auto reason =
+                    fmt::format("Inner block weighting F1 "
+                                "must not exceed one. Got {}",
+                                wpave.inner_weight());
+
+                throw OpmInputError {
+                    reason, handlerContext.keyword.location()
+                };
+            }
+
+            if ((wpave.conn_weight() < 0.0) ||
+                (wpave.conn_weight() > 1.0))
+            {
+                const auto reason =
+                    fmt::format("Connection weighting factor F2 "
+                                "must be between zero and one, "
+                                "inclusive. Got {} instead.",
+                                wpave.conn_weight());
+
+                throw OpmInputError {
+                    reason, handlerContext.keyword.location()
+                };
+            }
+
             for (const auto& well_name : well_names)
                 this->updateWPAVE(well_name, handlerContext.currentStep, wpave);
         }

--- a/src/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/PAvgCalculator.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2020 Equinor ASA.
+  Copyright 2020, 2023 Equinor ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -16,312 +16,1077 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <fmt/format.h>
-#include <numeric>
 
-
-#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
-#include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
 #include <opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
+#include <opm/input/eclipse/Schedule/Well/PAvgDynamicSourceData.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <cstdio>
+
+#include <fmt/format.h>
+
+namespace {
+
+/// Get linearised, global cell ID from IJK tuple
+///
+/// \param[in] cellIndexMap Cell index triple map ((I,J,K) <-> global).
+///
+/// \param[in] i Cell's global Cartesian I index
+/// \param[in] j Cell's global Cartesian J index
+/// \param[in] k Cell's global Cartesian K index
+///
+/// \return Linearised global cell ID.  Nullopt if any of the IJK indices
+///   are out of bounds or if cell (I,J,K) is inactive.
+std::optional<std::size_t>
+globalCellIndex(const Opm::GridDims& cellIndexMap,
+                const std::size_t    i,
+                const std::size_t    j,
+                const std::size_t    k)
+{
+    if ((i >= cellIndexMap.getNX()) ||
+        (j >= cellIndexMap.getNY()) ||
+        (k >= cellIndexMap.getNZ()))
+    {
+        return {};
+    }
+
+    return cellIndexMap.getGlobalIndex(i, j, k);
+}
+
+/// Compute pressure correction/offset
+///
+/// \param[in] density Mixture density (kg/m^3)
+///
+/// \param[in] depth Connection depth (m)
+///
+/// \param[in] gravity Strength of gravity acceleration (m/s^2)
+///
+/// \param[in] refDepth Reference depth to which to gravity correct a
+///   pressure value (m)
+double pressureOffset(const double density,
+                      const double depth,
+                      const double gravity,
+                      const double refDepth)
+{
+    return density * (refDepth - depth) * gravity;
+}
+
+template <typename T, typename W>
+class WeightedRunningAverage;
+
+template <typename T, typename W>
+T value(const WeightedRunningAverage<T, W>& avg);
+
+/// Maintain a running sum with compensated (Kahan) summation
+///
+///   https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+///
+/// \tparam T Element type.  Typically built-in arithmetic type like \c
+///   double.
+template <typename T>
+class RunningCompensatedSummation
+{
+public:
+    /// Implicit conversion to T when reading the value.
+    operator const T&() const { return this->value_; }
+
+    // Writing should be explicit at the call site.
+    T& mutableValue() { return this->value_; }
+
+    /// Accumulation operator.
+    ///
+    /// Disregards error contribution from sum of other terms.
+    ///
+    /// \param[in] other Sum of other terms.
+    ///
+    /// \return \code *this \endcode
+    RunningCompensatedSummation&
+    operator+=(const RunningCompensatedSummation& other)
+    {
+        // Intentionally discard other.err_.
+        return *this += other.value_;
+    }
+
+    /// Accumulation operator
+    ///
+    /// Accumulates term and estimates error in new sum.
+    ///
+    /// \param[in] x New term
+    ///
+    /// \return \code *this \endcode
+    RunningCompensatedSummation& operator+=(const T& x)
+    {
+        const auto t = this->value_;
+
+        this->err_   += x;
+        this->value_  = t + this->err_;
+        this->err_   += t - this->value_;
+
+        return *this;
+    }
+
+    /// Multiplication operator
+    ///
+    /// Multiplies sum value, leaves error intact.
+    ///
+    /// \param[in] alpha Scalar factor
+    ///
+    /// \return \code *this \endcode
+    RunningCompensatedSummation& operator*=(const T& alpha)
+    {
+        this->value_ *= alpha;
+
+        return *this;
+    }
+
+    /// Zero out sum value and error estimate
+    void clear()
+    {
+        this->value_ = T{};
+        this->err_ = T{};
+    }
+
+private:
+    /// Sum value
+    T value_{};
+
+    /// Error estimate
+    T err_{};
+};
+
+/// Maintain a weighted running average with compensated summation
+///
+/// \tparam T Element type
+///
+/// \tparam W Weighting type.  Typically a built-in arithmetic type such as
+///   \c double.
+template <typename T, typename W = double>
+class WeightedRunningAverage
+{
+public:
+    /// Zero out value and weight members
+    void clear()
+    {
+        this->sum_.clear();
+        this->weight_.clear();
+    }
+
+    /// Accumulate weighted term into current sum
+    ///
+    /// \param[in] x Term
+    /// \param[in] w Weight of \p x when included in current sum
+    /// \return \code *this \endcode
+    WeightedRunningAverage& add(const T& x, const W& w = W{1})
+    {
+        this->sum_    += w * x;
+        this->weight_ += w;
+
+        return *this;
+    }
+
+    /// Accumulate other weighted running average into current sum, while
+    /// applying a new weight to the average value.
+    ///
+    /// \param[in] x Weigthed running average
+    ///
+    /// \param[in] w Weight applied to value of \p x when included in
+    ///   current sum.
+    ///
+    /// \return \code *this \endcode
+    WeightedRunningAverage& add(const WeightedRunningAverage& x, const W& w)
+    {
+        return this->add(value(x), w);
+    }
+
+    /// Multiplication operator
+    ///
+    /// Multiplies value by constant factor
+    ///
+    /// \param[in] alpha Multiplication factor
+    /// \return \code *this \endcode
+    WeightedRunningAverage& operator*=(const W& alpha)
+    {
+        this->sum_ *= alpha;
+
+        return *this;
+    }
+
+    /// Accumulate weighted running average into current average
+    ///
+    /// \param[in] other Other weighted running average
+    /// \return \code *this \endcode
+    WeightedRunningAverage& operator+=(const WeightedRunningAverage& other)
+    {
+        this->sum_    += other.sum_;
+        this->weight_ += other.weight_;
+
+        return *this;
+    }
+
+    /// Get read/write access to weighted running sum value
+    T& mutableSum() { return this->sum_.mutableValue(); }
+
+    /// Get read/write access to total accumulated weight
+    W& mutableWeight() { return this->weight_.mutableValue(); }
+
+    /// Get read-only access to weighted running sum value
+    const T& sum()  const { return this->sum_; }
+
+    /// Get read-only access to total accumulated weight
+    const W& weight() const { return this->weight_; }
+
+private:
+    /// Weighted running sum value
+    RunningCompensatedSummation<T> sum_{};
+
+    /// Total accumulated weight
+    RunningCompensatedSummation<W> weight_{};
+};
+
+/// Calculate value of weighted running average
+///
+/// \tparam T Element type
+///
+/// \tparam W Weighting type.  Typically a built-in arithmetic type such as
+///   \c double.
+///
+/// \param[in] avg Weighted running average
+///
+/// \return Value of weighted running average
+template <typename T, typename W>
+T value(const WeightedRunningAverage<T, W>& avg)
+{
+    using std::abs;
+
+    const auto w = avg.weight();
+
+    return (abs(w) > W{})
+        ? avg.sum() / w
+        : T{};
+}
+
+/// Zero out collection of weighted running averages
+///
+/// \tparam T Element type
+///
+/// \tparam W Weighting type.  Typically a built-in arithmetic type such as
+///   \c double.
+///
+/// \tparam N Number of averages in collection
+///
+/// \param[in] avg Collection of weighted running averages
+template <typename T, typename W, std::size_t N>
+void clear(std::array<WeightedRunningAverage<T,W>, N>& avg)
+{
+    for (auto& a : avg) {
+        a.clear();
+    }
+}
+
+} // Anonymous namespace
 
 namespace Opm {
 
-namespace {
-std::optional<PAvgCalculator::Neighbour> make_neighbour(const EclipseGrid& grid, std::size_t i, std::size_t j, std::size_t k) {
-
-    if (i >= grid.getNX())
-        return {};
-
-    if (j >= grid.getNY())
-        return {};
-
-    if (k >= grid.getNZ())
-        return {};
-
-    if (!grid.cellActive(i,j,k))
-        return {};
-
-    double porv = -1;
-    return PAvgCalculator::Neighbour(porv, grid.getGlobalIndex(i,j,k));
-}
-}
-
-
-const std::string& PAvgCalculator::wname() const {
-    return this->well_name;
-}
-
-
-PAvgCalculator::PAvgCalculator(const std::string& well, double well_ref_depth, const EclipseGrid& grid, const std::vector<double>& porv, const WellConnections& connections, const PAvg& pavg) :
-    well_name(well),
-    m_pavg(pavg),
-    ref_depth(well_ref_depth)
+/// Implementation class for calculator's accumulator
+class PAvgCalculator::Accumulator::Impl
 {
-    if (porv.size() != grid.getCartesianSize())
-        throw std::logic_error("Should pass a GLOBAL porv vector");
+public:
+    /// Add contribution from centre/connecting cell
+    ///
+    /// \param[in] weight Pressure weighting factor
+    /// \param[in] press Pressure value
+    void addCentre(const double weight, const double press)
+    {
+        this->term_[0].add(press, weight);
+    }
+
+    /// Add contribution from direct, rectangular, level 1 neighbouring cell
+    ///
+    /// \param[in] weight Pressure weighting factor
+    /// \param[in] press Pressure value
+    void addRectangular(const double weight, const double press)
+    {
+        this->term_[1].add(press, weight);
+    }
+
+    /// Add contribution from diagonal, level 2 neighbouring cell
+    ///
+    /// \param[in] weight Pressure weighting factor
+    /// \param[in] press Pressure value
+    void addDiagonal(const double weight, const double press)
+    {
+        this->term_[2].add(press, weight);
+    }
+
+    /// Add contribution from other accumulator
+    ///
+    /// This typically incorporates a set of results from a single reservoir
+    /// connection into a larger sum across all connections.
+    ///
+    /// \param[in] weight Pressure weighting factor
+    /// \param[in] other Contribution from other accumulation process.
+    void add(const double weight, const Impl& other)
+    {
+        for (auto i = 0*this->avg_.size(); i < this->avg_.size(); ++i) {
+            this->avg_[i].add(other.avg_[i], weight);
+        }
+    }
+
+    /// Zero out/clear WBP result buffer
+    void prepareAccumulation()
+    {
+        clear(this->avg_);
+    }
+
+    /// Zero out/clear WBP term buffer
+    void prepareContribution()
+    {
+        clear(this->term_);
+    }
+
+    /// Accumulate current source term into result buffer whilst applying
+    /// any user-prescribed term weighting.
+    ///
+    /// \param[in] innerWeight Weighting factor for inner/connecting cell
+    ///   contributions.  Outer cells weighted by 1-innerWeight where
+    ///   applicable.  If inner weight factor is negative, no weighting is
+    ///   applied.  Typically the F1 weighting factor from the WPAVE
+    ///   keyword.
+    void commitContribution(const double innerWeight)
+    {
+        // 1 = Inner only, no weighting
+        this->avg_[0] += this->term_[0];
+
+        // 4 = Rectangular only, no weighting
+        this->avg_[1] += this->term_[1];
+
+        if (innerWeight < 0.0) {
+            // No term weighting.  Avg_[2] (5) and avg_[3] (9) are direct
+            // sums of two or more term contributions.
+            this->combineDirect();
+        }
+        else {
+            // Term weighting applies to quantites that combine inner and
+            // outer blocks (neighbours).
+            this->combineWeighted(innerWeight);
+        }
+    }
+
+    /// Get buffer of intermediate, local results.
+    LocalRunningAverages getRunningAverages() const
+    {
+        LocalRunningAverages a{};
+
+        auto j = 0*a.size();
+        for (const auto& avg : this->avg_) {
+            a[j++] = avg.sum();
+            a[j++] = avg.weight();
+        }
+
+        return a;
+    }
+
+    /// Assign coalesced/global contributions
+    ///
+    /// \param[in] avg Buffer of coalesced global contributions.
+    void assignRunningAverages(const LocalRunningAverages& a)
+    {
+        auto j = 0*a.size();
+        for (auto& avg : this->avg_) {
+            avg.mutableSum()    = a[j++];
+            avg.mutableWeight() = a[j++];
+        }
+    }
+
+    /// Retrieve block-average pressure value of specific type
+    ///
+    /// \param[in] type Kind of block-average pressure
+    ///
+    /// \return Value of specified block-average pressure quantity
+    double getAverageValue(const Result::WBPMode type) const
+    {
+        return value(this->avg_[static_cast<std::size_t>(type)]);
+    }
+
+private:
+    /// Result array.
+    ///
+    /// Combinations of term contributions.  Indices mapped as follows
+    ///
+    ///   [0] -> WBP  == Centre block
+    ///   [1] -> WBP4 == Rectangular neighbours
+    ///   [2] -> WBP5 == Inner + Rectangular
+    ///   [3] -> WBP9 == Inner + Rectangular + Diagonal
+    std::array<WeightedRunningAverage<double>, 4> avg_{};
+
+    /// Term contributions
+    ///
+    /// Indices mapped as follows
+    ///
+    ///   [0] -> Centre block
+    ///   [1] -> Rectangular neighbours
+    ///   [2] -> Diagonal neighbours
+    std::array<WeightedRunningAverage<double>, 3> term_{};
+
+    /// Subsume combinations of term values into block-averaged pressures
+    ///
+    /// No term weighting applied.  Writes to avg_[2] and avg_[3].
+    void combineDirect()
+    {
+        // 5 = Inner + rectangular
+        this->avg_[2] += this->term_[0];
+        this->avg_[2] += this->term_[1];
+
+        // 9 = Inner + rectangular + diagonal
+        this->avg_[3] += this->term_[0];
+        this->avg_[3] += this->term_[1];
+        this->avg_[3] += this->term_[2];
+    }
+
+    /// Subsume weighted combinations of term values into block-averaged
+    /// pressures
+    ///
+    /// Writes to avg_[2] and avg_[3].
+    ///
+    /// \param[in] innerWeight Weighting factor for inner/connecting cell
+    ///   contributions.  Outer cells weighted by 1-innerWeight where
+    ///   applicable.  Typically the F1 weighting factor from the WPAVE
+    ///   keyword.
+    void combineWeighted(const double innerWeight)
+    {
+        // WBP5 = w*Centre + (1-w)*Rectangular
+        this->avg_[2]
+            .add(this->term_[0],       innerWeight)
+            .add(this->term_[1], 1.0 - innerWeight);
+
+        // WBP9 = w*Centre + (1-w)*(Rectangular + Diagonal)
+        auto outer = this->term_[1];
+        outer     += this->term_[2];
+        this->avg_[3]
+            .add(this->term_[0],       innerWeight)
+            .add(outer         , 1.0 - innerWeight);
+    }
+};
+
+PAvgCalculator::Accumulator::Accumulator()
+    : pImpl_ { std::make_unique<Impl>() }
+{}
+
+PAvgCalculator::Accumulator::~Accumulator() = default;
+
+PAvgCalculator::Accumulator::Accumulator(const Accumulator& rhs)
+    : pImpl_ { std::make_unique<Impl>(*rhs.pImpl_) }
+{}
+
+PAvgCalculator::Accumulator::Accumulator(Accumulator&& rhs)
+    : pImpl_ { std::move(rhs.pImpl_) }
+{}
+
+PAvgCalculator::Accumulator&
+PAvgCalculator::Accumulator::operator=(const Accumulator& rhs)
+{
+    this->pImpl_ = std::make_unique<Impl>(*rhs.pImpl_);
+    return *this;
+}
+
+PAvgCalculator::Accumulator&
+PAvgCalculator::Accumulator::operator=(Accumulator&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+    return *this;
+}
+
+PAvgCalculator::Accumulator&
+PAvgCalculator::Accumulator::addCentre(const double weight,
+                                       const double press)
+{
+    this->pImpl_->addCentre(weight, press);
+    return *this;
+}
+
+PAvgCalculator::Accumulator&
+PAvgCalculator::Accumulator::addRectangular(const double weight,
+                                            const double press)
+{
+    this->pImpl_->addRectangular(weight, press);
+    return *this;
+}
+
+PAvgCalculator::Accumulator&
+PAvgCalculator::Accumulator::addDiagonal(const double weight,
+                                         const double press)
+{
+    this->pImpl_->addDiagonal(weight, press);
+    return *this;
+}
+
+PAvgCalculator::Accumulator&
+PAvgCalculator::Accumulator::add(const double       weight,
+                                 const Accumulator& other)
+{
+    this->pImpl_->add(weight, *other.pImpl_);
+    return *this;
+}
+
+void PAvgCalculator::Accumulator::prepareAccumulation()
+{
+    this->pImpl_->prepareAccumulation();
+}
+
+void PAvgCalculator::Accumulator::prepareContribution()
+{
+    this->pImpl_->prepareContribution();
+}
+
+void PAvgCalculator::Accumulator::commitContribution(const double innerWeight)
+{
+    this->pImpl_->commitContribution(innerWeight);
+}
+
+PAvgCalculator::Accumulator::LocalRunningAverages
+PAvgCalculator::Accumulator::getRunningAverages() const
+{
+    return this->pImpl_->getRunningAverages();
+}
+
+void
+PAvgCalculator::Accumulator::
+assignRunningAverages(const LocalRunningAverages& avg)
+{
+    this->pImpl_->assignRunningAverages(avg);
+}
+
+PAvgCalculator::Result
+PAvgCalculator::Accumulator::getFinalResult() const
+{
+    auto result = Result{};
+
+    for (const auto& type : {
+            Result::WBPMode::WBP,
+            Result::WBPMode::WBP4,
+            Result::WBPMode::WBP5,
+            Result::WBPMode::WBP9,
+        })
+    {
+        result.set(type, this->pImpl_->getAverageValue(type));
+    }
+
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+
+PAvgCalculator::PAvgCalculator(const GridDims&        cellIndexMap,
+                               const WellConnections& connections)
+{
+    this->openConns_.reserve(connections.size());
+
+    auto setupHelperMap = SetupMap{};
 
     for (const auto& conn : connections) {
-        if (conn.state() == ::Opm::Connection::State::OPEN || !this->m_pavg.open_connections()) {
-            Connection wp_conn(porv[conn.global_index()], conn.CF(), conn.dir(), conn.global_index());
-            this->add_connection(wp_conn);
+        // addConnection() mutates setupHelperMap
+        this->addConnection(cellIndexMap, conn, setupHelperMap);
+    }
+}
+
+PAvgCalculator::~PAvgCalculator() = default;
+
+void PAvgCalculator::pruneInactiveWBPCells(const std::vector<bool>& isActive)
+{
+    assert (isActive.size() == this->contributingCells_.size());
+
+    auto allIx = std::vector<ContrIndexType>(isActive.size());
+    std::iota(allIx.begin(), allIx.end(), ContrIndexType{0});
+
+    auto activeIx = std::vector<ContrIndexType>{};
+    activeIx.reserve(allIx.size());
+    std::copy_if(allIx.begin(), allIx.end(), std::back_inserter(activeIx),
+                 [&isActive](const auto i) { return isActive[i]; });
+
+    if (activeIx.size() == allIx.size()) {
+        // All cells active.  Nothing else to do here.
+        return;
+    }
+
+    // Filter contributingCells_ down to active cells only.
+    {
+        auto newWBPCells = std::vector<std::size_t>{};
+        newWBPCells.reserve(activeIx.size());
+
+        for (const auto origCell : activeIx) {
+            newWBPCells.push_back(this->contributingCells_[origCell]);
         }
+
+        this->contributingCells_.swap(newWBPCells);
     }
 
-    auto size = this->m_connections.size();
-    for (std::size_t index = 0; index < size; index++) {
-        auto& conn = this->m_connections[index];
-        auto [i,j,k] = grid.getIJK(conn.global_index);
-        if (conn.dir == ::Opm::Connection::Direction::X) {
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i,j  ,k+1), true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i,j  ,k-1), true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i,j+1,k),   true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i,j-1,k),   true);
-
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i,j+1,k+1), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i,j+1,k-1), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i,j-1,k+1), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i,j-1,k-1), false);
-        }
-
-        if (conn.dir == ::Opm::Connection::Direction::Y) {
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i+1,j,k), true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i-1,j,k), true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i  ,j,k+1), true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i  ,j,k-1), true);
-
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i+1,j,k+1), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i-1,j,k+1), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i+1,j,k-1), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i-1,j,k-1), false);
-        }
-
-        if (conn.dir == ::Opm::Connection::Direction::Z) {
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i+1,j  ,k), true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i-1,j  ,k), true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i  ,j+1,k), true);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i  ,j-1,k), true);
-
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i+1,j+1,k), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i-1,j+1,k), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i+1,j-1,k), false);
-            this->add_neighbour(conn.global_index, make_neighbour(grid, i-1,j-1,k), false);
-        }
-    }
-    for (const auto& [ijk, _] : this->m_index_map) {
-        (void)_;
-        this->m_index_list.push_back(ijk);
+    // Re-map/renumber original element indices to active cells only.
+    //
+    // 1) Establish new element indices.  Note: This loop leaves zeros in
+    // inactive cells.  That's intentional and we must use 'isActive' to
+    // filter the 'cell' and '*Neighbours' data members of PAvgConnection.
+    auto newIndex = std::vector<ContrIndexType>(allIx.size());
+    for (auto i = 0*activeIx.size(); i < activeIx.size(); ++i) {
+        newIndex[activeIx[i]] = i;
     }
 
-    this->pressure.resize( this->m_index_list.size() );
-    this->valid_pressure.resize( this->m_index_list.size(), 0 );
-}
+    const auto neighList = std::array {
+        &PAvgConnection::rectNeighbours,
+        &PAvgConnection::diagNeighbours,
+    };
 
+    // 2) Affect element index renumbering.
+    for (auto& conn : this->connections_) {
+        conn.cell = newIndex[conn.cell]; // Known to be active.
 
-void PAvgCalculator::add_connection(const PAvgCalculator::Connection& conn) {
-    this->m_index_map.insert(std::make_pair( conn.global_index, this->m_index_map.size()));
-    this->m_connections.push_back(conn);
-}
+        for (auto& neighbours : neighList) {
+            auto newNeigbour = std::vector<ContrIndexType>{};
+            newNeigbour.reserve((conn.*neighbours).size());
 
-void PAvgCalculator::add_neighbour(std::size_t global_index, std::optional<PAvgCalculator::Neighbour> neighbour, bool rect_neighbour) {
-    if (neighbour) {
-        this->m_index_map.insert(std::make_pair( neighbour->global_index, this->m_index_map.size()));
-        auto& conn = this->m_connections[ this->m_index_map[global_index] ];
-        if (rect_neighbour)
-            conn.rect_neighbours.push_back(neighbour.value());
-        else
-            conn.diag_neighbours.push_back(neighbour.value());
-    }
-}
-
-
-const std::vector< std::size_t >& PAvgCalculator::index_list() const {
-    return this->m_index_list;
-}
-
-bool PAvgCalculator::add_pressure(std::size_t global_index, double block_pressure) {
-    auto index_iter = this->m_index_map.find(global_index);
-    if (index_iter == this->m_index_map.end())
-        return false;
-
-    auto storage_index = index_iter->second;
-    this->pressure[storage_index] = block_pressure;
-    this->valid_pressure[storage_index] = 1;
-    return true;
-}
-
-
-double PAvgCalculator::get_pressure(std::size_t global_index) const {
-    auto storage_index = this->m_index_map.at(global_index);
-    if (this->valid_pressure[storage_index])
-        return this->pressure[storage_index];
-
-    auto msg = fmt::format("Tried to access pressure in invalid cell: {}", global_index);
-    throw std::runtime_error(msg);
-}
-
-
-
-double PAvgCalculator::cf_avg(const std::vector<std::optional<double>>& block_pressure) const {
-    double pressure_sum = 0;
-    double cf_sum = 0;
-
-    for (std::size_t index = 0; index < block_pressure.size(); index++) {
-        if (block_pressure[index]) {
-            const auto& conn = this->m_connections[index];
-            pressure_sum += block_pressure[index].value() * conn.cfactor;
-            cf_sum += conn.cfactor;
-        }
-    }
-
-    if (cf_sum == 0)
-        return 0;
-    return pressure_sum / cf_sum;
-}
-
-double PAvgCalculator::wbp() const {
-    return this->wbp(PAvgCalculator::WBPMode::WBP);
-}
-
-double PAvgCalculator::wbp4() const {
-    return this->wbp(PAvgCalculator::WBPMode::WBP4);
-}
-
-double PAvgCalculator::wbp5() const {
-    return this->wbp(PAvgCalculator::WBPMode::WBP5);
-}
-
-double PAvgCalculator::wbp9() const {
-    return this->wbp(PAvgCalculator::WBPMode::WBP9);
-}
-
-
-std::pair<double,double> PAvgCalculator::porv_pressure(std::size_t global_index) const {
-    auto storage_index = this->m_index_map.at(global_index);
-    const auto& conn = this->m_connections[storage_index];
-    return std::make_pair(conn.porv, this->get_pressure(global_index));
-}
-
-
-static double weighted_avg(const std::vector<std::pair<double, double>>& wp) {
-    if (wp.empty())
-        return 0;
-
-    double pressure_sum = 0;
-    double weight_sum = 0;
-
-    for (const auto& [weight, pressure] : wp) {
-        weight_sum += weight;
-        pressure_sum += weight * pressure;
-    }
-
-    return pressure_sum / weight_sum;
-}
-
-
-
-std::vector<std::optional<double>> PAvgCalculator::block_pressures(PAvgCalculator::WBPMode mode) const{
-    std::vector<std::optional<double>> block_pressure;
-    for (const auto& conn : this->m_connections) {
-        const double F1 = this->m_pavg.inner_weight();
-        if (F1 >= 0) {
-            std::optional<double> central_pressure;
-            double neighbour_pressure = 0;
-            std::size_t neighbour_count = 0;
-
-            if (mode != PAvgCalculator::WBPMode::WBP4)
-                central_pressure = this->get_pressure(conn.global_index);
-
-            if (mode != PAvgCalculator::WBPMode::WBP) {
-                for (const auto& neighbour : conn.rect_neighbours) {
-                    neighbour_pressure += this->get_pressure(neighbour.global_index);
-                    neighbour_count += 1;
-                }
-
-                if (mode == PAvgCalculator::WBPMode::WBP9) {
-                    for (const auto& neighbour : conn.diag_neighbours) {
-                        neighbour_pressure += this->get_pressure(neighbour.global_index);
-                        neighbour_count += 1;
-                    }
+            for (const auto& neighbour : conn.*neighbours) {
+                if (isActive[neighbour]) {
+                    newNeigbour.push_back(newIndex[neighbour]);
                 }
             }
-            if (neighbour_count == 0) {
-                if (central_pressure)
-                    block_pressure.push_back( central_pressure.value() );
-            } else {
-                if (central_pressure)
-                    block_pressure.push_back( F1 * central_pressure.value() + (1 - F1) * neighbour_pressure / neighbour_count );
-                else
-                    block_pressure.push_back( neighbour_pressure / neighbour_count );
-            }
-        } else {
-            std::vector<std::pair<double, double>> wp;
-            if (mode != PAvgCalculator::WBPMode::WBP4)
-                wp.emplace_back(this->porv_pressure(conn.global_index));
 
-            if (mode != PAvgCalculator::WBPMode::WBP) {
-                for (const auto& neighbour : conn.rect_neighbours)
-                    wp.push_back( this->porv_pressure(neighbour.global_index));
-
-                if (mode == PAvgCalculator::WBPMode::WBP9) {
-                    for (const auto& neighbour : conn.diag_neighbours)
-                        wp.push_back( this->porv_pressure(neighbour.global_index));
-                }
-            }
-            if (!wp.empty())
-                block_pressure.push_back( weighted_avg(wp) );
-        }
-    }
-    return block_pressure;
-}
-
-
-
-double PAvgCalculator::wbp(PAvgCalculator::WBPMode mode) const {
-    const double F2 = this->m_pavg.conn_weight();
-    double conn_pressure = 0;
-    if (F2 > 0) {
-        auto block_pressure = this->block_pressures(mode);
-        conn_pressure = this->cf_avg(block_pressure);
-    }
-
-    double porv_pressure = 0;
-    if (F2 < 1) {
-        std::vector<std::pair<double, double>> wp;
-        for (const auto& conn : this->m_connections) {
-
-            if (mode != PAvgCalculator::WBPMode::WBP4)
-                wp.emplace_back(this->porv_pressure(conn.global_index));
-
-            if (mode != PAvgCalculator::WBPMode::WBP) {
-                for (const auto& neighbour : conn.rect_neighbours)
-                    wp.push_back( this->porv_pressure(neighbour.global_index));
-
-                if (mode == PAvgCalculator::WBPMode::WBP9) {
-                    for (const auto& neighbour : conn.diag_neighbours)
-                        wp.push_back( this->porv_pressure(neighbour.global_index));
-                }
-            }
-        }
-        porv_pressure = weighted_avg(wp);
-    }
-
-    return F2 * conn_pressure + (1 - F2) * porv_pressure;
-}
-
-void PAvgCalculator::update(const std::vector<double>& p, const std::vector<char>& m) {
-    if (p.size() != this->pressure.size())
-        std::logic_error("Wrong size in update");
-
-    for (std::size_t index=0; index < p.size(); index++) {
-        if (m[index]) {
-            if (this->valid_pressure[index])
-                std::logic_error("Internal error - trying to update already valid pressure element");
-
-            this->pressure[index] = p[index];
-            this->valid_pressure[index] = 1;
+            (conn.*neighbours).swap(newNeigbour);
         }
     }
 }
 
+void PAvgCalculator::inferBlockAveragePressures(const Sources& sources,
+                                                const PAvg&    controls,
+                                                const double   gravity,
+                                                const double   refDepth)
+{
+    this->accumulateLocalContributions(sources, controls, gravity, refDepth);
+
+    this->collectGlobalContributions();
+
+    this->assignResults(controls);
 }
+
+std::vector<std::size_t> PAvgCalculator::allWellConnections() const
+{
+    auto ix = std::vector<std::size_t>(this->connections_.size());
+    std::iota(ix.begin(), ix.end(), std::size_t{0});
+
+    return ix;
+}
+
+void PAvgCalculator::accumulateLocalContributions(const Sources& sources,
+                                                  const PAvg&    controls,
+                                                  const double   gravity,
+                                                  const double   refDepth)
+{
+    this->accumCTF_.prepareAccumulation();
+    this->accumPV_.prepareAccumulation();
+
+    const auto connDP =
+        this->connectionPressureOffset(sources, controls, gravity, refDepth);
+
+    if (controls.open_connections()) {
+        this->accumulateLocalContribOpen(sources, controls, connDP);
+    }
+    else {
+        this->accumulateLocalContribAll(sources, controls, connDP);
+    }
+}
+
+void PAvgCalculator::collectGlobalContributions()
+{}
+
+void PAvgCalculator::assignResults(const PAvg& controls)
+{
+    const auto F2 = controls.conn_weight();
+
+    this->averagePressures_ =
+        linearCombination(F2      , this->accumCTF_.getFinalResult(),
+                          1.0 - F2, this->accumPV_ .getFinalResult());
+}
+
+void PAvgCalculator::addConnection(const GridDims&   cellIndexMap,
+                                   const Connection& conn,
+                                   SetupMap&         setupHelperMap)
+{
+    const auto& [localCellPos, newCellInserted] = setupHelperMap
+        .emplace(conn.global_index(), this->contributingCells_.size());
+
+    if (newCellInserted) {
+        this->contributingCells_.push_back(localCellPos->first);
+    }
+
+    if (conn.state() == Connection::State::OPEN) {
+        // Must be sequenced before connctions_.emplace_back()
+        this->openConns_.push_back(this->connections_.size());
+    }
+
+    this->connections_.emplace_back(conn.CF(), conn.depth(),
+                                    localCellPos->second);
+
+    if (conn.dir() == Connection::Direction::X) {
+        this->addNeighbours_X(cellIndexMap, setupHelperMap);
+    }
+    else if (conn.dir() == Connection::Direction::Y) {
+        this->addNeighbours_Y(cellIndexMap, setupHelperMap);
+    }
+    else if (conn.dir() == Connection::Direction::Z) {
+        this->addNeighbours_Z(cellIndexMap, setupHelperMap);
+    }
+}
+
+void PAvgCalculator::addNeighbour(std::optional<std::size_t> neighbour,
+                                  const NeighbourKind        neighbourKind,
+                                  SetupMap&                  setupHelperMap)
+{
+    if (! neighbour) {
+        return;
+    }
+
+    const auto& [localCellPos, newCellInserted] = setupHelperMap
+        .emplace(*neighbour, this->contributingCells_.size());
+
+    if (newCellInserted) {
+        this->contributingCells_.push_back(localCellPos->first);
+    }
+
+    auto& neighbours = (neighbourKind == NeighbourKind::Rectangular)
+        ? this->connections_.back().rectNeighbours
+        : this->connections_.back().diagNeighbours;
+
+    neighbours.push_back(localCellPos->second);
+}
+
+std::size_t PAvgCalculator::lastConnsCell() const
+{
+    return this->contributingCells_[this->connections_.back().cell];
+}
+
+void PAvgCalculator::addNeighbours_X(const GridDims& cellIndexMap, SetupMap& setupHelperMap)
+{
+    const auto& [i, j, k] = cellIndexMap.getIJK(this->lastConnsCell());
+
+    this->addNeighbour(globalCellIndex(cellIndexMap, i,j  ,k+1), NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i,j  ,k-1), NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i,j+1,k),   NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i,j-1,k),   NeighbourKind::Rectangular, setupHelperMap);
+
+    this->addNeighbour(globalCellIndex(cellIndexMap, i,j+1,k+1), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i,j+1,k-1), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i,j-1,k+1), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i,j-1,k-1), NeighbourKind::Diagonal, setupHelperMap);
+}
+
+void PAvgCalculator::addNeighbours_Y(const GridDims& cellIndexMap, SetupMap& setupHelperMap)
+{
+    const auto& [i, j, k] = cellIndexMap.getIJK(this->lastConnsCell());
+
+    this->addNeighbour(globalCellIndex(cellIndexMap, i+1,j,k),   NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i-1,j,k),   NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i  ,j,k+1), NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i  ,j,k-1), NeighbourKind::Rectangular, setupHelperMap);
+
+    this->addNeighbour(globalCellIndex(cellIndexMap, i+1,j,k+1), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i-1,j,k+1), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i+1,j,k-1), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i-1,j,k-1), NeighbourKind::Diagonal, setupHelperMap);
+}
+
+void PAvgCalculator::addNeighbours_Z(const GridDims& cellIndexMap, SetupMap& setupHelperMap)
+{
+    const auto& [i, j, k] = cellIndexMap.getIJK(this->lastConnsCell());
+
+    this->addNeighbour(globalCellIndex(cellIndexMap, i+1,j  ,k), NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i-1,j  ,k), NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i  ,j+1,k), NeighbourKind::Rectangular, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i  ,j-1,k), NeighbourKind::Rectangular, setupHelperMap);
+
+    this->addNeighbour(globalCellIndex(cellIndexMap, i+1,j+1,k), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i-1,j+1,k), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i+1,j-1,k), NeighbourKind::Diagonal, setupHelperMap);
+    this->addNeighbour(globalCellIndex(cellIndexMap, i-1,j-1,k), NeighbourKind::Diagonal, setupHelperMap);
+}
+
+template <typename ConnIndexMap, typename CTFPressureWeightFunction>
+void PAvgCalculator::accumulateLocalContributions(const Sources&             sources,
+                                                  const PAvg&                controls,
+                                                  const std::vector<double>& connDP,
+                                                  ConnIndexMap               connIndex,
+                                                  CTFPressureWeightFunction  ctfPressWeight)
+{
+    using PressureTermHandler =
+        Accumulator& (Accumulator::*)(const double weight,
+                                      const double press);
+
+    // PrepareContribution() is not needed for accumCTF_, but on the other
+    // hand does no real harm either.  Keep it for symmetry because we *do*
+    // need to prepare accumPV_.
+    this->accumCTF_.prepareContribution();
+    this->accumPV_ .prepareContribution();
+
+    // Intermediate, per connection results pertaining to CTF-weighted sum.
+    auto accumCTF_c = Accumulator{};
+
+    auto addContrib = [&sources, &ctfPressWeight, &accumCTF_c, this]
+        (const ContrIndexType i, const double dp, PressureTermHandler handler)
+    {
+        using Item = PAvgDynamicSourceData::SourceDataSpan<const double>::Item;
+
+        const auto src = sources.wellBlocks()[this->contributingCells_[i]];
+        const auto p   = src[Item::Pressure] + dp;
+
+        // Use std::invoke() to simplify the calling syntax here.
+        std::invoke(handler, accumCTF_c    , ctfPressWeight(src), p);
+        std::invoke(handler, this->accumPV_, src[Item::PoreVol] , p);
+    };
+
+    const auto handlers = std::array {
+        std::pair { &PAvgConnection::rectNeighbours, &Accumulator::addRectangular },
+        std::pair { &PAvgConnection::diagNeighbours, &Accumulator::addDiagonal },
+    };
+
+    const auto nconn = connDP.size();
+    for (auto connID = 0*nconn; connID < nconn; ++connID) {
+        accumCTF_c.prepareAccumulation();
+        accumCTF_c.prepareContribution();
+
+        const auto& conn = this->connections_[connIndex(connID)];
+
+        // 1) Connecting cell
+        addContrib(conn.cell, connDP[connID], &Accumulator::addCentre);
+
+        // 2) Connecting cell's neighbours.
+        for (const auto& [neighbours, handler] : handlers) {
+            for (const auto& neighIdx : conn.*neighbours) {
+                addContrib(neighIdx, connDP[connID], handler);
+            }
+        }
+
+        accumCTF_c.commitContribution(controls.inner_weight());
+
+        this->accumCTF_.add(conn.ctf, accumCTF_c);
+    }
+
+    // Infer {1,4,5,9} values from {Centre, Rectangular, Diagonal} term
+    // contributions in PV-based accumulation.  Must happen before
+    // collectGlobalContributions(), and this is a reasonable location.
+    this->accumPV_.commitContribution();
+}
+
+template <typename ConnIndexMap>
+void PAvgCalculator::accumulateLocalContributions(const Sources&             sources,
+                                                  const PAvg&                controls,
+                                                  const std::vector<double>& connDP,
+                                                  ConnIndexMap&&             connIndex)
+{
+    if (controls.inner_weight() < 0.0) {
+        // F1 < 0 => pore-volume weighting of individual cell contributions,
+        // no weighting when commiting term.
+
+        this->accumulateLocalContributions(sources, controls, connDP,
+                                           std::forward<ConnIndexMap>(connIndex),
+                                           [](const auto& src)
+                                           {
+                                               using Span = std::remove_cv_t<
+                                                   std::remove_reference_t<decltype(src)>>;
+                                               using Item = typename Span::Item;
+
+                                               return src[Item::PoreVol];
+                                           });
+    }
+    else {
+        // F1 >= 0 => unit weighting of individual cell contributions,
+        // F1-weighting when committing term.
+
+        this->accumulateLocalContributions(sources, controls, connDP,
+                                           std::forward<ConnIndexMap>(connIndex),
+                                           [](const auto&) { return 1.0; });
+    }
+}
+
+void PAvgCalculator::accumulateLocalContribOpen(const Sources&             sources,
+                                                const PAvg&                controls,
+                                                const std::vector<double>& connDP)
+{
+    assert (connDP.size() == this->openConns_.size());
+
+    this->accumulateLocalContributions(sources, controls, connDP,
+                                       [this](const auto i)
+                                       { return this->openConns_[i]; });
+}
+
+void PAvgCalculator::accumulateLocalContribAll(const Sources&             sources,
+                                               const PAvg&                controls,
+                                               const std::vector<double>& connDP)
+{
+    assert (connDP.size() == this->connections_.size());
+
+    this->accumulateLocalContributions(sources, controls, connDP,
+                                       [](const auto i) { return i; });
+}
+
+template <typename ConnIndexMap>
+std::vector<double>
+PAvgCalculator::connectionPressureOffsetWell(const std::size_t nconn,
+                                             const Sources&    sources,
+                                             const double      gravity,
+                                             const double      refDepth,
+                                             ConnIndexMap      connIndex) const
+{
+    auto dp = std::vector<double>(nconn);
+
+    auto density = [&sources](const auto connIx)
+    {
+        using Item = PAvgDynamicSourceData::SourceDataSpan<const double>::Item;
+
+        return sources.wellConns()[connIx][Item::MixtureDensity];
+    };
+
+    for (auto connID = 0*nconn; connID < nconn; ++connID) {
+        const auto  connIx = connIndex(connID);
+        const auto& conn = this->connections_[connIx];
+
+        dp[connID] = pressureOffset(density(connIx), conn.depth, gravity, refDepth);
+    }
+
+    return dp;
+}
+
+template <typename ConnIndexMap>
+std::vector<double>
+PAvgCalculator::connectionPressureOffsetRes(const std::size_t nconn,
+                                            const Sources&    sources,
+                                            const double      gravity,
+                                            const double      refDepth,
+                                            ConnIndexMap      connIndex) const
+{
+    auto dp = std::vector<double>(nconn);
+
+    const auto neighList = std::array {
+        &PAvgConnection::rectNeighbours,
+        &PAvgConnection::diagNeighbours,
+    };
+
+    auto density = WeightedRunningAverage<double, double>{};
+
+    auto includeDensity = [this, &sources, &density](const ContrIndexType i)
+    {
+        using Item = PAvgDynamicSourceData::SourceDataSpan<const double>::Item;
+
+        const auto src = sources.wellBlocks()[this->contributingCells_[i]];
+
+        density.add(src[Item::MixtureDensity], src[Item::PoreVol]);
+    };
+
+    for (auto connID = 0*nconn; connID < nconn; ++connID) {
+        density.clear();
+
+        const auto& conn = this->connections_[connIndex(connID)];
+
+        includeDensity(conn.cell);
+
+        for (const auto& neighbours : neighList) {
+            for (const auto& neighIdx : conn.*neighbours) {
+                includeDensity(neighIdx);
+            }
+        }
+
+        dp[connID] = pressureOffset(value(density), conn.depth, gravity, refDepth);
+    }
+
+    return dp;
+}
+
+std::vector<double>
+PAvgCalculator::connectionPressureOffset(const Sources& sources,
+                                         const PAvg&    controls,
+                                         const double   gravity,
+                                         const double   refDepth) const
+{
+    const auto nconn = controls.open_connections()
+        ? this->openConns_.size()
+        : this->connections_.size();
+
+    if ((controls.depth_correction() == PAvg::DepthCorrection::NONE) ||
+        ! std::isnormal(gravity))
+    {
+        // No depth correction.  Either because the run explicitly requests
+        // NONE for this or all wells, or because gravity effects are turned
+        // off (gravity == 0) globally; possibly due to the NOGRAV keyword.
+        // Unexpected case such as denormalised or non-finite values of
+        // 'gravity' go here too.
+
+        return std::vector<double>(nconn, 0.0);
+    }
+
+    if (controls.depth_correction() == PAvg::DepthCorrection::RES) {
+        if (! controls.open_connections()) {
+            return this->connectionPressureOffsetRes(nconn, sources, gravity, refDepth,
+                                                     [](const auto i) { return i; });
+        }
+
+        return this->connectionPressureOffsetRes(nconn, sources, gravity, refDepth,
+                                                 [this](const auto i)
+                                                 {
+                                                     return this->openConns_[i];
+                                                 });
+    }
+
+    if (controls.depth_correction() != PAvg::DepthCorrection::WELL) {
+        throw std::invalid_argument {
+            fmt::format("Unsupported WPAVE depth correction flag '{}'",
+                        static_cast<int>(controls.depth_correction()))
+        };
+    }
+
+    if (! controls.open_connections()) {
+        return this->connectionPressureOffsetWell(nconn, sources, gravity, refDepth,
+                                                  [](const auto i) { return i; });
+    }
+
+    return this->connectionPressureOffsetWell(nconn, sources, gravity, refDepth,
+                                              [this](const auto i)
+                                              {
+                                                  return this->openConns_[i];
+                                              });
+}
+
+// ---------------------------------------------------------------------------
+
+PAvgCalculator::Result
+linearCombination(const double alpha, PAvgCalculator::Result        x,
+                  const double beta , const PAvgCalculator::Result& y)
+{
+    std::transform(x.wbp_.begin(), x.wbp_.end(),
+                   y.wbp_.begin(),
+                   x.wbp_.begin(),
+                   [alpha, beta](const double xi, const double yi)
+                   {
+                       return alpha*xi + beta*yi;
+                   });
+
+    return x;
+}
+
+} // namespace Opm

--- a/tests/test_PAvgCalculator.cpp
+++ b/tests/test_PAvgCalculator.cpp
@@ -1,0 +1,1607 @@
+/*
+  Copyright (c) 2023 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE test_PAvgCalculator
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
+#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
+#include <opm/input/eclipse/Schedule/Well/PAvgDynamicSourceData.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+
+#include <opm/input/eclipse/Units/Units.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <type_traits>
+#include <vector>
+
+// ===========================================================================
+
+namespace {
+    std::size_t globIndex(const std::array<int,3>& ijk,
+                          const std::array<int,3>& dims)
+    {
+        return ijk[0] + dims[0]*(ijk[1] + static_cast<std::size_t>(dims[1])*ijk[2]);
+    }
+
+    Opm::WellConnections qfsProducer(const std::array<int,3>& dims, const int top = 0)
+    {
+        auto conns = std::vector<Opm::Connection>{};
+
+        // One cell in from corner in both I- and J- directions.
+        const auto i = (dims[0] - 1) - 1;
+        const auto j = (dims[1] - 1) - 1;
+
+        for (auto k = top; k < static_cast<int>(dims.size()); ++k) {
+            conns.emplace_back(i, j, k, globIndex({i, j, k}, dims), k,
+                               2000 + (2*k + 1) / static_cast<double>(2),
+                               Opm::Connection::State::OPEN,
+                               k / 100.0, 1.0, 1.0, 0.5, 0.5, 1.0, 0.0, 0,
+                               Opm::Connection::Direction::Z,
+                               Opm::Connection::CTFKind::DeckValue, k, false);
+        }
+
+        return { Opm::Connection::Order::INPUT, i, j, conns };
+    }
+
+    Opm::WellConnections centreProducer(const int numLayers = 10,
+                                        const int topConn   = 0,
+                                        const int numConns  = 4)
+    {
+        auto conns = std::vector<Opm::Connection>{};
+
+        const auto dims = std::array { 5, 5, numLayers };
+
+        const auto i = 2;
+        const auto j = 2;
+        const auto kMax = std::min(dims[2] - 1, topConn + numConns);
+
+        const auto state = std::array {
+            Opm::Connection::State::OPEN,
+            Opm::Connection::State::SHUT,
+            Opm::Connection::State::OPEN,
+        };
+
+        for (auto k = topConn; k < kMax; ++k) {
+            conns.emplace_back(i, j, k, globIndex({i, j, k}, dims), k - topConn,
+                               2000 + (2*k + 1) / static_cast<double>(2),
+
+                               // Open, Shut, Open, Open, Shut, ...
+                               state[(k - topConn) % state.size()],
+
+                               // 0.03, 0.0, 0.01, 0.02, 0.03, ...
+                               ((k + 3 - topConn) % 4) / 100.0,
+
+                               1.0, 1.0, 0.5, 0.5, 1.0, 0.0, 0,
+                               Opm::Connection::Direction::Z,
+                               Opm::Connection::CTFKind::DeckValue, k - topConn, false);
+        }
+
+        return { Opm::Connection::Order::INPUT, i, j, conns };
+    }
+
+    Opm::WellConnections horizontalProducer_X(const std::array<int,3>& dims,
+                                              const int                left     = 0,
+                                              const int                numConns = 3)
+    {
+        auto conns = std::vector<Opm::Connection>{};
+
+        const auto j = std::max((dims[1] - 1) - 1, 1);
+        const auto k = dims[2] - 1;
+        const auto iMax = std::min(dims[0] - 1, left + numConns);
+
+        for (auto i = left; i < iMax; ++i) {
+            conns.emplace_back(i, j, k, globIndex({i, j, k}, dims), i - left,
+                               2000 + (2*k + 1) / static_cast<double>(2),
+                               Opm::Connection::State::OPEN,
+                               i / 100.0, 1.0, 1.0, 0.5, 0.5, 1.0, 0.0, 0,
+                               Opm::Connection::Direction::X,
+                               Opm::Connection::CTFKind::DeckValue, i - left, false);
+        }
+
+        return { Opm::Connection::Order::INPUT, left, j, conns };
+    }
+
+    Opm::EclipseGrid shoeBox(const std::array<int,3>& dims)
+    {
+        return Opm::EclipseGrid(dims[0], dims[1], dims[2]);
+    }
+
+    double standardGravity()
+    {
+        return Opm::unit::gravity;
+    }
+
+    double simpleCalculationGravity()
+    {
+        return 10.0;
+    }
+
+    template <typename T>
+    std::vector<T> sort(std::vector<T> v)
+    {
+        std::sort(v.begin(), v.end());
+        return v;
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Basic_Operations)
+
+BOOST_AUTO_TEST_CASE(Construct)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in column (9,9) of bottom layer,
+    // meaning cell (9,9,3) only.
+    auto prod = Opm::PAvgCalculator {
+        shoeBox(dims), qfsProducer(dims, 2)
+    };
+
+    const auto wbpCells = sort(prod.allWBPCells());
+    const auto wbpConns = sort(prod.allWellConnections());
+
+    const auto expectCells = sort(std::vector {
+        globIndex({7, 7, 2}, dims), globIndex({8, 7, 2}, dims), globIndex({9, 7, 2}, dims),
+        globIndex({7, 8, 2}, dims), globIndex({8, 8, 2}, dims), globIndex({9, 8, 2}, dims),
+        globIndex({7, 9, 2}, dims), globIndex({8, 9, 2}, dims), globIndex({9, 9, 2}, dims),
+    });
+
+    const auto expectConns = std::vector { std::size_t{0} };
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(wbpCells   .begin(), wbpCells   .end(),
+                                  expectCells.begin(), expectCells.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(wbpConns   .begin(), wbpConns   .end(),
+                                  expectConns.begin(), expectConns.end());
+}
+
+BOOST_AUTO_TEST_CASE(Construct_Three_Layers)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in column (9,9) of all layers,
+    // meaning cells (9,9,1), (9,9,2), and (9,9,3).
+    auto prod = Opm::PAvgCalculator {
+        shoeBox(dims), qfsProducer(dims)
+    };
+
+    const auto wbpCells = sort(prod.allWBPCells());
+    const auto wbpConns = sort(prod.allWellConnections());
+
+    const auto expectCells = sort(std::vector {
+        globIndex({7, 7, 0}, dims), globIndex({8, 7, 0}, dims), globIndex({9, 7, 0}, dims),
+        globIndex({7, 8, 0}, dims), globIndex({8, 8, 0}, dims), globIndex({9, 8, 0}, dims),
+        globIndex({7, 9, 0}, dims), globIndex({8, 9, 0}, dims), globIndex({9, 9, 0}, dims),
+
+        globIndex({7, 7, 1}, dims), globIndex({8, 7, 1}, dims), globIndex({9, 7, 1}, dims),
+        globIndex({7, 8, 1}, dims), globIndex({8, 8, 1}, dims), globIndex({9, 8, 1}, dims),
+        globIndex({7, 9, 1}, dims), globIndex({8, 9, 1}, dims), globIndex({9, 9, 1}, dims),
+
+        globIndex({7, 7, 2}, dims), globIndex({8, 7, 2}, dims), globIndex({9, 7, 2}, dims),
+        globIndex({7, 8, 2}, dims), globIndex({8, 8, 2}, dims), globIndex({9, 8, 2}, dims),
+        globIndex({7, 9, 2}, dims), globIndex({8, 9, 2}, dims), globIndex({9, 9, 2}, dims),
+    });
+
+    const auto expectConns = std::vector {
+        std::size_t{0}, std::size_t{1}, std::size_t{2},
+    };
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(wbpCells   .begin(), wbpCells   .end(),
+                                  expectCells.begin(), expectCells.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(wbpConns   .begin(), wbpConns   .end(),
+                                  expectConns.begin(), expectConns.end());
+}
+
+BOOST_AUTO_TEST_CASE(Construct_Horizontal_X_5_Cols)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in X direction in columns 3:7 of row (:,9,3)
+    // meaning cells (3,9,3), (4,9,3), (5,9,3), (6,9,3), and (7,9,3).
+    auto prod = Opm::PAvgCalculator {
+        shoeBox(dims), horizontalProducer_X(dims, 2, 5)
+    };
+
+    const auto wbpCells = sort(prod.allWBPCells());
+    const auto wbpConns = sort(prod.allWellConnections());
+
+    const auto expectCells = sort(std::vector {
+        // Column 2
+        globIndex({2, 7, 1}, dims), globIndex({2, 8, 1}, dims), globIndex({2, 9, 1}, dims),
+        globIndex({2, 7, 2}, dims), globIndex({2, 8, 2}, dims), globIndex({2, 9, 2}, dims),
+
+        // Column 3
+        globIndex({3, 7, 1}, dims), globIndex({3, 8, 1}, dims), globIndex({3, 9, 1}, dims),
+        globIndex({3, 7, 2}, dims), globIndex({3, 8, 2}, dims), globIndex({3, 9, 2}, dims),
+
+        // Column 4
+        globIndex({4, 7, 1}, dims), globIndex({4, 8, 1}, dims), globIndex({4, 9, 1}, dims),
+        globIndex({4, 7, 2}, dims), globIndex({4, 8, 2}, dims), globIndex({4, 9, 2}, dims),
+
+        // Column 5
+        globIndex({5, 7, 1}, dims), globIndex({5, 8, 1}, dims), globIndex({5, 9, 1}, dims),
+        globIndex({5, 7, 2}, dims), globIndex({5, 8, 2}, dims), globIndex({5, 9, 2}, dims),
+
+        // Column 6
+        globIndex({6, 7, 1}, dims), globIndex({6, 8, 1}, dims), globIndex({6, 9, 1}, dims),
+        globIndex({6, 7, 2}, dims), globIndex({6, 8, 2}, dims), globIndex({6, 9, 2}, dims),
+    });
+
+    const auto expectConns = std::vector {
+        std::size_t{0}, std::size_t{1}, std::size_t{2}, std::size_t{3}, std::size_t{4},
+    };
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(wbpCells   .begin(), wbpCells   .end(),
+                                  expectCells.begin(), expectCells.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(wbpConns   .begin(), wbpConns   .end(),
+                                  expectConns.begin(), expectConns.end());
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Basic_Operations
+
+// ===========================================================================
+
+namespace {
+    struct CalculatorSetup
+    {
+        template <typename... Args>
+        CalculatorSetup(Args&&... args)
+            : calc        { std::forward<Args>(args)... }
+            , wbpCells    { sort(calc.allWBPCells()) }
+            , wbpConns    { sort(calc.allWellConnections()) }
+            , blockSource { wbpCells }
+            , connSource  { wbpConns }
+        {
+            this->sources.wellBlocks(blockSource).wellConns(connSource);
+        }
+
+        Opm::PAvgCalculator          calc;
+        std::vector<std::size_t>     wbpCells{};
+        std::vector<std::size_t>     wbpConns{};
+        Opm::PAvgDynamicSourceData   blockSource;
+        Opm::PAvgDynamicSourceData   connSource;
+        Opm::PAvgCalculator::Sources sources{};
+    };
+
+    namespace AveragingControls {
+        Opm::PAvg defaults()
+        {
+            // F1=0.5, F2=1, DepthCorr=Well, Conn=Open
+            return {};
+        }
+
+        namespace F1 {
+            Opm::PAvg zero()
+            {
+                // Default, except set F1 = 0.0;
+                const auto F1 = 0.0;
+                const auto dflt = defaults();
+
+                return {
+                    F1,
+                    dflt.conn_weight(),
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg negative()
+            {
+                // Default, except set F1 < 0.0;
+                const auto F1 = -1.0;   // < 0
+                const auto dflt = defaults();
+
+                return {
+                    F1,
+                    dflt.conn_weight(),
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg small()
+            {
+                // Default, except set F1 to a small value
+                const auto F1 = 1.0e-2;
+                const auto dflt = defaults();
+
+                return {
+                    F1,
+                    dflt.conn_weight(),
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg high()
+            {
+                // Default, except set F1 to a high value
+                const auto F1 = 1.0 - 1.0e-2;
+                const auto dflt = defaults();
+
+                return {
+                    F1,
+                    dflt.conn_weight(),
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg max()
+            {
+                // Default, except set F1 to its maximum value (1.0)
+                const auto F1 = 1.0;
+                const auto dflt = defaults();
+
+                return {
+                    F1,
+                    dflt.conn_weight(),
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+        } // namespace F1
+
+        namespace F2 {
+            Opm::PAvg zero()
+            {
+                // Default, except set F2 to zero
+                const auto F2 = 0.0;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    F2,
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg small()
+            {
+                // Default, except set F2 to a small value
+                const auto F2 = 1.0e-2;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    F2,
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg quarter()
+            {
+                // Default, except set F2 to 1/4
+                const auto F2 = 0.25;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    F2,
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg mid()
+            {
+                // Default, except set F2 to 1/2
+                const auto F2 = 0.5;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    F2,
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg threeQuarters()
+            {
+                // Default, except set F2 to 3/4
+                const auto F2 = 0.75;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    F2,
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg high()
+            {
+                // Default, except set F2 to a high value (near default of 1)
+                const auto F2 = 1.0 - 1.0e-2;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    F2,
+                    dflt.depth_correction(),
+                    dflt.open_connections()
+                };
+            }
+        } // namespace F2
+
+        namespace Connections {
+            Opm::PAvg open()
+            {
+                // Same as default
+                return defaults();
+            }
+
+            Opm::PAvg all()
+            {
+                // Default, except averaging procedure applies to all
+                // connections whether open or shut.
+                const auto use_open = false;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    dflt.conn_weight(),
+                    dflt.depth_correction(),
+                    use_open
+                };
+            }
+        } // namespace DepthCorr
+
+        namespace DepthCorrection {
+            Opm::PAvg well_open()
+            {
+                // Same as default
+                return defaults();
+            }
+
+            Opm::PAvg well_all()
+            {
+                // Default, except averaging procedure applies to all
+                // connections whether open or shut.
+                const auto use_open = false;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    dflt.conn_weight(),
+                    dflt.depth_correction(),
+                    use_open
+                };
+            }
+
+            Opm::PAvg reservoir_open()
+            {
+                // Default, except mixture density for depth correction is
+                // inferred from grid blocks.
+                const auto depth_correction = Opm::PAvg::DepthCorrection::RES;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    dflt.conn_weight(),
+                    depth_correction,
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg reservoir_all()
+            {
+                // Default, except mixture density for depth correction is
+                // inferred from grid blocks of all connections.
+                const auto depth_correction = Opm::PAvg::DepthCorrection::RES;
+                const auto use_open = false;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    dflt.conn_weight(),
+                    depth_correction,
+                    use_open
+                };
+            }
+
+            Opm::PAvg none_open()
+            {
+                // Default, except we don't use depth-corrected pressure values
+                const auto depth_correction = Opm::PAvg::DepthCorrection::NONE;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    dflt.conn_weight(),
+                    depth_correction,
+                    dflt.open_connections()
+                };
+            }
+
+            Opm::PAvg none_all()
+            {
+                // Default, except we don't use depth-corrected pressure
+                // values and we infer WBPn from all well connections.
+                const auto depth_correction = Opm::PAvg::DepthCorrection::NONE;
+                const auto use_open = false;
+                const auto dflt = defaults();
+
+                return {
+                    dflt.inner_weight(),
+                    dflt.conn_weight(),
+                    depth_correction,
+                    use_open
+                };
+            }
+        }
+    } // namespace AverageControls
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Equal_Pore_Volumes)
+
+namespace {
+    struct Setup : public CalculatorSetup
+    {
+        Setup(const std::array<int,3>& dims, const int top = 2)
+            : CalculatorSetup { shoeBox(dims), qfsProducer(dims, top) }
+        {}
+    };
+
+    void assignCellPress(const std::vector<double>& cellPress,
+                         Setup&                     cse)
+    {
+        using Span = std::remove_cv_t<
+            std::remove_reference_t<decltype(cse.blockSource[0])>>;
+        using Item = typename Span::Item;
+
+        for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
+            cse.blockSource[cse.wbpCells[block]]
+                .set(Item::Pressure, cellPress[block])
+                .set(Item::PoreVol, 1.25)
+                .set(Item::MixtureDensity, 0.1);
+        }
+    }
+
+    void assignConnPress(const std::vector<double>& connPress,
+                         Setup&                     cse)
+    {
+        using Span = std::remove_cv_t<
+            std::remove_reference_t<decltype(cse.connSource[0])>>;
+        using Item = typename Span::Item;
+
+        for (auto conn = 0*connPress.size(); conn < connPress.size(); ++conn) {
+            cse.connSource[conn]
+                .set(Item::Pressure, connPress[conn])
+                .set(Item::PoreVol, 0.5)
+                .set(Item::MixtureDensity, 0.1);
+        }
+    }
+
+    void assignPressureBottomLayer(Setup& cse)
+    {
+        assignCellPress({
+            85.0,  90.0,  95.0,
+            90.0, 100.0, 110.0,
+            90.0, 100.0, 120.0,
+        }, cse);
+
+        assignConnPress({80.0}, cse);
+    }
+
+    // Special pressure field to generate WBPn = 42 with default WPAVE
+    // controls (PAvg{}) and simpleCalculationGravity().
+    void assignPressureThreeLayers_Symmetric_42(Setup& cse)
+    {
+        assignCellPress({
+            // K=0 => 40
+            20.0, 30.0, 40.0,
+            30.0, 40.0, 50.0,
+            40.0, 50.0, 60.0,
+
+            // K=1 => 41 (+ 1)
+            22.0, 32.0, 42.0,
+            32.0, 42.0, 52.0,
+            42.0, 52.0, 62.0,
+
+            // K=2 => 42.5 (+ 2)
+            24.5, 34.5, 44.5,
+            34.5, 44.5, 54.5,
+            44.5, 54.5, 64.5,
+        }, cse);
+
+        assignConnPress({35.0, 37.0, 39.0}, cse);
+    }
+
+    // Random pressure field generated by Octave statement
+    //
+    //     1234 + fix(100 * rand)
+    void assignPressureThreeLayers_Rand_1234(Setup& cse)
+    {
+        assignCellPress({
+            // K=0
+            1245.0,  1283.0,  1329.0,
+            1268.0,  1292.0,  1256.0,
+            1309.0,  1259.0,  1284.0,
+
+            // K=1
+            1303.0,  1323.0,  1329.0,
+            1288.0,  1247.0,  1248.0,
+            1259.0,  1318.0,  1259.0,
+
+            // K=2
+            1315.0,  1258.0,  1326.0,
+            1268.0,  1253.0,  1259.0,
+            1295.0,  1281.0,  1269.0,
+        }, cse);
+
+        assignConnPress({1222.0, 1232.0, 1242.0}, cse);
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Bottom_Layer)
+
+BOOST_AUTO_TEST_CASE(Default_Control_No_Depth_Difference)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in cell (9,9,3) only
+    Setup cse { dims };
+
+    assignPressureBottomLayer(cse);
+
+    const auto controls = AveragingControls::defaults();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2002.5; // BHP reference depth => zero depth correction
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 100.00, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4),  97.50, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5),  98.75, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9),  98.75, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Default_Control_Elevate_Two_Cell_Thicknesses)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in cell (9,9,3) only
+    Setup cse { dims };
+
+    assignPressureBottomLayer(cse);
+
+    const auto controls = AveragingControls::defaults();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.5; // BHP reference depth - 2m => 2 Pa depth correction
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 100.00 - 2.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4),  97.50 - 2.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5),  98.75 - 2.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9),  98.75 - 2.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Bottom_Layer
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(All_Layers)
+
+BOOST_AUTO_TEST_CASE(Default_Control_WBPn_42)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Symmetric_42(cse);
+
+    const auto controls = AveragingControls::defaults();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.5; // BHP reference depth => depth correction in layers 1, and 2.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 42.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 42.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 42.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 42.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Default_Control_Rand_1234)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::defaults();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.5; // BHP reference depth => depth correction in layers 1, and 2.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1249.3333333333335, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1274.0833333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1261.7083333333335, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1266.9375000000000, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Default_Control_Rand_1234_Depth_Bottom_of_Centre)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::defaults();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2002.0; // Centre layer bottom depth => depth correction in all layers
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1250.833333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1275.583333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1263.208333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1268.437500000000, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Centre_F1_Zero)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F1::zero();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2001.5; // Centre layer centre depth => depth correction in layers 0 and 2.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1250.333333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1275.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1275.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1285.541666666667, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Centre_F1_Negative)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F1::negative();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2001.5; // Centre layer centre depth => depth correction in layers 0 and 2.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1250.333333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1275.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1270.133333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1281.629629629630, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Centre_F1_Small)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F1::small();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2001.5; // Centre layer centre depth => depth correction in layers 0 and 2.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1250.333333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1275.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1274.835833333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1285.189583333334, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Centre_F1_High)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F1::high();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2001.5; // Centre layer centre depth => depth correction in layers 0 and 2.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1250.333333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1275.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1250.580833333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1250.685416666667, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Centre_F1_Max)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F1::max();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2001.5; // Centre layer centre depth => depth correction in layers 0 and 2.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1250.333333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1275.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1250.333333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1250.333333333333, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Top_F2_Zero)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F2::zero();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.0; // Top layer top depth => depth correction in all layers
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1262.500000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1274.250000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1271.900000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1280.833333333333, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Top_F2_Small)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F2::small();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.0; // Top layer top depth => depth correction in all layers
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1262.363333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1274.243333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1271.793083333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1280.689375000000, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Top_F2_Quarter)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F2::quarter();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.0; // Top layer top depth => depth correction in all layers
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1259.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1274.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1269.227083333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1277.234375000000, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Top_F2_Mid)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F2::mid();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.0; // Top layer top depth => depth correction in all layers
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1255.666666666667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1273.916666666667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1266.554166666667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1273.635416666667, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Top_F2_Three_Quarters)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F2::threeQuarters();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.0; // Top layer top depth => depth correction in all layers
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1252.250000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1273.750000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1263.881250000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1270.036458333333, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Rand_1234_Top_F2_High)
+{
+    const auto dims = std::array { 10, 10, 3 };
+
+    // Producer connected in Z direction in cells (9,9,1), (9,9,2), and
+    // (9,9,3)
+    Setup cse { dims, 0 };
+
+    assignPressureThreeLayers_Rand_1234(cse);
+
+    const auto controls = AveragingControls::F2::high();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.0; // Top layer top depth => depth correction in all layers
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1248.970000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1273.590000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1261.315250000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1266.581458333334, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // All_Layers
+
+BOOST_AUTO_TEST_SUITE_END() // Equal_Pore_Volumes
+
+// ===========================================================================
+
+namespace {
+    // Octave: 1234 + fix(100 * rand([3, 3, 6]))
+    std::vector<double> pressureField()
+    {
+        return {
+            // K=2
+            1.302000e+03, 1.308000e+03, 1.279000e+03,
+            1.242000e+03, 1.256000e+03, 1.325000e+03,
+            1.249000e+03, 1.316000e+03, 1.287000e+03,
+
+            // K=3
+            1.333000e+03, 1.241000e+03, 1.278000e+03,
+            1.244000e+03, 1.330000e+03, 1.234000e+03,
+            1.311000e+03, 1.315000e+03, 1.320000e+03,
+
+            // K=4
+            1.242000e+03, 1.273000e+03, 1.259000e+03,
+            1.314000e+03, 1.277000e+03, 1.325000e+03,
+            1.252000e+03, 1.260000e+03, 1.248000e+03,
+
+            // K=5
+            1.247000e+03, 1.320000e+03, 1.291000e+03,
+            1.288000e+03, 1.248000e+03, 1.319000e+03,
+            1.296000e+03, 1.269000e+03, 1.285000e+03,
+
+            // K=6
+            1.274000e+03, 1.241000e+03, 1.257000e+03,
+            1.246000e+03, 1.252000e+03, 1.257000e+03,
+            1.275000e+03, 1.238000e+03, 1.324000e+03,
+
+            // K=7
+            1.328000e+03, 1.283000e+03, 1.282000e+03,
+            1.267000e+03, 1.324000e+03, 1.270000e+03,
+            1.245000e+03, 1.312000e+03, 1.272000e+03,
+        };
+    }
+
+    // Octave: fix(1e6 * (123.4 + 56.7*rand([3, 3, 6]))) / 1e6
+    std::vector<double> poreVolume()
+    {
+        return {
+            // K=2
+            1.301471680e+02, 1.516572410e+02, 1.778174820e+02,
+            1.426998700e+02, 1.565846810e+02, 1.360901360e+02,
+            1.659968420e+02, 1.378638930e+02, 1.520877640e+02,
+
+            // K=3
+            1.630376500e+02, 1.739142140e+02, 1.777918230e+02,
+            1.544271200e+02, 1.312600050e+02, 1.318649700e+02,
+            1.380007180e+02, 1.710686680e+02, 1.378177990e+02,
+
+            // K=4
+            1.695699490e+02, 1.372078650e+02, 1.760892470e+02,
+            1.432440790e+02, 1.345469500e+02, 1.376364540e+02,
+            1.583297330e+02, 1.502354770e+02, 1.433390940e+02,
+
+            // K=5
+            1.705079830e+02, 1.565844730e+02, 1.545693280e+02,
+            1.754048800e+02, 1.396070720e+02, 1.663332520e+02,
+            1.661364390e+02, 1.449712790e+02, 1.555954870e+02,
+
+            // K=6
+            1.277009380e+02, 1.264589710e+02, 1.534962210e+02,
+            1.675787810e+02, 1.763584050e+02, 1.307656820e+02,
+            1.556523010e+02, 1.500144490e+02, 1.240748470e+02,
+
+            // K=7
+            1.425148530e+02, 1.325957360e+02, 1.684359330e+02,
+            1.410458920e+02, 1.533678280e+02, 1.327922820e+02,
+            1.575323760e+02, 1.383104710e+02, 1.604862840e+02,
+        };
+    }
+
+    // Octave: 0.1 + round(0.1 * rand([3, 3, 6]), 2)
+    std::vector<double> mixtureDensity()
+    {
+        return {
+            // K=2
+            0.120, 0.120, 0.120,
+            0.140, 0.130, 0.190,
+            0.140, 0.120, 0.190,
+
+            // K=3
+            0.200, 0.140, 0.110,
+            0.130, 0.140, 0.160,
+            0.130, 0.160, 0.170,
+
+            // K=4
+            0.120, 0.110, 0.130,
+            0.130, 0.140, 0.150,
+            0.110, 0.130, 0.180,
+
+            // K=5
+            0.100, 0.190, 0.170,
+            0.150, 0.160, 0.120,
+            0.150, 0.200, 0.150,
+
+            // K=6
+            0.150, 0.120, 0.150,
+            0.160, 0.170, 0.140,
+            0.140, 0.200, 0.100,
+
+            // K=7
+            0.190, 0.190, 0.180,
+            0.110, 0.130, 0.130,
+            0.170, 0.110, 0.170,
+        };
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Open_Shut)
+
+BOOST_AUTO_TEST_SUITE(Equal_Pore_Volumes)
+
+namespace {
+    struct Setup : public CalculatorSetup
+    {
+        Setup()
+            : CalculatorSetup { shoeBox({5, 5, 10}), centreProducer(10, 2, 6) }
+        {
+            using Span = std::remove_cv_t<
+                std::remove_reference_t<decltype(this->blockSource[0])>>;
+            using Item = typename Span::Item;
+
+            const auto cellPress = pressureField();
+
+            for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
+                this->blockSource[this->wbpCells[block]]
+                    .set(Item::Pressure, cellPress[block])
+                    .set(Item::PoreVol, 1.25)
+                    .set(Item::MixtureDensity, 0.1);
+            }
+
+            for (auto conn = 0*this->wbpConns.size(); conn < this->wbpConns.size(); ++conn) {
+                this->connSource[conn]
+                    .set(Item::Pressure, 1222.0)
+                    .set(Item::PoreVol, 1.25)
+                    .set(Item::MixtureDensity, 0.1);
+            }
+        }
+    };
+}
+
+BOOST_AUTO_TEST_CASE(TopOfFormation_OpenConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).  Connections (3,3,4) and (3,3,7) are
+    // shut.
+    Setup cse{};
+
+    const auto controls = AveragingControls::Connections::open();
+    const auto gravity  = simpleCalculationGravity();
+    const auto refDepth = 2000.0; // Top of formation.  Depth correction in all layers.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1253.000000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1293.541666666667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1273.270833333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1267.572916666667, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(TopOfFormation_AllConns_StandardGravity)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).
+    Setup cse{};
+
+    const auto controls = AveragingControls::Connections::all();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2000.0; // Top of formation.  Depth correction in all layers.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1250.591304166667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1275.452415277778, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1263.021859722222, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1262.306581944444, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Equal_Pore_Volumes
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Variable_Pore_Volumes)
+
+namespace {
+    struct Setup : public CalculatorSetup
+    {
+        Setup()
+            : CalculatorSetup { shoeBox({5, 5, 10}), centreProducer(10, 2, 6) }
+        {
+            using Span = std::remove_cv_t<
+                std::remove_reference_t<decltype(this->blockSource[0])>>;
+            using Item = typename Span::Item;
+
+            const auto cellPress = pressureField();
+            const auto poreVol = poreVolume();
+
+            for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
+                this->blockSource[this->wbpCells[block]]
+                    .set(Item::Pressure, cellPress[block])
+                    .set(Item::PoreVol, poreVol[block])
+                    .set(Item::MixtureDensity, 0.1);
+            }
+
+            for (auto conn = 0*this->wbpConns.size(); conn < this->wbpConns.size(); ++conn) {
+                this->connSource[conn]
+                    .set(Item::Pressure, 1222.0)
+                    .set(Item::PoreVol, 1.25)
+                    .set(Item::MixtureDensity, 0.1);
+            }
+        }
+    };
+}
+
+BOOST_AUTO_TEST_CASE(CentreOfFormation_OpenConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).  Connections (3,3,4) and (3,3,7) are
+    // shut.
+    Setup cse{};
+
+    const auto controls = AveragingControls::Connections::open();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2005.0; // Bottom of layer 5.  Depth correction in all layers.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1257.977442500000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1298.519109166667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1278.248275833334, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1272.550359166667, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(BottomOfFormation_AllConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).  Connections (3,3,4) and (3,3,7) are
+    // shut.
+    Setup cse{};
+
+    const auto controls = AveragingControls::Connections::all();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2010.0; // Bottom of layer 10.  Depth correction in all layers.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1.260397954166667e+03, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1.285259065277778e+03, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1.272828509722222e+03, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1.272113231944445e+03, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Variable_Pore_Volumes
+
+BOOST_AUTO_TEST_SUITE_END() // Open_Shut
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Depth_Correction)
+
+namespace {
+    struct Setup : public CalculatorSetup
+    {
+        Setup()
+            : CalculatorSetup { shoeBox({5, 5, 10}), centreProducer(10, 2, 6) }
+        {
+            using Span = std::remove_cv_t<
+                std::remove_reference_t<decltype(this->blockSource[0])>>;
+            using Item = typename Span::Item;
+
+            const auto cellPress = pressureField();
+            const auto poreVol = poreVolume();
+            const auto mixDens = mixtureDensity();
+
+            for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
+                this->blockSource[this->wbpCells[block]]
+                    .set(Item::Pressure, cellPress[block])
+                    .set(Item::PoreVol, poreVol[block])
+                    .set(Item::MixtureDensity, mixDens[block]);
+            }
+
+            const auto wellBoreDens = std::vector {
+                0.1, 0.12, 0.14, 0.16, 0.18, 0.2,
+            };
+
+            for (auto conn = 0*this->wbpConns.size(); conn < this->wbpConns.size(); ++conn) {
+                this->connSource[conn]
+                    .set(Item::Pressure, 1222.0)
+                    .set(Item::PoreVol, 1.25)
+                    .set(Item::MixtureDensity, wellBoreDens[conn]);
+            }
+        }
+    };
+}
+
+BOOST_AUTO_TEST_CASE(TopOfFormation_Well_OpenConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).  Connections (3,3,4) and (3,3,7) are
+    // shut.
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::well_open();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2002.5; // BHP reference depth.  Depth correction in layers 4..8.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1254.806625666667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1295.348292333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1275.077459000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1269.379542333333, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(TopOfFormation_Well_AllConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::well_all();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2000.0; // Top of formation.  Depth correction in all layers.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1247.976197500000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1272.837308611111, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1260.406753055556, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1259.691475277778, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(TopOfFormation_Reservoir_OpenConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).  Connections (3,3,4) and (3,3,7) are
+    // shut.
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::reservoir_open();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2000.0; // Top of formation.  Depth correction in all layers.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1251.379769151233, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1291.921435817900, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1271.650602484567, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1265.952685817900, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(BHPRefDepth_Reservoir_AllConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::reservoir_all();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2002.5; // BHP reference depth.  Depth correction in layers 4..8.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1251.972089001828, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1276.833200112939, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1264.402644557383, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1263.687366779606, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(TopOfFormation_None_OpenConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).  Connections (3,3,4) and (3,3,7) are
+    // shut.
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::none_open();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2000.0; // Top of formation.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1256.833333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1297.375000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1277.104166666667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1271.406250000000, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(SeaLevel_None_OpenConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).  Connections (3,3,4) and (3,3,7) are
+    // shut.
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::none_open();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 0.0; // Sea level.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1256.833333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1297.375000000000, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1277.104166666667, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1271.406250000000, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(TopOfFormation_None_AllConns)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).
+    Setup cse{};
+
+    const auto controls = AveragingControls::DepthCorrection::none_all();
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2000.0; // Top of formation.  Depth correction in all layers.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1255.222222222222, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1280.083333333333, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1267.652777777778, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1266.937500000000, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Depth_Correction
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Integration)
+
+namespace {
+    struct Setup : public CalculatorSetup
+    {
+        Setup()
+            : CalculatorSetup { shoeBox({5, 5, 10}), centreProducer(10, 2, 6) }
+        {
+            using Span = std::remove_cv_t<
+                std::remove_reference_t<decltype(this->blockSource[0])>>;
+            using Item = typename Span::Item;
+
+            const auto cellPress = pressureField();
+            const auto poreVol = poreVolume();
+            const auto mixDens = mixtureDensity();
+
+            for (auto block = 0*cellPress.size(); block < cellPress.size(); ++block) {
+                this->blockSource[this->wbpCells[block]]
+                    .set(Item::Pressure, cellPress[block])
+                    .set(Item::PoreVol, poreVol[block])
+                    .set(Item::MixtureDensity, mixDens[block]);
+            }
+
+            const auto wellBoreDens = std::vector {
+                0.1, 0.12, 0.14, 0.16, 0.18, 0.2,
+            };
+
+            for (auto conn = 0*this->wbpConns.size(); conn < this->wbpConns.size(); ++conn) {
+                this->connSource[conn]
+                    .set(Item::Pressure, 1222.0)
+                    .set(Item::PoreVol, 1.25)
+                    .set(Item::MixtureDensity, wellBoreDens[conn]);
+            }
+        }
+    };
+}
+
+BOOST_AUTO_TEST_CASE(All_Specified)
+{
+    // Producer connected in Z direction in cells (3,3,3), (3,3,4), (3,3,5),
+    // (3,3,6), (3,3,7), and (3,3,8).  Connections (3,3,4) and (3,3,7) are
+    // shut.
+    Setup cse{};
+
+    const auto F1 = 0.875;
+    const auto F2 = 0.123;
+    const auto depthCorr = Opm::PAvg::DepthCorrection::RES;
+    const auto useOpen = false;
+
+    const auto controls = Opm::PAvg { F1, F2, depthCorr, useOpen };
+    const auto gravity  = standardGravity();
+    const auto refDepth = 2001.0; // Top cell bottom.  Depth correction in all layers.
+
+    cse.calc.inferBlockAveragePressures(cse.sources, controls, gravity, refDepth);
+
+    const auto avgPress = cse.calc.averagePressures();
+    using WBPMode = Opm::PAvgCalculator::Result::WBPMode;
+
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP) , 1270.833785766429, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP4), 1273.997383589501, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP5), 1271.300397582907, 1.0e-8);
+    BOOST_CHECK_CLOSE(avgPress.value(WBPMode::WBP9), 1271.175182912842, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration


### PR DESCRIPTION
This PR implements the `WPAVE` keyword and its associate WBPn well level report quantities.  We support all valid settings of `WPAVE` and `WWPAVE`.  The various weighted averages are accumulated through compensated summation of both the numerator and denominator terms for the inner block, the direct/immediate level 1 neighbours, and the diagonal level 2 neighbours.  We combine those contributions to the `WBP`, `WBP4`, `WBP5`, and `WBP9` terms when we "commit" the contributions (`Accumulator::commitContributions()`), per connection for values weighted by the connection transmissibility factor, and per well for values weighted by pore volumes.

We distinguish `OPEN` from `ALL` connections through callback functions in the implementation of `accumulateLocalContributions()` and the per connection weighting terms are provided as another set of callback functions depending on the value of the inner block weighting factor F1.

Depth correction (`NONE`, `WELL`, or `RES`) is affected through a separate set of callback functions used in the implementation of `connectionPressureOffset()`.

We discover source locations in a two-step process.  At WBPn calculation construction time, we exclude only those cells that are outside the model's dimensions.  The user is then expected to call member function `pruneInactiveWBPCells()`, typically at the `CalculatorCollection` level, at a later time in order to prune inactive cells.  This two-step split is necessary because we do not have a complete global view of the model's active cells in a parallel run.  It is very possible that the WBPn calculation on one rank will require source values from another rank and that begets this extra caution.

The user must call `inferBlockAveragePressures()` to compute the WBPn values.  Once completed, the result values may be extracted by calling member function `averagePressures()`.  We expect that the user will provide a complete set of up-to-date source values when calling this member function, both at the reservoir and the well connection levels.