### PR TITLE
Prepare for Adding Segment Level UDQ Information to Restart File

### DIFF
--- a/opm/output/eclipse/InteHEAD.hpp
+++ b/opm/output/eclipse/InteHEAD.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2021 Equinor ASA.
+  Copyright 2021-2024 Equinor ASA.
   Copyright 2016, 2017, 2018 Statoil ASA.
 
   This file is part of the Open Porous Media Project (OPM).
@@ -34,7 +34,7 @@ class Phases;
 class ScheduleState;
 class UnitSystem;
 
-}
+} // namespace Opm
 
 namespace Opm { namespace RestartIO {
 
@@ -42,110 +42,131 @@ namespace Opm { namespace RestartIO {
     {
     public:
         struct WellTableDim {
-            int numWells;
-            int maxPerf;
-            int maxWellInGroup;
-            int maxGroupInField;
-            int maxWellsInField;
-            int mxwlstprwel;
-            int mxdynwlst;
+            int numWells{};
+            int maxPerf{};
+            int maxWellInGroup{};
+            int maxGroupInField{};
+            int maxWellsInField{};
+            int mxwlstprwel{};
+            int mxdynwlst{};
         };
 
         struct WellSegDims {
-            int nsegwl;
-            int nswlmx;
-            int nsegmx;
-            int nlbrmx;
-            int nisegz;
-            int nrsegz;
-            int nilbrz;
+            int nsegwl{};
+            int nswlmx{};
+            int nsegmx{};
+            int nlbrmx{};
+            int nisegz{};
+            int nrsegz{};
+            int nilbrz{};
         };
 
         struct RegDims {
-            int ntfip;
-            int nmfipr;
-            int nrfreg;
-            int ntfreg;
-            int nplmix;
+            int ntfip{};
+            int nmfipr{};
+            int nrfreg{};
+            int ntfreg{};
+            int nplmix{};
         };
 
         struct RockOpts {
-            int ttyp;
+            int ttyp{};
         };
 
         struct TimePoint {
-            int year;
-            int month;          // 1..12
-            int day;            // 1..31
+            int year{};
+            int month{};          // 1..12
+            int day{};            // 1..31
 
-            int hour;           // 0..23
-            int minute;         // 0..59
-            int second;         // 0..59
+            int hour{};           // 0..23
+            int minute{};         // 0..59
+            int second{};         // 0..59
 
-            int microseconds;   // 0..999999
+            int microseconds{};   // 0..999999
         };
 
         struct Phases {
-            int oil;
-            int water;
-            int gas;
+            int oil{};
+            int water{};
+            int gas{};
         };
 
         struct TuningPar {
-            int newtmx;
-            int newtmn;
-            int litmax;
-            int litmin;
-            int mxwsit;
-            int mxwpit;
-            int wseg_mx_rst;
-        };
-	
-	struct Group {
-	  int ngroups;
-	};
-	
-	struct UdqParam {
-	  int    udqParam_1;
-      int    no_wudqs;
-      int    no_gudqs;
-      int    no_fudqs;
-      int    no_iuads;
-      int    no_iuaps;
-	};
-
-    struct ActionParam {
-      int   no_actions;
-      int   max_no_sched_lines_per_action;
-      int   max_no_conditions_per_action;
-      int   max_no_characters_per_line;
-     };
-     
-     struct GuideRateNominatedPhase {
-      int   nominated_phase;
-     };
-
-
-     struct ActiveNetwork {
-         int actnetwrk;
-     };
-
-     struct NetworkDims {
-            int noactnod;
-            int noactbr;
-            int nodmax;
-            int nbrmax;
-            int nibran;
-            int nrbran;
-            int ninode;
-            int nrnode;
-            int nznode;
-            int ninobr;
+            int newtmx{};
+            int newtmn{};
+            int litmax{};
+            int litmin{};
+            int mxwsit{};
+            int mxwpit{};
+            int wseg_mx_rst{};
         };
 
-     struct NetBalanceDims {
-            int maxNoIterationsNBC;
-            int maxNoIterationsTHP;
+        struct Group {
+            int ngroups{};
+        };
+
+        struct UdqParam {
+            int udqParam_1{};
+
+            /// Number of field-level UDQ parameters (FU*)
+            int num_field_udqs{};
+
+            /// Number of group-level UDQ parameters (GU*)
+            int num_group_udqs{};
+
+            /// Number of region-level UDQ parameters (RU*)
+            int num_reg_udqs{};
+
+            /// Number of well-level UDQ parameters (WU*)
+            int num_well_udqs{};
+
+            /// Number of segment-level UDQ parameters (SU*)
+            int num_seg_udqs{};
+
+            /// Number of connection-level UDQ parameters (CU*)
+            int num_conn_udqs{};
+
+            /// Number of aquifer-level UDQ parameters (AU*)
+            int num_aqu_udqs{};
+
+            /// Number of block-level UDQ parameters (BU*)
+            int num_blk_udqs{};
+
+            int num_iuads{};
+            int num_iuaps{};
+        };
+
+        struct ActionParam {
+            int no_actions{};
+            int max_no_sched_lines_per_action{};
+            int max_no_conditions_per_action{};
+            int max_no_characters_per_line{};
+        };
+
+        struct GuideRateNominatedPhase {
+            int nominated_phase;
+        };
+
+        struct ActiveNetwork {
+            int actnetwrk;
+        };
+
+        struct NetworkDims {
+            int noactnod{};
+            int noactbr{};
+            int nodmax{};
+            int nbrmax{};
+            int nibran{};
+            int nrbran{};
+            int ninode{};
+            int nrnode{};
+            int nznode{};
+            int ninobr{};
+        };
+
+        struct NetBalanceDims {
+            int maxNoIterationsNBC{};
+            int maxNoIterationsTHP{};
         };
 
         struct AquiferDims {
@@ -193,7 +214,7 @@ namespace Opm { namespace RestartIO {
             // Number of data elements per connection in ACAQ array.
             int numDoubConnElem {4};
         };
-     
+
         InteHEAD();
         ~InteHEAD() = default;
 
@@ -237,6 +258,7 @@ namespace Opm { namespace RestartIO {
         InteHEAD& liftOptParam(int in_enc);
 
         static int numRsegElem(const Opm::Phases& phase);
+
         const std::vector<int>& data() const
         {
             return this->data_;

--- a/opm/output/eclipse/VectorItems/intehead.hpp
+++ b/opm/output/eclipse/VectorItems/intehead.hpp
@@ -155,22 +155,28 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         MAX_ACT_COND = 245, //  Maximum number of conditions pr action
         MAX_AN_AQUIFER_ID = 252, // Maximum aquifer ID of all analytic aquifers (<= AQUDIMS(5))
 
-        NO_FIELD_UDQS = 262, //  No of Field UDQ data (parameters) /
-        NO_GROUP_UDQS = 263, //  No of Group UDQ data (parameters) /
-        NO_WELL_UDQS = 266, //  No of Well UDQ data (parameters) /
-        UDQPAR_1 = 267, //  Integer seed value for the RAND /
+        NO_CONN_UDQS = 261,     // Number of connection-level UDQ parameters
+        NO_FIELD_UDQS = 262,    // Number of field-level UDQ parameters
+        NO_GROUP_UDQS = 263,    // Number of group-level UDQ parameters
+        NO_REG_UDQS = 264,      // Number of region-level UDQ parameters
+        NO_SEG_UDQS = 265,      // Number of segment-level UDQ parameters
+        NO_WELL_UDQS = 266,     // Number of well-level UDQ parameters
+        UDQPAR_1 = 267,         // Integer seed value for the RAND
 
-        AQU_UNKNOWN_1 = 269,  // Not characterised.  Equal to NAQUIF in all cases seen so far.
+        AQU_UNKNOWN_1 = 269, // Not characterised.  Equal to NAQUIF in all cases seen so far.
         MAX_ANALYTIC_AQUIFERS = 286, // Declared maximum number of analytic aquifers in model.  AQUDIMS(5).
 
-        NO_IUADS = 290, //  No IUADs
-        NO_IUAPS = 291, //  No IUAPs
+        NO_AQU_UDQS = 288,      // Number of aquifer-level UDQ parameters
+        NO_BLK_UDQS = 289,      // Number of block-level UDQ parameters
+
+        NO_IUADS = 290,         //  No IUADs
+        NO_IUAPS = 291,         //  No IUAPs
         RSEED = 296,
 
         MAXDYNWELLST = 302, //  Maximum number of dynamic well lists (default = 1)
 
-        ISECND = 410 //  ISECND = current simulation time HH:MM:SS - number of seconds (SS), reported in microseconds
-                     //  (0-59,999,999)
+        ISECND = 410,  // ISECND = current simulation time HH:MM:SS - number
+                       // of seconds (SS), reported in microseconds (0 .. 59,999,999)
     };
 
     namespace InteheadValues {

--- a/src/opm/output/eclipse/CreateInteHead.cpp
+++ b/src/opm/output/eclipse/CreateInteHead.cpp
@@ -362,26 +362,22 @@ namespace {
                 const std::size_t     rptStep,
                 const std::size_t     simStep)
     {
+        auto param = Opm::RestartIO::InteHEAD::UdqParam{};
+
         if (rptStep == std::size_t{0}) {
-            return { 0, 0, 0, 0, 0, 0 };
+            return param;
         }
 
-        const auto& udq_par = rspec.udqParams();
-        const auto r_seed   = udq_par.rand_seed();
-        const auto no_wudq  = noWellUdqs(sched, rptStep, simStep);
-        const auto no_gudq  = noGroupUdqs(sched, rptStep, simStep);
-        const auto no_fudq  = noFieldUdqs(sched, rptStep, simStep);
-        const auto no_iuads = noIuads(sched, rptStep, simStep);
-        const auto no_iuaps = noIuaps(sched, rptStep, simStep);
+        param.udqParam_1 = rspec.udqParams().rand_seed();
 
-        return {
-            r_seed,
-            static_cast<int>(no_wudq),
-            static_cast<int>(no_gudq),
-            static_cast<int>(no_fudq),
-            static_cast<int>(no_iuads),
-            static_cast<int>(no_iuaps)
-        };
+        param.num_field_udqs = noFieldUdqs(sched, rptStep, simStep);
+        param.num_group_udqs = noGroupUdqs(sched, rptStep, simStep);
+        param.num_well_udqs  = noWellUdqs (sched, rptStep, simStep);
+
+        param.num_iuads = noIuads(sched, rptStep, simStep);
+        param.num_iuaps = noIuaps(sched, rptStep, simStep);
+
+        return param;
     }
 
     Opm::RestartIO::InteHEAD::ActionParam

--- a/src/opm/output/eclipse/InteHEAD.cpp
+++ b/src/opm/output/eclipse/InteHEAD.cpp
@@ -316,13 +316,13 @@ enum index : std::vector<int>::size_type {
   ih_258       =      258       ,              //       0
   ih_259       =      259       ,              //       0
   ih_260       =      260       ,              //       0
-  ih_261       =      261       ,              //       0
-  NOFUDQS      =      VI::intehead::NO_FIELD_UDQS,    //       0
-  NOGUDQS      =      VI::intehead::NO_GROUP_UDQS,    //       0
-  ih_264       =      264       ,              //       0
-  ih_265       =      265       ,              //       0
-  NOWUDQS      =      VI::intehead::NO_WELL_UDQS,     //       0
-  UDQPAR_1     =      VI::intehead::UDQPAR_1,  //       0
+  NUM_CONN_UDQS  =    VI::intehead::NO_CONN_UDQS,     //       0
+  NUM_FIELD_UDQS =    VI::intehead::NO_FIELD_UDQS,    //       0
+  NUM_GROUP_UDQS =    VI::intehead::NO_GROUP_UDQS,    //       0
+  NUM_REG_UDQS   =    VI::intehead::NO_REG_UDQS,      //       0
+  NUM_SEG_UDQS   =    VI::intehead::NO_SEG_UDQS,      //       0
+  NUM_WELL_UDQS  =    VI::intehead::NO_WELL_UDQS,     //       0
+  UDQPAR_1       =    VI::intehead::UDQPAR_1,         //       0
   ih_268       =      268       ,              //       0
   AQU_UNKNOWN_1=      VI::intehead::AQU_UNKNOWN_1,              //       0  Not characterised.  Equal to NAQUIF in all cases seen so far.
   ih_270       =      270       ,              //       0
@@ -343,10 +343,10 @@ enum index : std::vector<int>::size_type {
   ih_285       =      285       ,              //       0
   MAX_ANALYTIC_AQUIFERS= VI::intehead::MAX_ANALYTIC_AQUIFERS, //  Declared maximum number of analytic aquifers in model.  AQUDIMS(5).
   ih_287       =      287       ,              //       0
-  ih_288       =      288       ,              //       0
-  ih_289       =      289       ,              //       0
-  NOIUADS       =      VI::intehead::NO_IUADS,  //       0
-  NOIUAPS       =      VI::intehead::NO_IUAPS,  //       0
+  NUM_AQU_UDQS =      VI::intehead::NO_AQU_UDQS,      //       0
+  NUM_BLK_UDQS =      VI::intehead::NO_BLK_UDQS,      //       0
+  NUM_IUADS    =      VI::intehead::NO_IUADS,  //       0
+  NUM_IUAPS    =      VI::intehead::NO_IUAPS,  //       0
   ih_292       =      292       ,              //       0
   ih_293       =      293       ,              //       0
   ih_294       =      294       ,              //       0
@@ -732,13 +732,20 @@ Opm::RestartIO::InteHEAD&
 Opm::RestartIO::InteHEAD::
 udqParam_1(const UdqParam& udq_par)
 {
-    this -> data_[UDQPAR_1]     = - udq_par.udqParam_1;
-    this -> data_[R_SEED]       = - udq_par.udqParam_1;
-    this -> data_[NOWUDQS]      = udq_par.no_wudqs;
-    this -> data_[NOGUDQS]      = udq_par.no_gudqs;
-    this -> data_[NOFUDQS]      = udq_par.no_fudqs;
-    this -> data_[NOIUADS]      = udq_par.no_iuads;
-    this -> data_[NOIUAPS]      = udq_par.no_iuaps;
+    this->data_[UDQPAR_1] = - udq_par.udqParam_1;
+    this->data_[R_SEED]   = - udq_par.udqParam_1;
+
+    this->data_[NUM_CONN_UDQS]  = udq_par.num_conn_udqs;
+    this->data_[NUM_FIELD_UDQS] = udq_par.num_field_udqs;
+    this->data_[NUM_REG_UDQS]   = udq_par.num_reg_udqs;
+    this->data_[NUM_GROUP_UDQS] = udq_par.num_group_udqs;
+    this->data_[NUM_SEG_UDQS]   = udq_par.num_seg_udqs;
+    this->data_[NUM_WELL_UDQS]  = udq_par.num_well_udqs;
+    this->data_[NUM_AQU_UDQS]   = udq_par.num_aqu_udqs;
+    this->data_[NUM_BLK_UDQS]   = udq_par.num_blk_udqs;
+
+    this->data_[NUM_IUADS] = udq_par.num_iuads;
+    this->data_[NUM_IUAPS] = udq_par.num_iuaps;
 
     return *this;
 }


### PR DESCRIPTION
In particular, identify more UDQ-related items in INTEHEAD and add more members to `InteHEAD::UdqParam` to hold counts of additional UDQ categories.

While here, also ensure that default-constructed objects of various `InteHEAD::*` structures have well-defined values.