### PR TITLE
Make FIP* Array Names Unique Only Up to First Three Characters

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -518,7 +518,7 @@ public:
 
     std::size_t num_int() const
     {
-        return this->int_data.size();
+        return this->int_data.size() + this->fipreg_data_.size();
     }
 
     std::size_t num_double() const
@@ -580,6 +580,8 @@ private:
     template <typename T>
     Fieldprops::FieldData<T>& init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<T>& kw_info);
 
+    Fieldprops::FieldData<int>& init_get_fipreg(const std::string& keyword, const Fieldprops::keywords::keyword_info<int>& kw_info);
+
     std::string region_name(const DeckItem& region_item);
     std::vector<Box::cell_index> region_index( const std::string& region_name, int region_value );
     void handle_OPERATE(const DeckKeyword& keyword, Box box);
@@ -612,6 +614,7 @@ private:
     std::vector<MultregpRecord> multregp;
     std::unordered_map<std::string, Fieldprops::FieldData<int>> int_data;
     std::unordered_map<std::string, Fieldprops::FieldData<double>> double_data;
+    OrderedMap<Fieldprops::FieldData<int>, 6> fipreg_data_{};
 
     std::unordered_map<std::string,Fieldprops::TranCalculator> tran;
 };

--- a/opm/input/eclipse/EclipseState/Util/OrderedMap.hpp
+++ b/opm/input/eclipse/EclipseState/Util/OrderedMap.hpp
@@ -190,6 +190,25 @@ public:
         }
     }
 
+    template <typename... Args>
+    std::pair<iter_type, bool> emplace(std::string_view key, Args&&... args)
+    {
+        auto [ipos, inserted] = this->m_map.emplace(key, this->m_vector.size());
+
+        if (inserted) {
+            // New element.  Add to end.
+            this->m_vector.emplace_back
+                (std::piecewise_construct,
+                 std::forward_as_tuple(key),
+                 std::forward_as_tuple(std::forward<Args>(args)...));
+        }
+        else {
+            // Existing element.  Make sure we have the correct key.
+            this->m_vector[ipos->second].first = key;
+        }
+
+        return { this->m_vector.begin() + ipos->second, inserted };
+    }
 
     T& get(const std::string& key) {
         auto iter = m_map.find( key );

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1849,6 +1849,47 @@ BOOST_AUTO_TEST_CASE(SatFunc_EndPts_Family_II_TolCrit_Large) {
 
 // =====================================================================
 
+BOOST_AUTO_TEST_CASE(Equivalent_FIP_Keys) {
+    std::string deck_string = R"(
+GRID
+
+PORO
+   200*0.15 /
+
+REGIONS
+
+FIPUNIT
+  100*1 100*2 /
+
+FIPUNIX
+  100*3 100*4 /
+)";
+
+    const EclipseGrid grid { 10, 10, 2 };
+    const Deck deck = Parser{}.parseString(deck_string);
+
+    BOOST_CHECK_MESSAGE(deck.hasKeyword("FIPUNIT"),
+                        R"(Input deck must have "FIPUNIT" region set)");
+
+    BOOST_CHECK_MESSAGE(deck.hasKeyword("FIPUNIX"),
+                        R"(Input deck must have "FIPUNIX" region set)");
+
+    const FieldPropsManager fpm {
+        deck, Phases{true, true, true}, grid, TableManager()
+    };
+
+    const auto& fipuni = fpm.get_int("FIPUNI");
+    auto expect = std::vector<int>(100, 3);
+    {
+        const auto l2 = std::vector<int>(100, 4);
+        expect.insert(expect.end(), l2.begin(), l2.end());
+    };
+
+    // FIPUNI <=> FIPUNIX
+    BOOST_CHECK_EQUAL_COLLECTIONS(fipuni.begin(), fipuni.end(),
+                                  expect.begin(), expect.end());
+}
+
 BOOST_AUTO_TEST_CASE(GET_FIPXYZ) {
     std::string deck_string = R"(
 GRID


### PR DESCRIPTION
This PR adds a special-purpose data member, `fipreg_data_`, to the `FieldProps` class.  The new data member uses the `MAX_CHARS` support of class `OrderedMap` to make `FIP*` region set names unique only up to the first three characters after the `"FIP"` prefix.  This is a compatibility measure.  As an example, following this PR the region sets

 * `FIPUNIT`
 * `FIPUNIX`

are treated as the same and the one entered *last* will override the one entered first.

This behaviour is motivated by summary vector namings which takes at most the first three non-"FIP" characters into account at the region level&ndash;e.g. `ROPR_UNI` for the `FIPUNIT`/`FIPUNIX` region set above.

To this end, also add an `emplace`-like operation to `OrderedMap`.  This isn't quite the same as the general `emplace()` member function of `std::map<>`/`std::unordered_map<>`, because `OrderedMap::emplace()` knows that the key type is string-like and therefore uses a distinct parameter for the key.  We also take special care to always update the `key` part even when not inserting a new element.  The reason is that the `emplace()` call might have used a different yet equivalent key to one added earlier.  In this case, the new key should override the existing key.