### PR TITLE
fixed: adjust boost version check

### DIFF
--- a/tests/material/test_components.cpp
+++ b/tests/material/test_components.cpp
@@ -101,7 +101,7 @@ void testAllComponents()
 template<class Scalar>
 bool close_at_tolerance(Scalar n1, Scalar n2, Scalar tolerance)
 {
-#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 71
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 64
     auto comp = boost::test_tools::close_at_tolerance<Scalar>(boost::test_tools::percent_tolerance_t<Scalar>(tolerance*100.0));
 #else
     auto comp = boost::math::fpc::close_at_tolerance<Scalar>(tolerance);


### PR DESCRIPTION
1.66 already has the boost::fpc scope

Well, this came back to bite me pretty quick. In EL8 boost 1.66 is in use...