### PR TITLE
[bugfix] Use numComponents when accessing K_/moleFractions_ in PTFlash.

### DIFF
--- a/opm/material/constraintsolvers/PTFlash.hpp
+++ b/opm/material/constraintsolvers/PTFlash.hpp
@@ -928,7 +928,7 @@ protected:
             secondary_z[idx] = SecondaryEval(Opm::getValue(z[idx]), idx + 1);
         }
         // set up the mole fractions
-        for (unsigned idx = 0; idx < num_equations; ++idx) {
+        for (unsigned idx = 0; idx < numComponents; ++idx) {
             // TODO: double checking that fluid_state_scalar returns a scalar here
             const auto x_i = fluid_state_scalar.moleFraction(oilPhaseIdx, idx);
             secondary_fluid_state.setMoleFraction(FluidSystem::oilPhaseIdx, idx, x_i);


### PR DESCRIPTION
Previously we did read and write out of bounds as num_equations might be bigger than numComponents. For GCC-13 this even caused endless loops.

Closes #3603 