### PR TITLE
Support Regular Expression Suffix for Keyword Matching

### DIFF
--- a/opm/input/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/input/eclipse/Parser/ParserKeyword.hpp
@@ -94,7 +94,9 @@ namespace Opm {
         static bool validInternalName(const std::string& name);
         static bool validDeckName(const std::string_view& name);
         bool hasMatchRegex() const;
+        bool hasMatchRegexSuffix() const;
         void setMatchRegex(const std::string& deckNameRegexp);
+        void setMatchRegexSuffix(const std::string& deckNameRegexp);
         bool matches(const std::string_view& ) const;
         bool hasDimension() const;
         void addRecord( ParserRecord );
@@ -154,6 +156,7 @@ namespace Opm {
         std::unordered_set<std::string> m_validSectionNames;
         std::string m_matchRegexString;
         std::regex m_matchRegex;
+        std::string m_matchRegexSuffix{};
         std::vector< ParserRecord > m_records;
         std::string m_Description;
         bool raw_string_keyword = false;
@@ -175,6 +178,7 @@ namespace Opm {
         void initSizeKeyword(bool table_collection, const Json::JsonObject& sizeObject);
         void addItems( const Json::JsonObject& jsonConfig);
         void parseRecords( const Json::JsonObject& recordsConfig);
+        bool matchesDeckNames(std::string_view name) const;
     };
 
 std::ostream& operator<<( std::ostream&, const ParserKeyword& );


### PR DESCRIPTION
This is mostly to have a general solution for matching region level summary keywords which may reference a user-defined region set (`FIP` keyword, e.g., `FIPXYZ`) through tags like

 * `RPR__XYZ` &ndash; Average pressure in region, FIPXYZ region set
 * `ROPR_XYZ` &ndash; Oil production rate in region, FIPXYZ region set
 * `RODENXYZ` &ndash; Average oil density in region, FIPXYZ region set

The initial approach introduced in commit cfbafc236 was limited to selected keywords.

To this end, add a new data member
```C++
std::string ParserKeyword::m_matchRegexSuffix
```
and introduce a new member function
```C++
bool ParserKeyword::matchesDeckNames()
```
which matches a candidate keyword string against the `m_deckNames`, and, if applicable, as a regular expression against `m_deckNames` when appended `m_matchRegexSuffix`.