### PR TITLE
updating crossflow and auto-shutin with new WELSPECS

### DIFF
--- a/opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp
@@ -55,7 +55,7 @@ public:
         this->controls = 0;
     }
 
-    bool zeroRateLimit() const {
+    bool anyZeroRateConstraint() const {
         auto is_zero = [](const double x)
         {
             return std::isfinite(x) && !std::isnormal(x);

--- a/opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionControls.hpp
@@ -24,6 +24,8 @@
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 
+#include <cmath>
+
 namespace Opm {
 
 struct WellInjectionControls {
@@ -51,6 +53,23 @@ public:
 
     void clearControls(){
         this->controls = 0;
+    }
+
+    bool zeroRateLimit() const {
+        auto is_zero = [](const double x)
+        {
+            return std::isfinite(x) && !std::isnormal(x);
+        };
+
+        if (this->hasControl(WellInjectorCMode::RATE) && is_zero(this->surface_rate) ) {
+            return true;
+        }
+
+        if (this->hasControl(WellInjectorCMode::RESV) && is_zero(this->reservoir_rate) ) {
+            return true;
+        }
+
+        return false;
     }
 
     double bhp_limit;

--- a/opm/input/eclipse/Schedule/Well/WellProductionControls.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionControls.hpp
@@ -56,7 +56,7 @@ public:
         this->controls = 0;
     }
 
-    bool zeroRateLimit() const {
+    bool anyZeroRateConstraint() const {
         auto is_zero = [](const double x)
         {
             return std::isfinite(x) && !std::isnormal(x);

--- a/opm/input/eclipse/Schedule/Well/WellProductionControls.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionControls.hpp
@@ -24,6 +24,8 @@
 #include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellEnums.hpp>
 
+#include <cmath>
+
 namespace Opm {
 
 struct WellProductionControls {
@@ -52,6 +54,35 @@ public:
 
     void clearControls(){
         this->controls = 0;
+    }
+
+    bool zeroRateLimit() const {
+        auto is_zero = [](const double x)
+        {
+            return std::isfinite(x) && !std::isnormal(x);
+        };
+
+        if (this->hasControl(WellProducerCMode::ORAT) && is_zero(this->oil_rate)) {
+            return true;
+        }
+
+        if (this->hasControl(WellProducerCMode::WRAT) && is_zero(this->water_rate)) {
+            return true;
+        }
+
+        if (this->hasControl(WellProducerCMode::GRAT) && is_zero(this->gas_rate)) {
+            return true;
+        }
+
+        if (this->hasControl(WellProducerCMode::LRAT) && is_zero(this->liquid_rate)) {
+            return true;
+        }
+
+        if (this->hasControl(WellProducerCMode::RESV) && is_zero(this->resv_rate)) {
+            return true;
+        }
+
+        return false;
     }
 
     bool operator==(const WellProductionControls& other) const

--- a/src/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/src/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -37,6 +37,7 @@
 #include <fmt/format.h>
 
 #include <stdexcept>
+#include <iostream>
 
 namespace Opm {
 
@@ -236,6 +237,7 @@ welspecsUpdateExistingWells(const DeckRecord&               record,
 
     for (const auto& wellName : wellNames) {
         auto well = state().wells.get(wellName);
+        std::cout << " well " << wellName << "prev allow_crossflow? " << well.getAllowCrossFlow() << " now allow_crossflow? " << allow_crossflow << std::endl;
 
         const auto updateHead = well.updateHead(I, J);
         const auto updateRefD = well.updateRefDepth(ref_depth);
@@ -243,6 +245,7 @@ welspecsUpdateExistingWells(const DeckRecord&               record,
         const auto updatePVT  = well.updatePVTTable(pvt_table);
         const auto updateCrossflow = well.updateCrossFlow(allow_crossflow);
         const auto updateShutin = well.updateAutoShutin(auto_shutin);
+        std::cout << " well " << wellName << " updateCrossflow ? " << updateCrossflow << " new allow_crossflow " << well.getAllowCrossFlow() << std::endl;
 
         if (updateHead || updateRefD || updateDRad || updatePVT || updateCrossflow || updateShutin) {
             well.updateRefDepth();

--- a/src/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/src/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -237,7 +237,6 @@ welspecsUpdateExistingWells(const DeckRecord&               record,
 
     for (const auto& wellName : wellNames) {
         auto well = state().wells.get(wellName);
-        std::cout << " well " << wellName << "prev allow_crossflow? " << well.getAllowCrossFlow() << " now allow_crossflow? " << allow_crossflow << std::endl;
 
         const auto updateHead = well.updateHead(I, J);
         const auto updateRefD = well.updateRefDepth(ref_depth);
@@ -245,7 +244,6 @@ welspecsUpdateExistingWells(const DeckRecord&               record,
         const auto updatePVT  = well.updatePVTTable(pvt_table);
         const auto updateCrossflow = well.updateCrossFlow(allow_crossflow);
         const auto updateShutin = well.updateAutoShutin(auto_shutin);
-        std::cout << " well " << wellName << " updateCrossflow ? " << updateCrossflow << " new allow_crossflow " << well.getAllowCrossFlow() << std::endl;
 
         if (updateHead || updateRefD || updateDRad || updatePVT || updateCrossflow || updateShutin) {
             well.updateRefDepth();

--- a/src/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/src/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -228,6 +228,12 @@ welspecsUpdateExistingWells(const DeckRecord&               record,
         ref_depth.emplace(ref_d.getSIDouble(0));
     }
 
+    const std::string& cross_flow_str = record.getItem<Kw::CROSSFLOW>().getTrimmedString(0);
+    const bool allow_crossflow = cross_flow_str != "NO";
+
+    const std::string& shutin_str = record.getItem<Kw::AUTO_SHUTIN>().getTrimmedString(0);
+    const bool auto_shutin = shutin_str != "STOP";
+
     for (const auto& wellName : wellNames) {
         auto well = state().wells.get(wellName);
 
@@ -235,8 +241,10 @@ welspecsUpdateExistingWells(const DeckRecord&               record,
         const auto updateRefD = well.updateRefDepth(ref_depth);
         const auto updateDRad = well.updateDrainageRadius(drainageRadius);
         const auto updatePVT  = well.updatePVTTable(pvt_table);
+        const auto updateCrossflow = well.updateCrossFlow(allow_crossflow);
+        const auto updateShutin = well.updateAutoShutin(auto_shutin);
 
-        if (updateHead || updateRefD || updateDRad || updatePVT) {
+        if (updateHead || updateRefD || updateDRad || updatePVT || updateCrossflow || updateShutin) {
             well.updateRefDepth();
 
             state().wellgroup_events()

--- a/src/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -162,6 +162,7 @@ void handleWCONHIST(HandlerContext& handlerContext)
             if (handlerContext.getWellStatus(well_name) == WellStatus::OPEN) {
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::REQUEST_OPEN_WELL);
             }
+
         }
     }
 }
@@ -216,7 +217,6 @@ void handleWCONINJE(HandlerContext& handlerContext)
                 update_well = true;
             }
 
-            // const bool crossFlow = well2.getAllowCrossFlow();
             if (update_well) {
                 handlerContext.state().events().addEvent(ScheduleEvents::INJECTION_UPDATE);
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::INJECTION_UPDATE);
@@ -284,7 +284,6 @@ void handleWCONINJH(HandlerContext& handlerContext)
                 update_well = true;
             }
 
-            // const bool crossFlow = well2.getAllowCrossFlow();
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::INJECTION_UPDATE );
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::INJECTION_UPDATE);

--- a/src/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
+++ b/src/opm/input/eclipse/Schedule/Well/WellKeywordHandlers.cpp
@@ -158,26 +158,10 @@ void handleWCONHIST(HandlerContext& handlerContext)
                 handlerContext.state().wells.update( well2 );
             }
 
-            if (!well2.getAllowCrossFlow()) {
-                // The numerical content of the rate UDAValues is accessed unconditionally;
-                // since this is in history mode use of UDA values is not allowed anyway.
-                const auto& oil_rate = properties->OilRate;
-                const auto& water_rate = properties->WaterRate;
-                const auto& gas_rate = properties->GasRate;
-                if (oil_rate.zero() && water_rate.zero() && gas_rate.zero()) {
-                    std::string msg =
-                        "Well " + well2.name() + " is a history matched well with zero rate where crossflow is banned. " +
-                        "This well will be closed at " + std::to_string(handlerContext.elapsed_seconds() / (60*60*24)) + " days";
-                    OpmLog::note(msg);
-                    handlerContext.updateWellStatus(well_name,  Well::Status::SHUT);
-                }
-            }
-
             // Always check if well can be opened (it could have been closed for numerical reasons and possible to operate with new params)
             if (handlerContext.getWellStatus(well_name) == WellStatus::OPEN) {
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::REQUEST_OPEN_WELL);
             }
-
         }
     }
 }
@@ -232,7 +216,7 @@ void handleWCONINJE(HandlerContext& handlerContext)
                 update_well = true;
             }
 
-            const bool crossFlow = well2.getAllowCrossFlow();
+            // const bool crossFlow = well2.getAllowCrossFlow();
             if (update_well) {
                 handlerContext.state().events().addEvent(ScheduleEvents::INJECTION_UPDATE);
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::INJECTION_UPDATE);
@@ -240,28 +224,6 @@ void handleWCONINJE(HandlerContext& handlerContext)
                     handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::INJECTION_TYPE_CHANGED);
                 }
                 handlerContext.state().wells.update( std::move(well2) );
-            }
-
-            // if the well has zero surface rate limit or reservior rate limit, while does not allow crossflow,
-            // it should be turned off.
-            if ( ! crossFlow ) {
-                std::string msg =
-                    "Well " + well_name + " is an injector with zero rate where crossflow is banned. " +
-                    "This well will be closed at " + std::to_string(handlerContext.elapsed_seconds() / (60*60*24)) + " days";
-
-                if (injection->surfaceInjectionRate.is<double>()) {
-                    if (injection->hasInjectionControl(Well::InjectorCMode::RATE) && injection->surfaceInjectionRate.zero()) {
-                        OpmLog::note(msg);
-                        handlerContext.updateWellStatus(well_name, Well::Status::SHUT);
-                    }
-                }
-
-                if (injection->reservoirInjectionRate.is<double>()) {
-                    if (injection->hasInjectionControl(Well::InjectorCMode::RESV) && injection->reservoirInjectionRate.zero()) {
-                        OpmLog::note(msg);
-                        handlerContext.updateWellStatus(well_name, Well::Status::SHUT);
-                    }
-                }
             }
 
             if (handlerContext.state().wells.get( well_name ).getStatus() == Well::Status::OPEN) {
@@ -322,7 +284,7 @@ void handleWCONINJH(HandlerContext& handlerContext)
                 update_well = true;
             }
 
-            const bool crossFlow = well2.getAllowCrossFlow();
+            // const bool crossFlow = well2.getAllowCrossFlow();
             if (update_well) {
                 handlerContext.state().events().addEvent( ScheduleEvents::INJECTION_UPDATE );
                 handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::INJECTION_UPDATE);
@@ -330,14 +292,6 @@ void handleWCONINJH(HandlerContext& handlerContext)
                     handlerContext.state().wellgroup_events().addEvent( well_name, ScheduleEvents::INJECTION_TYPE_CHANGED);
                 }
                 handlerContext.state().wells.update( std::move(well2) );
-            }
-
-            if ( ! crossFlow && (injection->surfaceInjectionRate.zero())) {
-                std::string msg =
-                    "Well " + well_name + " is an injector with zero rate where crossflow is banned. " +
-                    "This well will be closed at " + std::to_string(handlerContext.elapsed_seconds() / (60*60*24)) + " days";
-                OpmLog::note(msg);
-                handlerContext.updateWellStatus(well_name, Well::Status::SHUT);
             }
 
             // Always check if well can be opened (it could have been closed for numerical reasons and possible to operate with new params)

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -296,6 +296,11 @@ DATES             -- 2
  10  JUL 2007 /
 /
 
+WELSPECS
+     'BAN'        'OP'   20   51  3.92       'OIL'  2*  STOP YES /
+/
+
+
 WCONPROD
      'BAN'      'OPEN'      'ORAT'      0.000      0.000      0.000  5* /
 /
@@ -686,12 +691,27 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
     BOOST_CHECK_EQUAL(schedule.getWell("BAN", 0).getAllowCrossFlow(), false);
     BOOST_CHECK_EQUAL(schedule.getWell("ALLOW", 0).getAllowCrossFlow(), true);
     BOOST_CHECK_EQUAL(schedule.getWell("DEFAULT", 0).getAllowCrossFlow(), true);
-    BOOST_CHECK(Well::Status::SHUT == schedule.getWell("BAN", 0).getStatus());
+    // we do not SHUT wells due to crossflow flag in the parser
+    BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 0).getStatus());
     BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 1).getStatus());
     BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 2).getStatus());
-    BOOST_CHECK(Well::Status::SHUT == schedule.getWell("BAN", 3).getStatus());
+    BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 3).getStatus());
     BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 4).getStatus());
     BOOST_CHECK(Well::Status::OPEN == schedule.getWell("BAN", 5).getStatus());
+
+    BOOST_CHECK_EQUAL(false, schedule.getWell("BAN", 0).getAllowCrossFlow() );
+    BOOST_CHECK_EQUAL(false, schedule.getWell("BAN", 1).getAllowCrossFlow() );
+    BOOST_CHECK_EQUAL(true, schedule.getWell("BAN", 2).getAllowCrossFlow() );
+    BOOST_CHECK_EQUAL(true, schedule.getWell("BAN", 3).getAllowCrossFlow() );
+    BOOST_CHECK_EQUAL(true, schedule.getWell("BAN", 4).getAllowCrossFlow() );
+    BOOST_CHECK_EQUAL(true, schedule.getWell("BAN", 5).getAllowCrossFlow() );
+
+    BOOST_CHECK_EQUAL(true, schedule.getWell("BAN", 0).getAutomaticShutIn() );
+    BOOST_CHECK_EQUAL(true, schedule.getWell("BAN", 1).getAutomaticShutIn() );
+    BOOST_CHECK_EQUAL(false, schedule.getWell("BAN", 2).getAutomaticShutIn() );
+    BOOST_CHECK_EQUAL(false, schedule.getWell("BAN", 3).getAutomaticShutIn() );
+    BOOST_CHECK_EQUAL(false, schedule.getWell("BAN", 4).getAutomaticShutIn() );
+    BOOST_CHECK_EQUAL(false, schedule.getWell("BAN", 5).getAutomaticShutIn() );
 }
 
 namespace {

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
         BOOST_CHECK( Well::Status::OPEN == sched.getWell("W_1", 11).getStatus( ));
         BOOST_CHECK( Well::Status::OPEN == sched.getWell("W_1", 12).getStatus( ));
-        BOOST_CHECK( Well::Status::SHUT == sched.getWell("W_1", 13).getStatus( ));
+        BOOST_CHECK( Well::Status::OPEN == sched.getWell("W_1", 13).getStatus( ));
         BOOST_CHECK( Well::Status::OPEN == sched.getWell("W_1", 14).getStatus( ));
         {
             SummaryState st(TimeService::now());


### PR DESCRIPTION
The PR is targeting the following scenario. 

```
WELSPECS with crossflow on
WCONHIST give a ZERO rate

DATES

WELSPECS with crossflow off.

DATES
WELSPECS with crossflow on
```

Basically, part of the properties from the WELSPECS can be updated without providing a new WCON* keyword.  Then for the scenario with zero rate constraints from the WCON* keyword, the well status might be OPEN or SHUT depending on the new WELSPECS input. 

The current master could not handle the above behavior. 

I also include the aut shut-in in the PR, but that is not the motivation of the PR, just seeing it should be done in the same manner. 
