### PR TITLE
Fail if Damaris is requested and not found

### DIFF
--- a/cmake/Modules/UseDamaris.cmake
+++ b/cmake/Modules/UseDamaris.cmake
@@ -18,7 +18,7 @@ if(USE_DAMARIS_LIB AND MPI_FOUND)
       message(STATUS "The Damaris library does NOT have Catalyst support")
     endif()
   else()
-    message(STATUS "The Damaris library was requested but NOT found")
+    message(FATAL_ERROR "The Damaris library was requested but NOT found")
   endif()
 else()  # User did not request Damaris support
   unset(HAVE_DAMARIS)


### PR DESCRIPTION
In the current setup, `USE_DAMARIS_LIB` is set to `OFF` by default, but setting it to `ON` does not issue an error if Damaris is not found. This PR issues an error if `USE_DAMARIS_LIB==ON` and Damaris is not found.