### PR TITLE
Track Pending Assignments in UDQ Configuration Object

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp
@@ -101,6 +101,8 @@ namespace Opm {
                         const std::vector<std::string>& expression,
                         std::size_t                     report_step);
 
+        bool clear_pending_assignments();
+
         void eval_assign(std::size_t           report_step,
                          const Schedule&       sched,
                          const WellMatcher&    wm,
@@ -147,6 +149,7 @@ namespace Opm {
             serializer(units);
             serializer(input_index);
             serializer(type_count);
+            serializer(pending_assignments_);
 
             // The UDQFunction table is constant up to udq_params, so we can
             // just construct a new instance here.
@@ -174,12 +177,13 @@ namespace Opm {
         OrderedMap<UDQIndex> input_index;
         std::map<UDQVarType, std::size_t> type_count;
 
+        mutable std::vector<std::string> pending_assignments_{};
+
         void add_node(const std::string& quantity, UDQAction action);
         UDQAction action_type(const std::string& udq_key) const;
 
         void eval_assign(std::size_t     report_step,
                          const Schedule& sched,
-                         UDQState&       udq_state,
                          UDQContext&     context) const;
 
         void eval_define(std::size_t report_step,

--- a/opm/input/eclipse/Schedule/UDQ/UDQContext.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQContext.hpp
@@ -59,7 +59,7 @@ namespace Opm {
         std::optional<double> get_segment_var(const std::string& well, const std::string& var, std::size_t segment) const;
 
         void add(const std::string& key, double value);
-        void update_assign(std::size_t report_step, const std::string& keyword, const UDQSet& udq_result);
+        void update_assign(const std::string& keyword, const UDQSet& udq_result);
         void update_define(std::size_t report_step, const std::string& keyword, const UDQSet& udq_result);
 
         const UDQFunctionTable& function_table() const;

--- a/opm/input/eclipse/Schedule/UDQ/UDQState.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQState.hpp
@@ -53,8 +53,7 @@ public:
     double get_segment_var(const std::string& well, const std::string& var, const std::size_t segment) const;
 
     void add_define(std::size_t report_step, const std::string& udq_key, const UDQSet& result);
-    void add_assign(std::size_t report_step, const std::string& udq_key, const UDQSet& result);
-    bool assign(std::size_t report_step, const std::string& udq_key) const;
+    void add_assign(const std::string& udq_key, const UDQSet& result);
     bool define(const std::string& udq_key, const std::pair<UDQUpdate, std::size_t>& update_status) const;
     double undefined_value() const;
 
@@ -70,7 +69,6 @@ public:
         serializer(this->well_values);
         serializer(this->group_values);
         serializer(this->segment_values);
-        serializer(this->assignments);
         serializer(this->defines);
     }
 
@@ -87,7 +85,6 @@ private:
     // [var][well][segment] -> double
     std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<std::size_t, double>>> segment_values{};
 
-    std::unordered_map<std::string, std::size_t> assignments;
     std::unordered_map<std::string, std::size_t> defines;
 
     void add(const std::string& udq_key, const UDQSet& result);

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQContext.cpp
@@ -218,11 +218,10 @@ namespace Opm {
         return this->udqft;
     }
 
-    void UDQContext::update_assign(const std::size_t  report_step,
-                                   const std::string& keyword,
+    void UDQContext::update_assign(const std::string& keyword,
                                    const UDQSet&      udq_result)
     {
-        this->udq_state.add_assign(report_step, keyword, udq_result);
+        this->udq_state.add_assign(keyword, udq_result);
         this->summary_state.update_udq(udq_result, this->udq_state.undefined_value());
     }
 

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQState.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQState.cpp
@@ -291,9 +291,8 @@ void UDQState::add_define(std::size_t report_step, const std::string& udq_key, c
     this->add(udq_key, result);
 }
 
-void UDQState::add_assign(std::size_t report_step, const std::string& udq_key, const UDQSet& result)
+void UDQState::add_assign(const std::string& udq_key, const UDQSet& result)
 {
-    this->assignments[udq_key] = report_step;
     this->add(udq_key, result);
 }
 
@@ -364,7 +363,6 @@ bool UDQState::operator==(const UDQState& other) const
         && (this->well_values == other.well_values)
         && (this->group_values == other.group_values)
         && (this->segment_values == other.segment_values)
-        && (this->assignments == other.assignments)
         && (this->defines == other.defines);
 }
 
@@ -373,7 +371,6 @@ UDQState UDQState::serializationTestObject()
     UDQState st;
     st.undef_value = 78;
     st.scalar_values = {{"FU1", 100}, {"FU2", 200}};
-    st.assignments = {{"GU1", 99}, {"GU2", 199}};
     st.defines = {{"DU1", 299}, {"DU2", 399}};
 
     st.well_values.emplace("W1", std::unordered_map<std::string, double>{{"U1", 100}, {"U2", 200}});
@@ -408,14 +405,6 @@ UDQState UDQState::serializationTestObject()
     st.segment_values["SUSPECT"];
 
     return st;
-}
-
-bool UDQState::assign(std::size_t report_step, const std::string& udq_key) const
-{
-    auto assign_iter = this->assignments.find(udq_key);
-
-    return (assign_iter == this->assignments.end())
-        || (report_step > assign_iter->second);
 }
 
 bool UDQState::define(const std::string&                       udq_key,

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -2851,7 +2851,7 @@ UDQ
     const auto& udq = schedule.getUDQConfig(1);
     {
         const auto& ass = udq.assign("FUBHPP1");
-        context.update_assign(1, "FUBHPP1", ass.eval());
+        context.update_assign("FUBHPP1", ass.eval());
     }
     const auto& def = udq.define("WUDELTA");
     auto res = def.eval(context);


### PR DESCRIPTION
The existing implementation used the UDQ State object to track pending `ASSIGN` operations, mainly in terms of the report step index, but this implies that the logic implicitly assumes an `ASSIGN` operation can run at most once per report step.  That assumption usually holds, but fails if the `ASSIGN` operation is triggered from an `ACTIONX` block that happens to run multiple times within a report step.

This PR instead introduces a new data member,
```
UDQConfig::pending_assignments_
```
that keeps track of all `ASSIGN` operations that have been added for the current report step.  We clear those pending assignments when forming a new `Schedule` block (`ScheduleState` object), under the assumption that all pending `ASSIGN` operations have been affected at the previous time level (report step).

In effect, this new data member assumes the role of
```
UDQState::assignments
```
and we therefore remove that data member and update the signature of
```
UDQState::add_assign()
```
to account for the fact that the 'report_step' parameter is no longer needed.