### PR TITLE
Omit OPM Version Information in RSM File

### DIFF
--- a/src/opm/io/eclipse/ESmry_write_rsm.cpp
+++ b/src/opm/io/eclipse/ESmry_write_rsm.cpp
@@ -44,8 +44,6 @@
 
 #include <fmt/format.h>
 
-#include "project-version.h"
-
 namespace {
 
     constexpr std::size_t column_width { 8 } ;
@@ -72,7 +70,7 @@ namespace {
 
     std::string block_header_line(const std::string& run_name) {
         std::string date_string = format_date(Opm::TimeService::from_time_t(std::time(nullptr)));
-        return "SUMMARY OF RUN " + run_name + " at: " + date_string + "  OPM FLOW " + PROJECT_VERSION_NAME;
+        return "SUMMARY OF RUN " + run_name + " at: " + date_string;
     }
 
     void write_line(std::ostream& os, const std::string& line, char prefix = ' ') {


### PR DESCRIPTION
The version information leads to long install times and doesn't really provide any benefit to the user.