### PR TITLE
Emit WBPn Summary Vectors to Summary Result File

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1258,6 +1258,27 @@ inline quantity node_pressure(const fn_args& args)
     return { nodePos->second.pressure, measure::pressure };
 }
 
+template <Opm::data::WellBlockAvgPress::Quantity wbp_quantity>
+quantity well_block_average_pressure(const fn_args& args)
+{
+    // Note: This WBP evaluation function is supported only at the well
+    // level.  There is intentionally no loop over args.schedule_wells.
+
+    const quantity zero = { 0.0, measure::pressure };
+
+    if (args.schedule_wells.empty())
+        return zero;
+
+    // No need to exclude status == SHUT here as the WBP quantity is well
+    // defined for shut wells too.
+    auto p = args.wbp.values.find(args.schedule_wells.front()->name());
+    if (p == args.wbp.values.end()) {
+        return zero;
+    }
+
+    return { p->second[wbp_quantity], measure::pressure };
+}
+
 template <Opm::Phase phase>
 inline quantity production_history(const fn_args& args)
 {
@@ -1862,6 +1883,10 @@ static const auto funs = std::unordered_map<std::string, ofun> {
     { "WSTAT", wstat },
     { "WBHP", bhp },
     { "WTHP", thp },
+    { "WBP" , well_block_average_pressure<Opm::data::WellBlockAvgPress::Quantity::WBP>  },
+    { "WBP4", well_block_average_pressure<Opm::data::WellBlockAvgPress::Quantity::WBP4> },
+    { "WBP5", well_block_average_pressure<Opm::data::WellBlockAvgPress::Quantity::WBP5> },
+    { "WBP9", well_block_average_pressure<Opm::data::WellBlockAvgPress::Quantity::WBP9> },
     { "WTPCHEA", temperature< producer >},
     { "WTICHEA", temperature< injector >},
     { "WVPRT", res_vol_production_target },

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -684,6 +684,14 @@ WTICSEA
 -- Performance
 WBHP
 /
+WBP
+ 'W_1' 'W_2' /
+WBP4
+ 'W_1' /
+WBP5
+ 'W_1' /
+WBP9
+ 'W_1' /
 WBHPH
 /
 WTHP

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -572,6 +572,17 @@ BOOST_AUTO_TEST_CASE(well_keywords)
     cfg.ta.makeSubDir( "PATH" );
     cfg.name = "PATH/CASE";
 
+    {
+        using Quantity = data::WellBlockAvgPress::Quantity;
+
+        auto& wbp = cfg.wbp.values["W_1"];
+
+        wbp[Quantity::WBP]  = 123.456*unit::barsa;
+        wbp[Quantity::WBP4] = 123.567*unit::barsa;
+        wbp[Quantity::WBP5] = 123.678*unit::barsa;
+        wbp[Quantity::WBP9] = 123.789*unit::barsa;
+    }
+
     SummaryState st(TimeService::now());
 
     out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
@@ -814,6 +825,14 @@ BOOST_AUTO_TEST_CASE(well_keywords)
     BOOST_CHECK_CLOSE( 0.1, ecl_sum_get_well_var( resp, 1, "W_1", "WBHP" ), 1e-5 );
     BOOST_CHECK_CLOSE( 1.1, ecl_sum_get_well_var( resp, 1, "W_2", "WBHP" ), 1e-5 );
     BOOST_CHECK_CLOSE( 2.1, ecl_sum_get_well_var( resp, 1, "W_3", "WBHP" ), 1e-5 );
+
+    // WBP
+    BOOST_CHECK_CLOSE( 123.456, ecl_sum_get_well_var( resp, 1, "W_1", "WBP"  ), 1e-5 );
+    BOOST_CHECK_CLOSE( 123.567, ecl_sum_get_well_var( resp, 1, "W_1", "WBP4" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 123.678, ecl_sum_get_well_var( resp, 1, "W_1", "WBP5" ), 1e-5 );
+    BOOST_CHECK_CLOSE( 123.789, ecl_sum_get_well_var( resp, 1, "W_1", "WBP9" ), 1e-5 );
+
+    BOOST_CHECK_CLOSE( 0.0, ecl_sum_get_well_var( resp, 1, "W_2", "WBP"  ), 1e-5 );
 
     /* THP */
     BOOST_CHECK_CLOSE( 0.2, ecl_sum_get_well_var( resp, 1, "W_1", "WTHP" ), 1e-5 );


### PR DESCRIPTION
This PR hooks the WBPn result vectors up to the summary file writing process.