### PR TITLE
Fix Multiple Issues in MSW Output Array Creation Logic

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/Valve.hpp
+++ b/opm/input/eclipse/Schedule/MSW/Valve.hpp
@@ -69,6 +69,7 @@ namespace Opm {
 
         // Status: OPEN or SHUT
         ICDStatus status() const;
+        int ecl_status() const;
 
         void setConMaxCrossArea(const double area);
 

--- a/opm/output/eclipse/AggregateMSWData.hpp
+++ b/opm/output/eclipse/AggregateMSWData.hpp
@@ -36,39 +36,18 @@ namespace Opm {
 
 namespace Opm { namespace RestartIO { namespace Helpers {
 
-    struct BranchSegmentPar {
-      int outletS;
-      int noSegInBranch;
-      int firstSeg;
-      int lastSeg;
-      int branch;
-    };
-
-    struct SegmentSetSourceSinkTerms {
-      std::vector<double> qosc;
-      std::vector<double> qwsc;
-      std::vector<double> qgsc;
-    };
-
-    struct SegmentSetFlowRates {
-      std::vector<double> sofr;
-      std::vector<double> swfr;
-      std::vector<double> sgfr;
-    };
-
     class AggregateMSWData
     {
     public:
         explicit AggregateMSWData(const std::vector<int>& inteHead);
 
-        void captureDeclaredMSWData(const Opm::Schedule& sched,
-                                     const std::size_t    rptStep,
-				     const Opm::UnitSystem& units,
-				     const std::vector<int>& inteHead,
-				     const Opm::EclipseGrid&  grid,
-				     const Opm::SummaryState& smry,
-				     const Opm::data::Wells&  wr
-				   );
+        void captureDeclaredMSWData(const Opm::Schedule&     sched,
+                                    const std::size_t        rptStep,
+                                    const Opm::UnitSystem&   units,
+                                    const std::vector<int>&  inteHead,
+                                    const Opm::EclipseGrid&  grid,
+                                    const Opm::SummaryState& smry,
+                                    const Opm::data::Wells&  wr);
 
         /// Retrieve Integer Multisegment well data Array.
         const std::vector<int>& getISeg() const
@@ -93,7 +72,6 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         {
             return this->iLBR_.data();
         }
-
 
     private:
         /// Aggregate 'ISEG' array (Integer) for all multisegment wells

--- a/opm/output/eclipse/AggregateMSWData.hpp
+++ b/opm/output/eclipse/AggregateMSWData.hpp
@@ -84,8 +84,7 @@ namespace Opm { namespace RestartIO { namespace Helpers {
         WindowedArray<int> iLBS_;
 
         /// Aggregate 'ILBR' array (Integer) for all multisegment wells
-        WindowedArray<int> iLBR_;
-
+        WindowedMatrix<int> iLBR_;
     };
 
 }}} // Opm::RestartIO::Helpers

--- a/opm/output/eclipse/VectorItems/msw.hpp
+++ b/opm/output/eclipse/VectorItems/msw.hpp
@@ -40,6 +40,16 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
     } // ISeg
 
+    namespace ILbr {
+        enum index : std::vector<int>::size_type {
+            OutletSegment          = 0, // Branch's outlet segment (one-based)
+            NumBranchSegments      = 1, // Number of segments on branch
+            FirstSegment           = 2, // First segment on branch (kick-off, heel)
+            LastSegment            = 3, // Last segment on branch (toe)
+            KickOffDiscoveryOffset = 4, // Segment traversal order at which this branch was encountered
+        };
+    } // ILbr
+
     namespace RSeg {
         enum index : std::vector<double>::size_type {
             DistOutlet      = 0, // Segment's distance to outlet

--- a/src/opm/input/eclipse/Schedule/MSW/Valve.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/Valve.cpp
@@ -18,9 +18,11 @@
 */
 
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
+
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
+#include "icd_convert.hpp"
 
 namespace Opm {
 
@@ -128,6 +130,11 @@ namespace Opm {
 
     ICDStatus Valve::status() const {
         return m_status;
+    }
+
+    int Valve::ecl_status() const
+    {
+        return to_int(this->status());
     }
 
     double Valve::conFlowCoefficient() const {

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -495,7 +495,6 @@ namespace {
                 VectorItems::ISeg::index;
 
             const auto& sicd = segment.spiralICD();
-            iSeg[baseIndex + Ix::SegmentType] = segment.ecl_type_id();
             iSeg[baseIndex + Ix::ICDScalingMode] = sicd.methodFlowScaling();
             iSeg[baseIndex + Ix::ICDOpenShutFlag] = sicd.ecl_status();
         }
@@ -509,9 +508,19 @@ namespace {
                 VectorItems::ISeg::index;
 
             const auto& aicd = segment.autoICD();
-            iSeg[baseIndex + Ix::SegmentType] = segment.ecl_type_id();
             iSeg[baseIndex + Ix::ICDScalingMode] = aicd.methodFlowScaling();
             iSeg[baseIndex + Ix::ICDOpenShutFlag] = aicd.ecl_status();
+        }
+
+        template <class ISegArray>
+        void assignValveCharacteristics(const Opm::Segment& segment,
+                                        const std::size_t   baseIndex,
+                                        ISegArray&          iSeg)
+        {
+            using Ix = ::Opm::RestartIO::Helpers::VectorItems::ISeg::index;
+
+            const auto& valve = segment.valve();
+            iSeg[baseIndex + Ix::ICDOpenShutFlag] = valve.ecl_status();
         }
 
         template <class ISegArray>
@@ -522,8 +531,13 @@ namespace {
             if (segment.isSpiralICD()) {
                 assignSpiralICDCharacteristics(segment, baseIndex, iSeg);
             }
+
             if (segment.isAICD()) {
                 assignAICDCharacteristics(segment, baseIndex, iSeg);
+            }
+
+            if (segment.isValve()) {
+                assignValveCharacteristics(segment, baseIndex, iSeg);
             }
         }
 

--- a/src/opm/output/eclipse/AggregateMSWData.cpp
+++ b/src/opm/output/eclipse/AggregateMSWData.cpp
@@ -565,7 +565,7 @@ namespace {
                     const auto& segment = welSegSet[ind];
                     auto segNumber = segment.segmentNumber();
                     auto iS = (segNumber-1)*noElmSeg;
-                    iSeg[iS + Ix::SegNo]          = welSegSet[orderedSegmentNo[ind]].segmentNumber();
+                    iSeg[ind*noElmSeg + Ix::SegNo] = welSegSet[orderedSegmentNo[ind]].segmentNumber();
                     iSeg[iS + Ix::OutSeg]         = segment.outletSegment();
                     iSeg[iS + Ix::InSegCurBranch] = (inflowSegmentCurBranch(well.name(), welSegSet, ind) == 0) ? 0 : welSegSet[inflowSegmentCurBranch(well.name(), welSegSet, ind)].segmentNumber();
                     iSeg[iS + Ix::BranchNo]       = segment.branchNumber();
@@ -838,6 +838,7 @@ namespace {
                 bool haveWellRes = (well.getStatus() != Opm::Well::Status::SHUT) ? (wRatesIt != wr.end()) : false;
                 const auto volFromLengthUnitConv = units.from_si(M::length, units.from_si(M::length, units.from_si(M::length, 1.)));
                 const auto areaFromLengthUnitConv =  units.from_si(M::length, units.from_si(M::length, 1.));
+
                 //
                 //Initialize temporary variables
                 double temp_o = 0.;
@@ -845,17 +846,15 @@ namespace {
                 double temp_g = 0.;
 
                 // find well connections and calculate segment rates based on well connection production/injection terms
-                auto sSFR = SegmentSetFlowRates{};
-                if (haveWellRes) {
-                    sSFR = getSegmentSetFlowRates(welSegSet, wRatesIt->second.connections, welConns, units);
-                }
+                const auto sSFR = haveWellRes
+                    ? getSegmentSetFlowRates(welSegSet, wRatesIt->second.connections, welConns, units)
+                    : SegmentSetFlowRates{};
 
                 auto get = [&smry, &wname](const std::string& vector, const std::string& segment_nr)
                 {
                     const auto key = vector + ':' + wname + ':' + segment_nr;
                     return smry.get(key, 0.0);
                 };
-
 
                 // Treat the top segment individually
                 {

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -153,6 +153,96 @@ Opm::data::Wells wr()
     return xw;
 }
 
+//------------------------------------------------------------------+
+// Models a multi-lateral well with the following segment structure |
+//------------------------------------------------------------------+
+//                                                                  |
+//                     12   13    14     15     16                  |
+//                   o----o----o-----o------o-----o (2)             |
+//              11  /              20 \   21 \                      |
+//                 /                   o      o (6)                 |
+//                /                     \                           |
+//               /                    22 \  23   24                 |
+//   1   2   3  /  4   5   6              o----o----o (5)           |
+//  ---o---o---o-----o---o---o (1)                                  |
+//                        \                                         |
+//                       7 \  8   9    10                           |
+//                          o---o---o-----o (3)                     |
+//                                         \                        |
+//                                       17 \   18   19             |
+//                                           o----o----o (4)        |
+//------------------------------------------------------------------+
+//  Branch (1):  1,  2,  3,  4,  5,  6                              |
+//  Branch (2): 11, 12, 13, 14, 15, 16                              |
+//  Branch (3):  7,  8,  9, 10                                      |
+//  Branch (4): 17, 18, 19                                          |
+//  Branch (5): 20, 22, 23, 24                                      |
+//  Branch (6): 12                                                  |
+//------------------------------------------------------------------+
+Opm::Deck multilaterals()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+START
+29 'SEP' 2023 /
+DIMENS
+10 10 3 /
+OIL
+GAS
+WATER
+DISGAS
+VAPOIL
+GRID
+DXV
+10*100.0 /
+DYV
+10*100.0 /
+DZV
+3*5.0 /
+PERMX
+300*100.0 /
+COPY
+PERMX PERMY /
+PERMX PERMZ /
+/
+MULTIPLY
+PERMZ 0.1 /
+/
+PORO
+300*0.3 /
+DEPTHZ
+121*2000.0 /
+SCHEDULE
+WELSPECS
+ 'MLP' 'G' 10 10 2002.5 'OIL' /
+/
+COMPDAT
+ 'MLP' 10 10 3 3 'OPEN' 1* 123.4 /
+/
+WELSEGS
+ 'MLP' 2002.5 0.0 1* 'INC' 'H--' /
+--
+  2  6 1  1 0.1 0.1 0.2 0.01 /
+  7 10 3  5 0.1 0.1 0.2 0.01 /
+ 11 16 2  3 0.1 0.1 0.2 0.01 /
+ 17 19 4 10 0.1 0.1 0.2 0.01 /
+ 20 20 5 14 0.1 0.1 0.2 0.01 /
+ 21 21 6 15 0.1 0.1 0.2 0.01 /
+ 22 24 5 20 0.1 0.1 0.2 0.01 /
+/
+COMPSEGS
+ 'MLP' /
+--
+ 10 10 3 5 0.0 1.0 'Z' /
+/
+WCONPROD
+ 'MLP' 'OPEN' 'ORAT' 321.0 4* 10.0 /
+/
+TSTEP
+5*30 /
+END
+)");
+}
+
 } // Anonymous namespace
 
 struct SimulationCase
@@ -404,6 +494,67 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
         //WINJ
         BOOST_CHECK_EQUAL(iLBs[start + 0] ,  14); // WINJ-branch   2, first segment in branch
 
+    }
+}
+
+// The segments must appear in the following depth first search toe-to-heel
+// order in ISEG[0].  We furthermore, go along kick-off branches before
+// searching the main branch.  Note that this order is *different* from
+// ILBS/ILBR.
+//
+//     24, 23, 22, 20,         -- Branch (5)
+//     21,                     -- Branch (6)
+//     16, 15, 14, 13, 12, 11, -- Branch (2)
+//     19, 18, 17,             -- Branch (4)
+//     10,  9,  8,  7,         -- Branch (3)
+//      6,  5,  4,  3,  2,  1, -- Branch (1)
+//
+BOOST_AUTO_TEST_CASE(Multilateral_Segments_ISEG_0)
+{
+    const auto cse = SimulationCase { multilaterals() };
+
+    const auto& es    = cse.es;
+    const auto& grid  = cse.grid;
+    const auto& sched = cse.sched;
+    const auto& units = es.getUnits();
+    const auto  smry  = Opm::SummaryState { Opm::TimeService::now() };
+
+    // Report Step 1: 2023-09-29 --> 2023-10-23
+    const auto rptStep = std::size_t {1};
+
+    const double secs_elapsed = 30 * 86'400.0;
+    const auto ih = Opm::RestartIO::Helpers::
+        createInteHead(es, grid, sched, secs_elapsed,
+                       rptStep, rptStep + 1, rptStep);
+
+    const auto xw = Opm::data::Wells {};
+
+    auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
+    amswd.captureDeclaredMSWData(sched, rptStep, units,
+                                 ih, grid, smry, xw);
+
+    auto isegOffset = [&ih](const int ix)
+    {
+        return ih[VI::intehead::NISEGZ] * ix;
+    };
+
+    const auto expect = std::vector {
+        24, 23, 22, 20,         // Branch (5)
+        21,                     // Branch (6)
+        16, 15, 14, 13, 12, 11, // Branch (2)
+        19, 18, 17,             // Branch (4)
+        10,  9,  8,  7,         // Branch (3)
+         6,  5,  4,  3,  2,  1, // Branch (1)
+    };
+
+    const auto& iseg = amswd.getISeg();
+
+    for (auto i = 0*expect.size(); i < expect.size(); ++i) {
+        BOOST_CHECK_MESSAGE(iseg[isegOffset(i)] == expect[i],
+                            "ISEG[0](" << i << ") == "
+                            << iseg[isegOffset(i)]
+                            << " differs from expected value "
+                            << expect[i]);
     }
 }
 

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -18,41 +18,50 @@
 */
 
 #define BOOST_TEST_MODULE Aggregate_MSW_Data
+
 #include <opm/output/eclipse/AggregateMSWData.hpp>
-#include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/output/eclipse/AggregateWellData.hpp>
-#include <opm/input/eclipse/Python/Python.hpp>
-
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
-#include <opm/output/eclipse/VectorItems/well.hpp>
 #include <opm/output/eclipse/VectorItems/msw.hpp>
+#include <opm/output/eclipse/VectorItems/well.hpp>
+
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <opm/output/data/Wells.hpp>
 
 #include <opm/io/eclipse/rst/segment.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
+
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+
 #include <opm/common/utility/TimeService.hpp>
 
-#include <exception>
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <memory>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
-#include <cstddef>
 
 namespace {
 
 namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 
-Opm::Deck first_sim(std::string fname) {
-    return Opm::Parser {} .parseFile(fname);
+Opm::Deck first_sim(const std::string& fname)
+{
+    return Opm::Parser {}.parseFile(fname);
 }
 
 Opm::SummaryState sim_state()
@@ -92,6 +101,7 @@ Opm::SummaryState sim_state()
     state.update_well_var("WINJ", "WBHP",  234.);
     return state;
 }
+
 Opm::data::Wells wr()
 {
     using o = ::Opm::data::Rates::opt;
@@ -142,28 +152,26 @@ Opm::data::Wells wr()
     }
     return xw;
 }
-}
+
+} // Anonymous namespace
 
 struct SimulationCase
 {
     explicit SimulationCase(const Opm::Deck& deck)
-        : es   ( deck )
-        , grid ( deck )
-        , python( std::make_shared<Opm::Python>() )
-        , sched( deck, es, python )
+        : es   (deck)
+        , grid (deck)
+        , sched(deck, es, std::make_shared<Opm::Python>())
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
-    std::shared_ptr<Opm::Python>  python;
     Opm::Schedule     sched;
 };
 
 // =====================================================================
 
 BOOST_AUTO_TEST_SUITE(Aggregate_MSW)
-
 
 // test dimensions of multisegment data
 BOOST_AUTO_TEST_CASE (Constructor)
@@ -191,46 +199,36 @@ BOOST_AUTO_TEST_CASE (Constructor)
     const auto nrsegz = VI::intehead::NRSEGZ;
     const auto nlbrmx = VI::intehead::NLBRMX;
     const auto nilbrz = VI::intehead::NILBRZ;
+
     BOOST_CHECK_EQUAL(static_cast<int>(amswd.getISeg().size()), ih[nswlmx] * ih[nsegmx] * ih[nisegz]);
     BOOST_CHECK_EQUAL(static_cast<int>(amswd.getRSeg().size()), ih[nswlmx] * ih[nsegmx] * ih[nrsegz]);
     BOOST_CHECK_EQUAL(static_cast<int>(amswd.getILBs().size()), ih[nswlmx] * ih[nlbrmx]);
     BOOST_CHECK_EQUAL(static_cast<int>(amswd.getILBr().size()), ih[nswlmx] * ih[nlbrmx] * ih[nilbrz]);
 }
 
-
 BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
 {
-
     const auto simCase = SimulationCase {first_sim("TEST_AGGREGATE_MSW.DATA")};
 
-    Opm::EclipseState es = simCase.es;
-    Opm::Runspec rspec   = es.runspec();
-    Opm::SummaryState smry = sim_state();
-    Opm::Schedule     sched = simCase.sched;
-    Opm::EclipseGrid  grid = simCase.grid;
-    const auto& units    = es.getUnits();
-
+    const auto& es    = simCase.es;
+    const auto& grid  = simCase.grid;
+    const auto& sched = simCase.sched;
+    const auto& units = es.getUnits();
+    const auto  smry  = sim_state();
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t {1};
 
-    double secs_elapsed = 3.1536E07;
+    const double secs_elapsed = 3.1536E07;
     const auto ih = Opm::RestartIO::Helpers::
-                    createInteHead(es, grid, sched, secs_elapsed,
-                                   rptStep, rptStep+1, rptStep);
-
-    //BOOST_CHECK_EQUAL(ih.nwells, MockIH::Sz{2});
+        createInteHead(es, grid, sched, secs_elapsed,
+                       rptStep, rptStep + 1, rptStep);
 
     const Opm::data::Wells wrc = wr();
+
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(simCase.sched,
-                                 rptStep,
-                                 units,
-                                 ih,
-                                 grid,
-                                 smry,
-                                 wrc
-                                );
+    amswd.captureDeclaredMSWData(sched, rptStep, units,
+                                 ih, grid, smry, wrc);
 
     // ISEG (PROD)
     {
@@ -409,39 +407,31 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
     }
 }
 
-
-BOOST_AUTO_TEST_CASE(MSW_AICD) {
+BOOST_AUTO_TEST_CASE(MSW_AICD)
+{
     const auto simCase = SimulationCase {first_sim("TEST_AGGREGATE_MSW.DATA")};
 
-    Opm::EclipseState es = simCase.es;
-    Opm::Runspec rspec   = es.runspec();
-    Opm::SummaryState smry = sim_state();
-    Opm::Schedule     sched = simCase.sched;
-    Opm::EclipseGrid  grid = simCase.grid;
-    const auto& units    = es.getUnits();
-
+    const auto& es    = simCase.es;
+    const auto& grid  = simCase.grid;
+    const auto& sched = simCase.sched;
+    const auto& units = es.getUnits();
+    const auto  smry  = sim_state();
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t {1};
 
-    double secs_elapsed = 3.1536E07;
+    const double secs_elapsed = 3.1536E07;
     const auto ih = Opm::RestartIO::Helpers::
-                    createInteHead(es, grid, sched, secs_elapsed,
-                                   rptStep, rptStep+1, rptStep);
-
+        createInteHead(es, grid, sched, secs_elapsed,
+                       rptStep, rptStep + 1, rptStep);
 
     const Opm::data::Wells wrc = wr();
-    auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(simCase.sched,
-                                 rptStep,
-                                 units,
-                                 ih,
-                                 grid,
-                                 smry,
-                                 wrc
-                                );
 
-// ISEG (PROD)
+    auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
+    amswd.captureDeclaredMSWData(sched, rptStep, units,
+                                 ih, grid, smry, wrc);
+
+    // ISEG (PROD)
     {
         const auto& iSeg = amswd.getISeg();
         auto start = 7*ih[VI::intehead::NISEGZ];
@@ -507,48 +497,38 @@ BOOST_AUTO_TEST_CASE(MSW_AICD) {
         BOOST_CHECK_CLOSE(rseg[i0 + VI::RSeg::index::flowFractionOilViscosityExponent], 1.01 , 1.0e-10);
         BOOST_CHECK_CLOSE(rseg[i0 + VI::RSeg::index::flowFractionWaterViscosityExponent], 1.02 , 1.0e-10);
         BOOST_CHECK_CLOSE(rseg[i0 + VI::RSeg::index::flowFractionGasViscosityExponent], 1.03  , 1.0e-10);
-
     }
-
 }
 
-
-BOOST_AUTO_TEST_CASE(MSW_RST) {
+BOOST_AUTO_TEST_CASE(MSW_RST)
+{
     const auto simCase = SimulationCase {first_sim("TEST_AGGREGATE_MSW.DATA")};
 
-    Opm::EclipseState es = simCase.es;
-    Opm::Runspec rspec   = es.runspec();
-    Opm::SummaryState smry = sim_state();
-    Opm::Schedule     sched = simCase.sched;
-    Opm::EclipseGrid  grid = simCase.grid;
-    const auto& units    = es.getUnits();
-
+    const auto& es    = simCase.es;
+    const auto& grid  = simCase.grid;
+    const auto& sched = simCase.sched;
+    const auto& units = es.getUnits();
+    const auto  smry  = sim_state();
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t {1};
 
-    double secs_elapsed = 3.1536E07;
+    const double secs_elapsed = 3.1536E07;
     const auto ih = Opm::RestartIO::Helpers::
-                    createInteHead(es, grid, sched, secs_elapsed,
-                                   rptStep, rptStep+1, rptStep);
-
+        createInteHead(es, grid, sched, secs_elapsed,
+                       rptStep, rptStep + 1, rptStep);
 
     const Opm::data::Wells wrc = wr();
+
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
-    amswd.captureDeclaredMSWData(simCase.sched,
-                                 rptStep,
-                                 units,
-                                 ih,
-                                 grid,
-                                 smry,
-                                 wrc
-                                );
+    amswd.captureDeclaredMSWData(sched, rptStep, units,
+                                 ih, grid, smry, wrc);
 
     const auto& iseg = amswd.getISeg();
     const auto& rseg = amswd.getRSeg();
-    auto segment = Opm::RestartIO::RstSegment(simCase.es.getUnits(), 1, iseg.data(), rseg.data());
+
+    auto segment = Opm::RestartIO::RstSegment(simCase.es.getUnits(), 1,
+                                              iseg.data(), rseg.data());
 }
 
-
-
-BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()     // Aggregate_MSW


### PR DESCRIPTION
The existing approach was a little too fragile in the light of unexpected segment/branch numbering schemes and would occasionally populate the output arrays in unexpected/inconsistent ways.  This issue was especially pronounced for the `ILBR` and `ILBS` arrays.

This new version switches to a strict depth-first search order of the segment tree, with the additional restriction that we search to the end (toe) of the current branch before starting to search the next branch.  Branches are enqueued in order of discovery.  To simplify the array references we also switch `AggregateMSWData::iLBR_` to a `WindowedMatrix<int>` and use named item indices instead of pure numeric values.

We also ensure to set the `ISEG` open/shut flag for valves (keyword `WSEGVALVE`).  This was missing in the earlier logic, and fill `ISEG[0]` in a linear way without a direct correspondence to the segment itself.  This change is based on new insight.