### PR TITLE
Remove Unnecessary Semicolons on Closing Braces

### DIFF
--- a/opm/material/viscositymodels/LBC.hpp
+++ b/opm/material/viscositymodels/LBC.hpp
@@ -122,6 +122,6 @@ public:
 
 };
 
-}; // namespace Opm
+} // namespace Opm
 
 #endif // LBC_HPP

--- a/src/opm/input/eclipse/Generator/KeywordGenerator.cpp
+++ b/src/opm/input/eclipse/Generator/KeywordGenerator.cpp
@@ -123,7 +123,7 @@ struct Builtin {
             for (const auto& kw: keywords)
             {
                 newHeader << fmt::format("    const ::Opm::ParserKeyword get_{0}();\n",kw.className());
-                source << fmt::format("const ::Opm::ParserKeyword Builtin::get_{0}() {{ return {0}(); }};\n",kw.className());
+                source << fmt::format("const ::Opm::ParserKeyword Builtin::get_{0}() {{ return {0}(); }}\n",kw.className());
             }
         }
 

--- a/src/opm/io/eclipse/EInit.cpp
+++ b/src/opm/io/eclipse/EInit.cpp
@@ -92,7 +92,7 @@ int EInit::get_array_index(const std::string& name, const std::string& grid_name
 
         return lgr_array_index[lgr_index].at(name);
     }
-};
+}
 
 int EInit::activeCells(const std::string& grid_name) const
 {


### PR DESCRIPTION
These generate diagnostic messages from GCC at `-pedantic` levels.