### PR TITLE
fixed: refine the libfmt fetchcontent approach

### DIFF
--- a/cmake/Modules/DownloadFmt.cmake
+++ b/cmake/Modules/DownloadFmt.cmake
@@ -3,11 +3,10 @@ FetchContent_Declare(fmt
                      DOWNLOAD_EXTRACT_TIMESTAMP ON
                      URL https://github.com/fmtlib/fmt/archive/refs/tags/10.1.1.tar.gz
                      URL_HASH SHA512=288c349baac5f96f527d5b1bed0fa5f031aa509b4526560c684281388e91909a280c3262a2474d963b5d1bf7064b1c9930c6677fe54a0d8f86982d063296a54c)
-FetchContent_MakeAvailable(fmt)
+FetchContent_Populate(fmt)
 
 # We do not want to use the target directly as that means it ends up
-# in our depends list for downstream modules. Instead, use header
-# only mode.
-get_target_property(fmt_inc fmt::fmt INTERFACE_INCLUDE_DIRECTORIES)
+# in our depends list for downstream modules and the installation list.
+# Instead, we just download and use header only mode.
 add_compile_definitions(FMT_HEADER_ONLY)
-include_directories(${fmt_inc})
+include_directories(${fmt_SOURCE_DIR}/include)


### PR DESCRIPTION
rather than doing a full MakeAvailable, only download, prepare then use from source directory.

old approach caused some issues in certain build configurations.