### PR TITLE
Identify Standard Network as Active for NETBALAN Initialisation

### DIFF
--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -204,12 +204,12 @@ public:
 
     bool extendedNetwork() const
     {
-        return this->extNetwork_;
+        return this->type_ == Type::Extended;
     }
 
     bool standardNetwork() const
     {
-        return this->stdNetwork_;
+        return this->type_ == Type::Standard;
     }
 
     bool active() const
@@ -229,12 +229,12 @@ public:
     }
 
 private:
+    enum class Type { None, Extended, Standard, };
+
     int nMaxNoNodes;
     int nMaxNoBranches;
     int nMaxNoBranchesConToNode;
-
-    bool extNetwork_{false};
-    bool stdNetwork_{false};
+    Type type_{ Type::None };
 };
 
 class AquiferDimensions {

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -202,7 +202,21 @@ public:
         return this->nMaxNoBranchesConToNode;
     }
 
-    bool active() const;
+    bool extendedNetwork() const
+    {
+        return this->extNetwork_;
+    }
+
+    bool standardNetwork() const
+    {
+        return this->stdNetwork_;
+    }
+
+    bool active() const
+    {
+        return this->extendedNetwork()
+            || this->standardNetwork();
+    }
 
     bool operator==(const NetworkDims& data) const;
 
@@ -218,6 +232,9 @@ private:
     int nMaxNoNodes;
     int nMaxNoBranches;
     int nMaxNoBranchesConToNode;
+
+    bool extNetwork_{false};
+    bool stdNetwork_{false};
 };
 
 class AquiferDimensions {

--- a/src/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -270,27 +270,28 @@ bool WellSegmentDims::operator==(const WellSegmentDims& data) const
         && (this->location() == data.location());
 }
 
-NetworkDims::NetworkDims() :
-    nMaxNoNodes( 0 ),
-    nMaxNoBranches( 0 ),
-    nMaxNoBranchesConToNode( ParserKeywords::NETWORK::NBCMAX::defaultValue )
+NetworkDims::NetworkDims()
+    : nMaxNoNodes(0)
+    , nMaxNoBranches(0)
+    , nMaxNoBranchesConToNode(ParserKeywords::NETWORK::NBCMAX::defaultValue)
 {}
 
-NetworkDims::NetworkDims(const Deck& deck) : NetworkDims()
+NetworkDims::NetworkDims(const Deck& deck)
+    : NetworkDims{}
 {
-    if (deck.hasKeyword("NETWORK")) {
-        const auto& wsd = deck["NETWORK"][0].getRecord(0);
+    if (deck.hasKeyword<ParserKeywords::NETWORK>()) {
+        const auto& wsd = deck.get<ParserKeywords::NETWORK>()[0].getRecord(0);
 
-        this->nMaxNoNodes   = wsd.getItem("NODMAX").get<int>(0);
-        this->nMaxNoBranches   = wsd.getItem("NBRMAX").get<int>(0);
-        this->nMaxNoBranchesConToNode = wsd.getItem("NBCMAX").get<int>(0);
+        this->nMaxNoNodes    = wsd.getItem<ParserKeywords::NETWORK::NODMAX>().get<int>(0);
+        this->nMaxNoBranches = wsd.getItem<ParserKeywords::NETWORK::NBRMAX>().get<int>(0);
+        this->nMaxNoBranchesConToNode = wsd.getItem<ParserKeywords::NETWORK::NBCMAX>().get<int>(0);
+
+        this->extNetwork_ = true;
+    }
+    else if (deck.hasKeyword<ParserKeywords::GRUPNET>()) {
+        this->stdNetwork_ = true;
     }
 }
-
-bool NetworkDims::active() const {
-    return this->nMaxNoNodes > 0;
-}
-
 
 NetworkDims NetworkDims::serializationTestObject()
 {

--- a/src/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/src/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -286,10 +286,10 @@ NetworkDims::NetworkDims(const Deck& deck)
         this->nMaxNoBranches = wsd.getItem<ParserKeywords::NETWORK::NBRMAX>().get<int>(0);
         this->nMaxNoBranchesConToNode = wsd.getItem<ParserKeywords::NETWORK::NBCMAX>().get<int>(0);
 
-        this->extNetwork_ = true;
+        this->type_ = Type::Extended;
     }
     else if (deck.hasKeyword<ParserKeywords::GRUPNET>()) {
-        this->stdNetwork_ = true;
+        this->type_ = Type::Standard;
     }
 }
 


### PR DESCRIPTION
This commit extends the `NetworkDims::active()` function to return true also for runs using the standard network model (keyword `GRUPNET`).  Previously, this member function would return true only for runs using the extended network model.

This matters, because the initial network balance object's constructor in member function [`Schedule::create_first()`](https://github.com/OPM/opm-common/blob/d63ec44775ccab11ca6d61d3adf51e7662e38fd3/src/opm/input/eclipse/Schedule/Schedule.cpp#L2223) performs different actions depending on whether or not the `NetworkDims` are "active".  In particular, its pressure convergence limit will be [set to zero](https://github.com/OPM/opm-common/blob/d63ec44775ccab11ca6d61d3adf51e7662e38fd3/src/opm/input/eclipse/Schedule/Network/Balance.cpp#L117) unless networks are active in the run.  If there are then no explicit `NETBALAN` keywords, then we will try to solve standard networks to a pressure convergence limit of zero which will typically fail.

To this end, add two flags to the `NetworkDims` structure, one to identify whether or not we're using the extended network model and one to identify whether or not we're using the standard network model.  Reimplement the `active()` member function in terms of these flags instead of checking the number of network nodes.