### PR TITLE
Fix build with older versions of boost

### DIFF
--- a/tests/material/test_2dtables.cpp
+++ b/tests/material/test_2dtables.cpp
@@ -29,6 +29,8 @@
  */
 #include "config.h"
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE 2DTables
 #include <boost/test/unit_test.hpp>
 
@@ -284,7 +286,7 @@ struct Test
     }
 };
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(UniformTabulatedFunction1, Scalar, Types)
 {

--- a/tests/material/test_blackoilfluidstate.cpp
+++ b/tests/material/test_blackoilfluidstate.cpp
@@ -28,6 +28,8 @@
  */
 #include "config.h"
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE BlackOilFluidState
 #include <boost/test/unit_test.hpp>
 
@@ -37,7 +39,8 @@
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/checkFluidSystem.hpp>
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(ApiConformance, Scalar, Types)
 {
     using FluidSystem = Opm::BlackOilFluidSystem<Scalar>;

--- a/tests/material/test_co2brine_ptflash.cpp
+++ b/tests/material/test_co2brine_ptflash.cpp
@@ -32,7 +32,11 @@
 
 #define BOOST_TEST_MODULE Co2BrinePtFlash
 #include <boost/test/unit_test.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 > 66
 #include <boost/test/data/test_case.hpp>
+#endif
 
 #include <opm/material/constraintsolvers/PTFlash.hpp>
 #include <opm/material/fluidsystems/Co2BrineFluidSystem.hh>
@@ -55,8 +59,15 @@ using FluidState = Opm::CompositionalFluidState<Evaluation, FluidSystem>;
 
 std::vector<std::string> test_methods {"newton", "ssi", "ssi+newton"};
 
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 > 66
 BOOST_DATA_TEST_CASE(PtFlash, test_methods)
+#else
+BOOST_AUTO_TEST_CASE(PtFlash)
+#endif
 {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 67
+for (const auto& sample : test_methods) {
+#endif
     // Initial: the primary variables are, pressure, molar fractions of the first and second component
     Evaluation p_init = Evaluation::createVariable(10e5, 0); // 10 bar
     ComponentVector comp;
@@ -168,10 +179,20 @@ BOOST_DATA_TEST_CASE(PtFlash, test_methods)
 
     BOOST_CHECK_MESSAGE(Opm::MathToolbox<Evaluation>::isSame(L, ref_L, 2e-3),
                         "L does not match");
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 67
+}
+#endif
 }
 
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 > 66
 BOOST_DATA_TEST_CASE(PtFlashSingle, test_methods)
+#else
+BOOST_AUTO_TEST_CASE(PtFlashSingle)
+#endif
 {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 67
+for (const auto& sample : test_methods) {
+#endif
     // setting up a system that we know activates the calculations for a single-phase system
     // Initial: the primary variables are, pressure, molar fractions of the first and second component
     ComponentVector comp;
@@ -266,4 +287,7 @@ BOOST_DATA_TEST_CASE(PtFlashSingle, test_methods)
                         "L does not match");
 
     // TODO: we should also check densities, viscosities, saturations and so on
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 67
+}
+#endif
 }

--- a/tests/material/test_co2brinepvt.cpp
+++ b/tests/material/test_co2brinepvt.cpp
@@ -29,6 +29,8 @@
  */
 #include "config.h"
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE Co2BrinePvt
 #include <boost/test/unit_test.hpp>
 
@@ -239,7 +241,7 @@ void ensurePvtApiBrineOil(const BrinePvt& brinePvt)
     }
 }
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Oil, Scalar, Types)
 {

--- a/tests/material/test_components.cpp
+++ b/tests/material/test_components.cpp
@@ -31,7 +31,13 @@
 
 #define BOOST_TEST_MODULE Components
 #include <boost/test/unit_test.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
 #include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>

--- a/tests/material/test_components.cpp
+++ b/tests/material/test_components.cpp
@@ -27,6 +27,8 @@
  */
 #include "config.h"
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE Components
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
@@ -97,7 +99,7 @@ bool close_at_tolerance(Scalar n1, Scalar n2, Scalar tolerance)
     return comp(n1, n2);
 }
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(All, Scalar, Types)
 {

--- a/tests/material/test_components.cpp
+++ b/tests/material/test_components.cpp
@@ -101,7 +101,11 @@ void testAllComponents()
 template<class Scalar>
 bool close_at_tolerance(Scalar n1, Scalar n2, Scalar tolerance)
 {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    auto comp = boost::test_tools::close_at_tolerance<Scalar>(boost::test_tools::percent_tolerance_t<Scalar>(tolerance*100.0));
+#else
     auto comp = boost::math::fpc::close_at_tolerance<Scalar>(tolerance);
+#endif
     return comp(n1, n2);
 }
 

--- a/tests/material/test_eclblackoilfluidsystem.cpp
+++ b/tests/material/test_eclblackoilfluidsystem.cpp
@@ -33,6 +33,8 @@
 #error "The test for the black oil fluid system classes requires ecl input support in opm-common"
 #endif
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE EclBlackOilFluidSystem
 #include <boost/test/unit_test.hpp>
 
@@ -611,7 +613,7 @@ static constexpr const char* deckString1 =
     "      860.04 1033.0    0.853  /\n"
     "\n";
 
-using Types = std::tuple<double,Opm::DenseAd::Evaluation<double,2>>;
+using Types = boost::mpl::list<double,Opm::DenseAd::Evaluation<double,2>>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(BlackOil, Evaluation, Types)
 {

--- a/tests/material/test_eclblackoilpvt.cpp
+++ b/tests/material/test_eclblackoilpvt.cpp
@@ -33,6 +33,8 @@
 #error "The test for the black oil PVT classes requires eclipse input support in opm-common"
 #endif
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE EclBlackOilPvt
 #include <boost/test/unit_test.hpp>
 
@@ -246,7 +248,8 @@ struct Fixture {
 
 BOOST_FIXTURE_TEST_SUITE(Generic, Fixture)
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(ApiConformance, Scalar, Types)
 {
     Opm::GasPvtMultiplexer<Scalar> gasPvt;

--- a/tests/material/test_eclmateriallawmanager.cpp
+++ b/tests/material/test_eclmateriallawmanager.cpp
@@ -34,6 +34,8 @@
 #error "The test for EclMaterialLawManager requires eclipse input support in opm-common"
 #endif
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE EclMaterialLawManager
 #include <boost/test/unit_test.hpp>
 
@@ -611,7 +613,7 @@ struct Fixture {
     using MaterialLaw = typename MaterialLawManager::MaterialLaw;
 };
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 BOOST_AUTO_TEST_CASE_TEMPLATE(Fam1Fam2Hysteresis, Scalar, Types)
 {
     using MaterialLaw = typename Fixture<Scalar>::MaterialLaw;

--- a/tests/material/test_fluidmatrixinteractions.cpp
+++ b/tests/material/test_fluidmatrixinteractions.cpp
@@ -29,6 +29,8 @@
  */
 #include "config.h"
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE FluidMatrixInteractions
 #include <boost/test/unit_test.hpp>
 
@@ -254,7 +256,7 @@ void testThreePhaseApi()
     }
 }
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(ApiConformance, Scalar, Types)
 {

--- a/tests/material/test_fluidsystems.cpp
+++ b/tests/material/test_fluidsystems.cpp
@@ -28,6 +28,8 @@
  */
 #include "config.h"
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE FluidSystems
 #include <boost/test/unit_test.hpp>
 
@@ -164,7 +166,7 @@ void ensureBlackoilApi()
     }
 }
 
-using EvalTypes = std::tuple<float,double,Opm::DenseAd::Evaluation<float,3>,Opm::DenseAd::Evaluation<double,3>>;
+using EvalTypes = boost::mpl::list<float,double,Opm::DenseAd::Evaluation<float,3>,Opm::DenseAd::Evaluation<double,3>>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(SimpleModularFluidState, Eval, EvalTypes)
 {
@@ -247,7 +249,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(SaturationOverlayFluidState, Eval, EvalTypes)
     checkFluidState<Eval>(fs);
 }
 
-using ScalarTypes = std::tuple<float,double>;
+using ScalarTypes = boost::mpl::list<float,double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(BlackoilFluidSystem, Scalar, ScalarTypes)
 {

--- a/tests/material/test_h2brinepvt.cpp
+++ b/tests/material/test_h2brinepvt.cpp
@@ -29,6 +29,8 @@
  */
 #include "config.h"
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE H2BrinePvt
 #include <boost/test/unit_test.hpp>
 
@@ -241,7 +243,7 @@ void ensurePvtApiBrineOil(const BrinePvt& brinePvt)
     }
 }
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(Oil, Scalar, Types)
 {

--- a/tests/material/test_immiscibleflash.cpp
+++ b/tests/material/test_immiscibleflash.cpp
@@ -35,6 +35,8 @@
 #define BOOST_TEST_MODULE ImmiscibleFlash
 #include <boost/test/unit_test.hpp>
 
+#include <boost/mpl/list.hpp>
+
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp>
 #include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
@@ -153,7 +155,7 @@ void completeReferenceFluidState(FluidState& fs,
     }
 }
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 
 template<class Scalar>
 struct Fixture {

--- a/tests/material/test_ncpflash.cpp
+++ b/tests/material/test_ncpflash.cpp
@@ -35,6 +35,8 @@
 #define BOOST_TEST_MODULE NcpFlash
 #include <boost/test/unit_test.hpp>
 
+#include <boost/mpl/list.hpp>
+
 #include <opm/material/constraintsolvers/NcpFlash.hpp>
 #include <opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp>
 #include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
@@ -219,7 +221,7 @@ struct Fixture {
     MaterialLawParams matParams;
 };
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(SinglePhaseGas, Scalar, Types)
 {

--- a/tests/material/test_tabulation.cpp
+++ b/tests/material/test_tabulation.cpp
@@ -29,6 +29,8 @@
  */
 #include "config.h"
 
+#include <boost/mpl/list.hpp>
+
 #define BOOST_TEST_MODULE Tabulation
 #include <boost/test/unit_test.hpp>
 
@@ -38,7 +40,7 @@
 #include <iostream>
 #include <tuple>
 
-using Types = std::tuple<float,double>;
+using Types = boost::mpl::list<float,double>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(H2O, Scalar, Types)
 {

--- a/tests/material/test_threecomponents_ptflash.cpp
+++ b/tests/material/test_threecomponents_ptflash.cpp
@@ -31,7 +31,11 @@
 
 #define BOOST_TEST_MODULE PtFlash
 #include <boost/test/unit_test.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 > 66
 #include <boost/test/data/test_case.hpp>
+#endif
 
 #include <opm/material/constraintsolvers/PTFlash.hpp>
 #include <opm/material/fluidsystems/ThreeComponentFluidSystem.hh>
@@ -52,8 +56,15 @@ using FluidState = Opm::CompositionalFluidState<Evaluation, FluidSystem>;
 
 std::vector<std::string> test_methods {"newton", "ssi", "ssi+newton"};
 
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 > 66
 BOOST_DATA_TEST_CASE(PtFlash, test_methods)
+#else
+BOOST_AUTO_TEST_CASE(PtFlash)
+#endif
 {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 67
+for (const auto& sample : test_methods) {
+#endif
     // Initial: the primary variables are, pressure, molar fractions of the first and second component
     Evaluation p_init = Evaluation::createVariable(10e5, 0); // 10 bar
     ComponentVector comp;
@@ -204,4 +215,8 @@ BOOST_DATA_TEST_CASE(PtFlash, test_methods)
 
     BOOST_CHECK_MESSAGE(Opm::MathToolbox<Evaluation>::isSame(L, ref_L, 2e-3),
                         "L does not match");
+
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 67
+}
+#endif
 }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -23,7 +23,13 @@
 #define BOOST_TEST_MODULE ACTIONX
 
 #include <boost/test/unit_test.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
 #include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 #include <opm/common/utility/TimeService.hpp>
 #include <opm/common/utility/OpmInputError.hpp>

--- a/tests/parser/EclipseStateTests.cpp
+++ b/tests/parser/EclipseStateTests.cpp
@@ -23,6 +23,8 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <boost/test/unit_test.hpp>
 
+#include <boost/version.hpp>
+
 #include <opm/input/eclipse/Python/Python.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
@@ -42,7 +44,11 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 using namespace Opm;
 
 inline std::string prepath() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 static Deck createDeckTOP() {

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -28,7 +28,12 @@
 #define BOOST_TEST_MODULE FieldPropsTests
 
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
 #include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 #include <opm/common/utility/OpmInputError.hpp>
 

--- a/tests/parser/ParserIncludeTests.cpp
+++ b/tests/parser/ParserIncludeTests.cpp
@@ -21,6 +21,8 @@
 #define BOOST_TEST_MODULE ParserTests
 #include <boost/test/unit_test.hpp>
 
+#include <boost/version.hpp>
+
 #include <filesystem>
 #include <iostream>
 #include <opm/common/utility/OpmInputError.hpp>
@@ -34,7 +36,11 @@
 #include <iostream>
 
 inline std::string prefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 

--- a/tests/parser/ParserTests.cpp
+++ b/tests/parser/ParserTests.cpp
@@ -20,6 +20,8 @@
 #define BOOST_TEST_MODULE ParserTests
 #include <boost/test/unit_test.hpp>
 
+#include <boost/version.hpp>
+
 #include <opm/json/JsonObject.hpp>
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
@@ -68,7 +70,11 @@ constexpr ParserItem::itype DOUBLE = ParserItem::itype::DOUBLE;
 
 
 std::string prefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 ParserKeyword createDynamicSized(const std::string& kw) {

--- a/tests/parser/PvtxTableTests.cpp
+++ b/tests/parser/PvtxTableTests.cpp
@@ -21,6 +21,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <boost/version.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
@@ -48,7 +50,11 @@
 using namespace Opm;
 
 inline std::string prefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 BOOST_AUTO_TEST_CASE( PvtxNumTables1 ) {

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -29,7 +29,13 @@
 #define BOOST_TEST_MODULE ScheduleTests
 
 #include <boost/test/unit_test.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
 #include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 #include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/common/utility/TimeService.hpp>

--- a/tests/parser/integration/BoxTest.cpp
+++ b/tests/parser/integration/BoxTest.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <boost/version.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
@@ -36,7 +37,11 @@ using namespace Opm;
 namespace {
 
 std::string prefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 Deck makeDeck(const std::string& fileName) {

--- a/tests/parser/integration/CarfinTest.cpp
+++ b/tests/parser/integration/CarfinTest.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <boost/version.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
@@ -36,7 +37,11 @@ using namespace Opm;
 namespace {
 
 std::string prefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 Deck makeDeck(const std::string& fileName) {

--- a/tests/parser/integration/EclipseGridCreateFromDeck.cpp
+++ b/tests/parser/integration/EclipseGridCreateFromDeck.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <boost/version.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
@@ -34,7 +35,11 @@
 using namespace Opm;
 
 inline std::string prefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(CreateCPGrid) {

--- a/tests/parser/integration/IOConfigIntegrationTest.cpp
+++ b/tests/parser/integration/IOConfigIntegrationTest.cpp
@@ -20,6 +20,7 @@
 #define BOOST_TEST_MODULE IOCONFIG_INTEGRATION_TEST
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <boost/version.hpp>
 
 #include <ctime>
 #include <map>
@@ -40,7 +41,11 @@ using namespace Opm;
 namespace {
 
 std::string path_prefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 void verifyRestartConfig( const Schedule& sched, std::map<int, boost::gregorian::date>& rptConfig) {

--- a/tests/parser/integration/IntegrationTests.cpp
+++ b/tests/parser/integration/IntegrationTests.cpp
@@ -20,6 +20,8 @@
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <boost/version.hpp>
+
 #include <opm/common/utility/OpmInputError.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
@@ -37,7 +39,11 @@
 using namespace Opm;
 
 inline std::string pathprefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 namespace {

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -20,6 +20,8 @@
 #define BOOST_TEST_MODULE ParserKeywordsIntegrationTests
 #include <boost/test/unit_test.hpp>
 
+#include <boost/version.hpp>
+
 #include <opm/common/utility/OpmInputError.hpp>
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
@@ -45,7 +47,11 @@
 using namespace Opm;
 
 inline std::string pathprefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 BOOST_AUTO_TEST_CASE( debug ) {

--- a/tests/parser/integration/Polymer.cpp
+++ b/tests/parser/integration/Polymer.cpp
@@ -19,6 +19,7 @@
 
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
@@ -31,7 +32,11 @@
 using namespace Opm;
 
 inline std::string pathprefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 BOOST_AUTO_TEST_CASE( parse_polymer_tables ) {

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <boost/version.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
@@ -45,7 +46,11 @@ using namespace Opm;
 
 
 inline std::string pathprefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(CreateSchedule) {

--- a/tests/parser/integration/TransMultIntegrationTests.cpp
+++ b/tests/parser/integration/TransMultIntegrationTests.cpp
@@ -18,6 +18,7 @@
 
 #define BOOST_TEST_MODULE TransMultTests
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
@@ -29,7 +30,11 @@
 using namespace Opm;
 
 inline std::string pathprefix() {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+    return boost::unit_test::framework::master_test_suite().argv[2];
+#else
     return boost::unit_test::framework::master_test_suite().argv[1];
+#endif
 }
 
 BOOST_AUTO_TEST_CASE(MULTFLT_IN_SCHEDULE) {

--- a/tests/test_nonuniformtablelinear.cpp
+++ b/tests/test_nonuniformtablelinear.cpp
@@ -24,7 +24,13 @@
 
 #define BOOST_TEST_MODULE NonuniformTableLinearTests
 #include <boost/test/unit_test.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
 #include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 #include <opm/common/utility/numeric/NonuniformTableLinear.hpp>
 

--- a/tests/test_uniformtablelinear.cpp
+++ b/tests/test_uniformtablelinear.cpp
@@ -23,10 +23,14 @@
 
 #define BOOST_TEST_MODULE UniformTableLinearTests
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#include <boost/test/floating_point_comparison.hpp>
+#else
 #include <boost/test/tools/floating_point_comparison.hpp>
+#endif
+
 #include <opm/common/utility/numeric/UniformTableLinear.hpp>
-
-
 
 BOOST_AUTO_TEST_CASE(table_operations)
 {


### PR DESCRIPTION
In particular needed for redhat builds. Full disclosure: I could not actually find when support for the command line parameter separator was added, so I just used version 1.71 as the barrier since that is lower than the oldest ubuntu / debian version we have to deal with.