### PR TITLE
-- added function need to test solver without multiplexer

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclDefaultMaterial.hpp
@@ -199,6 +199,12 @@ public:
         Valgrind::CheckDefined(krnSwMdc);
     }
 
+
+    static Scalar trappedGasSaturation(const Params& params)
+    {
+     
+        return params.gasOilParams().SnTrapped();
+    }
     /*
      * Hysteresis parameters for gas-oil
      * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)


### PR DESCRIPTION
Added need function to use standalone ecldefault relperms. 
The intent is to be used with flowexperimental:flow_blackoil_fast, which can give significant speedup of property update.