### PR TITLE
make_ext_smry update - check if time step data exists

### DIFF
--- a/examples/make_ext_smry.cpp
+++ b/examples/make_ext_smry.cpp
@@ -106,9 +106,14 @@ int main(int argc, char **argv) {
 
         try {
             Opm::EclIO::ESmry smry{ argv[f + argOffset] };
-            status[f] = smry.make_esmry_file();
-            if (! status[f]) {
-                std::cerr << "\n! Warning, smspec already have one esmry file, existing kept use option -f to replace this\n";
+
+            if (smry.numberOfTimeSteps() > 0){
+                status[f] = smry.make_esmry_file();
+                if (! status[f]) {
+                    std::cerr << "\n! Warning, smspec already have one esmry file, existing kept use option -f to replace this\n";
+                }
+            } else {
+                std::cerr << "\n! summary file doesn't hold any time step data, ESMRY file not created. \n";
             }
 
         } catch (...) {


### PR DESCRIPTION
The PR is improving program make_ext_smry with respect to robustness. The program will now check if number of time steps are in summary file is greater that 0 before trying to write an ESMRY file. 