### PR TITLE
Fix invB from density in co2/h2 store and use density/internalEnergy from co2/h2 directly

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -137,23 +137,25 @@ public:
      * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
      */
     template <class Evaluation>
-    Evaluation internalEnergy(unsigned regionIdx,
+    Evaluation internalEnergy(unsigned /*regionIdx*/,
                         const Evaluation& temperature,
                         const Evaluation& pressure,
-                        const Evaluation& rv,
-                        const Evaluation& rvw) const
+                        const Evaluation& /*rv*/,
+                        const Evaluation& /*rvw*/) const
     {
         OPM_TIMEBLOCK_LOCAL(internalEnergy);
-        // assume ideal mixture
-        Evaluation result = 0;
+        // use the gasInternalEnergy of CO2
+        return CO2::gasInternalEnergy(temperature, pressure, extrapolate); 
 
+        // account for H2O in the gas phase
+        // Evaluation result = 0;
         // The CO2STORE option both works for GAS/WATER and GAS/OIL systems
         // Either rv og rvw should be zero
-        assert(rv == 0.0 || rvw == 0.0);
-        const Evaluation xBrine = convertRvwToXgW_(max(rvw,rv),regionIdx);
-        result += xBrine * H2O::gasInternalEnergy(temperature, pressure);
-        result += (1 - xBrine) * CO2::gasInternalEnergy(temperature, pressure, extrapolate);
-        return result;
+        //assert(rv == 0.0 || rvw == 0.0);
+        //const Evaluation xBrine = convertRvwToXgW_(max(rvw,rv),regionIdx);
+        //result += xBrine * H2O::gasInternalEnergy(temperature, pressure);
+        //result += (1 - xBrine) * CO2::gasInternalEnergy(temperature, pressure, extrapolate);
+        //return result;
     }
 
     /*!
@@ -194,14 +196,15 @@ public:
         if (!enableVaporization_)
             return CO2::gasDensity(temperature, pressure, extrapolate)/gasReferenceDensity_[regionIdx];
 
-        // assume ideal mixture
-        // The CO2STORE option both works for GAS/WATER and GAS/OIL systems
-        // Either rv og rvw should be zero
-        assert(rv == 0.0 || rvw == 0.0);
-        const Evaluation xBrine = convertRvwToXgW_(max(rvw,rv),regionIdx);
+        // Use CO2 density for the gas phase.
         const auto& rhoCo2 = CO2::gasDensity(temperature, pressure, extrapolate);
-        const auto& rhoH2O = H2O::gasDensity(temperature, pressure);
-        return 1.0 / ( ( xBrine/rhoH2O + (1.0 - xBrine)/rhoCo2) * gasReferenceDensity_[regionIdx]);
+        //const auto& rhoH2O = H2O::gasDensity(temperature, pressure);
+        //The CO2STORE option both works for GAS/WATER and GAS/OIL systems
+        //Either rv og rvw should be zero
+        //assert(rv == 0.0 || rvw == 0.0);
+        //const Evaluation xBrine = convertRvwToXgW_(max(rvw,rv),regionIdx);
+        //const auto rho = 1.0/(xBrine/rhoH2O + (1.0 - xBrine)/rhoCo2);
+        return rhoCo2/(gasReferenceDensity_[regionIdx] + max(rvw,rv)*brineReferenceDensity_[regionIdx]);
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/H2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/H2GasPvt.hpp
@@ -130,25 +130,27 @@ public:
     *
     */
     template <class Evaluation>
-    Evaluation internalEnergy(unsigned regionIdx,
+    Evaluation internalEnergy(unsigned /*regionIdx*/,
                         const Evaluation& temperature,
                         const Evaluation& pressure,
-                        const Evaluation& rv,
-                        const Evaluation& rvw) const
+                        const Evaluation& /*rv*/,
+                        const Evaluation& /*rvw*/) const
     {
-        /* NOTE: Assume ideal mixing */
-
+        // use the gasInternalEnergy of H2
+        return H2::gasInternalEnergy(temperature, pressure, extrapolate);
+        
+        // TODO: account for H2O in the gas phase
         // Init output
-        Evaluation result = 0;
+        //Evaluation result = 0;
 
         // We have to check that one of RV and RVW is zero since H2STORE works with either GAS/WATER or GAS/OIL system
-        assert(rv == 0.0 || rvw == 0.0);
+        //assert(rv == 0.0 || rvw == 0.0);
 
         // Calculate each component contribution and return weighted sum
-        const Evaluation xBrine = convertRvwToXgW_(max(rvw, rv), regionIdx);
-        result += xBrine * H2O::gasInternalEnergy(temperature, pressure);
-        result += (1 - xBrine) * H2::gasInternalEnergy(temperature, pressure, extrapolate);
-        return result;
+        //const Evaluation xBrine = convertRvwToXgW_(max(rvw, rv), regionIdx);
+        //result += xBrine * H2O::gasInternalEnergy(temperature, pressure);
+        //result += (1 - xBrine) * H2::gasInternalEnergy(temperature, pressure, extrapolate);
+        //return result;
     }
 
     /*!
@@ -189,16 +191,15 @@ public:
         if (!enableVaporization_)
             return H2::gasDensity(temperature, pressure, extrapolate)/gasReferenceDensity_[regionIdx];
 
-        /* NOTE: Assume ideal mixing! */
-
-        // We have to check that one of RV and RVW is zero since H2STORE works with either GAS/WATER or GAS/OIL system
-        assert(rv == 0.0 || rvw == 0.0);
-
-        // Calculate each component contribution and return weighted sum
-        const Evaluation xBrine = convertRvwToXgW_(max(rvw, rv),regionIdx);
+        // Use CO2 density for the gas phase.
         const auto& rhoH2 = H2::gasDensity(temperature, pressure, extrapolate);
-        const auto& rhoH2O = H2O::gasDensity(temperature, pressure);
-        return 1.0 / ((xBrine / rhoH2O + (1.0 - xBrine) / rhoH2) * gasReferenceDensity_[regionIdx]); 
+        //const auto& rhoH2O = H2O::gasDensity(temperature, pressure);
+        //The H2STORE option both works for GAS/WATER and GAS/OIL systems
+        //Either rv og rvw should be zero
+        //assert(rv == 0.0 || rvw == 0.0);
+        //const Evaluation xBrine = convertRvwToXgW_(max(rvw,rv),regionIdx);
+        //const auto rho = 1.0/(xBrine/rhoH2O + (1.0 - xBrine)/rhoH2);
+        return rhoH2/(gasReferenceDensity_[regionIdx] + max(rvw,rv)*brineReferenceDensity_[regionIdx]);
     }
 
     /*!

--- a/tests/material/test_components.cpp
+++ b/tests/material/test_components.cpp
@@ -142,6 +142,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(SimpleH2O, Scalar, Types)
                                                     1e-3*H2O::liquidDensity(T,p).value()),
                                 "oops: the water density based on Hu-Duan has more then 1e-3 deviation from IAPWS'97");
 
+            BOOST_CHECK_MESSAGE(EvalToolbox::isSame(H2O::liquidEnthalpy(T,p),
+                                                    SimpleHuDuanH2O::liquidEnthalpy(T,p),
+                                                    1e-3*H2O::liquidEnthalpy(T,p).value()),
+                                "oops: the liquid enthalpy in Simple-Hu-Duan has more then 1e-3 deviation from IAPWS'97");
+
             if (T >= 570) // for temperature larger then 570 the viscosity based on HuDuan is too far from IAPWS.
                 continue;
 


### PR DESCRIPTION
We assume that the density and the internal energy of the gas phase is not affected by the water content.

This avoid usage of gasDensity/gasInternalEnergy based on ideal gas assumptions implemented in simpleHuDuanH2O.hpp.

Add test that compares liquidEnthalpy of SimpleHuDuanH2O and H2O based on IAPWS