### PR TITLE
trying to warn about too big segment depth change

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.cpp
@@ -63,11 +63,6 @@ namespace Opm {
     }
 
 
-    WellSegments::WellSegments(const DeckKeyword& keyword, const UnitSystem& unit_system) {
-        this->loadWELSEGS(keyword, unit_system);
-    }
-
-
     WellSegments WellSegments::serializationTestObject()
     {
         WellSegments result;

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -111,6 +111,8 @@ namespace Opm {
         const std::vector<Segment>::const_iterator begin() const;
         const std::vector<Segment>::const_iterator end() const;
 
+        void checkSegmentDepthConsistency(const std::string& well_name) const;
+
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
@@ -122,7 +124,7 @@ namespace Opm {
     private:
         void processABS();
         void processINC(double depth_top, double length_top);
-        void process(LengthDepth length_depth, double depth_top, double length_top);
+        void process(const std::string& well_name, LengthDepth length_depth, double depth_top, double length_top);
         void addSegment(const Segment& new_segment);
         void addSegment(const int segment_number,
                         const int branch,

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -70,7 +70,6 @@ namespace Opm {
         WellSegments() = default;
         WellSegments(CompPressureDrop compDrop,
                      const std::vector<Segment>& segments);
-        WellSegments(const DeckKeyword& keyword, const UnitSystem& unit_system);
         void loadWELSEGS( const DeckKeyword& welsegsKeyword, const UnitSystem& unit_system);
 
         static WellSegments serializationTestObject();

--- a/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
+++ b/opm/input/eclipse/Schedule/MSW/WellSegments.hpp
@@ -29,6 +29,7 @@
 namespace Opm {
     class SICD;
     class AutoICD;
+    class UnitSystem;
     class Valve;
     class WellConnections;
 }
@@ -69,8 +70,8 @@ namespace Opm {
         WellSegments() = default;
         WellSegments(CompPressureDrop compDrop,
                      const std::vector<Segment>& segments);
-        explicit WellSegments(const DeckKeyword& keyword);
-        void loadWELSEGS( const DeckKeyword& welsegsKeyword);
+        WellSegments(const DeckKeyword& keyword, const UnitSystem& unit_system);
+        void loadWELSEGS( const DeckKeyword& welsegsKeyword, const UnitSystem& unit_system);
 
         static WellSegments serializationTestObject();
 
@@ -111,7 +112,7 @@ namespace Opm {
         const std::vector<Segment>::const_iterator begin() const;
         const std::vector<Segment>::const_iterator end() const;
 
-        void checkSegmentDepthConsistency(const std::string& well_name) const;
+        void checkSegmentDepthConsistency(const std::string& well_name, const UnitSystem& unit_system) const;
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -124,7 +125,8 @@ namespace Opm {
     private:
         void processABS();
         void processINC(double depth_top, double length_top);
-        void process(const std::string& well_name, LengthDepth length_depth, double depth_top, double length_top);
+        void process(const std::string& well_name, const UnitSystem& unit_system,
+                     LengthDepth length_depth, double depth_top, double length_top);
         void addSegment(const Segment& new_segment);
         void addSegment(const int segment_number,
                         const int branch,

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1798,7 +1798,10 @@ bool Well::handleWELSEGS(const DeckKeyword& keyword)
         this->updateSegments(std::move(new_segments));
     }
     else {
-        this->updateSegments(std::make_shared<WellSegments>(keyword, *unit_system));
+        auto well_segments = std::make_shared<WellSegments>();
+        well_segments->loadWELSEGS(keyword, *unit_system);
+
+        this->updateSegments(std::move(well_segments));
     }
 
     return true;

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1793,12 +1793,12 @@ bool Well::handleWELSEGS(const DeckKeyword& keyword)
 {
     if (this->segments != nullptr) {
         auto new_segments = std::make_shared<WellSegments>(*this->segments);
-        new_segments->loadWELSEGS(keyword);
+        new_segments->loadWELSEGS(keyword, *unit_system);
 
         this->updateSegments(std::move(new_segments));
     }
     else {
-        this->updateSegments(std::make_shared<WellSegments>(keyword));
+        this->updateSegments(std::make_shared<WellSegments>(keyword, *unit_system));
     }
 
     return true;

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -45,6 +45,8 @@
 
 #include <opm/input/eclipse/Python/Python.hpp>
 
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
@@ -130,8 +132,10 @@ WSEGAICD
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
+    const Opm::UnitSystem unit_system {}; // Metric by default
+
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs);
+    Opm::WellSegments segment_set(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
 
@@ -297,8 +301,10 @@ WSEGSICD
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
+    const Opm::UnitSystem unit_system {}; // Metric by default
+
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs);
+    Opm::WellSegments segment_set(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
 
@@ -467,8 +473,10 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS)
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
+    const Opm::UnitSystem unit_system {}; // Metric by default
+
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs);
+    Opm::WellSegments segment_set(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
 
@@ -549,8 +557,10 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS)
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
+    const Opm::UnitSystem unit_system {}; // Metric by default
+
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs);
+    Opm::WellSegments segment_set(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
 
@@ -636,8 +646,10 @@ BOOST_AUTO_TEST_CASE(testwsegvalv)
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
+    const Opm::UnitSystem unit_system {}; // Metric by default
+
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs);
+    Opm::WellSegments segment_set(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(8U, segment_set.size());
 

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -132,10 +132,10 @@ WSEGAICD
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::UnitSystem unit_system {}; // Metric by default
-
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs, unit_system);
+    Opm::WellSegments segment_set{};
+    const Opm::UnitSystem unit_system {}; // Metric by default
+    segment_set.loadWELSEGS(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
 
@@ -301,10 +301,10 @@ WSEGSICD
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::UnitSystem unit_system {}; // Metric by default
-
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs, unit_system);
+    Opm::WellSegments segment_set{};
+    const Opm::UnitSystem unit_system {}; // Metric by default
+    segment_set.loadWELSEGS(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(7U, segment_set.size());
 
@@ -473,10 +473,10 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS)
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::UnitSystem unit_system {}; // Metric by default
-
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs, unit_system);
+    Opm::WellSegments segment_set{};
+    const Opm::UnitSystem unit_system {}; // Metric by default
+    segment_set.loadWELSEGS(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
 
@@ -557,10 +557,10 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS)
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::UnitSystem unit_system {}; // Metric by default
-
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs, unit_system);
+    Opm::WellSegments segment_set{};
+    const Opm::UnitSystem unit_system {}; // Metric by default
+    segment_set.loadWELSEGS(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(6U, segment_set.size());
 
@@ -646,10 +646,10 @@ BOOST_AUTO_TEST_CASE(testwsegvalv)
     const Opm::DeckKeyword compsegs = deck["COMPSEGS"].back();
     BOOST_CHECK_EQUAL( 8U, compsegs.size() );
 
-    const Opm::UnitSystem unit_system {}; // Metric by default
-
     const Opm::DeckKeyword welsegs = deck["WELSEGS"].back();
-    Opm::WellSegments segment_set(welsegs, unit_system);
+    Opm::WellSegments segment_set{};
+    const Opm::UnitSystem unit_system {}; // Metric by default
+    segment_set.loadWELSEGS(welsegs, unit_system);
 
     BOOST_CHECK_EQUAL(8U, segment_set.size());
 


### PR DESCRIPTION
It will give warning when there is segments that are defined with depth change larger than the segment length. 

Something like the following,
```
Warning:  Segment 3 of well PROD01 has a depth change of 26 meters, while it has a length of 25 meters, which is unphysical.

Warning:  Segment 4 of well PROD01 has a depth change of 33 meters, while it has a length of 25 meters, which is unphysical.
```

It is using the internal unit system `SI`, it might be better to use the original unit from the DATA file, while it might be more involved. Please suggest. 