### PR TITLE
linearInterpolation.hpp: reformat and use stl

### DIFF
--- a/opm/common/utility/numeric/linearInterpolation.hpp
+++ b/opm/common/utility/numeric/linearInterpolation.hpp
@@ -22,86 +22,80 @@
 #define OPM_LINEARINTERPOLATION_HEADER_INCLUDED
 
 
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 namespace Opm
 {
 
-    inline int tableIndex(const std::vector<double>& table, double x)
-    {
-	// Returns an index in an ordered table such that x is between
-	// table[j] and table[j+1]. If x is out of range, first or last
-	// interval is returned; Binary search.
-	int n = table.size() - 1;
-	if (n < 2) {
-	    return 0;
-	}
-	int jl = 0;
-	int ju = n;
-	bool ascend = (table[n] > table[0]);
-	while (ju - jl > 1) {
-	    int jm = (ju + jl)/2;   // Compute a midpoint
-	    if ( (x >= table[jm]) == ascend) {
-		jl = jm;     // Replace lower limit
-	    } else {
-		ju = jm;     // Replace upper limit
-	    }
-	}
-	return jl;
+inline int tableIndex(const std::vector<double>& table, double x)
+{
+    // Returns an index in an ordered table such that x is between
+    // table[j] and table[j+1]. If x is out of range, first or last
+    // interval is returned; Binary search.
+    int n = table.size() - 1;
+    if (n < 2) {
+        return 0;
     }
-
-
-    inline double linearInterpolationDerivative(const std::vector<double>& xv,
-                                                const std::vector<double>& yv, double x)
-    {
-        // Extrapolates if x is outside xv
-	int ix1 = tableIndex(xv, x);
-	int ix2 = ix1 + 1;
-	return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1]);
-    }
-
-    inline double linearInterpolation(const std::vector<double>& xv,
-                                      const std::vector<double>& yv, double x)
-    {
-	// Extrapolates if x is outside xv
-	int ix1 = tableIndex(xv, x);
-	int ix2 = ix1 + 1;
-	return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
-    }
-
-    inline double linearInterpolationNoExtrapolation(const std::vector<double>& xv,
-                                                     const std::vector<double>& yv, double x)
-    {
-        // Return end values if x is outside xv
-        if (x < xv.front()) {
-            return yv.front();
+    int jl = 0;
+    int ju = n;
+    bool ascend = (table[n] > table[0]);
+    while (ju - jl > 1) {
+        int jm = (ju + jl)/2;   // Compute a midpoint
+        if ( (x >= table[jm]) == ascend) {
+            jl = jm;     // Replace lower limit
+        } else {
+            ju = jm;     // Replace upper limit
         }
-        if (x > xv.back()) {
-            return yv.back();
-        }
+    }
+    return jl;
+}
 
-        int ix1 = tableIndex(xv, x);
-        int ix2 = ix1 + 1;
-        return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
+
+inline double linearInterpolationDerivative(const std::vector<double>& xv,
+                                            const std::vector<double>& yv, double x)
+{
+    // Extrapolates if x is outside xv
+    int ix1 = tableIndex(xv, x);
+    int ix2 = ix1 + 1;
+    return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1]);
+}
+
+inline double linearInterpolation(const std::vector<double>& xv,
+                                  const std::vector<double>& yv, double x)
+{
+    // Extrapolates if x is outside xv
+    int ix1 = tableIndex(xv, x);
+    int ix2 = ix1 + 1;
+    return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
+}
+
+inline double linearInterpolationNoExtrapolation(const std::vector<double>& xv,
+                                                 const std::vector<double>& yv, double x)
+{
+    // Return end values if x is outside xv
+    if (x < xv.front()) {
+        return yv.front();
+    }
+    if (x > xv.back()) {
+        return yv.back();
     }
 
-    inline double linearInterpolation(const std::vector<double>& xv,
-                                      const std::vector<double>& yv,
-                                      double x, int& ix1)
-    {
-	// Extrapolates if x is outside xv
-	ix1 = tableIndex(xv, x);
-	int ix2 = ix1 + 1;
-	return (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
-    }
+    int ix1 = tableIndex(xv, x);
+    int ix2 = ix1 + 1;
+    return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
+}
 
-
+inline double linearInterpolation(const std::vector<double>& xv,
+                                  const std::vector<double>& yv,
+                                  double x, int& ix1)
+{
+    // Extrapolates if x is outside xv
+    ix1 = tableIndex(xv, x);
+    int ix2 = ix1 + 1;
+    return (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
+}
 
 } // namespace Opm
-
-
-
-
 
 #endif // OPM_LINEARINTERPOLATION_HEADER_INCLUDED

--- a/opm/common/utility/numeric/linearInterpolation.hpp
+++ b/opm/common/utility/numeric/linearInterpolation.hpp
@@ -28,27 +28,22 @@
 namespace Opm
 {
 
+//! \brief Returns an index in an ordered table such that x is between
+//!        table[j] and table[j+1].
+//! \details If x is out of bounds, it returns a clamped index
 inline int tableIndex(const std::vector<double>& table, double x)
 {
-    // Returns an index in an ordered table such that x is between
-    // table[j] and table[j+1]. If x is out of range, first or last
-    // interval is returned; Binary search.
-    int n = table.size() - 1;
-    if (n < 2) {
+    if (table.size() < 2)
         return 0;
-    }
-    int jl = 0;
-    int ju = n;
-    bool ascend = (table[n] > table[0]);
-    while (ju - jl > 1) {
-        int jm = (ju + jl)/2;   // Compute a midpoint
-        if ( (x >= table[jm]) == ascend) {
-            jl = jm;     // Replace lower limit
-        } else {
-            ju = jm;     // Replace upper limit
-        }
-    }
-    return jl;
+
+    const auto lower = std::lower_bound(table.begin(), table.end(), x);
+
+    if (lower == table.end())
+        return table.size()-2;
+    else if (lower == table.begin())
+        return 0;
+    else
+      return std::distance(table.begin(), lower)-1;
 }
 
 

--- a/opm/common/utility/numeric/linearInterpolation.hpp
+++ b/opm/common/utility/numeric/linearInterpolation.hpp
@@ -46,23 +46,29 @@ inline int tableIndex(const std::vector<double>& table, double x)
       return std::distance(table.begin(), lower)-1;
 }
 
+inline std::pair<double, int>
+linearInterpolationSlope(const std::vector<double>& xv,
+                         const std::vector<double>& yv,
+                         const double x)
+{
+    const auto i = Opm::tableIndex(xv, x);
+    return { (yv[i + 1] - yv[i]) / (xv[i + 1] - xv[i]), i };
+}
+
 
 inline double linearInterpolationDerivative(const std::vector<double>& xv,
                                             const std::vector<double>& yv, double x)
 {
     // Extrapolates if x is outside xv
-    int ix1 = tableIndex(xv, x);
-    int ix2 = ix1 + 1;
-    return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1]);
+    return linearInterpolationSlope(xv, yv, x).first;
 }
 
 inline double linearInterpolation(const std::vector<double>& xv,
                                   const std::vector<double>& yv, double x)
 {
     // Extrapolates if x is outside xv
-    int ix1 = tableIndex(xv, x);
-    int ix2 = ix1 + 1;
-    return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
+    const auto& [t, i] = linearInterpolationSlope(xv, yv, x);
+    return t * (x - xv[i]) + yv[i];
 }
 
 inline double linearInterpolationNoExtrapolation(const std::vector<double>& xv,
@@ -76,9 +82,7 @@ inline double linearInterpolationNoExtrapolation(const std::vector<double>& xv,
         return yv.back();
     }
 
-    int ix1 = tableIndex(xv, x);
-    int ix2 = ix1 + 1;
-    return  (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
+    return linearInterpolation(xv, yv, x);
 }
 
 inline double linearInterpolation(const std::vector<double>& xv,
@@ -86,9 +90,9 @@ inline double linearInterpolation(const std::vector<double>& xv,
                                   double x, int& ix1)
 {
     // Extrapolates if x is outside xv
-    ix1 = tableIndex(xv, x);
-    int ix2 = ix1 + 1;
-    return (yv[ix2] - yv[ix1])/(xv[ix2] - xv[ix1])*(x - xv[ix1]) + yv[ix1];
+    double t;
+    std::tie(t, ix1) = linearInterpolationSlope(xv, yv, x);
+    return t * (x - xv[ix1]) + yv[ix1];
 }
 
 } // namespace Opm


### PR DESCRIPTION
Remove tabs and reformat. And replace home-grown binary search with std::lower_bound.