### PR TITLE
Make CMake fail on non-64bit systems.

### DIFF
--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -110,8 +110,8 @@ macro (OpmInitDirVars)
   endif (COMMAND dir_hook)
 endmacro ()
 
-if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
-  message(FATAL_ERROR "OPM will only work correctly on 64bit systems!")
+if("${CMAKE_SIZEOF_VOID_P}" LESS 8)
+  message(FATAL_ERROR "OPM will only work correctly on 64bit (or higher) systems!")
 endif()
 
 OpmInitProjVars ()

--- a/cmake/Modules/OpmInit.cmake
+++ b/cmake/Modules/OpmInit.cmake
@@ -110,6 +110,10 @@ macro (OpmInitDirVars)
   endif (COMMAND dir_hook)
 endmacro ()
 
+if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+  message(FATAL_ERROR "OPM will only work correctly on 64bit systems!")
+endif()
+
 OpmInitProjVars ()
 OpmInitDirVars ()
 


### PR DESCRIPTION
Running simulations on those does not make sense as it seriously limits the time span that can be simulated. In addition the OPM code neglects 32bit issues at various places as it was written at a time where 64bit was already ubiquitous.

Currently, we would fail in some regression tests on 32bit systems. With this change CMake will already check whether it is run on a 64bit (or higher) system and already fail if this is not the case.

A patch I never upstreamed from Debian.