### PR TITLE
Distinguish Background From Effective CTFs

### DIFF
--- a/opm/output/eclipse/VectorItems/connection.hpp
+++ b/opm/output/eclipse/VectorItems/connection.hpp
@@ -44,7 +44,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
     namespace SConn {
         enum index : std::vector<float>::size_type {
-            ConnTrans    =  0, // Connection transmissibility factor
+            EffConnTrans =  0, // Effective connection transmissibility factor (incl. ROCKTAB &c)
             Depth        =  1, // Connection centre depth
             Diameter     =  2, // Connection diameter
 
@@ -54,7 +54,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             CFDenom = 6,    // Denominator in connection transmissibility
                             // factor expression
 
-            item12       = 11, // Connection transmissibility factor
+            ConnTrans = 11, // Connection transmissibility factor
 
             SegDistEnd   = 20, // Distance to end of connection in segment
             SegDistStart = 21, // Distance to start of connection in segment

--- a/src/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/src/opm/output/eclipse/AggregateConnectionData.cpp
@@ -180,7 +180,7 @@ namespace {
                 return static_cast<float>(units.from_si(u, x));
             };
 
-            sConn[Ix::ConnTrans] =
+            sConn[Ix::EffConnTrans] = sConn[Ix::ConnTrans] =
                 scprop(M::transmissibility, conn.CF());
 
             sConn[Ix::Depth]    = scprop(M::length, conn.depth());
@@ -192,8 +192,6 @@ namespace {
             sConn[Ix::SkinFactor] = conn.skinFactor();
 
             sConn[Ix::CFDenom] = conn.ctfProperties().peaceman_denom;
-
-            sConn[Ix::item12] = sConn[Ix::ConnTrans];
 
             if (conn.attachedToSegment()) {
                 const auto& [start, end] = *conn.perf_range();
@@ -223,8 +221,15 @@ namespace {
                 return static_cast<float>(units.from_si(u, x));
             };
 
-            sConn[Ix::item12] = sConn[Ix::ConnTrans] =
+            sConn[Ix::EffConnTrans] = sConn[Ix::ConnTrans] =
                 scprop(M::transmissibility, xconn.trans_factor);
+
+            // xconn.trans_factor == CTFAC == CF * rock compaction.  Divide
+            // out the rock compaction contribution to infer the "real"
+            // connection transmissibility factor.  No additional unit
+            // conversion needed since the rock compaction effect (keyword
+            // ROCKTAB) is imparted through a dimensionless multiplier.
+            sConn[Ix::ConnTrans] /= xconn.compact_mult;
         }
     } // SConn
 

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -502,6 +502,7 @@ END
                     c.pressure = 215.0;
                     c.index = connections[i].global_index();
                     c.trans_factor = connections[i].CF();
+                    c.compact_mult = 0.875;
 
                     const auto& global_index = connections[i].global_index();
                     sum_state.update_conn_var("PROD", "CWPR", global_index + 1, qw * (i + 1));
@@ -543,6 +544,7 @@ END
                     c.pressure = 218.0;
                     c.index = connections[i].global_index();
                     c.trans_factor = connections[i].CF();
+                    c.compact_mult = 0.987;
 
                     const auto& global_index = connections[i].global_index();
                     sum_state.update_conn_var("WINJ", "CWIR", global_index+ 1, qw*(i + 1));
@@ -683,12 +685,12 @@ BOOST_AUTO_TEST_CASE(Declared_Connection_Data)
         const auto& sconn = amconn.getSConn();
         int connNo = 1;
         auto i0 = (connNo - 1) * ih.nsconz;
-        BOOST_CHECK_CLOSE(sconn[i0 + Ix::ConnTrans], 2.55826545, 1.0e-5); // PROD - conn 1 : Transmissibility factor
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffConnTrans], 2.55826545, 1.0e-5); // PROD - conn 1 : Effective transmissibility factor
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Depth], 7050., 1.0e-5); // PROD - conn 1 : Centre depth
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Diameter], 0.20, 1.0e-5); // PROD - conn 1 : diameter
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveKH], 1581.13879, 1.0e-5); // PROD - conn 1 : effective kh-product
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::CFDenom], 4.37696314, 1.0e-5);
-        BOOST_CHECK_CLOSE(sconn[i0 + Ix::item12], 2.55826545, 1.0e-5); // PROD - conn 1 : Transmissibility factor
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::ConnTrans], 2.55826545 / 0.875, 1.0e-5); // PROD - conn 1 : Transmissibility factor
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistEnd], 130., 1.0e-5); // PROD - conn 1 : Distance to end of connection in segment
         BOOST_CHECK_CLOSE(
@@ -698,12 +700,12 @@ BOOST_AUTO_TEST_CASE(Declared_Connection_Data)
         // Well no 2 - WINJ well
         connNo = 3;
         i0 = ih.ncwmax * ih.nsconz + (connNo - 1) * ih.nsconz;
-        BOOST_CHECK_CLOSE(sconn[i0 + Ix::ConnTrans], 2.55826545, 1.0e-5); // WINJ - conn 3 : Transmissibility factor
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffConnTrans], 2.55826545, 1.0e-5); // WINJ - conn 3 : Effective transmissibility factor
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Depth], 7250., 1.0e-5); // WINJ - conn 3 : Centre depth
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Diameter], 0.20, 1.0e-5); // WINJ - conn 3 : diameter
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveKH], 1581.13879, 1.0e-5); // WINJ - conn 3 : effective kh-product
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::CFDenom], 4.37696314, 1.0e-5);
-        BOOST_CHECK_CLOSE(sconn[i0 + Ix::item12], 2.55826545, 1.0e-5); // WINJ - conn 3 : Transmissibility factor
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::ConnTrans], 2.55826545 / 0.987, 1.0e-5); // WINJ - conn 3 : Transmissibility factor
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistEnd], 0., 1.0e-5); // WINJ - conn 3 : Distance to end of connection in segment
         BOOST_CHECK_CLOSE(
@@ -712,12 +714,12 @@ BOOST_AUTO_TEST_CASE(Declared_Connection_Data)
 
         connNo = 4;
         i0 = ih.ncwmax * ih.nsconz + (connNo - 1) * ih.nsconz;
-        BOOST_CHECK_CLOSE(sconn[i0 + Ix::ConnTrans], 2.55826545, 1.0e-5); // WINJ - conn 4 : Transmissibility factor
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffConnTrans], 2.55826545, 1.0e-5); // WINJ - conn 4 : Effective transmissibility factor
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Depth], 7250., 1.0e-5); // WINJ - conn 4 : Centre depth
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::Diameter], 0.20, 1.0e-5); // WINJ - conn 4 : diameter
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::EffectiveKH], 1581.13879, 1.0e-5); // WINJ - conn 4 : effective kh-product
         BOOST_CHECK_CLOSE(sconn[i0 + Ix::CFDenom], 4.37696314, 1.0e-5);
-        BOOST_CHECK_CLOSE(sconn[i0 + Ix::item12], 2.55826545, 1.0e-5); // WINJ - conn 4 : Transmissibility factor
+        BOOST_CHECK_CLOSE(sconn[i0 + Ix::ConnTrans], 2.55826545 / 0.987, 1.0e-5); // WINJ - conn 4 : Transmissibility factor
         BOOST_CHECK_CLOSE(
             sconn[i0 + Ix::SegDistEnd], 0., 1.0e-5); // WINJ - conn 4 : Distance to end of connection in segment
         BOOST_CHECK_CLOSE(


### PR DESCRIPTION
`SCON[0]` holds the effective connection transmissibility factor, including pressure dependent multipliers such as those arising from rock compaction.  This PR distinguishes `SCON[0]` from `SCON[11]`, with the latter holding the background from geometry and "static" multipliers (e.g., keywords `WPIMULT` and `WELPI`).