### PR TITLE
[testing] default to 1.01325 for BHP in WCONPROD only works in METRIC unit

### DIFF
--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/W/WCONPROD
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/W/WCONPROD
@@ -59,7 +59,6 @@
       "item": 9,
       "name": "BHP",
       "value_type": "UDA",
-      "default": 1.01325,
       "dimension": "Pressure"
     },
     {


### PR DESCRIPTION
it does not work for other units.