### PR TITLE
Decouple WHISTCTL From History Control Setting on Restart

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -394,6 +394,7 @@ public:
 
     Well(const RestartIO::RstWell& rst_well,
          int report_step,
+         int rst_whistctl_cmode,
          const TracerConfig& tracer_config,
          const UnitSystem& unit_system,
          double udq_undefined);

--- a/opm/io/eclipse/rst/header.hpp
+++ b/opm/io/eclipse/rst/header.hpp
@@ -70,6 +70,7 @@ struct RstHeader {
     int nacaqz;
     int tstep;
     int report_step;
+    int histctl_override;
     int newtmx;
     int newtmn;
     int litmax;

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -92,7 +92,7 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         NUM_SOLVER_STEPS = 67, //
         REPORT_STEP = 68, //
 
-        WHISTC = 71, //  Calendar year of report step
+        WHISTC = 71, // History matching wells control mode override (WHISTCTL(1)).
 
         ACTNETWRK = 74, //  Indicator for active external network (= 0: no active network, = 2 Active network)
 

--- a/src/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/src/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1693,7 +1693,7 @@ namespace {
                             const FieldPropsManager&   fp)
     {
         const auto report_step = rst_state.header.report_step - 1;
-        double udq_undefined = 0;
+
         for (const auto& rst_group : rst_state.groups) {
             this->addGroup(rst_group, report_step);
             const auto& group = this->snapshots.back().groups.get( rst_group.name );
@@ -1735,11 +1735,19 @@ namespace {
         }
 
         for (const auto& rst_well : rst_state.wells) {
-            Opm::Well well(rst_well, report_step, tracer_config, this->m_static.m_unit_system, udq_undefined);
-            std::vector<Opm::Connection> rst_connections;
+            auto well = Well {
+                rst_well,
+                report_step,
+                rst_state.header.histctl_override,
+                tracer_config,
+                this->m_static.m_unit_system,
+                rst_state.header.udq_undefined
+            };
 
-            for (const auto& rst_conn : rst_well.connections)
+            auto rst_connections = std::vector<Connection> {};
+            for (const auto& rst_conn : rst_well.connections) {
                 rst_connections.emplace_back(rst_conn, grid, fp);
+            }
 
             if (rst_well.segments.empty()) {
                 Opm::WellConnections connections(order_from_int(rst_well.completion_ordering),

--- a/src/opm/io/eclipse/rst/header.cpp
+++ b/src/opm/io/eclipse/rst/header.cpp
@@ -70,6 +70,7 @@ RstHeader::RstHeader(const Runspec& runspec_, const Opm::UnitSystem& unit_system
     nacaqz(intehead[VI::intehead::NACAQZ]),
     tstep(intehead[VI::intehead::NUM_SOLVER_STEPS]),
     report_step(intehead[VI::intehead::REPORT_STEP]),
+    histctl_override(intehead[VI::intehead::WHISTC]),
     newtmx(intehead[VI::intehead::NEWTMX]),
     newtmn(intehead[VI::intehead::NEWTMN]),
     litmax(intehead[VI::intehead::LITMAX]),

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -664,9 +664,12 @@ BOOST_AUTO_TEST_CASE(Construct_Well_Guide_Rates_Group_Control_Object)
 
     auto makeRestartWell = [&state](const std::string& well_name)
     {
+        const auto rst_whistctl_cmode = 0; // NONE (WHISTCTL keyword not entered)
+
         return Opm::Well {
             state.get_well(well_name),
             static_cast<int>(rptStep),
+            rst_whistctl_cmode,
             Opm::TracerConfig{},
             Opm::UnitSystem::newMETRIC(),
             1.0e+20
@@ -748,9 +751,12 @@ BOOST_AUTO_TEST_CASE(Construct_Well_Explicit_THP_Control_Options_Object)
 
     auto makeTHPOptions = [&state](const std::string& well_name)
     {
+        const auto rst_whistctl_cmode = 0; // NONE (WHISTCTL keyword not entered).
+
         return Opm::Well {
             state.get_well(well_name),
             static_cast<int>(rptStep),
+            rst_whistctl_cmode,
             Opm::TracerConfig{},
             Opm::UnitSystem::newMETRIC(),
             1.0e+20


### PR DESCRIPTION
The current master sources conflates history control with the `WHISTCTL` setting, thus failing to respect any control mode setting in `WCONHIST` in the case of simulation restart in the historic period.

This PR decouples any `WHISTCTL` setting (`INTEHEAD[71]`) from that of the control mode setting specified in `WCONHIST` thereby supporting both modes when a simulation is restarted in the historic period. This, in turn, fixes simulation restart on a real field.