### PR TITLE
Add Procedure for Calculating Basic FIP Region Statistics

### DIFF
--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -34,6 +34,7 @@
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FIPRegionStatistics.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
@@ -56,6 +57,14 @@
 #include <fmt/format.h>
 
 #include <filesystem>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <stddef.h>
 
 namespace {
     void verify_consistent_restart_information(const Opm::DeckKeyword& restart_keyword,
@@ -199,6 +208,26 @@ namespace Opm {
         return this->field_props;
     }
 
+    void EclipseState::computeFipRegionStatistics()
+    {
+        if (! this->fipRegionStatistics_.has_value()) {
+            this->fipRegionStatistics_
+                .emplace(declaredMaxRegionID(this->runspec()),
+                         this->fieldProps(),
+                         [](std::vector<int>&) { /* do nothing*/ });
+        }
+    }
+
+    const FIPRegionStatistics& EclipseState::fipRegionStatistics() const
+    {
+        if (! this->fipRegionStatistics_.has_value()) {
+            throw std::logic_error {
+                "FIP Region Statistics have not been prepared"
+            };
+        }
+
+        return *this->fipRegionStatistics_;
+    }
 
     const TableManager& EclipseState::getTableManager() const {
         return m_tables;

--- a/opm/input/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.hpp
@@ -24,6 +24,7 @@
 #include <opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FIPRegionStatistics.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/LgrCollection.hpp>
@@ -95,6 +96,10 @@ namespace Opm {
         virtual const FieldPropsManager& fieldProps() const;
         // Always the non-parallel field properties
         virtual const FieldPropsManager& globalFieldProps() const;
+
+        virtual void computeFipRegionStatistics();
+        const FIPRegionStatistics& fipRegionStatistics() const;
+
         const TableManager& getTableManager() const;
         const EclipseConfig& getEclipseConfig() const;
         const EclipseConfig& cfg() const;
@@ -152,6 +157,7 @@ namespace Opm {
             serializer(tracer_config);
             serializer(m_micppara);
             serializer(wag_hyst_config);
+            serializer(this->fipRegionStatistics_);
         }
 
         static bool rst_cmp(const EclipseState& full_state, const EclipseState& rst_state);
@@ -193,6 +199,8 @@ namespace Opm {
         FaultCollection m_faults{};
 
         std::optional<std::map<std::string, double> > m_restart_network_pressures{std::nullopt};
+
+        std::optional<FIPRegionStatistics> fipRegionStatistics_{std::nullopt};
     };
 } // namespace Opm
 


### PR DESCRIPTION
This PR adds two new member functions
```
EclipseState::computeFipRegionStatistics()
EclipseState::fipRegionStatistics()
```
the first of which constructs a FIP region statistics object for the current run's fluid-in-place region and the second of which returns that object.  The initial design constructed the object on first call to `fipRegionStatistics()`, but this does not work in parallel.