### PR TITLE
Implement NOAQUNNC Region Multiplier Behaviour in MULTREGT

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -98,6 +98,8 @@ namespace Opm {
         bool operator==(const MULTREGTScanner& data) const;
         MULTREGTScanner& operator=(const MULTREGTScanner& data);
 
+        void applyNumericalAquifer(const std::vector<std::size_t>& aquifer_cells);
+
         double getRegionMultiplier(std::size_t globalCellIdx1,
                                    std::size_t globalCellIdx2,
                                    FaceDir::DirEnum faceDir) const;
@@ -112,6 +114,7 @@ namespace Opm {
             serializer(m_searchMap);
 
             serializer(regions);
+            serializer(aquifer_cells);
         }
 
     private:
@@ -126,6 +129,7 @@ namespace Opm {
         std::vector<MULTREGTRecord> m_records{};
         std::map<std::string, MULTREGTSearchMap> m_searchMap{};
         std::map<std::string, std::vector<int>> regions{};
+        std::vector<std::size_t> aquifer_cells{};
 
         void addKeyword(const DeckKeyword& deckKeyword);
         void assertKeywordSupported(const DeckKeyword& deckKeyword);

--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -104,6 +104,8 @@ namespace Opm {
                                    std::size_t globalCellIdx2,
                                    FaceDir::DirEnum faceDir) const;
 
+        double getRegionMultiplierNNC(std::size_t globalCellIdx1,
+                                      std::size_t globalCellIdx2) const;
 
         template <class Serializer>
         void serializeOp(Serializer& serializer)

--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -133,6 +133,9 @@ namespace Opm {
 
         void addKeyword(const DeckKeyword& deckKeyword);
         void assertKeywordSupported(const DeckKeyword& deckKeyword);
+
+        bool isAquNNC(std::size_t globalCellIdx1, std::size_t globalCellIdx2) const;
+        bool isAquCell(std::size_t globalCellIdx) const;
     };
 
 } // namespace Opm

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
@@ -56,6 +56,7 @@ namespace Opm {
         double getMultiplier(size_t globalIndex, FaceDir::DirEnum faceDir) const;
         double getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const;
         double getRegionMultiplier( size_t globalCellIndex1, size_t globalCellIndex2, FaceDir::DirEnum faceDir) const;
+        double getRegionMultiplierNNC(std::size_t globalCellIndex1, std::size_t globalCellIndex2) const;
         void applyMULT(const std::vector<double>& srcMultProp, FaceDir::DirEnum faceDir);
         void applyMULTFLT(const FaultCollection& faults);
         void applyMULTFLT(const Fault& fault);

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
@@ -59,6 +59,7 @@ namespace Opm {
         void applyMULT(const std::vector<double>& srcMultProp, FaceDir::DirEnum faceDir);
         void applyMULTFLT(const FaultCollection& faults);
         void applyMULTFLT(const Fault& fault);
+        void applyNumericalAquifer(const std::vector<std::size_t>& aquifer_cells);
 
         bool operator==(const TransMult& data) const;
 

--- a/src/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/src/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -352,6 +352,8 @@ namespace Opm {
         // Add NNCs between aquifer cells and first aquifer cell and aquifer
         // connections.
         this->appendInputNNC(numerical_aquifer.aquiferCellNNCs());
+
+        this->m_transMult.applyNumericalAquifer(numerical_aquifer.allAquiferCellIds());
     }
 
     void EclipseState::applyMULTXYZ() {

--- a/src/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -205,6 +205,7 @@ namespace Opm {
                                               std::forward_as_tuple(std::make_pair(1, 2)),
                                               std::forward_as_tuple(0));
         result.regions = {{"test3", {11}}};
+        result.aquifer_cells = { std::size_t{17}, std::size_t{29} };
 
         return result;
     }
@@ -215,6 +216,7 @@ namespace Opm {
             && (this->m_records == data.m_records)
             && (this->m_searchMap == data.m_searchMap)
             && (this->regions == data.regions)
+            && (this->aquifer_cells == data.aquifer_cells)
             ;
     }
 
@@ -226,8 +228,21 @@ namespace Opm {
         this->m_records = data.m_records;
         this->m_searchMap = data.m_searchMap;
         this->regions = data.regions;
+        this->aquifer_cells = data.aquifer_cells;
 
         return *this;
+    }
+
+    void MULTREGTScanner::applyNumericalAquifer(const std::vector<std::size_t>& aquifer_cells_arg)
+    {
+        this->aquifer_cells.insert(this->aquifer_cells.end(),
+                                   aquifer_cells_arg.begin(),
+                                   aquifer_cells_arg.end());
+
+        std::sort(this->aquifer_cells.begin(), this->aquifer_cells.end());
+        this->aquifer_cells.erase(std::unique(this->aquifer_cells.begin(),
+                                              this->aquifer_cells.end()),
+                                  this->aquifer_cells.end());
     }
 
     // This function will check the region values in globalIndex1 and

--- a/src/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
@@ -156,6 +156,10 @@ namespace Opm {
         }
     }
 
+    void TransMult::applyNumericalAquifer(const std::vector<std::size_t>& aquifer_cells) {
+        m_multregtScanner.applyNumericalAquifer(aquifer_cells);
+    }
+
     bool TransMult::operator==(const TransMult& data) const {
         return this->m_nx == data.m_nx &&
                this->m_ny == data.m_ny &&

--- a/src/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
@@ -114,6 +114,10 @@ namespace Opm {
         return m_multregtScanner.getRegionMultiplier(globalCellIndex1, globalCellIndex2, faceDir);
     }
 
+    double TransMult::getRegionMultiplierNNC(std::size_t globalCellIndex1, std::size_t globalCellIndex2) const {
+        return m_multregtScanner.getRegionMultiplierNNC(globalCellIndex1, globalCellIndex2);
+    }
+
     bool TransMult::hasDirectionProperty(FaceDir::DirEnum faceDir) const {
         return m_trans.count(faceDir) == 1;
     }


### PR DESCRIPTION
This PR implements the `NOAQUNNC` behaviour in member function
```C++
MULTREGTScanner::getRegionMultiplier()
```
We use a new data member `MULTREGTScanner::aquifer_cells` to identify connections to and within numerical aquifers and ignore those if the record stipulates `NOAQUNNC` behaviour.  This data member holds a sorted sequence of Cartesian/global cell indices corresponding to the cells which comprise the model's numerical aquifers.  These are needed to properly identify whether or not a connection&ndash;i.e., a cell pair&ndash;would constitute a "numerical aquifer connection" and be subject to `NOAQUNNC` treatment.

We assign the numerical aquifer cells as part of member function
```C++
EclipseState::conveyNumericalAquiferEffects()
```
which runs at `EclipseState` construction time.  We know all numerical aquifers at that point.

While here, also add a means of calculating multiplier values for non-neighbouring connections without an associate face direction. This is intended as a possibly temporary measure for processing explicitly assigned NNCs (keywords `NNC`/`EDITNNC`/`EDITNNCR`) along with those NNCs arising from numerical aquifers, and for which there is no associate face direction.

Finally, add a set of unit tests to probe the implementation of all `MULTREGT` connection behaviours as exhibited by `MULTREGTScanner` member functions `getRegionMultiplier()` and `getRegionMultiplierNNC()`.