### PR TITLE
Revert "Add mass co2 in place summary vectors"

### DIFF
--- a/opm/output/eclipse/Inplace.hpp
+++ b/opm/output/eclipse/Inplace.hpp
@@ -58,11 +58,6 @@ public:
         CO2InGasPhaseMob = 18,
         WaterInGasPhase = 19,
         WaterInWaterPhase = 20,
-        CO2Mass = 21,
-        CO2MassInWaterPhase = 22,
-        CO2MassInGasPhase = 23,
-        CO2MassInGasPhaseInMob = 24,
-        CO2MassInGasPhaseMob = 25,
     };
 
     /*

--- a/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/src/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -161,12 +161,7 @@ struct SummaryConfigContext {
          {"SWAT" , {"BSWAT"}},
          {"SGAS" , {"BSGAS"}},
          {"SALT" , {"FSIP"}},
-         {"TEMP" , {"BTCNFHEA"}},
-         {"GMIP"  , {"RGMIP", "FGMIP"}},
-         {"GMGP"  , {"RGMGP", "FGMGP"}},
-         {"GMDS"  , {"RGMDS", "FGMDS"}},
-         {"GMTR"  , {"RGMTR", "FGMTR"}},
-         {"GMMO"  , {"RGMMO", "FGMMO"}}
+         {"TEMP" , {"BTCNFHEA"}}
     };
 
     using keyword_set = std::unordered_set<std::string>;

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/F/FIELD_PROBE
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/F/FIELD_PROBE
@@ -291,12 +291,7 @@
     "FTPRALK",
     "FTPTALK",
     "FTIRALK",
-    "FTITALK",
-    "FGMIP",
-    "FGMGP",
-    "FGMDS",
-    "FGMTR",
-    "FGMMO"
+    "FTITALK"
   ],
   "deck_name_regex": "FU.+|FTPR.+|FTPT.+|FTPC.+|FTIR.+|FTIT.+|FTIC.+|FTIPT.+|FTIPF.+|FTIPS|FTIP[1-9][0-9]*.+|FTPR.+|FTPT.+|FTPC.+|FTIR.+|FTIT.+|FTIC.+|FTADS.+|FTDCY.+|FTIRF.+|FTIRS.+|FTPRF.+|FTPRS.+|FTITF.+|FTITS.+|FTPTF.+|FTPTS.+|FTICF.+|FTICS.+|FTPCF.+|FTPCS.+"
 }

--- a/src/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION_PROBE
+++ b/src/opm/input/eclipse/share/keywords/000_Eclipse100/R/REGION_PROBE
@@ -107,12 +107,7 @@
     "RNFT",
     "RTIPTSUR",
     "RTFTTSUR",
-    "RTADSUR",
-    "RGMIP",
-    "RGMGP",
-    "RGMDS",
-    "RGMTR",
-    "RGMMO"
+    "RTADSUR"
   ],
     "CommentTracer": "???",
     "deck_name_regex": "RU.+|RTIPF.+|RTIPS.+|RTFTF.+|RTFTS.+|RTFTT.+|RTIPT.+|RTIPF.+|RTIPS.+|RTIP[1-9][0-9]*.+|RTFTT.+|RTFTF.+|RTFTS.+|RTFT[1-9][0-9]*.+|RTADS.+|RTDCY.+",

--- a/src/opm/output/eclipse/Inplace.cpp
+++ b/src/opm/output/eclipse/Inplace.cpp
@@ -160,11 +160,6 @@ const std::vector<Inplace::Phase>& Inplace::phases() {
         Inplace::Phase::CO2InGasPhaseMob,
         Inplace::Phase::WaterInGasPhase,
         Inplace::Phase::WaterInWaterPhase,
-        Inplace::Phase::CO2Mass,
-        Inplace::Phase::CO2MassInWaterPhase,
-        Inplace::Phase::CO2MassInGasPhase,
-        Inplace::Phase::CO2MassInGasPhaseInMob,
-        Inplace::Phase::CO2MassInGasPhaseMob,
     };
 
     return phases_;

--- a/src/opm/output/eclipse/Summary.cpp
+++ b/src/opm/output/eclipse/Summary.cpp
@@ -2547,11 +2547,6 @@ static const auto single_values_units = UnitTable {
     {"FWCD"     , Opm::UnitSystem::measure::moles },
     {"FWIPG"    , Opm::UnitSystem::measure::liquid_surface_volume },
     {"FWIPL"    , Opm::UnitSystem::measure::liquid_surface_volume },
-    {"FGMIP"    , Opm::UnitSystem::measure::mass },
-    {"FGMGP"    , Opm::UnitSystem::measure::mass },
-    {"FGMDS"    , Opm::UnitSystem::measure::mass },
-    {"FGMTR"    , Opm::UnitSystem::measure::mass },
-    {"FGMMO"    , Opm::UnitSystem::measure::mass },
 };
 
 static const auto region_units = UnitTable {
@@ -2572,11 +2567,6 @@ static const auto region_units = UnitTable {
     {"RWCD"  , Opm::UnitSystem::measure::moles },
     {"RWIPG" , Opm::UnitSystem::measure::liquid_surface_volume },
     {"RWIPL" , Opm::UnitSystem::measure::liquid_surface_volume },
-    {"RGMIP" , Opm::UnitSystem::measure::mass },
-    {"RGMGP" , Opm::UnitSystem::measure::mass },
-    {"RGMDS" , Opm::UnitSystem::measure::mass },
-    {"RGMTR" , Opm::UnitSystem::measure::mass },
-    {"RGMMO" , Opm::UnitSystem::measure::mass },
 };
 
 static const auto interregion_units = UnitTable {


### PR DESCRIPTION
Reverts OPM/opm-common#3868

We must merge the original along with its downstream companion OPM/opm-simulators#5114.