### PR TITLE
Emit Region Level Average Pressure Weighted by HC Volume

### DIFF
--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2460,6 +2460,7 @@ static const auto single_values_units = UnitTable {
 static const auto region_units = UnitTable {
     {"RPR"   , Opm::UnitSystem::measure::pressure},
     {"RPRP"  , Opm::UnitSystem::measure::pressure},
+    {"RPRH"  , Opm::UnitSystem::measure::pressure},
     {"RRPV"  , Opm::UnitSystem::measure::volume },
     {"ROIP"  , Opm::UnitSystem::measure::liquid_surface_volume },
     {"ROIPL" , Opm::UnitSystem::measure::liquid_surface_volume },

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -282,6 +282,8 @@ BOVIS
 --  Region data
 RPR
 /
+RPRH
+/
 ROPT
 /
 RGPT

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -1755,6 +1755,13 @@ BOOST_AUTO_TEST_CASE(region_vars) {
         region_values["RPR"] = values;
     }
     {
+        std::vector<double> values(10, 0.0);
+        for (size_t r=1; r <= 10; r++) {
+            values[r - 1] = r * r * 2.5;
+        }
+        region_values["RPRH"] = values;
+    }
+    {
         double area = cfg.grid.getNX() * cfg.grid.getNY();
         std::vector<double> values(10, 0.0);
         for (size_t r=1; r <= 10; r++) {
@@ -1847,13 +1854,27 @@ BOOST_AUTO_TEST_CASE(region_vars) {
     auto res = readsum( cfg.name );
     const auto* resp = res.get();
 
-    BOOST_CHECK( ecl_sum_has_general_var( resp , "RPR:1"));
-    BOOST_CHECK( ecl_sum_has_general_var( resp , "RPR:10"));
-    BOOST_CHECK( !ecl_sum_has_general_var( resp , "RPR:21"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPR:1"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPR:10"));
+    BOOST_CHECK(!ecl_sum_has_general_var(resp, "RPR:21"));
+
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:1"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:2"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:3"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:4"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:5"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:6"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:7"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:8"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:9"));
+    BOOST_CHECK( ecl_sum_has_general_var(resp, "RPRH:10"));
+    BOOST_CHECK(!ecl_sum_has_general_var(resp, "RPRH:21"));
+
     UnitSystem units( UnitSystem::UnitType::UNIT_TYPE_METRIC );
 
     for (size_t r=1; r <= 10; r++) {
         std::string rpr_key   = "RPR:"   + std::to_string( r );
+        std::string rprh_key  = "RPRH:"  + std::to_string( r );
         std::string roip_key  = "ROIP:"  + std::to_string( r );
         std::string rwip_key  = "RWIP:"  + std::to_string( r );
         std::string rgip_key  = "RGIP:"  + std::to_string( r );
@@ -1863,7 +1884,8 @@ BOOST_AUTO_TEST_CASE(region_vars) {
         std::string rgipg_key = "RGIPG:" + std::to_string( r );
         double area = cfg.grid.getNX() * cfg.grid.getNY();
 
-        //BOOST_CHECK_CLOSE(   r * 1.0        , units.to_si( UnitSystem::measure::pressure , ecl_sum_get_general_var( resp, 1, rpr_key.c_str())) , 1e-5);
+        BOOST_CHECK_CLOSE(r *     1.0, units.to_si(UnitSystem::measure::pressure, ecl_sum_get_general_var(resp, 1, rpr_key)) , 1.0e-5);
+        BOOST_CHECK_CLOSE(r * r * 2.5, units.to_si(UnitSystem::measure::pressure, ecl_sum_get_general_var(resp, 1, rprh_key)), 1.0e-5);
 
         // There is one inactive cell in the bottom layer.
         if (r == 10)


### PR DESCRIPTION
The simulator already calculates the requisite values, but due to the requisite summary keyword `RPRH` not being listed among the known region level vectors the output layer did not write the values to the summary file.  This PR adds the requisite table entry.