### PR TITLE
Fix cmake warning with line order change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(opm-common C CXX)
 cmake_minimum_required (VERSION 3.10)
+project(opm-common C CXX)
 
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)


### PR DESCRIPTION
Change line order to fix this warning
> ```
> CMake Warning (dev) at CMakeLists.txt:16 (project):
>   cmake_minimum_required() should be called prior to this top-level project()
>   call.  Please see the cmake-commands(7) manual for usage documentation of
>   both commands.
> This warning is for project developers.  Use -Wno-dev to suppress it.
> ```