### PR TITLE
Allow invalid WCONINJH control mode

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -168,7 +168,7 @@ public:
 
         void handleWELTARG(WELTARGCMode cmode, const UDAValue& new_arg, double SIFactorP);
         void handleWCONINJE(const DeckRecord& record, bool availableForGroupControl, const std::string& well_name);
-        void handleWCONINJH(const DeckRecord& record, bool is_producer, const std::string& well_name);
+        void handleWCONINJH(const DeckRecord& record, const bool is_producer, const std::string& well_name, const KeywordLocation& loc);
         bool hasInjectionControl(InjectorCMode controlModeArg) const {
             if (injectionControls & static_cast<int>(controlModeArg))
                 return true;

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1371,7 +1371,7 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                 auto well2 = this->snapshots.back().wells.get( well_name );
                 auto injection = std::make_shared<Well::WellInjectionProperties>(well2.getInjectionProperties());
                 auto previousInjectorType = injection->injectorType;
-                injection->handleWCONINJH(record, well2.isProducer(), well_name);
+                injection->handleWCONINJH(record, well2.isProducer(), well_name, handlerContext.keyword.location());
                 const bool switching_from_producer = well2.isProducer();
 
                 if (well2.updateInjection(injection))


### PR DESCRIPTION
Make it a warning instead of an error to specify an invalid control mode in WCONINJH. Motivated by the need to accept deck output that contain this error, that is generated by preprocessing tools.

The generated files may specify RESV, and the engineers expect this to be ignored, and the default (RATE) control being used instead.