### PR TITLE
introducing a new event type REQUEST_OPEN_WELL

### DIFF
--- a/opm/input/eclipse/Schedule/Events.hpp
+++ b/opm/input/eclipse/Schedule/Events.hpp
@@ -126,6 +126,13 @@ namespace Opm
              * The well has been affected in an ACTIONX keyword.
              */
             ACTIONX_WELL_EVENT = (1 << 20),
+
+            /*
+             * Some SCHEDULE keywords can set a well to be OPEN to open a previously STOPped or SHUT well.
+             * The well is SHUT/STOP due to various causes (SCHEDULE, economical, physical, etc.)
+             * For now, the WELOPEN, WCONPROD and WCONINJE keywords are considered with this event
+             */
+            REQUEST_OPEN_WELL = (1 << 21),
         };
     }
 

--- a/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/KeywordHandlers.cpp
@@ -1316,6 +1316,10 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                 if (well2.updateHasProduced())
                     update_well = true;
 
+                if (well2.getStatus() == WellStatus::OPEN) {
+                    this->snapshots.back().wellgroup_events().addEvent(well2.name(), ScheduleEvents::REQUEST_OPEN_WELL);
+                }
+
                 if (update_well) {
                     this->snapshots.back().events().addEvent( ScheduleEvents::PRODUCTION_UPDATE );
                     this->snapshots.back().wellgroup_events().addEvent( well2.name(), ScheduleEvents::PRODUCTION_UPDATE);
@@ -1388,6 +1392,10 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                             this->updateWellStatus( well_name, handlerContext.currentStep, Well::Status::SHUT);
                         }
                     }
+                }
+
+                if (this->snapshots.back().wells.get( well_name ).getStatus() == Well::Status::OPEN) {
+                    this->snapshots.back().wellgroup_events().addEvent(well_name, ScheduleEvents::REQUEST_OPEN_WELL);
                 }
 
                 auto udq_active = this->snapshots.back().udq_active.get();
@@ -1525,6 +1533,10 @@ File {} line {}.)", wname, location.keyword, location.filename, location.lineno)
                         if (did_flow_update) {
                             this->snapshots[currentStep].wells.update(std::move(well2));
                         }
+                    }
+
+                    if (new_well_status == open) {
+                        this->snapshots.back().wellgroup_events().addEvent( wname, ScheduleEvents::REQUEST_OPEN_WELL);
                     }
                 }
                 continue;


### PR DESCRIPTION
Some SCHEDULE keywords can set a well to be OPEN to open a reviouly STOP or SHUT well. The well is SHUT/STOP due to various causes (SCHEDULE, economical, physical, etc.) For now, the WELOPEN, WCONPROD and WCONINJE keywords are considered with this event. In the future, other keywords can be involved if found to have the similar OPENing functionality.

I was struggling the name of the event, any suggestions are welcome. 