### PR TITLE
Check if UDQ name is valid (not necessarily defined) when creating UDAs

### DIFF
--- a/src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -68,7 +68,7 @@ namespace Opm {
         Well::WellInjectionProperties result;
         result.name = "test";
         result.surfaceInjectionRate = UDAValue(1.0);
-        result.reservoirInjectionRate = UDAValue("test");
+        result.reservoirInjectionRate = UDAValue("FUTEST");
         result.BHPTarget = UDAValue(2.0);
         result.THPTarget = UDAValue(3.0);
         result.bhp_hist_limit = 4.0;

--- a/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -65,7 +65,7 @@ namespace Opm {
         Well::WellProductionProperties result;
         result.name = "test";
         result.OilRate = UDAValue(1.0);
-        result.WaterRate = UDAValue("test");
+        result.WaterRate = UDAValue("FUTEST");
         result.GasRate = UDAValue(2.0);
         result.LiquidRate = UDAValue(3.0);
         result.ResVRate = UDAValue(4.0);

--- a/tests/parser/DeckTests.cpp
+++ b/tests/parser/DeckTests.cpp
@@ -744,8 +744,8 @@ COMPDAT
 /
 
 WCONPROD
-  'P1' 'OPEN' 'ORAT'  123.4  0.0  0.0  0.0  0.0 100 100 42 'UDA' /
-  'P2' 'OPEN' 'ORAT'  123.4  0.0  0.0  0.0  0.0 100 100 43 'UDA' /
+  'P1' 'OPEN' 'ORAT'  123.4  0.0  0.0  0.0  0.0 100 100 42 'FUDA' /
+  'P2' 'OPEN' 'ORAT'  123.4  0.0  0.0  0.0  0.0 100 100 43 'FUDA' /
 /
 
 DATES

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -271,7 +271,7 @@ GUIDERAT
   1*  'COMB'  1.0 1.0 /
 
 LINCOM
-  1  2  'WWCT:OPX' /)";
+  1  2  'FUWCT' /)";
 
     /* The 'COMB' target mode is not supported */
     BOOST_CHECK_THROW(create_schedule(input), std::exception);
@@ -297,7 +297,7 @@ GUIDERAT
   1*  'OIL'  1.0 1.0 /
 
 LINCOM
-  1  2  'WWCT:OPX' /
+  1  2  'FUWCT' /
 
 TSTEP
   1 1 1 1 1 1 1 1 1 1 1 /)";


### PR DESCRIPTION
Note: With this addition, the utility function 'bool is_udq(const std::string&)' is defined at five different locations (SummaryConfig.cpp, UDQState.cpp, UDQContext.cpp, UDQASTNode.cpp and now UDAValue.cpp). Would probably make sense to unify these? (indepent of this PR..) 