### PR TITLE
Avoid connection depth = 0 when segment is specified without depth in COMPSEGS

### DIFF
--- a/src/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -126,11 +126,6 @@ struct Record {
         const double depth_change_segment = segment_depth - interpolation_detph;
         const double segment_length = segment_distance - interpolation_distance;
 
-        // if (segment_length == 0.) {
-        //     throw std::runtime_error("Zero segment length is botained when doing interpolation between segment "
-        //                               + std::to_string(segment_number) + " and segment " + std::to_string(interpolation_segment_number) );
-        // }
-
         // Use segment depth if length of sement is 0
         if (segment_length == 0.) {
             center_depth = segment_depth;


### PR DESCRIPTION
Perform the connection-depth-from-segments calculations even if the segment number is specified.