### PR TITLE
Load D-Factor Correlation Parameters From Restart File

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -59,6 +59,7 @@ namespace {
         props.connection_length = rst_conn.length;
         props.skin_factor = rst_conn.skin_factor;
         props.d_factor = 0.0;
+        props.static_dfac_corr_coeff = rst_conn.static_dfac_corr_coeff;
         props.peaceman_denom = rst_conn.denom;
 
         return props;

--- a/opm/input/eclipse/Schedule/Well/WDFAC.cpp
+++ b/opm/input/eclipse/Schedule/Well/WDFAC.cpp
@@ -56,6 +56,18 @@ namespace Opm {
 
     // -------------------------------------------------------------------------
 
+    WDFAC::WDFAC(const RestartIO::RstWell& rst_well)
+        : m_type { WDFacType::NONE }
+        , m_d    { 0.0 }
+        , m_corr { rst_well.dfac_corr_coeff_a    ,
+                   rst_well.dfac_corr_exponent_b ,
+                   rst_well.dfac_corr_exponent_c }
+    {
+        if (m_corr.coeff_a > 0.0) {
+            this->m_type = WDFacType::DAKEMODEL;
+        }
+    }
+
     WDFAC WDFAC::serializationTestObject()
     {
         WDFAC result;

--- a/opm/input/eclipse/Schedule/Well/WDFAC.hpp
+++ b/opm/input/eclipse/Schedule/Well/WDFAC.hpp
@@ -105,6 +105,17 @@ namespace Opm {
             }
         };
 
+        /// Default constructor
+        WDFAC() = default;
+
+        /// Constructor
+        ///
+        /// Creates an object from restart information
+        ///
+        /// \param[in] rst_well Linearised well-level restart information,
+        ///   including D-factor parameters.
+        explicit WDFAC(const RestartIO::RstWell& rst_well);
+
         /// Serialisation test object
         static WDFAC serializationTestObject();
 

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -312,7 +312,7 @@ Well::Well(const RestartIO::RstWell& rst_well,
     injection(std::make_shared<WellInjectionProperties>(unit_system_arg, wname)),
     wvfpdp(std::make_shared<WVFPDP>()),
     wvfpexp(explicitTHPOptions(rst_well)),
-    wdfac(std::make_shared<WDFAC>()),
+    wdfac(std::make_shared<WDFAC>(rst_well)),
     status(status_from_int(rst_well.well_status)),
     well_temperature(Metric::TemperatureOffset + ParserKeywords::STCOND::TEMPERATURE::defaultValue),
     well_inj_mult(std::nullopt)

--- a/opm/io/eclipse/rst/connection.cpp
+++ b/opm/io/eclipse/rst/connection.cpp
@@ -70,6 +70,15 @@ float as_float(const double x)
     return static_cast<float>(x);
 }
 
+float staticDFactorCorrCoeff(const Opm::UnitSystem& usys,
+                             const float            coeff)
+{
+    using M = ::Opm::UnitSystem::measure;
+
+    // Coefficient's units are [D] * [viscosity]
+    return as_float(usys.to_si(M::viscosity, usys.to_si(M::dfactor, coeff)));
+}
+
 double pressEquivRadius(const float denom,
                         const float skin,
                         const float rw)
@@ -116,6 +125,7 @@ Opm::RestartIO::RstConnection::RstConnection(const UnitSystem& unit_system,
     , kh                     { as_float(unit_system.to_si(M::effective_Kh, scon[VI::SConn::EffectiveKH])) }
     , denom                  { scon[VI::SConn::CFDenom] }
     , length                 { as_float(unit_system.to_si(M::length, scon[VI::SConn::EffectiveLength])) }
+    , static_dfac_corr_coeff { staticDFactorCorrCoeff(unit_system, scon[VI::SConn::StaticDFacCorrCoeff]) }
     , segdist_end            { as_float(unit_system.to_si(M::length, scon[VI::SConn::SegDistEnd])) }
     , segdist_start          { as_float(unit_system.to_si(M::length, scon[VI::SConn::SegDistStart])) }
       // -----------------------------------------------------------------

--- a/opm/io/eclipse/rst/connection.hpp
+++ b/opm/io/eclipse/rst/connection.hpp
@@ -60,6 +60,7 @@ struct RstConnection
     float kh;
     float denom;
     float length;
+    float static_dfac_corr_coeff;
     float segdist_end;
     float segdist_start;
 

--- a/opm/io/eclipse/rst/state.cpp
+++ b/opm/io/eclipse/rst/state.cpp
@@ -3,7 +3,8 @@
 
   This file is part of the Open Porous Media project (OPM).
 
-  OPM is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 

--- a/opm/io/eclipse/rst/well.hpp
+++ b/opm/io/eclipse/rst/well.hpp
@@ -126,6 +126,9 @@ struct RstWell
     float glift_min_rate;
     float glift_weight_factor;
     float glift_inc_weight_factor;
+    float dfac_corr_coeff_a{};
+    float dfac_corr_exponent_b{};
+    float dfac_corr_exponent_c{};
     std::vector<float> tracer_concentration_injection;
 
     double oil_rate;


### PR DESCRIPTION
This PR loads the connection level Peaceman denominator value, static D-factor correlation coefficient, and connection interval length from the restart file and forwards these values from the `RstConnection` type to the regular `Connection` type.  Furthermore, we load the well-level D-factor correlation parameters `A`, `B`, and `C` of the `WDFACCOR` keyword into the `WDFAC` type at restart time.

Collectively, these changes enable restarting simulation runs using the `WDFACCOR` keyword.