### PR TITLE
Blackoilthermal fixes enthalpy change2mix nowork

### DIFF
--- a/opm/material/common/UniformTabulated2DFunction.hpp
+++ b/opm/material/common/UniformTabulated2DFunction.hpp
@@ -195,7 +195,7 @@ public:
     Evaluation eval(const Evaluation& x, const Evaluation& y, bool extrapolate) const
     {
 #ifndef NDEBUG
-        if (!extrapolate && !applies(x,y)) {
+        if (!applies(x,y)) {
             std::string msg = "Attempt to get tabulated value for ("
                 +std::to_string(double(scalarValue(x)))+", "+std::to_string(double(scalarValue(y)))
                 +") on a table of extent "
@@ -212,6 +212,15 @@ public:
             }
 
         };
+#else
+        if (!extrapolate && !applies(x,y)){
+            std::string msg = "Attempt to get tabulated value for ("
+                +std::to_string(double(scalarValue(x)))+", "+std::to_string(double(scalarValue(y)))
+                +") on a table of extent "
+                +std::to_string(xMin())+" to "+std::to_string(xMax())+" times "
+                +std::to_string(yMin())+" to "+std::to_string(yMax());
+            throw NumericalProblem(msg);
+        }
 #endif
 
         Evaluation alpha = xToI(x);

--- a/opm/material/fluidstates/BlackOilFluidState.hpp
+++ b/opm/material/fluidstates/BlackOilFluidState.hpp
@@ -510,7 +510,12 @@ public:
      * exception!
      */
     Scalar internalEnergy(unsigned phaseIdx) const
-    { return (*enthalpy_)[canonicalToStoragePhaseIndex_(phaseIdx)] - pressure(phaseIdx)/density(phaseIdx); }
+    {   auto& energy = (*enthalpy_)[canonicalToStoragePhaseIndex_(phaseIdx)];
+        if(!FluidSystem::enthalpyEqualEnergy()){
+            energy -= pressure(phaseIdx)/density(phaseIdx);
+        }
+        return energy;
+    }
 
     //////
     // slow methods

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -1264,7 +1264,12 @@ public:
         // should preferably not be used values should be taken from intensive quantities fluid state.
         OpmLog::warning("Not need: try to take enthalpy from fluidState");
         const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
-        return internalEnergy<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx) + p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
+        const auto& energy = internalEnergy<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
+        if(!enthalpy_eq_energy_){
+            // used for simplified models
+            energy += p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
+        }
+        return energy;
     }
 
     /*!
@@ -1672,6 +1677,13 @@ public:
         default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
         }
     }
+    void setEnergyEqualEnthalpy(bool enthalpy_eq_energy){
+        enthalpy_eq_energy_ = enthalpy_eq_energy;
+    }
+
+    bool enthalpyEqualEnergy const{
+        return enthalpy_eq_energy_;
+    }
 
 private:
     static void resizeArrays_(std::size_t numRegions);
@@ -1699,6 +1711,7 @@ private:
     static std::array<short, numPhases> canonicalToActivePhaseIdx_;
 
     static bool isInitialized_;
+    inline static bool enthalpy_eq_energy_ = false
 };
 
 template <class Scalar, class IndexTraits>

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -1095,6 +1095,7 @@ public:
                 return oilEnergy;
             }
             is_mixing = true;
+            break;
         }
         case waterPhaseIdx: {
             if(!waterPvt_->mixingEnergy()){
@@ -1106,7 +1107,7 @@ public:
                 return waterEnergy;
             }
             is_mixing = true;
-
+            break;
         }
         case gasPhaseIdx: {
             if(!gasPvt_->mixingEnergy()){
@@ -1118,6 +1119,7 @@ public:
                 return gasEnergy;
             }
             is_mixing = true;
+            break;
         }
         }
         assert(is_mixing==true);

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -531,6 +531,12 @@ public:
                             unsigned phaseIdx)
     { return enthalpy<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
 
+    template <class FluidState, class LhsEval = typename FluidState::Scalar, class ParamCacheEval = LhsEval>
+    static LhsEval internalEnergy(const FluidState& fluidState,
+                                  const ParameterCache<ParamCacheEval>& paramCache,
+                                  unsigned phaseIdx)
+    { return internalEnergy<FluidState, LhsEval>(fluidState, phaseIdx, paramCache.regionIndex()); }
+
     /****************************************
      * thermodynamic quantities (black-oil specific version: Note that the PVT region
      * index is explicitly passed instead of a parameter cache object)
@@ -672,7 +678,7 @@ public:
 
                 return
                     bg*referenceDensity(gasPhaseIdx, regionIdx)
-                    + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx) 
+                    + Rv*bg*referenceDensity(oilPhaseIdx, regionIdx)
                     + Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx) ;
             }
 
@@ -771,7 +777,7 @@ public:
                     && Rvw >= (1.0 - 1e-10)*gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))
                     && fluidState.saturation(oilPhaseIdx) > 0.0
                     && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                 { 
+                 {
                     return gasPvt_->saturatedInverseFormationVolumeFactor(regionIdx, T, p);
                  } else {
                      return gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
@@ -790,7 +796,7 @@ public:
                 }
             }
 
-            if (enableVaporizedWater()) { 
+            if (enableVaporizedWater()) {
                 const auto& Rvw = BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 if (fluidState.saturation(waterPhaseIdx) > 0.0
                     && Rvw >= (1.0 - 1e-10)*gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
@@ -801,7 +807,7 @@ public:
                     return gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
                 }
             }
-            
+
             const LhsEval Rv(0.0);
             const LhsEval Rvw(0.0);
             return gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
@@ -1016,7 +1022,7 @@ public:
                     && Rvw >= (1.0 - 1e-10)*gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p))
                     && fluidState.saturation(oilPhaseIdx) > 0.0
                     && Rv >= (1.0 - 1e-10)*gasPvt_->saturatedOilVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
-                 { 
+                 {
                      return gasPvt_->saturatedViscosity(regionIdx, T, p);
                  } else {
                      return gasPvt_->viscosity(regionIdx, T, p, Rv, Rvw);
@@ -1038,7 +1044,7 @@ public:
                 if (fluidState.saturation(waterPhaseIdx) > 0.0
                     && Rvw >= (1.0 - 1e-10)*gasPvt_->saturatedWaterVaporizationFactor(regionIdx, scalarValue(T), scalarValue(p)))
                 {
-                    return gasPvt_->saturatedViscosity(regionIdx, T, p); 
+                    return gasPvt_->saturatedViscosity(regionIdx, T, p);
                 } else {
                     const LhsEval Rv(0.0);
                     return gasPvt_->viscosity(regionIdx, T, p, Rv, Rvw);
@@ -1071,42 +1077,192 @@ public:
         throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
     }
 
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    static LhsEval internalEnergy(const FluidState& fluidState,
+                                  unsigned phaseIdx,
+                                  unsigned regionIdx){
+        bool is_mixing = false;
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+
+        switch (phaseIdx) {
+        case oilPhaseIdx: {
+            if(!oilPvt_->mixingEnergy()){
+                const auto& oilEnergy =
+                    oilPvt_->internalEnergy(regionIdx, T, p,
+                                            BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+
+                return oilEnergy;
+            }
+            is_mixing = true;
+        }
+        case waterPhaseIdx: {
+            if(!waterPvt_->mixingEnergy()){
+                const auto waterEnergy =
+                    waterPvt_->internalEnergy(regionIdx, T, p,
+                                              BlackOil::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                                              BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+
+                return waterEnergy;
+            }
+            is_mixing = true;
+
+        }
+        case gasPhaseIdx: {
+            if(!gasPvt_->mixingEnergy()){
+                const auto gasEnergy =
+                    gasPvt_->internalEnergy(regionIdx, T, p,
+                                            BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                                            BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+
+                return gasEnergy;
+            }
+            is_mixing = true;
+        }
+        }
+        assert(is_mixing==true);
+        const auto& energy = internalMixingTotalEnergy<FluidState,LhsEval>(fluidState, phaseIdx, regionIdx);
+        const auto& phase_density = density<FluidState,LhsEval>(fluidState, phaseIdx, regionIdx);
+        return energy/phase_density;
+    }
+
+
+    template <class FluidState, class LhsEval = typename FluidState::Scalar>
+    static LhsEval internalMixingTotalEnergy(const FluidState& fluidState,
+                                             unsigned phaseIdx,
+                                             unsigned regionIdx)
+    {
+        assert(phaseIdx <= numPhases);
+        assert(regionIdx <= numRegions());
+        const LhsEval& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
+        const LhsEval& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
+        const LhsEval& saltConcentration = BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+        // to avoid putting all thermal into the interface of the multiplexer
+        switch (phaseIdx) {
+        case oilPhaseIdx: {
+            auto oilEnergy = oilPvt_->internalEnergy(regionIdx, T, p,
+                                                     BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+            assert(oilPvt_->mixingEnergy());
+            //mixing energy adsed
+            if (enableDissolvedGas()) {
+                // miscible oil
+                const LhsEval& Rs = BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
+                const auto& gasEnergy =
+                    gasPvt_->internalEnergy(regionIdx, T, p,
+                                            BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                                            BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto hVapG = gasPvt_->hVap(regionIdx);// pressure correction ? assume equal to energy change
+                return
+                    oilEnergy*bo*referenceDensity(oilPhaseIdx, regionIdx)
+                    + (gasEnergy-hVapG)*Rs*bo*referenceDensity(gasPhaseIdx, regionIdx);
+            }
+
+            // immiscible oil
+            const LhsEval Rs(0.0);
+            const auto& bo = oilPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rs);
+
+            return oilEnergy*referenceDensity(phaseIdx, regionIdx)*bo;
+        }
+
+        case gasPhaseIdx: {
+            const auto& gasEnergy =
+                gasPvt_->internalEnergy(regionIdx, T, p,
+                                        BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                                        BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+            assert(gasPvt_->mixingEnergy());
+            if (enableVaporizedOil() && enableVaporizedWater()) {
+                const auto& oilEnergy =
+                    oilPvt_->internalEnergy(regionIdx, T, p,
+                                            BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto waterEnergy =
+                    waterPvt_->internalEnergy(regionIdx, T, p,
+                                              BlackOil::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                                              BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                // gas containing vaporized oil and vaporized water
+                const LhsEval& Rv = BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& Rvw = BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
+                const auto hVapO = oilPvt_->hVap(regionIdx);
+                const auto hVapW = waterPvt_->hVap(regionIdx);
+                return
+                    gasEnergy*bg*referenceDensity(gasPhaseIdx, regionIdx)
+                    + (oilEnergy+hVapO)*Rv*bg*referenceDensity(oilPhaseIdx, regionIdx)
+                    + (waterEnergy+hVapW)*Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+            }
+            if (enableVaporizedOil()) {
+                const auto& oilEnergy =
+                    oilPvt_->internalEnergy(regionIdx, T, p,
+                                            BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                // miscible gas
+                const LhsEval Rvw(0.0);
+                const LhsEval& Rv = BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
+                const auto hVapO = oilPvt_->hVap(regionIdx);
+                return
+                    gasEnergy*bg*referenceDensity(gasPhaseIdx, regionIdx)
+                    + (oilEnergy+hVapO)*Rv*bg*referenceDensity(oilPhaseIdx, regionIdx);
+            }
+            if (enableVaporizedWater()) {
+                // gas containing vaporized water
+                const LhsEval Rv(0.0);
+                const LhsEval& Rvw = BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
+                const LhsEval& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
+                const auto waterEnergy =
+                    waterPvt_->internalEnergy(regionIdx, T, p,
+                                              BlackOil::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                                              BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                const auto hVapW = waterPvt_->hVap(regionIdx);
+                return
+                    gasEnergy*bg*referenceDensity(gasPhaseIdx, regionIdx)
+                    + (waterEnergy+hVapW)*Rvw*bg*referenceDensity(waterPhaseIdx, regionIdx);
+            }
+
+            // immiscible gas
+            const LhsEval Rv(0.0);
+            const LhsEval Rvw(0.0);
+            const auto& bg = gasPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rv, Rvw);
+            return gasEnergy*bg*referenceDensity(phaseIdx, regionIdx);
+        }
+
+        case waterPhaseIdx:
+            const auto waterEnergy =
+                waterPvt_->internalEnergy(regionIdx, T, p,
+                                          BlackOil::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                                          BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+            assert(waterPvt_->mixingEnergy());
+            if (enableDissolvedGasInWater()) {
+                const auto& gasEnergy =
+                    gasPvt_->internalEnergy(regionIdx, T, p,
+                                            BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
+                                            BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx));
+                // gas miscible in water
+                const LhsEval& Rsw = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
+                const LhsEval& bw = waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
+                return
+                    waterEnergy*bw*referenceDensity(waterPhaseIdx, regionIdx)
+                    + gasEnergy*Rsw*bw*referenceDensity(gasPhaseIdx, regionIdx);
+            }
+            const LhsEval Rsw(0.0);
+            return
+                waterEnergy*referenceDensity(waterPhaseIdx, regionIdx)
+                * waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
+        }
+        throw std::logic_error("Unhandled phase index " + std::to_string(phaseIdx));
+    }
+
+
+
     //! \copydoc BaseFluidSystem::enthalpy
     template <class FluidState, class LhsEval = typename FluidState::Scalar>
     static LhsEval enthalpy(const FluidState& fluidState,
                             unsigned phaseIdx,
                             unsigned regionIdx)
     {
-        assert(phaseIdx <= numPhases);
-        assert(regionIdx <= numRegions());
-
+        // should preferably not be used values should be taken from intensive quantities fluid state.
+        OpmLog::warning("Not need: try to take enthalpy from fluidState");
         const auto& p = decay<LhsEval>(fluidState.pressure(phaseIdx));
-        const auto& T = decay<LhsEval>(fluidState.temperature(phaseIdx));
-
-        switch (phaseIdx) {
-        case oilPhaseIdx:
-            return
-                oilPvt_->internalEnergy(regionIdx, T, p, BlackOil::template getRs_<ThisType, FluidState, LhsEval>(fluidState, regionIdx))
-                + p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
-
-        case gasPhaseIdx:
-            return
-                 gasPvt_->internalEnergy(regionIdx, T, p,
-                 BlackOil::template getRv_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                  BlackOil::template getRvw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx))
-                  + p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
-
-        case waterPhaseIdx:
-            return
-                waterPvt_->internalEnergy(regionIdx, T, p,
-                                          BlackOil::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx),
-                                          BlackOil::template getSaltConcentration_<ThisType, FluidState, LhsEval>(fluidState, regionIdx))
-                + p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
-
-        default: throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
-        }
-
-        throw std::logic_error("Unhandled phase index "+std::to_string(phaseIdx));
+        return internalEnergy<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx) + p/density<FluidState, LhsEval>(fluidState, phaseIdx, regionIdx);
     }
 
     /*!

--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.hpp
@@ -84,8 +84,8 @@ public:
         : salinity_(salinity)
     {
         // Throw an error if reference state is not (T, p) = (15.56 C, 1 atm) = (288.71 K, 1.01325e5 Pa)
-        if (T_ref != Scalar(288.71) || P_ref != Scalar(1.01325e5)) {    
-            OPM_THROW(std::runtime_error, 
+        if (T_ref != Scalar(288.71) || P_ref != Scalar(1.01325e5)) {
+            OPM_THROW(std::runtime_error,
                 "BrineCo2Pvt class can only be used with default reference state (T, P) = (288.71 K, 1.01325e5 Pa)!");
         }
         setActivityModelSalt(activityModel);
@@ -173,6 +173,10 @@ public:
      */
     unsigned numRegions() const
     { return brineReferenceDensity_.size(); }
+
+    Scalar hVap(unsigned ) const{
+        return 0;
+    }
 
     /*!
      * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
@@ -314,8 +318,8 @@ public:
                                                      const Evaluation& temperature,
                                                      const Evaluation& pressure) const
     {
- 	OPM_TIMEFUNCTION_LOCAL();
-	Evaluation rs_sat = rsSat(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
+    OPM_TIMEFUNCTION_LOCAL();
+    Evaluation rs_sat = rsSat(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
         return (1.0 - convertRsToXoG_(rs_sat,regionIdx)) * density(regionIdx, temperature, pressure, rs_sat, Evaluation(salinity_[regionIdx]))/brineReferenceDensity_[regionIdx];
     }
 
@@ -423,8 +427,8 @@ public:
                        const Evaluation& Rs,
                        const Evaluation& salinity) const
     {
-	OPM_TIMEFUNCTION_LOCAL();        
-	Evaluation xlCO2 = convertXoGToxoG_(convertRsToXoG_(Rs,regionIdx), salinity);
+    OPM_TIMEFUNCTION_LOCAL();
+    Evaluation xlCO2 = convertXoGToxoG_(convertRsToXoG_(Rs,regionIdx), salinity);
         Evaluation result = liquidDensity_(temperature,
                                         pressure,
                                         xlCO2,
@@ -440,12 +444,12 @@ public:
                      const Evaluation& pressure,
                      const Evaluation& salinity) const
     {
-	    OPM_TIMEFUNCTION_LOCAL();
+        OPM_TIMEFUNCTION_LOCAL();
         if (!enableDissolution_)
             return 0.0;
 
         // calulate the equilibrium composition for the given
-        // temperature and pressure. 
+        // temperature and pressure.
         Evaluation xgH2O;
         Evaluation xlCO2;
         BinaryCoeffBrineCO2::calculateMoleFractions(temperature,

--- a/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineH2Pvt.hpp
@@ -141,6 +141,10 @@ public:
     /*!
     * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
     */
+    Scalar hVap(unsigned /*regionIdx*/) const{
+        return 0.0;
+    }
+
     template <class Evaluation>
     Evaluation internalEnergy(unsigned regionIdx,
                         const Evaluation& temperature,
@@ -236,7 +240,7 @@ public:
     {
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature, pressure, saltconcentration);
         Evaluation rsSat = rsSat_(regionIdx, temperature, pressure, salinity);
-        return (1.0 - convertRsToXoG_(rsSat,regionIdx)) * 
+        return (1.0 - convertRsToXoG_(rsSat,regionIdx)) *
             density_(regionIdx, temperature, pressure, rsSat, salinity) / brineReferenceDensity_[regionIdx];
     }
 
@@ -251,7 +255,7 @@ public:
                                             const Evaluation& saltConcentration) const
     {
         const Evaluation salinity = salinityFromConcentration(regionIdx, temperature, pressure, saltConcentration);
-        return (1.0 - convertRsToXoG_(Rs,regionIdx)) * 
+        return (1.0 - convertRsToXoG_(Rs,regionIdx)) *
             density_(regionIdx, temperature, pressure, Rs, salinity) / brineReferenceDensity_[regionIdx];
     }
 
@@ -264,8 +268,8 @@ public:
                                             const Evaluation& pressure,
                                             const Evaluation& Rs) const
     {
-        return (1.0 - convertRsToXoG_(Rs, regionIdx)) * 
-            density_(regionIdx, temperature, pressure, Rs, Evaluation(salinity_[regionIdx])) / 
+        return (1.0 - convertRsToXoG_(Rs, regionIdx)) *
+            density_(regionIdx, temperature, pressure, Rs, Evaluation(salinity_[regionIdx])) /
                 brineReferenceDensity_[regionIdx];
     }
 
@@ -278,8 +282,8 @@ public:
                                                      const Evaluation& pressure) const
     {
         Evaluation rsSat = rsSat_(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
-        return (1.0 - convertRsToXoG_(rsSat, regionIdx)) * 
-            density_(regionIdx, temperature, pressure, rsSat, Evaluation(salinity_[regionIdx])) / 
+        return (1.0 - convertRsToXoG_(rsSat, regionIdx)) *
+            density_(regionIdx, temperature, pressure, rsSat, Evaluation(salinity_[regionIdx])) /
                 brineReferenceDensity_[regionIdx];
     }
 
@@ -398,7 +402,7 @@ private:
 
     /*!
     * \brief Calculate density of aqueous solution (H2O-NaCl/brine and H2).
-    * 
+    *
     * \param temperature temperature [K]
     * \param pressure pressure [Pa]
     * \param Rs gas dissolution factor [-]
@@ -426,7 +430,7 @@ private:
     /*!
     * \brief Calculated the density of the aqueous solution where contributions of salinity and dissolved H2 is taken
     * into account.
-    * 
+    *
     * \param T temperature [K]
     * \param pl liquid pressure [Pa]
     * \param xlH2 mole fraction H2 [-]
@@ -444,9 +448,9 @@ private:
 
         // check if pressure and temperature is valid
         if(!extrapolate && T < 273.15) {
-            const std::string msg = 
+            const std::string msg =
                 "Liquid density for Brine and H2 is only "
-                "defined above 273.15K (is " + 
+                "defined above 273.15K (is " +
                 std::to_string(getValue(T)) + "K)";
             throw NumericalProblem(msg);
         }
@@ -470,7 +474,7 @@ private:
     /*!
     * \brief Density of aqueous solution with dissolved H2. Formula from Li et al. (2018) and Garica, Lawrence Berkeley
     * National Laboratory, 2001.
-    * 
+    *
     * \param temperature [K]
     * \param pl liquid pressure [Pa]
     * \param xlH2 mole fraction [-]
@@ -503,7 +507,7 @@ private:
     /*!
     * \brief Convert a gas dissolution factor to the the corresponding mass fraction of the gas component in the oil
     * phase.
-    * 
+    *
     * \param Rs gass dissolution factor [-]
     * \param regionIdx region index
     */
@@ -547,7 +551,7 @@ private:
     /*!
     * \brief Convert the mass fraction of the gas component in the oil phase to the corresponding gas dissolution
     * factor.
-    * 
+    *
     * \param XoG mass fraction [-]
     * \param regionIdx region index
     */
@@ -579,7 +583,7 @@ private:
 
         // calulate the equilibrium composition for the given temperature and pressure
         LhsEval xlH2 = BinaryCoeffBrineH2::calculateMoleFractions(temperature, pressure, salinity, extrapolate);
-        
+
         // normalize the phase compositions
         xlH2 = max(0.0, min(1.0, xlH2));
 
@@ -654,9 +658,9 @@ private:
     }
 
     template <class LhsEval>
-    const LhsEval salinityFromConcentration(unsigned regionIdx, 
-                                            const LhsEval&T, 
-                                            const LhsEval& P, 
+    const LhsEval salinityFromConcentration(unsigned regionIdx,
+                                            const LhsEval&T,
+                                            const LhsEval& P,
                                             const LhsEval& saltConcentration) const
     {
         if (enableSaltConcentration_)

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -71,7 +71,7 @@ public:
     {
         // Throw an error if reference state is not (T, p) = (15.56 C, 1 atm) = (288.71 K, 1.01325e5 Pa)
         if (T_ref != Scalar(288.71) || P_ref != Scalar(1.01325e5)) {
-            OPM_THROW(std::runtime_error, 
+            OPM_THROW(std::runtime_error,
                 "BrineCo2Pvt class can only be used with default reference state (T, P) = (288.71 K, 1.01325e5 Pa)!");
         }
         setActivityModelSalt(activityModel);
@@ -146,6 +146,9 @@ public:
     unsigned numRegions() const
     { return gasReferenceDensity_.size(); }
 
+    Scalar hVap(unsigned ) const{
+        return 0;
+    }
     /*!
      * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
      */
@@ -158,7 +161,7 @@ public:
     {
         OPM_TIMEBLOCK_LOCAL(internalEnergy);
         // use the gasInternalEnergy of CO2
-        return CO2::gasInternalEnergy(temperature, pressure, extrapolate); 
+        return CO2::gasInternalEnergy(temperature, pressure, extrapolate);
 
         // account for H2O in the gas phase
         // Evaluation result = 0;

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityBrinePvt.hpp
@@ -107,6 +107,9 @@ public:
         throw std::runtime_error("Requested the enthalpy of water but the thermal option is not enabled");
     }
 
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp
@@ -140,7 +140,9 @@ public:
     {
         throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
     }
-
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of gas saturated oil given a pressure
      *        and a phase composition.

--- a/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp
@@ -140,7 +140,9 @@ public:
     {
         throw std::runtime_error("Requested the enthalpy of water but the thermal option is not enabled");
     }
-
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
@@ -232,9 +234,9 @@ public:
 
         // TODO (?): consider the salt concentration of the brine
         bw = (1.0 + X*(1.0 + X/2.0))/BwRef;
-        
+
         Scalar BwMuwRef = waterViscosity_[regionIdx]*BwRef;
-        
+
         const Evaluation& Y =
             (waterCompressibility_[regionIdx] - waterViscosibility_[regionIdx])
             * (pressure - pRef);
@@ -261,7 +263,7 @@ public:
     {
         throw std::runtime_error("Not implemented: The PVT model does not provide a diffusionCoefficient()");
     }
-    
+
     /*!
      * \brief Returns the gas dissolution factor \f$R_s\f$ [m^3/m^3] of the water phase.
      */

--- a/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp
@@ -114,6 +114,9 @@ public:
         throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
     }
 
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */

--- a/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp
@@ -126,7 +126,9 @@ public:
     {
         throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
     }
-
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
@@ -199,10 +201,10 @@ public:
     template <class Evaluation = Scalar>
     Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
                                               const Evaluation& /*temperature*/,
-                                              const Evaluation& /*pressure*/, 
+                                              const Evaluation& /*pressure*/,
                                               const Evaluation& /*saltConcentration*/) const
     { return 0.0; }
-    
+
 
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the oil phase.

--- a/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/DryHumidGasPvt.hpp
@@ -151,7 +151,9 @@ public:
     {
         throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
     }
-
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -163,7 +163,7 @@ public:
     bool mixingEnergy(){
         switch (gasPvtApproach_) {
         case GasPvtApproach::ThermalGas: {
-            return false;
+            return true;
             break;
         }
         default: {

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtMultiplexer.hpp
@@ -160,6 +160,18 @@ public:
         }
     }
 
+    bool mixingEnergy(){
+        switch (gasPvtApproach_) {
+        case GasPvtApproach::ThermalGas: {
+            return false;
+            break;
+        }
+        default: {
+            return false;
+        }
+        }
+    }
+
 #if HAVE_ECL_INPUT
     /*!
      * \brief Initialize the parameters for gas using an ECL deck.
@@ -179,7 +191,7 @@ public:
         case GasPvtApproach::DryHumidGas:
             realGasPvt_ = new DryHumidGasPvt<Scalar>;
             break;
-        
+
         case GasPvtApproach::WetHumidGas:
             realGasPvt_ = new WetHumidGasPvt<Scalar>;
             break;
@@ -196,7 +208,7 @@ public:
             realGasPvt_ = new Co2GasPvt<Scalar>;
             break;
 
-	    case GasPvtApproach::H2Gas:
+        case GasPvtApproach::H2Gas:
             realGasPvt_ = new H2GasPvt<Scalar>;
             break;
 
@@ -237,6 +249,9 @@ public:
                         const Evaluation& Rv,
                         const Evaluation& Rvw) const
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.internalEnergy(regionIdx, temperature, pressure, Rv, Rvw)); return 0; }
+
+    Scalar hVap(unsigned regionIdx) const
+    { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.hVap(regionIdx)); return 0; }
 
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
@@ -306,14 +321,14 @@ public:
                                               const Evaluation& temperature,
                                               const Evaluation& pressure) const
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedWaterVaporizationFactor(regionIdx, temperature, pressure)); return 0; }
-    
+
     /*!
      * \brief Returns the water vaporization factor \f$R_vw\f$ [m^3/m^3] of water saturated gas.
      */
     template <class Evaluation = Scalar>
     Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& temperature,
-                                              const Evaluation& pressure, 
+                                              const Evaluation& pressure,
                                               const Evaluation& saltConcentration) const
     { OPM_GAS_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedWaterVaporizationFactor(regionIdx, temperature, pressure, saltConcentration)); return 0; }
 
@@ -474,7 +489,7 @@ public:
         case GasPvtApproach::Co2Gas:
             realGasPvt_ = new Co2GasPvt<Scalar>(*static_cast<const Co2GasPvt<Scalar>*>(data.realGasPvt_));
             break;
-	case GasPvtApproach::H2Gas:
+    case GasPvtApproach::H2Gas:
             realGasPvt_ = new H2GasPvt<Scalar>(*static_cast<const H2GasPvt<Scalar>*>(data.realGasPvt_));
             break;
         default:

--- a/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.hpp
@@ -119,6 +119,7 @@ public:
         gasJTRefPres_.resize(numRegions);
         gasJTC_.resize(numRegions);
         rhoRefO_.resize(numRegions);
+        hVap_.resize(numRegions, 0.0);
     }
 
     void setVapPars(const Scalar par1, const Scalar par2)
@@ -152,7 +153,7 @@ public:
 
     size_t numRegions() const
     { return viscrefPress_.size(); }
- 
+
 
     /*!
      * \brief Returns the specific internal energy [J/kg] of gas given a set of parameters.
@@ -162,7 +163,7 @@ public:
                               const Evaluation& temperature,
                               const Evaluation& pressure,
                               const Evaluation& Rv,
-                              const Evaluation& ) const
+                              [[maybe_unused]] const Evaluation& RvW) const
     {
         if (!enableInternalEnergy_)
              throw std::runtime_error("Requested the internal energy of gas but it is disabled");
@@ -174,14 +175,16 @@ public:
             return internalEnergyCurves_[regionIdx].eval(temperature, /*extrapolate=*/true);
         }
         else {
+            // NB should probably be revisited with adding more or restrict to linear internal energy
+            OpmLog::warning("Experimental code for jouleThomson: simulation will be slower");
             Evaluation Tref = gasdentRefTemp_[regionIdx];
-            Evaluation Pref = gasJTRefPres_[regionIdx]; 
-            Scalar JTC = gasJTC_[regionIdx]; // if JTC is default then JTC is calculated
+            Evaluation Pref = gasJTRefPres_[regionIdx];
+            Scalar JTC = gasJTC_[regionIdx]; // if JTC is default then JTC is calculaited
             Evaluation Rvw = 0.0;
 
             Evaluation invB = inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rv, Rvw);
-            constexpr const Scalar hVap = 480.6e3; // [J / kg]
-            Evaluation Cp = (internalEnergyCurves_[regionIdx].eval(temperature, /*extrapolate=*/true) - hVap)/temperature;
+            // NB this assumes internalEnergyCurve(0) = 0 derivative should be used add Cp table ??
+            Evaluation Cp = (internalEnergyCurves_[regionIdx].eval(temperature, /*extrapolate=*/true))/temperature;
             Evaluation density = invB * (gasReferenceDensity(regionIdx) + Rv * rhoRefO_[regionIdx]);
 
             Evaluation enthalpyPres;
@@ -191,7 +194,7 @@ public:
             else if(enableThermalDensity_) {
                 Scalar c1T = gasdentCT1_[regionIdx];
                 Scalar c2T = gasdentCT2_[regionIdx];
-              
+
                 Evaluation alpha = (c1T + 2 * c2T * (temperature - Tref)) /
                     (1 + c1T  *(temperature - Tref) + c2T * (temperature - Tref) * (temperature - Tref));
 
@@ -205,7 +208,7 @@ public:
                     // see e.g.https://en.wikipedia.org/wiki/Joule-Thomson_effect for a derivation of the Joule-Thomson coeff.
                     Evaluation jouleThomsonCoefficient = -(1.0/Cp) * (1.0 - alpha * temperature)/rho;
                     Evaluation deltaEnthalpyPres = -Cp * jouleThomsonCoefficient * deltaP;
-                    enthalpyPres = enthalpyPresPrev + deltaEnthalpyPres; 
+                    enthalpyPres = enthalpyPresPrev + deltaEnthalpyPres;
                     enthalpyPresPrev = enthalpyPres;
                 }
             }
@@ -229,12 +232,12 @@ public:
                          const Evaluation& Rv,
                          const Evaluation& Rvw) const
     {
-        
+
         const auto& isothermalMu = isothermalPvt_->viscosity(regionIdx, temperature, pressure, Rv, Rvw);
         if (!enableThermalViscosity())
             return isothermalMu;
 
-        // compute the viscosity deviation due to temperature        
+        // compute the viscosity deviation due to temperature
         const auto& muGasvisct = gasvisctCurves_[regionIdx].eval(temperature, /*extrapolate=*/true);
         return muGasvisct/viscRef_[regionIdx]*isothermalMu;
     }
@@ -332,11 +335,11 @@ public:
     template <class Evaluation = Scalar>
     Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
                                               const Evaluation& /*temperature*/,
-                                              const Evaluation& /*pressure*/, 
+                                              const Evaluation& /*pressure*/,
                                               const Evaluation& /*saltConcentration*/) const
     { return 0.0; }
 
-    
+
 
     /*!
      * \brief Returns the oil vaporization factor \f$R_v\f$ [m^3/m^3] of the gas phase.
@@ -391,6 +394,10 @@ public:
 
     const Scalar gasReferenceDensity(unsigned regionIdx) const
     { return isothermalPvt_->gasReferenceDensity(regionIdx); }
+
+    const Scalar hVap(unsigned regionIdx) const {
+        return this->hVap_[regionIdx];
+    }
 
     const std::vector<TabulatedOneDFunction>& gasvisctCurves() const
     { return gasvisctCurves_; }
@@ -485,6 +492,7 @@ private:
     std::vector<Scalar> gasJTC_;
 
     std::vector<Scalar> rhoRefO_;
+    std::vector<Scalar> hVap_;
 
     // piecewise linear curve representing the internal energy of gas
     std::vector<TabulatedOneDFunction> internalEnergyCurves_;

--- a/opm/material/fluidsystems/blackoilpvt/H2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/H2GasPvt.hpp
@@ -125,6 +125,9 @@ public:
     unsigned numRegions() const
     { return gasReferenceDensity_.size(); }
 
+    Scalar hVap(unsigned ) const{
+        return 0;
+    }
     /*!
     * \brief Returns the specific enthalpy [J/kg] of gas given a set of parameters.
     *
@@ -138,7 +141,7 @@ public:
     {
         // use the gasInternalEnergy of H2
         return H2::gasInternalEnergy(temperature, pressure, extrapolate);
-        
+
         // TODO: account for H2O in the gas phase
         // Init output
         //Evaluation result = 0;
@@ -162,8 +165,8 @@ public:
                          const Evaluation& pressure,
                          const Evaluation& /*Rv*/,
                          const Evaluation& /*Rvw*/) const
-    { 
-        return saturatedViscosity(regionIdx, temperature, pressure); 
+    {
+        return saturatedViscosity(regionIdx, temperature, pressure);
     }
 
     /*!
@@ -232,7 +235,7 @@ public:
     Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& temperature,
                                               const Evaluation& pressure) const
-    { 
+    {
         return rvwSat_(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
     }
 
@@ -242,9 +245,9 @@ public:
     template <class Evaluation = Scalar>
     Evaluation saturatedWaterVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& temperature,
-                                              const Evaluation& pressure, 
+                                              const Evaluation& pressure,
                                               const Evaluation& saltConcentration) const
-    { 
+    {
         const Evaluation salinity = salinityFromConcentration(temperature, pressure, saltConcentration);
         return rvwSat_(regionIdx, temperature, pressure, salinity);
      }
@@ -258,8 +261,8 @@ public:
                                               const Evaluation& pressure,
                                               const Evaluation& /*oilSaturation*/,
                                               const Evaluation& /*maxOilSaturation*/) const
-    { 
-        return rvwSat_(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx])); 
+    {
+        return rvwSat_(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
     }
 
     /*!
@@ -269,7 +272,7 @@ public:
     Evaluation saturatedOilVaporizationFactor(unsigned regionIdx,
                                               const Evaluation& temperature,
                                               const Evaluation& pressure) const
-    { 
+    {
         return rvwSat_(regionIdx, temperature, pressure, Evaluation(salinity_[regionIdx]));
     }
 
@@ -308,11 +311,11 @@ private:
         // If water vaporization is disabled, we return zero
         if (!enableVaporization_)
             return 0.0;
-        
+
         // From Li et al., Int. J. Hydrogen Energ., 2018, water mole fraction is calculated assuming ideal mixing
         LhsEval pw_sat = H2O::vaporPressure(temperature);
         LhsEval yH2O = pw_sat / pressure;
-        
+
         // normalize the phase compositions
         yH2O = max(0.0, min(1.0, yH2O));
         return convertXgWToRvw(convertxgWToXgW(yH2O, salinity), regionIdx);
@@ -359,8 +362,8 @@ private:
 
     template <class LhsEval>
     const LhsEval salinityFromConcentration(const LhsEval&T, const LhsEval& P, const LhsEval& saltConcentration) const
-    { 
-        return saltConcentration / H2O::liquidDensity(T, P, true); 
+    {
+        return saltConcentration / H2O::liquidDensity(T, P, true);
     }
 
 };  // end class H2GasPvt

--- a/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/LiveOilPvt.hpp
@@ -161,6 +161,10 @@ public:
         throw std::runtime_error("Requested the enthalpy of oil but the thermal option is not enabled");
     }
 
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
+
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -154,7 +154,7 @@ public:
     bool mixingEnergy(){
         switch (approach_) {
         case OilPvtApproach::ThermalOil: {
-            return false;
+            return true;
             break;
         }
         default: {

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtMultiplexer.hpp
@@ -142,7 +142,7 @@ public:
             delete &getRealPvt<OilPvtApproach::BrineCo2>();
             break;
         }
-	    case OilPvtApproach::BrineH2: {
+        case OilPvtApproach::BrineH2: {
             delete &getRealPvt<OilPvtApproach::BrineH2>();
             break;
         }
@@ -151,6 +151,17 @@ public:
         }
     }
 
+    bool mixingEnergy(){
+        switch (approach_) {
+        case OilPvtApproach::ThermalOil: {
+            return false;
+            break;
+        }
+        default: {
+            return false;
+        }
+        }
+    }
 #if HAVE_ECL_INPUT
     /*!
      * \brief Initialize the parameters for water using an ECL state.
@@ -191,6 +202,8 @@ public:
                         const Evaluation& Rs) const
     { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.internalEnergy(regionIdx, temperature, pressure, Rs)); return 0; }
 
+    Scalar hVap(unsigned regionIdx) const
+    { OPM_OIL_PVT_MULTIPLEXER_CALL(return pvtImpl.hVap(regionIdx)); return 0; }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
@@ -421,7 +434,7 @@ public:
         case OilPvtApproach::BrineCo2:
             realOilPvt_ = new BrineCo2Pvt<Scalar>(*static_cast<const BrineCo2Pvt<Scalar>*>(data.realOilPvt_));
             break;
-	    case OilPvtApproach::BrineH2:
+        case OilPvtApproach::BrineH2:
             realOilPvt_ = new BrineH2Pvt<Scalar>(*static_cast<const BrineH2Pvt<Scalar>*>(data.realOilPvt_));
             break;
         default:

--- a/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/OilPvtThermal.hpp
@@ -122,6 +122,7 @@ public:
         oilJTRefPres_.resize(numRegions);
         oilJTC_.resize(numRegions);
         rhoRefG_.resize(numRegions);
+        hVap_.resize(numRegions, 0.0);
     }
 
     void setVapPars(const Scalar par1, const Scalar par2)
@@ -175,8 +176,9 @@ public:
             return internalEnergyCurves_[regionIdx].eval(temperature, /*extrapolate=*/true);
         }
         else {
+            OpmLog::warning("Experimental code for jouleThomson: simulation will be slower");
             Evaluation Tref = oildentRefTemp_[regionIdx];
-            Evaluation Pref = oilJTRefPres_[regionIdx]; 
+            Evaluation Pref = oilJTRefPres_[regionIdx];
             Scalar JTC = oilJTC_[regionIdx]; // if JTC is default then JTC is calculated
 
             Evaluation invB = inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rs);
@@ -202,9 +204,9 @@ public:
                     Evaluation rho = inverseFormationVolumeFactor(regionIdx, temperature, Pnew, Rs) *
                                      (oilReferenceDensity(regionIdx) + Rs * rhoRefG_[regionIdx]) ;
                     // see e.g.https://en.wikipedia.org/wiki/Joule-Thomson_effect for a derivation of the Joule-Thomson coeff.
-                    Evaluation jouleThomsonCoefficient = -(1.0/Cp) * (1.0 - alpha * temperature)/rho;  
+                    Evaluation jouleThomsonCoefficient = -(1.0/Cp) * (1.0 - alpha * temperature)/rho;
                     Evaluation deltaEnthalpyPres = -Cp * jouleThomsonCoefficient * deltaP;
-                    enthalpyPres = enthalpyPresPrev + deltaEnthalpyPres; 
+                    enthalpyPres = enthalpyPresPrev + deltaEnthalpyPres;
                     enthalpyPresPrev = enthalpyPres;
                 }
             }
@@ -358,6 +360,10 @@ public:
     const Scalar oilReferenceDensity(unsigned regionIdx) const
     { return isothermalPvt_->oilReferenceDensity(regionIdx); }
 
+    const Scalar hVap(unsigned regionIdx) const {
+        return this->hVap_[regionIdx];
+    }
+
     const std::vector<TabulatedOneDFunction>& oilvisctCurves() const
     { return oilvisctCurves_; }
 
@@ -457,6 +463,7 @@ private:
     std::vector<Scalar> oilJTC_;
 
     std::vector<Scalar> rhoRefG_;
+    std::vector<Scalar> hVap_;
 
     // piecewise linear curve representing the internal energy of oil
     std::vector<TabulatedOneDFunction> internalEnergyCurves_;

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -134,7 +134,7 @@ public:
     bool mixingEnergy(){
         switch (approach_) {
         case WaterPvtApproach::ThermalWater: {
-            return false;
+            return true;
             break;
         }
         default: {

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtMultiplexer.hpp
@@ -131,7 +131,17 @@ public:
             break;
         }
     }
-
+    bool mixingEnergy(){
+        switch (approach_) {
+        case WaterPvtApproach::ThermalWater: {
+            return false;
+            break;
+        }
+        default: {
+            return false;
+        }
+        }
+    }
 #if HAVE_ECL_INPUT
     /*!
      * \brief Initialize the parameters for water using an ECL deck.
@@ -172,6 +182,8 @@ public:
                         const Evaluation& saltconcentration) const
     { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.internalEnergy(regionIdx, temperature, pressure, Rsw, saltconcentration)); return 0; }
 
+    Scalar hVap(unsigned regionIdx) const
+    { OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.hVap(regionIdx)); return 0; }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
@@ -208,7 +220,7 @@ public:
                                             const Evaluation& pressure,
                                             const Evaluation& Rsw,
                                             const Evaluation& saltconcentration) const
-    {   
+    {
         OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rsw, saltconcentration));
         return 0;
     }
@@ -221,7 +233,7 @@ public:
                                                      const Evaluation& temperature,
                                                      const Evaluation& pressure,
                                                      const Evaluation& saltconcentration) const
-    {   
+    {
         OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedInverseFormationVolumeFactor(regionIdx, temperature, pressure, saltconcentration));
         return 0;
     }
@@ -234,9 +246,9 @@ public:
                                              const Evaluation& temperature,
                                              const Evaluation& pressure,
                                              const Evaluation& saltconcentration) const
-    { 
-        OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasDissolutionFactor(regionIdx, temperature, pressure, saltconcentration)); 
-        return 0; 
+    {
+        OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.saturatedGasDissolutionFactor(regionIdx, temperature, pressure, saltconcentration));
+        return 0;
     }
 
     /*!
@@ -262,7 +274,7 @@ public:
                                     const Evaluation& pressure,
                                     unsigned compIdx) const
     {
-      OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.diffusionCoefficient(temperature, pressure, compIdx)); 
+      OPM_WATER_PVT_MULTIPLEXER_CALL(return pvtImpl.diffusionCoefficient(temperature, pressure, compIdx));
       return 0;
     }
 

--- a/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WaterPvtThermal.hpp
@@ -130,6 +130,7 @@ public:
         watJTRefPres_.resize(numRegions);
         watJTC_.resize(numRegions);
         internalEnergyCurves_.resize(numRegions);
+        hVap_.resize(numRegions,0.0);
     }
 
     void setVapPars(const Scalar par1, const Scalar par2)
@@ -161,6 +162,10 @@ public:
     bool enableThermalViscosity() const
     { return enableThermalViscosity_; }
 
+    Scalar hVap(unsigned regionIdx) const {
+        return this->hVap_[regionIdx];
+    }
+
     size_t numRegions() const
     { return pvtwRefPress_.size(); }
 
@@ -185,7 +190,7 @@ public:
         }
         else {
             Evaluation Tref = watdentRefTemp_[regionIdx];
-            Evaluation Pref = watJTRefPres_[regionIdx]; 
+            Evaluation Pref = watJTRefPres_[regionIdx];
             Scalar JTC =watJTC_[regionIdx]; // if JTC is default then JTC is calculated
 
             Evaluation invB = inverseFormationVolumeFactor(regionIdx, temperature, pressure, Rsw, saltconcentration);
@@ -209,9 +214,9 @@ public:
                 for (size_t i = 0; i < N; ++i) {
                     Evaluation Pnew = Pref + i * deltaP;
                     Evaluation rho = inverseFormationVolumeFactor(regionIdx, temperature, Pnew, Rsw, saltconcentration) * waterReferenceDensity(regionIdx);
-                    Evaluation jouleThomsonCoefficient = -(1.0/Cp) * (1.0 - alpha * temperature)/rho;  
+                    Evaluation jouleThomsonCoefficient = -(1.0/Cp) * (1.0 - alpha * temperature)/rho;
                     Evaluation deltaEnthalpyPres = -Cp * jouleThomsonCoefficient * deltaP;
-                    enthalpyPres = enthalpyPresPrev + deltaEnthalpyPres; 
+                    enthalpyPres = enthalpyPresPrev + deltaEnthalpyPres;
                     enthalpyPresPrev = enthalpyPres;
                 }
             }
@@ -464,6 +469,7 @@ private:
 
     // piecewise linear curve representing the internal energy of water
     std::vector<TabulatedOneDFunction> internalEnergyCurves_;
+    std::vector<Scalar> hVap_;
 
     bool enableThermalDensity_;
     bool enableJouleThomson_;

--- a/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp
@@ -163,7 +163,9 @@ public:
     {
         throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
     }
-
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
@@ -229,7 +231,7 @@ public:
     template <class Evaluation = Scalar>
     Evaluation saturatedWaterVaporizationFactor(unsigned /*regionIdx*/,
                                               const Evaluation& /*temperature*/,
-                                              const Evaluation& /*pressure*/, 
+                                              const Evaluation& /*pressure*/,
                                               const Evaluation& /*saltConcentration*/) const
     { return 0.0; }
 

--- a/opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/WetHumidGasPvt.hpp
@@ -132,7 +132,9 @@ public:
     {
         throw std::runtime_error("Requested the enthalpy of gas but the thermal option is not enabled");
     }
-
+    Scalar hVap(unsigned) const{
+        throw std::runtime_error("Requested the hvap of oil but the thermal option is not enabled");
+    }
     /*!
      * \brief Returns the dynamic viscosity [Pa s] of the fluid phase given a set of parameters.
      */
@@ -190,7 +192,7 @@ public:
                                             const Evaluation& Rvw) const
     {
         const Evaluation& temperature = 1E30;
-        
+
         if (Rv >= (1.0 - 1e-10)*saturatedOilVaporizationFactor(regionIdx, temperature, pressure)) {
             return inverseGasBRvSat_[regionIdx].eval(pressure, Rvw, /*extrapolate=*/true);
         }

--- a/src/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
+++ b/src/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
@@ -164,8 +164,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
             std::vector<double> uSamples(temperatureColumn.size());
 
             // this is the heat capasity for gas without dissolution which is handled else where
-            const Scalar hVap = 480.6e3;
-            Scalar u = temperatureColumn[0]*cvGasColumn[0] + hVap;
+            Scalar u = temperatureColumn[0]*cvGasColumn[0];
             for (size_t i = 0;; ++i) {
                 uSamples[i] = u;
 

--- a/src/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
+++ b/src/opm/material/fluidsystems/blackoilpvt/GasPvtThermal.cpp
@@ -85,12 +85,12 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 
             viscrefPress_[regionIdx] = viscrefTable[regionIdx].reference_pressure;
 
-            // Temperature used to calculate the reference viscosity [K]. 
+            // Temperature used to calculate the reference viscosity [K].
             // The value dooes not matter as the underlying PVT object is isothermal.
             constexpr const Scalar Tref = 273.15 + 20;
-            //TODO: For now I just assumed the default references RV and RVW = 0, 
-            // we could add these two parameters to a new item keyword VISCREF 
-            //or create a new keyword for gas. 
+            //TODO: For now I just assumed the default references RV and RVW = 0,
+            // we could add these two parameters to a new item keyword VISCREF
+            //or create a new keyword for gas.
             constexpr const Scalar Rvref = 0.0;
             constexpr const Scalar Rvwref = 0.0;
             // compute the reference viscosity using the isothermal PVT object.
@@ -98,7 +98,7 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
                 isothermalPvt_->viscosity(regionIdx,
                                           Tref,
                                           viscrefPress_[regionIdx],
-                                          Rvref, 
+                                          Rvref,
                                           Rvwref);
         }
     }
@@ -163,13 +163,8 @@ initFromState(const EclipseState& eclState, const Schedule& schedule)
 
             std::vector<double> uSamples(temperatureColumn.size());
 
-            // the specific enthalpy of vaporization. since ECL does not seem to
-            // feature a proper way to specify this quantity, we use the value for
-            // methane. A proper model would also need to consider the enthalpy
-            // change due to dissolution, i.e. the enthalpies of the gas and oil
-            // phases should depend on the phase composition
-            const Scalar hVap = 480.6e3; // [J / kg]
-
+            // this is the heat capasity for gas without dissolution which is handled else where
+            const Scalar hVap = 480.6e3;
             Scalar u = temperatureColumn[0]*cvGasColumn[0] + hVap;
             for (size_t i = 0;; ++i) {
                 uSamples[i] = u;


### PR DESCRIPTION
Changes to make it possible to set energy and enthalpy equal for blackoil simulations. This remove possible work terms form the simulator. It builds on to other pull requests.

Finally one would set enthalpy_eq_energy_ = true for TEMP option and false for all others