### PR TITLE
Fix Embedded Python Test

### DIFF
--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -17,30 +17,39 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stdexcept>
-#include <memory>
-
 #define BOOST_TEST_MODULE EMBEDDED_PYTHON
 
 #include <boost/test/unit_test.hpp>
 
 #include <opm/input/eclipse/Python/Python.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
+
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
-#include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/common/utility/TimeService.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
+
+#include <opm/common/utility/TimeService.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 using namespace Opm;
 
 #ifndef EMBEDDED_PYTHON
 
-BOOST_AUTO_TEST_CASE(INSTANTIATE) {
+BOOST_AUTO_TEST_CASE(INSTANTIATE)
+{
     Python python;
     BOOST_CHECK(!python.enabled());
     BOOST_CHECK_THROW(python.exec("print('Hello world')"), std::logic_error);
@@ -54,24 +63,25 @@ BOOST_AUTO_TEST_CASE(INSTANTIATE) {
     BOOST_CHECK(!python_off.enabled());
 }
 
-#else
+#else // EMBEDDED_PYTHON
 
-BOOST_AUTO_TEST_CASE(INSTANTIATE) {
+BOOST_AUTO_TEST_CASE(INSTANTIATE)
+{
     auto python = std::make_shared<Python>();
-    BOOST_CHECK(Python::supported());
-    BOOST_CHECK(python->enabled());
+    BOOST_CHECK_MESSAGE(Python::supported(), "Python interpreter must be available when we have Embedded Python support");
+    BOOST_CHECK_MESSAGE(python->enabled(), "Python interpreter must be enabled in a default-constructed Python object when we have Embedded Python support");
     BOOST_CHECK_NO_THROW(python->exec("import sys"));
 
     Parser parser;
     Deck deck;
-    std::string python_code = R"(
+    const std::string python_code = R"(
 print('Parser: {}'.format(context.parser))
 print('Deck: {}'.format(context.deck))
 kw = context.DeckKeyword( context.parser['FIELD'] )
 context.deck.add(kw)
 )";
-    BOOST_CHECK_NO_THROW( python->exec(python_code, parser, deck));
-    BOOST_CHECK( deck.hasKeyword("FIELD") );
+    BOOST_CHECK_NO_THROW(python->exec(python_code, parser, deck));
+    BOOST_CHECK(deck.hasKeyword("FIELD"));
 }
 
 
@@ -114,8 +124,8 @@ BOOST_AUTO_TEST_CASE(PYINPUT_BASIC) {
 
 }
 
-
-BOOST_AUTO_TEST_CASE(PYACTION) {
+BOOST_AUTO_TEST_CASE(PYACTION)
+{
     Parser parser;
     auto python = std::make_shared<Python>(Python::Enable::ON);
     auto deck = parser.parseFile("EMBEDDED_PYTHON.DATA");
@@ -172,8 +182,8 @@ BOOST_AUTO_TEST_CASE(PYACTION) {
     BOOST_CHECK( actions.pending_python(action_state).size() == 2);
 }
 
-
-BOOST_AUTO_TEST_CASE(Python_Constructor) {
+BOOST_AUTO_TEST_CASE(Python_Constructor)
+{
     Python python_off(Python::Enable::OFF);
     BOOST_CHECK(!python_off.enabled());
 
@@ -184,7 +194,8 @@ BOOST_AUTO_TEST_CASE(Python_Constructor) {
     BOOST_CHECK_THROW(Python python_throw(Python::Enable::ON), std::logic_error);
 }
 
-BOOST_AUTO_TEST_CASE(Python_Constructor2) {
+BOOST_AUTO_TEST_CASE(Python_Constructor2)
+{
     Python python_cond1(Python::Enable::TRY);
     BOOST_CHECK(python_cond1.enabled());
 
@@ -192,9 +203,4 @@ BOOST_AUTO_TEST_CASE(Python_Constructor2) {
     BOOST_CHECK(!python_cond2.enabled());
 }
 
-#endif
-
-
-
-
-
+#endif  // EMBEDDED_PYTHON

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -51,11 +51,10 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(INSTANTIATE)
 {
     Python python;
-    BOOST_CHECK(!python.enabled());
-    BOOST_CHECK_THROW(python.exec("print('Hello world')"), std::logic_error);
-    BOOST_CHECK(! Python::supported() );
+    BOOST_CHECK_MESSAGE(!python.enabled(), "Python must not be enabled in a default-constructed Python object unless we have Embedded Python support");
+    BOOST_CHECK_MESSAGE(!python.exec("print('Hello world')"), "Default-constructed Python object must not run Python code unless we have Embedded Python support");
+    BOOST_CHECK_MESSAGE(!Python::supported(), "Python must not be supported unless we have Embedded Python support");
 
-    BOOST_CHECK_THROW( Python{Python::Enable::ON}, std::logic_error );
     Python python_cond(Python::Enable::TRY);
     BOOST_CHECK(!python_cond.enabled());
 


### PR DESCRIPTION
In particular,

 * Emit more useful diagnostic messages if a test fails
 * Catch up to changing semantics of certain `Python` class member functions
 * Handle the case of Python's `NumPy` module not being available

PR #3561 switched `Python::exec()` to return `false` instead of throwing an exception if the configuration does not have `EMBEDDED_PYTHON` so we must account for this in the corresponding unit test.