### PR TITLE
fixed: pass through perf-range as an optional

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Connection.hpp
+++ b/opm/input/eclipse/Schedule/Well/Connection.hpp
@@ -151,7 +151,7 @@ namespace RestartIO {
         void updateSegment(int segment_number_arg,
                            double center_depth_arg,
                            std::size_t compseg_insert_index,
-                           const std::pair<double,double>& perf_range);
+                           const std::optional<std::pair<double,double>>& perf_range);
         std::size_t sort_value() const;
         const bool& getDefaultSatTabId() const;
         void setDefaultSatTabId(bool id);

--- a/src/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
+++ b/src/opm/input/eclipse/Schedule/MSW/Compsegs.cpp
@@ -331,7 +331,8 @@ namespace {
                     connection.updateSegment(compseg.segment_number,
                                              cdepth,
                                              compseg.m_seqIndex,
-                                             { compseg.m_distance_start, compseg.m_distance_end });
+                                             std::make_pair(compseg.m_distance_start,
+                                                            compseg.m_distance_end));
                 }
             }
 

--- a/src/opm/input/eclipse/Schedule/Well/Connection.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/Connection.cpp
@@ -281,7 +281,7 @@ const std::optional<std::pair<double, double>>& Connection::perf_range() const {
     void Connection::updateSegment(int segment_number_arg,
                                    double center_depth_arg,
                                    std::size_t compseg_insert_index,
-                                   const std::pair<double, double>& perf_range) {
+                                   const std::optional<std::pair<double, double>>& perf_range) {
         this->segment_number = segment_number_arg;
         this->center_depth = center_depth_arg;
         this->m_sort_value = compseg_insert_index;

--- a/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellConnections.cpp
@@ -519,7 +519,7 @@ namespace Opm {
                 prev->updateSegment(conSegNo,
                                     depth,
                                     css_ind,
-                                    *perf_range);
+                                    perf_range);
             }
         }
     }


### PR DESCRIPTION
we should not dereference it for STDW where it is expected to be empty