### PR TITLE
Save and Restore ICD Scaling Factor for SICDs Too

### DIFF
--- a/opm/input/eclipse/Schedule/MSW/SICD.cpp
+++ b/opm/input/eclipse/Schedule/MSW/SICD.cpp
@@ -74,7 +74,7 @@ namespace Opm {
         , m_method_flow_scaling    (rstSegment.icd_scaling_mode)
         , m_max_absolute_rate      (rstSegment.max_valid_flow_rate)
         , m_status                 (from_int<ICDStatus>(rstSegment.icd_status))
-        , m_scaling_factor         (-1.0)
+        , m_scaling_factor         (rstSegment.icd_scaling_factor)
     {}
 
     SICD::SICD(const double                 strength,

--- a/opm/input/eclipse/Schedule/MSW/Segment.cpp
+++ b/opm/input/eclipse/Schedule/MSW/Segment.cpp
@@ -21,6 +21,8 @@
 
 #include <opm/io/eclipse/rst/segment.hpp>
 
+#include <opm/output/eclipse/VectorItems/msw.hpp>
+
 #include <opm/input/eclipse/Schedule/MSW/AICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SICD.hpp>
 #include <opm/input/eclipse/Schedule/MSW/Valve.hpp>
@@ -46,17 +48,18 @@ namespace {
 
     Opm::Segment::SegmentType segmentTypeFromInt(const int ecl_id)
     {
-        using Type = Opm::Segment::SegmentType;
+        using SType = Opm::Segment::SegmentType;
+        using IType = Opm::RestartIO::Helpers::VectorItems::ISeg::Value::Type;
 
         switch (ecl_id) {
-        case -1: return Type::REGULAR;
-        case -7: return Type::SICD;
-        case -8: return Type::AICD;
-        case -5: return Type::VALVE;
+        case IType::Regular:   return SType::REGULAR;
+        case IType::SpiralICD: return SType::SICD;
+        case IType::AutoICD:   return SType::AICD;
+        case IType::Valve:     return SType::VALVE;
         }
 
         throw std::invalid_argument {
-            fmt::format("Unhandeled integer segment type {} ", ecl_id)
+            fmt::format("Unhandled integer segment type {}", ecl_id)
         };
     }
 
@@ -403,12 +406,13 @@ namespace Opm {
 
     int Segment::ecl_type_id() const
     {
-        switch (this->segmentType())
-        {
-        case SegmentType::REGULAR: return -1;
-        case SegmentType::SICD:    return -7;
-        case SegmentType::AICD:    return -8;
-        case SegmentType::VALVE:   return -5;
+        using IType = RestartIO::Helpers::VectorItems::ISeg::Value::Type;
+
+        switch (this->segmentType()) {
+        case SegmentType::REGULAR: return IType::Regular;
+        case SegmentType::SICD:    return IType::SpiralICD;
+        case SegmentType::AICD:    return IType::AutoICD;
+        case SegmentType::VALVE:   return IType::Valve;
         }
 
         throw std::invalid_argument {

--- a/opm/io/eclipse/rst/segment.cpp
+++ b/opm/io/eclipse/rst/segment.cpp
@@ -38,13 +38,14 @@ load_device_base_strength(const Opm::UnitSystem& unit_system,
                           const int              segment_type,
                           const double           base_strength_raw)
 {
-    auto unit = Opm::UnitSystem::measure::identity;
+    using VI::ISeg::Value::Type;
 
-    if (segment_type == -7) {   // SICD
-        unit = Opm::UnitSystem::measure::icd_strength;
+    auto unit = M::identity;
+    if (segment_type == Type::SpiralICD) {
+        unit = M::icd_strength;
     }
-    else if (segment_type == -8) { // AICD
-        unit = Opm::UnitSystem::measure::aicd_strength;
+    else if (segment_type == Type::AutoICD) {
+        unit = M::aicd_strength;
     }
 
     return unit_system.to_si(unit, base_strength_raw);

--- a/opm/io/eclipse/rst/segment.cpp
+++ b/opm/io/eclipse/rst/segment.cpp
@@ -33,6 +33,25 @@ double area_to_si(const Opm::UnitSystem& unit_system, const double raw_value)
     return unit_system.to_si(M::length, unit_system.to_si(M::length, raw_value));
 }
 
+double
+load_icd_scaling_factor(const Opm::UnitSystem& unit_system,
+                        const int*             iseg,
+                        const double*          rseg)
+{
+    const auto scalingFactor = rseg[VI::RSeg::ScalingFactor];
+    const auto scalingMethod = iseg[VI::ISeg::ICDScalingMode];
+
+    if ((scalingMethod == 1) ||
+        ((scalingMethod < 0) && (rseg[VI::RSeg::ICDLength] < 0.0)))
+    {
+        // Scaling factor is a length.  Convert to SI.
+        return unit_system.to_si(M::length, scalingFactor);
+    }
+
+    // Scaling factor is a relative measure.  No unit conversion needed.
+    return scalingFactor;
+}
+
 } // Anonymous namespace
 
 Opm::RestartIO::RstSegment::RstSegment(const UnitSystem& unit_system,
@@ -69,6 +88,7 @@ Opm::RestartIO::RstSegment::RstSegment(const UnitSystem& unit_system,
     , max_emulsion_ratio(                                        rseg[VI::RSeg::MaxEmulsionRatio])
     , max_valid_flow_rate(    unit_system.to_si(M::rate,         rseg[VI::RSeg::MaxValidFlowRate]))
     , icd_length(             unit_system.to_si(M::length,       rseg[VI::RSeg::ICDLength]))
+    , icd_scaling_factor(load_icd_scaling_factor(unit_system, iseg, rseg))
     , valve_area_fraction(                                       rseg[VI::RSeg::ValveAreaFraction])
     , aicd_flowrate_exponent(                                    rseg[VI::RSeg::FlowRateExponent])
     , aicd_viscosity_exponent(                                   rseg[VI::RSeg::ViscFuncExponent])

--- a/opm/io/eclipse/rst/segment.cpp
+++ b/opm/io/eclipse/rst/segment.cpp
@@ -34,6 +34,23 @@ double area_to_si(const Opm::UnitSystem& unit_system, const double raw_value)
 }
 
 double
+load_device_base_strength(const Opm::UnitSystem& unit_system,
+                          const int              segment_type,
+                          const double           base_strength_raw)
+{
+    auto unit = Opm::UnitSystem::measure::identity;
+
+    if (segment_type == -7) {   // SICD
+        unit = Opm::UnitSystem::measure::icd_strength;
+    }
+    else if (segment_type == -8) { // AICD
+        unit = Opm::UnitSystem::measure::aicd_strength;
+    }
+
+    return unit_system.to_si(unit, base_strength_raw);
+}
+
+double
 load_icd_scaling_factor(const Opm::UnitSystem& unit_system,
                         const int*             iseg,
                         const double*          rseg)
@@ -80,7 +97,7 @@ Opm::RestartIO::RstSegment::RstSegment(const UnitSystem& unit_system,
     , valve_area(             area_to_si(unit_system,            rseg[VI::RSeg::ValveArea]))
     , valve_flow_coeff(                                          rseg[VI::RSeg::ValveFlowCoeff])
     , valve_max_area(         area_to_si(unit_system,            rseg[VI::RSeg::ValveMaxArea]))
-    , base_strength(          unit_system.to_si(M::icd_strength, rseg[VI::RSeg::DeviceBaseStrength]))
+    , base_strength(load_device_base_strength(unit_system, segment_type, rseg[VI::RSeg::DeviceBaseStrength]))
     , fluid_density(          unit_system.to_si(M::density,      rseg[VI::RSeg::CalibrFluidDensity]))
     , fluid_viscosity(        unit_system.to_si(M::viscosity,    rseg[VI::RSeg::CalibrFluidViscosity]))
     , critical_water_fraction(                                   rseg[VI::RSeg::CriticalWaterFraction])

--- a/opm/io/eclipse/rst/segment.hpp
+++ b/opm/io/eclipse/rst/segment.hpp
@@ -68,6 +68,7 @@ struct RstSegment
     double max_emulsion_ratio{};
     double max_valid_flow_rate{};
     double icd_length{};
+    double icd_scaling_factor{};
     double valve_area_fraction{};
 
     double aicd_flowrate_exponent{};

--- a/opm/output/eclipse/VectorItems/msw.hpp
+++ b/opm/output/eclipse/VectorItems/msw.hpp
@@ -22,7 +22,7 @@
 
 #include <vector>
 
-namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems {
+namespace Opm::RestartIO::Helpers::VectorItems {
 
     namespace ISeg {
 
@@ -37,6 +37,15 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
             ICDScalingMode  = 18,
             ICDOpenShutFlag = 19,
         };
+
+        namespace Value {
+            enum Type {
+                AutoICD   = -8, // Segment is an AICD
+                SpiralICD = -7, // Segment is an SICD
+                Valve     = -5, // Segment is a Valve
+                Regular   = -1, // Regular segment (i.e., not a device &c)
+            };
+        } // Value
 
     } // ISeg
 
@@ -104,6 +113,6 @@ namespace Opm { namespace RestartIO { namespace Helpers { namespace VectorItems 
         };
     } // RSeg
 
-}}}} // Opm::RestartIO::Helpers::VectorItems
+} // Opm::RestartIO::Helpers::VectorItems
 
 #endif // OPM_OUTPUT_ECLIPSE_VECTOR_MSW_HPP

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -1066,24 +1066,23 @@ BOOST_AUTO_TEST_CASE(MSW_AICD)
 
     // ISEG (PROD)
     {
+        using VI::ISeg::Value::Type;
+
         const auto& iSeg = amswd.getISeg();
         auto start = 7*ih[VI::intehead::NISEGZ];
-        BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::SegmentType],     -8); // PROD-segment 8,
+        BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::SegmentType], Type::AutoICD); // PROD-segment 8,
         BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::ICDScalingMode],   1); // PROD-segment 8,
         BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::ICDOpenShutFlag],  0); // PROD-segment 8,
 
         start = 8*ih[VI::intehead::NISEGZ];
-        BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::SegmentType],     -8); // PROD-segment 9,
+        BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::SegmentType], Type::AutoICD); // PROD-segment 9,
         BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::ICDScalingMode],   1); // PROD-segment 9,
         BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::ICDOpenShutFlag],  0); // PROD-segment 9,
 
         start = 9*ih[VI::intehead::NISEGZ];
-        BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::SegmentType],     -8); // PROD-segment 10,
+        BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::SegmentType], Type::AutoICD); // PROD-segment 10,
         BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::ICDScalingMode],   0); // PROD-segment 10,
         BOOST_CHECK_EQUAL(iSeg[start + VI::ISeg::index::ICDOpenShutFlag],  0); // PROD-segment 10,
-
-
-
     }
 
     // RSEG (PROD)

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -1086,7 +1086,7 @@ BOOST_AUTO_TEST_CASE(MSW_AICD)
 
     }
 
-        // RSEG (PROD)
+    // RSEG (PROD)
     {
         // well no 1 - PROD
         const auto& rseg = amswd.getRSeg();


### PR DESCRIPTION
Previously, we would save this information&ndash;but never restore it&ndash;only for autonomous ICDs ("AICD").  This PR expands our restart support for segment level "devices" (Spiral ICDs, Autonomous ICDs, Valves) to utilise more of the information that is available in the restart file.  We introduce constructors for the device types from `RstSegment` and defer the reconstitution to those constructors.

While working on this, I also noticed a problem in the current master sources.  The [`icd_length`](https://github.com/OPM/opm-common/blob/2d2c262d881ab04e7bd8caa80a0b932440a8686e/opm/io/eclipse/rst/segment.cpp#L85) is treated as if it represents a volumetric flow rate at reservoir conditions, but it must be treated as a length.