### PR TITLE
Support Numbers in User Defined Region Set Names

### DIFF
--- a/opm/io/eclipse/SummaryNode.cpp
+++ b/opm/io/eclipse/SummaryNode.cpp
@@ -247,7 +247,7 @@ std::string
 Opm::EclIO::SummaryNode::normalise_region_keyword(const std::string& keyword)
 {
     static const auto region_kw = std::regex {
-        R"((R[A-Z]{2,4})(_{0,2}[A-Z]{3})?)"
+        R"((R[A-Z]{2,4})(_{0,2}[A-Z0-9]{3})?)"
     };
 
     auto keywordPieces = std::smatch {};


### PR DESCRIPTION
In particular, we should be able to recognise that

  - FIPAB1
  - FIPAB2

denote different region sets when normalising the region set names.