### PR TITLE
Separate Pure From Mixing "Phases" in In-Place Categories

### DIFF
--- a/opm/output/eclipse/Inplace.cpp
+++ b/opm/output/eclipse/Inplace.cpp
@@ -17,121 +17,140 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <opm/output/eclipse/Inplace.hpp>
+
 #include <algorithm>
-#include <exception>
-#include <optional>
+#include <cstddef>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include <fmt/format.h>
 
-#include <opm/output/eclipse/Inplace.hpp>
+namespace {
+
+static const std::string FIELD_NAME = std::string{"FIELD"};
+static const std::size_t FIELD_ID   = 0;
+
+std::size_t region_max(const std::unordered_map<std::size_t, double>& region_map)
+{
+    return std::accumulate(region_map.begin(), region_map.end(), std::size_t{0},
+                           [](const std::size_t max, const auto& elm)
+                           {
+                               return std::max(max, elm.first);
+                           });
+}
+
+std::size_t
+phase_region_max(const std::unordered_map<Opm::Inplace::Phase, std::unordered_map<std::size_t, double>>& phase_map)
+{
+    return std::accumulate(phase_map.begin(), phase_map.end(), std::size_t{0},
+                           [](const std::size_t max, const auto& region_map)
+                           {
+                               return std::max(max, region_max(region_map.second));
+                           });
+}
+
+template <typename Vector>
+Vector append(Vector first, const Vector& second)
+{
+    first.insert(first.end(), second.begin(), second.end());
+    return first;
+}
+
+} // Anonymous namespace
 
 namespace Opm {
 
-namespace {
-static const std::string FIELD_NAME = std::string{"FIELD"};
-static const std::size_t FIELD_ID   = 0;
-}
-
-
-Inplace Inplace::serializationTestObject() {
+Inplace Inplace::serializationTestObject()
+{
     Inplace result;
     result.add("test1", Phase::WaterResVolume, 1, 2.0);
 
     return result;
 }
 
-void Inplace::add(const std::string& region, Inplace::Phase phase, std::size_t region_id, double value) {
+void Inplace::add(const std::string& region, Inplace::Phase phase, std::size_t region_id, double value)
+{
     this->phase_values[region][phase][region_id] = value;
 }
 
-void Inplace::add(Inplace::Phase phase, double value) {
-    this->add( FIELD_NAME, phase, FIELD_ID, value );
+void Inplace::add(Inplace::Phase phase, double value)
+{
+    this->add(FIELD_NAME, phase, FIELD_ID, value);
 }
 
-double Inplace::get(const std::string& region, Inplace::Phase phase, std::size_t region_id) const {
+double Inplace::get(const std::string& region, Inplace::Phase phase, std::size_t region_id) const
+{
     auto region_iter = this->phase_values.find(region);
-    if (region_iter == this->phase_values.end())
+    if (region_iter == this->phase_values.end()) {
         throw std::logic_error(fmt::format("No such region: {}", region));
+    }
 
     auto phase_iter = region_iter->second.find(phase);
-    if (phase_iter == region_iter->second.end())
-        throw std::logic_error(fmt::format("No such phase: {}:{}", region, static_cast<int>(phase)));
+    if (phase_iter == region_iter->second.end()) {
+        throw std::logic_error(fmt::format("No such phase: {}:{}",
+                                           region, static_cast<int>(phase)));
+    }
 
     auto value_iter = phase_iter->second.find(region_id);
-    if (value_iter == phase_iter->second.end())
-        throw std::logic_error(fmt::format("No such region id: {}:{}:{}", region, static_cast<int>(phase), region_id));
+    if (value_iter == phase_iter->second.end()) {
+        throw std::logic_error(fmt::format("No such region id: {}:{}:{}",
+                                           region, static_cast<int>(phase), region_id));
+    }
 
     return value_iter->second;
 }
 
-double Inplace::get(Inplace::Phase phase) const {
+double Inplace::get(Inplace::Phase phase) const
+{
     return this->get(FIELD_NAME, phase, FIELD_ID);
 }
 
-bool Inplace::has(const std::string& region, Phase phase, std::size_t region_id) const {
+bool Inplace::has(const std::string& region, Phase phase, std::size_t region_id) const
+{
     auto region_iter = this->phase_values.find(region);
-    if (region_iter == this->phase_values.end())
+    if (region_iter == this->phase_values.end()) {
         return false;
+    }
 
     auto phase_iter = region_iter->second.find(phase);
-    if (phase_iter == region_iter->second.end())
+    if (phase_iter == region_iter->second.end()) {
         return false;
+    }
 
-    auto value_iter = phase_iter->second.find(region_id);
-    if (value_iter == phase_iter->second.end())
-        return false;
-
-    return true;
+    return phase_iter->second.find(region_id) != phase_iter->second.end();
 }
 
-bool Inplace::has(Phase phase) const {
+bool Inplace::has(Phase phase) const
+{
     return this->has(FIELD_NAME, phase, FIELD_ID);
 }
 
-namespace {
-std::size_t region_max(const std::unordered_map<std::size_t, double>& region_map) {
-    std::size_t max_value = 0;
-    for (const auto& [region_id, _] : region_map) {
-        (void)_;
-        max_value = std::max(max_value, region_id);
-    }
-    return max_value;
-}
+std::size_t Inplace::max_region() const
+{
+    return std::accumulate(this->phase_values.begin(), this->phase_values.end(), std::size_t{0},
+                           [](const std::size_t max, const auto& phase_map)
+                           {
+                               return std::max(max, phase_region_max(phase_map.second));
+                           });
 }
 
-std::size_t Inplace::max_region() const {
-    std::size_t max_value = 0;
-    for (const auto& [_, phase_map] : this->phase_values) {
-        (void)_;
-        for (const auto& [__, region_map] : phase_map) {
-            (void)__;
-            max_value = std::max(max_value, region_max(region_map));
-        }
-    }
-
-    return max_value;
-}
-
-std::size_t Inplace::max_region(const std::string& region_name) const {
-    std::optional<std::size_t> max_value;
-    const auto& region_iter = this->phase_values.find(region_name);
-    if (region_iter != this->phase_values.end()) {
-        max_value = 0;
-        for (const auto& [_, region_map] : region_iter->second) {
-            (void)_;
-            max_value = std::max(*max_value, region_max(region_map));
-        }
-    }
-
-    if (!max_value.has_value())
+std::size_t Inplace::max_region(const std::string& region_name) const
+{
+    auto region_iter = this->phase_values.find(region_name);
+    if (region_iter == this->phase_values.end()) {
         throw std::logic_error(fmt::format("No such region: {}", region_name));
+    }
 
-    return max_value.value();
+    return phase_region_max(region_iter->second);
 }
-
 
 // This should probably die - temporarily added for porting of ecloutputblackoilmodule
-std::vector<double> Inplace::get_vector(const std::string& region, Phase phase) const {
+std::vector<double> Inplace::get_vector(const std::string& region, Phase phase) const
+{
     std::vector<double> v(this->max_region(region), 0);
     const auto& region_map = this->phase_values.at(region).at(phase);
     for (const auto& [region_id, value] : region_map)
@@ -140,12 +159,20 @@ std::vector<double> Inplace::get_vector(const std::string& region, Phase phase) 
     return v;
 }
 
-
-const std::vector<Inplace::Phase>& Inplace::phases() {
-    static const std::vector<Phase> phases_ = {
+const std::vector<Inplace::Phase>& Inplace::phases()
+{
+    static const auto phases_ = append(std::vector {
         Inplace::Phase::WATER,
         Inplace::Phase::OIL,
         Inplace::Phase::GAS,
+        }, mixingPhases());
+
+    return phases_;
+}
+
+const std::vector<Inplace::Phase>& Inplace::mixingPhases()
+{
+    static const auto mixingPhases_ = std::vector {
         Inplace::Phase::OilInLiquidPhase,
         Inplace::Phase::OilInGasPhase,
         Inplace::Phase::GasInLiquidPhase,
@@ -167,7 +194,7 @@ const std::vector<Inplace::Phase>& Inplace::phases() {
         Inplace::Phase::CO2MassInGasPhaseMob,
     };
 
-    return phases_;
+    return mixingPhases_;
 }
 
 bool Inplace::operator==(const Inplace& rhs) const
@@ -175,4 +202,4 @@ bool Inplace::operator==(const Inplace& rhs) const
     return this->phase_values == rhs.phase_values;
 }
 
-}
+} // namespace Opm

--- a/opm/output/eclipse/Inplace.hpp
+++ b/opm/output/eclipse/Inplace.hpp
@@ -69,18 +69,99 @@ public:
         CO2MassInGasPhaseMob = 25,
     };
 
+    /// Create non-defaulted object suitable for testing the serialisation
+    /// operation.
     static Inplace serializationTestObject();
 
-    void add(const std::string& region, Phase phase, std::size_t region_number, double value);
+    /// Assign value of particular quantity in specific region of named
+    /// region set.
+    ///
+    /// \param[in] region Region set name such as FIPNUM or FIPABC.
+    ///
+    /// \param[in] phase In-place quantity.
+    ///
+    /// \param[in] region_number Region ID for which to assign a new
+    ///   in-place quantity value.
+    ///
+    /// \param[in] value Numerical value of \p phase quantity in \p
+    ///   region_number region of \p region region set.
+    void add(const std::string& region,
+             Phase              phase,
+             std::size_t        region_number,
+             double             value);
+
+    /// Assign field-level value of particular quantity.
+    ///
+    /// \param[in] phase In-place quantity.
+    ///
+    /// \param[in] value Numerical value of field-level \p phase quantity.
     void add(Phase phase, double value);
 
-    double get(const std::string& region, Phase phase, std::size_t region_number) const;
+    /// Retrieve numerical value of particular quantity in specific region
+    /// of named region set.
+    ///
+    /// This function will throw an exception if the requested value has not
+    /// been assigned in a previous call to add().
+    ///
+    /// \param[in] region Region set name such as FIPNUM or FIPABC.
+    ///
+    /// \param[in] phase In-place quantity.
+    ///
+    /// \param[in] region_number Region ID for which to retrieve a the
+    ///   in-place quantity value.
+    ///
+    /// \return Numerical value of \p phase quantity in \p region_number
+    ///   region of \p region region set.
+    double get(const std::string& region,
+               Phase              phase,
+               std::size_t        region_number) const;
+
+    /// Retrieve field-level value of particular quantity.
+    ///
+    /// This function will throw an exception if the requested value has not
+    /// been assigned in a previous call to add().
+    ///
+    /// \param[in] phase In-place quantity.
+    ///
+    /// \return Numerical value of field-level \p phase quantity.
     double get(Phase phase) const;
 
-    bool has(const std::string& region, Phase phase, std::size_t region_number) const;
+    /// Check existence of particular quantity in specific region of named
+    /// region set.
+    ///
+    /// \param[in] region Region set name such as FIPNUM or FIPABC.
+    ///
+    /// \param[in] phase In-place quantity.
+    ///
+    /// \param[in] region_number Region ID for which to check existence of
+    ///   the in-place quantity value.
+    ///
+    /// \return Whether or not a value of the specific quantity exists in
+    ///   the specific region of the named region set.
+    bool has(const std::string& region,
+             Phase              phase,
+             std::size_t        region_number) const;
+
+    /// Check existence of specific field-level quantity.
+    ///
+    /// \param[in] phase In-place quantity.
+    ///
+    /// \return Whether or not a value of the specific quantity exists at
+    ///   field level.
     bool has(Phase phase) const;
 
+    /// Retrieve the maximum region ID registered across all quantities in
+    /// all registered region sets.
     std::size_t max_region() const;
+
+    /// Retrieve the maximum region ID across all quantities registered for
+    /// a specific region set.
+    ///
+    /// \param[in] region_name Region set name such as FIPNUM or FIPABC.
+    ///
+    /// \return Maximum region ID across all quantities registered for \p
+    ///   region_name.  Zero if \p region_name does not have any registered
+    ///   quantities in this in-place quantity collection.
     std::size_t max_region(const std::string& region_name) const;
 
     /// Linearised per-region values for a given phase in a specific region
@@ -97,15 +178,31 @@ public:
     std::vector<double>
     get_vector(const std::string& region, Phase phase) const;
 
+    /// Get iterable list of all quantities which can be handled/updated in
+    /// a generic way.
     static const std::vector<Phase>& phases();
+
+    /// Get iterable list of all quantities, other than "pure" phases, which
+    /// can be handled/updated in a generic way.
     static const std::vector<Phase>& mixingPhases();
 
+    /// Serialisation interface.
+    ///
+    /// \tparam Serializer Object serialisation protocol implementation
+    ///
+    /// \param[in,out] serializer Serialisation object
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
         serializer(phase_values);
     }
 
+    /// Equality predicate.
+    ///
+    /// \param[in] rhs Object against which \c *this will be compared for
+    /// equality.
+    ///
+    /// \return Whether or not \c *this equals \p rhs.
     bool operator==(const Inplace& rhs) const;
 
 private:
@@ -113,6 +210,8 @@ private:
     using PhaseMap = std::unordered_map<Phase, ValueMap>;
     using RegionMap = std::unordered_map<std::string, PhaseMap>;
 
+    /// Numerical values of all registered quantities in all registered
+    /// region sets.
     RegionMap phase_values{};
 };
 

--- a/opm/output/eclipse/Inplace.hpp
+++ b/opm/output/eclipse/Inplace.hpp
@@ -20,35 +20,40 @@
 #ifndef ORIGINAL_OIP
 #define ORIGINAL_OIP
 
+#include <cstddef>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 namespace Opm {
 
-
-class Inplace {
+// The purpose of this class is to transport in-place values from the
+// simulator code to the summary output code.  The code is written very much
+// to fit in with the current implementation in the simulator.  Note that
+// the functions which don't take both a region name and a region number
+// argument are intended for totals, i.e., field-level values.
+class Inplace
+{
 public:
-
+    // The Inplace class is implemented in close relation to the black-oil
+    // output module in opm-simulators.  There are certain idiosyncracies
+    // here which are due to that coupling.  For instance the enum values
+    // PressurePV, HydroCarbonPV, PressureHydroCarbonPV, and
+    // DynamicPoreVolume are *not* included in the return value from
+    // phases().
     enum class Phase {
-        WATER = 0,
-        OIL = 1,
-        GAS = 2,
+        WATER = 0,              // Omitted from mixingPhases()
+        OIL = 1,                // Omitted from mixingPhases()
+        GAS = 2,                // Omitted from mixingPhases()
         OilInLiquidPhase = 3,
         OilInGasPhase = 4,
         GasInLiquidPhase = 5,
         GasInGasPhase = 6,
         PoreVolume = 7,
-        // The Inplace class is implemented in close relation to the
-        // ecloutputblackoilmodule in opm-simulators, ane there are
-        // certainly idiosyncracies here due to that coupling. For instance
-        // the enum values PressurePV, HydroCarbonPV, PressureHydroCarbonPV,
-        // and DynamicPoreVolume are *not* included in the return value from
-        // phases().
-        PressurePV = 8,
-        HydroCarbonPV = 9,
-        PressureHydroCarbonPV = 10,
-        DynamicPoreVolume = 11,
+        PressurePV = 8,             // Omitted from both phases() and mixingPhases()
+        HydroCarbonPV = 9,          // Omitted from both phases() and mixingPhases()
+        PressureHydroCarbonPV = 10, // Omitted from both phases() and mixingPhases()
+        DynamicPoreVolume = 11,     // Omitted from both phases() and mixingPhases()
         WaterResVolume = 12,
         OilResVolume = 13,
         GasResVolume = 14,
@@ -65,14 +70,6 @@ public:
         CO2MassInGasPhaseMob = 25,
     };
 
-    /*
-      The purpose of this class is to transport inplace values from the
-      simulator code to the summary output code. The code is written very much
-      to fit in with the current implementation in the simulator. The functions
-      which don't accept region_name & region_number arguments should be called
-      for totals, i.e. field properties.
-    */
-
     static Inplace serializationTestObject();
 
     void add(const std::string& region, Phase phase, std::size_t region_number, double value);
@@ -87,15 +84,14 @@ public:
     std::size_t max_region() const;
     std::size_t max_region(const std::string& region_name) const;
 
-    /*
-      The get_vector functions return a vector length max_region() which
-      contains the values added with the add() function and indexed with
-      (region_number - 1). This is an incarnation of id <-> index confusion and
-      should be replaced with a std::map instead.
-    */
+    // The get_vector functions return a vector length max_region() which
+    // contains the values added with the add() function and indexed with
+    // (region_number - 1). This is an incarnation of id <-> index confusion
+    // and should be replaced with a std::map instead.
     std::vector<double> get_vector(const std::string& region, Phase phase) const;
 
     static const std::vector<Phase>& phases();
+    static const std::vector<Phase>& mixingPhases();
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -109,7 +105,6 @@ private:
     std::unordered_map<std::string, std::unordered_map<Phase, std::unordered_map<std::size_t, double>>> phase_values;
 };
 
+} // namespace Opm
 
-}
-
-#endif
+#endif // ORIGINAL_OIP

--- a/tests/test_Inplace.cpp
+++ b/tests/test_Inplace.cpp
@@ -20,25 +20,29 @@
 #define BOOST_TEST_MODULE Inplace
 #include <boost/test/unit_test.hpp>
 
-
-
 #include <opm/output/eclipse/Inplace.hpp>
+
+#include <stdexcept>
+#include <vector>
 
 using namespace Opm;
 
+namespace {
 
-bool contains(const std::vector<Inplace::Phase>& phases, Inplace::Phase phase) {
+bool contains(const std::vector<Inplace::Phase>& phases, Inplace::Phase phase)
+{
     auto find_iter = std::find(phases.begin(), phases.end(), phase);
     return find_iter != phases.end();
 }
 
+} // Anonymous namespace
 
-BOOST_AUTO_TEST_CASE(TESTInplace) {
+BOOST_AUTO_TEST_CASE(TESTInplace)
+{
     Inplace oip;
 
     oip.add("FIPNUM", Inplace::Phase::OIL, 3, 100);
     oip.add("FIPNUM", Inplace::Phase::OIL, 6, 50);
-
 
     BOOST_CHECK_EQUAL( oip.get("FIPNUM", Inplace::Phase::OIL, 3) , 100);
     BOOST_CHECK_EQUAL( oip.get("FIPNUM", Inplace::Phase::OIL, 6) , 50);
@@ -46,7 +50,6 @@ BOOST_AUTO_TEST_CASE(TESTInplace) {
     BOOST_CHECK_THROW( oip.get("FIPNUM", Inplace::Phase::OIL, 4), std::exception);
     BOOST_CHECK_THROW( oip.get("FIPNUM", Inplace::Phase::GAS, 3), std::exception);
     BOOST_CHECK_THROW( oip.get("FIPX", Inplace::Phase::OIL, 3)  , std::exception);
-
 
     BOOST_CHECK_EQUAL( oip.max_region(), 6);
     BOOST_CHECK_EQUAL( oip.max_region("FIPNUM"), 6);
@@ -56,19 +59,175 @@ BOOST_AUTO_TEST_CASE(TESTInplace) {
     BOOST_CHECK_EQUAL( oip.get(Inplace::Phase::GAS) , 100);
     BOOST_CHECK_THROW( oip.get(Inplace::Phase::OIL), std::exception);
 
+    {
+        const auto v1 = oip.get_vector("FIPNUM", Inplace::Phase::OIL);
+        const std::vector<double> e1 = {0,0,100,0,0,50};
+        BOOST_CHECK_MESSAGE(v1 == e1, "In-place oil content must match expected");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(InPlace_Phases)
+{
     const auto& phases = Inplace::phases();
-    BOOST_CHECK(contains(phases, Inplace::Phase::WATER));
-    BOOST_CHECK(contains(phases, Inplace::Phase::OIL));
-    BOOST_CHECK(contains(phases, Inplace::Phase::GAS));
-    BOOST_CHECK(contains(phases, Inplace::Phase::OilInLiquidPhase));
-    BOOST_CHECK(contains(phases, Inplace::Phase::OilInGasPhase));
-    BOOST_CHECK(contains(phases, Inplace::Phase::GasInLiquidPhase));
-    BOOST_CHECK(contains(phases, Inplace::Phase::GasInGasPhase));
-    BOOST_CHECK(contains(phases, Inplace::Phase::PoreVolume));
 
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::WATER),
+                        R"(phases() must have "WATER")");
 
-    auto v1 = oip.get_vector("FIPNUM", Inplace::Phase::OIL);
-    std::vector<double> e1 = {0,0,100,0,0,50};
-    BOOST_CHECK( v1 == e1 );
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::OIL),
+                        R"(phases() must have "OIL")");
 
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::GAS),
+                        R"(phases() must have "GAS")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::OilInLiquidPhase),
+                        R"(phases() must have "OilInLiquidPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::OilInGasPhase),
+                        R"(phases() must have "OilInGasPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::GasInLiquidPhase),
+                        R"(phases() must have "GasInLiquidPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::GasInGasPhase),
+                        R"(phases() must have "GasInGasPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::PoreVolume),
+                        R"(phases() must have "PoreVolume")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::PressurePV),
+                        R"(phases() must NOT have "PressurePV")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::HydroCarbonPV),
+                        R"(phases() must NOT have "HydroCarbonPV")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::PressureHydroCarbonPV),
+                        R"(phases() must NOT have "PressureHydroCarbonPV")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::DynamicPoreVolume),
+                        R"(phases() must NOT have "DynamicPoreVolume")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::WaterResVolume),
+                        R"(phases() must have "WaterResVolume")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::OilResVolume),
+                        R"(phases() must have "OilResVolume")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::GasResVolume),
+                        R"(phases() must have "GasResVolume")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::SALT),
+                        R"(phases() must have "SALT")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2InWaterPhase),
+                        R"(phases() must have "CO2InWaterPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2InGasPhaseInMob),
+                        R"(phases() must have "CO2InGasPhaseInMob")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2InGasPhaseMob),
+                        R"(phases() must have "CO2InGasPhaseMob")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::WaterInGasPhase),
+                        R"(phases() must have "WaterInGasPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::WaterInWaterPhase),
+                        R"(phases() must have "WaterInWaterPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2Mass),
+                        R"(phases() must have "CO2Mass")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2MassInWaterPhase),
+                        R"(phases() must have "CO2MassInWaterPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2MassInGasPhase),
+                        R"(phases() must have "CO2MassInGasPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2MassInGasPhaseInMob),
+                        R"(phases() must have "CO2MassInGasPhaseInMob")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2MassInGasPhaseMob),
+                        R"(phases() must have "CO2MassInGasPhaseMob")");
+}
+
+BOOST_AUTO_TEST_CASE(InPlace_Mixing_Phases)
+{
+    const auto& phases = Inplace::mixingPhases();
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::WATER),
+                        R"(mixingPhases() must NOT have "WATER")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::OIL),
+                        R"(mixingPhases() must NOT have "OIL")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::GAS),
+                        R"(mixingPhases() must NOT have "GAS")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::OilInLiquidPhase),
+                        R"(mixingPhases() must have "OilInLiquidPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::OilInGasPhase),
+                        R"(mixingPhases() must have "OilInGasPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::GasInLiquidPhase),
+                        R"(mixingPhases() must have "GasInLiquidPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::GasInGasPhase),
+                        R"(mixingPhases() must have "GasInGasPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::PoreVolume),
+                        R"(mixingPhases() must have "PoreVolume")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::PressurePV),
+                        R"(mixingPhases() must NOT have "PressurePV")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::HydroCarbonPV),
+                        R"(mixingPhases() must NOT have "HydroCarbonPV")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::PressureHydroCarbonPV),
+                        R"(mixingPhases() must NOT have "PressureHydroCarbonPV")");
+
+    BOOST_CHECK_MESSAGE(! contains(phases, Inplace::Phase::DynamicPoreVolume),
+                        R"(mixingPhases() must NOT have "DynamicPoreVolume")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::WaterResVolume),
+                        R"(mixingPhases() must have "WaterResVolume")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::OilResVolume),
+                        R"(mixingPhases() must have "OilResVolume")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::GasResVolume),
+                        R"(mixingPhases() must have "GasResVolume")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::SALT),
+                        R"(mixingPhases() must have "SALT")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2InWaterPhase),
+                        R"(mixingPhases() must have "CO2InWaterPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2InGasPhaseInMob),
+                        R"(mixingPhases() must have "CO2InGasPhaseInMob")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2InGasPhaseMob),
+                        R"(mixingPhases() must have "CO2InGasPhaseMob")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::WaterInGasPhase),
+                        R"(mixingPhases() must have "WaterInGasPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::WaterInWaterPhase),
+                        R"(mixingPhases() must have "WaterInWaterPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2Mass),
+                        R"(mixingPhases() must have "CO2Mass")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2MassInWaterPhase),
+                        R"(mixingPhases() must have "CO2MassInWaterPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2MassInGasPhase),
+                        R"(mixingPhases() must have "CO2MassInGasPhase")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2MassInGasPhaseInMob),
+                        R"(mixingPhases() must have "CO2MassInGasPhaseInMob")");
+
+    BOOST_CHECK_MESSAGE(contains(phases, Inplace::Phase::CO2MassInGasPhaseMob),
+                        R"(mixingPhases() must have "CO2MassInGasPhaseMob")");
 }


### PR DESCRIPTION
The pure phases are treated differently from the others in the context of per-cell restart file output (result arrays `FIP*`, `RFIP*`, and `SFIP*`) so we should have a way excluding those from the general handling.  To this end, introduce a new helper function,
```
Inplace::mixingPhases()
```
which returns the list of known "phases" apart from the OIL, WATER, and GAS cases.  We then reimplement the helper function `phases()` in terms of `mixingPhases()`.