### PR TITLE
Rename UDQSet's Enumerated Item Type

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQAssign.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQAssign.cpp
@@ -52,7 +52,7 @@ void UDQAssign::AssignRecord::eval(UDQSet& values) const
     else {
         for (const auto& item : this->numbered_selector) {
             for (const auto& number : item.numbers) {
-                values.assign(item.well, number, this->value);
+                values.assign(item.name, number, this->value);
             }
         }
     }
@@ -87,20 +87,20 @@ UDQAssign::UDQAssign(const std::string&                     keyword,
     this->add_record(rst_selector, value, report_step);
 }
 
-UDQAssign::UDQAssign(const std::string&                              keyword,
-                     const std::vector<UDQSet::EnumeratedWellItems>& selector,
-                     double                                          value,
-                     std::size_t                                     report_step)
+UDQAssign::UDQAssign(const std::string&                          keyword,
+                     const std::vector<UDQSet::EnumeratedItems>& selector,
+                     double                                      value,
+                     std::size_t                                 report_step)
     : m_keyword(keyword)
     , m_var_type(UDQ::varType(keyword))
 {
     this->add_record(selector, value, report_step);
 }
 
-UDQAssign::UDQAssign(const std::string&                         keyword,
-                     std::vector<UDQSet::EnumeratedWellItems>&& selector,
-                     double                                     value,
-                     std::size_t                                report_step)
+UDQAssign::UDQAssign(const std::string&                     keyword,
+                     std::vector<UDQSet::EnumeratedItems>&& selector,
+                     double                                 value,
+                     std::size_t                            report_step)
     : m_keyword(keyword)
     , m_var_type(UDQ::varType(keyword))
 {
@@ -117,7 +117,7 @@ UDQAssign UDQAssign::serializationTestObject()
     result.records.emplace_back(std::unordered_set<std::string>{ "I-45" }, 3.1415, 3);
 
     // Class-template argument deduction for the vector element type.
-    result.records.emplace_back(std::vector { UDQSet::EnumeratedWellItems::serializationTestObject() }, 2.71828, 42);
+    result.records.emplace_back(std::vector { UDQSet::EnumeratedItems::serializationTestObject() }, 2.71828, 42);
 
     return result;
 }
@@ -136,16 +136,16 @@ void UDQAssign::add_record(const std::unordered_set<std::string>& rst_selector,
     this->records.emplace_back(rst_selector, value, report_step);
 }
 
-void UDQAssign::add_record(const std::vector<UDQSet::EnumeratedWellItems>& selector,
-                           const double                                    value,
-                           const std::size_t                               report_step)
+void UDQAssign::add_record(const std::vector<UDQSet::EnumeratedItems>& selector,
+                           const double                                value,
+                           const std::size_t                           report_step)
 {
     this->records.emplace_back(selector, value, report_step);
 }
 
-void UDQAssign::add_record(std::vector<UDQSet::EnumeratedWellItems>&& selector,
-                           const double                               value,
-                           const std::size_t                          report_step)
+void UDQAssign::add_record(std::vector<UDQSet::EnumeratedItems>&& selector,
+                           const double                           value,
+                           const std::size_t                      report_step)
 {
     this->records.emplace_back(std::move(selector), value, report_step);
 }
@@ -184,7 +184,7 @@ UDQSet UDQAssign::eval(const std::vector<std::string>& wgnames) const
     };
 }
 
-UDQSet UDQAssign::eval(const std::vector<UDQSet::EnumeratedWellItems>& items) const
+UDQSet UDQAssign::eval(const std::vector<UDQSet::EnumeratedItems>& items) const
 {
     if (this->m_var_type == UDQVarType::SEGMENT_VAR) {
         auto us = UDQSet { this->m_keyword, this->m_var_type, items };

--- a/opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQAssign.hpp
@@ -42,7 +42,7 @@ public:
     {
         std::vector<std::string> input_selector{};
         std::unordered_set<std::string> rst_selector{};
-        std::vector<UDQSet::EnumeratedWellItems> numbered_selector{};
+        std::vector<UDQSet::EnumeratedItems> numbered_selector{};
         double value{};
         std::size_t report_step{};
 
@@ -64,17 +64,17 @@ public:
             , report_step (report_step_arg)
         {}
 
-        AssignRecord(const std::vector<UDQSet::EnumeratedWellItems>& selector,
-                     const double                                    value_arg,
-                     const std::size_t                               report_step_arg)
+        AssignRecord(const std::vector<UDQSet::EnumeratedItems>& selector,
+                     const double                                value_arg,
+                     const std::size_t                           report_step_arg)
             : numbered_selector(selector)
             , value            (value_arg)
             , report_step      (report_step_arg)
         {}
 
-        AssignRecord(std::vector<UDQSet::EnumeratedWellItems>&& selector,
-                     const double                               value_arg,
-                     const std::size_t                          report_step_arg)
+        AssignRecord(std::vector<UDQSet::EnumeratedItems>&& selector,
+                     const double                           value_arg,
+                     const std::size_t                      report_step_arg)
             : numbered_selector(std::move(selector))
             , value            (value_arg)
             , report_step      (report_step_arg)
@@ -106,15 +106,15 @@ public:
               double                                 value,
               std::size_t                            report_step);
 
-    UDQAssign(const std::string&                              keyword,
-              const std::vector<UDQSet::EnumeratedWellItems>& selector,
-              double                                          value,
-              std::size_t                                     report_step);
+    UDQAssign(const std::string&                          keyword,
+              const std::vector<UDQSet::EnumeratedItems>& selector,
+              double                                      value,
+              std::size_t                                 report_step);
 
-    UDQAssign(const std::string&                         keyword,
-              std::vector<UDQSet::EnumeratedWellItems>&& selector,
-              double                                     value,
-              std::size_t                                report_step);
+    UDQAssign(const std::string&                     keyword,
+              std::vector<UDQSet::EnumeratedItems>&& selector,
+              double                                 value,
+              std::size_t                            report_step);
 
     static UDQAssign serializationTestObject();
 
@@ -129,15 +129,15 @@ public:
                     double                                 value,
                     std::size_t                            report_step);
 
-    void add_record(const std::vector<UDQSet::EnumeratedWellItems>& selector,
-                    double                                          value,
-                    std::size_t                                     report_step);
+    void add_record(const std::vector<UDQSet::EnumeratedItems>& selector,
+                    double                                      value,
+                    std::size_t                                 report_step);
 
-    void add_record(std::vector<UDQSet::EnumeratedWellItems>&& selector,
-                    double                                     value,
-                    std::size_t                                report_step);
+    void add_record(std::vector<UDQSet::EnumeratedItems>&& selector,
+                    double                                 value,
+                    std::size_t                            report_step);
 
-    UDQSet eval(const std::vector<UDQSet::EnumeratedWellItems>& items) const;
+    UDQSet eval(const std::vector<UDQSet::EnumeratedItems>& items) const;
     UDQSet eval(const std::vector<std::string>& wells) const;
     UDQSet eval() const;
     std::size_t report_step() const;

--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -101,7 +101,7 @@ namespace {
                 // segments.
                 const auto segSet = context.segments();
 
-                return [items = Opm::UDQSet::getSegmentItems(segSet)](const auto& assign)
+                return [items = Opm::UDQSet::enumerateItems(segSet)](const auto& assign)
                 {
                     return assign.eval(items);
                 };
@@ -705,7 +705,7 @@ namespace Opm {
         }
 
         auto items = UDQSet::
-            getSegmentItems(segmentMatcher->findSegments(setDescriptor));
+            enumerateItems(segmentMatcher->findSegments(setDescriptor));
 
         auto [asgnPos, inserted] = this->m_assignments
             .emplace(std::piecewise_construct,

--- a/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQDefine.cpp
@@ -488,10 +488,12 @@ UDQSet UDQDefine::scatter_scalar_segment_value(const UDQContext&            cont
                                                const std::optional<double>& value) const
 {
     if (! value.has_value()) {
-        return UDQSet::segments(this->m_keyword, UDQSet::getSegmentItems(context.segments()));
+        return UDQSet::segments(this->m_keyword, UDQSet::enumerateItems(context.segments()));
     }
 
-    return UDQSet::segments(this->m_keyword, UDQSet::getSegmentItems(context.segments()), *value);
+    return UDQSet::segments(this->m_keyword,
+                            UDQSet::enumerateItems(context.segments()),
+                            *value);
 }
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
@@ -148,14 +148,14 @@ bool UDQScalar::operator==(const UDQScalar& other) const
 // UDQSet Implementation Below Separator
 // ------------------------------------------------------------------------
 
-bool UDQSet::EnumeratedWellItems::operator==(const EnumeratedWellItems& that) const
+bool UDQSet::EnumeratedItems::operator==(const EnumeratedItems& that) const
 {
-    return (this->well == that.well)
+    return (this->name == that.name)
         && (this->numbers == that.numbers);
 }
 
-UDQSet::EnumeratedWellItems
-UDQSet::EnumeratedWellItems::serializationTestObject()
+UDQSet::EnumeratedItems
+UDQSet::EnumeratedItems::serializationTestObject()
 {
     return { "PROD01", std::vector<std::size_t>{ 17, 29 } };
 }
@@ -187,15 +187,15 @@ UDQSet::UDQSet(const std::string&              name,
         this->values.emplace_back(wgname);
 }
 
-UDQSet::UDQSet(const std::string&                      name,
-               const UDQVarType                        var_type,
-               const std::vector<EnumeratedWellItems>& items)
+UDQSet::UDQSet(const std::string&                  name,
+               const UDQVarType                    var_type,
+               const std::vector<EnumeratedItems>& items)
     : m_name    (name)
     , m_var_type(var_type)
 {
     for (const auto& item : items) {
         for (const auto& number : item.numbers) {
-            this->values.emplace_back(item.well, number);
+            this->values.emplace_back(item.name, number);
         }
     }
 }
@@ -272,15 +272,15 @@ UDQSet UDQSet::groups(const std::string&              name,
     return us;
 }
 
-UDQSet UDQSet::segments(const std::string&                      name,
-                        const std::vector<EnumeratedWellItems>& segments)
+UDQSet UDQSet::segments(const std::string&                  name,
+                        const std::vector<EnumeratedItems>& segments)
 {
     return { name, UDQVarType::SEGMENT_VAR, segments };
 }
 
-UDQSet UDQSet::segments(const std::string&                      name,
-                        const std::vector<EnumeratedWellItems>& segments,
-                        const double                            scalar_value)
+UDQSet UDQSet::segments(const std::string&                  name,
+                        const std::vector<EnumeratedItems>& segments,
+                        const double                        scalar_value)
 {
     auto us = UDQSet::segments(name, segments);
     us.assign(scalar_value);
@@ -772,16 +772,16 @@ bool UDQSet::operator==(const UDQSet& other) const
         && (this->values == other.values);
 }
 
-std::vector<UDQSet::EnumeratedWellItems>
-UDQSet::getSegmentItems(const SegmentSet& segSet)
+std::vector<UDQSet::EnumeratedItems>
+UDQSet::enumerateItems(const SegmentSet& segSet)
 {
     const auto numWells = segSet.numWells();
 
-    auto items = std::vector<Opm::UDQSet::EnumeratedWellItems>(numWells);
+    auto items = std::vector<Opm::UDQSet::EnumeratedItems>(numWells);
     for (auto wellID = 0*numWells; wellID < numWells; ++wellID) {
         auto segRange = segSet.segments(wellID);
 
-        items[wellID].well = segRange.well();
+        items[wellID].name = segRange.well();
         items[wellID].numbers.assign(segRange.begin(), segRange.end());
     }
 

--- a/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
@@ -186,23 +186,24 @@ class UDQSet
 {
 public:
     // Connections and segments.
-    struct EnumeratedWellItems {
-        std::string well{};
+    struct EnumeratedItems
+    {
+        std::string name{};
         std::vector<std::size_t> numbers{};
 
-        bool operator==(const EnumeratedWellItems& rhs) const;
-        static EnumeratedWellItems serializationTestObject();
+        bool operator==(const EnumeratedItems& rhs) const;
+        static EnumeratedItems serializationTestObject();
 
         template <class Serializer>
         void serializeOp(Serializer& serializer)
         {
-            serializer(this->well);
+            serializer(this->name);
             serializer(this->numbers);
         }
     };
 
-    static std::vector<EnumeratedWellItems>
-    getSegmentItems(const SegmentSet& segmentSet);
+    static std::vector<EnumeratedItems>
+    enumerateItems(const SegmentSet& segmentSet);
 
     /// Construct empty, named UDQ set of specific variable type
     ///
@@ -219,7 +220,8 @@ public:
     /// \param[in] var_type UDQ set's variable type.
     ///
     /// \param[in] wgnames Well or group names.
-    UDQSet(const std::string& name, UDQVarType var_type, const std::vector<std::string>& wgnames);
+    UDQSet(const std::string& name, UDQVarType var_type,
+           const std::vector<std::string>& wgnames);
 
     /// Construct named UDQ set of specific variable type for numbered well
     /// items-typically segments or connections.
@@ -231,7 +233,8 @@ public:
     /// \param[in] items Enumerated entities for which this UDQ set is
     ///    defined.  Typically represents a set of segments in an MS well or
     ///    a set of well/reservoir connections.
-    UDQSet(const std::string& name, UDQVarType var_type, const std::vector<EnumeratedWellItems>& items);
+    UDQSet(const std::string& name, UDQVarType var_type,
+           const std::vector<EnumeratedItems>& items);
 
     /// Construct empty, named UDQ set of specific variable type
     ///
@@ -252,7 +255,8 @@ public:
     /// \param[in] scalar_value Initial numeric value of this scalar set.
     ///    Empty optional or non-finite contained value leaves the UDQ set
     ///    undefined.
-    static UDQSet scalar(const std::string& name, const std::optional<double>& scalar_value);
+    static UDQSet scalar(const std::string& name,
+                         const std::optional<double>& scalar_value);
 
     /// Form a UDQ set pertaining to a single scalar value.
     ///
@@ -272,7 +276,8 @@ public:
     /// \param[in] name UDQ set name
     ///
     /// \param[in] wells Collection of named wells.
-    static UDQSet wells(const std::string& name, const std::vector<std::string>& wells);
+    static UDQSet wells(const std::string& name,
+                        const std::vector<std::string>& wells);
 
     /// Form a UDQ set pertaining to a set of named wells
     ///
@@ -283,14 +288,17 @@ public:
     /// \param[in] scalar_value Initial numeric value of every element of
     ///    this UDQ set.  Non-finite value leaves the UDQ set elements
     ///    undefined.
-    static UDQSet wells(const std::string& name, const std::vector<std::string>& wells, double scalar_value);
+    static UDQSet wells(const std::string& name,
+                        const std::vector<std::string>& wells,
+                        double scalar_value);
 
     /// Form a UDQ set pertaining to a set of named groups
     ///
     /// \param[in] name UDQ set name
     ///
     /// \param[in] wells Collection of named groups.
-    static UDQSet groups(const std::string& name, const std::vector<std::string>& groups);
+    static UDQSet groups(const std::string& name,
+                         const std::vector<std::string>& groups);
 
     /// Form a UDQ set pertaining to a set of named groups
     ///
@@ -301,7 +309,9 @@ public:
     /// \param[in] scalar_value Initial numeric value of every element of
     ///    this UDQ set.  Non-finite value leaves the UDQ set elements
     ///    undefined.
-    static UDQSet groups(const std::string& name, const std::vector<std::string>& groups, double scalar_value);
+    static UDQSet groups(const std::string& name,
+                         const std::vector<std::string>& groups,
+                         double scalar_value);
 
     /// Form a UDQ set at the field level
     ///
@@ -311,11 +321,12 @@ public:
     ///    this UDQ set.  Non-finite value leaves the UDQ set element
     ///    undefined.
     static UDQSet field(const std::string& name, double scalar_value);
-    static UDQSet segments(const std::string&                      name,
-                           const std::vector<EnumeratedWellItems>& segments);
-    static UDQSet segments(const std::string&                      name,
-                           const std::vector<EnumeratedWellItems>& segments,
-                           const double                            scalar_value);
+
+    static UDQSet segments(const std::string&                  name,
+                           const std::vector<EnumeratedItems>& segments);
+    static UDQSet segments(const std::string&                  name,
+                           const std::vector<EnumeratedItems>& segments,
+                           const double                        scalar_value);
 
     /// Assign value to every element of the UDQ set
     ///

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -1112,7 +1112,7 @@ BOOST_AUTO_TEST_CASE(UDQASSIGN_TEST) {
 BOOST_AUTO_TEST_CASE(UDQASSIGN_NUMBERED_ITEMS_TEST) {
     using Vsz = std::vector<std::size_t>;
 
-    const auto selector = UDQSet::EnumeratedWellItems {
+    const auto selector = UDQSet::EnumeratedItems {
         "PROD01", Vsz { 1, 3, 5, 7 }
     };
 
@@ -1121,10 +1121,10 @@ BOOST_AUTO_TEST_CASE(UDQASSIGN_NUMBERED_ITEMS_TEST) {
     };
 
     const auto segments = std::vector {
-        UDQSet::EnumeratedWellItems { "PROD01", Vsz { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, } },
-        UDQSet::EnumeratedWellItems { "PROD02", Vsz { 1, 2, 3, 4, 5, } },
-        UDQSet::EnumeratedWellItems { "PROD06", Vsz { 2, 4, 6, 8, 10, } },
-        UDQSet::EnumeratedWellItems { "I-45", Vsz { 1, 2, 3, } },
+        UDQSet::EnumeratedItems { "PROD01", Vsz { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, } },
+        UDQSet::EnumeratedItems { "PROD02", Vsz { 1, 2, 3, 4, 5, } },
+        UDQSet::EnumeratedItems { "PROD06", Vsz { 2, 4, 6, 8, 10, } },
+        UDQSet::EnumeratedItems { "I-45", Vsz { 1, 2, 3, } },
     };
 
     const auto us = as.eval(segments);


### PR DESCRIPTION
When we add support for using region-level summary vectors in the defining expressions of field-level UDQs, we need to represent other collections of (name,number) pairs.  In other words, we don't just need enumerated well items anymore.

This generalisation means that the existing segment-level `UDQSet` support becomes a little more opaque since we now assign the item's `name` instead of the item's `well`, but this is nevertheless preferable to introducing another type for a very similar concept.