### PR TITLE
Add temperature as optional input for Source

### DIFF
--- a/opm/input/eclipse/Schedule/Source.hpp
+++ b/opm/input/eclipse/Schedule/Source.hpp
@@ -46,7 +46,8 @@ public:
         std::array<int, 3> ijk;
         SourceComponent component;
         double rate;
-        double hrate;   
+        std::optional<double> hrate;
+        std::optional<double> temperature;  
 
         SourceCell() = default;
         explicit SourceCell(const DeckRecord& record);
@@ -64,6 +65,7 @@ public:
             serializer(component);
             serializer(rate);
             serializer(hrate);
+            serializer(temperature);
         }
     };
 
@@ -78,7 +80,11 @@ public:
     bool operator==(const Source& other) const;
 
     double rate(const std::pair<std::array<int, 3>, SourceComponent>& input ) const;
-    double hrate(const std::array<int, 3>& input ) const;
+    double hrate(const std::pair<std::array<int, 3>, SourceComponent>& input ) const;
+    double temperature(const std::pair<std::array<int, 3>, SourceComponent>& input) const;
+    bool hasHrate(const std::pair<std::array<int, 3>, SourceComponent>& input) const;
+    bool hasTemperature(const std::pair<std::array<int, 3>, SourceComponent>& input) const;
+    bool hasSource(const std::array<int, 3>& input) const;
 
     void updateSource(const DeckRecord& record);
 

--- a/src/opm/input/eclipse/share/keywords/900_OPM/S/SOURCE
+++ b/src/opm/input/eclipse/share/keywords/900_OPM/S/SOURCE
@@ -30,8 +30,12 @@
     {
        "name": "HRATE",
        "value_type": "DOUBLE",
-       "dimension": "Energy/Time",
-       "default": 0
+       "dimension": "Energy/Time"
+    },
+    {
+      "name": "TEMP",
+      "value_type": "DOUBLE",
+      "dimension": "Temperature"
     }
   ]
 }


### PR DESCRIPTION
For thermal runs with Source you can either specify the enthalpy or the temperature. If temperature is given, the simulator will compute the enthalpy from the temperature given and the pressure in the cell. 