### PR TITLE
Print a meaningful error message in case a (possibly faulty) output file cannot be loaded.

### DIFF
--- a/src/opm/io/eclipse/EclFile.cpp
+++ b/src/opm/io/eclipse/EclFile.cpp
@@ -53,10 +53,15 @@ void EclFile::load(bool preload) {
         std::int64_t num;
         int sizeOfElement;
 
-        if (formatted) {
-            readFormattedHeader(fileH,arrName,num,arrType, sizeOfElement);
-        } else {
-            readBinaryHeader(fileH,arrName,num, arrType, sizeOfElement);
+        try {
+            if (formatted) {
+                readFormattedHeader(fileH,arrName,num,arrType, sizeOfElement);
+            } else {
+                readBinaryHeader(fileH,arrName,num, arrType, sizeOfElement);
+            }
+        } catch (const std::exception& e){
+            OPM_THROW(std::runtime_error,
+                fmt::format("Unable to read array header from {}: {} \nPlease check if the file is corrupt!", this->inputFilename, e.what()));
         }
 
         array_size.push_back(num);


### PR DESCRIPTION
This issue was noticed here: https://github.com/OPM/opm-common/issues/1037.

When a faulty file is detected, the program still continues because the error is caught here: https://github.com/OPM/opm-models/blob/a89ccecaa38aa552873a7a90f50902eb7327abd1/opm/models/parallel/tasklets.hh#L234

@blattms Is this the intended behavior or is this something to be discussed?