### PR TITLE
Provide file and line for errors because of unknown keywords.

### DIFF
--- a/src/opm/input/eclipse/Parser/Parser.cpp
+++ b/src/opm/input/eclipse/Parser/Parser.cpp
@@ -873,7 +873,12 @@ newRawKeyword(const std::string&      deck_name,
             return newRawKeyword(parserKeyword, keyword8, parserState, parser);
         }
         else {
-            parserState.parseContext.handleUnknownKeyword(deck_name, KeywordLocation{}, parserState.errors);
+            parserState.parseContext.handleUnknownKeyword(deck_name,
+                                                          KeywordLocation{
+                                                              deck_name,
+                                                              parserState.current_path().string(),
+                                                              parserState.line()
+                                                          }, parserState.errors);
             parserState.unknown_keyword = true;
 
             return nullptr;
@@ -888,7 +893,12 @@ newRawKeyword(const std::string&      deck_name,
     }
 
     if (ParserKeyword::validDeckName(deck_name)) {
-        parserState.parseContext.handleUnknownKeyword(deck_name, KeywordLocation{}, parserState.errors);
+        parserState.parseContext.handleUnknownKeyword(deck_name,
+                                                      KeywordLocation{
+                                                          deck_name,
+                                                          parserState.current_path().string(),
+                                                          parserState.line()},
+                                                      parserState.errors);
         parserState.unknown_keyword = true;
 
         return nullptr;


### PR DESCRIPTION
```
Error: Unknown keyword: KEY6

Error: Unrecoverable errors while loading input: Problem with keyword
In <memory string> line 0
Unknown keyword: KEY6
```
does not tell the user where his/her error is.

This is now changed to
```
Error: Unknown keyword: KEY6

Error: Unrecoverable errors while loading input: Problem with keyword NE6
In /path/to/include/grid/file.inc line 7
Unknown keyword: KEY6
```
which gives the user a greater chance of finding out what is wrong.