### PR TITLE
Don't Reference Non-Existent W/G Names From UDQ Set

### DIFF
--- a/src/opm/input/eclipse/Schedule/SummaryState.cpp
+++ b/src/opm/input/eclipse/Schedule/SummaryState.cpp
@@ -255,6 +255,11 @@ namespace Opm
         if (var_type == UDQVarType::WELL_VAR) {
             const std::vector<std::string> wells = this->wells(); // Intentional copy
             for (const auto& well : wells) {
+                if (! udq_set.has(well)) {
+                    this->update_well_var(well, udq_set.name(), undefined_value);
+                    continue;
+                }
+
                 const auto& udq_value = udq_set[well].value();
                 this->update_well_var(well, udq_set.name(), udq_value.value_or(undefined_value));
             }
@@ -262,6 +267,11 @@ namespace Opm
         else if (var_type == UDQVarType::GROUP_VAR) {
             const std::vector<std::string> groups = this->groups(); // Intentional copy
             for (const auto& group : groups) {
+                if (! udq_set.has(group)) {
+                    this->update_group_var(group, udq_set.name(), undefined_value);
+                    continue;
+                }
+
                 const auto& udq_value = udq_set[group].value();
                 this->update_group_var(group, udq_set.name(), udq_value.value_or(undefined_value));
             }

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -2905,3 +2905,30 @@ BOOST_AUTO_TEST_CASE(UDQ_ASSIGN_SEGMENT)
         BOOST_CHECK_EQUAL(all.size(), std::size_t{3}); // Three different SU* variables
     }
 }
+
+BOOST_AUTO_TEST_CASE(UDQ_Update_SummaryState)
+{
+    auto st = SummaryState { TimeService::now() };
+
+    // P2 not yet online
+    st.update_well_var("P1", "WBHP",  42.0);
+    st.update_well_var("P2", "WBHP",   0.0);
+    st.update_well_var("P3", "WBHP", 121.2);
+
+    // BB not yet online
+    st.update_group_var("G1", "GOPR", 1222.0);
+    st.update_group_var("BB", "GOPR",    0.0);
+    st.update_group_var("AA", "GOPR", 1234.5);
+
+    // P2 not yet online
+    st.update_udq(UDQSet::wells("WUBAR", { "P1", "P3" }, 17.29), -123.4);
+    BOOST_CHECK_CLOSE(st.get_well_var("P1", "WUBAR"),   17.29, 1.0e-8);
+    BOOST_CHECK_CLOSE(st.get_well_var("P2", "WUBAR"), -123.4 , 1.0e-8);
+    BOOST_CHECK_CLOSE(st.get_well_var("P3", "WUBAR"),   17.29, 1.0e-8);
+
+    // BB not yet online
+    st.update_udq(UDQSet::groups("GUNDA_ST", { "G1", "AA" }, 652.44), -123.4);
+    BOOST_CHECK_CLOSE(st.get_group_var("AA", "GUNDA_ST"),  652.44, 1.0e-8);
+    BOOST_CHECK_CLOSE(st.get_group_var("BB", "GUNDA_ST"), -123.4 , 1.0e-8);
+    BOOST_CHECK_CLOSE(st.get_group_var("G1", "GUNDA_ST"),  652.44, 1.0e-8);
+}


### PR DESCRIPTION
Member function `SummaryState::update_udq()` did not take into account the possibility that wells or groups might not yet have come online. In particular, `UDQSet::operator[](const string&)` will [throw an exception](https://github.com/OPM/opm-common/blob/a4f9fb1dd855d7c9183b095f4b3194ae43786413/src/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp#L496-L498) if the argument string does not name an existing member of the UDQ set.

This PR makes the call to `operator[]()` conditional on the named entity existing and thereby enables updating well and group level UDQs before these names have been entered in, e.g., `WELSPECS` or `GRUPTREE`.  Missing entities get the `undefined_value`.