### PR TITLE
Implementation of CSKIN

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -688,6 +688,7 @@ namespace Opm
         void handleCOMPORD   (HandlerContext&);
         void handleCOMPSEGS  (HandlerContext&);
         void handleCOMPTRAJ  (HandlerContext&);
+        void handleCSKIN     (HandlerContext&);
         void handleDRSDT     (HandlerContext&);
         void handleDRSDTCON  (HandlerContext&);
         void handleDRSDTR    (HandlerContext&);

--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -116,6 +116,7 @@ namespace RestartIO {
         int complnum() const;
         int segment() const;
         double CF() const;
+        double wpimult() const;
         double Kh() const;
         double rw() const;
         double r0() const;
@@ -134,6 +135,8 @@ namespace RestartIO {
 
         void setState(State state);
         void setComplnum(int compnum);
+        void setSkinFactor(double skin_factor);
+        void setCF(double CF);
         void scaleWellPi(double wellPi);
         bool prepareWellPIScaling();
         bool applyWellPIScaling(const double scaleFactor);
@@ -263,6 +266,9 @@ namespace RestartIO {
 
         // Whether or not this Connection is subject to WELPI scaling.
         bool m_subject_to_welpi = false;
+
+        // For applying last known WPIMULT to when calculating connection transmissibilty factor in CSKIN
+        double m_wpimult = 1.0;
 
         std::optional<FilterCake> m_filter_cake;
 

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -479,6 +479,7 @@ public:
     bool handleWELSEGS(const DeckKeyword& keyword);
     bool handleCOMPSEGS(const DeckKeyword& keyword, const ScheduleGrid& grid, const ParseContext& parseContext, ErrorGuard& errors);
     bool handleWELOPENConnections(const DeckRecord& record, Connection::State status);
+    bool handleCSKINConnections(const DeckRecord& record);
     bool handleCOMPLUMP(const DeckRecord& record);
     bool handleWPIMULT(const DeckRecord& record);
     bool handleWINJCLN(const DeckRecord& record, const KeywordLocation& location);

--- a/src/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -210,8 +210,20 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
         this->m_complnum = complnum;
     }
 
+    void Connection::setSkinFactor(double skin_factor) {
+        this->m_skin_factor = skin_factor;
+    }
+
+    void Connection::setCF(double CF) {
+        this->m_CF = CF;
+    }
+
     double Connection::CF() const {
         return this->m_CF;
+    }
+
+    double Connection::wpimult() const {
+        return this->m_wpimult;
     }
 
     double Connection::Kh() const {
@@ -263,6 +275,7 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
     }
 
     void Connection::scaleWellPi(double wellPi) {
+        this->m_wpimult = wellPi;
         this->m_CF *= wellPi;
     }
 
@@ -273,6 +286,7 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
 
         return update;
     }
+    
 
     bool Connection::applyWellPIScaling(const double scaleFactor) {
         if (! this->m_subject_to_welpi)

--- a/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -443,8 +443,12 @@ namespace Opm {
                     if (KhItem.defaultApplied(0) || KhItem.getSIDouble(0) < 0) {
                         Kh = CF * (std::log(r0 / std::min(r0, rw)) + skin_factor) / angle;
                     } else {
-                        if (Kh < 0)
+                        if (Kh < 0) {
                             Kh = std::sqrt(K[0] * K[1]) * D[2];
+
+                            // Compute r0 to be consistent with other parameters
+                            r0 = RestartIO::RstConnection::inverse_peaceman(CF, Kh, rw, skin_factor);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR implements the CSKIN keyword to modify the skin factor. This in turn triggers a recalculation of the well connection transmissibility factor. A couple of notes:

* To make CSKIN work correctly with WPIMULT, we store the scale factor from WPIMULT and apply it to the connection factor in a very straightforward matter.
* In COMPDAT I added a recalculation of effective pressure radius when Kh is set to 0.0. If not, the recalculation of the connection factor with CSKIN would be wrong

Related PR in opm-simulators and opm-tests are given in ... and ... 