### PR TITLE
Support for SGWFN sat functions (format type 2)

### DIFF
--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -343,8 +343,8 @@ public:
 
     enum class KeywordFamily {
         Family_I,               // SGOF, SWOF, SLGOF
-        Family_II,              // SGFN, SOF{2,3}, SWFN
-        Family_III,              // GSF, WSF
+        Family_II,              // SGFN, SOF{2,3}, SWFN, SGWFN
+        Family_III,             // GSF, WSF
 
         Undefined,
     };

--- a/src/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -96,11 +96,13 @@ namespace {
         // note: we allow for SOF2 to be part of family1 for threeP +
         // solvent simulations.
 
-        const auto family2 =      // SGFN, SOF{2,3}, SWFN
-            (gas && deck.hasKeyword<Opm::ParserKeywords::SGFN>()) ||
+        const auto family2 =      // SGFN, SOF{2,3}, SWFN, SGWFN
+            (gas && (deck.hasKeyword<Opm::ParserKeywords::SGFN>() ||
+                     deck.hasKeyword<Opm::ParserKeywords::SGWFN>())) ||
             (oil && ((threeP && deck.hasKeyword<Opm::ParserKeywords::SOF3>()) ||
                      (twoP && deck.hasKeyword<Opm::ParserKeywords::SOF2>()))) ||
-            (wat && deck.hasKeyword<Opm::ParserKeywords::SWFN>());
+            (wat && (deck.hasKeyword<Opm::ParserKeywords::SWFN>() ||
+                     deck.hasKeyword<Opm::ParserKeywords::SGWFN>()));
         const auto family3 = //WSF, GSF gas-water CO2STORE case
             deck.hasKeyword<Opm::ParserKeywords::GSF>() &&
             deck.hasKeyword<Opm::ParserKeywords::WSF>();


### PR DESCRIPTION
Although in the manual it is stated that SGWFN is supported, the simulator ends with
```
Simulation aborted as program threw an unexpected exception: Could not allocate the problem: Saturation functions must be specified using either family 1 or family 2 keywords
Use either SGOF (or SLGOF) and/or SWOF or SGFN/SWFN and SOF2/SOF3
```
This PR adds support for this keyword. It has been tested using the first table in [SGOF_R.INCL](https://github.com/OPM/opm-tests/blob/master/three_phase_relperm/SGOF_R.INCL) in two CO2STORE decks (the first one with GAS OIL SGOF and the second one with GAS WATER SGWFN (see attached zip)), giving the same results.
![sgwfn_vs_sgof](https://github.com/OPM/opm-common/assets/61784809/b45e960b-60a9-4237-86c0-e770b5106a8b)
[Test_sgwfn_sgof.zip](https://github.com/OPM/opm-common/files/12860948/Test_sgwfn_sgof.zip)