### PR TITLE
[refactor] Remove numElems in lookup assigners

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -143,20 +143,19 @@ private:
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
         //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
         //        leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
-        void run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                 const unsigned int, bool)>& fieldPropIntOnLeafAssigner,
+        void run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
                  const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
     private:
         class HystParams;
         // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
-        void copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                               const unsigned int, bool)>& fieldPropIntOnLeafAssigner);
+        void copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+                               fieldPropIntOnLeafAssigner);
         // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
         void copyIntArray_(std::vector<int>& dest, const std::string keyword,
-                           const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                           const unsigned int, bool)>& fieldPropIntOnLeafAssigner);
+                           const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+                           fieldPropIntOnLeafAssigner);
         unsigned imbRegion_(std::vector<int>& array, unsigned elemIdx);
         void initArrays_(
                          std::vector<std::vector<int>*>& satnumArray,
@@ -164,10 +163,10 @@ private:
                          std::vector<std::vector<MaterialLawParams>*>& mlpArray);
         void initMaterialLawParamVectors_();
         void initOilWaterScaledEpsInfo_();
-        // \brief Function argument 'fieldPropIntOnLeadAssigner' needed to lookup
+        // \brief Function argument 'fieldProptOnLeadAssigner' needed to lookup
         //        field properties of cells on the leaf grid view for CpGrid with local grid refinement.
-        void initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                                    const unsigned int, bool)>& fieldPropIntOnLeafAssigner);
+        void initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+                                    fieldPropIntOnLeafAssigner);
         void initThreePhaseParams_(
                                    HystParams &hystParams,
                                    MaterialLawParams& materialParams,
@@ -278,8 +277,8 @@ public:
     //        Function argument 'lookupIdxOnLevelZeroAssigner' is added to lookup, for each
     //        leaf gridview cell with index 'elemIdx', its 'lookupIdx' (index of the parent/equivalent cell on level zero).
     void initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
-                               const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                               const unsigned int,bool)>& fieldPropIntOnLeafAssigner,
+                               const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
+                               fieldPropIntOnLeafAssigner,
                                const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner);
 
     /*!

--- a/opm/material/thermal/EclThermalLawManager.hpp
+++ b/opm/material/thermal/EclThermalLawManager.hpp
@@ -84,7 +84,7 @@ private:
     /*!
      * \brief Initialize the parameters for the solid energy law using using SPECROCK and friends.
      */
-    void initSpecrock_(const EclipseState& eclState, size_t numElems,
+    void initSpecrock_(const EclipseState& eclState,
                        const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&, bool)>&
                        fieldPropIntOnLeafAssigner);
 

--- a/opm/material/thermal/EclThermalLawManager.hpp
+++ b/opm/material/thermal/EclThermalLawManager.hpp
@@ -64,11 +64,10 @@ public:
     using ThermalConductionLawParams = typename ThermalConductionLaw::Params;
 
     void initParamsForElements(const EclipseState& eclState, size_t numElems,
-                               const std::function<std::vector<double>(const FieldPropsManager&, const std::string&, const unsigned int&)>&
-                               assignFieldPropsDoubleOnLeaf,
+                               const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>&
+                               fieldPropDoubleOnLeafAssigner,
                                const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&,
-                               const unsigned int&, bool)>&
-                               assignFieldPropsIntOnLeaf);
+                               bool)>& fieldPropIntOnLeafAssigner);
 
     const SolidEnergyLawParams& solidEnergyLawParams(unsigned elemIdx) const;
 
@@ -79,15 +78,15 @@ private:
      * \brief Initialize the parameters for the solid energy law using using HEATCR and friends.
      */
     void initHeatcr_(const EclipseState& eclState, size_t numElems,
-                     const std::function<std::vector<double>(const FieldPropsManager&, const std::string&, const unsigned int&)>&
-                     assignFieldPropsDoubleOnLeaf);
+                     const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>&
+                     fieldPropDoubleOnLeafAssigner);
 
     /*!
      * \brief Initialize the parameters for the solid energy law using using SPECROCK and friends.
      */
     void initSpecrock_(const EclipseState& eclState, size_t numElems,
-                       const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&,
-                                                                     const unsigned int&, bool)>& assignFieldPropsIntOnLeaf);
+                       const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&, bool)>&
+                       fieldPropIntOnLeafAssigner);
 
     /*!
      * \brief Specify the solid energy law by setting heat capacity of rock to 0
@@ -98,15 +97,15 @@ private:
      * \brief Initialize the parameters for the thermal conduction law using THCONR and friends.
      */
     void initThconr_(const EclipseState& eclState, size_t numElems,
-                     const std::function<std::vector<double>(const FieldPropsManager&, const std::string&, const unsigned int&)>&
-                     assignFieldPropsDoubleOnLeaf);
+                     const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>&
+                     fieldPropsDoubleOnLeafAssigner);
 
     /*!
      * \brief Initialize the parameters for the thermal conduction law using THCROCK and friends.
      */
     void initThc_(const EclipseState& eclState, size_t numElems,
-                  const std::function<std::vector<double>(const FieldPropsManager&, const std::string&, const unsigned int&)>&
-                  assignFieldPropsDoubleOnLeaf);
+                  const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>&
+                  fieldPropsDoubleOnLeafAssigner);
 
     /*!
      * \brief Disable thermal conductivity

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -132,8 +132,7 @@ initFromState(const EclipseState& eclState)
 template<class TraitsT>
 void EclMaterialLawManager<TraitsT>::
 initParamsForElements(const EclipseState& eclState, size_t numCompressedElems,
-                      const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                      const unsigned int, bool)>& fieldPropIntOnLeafAssigner,
+                      const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner,
                       const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner)
 {
     InitParams initParams {*this, eclState, numCompressedElems};

--- a/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
+++ b/src/opm/material/fluidmatrixinteractions/EclMaterialLawManagerInitParams.cpp
@@ -52,7 +52,7 @@ InitParams(EclMaterialLawManager<Traits>& parent, const EclipseState& eclState, 
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::
-run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, const unsigned int, bool)>&
+run(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>&
     fieldPropIntOnLeafAssigner,
     const std::function<unsigned(unsigned)>& lookupIdxOnLevelZeroAssigner) {
     readUnscaledEpsPointsVectors_();
@@ -92,8 +92,7 @@ run(const std::function<std::vector<int>(const FieldPropsManager&, const std::st
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::
-copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&,
-                  const unsigned int, bool)>& fieldPropIntOnLeafAssigner)
+copySatnumArrays_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     copyIntArray_(this->parent_.krnumXArray_, "KRNUMX", fieldPropIntOnLeafAssigner);
     copyIntArray_(this->parent_.krnumYArray_, "KRNUMY", fieldPropIntOnLeafAssigner);
@@ -113,11 +112,10 @@ template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::
 copyIntArray_(std::vector<int>& dest, const std::string keyword,
-              const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, const unsigned int, bool)>&
-              fieldPropIntOnLeafAssigner)
+              const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     if (this->eclState_.fieldProps().has_int(keyword)) {
-        dest = fieldPropIntOnLeafAssigner(this->eclState_.fieldProps(), keyword, this->numCompressedElems_, /*needsTranslation*/true);
+        dest = fieldPropIntOnLeafAssigner(this->eclState_.fieldProps(), keyword, /*needsTranslation*/true);
     }
 }
 
@@ -182,16 +180,14 @@ initOilWaterScaledEpsInfo_()
 template <class Traits>
 void
 EclMaterialLawManager<Traits>::InitParams::
-initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, const unsigned int, bool)>&
-                       fieldPropIntOnLeafAssigner)
+initSatnumRegionArray_(const std::function<std::vector<int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropIntOnLeafAssigner)
 {
     // copy the SATNUM grid property. in some cases this is not necessary, but it
     // should not require much memory anyway...
     auto &satnumArray = this->parent_.satnumRegionArray_;
     satnumArray.resize(this->numCompressedElems_);
     if (this->eclState_.fieldProps().has_int("SATNUM")) {
-        satnumArray = fieldPropIntOnLeafAssigner(this->eclState_.fieldProps(), "SATNUM",
-                                                    this->numCompressedElems_, /*needsTranslation*/true);
+        satnumArray = fieldPropIntOnLeafAssigner(this->eclState_.fieldProps(), "SATNUM", /*needsTranslation*/true);
     }
     else {
         std::fill(satnumArray.begin(), satnumArray.end(), 0);

--- a/src/opm/material/thermal/EclThermalLawManager.cpp
+++ b/src/opm/material/thermal/EclThermalLawManager.cpp
@@ -56,7 +56,7 @@ initParamsForElements(const EclipseState& eclState, size_t numElems,
     if (has_heatcr)
         initHeatcr_(eclState, numElems, fieldPropsDoubleOnLeafAssigner);
     else if (tableManager.hasTables("SPECROCK"))
-        initSpecrock_(eclState, numElems, fieldPropsIntOnLeafAssigner);
+        initSpecrock_(eclState, fieldPropsIntOnLeafAssigner);
     else
         initNullRockEnergy_();
 
@@ -144,7 +144,7 @@ initHeatcr_(const EclipseState& eclState, size_t numElems,
 
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
-initSpecrock_(const EclipseState& eclState, size_t numElems,
+initSpecrock_(const EclipseState& eclState,
               const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropsIntOnLeafAssigner)
 {
     solidEnergyApproach_ = EclSolidEnergyApproach::Specrock;

--- a/src/opm/material/thermal/EclThermalLawManager.cpp
+++ b/src/opm/material/thermal/EclThermalLawManager.cpp
@@ -40,10 +40,9 @@ namespace Opm {
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
 initParamsForElements(const EclipseState& eclState, size_t numElems,
-                      const std::function<std::vector<double>(const FieldPropsManager&, const std::string&,
-                      const unsigned int&)>& assignFieldPropsDoubleOnLeaf,
-                      const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&,
-                      const unsigned int&, bool)>& assignFieldPropsIntOnLeaf)
+                      const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>& fieldPropsDoubleOnLeafAssigner,
+                      const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&, bool)>&
+                      fieldPropsIntOnLeafAssigner)
 {
     const auto& fp = eclState.fieldProps();
     const auto& tableManager = eclState.getTableManager();
@@ -55,16 +54,16 @@ initParamsForElements(const EclipseState& eclState, size_t numElems,
                    fp.has_double("THCWATER");
 
     if (has_heatcr)
-        initHeatcr_(eclState, numElems, assignFieldPropsDoubleOnLeaf);
+        initHeatcr_(eclState, numElems, fieldPropsDoubleOnLeafAssigner);
     else if (tableManager.hasTables("SPECROCK"))
-        initSpecrock_(eclState, numElems, assignFieldPropsIntOnLeaf);
+        initSpecrock_(eclState, numElems, fieldPropsIntOnLeafAssigner);
     else
         initNullRockEnergy_();
 
     if (has_thconr)
-        initThconr_(eclState, numElems, assignFieldPropsDoubleOnLeaf);
+        initThconr_(eclState, numElems, fieldPropsDoubleOnLeafAssigner);
     else if (has_thc)
-        initThc_(eclState, numElems, assignFieldPropsDoubleOnLeaf);
+        initThc_(eclState, numElems, fieldPropsDoubleOnLeafAssigner);
     else
         initNullCond_();
 }
@@ -121,16 +120,15 @@ thermalConductionLawParams(unsigned elemIdx) const
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
 initHeatcr_(const EclipseState& eclState, size_t numElems,
-            const std::function<std::vector<double>(const FieldPropsManager&, const std::string&, const unsigned int&)>&
-            assignFieldPropsDoubleOnLeaf)
+            const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>& fieldPropsDoubleOnLeafAssigner)
 {
     solidEnergyApproach_ = EclSolidEnergyApproach::Heatcr;
     // actually the value of the reference temperature does not matter for energy
     // conservation. We set it anyway to faciliate comparisons with ECL
     HeatcrLawParams::setReferenceTemperature(FluidSystem::surfaceTemperature);
 
-    const std::vector<double>& heatcrData = assignFieldPropsDoubleOnLeaf(eclState.fieldProps(), "HEATCR", numElems);
-    const std::vector<double>& heatcrtData = assignFieldPropsDoubleOnLeaf(eclState.fieldProps(), "HEATCRT", numElems);
+    const std::vector<double>& heatcrData = fieldPropsDoubleOnLeafAssigner(eclState.fieldProps(), "HEATCR");
+    const std::vector<double>& heatcrtData = fieldPropsDoubleOnLeafAssigner(eclState.fieldProps(), "HEATCRT");
     solidEnergyLawParams_.resize(numElems);
     for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
         auto& elemParam = solidEnergyLawParams_[elemIdx];
@@ -147,13 +145,12 @@ initHeatcr_(const EclipseState& eclState, size_t numElems,
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
 initSpecrock_(const EclipseState& eclState, size_t numElems,
-              const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&, const unsigned int&, bool)>&
-              assignFieldPropsIntOnLeaf)
+              const std::function<std::vector<unsigned int>(const FieldPropsManager&, const std::string&, bool)>& fieldPropsIntOnLeafAssigner)
 {
     solidEnergyApproach_ = EclSolidEnergyApproach::Specrock;
 
     // initialize the element index -> SATNUM index mapping
-    elemToSatnumIdx_ = assignFieldPropsIntOnLeaf(eclState.fieldProps(),"SATNUM", numElems, true /*needs translation*/);
+    elemToSatnumIdx_ = fieldPropsIntOnLeafAssigner(eclState.fieldProps(),"SATNUM", true /*needs translation*/);
     // SATNUM Data contains Fortran-style indices, i.e., they start with 1 instead of 0!
 
     // internalize the SPECROCK table
@@ -190,8 +187,7 @@ initNullRockEnergy_()
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
 initThconr_(const EclipseState& eclState, size_t numElems,
-            const std::function<std::vector<double>(const FieldPropsManager&, const std::string&, const unsigned int&)>&
-            assignFieldPropsDoubleOnLeaf)
+            const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>& fieldPropsDoubleOnLeafAssigner)
 {
     thermalConductivityApproach_ = EclThermalConductionApproach::Thconr;
 
@@ -199,10 +195,10 @@ initThconr_(const EclipseState& eclState, size_t numElems,
     std::vector<double> thconrData;
     std::vector<double> thconsfData;
     if (fp.has_double("THCONR"))
-        thconrData  = assignFieldPropsDoubleOnLeaf(fp, "THCONR", numElems);
+        thconrData  = fieldPropsDoubleOnLeafAssigner(fp, "THCONR");
 
     if (fp.has_double("THCONSF"))
-        thconsfData =  assignFieldPropsDoubleOnLeaf(fp, "THCONSF", numElems);
+        thconsfData =  fieldPropsDoubleOnLeafAssigner(fp, "THCONSF");
 
     thermalConductionLawParams_.resize(numElems);
     for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
@@ -223,8 +219,7 @@ initThconr_(const EclipseState& eclState, size_t numElems,
 template<class Scalar, class FluidSystem>
 void EclThermalLawManager<Scalar,FluidSystem>::
 initThc_(const EclipseState& eclState, size_t numElems,
-         const std::function<std::vector<double>(const FieldPropsManager&, const std::string&, const unsigned int&)>&
-         assignFieldPropsDoubleOnLeaf)
+         const std::function<std::vector<double>(const FieldPropsManager&, const std::string&)>& fieldPropsDoubleOnLeafAssigner)
 {
     thermalConductivityApproach_ = EclThermalConductionApproach::Thc;
 
@@ -235,18 +230,18 @@ initThc_(const EclipseState& eclState, size_t numElems,
     std::vector<double> thcwaterData;
 
     if (fp.has_double("THCROCK"))
-        thcrockData = assignFieldPropsDoubleOnLeaf(fp, "THCROCK", numElems);
+        thcrockData = fieldPropsDoubleOnLeafAssigner(fp, "THCROCK");
 
     if (fp.has_double("THCOIL"))
-        thcoilData = assignFieldPropsDoubleOnLeaf(fp, "THCOIL", numElems);
+        thcoilData = fieldPropsDoubleOnLeafAssigner(fp, "THCOIL");
 
     if (fp.has_double("THCGAS"))
-        thcgasData =  assignFieldPropsDoubleOnLeaf(fp, "THCGAS", numElems);
+        thcgasData =  fieldPropsDoubleOnLeafAssigner(fp, "THCGAS");
 
     if (fp.has_double("THCWATER"))
-        thcwaterData = assignFieldPropsDoubleOnLeaf(fp, "THCWATER", numElems);
+        thcwaterData = fieldPropsDoubleOnLeafAssigner(fp, "THCWATER");
 
-    const std::vector<double>& poroData = assignFieldPropsDoubleOnLeaf(fp, "PORO", numElems);
+    const std::vector<double>& poroData = fieldPropsDoubleOnLeafAssigner(fp, "PORO");
 
     thermalConductionLawParams_.resize(numElems);
     for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {

--- a/tests/material/test_eclmateriallawmanager.cpp
+++ b/tests/material/test_eclmateriallawmanager.cpp
@@ -621,12 +621,13 @@ class FieldPropsManager;
 // To support Local Grid Refinement for CpGrid, additional arguments have been added
 // in some EclMaterialLawManager(InitParams) member functions. Therefore, we define
 // some lambda expressions that does not affect this test file.
-std::function<std::vector<int>(const Opm::FieldPropsManager&, const std::string&, const unsigned int, bool)> doOldLookup =
-    [](const Opm::FieldPropsManager& fieldPropManager, const std::string& propString, const unsigned int numElems, bool needsTranslation)
+std::function<std::vector<int>(const Opm::FieldPropsManager&, const std::string&, bool)> doOldLookup =
+    [](const Opm::FieldPropsManager& fieldPropManager, const std::string& propString, bool needsTranslation)
     {
         std::vector<int> dest;
-        dest.resize(numElems);
         const auto& intRawData = fieldPropManager.get_int(propString);
+        unsigned int numElems =  intRawData.size();
+        dest.resize(numElems);
         for (unsigned elemIdx = 0; elemIdx < numElems; ++elemIdx) {
             dest[elemIdx] = intRawData[elemIdx] - needsTranslation;
         }


### PR DESCRIPTION
Unnecessary function argument numElements  has been removed in OPM/opm-grid#704. Associated PR in opm-simulators is coming soon. 