### PR TITLE
Fix warning from external code.

### DIFF
--- a/external/resinsight/LibCore/cvfTrace.cpp
+++ b/external/resinsight/LibCore/cvfTrace.cpp
@@ -96,7 +96,7 @@ void Trace::show(const char* format, ...)
 #elif defined(CVF_ANDROID)
     __android_log_print(ANDROID_LOG_DEBUG, "CVF_TAG", format, argList);
 #else
-    vsprintf(temp, format, argList);
+    vsnprintf(temp, maxFormatLength, format, argList);
 #endif
 
     va_end(argList);    


### PR DESCRIPTION
Not sure how we should maintain this external code in principle, but avoiding a build warning should be ok I think.