### PR TITLE
SALTSOL: change units of item 1 to Salinity

### DIFF
--- a/src/opm/input/eclipse/share/keywords/900_OPM/S/SALTSOL
+++ b/src/opm/input/eclipse/share/keywords/900_OPM/S/SALTSOL
@@ -12,7 +12,7 @@
       "name": "DATA",
       "value_type": "DOUBLE",
       "size_type": "ALL",
-      "dimension": ["Density","Density"]
+      "dimension": ["Salinity","Density"]
     }
   ]
 }


### PR DESCRIPTION
I believe item 1 (SALTSOL) should have units of Salinity (LB/STB) rather than density (LB/FT3) to be consistent with e.g. SALTVD. This only affects FIELD units.