### PR TITLE
Support Changing Selected Well Properties Through WELSPECS

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -659,6 +659,16 @@ namespace Opm
 
         bool isWList(std::size_t report_step, const std::string& pattern) const;
 
+        void welspecsCreateNewWell(const DeckRecord&  record,
+                                   const std::string& wellName,
+                                   const std::string& groupName,
+                                   HandlerContext&    handlerContext);
+
+        void welspecsUpdateExistingWells(const DeckRecord&               record,
+                                         const std::vector<std::string>& wellNames,
+                                         const std::string&              groupName,
+                                         HandlerContext&                 handlerContext);
+
         void applyEXIT(const DeckKeyword&, std::size_t currentStep);
         SimulatorUpdate applyAction(std::size_t reportStep, const std::string& action_name, const std::vector<std::string>& matching_wells);
 

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -445,11 +445,11 @@ public:
     bool updatePrediction(bool prediction_mode);
     bool updateAutoShutin(bool auto_shutin);
     bool updateCrossFlow(bool allow_cross_flow);
-    bool updatePVTTable(int pvt_table);
-    bool updateHead(int I, int J);
+    bool updatePVTTable(std::optional<int> pvt_table);
+    bool updateHead(std::optional<int> I, std::optional<int> J);
     void updateRefDepth();
-    bool updateRefDepth(const std::optional<double>& ref_dpeth);
-    bool updateDrainageRadius(double drainage_radius);
+    bool updateRefDepth(std::optional<double> ref_dpeth);
+    bool updateDrainageRadius(std::optional<double> drainage_radius);
     void updateSegments(std::shared_ptr<WellSegments> segments_arg);
     bool updateConnections(std::shared_ptr<WellConnections> connections, bool force);
     bool updateConnections(std::shared_ptr<WellConnections> connections, const ScheduleGrid& grid);
@@ -539,6 +539,7 @@ public:
         serializer(has_produced);
         serializer(has_injected);
         serializer(prediction_mode);
+        serializer(derive_refdepth_from_conns_);
         serializer(econ_limits);
         serializer(foam_properties);
         serializer(polymer_properties);
@@ -586,6 +587,7 @@ private:
     bool has_produced = false;
     bool has_injected = false;
     bool prediction_mode = true;
+    bool derive_refdepth_from_conns_ { true };
 
     std::shared_ptr<WellEconProductionLimits> econ_limits;
     std::shared_ptr<WellFoamProperties> foam_properties;

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1687,9 +1687,9 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                 fip_region_number != Kw::FIP_REGION::defaultValue)
             {
                 const auto& location = handlerContext.keyword.location();
-                const auto msg = fmt::format("FIP region {} in WELSPECS keyword "
-                                             "in file {} line {} is unsupported. "
-                                             "Using default value {}.",
+                const auto msg = fmt::format("Non-defaulted FIP region {} in WELSPECS keyword "
+                                             "in file {} line {} is not supported. "
+                                             "Reset to default value {}.",
                                              fip_region_number,
                                              location.filename,
                                              location.lineno,
@@ -1701,9 +1701,9 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                 density_calc_type != Kw::DENSITY_CALC::defaultValue)
             {
                 const auto& location = handlerContext.keyword.location();
-                const auto msg = fmt::format("Density calculation method '{}' in WELSPECS keyword "
-                                             "in file {} line {} is unsupported. "
-                                             "Using default value {}.",
+                const auto msg = fmt::format("Non-defaulted density calculation method '{}' "
+                                             "in WELSPECS keyword in file {} line {} is "
+                                             "not supported. Reset to default value {}.",
                                              density_calc_type,
                                              location.filename,
                                              location.lineno,
@@ -1720,15 +1720,11 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
             // 'wellName' matches any existing well names through pattern
             // matching before treating the wellName as a simple well name.
             //
-            // Note also that we use the wellNames(name, step, matching)
-            // overload instead of wellNames(name, handlerContext) since the
-            // latter throws an exception if the list of candidate wells is
-            // empty.  That's the wrong behaviour here, because an empty
-            // list just means that we're creating a new well in this case.
+            // An empty list of well names is okay since that means we're
+            // creating a new well in this case.
+            const auto allowEmptyWellList = true;
             const auto existingWells =
-                this->wellNames(wellName,
-                                handlerContext.currentStep,
-                                handlerContext.matching_wells);
+                this->wellNames(wellName, handlerContext, allowEmptyWellList);
 
             if (groupName == "FIELD") {
                 if (existingWells.empty()) {

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1772,6 +1772,83 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         return sched_state->wlist_manager.get().hasList(pattern);
     }
 
+    void Schedule::welspecsCreateNewWell(const DeckRecord&  record,
+                                         const std::string& wellName,
+                                         const std::string& groupName,
+                                         HandlerContext&    handlerContext)
+    {
+        auto wellConnectionOrder = Connection::Order::TRACK;
+
+        if (const auto& compord = handlerContext.block.get("COMPORD");
+            compord.has_value())
+        {
+            const auto nrec = compord->size();
+
+            for (auto compordRecordNr = 0*nrec; compordRecordNr < nrec; ++compordRecordNr) {
+                const auto& compordRecord = compord->getRecord(compordRecordNr);
+
+                const std::string& wellNamePattern = compordRecord.getItem(0).getTrimmedString(0);
+
+                if (Well::wellNameInWellNamePattern(wellName, wellNamePattern)) {
+                    const std::string& compordString = compordRecord.getItem(1).getTrimmedString(0);
+                    wellConnectionOrder = Connection::OrderFromString(compordString);
+                }
+            }
+        }
+
+        this->addWell(wellName, record, handlerContext.currentStep, wellConnectionOrder);
+        this->addWellToGroup(groupName, wellName, handlerContext.currentStep);
+
+        handlerContext.affected_well(wellName);
+    }
+
+    void Schedule::welspecsUpdateExistingWells(const DeckRecord&               record,
+                                               const std::vector<std::string>& wellNames,
+                                               const std::string&              groupName,
+                                               HandlerContext&                 handlerContext)
+    {
+        using Kw = ParserKeywords::WELSPECS;
+
+        const auto& headI = record.getItem<Kw::HEAD_I>();
+        const auto& headJ = record.getItem<Kw::HEAD_J>();
+        const auto& pvt   = record.getItem<Kw::P_TABLE>();
+        const auto& drad  = record.getItem<Kw::D_RADIUS>();
+        const auto& ref_d = record.getItem<Kw::REF_DEPTH>();
+
+        const auto I = headI.get<int>(0) - 1;
+        const auto J = headJ.get<int>(0) - 1;
+
+        const auto pvt_table = pvt.get<int>(0);
+        const auto drainageRadius = drad.getSIDouble(0);
+
+        auto ref_depth = std::optional<double>{};
+        if (ref_d.hasValue(0)) {
+            ref_depth.emplace(ref_d.getSIDouble(0));
+        }
+
+        for (const auto& wellName : wellNames) {
+            auto well = this->snapshots.back().wells.get(wellName);
+
+            const auto updateHead = well.updateHead(I, J);
+            const auto updateRefD = well.updateRefDepth(ref_depth);
+            const auto updateDRad = well.updateDrainageRadius(drainageRadius);
+            const auto updatePVT  = well.updatePVTTable(pvt_table);
+
+            if (updateHead || updateRefD || updateDRad || updatePVT) {
+                well.updateRefDepth();
+
+                this->snapshots.back().wellgroup_events()
+                    .addEvent(wellName, ScheduleEvents::WELL_WELSPECS_UPDATE);
+
+                this->snapshots.back().wells.update(std::move(well));
+
+                handlerContext.affected_well(wellName);
+            }
+
+            this->addWellToGroup(groupName, wellName, handlerContext.currentStep);
+        }
+    }
+
     const std::map< std::string, int >& Schedule::rst_keywords( size_t report_step ) const {
         if (report_step == 0)
             return this->m_static.rst_config.keywords;

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1815,14 +1815,14 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         const auto& drad  = record.getItem<Kw::D_RADIUS>();
         const auto& ref_d = record.getItem<Kw::REF_DEPTH>();
 
-        const auto I = headI.get<int>(0) - 1;
-        const auto J = headJ.get<int>(0) - 1;
+        const auto I = headI.defaultApplied(0) ? std::nullopt : std::optional<int> {headI.get<int>(0) - 1};
+        const auto J = headJ.defaultApplied(0) ? std::nullopt : std::optional<int> {headJ.get<int>(0) - 1};
 
-        const auto pvt_table = pvt.get<int>(0);
-        const auto drainageRadius = drad.getSIDouble(0);
+        const auto pvt_table = pvt.defaultApplied(0) ? std::nullopt : std::optional<int> { pvt.get<int>(0) };
+        const auto drainageRadius = drad.defaultApplied(0) ? std::nullopt : std::optional<double> { drad.getSIDouble(0) };
 
         auto ref_depth = std::optional<double>{};
-        if (ref_d.hasValue(0)) {
+        if (! ref_d.defaultApplied(0) && ref_d.hasValue(0)) {
             ref_depth.emplace(ref_d.getSIDouble(0));
         }
 


### PR DESCRIPTION
This PR enables updating individual well properties for one or more wells using the `WELSPECS` keyword.  In particular, this revised logic enables changing the controlling group without affecting any other well property such as the location of the well head or the well reference depth.

Defaulted properties do not affect change in `Well::update*()`.  This, in turn, begets a change to the logic of how we update the reference depths.  Previously, we always interpreted a defaulted reference depth item as

> Compute the reference depth from the location of the well's reservoir connections

We now alter this interpretation slightly to mean

> Don't recompute the reference depth if the input has already assigned a numerical value for this property

If the input has never assigned an explicit numerical value for the reference depth, then we continue using the original interpretation of a defaulted reference depth item&ndash;e.g., to update the reference depth as a result of new reservoir connections.

The simulation can request the original interpretation even after having assigned a numeric reference depth, by entering a new `WELSPECS` keyword specifying a negative value for the the reference depth item.

To this end, introduce a new data member in the Well class,
```C++
bool Well::derive_refdepth_from_conns_
```
which tracks whether or not the reference depth has been assigned an explicit numeric value.

As an example, this new WELSPECS behaviour enables using something like
```
ACTIONX
  A  1 /
  WOPR 'P*' < 123.4 /
  /
  WELSPECS
    '?' 'LOWPRESS' /
  /
ENDACTIO
```
as a way to move all wells matching the pattern `'P*'`, and with a low oil production rate, to the group `'LOWPRESS'`.  This could, in turn, apply a different set of group-level production controls to those wells.

As a means to this end we also create new helper functions
```C++
Schedule::welspecsCreateNewWell()
Schedule::welspecsUpdateExistingWells()
```
which handle the creation of a new well or the property update of one or more existing wells, respectively, in the context of processing records in the `WELSPECS` keyword.  We pass a vector of well names as an argument to the update function.  Furthermore, we construct this vector using normal `wellNames()` processing which enables using patterns and well list names such as

  * `'P-2'`
  * `'PROD-*'`
  * `'?'`
  * `'*PROD'`