### PR TITLE
Fix MSIM UDQ Configuration Lookup

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -127,7 +127,7 @@ void msim::run_step(WellTestState& wtest_state, UDQState& udq_state, data::Solut
                           /* initial_inplace = */ {},
                           /* inplace = */ {});
 
-        this->schedule.getUDQConfig(report_step)
+        this->schedule.getUDQConfig(report_step - 1)
             .eval(report_step, this->schedule, schedule.wellMatcher(report_step), this->st, udq_state);
 
         this->output(wtest_state,

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -346,18 +346,20 @@ BOOST_AUTO_TEST_CASE(UDQ_WUWCT) {
         {
             const auto& fu_time = ecl_sum.get_at_rstep("FU_TIME");
             BOOST_CHECK_CLOSE(fu_time[7 - 1], 212, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[8 - 1], 243, 1e-5);
             // UPDATE OFF
-            BOOST_CHECK_CLOSE(fu_time[8 - 1], 212, 1e-5);
-            BOOST_CHECK_CLOSE(fu_time[9 - 1] , 212, 1e-5);
-            BOOST_CHECK_CLOSE(fu_time[10 - 1], 212, 1e-5);
-            BOOST_CHECK_CLOSE(fu_time[11 - 1], 212, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[9 - 1] , 243, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[10 - 1], 243, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[11 - 1], 243, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[12 - 1], 243, 1e-5);
             // UPDATE NEXT
-            BOOST_CHECK_CLOSE(fu_time[12 - 1], 342, 1e-5);
-            BOOST_CHECK_CLOSE(fu_time[13 - 1], 342, 1e-5);
-            BOOST_CHECK_CLOSE(fu_time[14 - 1], 342, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[13 - 1], 372, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[14 - 1], 372, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[15 - 1], 372, 1e-5);
             // UPDATE ON
-            BOOST_CHECK_CLOSE(fu_time[15 - 1], 456, 1e-5);
             BOOST_CHECK_CLOSE(fu_time[16 - 1], 487, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[17 - 1], 517, 1e-5);
+            BOOST_CHECK_CLOSE(fu_time[18 - 1], 548, 1e-5);
         }
     }
 }


### PR DESCRIPTION
The MSIM `report_step` is a [one-based index](https://github.com/OPM/opm-common/blob/d6ed5f754c60ee053601ea63ae6dab7b5c6b2b9f/msim/src/msim.cpp#L60) so we must subtract one before looking up the pertinent `Schedule` information.