### PR TITLE
Improve error handling of grid keywords

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -80,6 +80,8 @@ namespace Opm {
         explicit EclipseGrid(const Deck& deck, const int * actnum = nullptr);
 
         static bool hasGDFILE(const Deck& deck);
+        static bool hasRadialKeywords(const Deck& deck);
+        static bool hasSpiderKeywords(const Deck& deck);
         static bool hasCylindricalKeywords(const Deck& deck);
         static bool hasCornerPointKeywords(const Deck&);
         static bool hasCartesianKeywords(const Deck&);


### PR DESCRIPTION
Improve the handling of errors related to the grid keywords. Missing or ambiguous keywords are detected and the error messages lists the valid options.

Closes: #3551 