### PR TITLE
Add support for WLIST in ACTIONX

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -654,6 +654,8 @@ namespace Opm
 
         bool must_write_rst_file(std::size_t report_step) const;
 
+        bool isWList(std::size_t report_step, const std::string& pattern) const;
+
         void applyEXIT(const DeckKeyword&, std::size_t currentStep);
         SimulatorUpdate applyAction(std::size_t reportStep, const std::string& action_name, const std::vector<std::string>& matching_wells);
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -645,7 +645,9 @@ namespace Opm
 
         void prefetch_cell_properties(const ScheduleGrid& grid, const DeckKeyword& keyword);
         void store_wgnames(const DeckKeyword& keyword);
-        std::vector<std::string> wellNames(const std::string& pattern, const HandlerContext& context);
+        std::vector<std::string> wellNames(const std::string& pattern,
+                                           const HandlerContext& context,
+                                           bool allowEmpty = false);
         std::vector<std::string> wellNames(const std::string& pattern, std::size_t timeStep, const std::vector<std::string>& matching_wells, InputErrorAction error_action, ErrorGuard& errors, const KeywordLocation& location) const;
         void invalidNamePattern( const std::string& namePattern, const HandlerContext& context) const;
         static std::string formatDate(std::time_t t);

--- a/src/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -67,7 +67,7 @@ bool ActionX::valid_keyword(const std::string& keyword) {
         "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",
         "UDQ",
-        "WCONINJE", "WCONPROD", "WECON", "WEFAC", "WELOPEN", "WELPI", "WELTARG", "WGRUPCON", "WPIMULT", "WELSEGS", "WELSPECS", "WSEGVALV", "WTEST", "WTMULT",
+        "WCONINJE", "WCONPROD", "WECON", "WEFAC", "WELOPEN", "WELPI", "WELTARG", "WGRUPCON", "WPIMULT", "WELSEGS", "WELSPECS", "WSEGVALV", "WTEST", "WTMULT", "WLIST",
         "TEST"
     };
     return (actionx_allowed_list.find(keyword) != actionx_allowed_list.end());

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1984,7 +1984,9 @@ Well{0} entered with 'FIELD' parent group:
                 throw std::invalid_argument("The action:" + action + " is not recognized.");
 
             for (const auto& well_arg : well_args) {
-                const auto& names = this->wellNames(well_arg, handlerContext.currentStep);
+                // does not use overload for context to avoid throw
+                const auto& names = this->wellNames(well_arg, handlerContext.currentStep,
+                                                    handlerContext.matching_wells);
                 if (names.empty() && well_arg.find("*") == std::string::npos)
                     throw std::invalid_argument("The well: " + well_arg + " has not been defined in the WELSPECS");
 

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1494,7 +1494,9 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
         for (const auto& record : keyword) {
             const auto& wellNamePattern = record.getItem( "WELL" ).getTrimmedString(0);
             const auto& status_str = record.getItem( "STATUS" ).getTrimmedString( 0 );
-            const auto well_names = this->wellNames(wellNamePattern, handlerContext);
+            const auto well_names = this->wellNames(wellNamePattern, handlerContext,
+                                                    isWList(handlerContext.currentStep,
+                                                            wellNamePattern));
 
             /* if all records are defaulted or just the status is set, only
              * well status is updated

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1757,6 +1757,17 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return this->snapshots[report_step].rst_file(rst_config, previous_output);
     }
 
+    bool Schedule::isWList(std::size_t report_step, const std::string& pattern) const
+    {
+        const ScheduleState * sched_state;
+
+        if (report_step < this->snapshots.size())
+            sched_state = &this->snapshots[report_step];
+        else
+            sched_state = &this->snapshots.back();
+
+        return sched_state->wlist_manager.get().hasList(pattern);
+    }
 
     const std::map< std::string, int >& Schedule::rst_keywords( size_t report_step ) const {
         if (report_step == 0)

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1216,11 +1216,14 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
 
 
 
-    std::vector<std::string> Schedule::wellNames(const std::string& pattern, const HandlerContext& context) {
+    std::vector<std::string> Schedule::wellNames(const std::string& pattern,
+                                                 const HandlerContext& context,
+                                                 bool allowEmpty)
+    {
         std::vector<std::string> valid_names;
         const auto& report_step = context.currentStep;
         auto names = this->wellNames(pattern, report_step, context.matching_wells);
-        if (names.empty()) {
+        if (names.empty() && !allowEmpty) {
             const auto& location = context.keyword.location();
             if (this->action_wgnames.has_well(pattern)) {
                 std::string msg = fmt::format(R"(Well: {} not yet defined for keyword {}.


### PR DESCRIPTION
This adds support for WLIST in ACTION.

It is quite conservative in what is supported, in particular for now only WELOPEN is allowed to be processed for lists
that are empty until actions are processed. This should likely be extended to some more keywords before merge.