### PR TITLE
Enable Summary File Output of Depth-Corrected Phase Pressures

### DIFF
--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -2660,6 +2660,9 @@ static const auto block_units = UnitTable {
     // Pressure quantities
     {"BPR"      , Opm::UnitSystem::measure::pressure},
     {"BPRESSUR" , Opm::UnitSystem::measure::pressure},
+    {"BPPO"     , Opm::UnitSystem::measure::pressure},
+    {"BPPG"     , Opm::UnitSystem::measure::pressure},
+    {"BPPW"     , Opm::UnitSystem::measure::pressure},
 
     // Volumes and ratios
     {"BRPV"     , Opm::UnitSystem::measure::volume},


### PR DESCRIPTION
This PR makes the per-cell (block) summary vector configuration system aware of the depth-corrected phase pressure vectors
```
BPPO, BPPG, BPPW
```
These will now be output to the summary file if requested from the `SUMMARY` section.