### PR TITLE
Refactor HystParams to support LGRs

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -141,8 +141,11 @@ private:
         InitParams(EclMaterialLawManager<TraitsT>& parent, const EclipseState& eclState, size_t numCompressedElems);
         // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
+        //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
+        //        leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
         void run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                 const unsigned int, bool)>& fieldPropIntOnLeafAssigner);
+                 const unsigned int, bool)>& fieldPropIntOnLeafAssigner,
+                 const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
     private:
         class HystParams;
         // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
@@ -186,23 +189,37 @@ private:
             std::shared_ptr<OilWaterTwoPhaseHystParams> getOilWaterParams();
             std::shared_ptr<GasWaterTwoPhaseHystParams> getGasWaterParams();
             void setConfig(unsigned satRegionIdx);
-            void setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx);
-            void setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx);
-            void setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx);
-            void setImbibitionParamsOilGas(unsigned elemIdx, unsigned satRegionIdx);
-            void setImbibitionParamsOilWater(unsigned elemIdx, unsigned satRegionIdx);
-            void setImbibitionParamsGasWater(unsigned elemIdx, unsigned satRegionIdx);
+            // Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
+            // leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
+            void setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
+                                         const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
+            void setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
+                                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
+            void setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
+                                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
+            void setImbibitionParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
+                                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
+            void setImbibitionParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
+                                             const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
+            void setImbibitionParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
+                                             const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
         private:
             bool hasGasWater_();
             bool hasGasOil_();
             bool hasOilWater_();
 
-            std::tuple<EclEpsScalingPointsInfo<Scalar>, EclEpsScalingPoints<Scalar>> readScaledEpsPoints_(
-                                                                                                          const EclEpsGridProperties& epsGridProperties, unsigned elemIdx, EclTwoPhaseSystemType type);
+            // Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
+            // leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
             std::tuple<EclEpsScalingPointsInfo<Scalar>, EclEpsScalingPoints<Scalar>>
-            readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type);
+            readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties, unsigned elemIdx, EclTwoPhaseSystemType type,
+                                 const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
             std::tuple<EclEpsScalingPointsInfo<Scalar>, EclEpsScalingPoints<Scalar>>
-            readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type);
+            readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type,
+                                         const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
+            std::tuple<EclEpsScalingPointsInfo<Scalar>, EclEpsScalingPoints<Scalar>>
+            readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
+                                           const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
+
             EclMaterialLawManager<TraitsT>::InitParams& init_params_;
             EclMaterialLawManager<TraitsT>& parent_;
             const EclipseState& eclState_;
@@ -258,9 +275,12 @@ public:
 
     // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
     //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
+    //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
+    //        leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
     void initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
                                const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                               const unsigned int,bool)>& fieldPropIntOnLeafAssigner);
+                               const unsigned int,bool)>& fieldPropIntOnLeafAssigner,
+                               const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
 
     /*!
      * \brief Modify the initial condition according to the SWATINIT keyword.

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -133,10 +133,11 @@ template<class TraitsT>
 void EclMaterialLawManager<TraitsT>::
 initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
                       const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                      const unsigned int, bool)>& fieldPropIntOnLeafAssigner)
+                      const unsigned int, bool)>& fieldPropIntOnLeafAssigner,
+                      const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     InitParams initParams {*this, eclState, numCompressedElems};
-    initParams.run(fieldPropIntOnLeafAssigner);
+    initParams.run(fieldPropIntOnLeafAssigner, lookupIdxOnLevelZeroAssigner);
 }
 
 template<class TraitsT>

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerHystParams.cpp
@@ -95,11 +95,12 @@ setConfig(unsigned satRegionIdx)
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx)
+setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx,
+                          const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     if (hasGasWater_()) {
         auto [gasWaterScaledInfo, gasWaterScaledPoints]
-            = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasWater);
+            = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasWater, lookupIdxOnLevelZeroAssigner);
         GasWaterEpsTwoPhaseParams gasWaterDrainParams;
         gasWaterDrainParams.setConfig(this->parent_.gasWaterConfig_);
         gasWaterDrainParams.setUnscaledPoints(this->parent_.gasWaterUnscaledPointsVector_[satRegionIdx]);
@@ -113,11 +114,12 @@ setDrainageParamsGasWater(unsigned elemIdx, unsigned satRegionIdx)
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx)
+setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx,
+                        const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     if (hasGasOil_()) {
         auto [gasOilScaledInfo, gasOilScaledPoints]
-            = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasOil);
+            = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::GasOil, lookupIdxOnLevelZeroAssigner);
         GasOilEpsTwoPhaseParams gasOilDrainParams;
         gasOilDrainParams.setConfig(this->parent_.gasOilConfig_);
         gasOilDrainParams.setUnscaledPoints(this->parent_.gasOilUnscaledPointsVector_[satRegionIdx]);
@@ -131,14 +133,15 @@ setDrainageParamsOilGas(unsigned elemIdx, unsigned satRegionIdx)
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx)
+setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx,
+                          const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     // We need to compute the oil-water scaled info even if we are running a two-phase case without
     // water (e.g. gas-oil). The reason is that the oil-water scaled info is used when computing
     // the initial condition see e.g. equilibrationhelpers.cc and initstateequil.cc
     // Therefore, the below 7 lines should not be put inside the if(hasOilWater_){} below.
     auto [oilWaterScaledInfo, oilWaterScaledPoints]
-        = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::OilWater);
+        = readScaledEpsPointsDrainage_(elemIdx, EclTwoPhaseSystemType::OilWater, lookupIdxOnLevelZeroAssigner);
     // TODO: This will reassign the same EclEpsScalingPointsInfo for each facedir
     //  since we currently does not support facedir for the scaling points info
     //  When such support is added, we need to extend the below vector which has info for each cell
@@ -158,11 +161,12 @@ setDrainageParamsOilWater(unsigned elemIdx, unsigned satRegionIdx)
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx)
+setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx,
+                            const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     if (hasGasWater_()) {
         auto [gasWaterScaledInfo, gasWaterScaledPoints]
-            = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::GasWater);
+            = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::GasWater, lookupIdxOnLevelZeroAssigner);
         GasWaterEpsTwoPhaseParams gasWaterImbParamsHyst;
         gasWaterImbParamsHyst.setConfig(this->parent_.gasWaterConfig_);
         gasWaterImbParamsHyst.setUnscaledPoints(this->parent_.gasWaterUnscaledPointsVector_[imbRegionIdx]);
@@ -179,11 +183,12 @@ setImbibitionParamsGasWater(unsigned elemIdx, unsigned imbRegionIdx)
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx)
+setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx,
+                          const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     if (hasGasOil_()) {
         auto [gasOilScaledInfo, gasOilScaledPoints]
-            = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::GasOil);
+            = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::GasOil, lookupIdxOnLevelZeroAssigner);
 
         GasOilEpsTwoPhaseParams gasOilImbParamsHyst;
         gasOilImbParamsHyst.setConfig(this->parent_.gasOilConfig_);
@@ -200,11 +205,12 @@ setImbibitionParamsOilGas(unsigned elemIdx, unsigned imbRegionIdx)
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx)
+setImbibitionParamsOilWater(unsigned elemIdx, unsigned imbRegionIdx,
+                            const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     if (hasOilWater_()) {
         auto [oilWaterScaledInfo, oilWaterScaledPoints]
-            = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::OilWater);
+            = readScaledEpsPointsImbibition_(elemIdx, EclTwoPhaseSystemType::OilWater, lookupIdxOnLevelZeroAssigner);
         OilWaterEpsTwoPhaseParams oilWaterImbParamsHyst;
         oilWaterImbParamsHyst.setConfig(this->parent_.oilWaterConfig_);
         oilWaterImbParamsHyst.setUnscaledPoints(this->parent_.oilWaterUnscaledPointsVector_[imbRegionIdx]);
@@ -250,15 +256,20 @@ std::tuple<
   EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
 >
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties, unsigned elemIdx, EclTwoPhaseSystemType type)
+readScaledEpsPoints_(const EclEpsGridProperties& epsGridProperties, unsigned elemIdx, EclTwoPhaseSystemType type,
+                     const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {
     const EclEpsConfig& config = (type == EclTwoPhaseSystemType::OilWater)?  *(this->parent_.oilWaterConfig_): *(this->parent_.gasOilConfig_);
-    unsigned satRegionIdx = epsGridProperties.satRegion( elemIdx );
+    // For CpGrids with LGRs, field prop is inherited from parent/equivalent cell from level 0.
+    // 'lookupIdx' is the index on level zero of the parent cell or the equivalent cell of the
+    // leaf grid view cell with index 'elemIdx'.
+    const auto lookupIdx = fieldPropIdxOnLevelZero(elemIdx);
+    unsigned satRegionIdx = epsGridProperties.satRegion( lookupIdx /* coincides with elemIdx when no LGRs */ );
     // Copy-construct a new instance of EclEpsScalingPointsInfo
     EclEpsScalingPointsInfo<Scalar> destInfo(this->parent_.unscaledEpsInfo_[satRegionIdx]);
     // TODO: currently epsGridProperties does not implement a face direction, e.g. SWLX, SWLY,...
     //  when these keywords get implemented, we need to use include facedir in the lookup
-    destInfo.extractScaled(this->eclState_, epsGridProperties, elemIdx);
+    destInfo.extractScaled(this->eclState_, epsGridProperties, lookupIdx /* coincides with elemIdx when no LGRs */);
 
     EclEpsScalingPoints<Scalar> destPoint;
     destPoint.init(destInfo, config, type);
@@ -271,10 +282,11 @@ std::tuple<
   EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
 >
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type)
+readScaledEpsPointsDrainage_(unsigned elemIdx, EclTwoPhaseSystemType type,
+                             const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {
     const auto& epsGridProperties = this->init_params_.epsGridProperties_;
-    return readScaledEpsPoints_(*epsGridProperties, elemIdx, type);
+    return readScaledEpsPoints_(*epsGridProperties, elemIdx, type, fieldPropIdxOnLevelZero);
 }
 
 template <class Traits>
@@ -283,10 +295,11 @@ std::tuple<
   EclEpsScalingPoints<typename EclMaterialLawManager<Traits>::Scalar>
 >
 EclMaterialLawManager<Traits>::InitParams::HystParams::
-readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type)
+readScaledEpsPointsImbibition_(unsigned elemIdx, EclTwoPhaseSystemType type,
+                               const std::function<unsigned(unsigned)>& fieldPropIdxOnLevelZero)
 {
     const auto& epsGridProperties = this->init_params_.epsImbGridProperties_;
-    return readScaledEpsPoints_(*epsGridProperties, elemIdx, type);
+    return readScaledEpsPoints_(*epsGridProperties, elemIdx, type, fieldPropIdxOnLevelZero);
 }
 
 // Make some actual code, by realizing the previously defined templated class

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
@@ -53,7 +53,8 @@ template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::
 run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, const unsigned int, bool)>&
-    fieldPropIntOnLeafAssigner) {
+    fieldPropIntOnLeafAssigner,
+    const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner) {
     readUnscaledEpsPointsVectors_();
     readEffectiveParameters_();
     initSatnumRegionArray_(fieldPropIntOnLeafAssigner);
@@ -71,14 +72,14 @@ run(const std::function<std::vector<int>(const FieldPropsManager&, const std::st
             //unsigned satNumCell = this->parent_.satnumRegionArray_[elemIdx];
             HystParams hystParams {*this};
             hystParams.setConfig(satRegionIdx);
-            hystParams.setDrainageParamsOilGas(elemIdx, satRegionIdx);
-            hystParams.setDrainageParamsOilWater(elemIdx, satRegionIdx);
-            hystParams.setDrainageParamsGasWater(elemIdx, satRegionIdx);
+            hystParams.setDrainageParamsOilGas(elemIdx, satRegionIdx, lookupIdxOnLevelZeroAssigner);
+            hystParams.setDrainageParamsOilWater(elemIdx, satRegionIdx, lookupIdxOnLevelZeroAssigner);
+            hystParams.setDrainageParamsGasWater(elemIdx, satRegionIdx, lookupIdxOnLevelZeroAssigner);
             if (this->parent_.enableHysteresis()) {
                 unsigned imbRegionIdx = imbRegion_(*imbnumArray[i], elemIdx);
-                hystParams.setImbibitionParamsOilGas(elemIdx, imbRegionIdx);
-                hystParams.setImbibitionParamsOilWater(elemIdx, imbRegionIdx);
-                hystParams.setImbibitionParamsGasWater(elemIdx, imbRegionIdx);
+                hystParams.setImbibitionParamsOilGas(elemIdx, imbRegionIdx, lookupIdxOnLevelZeroAssigner);
+                hystParams.setImbibitionParamsOilWater(elemIdx, imbRegionIdx, lookupIdxOnLevelZeroAssigner);
+                hystParams.setImbibitionParamsGasWater(elemIdx, imbRegionIdx, lookupIdxOnLevelZeroAssigner);
             }
             hystParams.finalize();
             initThreePhaseParams_(hystParams, (*mlpArray[i])[elemIdx], satRegionIdx, elemIdx);

--- a/tests/material/test_eclmateriallawmanager.cpp
+++ b/tests/material/test_eclmateriallawmanager.cpp
@@ -618,9 +618,9 @@ namespace Opm
 class FieldPropsManager;
 }
 
-// To support Local Grid Refinement for CpGrid, an additional argument has been added
+// To support Local Grid Refinement for CpGrid, additional arguments have been added
 // in some EclMaterialLawManager(InitParams) member functions. Therefore, we define
-// a lambda expression that does not affect this test file.
+// some lambda expressions that does not affect this test file.
 std::function<std::vector<int>(const Opm::FieldPropsManager&, const std::string&, const unsigned int, bool)> doOldLookup =
     [](const Opm::FieldPropsManager& fieldPropManager, const std::string& propString, const unsigned int numElems, bool needsTranslation)
     {
@@ -632,6 +632,8 @@ std::function<std::vector<int>(const Opm::FieldPropsManager&, const std::string&
         }
         return dest;
     };
+
+std::function<unsigned(unsigned)> doNothing = [](unsigned elemIdx){ return elemIdx;};
 
 using Types = boost::mpl::list<float,double>;
 BOOST_AUTO_TEST_CASE_TEMPLATE(Fam1Fam2Hysteresis, Scalar, Types)
@@ -650,7 +652,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Fam1Fam2Hysteresis, Scalar, Types)
 
     MaterialLawManager fam1materialLawManager;
     fam1materialLawManager.initFromState(eclState);
-    fam1materialLawManager.initParamsForElements(eclState, n, doOldLookup);
+    fam1materialLawManager.initParamsForElements(eclState, n, doOldLookup, doNothing);
 
     BOOST_CHECK(!fam1materialLawManager.enableEndPointScaling());
     BOOST_CHECK(!fam1materialLawManager.enableHysteresis());
@@ -660,7 +662,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Fam1Fam2Hysteresis, Scalar, Types)
 
     MaterialLawManager fam2MaterialLawManager;
     fam2MaterialLawManager.initFromState(fam2EclState);
-    fam2MaterialLawManager.initParamsForElements(fam2EclState, n, doOldLookup);
+    fam2MaterialLawManager.initParamsForElements(fam2EclState, n, doOldLookup, doNothing);
 
     BOOST_CHECK(!fam2MaterialLawManager.enableEndPointScaling());
     BOOST_CHECK(!fam2MaterialLawManager.enableHysteresis());
@@ -670,7 +672,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Fam1Fam2Hysteresis, Scalar, Types)
 
     MaterialLawManager hysterMaterialLawManager;
     hysterMaterialLawManager.initFromState(hysterEclState);
-    hysterMaterialLawManager.initParamsForElements(hysterEclState, n, doOldLookup);
+    hysterMaterialLawManager.initParamsForElements(hysterEclState, n, doOldLookup, doNothing);
 
     BOOST_CHECK(!hysterMaterialLawManager.enableEndPointScaling());
     BOOST_CHECK(hysterMaterialLawManager.enableHysteresis());
@@ -759,14 +761,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GasOil, Scalar, Types)
 
     MaterialLawManager fam1materialLawManager;
     fam1materialLawManager.initFromState(fam1EclState);
-    fam1materialLawManager.initParamsForElements(fam1EclState, n, doOldLookup);
+    fam1materialLawManager.initParamsForElements(fam1EclState, n, doOldLookup, doNothing);
 
     const auto fam2Deck = parser.parseString(fam2DeckStringGasOil);
     const Opm::EclipseState fam2EclState(fam2Deck);
 
     MaterialLawManager fam2MaterialLawManager;
     fam2MaterialLawManager.initFromState(fam2EclState);
-    fam2MaterialLawManager.initParamsForElements(fam2EclState, n, doOldLookup);
+    fam2MaterialLawManager.initParamsForElements(fam2EclState, n, doOldLookup, doNothing);
 
     for (unsigned elemIdx = 0; elemIdx < n; ++elemIdx) {
         for (int i = 0; i < 100; ++ i) {
@@ -821,14 +823,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(GasWater, Scalar, Types)
 
     MaterialLawManager fam2materialLawManager;
     fam2materialLawManager.initFromState(fam2EclState);
-    fam2materialLawManager.initParamsForElements(fam2EclState, n, doOldLookup);
+    fam2materialLawManager.initParamsForElements(fam2EclState, n, doOldLookup, doNothing);
 
     const auto fam3Deck = parser.parseString(fam3DeckStringGasWater);
     const Opm::EclipseState fam3EclState(fam3Deck);
 
     MaterialLawManager fam3materialLawManager;
     fam3materialLawManager.initFromState(fam3EclState);
-    fam3materialLawManager.initParamsForElements(fam3EclState, n, doOldLookup);
+    fam3materialLawManager.initParamsForElements(fam3EclState, n, doOldLookup, doNothing);
 
     for (unsigned elemIdx = 0; elemIdx < n; ++elemIdx) {
         for (int i = 0; i < 100; ++ i) {
@@ -886,7 +888,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Let, Scalar, Types)
 
     MaterialLawManager letmaterialLawManager;
     letmaterialLawManager.initFromState(letEclState);
-    letmaterialLawManager.initParamsForElements(letEclState, n, doOldLookup);
+    letmaterialLawManager.initParamsForElements(letEclState, n, doOldLookup, doNothing);
 
     Scalar Swco = 0.1;
     Scalar psi2Pa = 6894.7573;


### PR DESCRIPTION
A function argument has been added in many member functions of EclMaterialLawManager(HystParams) to support LGRs. To main goal is to be able to assign the lookup index of a leaf grid view cell, which is the index of its parent or equivalent cell on level zero, when the grid is a CpGrid with LGRs.
