### PR TITLE
Normalise Region Level Summary Keywords for Lookup Purposes

### DIFF
--- a/opm/io/eclipse/SummaryNode.hpp
+++ b/opm/io/eclipse/SummaryNode.hpp
@@ -81,6 +81,8 @@ struct SummaryNode {
     static std::string normalise_keyword(const Category     category,
                                          const std::string& keyword);
 
+    static std::string normalise_region_keyword(const std::string& keyword);
+
     static inline std::string normalise_keyword(const std::string& keyword)
     {
         return normalise_keyword(category_from_keyword(keyword), keyword);

--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1067,7 +1067,7 @@ inline void keywordR(SummaryConfig::keyword_list& list,
     auto param = SummaryConfigNode {
         keyword, SummaryConfigNode::Category::Region, deck_keyword.location()
     }
-    .parameterType(parseKeywordType(keyword))
+    .parameterType(parseKeywordType(EclIO::SummaryNode::normalise_region_keyword(keyword)))
     .fip_region( region_name.value() )
     .isUserDefined( is_udq(keyword) );
 

--- a/src/opm/io/eclipse/SummaryNode.cpp
+++ b/src/opm/io/eclipse/SummaryNode.cpp
@@ -243,6 +243,21 @@ Opm::EclIO::SummaryNode::normalise_keyword(const Opm::EclIO::SummaryNode::Catego
         : keyword;
 }
 
+std::string
+Opm::EclIO::SummaryNode::normalise_region_keyword(const std::string& keyword)
+{
+    static const auto region_kw = std::regex {
+        R"((R[A-Z]{2,4})(_{0,2}[A-Z]{3})?)"
+    };
+
+    auto keywordPieces = std::smatch {};
+    if (std::regex_match(keyword, keywordPieces, region_kw)) {
+        return keywordPieces[1].str();
+    }
+
+    return keyword;
+}
+
 std::optional<std::string> Opm::EclIO::SummaryNode::display_name() const {
     if (use_name(category)) {
         return wgname;

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -3677,8 +3677,9 @@ namespace Evaluator {
 
     bool Factory::isFunctionRelation()
     {
-        const auto normKw = Opm::EclIO::SummaryNode::
-            normalise_keyword(this->node_->category, this->node_->keyword);
+        const auto normKw = (this->node_->category == Opm::EclIO::SummaryNode::Category::Region)
+            ? Opm::EclIO::SummaryNode::normalise_region_keyword(this->node_->keyword)
+            : Opm::EclIO::SummaryNode::normalise_keyword(this->node_->category, this->node_->keyword);
 
         auto pos = funs.find(normKw);
         if (pos != funs.end()) {


### PR DESCRIPTION
Region level summary keywords may have suffixes which refer to user defined region sets (`FIP*` keyword).  This commit prunes those suffixes when performing function lookup, so that we do not get false negatives.

To this end, introduce a new helper function
```C++
EclIO::SummaryNode::normalise_region_keyword()
```
and use this both when determining the summary keyword type (rate, cumulative, pressure &c) and when looking up evaluation functions for region level summary vectors.  The new helper could arguably have been integrated into the existing `normalise_keyword()` helper function, but that would have necessitated a different change elsewhere in the code base.  For now, we keep this helper as a separate function.