### PR TITLE
Enable SummaryConfig Inclusion of UDQ/ACTIONX Vectors

### DIFF
--- a/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -169,6 +169,11 @@ namespace Opm {
             SummaryConfig& merge( const SummaryConfig& );
             SummaryConfig& merge( SummaryConfig&& );
 
+            keyword_list
+            registerRequisiteUDQorActionSummaryKeys(const std::vector<std::string>& extraKeys,
+                                                    const EclipseState&             es,
+                                                    const Schedule&                 sched);
+
             /*
               The hasKeyword() method will consult the internal set
               'short_keywords', i.e. the query should be based on pure


### PR DESCRIPTION
This PR adds a new helper function,
```
SummaryConfig::registerRequisiteUDQorActionSummaryKeys
```
which allows the caller to pass a list (`vector<string>`) of summary vector names that are used in the defining expressions of UDQs and in the condition blocks of `ACTIONX` keywords.  The `SummaryConfig` object will expand the list to a full sequence of summary nodes and include those in the internal list of "known" vectors.  The function returns those nodes which did not already exist from processing the `SUMMARY` section at construction time.

This is in preparation of generalising the `UDQ`/`ACTIONX` support in [`Summary.cpp`](https://github.com/OPM/opm-common/blob/07715bb44fdcb921340ffafd011de6031356c37f/opm/output/eclipse/Summary.cpp#L4559-L4563) to also include region-level summary vectors.