### PR TITLE
Enable Using Region Level Quantities in Field Level UDQs

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQASTNode.hpp
@@ -106,6 +106,9 @@ private:
     UDQSet eval_segment_expression(const std::string& string_value,
                                    const UDQContext&  context) const;
 
+    UDQSet eval_region_expression(const std::string& string_value,
+                                  const UDQContext&  context) const;
+
     UDQSet eval_scalar_function(const UDQVarType  target_type,
                                 const UDQContext& context) const;
 

--- a/opm/input/eclipse/Schedule/UDQ/UDQContext.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQContext.hpp
@@ -74,6 +74,11 @@ namespace Opm {
                         const std::string& var,
                         std::size_t segment) const;
 
+        std::optional<double>
+        get_region_var(const std::string& regSet,
+                       const std::string& var,
+                       std::size_t region) const;
+
         const UDT& get_udt(const std::string& name) const;
 
         void add(const std::string& key, double value);
@@ -89,6 +94,10 @@ namespace Opm {
         std::vector<std::string> groups() const;
         SegmentSet segments() const;
         SegmentSet segments(const std::vector<std::string>& set_descriptor) const;
+
+        RegionSetMatchResult regions() const;
+        RegionSetMatchResult regions(const std::string&              vector_name,
+                                     const std::vector<std::string>& set_descriptor) const;
 
     private:
         struct Matchers
@@ -111,6 +120,7 @@ namespace Opm {
         std::unordered_map<std::string, double> values;
 
         void ensure_segment_matcher_exists() const;
+        void ensure_region_matcher_exists() const;
     };
 
 } // namespace Opm

--- a/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQSet.cpp
@@ -19,6 +19,7 @@
 
 #include <opm/input/eclipse/Schedule/UDQ/UDQSet.hpp>
 
+#include <opm/input/eclipse/EclipseState/Grid/RegionSetMatcher.hpp>
 #include <opm/input/eclipse/Schedule/MSW/SegmentMatcher.hpp>
 
 #include <opm/common/utility/shmatch.hpp>
@@ -283,6 +284,21 @@ UDQSet UDQSet::segments(const std::string&                  name,
                         const double                        scalar_value)
 {
     auto us = UDQSet::segments(name, segments);
+    us.assign(scalar_value);
+    return us;
+}
+
+UDQSet UDQSet::regions(const std::string&                  name,
+                       const std::vector<EnumeratedItems>& regSetColl)
+{
+    return { name, UDQVarType::REGION_VAR, regSetColl };
+}
+
+UDQSet UDQSet::regions(const std::string&                  name,
+                       const std::vector<EnumeratedItems>& regSetColl,
+                       const double                        scalar_value)
+{
+    auto us = UDQSet::regions(name, regSetColl);
     us.assign(scalar_value);
     return us;
 }
@@ -783,6 +799,24 @@ UDQSet::enumerateItems(const SegmentSet& segSet)
 
         items[wellID].name = segRange.well();
         items[wellID].numbers.assign(segRange.begin(), segRange.end());
+    }
+
+    return items;
+}
+
+std::vector<UDQSet::EnumeratedItems>
+UDQSet::enumerateItems(const RegionSetMatchResult& regSetColl)
+{
+    const auto numRegSets = regSetColl.numRegionSets();
+
+    auto items = std::vector<Opm::UDQSet::EnumeratedItems>(numRegSets);
+    for (auto rsetIx = 0*numRegSets; rsetIx < numRegSets; ++rsetIx) {
+        auto regIxRange = regSetColl.regions(rsetIx);
+
+        if (regIxRange.empty()) { continue; }
+
+        items[rsetIx].name = regIxRange.regionSet();
+        items[rsetIx].numbers.assign(regIxRange.begin(), regIxRange.end());
     }
 
     return items;

--- a/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQSet.hpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 namespace Opm {
+    class RegionSetMatchResult;
     class SegmentSet;
 } // namespace Opm
 
@@ -203,6 +204,9 @@ public:
     };
 
     static std::vector<EnumeratedItems>
+    enumerateItems(const RegionSetMatchResult& regionSet);
+
+    static std::vector<EnumeratedItems>
     enumerateItems(const SegmentSet& segmentSet);
 
     /// Construct empty, named UDQ set of specific variable type
@@ -327,6 +331,12 @@ public:
     static UDQSet segments(const std::string&                  name,
                            const std::vector<EnumeratedItems>& segments,
                            const double                        scalar_value);
+
+    static UDQSet regions(const std::string&                  name,
+                          const std::vector<EnumeratedItems>& regSetColl);
+    static UDQSet regions(const std::string&                  name,
+                          const std::vector<EnumeratedItems>& regSetColl,
+                          const double                        scalar_value);
 
     /// Assign value to every element of the UDQ set
     ///


### PR DESCRIPTION
This PR activates support for using region-level summary vectors in the defining expressions of field-level UDQs.  In particular, we add support for evaluating region-level expressions in the UDQ AST node, retrieving the values of region-level variables as UDQ sets, and matching region-level expressions in the UDQ context.

Collectively, these changes enable evaluating UDQs defined as
```
UDQ
DEFINE FURE2 (ROIP_RE2 2)+(ROIP_RE2 4)+(ROIP_RE2 5) /
DEFINE FUGIRD ((0.3*(RGPR_RE2 1)+(RGPR_RE2 2)+(RGPR_RE2 3))/(GEFF TEST)*(1+FUGASX))   /
DEFINE FUGIRDX (ROIP_RE2 2)/(FURE2)*(0.3*(RGPR_RE2 1)+(RGPR_RE2 2)+(RGPR_RE2 3))/(GEFF TEST)*(1+FUGASX)  /
/
```
which occur in the [`UDQ_REG-01`](https://github.com/OPM/opm-tests/blob/e17200d24e198baea9e1628b42b695231b299396/udq_actionx/UDQ_REG-01.DATA#L309-L323) example model in the OPM-Tests repository (OPM/opm-tests#1129).