### PR TITLE
adding ThreeComponentFluidSystem.hh to CMakeLists_files

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -881,6 +881,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
       opm/material/fluidsystems/H2OAirFluidSystem.hpp
       opm/material/fluidsystems/H2ON2FluidSystem.hpp
+      opm/material/fluidsystems/ThreeComponentFluidSystem.hh
       opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
       opm/material/fluidmatrixinteractions/SatCurveMultiplexerParams.hpp
       opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp


### PR DESCRIPTION
to let other modules be able to access it.

Backport of #3714