### PR TITLE
Add Container for Datum Depths From Simulation Input

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -148,6 +148,7 @@ if(ENABLE_ECL_INPUT)
     opm/input/eclipse/EclipseState/IOConfig/FIPConfig.cpp
     opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
     opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.cpp
+    opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.cpp
     opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.cpp
     opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
     opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -481,6 +482,7 @@ if(ENABLE_ECL_INPUT)
     tests/test_ActiveGridCells.cpp
     tests/test_CopyablePtr.cpp
     tests/test_CSRGraphFromCoordinates.cpp
+    tests/test_DatumDepth.cpp
     tests/test_ERsm.cpp
     tests/test_GuideRate.cpp
     tests/test_RestartFileView.cpp
@@ -1321,10 +1323,11 @@ if(ENABLE_ECL_INPUT)
        opm/input/eclipse/Schedule/MSW/WellSegments.hpp
        opm/input/eclipse/Schedule/MSW/AICD.hpp
        opm/input/eclipse/Schedule/MSW/SICD.hpp
-       opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
        opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp
+       opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp
        opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp
        opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+       opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
        opm/input/eclipse/Schedule/MSW/Valve.hpp
        opm/input/eclipse/EclipseState/IOConfig/FIPConfig.hpp
        opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp

--- a/opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.cpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.cpp
@@ -1,0 +1,342 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp>
+
+#include <opm/common/ErrorMacros.hpp>
+
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+
+#include <opm/input/eclipse/Parser/ParserKeywords/D.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/E.hpp>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+// ===========================================================================
+
+Opm::DatumDepth::Global::Global(const SOLUTIONSection& soln)
+{
+    if (soln.hasKeyword<ParserKeywords::DATUM>()) {
+        // Keyword DATUM entered in SOLUTION section.  Use global datum
+        // depth from there.
+        this->depth_ = soln.get<ParserKeywords::DATUM>()
+            .back()
+            .getRecord(0)
+            .getItem<ParserKeywords::DATUM::DEPTH>()
+            .getSIDouble(0);
+    }
+    else {
+        // Keyword DATUM not entered in SOLUTION section, but EQUIL exists
+        // in the model.  Global datum depth is first equilibration region's
+        // datum depth (item 1).
+
+        assert (soln.hasKeyword<ParserKeywords::EQUIL>());
+
+        this->depth_ = soln.get<ParserKeywords::EQUIL>()
+            .back()
+            .getRecord(0)
+            .getItem<ParserKeywords::EQUIL::DATUM_DEPTH>()
+            .getSIDouble(0);
+    }
+}
+
+Opm::DatumDepth::Global
+Opm::DatumDepth::Global::serializationTestObject()
+{
+    auto g = Global{};
+    g.depth_ = 1234.56;
+
+    return g;
+}
+
+// ---------------------------------------------------------------------------
+
+namespace {
+    const std::vector<double>&
+    datumDepthVector(const Opm::DeckKeyword& datum)
+    {
+        return datum.getRecord(0)
+            .getItem<Opm::ParserKeywords::DATUMR::data>()
+            .getSIDoubleData();
+    }
+
+    const std::vector<double>&
+    datumRDepthVector(const Opm::SOLUTIONSection& soln)
+    {
+        return datumDepthVector(soln.get<Opm::ParserKeywords::DATUMR>().back());
+    }
+}
+
+Opm::DatumDepth::DefaultRegion::DefaultRegion(const SOLUTIONSection& soln)
+    : depth_ { datumRDepthVector(soln) }
+{}
+
+Opm::DatumDepth::DefaultRegion
+Opm::DatumDepth::DefaultRegion::serializationTestObject()
+{
+    auto d = DefaultRegion{};
+
+    d.depth_ = { 123.45, 678.91 };
+
+    return d;
+}
+
+// ---------------------------------------------------------------------------
+
+namespace {
+
+    bool allBlank(std::string_view s)
+    {
+        return s.empty() ||
+            std::all_of(s.begin(), s.end(),
+                        [](const unsigned char c)
+                        { return std::isspace(c); });
+    }
+
+    // Trim initial "FIP" prefix
+    std::string_view normaliseRSetName(std::string_view rset)
+    {
+        return (rset.find("FIP") == std::string_view::size_type{0})
+            ? rset.substr(3) : rset;
+    }
+
+    /// Bring all DATUMRX record into a single map<>
+    std::unordered_map<std::string, std::vector<double>>
+    normaliseDatumRX(const Opm::SOLUTIONSection& soln)
+    {
+        using Kw = Opm::ParserKeywords::DATUMRX;
+
+        auto depth = std::unordered_map<std::string, std::vector<double>>{};
+
+        for (const auto& datumrx : soln.get<Kw>()) {
+            for (const auto& record : datumrx) {
+                const auto& rsetItem = record.getItem<Kw::REGION_FAMILY>();
+                const auto& rset =
+                    (rsetItem.defaultApplied(0) ||
+                     allBlank(rsetItem.get<std::string>(0)))
+                    ? "NUM"     // FIPNUM
+                    : std::string { normaliseRSetName(rsetItem.getTrimmedString(0)) };
+
+                depth.insert_or_assign(rset, record.getItem(1).getSIDoubleData());
+            }
+        }
+
+        return depth;
+    }
+
+    /// Internalise DATUMR information as fallback for DATUMRX
+    std::vector<double> datumRXDefault(const Opm::SOLUTIONSection& soln)
+    {
+        const auto datumR_ix = soln.index(Opm::ParserKeywords::DATUMR::keywordName);
+        if (! datumR_ix.empty() &&
+            (datumR_ix.back() < soln.index(Opm::ParserKeywords::DATUMRX::keywordName).front()))
+        {
+            return datumDepthVector(soln[datumR_ix.back()]);
+        }
+
+        // No fall-back DATUMR vector exists.
+        return {};
+    }
+
+    /// Build internal representation of DATUMRX information.
+    ///
+    /// \param[in] soln SOLUTION section information
+    ///
+    /// \return Internal representation
+    ///
+    ///   - get<0> Normalised region set names (FIP prefix dropped)
+    ///   - get<1> Start pointers for each region set
+    ///   - get<2> Linearised datum depths for all regions in all region sets
+    ///   - get<3> Fallback per-region datum depths
+    std::tuple<std::vector<std::string>,
+               std::vector<std::vector<double>::size_type>,
+               std::vector<double>,
+               std::vector<double>>
+    internaliseDatumRX(const Opm::SOLUTIONSection& soln)
+    {
+        auto rsetNames = std::vector<std::string>{};
+        auto rsetStart = std::vector<std::vector<double>::size_type>{};
+        auto depth = std::vector<double>{};
+
+        rsetStart.push_back(0);
+        for (const auto& [rset, rset_depth] : normaliseDatumRX(soln)) {
+            rsetNames.push_back(rset);
+            depth.insert(depth.end(), rset_depth.begin(), rset_depth.end());
+            rsetStart.push_back(depth.size());
+        }
+
+        return {
+            std::move(rsetNames),
+            std::move(rsetStart),
+            std::move(depth),
+            datumRXDefault(soln)
+        };
+    }
+}
+
+Opm::DatumDepth::UserDefined::UserDefined(const SOLUTIONSection& soln)
+{
+    std::tie(this->rsetNames_,
+             this->rsetStart_,
+             this->depth_,
+             this->default_) = internaliseDatumRX(soln);
+
+    /// Build name->index lookup table.  Sort indexes alphabetically by
+    /// region set names.
+    this->rsetIndex_.resize(this->rsetNames_.size());
+    std::iota(this->rsetIndex_.begin(), this->rsetIndex_.end(),
+              std::vector<double>::size_type{0});
+
+    std::sort(this->rsetIndex_.begin(), this->rsetIndex_.end(),
+              [this](const auto i1, const auto i2)
+              {
+                  return this->rsetNames_[i1] < this->rsetNames_[i2];
+              });
+}
+
+Opm::DatumDepth::UserDefined
+Opm::DatumDepth::UserDefined::serializationTestObject()
+{
+    using namespace std::string_literals;
+
+    auto u = UserDefined{};
+
+    u.rsetNames_ = { "NUM"s, "ABC"s, "UNIT"s };
+    u.rsetStart_ = { 0, 1, 2, 3, };
+    u.depth_ = { 17.29, 2.718, -3.1415, };
+    u.default_ = { 355.113, };
+    u.rsetIndex_ = { 1, 0, 2, };
+
+    return u;
+}
+
+double
+Opm::DatumDepth::UserDefined::operator()(std::string_view rset, const int region) const
+{
+    auto canonicalRSet = normaliseRSetName(rset);
+
+    auto ixPos = std::lower_bound(this->rsetIndex_.begin(), this->rsetIndex_.end(),
+                                  canonicalRSet,
+                                  [this](const auto i, std::string_view rsName)
+                                  {
+                                      return this->rsetNames_[i] < rsName;
+                                  });
+
+    if ((ixPos == this->rsetIndex_.end()) || (this->rsetNames_[*ixPos] != canonicalRSet)) {
+        // Rset not among those explicitly defined in the DATUMRX input.
+        // Fall back to the default per-region datum depths from DATUMR.
+        return this->depthValue(rset, this->default_.begin(), this->default_.end(), region);
+    }
+
+    auto begin = this->depth_.begin() + this->rsetStart_[*ixPos + 0];
+    auto end   = this->depth_.begin() + this->rsetStart_[*ixPos + 1];
+
+    return this->depthValue(rset, begin, end, region);
+}
+
+double
+Opm::DatumDepth::UserDefined::depthValue(std::string_view                           rset,
+                                         const std::vector<double>::const_iterator  begin,
+                                         const std::vector<double>::const_iterator  end,
+                                         const std::vector<double>::difference_type ix) const
+{
+    if (end == begin) {
+        const auto msg =
+            fmt::format("Region set {} does not have a "
+                        "valid entry in DATUMRX or "
+                        "fallback datum depths (DATUMR) "
+                        "are not available", rset);
+
+        OPM_THROW_NOLOG(std::invalid_argument, msg);
+    }
+
+    return (ix >= std::distance(begin, end))
+        ? *(end - 1)            // Regions beyond last get final value
+        : *(begin + ix);
+}
+
+// ===========================================================================
+
+Opm::DatumDepth::DatumDepth(const SOLUTIONSection& soln)
+{
+    // Please note that the case order is quite deliberate here; from most
+    // specific to least specific.  This is *mostly* because DATUMRX falls
+    // back to DATUMR for those region sets which are not explicitly defined
+    // in DATUMRX.  We defer that complexity to the UserDefined constructor.
+
+    if (soln.hasKeyword<ParserKeywords::DATUMRX>()) {
+        this->datum_.emplace<UserDefined>(soln);
+    }
+    else if (soln.hasKeyword<ParserKeywords::DATUMR>()) {
+        this->datum_.emplace<DefaultRegion>(soln);
+    }
+    else if (soln.hasKeyword<ParserKeywords::DATUM>() ||
+             soln.hasKeyword<ParserKeywords::EQUIL>())
+    {
+        this->datum_.emplace<Global>(soln);
+    }
+
+    // If neither of the above conditions trigger, then the datum depth for
+    // depth-corrected pressures (e.g., summary vector BPPO) is zero.  This
+    // corresponds to a default constructed first member of this->datum_ so
+    // there's no additional initialisation logic needed here.
+}
+
+Opm::DatumDepth
+Opm::DatumDepth::serializationTestObjectZero()
+{
+    return {};
+}
+
+Opm::DatumDepth
+Opm::DatumDepth::serializationTestObjectGlobal()
+{
+    auto d = DatumDepth{};
+    d.datum_ = Global::serializationTestObject();
+    return d;
+}
+
+Opm::DatumDepth
+Opm::DatumDepth::serializationTestObjectDefaultRegion()
+{
+    auto d = DatumDepth{};
+    d.datum_ = DefaultRegion::serializationTestObject();
+    return d;
+}
+
+Opm::DatumDepth
+Opm::DatumDepth::serializationTestObjectUserDefined()
+{
+    auto d = DatumDepth{};
+    d.datum_ = UserDefined::serializationTestObject();
+    return d;
+}

--- a/opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp
@@ -1,0 +1,389 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DATUM_DEPTH_HPP_INCLUDED
+#define DATUM_DEPTH_HPP_INCLUDED
+
+#include <cassert>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+/// Encapsulation of the DATUM* familiy of SOLUTION section keywords which
+/// specify depths against which to compute depth corrected cell (block),
+/// region, and field-level pressures/potentials.  This information goes
+/// into the definition of summary keywords [FRB]PP[OGW].
+
+namespace Opm {
+    class SOLUTIONSection;
+} // namespace Opm
+
+namespace Opm {
+
+    /// Wrapper class which handles the full familiy of datum depth
+    /// keywords.
+    class DatumDepth
+    {
+    public:
+        /// Default constructor.
+        DatumDepth() = default;
+
+        /// Constructor from SOLUTION section information
+        ///
+        /// \param[in] soln SOLUTION section container.
+        explicit DatumDepth(const SOLUTIONSection& soln);
+
+        /// Form serialisation test object for the case of no datum depth
+        /// (=> datum depth = zero).
+        static DatumDepth serializationTestObjectZero();
+
+        /// Form serialisation test object for the case of a single global
+        /// reference depth--either from the DATUM keyword or from the datum
+        /// depth of the first equilibration region.
+        static DatumDepth serializationTestObjectGlobal();
+
+        /// Form serialisation test object for the case of per-region
+        /// reference depths in the DATUMR keyword.  Tied to the standard
+        /// FIPNUM region set.
+        static DatumDepth serializationTestObjectDefaultRegion();
+
+        /// Form serialisation test object for the case of per-region
+        /// reference depth for user-defined region sets in the DATUMRX
+        /// keyword.
+        static DatumDepth serializationTestObjectUserDefined();
+
+        /// Retrieve datum depth in particular region of standard FIPNUM
+        /// region set.
+        ///
+        /// \param[in] region Zero-based region index.
+        ///
+        /// \return Datum/reference depth in region \p region of standard
+        ///   FIPNUM region set.
+        double operator()(const int region) const
+        {
+            return (*this)("FIPNUM", region);
+        }
+
+        /// Retrieve datum depth in particular region of named region set.
+        ///
+        /// \param[in] rset Region set name, e.g., FIPNUM.
+        ///
+        /// \param[in] region Zero-based region index.
+        ///
+        /// \return Datum/reference depth in region \p region of region set
+        /// \p rset.
+        double operator()(std::string_view rset, const int region) const
+        {
+            return std::visit([rset, region](const auto& datumDepthImpl)
+            { return datumDepthImpl(rset, region); }, this->datum_);
+        }
+
+        /// Equality predicate.
+        ///
+        /// \param[in] that Object against which \c *this will be compared
+        /// for equality.
+        ///
+        /// \return Whether or not \c *this equals \p that.
+        bool operator==(const DatumDepth& that) const
+        {
+            return this->datum_ == that.datum_;
+        }
+
+        /// Serialisation interface.
+        ///
+        /// \tparam Serializer Object serialisation protocol implementation
+        ///
+        /// \param[in,out] serializer Serialisation object
+        template <class Serializer>
+        void serializeOp(Serializer& serializer)
+        {
+            serializer(this->datum_);
+        }
+
+    private:
+        /// Neither DATUM* nor EQUIL specified => datum depth = 0
+        class Zero
+        {
+        public:
+            /// Retrieve datum depth.
+            ///
+            /// Always returns zero.
+            ///
+            /// \param[in] rset Region set name, e.g., FIPNUM.
+            ///
+            /// \param[in] region Zero-based region index.
+            ///
+            /// \return Datum/reference depth in region \p region of region
+            /// set \p rset (= 0).
+            double operator()([[maybe_unused]] std::string_view rset,
+                              [[maybe_unused]] const int        region) const
+            {
+                return 0.0;
+            }
+
+            /// Form serialisation test object.
+            static Zero serializationTestObject() { return {}; }
+
+            /// Equality predicate.
+            bool operator==(const Zero&) const { return true; }
+
+            /// Serialisation interface
+            ///
+            /// \tparam Serializer Object serialisation protocol
+            /// implementation
+            ///
+            /// \param[in,out] serializer Serialisation object
+            template <class Serializer>
+            void serializeOp([[maybe_unused]] Serializer& serializer)
+            {}                  // Nothing to do
+        };
+
+        /// Implementation of DATUM keyword with fallback to EQUIL
+        class Global
+        {
+        public:
+            /// Default constructor.
+            Global() = default;
+
+            /// Constructor from SOLUTION section information
+            ///
+            /// \param[in] soln SOLUTION section container.
+            explicit Global(const SOLUTIONSection& soln);
+
+            /// Retrieve datum depth.
+            ///
+            /// \param[in] rset Region set name, e.g., FIPNUM.
+            ///
+            /// \param[in] region Zero-based region index.
+            ///
+            /// \return Datum/reference depth in region \p region of region
+            /// set \p rset (= globally configured reference depth).
+            double operator()([[maybe_unused]] std::string_view rset,
+                              [[maybe_unused]] const int        region) const
+            {
+                return this->depth_;
+            }
+
+            /// Form serialisation test object.
+            static Global serializationTestObject();
+
+            /// Equality predicate.
+            ///
+            /// \param[in] that Object against which \c *this will be
+            /// compared for equality.
+            ///
+            /// \return Whether or not \c *this equals \p that.
+            bool operator==(const Global& that) const
+            {
+                return this->depth_ == that.depth_;
+            }
+
+            /// Serialisation interface
+            ///
+            /// \tparam Serializer Object serialisation protocol
+            /// implementation
+            ///
+            /// \param[in,out] serializer Serialisation object
+            template <class Serializer>
+            void serializeOp(Serializer& serializer)
+            {
+                serializer(this->depth_);
+            }
+
+        private:
+            /// Globally configured reference depth for all regions in all
+            /// region sets.
+            double depth_{};
+        };
+
+        /// Implementation of DATUMR keyword
+        class DefaultRegion
+        {
+        public:
+            /// Default constructor.
+            DefaultRegion() = default;
+
+            /// Constructor from SOLUTION section information
+            ///
+            /// \param[in] soln SOLUTION section container.
+            explicit DefaultRegion(const SOLUTIONSection& soln);
+
+            /// Form serialisation test object.
+            static DefaultRegion serializationTestObject();
+
+            /// Retrieve datum depth.
+            ///
+            /// \param[in] rset Region set name, e.g., FIPNUM.
+            ///
+            /// \param[in] region Zero-based region index.
+            ///
+            /// \return Datum/reference depth in region \p region of region
+            /// set \p rset.
+            double operator()([[maybe_unused]] std::string_view rset,
+                              const int region) const
+            {
+                assert (! this->depth_.empty());
+
+                // Note: depth_.back() is intentional for region >= size().
+                // If the input supplies fewer depth values than there are
+                // regions, then the remaining regions implicitly have the
+                // same datum depth as the last fully specified region.
+                return (region < static_cast<int>(this->depth_.size()))
+                    ? this->depth_[region] : this->depth_.back();
+            }
+
+            /// Equality predicate.
+            ///
+            /// \param[in] that Object against which \c *this will be
+            /// compared for equality.
+            ///
+            /// \return Whether or not \c *this equals \p that.
+            bool operator==(const DefaultRegion& that) const
+            {
+                return this->depth_ == that.depth_;
+            }
+
+            /// Serialisation interface
+            ///
+            /// \tparam Serializer Object serialisation protocol
+            /// implementation
+            ///
+            /// \param[in,out] serializer Serialisation object
+            template <class Serializer>
+            void serializeOp(Serializer& serializer)
+            {
+                serializer(this->depth_);
+            }
+
+        private:
+            /// Reference depths for all regions in default (FIPNUM) region
+            /// set.
+            std::vector<double> depth_{};
+        };
+
+        /// Implementation of DATUMRX keyword
+        class UserDefined
+        {
+        public:
+            /// Default constructor.
+            UserDefined() = default;
+
+            /// Constructor from SOLUTION section information
+            ///
+            /// \param[in] soln SOLUTION section container.
+            explicit UserDefined(const SOLUTIONSection& soln);
+
+            /// Form serialisation test object.
+            static UserDefined serializationTestObject();
+
+            /// Retrieve datum depth.
+            ///
+            /// \param[in] rset Region set name, e.g., FIPNUM.
+            ///
+            /// \param[in] region Zero-based region index.
+            ///
+            /// \return Datum/reference depth in region \p region of region
+            /// set \p rset (= globally configured reference depth).
+            double operator()(std::string_view rset, const int region) const;
+
+            /// Equality predicate.
+            ///
+            /// \param[in] that Object against which \c *this will be
+            /// compared for equality.
+            ///
+            /// \return Whether or not \c *this equals \p that.
+            bool operator==(const UserDefined& that) const
+            {
+                return (this->rsetNames_ == that.rsetNames_)
+                    && (this->rsetStart_ == that.rsetStart_)
+                    && (this->depth_     == that.depth_)
+                    && (this->default_   == that.default_)
+                    && (this->rsetIndex_ == that.rsetIndex_)
+                    ;
+            }
+
+            /// Serialisation interface
+            ///
+            /// \tparam Serializer Object serialisation protocol
+            /// implementation
+            ///
+            /// \param[in,out] serializer Serialisation object
+            template <class Serializer>
+            void serializeOp(Serializer& serializer)
+            {
+                serializer(this->rsetNames_);
+                serializer(this->rsetStart_);
+                serializer(this->depth_);
+                serializer(this->default_);
+                serializer(this->rsetIndex_);
+            }
+
+        private:
+            /// Known region sets, in order of appearance in DATUMRX.
+            /// Initial 'FIP' name prefix pruned.
+            std::vector<std::string> rsetNames_{};
+
+            /// Region set start pointers into \c depth_
+            std::vector<std::vector<double>::size_type> rsetStart_{};
+
+            /// Per region region reference depth values indexed by \c
+            /// rsetStart_ and the region index.
+            std::vector<double> depth_{};
+
+            /// Per-region reference depth of fallback specification
+            /// (DATUMR) if present.
+            std::vector<double> default_{};
+
+            /// Ordered indices into \c rsetNames_ and \c rsetStart_ to
+            /// enable O(log n) binary search lookup of name->index mapping.
+            std::vector<std::vector<std::string>::size_type> rsetIndex_{};
+
+            /// Retrive datum depth for specific region in specific region set.
+            ///
+            /// \param[in] rset Region set name.  For diagnostic purposes only.
+            ///
+            /// \param[in] begin Start of region set's subrange in \c depth_
+            ///   or \code default_.begin() if \p rset is not among the
+            ///   known region sets.
+            ///
+            /// \param[in] end One past the end of region set's subrange in
+            ///   \c depth_ or \code default_.end() if \p rset is not among
+            ///   the known region sets.
+            ///
+            /// \param[in] ix Zero-based region index.
+            ///
+            /// \return Datum depth for region \p ix in region set \p rset
+            ///   if range [begin, end) is non-empty.  Exception of type \c
+            ///   invalid_argument otherwise (end == begin).
+            double depthValue(std::string_view                     rset,
+                              std::vector<double>::const_iterator  begin,
+                              std::vector<double>::const_iterator  end,
+                              std::vector<double>::difference_type ix) const;
+        };
+
+        /// Datum depth implementation object.
+        std::variant<Zero, Global, DefaultRegion, UserDefined> datum_{};
+    };
+
+} // namespace Opm
+
+#endif // DATUM_DEPTH_HPP_INCLUDED

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/D/DATUMRX
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/D/DATUMRX
@@ -6,11 +6,13 @@
   "items": [
     {
       "name": "REGION_FAMILY",
-      "value_type": "STRING"
+      "value_type": "STRING",
+      "default": ""
     },
     {
       "name": "DEPTH",
       "value_type": "DOUBLE",
+      "size_type": "ALL",
       "dimension": "Length"
     }
   ]

--- a/tests/test_DatumDepth.cpp
+++ b/tests/test_DatumDepth.cpp
@@ -1,0 +1,522 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  Copyright 2024 Equinor
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Datum_Depth_Manager
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <stdexcept>
+#include <string>
+
+namespace {
+    Opm::DatumDepth makeDatumDepth(const std::string& inputString)
+    {
+        return Opm::DatumDepth {
+            Opm::SOLUTIONSection { Opm::Parser{}.parseString(inputString) }
+        };
+    }
+}
+
+BOOST_AUTO_TEST_SUITE(Basic_Operations)
+
+BOOST_AUTO_TEST_CASE(Default)
+{
+    const auto dd = Opm::DatumDepth{};
+
+    BOOST_CHECK_CLOSE(dd(1), 0.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 11), 0.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("NOSUCHREG", 22), 0.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Basic_Operations
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Unset)
+
+BOOST_AUTO_TEST_CASE(No_Solution_Data)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+END
+)");
+
+    BOOST_CHECK_CLOSE(dd(1), 0.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 11), 0.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("NOSUCHREG", 22), 0.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(No_Equilibration_Data)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+PRESSURE
+10*123.4 /
+SWAT
+10*0.123 /
+SGAS
+10*0.4 /
+END
+)");
+
+    BOOST_CHECK_CLOSE(dd(1), 0.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 11), 0.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("NOSUCHREG", 22), 0.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Unset
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Global)
+
+BOOST_AUTO_TEST_CASE(Equilibration_Single_Region)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+EQLDIMS
+/
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2005.0 123.4 2015.0 2.34 1995.0 0.0 /
+END
+)");
+
+    // Datum depth in first equilibration region
+    const auto expect = 2005.0;
+
+    BOOST_CHECK_CLOSE(dd(1), expect, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 11), expect, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("NOSUCHREG", 22), expect, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Equilibration_Multiple_Regions)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+EQLDIMS
+3 /
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2005.0 123.4 2015.0 2.34 1995.0 0.0 /
+  2100.0 157.9 2015.0 2.34 1995.0 0.0 /
+  / -- Copy of region 2
+END
+)");
+
+    // Datum depth in first equilibration region
+    const auto expect = 2005.0;
+
+    BOOST_CHECK_CLOSE(dd(1), expect, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 11), expect, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("NOSUCHREG", 22), expect, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Explicit_Datum_Keyword)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+EQLDIMS
+3 /
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+DATUM
+  2007.5 /
+EQUIL
+  2005.0 123.4 2015.0 2.34 1995.0 0.0 /
+  2100.0 157.9 2015.0 2.34 1995.0 0.0 /
+  / -- Copy of region 2
+END
+)");
+
+    // Datum depth from 'DATUM' keyword
+    const auto expect = 2007.5;
+
+    BOOST_CHECK_CLOSE(dd(1), expect, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 11), expect, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("NOSUCHREG", 22), expect, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Explicit_Datum_Keyword_Order_Reversed)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+EQLDIMS
+/
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2005.0 123.4 2015.0 2.34 1995.0 0.0 /
+DATUM
+  2007.5 /
+END
+)");
+
+    // Datum depth from 'DATUM' keyword
+    const auto expect = 2007.5;
+
+    BOOST_CHECK_CLOSE(dd(1), expect, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 11), expect, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("NOSUCHREG", 22), expect, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Global
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Default_RegSet)
+
+BOOST_AUTO_TEST_CASE(Fully_Specified)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+TABDIMS
+ 4* 5 / // NTFIP (=TABDIMS(5)) = 5
+EQLDIMS
+/
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2015.0 123.4 2015.0 2.34 1995.0 0.0 /
+DATUMR
+  2001.0 2002.0 2003.0 2004.0 2005.0 /
+END
+)");
+
+    BOOST_CHECK_CLOSE(dd(1 - 1), 2001.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(2 - 1), 2002.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(3 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(4 - 1), 2004.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(5 - 1), 2005.0, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 1 - 1), 2001.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 2 - 1), 2002.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 3 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 4 - 1), 2004.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 5 - 1), 2005.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(Defaulted_High_Regions)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+TABDIMS
+ 4* 5 / // NTFIP (=TABDIMS(5)) = 5
+EQLDIMS
+/
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2015.0 123.4 2015.0 2.34 1995.0 0.0 /
+DATUMR
+  2001.0 2002.0 2003.0 /
+END
+)");
+
+    BOOST_CHECK_CLOSE(dd(1 - 1), 2001.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(2 - 1), 2002.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(3 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(4 - 1), 2003.0, 1.0e-8); // Defaults to region 3
+    BOOST_CHECK_CLOSE(dd(5 - 1), 2003.0, 1.0e-8); // Defaults to region 3
+
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 1 - 1), 2001.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 2 - 1), 2002.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 3 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 4 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 5 - 1), 2003.0, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_SUITE_END()     // Default_RegSet
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Extended_Region_Sets)
+
+BOOST_AUTO_TEST_CASE(Fully_Specified)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+TABDIMS
+ 4* 5 / // NTFIP (=TABDIMS(5)) = 5
+EQLDIMS
+/
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2015.0 123.4 2015.0 2.34 1995.0 0.0 /
+DATUMRX
+  '' 2001.0 2002.0 2003.0 2004.0 2005.0 / -- FIPNUM
+  'FIPRE2' 2001.5 2002.5 2003.5 2004.5 2005.5 /
+/
+END
+)");
+
+    BOOST_CHECK_CLOSE(dd(1 - 1), 2001.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(2 - 1), 2002.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(3 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(4 - 1), 2004.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(5 - 1), 2005.0, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 1 - 1), 2001.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 2 - 1), 2002.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 3 - 1), 2003.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 4 - 1), 2004.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 5 - 1), 2005.5, 1.0e-8);
+
+    // No default datum depth (DATUMR missing) => exception for unknown sets.
+    BOOST_CHECK_THROW(dd("FIPUNKNW", 5 - 1), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(Defaulted_High_Regions)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+TABDIMS
+ 4* 5 / // NTFIP (=TABDIMS(5)) = 5
+EQLDIMS
+/
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2015.0 123.4 2015.0 2.34 1995.0 0.0 /
+DATUMRX
+  '' 2001.0 2002.0 2003.0 / -- FIPNUM
+  'FIPRE2' 2001.5 2002.5 /
+/
+END
+)");
+
+    BOOST_CHECK_CLOSE(dd(1 - 1), 2001.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(2 - 1), 2002.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(3 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(4 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(5 - 1), 2003.0, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 1 - 1), 2001.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 2 - 1), 2002.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 3 - 1), 2002.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 4 - 1), 2002.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 5 - 1), 2002.5, 1.0e-8);
+
+    // No default datum depth (DATUMR missing) => exception for unknown sets.
+    BOOST_CHECK_THROW(dd("FIPUNKNW", 5 - 1), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(DatumR_Fallback)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+TABDIMS
+ 4* 5 / // NTFIP (=TABDIMS(5)) = 5
+EQLDIMS
+/
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2015.0 123.4 2015.0 2.34 1995.0 0.0 /
+DATUMR
+  1995.1 1996.1 1997.1 1998.1 1999.1 /
+DATUMRX
+  '' 2001.0 2002.0 2003.0 2004.0 2005.0 / -- FIPNUM
+  'FIPRE2' 2001.5 2002.5 2003.5 2004.5 2005.5 /
+/
+END
+)");
+
+    BOOST_CHECK_CLOSE(dd(1 - 1), 2001.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(2 - 1), 2002.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(3 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(4 - 1), 2004.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(5 - 1), 2005.0, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 1 - 1), 2001.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 2 - 1), 2002.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 3 - 1), 2003.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 4 - 1), 2004.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 5 - 1), 2005.5, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(dd("FIPABC", 1 - 1), 1995.1, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPABC", 2 - 1), 1996.1, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPABC", 3 - 1), 1997.1, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPABC", 4 - 1), 1998.1, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPABC", 5 - 1), 1999.1, 1.0e-8);
+}
+
+BOOST_AUTO_TEST_CASE(DatumR_No_Fallback)
+{
+    const auto dd = makeDatumDepth(R"(RUNSPEC
+DIMENS
+1 5 2 /
+TABDIMS
+ 4* 5 / // NTFIP (=TABDIMS(5)) = 5
+EQLDIMS
+/
+GRID
+DXV
+100.0 /
+DYV
+5*100.0 /
+DZV
+2*10.0 /
+DEPTHZ
+12*2000.0 /
+SOLUTION
+EQUIL
+  2015.0 123.4 2015.0 2.34 1995.0 0.0 /
+DATUMRX
+  '' 2001.0 2002.0 2003.0 2004.0 2005.0 / -- FIPNUM
+  'FIPRE2' 2001.5 2002.5 2003.5 2004.5 2005.5 /
+--
+-- DATUMR *after* DATUMRX => no fallback
+--
+DATUMR
+  1995.1 1996.1 1997.1 1998.1 1999.1 /
+/
+END
+)");
+
+    BOOST_CHECK_CLOSE(dd(1 - 1), 2001.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(2 - 1), 2002.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(3 - 1), 2003.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(4 - 1), 2004.0, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd(5 - 1), 2005.0, 1.0e-8);
+
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 1 - 1), 2001.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 2 - 1), 2002.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 3 - 1), 2003.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 4 - 1), 2004.5, 1.0e-8);
+    BOOST_CHECK_CLOSE(dd("FIPRE2", 5 - 1), 2005.5, 1.0e-8);
+
+    BOOST_CHECK_THROW(dd("FIPABC", 1 - 1), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END()      // Extended_Region_Sets

--- a/tests/test_Serialization.cpp
+++ b/tests/test_Serialization.cpp
@@ -24,20 +24,19 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <memory>
-#include <tuple>
-#include <utility>
-
 #include <opm/common/OpmLog/KeywordLocation.hpp>
+
+#include <opm/output/data/Aquifer.hpp>
+#include <opm/output/eclipse/RestartValue.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
+
 #include <opm/input/eclipse/EclipseState/Aquifer/Aquancon.hpp>
 #include <opm/input/eclipse/EclipseState/Aquifer/AquiferCT.hpp>
 #include <opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Aquifer/Aquifetp.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseConfig.hpp>
-#include <opm/input/eclipse/EclipseState/Runspec.hpp>
-#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FaceDir.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
@@ -46,85 +45,22 @@
 #include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/TranCalculator.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/TransMult.hpp>
+#include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/Equil.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/FoamConfig.hpp>
 #include <opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp>
-#include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
-#include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
-#include <opm/input/eclipse/Schedule/RSTConfig.hpp>
-#include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
-#include <opm/input/eclipse/Schedule/Action/State.hpp>
-#include <opm/input/eclipse/Schedule/Action/ActionAST.hpp>
-#include <opm/input/eclipse/Schedule/Action/PyAction.hpp>
-#include <opm/input/eclipse/Schedule/Action/Actions.hpp>
-#include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
-#include <opm/input/eclipse/Schedule/Action/ASTNode.hpp>
-#include <opm/input/eclipse/Schedule/Action/Condition.hpp>
-#include <opm/input/eclipse/Schedule/Events.hpp>
-#include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
-#include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
-#include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
-#include <opm/input/eclipse/Schedule/Group/Group.hpp>
-#include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
-#include <opm/input/eclipse/Schedule/Group/GuideRateModel.hpp>
-#include <opm/input/eclipse/Schedule/MessageLimits.hpp>
-#include <opm/input/eclipse/Schedule/MSW/icd.hpp>
-#include <opm/input/eclipse/Schedule/MSW/AICD.hpp>
-#include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
-#include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
-#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
-#include <opm/input/eclipse/Schedule/Network/Balance.hpp>
-#include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
-#include <opm/input/eclipse/Schedule/Well/FilterCake.hpp>
-#include <opm/input/eclipse/Schedule/Network/Node.hpp>
-#include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
-#include <opm/input/eclipse/Schedule/RFTConfig.hpp>
-#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
-#include <opm/input/eclipse/Schedule/Tuning.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQFunction.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQInput.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
-#include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
-#include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
-#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
-#include <opm/input/eclipse/Schedule/Well/NameOrder.hpp>
-#include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
-#include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
-#include <opm/input/eclipse/Schedule/Well/WList.hpp>
-#include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
-#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
-
-#include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
-#include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
+#include <opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Aqudims.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/ColumnSchema.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/DenT.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/Eqldims.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/FlatTable.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/DenT.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/JFunc.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PlymwinjTable.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
@@ -142,25 +78,95 @@
 #include <opm/input/eclipse/EclipseState/Tables/TableContainer.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableSchema.hpp>
-#include <opm/output/data/Aquifer.hpp>
-#include <opm/output/eclipse/RestartValue.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
+
+#include <opm/input/eclipse/Schedule/Action/ASTNode.hpp>
+#include <opm/input/eclipse/Schedule/Action/ActionAST.hpp>
+#include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
+#include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
+#include <opm/input/eclipse/Schedule/Action/Actions.hpp>
+#include <opm/input/eclipse/Schedule/Action/Condition.hpp>
+#include <opm/input/eclipse/Schedule/Action/PyAction.hpp>
+#include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Events.hpp>
+#include <opm/input/eclipse/Schedule/GasLiftOpt.hpp>
+#include <opm/input/eclipse/Schedule/Group/GConSale.hpp>
+#include <opm/input/eclipse/Schedule/Group/GConSump.hpp>
+#include <opm/input/eclipse/Schedule/Group/Group.hpp>
+#include <opm/input/eclipse/Schedule/Group/GroupEconProductionLimits.hpp>
+#include <opm/input/eclipse/Schedule/Group/GuideRateConfig.hpp>
+#include <opm/input/eclipse/Schedule/Group/GuideRateModel.hpp>
+#include <opm/input/eclipse/Schedule/MSW/AICD.hpp>
+#include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
+#include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
+#include <opm/input/eclipse/Schedule/MSW/WellSegments.hpp>
+#include <opm/input/eclipse/Schedule/MSW/icd.hpp>
+#include <opm/input/eclipse/Schedule/MessageLimits.hpp>
+#include <opm/input/eclipse/Schedule/Network/Balance.hpp>
+#include <opm/input/eclipse/Schedule/Network/ExtNetwork.hpp>
+#include <opm/input/eclipse/Schedule/Network/Node.hpp>
+#include <opm/input/eclipse/Schedule/OilVaporizationProperties.hpp>
+#include <opm/input/eclipse/Schedule/RFTConfig.hpp>
+#include <opm/input/eclipse/Schedule/RPTConfig.hpp>
+#include <opm/input/eclipse/Schedule/RSTConfig.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/ScheduleTypes.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Tuning.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQActive.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQDefine.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQFunction.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQInput.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
+#include <opm/input/eclipse/Schedule/VFPInjTable.hpp>
+#include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
+#include <opm/input/eclipse/Schedule/Well/Connection.hpp>
+#include <opm/input/eclipse/Schedule/Well/FilterCake.hpp>
+#include <opm/input/eclipse/Schedule/Well/NameOrder.hpp>
+#include <opm/input/eclipse/Schedule/Well/PAvg.hpp>
+#include <opm/input/eclipse/Schedule/Well/WDFAC.hpp>
+#include <opm/input/eclipse/Schedule/Well/WList.hpp>
+#include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
+#include <opm/input/eclipse/Schedule/Well/WVFPDP.hpp>
+#include <opm/input/eclipse/Schedule/Well/WVFPEXP.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellBrineProperties.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellEconProductionLimits.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellFoamProperties.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellMICPProperties.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellPolymerProperties.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellTestConfig.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellTracerProperties.hpp>
+#include <opm/input/eclipse/Schedule/WriteRestartFileEvents.hpp>
+
 #include <opm/common/utility/Serializer.hpp>
 #include <opm/common/utility/MemPacker.hpp>
 
-template<class T>
-std::tuple<T,int,int> PackUnpack(T& in)
-{
-    Opm::Serialization::MemPacker packer;
-    Opm::Serializer ser(packer);
-    ser.pack(in);
-    const size_t pos1 = ser.position();
-    T out{};
-    ser.unpack(out);
-    const size_t pos2 = ser.position();
+#include <memory>
+#include <tuple>
+#include <utility>
 
-    return std::make_tuple(out, pos1, pos2);
+namespace {
+    template<class T>
+    std::tuple<T,int,int> PackUnpack(T& in)
+    {
+        Opm::Serialization::MemPacker packer;
+        Opm::Serializer ser(packer);
+        ser.pack(in);
+        const size_t pos1 = ser.position();
+        T out{};
+        ser.unpack(out);
+        const size_t pos2 = ser.position();
+
+        return std::make_tuple(out, pos1, pos2);
+    }
 }
-
 
 #define TEST_FOR_TYPE_NAMED_OBJ(TYPE, NAME, OBJ) \
 BOOST_AUTO_TEST_CASE(NAME) \
@@ -219,6 +225,10 @@ TEST_FOR_TYPE_NAMED(data::Well, dataWell)
 TEST_FOR_TYPE_NAMED(data::Wells, Wells)
 TEST_FOR_TYPE_NAMED(data::WellBlockAvgPress, dataWBPObject)
 TEST_FOR_TYPE_NAMED(data::WellBlockAveragePressures, dataWBPCollection)
+TEST_FOR_TYPE_NAMED_OBJ(DatumDepth, DatumDepth_Zero, serializationTestObjectZero)
+TEST_FOR_TYPE_NAMED_OBJ(DatumDepth, DatumDepth_Global, serializationTestObjectGlobal)
+TEST_FOR_TYPE_NAMED_OBJ(DatumDepth, DatumDepth_DefaultRegion, serializationTestObjectDefaultRegion)
+TEST_FOR_TYPE_NAMED_OBJ(DatumDepth, DatumDepth_UserDefined, serializationTestObjectUserDefined)
 TEST_FOR_TYPE(Deck)
 TEST_FOR_TYPE(DeckItem)
 TEST_FOR_TYPE(DeckKeyword)
@@ -336,7 +346,6 @@ TEST_FOR_TYPE(WellTestState)
 TEST_FOR_TYPE(WellType)
 TEST_FOR_TYPE(WListManager)
 TEST_FOR_TYPE(WriteRestartFileEvents)
-
 
 namespace {
 


### PR DESCRIPTION
The input keywords `EQUIL`, `DATUM`, `DATUMR`, and `DATUMRX` define global or per-region depths to which per-cell phase pressures may be corrected.  These depths go into calculating the `BPPO`, `BPPG`, and `BPPW` summary vectors.  This PR introduces a new helper class, `DatumDepth`, which internalises the information contained in those keywords and supports retrieving pertinent datum depths given a region ID and a region set name.

While here, also amend the data model for the `DATUMRX` keyword.  If the region set name is defaulted&ndash;or entered as all blanks&ndash;then that should be treated as the built-in `FIPNUM` region set.