### PR TITLE
remove warnings in co2store with NDEBUG on

### DIFF
--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -194,7 +194,11 @@ public:
     template <class Evaluation>
     Evaluation eval(const Evaluation& x, const Evaluation& y, bool extrapolate) const
     {
-        if (!applies(x,y))
+#ifndef NDEBUG
+     if (!applies(x,y))
+#elseif
+     if (!extrapolate && !applies(x,y))
+#endif
         {
             std::string msg = "Attempt to get tabulated value for ("
                 +std::to_string(double(scalarValue(x)))+", "+std::to_string(double(scalarValue(y)))
@@ -212,6 +216,7 @@ public:
             }
 
         };
+
 
         Evaluation alpha = xToI(x);
         Evaluation beta = yToJ(y);

--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -195,11 +195,7 @@ public:
     Evaluation eval(const Evaluation& x, const Evaluation& y, bool extrapolate) const
     {
 #ifndef NDEBUG
-     if (!applies(x,y))
-#elseif
-     if (!extrapolate && !applies(x,y))
-#endif
-        {
+        if (!extrapolate && !applies(x,y)) {
             std::string msg = "Attempt to get tabulated value for ("
                 +std::to_string(double(scalarValue(x)))+", "+std::to_string(double(scalarValue(y)))
                 +") on a table of extent "
@@ -216,7 +212,7 @@ public:
             }
 
         };
-
+#endif
 
         Evaluation alpha = xToI(x);
         Evaluation beta = yToJ(y);


### PR DESCRIPTION
remove warnings in co2store when NDEBUG is on. In CO2STORE can be slow if a lot of extrapolation is done.
In simulations one should limit the pressures by --temperature-min/max --pressure-min/max so that table is ok.