### PR TITLE
Support SWATINIT-Like Rescaling of PCOW at Restart

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -257,6 +257,16 @@ public:
                          Scalar pcow,
                          Scalar Sw);
 
+    /// Apply SWATINIT-like scaling of oil/water capillary pressure curve at
+    /// simulation restart.
+    ///
+    /// \param[in] elemIdx Active cell index
+    ///
+    /// \param[in] maxPcow Scaled maximum oil/water capillary pressure.
+    ///   Typically the PPCW restart file array's entry for the
+    ///   corresponding cell.
+    void applyRestartSwatInit(const unsigned elemIdx, const Scalar maxPcow);
+
     bool enableEndPointScaling() const
     { return enableEndPointScaling_; }
 

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -212,6 +212,24 @@ applySwatinit(unsigned elemIdx,
 }
 
 template<class TraitsT>
+void
+EclMaterialLawManager<TraitsT>::applyRestartSwatInit(const unsigned elemIdx,
+                                                     const Scalar   maxPcow)
+{
+    // Maximum capillary pressure adjusted from SWATINIT data.
+
+    auto& elemScaledEpsInfo =
+        this->oilWaterScaledEpsInfoDrainage_[elemIdx];
+
+    elemScaledEpsInfo.maxPcow = maxPcow;
+
+    this->oilWaterScaledEpsPointsDrainage(elemIdx)
+        .init(elemScaledEpsInfo,
+              *this->oilWaterEclEpsConfig_,
+              EclTwoPhaseSystemType::OilWater);
+}
+
+template<class TraitsT>
 const typename EclMaterialLawManager<TraitsT>::MaterialLawParams&
 EclMaterialLawManager<TraitsT>::
 connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const


### PR DESCRIPTION
This commit adds a new, very specialised, operation to the material law manager,
```C++
void EclMaterialLawManager::applyRestartSwatInit(cell, maxPcow)
```
This will apply a `SWATINIT`-like rescaling of the oil/water capillary pressure curve based on a caller-provided maximum capillary pressure value.  The primary use case is this maximum value being taken from the `PPCW` array in a restart file at simulation restart time.  We assign the `maxPcow` member of the associate `EpsInfo` structure and reinitialise the `EpsPoints` structure using this new information. The latter is needed lest the `maxPcnw()` function return incorrect values in restarted simulations.