### PR TITLE
Write D-Factor Correlation Parameters to Restart File

### DIFF
--- a/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/opm/output/eclipse/AggregateConnectionData.cpp
@@ -167,6 +167,16 @@ namespace {
             };
         }
 
+        double staticDFacCorrCoeff(const Opm::Connection::CTFProperties& ctf_props,
+                                   const Opm::UnitSystem&                units)
+        {
+            using M = Opm::UnitSystem::measure;
+
+            // Coefficient's units are [D] * [viscosity]
+
+            return units.from_si(M::viscosity, units.from_si(M::dfactor, ctf_props.static_dfac_corr_coeff));
+        }
+
         template <class SConnArray>
         void staticContrib(const Opm::Connection& conn,
                            const Opm::UnitSystem& units,
@@ -204,6 +214,9 @@ namespace {
 
             sConn[Ix::EffectiveLength] =
                 scprop(M::length, conn.connectionLength());
+
+            sConn[Ix::StaticDFacCorrCoeff] =
+                staticDFacCorrCoeff(conn.ctfProperties(), units);
 
             sConn[Ix::CFInDeck] = conn.ctfAssignedFromInput() ? 1.0f : 0.0f;
         }
@@ -324,12 +337,12 @@ AggregateConnectionData(const std::vector<int>& inteHead)
 
 void
 Opm::RestartIO::Helpers::AggregateConnectionData::
-captureDeclaredConnData(const Schedule&        sched,
-                        const EclipseGrid&     grid,
-                        const UnitSystem&      units,
-                        const data::Wells& xw,
-                        const SummaryState&    summary_state,
-                        const std::size_t      sim_step)
+captureDeclaredConnData(const Schedule&     sched,
+                        const EclipseGrid&  grid,
+                        const UnitSystem&   units,
+                        const data::Wells&  xw,
+                        const SummaryState& summary_state,
+                        const std::size_t   sim_step)
 {
     wellConnectionLoop(sched, sim_step, grid, xw, [&units, &summary_state, this]
         (const std::string&      wellName,

--- a/opm/output/eclipse/VectorItems/connection.hpp
+++ b/opm/output/eclipse/VectorItems/connection.hpp
@@ -64,6 +64,9 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
 
             EffectiveLength = 31, // Effective length of connection's perforation interval.
 
+            StaticDFacCorrCoeff = 37, // Static component of Forchheimer
+                                      // D-factor correlation.
+
             CFInDeck     = 40, // = 0 for connection factor not defined, = 1 for connection factor defined
         };
     } // SConn

--- a/opm/output/eclipse/VectorItems/well.hpp
+++ b/opm/output/eclipse/VectorItems/well.hpp
@@ -331,6 +331,9 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             VfpBhpScalingFact = 83, // Tubing pressure loss scaling factor (WVFPDP(3))
             WGrupConGRScaling = 84, // Guide rate scaling factor (WGRUPCON(5))
 
+            DFacCorrCoeffA = 104, // Coefficient 'A' of D-factor correlation (WDFACCOR(2))
+            DFacCorrExpB   = 105, // Exponent 'B' of D-factor correlation (WDFACCOR(3))
+            DFacCorrExpC   = 106, // Exponent 'C' of D-factor correlation (WDFACCOR(4))
 
             LOincFac          = 115,
 


### PR DESCRIPTION
In particular the Dake model D-factor correlation parameters `A`, `B`, and `C` go into `SWEL` at locations 104, 105, and 106,
respectively.  Additionally, the static product
```math
A \cdot (K / K_0)^B \cdot \phi^C \cdot (K / (r_w \cdot h))
```
goes into `SCON[37]` of the affected reservoir connections.