### PR TITLE
Use Existing Cartesian-to-IJK Functionality to Determine NNCs in MULTREGT

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -21,6 +21,7 @@
 #define OPM_PARSER_MULTREGTSCANNER_HPP
 
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
 
 #include <cstddef>
 #include <map>
@@ -33,7 +34,6 @@ namespace Opm {
     class DeckRecord;
     class DeckKeyword;
     class FieldPropsManager;
-    class GridDims;
 
 } // namespace Opm
 
@@ -102,9 +102,7 @@ namespace Opm {
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            serializer(nx);
-            serializer(ny);
-            serializer(nz);
+            serializer(gridDims);
             serializer(default_region);
             serializer(m_records);
             serializer(m_searchMap);
@@ -114,7 +112,7 @@ namespace Opm {
     private:
         using MULTREGTSearchMap = std::map< std::pair<int, int>, std::vector<MULTREGTRecord>::size_type>;
 
-        std::size_t nx = 0,ny = 0, nz = 0;
+        GridDims gridDims{};
         const FieldPropsManager* fp{nullptr};
         std::string default_region{};
 

--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -76,7 +76,7 @@ namespace Opm {
         }
     };
 
-    typedef std::map< std::pair<int , int> , const MULTREGTRecord * >  MULTREGTSearchMap;
+    using MULTREGTSearchMap = std::map< std::pair<int, int>, std::vector<MULTREGTRecord>::size_type>;
     typedef std::tuple<size_t , FaceDir::DirEnum , double> MULTREGTConnection;
 
 
@@ -106,18 +106,12 @@ namespace Opm {
             serializer(ny);
             serializer(nz);
             serializer(m_records);
-            ExternalSearchMap searchMap = getSearchMap();
-            serializer(searchMap);
-            if (m_searchMap.empty())
-                constructSearchMap(searchMap);
+            serializer(m_searchMap);
             serializer(regions);
             serializer(default_region);
         }
 
     private:
-        ExternalSearchMap getSearchMap() const;
-        void constructSearchMap(const ExternalSearchMap& searchMap);
-
         void addKeyword( const DeckKeyword& deckKeyword, const std::string& defaultRegion);
         void assertKeywordSupported(const DeckKeyword& deckKeyword);
         std::size_t nx = 0,ny = 0, nz = 0;

--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -17,11 +17,16 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
 #ifndef OPM_PARSER_MULTREGTSCANNER_HPP
 #define OPM_PARSER_MULTREGTSCANNER_HPP
 
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace Opm {
 
@@ -30,9 +35,11 @@ namespace Opm {
     class FieldPropsManager;
     class GridDims;
 
+} // namespace Opm
+
+namespace Opm {
+
     namespace MULTREGT {
-
-
         enum NNCBehaviourEnum {
             NNC = 1,
             NONNC = 2,
@@ -42,12 +49,10 @@ namespace Opm {
 
         std::string RegionNameFromDeckValue(const std::string& stringValue);
         NNCBehaviourEnum NNCBehaviourFromString(const std::string& stringValue);
-    }
+    } // namespace MULTREGT
 
-
-
-
-    struct MULTREGTRecord {
+    struct MULTREGTRecord
+    {
         int src_value;
         int target_value;
         double trans_mult;
@@ -76,25 +81,20 @@ namespace Opm {
         }
     };
 
-    using MULTREGTSearchMap = std::map< std::pair<int, int>, std::vector<MULTREGTRecord>::size_type>;
-    typedef std::tuple<size_t , FaceDir::DirEnum , double> MULTREGTConnection;
-
-
-
-    class MULTREGTScanner {
-
+    class MULTREGTScanner
+    {
     public:
-        using ExternalSearchMap = std::map<std::string, std::map<std::pair<int,int>, int>>;
-
         MULTREGTScanner() = default;
         MULTREGTScanner(const MULTREGTScanner& data);
         MULTREGTScanner(const GridDims& grid,
                         const FieldPropsManager* fp_arg,
-                        const std::vector< const DeckKeyword* >& keywords);
+                        const std::vector<const DeckKeyword*>& keywords);
 
         static MULTREGTScanner serializationTestObject();
 
-        double getRegionMultiplier(size_t globalCellIdx1, size_t globalCellIdx2, FaceDir::DirEnum faceDir) const;
+        double getRegionMultiplier(std::size_t globalCellIdx1,
+                                   std::size_t globalCellIdx2,
+                                   FaceDir::DirEnum faceDir) const;
 
         bool operator==(const MULTREGTScanner& data) const;
         MULTREGTScanner& operator=(const MULTREGTScanner& data);
@@ -105,23 +105,27 @@ namespace Opm {
             serializer(nx);
             serializer(ny);
             serializer(nz);
+            serializer(default_region);
             serializer(m_records);
             serializer(m_searchMap);
             serializer(regions);
-            serializer(default_region);
         }
 
     private:
-        void addKeyword( const DeckKeyword& deckKeyword, const std::string& defaultRegion);
-        void assertKeywordSupported(const DeckKeyword& deckKeyword);
+        using MULTREGTSearchMap = std::map< std::pair<int, int>, std::vector<MULTREGTRecord>::size_type>;
+
         std::size_t nx = 0,ny = 0, nz = 0;
-        const FieldPropsManager* fp = nullptr;
-        std::vector< MULTREGTRecord > m_records;
-        std::map<std::string , MULTREGTSearchMap> m_searchMap;
-        std::map<std::string, std::vector<int>> regions;
-        std::string default_region;
+        const FieldPropsManager* fp{nullptr};
+        std::string default_region{};
+
+        std::vector<MULTREGTRecord> m_records{};
+        std::map<std::string, MULTREGTSearchMap> m_searchMap{};
+        std::map<std::string, std::vector<int>> regions{};
+
+        void addKeyword(const DeckKeyword& deckKeyword);
+        void assertKeywordSupported(const DeckKeyword& deckKeyword);
     };
 
-}
+} // namespace Opm
 
 #endif // OPM_PARSER_MULTREGTSCANNER_HPP


### PR DESCRIPTION
This PR replaces the data members `nx`, `ny`, and `nz` with a copy of the `GridDims` object passed as an argument to the constructor.  In turn, this enables using `GridDims::getIJK()` to compute the cell's IJK tuple from its global Cartesian index instead of implementing the same calculation locally (and incorrectly).

While here, also include the layer index (K) in determining whether or not a connection is an NNC, and do this just once instead of once for each MULTREGT record.  Cells (I,J,K) and (I,J,K+3) might be connected across pinched-out layers and for the purposes of MULTREGT that connection should be treated as an NNC.