### PR TITLE
Fix well connection rel. perm. parameters for two-phase cases 

### DIFF
--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -291,10 +291,18 @@ connectionMaterialLawParams(unsigned satRegionIdx, unsigned elemIdx) const
 
     case EclMultiplexerApproach::TwoPhase: {
         auto& realParams = mlp.template getRealParams<EclMultiplexerApproach::TwoPhase>();
-        realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
-        realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
-        realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
-        realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
+        if (realParams.approach() == EclTwoPhaseApproach::GasOil) {
+            realParams.gasOilParams().drainageParams().setUnscaledPoints(gasOilUnscaledPointsVector_[satRegionIdx]);
+            realParams.gasOilParams().drainageParams().setEffectiveLawParams(gasOilEffectiveParamVector_[satRegionIdx]);
+        }
+        else if (realParams.approach() == EclTwoPhaseApproach::GasWater) {
+            realParams.gasWaterParams().drainageParams().setUnscaledPoints(gasWaterUnscaledPointsVector_[satRegionIdx]);
+            realParams.gasWaterParams().drainageParams().setEffectiveLawParams(gasWaterEffectiveParamVector_[satRegionIdx]);
+        }
+        else if (realParams.approach() == EclTwoPhaseApproach::OilWater) {
+            realParams.oilWaterParams().drainageParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[satRegionIdx]);
+            realParams.oilWaterParams().drainageParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[satRegionIdx]);
+        }
 //            if (enableHysteresis()) {
 //                realParams.oilWaterParams().imbibitionParams().setUnscaledPoints(oilWaterUnscaledPointsVector_[impRegionIdx]);
 //                realParams.oilWaterParams().imbibitionParams().setEffectiveLawParams(oilWaterEffectiveParamVector_[impRegionIdx]);


### PR DESCRIPTION
Fixed a bug where setting SATNUM in COMPDAT (option no. 7) to a value other than cell SATNUM resulted in Segmentation fault in two-phase cases. Now we check which two-phase approach is active and set correct rel. perm. parameters accordingly.