### PR TITLE
GroupEconProductionLimits: clean up includes

### DIFF
--- a/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp
+++ b/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp
@@ -20,20 +20,19 @@
 #ifndef GROUP_ECON_PRODUCTION_LIMITS_H
 #define GROUP_ECON_PRODUCTION_LIMITS_H
 
-#include <map>
-#include <string>
-#include <optional>
-
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/common/utility/Serializer.hpp>
 #include <opm/common/utility/MemPacker.hpp>
+
+#include <map>
+#include <optional>
+#include <string>
 
 namespace Opm {
 
 class DeckRecord;
+class Schedule;
+class SummaryState;
 
 class GroupEconProductionLimits {
 public:

--- a/src/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.cpp
@@ -17,10 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
+
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
 
-#include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include "../eval_uda.hpp"
 

--- a/src/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/Group/GroupKeywordHandlers.cpp
@@ -33,6 +33,7 @@
 #include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
 #include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
 #include <opm/input/eclipse/Schedule/ScheduleState.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleStatic.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 


### PR DESCRIPTION
Remove unneeded UnitSystem include and forward Schedule and SummaryState.