### PR TITLE
Add mass fraction diffusion coefficients

### DIFF
--- a/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/input/eclipse/EclipseState/Tables/TableManager.hpp
@@ -204,6 +204,8 @@ namespace Opm {
 
         int actco2s() const;
 
+        bool diffMoleFraction() const;
+
         bool operator==(const TableManager& data) const;
 
         template<class Serializer>
@@ -265,6 +267,7 @@ namespace Opm {
             serializer(m_rtemp);
             serializer(m_salinity);
             serializer(m_actco2s);
+            serializer(m_diff_mole_fraction);
             serializer(m_tlmixpar);
             serializer(m_ppcwmax);
             if (!serializer.isSerializing()) {
@@ -417,6 +420,7 @@ namespace Opm {
         double m_rtemp {288.7056}; // 60 Fahrenheit in Kelvin
         double m_salinity {0.0};
         int m_actco2s {3};
+        bool m_diff_mole_fraction {true};
 
         struct SplitSimpleTables {
           size_t plyshMax = 0;

--- a/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/src/opm/input/eclipse/EclipseState/Tables/TableManager.cpp
@@ -181,9 +181,16 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
 
         if( deck.hasKeyword( "DIFFCWAT" ) )
             this->m_diffCoeffWatTable = DiffCoeffWatTable( deck["DIFFCWAT"].back() );
+        else if (deck.hasKeyword( "DIFFAWAT" ) )
+            this->m_diffCoeffWatTable = DiffCoeffWatTable( deck["DIFFAWAT"].back() );
 
         if( deck.hasKeyword( "DIFFCGAS" ) )
             this->m_diffCoeffGasTable = DiffCoeffGasTable( deck["DIFFCGAS"].back() );
+        else if ( deck.hasKeyword( "DIFFAGAS" ) )
+            this->m_diffCoeffGasTable = DiffCoeffGasTable( deck["DIFFAGAS"].back() );
+        
+        if (deck.hasKeyword( "DIFFAWAT" ) || deck.hasKeyword( "DIFFAGAS" ))
+            this->m_diff_mole_fraction = false;
 
         if( deck.hasKeyword( "ROCK" ) )
             this->m_rockTable = RockTable( deck["ROCK"].back() );
@@ -329,6 +336,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         result.m_rtemp = 1.0;
         result.m_salinity = 1.0;
         result.m_actco2s = 3;
+        result.m_diff_mole_fraction = true;
         result.m_tlmixpar = TLMixpar::serializationTestObject();
         result.m_ppcwmax = Ppcwmax::serializationTestObject();
         return result;
@@ -1262,6 +1270,10 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
         return this->m_actco2s;
     }
 
+    bool TableManager::diffMoleFraction() const {
+        return this->m_diff_mole_fraction;
+    }
+
     std::size_t TableManager::gas_comp_index() const {
         return this->m_gas_comp_index;
     }
@@ -1316,6 +1328,7 @@ std::optional<JFunc> make_jfunc(const Deck& deck) {
                m_rtemp == data.m_rtemp &&
                m_salinity == data.m_salinity &&
                m_actco2s == data.m_actco2s &&
+               m_diff_mole_fraction == data.m_diff_mole_fraction &&
                m_gas_comp_index == data.m_gas_comp_index;
     }
 

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFAGAS
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFAGAS
@@ -1,5 +1,5 @@
 {
-  "name": "DIFFCGAS",
+  "name": "DIFFAGAS",
   "comment": "Hardcoded two components.",
   "sections": [
     "PROPS"
@@ -9,7 +9,7 @@
     "item": "NTPVT"
   },
   "requires": ["GAS", "WATER"],
-  "prohibits": ["DIFFAWAT", "DIFFAGAS"],
+  "prohibits": ["DIFFCWAT", "DIFFCGAS"],
   "items": [
   {
     "name": "CO2_IN_GAS",

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFAWAT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFAWAT
@@ -1,5 +1,5 @@
 {
-  "name": "DIFFCGAS",
+  "name": "DIFFAWAT",
   "comment": "Hardcoded two components.",
   "sections": [
     "PROPS"
@@ -9,17 +9,17 @@
     "item": "NTPVT"
   },
   "requires": ["GAS", "WATER"],
-  "prohibits": ["DIFFAWAT", "DIFFAGAS"],
+  "prohibits": ["DIFFCWAT", "DIFFCGAS"],
   "items": [
   {
-    "name": "CO2_IN_GAS",
+    "name": "CO2_IN_WATER",
     "value_type": "DOUBLE",
     "dimension": "Length*Length/Time"
   },
   {
-    "name": "H20_IN_GAS",
+    "name": "H20_IN_WATER",
     "value_type": "DOUBLE",
     "dimension": "Length*Length/Time"
   }
-]
+  ]
 }

--- a/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFCWAT
+++ b/src/opm/input/eclipse/share/keywords/001_Eclipse300/D/DIFFCWAT
@@ -8,6 +8,8 @@
     "keyword": "TABDIMS",
     "item": "NTPVT"
   },
+  "requires": ["GAS", "WATER"],
+  "prohibits": ["DIFFAWAT", "DIFFAGAS"],
   "items": [
   {
     "name": "CO2_IN_WATER",

--- a/src/opm/input/eclipse/share/keywords/keyword_list.cmake
+++ b/src/opm/input/eclipse/share/keywords/keyword_list.cmake
@@ -1057,6 +1057,8 @@ set( keywords
      001_Eclipse300/C/CREF
      001_Eclipse300/C/CREFW
      001_Eclipse300/C/CREFWS
+     001_Eclipse300/D/DIFFAGAS
+     001_Eclipse300/D/DIFFAWAT
      001_Eclipse300/D/DIFFCGAS
      001_Eclipse300/D/DIFFCWAT
      001_Eclipse300/D/DREF


### PR DESCRIPTION
Adds keywords DIFFAGAS and DIFFAWAT which are equivalent with DIFFCGAS and DIFFCWAT assumes a mass and not mol fraction formulation of diffusion. 