### PR TITLE
Don't Narrow String Literal to Bool

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Tables/Ppcwmax.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/Ppcwmax.cpp
@@ -70,7 +70,7 @@ std::vector< PpcwmaxRecord >::const_iterator Ppcwmax::end() const {
 }
 
 Ppcwmax Ppcwmax::serializationTestObject() {
-    return Ppcwmax({{45.0, "YES"}});
+    return Ppcwmax({{45.0, true}});
 }
 
 


### PR DESCRIPTION
This isn't portable.