### PR TITLE
adding GenericOilGasFluidSystem.hh to contain different components

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -906,7 +906,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidsystems/H2OAirFluidSystem.hpp
       opm/material/fluidsystems/H2ON2FluidSystem.hpp
       opm/material/fluidsystems/ThreeComponentFluidSystem.hh
-      opm/material/fluidsystems/GenericFluidSystem.hh
+      opm/material/fluidsystems/GenericOilGasFluidSystem.hpp
       opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
       opm/material/fluidmatrixinteractions/SatCurveMultiplexerParams.hpp
       opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -906,6 +906,7 @@ list( APPEND PUBLIC_HEADER_FILES
       opm/material/fluidsystems/H2OAirFluidSystem.hpp
       opm/material/fluidsystems/H2ON2FluidSystem.hpp
       opm/material/fluidsystems/ThreeComponentFluidSystem.hh
+      opm/material/fluidsystems/GenericFluidSystem.hh
       opm/material/fluidmatrixinteractions/EclTwoPhaseMaterial.hpp
       opm/material/fluidmatrixinteractions/SatCurveMultiplexerParams.hpp
       opm/material/fluidmatrixinteractions/EclTwoPhaseMaterialParams.hpp

--- a/opm/material/checkFluidSystem.hpp
+++ b/opm/material/checkFluidSystem.hpp
@@ -49,6 +49,7 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <typeinfo>
 
 /*!
@@ -373,7 +374,7 @@ void checkFluidSystem()
 
     // test for phaseName(), isLiquid() and isIdealGas()
     for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-        [[maybe_unused]] std::string name = FluidSystem::phaseName(phaseIdx);
+        [[maybe_unused]] std::string name{FluidSystem::phaseName(phaseIdx)};
         bool bVal = FluidSystem::isLiquid(phaseIdx);
         bVal = FluidSystem::isIdealGas(phaseIdx);
         bVal = !bVal; // get rid of GCC warning (only occurs with paranoid warning flags)
@@ -382,7 +383,7 @@ void checkFluidSystem()
     // test for molarMass() and componentName()
     for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx) {
         val = FluidSystem::molarMass(compIdx);
-        std::string name = FluidSystem::componentName(compIdx);
+        std::string{FluidSystem::componentName(compIdx)};
     }
 }
 

--- a/opm/material/constraintsolvers/CompositionFromFugacities.hpp
+++ b/opm/material/constraintsolvers/CompositionFromFugacities.hpp
@@ -36,6 +36,7 @@
 #include <dune/common/fmatrix.hh>
 
 #include <limits>
+#include <string_view>
 
 namespace Opm {
 
@@ -178,7 +179,7 @@ public:
 
         std::string msg =
             std::string("Calculating the ")
-            + FluidSystem::phaseName(phaseIdx)
+            + FluidSystem::phaseName(phaseIdx).data()
             + "Phase composition failed. Initial {x} = {";
         for (const auto& v : xInit)
             msg += " " + std::to_string(cast(getValue(v)));

--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -30,6 +30,7 @@
 #include <opm/common/utility/Demangle.hpp>
 
 #include <stdexcept>
+#include <string_view>
 
 #include "NullParameterCache.hpp"
 
@@ -137,7 +138,7 @@ public:
      *
      * \copydoc Doxygen::compIdxParam
      */
-    static const char* componentName(unsigned /*compIdx*/)
+    static std::string_view componentName(unsigned /*compIdx*/)
     {
         throw std::runtime_error(not_implemented("componentName"));
     }
@@ -296,11 +297,11 @@ public:
     }
 
 private:
-    static std::string not_implemented(const char* method)
+    static std::string not_implemented(const std::string_view method)
     {
         return "Not implemented: The fluid system '" +
                demangle(typeid(Implementation).name()) +
-               "'  does not provide a " + method + "() method!";
+               "'  does not provide a " + method.data() + "() method!";
     }
 };
 

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -47,6 +47,7 @@
 #include <cstddef>
 #include <memory>
 #include <stdexcept>
+#include <string_view>
 #include <vector>
 
 namespace Opm {
@@ -360,7 +361,7 @@ public:
     static Scalar surfaceTemperature;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName(unsigned phaseIdx);
+    static std::string_view phaseName(unsigned phaseIdx);
 
     //! \copydoc BaseFluidSystem::isLiquid
     static bool isLiquid(unsigned phaseIdx)
@@ -406,7 +407,7 @@ public:
     static unsigned soluteComponentIndex(unsigned phaseIdx);
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName(unsigned compIdx);
+    static std::string_view componentName(unsigned compIdx);
 
     //! \copydoc BaseFluidSystem::molarMass
     static Scalar molarMass(unsigned compIdx, unsigned regionIdx = 0)

--- a/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
+++ b/opm/material/fluidsystems/BrineCO2FluidSystem.hpp
@@ -45,6 +45,8 @@
 #include <opm/material/binarycoefficients/Brine_CO2.hpp>
 #include <opm/material/binarycoefficients/H2O_N2.hpp>
 
+#include <string_view>
+
 namespace Opm {
 
 // Silence compiler warnings about use of variables
@@ -100,7 +102,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::phaseName
      */
-    static const char* phaseName(unsigned phaseIdx)
+    static std::string_view phaseName(unsigned phaseIdx)
     {
         static const char* name[] = {
             "liquid",
@@ -167,7 +169,7 @@ public:
     /*!
      * \copydoc BaseFluidSystem::componentName
      */
-    static const char* componentName(unsigned compIdx)
+    static std::string_view componentName(unsigned compIdx)
     {
         static const char* name[] = {
             Brine::name(),

--- a/opm/material/fluidsystems/Co2BrineFluidSystem.hh
+++ b/opm/material/fluidsystems/Co2BrineFluidSystem.hh
@@ -35,6 +35,8 @@
 #include <opm/material/fluidsystems/PTFlashParameterCache.hpp>
 #include <opm/material/viscositymodels/LBC.hpp>
 
+#include <string_view>
+
 namespace Opm {
 /*!
  * \ingroup FluidSystem
@@ -139,7 +141,7 @@ namespace Opm {
         }
 
         //! \copydoc BaseFluidSystem::phaseName
-        static const char* phaseName(unsigned phaseIdx)
+        static std::string_view phaseName(unsigned phaseIdx)
         {
                 static const char* name[] = {"o",  // oleic phase
                                              "g"};  // gas phase
@@ -149,7 +151,7 @@ namespace Opm {
         }
 
         //! \copydoc BaseFluidSystem::componentName
-        static const char* componentName(unsigned compIdx)
+        static std::string_view componentName(unsigned compIdx)
         {
                 static const char* name[] = {
                         Comp0::name(),

--- a/opm/material/fluidsystems/GasPhase.hpp
+++ b/opm/material/fluidsystems/GasPhase.hpp
@@ -27,6 +27,8 @@
 #ifndef OPM_GAS_PHASE_HPP
 #define OPM_GAS_PHASE_HPP
 
+#include <string_view>
+
 namespace Opm {
 
 /*!
@@ -45,7 +47,7 @@ public:
     /*!
      * \brief A human readable name for the component.
      */
-    static const char* name()
+    static std::string_view name()
     { return Component::name(); }
 
     /*!

--- a/opm/material/fluidsystems/GenericFluidSystem.hh
+++ b/opm/material/fluidsystems/GenericFluidSystem.hh
@@ -1,0 +1,215 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2022 SINTEF Digital, Mathematics and Cybernetics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+
+#ifndef OPM_GENERICFLUIDSYSTEM_HH
+#define OPM_GENERICFLUIDSYSTEM_HH
+
+#include <opm/material/fluidsystems/BaseFluidSystem.hpp>
+
+// TODO: this is something else need to check
+#include <opm/material/fluidsystems/PTFlashParameterCache.hpp>
+#include <opm/material/viscositymodels/LBC.hpp>
+
+namespace Opm {
+
+    template <typename Scalar>
+    struct ComponentParam {
+        std::string name;
+        Scalar molar_mass;
+        Scalar critic_temp;
+        Scalar critic_pres;
+        Scalar critic_vol;
+        Scalar acentric_factor;
+
+        ComponentParam(const std::string_view name_, const Scalar molar_mass_, const Scalar critic_temp_,
+                       const Scalar critic_pres_, const Scalar critic_vol_, const Scalar acentric_factor_)
+                       : name(name_),
+                         molar_mass(molar_mass_),
+                         critic_temp(critic_temp_),
+                         critic_pres(critic_pres_),
+                         critic_vol(critic_vol_),
+                         acentric_factor(acentric_factor_)
+        {}
+    };
+/*!
+ * \ingroup FluidSystem
+ *
+ * \brief A two phase three component fluid system with components
+ * CO2, Methane and NDekan
+ */
+    template<class Scalar, int NumComp>
+    class GenericFluidSystem : public Opm::BaseFluidSystem<Scalar, GenericFluidSystem<Scalar, NumComp> > {
+    public:
+        // TODO: I do not think these should be constant in fluidsystem, will try to make it non-constant later
+        static const int numPhases=2;
+        static const int numComponents = NumComp;
+        static const int numMisciblePhases=2;
+        static const int numMiscibleComponents = 3;
+        // TODO: phase location should be more general
+        static constexpr int oilPhaseIdx = 0;
+        static constexpr int gasPhaseIdx = 1;
+
+        template <class ValueType>
+        using ParameterCache = Opm::PTFlashParameterCache<ValueType, GenericFluidSystem<Scalar, NumComp>>;
+        using ViscosityModel = typename Opm::ViscosityModels<Scalar, GenericFluidSystem<Scalar, NumComp>>;
+        using PengRobinsonMixture = typename Opm::PengRobinsonMixture<Scalar, GenericFluidSystem<Scalar, NumComp>>;
+
+        template<typename Param>
+        static void addComponent(const Param& param)
+        {
+            assert(component_param_.size() <= numComponents);
+            if (component_param_.size() == numComponents) {
+                std::cout << " the fluid system has reached maximum " << numComponents << " component,"
+                          << " the component " << param.name << " will not be added " << std::endl;
+            }
+            component_param_.push_back(param);
+        }
+
+        static void init()
+        {
+            component_param_.reserve(numComponents);
+        }
+
+        /*!
+         * \brief The acentric factor of a component [].
+         *
+         * \copydetails Doxygen::compIdxParam
+         */
+        static Scalar acentricFactor(unsigned compIdx)
+        {
+            return component_param_[compIdx].acentric_factor;
+        }
+        /*!
+         * \brief Critical temperature of a component [K].
+         *
+         * \copydetails Doxygen::compIdxParam
+         */
+        static Scalar criticalTemperature(unsigned compIdx)
+        {
+            return component_param_[compIdx].critic_temp;
+        }
+        /*!
+         * \brief Critical pressure of a component [Pa].
+         *
+         * \copydetails Doxygen::compIdxParam
+         */
+        static Scalar criticalPressure(unsigned compIdx)
+        {
+            return component_param_[compIdx].critic_pres;
+        }
+        /*!
+        * \brief Critical volume of a component [m3].
+        *
+        * \copydetails Doxygen::compIdxParam
+        */
+        static Scalar criticalVolume(unsigned compIdx)
+        {
+            return component_param_[compIdx].critic_vol;
+        }
+
+        //! \copydoc BaseFluidSystem::molarMass
+        static Scalar molarMass(unsigned compIdx)
+        {
+            return component_param_[compIdx].molar_mass;
+        }
+
+        /*!
+         * \brief Returns the interaction coefficient for two components.
+         *.
+         */
+        static Scalar interactionCoefficient(unsigned /*comp1Idx*/, unsigned /*comp2Idx*/)
+        {
+            // TODO: some data structure is needed to support this
+            return 0.0;
+        }
+
+        //! \copydoc BaseFluidSystem::phaseName
+        static const char* phaseName(unsigned phaseIdx)
+        {
+                static const char* name[] = {"o",  // oleic phase
+                                             "g"};  // gas phase
+
+                assert(phaseIdx < 2);
+                return name[phaseIdx];
+        }
+
+        //! \copydoc BaseFluidSystem::componentName
+        static const char* componentName(unsigned compIdx)
+        {
+            return component_param_[compIdx].name.c_str();
+        }
+
+        /*!
+         * \copydoc BaseFluidSystem::density
+         */
+        template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
+        static LhsEval density(const FluidState& fluidState,
+                               const ParameterCache<ParamCacheEval>& paramCache,
+                               unsigned phaseIdx)
+        {
+
+            LhsEval dens;
+            if (phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx) {
+                dens = fluidState.averageMolarMass(phaseIdx) / paramCache.molarVolume(phaseIdx);
+            }
+            return dens;
+
+        }
+
+        //! \copydoc BaseFluidSystem::viscosity
+        template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
+        static LhsEval viscosity(const FluidState& fluidState,
+                                 const ParameterCache<ParamCacheEval>& paramCache,
+                                 unsigned phaseIdx)
+        {
+            // Use LBC method to calculate viscosity
+            LhsEval mu;
+            mu = ViscosityModel::LBC(fluidState, paramCache, phaseIdx); 
+            return mu;
+
+        }
+
+        //! \copydoc BaseFluidSystem::fugacityCoefficient
+        template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
+        static LhsEval fugacityCoefficient(const FluidState& fluidState,
+                                           const ParameterCache<ParamCacheEval>& paramCache,
+                                           unsigned phaseIdx,
+                                           unsigned compIdx)
+        {
+            assert(phaseIdx < numPhases);
+            assert(compIdx < numComponents);
+
+            LhsEval phi = PengRobinsonMixture::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
+            return phi;
+        }
+    private:
+        static std::vector<ComponentParam<Scalar>> component_param_;
+    };
+
+    template <class Scalar, int NumComp>
+    std::vector<ComponentParam<Scalar>>
+    GenericFluidSystem<Scalar, NumComp>::component_param_;
+}
+#endif // OPM_GENERICFLUIDSYSTEM_HH

--- a/opm/material/fluidsystems/GenericFluidSystem.hh
+++ b/opm/material/fluidsystems/GenericFluidSystem.hh
@@ -181,7 +181,7 @@ namespace Opm {
 
             LhsEval dens;
             if (phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx) {
-                dens = fluidState.averageMolarMass(phaseIdx) / paramCache.molarVolume(phaseIdx);
+                dens = decay<LhsEval>(fluidState.averageMolarMass(phaseIdx) / paramCache.molarVolume(phaseIdx));
             }
             return dens;
 
@@ -194,10 +194,7 @@ namespace Opm {
                                  unsigned phaseIdx)
         {
             // Use LBC method to calculate viscosity
-            LhsEval mu;
-            mu = ViscosityModel::LBC(fluidState, paramCache, phaseIdx); 
-            return mu;
-
+            return decay<LhsEval>(ViscosityModel::LBC(fluidState, paramCache, phaseIdx));
         }
 
         //! \copydoc BaseFluidSystem::fugacityCoefficient
@@ -210,8 +207,39 @@ namespace Opm {
             assert(phaseIdx < numPhases);
             assert(compIdx < numComponents);
 
-            LhsEval phi = PengRobinsonMixture::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx);
-            return phi;
+            return decay<LhsEval>(PengRobinsonMixture::computeFugacityCoefficient(fluidState, paramCache, phaseIdx, compIdx));
+        }
+
+        //! \copydoc BaseFluidSystem::isCompressible
+        static bool isCompressible([[maybe_unused]] unsigned phaseIdx)
+        {
+            assert(phaseIdx < numPhases);
+
+            return true;
+        }
+
+        //! \copydoc BaseFluidSystem::isIdealMixture
+        static bool isIdealMixture([[maybe_unused]] unsigned phaseIdx)
+        {
+            assert(phaseIdx < numPhases);
+
+            return false;
+        }
+
+        //! \copydoc BaseFluidSystem::isLiquid
+        static bool isLiquid(unsigned phaseIdx)
+        {
+            assert(phaseIdx < numPhases);
+
+            return (phaseIdx == 0);
+        }
+
+        //! \copydoc BaseFluidSystem::isIdealGas
+        static bool isIdealGas(unsigned phaseIdx)
+        {
+            assert(phaseIdx < numPhases);
+
+            return (phaseIdx == 1);
         }
     private:
         static std::vector<ComponentParam<Scalar>> component_param_;

--- a/opm/material/fluidsystems/GenericFluidSystem.hh
+++ b/opm/material/fluidsystems/GenericFluidSystem.hh
@@ -34,6 +34,7 @@
 
 #include <cassert>
 #include <string>
+#include <string_view>
 
 #include <fmt/format.h>
 
@@ -154,7 +155,7 @@ namespace Opm {
         }
 
         //! \copydoc BaseFluidSystem::phaseName
-        static const char* phaseName(unsigned phaseIdx)
+        static std::string_view phaseName(unsigned phaseIdx)
         {
                 static const char* name[] = {"o",  // oleic phase
                                              "g"};  // gas phase
@@ -164,9 +165,9 @@ namespace Opm {
         }
 
         //! \copydoc BaseFluidSystem::componentName
-        static const char* componentName(unsigned compIdx)
+        static std::string_view componentName(unsigned compIdx)
         {
-            return component_param_[compIdx].name.c_str();
+            return component_param_[compIdx].name;
         }
 
         /*!

--- a/opm/material/fluidsystems/GenericOilGasFluidSystem.hpp
+++ b/opm/material/fluidsystems/GenericOilGasFluidSystem.hpp
@@ -23,8 +23,8 @@
   copyright holders.
 */
 
-#ifndef OPM_GENERICFLUIDSYSTEM_HH
-#define OPM_GENERICFLUIDSYSTEM_HH
+#ifndef OPM_GENERICOILGASFLUIDSYSTEM_HPP
+#define OPM_GENERICOILGASFLUIDSYSTEM_HPP
 
 #include <opm/common/OpmLog/OpmLog.hpp>
 
@@ -68,7 +68,7 @@ namespace Opm {
  * \tparam NumComp The number of the components in the fluid system.
  */
     template<class Scalar, int NumComp>
-    class GenericFluidSystem : public BaseFluidSystem<Scalar, GenericFluidSystem<Scalar, NumComp> > {
+    class GenericOilGasFluidSystem : public BaseFluidSystem<Scalar, GenericOilGasFluidSystem<Scalar, NumComp> > {
     public:
         // TODO: I do not think these should be constant in fluidsystem, will try to make it non-constant later
         static const int numPhases=2;
@@ -80,9 +80,9 @@ namespace Opm {
         static constexpr int gasPhaseIdx = 1;
 
         template <class ValueType>
-        using ParameterCache = Opm::PTFlashParameterCache<ValueType, GenericFluidSystem<Scalar, NumComp>>;
-        using ViscosityModel = Opm::ViscosityModels<Scalar, GenericFluidSystem<Scalar, NumComp>>;
-        using PengRobinsonMixture = Opm::PengRobinsonMixture<Scalar, GenericFluidSystem<Scalar, NumComp>>;
+        using ParameterCache = Opm::PTFlashParameterCache<ValueType, GenericOilGasFluidSystem<Scalar, NumComp>>;
+        using ViscosityModel = Opm::ViscosityModels<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
+        using PengRobinsonMixture = Opm::PengRobinsonMixture<Scalar, GenericOilGasFluidSystem<Scalar, NumComp>>;
 
         template<typename Param>
         static void addComponent(const Param& param)
@@ -108,6 +108,9 @@ namespace Opm {
          */
         static Scalar acentricFactor(unsigned compIdx)
         {
+            assert(isConsistent());
+            assert(compIdx < numComponents);
+
             return component_param_[compIdx].acentric_factor;
         }
         /*!
@@ -117,6 +120,9 @@ namespace Opm {
          */
         static Scalar criticalTemperature(unsigned compIdx)
         {
+            assert(isConsistent());
+            assert(compIdx < numComponents);
+
             return component_param_[compIdx].critic_temp;
         }
         /*!
@@ -126,6 +132,9 @@ namespace Opm {
          */
         static Scalar criticalPressure(unsigned compIdx)
         {
+            assert(isConsistent());
+            assert(compIdx < numComponents);
+
             return component_param_[compIdx].critic_pres;
         }
         /*!
@@ -135,12 +144,18 @@ namespace Opm {
         */
         static Scalar criticalVolume(unsigned compIdx)
         {
+            assert(isConsistent());
+            assert(compIdx < numComponents);
+
             return component_param_[compIdx].critic_vol;
         }
 
         //! \copydoc BaseFluidSystem::molarMass
         static Scalar molarMass(unsigned compIdx)
         {
+            assert(isConsistent());
+            assert(compIdx < numComponents);
+
             return component_param_[compIdx].molar_mass;
         }
 
@@ -150,6 +165,7 @@ namespace Opm {
          */
         static Scalar interactionCoefficient(unsigned /*comp1Idx*/, unsigned /*comp2Idx*/)
         {
+            assert(isConsistent());
             // TODO: some data structure is needed to support this
             return 0.0;
         }
@@ -160,13 +176,16 @@ namespace Opm {
                 static const char* name[] = {"o",  // oleic phase
                                              "g"};  // gas phase
 
-                assert(phaseIdx < 2);
+                assert(phaseIdx < numPhases);
                 return name[phaseIdx];
         }
 
         //! \copydoc BaseFluidSystem::componentName
         static std::string_view componentName(unsigned compIdx)
         {
+            assert(isConsistent());
+            assert(compIdx < numComponents);
+
             return component_param_[compIdx].name;
         }
 
@@ -178,6 +197,8 @@ namespace Opm {
                                const ParameterCache<ParamCacheEval>& paramCache,
                                unsigned phaseIdx)
         {
+            assert(isConsistent());
+            assert(phaseIdx < numPhases);
 
             LhsEval dens;
             if (phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx) {
@@ -193,6 +214,8 @@ namespace Opm {
                                  const ParameterCache<ParamCacheEval>& paramCache,
                                  unsigned phaseIdx)
         {
+            assert(isConsistent());
+            assert(phaseIdx < numPhases);
             // Use LBC method to calculate viscosity
             return decay<LhsEval>(ViscosityModel::LBC(fluidState, paramCache, phaseIdx));
         }
@@ -204,6 +227,7 @@ namespace Opm {
                                            unsigned phaseIdx,
                                            unsigned compIdx)
         {
+            assert(isConsistent());
             assert(phaseIdx < numPhases);
             assert(compIdx < numComponents);
 
@@ -242,11 +266,15 @@ namespace Opm {
             return (phaseIdx == 1);
         }
     private:
+        static bool isConsistent() {
+            return component_param_.size() == NumComp;
+        }
+
         static std::vector<ComponentParam<Scalar>> component_param_;
     };
 
     template <class Scalar, int NumComp>
     std::vector<ComponentParam<Scalar>>
-    GenericFluidSystem<Scalar, NumComp>::component_param_;
+    GenericOilGasFluidSystem<Scalar, NumComp>::component_param_;
 }
-#endif // OPM_GENERICFLUIDSYSTEM_HH
+#endif // OPM_GENERICOILGASFLUIDSYSTEM_HPP

--- a/opm/material/fluidsystems/H2OAirFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirFluidSystem.hpp
@@ -39,6 +39,7 @@
 #include <opm/material/common/Valgrind.hpp>
 
 #include <cassert>
+#include <string_view>
 
 namespace Opm {
 
@@ -80,7 +81,7 @@ public:
     static const int gasPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName(unsigned phaseIdx)
+    static std::string_view phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case liquidPhaseIdx: return "liquid";
@@ -140,7 +141,7 @@ public:
     static const int AirIdx = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName(unsigned compIdx)
+    static std::string_view componentName(unsigned compIdx)
     {
         switch (compIdx)
         {

--- a/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirMesityleneFluidSystem.hpp
@@ -42,6 +42,8 @@
 #include <opm/material/binarycoefficients/H2O_Mesitylene.hpp>
 #include <opm/material/binarycoefficients/Air_Mesitylene.hpp>
 
+#include <string_view>
+
 namespace Opm {
 
 /*!
@@ -159,7 +161,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName(unsigned phaseIdx)
+    static std::string_view phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case waterPhaseIdx: return "water";
@@ -170,7 +172,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName(unsigned compIdx)
+    static std::string_view componentName(unsigned compIdx)
     {
         switch (compIdx) {
         case H2OIdx: return H2O::name();

--- a/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2OAirXyleneFluidSystem.hpp
@@ -40,6 +40,8 @@
 #include "BaseFluidSystem.hpp"
 #include "NullParameterCache.hpp"
 
+#include <string_view>
+
 namespace Opm {
 
 /*!
@@ -126,7 +128,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName(unsigned phaseIdx)
+    static std::string_view phaseName(unsigned phaseIdx)
     {
         switch (phaseIdx) {
         case waterPhaseIdx: return "water";
@@ -137,7 +139,7 @@ public:
     }
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName(unsigned compIdx)
+    static std::string_view componentName(unsigned compIdx)
     {
         switch (compIdx) {
         case H2OIdx: return H2O::name();

--- a/opm/material/fluidsystems/H2ON2FluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2FluidSystem.hpp
@@ -39,6 +39,7 @@
 #include <opm/material/common/Valgrind.hpp>
 
 #include <cassert>
+#include <string_view>
 
 namespace Opm {
 
@@ -78,7 +79,7 @@ public:
     static const int gasPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName(unsigned phaseIdx)
+    static std::string_view phaseName(unsigned phaseIdx)
     {
         static const char* name[] = {
             "liquid",
@@ -149,7 +150,7 @@ public:
     typedef SimpleN2 N2;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName(unsigned compIdx)
+    static std::string_view componentName(unsigned compIdx)
     {
         static const char* name[] = {
             H2O::name(),

--- a/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp
@@ -39,6 +39,7 @@
 #include <opm/material/common/Valgrind.hpp>
 
 #include <cassert>
+#include <string_view>
 
 namespace Opm {
 
@@ -77,7 +78,7 @@ public:
     static const int liquidPhaseIdx = 0;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName([[maybe_unused]] unsigned phaseIdx)
+    static std::string_view phaseName([[maybe_unused]] unsigned phaseIdx)
     {
         assert(phaseIdx == liquidPhaseIdx);
 
@@ -137,7 +138,7 @@ public:
     typedef SimpleN2 N2;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName(unsigned compIdx)
+    static std::string_view componentName(unsigned compIdx)
     {
         static const char* name[] = {
             H2O::name(),

--- a/opm/material/fluidsystems/LiquidPhase.hpp
+++ b/opm/material/fluidsystems/LiquidPhase.hpp
@@ -27,6 +27,8 @@
 #ifndef OPM_LIQUID_PHASE_HPP
 #define OPM_LIQUID_PHASE_HPP
 
+#include <string_view>
+
 namespace Opm {
 
 /*!
@@ -41,7 +43,7 @@ public:
     typedef ComponentT Component;
 
     //! \copydoc GasPhase::name
-    static const char* name()
+    static std::string_view name()
     { return Component::name(); }
 
     //! \copydoc GasPhase::isLiquid

--- a/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/SinglePhaseFluidSystem.hpp
@@ -39,6 +39,7 @@
 
 #include <limits>
 #include <cassert>
+#include <string_view>
 
 namespace Opm {
 
@@ -72,7 +73,7 @@ public:
     static const int numPhases = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName([[maybe_unused]] unsigned phaseIdx)
+    static std::string_view phaseName([[maybe_unused]] unsigned phaseIdx)
     {
         assert(phaseIdx < numPhases);
 
@@ -122,7 +123,7 @@ public:
     static const int numComponents = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName([[maybe_unused]] unsigned compIdx)
+    static std::string_view componentName([[maybe_unused]] unsigned compIdx)
     {
         assert(compIdx < numComponents);
 

--- a/opm/material/fluidsystems/Spe5FluidSystem.hpp
+++ b/opm/material/fluidsystems/Spe5FluidSystem.hpp
@@ -35,6 +35,8 @@
 
 #include <opm/material/common/Spline.hpp>
 
+#include <string_view>
+
 namespace Opm {
 
 /*!
@@ -86,7 +88,7 @@ public:
     typedef ::Opm::H2O<Scalar> H2O;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName(unsigned phaseIdx)
+    static std::string_view phaseName(unsigned phaseIdx)
     {
         static const char* name[] = {
             "gas",
@@ -148,7 +150,7 @@ public:
     static const int C20Idx = 6; //!< Index of the C20 component
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName(unsigned compIdx)
+    static std::string_view componentName(unsigned compIdx)
     {
         static const char* name[] = {
             H2O::name(),

--- a/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
+++ b/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
@@ -31,6 +31,8 @@
 #include <opm/material/components/C10.hpp>
 #include <opm/material/components/C1.hpp>
 
+#include <string_view>
+
 
 // TODO: this is something else need to check
 #include <opm/material/fluidsystems/PTFlashParameterCache.hpp>
@@ -148,7 +150,7 @@ namespace Opm {
         }
 
         //! \copydoc BaseFluidSystem::phaseName
-        static const char* phaseName(unsigned phaseIdx)
+        static std::string_view phaseName(unsigned phaseIdx)
         {
                 static const char* name[] = {"o",  // oleic phase
                                              "g"};  // gas phase
@@ -158,7 +160,7 @@ namespace Opm {
         }
 
         //! \copydoc BaseFluidSystem::componentName
-        static const char* componentName(unsigned compIdx)
+        static std::string_view componentName(unsigned compIdx)
         {
                 static const char* name[] = {
                         Comp0::name(),

--- a/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
+++ b/opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp
@@ -27,8 +27,9 @@
 #ifndef OPM_TWO_PHASE_IMMISCIBLE_FLUID_SYSTEM_HPP
 #define OPM_TWO_PHASE_IMMISCIBLE_FLUID_SYSTEM_HPP
 
-#include <limits>
 #include <cassert>
+#include <limits>
+#include <string_view>
 
 #include <opm/material/fluidsystems/LiquidPhase.hpp>
 #include <opm/material/fluidsystems/GasPhase.hpp>
@@ -81,7 +82,7 @@ public:
     static const int nonWettingPhaseIdx = 1;
 
     //! \copydoc BaseFluidSystem::phaseName
-    static const char* phaseName(unsigned phaseIdx)
+    static std::string_view phaseName(unsigned phaseIdx)
     {
         assert(phaseIdx < numPhases);
 
@@ -147,7 +148,7 @@ public:
     static const int nonWettingCompIdx = 1;
 
     //! \copydoc BaseFluidSystem::componentName
-    static const char* componentName(unsigned compIdx)
+    static std::string_view componentName(unsigned compIdx)
     {
         assert(compIdx < numComponents);
 

--- a/src/opm/material/fluidsystems/BlackOilFluidSystem.cpp
+++ b/src/opm/material/fluidsystems/BlackOilFluidSystem.cpp
@@ -32,6 +32,8 @@
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 #endif
 
+#include <string_view>
+
 #include <fmt/format.h>
 
 namespace Opm {
@@ -293,7 +295,7 @@ void BlackOilFluidSystem<Scalar,IndexTraits>::initEnd()
 }
 
 template <class Scalar, class IndexTraits>
-const char* BlackOilFluidSystem<Scalar,IndexTraits>::
+std::string_view BlackOilFluidSystem<Scalar,IndexTraits>::
 phaseName(unsigned phaseIdx)
 {
     switch (phaseIdx) {
@@ -349,7 +351,7 @@ soluteComponentIndex(unsigned phaseIdx)
 }
 
 template <class Scalar, class IndexTraits>
-const char* BlackOilFluidSystem<Scalar,IndexTraits>::
+std::string_view BlackOilFluidSystem<Scalar,IndexTraits>::
 componentName(unsigned compIdx)
 {
     switch (compIdx) {

--- a/tests/material/test_fluidsystems.cpp
+++ b/tests/material/test_fluidsystems.cpp
@@ -34,6 +34,12 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/material/checkFluidSystem.hpp>
+
+#include <opm/material/components/C1.hpp>
+#include <opm/material/components/C10.hpp>
+#include <opm/material/components/N2.hpp>
+#include <opm/material/components/SimpleCO2.hpp>
+
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
 
@@ -42,6 +48,7 @@
 #include <opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidsystems/BrineCO2FluidSystem.hpp>
+#include <opm/material/fluidsystems/GenericFluidSystem.hh>
 #include <opm/material/fluidsystems/H2ON2FluidSystem.hpp>
 #include <opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp>
 #include <opm/material/fluidsystems/H2OAirFluidSystem.hpp>
@@ -378,6 +385,30 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeComponentFluidSystem, Scalar, ScalarTypes)
 {
     using Evaluation = Opm::DenseAd::Evaluation<Scalar,3>;
     using FluidSystem = Opm::ThreeComponentFluidSystem<Scalar>;
+
+    checkFluidSystem<Scalar, FluidSystem, Scalar, Scalar>();
+    checkFluidSystem<Scalar, FluidSystem, Evaluation, Scalar>();
+    checkFluidSystem<Scalar, FluidSystem, Evaluation, Evaluation>();
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(GenericFluidSystem, Scalar, ScalarTypes)
+{
+    using Evaluation = Opm::DenseAd::Evaluation<Scalar, 4>;
+    using FluidSystem = Opm::GenericFluidSystem<Scalar, 4>;
+
+    using CompParm = Opm::ComponentParam<Scalar>;
+    using CO2 = Opm::SimpleCO2<Scalar>;
+    using C1 = Opm::C1<Scalar>;
+    using N2 = Opm::N2<Scalar>;
+    using C10 = Opm::C10<Scalar>;
+    FluidSystem::addComponent(CompParm {CO2::name(), CO2::molarMass(), CO2::criticalTemperature(),
+                                        CO2::criticalPressure(), CO2::criticalVolume(), CO2::acentricFactor()});
+    FluidSystem::addComponent(CompParm {C1::name(), C1::molarMass(), C1::criticalTemperature(),
+                                        C1::criticalPressure(), C1::criticalVolume(), C1::acentricFactor()});
+    FluidSystem::addComponent(CompParm{C10::name(), C10::molarMass(), C10::criticalTemperature(),
+                                       C10::criticalPressure(), C10::criticalVolume(), C10::acentricFactor()});
+    FluidSystem::addComponent(CompParm{N2::name(), N2::molarMass(), N2::criticalTemperature(),
+                                       N2::criticalPressure(), N2::criticalVolume(), N2::acentricFactor()});
 
     checkFluidSystem<Scalar, FluidSystem, Scalar, Scalar>();
     checkFluidSystem<Scalar, FluidSystem, Evaluation, Scalar>();

--- a/tests/material/test_fluidsystems.cpp
+++ b/tests/material/test_fluidsystems.cpp
@@ -396,7 +396,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GenericFluidSystem, Scalar, ScalarTypes)
     using Evaluation = Opm::DenseAd::Evaluation<Scalar, 4>;
     using FluidSystem = Opm::GenericOilGasFluidSystem<Scalar, 4>;
 
-    using CompParm = Opm::ComponentParam<Scalar>;
+    using CompParm = typename FluidSystem::ComponentParam;
     using CO2 = Opm::SimpleCO2<Scalar>;
     using C1 = Opm::C1<Scalar>;
     using N2 = Opm::N2<Scalar>;

--- a/tests/material/test_fluidsystems.cpp
+++ b/tests/material/test_fluidsystems.cpp
@@ -48,7 +48,7 @@
 #include <opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidsystems/BrineCO2FluidSystem.hpp>
-#include <opm/material/fluidsystems/GenericFluidSystem.hh>
+#include <opm/material/fluidsystems/GenericOilGasFluidSystem.hpp>
 #include <opm/material/fluidsystems/H2ON2FluidSystem.hpp>
 #include <opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp>
 #include <opm/material/fluidsystems/H2OAirFluidSystem.hpp>
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeComponentFluidSystem, Scalar, ScalarTypes)
 BOOST_AUTO_TEST_CASE_TEMPLATE(GenericFluidSystem, Scalar, ScalarTypes)
 {
     using Evaluation = Opm::DenseAd::Evaluation<Scalar, 4>;
-    using FluidSystem = Opm::GenericFluidSystem<Scalar, 4>;
+    using FluidSystem = Opm::GenericOilGasFluidSystem<Scalar, 4>;
 
     using CompParm = Opm::ComponentParam<Scalar>;
     using CO2 = Opm::SimpleCO2<Scalar>;


### PR DESCRIPTION
it has the NumComp as a template parameter, so that we can instantiate FluidSystem with different number of components.

And also, we can add different components into the FluidSystem.


The main purpose of this PR is that for ThreeComponentFluidSystem, (for example, it is used in [co2ptflashproblem.hh](https://github.com/OPM/opm-models/pull/855/files#diff-089d65d691a91b833ea8ff392384b0258fd92ccb7312aa308463a5d51b3cee3b) )

Both the number of the components and number of the components are fixed. (Three Components, and they are the predefined CO2, C1 and C10 respectively. )

Not totally sure if will always work, but with the GenericFluidSystem introduced in this PR, we can specify the number of the components (compilation time), and also the component (the component does not need to be predefined anywhere, because we can feed in any component parameters we want. )