### PR TITLE
Fix Numerous Smaller Issues in the SummaryConfig Type

### DIFF
--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1014,9 +1014,7 @@ void keywordR(SummaryConfig::keyword_list& list,
         return;
     }
 
-    const auto& item = deck_keyword.getDataRecord().getDataItem();
-    std::vector<int> regions;
-
+    auto regions = std::vector<int>{};
 
     // Assume that the FIPNUM array contains the values {1,2,4}; i.e. the
     // maximum value is 4 and the value 3 is missing.  Values which are too
@@ -1033,8 +1031,11 @@ void keywordR(SummaryConfig::keyword_list& list,
     // is also the main reason to treat these quite similar error conditions
     // differently.
 
+    if (! deck_keyword.empty() &&
+        (deck_keyword.getDataRecord().getDataItem().data_size() > 0))
+    {
+        const auto& item = deck_keyword.getDataRecord().getDataItem();
 
-    if (item.data_size() > 0) {
         for (const auto& region_id : item.getData<int>()) {
             const auto& region_set = context.regions.at(region_name.value());
             auto max_iter = region_set.rbegin();

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -1542,6 +1542,10 @@ inline void handleKW( SummaryConfig::keyword_list& list,
 
 SummaryConfigNode::Type parseKeywordType(std::string keyword)
 {
+    if (parseKeywordCategory(keyword) == SummaryConfigNode::Category::Region) {
+        keyword = EclIO::SummaryNode::normalise_region_keyword(keyword);
+    }
+
     if (is_well_completion(keyword)) {
         keyword.pop_back();
     }

--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -118,51 +118,47 @@ struct SummaryConfigContext {
          "DAY", "MONTH", "YEAR"
     };
 
-    /*
-      The variable type 'ECL_SMSPEC_MISC_TYPE' is a catch-all variable
-      type, and will by default internalize keywords like 'ALL' and
-      'PERFORMA', where only the keywords in the expanded list should
-      be included.
-    */
-    const std::map<std::string, std::vector<std::string>> meta_keywords = {{"PERFORMA", PERFORMA_keywords},
-                                                                           {"NMESSAGE", NMESSAGE_keywords},
-                                                                           {"DATE", DATE_keywords},
-                                                                           {"ALL", ALL_keywords},
-                                                                           {"FMWSET", FMWSET_keywords},
-                                                                           {"GMWSET", GMWSET_keywords}};
+    const std::map<std::string, std::vector<std::string>> meta_keywords = {
+        {"PERFORMA", PERFORMA_keywords},
+        {"NMESSAGE", NMESSAGE_keywords},
+        {"DATE",     DATE_keywords},
+        {"ALL",      ALL_keywords},
+        {"FMWSET",   FMWSET_keywords},
+        {"GMWSET",   GMWSET_keywords},
+    };
 
     // This is a hardcoded mapping between 3D field keywords,
     // e.g. 'PRESSURE' and 'SWAT' and summary keywords like 'RPR' and
     // 'BPR'. The purpose of this mapping is to maintain an overview of
     // which 3D field keywords are needed by the Summary calculation
     // machinery, based on which summary keywords are requested.
-    const std::map<std::string , std::set<std::string>> required_fields =  {
-         {"PRESSURE", {"FPR" , "RPR*" , "BPR"}},
-         {"RPV", {"FRPV", "RRPV*"}},
-         {"OIP"  , {"ROIP*" , "FOIP" , "FOE"}},
-         {"OIPR" , {"FOIPR"}},
-         {"OIPL" , {"ROIPL*" ,"FOIPL" }},
-         {"OIPG" , {"ROIPG*" ,"FOIPG"}},
-         {"GIP"  , {"RGIP*", "FGIP"}},
-         {"GIPR" , {"FGIPR"}},
-         {"GIPL" , {"RGIPL*" , "FGIPL"}},
-         {"GIPG" , {"RGIPG*", "FGIPG"}},
-         {"WIP"  , {"RWIP*" , "FWIP"}},
-         {"WIPR" , {"FWIPR"}},
-         {"WIPL" , {"RWIPL*" , "FWIPL"}},
-         {"WIPG" , {"RWIPG*", "FWIPG"}},
-         {"WCD"  , {"RWCD", "FWCD"}},
-         {"GCDI"  , {"RGCDI", "FGCDI"}},
-         {"GCDM"  , {"RGCDM", "FGCDM"}},
-         {"SWAT" , {"BSWAT"}},
-         {"SGAS" , {"BSGAS"}},
-         {"SALT" , {"FSIP"}},
-         {"TEMP" , {"BTCNFHEA"}},
-         {"GMIP"  , {"RGMIP", "FGMIP"}},
-         {"GMGP"  , {"RGMGP", "FGMGP"}},
-         {"GMDS"  , {"RGMDS", "FGMDS"}},
-         {"GMTR"  , {"RGMTR", "FGMTR"}},
-         {"GMMO"  , {"RGMMO", "FGMMO"}}
+    const std::map<std::string, std::set<std::string>> required_fields = {
+         {"PRESSURE", {"FPR", "RPR*", "BPR"}},
+         {"RPV",      {"FRPV", "RRPV*"}},
+         {"OIP",      {"ROIP*", "FOIP", "FOE"}},
+         {"OIPR",     {"FOIPR"}},
+         {"OIPL",     {"ROIPL*", "FOIPL"}},
+         {"OIPG",     {"ROIPG*", "FOIPG"}},
+         {"GIP",      {"RGIP*", "FGIP" }},
+         {"GIPR",     {"FGIPR"}},
+         {"GIPL",     {"RGIPL*", "FGIPL"}},
+         {"GIPG",     {"RGIPG*", "FGIPG"}},
+         {"WIP",      {"RWIP*", "FWIP" }},
+         {"WIPR",     {"FWIPR"}},
+         {"WIPL",     {"RWIPL*", "FWIPL"}},
+         {"WIPG",     {"RWIPG*", "FWIPG"}},
+         {"WCD",      {"RWCD", "FWCD" }},
+         {"GCDI",     {"RGCDI", "FGCDI"}},
+         {"GCDM",     {"RGCDM", "FGCDM"}},
+         {"SWAT",     {"BSWAT"}},
+         {"SGAS",     {"BSGAS"}},
+         {"SALT",     {"FSIP"}},
+         {"TEMP",     {"BTCNFHEA"}},
+         {"GMIP",     {"RGMIP", "FGMIP"}},
+         {"GMGP",     {"RGMGP", "FGMGP"}},
+         {"GMDS",     {"RGMDS", "FGMDS"}},
+         {"GMTR",     {"RGMTR", "FGMTR"}},
+         {"GMMO",     {"RGMMO", "FGMMO"}},
     };
 
     using keyword_set = std::unordered_set<std::string>;

--- a/opm/output/eclipse/RegionCache.hpp
+++ b/opm/output/eclipse/RegionCache.hpp
@@ -15,11 +15,12 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
 #ifndef OPM_REGION_CACHE_HPP
 #define OPM_REGION_CACHE_HPP
 
+#include <cstddef>
 #include <map>
 #include <set>
 #include <string>
@@ -29,22 +30,36 @@ namespace Opm {
     class Schedule;
     class EclipseGrid;
     class FieldPropsManager;
+} // namespace Opm
 
-namespace out {
+namespace Opm { namespace out {
     class RegionCache {
     public:
         RegionCache() = default;
-        RegionCache(const std::set<std::string>& fip_regions, const FieldPropsManager& fp, const EclipseGrid& grid, const Schedule& schedule);
-        const std::vector<std::pair<std::string,size_t>>& connections( const std::string& region_name, int region_id ) const;
+        RegionCache(const std::set<std::string>& fip_regions,
+                    const FieldPropsManager&     fp,
+                    const EclipseGrid&           grid,
+                    const Schedule&              schedule);
 
-        // A well is assigned to the region_id where the first connection is
+        void buildCache(const std::set<std::string>& fip_regions,
+                        const FieldPropsManager&     fp,
+                        const EclipseGrid&           grid,
+                        const Schedule&              schedule);
+
+        const std::vector<std::pair<std::string, std::size_t>>&
+        connections(const std::string& region_name, int region_id) const;
+
+        // A well is assigned to the region_id of its first connection.
         std::vector<std::string> wells(const std::string& region_name, int region_id) const;
-    private:
-        std::vector<std::pair<std::string,size_t>> connections_empty;
-        std::map<std::pair<std::string, int> , std::vector<std::pair<std::string,size_t>>> connection_map;
-        std::map<std::pair<std::string, int>, std::vector<std::string>> well_map;
-    };
-}
-}
 
-#endif
+    private:
+        std::vector<std::pair<std::string, std::size_t>> connections_empty{};
+
+        std::map<std::pair<std::string, int>,
+                 std::vector<std::pair<std::string, std::size_t>>> connection_map{};
+
+        std::map<std::pair<std::string, int>, std::vector<std::string>> well_map{};
+    };
+}} // namespace Opm::out
+
+#endif // OPM_REGION_CACHE_HPP

--- a/opm/output/eclipse/RegionCache.hpp
+++ b/opm/output/eclipse/RegionCache.hpp
@@ -53,12 +53,12 @@ namespace Opm { namespace out {
         std::vector<std::string> wells(const std::string& region_name, int region_id) const;
 
     private:
-        std::vector<std::pair<std::string, std::size_t>> connections_empty{};
+        using RegID = std::pair<std::string, int>;            // { Region set, region ID }
+        using WellConn = std::pair<std::string, std::size_t>; // { Well name, cell ID }
 
-        std::map<std::pair<std::string, int>,
-                 std::vector<std::pair<std::string, std::size_t>>> connection_map{};
-
-        std::map<std::pair<std::string, int>, std::vector<std::string>> well_map{};
+        std::vector<WellConn> connections_empty{};
+        std::map<RegID, std::vector<WellConn>> connection_map{};
+        std::map<RegID, std::vector<std::string>> well_map{};
     };
 }} // namespace Opm::out
 


### PR DESCRIPTION
In particular, the `SummaryConfig` class did not properly account for non-default region sets&ndash;e.g., `FIPABC`&ndash;in all aspects of region level summary keyword processing.  For instance, keywords like `RGPR_ABC` would be classified as an `Unknown` type instead of a `Rate` keyword.  Moreover, the `require3DField()` member function would similarly fail to recognize those kinds of region-level keywords.  This PR switches to using `SummaryConfig::match()` as part of the implementation of `require3DField()`.

While here, also refactor the `RegionCache` construction process in preparation of adding support for region-level summary vectors in `UDQs` and `ACTIONX` condition blocks.  Since we don't know which summary keywords are ultimately referenced until we've parsed the complete `SCHEDULE` section and its UDQs and `ACTIONX` keywords we need deferred construction of the `RegionCache` object.  On the other hand, this work should arguably happen outside `Summary.cpp` so this is **mostly** a stop-gap tactic until such time as we can properly uncouple the construction sequence here.