### PR TITLE
fixed: add hints in zoltan find rule to work with RH mpi folder structure

### DIFF
--- a/cmake/Modules/FindZOLTAN.cmake
+++ b/cmake/Modules/FindZOLTAN.cmake
@@ -26,6 +26,7 @@ find_package(PTScotch)
 # search for files which implements this module
 find_path (ZOLTAN_INCLUDE_DIR
   NAMES "zoltan.h"
+  HINTS $ENV{MPI_INCLUDE}
   PATHS ${ZOLTAN_SEARCH_PATH}
   PATH_SUFFIXES include trilinos
   ${ZOLTAN_NO_DEFAULT_PATH})
@@ -37,6 +38,7 @@ endif (CMAKE_SIZEOF_VOID_P)
 
 find_library(ZOLTAN_LIBRARY
   NAMES zoltan trilinos_zoltan
+  HINTS $ENV{MPI_LIB}
   PATHS ${ZOLTAN_SEARCH_PATH}
   PATH_SUFFIXES "lib/.libs" "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
   ${ZOLTAN_NO_DEFAULT_PATH})


### PR DESCRIPTION
QOL for redhat, so users don't have to specify zoltan paths manually.

RHEL does not install mpi dependent libs in standard paths but rather in paths which are made available for runtime using the mpi/xxx modules. However, these paths are not supplied on configure time forcing manual specification when building on rhel. To make life easier for those users, supply the hints provided in the ```MPI_INCLUDE``` and ```MPI_LIB``` environment variables supplied by the module command.