### PR TITLE
[fix] AggregateActionX: Do not assume an ACTIONX condition exists

### DIFF
--- a/src/opm/output/eclipse/AggregateActionxData.cpp
+++ b/src/opm/output/eclipse/AggregateActionxData.cpp
@@ -324,10 +324,10 @@ const std::map<logic_enum, int> logicalToIndex_17 = {
             std::size_t offset = 0;
             const auto& actx_cond = actx.conditions();
             int first_greater = 0;
+            if( !actx_cond.empty() &&
+                actx_cond[0].cmp == Opm::Action::Comparator::LESS)
             {
-                const auto& first_cond = actx_cond[0];
-                if (first_cond.cmp == Opm::Action::Comparator::LESS)
-                    first_greater = 1;
+                first_greater = 1;
             }
 
             for (const auto& cond : actx_cond) {


### PR DESCRIPTION
backport of #3713 
The rest of the code allows an ACTIONX keyword without any condition (Such an action will never be evaluated). Yet AggregateActionXData assumed that there is always at least one condition. This lead to a segmentation fault if that was not the case.

It seemed like iAC[offset + Ix::FirstGreater] is used nowhere and therefore we now always use 0 there. I was not brave enouogh to remove the storage for it, because I fear this might break backwards compatibility of the output layer.