### PR TITLE
Do Not Blindly Remove Blanks in ZLACT

### DIFF
--- a/src/opm/io/eclipse/rst/state.cpp
+++ b/src/opm/io/eclipse/rst/state.cpp
@@ -19,6 +19,7 @@
 #include <opm/io/eclipse/rst/state.hpp>
 
 #include <opm/io/eclipse/RestartFileView.hpp>
+#include <opm/io/eclipse/PaddedOutputString.hpp>
 
 #include <opm/io/eclipse/rst/aquifer.hpp>
 #include <opm/io/eclipse/rst/action.hpp>
@@ -344,8 +345,10 @@ void RstState::add_actions(const Parser& parser,
         auto zlact_offset = index * zlact_action_size;
         while (true) {
             std::string line;
-            for (std::size_t item_index = 0; item_index < actdims.line_size(); item_index++)
-                line += zlact[zlact_offset + item_index];
+            for (std::size_t item_index = 0; item_index < actdims.line_size(); item_index++) {
+                const auto padded = EclIO::PaddedOutputString<8> { zlact[zlact_offset + item_index] };
+                line += padded.c_str();
+            }
 
             line = trim_copy(line);
             if (line.empty())


### PR DESCRIPTION
Converting the `char[8]`-valued elements of the `ZLACT` restart file array to `std::string` will trailing trim blank spaces.  In certain circumstances, this process will end up removing meaningful blanks and create run-on keyword data strings that can no longer be parsed in context.

As an example, the `ACTIONX` block
```
WPIMULT
'PROD1' 1.23456 3* 1 4 /
```
might be stored in `ZLACT` as
```
ZLACT[0]: "WPIMULT "
ZLACT[1]: "        "
ZLACT[2]: "\n      "
ZLACT[3]: "'PROD1' "
ZLACT[4]: "1.23456 "
ZLACT[5]: "3* 1 4 /"
```
Upon restart, the string conversion would then trim the trailing blanks and we would get the keyword specification
```
WPIMULT
'PROD1'1.234563* 1 4 /
```
which the restart parser object is unable to make sense of.  That, in turn, means that we might get a diagnostic message of the form
```
Error: Problem with keyword WPIMULT
In <memory string> line 1.
Malformed floating point number '1.234563*'
```
and the simulation run would terminate early with
```
Error: Unrecoverable errors while loading input
```
This PR restores the trailing blanks by means of the helper class `PaddedOutputString<8>`.  It is more expensive than the current master sources approach, but it also ensures that we're able to restart simulation runs which would otherwise run into the problem described above.