### PR TITLE
Ensuring MSW ref depth is top node depth

### DIFF
--- a/src/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1426,6 +1426,10 @@ bool Well::handleWELSEGS(const DeckKeyword& keyword) {
         this->updateSegments(std::move(new_segments));
     } else
         this->updateSegments( std::make_shared<WellSegments>(keyword) );
+
+    // Ensure reference depth is depth of top segment node (as it should be)
+    this->ref_depth = this->segments->depthTopSegment();    
+
     return true;
 }
 


### PR DESCRIPTION
replacing the PR https://github.com/OPM/opm-common/pull/3641 by @vkip, which I messed up. 

Just re-creating it, which is hopefully minimal effort involved. 