### PR TITLE
Move 'processKeyword' to Implementation File

### DIFF
--- a/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
+++ b/opm/input/eclipse/EclipseState/Compositional/CompositionalConfig.hpp
@@ -20,16 +20,9 @@
 #ifndef OPM_COMPOSITIONALCONFIG_HPP
 #define OPM_COMPOSITIONALCONFIG_HPP
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Deck/DeckRecord.hpp>
-#include <opm/input/eclipse/Deck/DeckSection.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 
-#include <opm/common/utility/OpmInputError.hpp>
-
-#include <fmt/format.h>
-
-#include <optional>
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -72,8 +65,6 @@ public:
     // binary_interaction_coefficient will likely need some design when we know how we use it
     const std::vector<double>& binaryInteractionCoefficient(size_t eos_region) const;
 
-
-
     template<class Serializer>
     void serializeOp(Serializer& serializer)
     {
@@ -89,10 +80,11 @@ public:
         serializer(critical_volume);
         serializer(binary_interaction_coefficient);
     }
+
 private:
     // TODO: num_comps might not be totally necessary, while might be convenient.
     //  We can check the number of components without accessing Runspec
-    size_t num_comps = 0;
+    std::size_t num_comps = 0;
     double standard_temperature = 288.71; // Kelvin
     double standard_pressure = 1.0 * unit::atm; // 1 atm
     std::vector<std::string> comp_names;
@@ -103,68 +95,6 @@ private:
     std::vector<std::vector<double>> critical_temperature;
     std::vector<std::vector<double>> critical_volume;
     std::vector<std::vector<double>> binary_interaction_coefficient;
-
-    static void warningForExistingCompKeywords(const PROPSSection& section);
-
-    // The following function is used to parse the following keywords:
-    // MW, ACF, BIC, PCRIT, TCRIT and VCRIT
-    template<typename Keyword>
-    static void processKeyword(const PROPSSection& props_section,
-                               std::vector<std::vector<double>>& target,
-                               const std::size_t num_eos_res,
-                               const std::size_t num_values,
-                               const std::string& kw_name,
-                               const std::optional<double> default_value = std::nullopt) {
-        if ( !props_section.hasKeyword<Keyword>() ) {
-            return;
-        }
-        target.resize(num_eos_res);
-        for (auto& vec : target) {
-            if (default_value.has_value()) {
-                vec.resize(num_values, default_value.value());
-            } else {
-                vec.resize(num_values);
-            }
-        }
-
-        const auto& keywords = props_section.get<Keyword>();
-        // we do not allow multiple input of the keyword unless proven otherwise
-        if (keywords.size() > 1) {
-            throw OpmInputError(fmt::format("there are multiple {} keyword specifications", kw_name),
-                                keywords.begin()->location());
-        }
-
-        // there is no default value, we make sure we specify the exact number of values for
-        // all the EOS regions and components
-        const auto& kw = keywords.back();
-        if (kw.size() != num_eos_res) {
-            throw OpmInputError(fmt::format("there are {} EOS regions, while only {} regions are specified in {}",
-                                           num_eos_res, kw.size(),
-                                            kw_name), kw.location());
-        }
-
-        for (size_t i = 0; i < kw.size(); ++i) {
-            const auto& item = kw.getRecord(i).template getItem<typename Keyword::DATA>();
-            const auto data = item.getSIDoubleData();
-            if ( !default_value.has_value() ) { // when there is no default values, we should specify all the values
-                if (data.size() != num_values) {
-                    const auto msg = fmt::format("in keyword {}, {} values are specified, which is different from the number of components {}",
-                        kw_name, data.size(), num_values);
-                    throw OpmInputError(msg, kw.location());
-                }
-            } else {
-                if (data.size() > num_values) { // when there is default values, we should not specify more values than needed
-                    const auto msg = fmt::format("in keyword {}, {} values are specified, which is bigger than the number"
-                                                 " {} should be specified ",
-                                      kw_name, data.size(), num_values);
-                    throw OpmInputError(msg, kw.location());
-                }
-            }
-            // using copy here to consider the situation that there is default values, we might not specify all the values
-            // and keep the rest to be the default values
-            std::copy(data.begin(), data.end(), target[i].begin());
-        }
-    }
 };
 
 }


### PR DESCRIPTION
This means we can also move the `<fmt/format.h>` header to the implementation file whence translation units which transitively include `CompositionalConfig.hpp`, e.g., through `EcliseState.hpp` need not have format.h in the build's include path.

While here, also move the static function
```
warningForExistingCompKeywords
```
to the implementation file since this function is used only in that translation unit.