### PR TITLE
Store Peaceman Denominator and Connection Length in Restart File

### DIFF
--- a/opm/io/eclipse/rst/connection.hpp
+++ b/opm/io/eclipse/rst/connection.hpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
@@ -19,19 +20,27 @@
 #ifndef RST_CONNECTION
 #define RST_CONNECTION
 
-#include <array>
-
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
 
+#include <array>
+
 namespace Opm {
+
 class UnitSystem;
 
-namespace RestartIO {
+} // namespace Opm
 
-class Header;
+namespace Opm { namespace RestartIO {
 
-struct RstConnection {
-    RstConnection(const ::Opm::UnitSystem& unit_system, std::size_t rst_index, int nsconz, const int* icon, const float* scon, const double *xcon);
+struct RstConnection
+{
+    RstConnection(const UnitSystem& unit_system,
+                  std::size_t rst_index,
+                  int nsconz,
+                  const int* icon,
+                  const float* scon,
+                  const double *xcon);
+
     static double inverse_peaceman(double cf, double kh, double rw, double skin);
 
     std::size_t rst_index;
@@ -49,6 +58,8 @@ struct RstConnection {
     float depth;
     float diameter;
     float kh;
+    float denom;
+    float length;
     float segdist_end;
     float segdist_start;
 
@@ -60,11 +71,6 @@ struct RstConnection {
     double r0;
 };
 
+}} // namespace Opm::RestartIO
 
-}
-}
-
-
-
-
-#endif
+#endif // RST_CONNECTION

--- a/opm/output/eclipse/VectorItems/connection.hpp
+++ b/opm/output/eclipse/VectorItems/connection.hpp
@@ -50,6 +50,10 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
             EffectiveKH  =  3, // Effective Kh product of connection
             SkinFactor   =  4, // Skinfactor - item 'SKIN' from COMPDAT
+
+            CFDenom = 6,    // Denominator in connection transmissibility
+                            // factor expression
+
             item12       = 11, // Connection transmissibility factor
 
             SegDistEnd   = 20, // Distance to end of connection in segment
@@ -57,6 +61,9 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
             item30       = 29, // Unknown
             item31       = 30, // Unknown
+
+            EffectiveLength = 31, // Effective length of connection's perforation interval.
+
             CFInDeck     = 40, // = 0 for connection factor not defined, = 1 for connection factor defined
         };
     } // SConn

--- a/src/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -31,12 +31,15 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
+#include <cstddef>
 #include <exception>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -53,9 +56,10 @@ namespace {
         props.rw = rst_conn.diameter / 2;
         props.r0 = rst_conn.r0;
         props.re = 0.0;
-        props.connection_length = 0.0;
+        props.connection_length = rst_conn.length;
         props.skin_factor = rst_conn.skin_factor;
         props.d_factor = 0.0;
+        props.peaceman_denom = rst_conn.denom;
 
         return props;
     }
@@ -155,7 +159,7 @@ namespace Opm
                                                 rst_connection.segdist_end);
         }
 
-        //TODO recompute re and perf_length from the grid
+        // TODO: recompute re from the grid
     }
 
     Connection Connection::serializationTestObject()

--- a/src/opm/io/eclipse/rst/connection.cpp
+++ b/src/opm/io/eclipse/rst/connection.cpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
@@ -16,99 +17,119 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cmath>
-#include <stdexcept>
-
-#include <opm/io/eclipse/rst/header.hpp>
 #include <opm/io/eclipse/rst/connection.hpp>
+
 #include <opm/output/eclipse/VectorItems/connection.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
 
 namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
-
-namespace Opm {
-namespace RestartIO {
 
 namespace {
 
 template <typename T>
 T from_int(int);
 
-template <>
-Connection::State from_int(int int_state) {
-    if (int_state == 1)
-        return Connection::State::OPEN;
-
-    return Connection::State::SHUT;
+template<> Opm::Connection::State from_int(int int_state)
+{
+    return (int_state == 1)
+        ? Opm::Connection::State::OPEN
+        : Opm::Connection::State::SHUT;
 }
 
-template <>
-Connection::Direction from_int(int int_dir) {
+template<> Opm::Connection::Direction from_int(int int_dir)
+{
     switch (int_dir) {
-    case 1:
-        return Connection::Direction::X;
-    case 2:
-        return Connection::Direction::Y;
-    case 3:
-        return Connection::Direction::Z;
-    default:
-        throw std::invalid_argument("Can not convert: " + std::to_string(int_dir) + " to string");
+    case 1: return Opm::Connection::Direction::X;
+    case 2: return Opm::Connection::Direction::Y;
+    case 3: return Opm::Connection::Direction::Z;
     }
+
+    throw std::invalid_argument {
+        "Unable to convert direction value: " +
+        std::to_string(int_dir) + " to Direction category"
+    };
 }
 
-/*
-  That the CTFKind variable comes from a float looks extremely suspicious; but
-  it has been double checked ...
-*/
-Connection::CTFKind from_float(float float_kind) {
-    if (float_kind == 0)
-        return Connection::CTFKind::Defaulted;
-
-    return Connection::CTFKind::DeckValue;
-}
+// Note: CTFKind originates in SCON and is indeed a float.
+Opm::Connection::CTFKind from_float(float float_kind)
+{
+    return (float_kind == 0.0f)
+        ? Opm::Connection::CTFKind::Defaulted
+        : Opm::Connection::CTFKind::DeckValue;
 }
 
-double RstConnection::inverse_peaceman(double cf, double kh, double rw, double skin) {
+float as_float(const double x)
+{
+    return static_cast<float>(x);
+}
+
+double pressEquivRadius(const float denom,
+                        const float skin,
+                        const float rw)
+{
+    // Recall: denom = log(r0 / rw) + skin
+    return rw * std::exp(denom - skin);
+}
+
+} // Anonymous namespace
+
+double Opm::RestartIO::RstConnection::inverse_peaceman(double cf, double kh, double rw, double skin)
+{
     auto alpha = 3.14159265 * 2 * kh / cf - skin;
     return rw * std::exp(alpha);
 }
 
-using M  = ::Opm::UnitSystem::measure;
+using M = ::Opm::UnitSystem::measure;
 
-RstConnection::RstConnection(const ::Opm::UnitSystem& unit_system, std::size_t rst_index_, int nsconz, const int* icon, const float* scon, const double* xcon) :
-    rst_index(                                               rst_index_),
-    ijk(                                                    {icon[VI::IConn::CellI] - 1, icon[VI::IConn::CellJ] - 1, icon[VI::IConn::CellK] - 1}),
-    state(                                                   from_int<Connection::State>(icon[VI::IConn::ConnStat])),
-    drain_sat_table(                                         icon[VI::IConn::Drainage]),
-    imb_sat_table(                                           icon[VI::IConn::Imbibition]),
-    completion(                                              icon[VI::IConn::ComplNum]),
-    dir(                                                     from_int<Connection::Direction>(icon[VI::IConn::ConnDir])),
-    segment(                                                 icon[VI::IConn::Segment]),
-    cf_kind(                                                 from_float(1.0)),
-    skin_factor(                                             scon[VI::SConn::SkinFactor]),
-    cf(            unit_system.to_si(M::transmissibility,    scon[VI::SConn::ConnTrans])),
-    depth(         unit_system.to_si(M::length,              scon[VI::SConn::Depth])),
-    diameter(      unit_system.to_si(M::length,              scon[VI::SConn::Diameter])),
-    kh(            unit_system.to_si(M::effective_Kh,        scon[VI::SConn::EffectiveKH])),
-    segdist_end(   unit_system.to_si(M::length,              scon[VI::SConn::SegDistEnd])),
-    segdist_start( unit_system.to_si(M::length,              scon[VI::SConn::SegDistStart])),
-    oil_rate(      unit_system.to_si(M::liquid_surface_rate, xcon[VI::XConn::OilRate])),
-    water_rate(    unit_system.to_si(M::liquid_surface_rate, xcon[VI::XConn::WaterRate])),
-    gas_rate(      unit_system.to_si(M::gas_surface_rate,    xcon[VI::XConn::GasRate])),
-    pressure(      unit_system.to_si(M::pressure,            xcon[VI::XConn::Pressure])),
-    resv_rate(     unit_system.to_si(M::rate,                xcon[VI::XConn::ResVRate])),
-    r0( RstConnection::inverse_peaceman(this->cf, this->kh, this->diameter/2, this->skin_factor) )
-    /*
-      r0: The r0 quantity is currently not written or read from the restart
-          file. If the r0 value is given explicitly in the deck it is possible
-          to give a value which is not consistent with the Peaceman formula -
-          that value will be lost when loading back from a restart file.
-    */
+Opm::RestartIO::RstConnection::RstConnection(const UnitSystem& unit_system,
+                                             const std::size_t rst_index_,
+                                             const int         nsconz,
+                                             const int*        icon,
+                                             const float*      scon,
+                                             const double*     xcon)
+    : rst_index { rst_index_ }
+      // -----------------------------------------------------------------
+      // Integer values (ICON)
+    , ijk             { icon[VI::IConn::CellI] - 1 ,
+                        icon[VI::IConn::CellJ] - 1 ,
+                        icon[VI::IConn::CellK] - 1 }
+    , state           { from_int<Connection::State>(icon[VI::IConn::ConnStat]) }
+    , drain_sat_table { icon[VI::IConn::Drainage] }
+    , imb_sat_table   { icon[VI::IConn::Imbibition] }
+    , completion      { icon[VI::IConn::ComplNum] }
+    , dir             { from_int<Connection::Direction>(icon[VI::IConn::ConnDir]) }
+    , segment         { icon[VI::IConn::Segment] }
+      // -----------------------------------------------------------------
+      // Float values (SCON)
+    , cf_kind                { from_float(1.0f) }
+    , skin_factor            { scon[VI::SConn::SkinFactor] }
+    , cf                     { as_float(unit_system.to_si(M::transmissibility, scon[VI::SConn::ConnTrans])) }
+    , depth                  { as_float(unit_system.to_si(M::length, scon[VI::SConn::Depth])) }
+    , diameter               { as_float(unit_system.to_si(M::length, scon[VI::SConn::Diameter])) }
+    , kh                     { as_float(unit_system.to_si(M::effective_Kh, scon[VI::SConn::EffectiveKH])) }
+    , denom                  { scon[VI::SConn::CFDenom] }
+    , length                 { as_float(unit_system.to_si(M::length, scon[VI::SConn::EffectiveLength])) }
+    , segdist_end            { as_float(unit_system.to_si(M::length, scon[VI::SConn::SegDistEnd])) }
+    , segdist_start          { as_float(unit_system.to_si(M::length, scon[VI::SConn::SegDistStart])) }
+      // -----------------------------------------------------------------
+      // Double values (XCON)
+    , oil_rate   { unit_system.to_si(M::liquid_surface_rate, xcon[VI::XConn::OilRate]) }
+    , water_rate { unit_system.to_si(M::liquid_surface_rate, xcon[VI::XConn::WaterRate]) }
+    , gas_rate   { unit_system.to_si(M::gas_surface_rate, xcon[VI::XConn::GasRate]) }
+    , pressure   { unit_system.to_si(M::pressure, xcon[VI::XConn::Pressure]) }
+    , resv_rate  { unit_system.to_si(M::rate, xcon[VI::XConn::ResVRate]) }
+      // -----------------------------------------------------------------
+      // Derived quantities
+    , r0 { pressEquivRadius(this->denom, this->skin_factor, this->diameter / 2) }
 {
-    if (static_cast<std::size_t>(nsconz) > VI::SConn::CFInDeck)
+    if (static_cast<std::size_t>(nsconz) > VI::SConn::CFInDeck) {
         this->cf_kind = from_float(scon[VI::SConn::CFInDeck]);
-}
-
-}
+    }
 }

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -191,8 +191,9 @@ namespace {
 
             sConn[Ix::SkinFactor] = conn.skinFactor();
 
-            sConn[Ix::item12] = sConn[Ix::ConnTrans];
+            sConn[Ix::CFDenom] = conn.ctfProperties().peaceman_denom;
 
+            sConn[Ix::item12] = sConn[Ix::ConnTrans];
 
             if (conn.attachedToSegment()) {
                 const auto& [start, end] = *conn.perf_range();
@@ -202,7 +203,11 @@ namespace {
 
             sConn[Ix::item30] = -1.0e+20f;
             sConn[Ix::item31] = -1.0e+20f;
-            sConn[Ix::CFInDeck] = (conn.ctfAssignedFromInput()) ? 1 : 0;
+
+            sConn[Ix::EffectiveLength] =
+                scprop(M::length, conn.connectionLength());
+
+            sConn[Ix::CFInDeck] = conn.ctfAssignedFromInput() ? 1.0f : 0.0f;
         }
 
         template <class SConnArray>

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -687,11 +687,13 @@ BOOST_AUTO_TEST_CASE(Declared_Connection_Data)
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Depth], 7050., 1.0e-5); // PROD - conn 1 : Centre depth
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Diameter], 0.20, 1.0e-5); // PROD - conn 1 : diameter
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveKH], 1581.13879, 1.0e-5); // PROD - conn 1 : effective kh-product
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::CFDenom], 4.37696314, 1.0e-5);
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::item12], 2.55826545, 1.0e-5); // PROD - conn 1 : Transmissibility factor
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistEnd], 130., 1.0e-5); // PROD - conn 1 : Distance to end of connection in segment
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistStart], 30., 1.0e-5); // PROD - conn 1 : Distance to start of connection in segment
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveLength], 100.0, 1.0e-5);
 
         // Well no 2 - WINJ well
         connNo = 3;
@@ -700,11 +702,13 @@ BOOST_AUTO_TEST_CASE(Declared_Connection_Data)
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Depth], 7250., 1.0e-5); // WINJ - conn 3 : Centre depth
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Diameter], 0.20, 1.0e-5); // WINJ - conn 3 : diameter
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveKH], 1581.13879, 1.0e-5); // WINJ - conn 3 : effective kh-product
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::CFDenom], 4.37696314, 1.0e-5);
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::item12], 2.55826545, 1.0e-5); // WINJ - conn 3 : Transmissibility factor
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistEnd], 0., 1.0e-5); // WINJ - conn 3 : Distance to end of connection in segment
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistStart], 0., 1.0e-5); // WINJ - conn 3 : Distance to start of connection in segment
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveLength], 100.0, 1.0e-5);
 
         connNo = 4;
         i0 = ih.ncwmax * ih.nsconz + (connNo - 1) * ih.nsconz;
@@ -712,11 +716,13 @@ BOOST_AUTO_TEST_CASE(Declared_Connection_Data)
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Depth], 7250., 1.0e-5); // WINJ - conn 4 : Centre depth
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Diameter], 0.20, 1.0e-5); // WINJ - conn 4 : diameter
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveKH], 1581.13879, 1.0e-5); // WINJ - conn 4 : effective kh-product
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::CFDenom], 4.37696314, 1.0e-5);
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::item12], 2.55826545, 1.0e-5); // WINJ - conn 4 : Transmissibility factor
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistEnd], 0., 1.0e-5); // WINJ - conn 4 : Distance to end of connection in segment
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistStart], 0., 1.0e-5); // WINJ - conn 4 : Distance to start of connection in segment
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveLength], 100.0, 1.0e-5);
     }
 
     // XCONN (PROD)  + (WINJ)


### PR DESCRIPTION
This PR writes the value of the denominator expression in Peaceman's formula to `SCON[6]` and the connection's interval length to `SCON[31]` in the restart file.  Using this information at restart time is the subject of follow-up work.
