### PR TITLE
[fix] reflect inactive cells due to MINPV/PINCH in Schedule::complete…

### DIFF
--- a/opm/input/eclipse/Schedule/CompletedCells.hpp
+++ b/opm/input/eclipse/Schedule/CompletedCells.hpp
@@ -116,6 +116,26 @@ public:
         serializer(this->cells);
     }
 
+    std::unordered_map<std::size_t, Cell>::iterator begin()
+    {
+        return cells.begin();
+    }
+
+    std::unordered_map<std::size_t, Cell>::const_iterator begin() const
+    {
+        return cells.begin();
+    }
+
+    std::unordered_map<std::size_t, Cell>::iterator end()
+    {
+        return cells.end();
+    }
+
+    std::unordered_map<std::size_t, Cell>::const_iterator end() const
+    {
+        return cells.end();
+    }
+
 private:
     GridDims dims;
     std::unordered_map<std::size_t, Cell> cells;

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -24,14 +24,14 @@
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/common/utility/OpmInputError.hpp>
-#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
+#include <opm/common/utility/ActiveGridCells.hpp>
 #include <opm/common/utility/String.hpp>
 #include <opm/common/utility/numeric/cmp.hpp>
 #include <opm/common/utility/shmatch.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
-
+#include <opm/input/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
@@ -1320,6 +1320,14 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
 
 
     void Schedule::filterConnections(const ActiveGridCells& grid) {
+        // Due MINPV/PINCH processing more of the completed_cells might now
+        // inactive. Hence we update them here.
+        for ([[maybe_unused]] auto& [index, cell] : this->completed_cells) {
+            if (!grid.cellActive(cell.i, cell.j, cell.k)) {
+                assert(cell.props);
+                cell.props.value().active_index = -1;
+            }
+        }
         for (auto& sched_state : this->snapshots) {
             for (auto& well : sched_state.wells()) {
                 well.get().filterConnections(grid);


### PR DESCRIPTION
…d_cells

Previously only cells were marked as inactive that were inactive before MINPV/PINCH was applied and those inactive due to MINPV/PINCH might still have been active. This presented a problem whenever ACTIONX was run as this would recreate the schedule using the information in Schedule::completed_cells. We experienced problems because wells suddenly had completions in active cells.

With this commit we use filterConnections (called after MINPV/PINCH processing and creation of the grid in opm-simulators) to also mark cells in Schedule::completed_cells as inactive that became inactive due to MINPV/PINCH or small volumes.