### PR TITLE
Fix encoding of file to silence warning.

### DIFF
--- a/tests/test_cubic.cpp
+++ b/tests/test_cubic.cpp
@@ -5,7 +5,7 @@
 // Created: Tue Dec  8 12:25:30 2009
 //
 // Author(s): Atgeirr F Rasmussen <atgeirr@sintef.no>
-//            Bård Skaflestad     <bard.skaflestad@sintef.no>
+//            BÃ¥rd Skaflestad     <bard.skaflestad@sintef.no>
 //
 // $Date$
 //


### PR DESCRIPTION
It looks the same in github, but in git on the command line I see a difference, and I get a compiler warning.
```
-//            B<E5>rd Skaflestad     <bard.skaflestad@sintef.no>
+//            Bård Skaflestad     <bard.skaflestad@sintef.no>
```