### PR TITLE
Recognise Extension Keywords Whose Names Exceed Size Limits

### DIFF
--- a/opm/input/eclipse/Parser/Parser.hpp
+++ b/opm/input/eclipse/Parser/Parser.hpp
@@ -97,7 +97,30 @@ namespace Opm {
         bool hasKeyword( const std::string& ) const;
         const ParserKeyword& getKeyword(const std::string& name) const;
 
-        bool isRecognizedKeyword( const std::string_view& deckKeywordName) const;
+        /// Whether or not string is a valid keyword.
+        ///
+        /// The full keyword recognition process first verifies that the
+        /// input string looks like a valid keyword and, if so matches that
+        /// string against the builtin set of known keywords.  The function
+        /// additionally includes those keywords that match against keyword
+        /// collections, typically the SUMMARY section "meta" keywords in
+        /// the *_PROBE files.
+        ///
+        /// \return Whether or not \p deckKeywordName is a builtin deck
+        /// keyword or a known summary keyword.
+        bool isRecognizedKeyword(std::string_view deckKeywordName) const;
+
+        /// Whether or not string is a valid keyword.
+        ///
+        /// First checks that the input string looks like a valid keyword
+        /// and, if so, matches the string against the builtin set of known
+        /// keywords.
+        ///
+        /// \param[in] deckKeywordName Potential deck keyword.
+        ///
+        /// \return Whether or not \p deckKeywordName is a builtin deck keyword.
+        bool isBaseRecognizedKeyword(std::string_view deckKeywordName) const;
+
         const ParserKeyword& getParserKeywordFromDeckName(const std::string_view& deckKeywordName) const;
         std::vector<std::string> getAllDeckNames () const;
 

--- a/src/opm/input/eclipse/Parser/Parser.cpp
+++ b/src/opm/input/eclipse/Parser/Parser.cpp
@@ -881,6 +881,13 @@ newRawKeyword(const std::string&      deck_name,
 
             return newRawKeyword(parserKeyword, keyword8, parserState, parser);
         }
+        else if (parser.isBaseRecognizedKeyword(deck_name)) {
+            // Typically an OPM extended keyword such as STRESSEQUILNUM.
+            parserState.unknown_keyword = false;
+            const auto& parserKeyword = parser.getParserKeywordFromDeckName(deck_name);
+
+            return newRawKeyword(parserKeyword, deck_name, parserState, parser);
+        }
         else {
             parserState.parseContext.handleUnknownKeyword(deck_name,
                                                           KeywordLocation {

--- a/src/opm/input/eclipse/Parser/Parser.cpp
+++ b/src/opm/input/eclipse/Parser/Parser.cpp
@@ -883,7 +883,7 @@ newRawKeyword(const std::string&      deck_name,
         }
         else {
             parserState.parseContext.handleUnknownKeyword(deck_name,
-                                                          KeywordLocation{
+                                                          KeywordLocation {
                                                               deck_name,
                                                               parserState.current_path().string(),
                                                               parserState.line()
@@ -1398,14 +1398,20 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
         return (m_wildCardKeywords.count(internalKeywordName) > 0);
     }
 
-    bool Parser::isRecognizedKeyword(const std::string_view& name ) const {
-        if( !ParserKeyword::validDeckName( name ) )
+    bool Parser::isRecognizedKeyword(std::string_view name) const
+    {
+        if (! ParserKeyword::validDeckName(name)) {
             return false;
+        }
 
-        if( m_deckParserKeywords.count( name ) )
-            return true;
+        return (this->m_deckParserKeywords.find(name) != this->m_deckParserKeywords.end())
+            || (this->matchingKeyword(name) != nullptr);
+    }
 
-        return bool( matchingKeyword( name ) );
+    bool Parser::isBaseRecognizedKeyword(std::string_view name) const
+    {
+        return ParserKeyword::validDeckName(name)
+            && (this->m_deckParserKeywords.find(name) != this->m_deckParserKeywords.end());
     }
 
 void Parser::addParserKeyword( ParserKeyword parserKeyword ) {

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -2354,12 +2354,36 @@ GUIDERATE
 /
 )";
 
+   const auto stressequilnum_string = std::string { R"(RUNSPEC
+DIMENS
+1 5 2 /
+REGIONS
+STRESSEQUILNUM
+1 1 1 1 1
+2 2 2 2 2 /
+END
+)" };
+
    parseContext.update(ParseContext::PARSE_LONG_KEYWORD, Opm::InputErrorAction::THROW_EXCEPTION);
    BOOST_CHECK_THROW(parser.parseString(deck_string, parseContext, errors), OpmInputError);
 
-   parseContext.update(ParseContext::PARSE_LONG_KEYWORD, Opm::InputErrorAction::IGNORE);
-   auto deck = parser.parseString(deck_string, parseContext, errors);
-   BOOST_CHECK( deck.hasKeyword("GUIDERAT") );
+   errors.clear();
+
+   {
+       parseContext.update(ParseContext::PARSE_LONG_KEYWORD, Opm::InputErrorAction::IGNORE);
+       auto deck = parser.parseString(deck_string, parseContext, errors);
+       BOOST_CHECK( deck.hasKeyword("GUIDERAT") );
+   }
+
+   errors.clear();
+
+   {
+       parseContext.update(ParseContext::PARSE_LONG_KEYWORD, Opm::InputErrorAction::THROW_EXCEPTION);
+       const auto deck = parser.parseString(stressequilnum_string, parseContext, errors);
+
+       BOOST_CHECK_MESSAGE(deck.hasKeyword("STRESSEQUILNUM"),
+                           R"(Long keyword "STRESSEQUILNUM" must be present in input deck)");
+   }
 }
 
 BOOST_AUTO_TEST_CASE(DynamicParser1) {


### PR DESCRIPTION
This PR adds targeted support for identifying keywords whose names exceed the maximum compatibility keyword length limit.  This, in turn, enables seamless recognition of extension keywords such as
```
STRESSEQUILNUM
```
without compromising the parser's ability to identify long keyword names that match existing keywords in the first eight characters. For example, the input string `GUIDERATE` will still match the keyword `GUIDERAT` (without the trailing "E") and will not be accidentally treated as a SUMMARY section request to output a group level UDQ vector.

To this end split keyword recognition into two parts.  The 'base' checks that the input string looks like a valid keyword and, if so, matches the string against the builtin set of known keywords.  The full keyword recognition process additionally includes those keywords that match against keyword collections, typically the SUMMARY section "meta" keywords in the `*_PROBE` files.

This PR supersedes and closes #3638.