### PR TITLE
BUGFIX: Use salinity values when salt concentration (BRINE) is not considered

### DIFF
--- a/src/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
+++ b/src/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
@@ -49,7 +49,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
     }
 
     setEnableDissolvedGas(eclState.getSimulationConfig().hasDISGASW() || eclState.getSimulationConfig().hasDISGAS());
-
+    setEnableSaltConcentration(eclState.runspec().phases().active(Phase::BRINE));
     // We only supported single pvt region for the co2-brine module
     size_t numRegions = 1;
     setNumRegions(numRegions);


### PR DESCRIPTION
I bug was introduced in https://github.com/OPM/opm-common/pull/3433 that neglected the input salinity