### PR TITLE
not considering numerical aquifers cells inside reservoir

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Aquifer/AquiferHelpers.hpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/AquiferHelpers.hpp
@@ -22,12 +22,15 @@
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
 
 #include <vector>
+#include <optional>
+#include <unordered_set>
 
 namespace Opm {
     class EclipseGrid;
     namespace AquiferHelpers {
         bool neighborCellInsideReservoirAndActive(const EclipseGrid &grid, int i, int j, int k,
-                                                  FaceDir::DirEnum faceDir, const std::vector<int>& actnum);
+                                                  FaceDir::DirEnum faceDir, const std::vector<int>& actnum,
+                                                  const std::optional<const std::unordered_set<std::size_t>>& numerical_aquifer_cells = std::nullopt);
     }
 }
 

--- a/src/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
+++ b/src/opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.cpp
@@ -26,6 +26,8 @@
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/SingleNumericalAquifer.hpp>
 #include "../AquiferHelpers.hpp"
 
+#include <unordered_set>
+
 namespace Opm {
     SingleNumericalAquifer::SingleNumericalAquifer(const size_t aqu_id)
             : id_(aqu_id)
@@ -158,6 +160,11 @@ namespace Opm {
     }
 
     void SingleNumericalAquifer::postProcessConnections(const EclipseGrid& grid, const std::vector<int>& actnum) {
+        std::unordered_set<size_t> cell_global_indices;
+        for (const auto& cell : this->cells_) {
+            cell_global_indices.insert(cell.global_index);
+        }
+
         std::vector<NumericalAquiferConnection> conns;
         for (const auto& con : this->connections_) {
             const size_t i = con.I;
@@ -165,7 +172,7 @@ namespace Opm {
             const size_t k = con.K;
             if (!actnum[grid.getGlobalIndex(i, j, k)]) continue;
             if (con.connect_active_cell
-               || !AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, con.face_dir, actnum)) {
+               || !AquiferHelpers::neighborCellInsideReservoirAndActive(grid, i, j, k, con.face_dir, actnum, cell_global_indices)) {
                 conns.push_back(con);
             }
         }


### PR DESCRIPTION
since we forcefully make numerical aquifer cells active. If a connection cells is neighboring a numerical aquifer cell, we should create NNC for this connection.   The current code will not create the NNC connection because it is a numerical aquifer cell is considered to be an active cell and the connection will be considered as connecting two active cells. 