### PR TITLE
Added exception to mark time step being cut too often.

### DIFF
--- a/opm/common/Exceptions.hpp
+++ b/opm/common/Exceptions.hpp
@@ -66,6 +66,13 @@ public:
         : NumericalProblem(message)
     {}
 };
+class LinearTimeSteppingBreakdown : public NumericalProblem
+{
+public:
+    explicit LinearTimeSteppingBreakdown(const std::string &message)
+        : NumericalProblem(message)
+    {}
+};
 }
 
 #endif // OPM_EXCEPTIONS_HPP


### PR DESCRIPTION
This is needed for a more user friendly message in the simulator.