### PR TITLE
Rename LinearTimeSteppingBreakdown to TimeSteppingBreakdown

### DIFF
--- a/opm/common/Exceptions.hpp
+++ b/opm/common/Exceptions.hpp
@@ -66,10 +66,10 @@ public:
         : NumericalProblem(message)
     {}
 };
-class LinearTimeSteppingBreakdown : public NumericalProblem
+class TimeSteppingBreakdown : public NumericalProblem
 {
 public:
-    explicit LinearTimeSteppingBreakdown(const std::string &message)
+    explicit TimeSteppingBreakdown(const std::string &message)
         : NumericalProblem(message)
     {}
 };


### PR DESCRIPTION
Indeed that is more intuitive. I guess the previous name was due to copy & paste and forgetting to change things afterwards.

should be merged together with OPM/opm-simulators#4756