### PR TITLE
Replace if with assert in gas-oil only code.

### DIFF
--- a/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
+++ b/opm/material/fluidsystems/ThreeComponentFluidSystem.hh
@@ -178,13 +178,8 @@ namespace Opm {
                                const ParameterCache<ParamCacheEval>& paramCache,
                                unsigned phaseIdx)
         {
-
-            LhsEval dens;
-            if (phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx) {
-                dens = decay<LhsEval>(fluidState.averageMolarMass(phaseIdx) / paramCache.molarVolume(phaseIdx));
-            }
-            return dens;
-
+            assert(phaseIdx == oilPhaseIdx || phaseIdx == gasPhaseIdx); // This is a oil + gas only two-phase system
+            return decay<LhsEval>(fluidState.averageMolarMass(phaseIdx) / paramCache.molarVolume(phaseIdx));
         }
 
         //! \copydoc BaseFluidSystem::viscosity


### PR DESCRIPTION
Compiler warns that dens may be returned uninitialized if the if-clause is false. As this is a two-phase gas and oil only class, the correct thing is to assert() on the phase index.