### PR TITLE
Improve the error reporting for SALTSOL tables 

### DIFF
--- a/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -1582,9 +1582,15 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
             const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem("DATA");
             if (dataItem.data_size() > 0) {
-                std::shared_ptr<TableType> table = std::make_shared<TableType>( dataItem, tableIdx );
-                container.addTable( tableIdx , table );
-                lastComplete = tableIdx;
+                try {
+                    std::shared_ptr<TableType> table = std::make_shared<TableType>( dataItem, tableIdx );
+                    container.addTable( tableIdx , table );
+                    lastComplete = tableIdx;
+                } catch (const std::runtime_error& err) {
+                    throw OpmInputError(err, tableKeyword.location());
+                } catch (const std::invalid_argument& err) {
+                    throw OpmInputError(err, tableKeyword.location());
+                }
             }
             else if (tableIdx > static_cast<size_t>(0)) {
                 const auto& item = tableKeyword.getRecord(lastComplete).getItem("DATA");


### PR DESCRIPTION
A missing column in a SALTSOL table is not reported properly. It is reported without location info as an internal error, like so:
```
Error: 
An error occurred while creating the reservoir properties
Internal error: For table SALTSOL with ID 1: Number of input table elements (1) is not a multiple of table's specified number of columns (2)
```
The underlying reason is that in the constructor of the table, standard errors without the location error are thrown. This is fixed by catching them in the `initSimpleTableContainer` method of the `TableManager` class and transforming them into an `OpmInputError` with location information.

The error is then reported like this:
```
Error: Problem with keyword SALTSOL
In GASWATER_VAPWAT_PRECSALT.DATA line 179.
For table SALTSOL with ID 1: Number of input table elements (1) is not a multiple of table's specified number of columns (2)
```
