### PR TITLE
quell unused parameter warnings

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
@@ -112,15 +112,15 @@ public:
     static constexpr bool isCompositionDependent = false;
 
     template <class ContainerT, class FluidState>
-    static Scalar relpermOilInOilGasSystem(const Params& params,
-                                           const FluidState& fluidState){
+    static Scalar relpermOilInOilGasSystem(const Params& /*params*/,
+                                           const FluidState& /*fluidState*/) {
         throw std::logic_error {
             "relpermOilInOilGasSystem() is specific to three phases"
                 };
     }
     template <class ContainerT, class FluidState>
-    static Scalar relpermOilInOilWaterSystem(const Params& params,
-                                                 const FluidState& fluidState){
+    static Scalar relpermOilInOilWaterSystem(const Params& /*params*/,
+                                                 const FluidState& /*fluidState*/) {
         throw std::logic_error {
                 "relpermOilInOilWaterSystem() is specific to three phases"
                     };

--- a/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp
@@ -134,7 +134,9 @@ public:
         serializer(*oilWaterParams_);
         serializer(*gasWaterParams_);
     }
-    void setSwl(Scalar val){}
+
+    void setSwl(Scalar) {}
+
 private:
     EclTwoPhaseApproach approach_;
 


### PR DESCRIPTION
Shut the clang up!