### PR TITLE
changed to using input type unit convertions for field props

### DIFF
--- a/opm/input/eclipse/Deck/DeckItem.hpp
+++ b/opm/input/eclipse/Deck/DeckItem.hpp
@@ -151,6 +151,10 @@ namespace Opm {
         }
 
         void reserve_additionalRawString(std::size_t);
+
+        const std::vector<Dimension>& getActiveDimensions() const{
+            return active_dimensions;
+        }
     private:
         mutable std::vector< double > dval;
         std::vector< int > ival;
@@ -180,4 +184,3 @@ namespace Opm {
     };
 }
 #endif  /* DECKITEM_HPP */
-

--- a/opm/input/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/input/eclipse/Deck/DeckKeyword.hpp
@@ -69,6 +69,9 @@ namespace Opm {
         const std::vector<int>& getIntData() const;
         const std::vector<double>& getRawDoubleData() const;
         const std::vector<double>& getSIDoubleData() const;
+        const std::vector<Dimension>&  getActiveDimensions() const{
+            return this->getDataRecord().getDataItem().getActiveDimensions();
+        }
         const std::vector<std::string>& getStringData() const;
         const std::vector<value::status>& getValueStatus() const;
         size_t getDataSize() const;
@@ -116,4 +119,3 @@ namespace Opm {
 }
 
 #endif  /* DECKKEYWORD_HPP */
-

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -519,6 +519,9 @@ public:
         return tran;
     }
 
+    const UnitSystem& getUnitSystem() const {
+        return this->unit_system;
+    }
 private:
     void scanGRIDSection(const GRIDSection& grid_section);
     void scanGRIDSectionOnlyACTNUM(const GRIDSection& grid_section);

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -18,7 +18,6 @@
 
 #ifndef FIELDPROPS_MANAGER_HPP
 #define FIELDPROPS_MANAGER_HPP
-
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -34,6 +33,7 @@ class TranCalculator;
 template<typename T> struct FieldData;
 }
 class FieldProps;
+class UnitSystem;
 class Phases;
 class TableManager;
 class NumericalAquifers;
@@ -49,6 +49,7 @@ public:
     virtual ~FieldPropsManager() = default;
 
     virtual void reset_actnum(const std::vector<int>& actnum);
+    const UnitSystem& getUnitSystem() const;
     const std::string& default_region() const;
     virtual std::vector<int> actnum() const;
     virtual std::vector<double> porv(bool global = false) const;
@@ -122,6 +123,7 @@ public:
           const std::vector<int>& satnum = fp.get_copy<int>("SATNUM")
           fp.has<int>("SATNUM") -> false
     */
+
 
 
     template <typename T>

--- a/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -839,7 +839,18 @@ void FieldProps::handle_double_keyword(Section section, const Fieldprops::keywor
     auto& field_data = this->init_get<double>(keyword_name, kw_info);
     const auto& deck_data = keyword.getSIDoubleData();
     const auto& deck_status = keyword.getValueStatus();
-
+#ifndef NDEBUG
+    const auto& kwunit = kw_info.unit;
+    double si_factor = 1.0;
+    if (kwunit) {
+        const auto& dim = unit_system.parse(*kwunit);
+        si_factor = dim.getSIScaling();
+    }
+    const std::vector<Dimension>& deckdims = keyword.getActiveDimensions();
+    for (const auto& dim : deckdims) {
+        assert(dim.getSIScaling() == si_factor);
+    }
+#endif
     if ((section == Section::EDIT || section == Section::SCHEDULE) && kw_info.multiplier)
         multiply_deck(kw_info, keyword, field_data, deck_data, deck_status, box);
     else

--- a/src/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -26,6 +26,9 @@
 
 namespace Opm {
 
+const UnitSystem& FieldPropsManager::getUnitSystem() const{
+    return this->fp->getUnitSystem();
+}
 
 bool FieldPropsManager::operator==(const FieldPropsManager& other) const {
     return *this->fp == *other.fp;

--- a/src/opm/output/eclipse/WriteInit.cpp
+++ b/src/opm/output/eclipse/WriteInit.cpp
@@ -393,10 +393,13 @@ namespace {
             const auto& unit_system = fp.getUnitSystem();
             auto data = fp.get_double(prop.name);
             const auto& kw_info = ::Opm::Fieldprops::keywords::global_kw_info<double>(prop.name);
-            assert(kw_info.unit);
-            const auto& dim = unit_system.parse( *kw_info.unit );
-            for(auto& val: data){
-                val = dim.convertSiToRaw(val);
+            if(kw_info.unit){
+                const auto& dim = unit_system.parse( *kw_info.unit );
+                for(auto& val: data){
+                    val = dim.convertSiToRaw(val);
+                }
+            }else{
+                // option kw_info.unit not set assume unit conversion
             }
             write(prop, std::move(data));
         }


### PR DESCRIPTION
-- make input and output consistent without more than input definition
-- simplifies output of field props with combined units (i.e. length^i time^j temperature^k