### PR TITLE
Restore UDQ Update Status on Simulation Restart

### DIFF
--- a/opm/io/eclipse/rst/udq.hpp
+++ b/opm/io/eclipse/rst/udq.hpp
@@ -68,6 +68,7 @@ public:
     void add_value(const std::string& wgname, double value);
 
     bool is_define() const;
+    UDQUpdate updateStatus() const;
     double assign_value() const;
     const std::unordered_set<std::string>& assign_selector() const;
     const std::string& expression() const;

--- a/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/src/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -37,6 +37,7 @@
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <functional>
 #include <stdexcept>
@@ -154,6 +155,12 @@ namespace Opm {
                                  location,
                                  { rst_udq.expression() },
                                  rst_state.header.report_step);
+
+                auto pos = this->m_definitions.find(rst_udq.name);
+                assert (pos != this->m_definitions.end());
+
+                pos->second.update_status(rst_udq.updateStatus(),
+                                          rst_state.header.report_step);
             }
             else {
                 this->add_assign(rst_udq.name,

--- a/src/opm/io/eclipse/rst/udq.cpp
+++ b/src/opm/io/eclipse/rst/udq.cpp
@@ -55,10 +55,15 @@ RstUDQ::RstUDQ(const std::string& name_arg, const std::string& unit_arg)
 {
 }
 
-
-
 bool RstUDQ::is_define() const {
     return std::holds_alternative<RstDefine>(this->data);
+}
+
+UDQUpdate RstUDQ::updateStatus() const
+{
+    return this->is_define()
+        ? std::get<RstDefine>(this->data).status
+        : UDQUpdate::OFF;
 }
 
 void RstUDQ::add_value(const std::string& wgname, double value) {


### PR DESCRIPTION
The current master sources implicitly assume that all UDQs loaded from the restart file have an `UPDATE` status of `ON`.  This commit allows the restart code to inspect the actual update status and to use that status in the UDQ configuration object when restarting the simulation run.

Closes #3808 