### PR TITLE
Collect Dynamic Connection Level Transmissibilty Multiplier

### DIFF
--- a/opm/output/data/Wells.hpp
+++ b/opm/output/data/Wells.hpp
@@ -35,9 +35,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace Opm {
-
-    namespace data {
+namespace Opm { namespace data {
 
     class Rates {
         /* Methods are defined inline for performance, as the actual *work* done
@@ -256,22 +254,25 @@ namespace Opm {
         double effective_Kh;
         double trans_factor;
         double d_factor;
+        double compact_mult{1.0}; // Rock compaction transmissibility multiplier (ROCKTAB)
 
         ConnectionFiltrate filtrate;
 
         bool operator==(const Connection& conn2) const
         {
-            return index == conn2.index &&
-                   rates == conn2.rates &&
-                   pressure == conn2.pressure &&
-                   reservoir_rate == conn2.reservoir_rate &&
-                   cell_pressure == conn2.cell_pressure &&
-                   cell_saturation_water == conn2.cell_saturation_water &&
-                   cell_saturation_gas == conn2.cell_saturation_gas &&
-                   effective_Kh == conn2.effective_Kh &&
-                   trans_factor == conn2.trans_factor &&
-                   d_factor == conn2.d_factor &&
-                   filtrate == conn2.filtrate;
+            return (index == conn2.index)
+                && (rates == conn2.rates)
+                && (pressure == conn2.pressure)
+                && (reservoir_rate == conn2.reservoir_rate)
+                && (cell_pressure == conn2.cell_pressure)
+                && (cell_saturation_water == conn2.cell_saturation_water)
+                && (cell_saturation_gas == conn2.cell_saturation_gas)
+                && (effective_Kh == conn2.effective_Kh)
+                && (trans_factor == conn2.trans_factor)
+                && (d_factor == conn2.d_factor)
+                && (compact_mult == conn2.compact_mult)
+                && (filtrate == conn2.filtrate)
+                ;
         }
 
         template <class MessageBufferType>
@@ -294,15 +295,18 @@ namespace Opm {
             serializer(effective_Kh);
             serializer(trans_factor);
             serializer(d_factor);
+            serializer(compact_mult);
             serializer(filtrate);
         }
 
         static Connection serializationTestObject()
         {
-            return Connection{1, Rates::serializationTestObject(),
-                              2.0, 3.0, 4.0, 5.0,
-                              6.0, 7.0, 8.0, 9.0,
-                              ConnectionFiltrate::serializationTestObject() };
+            return Connection {
+                1, Rates::serializationTestObject(),
+                2.0, 3.0, 4.0, 5.0,
+                6.0, 7.0, 8.0, 9.0, 0.987,
+                ConnectionFiltrate::serializationTestObject()
+            };
         }
     };
 
@@ -1186,6 +1190,7 @@ namespace Opm {
             buffer.write(this->effective_Kh);
             buffer.write(this->trans_factor);
             buffer.write(this->d_factor);
+            buffer.write(this->compact_mult);
             this->filtrate.write(buffer);
     }
 
@@ -1202,6 +1207,7 @@ namespace Opm {
         json_data.add_item("Kh", this->effective_Kh);
         json_data.add_item("trans_factor", this->trans_factor);
         json_data.add_item("d_factor", this->d_factor);
+        json_data.add_item("compact_mult", this->compact_mult);
     }
 
     template <class MessageBufferType>
@@ -1348,6 +1354,7 @@ namespace Opm {
             buffer.read(this->effective_Kh);
             buffer.read(this->trans_factor);
             buffer.read(this->d_factor);
+            buffer.read(this->compact_mult);
             this->filtrate.read(buffer);
    }
 

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -732,12 +732,12 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         std::vector<Opm::data::Connection> well1_comps(9);
         Opm::data::ConnectionFiltrate con_filtrate {0.1, 1, 3, 0.4, 1.e-9, 0.2, 0.05, 10.}; // values are not used in this test
         for (size_t i = 0; i < 9; ++i) {
-            Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 1.2e3, 4.321, 0.0, con_filtrate};
+            Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i), r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 1.2e3, 4.321, 0.0, 1.23, con_filtrate};
             well1_comps[i] = std::move(well_comp);
         }
         std::vector<Opm::data::Connection> well2_comps(6);
         for (size_t i = 0; i < 6; ++i) {
-            Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 0.15, 0.54321, 0.0, con_filtrate};
+            Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3), r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 0.15, 0.54321, 0.0, 0.98, con_filtrate};
             well2_comps[i] = std::move(well_comp);
         }
 
@@ -871,12 +871,12 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
                 std::vector<Opm::data::Connection> well1_comps(9);
                 Opm::data::ConnectionFiltrate con_filtrate {0.1, 1, 3, 0.4, 1.e-9, 0.2, 0.05, 10.}; // values are not used in this test
                 for (size_t i = 0; i < 9; ++i) {
-                    Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i) ,r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 3.14e5, 0.1234, 0.0, con_filtrate};
+                    Opm::data::Connection well_comp { grid.getGlobalIndex(8,8,i), r1, 0.0 , 0.0, (double)i, 0.1*i,0.2*i, 3.14e5, 0.1234, 0.0, 1.23, con_filtrate};
                     well1_comps[i] = std::move(well_comp);
                 }
                 std::vector<Opm::data::Connection> well2_comps(6);
                 for (size_t i = 0; i < 6; ++i) {
-                    Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3) ,r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 355.113, 0.9876, 0.0, con_filtrate};
+                    Opm::data::Connection well_comp { grid.getGlobalIndex(3,3,i+3), r2, 0.0 , 0.0, (double)i, i*0.1,i*0.2, 355.113, 0.9876, 0.0, 0.98, con_filtrate};
                     well2_comps[i] = std::move(well_comp);
                 }
 

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -187,15 +187,15 @@ data::Wells mkWells() {
      *  input deck. All other entries in the well structures are arbitrary.
      */
     Opm::data::ConnectionFiltrate con_filtrate {0.1, 1, 3, 0.4, 1.e-9, 0.2, 0.05, 10.}; // values are not used in this test
-    w1.connections.push_back( { 88, rc1, 30.45, 123.4, 543.21, 0.62, 0.15, 1.0e3, 1.234, 0.0, con_filtrate } );
-    w1.connections.push_back( { 288, rc2, 33.19, 123.4, 432.1, 0.26, 0.45, 2.56, 2.345, 0.0, con_filtrate } );
+    w1.connections.push_back( { 88, rc1, 30.45, 123.4, 543.21, 0.62, 0.15, 1.0e3, 1.234, 0.0, 1.23, con_filtrate } );
+    w1.connections.push_back( { 288, rc2, 33.19, 123.4, 432.1, 0.26, 0.45, 2.56, 2.345, 0.0, 0.98, con_filtrate } );
 
     w2.rates = r2;
     w2.thp = 2.0;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
     w2.control = 2;
-    w2.connections.push_back( { 188, rc3, 36.22, 123.4, 256.1, 0.55, 0.0125, 314.15, 3.456, 0.0, con_filtrate } );
+    w2.connections.push_back( { 188, rc3, 36.22, 123.4, 256.1, 0.55, 0.0125, 314.15, 3.456, 0.0, 2.46, con_filtrate } );
 
     {
         data::Wells wellRates;

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -319,11 +319,11 @@ data::Wells result_wells(const bool w3_injector = true)
     data::ConnectionFiltrate zero_filtrate {}; // only injecting connections are counted for filtration related
     data::ConnectionFiltrate con_filtrate = {0.1*sm3_pr_day(), 1*sm3(), 3, 0.01*unit::meter, 1.e-3*unit::darcy, 0.2, 0.05*unit::meter, 10.*unit::square(unit::meter)};
     data::ConnectionFiltrate w3_con_filtrate = w3_injector ? con_filtrate : zero_filtrate;
-    data::Connection well1_comp1 { 0  , crates1, 1.9 *unit::barsa, -123.4 *rm3_pr_day(), 314.15, 0.35 , 0.25,   2.718e2, 111.222*cp_rm3_per_db(), 0.0, zero_filtrate};
-    data::Connection well2_comp1 { 1  , crates2, 1.10*unit::barsa, - 23.4 *rm3_pr_day(), 212.1 , 0.78 , 0.0 ,  12.34   , 222.333*cp_rm3_per_db(), 0.0, zero_filtrate};
-    data::Connection well2_comp2 { 101, crates3, 1.11*unit::barsa, -234.5 *rm3_pr_day(), 150.6 , 0.001, 0.89, 100.0    , 333.444*cp_rm3_per_db(), 0.0, con_filtrate /* output should be zero since it is a producer */};
-    data::Connection well3_comp1 { 2  , crates3, 1.11*unit::barsa,  432.1 *rm3_pr_day(), 456.78, 0.0  , 0.15, 432.1    , 444.555*cp_rm3_per_db(), 0.0, w3_con_filtrate};
-    data::Connection well6_comp1 { 77 , crates6, 6.11*unit::barsa,  321.09*rm3_pr_day(), 656.78, 0.0  , 0.65, 632.1    , 555.666*cp_rm3_per_db(), 0.0, zero_filtrate};
+    data::Connection well1_comp1 { 0  , crates1, 1.9 *unit::barsa, -123.4 *rm3_pr_day(), 314.15, 0.35 , 0.25,   2.718e2, 111.222*cp_rm3_per_db(), 0.0, 1.0, zero_filtrate};
+    data::Connection well2_comp1 { 1  , crates2, 1.10*unit::barsa, - 23.4 *rm3_pr_day(), 212.1 , 0.78 , 0.0 ,  12.34   , 222.333*cp_rm3_per_db(), 0.0, 1.0, zero_filtrate};
+    data::Connection well2_comp2 { 101, crates3, 1.11*unit::barsa, -234.5 *rm3_pr_day(), 150.6 , 0.001, 0.89, 100.0    , 333.444*cp_rm3_per_db(), 0.0, 1.0, con_filtrate /* output should be zero since it is a producer */};
+    data::Connection well3_comp1 { 2  , crates3, 1.11*unit::barsa,  432.1 *rm3_pr_day(), 456.78, 0.0  , 0.15, 432.1    , 444.555*cp_rm3_per_db(), 0.0, 1.0, w3_con_filtrate};
+    data::Connection well6_comp1 { 77 , crates6, 6.11*unit::barsa,  321.09*rm3_pr_day(), 656.78, 0.0  , 0.65, 632.1    , 555.666*cp_rm3_per_db(), 0.0, 1.0, zero_filtrate};
 
     /*
       The completions

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -172,7 +172,7 @@ static data::Wells result_wells() {
       input deck.
     */
     data::ConnectionFiltrate con_filtrate {0.1, 1, 3, 0.4, 1.e-9, 0.2, 0.05, 10.}; // values are not tested in this test
-    data::Connection well1_comp1 { 0  , crates1, 1.9 , 123.4, 314.15, 0.35, 0.25, 2.718e2, 0.12345, 0.0, con_filtrate };
+    data::Connection well1_comp1 { 0, crates1, 1.9, 123.4, 314.15, 0.35, 0.25, 2.718e2, 0.12345, 0.0, 1.23, con_filtrate };
 
     /*
       The completions

--- a/tests/test_Wells.cpp
+++ b/tests/test_Wells.cpp
@@ -116,8 +116,8 @@ BOOST_AUTO_TEST_CASE(get_connections) {
      *  the completion keys (active indices) and well names correspond to the
      *  input deck. All other entries in the well structures are arbitrary.
      */
-    w1.connections.push_back( { 88, rc1, 30.45, 123.45, 543.21, 0.123, 0.5, 17.29, 0.1729,0.0,{}} );
-    w1.connections.push_back( { 288, rc2, 33.19, 67.89, 98.76, 0.5, 0.125, 355.113, 0.355113,0.0, {}} );
+    w1.connections.push_back( { 88, rc1, 30.45, 123.45, 543.21, 0.123, 0.5, 17.29, 0.1729, 0.0, 1.23, {}} );
+    w1.connections.push_back( { 288, rc2, 33.19, 67.89, 98.76, 0.5, 0.125, 355.113, 0.355113, 0.0, 0.98, {}} );
 
     {
         Json::JsonObject json_data;
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(get_connections) {
     w2.temperature = 4.56;
     w2.control = 2;
     w2.filtrate = {0.3, 3, 0.4}; // values are not tested in this test
-    w2.connections.push_back( { 188, rc3, 36.22, 19.28, 28.91, 0.125, 0.125, 3.141, 0.31415, 0.0, {}} );
+    w2.connections.push_back( { 188, rc3, 36.22, 19.28, 28.91, 0.125, 0.125, 3.141, 0.31415, 0.0, 1.21, {}} );
     data::Wells wellRates;
 
     wellRates["OP_1"] = w1;


### PR DESCRIPTION
This PR adds a new data member to the `data::Connection` structure,
```C++
double data::Connection::compact_mult
```
This provides a slot in which the simulator can communicate transmissibility multiplier values resulting from rock compaction. The goal is to be able to distinguish background transmissibility factors from the effective transmissibility factors which include rock compaction effects.