### PR TITLE
Support Region Set Tags For All Region Level Summary Vectors

### DIFF
--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION_PROBE
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION_PROBE
@@ -5,9 +5,9 @@
   ],
   "comment": "Tracer keywords where the 2nd letter is a 'T' should be compounded with the tracer name",
   "deck_names": [
-    "RRPV_[0-9A-Z][0-9A-Z][0-9A-Z]",
-    "ROEW_[0-9A-Z][0-9A-Z][0-9A-Z]",
-    "RHPV_[0-9A-Z][0-9A-Z][0-9A-Z]",
+    "RRPV",
+    "ROEW",
+    "RHPV",
     "ROSAT",
     "ROIP",
     "ROIPL",
@@ -109,9 +109,9 @@
     "RTFTTSUR",
     "RTADSUR"
   ],
-    "CommentFip": "This regexp should work for region output of arbitrary named FIPxxxx regions. Current implementation is not entirely correct",
     "CommentTracer": "???",
-    "deck_name_regex": "R[OGW]?[OIP][EPRT]_.+|RU.+|RTIPF.+|RTIPS.+|RTFTF.+|RTFTS.+|RTFTT.+|RTIPT.+|RTIPF.+|RTIPS.+|RTIP[1-9][0-9]*.+|RTFTT.+|RTFTF.+|RTFTS.+|RTFT[1-9][0-9]*.+|RTADS.+|RTDCY.+",
+    "deck_name_regex": "RU.+|RTIPF.+|RTIPS.+|RTFTF.+|RTFTS.+|RTFTT.+|RTIPT.+|RTIPF.+|RTIPS.+|RTIP[1-9][0-9]*.+|RTFTT.+|RTFTF.+|RTFTS.+|RTFT[1-9][0-9]*.+|RTADS.+|RTDCY.+",
+    "deck_name_regex_suffix": "_{0,2}[A-Z0-9]{3}",
     "data": {
         "value_type": "INT"
     }


### PR DESCRIPTION
This PR switches the existing, somewhat spotty, support for matching region set tags on region level summary vector keywords. We leverage the recent support for `deck_name_regex_suffix` keys in the JSON keyword model&ndash;see PR #3673&ndash;to extend the keyword matching algorithm to also account for these region set tags.

There is a potential for false positives here, but we'll use this as an initial proof-of-concept implementation.