### PR TITLE
add definitions of ACF, BIC, EOS, EOSNUM, PCRIT, TCRIT, VCRIT, XMF and YMF

### DIFF
--- a/src/opm/input/eclipse/Units/UnitSystem.cpp
+++ b/src/opm/input/eclipse/Units/UnitSystem.cpp
@@ -1174,6 +1174,7 @@ namespace {
         this->addDimension("SurfaceTension"  , 1.0);
         this->addDimension("Energy", 1.0);
         this->addDimension("PPM", 1.0);
+        this->addDimension("Moles", 1.0);
         this->addDimension("ContextDependent", 1.0);
     }
 
@@ -1213,6 +1214,7 @@ namespace {
         this->addDimension("SurfaceTension"  , PVT_M::SurfaceTension);
         this->addDimension("Energy", PVT_M::Energy);
         this->addDimension("PPM", PVT_M::PPM);
+        this->addDimension("Moles", PVT_M::Moles);
         this->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
         this->addDimension("Ymodule", PVT_M::Ymodule);
     }
@@ -1253,6 +1255,7 @@ namespace {
         this->addDimension("SurfaceTension"  , Lab::SurfaceTension);
         this->addDimension("Energy", Lab::Energy);
         this->addDimension("PPM", Lab::PPM);
+        this->addDimension("Moles", Lab::Moles);
         this->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
         this->addDimension("Ymodule", Lab::Ymodule);
     }
@@ -1294,6 +1297,7 @@ namespace {
         this->addDimension("SurfaceTension"  , Metric::SurfaceTension);
         this->addDimension("Energy", Metric::Energy);
         this->addDimension("PPM", Metric::PPM);
+        this->addDimension("Moles", Metric::Moles);
         this->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
         this->addDimension("Ymodule", Metric::Ymodule);
     }
@@ -1333,6 +1337,7 @@ namespace {
         this->addDimension("SurfaceTension"  , Field::SurfaceTension);
         this->addDimension("Energy", Field::Energy);
         this->addDimension("PPM", Field::PPM);
+        this->addDimension("Moles", Field::Moles);
         this->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
         this->addDimension("Ymodule", Field::Ymodule);
     }

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/T/TABDIMS
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/T/TABDIMS
@@ -56,7 +56,7 @@
     },
     {
       "item": 9,
-      "name": "NUM_STATE_EQ",
+      "name": "NUM_EOS_RES",
       "value_type": "INT",
       "default": 1,
       "comment": "This item is ECLIPSE300 specific"

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/T/TABDIMS
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/T/TABDIMS
@@ -56,7 +56,7 @@
     },
     {
       "item": 9,
-      "name": "NUM_EOS_RES",
+      "name": "NUM_STATE_EQ",
       "value_type": "INT",
       "default": 1,
       "comment": "This item is ECLIPSE300 specific"

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/A/ACF
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/A/ACF
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/A/ACF
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/A/ACF
@@ -1,0 +1,18 @@
+{
+  "name": "ACF",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_STATE_EQ"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "1"
+    }
+  ]
+}

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/B/BIC
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/B/BIC
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/B/BIC
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/B/BIC
@@ -1,0 +1,19 @@
+{
+  "name": "BIC",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_STATE_EQ"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "1",
+      "default" : 0
+    }
+  ]
+}

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/C/CREF
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/C/CREF
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "to set defaults for items of unspecified size.",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/C/CREFS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/C/CREFS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_EOS_RES"
+    "item": "NUM_EOS_SURFACE"
   },
   "comment": "to set defaults for items of unspecified size.",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/C/CREFS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/C/CREFS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "to set defaults for items of unspecified size.",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DREF
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DREF
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "and this also cannot (yet?) be specified.",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DREFS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DREFS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "and this also cannot (yet?) be specified.",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DREFS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DREFS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_EOS_RES"
+    "item": "NUM_EOS_SURFACE"
   },
   "comment": "and this also cannot (yet?) be specified.",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/E/EOS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/E/EOS
@@ -1,0 +1,18 @@
+{
+  "name": "EOS",
+  "sections": [
+    "RUNSPEC",
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_STATE_EQ"
+  },
+  "items": [
+    {
+      "name": "EQUATION",
+      "value_type": "STRING",
+      "default": "PR"
+    }
+  ]
+}

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/E/EOS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/E/EOS
@@ -6,7 +6,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/E/EOSNUM
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/E/EOSNUM
@@ -1,0 +1,9 @@
+{
+  "name": "EOSNUM",
+  "sections": [
+    "REGIONS"
+  ],
+  "data": {
+    "value_type": "INT"
+  }
+}

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MW
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MW
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MW
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MW
@@ -7,12 +7,12 @@
     "keyword": "TABDIMS",
     "item": "NUM_STATE_EQ"
   },
-  "comment": "Also note that there is no dimension for this item because there is no unit for 'molar weight' yet",
   "items": [
     {
       "name": "MOLAR_WEIGHT",
       "value_type": "DOUBLE",
-      "size_type": "ALL"
+      "size_type": "ALL",
+      "dimension": "Mass/Moles"
     }
   ]
 }

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MWS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MWS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "Also note that there is no dimension for this item because there is no unit for 'molar weight' yet",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MWS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MWS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_EOS_RES"
+    "item": "NUM_EOS_SURFACE"
   },
   "comment": "Also note that there is no dimension for this item because there is no unit for 'molar weight' yet",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MWS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/M/MWS
@@ -12,7 +12,8 @@
     {
       "name": "MOLAR_WEIGHT",
       "value_type": "DOUBLE",
-      "size_type": "ALL"
+      "size_type": "ALL",
+      "dimension": "Mass/Moles"
     }
   ]
 }

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PCRIT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PCRIT
@@ -1,0 +1,18 @@
+{
+  "name": "PCRIT",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_STATE_EQ"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "Pressure"
+    }
+  ]
+}

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PCRIT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PCRIT
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PREF
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PREF
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "Also note that there is no default for this item because the default is specified by STCOND",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PREFS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PREFS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "Also note that there is no default for this item because the default is specified by STCOND",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PREFS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/P/PREFS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_EOS_RES"
+    "item": "NUM_EOS_SURFACE"
   },
   "comment": "Also note that there is no default for this item because the default is specified by STCOND",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TCRIT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TCRIT
@@ -1,0 +1,18 @@
+{
+  "name": "TCRIT",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_STATE_EQ"
+  },
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": "Temperature"
+    }
+  ]
+}

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TCRIT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TCRIT
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TREF
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TREF
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "Also note that there is no default for this item because the default is specified by STCOND",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TREFS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TREFS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "Also note that there is no default for this item because the default is specified by STCOND",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TREFS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/T/TREFS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_EOS_RES"
+    "item": "NUM_EOS_SURFACE"
   },
   "comment": "Also note that there is no default for this item because the default is specified by STCOND",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/V/VCRIT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/V/VCRIT
@@ -1,0 +1,18 @@
+{
+  "name": "VCRIT",
+  "sections": [
+    "PROPS"
+  ],
+  "size": {
+    "keyword": "TABDIMS",
+    "item": "NUM_STATE_EQ"
+  },
+  "comment": "there is no dimension for this item because there is no unit for 'Moles' yet",
+  "items": [
+    {
+      "name": "DATA",
+      "value_type": "DOUBLE",
+      "size_type": "ALL"
+    }
+  ]
+}

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/V/VCRIT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/V/VCRIT
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "items": [
     {

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/V/VCRIT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/V/VCRIT
@@ -7,12 +7,12 @@
     "keyword": "TABDIMS",
     "item": "NUM_STATE_EQ"
   },
-  "comment": "there is no dimension for this item because there is no unit for 'Moles' yet",
   "items": [
     {
       "name": "DATA",
       "value_type": "DOUBLE",
-      "size_type": "ALL"
+      "size_type": "ALL",
+      "dimension": "GeometricVolume/Moles"
     }
   ]
 }

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/X/XMF
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/X/XMF
@@ -1,0 +1,11 @@
+{
+  "name": "XMF",
+  "sections": [
+    "SOLUTION"
+  ],
+  "data": {
+    "value_type": "DOUBLE",
+    "dimension": "1"
+  }
+}
+

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/Y/YMF
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/Y/YMF
@@ -1,0 +1,11 @@
+{
+  "name": "YMF",
+  "sections": [
+    "SOLUTION"
+  ],
+  "data": {
+    "value_type": "DOUBLE",
+    "dimension": "1"
+  }
+}
+

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACT1
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACT1
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "support default values for items of unknown size",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACT1S
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACT1S
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "support default values for items of unknown size",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACTOR
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACTOR
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "support default values for items of unknown size",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACTORS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACTORS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_EOS_RES"
+    "item": "NUM_EOS_SURFACE"
   },
   "comment": "support default values for items of unknown size",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACTORS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/Z/ZFACTORS
@@ -5,7 +5,7 @@
   ],
   "size": {
     "keyword": "TABDIMS",
-    "item": "NUM_STATE_EQ"
+    "item": "NUM_EOS_RES"
   },
   "comment": "support default values for items of unknown size",
   "items": [

--- a/src/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1045,7 +1045,9 @@ set( keywords
      000_Eclipse100/Z/ZIPPY2
      000_Eclipse100/Z/ZIPP2OFF
 
+     001_Eclipse300/A/ACF
      001_Eclipse300/A/ACTCO2S
+     001_Eclipse300/B/BIC
      001_Eclipse300/B/BLOCK_PROBE300
      001_Eclipse300/C/CIRCLE
      001_Eclipse300/C/CNAMES
@@ -1059,6 +1061,8 @@ set( keywords
      001_Eclipse300/D/DREF
      001_Eclipse300/D/DREFS
      001_Eclipse300/D/DZV
+     001_Eclipse300/E/EOS
+     001_Eclipse300/E/EOSNUM
      001_Eclipse300/F/FIELDSEP
      001_Eclipse300/G/GASVISCT
      001_Eclipse300/G/GASWAT
@@ -1074,12 +1078,14 @@ set( keywords
      001_Eclipse300/O/OILMW
      001_Eclipse300/O/OILVTIM
      001_Eclipse300/O/OPTIONS3
+     001_Eclipse300/P/PCRIT
      001_Eclipse300/P/PREF
      001_Eclipse300/P/PREFS
      001_Eclipse300/R/REGION2REGION_PROBE_E300
      001_Eclipse300/S/SALINITY
      001_Eclipse300/S/SOLID
      001_Eclipse300/S/STCOND
+     001_Eclipse300/T/TCRIT
      001_Eclipse300/T/TEMPI
      001_Eclipse300/T/TEMPVD
      001_Eclipse300/T/THCGAS
@@ -1090,12 +1096,15 @@ set( keywords
      001_Eclipse300/T/THERMAL
      001_Eclipse300/T/TREF
      001_Eclipse300/T/TREFS
+     001_Eclipse300/V/VCRIT
      001_Eclipse300/W/WELLSTRE
      001_Eclipse300/W/WELL_PROBE_COMP
      001_Eclipse300/W/WINJGAS
      001_Eclipse300/W/WINJTEMP
      001_Eclipse300/W/WATDENT
      001_Eclipse300/W/WSF
+     001_Eclipse300/X/XMF
+     001_Eclipse300/Y/YMF
      001_Eclipse300/Z/ZFACT1
      001_Eclipse300/Z/ZFACT1S
      001_Eclipse300/Z/ZFACTOR


### PR DESCRIPTION
ACF, BIC, EOS, EOSNUM, PCRIT, TCRIT, VCRIT, XMF, YMF

Not necessarily all correct, but helping to have an overview when creating the keywords. 

Some adjustments are expected when actually implementing them. 