### PR TITLE
pypi: build for python 3.11 and 3.12

### DIFF
--- a/python/generate-pypi-package.sh
+++ b/python/generate-pypi-package.sh
@@ -12,6 +12,8 @@ python_versions[cp37-cp37m]=/opt/python/cp37-cp37m/bin/python
 python_versions[cp38-cp38]=/opt/python/cp38-cp38/bin/python
 python_versions[cp39-cp39]=/opt/python/cp39-cp39/bin/python
 python_versions[cp310-cp310]=/opt/python/cp310-cp310/bin/python
+python_versions[cp311-cp311]=/opt/python/cp311-cp311/bin/python
+python_versions[cp312-cp312]=/opt/python/cp312-cp312/bin/python
 
 source /tmp/opm-common/python/setup-docker-image.sh
 


### PR DESCRIPTION
Now that we have a bumped pybind11 we can enable these two versions as well.

Part of #3658