### PR TITLE
Match Region Sets by Unique Prefix

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -597,6 +597,8 @@ private:
     void init_satfunc(const std::string& keyword, Fieldprops::FieldData<double>& satfunc);
     void init_porv(Fieldprops::FieldData<double>& porv);
     void init_tempi(Fieldprops::FieldData<double>& tempi);
+    std::string canonical_fipreg_name(const std::string& fipreg);
+    const std::string& canonical_fipreg_name(const std::string& fipreg) const;
 
     const UnitSystem unit_system;
     std::size_t nx,ny,nz;
@@ -612,6 +614,7 @@ private:
     std::vector<MultregpRecord> multregp;
     std::unordered_map<std::string, Fieldprops::FieldData<int>> int_data;
     std::unordered_map<std::string, Fieldprops::FieldData<double>> double_data;
+    std::unordered_map<std::string, std::string> fipreg_shortname_translation{};
 
     std::unordered_map<std::string,Fieldprops::TranCalculator> tran;
 };

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1849,6 +1849,47 @@ BOOST_AUTO_TEST_CASE(SatFunc_EndPts_Family_II_TolCrit_Large) {
 
 // =====================================================================
 
+BOOST_AUTO_TEST_CASE(Equivalent_FIP_Keys) {
+    std::string deck_string = R"(
+GRID
+
+PORO
+   200*0.15 /
+
+REGIONS
+
+FIPUNIT
+  100*1 100*2 /
+
+FIPUNIX
+  100*3 100*4 /
+)";
+
+    const EclipseGrid grid { 10, 10, 2 };
+    const Deck deck = Parser{}.parseString(deck_string);
+
+    BOOST_CHECK_MESSAGE(deck.hasKeyword("FIPUNIT"),
+                        R"(Input deck must have "FIPUNIT" region set)");
+
+    BOOST_CHECK_MESSAGE(deck.hasKeyword("FIPUNIX"),
+                        R"(Input deck must have "FIPUNIX" region set)");
+
+    const FieldPropsManager fpm {
+        deck, Phases{true, true, true}, grid, TableManager()
+    };
+
+    const auto& fipuni = fpm.get_int("FIPUNI");
+    auto expect = std::vector<int>(100, 3);
+    {
+        const auto l2 = std::vector<int>(100, 4);
+        expect.insert(expect.end(), l2.begin(), l2.end());
+    };
+
+    // FIPUNI <=> FIPUNIX
+    BOOST_CHECK_EQUAL_COLLECTIONS(fipuni.begin(), fipuni.end(),
+                                  expect.begin(), expect.end());
+}
+
 BOOST_AUTO_TEST_CASE(GET_FIPXYZ) {
     std::string deck_string = R"(
 GRID


### PR DESCRIPTION
This PR switches the region set tag matching algorithm to using unique prefixes.  This enables the parser to recognise that the summary vector
```
ROPR_UNI
```
should match up with the user defined region set `FIPUNIT`.  In the current master sources, the above summary vector would produce a diagnostic message saying that the region set `FIPUNI` (without the final `T`) does not exist.

We add a prefix-to-canonical region set name translation table to the `FieldProps` class and funnel all FIP-like requests through this translation table.  In the case of non-unique prefixes-e.g., `FIPUNIT` and `FIPUNIX`, we currently elect to have the last keyword entered in the simulation model "win".  This behaviour may be altered in the future if deemed appropriate/necessary.

Note: This is an alternative implementation which supersedes and closes #3621.