### PR TITLE
trim trailing and leading whitespace of paths in INCLUDE

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -564,7 +564,7 @@ EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
     void EclipseGrid::initBinaryGrid(const Deck& deck) {
 
         const DeckKeyword& gdfile_kw = deck["GDFILE"].back();
-        const std::string& gdfile_arg = gdfile_kw.getRecord(0).getItem("filename").get<std::string>(0);
+        const std::string& gdfile_arg = gdfile_kw.getRecord(0).getItem("filename").getTrimmedString(0);
         std::string filename = deck.makeDeckPath(gdfile_arg);
 
         std::unique_ptr<Opm::EclIO::EclFile> egridfile;

--- a/src/opm/input/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/GridDims.cpp
@@ -159,7 +159,7 @@ namespace Opm {
     void GridDims::binary_init(const Deck& deck)
     {
         const DeckKeyword& gdfile_kw = deck["GDFILE"].back();
-        const std::string& gdfile_arg = gdfile_kw.getRecord(0).getItem("filename").get<std::string>(0);
+        const std::string& gdfile_arg = gdfile_kw.getRecord(0).getItem("filename").getTrimmedString(0);
         const EclIO::EGrid egrid( deck.makeDeckPath(gdfile_arg) );
 
         const auto& dimens = egrid.dimension();

--- a/src/opm/input/eclipse/Parser/Parser.cpp
+++ b/src/opm/input/eclipse/Parser/Parser.cpp
@@ -1184,7 +1184,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
 
                     if (deck_keyword.name() == ParserKeywords::IMPORT::keywordName) {
                         bool formatted = deck_keyword.getRecord(0).getItem(1).get<std::string>(0)[0] == 'F';
-                        const auto& import_file = parserState.getIncludeFilePath(deck_keyword.getRecord(0).getItem(0).get<std::string>(0));
+                        const auto& import_file = parserState.getIncludeFilePath(deck_keyword.getRecord(0).getItem(0).getTrimmedString(0));
 
                         ImportContainer import(parser, parserState.deck.getActiveUnitSystem(), import_file.value().string(), formatted, parserState.deck.size());
                         for (auto kw : import)


### PR DESCRIPTION
An include directive with a path with trailing whitespace, e.g.

```
INCLUDE
  '/home/model/../include/file_trailing_ws.ext ' /
```
would produce the following error currently:
```
Error: No such file: /home/model/../include/file_trailing_ws.ext
```

The problem is really hard to detect for the user. As it seems that other simulators always trim these strings we now do the same and allow the above input.