### PR TITLE
[refactor] reduce size of maps used in MULTREGTScanner

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -120,6 +120,7 @@ namespace Opm {
         }
 
     private:
+        // For any key k in the map k.first <= k.second holds.
         using MULTREGTSearchMap = std::map<
             std::pair<int, int>,
             std::vector<MULTREGTRecord>::size_type
@@ -128,6 +129,8 @@ namespace Opm {
         GridDims gridDims{};
         const FieldPropsManager* fp{nullptr};
 
+        // For any record stored index of source region is less than
+        // or equal to target region.
         std::vector<MULTREGTRecord> m_records{};
         std::map<std::string, MULTREGTSearchMap> m_searchMap{};
         std::map<std::string, std::vector<int>> regions{};

--- a/src/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -164,10 +164,9 @@ namespace Opm {
                 // we add both directions, symmetrically, to the lookup
                 // table.
                 if (srcRegion != targetRegion) {
-                    std::pair<int,int> pair1{ srcRegion, targetRegion };
-                    std::pair<int,int> pair2{ targetRegion, srcRegion };
-                    searchPairs[pair1] = recordIx;
-                    searchPairs[pair2] = recordIx;
+                    std::pair<int,int> pair = (srcRegion <= targetRegion) ?
+                        std::make_pair(srcRegion, targetRegion) : std::make_pair(targetRegion, srcRegion);
+                    searchPairs[pair] = recordIx;
                 }
             }
             else {
@@ -306,11 +305,8 @@ namespace Opm {
             const int regionId1 = region_data[globalIndex1];
             const int regionId2 = region_data[globalIndex2];
 
-            auto regPairPos = regMap.find({ regionId1, regionId2 });
-            if ((regionId1 != regionId2) && !regPairFound(regMap, regPairPos)) {
-                // 1 -> 2 not found.  Try reverse direction.
-                regPairPos = regMap.find({ regionId2, regionId1 });
-            }
+            auto regPairPos = (regionId1 <= regionId2) ? regMap.find({ regionId1, regionId2 })
+                : regMap.find({ regionId2, regionId1 });
 
             if (! regPairFound(regMap, regPairPos)) {
                 // Neither 1->2 nor 2->1 found.  Move on to next region set.
@@ -434,7 +430,12 @@ namespace Opm {
 
             for (int src_region : src_regions) {
                 for (int target_region : target_regions) {
-                    m_records.push_back({src_region, target_region, trans_mult, directions, nnc_behaviour, region_name});
+                    if(src_region <= target_region) {
+                        m_records.push_back({src_region, target_region, trans_mult, directions, nnc_behaviour, region_name});
+                    }
+                    else {
+                        m_records.push_back({target_region, src_region, trans_mult, directions, nnc_behaviour, region_name});  
+                    }
                 }
             }
         }

--- a/src/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/src/opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -313,6 +313,8 @@ namespace Opm {
                 continue;
             }
 
+            assert(regionId1 != regionId2);
+
             const auto& record = this->m_records[regPairPos->second];
             const auto applyMultiplier =
                 (record.nnc_behaviour == MULTREGT::NNCBehaviourEnum::ALL) ||
@@ -354,15 +356,13 @@ namespace Opm {
             const auto regionId2 = region_data[globalCellIdx2];
 
             auto regPairPos = regMap.find({ regionId1, regionId2 });
-            if ((regionId1 != regionId2) && (regPairPos == regMap.end())) {
-                // 1 -> 2 not found.  Try reverse direction.
-                regPairPos = regMap.find({ regionId2, regionId1 });
-            }
 
             if (regPairPos == regMap.end()) {
                 // Neither 1->2 nor 2->1 found.  Move on to next region set.
                 continue;
             }
+
+            assert(regionId1 != regionId2);
 
             const auto& record = this->m_records[regPairPos->second];
 
@@ -430,8 +430,11 @@ namespace Opm {
 
             for (int src_region : src_regions) {
                 for (int target_region : target_regions) {
-                    if(src_region <= target_region) {
-                        m_records.push_back({src_region, target_region, trans_mult, directions, nnc_behaviour, region_name});
+                    if (src_region <= target_region) {
+                        // same region should not happen for defaulted regions
+                        if (src_region != target_region) {
+                            m_records.push_back({src_region, target_region, trans_mult, directions, nnc_behaviour, region_name});
+                        }
                     }
                     else {
                         m_records.push_back({target_region, src_region, trans_mult, directions, nnc_behaviour, region_name});  


### PR DESCRIPTION
For each region pair the direction does not matter ({1,2} is equivalent to {2,1}). Therefore we only store it once with this PR ensuring that the index of the source region is less than or equal to the target region. Lookup is also changed accordingly.