### PR TITLE
Hotfix for Month String 'FEB' Condition Restart Output Problem

### DIFF
--- a/opm/output/eclipse/AggregateActionxData.hpp
+++ b/opm/output/eclipse/AggregateActionxData.hpp
@@ -21,14 +21,8 @@
 #define OPM_AGGREGATE_Actionx_DATA_HPP
 
 #include <opm/output/eclipse/WindowedArray.hpp>
-#include <opm/io/eclipse/PaddedOutputString.hpp>
 
-#include <opm/input/eclipse/Schedule/UDQ/UDQInput.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
+#include <opm/io/eclipse/PaddedOutputString.hpp>
 
 #include <cstddef>
 #include <string>
@@ -36,23 +30,21 @@
 #include <map>
 
 namespace Opm {
-    class Schedule;
-    class UDQInput;
     class Actdims;
+    class Schedule;
+    class SummaryState;
+    class UDQInput;
+} // namespace Opm
 
-    namespace Action {
-        class State;
-    }
-} // Opm
-
-
+namespace Opm { namespace Action {
+    class State;
+}} // Opm::Action
 
 namespace Opm { namespace RestartIO { namespace Helpers {
     
 class AggregateActionxData
 {
 public:
-
     AggregateActionxData(const Opm::Schedule&      sched,
                          const Opm::Action::State& action_state,
                          const Opm::SummaryState&  st,
@@ -62,7 +54,6 @@ public:
     {
         return this->iACT_.data();
     }
-
    
     const std::vector<float>& getSACT() const
     {
@@ -88,20 +79,21 @@ public:
     {
         return this->iACN_.data();
     }
-        
+
+    // Note: Type 'double' despite the S* name.
     const std::vector<double>& getSACN() const
     {
         return this->sACN_.data();
     }
 
 private:
-    AggregateActionxData( const std::vector<int>&     rst_dims,
-                          std::size_t                 num_actions,
-                          const Opm::Actdims& actdims,
-                          const Opm::Schedule&        sched,
-                          const Opm::Action::State&   action_state,
-                          const Opm::SummaryState&    st,
-                          const std::size_t           simStep);
+    AggregateActionxData(const std::vector<int>&   rst_dims,
+                         std::size_t               num_actions,
+                         const Opm::Actdims&       actdims,
+                         const Opm::Schedule&      sched,
+                         const Opm::Action::State& action_state,
+                         const Opm::SummaryState&  st,
+                         const std::size_t         simStep);
 
     /// Aggregate 'IACT' array (Integer) for all ACTIONX data  (9 integers pr UDQ)
     WindowedArray<int> iACT_;
@@ -121,8 +113,8 @@ private:
     /// Aggregate 'IACN' array (Integer) for all Actionx data  (length 26* the max number of conditoins pr Actionx * the number of Actionx kwords)
     WindowedArray<int> iACN_;
 
-    /// Aggregate 'SACN' array (Integer) for all Actionx data  (16 * max number of Actionx conditions)
-    WindowedArray<double> sACN_;
+    /// Aggregate 'SACN' array (double precision floating-point) for all Actionx data  (16 * max number of Actionx conditions)
+    WindowedMatrix<double> sACN_;
 
 };
 


### PR DESCRIPTION
This PR is a quick-fix for a very peculiar problem in the `SACN` restart file output array.  We expect that a more complete fix will involve refactoring.  The problem is, that in conditions such as
```
MNTH >= FEB
```
in an `ACTIONX` condition block, the current master sources will unexpectedly interpret the leading `F` in `FEB` as introducing a field-level summary quantity (e.g., `FOPR`, `FPR`, or `FU_BAR`).  This, in turn, will lead to outputting a value of zero to the corresponding `SACN` item instead of the numerical month index for February (= 2).  When restarting a case with this erroneous specification the user will be greeted with an inscrutable diagnostic message, possibly referring to internal details of `std::unordered_map<>` (as retrieved from [`eclipseMonthNames()`](https://github.com/OPM/opm-common/blob/a147c2a4663eb1d999f77ff0da9cd71fbb25054c/src/opm/io/eclipse/rst/action.cpp#L89))

This commit introduces a special case for date comparisons involving months to ensure we go into the appropriate branch of the right-hand side processing.  A more complete fix will, as alluded to earlier, probably involve refactoring this logic a little bit.

While here, also switch to using `WindowedMatrix<double>` instead of `WindowedArray<double>` as the backing type for `sACN_`.  This removes some of the explicit index calculations in computing the correct view into `SACN` for the current condition.