### PR TITLE
Make TSTEP Output Correct for all Unit Systems

### DIFF
--- a/opm/input/eclipse/Schedule/ScheduleBlock.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleBlock.hpp
@@ -29,6 +29,10 @@
 #include <vector>
 
 namespace Opm {
+    class UnitSystem;
+}
+
+namespace Opm {
 
 class DeckOutput;
 
@@ -36,7 +40,7 @@ enum class ScheduleTimeType {
     START = 0,
     DATES = 1,
     TSTEP = 2,
-    RESTART = 3
+    RESTART = 3,
 };
 
 /*
@@ -65,8 +69,10 @@ public:
 
     bool operator==(const ScheduleBlock& other) const;
     static ScheduleBlock serializationTestObject();
+
     template<class Serializer>
-    void serializeOp(Serializer& serializer) {
+    void serializeOp(Serializer& serializer)
+    {
         serializer(m_time_type);
         serializer(m_start_time);
         serializer(m_end_time);
@@ -74,8 +80,9 @@ public:
         serializer(m_location);
     }
 
-    void dump_time(time_point current_time, DeckOutput& output) const;
-    void dump_deck(DeckOutput& output, time_point& current_time) const;
+    void dump_deck(const UnitSystem& usys,
+                   DeckOutput&       output,
+                   time_point&       current_time) const;
 
 private:
     ScheduleTimeType m_time_type;
@@ -83,6 +90,16 @@ private:
     std::optional<time_point> m_end_time;
     KeywordLocation m_location;
     std::vector<DeckKeyword> m_keywords;
+
+    void dump_time(const UnitSystem& usys,
+                   time_point        current_time,
+                   DeckOutput&       output) const;
+
+    void writeDates(DeckOutput& output) const;
+
+    void writeTStep(const UnitSystem& usys,
+                    time_point        current_time,
+                    DeckOutput&       output) const;
 };
 
 } // end namespace Opm

--- a/opm/input/eclipse/Schedule/ScheduleDeck.hpp
+++ b/opm/input/eclipse/Schedule/ScheduleDeck.hpp
@@ -39,6 +39,7 @@ namespace Opm {
     class DeckOutput;
     struct ScheduleDeckContext;
     class Runspec;
+    class UnitSystem;
 
     /*
       The purpose of the ScheduleDeck class is to serve as a container holding
@@ -76,7 +77,7 @@ namespace Opm {
             serializer(m_location);
         }
 
-        void dump_deck(std::ostream& os) const;
+        void dump_deck(std::ostream& os, const UnitSystem& usys) const;
 
     private:
         time_point m_restart_time;

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -2239,8 +2239,9 @@ void Schedule::create_next(const ScheduleBlock& block) {
     this->create_next(start_time, end_time);
 }
 
-void Schedule::dump_deck(std::ostream& os) const {
-    this->m_sched_deck.dump_deck(os);
+void Schedule::dump_deck(std::ostream& os) const
+{
+    this->m_sched_deck.dump_deck(os, this->getUnits());
 }
 
 std::ostream& operator<<(std::ostream& os, const Schedule& sched)

--- a/src/opm/input/eclipse/Schedule/ScheduleDeck.cpp
+++ b/src/opm/input/eclipse/Schedule/ScheduleDeck.cpp
@@ -31,6 +31,8 @@
 
 #include <opm/input/eclipse/Schedule/ScheduleRestartInfo.hpp>
 
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
 #include <chrono>
 #include <ctime>
 #include <unordered_set>
@@ -270,13 +272,17 @@ ScheduleDeck ScheduleDeck::serializationTestObject() {
     return deck;
 }
 
-void ScheduleDeck::dump_deck(std::ostream& os) const {
+void ScheduleDeck::dump_deck(std::ostream&     os,
+                             const UnitSystem& usys) const
+{
     DeckOutput output(os);
 
     output.write_string("SCHEDULE\n");
+
     auto current_time = this->m_blocks[0].start_time();
-    for (const auto& block : this->m_blocks)
-        block.dump_deck(output, current_time);
+    for (const auto& block : this->m_blocks) {
+        block.dump_deck(usys, output, current_time);
+    }
 }
 
 


### PR DESCRIPTION
The `ScheduleBlock::dump_deck()` member function would always assume time units of days when outputting a `TSTEP` value.  This assumption does not hold for LAB units, however, in which the time unit is hours.  Make the time unit correct by deferring the conversion to `UnitSystem::from_si(measure::time)` instead.

While here, also sort the member functions in `ScheduleBlock.cpp` in order of appearance in `ScheduleBlock.hpp` and switch to using `std::find_if()` instead of a raw loop.