### PR TITLE
Make sure TSINIT of TUNING only applies to one report step.

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -746,6 +746,12 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
         return update;
     }
 
+    void Schedule::clear_event(ScheduleEvents::Events event, std::size_t report_step) {
+        auto events = this->snapshots[report_step].events();
+        events.clearEvent(event);
+        this->snapshots[report_step].update_events(events);
+    }
+
 
     bool Schedule::updateWPAVE(const std::string& wname, std::size_t report_step, const PAvg& pavg) {
         const auto& well = this->getWell(wname, report_step);

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -205,6 +205,7 @@ namespace Opm
         void shut_well(const std::string& well_name, std::size_t report_step);
         void stop_well(const std::string& well_name, std::size_t report_step);
         void open_well(const std::string& well_name, std::size_t report_step);
+        void clear_event(ScheduleEvents::Events, std::size_t report_step);
         void applyWellProdIndexScaling(const std::string& well_name, const std::size_t reportStep, const double scalingFactor);
 
         std::vector<const Group*> getChildGroups2(const std::string& group_name, std::size_t timeStep) const;

--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -147,9 +147,15 @@ ScheduleState::ScheduleState(const ScheduleState& src, const time_point& start_t
         if (!this->next_tstep->every_report()) {
             this->next_tstep = std::nullopt;
         }
-    // Need to signal an event also for the persistance to take effect
-    this->events().addEvent(ScheduleEvents::TUNING_CHANGE);
+        // Need to signal an event also for the persistance to take effect
+        this->events().addEvent(ScheduleEvents::TUNING_CHANGE);
     }
+
+    // TSINIT from TUNING should only apply to one report step, but TUNING
+    // was copied from last ScheduleState. If that has TSINIT set then
+    // the first time step would be limited if a TUNING_CHANGE event happens
+    // e.g. because of above or because of NEXTSTEP in ACTIONX
+    this->m_tuning.TSINIT.reset();
 
     {
         auto new_udq = this->udq();

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -6028,3 +6028,31 @@ SOURCE
                       schedule.getUnits().to_si("Mass/Time", 0.01));
     }
 }
+
+BOOST_AUTO_TEST_CASE(clearEvent) {
+    std::string input = R"(
+START             -- 0
+19 JUN 2007 /
+
+SOLUTION
+
+SCHEDULE
+DATES             -- 1
+ 10  OKT 2008 /
+/
+
+NEXTSTEP
+ 10 /
+
+DATES             -- 1
+ 10  NOV 2008 /
+/
+)";
+    
+    auto schedule = make_schedule(input);
+    BOOST_CHECK(schedule[1].events().hasEvent(ScheduleEvents::TUNING_CHANGE));
+    // TUNING_CHANGE because NEXTSTEP cleared
+    BOOST_CHECK(schedule[2].events().hasEvent(ScheduleEvents::TUNING_CHANGE));
+    schedule.clear_event(ScheduleEvents::TUNING_CHANGE, 1);
+    BOOST_CHECK(!schedule[1].events().hasEvent(ScheduleEvents::TUNING_CHANGE));
+}

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
       BOOST_CHECK(event.hasEvent(ScheduleEvents::TUNING_CHANGE));
 
       /* Assume --enable-tuning=true, so the next time step spec in TUNING has an effect */
-      BOOST_CHECK_CLOSE(schedule[timestep].max_next_tstep(true), 2*Metric::Time, diff);
+      BOOST_CHECK_CLOSE(schedule[timestep].max_next_tstep(true), -1.0, diff);
   }
 
   /*** TIMESTEP 10 ***/

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
       // Because NEXTSTEP is persistent a tuning event is triggered at each report step
       BOOST_CHECK(event.hasEvent(ScheduleEvents::TUNING_CHANGE));
 
-			const auto& tuning = schedule[timestep].tuning();
+      const auto& tuning = schedule[timestep].tuning();
       std::optional<double> TSINIT_default = tuning.TSINIT;
       BOOST_CHECK(TSINIT_default == std::nullopt);
 


### PR DESCRIPTION
If there was a TUNING keyword recorded then it will also be part of all ScheduleState for later report steps. This becomes a problem for TSINIT which should only apply to one report step if another TUNING_EVENT happens.

Based on #3949 for convenience.