### PR TITLE
Allow implicit creation of production network nodes.

### DIFF
--- a/opm/input/eclipse/Schedule/Network/ExtNetwork.hpp
+++ b/opm/input/eclipse/Schedule/Network/ExtNetwork.hpp
@@ -37,10 +37,10 @@ class ExtNetwork {
 public:
     ExtNetwork() = default;
     bool active() const;
-    bool has_node(const std::string& name) const;
-    void add_node(Node node);
     void add_branch(Branch branch);
     void drop_branch(const std::string& uptree_node, const std::string& downtree_node);
+    bool has_node(const std::string& name) const;
+    void update_node(Node node);
     const Node& node(const std::string& name) const;
     const Node& root() const;
     std::vector<Branch> downtree_branches(const std::string& node) const;

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -915,7 +915,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
             }
 
             node.add_gas_lift_gas(add_gas_lift_gas);
-            ext_network.add_node(node);
+            ext_network.update_node(node);
         }
 
         this->snapshots.back().network.update( ext_network );

--- a/src/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
+++ b/src/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
@@ -75,11 +75,13 @@ const Node& ExtNetwork::root() const {
 
 void ExtNetwork::add_branch(Branch branch)
 {
-    if (!this->has_indexed_node_name(branch.downtree_node())) {
-        this->add_indexed_node_name(branch.downtree_node());
-    }
-    if (!this->has_indexed_node_name(branch.uptree_node())) {
-        this->add_indexed_node_name(branch.uptree_node());
+    for (const std::string& nodename : { branch.downtree_node(), branch.uptree_node() }) {
+        if (!this->has_node(nodename)) {
+            this->m_nodes.insert_or_assign(nodename, Node{nodename});
+        }
+        if (!this->has_indexed_node_name(nodename)) {
+            this->add_indexed_node_name(nodename);
+        }
     }
     this->m_branches.push_back( std::move(branch) );
 }
@@ -152,6 +154,9 @@ int ExtNetwork::NoOfBranches() const {
 
 void ExtNetwork::add_node(Node node)
 {
+    // This function should be called as a result of a NODEPROP deck
+    // entry (or equivalent from restart file). So the node should
+    // already exist, added in add_branch() from BRANPROP entries.
     std::string name = node.name();
     auto branch = std::find_if(this->m_branches.begin(), this->m_branches.end(),
                                [&name](const Branch& b) { return b.uptree_node() == name || b.downtree_node() == name;});

--- a/src/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
+++ b/src/opm/input/eclipse/Schedule/Network/ExtNetwork.cpp
@@ -152,7 +152,7 @@ int ExtNetwork::NoOfBranches() const {
   the only possibility.
 */
 
-void ExtNetwork::add_node(Node node)
+void ExtNetwork::update_node(Node node)
 {
     // This function should be called as a result of a NODEPROP deck
     // entry (or equivalent from restart file). So the node should

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -2001,7 +2001,7 @@ namespace {
 
                 node.add_gas_lift_gas(rst_node.add_lift_gas);
 
-                network.add_node(std::move(node));
+                network.update_node(std::move(node));
             }
 
             this->snapshots.back().network.update(std::move(network));

--- a/tests/parser/NetworkTests.cpp
+++ b/tests/parser/NetworkTests.cpp
@@ -318,3 +318,54 @@ BRANPROP
 
     BOOST_CHECK_EQUAL_COLLECTIONS(nodes.begin(), nodes.end(), expect.begin(), expect.end());
 }
+
+BOOST_AUTO_TEST_CASE(DefaultedNodes) {
+    const auto sched = make_schedule(R"(
+SCHEDULE
+
+GRUPTREE
+ 'PROD'    'FIELD' /
+
+ 'M5S'    'PLAT-A'  /
+ 'M5N'    'PLAT-A'  /
+
+ 'C1'     'M5N'  /
+ 'F1'     'M5N'  /
+ 'B1'     'M5S'  /
+ 'G1'     'M5S'  /
+/
+
+BRANPROP
+--  Downtree  Uptree   #VFP    ALQ
+    B1         PLAT-A    9999      1*      /
+    C1         PLAT-A    9999      1*      /
+/
+
+NODEPROP
+--  Node_name Pr    autoChock?      addGasLift?     Group_name
+     PLAT-A 21.0   NO     NO    1*  /
+--     B1    1*  YES      NO    1*  /
+--     C1    1*  YES     NO     'GROUP' /
+/
+
+TSTEP
+  10 /
+
+BRANPROP
+--  Downtree  Uptree   #VFP    ALQ
+    C1         PLAT-A    0 1*      /
+/
+)");
+
+    // The difference between this test and the NodeNames test above is that
+    // the NODEPROP entries for B1 and C1 have been commented out.
+
+    const auto expect = std::vector<std::string> {
+        "B1", "C1", "PLAT-A"
+    };
+
+    auto nodes = sched[0].network.get().node_names();
+    std::sort(nodes.begin(), nodes.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(nodes.begin(), nodes.end(), expect.begin(), expect.end());
+}


### PR DESCRIPTION
Nodes with default properties do not need any NODEPROP entries and can be implicitly created by being referred to in BRANPROP. This fixes a bug where such cases would cause an exception.

Creating as draft until test case has been added.