### PR TITLE
Extend the PYACTION functionality 

### DIFF
--- a/opm/input/eclipse/Schedule/Action/PyAction.hpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.hpp
@@ -45,15 +45,28 @@ public:
        unlimited,
        first_true
     };
+   enum class RunWhen {
+       post_step,
+       pre_step,
+       post_newton,
+       pre_newton,       
+       post_report,
+       pre_report
+   };
 
 
-    static RunCount from_string(std::string run_count);
+    static RunCount count_from_string(std::string run_count);
+    static std::string count_to_string(RunCount run_count);
+    static RunWhen  when_from_string(std::string run_when);
+    static std::string  when_to_string(RunWhen run_when);
     static PyAction serializationTestObject();
     PyAction() = default;
-    PyAction(std::shared_ptr<const Python> python, const std::string& name, RunCount run_count, const std::string& module_file);
+    PyAction(std::shared_ptr<const Python> python, const std::string& name, RunCount run_count, RunWhen run_when, const std::string& module_file);
     bool run(EclipseState& ecl_state, Schedule& schedule, std::size_t report_step, SummaryState& st,
-             const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) const;
+             const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) const;    
+    
     const std::string& name() const;
+    const std::string when() const;
     bool ready(const State& state) const;
     bool operator==(const PyAction& other) const;
 
@@ -62,6 +75,7 @@ public:
     {
         serializer(m_name);
         serializer(m_run_count);
+        serializer(m_run_when);
         serializer(module_file);
         serializer(m_active);
     }
@@ -72,6 +86,7 @@ private:
     mutable std::shared_ptr< PyRunModule > run_module;
     std::string m_name;
     RunCount m_run_count;
+    RunWhen m_run_when;
     std::string module_file;
     mutable bool m_active = true;
 };

--- a/python/tests/test_summarystate.py
+++ b/python/tests/test_summarystate.py
@@ -1,5 +1,6 @@
 import datetime
 import unittest
+import math
 
 import opm.io.sim
 
@@ -15,8 +16,7 @@ class TestSummaryState(unittest.TestCase):
         self.assertTrue("FOPT" in st)
         self.assertFalse("FWPR" in st)
 
-        with self.assertRaises(IndexError):
-            x = st["FWPR"]
+        self.assertTrue( math.isnan(st["FWPR"]) )            
 
         st.update_well_var("OP1", "WOPR", 100)
         st.update_well_var("OP2", "WOPR", 200)

--- a/src/opm/input/eclipse/Python/PyRunModule.cpp
+++ b/src/opm/input/eclipse/Python/PyRunModule.cpp
@@ -66,10 +66,44 @@ PyRunModule::PyRunModule(std::shared_ptr<const Python> python, const std::string
     if (this->module.is_none())
         throw std::runtime_error("Syntax error when loading Python module: " + fname);
 
-    if (py::hasattr(this->module, "run"))
-        this->run_function = this->module.attr("run");
-    if (this->run_function.is_none())
-        throw std::runtime_error("Python module: " + fname + " did not have run() method");
+    bool module_possibly_ok = false;
+    
+    if (py::hasattr(this->module, "run")) {
+        if (py::hasattr(this->module, "run_post_step")) {
+            throw std::runtime_error("Python module: " + fname + " has both run() and run_post_step() methods. Cannot decide which one to use..");
+        }
+        module_possibly_ok = true;    
+        this->run_post_step_function = this->module.attr("run");
+    }
+
+    if (py::hasattr(this->module, "run_post_step")) {
+        module_possibly_ok = true;
+        this->run_post_step_function = this->module.attr("run_post_step");
+    }
+    if (py::hasattr(this->module, "run_pre_step")) {
+        module_possibly_ok = true;
+        this->run_pre_step_function = this->module.attr("run_pre_step");
+    }
+    if (py::hasattr(this->module, "run_post_newton")) {
+        module_possibly_ok = true;
+        this->run_post_newton_function = this->module.attr("run_post_newton");
+    }
+    if (py::hasattr(this->module, "run_pre_newton")) {
+        module_possibly_ok = true;
+        this->run_pre_newton_function = this->module.attr("run_pre_newton");
+    }    
+    if (py::hasattr(this->module, "run_post_report")) {
+        module_possibly_ok = true;
+        this->run_post_report_function = this->module.attr("run_post_report");
+    }        
+    if (py::hasattr(this->module, "run_pre_report")) {
+        module_possibly_ok = true;
+        this->run_pre_report_function = this->module.attr("run_pre_report");
+    }
+            
+    
+    if (!module_possibly_ok)
+        throw std::runtime_error("Python module: " + fname + " has no suitable run* method");
 
     this->module.attr("storage") = this->storage;
 }
@@ -83,9 +117,63 @@ py::cpp_function py_actionx_callback(const std::function<void(const std::string&
 }
 
 bool PyRunModule::run(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+    return run_post_step(ecl_state, sched, report_step, st, actionx_callback);
+}
+
+bool PyRunModule::run_post_step(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+    if (this->run_post_step_function.is_none())
+        return false;
+        
     auto cpp_callback = py_actionx_callback(actionx_callback);
-    py::object result = this->run_function(&ecl_state, &sched, report_step, &st, cpp_callback);
+    py::object result = this->run_post_step_function(&ecl_state, &sched, report_step, &st, cpp_callback);
     return result.cast<bool>();
 }
+
+bool PyRunModule::run_pre_step(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+    if (this->run_pre_step_function.is_none())
+        return false;
+        
+    auto cpp_callback = py_actionx_callback(actionx_callback);
+    py::object result = this->run_pre_step_function(&ecl_state, &sched, report_step, &st, cpp_callback);
+    return result.cast<bool>();
+}
+
+bool PyRunModule::run_post_newton(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+    if (this->run_post_newton_function.is_none())
+        return false;
+        
+    auto cpp_callback = py_actionx_callback(actionx_callback);
+    py::object result = this->run_post_newton_function(&ecl_state, &sched, report_step, &st, cpp_callback);
+    return result.cast<bool>();
+}
+
+bool PyRunModule::run_pre_newton(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+    if (this->run_pre_newton_function.is_none())
+        return false;
+        
+    auto cpp_callback = py_actionx_callback(actionx_callback);
+    py::object result = this->run_pre_newton_function(&ecl_state, &sched, report_step, &st, cpp_callback);
+    return result.cast<bool>();
+}
+
+bool PyRunModule::run_pre_report(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+    if (this->run_pre_report_function.is_none())
+        return false;
+        
+    auto cpp_callback = py_actionx_callback(actionx_callback);
+    py::object result = this->run_pre_report_function(&ecl_state, &sched, report_step, &st, cpp_callback);
+    return result.cast<bool>();
+}
+
+bool PyRunModule::run_post_report(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+    if (this->run_post_report_function.is_none())
+        return false;
+        
+    auto cpp_callback = py_actionx_callback(actionx_callback);
+    py::object result = this->run_post_report_function(&ecl_state, &sched, report_step, &st, cpp_callback);
+    return result.cast<bool>();
+}
+
+
 
 }

--- a/src/opm/input/eclipse/Python/PyRunModule.hpp
+++ b/src/opm/input/eclipse/Python/PyRunModule.hpp
@@ -44,9 +44,20 @@ public:
     PyRunModule(std::shared_ptr<const Python> python, const std::string& fname);
 
     bool run(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback);
+    bool run_post_step(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback);
+    bool run_pre_step(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback);
+    bool run_post_newton(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback);
+    bool run_pre_newton(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback);    
+    bool run_post_report(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback);
+    bool run_pre_report(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback);                
 
 private:
-    py::object run_function = py::none();
+    py::object run_post_step_function = py::none();
+    py::object run_pre_step_function = py::none();
+    py::object run_post_newton_function = py::none();
+    py::object run_pre_newton_function = py::none();    
+    py::object run_post_report_function = py::none();
+    py::object run_pre_report_function = py::none();
     std::shared_ptr<const Python> python_handle;
     py::module module;
     py::module opm_embedded;

--- a/src/opm/input/eclipse/Schedule/Action/ActionContext.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionContext.cpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <limits>
+
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
@@ -51,6 +53,11 @@ namespace Action {
         const auto& iter = this->values.find(key);
         if (iter != this->values.end())
             return iter->second;
+
+        // Avoid hard crashes while ensuring all comparisons fail if key is not present
+        if (!this->summary_state.has(key)) {
+            return std::numeric_limits<double>::quiet_NaN();
+        }
 
         return this->summary_state.get(key);
     }

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -789,7 +789,8 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         }
 
         const auto& name = keyword.getRecord(0).getItem<ParserKeywords::PYACTION::NAME>().get<std::string>(0);
-        const auto& run_count = Action::PyAction::from_string( keyword.getRecord(0).getItem<ParserKeywords::PYACTION::RUN_COUNT>().get<std::string>(0) );
+        const auto& run_count = Action::PyAction::count_from_string( keyword.getRecord(0).getItem<ParserKeywords::PYACTION::RUN_COUNT>().get<std::string>(0) );
+        const auto& run_when = Action::PyAction::when_from_string( keyword.getRecord(0).getItem<ParserKeywords::PYACTION::RUN_WHEN>().get<std::string>(0) );        
         const auto& module_arg = keyword.getRecord(1).getItem<ParserKeywords::PYACTION::FILENAME>().get<std::string>(0);
         std::string module;
         if (this->m_static.m_input_path.empty())
@@ -797,7 +798,7 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         else
             module = this->m_static.m_input_path + "/" + module_arg;
 
-        Action::PyAction pyaction(this->m_static.m_python_handle, name, run_count, module);
+        Action::PyAction pyaction(this->m_static.m_python_handle, name, run_count, run_when, module);
         auto new_actions = this->snapshots.back().actions.get();
         new_actions.add(pyaction);
         this->snapshots.back().actions.update( std::move(new_actions) );

--- a/src/opm/input/eclipse/Schedule/SummaryState.cpp
+++ b/src/opm/input/eclipse/Schedule/SummaryState.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <ctime>
 #include <iomanip>
+#include <limits>
 #include <ostream>
 #include <set>
 #include <string>
@@ -305,7 +306,8 @@ namespace Opm
     {
         const auto iter = this->values.find(key);
         if (iter == this->values.end())
-            throw std::out_of_range("No such key: " + key);
+            // Avoid throwing to alleviate pains with PYACTION-ACTIONX callbacks
+            return std::numeric_limits<double>::quiet_NaN();
 
         return iter->second;
     }

--- a/src/opm/input/eclipse/share/keywords/900_OPM/P/PYACTION
+++ b/src/opm/input/eclipse/share/keywords/900_OPM/P/PYACTION
@@ -14,7 +14,12 @@
         "name": "RUN_COUNT",
         "value_type": "STRING",
         "default": "SINGLE"
-      }
+      },
+      {
+        "name": "RUN_WHEN",
+        "value_type": "STRING",
+        "default": "POST_STEP"
+      }      
     ],
     [
       {

--- a/tests/PYACTION.DATA
+++ b/tests/PYACTION.DATA
@@ -3,3 +3,8 @@ SCHEDULE
 PYACTION
    ACT1  Single /
    act1.py /
+   
+PYACTION
+   ACT1B  sIngLe PRE_REPORt /
+   act1.py /
+   

--- a/tests/act1.py
+++ b/tests/act1.py
@@ -4,6 +4,9 @@ import random
 def run():
     pass
 
+def run_pre_report():
+    print("Run this python code before one or more report steps")
+
 print("sin(0) = {}".format(sin(0)))
 #---
 if random.random() > 0.25:

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(PYACTION)
     SummaryState st(TimeService::now());
     const auto& pyaction_kw = deck.get<ParserKeywords::PYACTION>().front();
     const std::string& fname = pyaction_kw.getRecord(1).getItem(0).get<std::string>(0);
-    Action::PyAction py_action(python, "WCLOSE", Action::PyAction::RunCount::unlimited, deck.makeDeckPath(fname));
+    Action::PyAction py_action(python, "WCLOSE", Action::PyAction::RunCount::unlimited, Action::PyAction::RunWhen::post_step, deck.makeDeckPath(fname));
     auto actionx_callback = [] (const std::string&, const std::vector<std::string>&) { ;};
     Action::State action_state;
 

--- a/tests/parser/PYACTION.cpp
+++ b/tests/parser/PYACTION.cpp
@@ -38,10 +38,24 @@ BOOST_AUTO_TEST_CASE(ParsePYACTION) {
     const auto& record0 = keyword.getRecord(0);
     const auto& record1 = keyword.getRecord(1);
 
-    auto run_count = Action::PyAction::from_string(record0.getItem(1).get<std::string>(0));
+    auto run_count = Action::PyAction::count_from_string(record0.getItem(1).get<std::string>(0));
+    auto run_when = Action::PyAction::when_from_string(record0.getItem(2).get<std::string>(0));
+    // TODO|VK Should really do more checking than just the path... - should also be in constructor? 
     const std::string& ok_module = deck.makeDeckPath(record1.getItem(0).get<std::string>(0));
-    Action::PyAction pyaction(python, "ACT1", run_count, ok_module);
+    Action::PyAction pyaction(python, "ACT1", run_count, run_when, ok_module);
     BOOST_CHECK_EQUAL(pyaction.name(), "ACT1");
+    
+    // Second PYACTION keword, with non-default item record0 item 3
+    auto keyword2 = deck.get<ParserKeywords::PYACTION>()[1];
+    const auto& record20 = keyword2.getRecord(0);
+    const auto& record21 = keyword2.getRecord(1);
+    auto run_count2 = Action::PyAction::count_from_string(record20.getItem(1).get<std::string>(0));
+    auto run_when2 = Action::PyAction::when_from_string(record20.getItem(2).get<std::string>(0));
+    const std::string& ok_module2 = deck.makeDeckPath(record21.getItem(0).get<std::string>(0));
+    Action::PyAction pyaction2(python, "ACT1B", run_count2, run_when2, ok_module2);
+    BOOST_CHECK_EQUAL(pyaction2.name(), "ACT1B");
+    BOOST_CHECK_EQUAL(pyaction2.when(), "PRE_REPORT");
+    
 }
 
 
@@ -54,12 +68,13 @@ BOOST_AUTO_TEST_CASE(ParsePYACTION_Module_Run_Missing) {
     const auto& record0 = keyword.getRecord(0);
     const auto& record1 = keyword.getRecord(1);
 
-    auto run_count = Action::PyAction::from_string(record0.getItem(1).get<std::string>(0));
+    auto run_count = Action::PyAction::count_from_string(record0.getItem(1).get<std::string>(0));
+    auto run_when = Action::PyAction::when_from_string(record0.getItem(2).get<std::string>(0));    
     const std::string& ok_module = deck.makeDeckPath(record1.getItem(0).get<std::string>(0));
-    Action::PyAction pyaction(python, "ACT1", run_count, ok_module);
+    Action::PyAction pyaction(python, "ACT1", run_count, run_when, ok_module);
 
     const std::string& broken_module = deck.makeDeckPath("action_missing_run.py");
-    BOOST_CHECK_THROW(Action::PyAction(python , "ACT2", run_count, broken_module), std::runtime_error);
+    BOOST_CHECK_THROW(Action::PyAction(python , "ACT2", run_count, run_when, broken_module), std::runtime_error);
 
 }
 
@@ -71,12 +86,13 @@ BOOST_AUTO_TEST_CASE(ParsePYACTION_Module_Syntax_Error) {
     const auto& record0 = keyword.getRecord(0);
     const auto& record1 = keyword.getRecord(1);
 
-    auto run_count = Action::PyAction::from_string(record0.getItem(1).get<std::string>(0));
+    auto run_count = Action::PyAction::count_from_string(record0.getItem(1).get<std::string>(0));
+    auto run_when = Action::PyAction::when_from_string(record0.getItem(2).get<std::string>(0));    
     const std::string& ok_module = deck.makeDeckPath(record1.getItem(0).get<std::string>(0));
-    Action::PyAction pyaction(python, "ACT1", run_count, ok_module);
+    Action::PyAction pyaction(python, "ACT1", run_count, run_when, ok_module);
 
     const std::string& broken_module2 = deck.makeDeckPath("action_syntax_error.py");
-    BOOST_CHECK_THROW(Action::PyAction(python , "ACT2", run_count, broken_module2), std::exception);
+    BOOST_CHECK_THROW(Action::PyAction(python , "ACT2", run_count, run_when, broken_module2), std::exception);
 
 }
 
@@ -88,12 +104,13 @@ BOOST_AUTO_TEST_CASE(ParsePYACTION_ModuleMissing) {
     const auto& record0 = keyword.getRecord(0);
     const auto& record1 = keyword.getRecord(1);
 
-    auto run_count = Action::PyAction::from_string(record0.getItem(1).get<std::string>(0));
+    auto run_count = Action::PyAction::count_from_string(record0.getItem(1).get<std::string>(0));
+    auto run_when = Action::PyAction::when_from_string(record0.getItem(2).get<std::string>(0));    
     const std::string& ok_module = deck.makeDeckPath(record1.getItem(0).get<std::string>(0));
-    Action::PyAction pyaction(python, "ACT1", run_count, ok_module);
+    Action::PyAction pyaction(python, "ACT1", run_count, run_when, ok_module);
 
     const std::string& missing_module = deck.makeDeckPath("no_such_module.py");
-    BOOST_CHECK_THROW(Action::PyAction(python , "ACT2", run_count, missing_module), std::invalid_argument);
+    BOOST_CHECK_THROW(Action::PyAction(python , "ACT2", run_count, run_when, missing_module), std::invalid_argument);
 }
 
 #endif

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -589,7 +589,8 @@ BOOST_AUTO_TEST_CASE(UDQ_CONTEXT) {
     UDQState udq_state(udqp.undefinedValue());
     UDQContext ctx(func_table, {}, st, udq_state);
     BOOST_CHECK_EQUAL(*ctx.get("JAN"), 1.0);
-    BOOST_CHECK_THROW(ctx.get("NO_SUCH_KEY"), std::out_of_range);
+    //BOOST_CHECK_THROW(ctx.get("NO_SUCH_KEY"), std::out_of_range);
+    BOOST_CHECK(std::isnan(ctx.get("NO_SUCH_KEY").value()));
 
     for (std::string& key : std::vector<std::string>({"MSUMLINS", "MSUMNEWT", "NEWTON", "TCPU"}))
         BOOST_CHECK_NO_THROW( ctx.get(key) );
@@ -2313,6 +2314,12 @@ DEFINE FU_VAR91 GOPR TEST  /
 BOOST_AUTO_TEST_CASE(UDQ_KEY_ERROR) {
     std::string deck_string = R"(
 -- udq #2
+RUNSPEC
+
+UDQPARAM
+  2* -1.1234 /
+
+  
 SCHEDULE
 
 UDQ
@@ -2326,7 +2333,10 @@ UDQ
     UDQState udq_state(undefined_value);
     SummaryState st(TimeService::now());
 
-    BOOST_CHECK_THROW(udq.eval(0, schedule, {}, st, udq_state), std::exception);
+    //BOOST_CHECK_THROW(udq.eval(0, schedule, {}, st, udq_state), std::exception);
+    //With undefined vales now returned as NaN from SummaryState, this should eventually return UDQPARAM item 3 
+    udq.eval(0, schedule, {}, st, udq_state);
+    BOOST_CHECK_EQUAL(st.get("FU_VAR1"), -1.1234);
 }
 
 BOOST_AUTO_TEST_CASE(UDQ_ASSIGN) {

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -2482,7 +2482,8 @@ BOOST_AUTO_TEST_CASE(Test_SummaryState) {
     Opm::SummaryState st(TimeService::now());
     st.update("WWCT:OP_2", 100);
     BOOST_CHECK_CLOSE(st.get("WWCT:OP_2"), 100, 1e-5);
-    BOOST_CHECK_THROW(st.get("NO_SUCH_KEY"), std::out_of_range);
+    // BOOST_CHECK_THROW(st.get("NO_SUCH_KEY"), std::out_of_range);
+    BOOST_CHECK(std::isnan(st.get("NO_SUCH_KEY")));
     BOOST_CHECK(st.has("WWCT:OP_2"));
     BOOST_CHECK(!st.has("NO_SUCH_KEY"));
     BOOST_CHECK_EQUAL(st.get("WWCT:OP_99", -1), -1);


### PR DESCRIPTION
Prepare the ground for allowing PYACTION to be executed pre and post each newton iteration, timestep and report step. Default  remains post step, which is the current behavior, although not very explicit and sometimes confusing. (For example, ACTIONX blocks executed via the PYACTION actionx callback will take effect one time-step after an ACTIONX block placed at the same location in the .DATA file..)