### PR TITLE
Also search for Alberta with pkgconfig to be DUNE compliant

### DIFF
--- a/cmake/Modules/FindAlberta.cmake
+++ b/cmake/Modules/FindAlberta.cmake
@@ -44,3 +44,17 @@ else()
   set(ALBERTA_FOUND OFF)
   set(Alberta_FOUND OFF)
 endif()
+
+# PkgConfig targets are required if OPM modules are used as DUNE modules
+# (e.g. in Debian's Packaging automatic tests)
+find_package(PkgConfig)
+if(PkgConfig_FOUND)
+  set(_opm_alberta_bkup_path  ${CMAKE_PREFIX_PATH})
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${ALBERTA_ROOT})
+
+  foreach(dim RANGE 1 ${ALBERTA_MAX_WORLD_DIM})
+    pkg_check_modules(Alberta${dim}d IMPORTED_TARGET GLOBAL "alberta-grid_${dim}d")
+  endforeach()
+
+  set(CMAKE_PREFIX_PATH ${_opm_alberta_bkup_path})
+endif()


### PR DESCRIPTION
If OPM modules are used as DUNE modules then CMake otherwise complains about missing targets:

```
CMake Error at /usr/lib/x86_64-linux-gnu/cmake/dune-grid/dune-grid-targets.cmake:78 (set_target_properties):
  The link interface of target "dunealbertagrid1d" contains:

    PkgConfig::Alberta1d

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

```
upstreamed from Debian