### PR TITLE
Add Facility for Recording ACTIONX Well Structure Changes

### DIFF
--- a/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
+++ b/opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp
@@ -25,23 +25,27 @@
 
 namespace Opm {
 
-/*
-  This struct is used to communicate back from the Schdule::applyAction() what
-  needs to be updated in the simulator when execution is returned to the
-  simulator code.
-*/
+/// This struct is used to communicate back from the Schedule::applyAction()
+/// what needs to be updated in the simulator when execution is returned to
+/// the simulator code.
 
-
-struct SimulatorUpdate {
-    // These wells have been affected by the ACTIONX and the simulator needs to
+struct SimulatorUpdate
+{
+    // Wells affected by ACTIONX and for which the simulator needs to
     // reapply rates and state from the newly updated Schedule object.
     std::unordered_set<std::string> affected_wells;
 
-    // If one of the transmissibility multiplier keywords has been invoked as an
-    // ACTIONX keyword the simulator needs to recalculate the transmissibility.
+    // If one of the transmissibility multiplier keywords has been invoked
+    // as an ACTIONX keyword the simulator needs to recalculate the
+    // transmissibility.
     bool tran_update{false};
+
+    /// Whether or not well structure changed in processing an ACTIONX
+    /// block.  Typically because of a keyword like WELSPECS, COMPDAT,
+    /// and/or WELOPEN.
+    bool well_structure_changed{false};
 };
 
-}
+} // namespace Opm
 
-#endif
+#endif // SIMULATOR_UPDATE_HPP

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -514,11 +514,11 @@ namespace Opm
             const bool actionx_mode;
             const ParseContext& parseContext;
             ErrorGuard& errors;
-            SimulatorUpdate * sim_update;
-            const std::unordered_map<std::string, double> * target_wellpi;
-            std::unordered_map<std::string, double>* wpimult_global_factor;
-            WelSegsSet *welsegs_wells;
-            std::set<std::string>*compsegs_wells;
+            SimulatorUpdate* sim_update{nullptr};
+            const std::unordered_map<std::string, double>* target_wellpi{nullptr};
+            std::unordered_map<std::string, double>* wpimult_global_factor{nullptr};
+            WelSegsSet* welsegs_wells{nullptr};
+            std::set<std::string>* compsegs_wells{nullptr};
             const ScheduleGrid& grid;
 
             /// \param welsegs_wells All wells with a WELSEGS entry for checks.
@@ -531,8 +531,8 @@ namespace Opm
                            bool actionx_mode_,
                            const ParseContext& parseContext_,
                            ErrorGuard& errors_,
-                           SimulatorUpdate * sim_update_,
-                           const std::unordered_map<std::string, double> * target_wellpi_,
+                           SimulatorUpdate* sim_update_,
+                           const std::unordered_map<std::string, double>* target_wellpi_,
                            std::unordered_map<std::string, double>* wpimult_global_factor_,
                            WelSegsSet* welsegs_wells_,
                            std::set<std::string>* compsegs_wells_)
@@ -552,6 +552,7 @@ namespace Opm
             {}
 
             void affected_well(const std::string& well_name);
+            void record_well_structure_change();
 
             /// \brief Mark that the well occured in a  WELSEGS keyword
             void welsegs_handled(const std::string& well_name)


### PR DESCRIPTION
This commit adds a new member, well_structure_change, to the `SimulatorUpdate` structure.  The member defaults to `false`, but will be set to `true` if an `ACTIONX` block contains at least one of a select group of keywords that affect the model's well topology.

In particular, set this member to `true` if the `ACTIONX` block has at least one of the keywords

  - COMPDAT
  - WELOPEN
  - WELSPECS

This will enable adding simulator logic to open or create wells in the middle of a report step.