### PR TITLE
Reformat PAvg Class

### DIFF
--- a/opm/input/eclipse/Schedule/Well/PAvg.hpp
+++ b/opm/input/eclipse/Schedule/Well/PAvg.hpp
@@ -17,42 +17,64 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef PAVE_HPP
 #define PAVE_HPP
 
+namespace Opm {
+    class DeckRecord;
+} // Namespace Opm
 
 namespace Opm {
-class DeckRecord;
 
-class PAvg {
+class PAvg
+{
 public:
-    enum class DepthCorrection {
+    enum class DepthCorrection
+    {
         WELL = 1,
         RES  = 2,
-        NONE = 3
+        NONE = 3,
     };
 
     PAvg();
     explicit PAvg(const DeckRecord& record);
-    PAvg(double inner_weight, double conn_weight, DepthCorrection depth_correction, bool use_open_connections);
-
-    double inner_weight() const;
-    double conn_weight() const;
-    bool use_porv() const;
-    bool open_connections() const;
-    DepthCorrection depth_correction() const;
-
-
-    template<class Serializer>
-    void serializeOp(Serializer& serializer) {
-        serializer(m_inner_weight);
-        serializer(m_conn_weight);
-        serializer(m_depth_correction);
-        serializer(m_open_connections);
-    }
+    PAvg(double          inner_weight,
+         double          conn_weight,
+         DepthCorrection depth_correction,
+         bool            use_open_connections);
 
     static PAvg serializationTestObject();
+
+    double inner_weight() const
+    {
+        return this->m_inner_weight;
+    }
+
+    double conn_weight() const
+    {
+        return this->m_conn_weight;
+    }
+
+    bool open_connections() const
+    {
+        return this->m_open_connections;
+    }
+
+    DepthCorrection depth_correction() const
+    {
+        return this->m_depth_correction;
+    }
+
+    bool use_porv() const;
+
+    template <class Serializer>
+    void serializeOp(Serializer& serializer)
+    {
+        serializer(this->m_inner_weight);
+        serializer(this->m_conn_weight);
+        serializer(this->m_depth_correction);
+        serializer(this->m_open_connections);
+    }
 
     bool operator==(const PAvg& other) const;
     bool operator!=(const PAvg& other) const;
@@ -64,5 +86,6 @@ private:
     bool m_open_connections;
 };
 
-}
-#endif
+} // namespace Opm
+
+#endif // PAVE_HPP

--- a/src/opm/input/eclipse/Schedule/Well/PAvg.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/PAvg.cpp
@@ -16,124 +16,122 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <fmt/format.h>
 
 #include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
-namespace Opm {
+#include <string>
+#include <stdexcept>
+
+#include <fmt/format.h>
 
 namespace {
 
-PAvg::DepthCorrection depthCorrectionFromString(const std::string& s) {
-    if (s == "WELL")
-        return PAvg::DepthCorrection::WELL;
-
-    if (s == "RES")
-        return PAvg::DepthCorrection::RES;
-
-    if (s == "NONE")
-        return PAvg::DepthCorrection::NONE;
-
-    throw std::invalid_argument(fmt::format("{} not recognized as depth correction mode", s));
-}
-
-bool openConnectionsFromString(const std::string& s) {
-    if (s == "OPEN")
-        return true;
-
-    if (s == "ALL")
-        return false;
-
-    throw std::invalid_argument(fmt::format("{} not recognized as connection indicator", s));
-}
-
-
-}
-
-
-
-PAvg::PAvg() :
-    m_inner_weight(ParserKeywords::WPAVE::F1::defaultValue),
-    m_conn_weight(ParserKeywords::WPAVE::F2::defaultValue)
+Opm::PAvg::DepthCorrection
+depthCorrectionFromString(const std::string& s)
 {
-    m_depth_correction = depthCorrectionFromString( ParserKeywords::WPAVE::DEPTH_CORRECTION::defaultValue );
-    m_open_connections = openConnectionsFromString( ParserKeywords::WPAVE::CONNECTION::defaultValue );
+    if (s == "WELL") {
+        return Opm::PAvg::DepthCorrection::WELL;
+    }
+
+    if (s == "RES") {
+        return Opm::PAvg::DepthCorrection::RES;
+    }
+
+    if (s == "NONE") {
+        return Opm::PAvg::DepthCorrection::NONE;
+    }
+
+    throw std::invalid_argument {
+        fmt::format("{} not recognized as depth correction mode", s)
+    };
 }
 
-PAvg::PAvg(double inner_weight, double conn_weight, DepthCorrection depth_correction, bool use_open_connections) :
-    m_inner_weight(inner_weight),
-    m_conn_weight(conn_weight),
-    m_depth_correction(depth_correction),
-    m_open_connections(use_open_connections)
+bool openConnectionsFromString(const std::string& s)
+{
+    if (s == "OPEN") {
+        return true;
+    }
+
+    if (s == "ALL") {
+        return false;
+    }
+
+    throw std::invalid_argument {
+        fmt::format("{} not recognized as connection indicator", s)
+    };
+}
+
+} // Anonymous namespace
+
+namespace Opm {
+
+PAvg::PAvg()
+    : m_inner_weight(ParserKeywords::WPAVE::F1::defaultValue)
+    , m_conn_weight(ParserKeywords::WPAVE::F2::defaultValue)
+    , m_depth_correction(depthCorrectionFromString(ParserKeywords::WPAVE::DEPTH_CORRECTION::defaultValue))
+    , m_open_connections(openConnectionsFromString(ParserKeywords::WPAVE::CONNECTION::defaultValue))
 {}
 
-PAvg PAvg::serializationTestObject() {
-    return PAvg(0.10, 0.30, PAvg::DepthCorrection::NONE, false);
-}
+PAvg::PAvg(const double          inner_weight,
+           const double          conn_weight,
+           const DepthCorrection depth_correction,
+           const bool            use_open_connections)
+    : m_inner_weight(inner_weight)
+    , m_conn_weight(conn_weight)
+    , m_depth_correction(depth_correction)
+    , m_open_connections(use_open_connections)
+{}
 
 PAvg::PAvg(const DeckRecord& record)
     : PAvg()
 {
-    /*
-      This code uses the WPAVE keyword to access the content of the the record,
-      but the record can equally well come from a WWPAVE keyword - i.e. it is a
-      HARD assumption that the same item names is used both for WPAVE and
-      WWPAVE.
-    */
+    // This code uses the WPAVE keyword to access the content of the record,
+    // but the record can equally well come from a WWPAVE keyword--i.e., it
+    // is a HARD assumption that the same item names is used both for WPAVE
+    // and WWPAVE.
     using WPAVE = ParserKeywords::WPAVE;
-    const auto& item_inner_weight = record.getItem<WPAVE::F1>();
-    const auto& item_conn_weight = record.getItem<WPAVE::F2>();
-    const auto& item_depth_correction = record.getItem<WPAVE::DEPTH_CORRECTION>();
-    const auto& item_connections = record.getItem<WPAVE::CONNECTION>();
 
-    this->m_inner_weight = item_inner_weight.get<double>(0);
-    this->m_conn_weight = item_conn_weight.get<double>(0);
+    this->m_inner_weight = record.getItem<WPAVE::F1>().get<double>(0);
+    this->m_conn_weight  = record.getItem<WPAVE::F2>().get<double>(0);
 
-    if (!item_depth_correction.defaultApplied(0))
-        this->m_depth_correction = depthCorrectionFromString( item_depth_correction.get<std::string>(0) );
+    if (const auto& item_depth_correction = record.getItem<WPAVE::DEPTH_CORRECTION>();
+        !item_depth_correction.defaultApplied(0))
+    {
+        this->m_depth_correction = depthCorrectionFromString(item_depth_correction.get<std::string>(0));
+    }
 
-    if (!item_connections.defaultApplied(0))
-        this->m_open_connections = openConnectionsFromString( item_connections.get<std::string>(0) );
+    if (const auto& item_connections = record.getItem<WPAVE::CONNECTION>();
+        !item_connections.defaultApplied(0))
+    {
+        this->m_open_connections = openConnectionsFromString(item_connections.get<std::string>(0));
+    }
 }
 
-
-double PAvg::inner_weight() const {
-    return this->m_inner_weight;
+PAvg PAvg::serializationTestObject()
+{
+    return PAvg(0.10, 0.30, PAvg::DepthCorrection::NONE, false);
 }
 
-double PAvg::conn_weight() const {
-    return this->m_conn_weight;
+bool PAvg::use_porv() const
+{
+    return (this->m_conn_weight != 1)
+        || (this->m_inner_weight < 0);
 }
 
-PAvg::DepthCorrection PAvg::depth_correction() const {
-    return this->m_depth_correction;
+bool PAvg::operator==(const PAvg& other) const
+{
+    return (this->m_inner_weight == other.m_inner_weight)
+        && (this->m_conn_weight == other.m_conn_weight)
+        && (this->m_depth_correction == other.m_depth_correction)
+        && (this->m_open_connections == other.m_open_connections)
+        ;
 }
 
-bool PAvg::open_connections() const {
-    return this->m_open_connections;
-}
-
-bool PAvg::use_porv() const {
-    if (this->m_conn_weight != 1)
-        return true;
-
-    if (this->m_inner_weight < 0)
-        return true;
-
-    return false;
-}
-
-
-bool PAvg::operator==(const PAvg& other) const {
-    return this->m_inner_weight == other.m_inner_weight &&
-           this->m_conn_weight == other.m_conn_weight &&
-           this->m_depth_correction == other.m_depth_correction &&
-           this->m_open_connections == other.m_open_connections;
-}
-
-bool PAvg::operator!=(const PAvg& other) const {
+bool PAvg::operator!=(const PAvg& other) const
+{
     return !(*this == other);
 }
 


### PR DESCRIPTION
Mostly for readability.  While here, also switch to using compiled item names instead of raw strings to access the DeckItems which constitute the WPAVE and WWPAVE keywords.

Split off from #3559.