### PR TITLE
Fix A Couple of Compiler and Static Code Analysis Warnings

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -414,6 +414,9 @@ public:
             break;
         }
         }
+
+        // Should not get here...
+        return false;
     }
 };
 

--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -598,22 +598,6 @@ namespace Opm {
             static_cast<std::size_t>(Quantity::WBP9) + 1;
 
         std::array<double, NumQuantities> wbp_{};
-
-        std::string quantityName(const Quantity quantity) const
-        {
-            switch (quantity) {
-            case Quantity::WBP : return "WBP";
-            case Quantity::WBP4: return "WBP4";
-            case Quantity::WBP5: return "WBP5";
-            case Quantity::WBP9: return "WBP9";
-            }
-
-            throw std::invalid_argument {
-                "Unkown WBP quantity '" +
-                std::to_string(static_cast<int>(quantity)) +
-                "'"
-            };
-        }
     };
 
     struct Well {

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -45,7 +45,7 @@ namespace Opm {
 namespace Opm { namespace data {
     class GroupAndNetworkValues;
     class InterRegFlowMap;
-    class WellBlockAveragePressures;
+    struct WellBlockAveragePressures;
     class Wells;
 }} // namespace Opm::data
 

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -3520,8 +3520,7 @@ namespace Evaluator {
             this->st_,
             {}, {}, {},
             reg, this->grid_, this->sched_,
-            {}, {}, {},
-            Opm::UnitSystem(Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC)
+            {}, {}, {}, this->es_.getUnits()
         };
 
         const auto prm = this->paramFunction_(args);

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -228,8 +228,8 @@ struct setup
 
     // ------------------------------------------------------------------------
 
-    setup(std::string        case_name,
-          const std::string& path = "UDQ_ACTIONX_TEST1_U.DATA")
+    explicit setup(std::string        case_name,
+                   const std::string& path = "UDQ_ACTIONX_TEST1_U.DATA")
         : deck     { Parser{}.parseFile(path) }
         , es       { deck }
         , grid     { es.getInputGrid() }


### PR DESCRIPTION
In particular

  * Tag a single argument constructor as `explicit`,
  * Remove an unused private function
  * Fix mismatched tags (`struct` vs. `class`) in forward declaration
  * Return 'false' in an impossible `updateHyst()` case

While here, also use a real `UnitSystem` object instead of creating a METRIC system just to infer unit strings.