### PR TITLE
ESmry: fix out-of-bounds vector access

### DIFF
--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -1084,6 +1084,9 @@ bool ESmry::make_esmry_file()
 
         {
             std::vector<int> start_date_vect = start_vect;
+            if (start_date_vect.size() < 6) {
+                start_date_vect.resize(6);
+            }
 
             int sec = start_date_vect[5] / 1000000;
             int millisec = (start_date_vect[5] % 1000000) / 1000;

--- a/src/opm/io/eclipse/ESmry.cpp
+++ b/src/opm/io/eclipse/ESmry.cpp
@@ -1097,7 +1097,7 @@ bool ESmry::make_esmry_file()
             std::vector<std::string> units;
             units.reserve(keyword.size());
 
-            for (auto key : keyword)
+            for (const auto& key : keyword)
                 units.push_back(kwunits.at(key));
 
 


### PR DESCRIPTION
This vector comes from input input that can be shorter (e.g. in test_ExtESmry it only holds day-month-year)