### PR TITLE
[fix] Use minimum positive value of competing max initial time steps.

### DIFF
--- a/opm/input/eclipse/Schedule/ScheduleState.cpp
+++ b/opm/input/eclipse/Schedule/ScheduleState.cpp
@@ -382,7 +382,11 @@ Tuning& ScheduleState::tuning() {
 double ScheduleState::max_next_tstep(const bool enableTUNING) const {
     double tuning_value = (enableTUNING && this->m_tuning.TSINIT.has_value())  ? this->m_tuning.TSINIT.value() : -1.0;
     double next_value = this->next_tstep.has_value() ? this->next_tstep->value() : -1.0;
-    return std::max(next_value, tuning_value);
+    if (tuning_value > -1 and next_value > -1) {
+        return std::min(next_value, tuning_value);
+    } else {
+        return std::max(next_value, tuning_value);
+    }
 }
 
 void ScheduleState::update_events(Events events) {

--- a/tests/parser/TuningTests.cpp
+++ b/tests/parser/TuningTests.cpp
@@ -73,6 +73,26 @@ TUNING
 /
 WSEGITER
 /
+
+DATES
+1 FEB 1982 13:55:44 /  -- 11
+/
+TUNING
+2 300 0.3 0.30 6 0.6 0.2 2.25 2E20 10.0/
+/
+/
+NEXTSTEP
+ 1 /
+
+DATES
+10 FEB 1982 13:55:44 /  -- 12
+/
+TUNING
+1 300 0.3 0.30 6 0.6 0.2 2.25 2E20 10.0/
+/
+/
+NEXTSTEP
+ 2 /
 )";
 
 
@@ -378,4 +398,16 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
       BOOST_CHECK_EQUAL(NEWTMX, 13);     
 
   }
+  /*** TIMESTEP 11 ***/
+  {
+      std::size_t timestep = 11;
+      BOOST_CHECK_CLOSE(schedule[timestep].max_next_tstep(true), 1.0 * Metric::Time, diff);
+      BOOST_CHECK_CLOSE(schedule[timestep].max_next_tstep(false), 1.0 * Metric::Time, diff);
+  }
+  /*** TIMESTEP 12 ***/
+  {
+      std::size_t timestep = 12;
+      BOOST_CHECK_CLOSE(schedule[timestep].max_next_tstep(true), 1.0 * Metric::Time, diff);
+      BOOST_CHECK_CLOSE(schedule[timestep].max_next_tstep(false), 2.0 * Metric::Time, diff);
+  } 
 }


### PR DESCRIPTION
This can happen if both TUNING and NEXTSTEP are used. In this case the smaller positive value should be used.