### PR TITLE
Add Facility for Matching Region Level Summary Vector Expressions

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -140,6 +140,7 @@ if(ENABLE_ECL_INPUT)
     opm/input/eclipse/EclipseState/Grid/Operate.cpp
     opm/input/eclipse/EclipseState/Grid/PinchMode.cpp
     opm/input/eclipse/EclipseState/Grid/readKeywordCarfin.cpp
+    opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.cpp
     opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.cpp
     opm/input/eclipse/EclipseState/Grid/setKeywordBox.cpp
     opm/input/eclipse/EclipseState/Grid/TranCalculator.cpp
@@ -496,6 +497,7 @@ if(ENABLE_ECL_INPUT)
     tests/test_ESmry.cpp
     tests/test_ExtESmry.cpp
     tests/test_FIPRegionStatistics.cpp
+    tests/test_RegionSetMatcher.cpp
     tests/test_PAvgCalculator.cpp
     tests/test_PAvgDynamicSourceData.cpp
     tests/test_Serialization.cpp
@@ -1132,6 +1134,7 @@ if(ENABLE_ECL_INPUT)
        opm/input/eclipse/EclipseState/Grid/PinchMode.hpp
        opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
        opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp
+       opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.hpp
        opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
        opm/input/eclipse/EclipseState/Grid/Fault.hpp
        opm/input/eclipse/EclipseState/Grid/Box.hpp

--- a/opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.cpp
@@ -1,0 +1,382 @@
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/FIPRegionStatistics.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <charconv>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+
+class Opm::RegionSetMatcher::Impl
+{
+public:
+    explicit Impl(const FIPRegionStatistics& fipRegStats)
+        : fipRegStats_{ std::cref(fipRegStats) }
+    {}
+
+    template <class AddRegionSets>
+    RegionSetMatchResult findRegions(const SetDescriptor& request,
+                                     AddRegionSets        addRegions) const;
+
+private:
+    class RegIdxRange
+    {
+    public:
+        RegIdxRange(const int begin_arg, const int end_arg)
+            : begin_{begin_arg}, end_{end_arg}
+        {}
+
+        int begin() const { return this->begin_; }
+        int end()   const { return this->end_; }
+
+        bool empty() const { return this->end() <= this->begin(); }
+
+    private:
+        int begin_{};
+        int end_{};
+    };
+
+    std::reference_wrapper<const FIPRegionStatistics> fipRegStats_;
+
+    std::vector<std::string>
+    candidateRegionSets(const std::optional<std::string>& regionSet) const;
+
+    RegIdxRange
+    matchingRegions(const std::string&        regSet,
+                    const std::optional<int>& regionID) const;
+
+    RegIdxRange
+    matchingRegions(const std::string& regSet,
+                    const int          regionID) const;
+
+    RegIdxRange matchingRegions(const std::string& regSet) const;
+};
+
+template <class AddRegionSet>
+Opm::RegionSetMatchResult
+Opm::RegionSetMatcher::Impl::findRegions(const SetDescriptor& request,
+                                         AddRegionSet         addRegions) const
+{
+    auto regSetMatchResult = RegionSetMatchResult{};
+
+    for (const auto& regSet : this->candidateRegionSets(request.regionSet())) {
+        if (const auto regions = this->matchingRegions(regSet, request.regionID());
+            ! regions.empty())
+        {
+            addRegions(regSet, regions.begin(), regions.end(), regSetMatchResult);
+        }
+    }
+
+    return regSetMatchResult;
+}
+
+std::vector<std::string>
+Opm::RegionSetMatcher::Impl::
+candidateRegionSets(const std::optional<std::string>& regionSet) const
+{
+    return regionSet.has_value()
+        ? std::vector { *regionSet } // Specific region set
+        : this->fipRegStats_.get().regionSets();
+}
+
+Opm::RegionSetMatcher::Impl::RegIdxRange
+Opm::RegionSetMatcher::Impl::
+matchingRegions(const std::string&        regSet,
+                const std::optional<int>& regionID) const
+{
+    return regionID.has_value()
+        ? this->matchingRegions(regSet, *regionID)
+        : this->matchingRegions(regSet);
+}
+
+Opm::RegionSetMatcher::Impl::RegIdxRange
+Opm::RegionSetMatcher::Impl::
+matchingRegions(const std::string& regSet,
+                const int          regionID) const
+{
+    const auto maxRegID = this->fipRegStats_.get().maximumRegionID(regSet);
+
+    if ((maxRegID > 0) &&       // Region set exists
+        ((regionID <= maxRegID) ||
+         (regionID <= this->fipRegStats_.get().declaredMaximumRegionID())))
+    {
+        // 'RegionID' is within index range of 'regSet'.  Return range
+        // matching exactly that region ID (end == begin + 1).
+        return { regionID, regionID + 1 };
+    }
+
+    // If we get here, 'regSet' does not exist or does not contain
+    // 'regionID'.  Return empty range (end <= begin).
+    return { 0, 0 };
+}
+
+Opm::RegionSetMatcher::Impl::RegIdxRange
+Opm::RegionSetMatcher::Impl::matchingRegions(const std::string& regSet) const
+{
+    // No specific region ID => All regions match request provided 'regSet'
+    // exists.
+
+    const auto maxRegID = this->fipRegStats_.get().maximumRegionID(regSet);
+
+    if (maxRegID <= 0) {
+        // 'regSet' does not exist.  Return empty range (end <= begin).
+        return { 0, 0 };
+    }
+
+    // 'regSet' is a valid region set name.  Return range covering 1..MAX.
+    const auto maxID =
+        std::max(maxRegID, this->fipRegStats_.get().declaredMaximumRegionID());
+
+    return { 1, maxID + 1 };
+}
+
+// ===========================================================================
+// Public Interface Below Separator
+// ===========================================================================
+
+namespace {
+    std::string_view dequote(std::string_view s)
+    {
+        auto b = s.find_first_of("'");
+        if (b == std::string_view::npos) {
+            return s;
+        }
+
+        auto x = s.substr(b + 1);
+        auto e = x.find_first_of("'");
+        if (e == std::string_view::npos) {
+            throw std::invalid_argument {
+                fmt::format("Invalid quoted string |{}|", s)
+            };
+        }
+
+        return x.substr(0, e);
+    }
+
+    bool is_asterisk(std::string_view s)
+    {
+        const auto ast = std::regex { R"(\s*\*\s*)" };
+        return std::regex_match(s.begin(), s.end(), ast);
+    }
+} // Anonymous namespace
+
+Opm::RegionSetMatcher::SetDescriptor&
+Opm::RegionSetMatcher::SetDescriptor::regionID(const int region)
+{
+    if (region <= 0) {
+        // No specific region ID.
+        this->regionId_.reset();
+    }
+    else {
+        this->regionId_ = region;
+    }
+
+    return *this;
+}
+
+Opm::RegionSetMatcher::SetDescriptor&
+Opm::RegionSetMatcher::SetDescriptor::regionID(std::string_view region0)
+{
+    auto region = dequote(region0);
+
+    if (region.empty()) {
+        // Not specified
+        return this->regionID(0);
+    }
+
+    auto result = 0;
+    auto [ptr, ec] { std::from_chars(region.data(), region.data() + region.size(), result) };
+
+    if ((ec == std::errc{}) && (ptr == region.data() + region.size())) {
+        // Region ID is "7", or "'-1'", or something similar.
+        return this->regionID(result);
+    }
+    else if ((ec == std::errc::invalid_argument) && is_asterisk(region)) {
+        // Region ID is '*'.  Treat as all regions.
+        return this->regionID(0);
+    }
+    else {
+        // Region ID is some unrecognized number string other than '*'.
+        throw std::invalid_argument {
+            fmt::format("Invalid region ID number string |{}|", region0)
+        };
+    }
+}
+
+Opm::RegionSetMatcher::SetDescriptor&
+Opm::RegionSetMatcher::SetDescriptor::vectorName(std::string_view vector)
+{
+    const auto padLimit = std::string_view::size_type{5};
+
+    if (vector.size() < padLimit) {
+        // Canonical vector name like "RPR", "ROIP", or "RODEN".  Matches
+        // all region sets.
+        this->regionSet_.reset();
+    }
+    else {
+        // Specific vector name like "RPR__ABC", "ROIP_NUM", or "RODENTS1".
+        // Matches specific region set.
+        this->regionSet_ = vector.substr(padLimit);
+    }
+
+    return *this;
+}
+
+// ---------------------------------------------------------------------------
+
+std::vector<std::string_view>
+Opm::RegionSetMatchResult::regionSets() const
+{
+    auto regSetColl = std::vector<std::string_view>{};
+    regSetColl.reserve(this->numRegionSets());
+
+    auto ix = std::vector<std::vector<int>::size_type>::size_type{0};
+    for (const auto& regSet : this->regionSets_) {
+        const auto min = this->regionIDRange_[2*ix + 0];
+        const auto max = this->regionIDRange_[2*ix + 1];
+        if (max >= min) {
+            regSetColl.emplace_back(regSet);
+        }
+
+        ix += 1;
+    }
+
+    return regSetColl;
+}
+
+Opm::RegionSetMatchResult::RegionIndexRange
+Opm::RegionSetMatchResult::regions(std::string_view regSet) const
+{
+    using Ix = std::vector<std::string>::size_type;
+
+    // Get 'regSet's insertion index from list sorted alphabetically on
+    // region set names.  Client must call establishNameLookupIndex() prior
+    // to calling regions(string_view).
+
+    auto ixPos =
+        std::lower_bound(this->regionSetIndex_.begin(), this->regionSetIndex_.end(),
+                         regSet, [this](const Ix i, std::string_view rsetName)
+                         {
+                             return this->regionSets_[i] < rsetName;
+                         });
+
+    if ((ixPos == this->regionSetIndex_.end()) || (this->regionSets_[*ixPos] != regSet)) {
+        return this->regions(this->numRegionSets());
+    }
+    else {
+        return this->regions(*ixPos);
+    }
+}
+
+Opm::RegionSetMatchResult::RegionIndexRange
+Opm::RegionSetMatchResult::regions(const std::size_t regSet) const
+{
+    if (regSet >= this->numRegionSets()) {
+        // Non-existent region set.  Return empty range (last <= first)
+        return {};
+    }
+
+    const auto beginRegID = this->regionIDRange_[2*regSet + 0];
+    const auto endRegID   = this->regionIDRange_[2*regSet + 1];
+
+    return { beginRegID, endRegID, this->regionSets_[regSet] };
+}
+
+void Opm::RegionSetMatchResult::establishNameLookupIndex()
+{
+    using Ix = std::vector<std::string>::size_type;
+
+    // Sort well insertion/order indices alphabetically on region set names.
+    // Enables using std::lower_bound() in regions(string_view regSet).
+
+    this->regionSetIndex_.resize(this->regionSets_.size());
+    std::iota(this->regionSetIndex_.begin(), this->regionSetIndex_.end(), Ix{0});
+    std::sort(this->regionSetIndex_.begin(), this->regionSetIndex_.end(),
+              [this](const Ix i1, const Ix i2)
+              {
+                  return this->regionSets_[i1] < this->regionSets_[i2];
+              });
+}
+
+void Opm::RegionSetMatchResult::addRegionIndices(const std::string& regSet,
+                                                 const int          beginRegID,
+                                                 const int          endRegID)
+{
+    assert (endRegID > beginRegID);
+
+    this->regionSets_.push_back(regSet);
+
+    // Invariant: Push 'begin' before 'end'.
+    this->regionIDRange_.push_back(beginRegID);
+    this->regionIDRange_.push_back(endRegID);
+}
+
+// ---------------------------------------------------------------------------
+
+Opm::RegionSetMatcher::RegionSetMatcher(const FIPRegionStatistics& fipRegStats)
+    : pImpl_{ std::make_unique<Impl>(fipRegStats) }
+{}
+
+Opm::RegionSetMatcher::RegionSetMatcher(RegionSetMatcher&& rhs)
+    : pImpl_{ std::move(rhs.pImpl_) }
+{}
+
+Opm::RegionSetMatcher&
+Opm::RegionSetMatcher::operator=(RegionSetMatcher&& rhs)
+{
+    this->pImpl_ = std::move(rhs.pImpl_);
+    return *this;
+}
+
+Opm::RegionSetMatcher::~RegionSetMatcher() = default;
+
+Opm::RegionSetMatchResult
+Opm::RegionSetMatcher::findRegions(const SetDescriptor& selection) const
+{
+    auto regSetMatchResult = this->pImpl_->
+        findRegions(selection,
+                    [](const std::string&    regSet,
+                       const int             minRegionID,
+                       const int             maxRegionID,
+                       RegionSetMatchResult& matchResult)
+                    {
+                        matchResult.addRegionIndices(regSet, minRegionID, maxRegionID);
+                    });
+
+    regSetMatchResult.establishNameLookupIndex();
+
+    return regSetMatchResult;
+}

--- a/opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.hpp
@@ -1,0 +1,436 @@
+/*
+  Copyright 2024 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef REGION_SET_MATCHER_HPP
+#define REGION_SET_MATCHER_HPP
+
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+/// \file Facility for Identifying Region Collections Matching a UDQ Region Set.
+
+namespace Opm {
+    class FIPRegionStatistics;
+} // namespace Opm
+
+namespace Opm {
+
+class RegionSetMatcher;
+
+/// Result Set From RegionSetMatcher's Matching Process
+class RegionSetMatchResult
+{
+public:
+    /// Region Index Range for Single Region Set
+    class RegionIndexRange
+    {
+    public:
+        /// Simple forward iterator over a region index range.
+        class Iterator
+        {
+        public:
+            /// Iterator's category (forward iterator)
+            using iterator_category = std::forward_iterator_tag;
+
+            /// Iterator's value type
+            using value_type = int;
+
+            /// Iterator's difference type
+            using difference_type = int;
+
+            /// Iterator's pointer type (return type from operator->())
+            using pointer = int*;
+
+            /// Iterator's reference type (return type from operator*())
+            using reference = int&;
+
+            /// Pre-increment operator.
+            ///
+            /// \return *this.
+            Iterator& operator++()
+            {
+                ++this->i_;
+
+                return *this;
+            }
+
+            /// Post-increment operator.
+            ///
+            /// \return Iterator pointing to element prior to increment result.
+            Iterator operator++(int)
+            {
+                auto iter = *this;
+
+                ++(*this);
+
+                return iter;
+            }
+
+            /// Dereference operator
+            ///
+            /// \return Element at current position.
+            reference operator*() { return this->i_; }
+
+            /// Indirection operator
+            ///
+            /// \return Pointer to element at current position.
+            pointer operator->() { return &this->i_; }
+
+            /// Equality predicate
+            ///
+            /// \param[in] that Object to which \c *this will be compared for equality.
+            ///
+            /// \return Whether or not \c *this equals \p that.
+            bool operator==(Iterator that) const
+            {
+                return this->i_ == that.i_;
+            }
+
+            /// Inequality predicate
+            ///
+            /// \param[in] that Object to which \c *this will be compared for inequality.
+            ///
+            /// \return \code ! (*this == that)
+            bool operator!=(Iterator that) const
+            {
+                return ! (*this == that);
+            }
+
+            friend class RegionIndexRange;
+
+        private:
+            /// Constructor
+            ///
+            /// Accessible to RegionIndexRange only.
+            ///
+            /// \param[in] index range element value.
+            Iterator(int i) : i_{i} {}
+
+            /// Index range element value
+            int i_;
+        };
+
+        /// Start of Range.
+        Iterator begin() const { return { this->begin_ }; }
+
+        /// End of Range.
+        Iterator end() const { return { this->end_ }; }
+
+        /// Predicate for empty index range.
+        bool empty() const { return this->end_ <= this->begin_; }
+
+        /// Name of region set to which this index range is attached.
+        std::string_view regionSet() const { return this->region_; }
+
+        friend class RegionSetMatchResult;
+
+    private:
+        /// Beginning of index range
+        int begin_{};
+
+        /// End of Range
+        int end_{};
+
+        /// Name of region set to which this region index range is attached
+        std::string_view region_{};
+
+        /// Default Constructor.
+        ///
+        /// Empty range.
+        ///
+        /// For use by RegionSetMatchResult only.
+        RegionIndexRange() = default;
+
+        /// Non-Empty Range
+        ///
+        /// For use by RegionSetMatchResult only.
+        ///
+        /// \param[in] beginID Minimum region index value.
+        ///
+        /// \param[in] endID One more than the maximum region index value.
+        ///
+        /// \param[in] region Name of region set to which this index range
+        ///    is attached.
+        RegionIndexRange(int beginID, int endID, std::string_view region)
+            : begin_  { beginID }
+            , end_    { endID }
+            , region_ { region }
+        {}
+    };
+
+    /// Predicate for whether or not result set is empty.
+    ///
+    /// \return Whether or not result set is empty.
+    bool empty() const
+    {
+        return this->regionIDRange_.empty();
+    }
+
+    /// Predicate for whether or not result set applies to a single
+    /// region in a single region set.
+    ///
+    /// \return Whether or not result set is a single region in a single
+    ///   region set.  Useful to distinguish whether or not this result set
+    ///   generates a scalar UDQ or a UDQ set in the context of a region
+    ///   level UDQ.
+    bool isScalar() const
+    {
+        return (this->regionIDRange_.size() == std::vector<int>::size_type{2})
+            && (this->regionIDRange_.back() == this->regionIDRange_.front() + 1);
+    }
+
+    /// Retrieve list of (MS) well names covered by this result set.
+    ///
+    /// \return List MS well names covered by this result set.
+    std::vector<std::string_view> regionSets() const;
+
+    /// Retrieve number of region sets covered by this result set.
+    ///
+    /// \return Number of region sets covered by this result set.
+    std::size_t numRegionSets() const
+    {
+        return this->regionSets_.size();
+    }
+
+    /// Retrieve result set's region indices for a single region set.
+    ///
+    /// \param[in] regSet Named region set--e.g., FIPNUM or FIPABC.  Should
+    ///    usually be one of the items in the return value from \code
+    ///    regionSets() \endcode.
+    ///
+    /// \return range of \c regSet's region indices matching the input
+    ///    request.  Empty unless \p regSet is one of the return values from
+    ///    \code regionSets() \endcode.
+    RegionIndexRange regions(std::string_view regSet) const;
+
+    /// Retrieve result set's region indices for a single region set.
+    ///
+    /// \param[in] regSet Region set number.  Should be between zero and
+    ///    \code numRegionSets() - 1 \endcode inclusive.
+    ///
+    /// \return range of \c regSet's region indices matching the input
+    ///    request.  Empty unless \p regSet is between zero and \code
+    ///    numRegionSets() - 1 \endcode inclusive.
+    RegionIndexRange regions(const std::size_t regSet) const;
+
+    friend class RegionSetMatcher;
+
+private:
+    /// List of region sets covered by this result set.
+    std::vector<std::string> regionSets_{};
+
+    /// Name-to-index lookup table.
+    ///
+    /// User, i.e., the RegionSetMatcher, must call \code
+    /// establishNameLookupIndex() \endcode to prepare the lookup table.
+    std::vector<std::vector<std::string>::size_type> regionSetIndex_{};
+
+    /// Minimum and maximum region IDs for all region sets in this result set.
+    std::vector<int> regionIDRange_{};
+
+    /// Build region set name to region set number lookup index.
+    ///
+    /// For use by RegionSetMatcher only.
+    void establishNameLookupIndex();
+
+    /// Add non-empty range of region indices for single region set to
+    /// result set.
+    ///
+    /// For use by RegionSetMatcher only.
+    ///
+    /// \param[in] regSet Name of region set (e.g., FIPNUM or FIPABC).
+    ///
+    /// \param[in] beginRegID Minimum region ID in match result for \p regSet.
+    ///
+    /// \param[in] endRegID One more than the maximum region ID in match
+    ///   result for \p regSet.  Must not be less than \p minRegID.
+    void addRegionIndices(const std::string& regSet,
+                          int                beginRegID,
+                          int                endRegID);
+};
+
+/// Encapsulation of Matching Process for Region Level Expressions
+///
+/// Primary use case is determining the set of region indices used to define
+/// region level UDQs, or to evaluate region level expressions which go into
+/// other UDQs, e.g., at the field level.  Typical region level quantities in
+/// this context are
+///
+///    ROPR         - Oil production rate in all regions of *all* region sets
+///    ROPR_NUM     - Oil production rate in all regions of
+///                   standard/predefined 'FIPNUM' region set
+///    ROPR_ABC     - Oil production rate in all regions of
+///                   user defined 'FIPABC' region set.
+///    ROPR_ABC 42  - Oil production rate in region 42 of user defined
+///                   'FIPABC' region set.
+///
+/// The user initiates the matching process by constructing a SetDescriptor
+/// object, filling in the known pieces of information--the vector name and
+/// region ID--if applicable.  A SetDescriptor region ID will match all
+/// regions in the pertinent region set or region sets.
+///
+/// The matching process, \code RegionSetMatcher::findRegions() \endcode,
+/// forms a \c RegionSetMatchResult object which holds a list of matching
+/// region sets and their associate/corresponding matching region IDs.
+class RegionSetMatcher
+{
+public:
+    /// Description of Particular Region Set Collection
+    ///
+    /// User specified.
+    class SetDescriptor
+    {
+    public:
+        /// Assign request's region number.
+        ///
+        /// Non-positive matches all regions.
+        ///
+        /// \param[in] region Requests's region number.
+        ///
+        /// \return \code *this \endcode.
+        SetDescriptor& regionID(const int region);
+
+        /// Assign request's region number.
+        ///
+        /// String version.  Supports both quoted and unquoted strings.
+        /// Wildcard ('*') and string representation of a negative number
+        /// (e.g., '-1'), match all regions.
+        ///
+        /// \param[in] region Requests's region number.  Must be a text
+        ///    representation of an integer or one of the recognized options
+        ///    for matching all regions.  Throws exception otherwise.
+        ///
+        /// \return \code *this \endcode.
+        SetDescriptor& regionID(std::string_view region);
+
+        /// Retrieve request's region number
+        ///
+        /// \return Region number.  Unset if request matches all regions.
+        const std::optional<int>& regionID() const
+        {
+            return this->regionId_;
+        }
+
+        /// Assign request's vector name
+        ///
+        /// \param[in] vector.  Summary vector keyword, e.g., ROPR_ABC.
+        ///
+        /// \return \code *this \endcode.
+        SetDescriptor& vectorName(std::string_view vector);
+
+        /// Retrieve request's region set name
+        ///
+        /// \return Region set name.  Unset if request matches all region
+        ///    sets (e.g., vector = ROPR).
+        const std::optional<std::string>& regionSet() const
+        {
+            return this->regionSet_;
+        }
+
+    private:
+        /// Request's well name or well name pattern.  Unset if request
+        /// applies to all MS wells.
+        std::optional<std::string> regionSet_{};
+
+        /// Request's region index.  Unset if request applies to all
+        /// regions of pertinent region set.
+        std::optional<int> regionId_{};
+    };
+
+    /// Default constructor
+    ///
+    /// Disabled.
+    RegionSetMatcher() = delete;
+
+    /// Constructor
+    ///
+    /// \param[in] fipRegStats Basic statistics about model's region sets.
+    explicit RegionSetMatcher(const FIPRegionStatistics& fipRegStats);
+
+    /// Copy constructor
+    ///
+    /// Disabled.
+    ///
+    /// \param[in] rhs Source object.
+    RegionSetMatcher(const RegionSetMatcher& rhs) = delete;
+
+    /// Move constructor
+    ///
+    /// \param[in,out] rhs Source object.  Left in empty state upon return.
+    RegionSetMatcher(RegionSetMatcher&& rhs);
+
+    /// Assignment operator
+    ///
+    /// Disabled.
+    ///
+    /// \param[in] rhs Source object.
+    ///
+    /// \return \code *this \endcode.
+    RegionSetMatcher& operator=(const RegionSetMatcher& rhs) = delete;
+
+    /// Move-assignment operator
+    ///
+    /// \param[in,out] rhs Source object.  Left in empty state upon return.
+    ///
+    /// \return \code *this \endcode.
+    RegionSetMatcher& operator=(RegionSetMatcher&& rhs);
+
+    /// Destructor
+    ///
+    /// Needed to implement "pimpl" idiom.
+    ~RegionSetMatcher();
+
+    /// Determine collection of region sets and corresponding region indices
+    /// matching an input set description.
+    ///
+    /// Set is typically derived from description of user defined quantities
+    /// at the region level, e.g.,
+    ///
+    /// \code
+    ///   UDQ
+    ///   DEFINE RURAL ROPR_NUM + RWPR_NUM /
+    ///   /
+    /// \endcode
+    ///
+    /// which represents the surface level liquid production rate for all
+    /// regions in the region set 'FIPNUM'.
+    ///
+    /// \param[in] regSet selection description.
+    ///
+    /// \return Collection of region sets and corresponding region indices
+    ///    matching input set description.
+    RegionSetMatchResult findRegions(const SetDescriptor& regSet) const;
+
+private:
+    /// Implementation class.
+    class Impl;
+
+    /// Pointer to implementation.
+    std::unique_ptr<Impl> pImpl_{};
+};
+
+} // namespace Opm
+
+#endif // REGION_SET_MATCHER_HPP

--- a/tests/test_RegionSetMatcher.cpp
+++ b/tests/test_RegionSetMatcher.cpp
@@ -1,0 +1,676 @@
+/*
+  Copyright 2024 Equinor ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define BOOST_TEST_MODULE Region_Set_Matcher
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FIPRegionStatistics.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
+
+BOOST_AUTO_TEST_SUITE(Set_Descriptor)
+
+BOOST_AUTO_TEST_CASE(Default)
+{
+    const auto request = Opm::RegionSetMatcher::SetDescriptor{};
+
+    BOOST_CHECK_MESSAGE(! request.regionID().has_value(),
+                        "Defaulted SetDescriptor must NOT "
+                        "have a specific region ID");
+
+    BOOST_CHECK_MESSAGE(! request.regionSet().has_value(),
+                        "Defaulted SetDescriptor must NOT "
+                        "have a specific region set name");
+}
+
+BOOST_AUTO_TEST_SUITE(Region_ID)
+
+BOOST_AUTO_TEST_SUITE(Integer_Overload)
+
+BOOST_AUTO_TEST_CASE(Specific)
+{
+    auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID(123);
+
+    BOOST_REQUIRE_MESSAGE(request.regionID().has_value(),
+                          "Assigned SetDescriptor must "
+                          "have a specific region ID");
+
+    BOOST_CHECK_EQUAL(request.regionID().value(), 123);
+
+    request.regionID(1729);
+    BOOST_CHECK_EQUAL(request.regionID().value(), 1729);
+}
+
+BOOST_AUTO_TEST_CASE(NonPositive)
+{
+    auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID(0);
+
+    BOOST_CHECK_MESSAGE(! request.regionID().has_value(),
+                        "Zero region ID must NOT "
+                        "have a specifc region ID "
+                        "in the final descriptor");
+
+    request.regionID(-1);
+
+    BOOST_CHECK_MESSAGE(! request.regionID().has_value(),
+                        "Negative region ID must NOT "
+                        "have a specifc region ID "
+                        "in the final descriptor");
+}
+
+BOOST_AUTO_TEST_CASE(Positve_To_Negative)
+{
+    auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID(11);
+
+    BOOST_REQUIRE_MESSAGE(request.regionID().has_value(),
+                          "Assigned SetDescriptor must "
+                          "have a specific region ID");
+
+    BOOST_CHECK_EQUAL(request.regionID().value(), 11);
+
+    request.regionID(-1);
+
+    BOOST_CHECK_MESSAGE(! request.regionID().has_value(),
+                        "Negative region ID must NOT "
+                        "have a specifc region ID "
+                        "in the final descriptor");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integer_Overload
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(StringView_Overload)
+
+BOOST_AUTO_TEST_CASE(Specific)
+{
+    using namespace std::literals;
+
+    auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("123"sv);
+
+    BOOST_REQUIRE_MESSAGE(request.regionID().has_value(),
+                          "Assigned SetDescriptor must "
+                          "have a specific region ID");
+
+    BOOST_CHECK_EQUAL(request.regionID().value(), 123);
+
+    request.regionID("'1729'"sv);
+    BOOST_CHECK_EQUAL(request.regionID().value(), 1729);
+}
+
+BOOST_AUTO_TEST_CASE(NonPositive)
+{
+    using namespace std::literals;
+
+    auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("0"sv);
+
+    BOOST_CHECK_MESSAGE(! request.regionID().has_value(),
+                        "Zero region ID must NOT "
+                        "have a specifc region ID "
+                        "in the final descriptor");
+
+    request.regionID("'-1'");
+
+    BOOST_CHECK_MESSAGE(! request.regionID().has_value(),
+                        "Negative region ID must NOT "
+                        "have a specifc region ID "
+                        "in the final descriptor");
+}
+
+BOOST_AUTO_TEST_CASE(Asterisk)
+{
+    using namespace std::literals;
+
+    auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("*"sv);
+
+    BOOST_CHECK_MESSAGE(! request.regionID().has_value(),
+                        "Defaulted region ID must NOT "
+                        "have a specifc region ID "
+                        "in the final descriptor");
+}
+
+BOOST_AUTO_TEST_CASE(Positve_To_Negative)
+{
+    using namespace std::literals;
+
+    auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("'11'"sv);
+
+    BOOST_REQUIRE_MESSAGE(request.regionID().has_value(),
+                          "Assigned SetDescriptor must "
+                          "have a specific region iD");
+
+    BOOST_CHECK_EQUAL(request.regionID().value(), 11);
+
+    request.regionID("-1"sv);
+
+    BOOST_CHECK_MESSAGE(! request.regionID().has_value(),
+                        "Negative region ID must NOT "
+                        "have a specifc region ID "
+                        "in the final descriptor");
+}
+
+BOOST_AUTO_TEST_CASE(Invalid)
+{
+    using namespace std::literals;
+
+    BOOST_CHECK_THROW(const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("'1*'"sv), std::invalid_argument);
+
+    BOOST_CHECK_THROW(const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("'123;'"sv), std::invalid_argument);
+
+    BOOST_CHECK_THROW(const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("x"sv), std::invalid_argument);
+
+    BOOST_CHECK_THROW(const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("-123-"sv), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(Leading_And_Trailing_Blanks)
+{
+    using namespace std::literals;
+
+    BOOST_CHECK_THROW(const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID(" 123 "sv), std::invalid_argument);
+
+    BOOST_CHECK_THROW(const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("' 1729'"sv), std::invalid_argument);
+
+    BOOST_CHECK_THROW(const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .regionID("'27 '"sv), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // StringView_Overload
+
+BOOST_AUTO_TEST_SUITE_END() // Region_ID
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(RegionSet_Name)
+
+BOOST_AUTO_TEST_CASE(Single_Region_Set)
+{
+    const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .vectorName("ROPR_NUM");
+
+    BOOST_REQUIRE_MESSAGE(request.regionSet().has_value(),
+                          "Assigned SetDescriptor must "
+                          "have a specific region set name");
+
+    BOOST_CHECK_EQUAL(request.regionSet().value(), "NUM");
+}
+
+BOOST_AUTO_TEST_CASE(Single_Region_Set_UDQ)
+{
+    const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .vectorName("RUGBYZYX");
+
+    BOOST_REQUIRE_MESSAGE(request.regionSet().has_value(),
+                          "Assigned SetDescriptor must "
+                          "have a specific region set name");
+
+    BOOST_CHECK_EQUAL(request.regionSet().value(), "ZYX");
+}
+
+BOOST_AUTO_TEST_CASE(All_Region_Sets)
+{
+    const auto request = Opm::RegionSetMatcher::SetDescriptor{}
+        .vectorName("ROPR");
+
+    BOOST_REQUIRE_MESSAGE(! request.regionSet().has_value(),
+                          "SetDescriptor machting ALL sets must "
+                          "NOT have a specific region set name");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // RegionSet_Name
+
+BOOST_AUTO_TEST_SUITE_END() // Set_Descriptor
+
+// ===========================================================================
+
+BOOST_AUTO_TEST_SUITE(Matcher)
+
+namespace {
+    Opm::FIPRegionStatistics
+    makeFIPStats(const std::size_t declaredMaxRegID, const std::string& input)
+    {
+        const auto fp = Opm::EclipseState {
+            Opm::Parser{}.parseString(input)
+        }.fieldProps();
+
+        return Opm::FIPRegionStatistics {
+            declaredMaxRegID, fp, [](std::vector<int>&) {}
+        };
+    }
+} // Anonymous namespace
+
+BOOST_AUTO_TEST_SUITE(Single_Region_Set)
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    // FIP region statistics object lifetime must exceed RegionSetMatcher
+    // object lifetime.
+    const auto fipStats = makeFIPStats(4, R"(RUNSPEC
+DIMENS
+5 1 2 /
+GRID
+DXV
+5*100 /
+DYV
+100 /
+DZV
+2*5 /
+TOPS
+12*2000 /
+PORO
+10*0.3 /
+REGIONS
+FIPNUM
+ 1 1 1 2 2
+ 3 3 4 4 5 /
+)");
+
+    const auto matcher = Opm::RegionSetMatcher { fipStats };
+
+    const auto descr = Opm::RegionSetMatcher::SetDescriptor {}
+        .vectorName("ROPR_NUM").regionID(3);
+
+    const auto matchingRegions = matcher.findRegions(descr);
+
+    BOOST_CHECK_MESSAGE(! matchingRegions.empty(), "Matching range must be non-empty");
+    BOOST_CHECK_MESSAGE(matchingRegions.isScalar(),
+                        "Matching range must constitute a "
+                        "single region in a single region set");
+
+    {
+        const auto expect = std::vector<std::string> { "NUM" };
+        const auto regSets = matchingRegions.regionSets();
+        BOOST_CHECK_EQUAL_COLLECTIONS(regSets.begin(), regSets.end(),
+                                      expect .begin(), expect .end());
+    }
+
+    BOOST_CHECK_EQUAL(matchingRegions.numRegionSets(), std::size_t{1});
+
+    {
+        const auto regIxRange = matchingRegions.regions(0);
+        const auto expect = std::vector { 3 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    {
+        const auto regIxRange = matchingRegions.regions("NUM");
+        const auto expect = std::vector { 3 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(All_Regions_DeclaredMax)
+{
+    // FIP region statistics object lifetime must exceed RegionSetMatcher
+    // object lifetime.
+    const auto fipStats = makeFIPStats(4, R"(RUNSPEC
+DIMENS
+5 1 2 /
+GRID
+DXV
+5*100 /
+DYV
+100 /
+DZV
+2*5 /
+TOPS
+12*2000 /
+PORO
+10*0.3 /
+REGIONS
+FIPNUM
+ 1 1 1 2 2
+ 3 3 3 2 2 /
+)");
+
+    const auto matcher = Opm::RegionSetMatcher { fipStats };
+
+    const auto descr = Opm::RegionSetMatcher::SetDescriptor {}
+        .vectorName("ROPR_NUM");
+
+    const auto matchingRegions = matcher.findRegions(descr);
+
+    BOOST_CHECK_MESSAGE(! matchingRegions.empty(), "Matching range must be non-empty");
+    BOOST_CHECK_MESSAGE(! matchingRegions.isScalar(),
+                        "Matching range must constitute a "
+                        "multiple regions in a single region set");
+
+    {
+        const auto expect = std::vector<std::string> { "NUM" };
+        const auto regSets = matchingRegions.regionSets();
+        BOOST_CHECK_EQUAL_COLLECTIONS(regSets.begin(), regSets.end(),
+                                      expect .begin(), expect .end());
+    }
+
+    BOOST_CHECK_EQUAL(matchingRegions.numRegionSets(), std::size_t{1});
+
+    {
+        const auto regIxRange = matchingRegions.regions(0);
+        const auto expect = std::vector { 1, 2, 3, 4, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    {
+        const auto regIxRange = matchingRegions.regions("NUM");
+        const auto expect = std::vector { 1, 2, 3, 4, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(All_Regions_DefinedMax)
+{
+    // FIP region statistics object lifetime must exceed RegionSetMatcher
+    // object lifetime.
+    const auto fipStats = makeFIPStats(4, R"(RUNSPEC
+DIMENS
+5 1 2 /
+GRID
+DXV
+5*100 /
+DYV
+100 /
+DZV
+2*5 /
+TOPS
+12*2000 /
+PORO
+10*0.3 /
+REGIONS
+FIPNUM
+ 1 1 1 2 2
+ 3 3 3 5 5 /
+)");
+
+    const auto matcher = Opm::RegionSetMatcher { fipStats };
+
+    const auto descr = Opm::RegionSetMatcher::SetDescriptor {}
+        .vectorName("ROPR_NUM");
+
+    const auto matchingRegions = matcher.findRegions(descr);
+
+    BOOST_CHECK_MESSAGE(! matchingRegions.empty(), "Matching range must be non-empty");
+    BOOST_CHECK_MESSAGE(! matchingRegions.isScalar(),
+                        "Matching range must constitute a "
+                        "multiple regions in a single region set");
+
+    {
+        const auto expect = std::vector<std::string> { "NUM" };
+        const auto regSets = matchingRegions.regionSets();
+        BOOST_CHECK_EQUAL_COLLECTIONS(regSets.begin(), regSets.end(),
+                                      expect .begin(), expect .end());
+    }
+
+    BOOST_CHECK_EQUAL(matchingRegions.numRegionSets(), std::size_t{1});
+
+    {
+        const auto regIxRange = matchingRegions.regions(0);
+        const auto expect = std::vector { 1, 2, 3, 4, 5, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    {
+        const auto regIxRange = matchingRegions.regions("NUM");
+        const auto expect = std::vector { 1, 2, 3, 4, 5, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Single_Region_Set
+
+// ---------------------------------------------------------------------------
+
+BOOST_AUTO_TEST_SUITE(Multiple_Region_Sets)
+
+BOOST_AUTO_TEST_SUITE_END() // Multiple_Region_Sets
+
+BOOST_AUTO_TEST_CASE(Single_Region)
+{
+    // FIP region statistics object lifetime must exceed RegionSetMatcher
+    // object lifetime.
+    const auto fipStats = makeFIPStats(4, R"(RUNSPEC
+DIMENS
+5 1 2 /
+GRID
+DXV
+5*100 /
+DYV
+100 /
+DZV
+2*5 /
+TOPS
+12*2000 /
+PORO
+10*0.3 /
+REGIONS
+FIPNUM
+ 1 1 1 2 2
+ 3 3 4 4 5 /
+FIPABC
+ 1 1 1 2 2
+ 1 1 1 2 2 /
+)");
+
+    const auto matcher = Opm::RegionSetMatcher { fipStats };
+
+    const auto descr = Opm::RegionSetMatcher::SetDescriptor {}
+        .vectorName("ROPR").regionID(3);
+
+    const auto matchingRegions = matcher.findRegions(descr);
+
+    BOOST_CHECK_MESSAGE(! matchingRegions.empty(), "Matching range must be non-empty");
+    BOOST_CHECK_MESSAGE(! matchingRegions.isScalar(),
+                        "Matching range must constitute a "
+                        "single region in multiple region sets");
+
+    {
+        const auto expect = std::vector<std::string> { "ABC", "NUM" };
+        const auto regSets = matchingRegions.regionSets();
+        BOOST_CHECK_EQUAL_COLLECTIONS(regSets.begin(), regSets.end(),
+                                      expect .begin(), expect .end());
+    }
+
+    BOOST_CHECK_EQUAL(matchingRegions.numRegionSets(), std::size_t{2});
+
+    for (auto i = 0*matchingRegions.numRegionSets();
+         i < matchingRegions.numRegionSets(); ++i)
+    {
+        const auto regIxRange = matchingRegions.regions(i);
+        const auto expect = std::vector { 3 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    for (const auto* regSet : { "ABC", "NUM" }) {
+        const auto regIxRange = matchingRegions.regions(regSet);
+        const auto expect = std::vector { 3 };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(All_Regions_DeclaredMax)
+{
+    // FIP region statistics object lifetime must exceed RegionSetMatcher
+    // object lifetime.
+    const auto fipStats = makeFIPStats(4, R"(RUNSPEC
+DIMENS
+5 1 2 /
+GRID
+DXV
+5*100 /
+DYV
+100 /
+DZV
+2*5 /
+TOPS
+12*2000 /
+PORO
+10*0.3 /
+REGIONS
+FIPNUM
+ 1 1 1 2 2
+ 3 3 3 3 3 /
+FIPABC
+ 1 1 1 2 2
+ 1 1 1 2 2 /
+)");
+
+    const auto matcher = Opm::RegionSetMatcher { fipStats };
+
+    const auto descr = Opm::RegionSetMatcher::SetDescriptor {}
+        .vectorName("ROPR");
+
+    const auto matchingRegions = matcher.findRegions(descr);
+
+    BOOST_CHECK_MESSAGE(! matchingRegions.empty(), "Matching range must be non-empty");
+    BOOST_CHECK_MESSAGE(! matchingRegions.isScalar(),
+                        "Matching range must constitute a "
+                        "single region in multiple region sets");
+
+    {
+        const auto expect = std::vector<std::string> { "ABC", "NUM" };
+        const auto regSets = matchingRegions.regionSets();
+        BOOST_CHECK_EQUAL_COLLECTIONS(regSets.begin(), regSets.end(),
+                                      expect .begin(), expect .end());
+    }
+
+    BOOST_CHECK_EQUAL(matchingRegions.numRegionSets(), std::size_t{2});
+
+    for (auto i = 0*matchingRegions.numRegionSets();
+         i < matchingRegions.numRegionSets(); ++i)
+    {
+        const auto regIxRange = matchingRegions.regions(i);
+        const auto expect = std::vector { 1, 2, 3, 4, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    for (const auto* regSet : { "ABC", "NUM" }) {
+        const auto regIxRange = matchingRegions.regions(regSet);
+        const auto expect = std::vector { 1, 2, 3, 4, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(All_Regions_DefinedMax)
+{
+    // FIP region statistics object lifetime must exceed RegionSetMatcher
+    // object lifetime.
+    const auto fipStats = makeFIPStats(4, R"(RUNSPEC
+DIMENS
+5 1 2 /
+GRID
+DXV
+5*100 /
+DYV
+100 /
+DZV
+2*5 /
+TOPS
+12*2000 /
+PORO
+10*0.3 /
+REGIONS
+FIPNUM
+ 1 1 1 2 2
+ 3 3 5 5 4 /
+FIPABC
+ 1 1 1 2 2
+ 1 1 1 2 2 /
+)");
+
+    const auto matcher = Opm::RegionSetMatcher { fipStats };
+
+    const auto descr = Opm::RegionSetMatcher::SetDescriptor {}
+        .vectorName("ROPR");
+
+    const auto matchingRegions = matcher.findRegions(descr);
+
+    BOOST_CHECK_MESSAGE(! matchingRegions.empty(), "Matching range must be non-empty");
+    BOOST_CHECK_MESSAGE(! matchingRegions.isScalar(),
+                        "Matching range must constitute a "
+                        "single region in multiple region sets");
+
+    {
+        const auto expect = std::vector<std::string> { "ABC", "NUM" };
+        const auto regSets = matchingRegions.regionSets();
+        BOOST_CHECK_EQUAL_COLLECTIONS(regSets.begin(), regSets.end(),
+                                      expect .begin(), expect .end());
+    }
+
+    BOOST_CHECK_EQUAL(matchingRegions.numRegionSets(), std::size_t{2});
+
+
+    {
+        const auto regIxRange = matchingRegions.regions(0); // ABC
+        const auto expect = std::vector { 1, 2, 3, 4, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    {
+        const auto regIxRange = matchingRegions.regions(1); // NUM
+        const auto expect = std::vector { 1, 2, 3, 4, 5, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    {
+        const auto regIxRange = matchingRegions.regions("ABC");
+        const auto expect = std::vector { 1, 2, 3, 4, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+
+    {
+        const auto regIxRange = matchingRegions.regions("NUM");
+        const auto expect = std::vector { 1, 2, 3, 4, 5, };
+        BOOST_CHECK_EQUAL_COLLECTIONS(regIxRange.begin(), regIxRange.end(),
+                                      expect.begin(), expect.end());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Matcher


### PR DESCRIPTION
The primary use case is determining the set of region indices used to define region level UDQs, or to evaluate region level expressions which go into other UDQs, e.g., at the field level.  Typical region level quantities in this context are

 * `ROPR`: Oil production rate in all regions of *all* region sets
 
 * `ROPR_NUM`: Oil production rate in all regions of standard/predefined `FIPNUM` region set

 * `ROPR_ABC`: Oil production rate in all regions of user defined `FIPABC` region set.

 * `ROPR_ABC 42`: Oil production rate in region 42 of user defined `FIPABC` region set.

The user initiates the matching process by constructing a `SetDescriptor` object, filling in the known pieces of information&ndash;the vector name and region ID&ndash;if applicable.  A `SetDescriptor` region ID will match all regions in the pertinent region set or region sets.

The matching process, `RegionSetMatcher::findRegions()`, forms a `RegionSetMatchResult` object which holds a list of matching region sets and their associate/corresponding matching region IDs.