### PR TITLE
Properly Classify Capillary Pressure Keywords

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -185,7 +185,11 @@ static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {
 }
 
 namespace PROPS {
-static const std::unordered_map<std::string, keyword_info<double>> double_keywords = {{"SWATINIT", keyword_info<double>{}}};
+static const std::unordered_map<std::string, keyword_info<double>> double_keywords = {{"SWATINIT", keyword_info<double>{}},
+                                                                                      {"PCG",      keyword_info<double>{}.unit_string("Pressure")},
+                                                                                      {"IPCG",     keyword_info<double>{}.unit_string("Pressure")},
+                                                                                      {"PCW",      keyword_info<double>{}.unit_string("Pressure")},
+                                                                                      {"IPCW",     keyword_info<double>{}.unit_string("Pressure")}};
 static const std::unordered_map<std::string, keyword_info<int>> int_keywords = {};
 
 #define dirfunc(base) base, base "X", base "X-", base "Y", base "Y-", base "Z", base "Z-"
@@ -207,10 +211,6 @@ static const std::set<std::string> satfunc = {"SWLPC", "ISWLPC", "SGLPC", "ISGLP
                                               dirfunc("ISOGCR"),
                                               dirfunc("SWCR"),
                                               dirfunc("ISWCR"),
-                                              dirfunc("PCW"),
-                                              dirfunc("IPCW"),
-                                              dirfunc("PCG"),
-                                              dirfunc("IPCG"),
                                               dirfunc("KRW"),
                                               dirfunc("IKRW"),
                                               dirfunc("KRWR"),

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -226,6 +226,7 @@ static const std::set<std::string> satfunc = {"SWLPC", "ISWLPC", "SGLPC", "ISGLP
                                               dirfunc("KRGR"),
                                               dirfunc("IKRGR")};
 
+#undef dirfunc
 }
 
 namespace REGIONS {

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -226,21 +226,6 @@ static const std::set<std::string> satfunc = {"SWLPC", "ISWLPC", "SGLPC", "ISGLP
                                               dirfunc("KRGR"),
                                               dirfunc("IKRGR")};
 
-static const std::map<std::string,std::string> sogcr_shift = {{"SOGCR",    "SWL"},
-                                                              {"SOGCRX",   "SWLX"},
-                                                              {"SOGCRX-",  "SWLX-"},
-                                                              {"SOGCRY",   "SWLY"},
-                                                              {"SOGCRY-",  "SWLY-"},
-                                                              {"SOGCRZ",   "SWLZ"},
-                                                              {"SOGCRZ-",  "SWLZ-"},
-                                                              {"ISOGCR",   "ISWL"},
-                                                              {"ISOGCRX",  "ISWLX"},
-                                                              {"ISOGCRX-", "ISWLX-"},
-                                                              {"ISOGCRY",  "ISWLY"},
-                                                              {"ISOGCRY-", "ISWLY-"},
-                                                              {"ISOGCRZ",  "ISWLZ"},
-                                                              {"ISOGCRZ-", "ISWLZ-"}};
-
 }
 
 namespace REGIONS {

--- a/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -79,6 +79,12 @@ namespace {
             }
         };
     }
+
+    bool is_capillary_pressure(const std::string& keyword)
+    {
+        return (keyword == "PCW")  || (keyword == "PCG")
+            || (keyword == "IPCG") || (keyword == "IPCW");
+    }
 }
 
 namespace Opm {
@@ -675,8 +681,11 @@ Fieldprops::FieldData<double>& FieldProps::init_get(const std::string& keyword_n
     if (keyword == ParserKeywords::TEMPI::keywordName)
         this->init_tempi(this->double_data[keyword]);
 
-    if (Fieldprops::keywords::PROPS::satfunc.count(keyword) == 1)
+    if ((Fieldprops::keywords::PROPS::satfunc.count(keyword) == 1) ||
+        is_capillary_pressure(keyword))
+    {
         this->init_satfunc(keyword, this->double_data[keyword]);
+    }
 
     return this->double_data[keyword];
 }

--- a/src/opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
@@ -1933,8 +1933,8 @@ Opm::satfunc::init(const std::string&         keyword,
         dirfunc("SOWCR", SOWCREndpoint), dirfunc("ISOWCR", ISOWCREndpoint),
         dirfunc("SWCR",  SWCREndpoint),  dirfunc("ISWCR",  ISWCREndpoint),
 
-        dirfunc("PCG",   PCGEndpoint),   dirfunc("IPCG",   IPCGEndpoint),
-        dirfunc("PCW",   PCWEndpoint),   dirfunc("IPCW",   IPCWEndpoint),
+        {"PCG", PCGEndpoint},            {"IPCG", IPCGEndpoint},
+        {"PCW", PCWEndpoint},            {"IPCW", IPCWEndpoint},
 
         dirfunc("KRG",   KRGEndpoint),   dirfunc("IKRG",   IKRGEndpoint),
         dirfunc("KRGR",  KRGREndpoint),  dirfunc("IKRGR",  IKRGREndpoint),


### PR DESCRIPTION
These are not directionally dependent, and they have a unit string of `Pressure`.  This didn't use to matter, but upcoming changes
will depend on the unit string being correct.

While here, also tidy up an unused array left over from commit 146be0aa2 (PR #1749), and take care to remove a macro definition so that it does not escape the file in which it is defined.