### PR TITLE
Fix to build in macOS

### DIFF
--- a/cmake/Modules/UseCompVer.cmake
+++ b/cmake/Modules/UseCompVer.cmake
@@ -51,6 +51,7 @@ function (get_ld_version ver_name)
   execute_process (
     COMMAND ${CMAKE_LINKER} -v
     OUTPUT_VARIABLE _version
+    ERROR_VARIABLE _version
   )
 
   # keep only first line, even on Mac OS X there is no line end


### PR DESCRIPTION
In:
`Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: x86_64-apple-darwin22.6.0`
it results in the following error:
```
CMake Error at /Users/dmar/Github/opm/build/opm-common/opm-common-config.cmake:74 (include):
  include could not find requested file:
    /Users/dmar/Github/opm/build/opm-common/opm-common-targets.cmake
Call Stack (most recent call first):
  CMakeLists.txt:54 (find_package)
```
which is fixed by reverting part of https://github.com/OPM/opm-common/commit/78ecc958e7c6558018321965de50e50e339e5cbb