### PR TITLE
Make top level section errors more prominent / Allow global keywords before RUNSPEC

### DIFF
--- a/src/opm/input/eclipse/Parser/Parser.cpp
+++ b/src/opm/input/eclipse/Parser/Parser.cpp
@@ -74,11 +74,11 @@
 #include <fmt/format.h>
 
 namespace {
-    /// \brief Whether a keyword is a global keyword and how many to skip
+    /// \brief Whether a keyword is a global keyword.
     ///
     /// Those are allowed before RUNSPEC.
-    /// \return false if this is not a global keyword or the number of keywords to skip
-    ///               otherwise (including itself.
+    /// \return whether keyword is global (ECHO, NOECHO, INCLUDE,
+    ///         COLUMNS, FORMFEED, SKIP, SKIP100, SKIP300, END)
     bool isGlobalKeyword(const Opm::DeckKeyword& keyword ) {
         const auto& name = keyword.name();
         for( const auto& x : { "ECHO", "NOECHO",

--- a/tests/parser/integration/CheckDeckValidity.cpp
+++ b/tests/parser/integration/CheckDeckValidity.cpp
@@ -152,3 +152,35 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
         errorGuard.clear();
     }
 }
+BOOST_AUTO_TEST_CASE(Ignore_Leading_Global_Keywords)
+{
+
+    const auto* input_deck = R"(
+ECHO
+SKIP
+NOECHO
+COLUMNS
+ 10 10 /
+SKIP100
+SKIP300
+ENDSKIP
+FORMFEED
+ 10 /
+RUNSPEC
+DIMENS
+10 10 10 /
+GRID
+PROPS
+SOLUTION
+SCHEDULE
+)";
+
+    Opm::ErrorGuard errorGuard;
+    Opm::Parser parser;
+    Opm::ParseContext parseContext;
+    const auto deck = parser.parseString( input_deck);
+    BOOST_CHECK(Opm::checkDeck(deck, parser, parseContext, errorGuard, Opm::SectionTopology | Opm::KeywordSection));
+    // prevent std::exit(1) in ErrorGuard's destructor!
+    errorGuard.dump();
+    errorGuard.clear();
+}


### PR DESCRIPTION
If there are errors at the top level (e.g. RUNSPEC comes after NOECHO), we might get very many errors and the user might miss the relevant ones on top.

To fix this we will now print those errors last just before exiting the simulator because of these errors.