### PR TITLE
Expand Set of Categories for UDQ and ACTIONX Summary Vectors

### DIFF
--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -161,7 +161,7 @@ Opm::EclipseIO::Impl::Impl(const EclipseState& eclipseState,
     , outputDir     (eclipseState.getIOConfig().getOutputDir())
     , baseName      (uppercase(eclipseState.getIOConfig().getBaseName()))
     , summaryConfig (summary_config)
-    , summary       (eclipseState, summaryConfig, grid, schedule, base_name, writeEsmry)
+    , summary       (summaryConfig, eclipseState, grid, schedule, base_name, writeEsmry)
     , output_enabled(eclipseState.getIOConfig().getOutputEnabled())
 {
     if (const auto& aqConfig = this->es.aquifer();

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -412,3 +412,7 @@ const Opm::out::Summary& Opm::EclipseIO::summary() const
     return this->impl->summary;
 }
 
+const Opm::SummaryConfig& Opm::EclipseIO::finalSummaryConfig() const
+{
+    return this->impl->summaryConfig;
+}

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -62,30 +62,33 @@
 #include <sstream>
 #include <unordered_map>
 #include <utility>    // move
-
+#include <vector>
 
 namespace {
 
-inline std::string uppercase( std::string x ) {
-    std::transform( x.begin(), x.end(), x.begin(),
-        []( char c ) { return std::toupper( c ); } );
+std::string uppercase(std::string x)
+{
+    std::transform(x.begin(), x.end(), x.begin(),
+                   [](char c) { return std::toupper(c); });
 
     return x;
 }
 
-void ensure_directory_exists( const std::filesystem::path& odir )
+void ensure_directory_exists(const std::filesystem::path& odir)
 {
     namespace fs = std::filesystem;
 
-    if (fs::exists( odir ) && !fs::is_directory( odir ))
+    if (fs::exists(odir) && !fs::is_directory(odir)) {
         throw std::runtime_error {
             "Filesystem element '" + odir.generic_string()
             + "' already exists but is not a directory"
         };
+    }
 
     std::error_code ec{};
-    if (! fs::exists( odir ))
-        fs::create_directories( odir, ec );
+    if (! fs::exists(odir)) {
+        fs::create_directories(odir, ec);
+    }
 
     if (ec) {
         std::ostringstream msg;
@@ -98,31 +101,43 @@ void ensure_directory_exists( const std::filesystem::path& odir )
     }
 }
 
-}
+} // Anonymous namespace
 
-namespace Opm {
-class EclipseIO::Impl {
-    public:
-    Impl( const EclipseState&, EclipseGrid, const Schedule&, const SummaryConfig& , const std::string& baseName, const bool& writeEsmry);
-        void writeINITFile( const data::Solution& simProps, std::map<std::string, std::vector<int> > int_data, const std::vector<NNCdata>& nnc) const;
-        void writeEGRIDFile( const std::vector<NNCdata>& nnc );
-        std::pair<bool, bool> wantRFTOutput( const int report_step, const bool isSubstep ) const;
+class Opm::EclipseIO::Impl
+{
+public:
+    Impl(const EclipseState&,
+         EclipseGrid,
+         const Schedule&,
+         const SummaryConfig&,
+         const std::string& baseName,
+         const bool writeEsmry);
 
-        bool wantSummaryOutput(const int    report_step,
-                               const bool   isSubstep,
-                               const double secs_elapsed) const;
+    void writeINITFile(const data::Solution&                   simProps,
+                       std::map<std::string, std::vector<int>> int_data,
+                       const std::vector<NNCdata>&             nnc) const;
 
-        void recordSummaryOutput(const double secs_elapsed);
+    void writeEGRIDFile(const std::vector<NNCdata>& nnc);
 
-        const EclipseState& es;
-        EclipseGrid grid;
-        const Schedule& schedule;
-        std::string outputDir;
-        std::string baseName;
-        SummaryConfig summaryConfig;
-        out::Summary summary;
-        bool output_enabled;
-        std::optional<RestartIO::Helpers::AggregateAquiferData> aquiferData{std::nullopt};
+    std::pair<bool, bool> wantRFTOutput(const int report_step, const bool isSubstep) const;
+
+    bool wantSummaryOutput(const int    report_step,
+                           const bool   isSubstep,
+                           const double secs_elapsed) const;
+
+    void recordSummaryOutput(const double secs_elapsed);
+
+    const EclipseState& es;
+    EclipseGrid grid;
+
+    const Schedule& schedule;
+    std::string outputDir;
+    std::string baseName;
+    SummaryConfig summaryConfig;
+    out::Summary summary;
+    bool output_enabled;
+
+    std::optional<RestartIO::Helpers::AggregateAquiferData> aquiferData{std::nullopt};
 
 private:
     mutable bool sumthin_active_{false};
@@ -134,20 +149,20 @@ private:
     bool summaryAtRptOnly(const int report_step) const;
 };
 
-EclipseIO::Impl::Impl( const EclipseState& eclipseState,
-                       EclipseGrid grid_,
-                       const Schedule& schedule_,
-                       const SummaryConfig& summary_config,
-                       const std::string& base_name,
-                       const bool& writeEsmry)
-    : es( eclipseState )
-    , grid( std::move( grid_ ) )
-    , schedule( schedule_ )
-    , outputDir( eclipseState.getIOConfig().getOutputDir() )
-    , baseName( uppercase( eclipseState.getIOConfig().getBaseName() ) )
-    , summaryConfig( summary_config )
-    , summary( eclipseState, summaryConfig, grid , schedule, base_name, writeEsmry )
-    , output_enabled( eclipseState.getIOConfig().getOutputEnabled() )
+Opm::EclipseIO::Impl::Impl(const EclipseState& eclipseState,
+                           EclipseGrid          grid_,
+                           const Schedule&      schedule_,
+                           const SummaryConfig& summary_config,
+                           const std::string&   base_name,
+                           const bool           writeEsmry)
+    : es            (eclipseState)
+    , grid          (std::move(grid_))
+    , schedule      (schedule_)
+    , outputDir     (eclipseState.getIOConfig().getOutputDir())
+    , baseName      (uppercase(eclipseState.getIOConfig().getBaseName()))
+    , summaryConfig (summary_config)
+    , summary       (eclipseState, summaryConfig, grid, schedule, base_name, writeEsmry)
+    , output_enabled(eclipseState.getIOConfig().getOutputEnabled())
 {
     if (const auto& aqConfig = this->es.aquifer();
         aqConfig.connections().active() || aqConfig.hasNumericalAquifer())
@@ -158,10 +173,9 @@ EclipseIO::Impl::Impl( const EclipseState& eclipseState,
     }
 }
 
-
-void EclipseIO::Impl::writeINITFile(const data::Solution&                   simProps,
-                                    std::map<std::string, std::vector<int>> int_data,
-                                    const std::vector<NNCdata>&             nnc) const
+void Opm::EclipseIO::Impl::writeINITFile(const data::Solution&                   simProps,
+                                         std::map<std::string, std::vector<int>> int_data,
+                                         const std::vector<NNCdata>&             nnc) const
 {
     EclIO::OutputStream::Init initFile {
         EclIO::OutputStream::ResultSet { this->outputDir, this->baseName },
@@ -172,8 +186,8 @@ void EclipseIO::Impl::writeINITFile(const data::Solution&                   simP
                   simProps, std::move(int_data), nnc, initFile);
 }
 
-
-void EclipseIO::Impl::writeEGRIDFile( const std::vector<NNCdata>& nnc ) {
+void Opm::EclipseIO::Impl::writeEGRIDFile(const std::vector<NNCdata>& nnc)
+{
     const auto formatted = this->es.cfg().io().getFMTOUT();
 
     const auto ext = '.'
@@ -183,12 +197,12 @@ void EclipseIO::Impl::writeEGRIDFile( const std::vector<NNCdata>& nnc ) {
     const auto egridFile = (std::filesystem::path{ this->outputDir }
         / (this->baseName + ext)).generic_string();
 
-    this->grid.save( egridFile, formatted, nnc, this->es.getDeckUnitSystem());
+    this->grid.save(egridFile, formatted, nnc, this->es.getDeckUnitSystem());
 }
 
 std::pair<bool, bool>
-EclipseIO::Impl::wantRFTOutput( const int  report_step,
-                                const bool isSubstep ) const
+Opm::EclipseIO::Impl::wantRFTOutput(const int  report_step,
+                                    const bool isSubstep) const
 {
     if (isSubstep)
         return std::make_pair(false, false);
@@ -203,9 +217,9 @@ EclipseIO::Impl::wantRFTOutput( const int  report_step,
     return std::make_pair(step >= first_rft_out, step > first_rft_out);
 }
 
-bool EclipseIO::Impl::wantSummaryOutput(const int    report_step,
-                                        const bool   isSubstep,
-                                        const double secs_elapsed) const
+bool Opm::EclipseIO::Impl::wantSummaryOutput(const int    report_step,
+                                             const bool   isSubstep,
+                                             const double secs_elapsed) const
 {
     // Check this condition first because the end of a SUMTHIN interval
     // might coincide with a report step.  In that case we also need to
@@ -218,14 +232,14 @@ bool EclipseIO::Impl::wantSummaryOutput(const int    report_step,
             && (!this->sumthin_active_ || this->sumthin_triggered_));
 }
 
-void EclipseIO::Impl::recordSummaryOutput(const double secs_elapsed)
+void Opm::EclipseIO::Impl::recordSummaryOutput(const double secs_elapsed)
 {
     if (this->sumthin_triggered_)
         this->last_sumthin_output_ = secs_elapsed;
 }
 
-bool EclipseIO::Impl::checkAndRecordIfSumthinTriggered(const int    report_step,
-                                                       const double secs_elapsed) const
+bool Opm::EclipseIO::Impl::checkAndRecordIfSumthinTriggered(const int    report_step,
+                                                            const double secs_elapsed) const
 {
     const auto& sumthin = this->schedule[report_step - 1].sumthin();
 
@@ -235,45 +249,68 @@ bool EclipseIO::Impl::checkAndRecordIfSumthinTriggered(const int    report_step,
         && ! (secs_elapsed < this->last_sumthin_output_ + sumthin.value());
 }
 
-bool EclipseIO::Impl::summaryAtRptOnly(const int report_step) const
+bool Opm::EclipseIO::Impl::summaryAtRptOnly(const int report_step) const
 {
     return this->schedule[report_step - 1].rptonly();
 }
 
-/*
-int_data: Writes key(string) and integers vector to INIT file as eclipse keywords
-- Key: Max 8 chars.
-- Wrong input: invalid_argument exception.
-*/
-void EclipseIO::writeInitial( data::Solution simProps, std::map<std::string, std::vector<int> > int_data, const std::vector<NNCdata>& nnc) {
-    if( !this->impl->output_enabled )
+// ---------------------------------------------------------------------------
+
+Opm::EclipseIO::EclipseIO(const EclipseState&  es,
+                          EclipseGrid          grid,
+                          const Schedule&      schedule,
+                          const SummaryConfig& summary_config,
+                          const std::string&   baseName,
+                          const bool           writeEsmry)
+    : impl { std::make_unique<Impl>(es, std::move(grid),
+                                    schedule, summary_config,
+                                    baseName, writeEsmry) }
+{
+    if (! this->impl->output_enabled) {
         return;
+    }
 
-    {
-        const auto& es = this->impl->es;
-        const IOConfig& ioConfig = es.cfg().io();
+    ensure_directory_exists(this->impl->outputDir);
+}
 
-        simProps.convertFromSI( es.getUnits() );
-        if( ioConfig.getWriteINITFile() )
-            this->impl->writeINITFile( simProps , std::move(int_data), nnc );
+Opm::EclipseIO::~EclipseIO() = default;
 
-        if( ioConfig.getWriteEGRIDFile( ) )
-            this->impl->writeEGRIDFile( nnc );
+// int_data: Writes key(string) and integers vector to INIT file as eclipse keywords
+//  - Key: Max 8 chars.
+//  - Wrong input: invalid_argument exception.
+void Opm::EclipseIO::writeInitial(data::Solution                          simProps,
+                                  std::map<std::string, std::vector<int>> int_data,
+                                  const std::vector<NNCdata>&             nnc)
+{
+    if (! this->impl->output_enabled) {
+        return;
+    }
+
+    const auto& es = this->impl->es;
+    const auto& ioConfig = es.cfg().io();
+
+    if (ioConfig.getWriteINITFile()) {
+        simProps.convertFromSI(es.getUnits());
+        this->impl->writeINITFile(simProps, std::move(int_data), nnc);
+    }
+
+    if (ioConfig.getWriteEGRIDFile()) {
+        this->impl->writeEGRIDFile(nnc);
     }
 
 }
 
 // implementation of the writeTimeStep method
-void EclipseIO::writeTimeStep(const Action::State& action_state,
-                              const WellTestState& wtest_state,
-                              const SummaryState& st,
-                              const UDQState& udq_state,
-                              int report_step,
-                              bool  isSubstep,
-                              double secs_elapsed,
-                              RestartValue value,
-                              const bool write_double)
- {
+void Opm::EclipseIO::writeTimeStep(const Action::State& action_state,
+                                   const WellTestState& wtest_state,
+                                   const SummaryState&  st,
+                                   const UDQState&      udq_state,
+                                   const int            report_step,
+                                   const bool           isSubstep,
+                                   const double         secs_elapsed,
+                                   RestartValue         value,
+                                   const bool           write_double)
+{
     if (! this->impl->output_enabled) {
         return;
     }
@@ -295,20 +332,16 @@ void EclipseIO::writeTimeStep(const Action::State& action_state,
         this->impl->recordSummaryOutput(secs_elapsed);
     }
 
-
     if (final_step && !isSubstep && this->impl->summaryConfig.createRunSummary()) {
         std::filesystem::path outputDir { this->impl->outputDir } ;
         std::filesystem::path outputFile { outputDir / this->impl->baseName } ;
         EclIO::ESmry(outputFile).write_rsm_file();
     }
 
-    /*
-      Current implementation will not write restart files for substep,
-      but there is an unsupported option to the RPTSCHED keyword which
-      will request restart output from every timestep.
-    */
-    if(!isSubstep && schedule.write_rst_file(report_step))
-    {
+    // Current implementation will not write restart files for substep, but
+    // there is an unsupported option to the RPTSCHED keyword which will
+    // request restart output from every timestep.
+    if (!isSubstep && schedule.write_rst_file(report_step)) {
         EclIO::OutputStream::Restart rstFile {
             EclIO::OutputStream::ResultSet { this->impl->outputDir,
                                              this->impl->baseName },
@@ -348,51 +381,34 @@ void EclipseIO::writeTimeStep(const Action::State& action_state,
             std::stringstream ss;
             const auto& unit_system = this->impl->es.getUnits();
 
-            RptIO::write_report(ss, report.first, report.second, schedule, grid, unit_system, report_step);
+            RptIO::write_report(ss, report.first, report.second,
+                                schedule, grid, unit_system, report_step);
 
             auto log_string = ss.str();
-            if (!log_string.empty())
+            if (!log_string.empty()) {
                 OpmLog::note(log_string);
+            }
         }
     }
- }
+}
 
-
-RestartValue EclipseIO::loadRestart(Action::State& action_state, SummaryState& summary_state, const std::vector<RestartKey>& solution_keys, const std::vector<RestartKey>& extra_keys) const {
-    const auto& es                       = this->impl->es;
-    const auto& grid                     = this->impl->grid;
-    const auto& schedule                 = this->impl->schedule;
-    const InitConfig& initConfig         = es.getInitConfig();
-    const auto& ioConfig                 = es.getIOConfig();
-    const int report_step                = initConfig.getRestartStep();
-    const std::string filename           = ioConfig.getRestartFileName( initConfig.getRestartRootName(),
-                                                                        report_step,
-                                                                        false );
+Opm::RestartValue
+Opm::EclipseIO::loadRestart(Action::State&                 action_state,
+                            SummaryState&                  summary_state,
+                            const std::vector<RestartKey>& solution_keys,
+                            const std::vector<RestartKey>& extra_keys) const
+{
+    const auto& initConfig  = this->impl->es.getInitConfig();
+    const auto  report_step = initConfig.getRestartStep();
+    const auto  filename    = this->impl->es.getIOConfig()
+        .getRestartFileName(initConfig.getRestartRootName(), report_step, false);
 
     return RestartIO::load(filename, report_step, action_state, summary_state, solution_keys,
-                           es, grid, schedule, extra_keys);
+                           this->impl->es, this->impl->grid, this->impl->schedule, extra_keys);
 }
 
-EclipseIO::EclipseIO( const EclipseState& es,
-                      EclipseGrid grid,
-                      const Schedule& schedule,
-                      const SummaryConfig& summary_config,
-                      const std::string& baseName,
-                      const bool writeEsmry
-                    )
-    : impl( new Impl( es, std::move( grid ), schedule , summary_config, baseName, writeEsmry) )
+const Opm::out::Summary& Opm::EclipseIO::summary() const
 {
-    if( !this->impl->output_enabled )
-        return;
-
-    ensure_directory_exists( this->impl->outputDir );
-}
-
-const out::Summary& EclipseIO::summary() {
     return this->impl->summary;
 }
 
-
-EclipseIO::~EclipseIO() {}
-
-} // namespace Opm

--- a/opm/output/eclipse/EclipseIO.cpp
+++ b/opm/output/eclipse/EclipseIO.cpp
@@ -50,6 +50,8 @@
 #include <opm/io/eclipse/ESmry.hpp>
 #include <opm/io/eclipse/OutputStream.hpp>
 
+#include <opm/common/utility/String.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdlib>
@@ -65,14 +67,6 @@
 #include <vector>
 
 namespace {
-
-std::string uppercase(std::string x)
-{
-    std::transform(x.begin(), x.end(), x.begin(),
-                   [](char c) { return std::toupper(c); });
-
-    return x;
-}
 
 void ensure_directory_exists(const std::filesystem::path& odir)
 {

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -184,6 +184,7 @@ public:
                              const std::vector<RestartKey>& extra_keys = {}) const;
 
     const out::Summary& summary() const;
+    const SummaryConfig& finalSummaryConfig() const;
 
 private:
     class Impl;

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -22,16 +22,12 @@
 #ifndef OPM_ECLIPSE_WRITER_HPP
 #define OPM_ECLIPSE_WRITER_HPP
 
+#include <opm/output/data/Solution.hpp>
+
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <opm/output/data/Solution.hpp>
-
-namespace Opm { namespace out {
-    class Summary;
-}} // namespace Opm::out
 
 namespace Opm {
 
@@ -45,196 +41,153 @@ class SummaryConfig;
 class SummaryState;
 class UDQState;
 class WellTestState;
-namespace Action { class State; }
-/*!
- * \brief A class to write the reservoir state and the well state of a
- *        blackoil simulation to disk using the Eclipse binary format.
- */
-class EclipseIO {
+
+} // namespace Opm
+
+namespace Opm { namespace Action {
+    class State;
+}} // namespace Opm::Action
+
+namespace Opm { namespace out {
+    class Summary;
+}} // namespace Opm::out
+
+namespace Opm {
+/// \brief A class to write reservoir and well states of a blackoil
+///        simulation to disk.
+class EclipseIO
+{
 public:
-    /*!
-     * \brief Sets the common attributes required to write eclipse
-     *        binary files using ERT.
-     */
-    EclipseIO( const EclipseState& es,
-               EclipseGrid grid,
-               const Schedule& schedule,
-               const SummaryConfig& summary_config,
-               const std::string& basename = "",
-               const bool writeEsmry = false
-             );
+    /// \brief Sets common attributes required to write compatible result
+    /// files.
+    EclipseIO(const EclipseState&  es,
+              EclipseGrid          grid,
+              const Schedule&      schedule,
+              const SummaryConfig& summary_config,
+              const std::string&   basename = "",
+              const bool writeEsmry = false);
 
+    EclipseIO(const EclipseIO&) = delete;
 
-
-
-/**    \brief Output static properties in EGRID and INIT file.
-  *
-  *    Write the static eclipse data (grid, PVT curves, etc) to disk,
-  *    and set up additional initial properties. There are no specific
-  *    keywords to configure the output to the INIT files, it seems
-  *    like the algorithm is: "All available keywords are written to
-  *    INIT file". For the current code the algorithm is as such:
-  *
-  *
-  *    1. 3D properties which can be simply calculated in the output
-  *       layer are unconditionally written to disk, that currently
-  *       includes the DX, DY, DZ and DEPTH keyword.
-  *
-  *    2. All integer propeerties from the deck are written
-  *       unconditionally, that typically includes the MULTNUM, PVTNUM,
-  *       SATNUM and so on. Observe that the keywords PVTNUM, SATNUM,
-  *       EQLNUM and FIPNUM are autocreated in the output layer, so
-  *       they will be on disk even if they are not explicitly included
-  *       in the deck.
-  *
-  *    3. The PORV keyword will *always* be present in the INIT file,
-  *       and that keyword will have nx*ny*nz elements; all other 3D
-  *       properties will only have nactive elements.
-  *
-  *    4. For floating point 3D keywords from the deck - like PORO and
-  *       PERMX there is a *hardcoded* list in the writeINIFile( )
-  *       implementation of which keywords to output - if they are
-  *       available.
-  *
-  *    5. The container simProps contains additional 3D floating point
-  *       properties which have been calculated by the simulator, this
-  *       typically includes the transmissibilities TRANX, TRANY and
-  *       TRANZ but could in principle be anye floating point
-  *       property.
-  *
-  *       If you want the FOE keyword in the summary output the
-  *       simProps container must contain the initial OIP field.
-  *
-  *   In addition:
-  *
-  *   - The NNC argument is distributed between the EGRID and INIT
-  *     files.
-  *
-  *   - PVT curves are written unconditionally, saturation functions
-  *     are not yet written to disk.
-  */
-
-    void writeInitial( data::Solution simProps = data::Solution(), std::map<std::string, std::vector<int> > int_data = {}, const std::vector<NNCdata>& nnc = {});
-
-    /**
-     * \brief Overwrite the initial OIP values.
-     *
-     * These are also written when we call writeInitial if the simProps
-     * contains them. If not these are assumed to zero and the simulator
-     * can update them with this methods.
-     * \param simProps The properties containing at least OIP.
-     */
-    void overwriteInitialOIP( const data::Solution& simProps );
-
-    /*!
-     * \brief Write a reservoir state and summary information to disk.
-     *
-     *
-     * The reservoir state can be inspected with visualization tools like
-     * ResInsight.
-     *
-     * The summary information can then be visualized using tools from
-     * ERT or ECLIPSE. Note that calling this method is only
-     * meaningful after the first time step has been completed.
-     *
-     * The optional simProps vector contains fields which have been
-     * calculated by the simulator and are written to the restart
-     * file. Examples of such fields would be the relative
-     * permeabilities KRO, KRW and KRG and fluxes. The keywords which
-     * can be added here are represented with mnenonics in the RPTRST
-     * keyword.
-     *
-     * The extra_restart argument is an optional aergument which can
-     * be used to store arbitrary double vectors in the restart
-     * file. The following rules apply for the extra data:
-     *
-     *  1. There is no size constraints.
-     *
-     *  2. The keys must be unqiue across the SOlution container, and
-     *     also built in default keys like 'INTEHEAD'.
-     *
-     *  3. There is no unit conversion applied - the vectors are
-     *     written to disk verbatim.
-     *
-     * If the optional argument write_double is sent in as true the
-     * fields in the solution container will be written in double
-     * precision. OPM can load and restart from files with double
-     * precision keywords, but this is non-standard, and other third
-     * party applications might choke on those.
-     *
-     * The misc_summary_values argument is used to pass pass various
-     * summary values which are of type 'ECL_SMSPEC_MISC_VAR' to the
-     * summary writer. The ability to pass miscellanous values to the
-     * summary writer is not very flexible:
-     *
-     *  1. The keyword must be an already well defined ECLIPSE keyword
-     *     like e.g. one of the performance related keywords.
-     *
-     *  2. The keyword must have been requested in the SUMMARY section
-     *     of the input deck.
-     *
-     *  3. The dimension of the keyword must have specified in the
-     *     hardcoded static map misc_units in Summary.cpp.
-     */
-
-    void writeTimeStep( const Action::State& action_state,
-                        const WellTestState& wtest_state,
-                        const SummaryState& st,
-                        const UDQState& udq_state,
-                        int report_step,
-                        bool isSubstep,
-                        double seconds_elapsed,
-                        RestartValue value,
-                        const bool write_double = false);
-
-
-    /*
-      Will load solution data and wellstate from the restart
-      file. This method will consult the IOConfig object to get
-      filename and report step to restart from.
-
-      The map keys should be a map of keyword names and their
-      corresponding dimension object, i.e. to load the state from a
-      simple two phase simulation you would pass:
-
-         keys = {{"PRESSURE" , UnitSystem::measure::pressure},
-                 {"SWAT" , UnitSystem::measure::identity }}
-
-      For a three phase black oil simulation you would add pairs for
-      SGAS, RS and RV. If you ask for keys which are not found in the
-      restart file an exception will be raised, the happens if the
-      size of a vector is wrong.
-
-      The function will consult the InitConfig object in the
-      EclipseState object to determine which file and report step to
-      load.
-
-      The return value is of type 'data::Solution', which is the same
-      container type which is used by the EclipseIO, but observe
-      that the dim and target elements carry no information:
-
-         - The returned double data has been converted to SI.
-         . The target is unconditionally set to 'RESTART_SOLUTION'
-
-      The extra_keys argument can be used to request additional
-      kewyords from the restart value. The extra vectors will be
-      stored in the 'extra' field of the RestartValue return
-      value. These values must have been added to the restart file
-      previosuly with the extra argument to the writeTimeStep()
-      method. If the bool value in the map is true the value is
-      required, and the output layer will throw an exception if it is
-      missing, if the bool is false missing keywords will be ignored
-      (there will *not* be an empty vector in the return value).
-    */
-    RestartValue loadRestart(Action::State& action_state, SummaryState& summary_state, const std::vector<RestartKey>& solution_keys, const std::vector<RestartKey>& extra_keys = {}) const;
-    const out::Summary& summary();
-
-    EclipseIO( const EclipseIO& ) = delete;
     ~EclipseIO();
+
+    /// \brief Output static properties in EGRID and INIT file.
+    ///
+    /// Write the static ECLIPSE data (grid, PVT curves, etc) to disk, and
+    /// set up additional initial properties.  For the current code the
+    /// algorithm for selecting which vectors are written to the INIT file
+    /// is as follows:
+    ///
+    ///    1. 3D properties which can be simply calculated in the output
+    ///       layer are unconditionally written to disk, that currently
+    ///       includes the DX, DY, DZ and DEPTH keyword.
+    ///
+    ///    2. All integer propeerties from the deck are written
+    ///       unconditionally, that typically includes the MULTNUM, PVTNUM,
+    ///       SATNUM and so on.  Observe that the keywords PVTNUM, SATNUM,
+    ///       EQLNUM and FIPNUM are automatically created in the output
+    ///       layer, so they will be on disk even if they are not explicitly
+    ///       included in the deck.
+    ///
+    ///    3. The PORV keyword will *always* be present in the INIT file,
+    ///       and that keyword will have nx*ny*nz elements; all other 3D
+    ///       properties will only have nactive elements.
+    ///
+    ///    4. For floating point 3D keywords from the deck - like PORO and
+    ///       PERMX there is a *hardcoded* list in the writeINIFile()
+    ///       implementation of which keywords to output - if they are
+    ///       available.
+    ///
+    ///    5. The container simProps contains additional 3D floating point
+    ///       properties which have been calculated by the simulator, this
+    ///       typically includes the transmissibilities TRANX, TRANY and
+    ///       TRANZ but could in principle be anye floating point
+    ///       property.
+    ///
+    ///       If you want the FOE keyword in the summary output the
+    ///       simProps container must contain the initial OIP field.
+    ///
+    /// In addition:
+    ///   - The NNC argument is distributed between the EGRID and INIT files.
+    void writeInitial(data::Solution simProps = data::Solution(),
+                      std::map<std::string, std::vector<int>> int_data = {},
+                      const std::vector<NNCdata>& nnc = {});
+
+    /// \brief Overwrite the initial OIP values.
+    ///
+    /// These are also written when we call writeInitial if the simProps
+    /// contains them.  If not, these are assumed to zero and the simulator
+    /// can update them with this methods.
+    ///
+    /// \param[in] simProps The properties containing at least OIP.
+    void overwriteInitialOIP(const data::Solution& simProps);
+
+    /// \brief Write a reservoir state and summary information to disk.
+    ///
+    /// Calling this method is only meaningful after the first time step has
+    /// been completed.
+    ///
+    /// The RestartValue contains fields which have been calculated by the
+    /// simulator and are written to the restart file.  Examples of such
+    /// fields would be the relative permeabilities KRO, KRW and KRG and
+    /// fluxes.  The keywords which can be added here are represented with
+    /// mnenonics in the RPTRST keyword.
+    ///
+    /// If the optional argument write_double is sent in as true the fields
+    /// in the solution container will be written in double precision.  OPM
+    /// can load and restart from files with double precision keywords, but
+    /// this is non-standard, and other third party applications might choke
+    /// on those.
+    void writeTimeStep(const Action::State& action_state,
+                       const WellTestState& wtest_state,
+                       const SummaryState&  st,
+                       const UDQState&      udq_state,
+                       int                  report_step,
+                       bool                 isSubstep,
+                       double               seconds_elapsed,
+                       RestartValue         value,
+                       const bool write_double = false);
+
+    /// Will load solution data and wellstate from the restart file.  This
+    /// method will consult the IOConfig object to get filename and report
+    /// step to restart from.
+    ///
+    /// The map keys should be a map of keyword names and their
+    /// corresponding dimension object.  In other words, loading the state
+    /// from a simple two phase simulation you would pass:
+    ///
+    ///    keys = {
+    ///        {"PRESSURE" , UnitSystem::measure::pressure },
+    ///        {"SWAT"     , UnitSystem::measure::identity },
+    ///    }
+    ///
+    /// For a three phase black oil simulation you would add pairs for SGAS,
+    /// RS and RV.  If you request keys which are not found in the restart
+    /// file an exception will be raised.  This also happens if the size of
+    /// a vector does not match the expected size.
+    ///
+    /// The function will consult the InitConfig object in the EclipseState
+    /// object to determine which file and report step to load.
+    ///
+    /// The extra_keys argument can be used to request additional kewyords
+    /// from the restart value.  The extra vectors will be stored in the
+    /// 'extra' field of the return value.  These values must have been
+    /// added to the restart file previosuly with the extra argument to the
+    /// writeTimeStep() method.  If the bool value in the map is true the
+    /// value is required, and the output layer will throw an exception if
+    /// it is missing.  Otherwise, if the bool is false missing, keywords
+    /// will be ignored and there will not be an empty vector in the return
+    /// value.
+    RestartValue loadRestart(Action::State&                 action_state,
+                             SummaryState&                  summary_state,
+                             const std::vector<RestartKey>& solution_keys,
+                             const std::vector<RestartKey>& extra_keys = {}) const;
+
+    const out::Summary& summary() const;
 
 private:
     class Impl;
-    std::unique_ptr< Impl > impl;
+    std::unique_ptr<Impl> impl;
 };
 
 } // namespace Opm

--- a/opm/output/eclipse/Summary.hpp
+++ b/opm/output/eclipse/Summary.hpp
@@ -56,12 +56,12 @@ public:
     using BlockValues = std::map<std::pair<std::string, int>, double>;
     using InterRegFlowValues = std::unordered_map<std::string, data::InterRegFlowMap>;
 
-    Summary(const EclipseState&  es,
-            const SummaryConfig& sumcfg,
-            const EclipseGrid&   grid,
-            const Schedule&      sched,
-            const std::string&   basename = "",
-            const bool           writeEsmry = false);
+    Summary(SummaryConfig&      sumcfg,
+            const EclipseState& es,
+            const EclipseGrid&  grid,
+            const Schedule&     sched,
+            const std::string&  basename = "",
+            const bool          writeEsmry = false);
 
     ~Summary();
 

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -598,7 +598,7 @@ BOOST_AUTO_TEST_CASE(well_keywords)
 
     SummaryState st(TimeService::now());
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     writer.eval(st, 0, 0*day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
 
@@ -903,7 +903,7 @@ BOOST_AUTO_TEST_CASE(well_keywords_dynamic_close) {
 
     SummaryState st(TimeService::now());
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     writer.eval(st, 0, 0*day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
 
@@ -1093,7 +1093,7 @@ BOOST_AUTO_TEST_CASE(well_keywords_dynamic_close) {
 BOOST_AUTO_TEST_CASE(udq_keywords) {
     setup cfg( "test_summary_udq" );
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
@@ -1118,7 +1118,7 @@ BOOST_AUTO_TEST_CASE(udq_keywords) {
 BOOST_AUTO_TEST_CASE(group_keywords) {
     setup cfg( "test_summary_group" );
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
@@ -1275,7 +1275,7 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
 BOOST_AUTO_TEST_CASE(group_group) {
     setup cfg( "test_summary_group_group" , "group_group.DATA");
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
@@ -1349,8 +1349,8 @@ BOOST_AUTO_TEST_CASE(GLIR_and_ALQ)
     const auto deck  = Parser{}.parseFile("2_WLIFT_MODEL5_NOINC.DATA");
     const auto es    = EclipseState { deck };
     const auto sched = Schedule { deck, es, std::make_shared<Python>() };
-    const auto cfg   = SummaryConfig { deck, sched, es.fieldProps(), es.aquifer() };
     const auto name  = "glir_and_alq";
+    auto cfg         = SummaryConfig { deck, sched, es.fieldProps(), es.aquifer() };
 
     WorkArea ta{ "summary_test" };
     ta.makeSubDir(name);
@@ -1358,7 +1358,7 @@ BOOST_AUTO_TEST_CASE(GLIR_and_ALQ)
     const auto wellData = glir_alq_data();
 
     auto st = SummaryState { TimeService::now() };
-    auto writer = out::Summary{ es, cfg, es.getInputGrid(), sched, name };
+    auto writer = out::Summary{ cfg, es, es.getInputGrid(), sched, name };
     writer.eval(st, 0, 0*day, wellData, {}, {}, {}, {}, {});
     writer.add_timestep(st, 0, false);
 
@@ -1387,7 +1387,7 @@ BOOST_AUTO_TEST_CASE(GLIR_and_ALQ)
 BOOST_AUTO_TEST_CASE(connection_kewords) {
     setup cfg( "test_summary_connection" );
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
@@ -1553,7 +1553,7 @@ BOOST_AUTO_TEST_CASE(connection_kewords) {
 BOOST_AUTO_TEST_CASE(DATE) {
     setup cfg( "test_summary_DATE" );
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1, false);
@@ -1592,7 +1592,7 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
 
     auto single_values = out::Summary::GlobalProcessParameters {};
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
 
     single_values.insert_or_assign("FPR" , 123.45*barsa());
@@ -1765,7 +1765,7 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
 BOOST_AUTO_TEST_CASE(report_steps_time) {
     setup cfg( "test_summary_report_steps_time" );
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, fg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 1, 2 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1, false);
@@ -1792,7 +1792,7 @@ BOOST_AUTO_TEST_CASE(report_steps_time) {
 BOOST_AUTO_TEST_CASE(skip_unknown_var) {
     setup cfg( "test_summary_skip_unknown_var" );
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 1, 2 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1, false);
@@ -1907,7 +1907,7 @@ BOOST_AUTO_TEST_CASE(region_vars) {
     }
 
     {
-        out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+        out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
         SummaryState st(TimeService::now());
         writer.eval( st, 1, 2 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, region_values);
         writer.add_timestep( st, 1, false);
@@ -1972,7 +1972,7 @@ BOOST_AUTO_TEST_CASE(region_production) {
     setup cfg( "region_production" );
 
     {
-        out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+        out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
         SummaryState st(TimeService::now());
         writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
         writer.add_timestep( st, 0, false);
@@ -2004,7 +2004,7 @@ BOOST_AUTO_TEST_CASE(region_production) {
 BOOST_AUTO_TEST_CASE(region_injection) {
     setup cfg( "region_injection" );
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
@@ -2122,12 +2122,12 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(inter_region_flows)
 {
-    const auto cfg = setup{ "inter_region_flows" };
+    auto cfg = setup{ "inter_region_flows" };
 
     {
         auto st = SummaryState{ TimeService::now() };
         auto writer = out::Summary {
-            cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name
+            cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name
         };
 
         const auto values = interRegionFlows();
@@ -2262,7 +2262,7 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES)
     block_values.emplace(std::piecewise_construct, std::forward_as_tuple("BDENW", 1), std::forward_as_tuple(987.65*kg_pr_m3()));
     block_values.emplace(std::piecewise_construct, std::forward_as_tuple("BODEN", 1), std::forward_as_tuple(890.12*kg_pr_m3()));
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {}, block_values);
     writer.add_timestep( st, 0, false);
@@ -2332,7 +2332,7 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES)
 BOOST_AUTO_TEST_CASE(NODE_VARIABLES) {
     setup cfg( "test_summary_node" );
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
@@ -2387,7 +2387,7 @@ BOOST_AUTO_TEST_CASE( require3D )
 BOOST_AUTO_TEST_CASE(MISC) {
     setup cfg( "test_misc");
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     SummaryState st(TimeService::now());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
@@ -2406,7 +2406,7 @@ BOOST_AUTO_TEST_CASE(EXTRA) {
     setup cfg( "test_extra");
 
     {
-        out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
+        out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
         SummaryState st(TimeService::now());
         writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, { {"TCPU" , 0 }}, {}, {}, {});
         writer.add_timestep( st, 0, false);
@@ -2542,7 +2542,7 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
         // W_3 is a producer in SUMMARY_EFF_FAC.DATA
         setup cfg( "test_efficiency_factor", "SUMMARY_EFF_FAC.DATA", false );
 
-        out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule, cfg.name );
+        out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
         SummaryState st(TimeService::now());
         writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
         writer.add_timestep( st, 0, false);
@@ -2845,20 +2845,23 @@ BOOST_AUTO_TEST_SUITE_END() // Summary
 namespace {
     Opm::SummaryState calculateRestartVectors(const setup& config)
     {
+        // Intentional copy.
+        auto smcfg = config.config;
+
         ::Opm::out::Summary smry {
-            config.es, config.config, config.grid,
+            smcfg, config.es, config.grid,
             config.schedule, "Ignore.This"
         };
 
-      SummaryState st(TimeService::now());
-      smry.eval(st, 0, 0*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
-      smry.add_timestep(st, 0, false);
-      smry.eval(st, 1, 1*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
-      smry.add_timestep(st, 1, false);
-      smry.eval(st, 2, 2*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
-      smry.add_timestep(st, 2, false);
+        SummaryState st(TimeService::now());
+        smry.eval(st, 0, 0*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
+        smry.add_timestep(st, 0, false);
+        smry.eval(st, 1, 1*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
+        smry.add_timestep(st, 1, false);
+        smry.eval(st, 2, 2*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
+        smry.add_timestep(st, 2, false);
 
-      return st;
+        return st;
     }
 
     auto calculateRestartVectors()
@@ -3914,10 +3917,10 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(Write_Read)
 {
-    const setup config{"test.Restart.Segment.RW", "SOFR_TEST.DATA"};
+    setup config{"test.Restart.Segment.RW", "SOFR_TEST.DATA"};
 
     ::Opm::out::Summary writer {
-        config.es, config.config, config.grid, config.schedule
+        config.config, config.es, config.grid, config.schedule
     };
 
     SummaryState st(TimeService::now());

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -91,14 +91,9 @@ namespace {
         return smry->get(variable + ':' + groupname)[timeIdx];
     }
 
-} // Anonymous
-
-
+} // Anonymous namespace
 
 namespace {
-/* conversion factor for whenever 'day' is the unit of measure, whereas we
- * expect input in SI units (seconds)
- */
 
 std::unique_ptr< EclIO::ESmry > readsum( const std::string& base ) {
     return std::make_unique<EclIO::ESmry>(base);
@@ -107,6 +102,10 @@ std::unique_ptr< EclIO::ESmry > readsum( const std::string& base ) {
 using p_cmode = Opm::Group::ProductionCMode;
 using i_cmode = Opm::Group::InjectionCMode;
 
+/*
+ * conversion factor for whenever 'day' is the unit of measure, whereas we
+ * expect input in SI units (seconds)
+ */
 static const int day = 24 * 60 * 60;
 
 static data::Wells result_wells() {
@@ -264,7 +263,7 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
 
     SummaryState st(TimeService::now());
 
-    out::Summary writer( cfg.es, cfg.config, cfg.grid, cfg.schedule , cfg.name );
+    out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     writer.eval(st, 0, 0*day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
 
@@ -279,7 +278,6 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     //BOOST_CHECK( ecl_sum_has_report_step( resp, 1 ) );
     BOOST_CHECK( ecl_sum_has_group_var( resp, "TEST", "GMCTP" ) );
 
-
     // Integer flag indicating current active group control
     BOOST_CHECK_EQUAL( static_cast<int>(ecl_sum_get_group_var( resp, 1, "TEST", "GMCTP" )), 0 );
     BOOST_CHECK_EQUAL( static_cast<int>(ecl_sum_get_group_var( resp, 1, "LOWER", "GMCTW" )), 3 );
@@ -288,8 +286,6 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     BOOST_CHECK_EQUAL( static_cast<int>(ecl_sum_get_group_var( resp, 1, "UPPER", "GMCTP" )), 3 );
     BOOST_CHECK_EQUAL( static_cast<int>(ecl_sum_get_group_var( resp, 1, "UPPER", "GMCTW" )), 4 );
     BOOST_CHECK_EQUAL( static_cast<int>(ecl_sum_get_group_var( resp, 1, "UPPER", "GMCTG" )), 3 );
-
-
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR introduces and uses a new member function
```
SummaryConfig::registerRequisiteUDQorActionSummaryKeys()
```
as a means of constructing the expanded set of summary nodes referenced by defining expressions for UDQs and in condition blocks of the `ACTIONX` keyword.  We switch to using the `Evaluator::Factory` to construct evaluation function objects for those additional summary nodes.  In principle, this change enables using all known summary vector categories as part of the defining expressions in a `UDQ`, but additional testing is needed before claim to fully support such usage.

Since this change enables using region-level keywords here, we defer construction of the `regionCache_` until we've fully expanded the set of UDQs and `ACTIONX` keywords.

The downside to this change is that the `registerRequisite*` member function is non-`const` and therefore requires a mutable `SummaryConfig` object.  We have one such object within the `EclipseIO` container so this PR switches to taking that object by reference-to-mutable instead, and moves this parameter first in the `Summary` constructor argument list.

Client code gets read-only access to this more complete `SummaryConfig` object through the new member function
```
EclipseIO::finalSummaryConfig()
```