### PR TITLE
Tidy Up Certain Implementation Files

### DIFF
--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/OpmLog/InfoLogger.hpp>
@@ -27,27 +29,29 @@
 #include <opm/io/eclipse/rst/network.hpp>
 #include <opm/io/eclipse/ERst.hpp>
 
-#include <opm/input/eclipse/Deck/DeckSection.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/BoxManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/TransMult.hpp>
-#include <opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+
+#include <opm/input/eclipse/Units/Dimension.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
 #include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
-#include <opm/input/eclipse/Units/Dimension.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <fmt/format.h>
 

--- a/opm/input/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.hpp
@@ -20,26 +20,27 @@
 #ifndef OPM_ECLIPSE_STATE_HPP
 #define OPM_ECLIPSE_STATE_HPP
 
-#include <cstddef>
-#include <memory>
-#include <vector>
-#include <optional>
-
 #include <opm/input/eclipse/EclipseState/Aquifer/AquiferConfig.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseConfig.hpp>
-#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
-#include <opm/input/eclipse/EclipseState/MICPpara.hpp>
-#include <opm/input/eclipse/EclipseState/WagHysteresisConfig.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/TransMult.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
+#include <opm/input/eclipse/EclipseState/MICPpara.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/input/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
+#include <opm/input/eclipse/EclipseState/WagHysteresisConfig.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <vector>
 
 namespace Opm {
     class Deck;
@@ -152,7 +153,6 @@ namespace Opm {
         }
 
         static bool rst_cmp(const EclipseState& full_state, const EclipseState& rst_state);
-
 
     private:
         void initIOConfigPostSchedule(const Deck& deck);

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -20,24 +20,40 @@
 #define OPM_RUNSPEC_HPP
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
-#include <opm/input/eclipse/EclipseState/Phase.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
-#include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
-#include <opm/input/eclipse/EclipseState/EndpointScaling.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
-#include <opm/input/eclipse/Schedule/Action/Actdims.hpp>
 
+#include <opm/input/eclipse/EclipseState/EndpointScaling.hpp>
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Regdims.hpp>
+#include <opm/input/eclipse/EclipseState/Tables/Tabdims.hpp>
+
+#include <opm/input/eclipse/Schedule/Action/Actdims.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
+
+#include <bitset>
+#include <cstddef>
+#include <ctime>
 #include <optional>
-#include <string>
 
 namespace Opm {
-class Deck;
 
-class Phases {
+    class Deck;
+
+} // namespace Opm
+
+namespace Opm {
+
+class Phases
+{
 public:
     Phases() noexcept = default;
-    Phases( bool oil, bool gas, bool wat, bool solvent = false, bool polymer = false, bool energy = false,
-            bool polymw = false, bool foam = false, bool brine = false, bool zfraction = false ) noexcept;
+    Phases(bool oil, bool gas, bool wat,
+           bool solvent = false,
+           bool polymer = false,
+           bool energy = false,
+           bool polymw = false,
+           bool foam = false,
+           bool brine = false,
+           bool zfraction = false) noexcept;
 
     static Phases serializationTestObject();
 
@@ -53,9 +69,8 @@ public:
     }
 
 private:
-    std::bitset< NUM_PHASES_IN_ENUM > bits;
+    std::bitset<NUM_PHASES_IN_ENUM> bits;
 };
-
 
 class Welldims {
 public:
@@ -546,6 +561,6 @@ private:
 };
 
 
-}
+} // namespace Opm
 
 #endif // OPM_RUNSPEC_HPP

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -15,10 +15,14 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
 #ifndef OPM_SUMMARY_CONFIG_HPP
 #define OPM_SUMMARY_CONFIG_HPP
+
+#include <opm/io/eclipse/SummaryNode.hpp>
+
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 
 #include <array>
 #include <limits>
@@ -28,25 +32,29 @@
 #include <unordered_set>
 #include <vector>
 
-
-#include <opm/io/eclipse/SummaryNode.hpp>
-#include <opm/common/OpmLog/KeywordLocation.hpp>
+namespace Opm {
+    class AquiferConfig;
+    class Deck;
+    class EclipseState;
+    class ErrorGuard;
+    class FieldPropsManager;
+    class GridDims;
+    class ParseContext;
+    class Schedule;
+} // namespace Opm
 
 namespace Opm {
 
-    /*
-      Very small utility class to get value semantics on the smspec_node
-      pointers. This should die as soon as the smspec_node class proper gets
-      value semantics.
-    */
-
-    class SummaryConfigNode {
+    class SummaryConfigNode
+    {
     public:
         using Category = Opm::EclIO::SummaryNode::Category;
         using Type = Opm::EclIO::SummaryNode::Type;
 
         SummaryConfigNode() = default;
-        explicit SummaryConfigNode(std::string keyword, const Category cat, KeywordLocation loc_arg);
+        explicit SummaryConfigNode(std::string keyword,
+                                   const Category cat,
+                                   KeywordLocation loc_arg);
 
         static SummaryConfigNode serializationTestObject();
 
@@ -65,7 +73,7 @@ namespace Opm {
         const std::string& fip_region() const { return *this->fip_region_ ; }
 
         std::string uniqueNodeKey() const;
-        const KeywordLocation& location( ) const { return this->loc; }
+        const KeywordLocation& location() const { return this->loc; }
 
         operator Opm::EclIO::SummaryNode() const {
             return { keyword_, category_, type_, name_, number_, fip_region_, {}};
@@ -121,15 +129,8 @@ namespace Opm {
         return ! (lhs < rhs);
     }
 
-    class Deck;
-    class ErrorGuard;
-    class GridDims;
-    class ParseContext;
-    class Schedule;
-    class AquiferConfig;
-    class FieldPropsManager;
-
-    class SummaryConfig {
+    class SummaryConfig
+    {
         public:
             typedef SummaryConfigNode keyword_type;
             typedef std::vector< keyword_type > keyword_list;
@@ -245,6 +246,6 @@ namespace Opm {
             void handleProcessingInstruction(const std::string& keyword);
     };
 
-} //namespace Opm
+} // namespace Opm
 
-#endif
+#endif // OPM_SUMMARY_CONFIG_HPP

--- a/opm/input/eclipse/Schedule/Group/Group.cpp
+++ b/opm/input/eclipse/Schedule/Group/Group.cpp
@@ -16,6 +16,7 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>

--- a/opm/input/eclipse/Schedule/Group/Group.hpp
+++ b/opm/input/eclipse/Schedule/Group/Group.hpp
@@ -17,13 +17,16 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef GROUP2_HPP
-#define GROUP2_HPP
+#ifndef OPM_GROUP_HPP
+#define OPM_GROUP_HPP
+
+#include <opm/input/eclipse/EclipseState/Phase.hpp>
+#include <opm/input/eclipse/EclipseState/Util/IOrderSet.hpp>
+
+#include <opm/input/eclipse/Schedule/Group/GPMaint.hpp>
 
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
-#include <opm/input/eclipse/EclipseState/Util/IOrderSet.hpp>
-#include <opm/input/eclipse/EclipseState/Phase.hpp>
-#include <opm/input/eclipse/Schedule/Group/GPMaint.hpp>
+
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 
 #include <cstddef>
@@ -373,4 +376,4 @@ Group::GroupType operator &(Group::GroupType lhs, Group::GroupType rhs);
 
 }
 
-#endif
+#endif // OPM_GROUP_HPP

--- a/opm/input/eclipse/Schedule/SummaryState.cpp
+++ b/opm/input/eclipse/Schedule/SummaryState.cpp
@@ -35,7 +35,8 @@
 
 namespace {
 
-    bool is_total(const std::string& key) {
+    bool is_total(const std::string& key)
+    {
         static const std::vector<std::string> totals = {
             "OPT"  , "GPT"  , "WPT" , "GIT", "WIT", "OPTF" , "OPTS" , "OIT"  , "OVPT" , "OVIT" , "MWT" ,
             "WVPT" , "WVIT" , "GMT"  , "GPTF" , "SGT"  , "GST" , "FGT" , "GCT" , "GIMT" ,
@@ -67,7 +68,10 @@ namespace {
     using map2 = std::unordered_map<std::string, std::unordered_map<std::string, T>>;
 
     template <class T>
-    bool has_var(const map2<T>& values, const std::string& var1, const std::string& var2) {
+    bool has_var(const map2<T>& values,
+                 const std::string& var1,
+                 const std::string& var2)
+    {
         const auto& var1_iter = values.find(var1);
         if (var1_iter == values.end())
             return false;
@@ -80,7 +84,11 @@ namespace {
     }
 
     template <class T>
-    void erase_var(map2<T>& values, std::set<std::string>& var2_set, const std::string& var1, const std::string& var2) {
+    void erase_var(map2<T>& values,
+                   std::set<std::string>& var2_set,
+                   const std::string& var1,
+                   const std::string& var2)
+    {
         const auto& var1_iter = values.find(var1);
         if (var1_iter == values.end())
             return;
@@ -97,7 +105,9 @@ namespace {
     }
 
     template <class T>
-    std::vector<std::string> var2_list(const map2<T>& values, const std::string& var1) {
+    std::vector<std::string>
+    var2_list(const map2<T>& values, const std::string& var1)
+    {
         const auto& var1_iter = values.find(var1);
         if (var1_iter == values.end())
             return {};

--- a/opm/input/eclipse/Schedule/SummaryState.hpp
+++ b/opm/input/eclipse/Schedule/SummaryState.hpp
@@ -129,17 +129,17 @@ public:
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
-      serializer(sim_start);
-      serializer(elapsed);
-      serializer(values);
-      serializer(well_values);
-      serializer(m_wells);
-      serializer(well_names);
-      serializer(group_values);
-      serializer(m_groups);
-      serializer(group_names);
-      serializer(conn_values);
-      serializer(segment_values);
+        serializer(sim_start);
+        serializer(elapsed);
+        serializer(values);
+        serializer(well_values);
+        serializer(m_wells);
+        serializer(well_names);
+        serializer(group_values);
+        serializer(m_groups);
+        serializer(group_names);
+        serializer(conn_values);
+        serializer(segment_values);
     }
 
     static SummaryState serializationTestObject();

--- a/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
@@ -36,15 +36,27 @@ namespace Opm {
 class UDQASTNode
 {
 public:
-    UDQVarType var_type = UDQVarType::NONE;
+    UDQVarType var_type { UDQVarType::NONE };
 
     UDQASTNode();
     explicit UDQASTNode(UDQTokenType type_arg);
     explicit UDQASTNode(double scalar_value);
-    UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg, const UDQASTNode& left_arg);
-    UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg, const UDQASTNode& left, const UDQASTNode& right);
-    UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg);
-    UDQASTNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg, const std::vector<std::string>& selector);
+
+    UDQASTNode(UDQTokenType type_arg,
+               const std::variant<std::string, double>& value_arg,
+               const UDQASTNode& left_arg);
+
+    UDQASTNode(UDQTokenType type_arg,
+               const std::variant<std::string, double>& value_arg,
+               const UDQASTNode& left,
+               const UDQASTNode& right);
+
+    UDQASTNode(UDQTokenType type_arg,
+               const std::variant<std::string, double>& value_arg);
+
+    UDQASTNode(UDQTokenType type_arg,
+               const std::variant<std::string, double>& value_arg,
+               const std::vector<std::string>& selector);
 
     static UDQASTNode serializationTestObject();
 
@@ -119,13 +131,12 @@ private:
     UDQSet eval_table_lookup_well(const std::string& string_value,
                                   const UDQContext& context) const;
 
-
     void func_tokens(std::set<UDQTokenType>& tokens) const;
 };
 
 UDQASTNode operator*(const UDQASTNode&lhs, double rhs);
 UDQASTNode operator*(double lhs, const UDQASTNode& rhs);
 
-}
+} // namespace Opm
 
-#endif
+#endif // UDQASTNODE_HPP

--- a/opm/input/eclipse/Schedule/UDQ/UDQParser.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQParser.cpp
@@ -21,6 +21,13 @@
 
 #include <opm/common/OpmLog/KeywordLocation.hpp>
 
+#include <opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQToken.hpp>
+
+#include <opm/input/eclipse/Parser/ErrorGuard.hpp>
 #include <opm/input/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 
@@ -29,86 +36,164 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
 
 #include <fmt/format.h>
 
 namespace {
 
-    void dump_tokens(const std::string&                target_var,
-                     const std::vector<Opm::UDQToken>& tokens)
-    {
-        std::cout << target_var << " = ";
-
-        for (const auto& token : tokens) {
-            std::cout << token.str();
-        }
-
-        std::cout << std::endl;
-    }
-
-    // This function is extremely weak - hopefully it can be improved in the
-    // future.  See the comment in UDQEnums.hpp about 'UDQ type system'.
-    bool static_type_check(const Opm::UDQVarType lhs,
-                           const Opm::UDQVarType rhs)
-    {
-        if (lhs == rhs) {
-            return true;
-        }
-
-        if (rhs == Opm::UDQVarType::SCALAR) {
-            return true;
-        }
-
-        // This does not check if the rhs evaluates to a scalar.
-        if (rhs == Opm::UDQVarType::WELL_VAR) {
-            return lhs == Opm::UDQVarType::WELL_VAR;
-        }
-
-        if (rhs == Opm::UDQVarType::TABLE_LOOKUP)
-            return lhs == Opm::UDQVarType::WELL_VAR ||
-                   lhs == Opm::UDQVarType::FIELD_VAR ||
-                   lhs == Opm::UDQVarType::SEGMENT_VAR ||
-                   lhs == Opm::UDQVarType::GROUP_VAR;
-
-        return false;
-    }
-
-} // Anonymous namespace
-
-namespace Opm {
-
-UDQTokenType UDQParser::get_type(const std::string& arg) const
+void dump_tokens(const std::string&                target_var,
+                 const std::vector<Opm::UDQToken>& tokens)
 {
-    auto func_type = UDQ::funcType(arg);
+    std::cout << target_var << " = ";
 
-    if (func_type != UDQTokenType::error) {
+    for (const auto& token : tokens) {
+        std::cout << token.str();
+    }
+
+    std::cout << std::endl;
+}
+
+// This function is extremely weak - hopefully it can be improved in the
+// future.  See the comment in UDQEnums.hpp about 'UDQ type system'.
+bool static_type_check(const Opm::UDQVarType lhs,
+                       const Opm::UDQVarType rhs)
+{
+    if (lhs == rhs) {
+        return true;
+    }
+
+    if (rhs == Opm::UDQVarType::SCALAR) {
+        return true;
+    }
+
+    // This does not check if the rhs evaluates to a scalar.
+    if (rhs == Opm::UDQVarType::WELL_VAR) {
+        return lhs == Opm::UDQVarType::WELL_VAR;
+    }
+
+    if (rhs == Opm::UDQVarType::TABLE_LOOKUP) {
+        return (lhs == Opm::UDQVarType::WELL_VAR)
+            || (lhs == Opm::UDQVarType::FIELD_VAR)
+            || (lhs == Opm::UDQVarType::SEGMENT_VAR)
+            || (lhs == Opm::UDQVarType::GROUP_VAR);
+    }
+
+    return false;
+}
+
+struct UDQParseNode
+{
+    UDQParseNode(const Opm::UDQTokenType                  type_arg,
+                 const std::variant<std::string, double>& value_arg,
+                 const std::vector<std::string>&          selector_arg)
+        : type    (type_arg)
+        , value   (value_arg)
+        , selector(selector_arg)
+    {
+        if (type_arg == Opm::UDQTokenType::ecl_expr) {
+            this->var_type = Opm::UDQ::
+                targetType(std::get<std::string>(value_arg), selector_arg);
+        }
+    }
+
+    UDQParseNode(const Opm::UDQTokenType                  type_arg,
+                 const std::variant<std::string, double>& value_arg)
+        : UDQParseNode(type_arg, value_arg, {})
+    {}
+
+    // Implicit converting constructor.
+    UDQParseNode(const Opm::UDQTokenType type_arg)
+        : UDQParseNode(type_arg, "")
+    {}
+
+    std::string string() const
+    {
+        if (std::holds_alternative<std::string>(this->value)) {
+            return std::get<std::string>(this->value);
+        }
+        else {
+            return std::to_string(std::get<double>(this->value));
+        }
+    }
+
+    Opm::UDQTokenType type;
+    std::variant<std::string, double> value;
+    std::vector<std::string> selector;
+    Opm::UDQVarType var_type { Opm::UDQVarType::NONE };
+};
+
+class UDQParser
+{
+public:
+    UDQParser(const Opm::UDQParams&             udq_params1,
+              const std::vector<Opm::UDQToken>& tokens_)
+        : udq_params(udq_params1)
+        , udqft     (udq_params)
+        , tokens    (tokens_)
+    {}
+
+    Opm::UDQASTNode parse_set();
+
+    bool empty() const;
+    UDQParseNode current() const;
+
+private:
+    Opm::UDQASTNode parse_cmp();
+    Opm::UDQASTNode parse_add();
+    Opm::UDQASTNode parse_factor();
+    Opm::UDQASTNode parse_mul();
+    Opm::UDQASTNode parse_pow();
+
+    UDQParseNode next();
+
+    Opm::UDQTokenType get_type(const std::string& arg) const;
+    std::size_t current_size() const;
+
+    const Opm::UDQParams& udq_params;
+    Opm::UDQFunctionTable udqft;
+    std::vector<Opm::UDQToken> tokens;
+
+    std::vector<Opm::UDQToken>::size_type current_pos {};
+};
+
+Opm::UDQTokenType UDQParser::get_type(const std::string& arg) const
+{
+    auto func_type = Opm::UDQ::funcType(arg);
+
+    if (func_type != Opm::UDQTokenType::error) {
         return func_type;
     }
 
     if (arg == "(") {
-        return UDQTokenType::open_paren;
+        return Opm::UDQTokenType::open_paren;
     }
 
     if (arg == ")") {
-        return UDQTokenType::close_paren;
+        return Opm::UDQTokenType::close_paren;
     }
+
     if (arg == "[") {
-        return UDQTokenType::table_lookup_start;
+        return Opm::UDQTokenType::table_lookup_start;
     }
 
     if (arg == "]") {
-        return UDQTokenType::table_lookup_end;
+        return Opm::UDQTokenType::table_lookup_end;
     }
 
     {
         char* end_ptr;
         std::strtod(arg.c_str(), &end_ptr);
+
         if (std::strlen(end_ptr) == 0) {
-            return UDQTokenType::number;
+            return Opm::UDQTokenType::number;
         }
     }
 
-    return UDQTokenType::ecl_expr;
+    return Opm::UDQTokenType::ecl_expr;
 }
 
 bool UDQParser::empty() const
@@ -119,35 +204,40 @@ bool UDQParser::empty() const
 UDQParseNode UDQParser::next()
 {
     this->current_pos += 1;
+
     return this->current();
 }
 
 UDQParseNode UDQParser::current() const
 {
     if (this->empty()) {
-        return UDQTokenType::end;
+        return { Opm::UDQTokenType::end };
     }
 
     const auto& token = this->tokens[current_pos];
-    if (token.type() == UDQTokenType::number) {
-        return UDQParseNode(UDQTokenType::number, token.value());
+    if (token.type() == Opm::UDQTokenType::number) {
+        return { Opm::UDQTokenType::number, token.value() };
     }
 
-    if (token.type() == UDQTokenType::ecl_expr) {
-        return UDQParseNode(UDQTokenType::ecl_expr, token.value(), token.selector());
+    if (token.type() == Opm::UDQTokenType::ecl_expr) {
+        return { Opm::UDQTokenType::ecl_expr, token.value(), token.selector() };
     }
 
-    return UDQParseNode(this->get_type(std::get<std::string>(token.value())), token.value());
+    return {
+        this->get_type(std::get<std::string>(token.value())),
+        token.value()
+    };
 }
 
-UDQASTNode UDQParser::parse_factor()
+Opm::UDQASTNode UDQParser::parse_factor()
 {
     double sign = 1.0;
+
     auto current = this->current();
-    if ((current.type == UDQTokenType::binary_op_add) ||
-        (current.type == UDQTokenType::binary_op_sub))
+    if ((current.type == Opm::UDQTokenType::binary_op_add) ||
+        (current.type == Opm::UDQTokenType::binary_op_sub))
     {
-        if (current.type == UDQTokenType::binary_op_sub) {
+        if (current.type == Opm::UDQTokenType::binary_op_sub) {
             sign = -1.0;
         }
 
@@ -156,46 +246,54 @@ UDQASTNode UDQParser::parse_factor()
     }
 
 
-    if (current.type == UDQTokenType::open_paren) {
+    if (current.type == Opm::UDQTokenType::open_paren) {
         this->next();
         auto inner_expr = this->parse_set();
 
         current = this->current();
-        if (current.type != UDQTokenType::close_paren) {
-            return UDQASTNode(UDQTokenType::error);
+        if (current.type != Opm::UDQTokenType::close_paren) {
+            return Opm::UDQASTNode { Opm::UDQTokenType::error };
         }
 
         this->next();
         return sign * inner_expr;
     }
 
-    if (UDQ::scalarFunc(current.type) || UDQ::elementalUnaryFunc(current.type)) {
+    if (Opm::UDQ::scalarFunc(current.type) ||
+        Opm::UDQ::elementalUnaryFunc(current.type))
+    {
         auto func_node = current;
         auto next = this->next();
-        if (next.type == UDQTokenType::open_paren) {
+
+        if (next.type == Opm::UDQTokenType::open_paren) {
             this->next();
+
             auto arg_expr = this->parse_set();
 
             current = this->current();
-            if (current.type != UDQTokenType::close_paren) {
-                return UDQASTNode(UDQTokenType::error);
+            if (current.type != Opm::UDQTokenType::close_paren) {
+                return Opm::UDQASTNode { Opm::UDQTokenType::error };
             }
 
             this->next();
-            return sign * UDQASTNode(func_node.type, func_node.value, arg_expr);
+
+            return sign * Opm::UDQASTNode { func_node.type, func_node.value, arg_expr };
         }
         else {
-            return UDQASTNode(UDQTokenType::error);
+            return Opm::UDQASTNode { Opm::UDQTokenType::error };
         }
     }
 
-    UDQASTNode node(current.type, current.value, current.selector);
+    auto node = Opm::UDQASTNode {
+        current.type, current.value, current.selector
+    };
 
     this->next();
+
     return sign * node;
 }
 
-UDQASTNode UDQParser::parse_pow()
+Opm::UDQASTNode UDQParser::parse_pow()
 {
     auto left = this->parse_factor();
     if (this->empty()) {
@@ -203,26 +301,30 @@ UDQASTNode UDQParser::parse_pow()
     }
 
     auto current = this->current();
-    if (current.type == UDQTokenType::binary_op_pow) {
+    if (current.type == Opm::UDQTokenType::binary_op_pow) {
         this->next();
+
         if (this->empty()) {
-            return UDQASTNode(UDQTokenType::error);
+            return Opm::UDQASTNode { Opm::UDQTokenType::error };
         }
 
         auto right = this->parse_mul();
-        return UDQASTNode(current.type, current.value, left, right);
+
+        return { current.type, current.value, left, right };
     }
 
     return left;
 }
 
-UDQASTNode UDQParser::parse_mul()
+Opm::UDQASTNode UDQParser::parse_mul()
 {
-    std::vector<UDQASTNode> nodes;
+    auto nodes = std::vector<Opm::UDQASTNode>{};
     {
-        std::unique_ptr<UDQASTNode> current_node;
+        auto current_node = std::unique_ptr<Opm::UDQASTNode>{};
+
         while (true) {
             auto node = this->parse_pow();
+
             if (current_node) {
                 current_node->set_right(node);
                 nodes.push_back(*current_node);
@@ -236,14 +338,15 @@ UDQASTNode UDQParser::parse_mul()
             }
 
             auto current_token = this->current();
-            if ((current_token.type == UDQTokenType::binary_op_mul) ||
-                (current_token.type == UDQTokenType::binary_op_div))
+            if ((current_token.type == Opm::UDQTokenType::binary_op_mul) ||
+                (current_token.type == Opm::UDQTokenType::binary_op_div))
             {
-                current_node = std::make_unique<UDQASTNode>(current_token.type, current_token.value);
+                current_node = std::make_unique<Opm::UDQASTNode>
+                    (current_token.type, current_token.value);
 
                 this->next();
                 if (this->empty()) {
-                    return UDQASTNode( UDQTokenType::error );
+                    return Opm::UDQASTNode { Opm::UDQTokenType::error };
                 }
             }
             else {
@@ -252,10 +355,12 @@ UDQASTNode UDQParser::parse_mul()
         }
     }
 
-    UDQASTNode top_node = nodes.back();
+    auto top_node = nodes.back();
+
     if (nodes.size() > 1) {
-        UDQASTNode* current = &top_node;
-        for (std::size_t index = nodes.size() - 1; index > 0; index--) {
+        auto* current = &top_node;
+
+        for (std::size_t index = nodes.size() - 1; index > 0; --index) {
             current->set_left(nodes[index - 1]);
             current = current->get_left();
         }
@@ -264,12 +369,12 @@ UDQASTNode UDQParser::parse_mul()
     return top_node;
 }
 
-UDQASTNode UDQParser::parse_add()
+Opm::UDQASTNode UDQParser::parse_add()
 {
-    std::vector<UDQASTNode> nodes;
+    auto nodes = std::vector<Opm::UDQASTNode>{};
 
     {
-        std::unique_ptr<UDQASTNode> current_node;
+        auto current_node = std::unique_ptr<Opm::UDQASTNode>{};
         while (true) {
             auto node = this->parse_mul();
             if (current_node) {
@@ -285,33 +390,35 @@ UDQASTNode UDQParser::parse_add()
             }
 
             auto current_token = this->current();
-            if ((current_token.type == UDQTokenType::binary_op_add) ||
-                (current_token.type == UDQTokenType::binary_op_sub))
+            if ((current_token.type == Opm::UDQTokenType::binary_op_add) ||
+                (current_token.type == Opm::UDQTokenType::binary_op_sub))
             {
-                current_node = std::make_unique<UDQASTNode>
+                current_node = std::make_unique<Opm::UDQASTNode>
                     (current_token.type, current_token.value);
 
                 this->next();
                 if (this->empty()) {
-                    return UDQASTNode(UDQTokenType::error);
+                    return Opm::UDQASTNode { Opm::UDQTokenType::error };
                 }
             }
-            else if ((current_token.type == UDQTokenType::close_paren) ||
-                     UDQ::cmpFunc(current_token.type) ||
-                     UDQ::setFunc(current_token.type))
+            else if ((current_token.type == Opm::UDQTokenType::close_paren) ||
+                     Opm::UDQ::cmpFunc(current_token.type) ||
+                     Opm::UDQ::setFunc(current_token.type))
             {
                 break;
             }
             else {
-                return UDQASTNode(UDQTokenType::error);
+                return Opm::UDQASTNode { Opm::UDQTokenType::error };
             }
         }
     }
 
-    UDQASTNode top_node = nodes.back();
+    auto top_node = nodes.back();
+
     if (nodes.size() > 1) {
-        UDQASTNode* current = &top_node;
-        for (std::size_t index = nodes.size() - 1; index > 0; index--) {
+        auto* current = &top_node;
+
+        for (std::size_t index = nodes.size() - 1; index > 0; --index) {
             current->set_left(nodes[index - 1]);
             current = current->get_left();
         }
@@ -329,10 +436,10 @@ UDQASTNode UDQParser::parse_add()
 // The sum (a+b) is evaluated and then compared with c, that is the order of
 // presedence implemented here.  But reading the eclipse UDQ manual one can
 // get the imporession that the relation operators should bind "very
-// strong", i.e.  that (b < c) should be evaluated first, and then the
-// result of the comparison added to a.
+// strong", i.e., that (b < c) should be evaluated first, and then the
+// result of the comparison added to "a".
 
-UDQASTNode UDQParser::parse_cmp()
+Opm::UDQASTNode UDQParser::parse_cmp()
 {
     auto left = this->parse_add();
     if (this->empty()) {
@@ -340,22 +447,24 @@ UDQASTNode UDQParser::parse_cmp()
     }
 
     auto current = this->current();
-    if (UDQ::cmpFunc(current.type)) {
+
+    if (Opm::UDQ::cmpFunc(current.type)) {
         auto func_node = current;
 
         this->next();
         if (this->empty()) {
-            return UDQASTNode(UDQTokenType::error);
+            return Opm::UDQASTNode { Opm::UDQTokenType::error };
         }
 
         auto right = this->parse_cmp();
-        return UDQASTNode(current.type, current.value, left, right);
+
+        return { current.type, current.value, left, right };
     }
 
     return left;
 }
 
-UDQASTNode UDQParser::parse_set()
+Opm::UDQASTNode UDQParser::parse_set()
 {
     auto left = this->parse_cmp();
     if (this->empty()) {
@@ -363,94 +472,107 @@ UDQASTNode UDQParser::parse_set()
     }
 
     auto current = this->current();
-    if (UDQ::setFunc(current.type)) {
+
+    if (Opm::UDQ::setFunc(current.type)) {
         auto func_node = current;
 
         this->next();
         if (this->empty()) {
-            return UDQASTNode(UDQTokenType::error);
+            return Opm::UDQASTNode { Opm::UDQTokenType::error };
         }
 
         auto right = this->parse_set();
-        return UDQASTNode(current.type, current.value, left, right);
+
+        return { current.type, current.value, left, right };
     }
 
     return left;
 }
 
-UDQASTNode
-UDQParser::parse(const UDQParams&             udq_params,
-                 const UDQVarType             target_type,
-                 const std::string&           target_var,
-                 const KeywordLocation&       location,
-                 const std::vector<UDQToken>& tokens,
-                 const ParseContext&          parseContext,
-                 ErrorGuard&                  errors)
+} // Anonymous namespace
+
+// ===========================================================================
+
+std::unique_ptr<Opm::UDQASTNode>
+Opm::parseUDQExpression(const UDQParams&             udq_params,
+                        const UDQVarType             target_type,
+                        const std::string&           target_var,
+                        const KeywordLocation&       location,
+                        const std::vector<UDQToken>& tokens,
+                        const ParseContext&          parseContext,
+                        ErrorGuard&                  errors)
 {
-    UDQParser parser(udq_params, tokens);
-    parser.next();
+    auto parser = UDQParser { udq_params, tokens };
+
     auto tree = parser.parse_set();
 
-    if (!parser.empty()) {
-        auto current = parser.current();
-        std::string msg_fmt = fmt::format("Problem parsing UDQ {}\n"
-                                          "In {{file}} line {{line}}.\n"
-                                          "Extra unhandled data starting with item {}.",
-                                          target_var, current.string());
+    if (! parser.empty()) {
+        const auto current = parser.current();
+
+        const auto msg_fmt =
+            fmt::format("Problem parsing UDQ {}\n"
+                        "In {{file}} line {{line}}.\n"
+                        "Extra unhandled data starting with item {}.",
+                        target_var, current.string());
 
         parseContext.handleError(ParseContext::UDQ_PARSE_ERROR, msg_fmt, location, errors);
-        return UDQASTNode( udq_params.undefinedValue() );
+
+        return std::make_unique<UDQASTNode>(udq_params.undefinedValue());
     }
 
-    if (!tree.valid()) {
+    if (! tree.valid()) {
         std::string token_string;
         for (const auto& token : tokens) {
             token_string += token.str() + " ";
         }
 
-        std::string msg_fmt = fmt::format("Failed to parse UDQ {}\n"
-                                          "In {{file}} line {{line}}.\n"
-                                          "This can be a bug in flow or a "
-                                          "bug in the UDQ input string.\n"
-                                          "UDQ input: '{}'",
-                                          target_var, token_string);
+        const auto msg_fmt =
+            fmt::format("Failed to parse UDQ {}\n"
+                        "In {{file}} line {{line}}.\n"
+                        "This can be a bug in flow or a "
+                        "bug in the UDQ input string.\n"
+                        "UDQ input: '{}'",
+                        target_var, token_string);
 
         parseContext.handleError(ParseContext::UDQ_PARSE_ERROR, msg_fmt, location, errors);
-        return UDQASTNode( udq_params.undefinedValue() );
+
+        return std::make_unique<UDQASTNode>(udq_params.undefinedValue());
     }
 
-    if (!static_type_check(target_type, tree.var_type)) {
-        std::string msg_fmt = fmt::format("Failed to parse UDQ {}\n"
-                                          "In {{file}} line {{line}}.\n"
-                                          "Invalid type conversion detected "
-                                          "in UDQ expression expected: {}, got: {}",
-                                          target_var,
-                                          UDQ::typeName(target_type),
-                                          UDQ::typeName(tree.var_type));
+    if (! static_type_check(target_type, tree.var_type)) {
+        const auto msg_fmt =
+            fmt::format("Failed to parse UDQ {}\n"
+                        "In {{file}} line {{line}}.\n"
+                        "Invalid type conversion detected "
+                        "in UDQ expression expected: {}, got: {}",
+                        target_var,
+                        UDQ::typeName(target_type),
+                        UDQ::typeName(tree.var_type));
 
         parseContext.handleError(ParseContext::UDQ_TYPE_ERROR, msg_fmt, location, errors);
+
         if (parseContext.get(ParseContext::UDQ_TYPE_ERROR) != InputErrorAction::IGNORE) {
             dump_tokens(target_var, tokens);
         }
 
-        return UDQASTNode(udq_params.undefinedValue());
+        return std::make_unique<UDQASTNode>(udq_params.undefinedValue());
     }
 
     if (tree.var_type == UDQVarType::NONE) {
-        std::string msg_fmt = fmt::format("Failed to parse UDQ {}\n"
-                                          "In {{file}} line {{line}}.\n"
-                                          "Could not determine "
-                                          "expression type.", target_var);
+        const auto msg_fmt =
+            fmt::format("Failed to parse UDQ {}\n"
+                        "In {{file}} line {{line}}.\n"
+                        "Could not determine "
+                        "expression type.", target_var);
 
         parseContext.handleError(ParseContext::UDQ_TYPE_ERROR, msg_fmt, location, errors);
+
         if (parseContext.get(ParseContext::UDQ_TYPE_ERROR) != InputErrorAction::IGNORE) {
             dump_tokens(target_var, tokens);
         }
 
-        return UDQASTNode(udq_params.undefinedValue());
+        return std::make_unique<UDQASTNode>(udq_params.undefinedValue());
     }
 
-    return tree;
+    return std::make_unique<UDQASTNode>(std::move(tree));
 }
-
-} // namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQParser.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQParser.hpp
@@ -19,102 +19,33 @@
 #ifndef UDQPARSER_HPP
 #define UDQPARSER_HPP
 
-#include <opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQFunctionTable.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQToken.hpp>
 
+#include <memory>
 #include <string>
-#include <variant>
 #include <vector>
 
 namespace Opm {
 
-class ParseContext;
 class ErrorGuard;
 class KeywordLocation;
+class ParseContext;
+class UDQASTNode;
+class UDQParams;
 
 } // namespace Opm
 
 namespace Opm {
 
-struct UDQParseNode
-{
-    UDQParseNode(const UDQTokenType                       type_arg,
-                 const std::variant<std::string, double>& value_arg,
-                 const std::vector<std::string>&          selector_arg)
-        : type(type_arg)
-        , value(value_arg)
-        , selector(selector_arg)
-    {
-        if (type_arg == UDQTokenType::ecl_expr) {
-            this->var_type = UDQ::targetType(std::get<std::string>(value_arg), selector_arg);
-        }
-    }
-
-    UDQParseNode(UDQTokenType type_arg, const std::variant<std::string, double>& value_arg)
-        : UDQParseNode(type_arg, value_arg, {})
-    {}
-
-    // Implicit converting constructor.
-    UDQParseNode(UDQTokenType type_arg) : UDQParseNode(type_arg, "")
-    {}
-
-    std::string string() const
-    {
-        if (std::holds_alternative<std::string>(this->value)) {
-            return std::get<std::string>(this->value);
-        }
-        else {
-            return std::to_string(std::get<double>(this->value));
-        }
-    }
-
-    UDQTokenType type;
-    std::variant<std::string, double> value;
-    std::vector<std::string> selector;
-    UDQVarType var_type = UDQVarType::NONE;
-};
-
-class UDQParser
-{
-public:
-    static UDQASTNode
-    parse(const UDQParams&             udq_params,
-          UDQVarType                   target_type,
-          const std::string&           target_var,
-          const KeywordLocation&       location,
-          const std::vector<UDQToken>& tokens_,
-          const ParseContext&          parseContext,
-          ErrorGuard&                  errors);
-
-private:
-    UDQParser(const UDQParams&             udq_params1,
-              const std::vector<UDQToken>& tokens_)
-        : udq_params(udq_params1)
-        , udqft(UDQFunctionTable(udq_params))
-        , tokens(tokens_)
-    {}
-
-    UDQASTNode parse_set();
-    UDQASTNode parse_cmp();
-    UDQASTNode parse_add();
-    UDQASTNode parse_factor();
-    UDQASTNode parse_mul();
-    UDQASTNode parse_pow();
-
-    UDQParseNode current() const;
-    UDQParseNode next();
-    UDQTokenType get_type(const std::string& arg) const;
-    std::size_t current_size() const;
-    bool empty() const;
-
-    const UDQParams& udq_params;
-    UDQFunctionTable udqft;
-    std::vector<UDQToken> tokens;
-    ssize_t current_pos = -1;
-};
+    std::unique_ptr<UDQASTNode>
+    parseUDQExpression(const UDQParams&             udq_params,
+                       UDQVarType                   target_type,
+                       const std::string&           target_var,
+                       const KeywordLocation&       location,
+                       const std::vector<UDQToken>& tokens_,
+                       const ParseContext&          parseContext,
+                       ErrorGuard&                  errors);
 
 } // namespace Opm
 

--- a/opm/input/eclipse/Units/UnitSystem.hpp
+++ b/opm/input/eclipse/Units/UnitSystem.hpp
@@ -20,13 +20,14 @@
 #ifndef UNITSYSTEM_H
 #define UNITSYSTEM_H
 
-#include <string>
-#include <map>
-#include <vector>
-#include <memory>
-
 #include <opm/input/eclipse/Units/Dimension.hpp>
+
 #include <opm/input/eclipse/Schedule/UDQ/UDQEnums.hpp>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace Opm {
 


### PR DESCRIPTION
Mostly by splitting up long lines and re-sorting include statements. The one big API change here is that we make the UDQ expression parser private to the implementation file and switch to returning a `unique_ptr<>` directly instead of a `UDQASTNode` which is then used to form a `shared_ptr<>`.

All of this is in preparation of adding support for using region level summary vectors in the defining expressions of field-level UDQs.