### PR TITLE
Register errors concerning section topology in ErrorGuard.

### DIFF
--- a/opm/input/eclipse/Deck/DeckSection.hpp
+++ b/opm/input/eclipse/Deck/DeckSection.hpp
@@ -27,6 +27,7 @@
 namespace Opm {
 
 class Deck;
+class ErrorGuard;
 
 enum class Section {
     RUNSPEC,
@@ -63,6 +64,7 @@ class DeckSection : public DeckView {
         // the right order
         static bool checkSectionTopology(const Deck& deck,
                                          const Parser&,
+                                         ErrorGuard& errorGuard,
                                          bool ensureKeywordSectionAffiliation = false);
 
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -294,6 +294,7 @@ static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {
 template <typename T>
 keyword_info<T> global_kw_info(const std::string& name, bool allow_unsupported = false);
 
+bool is_oper_keyword(const std::string& name);
 } // end namespace keywords
 
 } // end namespace FieldProps

--- a/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -84,6 +84,12 @@ static const std::set<std::string> region_oper_keywords = {"MULTIREG", "ADDREG",
 static const std::set<std::string> box_keywords = {"BOX", "ENDBOX"};
 
 
+bool is_oper_keyword(const std::string& name)
+{
+    return (oper_keywords.find(name) != oper_keywords.end()
+            || region_oper_keywords.find(name) != region_oper_keywords.end());
+}
+
 std::string get_keyword_from_alias(const std::string& name) {
     if (ALIAS::aliased_keywords.count(name))
         return ALIAS::aliased_keywords.at(name);

--- a/src/opm/input/eclipse/EclipseState/checkDeck.cpp
+++ b/src/opm/input/eclipse/EclipseState/checkDeck.cpp
@@ -50,7 +50,7 @@ bool checkDeck( const Deck& deck, const Parser& parser, const ParseContext& pars
     // make sure all mandatory sections are present and that their order is correct
     if (enabledChecks & SectionTopology) {
         bool ensureKeywordSection = enabledChecks & KeywordSection;
-        deckValid = deckValid && DeckSection::checkSectionTopology(deck, parser, ensureKeywordSection);
+        deckValid = deckValid && DeckSection::checkSectionTopology(deck, parser, errorGuard, ensureKeywordSection);
     }
 
     const std::string& deckUnitSystem = uppercase(deck.getActiveUnitSystem().getName());

--- a/src/opm/input/eclipse/Parser/Parser.cpp
+++ b/src/opm/input/eclipse/Parser/Parser.cpp
@@ -1554,6 +1554,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
 
     bool DeckSection::checkSectionTopology(const Deck& deck,
                                            const Parser& parser,
+                                           Opm::ErrorGuard& errorGuard,
                                            bool ensureKeywordSectionAffiliation)
     {
         if( deck.size() == 0 ) {
@@ -1563,11 +1564,12 @@ std::vector<std::string> Parser::getAllDeckNames () const {
         }
 
         bool deckValid = true;
+        const std::string errorKey = "SECTION_TOPOLOGY_ERROR";
 
         if( deck[0].name() != "RUNSPEC" ) {
             std::string msg = "The first keyword of a valid deck must be RUNSPEC\n";
             auto curKeyword = deck[0];
-            OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+            errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
             deckValid = false;
         }
 
@@ -1587,7 +1589,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                     std::string msg =
                         "The keyword '"+curKeywordName+"' is located in the '"+curSectionName
                         +"' section where it is invalid";
-                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                    errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1598,7 +1600,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "GRID") {
                     std::string msg =
                         "The RUNSPEC section must be followed by GRID instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                    errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1608,7 +1610,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "EDIT" && curKeywordName != "PROPS") {
                     std::string msg =
                         "The GRID section must be followed by EDIT or PROPS instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                    errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1618,7 +1620,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "PROPS") {
                     std::string msg =
                         "The EDIT section must be followed by PROPS instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                    errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1628,7 +1630,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "REGIONS" && curKeywordName != "SOLUTION") {
                     std::string msg =
                         "The PROPS section must be followed by REGIONS or SOLUTION instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                    errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1638,7 +1640,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "SOLUTION") {
                     std::string msg =
                         "The REGIONS section must be followed by SOLUTION instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                    errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1648,7 +1650,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "SUMMARY" && curKeywordName != "SCHEDULE") {
                     std::string msg =
                         "The SOLUTION section must be followed by SUMMARY or SCHEDULE instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                    errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1658,7 +1660,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 if (curKeywordName != "SCHEDULE") {
                     std::string msg =
                         "The SUMMARY section must be followed by SCHEDULE instead of "+curKeywordName;
-                    OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                    errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                     deckValid = false;
                 }
 
@@ -1669,7 +1671,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
                 std::string msg =
                     "The SCHEDULE section must be the last one ("
                     +curKeywordName+" specified after SCHEDULE)";
-                OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+                errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
                 deckValid = false;
             }
         }
@@ -1679,7 +1681,7 @@ std::vector<std::string> Parser::getAllDeckNames () const {
             const auto& curKeyword = deck[deck.size() - 1];
             std::string msg =
                 "The last section of a valid deck must be SCHEDULE (is "+curSectionName+")";
-            OpmLog::warning(Log::fileMessage(curKeyword.location(), msg) );
+            errorGuard.addError(errorKey, Log::fileMessage(curKeyword.location(), msg) );
             deckValid = false;
         }
 

--- a/tests/parser/SectionTests.cpp
+++ b/tests/parser/SectionTests.cpp
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(Section_ValidDecks) {
                                 "SCHEDULE\n"
                                 "TEST5\n";
 
-    BOOST_CHECK( Opm::DeckSection::checkSectionTopology( parser.parseString( minimal, mode, errors ), parser) );
+    BOOST_CHECK( Opm::DeckSection::checkSectionTopology( parser.parseString( minimal, mode, errors ), parser, errors) );
 
     const std::string with_opt = "RUNSPEC\n"
                                 "TEST1\n"
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(Section_ValidDecks) {
                                 "SCHEDULE\n"
                                 "TEST8\n";
 
-    BOOST_CHECK(Opm::DeckSection::checkSectionTopology( parser.parseString( with_opt, mode, errors ), parser));
+    BOOST_CHECK(Opm::DeckSection::checkSectionTopology( parser.parseString( with_opt, mode, errors ), parser, errors));
 }
 
 BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                 "SCHEDULE\n"
                                 "TEST5\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( keyword_before_RUNSPEC, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( keyword_before_RUNSPEC, mode, errors ), parser, errors));
 
     const std::string wrong_order = "RUNSPEC\n"
                                     "TEST1\n"
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                     "SCHEDULE\n"
                                     "TEST8\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( wrong_order, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( wrong_order, mode, errors ), parser, errors));
 
     const std::string duplicate = "RUNSPEC\n"
                                   "TEST1\n"
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                   "SCHEDULE\n"
                                   "TEST8\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( duplicate, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( duplicate, mode, errors ), parser, errors));
 
     const std::string section_after_SCHEDULE = "RUNSPEC\n"
                                                "TEST1\n"
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                                "EDIT\n"
                                                "TEST3\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( section_after_SCHEDULE, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( section_after_SCHEDULE, mode, errors ), parser, errors));
 
     const std::string missing_runspec = "GRID\n"
                                         "TEST2\n"
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                         "SCHEDULE\n"
                                         "TEST5\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_runspec, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_runspec, mode, errors ), parser, errors));
 
 
     const std::string missing_GRID = "RUNSPEC\n"
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                      "SCHEDULE\n"
                                      "TEST5\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_GRID, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_GRID, mode, errors ), parser, errors));
 
    const std::string missing_PROPS = "RUNSPEC\n"
                                      "TEST1\n"
@@ -367,7 +367,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                      "SCHEDULE\n"
                                      "TEST5\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_PROPS, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_PROPS, mode, errors ), parser, errors));
 
     const std::string missing_SOLUTION = "RUNSPEC\n"
                                          "TEST1\n"
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                          "SCHEDULE\n"
                                          "TEST5\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_SOLUTION, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_SOLUTION, mode, errors ), parser, errors));
 
     const std::string missing_SCHEDULE = "RUNSPEC\n"
                                          "TEST1\n"
@@ -389,5 +389,5 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                          "SOLUTION\n"
                                          "TEST4\n";
 
-    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_SCHEDULE, mode, errors ), parser));
+    BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_SCHEDULE, mode, errors ), parser, errors));
 }

--- a/tests/parser/SectionTests.cpp
+++ b/tests/parser/SectionTests.cpp
@@ -253,6 +253,9 @@ BOOST_AUTO_TEST_CASE(Section_ValidDecks) {
                                 "TEST8\n";
 
     BOOST_CHECK(Opm::DeckSection::checkSectionTopology( parser.parseString( with_opt, mode, errors ), parser, errors));
+    // prevent std::exit(1) in ErrorGuard's destructor!
+    errors.dump();
+    errors.clear();
 }
 
 BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
@@ -390,4 +393,7 @@ BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
                                          "TEST4\n";
 
     BOOST_CHECK(!Opm::DeckSection::checkSectionTopology( parser.parseString( missing_SCHEDULE, mode, errors ), parser, errors));
+    // prevent std::exit(1) in ErrorGuard's destructor!
+    errors.dump();
+    errors.clear();
 }

--- a/tests/parser/integration/CheckDeckValidity.cpp
+++ b/tests/parser/integration/CheckDeckValidity.cpp
@@ -102,4 +102,7 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
         // this fails because of the incorrect BOX keyword
         BOOST_CHECK(!Opm::checkDeck(deck, parser, parseContext, errorGuard, Opm::SectionTopology | Opm::KeywordSection));
     }
+    // prevent std::exit(1) in ErrorGuard's destructor!
+    errorGuard.dump();
+    errorGuard.clear();
 }

--- a/tests/parser/integration/CheckDeckValidity.cpp
+++ b/tests/parser/integration/CheckDeckValidity.cpp
@@ -31,9 +31,9 @@
 BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
     Opm::Parser parser;
     Opm::ParseContext parseContext;
-    Opm::ErrorGuard errorGuard;
 
     {
+        Opm::ErrorGuard errorGuard;
         const char *correctDeckString =
             "RUNSPEC\n"
             "DIMENS\n"
@@ -55,9 +55,13 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
 
         auto deck = parser.parseString(correctDeckString);
         BOOST_CHECK(Opm::checkDeck(deck, parser, parseContext, errorGuard));
+        // prevent std::exit(1) in ErrorGuard's destructor!
+        errorGuard.dump();
+        errorGuard.clear();
     }
 
     {
+        Opm::ErrorGuard errorGuard;
         // wrong section ordering
         const char *correctDeckString =
             "GRID\n"
@@ -69,9 +73,13 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
         auto deck = parser.parseString(correctDeckString);
         BOOST_CHECK(!Opm::checkDeck(deck, parser, parseContext, errorGuard));
         BOOST_CHECK(Opm::checkDeck(deck, parser, parseContext, errorGuard, ~Opm::SectionTopology));
+        // prevent std::exit(1) in ErrorGuard's destructor!
+        errorGuard.dump();
+        errorGuard.clear();
     }
 
     {
+        Opm::ErrorGuard errorGuard;
         // the BOX keyword is in a section where it's not supposed to be
         const char *incorrectDeckString =
             "RUNSPEC\n"
@@ -101,8 +109,46 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
 
         // this fails because of the incorrect BOX keyword
         BOOST_CHECK(!Opm::checkDeck(deck, parser, parseContext, errorGuard, Opm::SectionTopology | Opm::KeywordSection));
+        // prevent std::exit(1) in ErrorGuard's destructor!
+        errorGuard.dump();
+        errorGuard.clear();
     }
-    // prevent std::exit(1) in ErrorGuard's destructor!
-    errorGuard.dump();
-    errorGuard.clear();
+
+    {
+        Opm::ErrorGuard errorGuard;
+        // the MULTIPLY TRANX is in a section where it's not supposed to be
+        const char *incorrectDeckString =
+            "RUNSPEC\n"
+            "DIMENS\n"
+            "3 3 3 /\n"
+            "GRID\n"
+            "DXV\n"
+            "1 1 1 /\n"
+            "DYV\n"
+            "1 1 1 /\n"
+            "DZV\n"
+            "1 1 1 /\n"
+            "TOPS\n"
+            "9*100 /\n"
+            "MULTIPLY\n"
+            "'TRANX' 20.0 /\n"
+            "'TRANY' 20.0 /\n"
+            "/\n"
+            "PROPS\n"
+            "SOLUTION\n"
+            "SCHEDULE\n";
+
+        auto deck = parser.parseString(incorrectDeckString);
+        BOOST_CHECK(!Opm::checkDeck(deck, parser, parseContext, errorGuard));
+
+        // this is supposed to succeed as we don't ensure that all keywords are in the
+        // correct section
+        BOOST_CHECK(Opm::checkDeck(deck, parser, parseContext, errorGuard, Opm::SectionTopology));
+
+        // this fails because of the incorrect TRANX keyword
+        BOOST_CHECK(!Opm::checkDeck(deck, parser, parseContext, errorGuard, Opm::SectionTopology | Opm::KeywordSection));
+        // prevent std::exit(1) in ErrorGuard's destructor!
+        errorGuard.dump();
+        errorGuard.clear();
+    }
 }


### PR DESCRIPTION
That will make those (e.g. EDITNNC in the GRiD section) fatal. In addition we now also check (region) operations on keywords such as
```
MULTIPLY
  'TRANX' 2.0 /
  'TRANY' 4.0 /
/