### PR TITLE
Tidy Up MULTREGT Scanner Implementation File

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -108,7 +108,6 @@ namespace Opm {
         {
             serializer(gridDims);
 
-            serializer(default_region);
             serializer(m_records);
             serializer(m_searchMap);
 
@@ -123,7 +122,6 @@ namespace Opm {
 
         GridDims gridDims{};
         const FieldPropsManager* fp{nullptr};
-        std::string default_region{};
 
         std::vector<MULTREGTRecord> m_records{};
         std::map<std::string, MULTREGTSearchMap> m_searchMap{};

--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -40,7 +40,8 @@ namespace Opm {
 namespace Opm {
 
     namespace MULTREGT {
-        enum NNCBehaviourEnum {
+        enum class NNCBehaviourEnum
+        {
             NNC = 1,
             NONNC = 2,
             ALL = 3,
@@ -60,13 +61,15 @@ namespace Opm {
         MULTREGT::NNCBehaviourEnum nnc_behaviour;
         std::string region_name;
 
-        bool operator==(const MULTREGTRecord& data) const {
-            return src_value == data.src_value &&
-                   target_value == data.target_value &&
-                   trans_mult == data.trans_mult &&
-                   directions == data.directions &&
-                   nnc_behaviour == data.nnc_behaviour &&
-                   region_name == data.region_name;
+        bool operator==(const MULTREGTRecord& data) const
+        {
+            return (src_value == data.src_value)
+                && (target_value == data.target_value)
+                && (trans_mult == data.trans_mult)
+                && (directions == data.directions)
+                && (nnc_behaviour == data.nnc_behaviour)
+                && (region_name == data.region_name)
+                ;
         }
 
         template<class Serializer>
@@ -92,25 +95,31 @@ namespace Opm {
 
         static MULTREGTScanner serializationTestObject();
 
+        bool operator==(const MULTREGTScanner& data) const;
+        MULTREGTScanner& operator=(const MULTREGTScanner& data);
+
         double getRegionMultiplier(std::size_t globalCellIdx1,
                                    std::size_t globalCellIdx2,
                                    FaceDir::DirEnum faceDir) const;
 
-        bool operator==(const MULTREGTScanner& data) const;
-        MULTREGTScanner& operator=(const MULTREGTScanner& data);
 
-        template<class Serializer>
+        template <class Serializer>
         void serializeOp(Serializer& serializer)
         {
             serializer(gridDims);
+
             serializer(default_region);
             serializer(m_records);
             serializer(m_searchMap);
+
             serializer(regions);
         }
 
     private:
-        using MULTREGTSearchMap = std::map< std::pair<int, int>, std::vector<MULTREGTRecord>::size_type>;
+        using MULTREGTSearchMap = std::map<
+            std::pair<int, int>,
+            std::vector<MULTREGTRecord>::size_type
+        >;
 
         GridDims gridDims{};
         const FieldPropsManager* fp{nullptr};


### PR DESCRIPTION
In particular, reorder the functions in the implementation file, mostly to group related functions and have the same order in the
declaration and the implementation files.  While here, also replace an `enum` with a strong `enum` since the type does not need to support arithmetic operations.

Finally, fix an error in the handling of the "default" region set.  Keyword `MULTREGT` has an independent default region set ([`MULTNUM`](https://github.com/OPM/opm-common/blob/a0e72a62c4790ed78910391a393bf9e1bc9347d9/src/opm/input/eclipse/share/keywords/000_Eclipse100/M/MULTREGT#L34)) and does not use the `GRIDOPTS`-based region set protocol of other `*REG` keywords.  Using that protocol ended up generating an input error when processing a description such as
```
MULTNUM
 ...
/
-- ...
MULTREGT
  1 2 0.1  1*  'ALL' / -- Item 6 unspecified => use MULTNUM
/
```
in an example model, because the [`GRIDOPTS` protocol](https://github.com/OPM/opm-common/blob/a0e72a62c4790ed78910391a393bf9e1bc9347d9/src/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp#L198) ended up defaulting to `FLUXNUM` instead of `MULTNUM`.