### PR TITLE
Better error handling for problems in conditions of ACTIONX.

### DIFF
--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -314,6 +314,14 @@ class KeywordLocation;
          */
         const static std::string ACTIONX_ILLEGAL_KEYWORD;
 
+        /*
+          Error flag marking parser errors ic ACTIONX conditions
+         */
+        const static std::string ACTIONX_CONDITION_ERROR;
+        /*
+          Error flag marking that an ACTIONX has no condition
+         */
+        const static std::string ACTIONX_NO_CONDITION;
 
         /*
           The RPTSCH, RPTSOL and RPTSCHED keywords have two alternative forms,

--- a/opm/input/eclipse/Schedule/Action/ActionX.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.hpp
@@ -75,8 +75,10 @@ class ActionX {
 public:
     ActionX();
     ActionX(const std::string& name, size_t max_run, double max_wait, std::time_t start_time);
-    ActionX(const DeckKeyword& kw, const Actdims& actimds, std::time_t start_time,
-            std::vector<std::pair<std::string, std::string>>& condition_errors);
+    ActionX(const std::string& name, size_t max_run, double max_wait,
+            std::time_t start_time,
+            const std::vector<Condition>&& conditions,
+            const std::vector<std::string>&& tokens);
     ActionX(const DeckRecord& record, std::time_t start_time);
     explicit ActionX(const RestartIO::RstAction& rst_action);
 
@@ -131,6 +133,15 @@ private:
     Action::AST condition;
     std::vector<Condition> m_conditions;
 };
+
+/// \brief Parse ActionX keyword.
+/// \param kw The keyword representation of ActionX
+/// \param actdims Dimensions for ActionX as specified in the deck.
+/// \param start_time The first time that the ActionX should be evaluated
+/// \return A tuple of the ActionX created and a vector that contains for each error experienced
+///         during parsing the string indicating the type of error and the error string itself.
+std::tuple<ActionX, std::vector<std::pair<std::string, std::string>>>
+parseActionX(const DeckKeyword& kw, const Actdims& actimds, std::time_t start_time);
 
 }
 }

--- a/opm/input/eclipse/Schedule/Action/ActionX.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.hpp
@@ -75,7 +75,8 @@ class ActionX {
 public:
     ActionX();
     ActionX(const std::string& name, size_t max_run, double max_wait, std::time_t start_time);
-    ActionX(const DeckKeyword& kw, const Actdims& actimds, std::time_t start_time);
+    ActionX(const DeckKeyword& kw, const Actdims& actimds, std::time_t start_time,
+            std::vector<std::pair<std::string, std::string>>& condition_errors);
     ActionX(const DeckRecord& record, std::time_t start_time);
     explicit ActionX(const RestartIO::RstAction& rst_action);
 

--- a/src/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/src/opm/input/eclipse/Parser/ParseContext.cpp
@@ -114,6 +114,8 @@ namespace Opm {
         this->addKey(SUMMARY_REGION_TOO_LARGE, InputErrorAction::WARN);
 
         addKey(ACTIONX_ILLEGAL_KEYWORD, InputErrorAction::THROW_EXCEPTION);
+        addKey(ACTIONX_CONDITION_ERROR, InputErrorAction::THROW_EXCEPTION);
+        addKey(ACTIONX_NO_CONDITION, InputErrorAction::WARN);
 
         addKey(RPT_MIXED_STYLE, InputErrorAction::WARN);
         addKey(RPT_UNKNOWN_MNEMONIC, InputErrorAction::WARN);
@@ -369,6 +371,8 @@ namespace Opm {
 
     const std::string ParseContext::SCHEDULE_INVALID_NAME = "SCHEDULE_INVALID_NAME";
     const std::string ParseContext::ACTIONX_ILLEGAL_KEYWORD = "ACTIONX_ILLEGAL_KEYWORD";
+    const std::string ParseContext::ACTIONX_CONDITION_ERROR = "ACTIONX_CONDITION_ERROR";
+    const std::string ParseContext::ACTIONX_NO_CONDITION = "ACTIONX_NO_CONDITION";
 
     const std::string ParseContext::SIMULATOR_KEYWORD_NOT_SUPPORTED = "SIMULATOR_KEYWORD_NOT_SUPPORTED";
     const std::string ParseContext::SIMULATOR_KEYWORD_NOT_SUPPORTED_CRITICAL = "SIMULATOR_KEYWORD_NOT_SUPPORTED_CRITICAL";

--- a/src/opm/input/eclipse/Schedule/Action/ActionParser.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionParser.cpp
@@ -22,6 +22,8 @@
 #include <cstdlib>
 #include <stdexcept>
 
+#include <fmt/format.h>
+
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include "ActionParser.hpp"
@@ -128,9 +130,9 @@ ParseNode Parser::current() const {
 Action::ASTNode Parser::parse_left() {
     auto current = this->current();
     if (current.type != TokenType::ecl_expr)
-        throw std::invalid_argument("Left side of comparison ("
-                                    + current.value + ") has to be "
-                                    "an expression!");
+        throw std::invalid_argument(fmt::format("Expected expression as left hand side "
+                                                "of comparison, but got {} instead.",
+                                                current.value));
 
     std::string func = current.value;
     FuncType func_type = get_func(current.value);

--- a/src/opm/input/eclipse/Schedule/Action/ActionParser.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionParser.cpp
@@ -128,7 +128,9 @@ ParseNode Parser::current() const {
 Action::ASTNode Parser::parse_left() {
     auto current = this->current();
     if (current.type != TokenType::ecl_expr)
-        return TokenType::error;
+        throw std::invalid_argument("Left side of comparison ("
+                                    + current.value + ") has to be "
+                                    "an expression!");
 
     std::string func = current.value;
     FuncType func_type = get_func(current.value);
@@ -270,14 +272,16 @@ Action::ASTNode Parser::parse(const std::vector<std::string>& tokens) {
         return ASTNode( start_node.type );
 
     auto tree = parser.parse_or();
+
+    if (tree.type == TokenType::error)
+        throw std::invalid_argument("Failed to parse ACTIONX condition.");
+
     auto current = parser.current();
     if (current.type != TokenType::end) {
         size_t index = parser.current_pos;
-        throw std::invalid_argument("Extra unhandled data starting with token[" + std::to_string(index) + "] = " + current.value);
+        throw std::invalid_argument("Extra unhandled data starting with token[" + std::to_string(index) + "] = " + current.value+
+                                    " in ACTIONX condition.");
     }
-
-    if (tree.type == TokenType::error)
-        throw std::invalid_argument("Failed to parse");
 
     return tree;
 }

--- a/src/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -85,8 +85,8 @@ parseActionX(const DeckKeyword& kw, const Actdims& actdims,
     const std::string name = record.getItem("NAME").getTrimmedString(0);
 
     for (size_t record_index = 1; record_index < kw.size(); record_index++) {
-        const auto& record = kw.getRecord(record_index);
-        const auto& cond_tokens = RawString::strings( record.getItem("CONDITION").getData<RawString>() );
+        const auto& cond_tokens = RawString::strings( kw.getRecord(record_index)
+                                                      .getItem("CONDITION").getData<RawString>() );
 
         for (const auto& token : cond_tokens)
             tokens.push_back(dequote(token, kw.location()));

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -665,11 +665,10 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
                 logger.location(location);
 
                 if (keyword.is<ParserKeywords::ACTIONX>()) {
-                    std::vector<std::pair<std::string, std::string>> condition_errors; //condition is parsed by ActionX constructor
-                    Action::ActionX action(keyword,
-                                           this->m_static.m_runspec.actdims(),
-                                           std::chrono::system_clock::to_time_t(this->snapshots[report_step].start_time()),
-                                           condition_errors);
+                    auto [action, condition_errors] =
+                        Action::parseActionX(keyword,
+                                              this->m_static.m_runspec.actdims(),
+                                              std::chrono::system_clock::to_time_t(this->snapshots[report_step].start_time()));
 
                     for(const auto& [ marker, msg]: condition_errors) {
                         parseContext.handleError(marker, msg, keyword.location(), errors);

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -665,9 +665,16 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
                 logger.location(location);
 
                 if (keyword.is<ParserKeywords::ACTIONX>()) {
+                    std::vector<std::pair<std::string, std::string>> condition_errors; //condition is parsed by ActionX constructor
                     Action::ActionX action(keyword,
                                            this->m_static.m_runspec.actdims(),
-                                           std::chrono::system_clock::to_time_t(this->snapshots[report_step].start_time()));
+                                           std::chrono::system_clock::to_time_t(this->snapshots[report_step].start_time()),
+                                           condition_errors);
+
+                    for(const auto& [ marker, msg]: condition_errors) {
+                        parseContext.handleError(marker, msg, keyword.location(), errors);
+                    }
+
                     while (true) {
                         keyword_index++;
                         if (keyword_index == block.size())

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -88,9 +88,10 @@ ACTIONX
     const auto& kw = deck["ACTIONX"].back();
 
 
-    std::vector<std::pair<std::string, std::string>> condition_errors;
-    Action::ActionX action2(kw, {}, 0, condition_errors);
+    const auto& [action2, condition_errors2 ] =
+        Action::parseActionX(kw, {}, 0);
     BOOST_CHECK_EQUAL(action2.name(), "ACTION");
+    BOOST_CHECK_EQUAL(condition_errors2.size(), 0U);
 
     // left hand side has to be an expression.
     // Check whether we add an error to condition_errors
@@ -102,10 +103,11 @@ ACTIONX
 /
 )"};
 
-    condition_errors.clear();
+
     const auto deck1 = Parser{}.parseString( action_kw_num_first);
-    const auto action3 = Action::ActionX(deck1["ACTIONX"].back(), {}, 0, condition_errors);
-    BOOST_CHECK_EQUAL(condition_errors.size(), 1U);
+    const auto& [action3, condition_errors3] =
+        Action::parseActionX(deck1["ACTIONX"].back(), {}, 0);
+    BOOST_CHECK_EQUAL(condition_errors3.size(), 1U);
 }
 
 

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -87,8 +87,25 @@ ACTIONX
     const auto deck = Parser{}.parseString( action_kw );
     const auto& kw = deck["ACTIONX"].back();
 
-    Action::ActionX action2(kw, {}, 0);
+
+    std::vector<std::pair<std::string, std::string>> condition_errors;
+    Action::ActionX action2(kw, {}, 0, condition_errors);
     BOOST_CHECK_EQUAL(action2.name(), "ACTION");
+
+    // left hand side has to be an expression.
+    // Check whether we add an error to condition_errors
+    // if that is not the case
+    const auto action_kw_num_first = std::string{ R"(
+ACTIONX
+   'ACTION' /
+   0.75 < WWCT OPX /
+/
+)"};
+
+    condition_errors.clear();
+    const auto deck1 = Parser{}.parseString( action_kw_num_first);
+    const auto action3 = Action::ActionX(deck1["ACTIONX"].back(), {}, 0, condition_errors);
+    BOOST_CHECK_EQUAL(condition_errors.size(), 1U);
 }
 
 


### PR DESCRIPTION
When encountering these (e.g. a number instead of an expression on the left hand side) the simulator would immediately abort with an error message like:
```
Error: An error occurred while creating the reservoir schedule
Internal error: Extra unhandled data starting with token[0] = 135

Error: Unrecoverable errors while loading input: Extra unhandled data starting with token[0] = 135
```
(The message above is for the number 135 on the left hand side)

With this change we now use the usual way of handling errors and warnings in the parser and continue parsing.

The error message for the problem above is now
```
Error: condition of action EX1 has the following error: Left side of comparsion (135) has to be an expression!

Error: Problem with keyword ACTIONX
In model.schedule line 562
condition of action EX1 has the following error: Left side of comparsion (135) has to be an expression!

Error: Unrecoverable errors while loading input: Problem with keyword ACTIONX
In model.schedule line 562
condition of action EX1 has the following error: Left side of comparsion (135) has to be an expression!