### PR TITLE
Missing header for g++ 12.2.0

### DIFF
--- a/opm/common/utility/numeric/linearInterpolation.hpp
+++ b/opm/common/utility/numeric/linearInterpolation.hpp
@@ -23,6 +23,7 @@
 
 
 #include <algorithm>
+#include <tuple>
 #include <vector>
 
 namespace Opm


### PR DESCRIPTION
Error message concerning use of std::tie which needs <tuple> header, for g++ (Debian 12.2.0-14) 12.2.0. File: linearInterpolation.hpp, line 94.
