### PR TITLE
Use Flow defaults for TSMINZ, TSFCNV and TFDIFF

### DIFF
--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/T/TUNING
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/T/TUNING
@@ -22,7 +22,7 @@
         "name": "TSMINZ",
         "value_type": "DOUBLE",
         "dimension": "Time",
-        "default": 0.1
+        "default": 8.64e-8
       },
       {
         "name": "TSMCHP",
@@ -43,12 +43,12 @@
       {
         "name": "TSFCNV",
         "value_type": "DOUBLE",
-        "default": 0.1
+        "default": 0.33
       },
       {
         "name": "TFDIFF",
         "value_type": "DOUBLE",
-        "default": 1.25
+        "default": 2.0
       },
       {
         "name": "THRUPT",


### PR DESCRIPTION
To eliminate side effects of --enable-tuning=true without any TUNING keyword or defaulted TUNING record items.