### PR TITLE
Make UnitSystem::*_si(string) Const Members

### DIFF
--- a/opm/input/eclipse/Units/UnitSystem.hpp
+++ b/opm/input/eclipse/Units/UnitSystem.hpp
@@ -116,8 +116,8 @@ namespace Opm {
 
         Dimension parse(const std::string& dimension) const;
 
-        double from_si( const std::string& dimension, double );
-        double to_si( const std::string& dimension, double );
+        double from_si( const std::string& dimension, double ) const;
+        double to_si( const std::string& dimension, double ) const;
         double from_si( measure, double ) const;
         double to_si( measure, double ) const;
         void from_si( measure, std::vector<double>& ) const;

--- a/src/opm/input/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/input/eclipse/Units/UnitSystem.cpp
@@ -242,7 +242,7 @@ namespace {
         "KG-M",
         "PPM", /*Parts per million */
         "GPa",
-        "DAY/SM3"
+        "DAY/SM3",
     };
 
     static_assert(numElems(from_metric_offset) == static_cast<std::size_t>(UnitSystem::measure::_count),
@@ -1594,12 +1594,14 @@ namespace {
             + this->measure_table_to_si_offset[ static_cast< int >( m ) ];
     }
 
-    double UnitSystem::from_si( const std::string& dimension, double value) {
+    double UnitSystem::from_si( const std::string& dimension, double value) const
+    {
         const auto& dim = this->parse(dimension);
         return dim.convertSiToRaw(value);
     }
 
-    double UnitSystem::to_si( const std::string& dimension, double value) {
+    double UnitSystem::to_si( const std::string& dimension, double value) const
+    {
         const auto& dim = this->parse(dimension);
         return dim.convertRawToSi(value);
     }


### PR DESCRIPTION
There is no need for these to require that the `UnitSystem` be mutable.