### PR TITLE
Internalise Model's Datum Depth from SOLUTION Section

### DIFF
--- a/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -36,18 +36,16 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/V.hpp>
 
-/*
-  The internalization of the CPR keyword has been temporarily
-  disabled, suddenly decks with 'CPR' in the summary section turned
-  up. Keywords with section aware keyword semantics is currently not
-  handled by the parser.
+#include <stdexcept>
 
-  When the CPR is added again the following keyword configuration must
-  be added:
-
-    {"name" : "CPR" , "sections" : ["RUNSPEC"], "size": 1 }
-
-*/
+// The internalization of the CPR keyword has been temporarily disabled,
+// suddenly decks with 'CPR' in the summary section turned up. Keywords with
+// section aware keyword semantics is currently not handled by the parser.
+//
+// When the CPR is added again the following keyword configuration must be
+// added:
+//
+//   {"name" : "CPR" , "sections" : ["RUNSPEC"], "size": 1 }
 
 namespace Opm {
 
@@ -61,37 +59,54 @@ namespace Opm {
     {
         if (DeckSection::hasRUNSPEC(deck)) {
             const RUNSPECSection runspec(deck);
+
             if (runspec.hasKeyword<ParserKeywords::CPR>()) {
                 const auto& cpr = runspec.get<ParserKeywords::CPR>().back();
-                if (cpr.size() > 0)
-                    throw std::invalid_argument("ERROR: In the RUNSPEC section the CPR keyword should contain EXACTLY one empty record.");
+                if (cpr.size() > 0) {
+                    throw std::invalid_argument {
+                        "ERROR: In the RUNSPEC section the CPR keyword "
+                        "should contain EXACTLY one empty record."
+                    };
+                }
 
                 m_useCPR = true;
             }
+
             if (runspec.hasKeyword<ParserKeywords::NONNC>()) {
                 const auto& nonnc = runspec.get<ParserKeywords::NONNC>().back();
-                if (nonnc.size() > 0)
-                    throw std::invalid_argument("ERROR: In the RUNSPEC section the NONNC keyword should contain EXACTLY one empty record.");
+                if (nonnc.size() > 0) {
+                    throw std::invalid_argument {
+                        "ERROR: In the RUNSPEC section the NONNC keyword "
+                        "should contain EXACTLY one empty record."
+                    };
+                }
 
                 m_useNONNC = true;
             }
+
             if (runspec.hasKeyword<ParserKeywords::DISGAS>()) {
                 m_DISGAS = true;
             }
+
             if (runspec.hasKeyword<ParserKeywords::DISGASW>()) {
                 m_DISGASW = true;
             }
+
             if (runspec.hasKeyword<ParserKeywords::VAPOIL>()) {
                 m_VAPOIL = true;
             }
+
             if (runspec.hasKeyword<ParserKeywords::VAPWAT>()) {
                 m_VAPWAT = true;
             }
+
             if (runspec.hasKeyword<ParserKeywords::DIFFUSE>()) {
                 m_diffuse = true;
             }
+
             this->m_isThermal = runspec.hasKeyword<ParserKeywords::THERMAL>()
                 || runspec.hasKeyword<ParserKeywords::TEMP>();
+
             if (runspec.hasKeyword<ParserKeywords::PRECSALT>()) {
                 m_PRECSALT = true;
             }
@@ -101,6 +116,7 @@ namespace Opm {
     SimulationConfig SimulationConfig::serializationTestObject()
     {
         SimulationConfig result;
+
         result.m_ThresholdPressure = ThresholdPressure::serializationTestObject();
         result.m_bcconfig = BCConfig::serializationTestObject();
         result.m_rock_config = RockConfig::serializationTestObject();
@@ -118,15 +134,18 @@ namespace Opm {
         return result;
     }
 
-    const RockConfig& SimulationConfig::rock_config() const {
+    const RockConfig& SimulationConfig::rock_config() const
+    {
         return this->m_rock_config;
     }
 
-    const ThresholdPressure& SimulationConfig::getThresholdPressure() const {
+    const ThresholdPressure& SimulationConfig::getThresholdPressure() const
+    {
         return m_ThresholdPressure;
     }
 
-    const BCConfig& SimulationConfig::bcconfig() const {
+    const BCConfig& SimulationConfig::bcconfig() const
+    {
         return m_bcconfig;
     }
 
@@ -135,43 +154,53 @@ namespace Opm {
         return this->m_datum_depth;
     }
 
-    bool SimulationConfig::useThresholdPressure() const {
+    bool SimulationConfig::useThresholdPressure() const
+    {
         return m_ThresholdPressure.active();
     }
 
-    bool SimulationConfig::useCPR() const {
+    bool SimulationConfig::useCPR() const
+    {
         return m_useCPR;
     }
 
-    bool SimulationConfig::useNONNC() const {
+    bool SimulationConfig::useNONNC() const
+    {
         return m_useNONNC;
     }
 
-    bool SimulationConfig::hasDISGAS() const {
+    bool SimulationConfig::hasDISGAS() const
+    {
         return m_DISGAS;
     }
 
-    bool SimulationConfig::hasDISGASW() const {
+    bool SimulationConfig::hasDISGASW() const
+    {
         return m_DISGASW;
     }
 
-    bool SimulationConfig::hasVAPOIL() const {
+    bool SimulationConfig::hasVAPOIL() const
+    {
         return m_VAPOIL;
     }
 
-    bool SimulationConfig::hasVAPWAT() const {
+    bool SimulationConfig::hasVAPWAT() const
+    {
         return m_VAPWAT;
     }
 
-    bool SimulationConfig::isThermal() const {
+    bool SimulationConfig::isThermal() const
+    {
         return this->m_isThermal;
     }
 
-    bool SimulationConfig::isDiffusive() const {
+    bool SimulationConfig::isDiffusive() const
+    {
         return this->m_diffuse;
     }
 
-    bool SimulationConfig::hasPRECSALT() const {
+    bool SimulationConfig::hasPRECSALT() const
+    {
         return m_PRECSALT;
     }
 

--- a/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -15,25 +15,29 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
 #ifndef OPM_SIMULATION_CONFIG_HPP
 #define OPM_SIMULATION_CONFIG_HPP
 
+#include <opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
+#include <opm/input/eclipse/EclipseState/SimulationConfig/DatumDepth.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/RockConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
-#include <opm/input/eclipse/EclipseState/SimulationConfig/BCConfig.hpp>
 
 namespace Opm {
 
     class Deck;
     class FieldPropsManager;
 
-    class SimulationConfig {
+} // namespace Opm
 
+namespace Opm {
+
+    class SimulationConfig
+    {
     public:
-
-        SimulationConfig();
+        SimulationConfig() = default;
         SimulationConfig(bool restart,
                          const Deck& deck,
                          const FieldPropsManager& fp);
@@ -43,6 +47,8 @@ namespace Opm {
         const RockConfig& rock_config() const;
         const ThresholdPressure& getThresholdPressure() const;
         const BCConfig& bcconfig() const;
+        const DatumDepth& datumDepths() const;
+
         bool useThresholdPressure() const;
         bool useCPR() const;
         bool useNONNC() const;
@@ -55,7 +61,8 @@ namespace Opm {
         bool hasPRECSALT() const;
 
         bool operator==(const SimulationConfig& data) const;
-        static bool rst_cmp(const SimulationConfig& full_config, const SimulationConfig& rst_config);
+        static bool rst_cmp(const SimulationConfig& full_config,
+                            const SimulationConfig& rst_config);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -63,6 +70,7 @@ namespace Opm {
             serializer(m_ThresholdPressure);
             serializer(m_bcconfig);
             serializer(m_rock_config);
+            serializer(this->m_datum_depth);
             serializer(m_useCPR);
             serializer(m_useNONNC);
             serializer(m_DISGAS);
@@ -76,22 +84,22 @@ namespace Opm {
 
     private:
         friend class EclipseState;
-        ThresholdPressure m_ThresholdPressure;
-        BCConfig m_bcconfig;
-        RockConfig m_rock_config;
-        bool m_useCPR;
-        bool m_useNONNC;
-        bool m_DISGAS;
-        bool m_DISGASW;
-        bool m_VAPOIL;
-        bool m_VAPWAT;
-        bool m_isThermal;
-        bool m_diffuse;
-        bool m_PRECSALT;
+
+        ThresholdPressure m_ThresholdPressure{};
+        BCConfig m_bcconfig{};
+        RockConfig m_rock_config{};
+        DatumDepth m_datum_depth{};
+        bool m_useCPR{false};
+        bool m_useNONNC{false};
+        bool m_DISGAS{false};
+        bool m_DISGASW{false};
+        bool m_VAPOIL{false};
+        bool m_VAPWAT{false};
+        bool m_isThermal{false};
+        bool m_diffuse{false};
+        bool m_PRECSALT{false};
     };
 
-} //namespace Opm
+} // namespace Opm
 
-
-
-#endif
+#endif // OPM_SIMULATION_CONFIG_HPP


### PR DESCRIPTION
This PR adds a `DatumDepth` data member to the `SimulationConfig` type and initialises this member from the `SOLUTION` section.  This, in turn, publishes the model's explicitly or implicitly defined datum depths&ndash;either global or per-region&ndash;to client code which may then use this to calculate depth-corrected phase pressures such as the `BPPO`, `BPPG`, and `BPPW` summary vectors.