### PR TITLE
Fix/complete support for operator .ne. (!=) in ACTIONX

### DIFF
--- a/opm/input/eclipse/Schedule/Action/Enums.hpp
+++ b/opm/input/eclipse/Schedule/Action/Enums.hpp
@@ -33,6 +33,7 @@ enum class Logical {
 
 enum class Comparator {
     EQUAL,
+    NOT_EQUAL,
     GREATER,
     LESS,
     GREATER_EQUAL,

--- a/src/opm/input/eclipse/Schedule/Action/ActionValue.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/ActionValue.cpp
@@ -12,7 +12,7 @@ inline std::string tokenString(TokenType op) {
     switch (op) {
 
     case TokenType::op_eq:
-        return "==";
+        return "=";
 
     case TokenType::op_ge:
         return ">=";

--- a/src/opm/input/eclipse/Schedule/Action/Condition.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/Condition.cpp
@@ -42,6 +42,9 @@ Comparator comparator(TokenType tt) {
     if (tt == TokenType::op_eq)
         return Comparator::EQUAL;
 
+    if (tt == TokenType::op_ne)
+        return Comparator::NOT_EQUAL;
+
     if (tt == TokenType::op_gt)
         return Comparator::GREATER;
 
@@ -247,6 +250,8 @@ int Condition::comparator_as_int() const {
         return 4;
     case Comparator::EQUAL:
         return 5;
+    case Comparator::NOT_EQUAL:
+        return 6;
     default:
         throw std::logic_error(fmt::format("Unhandeled value: {} in enum comparison", static_cast<int>(this->cmp)));
     }

--- a/src/opm/input/eclipse/Schedule/Action/Enums.cpp
+++ b/src/opm/input/eclipse/Schedule/Action/Enums.cpp
@@ -53,6 +53,8 @@ Comparator comparator_from_int(int cmp_int) {
         return Comparator::LESS_EQUAL;
     case 5:
         return Comparator::EQUAL;
+    case 6:
+        return Comparator::NOT_EQUAL;
     default:
         throw std::logic_error(fmt::format("Integer value: {} could not be converted to ACTIONX comparator", cmp_int));
     }
@@ -61,6 +63,9 @@ Comparator comparator_from_int(int cmp_int) {
 std::string comparator_as_string(Comparator cmp) {
     if (cmp == Comparator::EQUAL)
         return "=";
+
+    if (cmp == Comparator::NOT_EQUAL)
+        return "!=";
 
     if (cmp == Comparator::GREATER)
         return ">";

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -81,23 +81,39 @@ Schedule make_schedule(const std::string& deck_string, const ParseContext& parse
 
 
 BOOST_AUTO_TEST_CASE(Create) {
-    const auto action_kw = std::string{ R"(
+    auto check_operator = [](const std::string& comp_op)
+    {
+        BOOST_TEST_MESSAGE("Checking operator "+comp_op);
+        const auto action_kw = std::string{ R"(
 ACTIONX
    'ACTION' /
-   WWCT OPX  > 0.75 /
+   WWCT OPX
+ )"}
+        + comp_op + std::string{ R"(
+ 0.75 /
 /
 )"};
-    Action::ActionX action1("NAME", 10, 100, 0);
-    BOOST_CHECK_EQUAL(action1.name(), "NAME");
+        Action::ActionX action1("NAME", 10, 100, 0);
+        BOOST_CHECK_EQUAL(action1.name(), "NAME");
 
-    const auto deck = Parser{}.parseString( action_kw );
-    const auto& kw = deck["ACTIONX"].back();
+        const auto deck = Parser{}.parseString( action_kw );
+        const auto& kw = deck["ACTIONX"].back();
 
 
-    const auto& [action2, condition_errors2 ] =
-        Action::parseActionX(kw, {}, 0);
-    BOOST_CHECK_EQUAL(action2.name(), "ACTION");
-    BOOST_CHECK_EQUAL(condition_errors2.size(), 0U);
+        const auto& [action2, condition_errors2 ] =
+            Action::parseActionX(kw, {}, 0);
+        BOOST_CHECK_EQUAL(action2.name(), "ACTION");
+        BOOST_CHECK_EQUAL(condition_errors2.size(), 0U);
+    };
+
+    // Check the other operators
+    std::vector<std::string> operators =
+        { "=", ".eq.", "!=", ".ne.", "<=", ".le.", ">=", ".ge.", "<", ".lt.", ">", ".gt." };
+
+    for(const auto& op :operators)
+    {
+        check_operator(op);
+    }
 
     // left hand side has to be an expression.
     // Check whether we add an error to condition_errors


### PR DESCRIPTION
This is was already started but some bits and pieces where missing. This made the code not detecting the comparator `!=` or `.ne` leading to error messages as:
```
Could not determine right hand side / comparator for ACTIONX keyword at  ...
```

While at it, we now at least check the creation of all operators. Still, the test suite has quite some holes in this area...

This is WIP because I want to also test a new test in opm-tests first.