### PR TITLE
Add Transport Protocol for Segment Level Phase Densities

### DIFF
--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1150,6 +1150,7 @@ inline void keywordMISC( SummaryConfig::keyword_list& list,
             "SGFR" , "SGFRF", "SGFRS", "SGFT", "SGFV", "SGHF", "SGVIS",
             "SWFR" ,                   "SWFT", "SWFV", "SWHF", "SWVIS",
             "SGOR" , "SOGR" , "SWCT" , "SWGR" ,
+            "SODEN", "SGDEN", "SWDEN", "SMDEN", "SDENM",
             "SPR"  , "SPRD" , "SPRDH", "SPRDF", "SPRDA",
         };
 

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/S/SEGMENT_PROBE
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/S/SEGMENT_PROBE
@@ -4,6 +4,9 @@
     "SUMMARY"
   ],
   "deck_names": [
+    "SDENM",
+    "SMDEN",
+    "SGDEN",
     "SGFR",
     "SGFRF",
     "SGFRS",
@@ -12,6 +15,7 @@
     "SGHF",
     "SGOR",
     "SGVIS",
+    "SODEN",
     "SOFR",
     "SOFRF",
     "SOFRS",
@@ -26,6 +30,7 @@
     "SPRDF",
     "SPRDH",
     "SWCT",
+    "SWDEN",
     "SWFR",
     "SWFT",
     "SWFV",

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -1058,8 +1058,9 @@ inline quantity srate(const fn_args& args)
     });
 }
 
-template <Opm::data::SegmentPhaseQuantity::Item p>
-double segment_phase_quantity_value(const Opm::data::SegmentPhaseQuantity& q)
+template <typename Items>
+double segment_phase_quantity_value(const Opm::data::SegmentQuantity<Items>& q,
+                                    const typename Items::Item               p)
 {
     return q.has(p) ? q.get(p) : 0.0;
 }
@@ -1071,7 +1072,7 @@ quantity segment_flow_velocity(const fn_args& args)
         [](const Opm::data::Segment& segment)
     {
         // Note: Opposite velocity sign conventions in Flow vs. ECLIPSE.
-        return - segment_phase_quantity_value<p>(segment.velocity);
+        return - segment_phase_quantity_value(segment.velocity, p);
     });
 }
 
@@ -1081,7 +1082,7 @@ quantity segment_holdup_fraction(const fn_args& args)
     return segment_quantity(args, measure::identity,
         [](const Opm::data::Segment& segment)
     {
-        return segment_phase_quantity_value<p>(segment.holdup);
+        return segment_phase_quantity_value(segment.holdup, p);
     });
 }
 
@@ -1091,7 +1092,7 @@ quantity segment_viscosity(const fn_args& args)
     return segment_quantity(args, measure::viscosity,
         [](const Opm::data::Segment& segment)
     {
-        return segment_phase_quantity_value<p>(segment.viscosity);
+        return segment_phase_quantity_value(segment.viscosity, p);
     });
 }
 


### PR DESCRIPTION
This PR adds the requisite backing storage and parser support for capturing and transporting simulator-level calculation of 
phase and mixture density value for purpose of summary file output.  To this end, make `SegmentQuantity` into a template on a set of defined items and make `SegmentPhaseQuantity` into a specialisation of this template.  Add a new specialisation, `SegmentPhaseDensity`, which holds phase densities (oil, gas, water), and fluid mixture densities with and without flowing fraction exponents.

These will be used to transport the values needed to output segment level summary vectors

* SDENx -- Phase density of phase 'x' (O, G, W)
* SDENM -- Fluid mixture density without flowing fraction exponents
* SMDEN -- Fluid mixture density with flowing fraction exponents