### PR TITLE
Remove the need for a run-function in the python code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,17 +401,37 @@ if (OPM_ENABLE_PYTHON)
   pybind11_add_module(opmcommon_python
                       ${PYTHON_CXX_SOURCE_FILES}
                       ${PROJECT_BINARY_DIR}/python/cxx/builtin_pybind11.cpp)
+
   target_link_libraries(opmcommon_python PRIVATE
                         opmcommon)
+  if(OPM_ENABLE_EMBEDDED_PYTHON)
+    pybind11_add_module(opm_embedded
+                        ${PYTHON_CXX_SOURCE_FILES}
+                        ${PROJECT_BINARY_DIR}/python/cxx/builtin_pybind11.cpp)
+    target_link_libraries(opm_embedded PRIVATE
+                          opmcommon)
+  endif()
   if(TARGET pybind11::pybind11)
     target_link_libraries(opmcommon_python PRIVATE
                           pybind11::pybind11)
+    if(OPM_ENABLE_EMBEDDED_PYTHON)
+      target_link_libraries(opm_embedded PRIVATE
+                            pybind11::pybind11)
+    endif()
   else()
     target_include_directories(opmcommon_python SYSTEM PRIVATE ${pybind11_INCLUDE_DIRS})
+    if(OPM_ENABLE_EMBEDDED_PYTHON)
+      target_include_directories(opm_embedded SYSTEM PRIVATE ${pybind11_INCLUDE_DIRS})
+    endif()
   endif()
   set_target_properties(opmcommon_python PROPERTIES
                         LIBRARY_OUTPUT_DIRECTORY python/opm)
   add_dependencies(opmcommon_python copy_python)
+  if(OPM_ENABLE_EMBEDDED_PYTHON)
+    set_target_properties(opm_embedded PROPERTIES
+                          LIBRARY_OUTPUT_DIRECTORY python)
+    add_dependencies(opm_embedded copy_python)
+  endif()
 
   # Generate versioned setup.py
   configure_file(${PROJECT_SOURCE_DIR}/python/setup.py.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,11 @@ if (OPM_ENABLE_PYTHON)
       ## Need to install this Python script such that it can be used by opm-simulators when building against an installed
       ##  opm-common
       install( PROGRAMS "python/install.py" DESTINATION "${OPM_PYTHON_COMMON_DIR}" )
+
+      # Install the convenience library for PYACTION script development
+      if (OPM_ENABLE_EMBEDDED_PYTHON)
+            install(TARGETS opm_embedded DESTINATION ${DEST_PREFIX}${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_PREFIX})
+      endif()
   endif()
 
   # Observe that if the opmcommon library has been built as a shared library the

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -693,7 +693,6 @@ if(ENABLE_ECL_OUTPUT)
           tests/MSW_2WELSEGS.DATA
           tests/EXIT_TEST.DATA
           tests/action_syntax_error.py
-          tests/action_missing_run.py
           tests/EMBEDDED_PYTHON.DATA
           tests/ACTIONX_M1.DATA
           tests/ACTIONX_M1_MULTIPLE.DATA
@@ -705,12 +704,15 @@ if(ENABLE_ECL_OUTPUT)
           tests/msim/MSIM_PYACTION_CHANGING_SCHEDULE.DATA
           tests/msim/MSIM_PYACTION_CHANGING_SCHEDULE_ACTIONX_CALLBACK.DATA
           tests/msim/MSIM_PYACTION_INSERT_KEYWORD.DATA
+          tests/msim/MSIM_PYACTION_NO_RUN_FUNCTION.DATA
           tests/msim/action1.py
           tests/msim/action2.py
+          tests/msim/action2_no_run_function.py
           tests/msim/action3.py
           tests/msim/action3_actionx_callback.py
           tests/msim/action_count.py
           tests/msim/insert_keyword.py
+          tests/msim/action_count_no_run_function.py
           tests/VFP_CASE.DATA)
 endif()
 

--- a/opm/input/eclipse/Python/PyRunModule.cpp
+++ b/opm/input/eclipse/Python/PyRunModule.cpp
@@ -21,13 +21,14 @@ error BUG: The PyRunModule.hpp header should *not* be included in a configuratio
 #endif
 
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 
 #include "PyRunModule.hpp"
 
-#include <filesystem>
+#include <fmt/format.h>
 
 #include <pybind11/stl.h>
 namespace Opm {
@@ -45,33 +46,20 @@ PyRunModule::PyRunModule(std::shared_ptr<const Python> python, const std::string
     if (!fs::is_regular_file(file))
         throw std::invalid_argument("No such module: " + fname);
 
-    std::string module_name = file.filename().stem();
-    std::string module_path = file.parent_path().string();
-    if (!module_path.empty()) {
-        py::module sys = py::module::import("sys");
-        py::list sys_path = sys.attr("path");
-        {
-            bool have_path = false;
-            for (const auto& elm : sys_path) {
-                const std::string& path_elm = static_cast<py::str>(elm);
-                if (path_elm == module_path)
-                    have_path = true;
-            }
-            if (!have_path)
-                sys_path.append(py::str(module_path));
-        }
+    this->module_path = fs::current_path().string() / file.parent_path();
+    this->module_name = file.filename().stem();
+
+    // opm_embedded needs to be loaded before user defined module.
+    try {
+        this->opm_embedded = py::module::import("opm_embedded");
+    } catch (const std::exception& e) {
+        OpmLog::error(fmt::format("Exception thrown when loading Python module opm_embedded: {}"), e.what());
+        throw e;
+    } catch (...) {
+        std::string errorMessage = "General exception thrown when loading Python module opm_embedded!";
+        OpmLog::error(errorMessage);
+        throw std::runtime_error(errorMessage);
     }
-    this->opm_embedded = py::module::import("opm_embedded");
-    this->module = py::module::import(module_name.c_str());
-    if (this->module.is_none())
-        throw std::runtime_error("Syntax error when loading Python module: " + fname);
-
-    if (py::hasattr(this->module, "run"))
-        this->run_function = this->module.attr("run");
-    if (this->run_function.is_none())
-        throw std::runtime_error("Python module: " + fname + " did not have run() method");
-
-    this->module.attr("storage") = this->storage;
 }
 
 namespace {
@@ -82,10 +70,86 @@ py::cpp_function py_actionx_callback(const std::function<void(const std::string&
 
 }
 
-bool PyRunModule::run(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+bool PyRunModule::executeInnerRunFunction(const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
     auto cpp_callback = py_actionx_callback(actionx_callback);
-    py::object result = this->run_function(&ecl_state, &sched, report_step, &st, cpp_callback);
-    return result.cast<bool>();
+    try {
+        py::object result = this->run_function(this->opm_embedded.attr("current_ecl_state"), this->opm_embedded.attr("current_schedule"), this->opm_embedded.attr("current_report_step"), this->opm_embedded.attr("current_summary_state"), cpp_callback);
+        return result.cast<bool>();
+    } catch (const std::exception& e) {
+        OpmLog::error(fmt::format("Exception thrown when calling run(ecl_state, schedule, report_step, summary_state, actionx_callback) function of {}: {}", this->module_name, e.what()));
+        throw e;
+    } catch(...) {
+        auto errorMessage = fmt::format("General exception thrown when calling run(ecl_state, schedule, report_step, summary_state, actionx_callback) function of {}", this->module_name);
+        OpmLog::error(errorMessage);
+        throw std::runtime_error(errorMessage);
+    }
+}
+
+bool PyRunModule::run(EclipseState& ecl_state, Schedule& sched, std::size_t report_step, SummaryState& st, const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback) {
+    // The attributes need to be set before the user defined module is loaded; it needs to be set in every call.
+    this->opm_embedded.attr("current_report_step") = report_step;
+
+    if (!this->module) {
+        // The attributes need to be set before the user defined module is loaded; they need to be set only once since they are shared pointers.
+        this->opm_embedded.attr("current_schedule") = &sched;
+        this->opm_embedded.attr("current_summary_state") = &st;
+        this->opm_embedded.attr("current_ecl_state") = &ecl_state;
+        try {
+            if (!this->module_path.empty()) {
+                py::module sys = py::module::import("sys");
+                py::list sys_path = sys.attr("path");
+                {
+                    bool have_path = false;
+                    for (const auto& elm : sys_path) {
+                        const std::string& path_elm = static_cast<py::str>(elm);
+                        if (path_elm == this->module_path)
+                            have_path = true;
+                    }
+                    if (!have_path)
+                        sys_path.append(py::str(this->module_path));
+                }
+            }
+            this->module = py::module::import(this->module_name.c_str());
+        } catch (const std::exception& e) {
+            OpmLog::error(fmt::format("Exception thrown when loading Python module {}: {}", this->module_name, e.what()));
+            throw e;
+        } catch (...) {
+            auto errorMessage = fmt::format("General exception thrown when loading Python module {}", this->module_name);
+            OpmLog::error(errorMessage);
+            throw std::runtime_error(errorMessage);
+        }
+
+        if (this->module.is_none()) {
+            auto errorMessage = fmt::format("Syntax error when loading Python module: {}", this->module_name);
+            OpmLog::error(errorMessage);
+            throw std::runtime_error(errorMessage);
+        }
+
+        this->module.attr("storage") = this->storage;
+
+        if (py::hasattr(this->module, "run")) {
+            OpmLog::info(R"(PYACTION can be used without a run(ecl_state, schedule, report_step, summary_state, actionx_callback) function, its arguments are available as attributes of the module opm_embedded, try the following in your python script:
+                    
+import opm_embedded
+
+help(opm_embedded.current_ecl_state)
+help(opm_embedded.current_schedule)
+help(opm_embedded.current_report_step)
+help(opm_embedded.current_summary_state)
+)");
+            this->run_function = this->module.attr("run");
+            return this->executeInnerRunFunction(actionx_callback);
+        }
+    } else { // Module has been loaded already
+        if (!this->run_function.is_none()) {
+            return this->executeInnerRunFunction(actionx_callback);            
+        } else {
+            this->module.reload();
+        }
+    }
+
+    // The return value of this function is true; unless there is a run function, then the return value is the return value of that run function.
+    return true;
 }
 
 }

--- a/opm/input/eclipse/Python/PyRunModule.hpp
+++ b/opm/input/eclipse/Python/PyRunModule.hpp
@@ -27,17 +27,16 @@ error BUG: The PyRunModule.hpp header should *not* be included in a configuratio
 #include <pybind11/pybind11.h>
 namespace py = pybind11;
 
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
 #include <opm/input/eclipse/Python/Python.hpp>
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
 
 namespace Opm {
-
-class EclipseState;
-class Schedule;
-class SummaryState;
-
 
 class __attribute__((visibility("default"))) PyRunModule {
 public:
@@ -49,8 +48,11 @@ private:
     py::object run_function = py::none();
     std::shared_ptr<const Python> python_handle;
     py::module module;
+    std::filesystem::path module_path;
+    std::string module_name;
     py::module opm_embedded;
     py::dict storage;
+    bool executeInnerRunFunction(const std::function<void(const std::string&, const std::vector<std::string>&)>& actionx_callback);
 };
 
 }

--- a/opm/input/eclipse/Python/PythonInterp.cpp
+++ b/opm/input/eclipse/Python/PythonInterp.cpp
@@ -22,7 +22,6 @@
 #include <pybind11/embed.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
-#include <pybind11/pytypes.h>
 
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Parser/Parser.hpp>
@@ -38,11 +37,12 @@ namespace Opm {
 
 /*
   OPM_EMBEDDED_MODULE create a Python of all the Python/C++ classes which are
-  generated in the python::common::export_all() function in the wrapping code.
+  generated in the python::common::export_all_opm_embedded() function in the wrapping code.
+  The same module is created as a Pybind 11 module in export.cpp
 */
 
 OPM_EMBEDDED_MODULE(opm_embedded, module) {
-    python::common::export_all(module);
+    python::common::export_all_opm_embedded(module);
 }
 
 

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -274,7 +274,10 @@ Schedule::Schedule(const Deck& deck, const EclipseState& es, const std::optional
     std::time_t Schedule::posixEndTime() const {
         // This should indeed access the start_time() property of the last
         // snapshot.
-        return std::chrono::system_clock::to_time_t(this->snapshots.back().start_time());
+        if (this->snapshots.size() > 0)
+            return std::chrono::system_clock::to_time_t(this->snapshots.back().start_time());
+        else
+            return this->posixStartTime( );
     }
 
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -88,6 +88,7 @@ namespace Opm
     class Schedule {
     public:
         Schedule() = default;
+        ~Schedule() = default;
         explicit Schedule(std::shared_ptr<const Python> python_handle);
         Schedule(const Deck& deck,
                  const EclipseGrid& grid,

--- a/opm/input/eclipse/Schedule/SummaryState.hpp
+++ b/opm/input/eclipse/Schedule/SummaryState.hpp
@@ -75,6 +75,7 @@ public:
 
     // Only used for testing purposes.
     SummaryState() : SummaryState(std::time_t{0}) {}
+    ~SummaryState() = default;
 
     // The canonical way to update the SummaryState is through the
     // update_xxx() methods which will inspect the variable and either

--- a/python/README.md
+++ b/python/README.md
@@ -1,2 +1,5 @@
-Python bindings for the OPM-common module of the Open Porous Media project.
+This folder contains the Python bindings and code required for embedding python for the OPM-common module of the Open Porous Media project.
 
+For the Python bindings, see the [Python bindings of opm-simulators](https://github.com/OPM/opm-simulators/blob/master/python/README.md).
+
+For embedding python, see the [documentation](https://opm-project.org/?page_id=1454). 

--- a/python/cxx/eclipse_state.cpp
+++ b/python/cxx/eclipse_state.cpp
@@ -103,7 +103,10 @@ void python::common::export_EclipseState(py::module& module) {
     // this makes it possible to share the returned object with e.g. and
     //   opm.simulators.BlackOilSimulator Python object
     //
-    py::class_< EclipseState, std::shared_ptr<EclipseState> >( module, "EclipseState" )
+    py::class_< EclipseState, std::shared_ptr<EclipseState> >( module, "EclipseState", R"pbdoc(
+            The Opm::EclipseState class - this is a representation of all static properties in the model,
+            ranging from porosity to relperm tables. The content of the EclipseState is immutable and may not
+            be changed at runtime.)pbdoc")
         .def(py::init<const Deck&>())
         .def_property_readonly( "title", &EclipseState::getTitle )
         .def( "field_props",    &get_field_props, ref_internal)

--- a/python/cxx/export.cpp
+++ b/python/cxx/export.cpp
@@ -1,6 +1,9 @@
 #include <pybind11/pybind11.h>
 #include "export.hpp"
 
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
 
 void python::common::export_all(py::module& module) {
     export_ParseContext(module);
@@ -27,4 +30,22 @@ void python::common::export_all(py::module& module) {
 
 PYBIND11_MODULE(opmcommon_python, module) {
     python::common::export_all(module);
+}
+
+void python::common::export_all_opm_embedded(py::module& module) {
+    python::common::export_all(module);
+    module.attr("current_ecl_state") = std::make_shared<EclipseState>();
+    module.attr("current_summary_state") = std::make_shared<SummaryState>();
+    module.attr("current_schedule") = std::make_shared<Schedule>();
+    module.attr("current_report_step") = 0;
+    module.doc() = R"pbdoc(This is the opm_embedded module for embedding python code in PYACTION.)pbdoc";
+}
+
+/*
+  PYBIND11_MODULE create a Python of all the Python/C++ classes which are
+  generated in the python::common::export_all_opm_embedded() function in the wrapping code.
+  The same module is created as an embedded python module in PythonInterp.cpp
+*/
+PYBIND11_MODULE(opm_embedded, module) {
+    python::common::export_all_opm_embedded(module);
 }

--- a/python/cxx/export.hpp
+++ b/python/cxx/export.hpp
@@ -14,6 +14,7 @@ const py::return_value_policy move         = py::return_value_policy::move;
 
 namespace python::common {
 void export_all(py::module& module);
+void export_all_opm_embedded(py::module& module);
 void export_UnitSystem(py::module& module);
 void export_Connection(py::module& module);
 void export_Deck(py::module& module);

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -210,7 +210,10 @@ void python::common::export_Schedule(py::module& module) {
     // this makes it possible to share the returned object with e.g. and
     //   opm.simulators.BlackOilSimulator Python object
     //
-    py::class_< Schedule, std::shared_ptr<Schedule> >( module, "Schedule")
+    py::class_< Schedule, std::shared_ptr<Schedule> >( module, "Schedule", R"pbdoc(
+        The Opm::Schedule class - this is a representation of all the content from
+        the SCHEDULE section, notably all well and group information and the timestepping.
+    )pbdoc")
     .def(py::init<const Deck&, const EclipseState& >())
     .def("_groups", &get_groups )
     .def_property_readonly( "start",  &get_start_time )

--- a/python/cxx/summary_state.cpp
+++ b/python/cxx/summary_state.cpp
@@ -42,7 +42,7 @@ std::vector<std::string> wells(const SummaryState * st) {
 
 void python::common::export_SummaryState(py::module& module) {
 
-    py::class_<SummaryState>(module, "SummaryState")
+    py::class_<SummaryState, std::shared_ptr<SummaryState>>(module, "SummaryState")
         .def(py::init<std::time_t>())
         .def("update", &SummaryState::update)
         .def("update_well_var", &SummaryState::update_well_var)

--- a/python/cxx/summary_state.cpp
+++ b/python/cxx/summary_state.cpp
@@ -42,7 +42,10 @@ std::vector<std::string> wells(const SummaryState * st) {
 
 void python::common::export_SummaryState(py::module& module) {
 
-    py::class_<SummaryState, std::shared_ptr<SummaryState>>(module, "SummaryState")
+    py::class_<SummaryState, std::shared_ptr<SummaryState>>(module, "SummaryState", R"pbdoc(
+            The Opm::SummaryState class - this is where the current summary results of the simulator are stored.
+            The SummaryState class has methods to get hold of well, group and general variables.
+        )pbdoc")
         .def(py::init<std::time_t>())
         .def("update", &SummaryState::update)
         .def("update_well_var", &SummaryState::update_well_var)

--- a/tests/action_missing_run.py
+++ b/tests/action_missing_run.py
@@ -1,1 +1,0 @@
-import math

--- a/tests/msim/MSIM_PYACTION_NO_RUN_FUNCTION.DATA
+++ b/tests/msim/MSIM_PYACTION_NO_RUN_FUNCTION.DATA
@@ -1,0 +1,551 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2015-2024 Equinor ASA
+
+-- This simulation is based on the data given in 
+-- 'Comparison of Solutions to a Three-Dimensional
+-- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+-- Journal of Petroleum Technology, January 1981
+
+-- Here, python scripts added by the PYACTION keyword are executed. The whole
+-- python script is executed at the end of each timestep. For backwards compatibility,
+-- if the python script contains a run function, this function is executed at the end
+-- of each time step.
+-- This DATA-file MSIM_PYACTION.DATA does the same as this DATA-file; where the
+-- python scripts here, *_no_run_function.py, do not contain a run function.
+
+---------------------------------------------------------------------------
+------------------------ SPE1 - CASE 1 ------------------------------------
+---------------------------------------------------------------------------
+
+RUNSPEC
+-- -------------------------------------------------------------------------
+
+TITLE
+   SPE1 - CASE 1
+
+DIMENS
+   10 10 3 /
+
+-- The number of equilibration regions is inferred from the EQLDIMS
+-- keyword.
+EQLDIMS
+/
+
+-- The number of PVTW tables is inferred from the TABDIMS keyword;
+-- when no data is included in the keyword the default values are used.
+TABDIMS
+/
+
+OIL
+GAS
+WATER
+DISGAS
+-- As seen from figure 4 in Odeh, GOR is increasing with time,
+-- which means that dissolved gas is present
+
+FIELD
+
+START
+   1 'DEC' 2014 /
+
+WELLDIMS
+-- Item 1: maximum number of wells in the model
+--       - there are two wells in the problem; injector and producer
+-- Item 2: maximum number of grid blocks connected to any one well
+--       - must be one as the wells are located at specific grid blocks
+-- Item 3: maximum number of groups in the model
+--       - we are dealing with only one 'group'
+-- Item 4: maximum number of wells in any one group
+--       - there must be two wells in a group as there are two wells in total
+   5 1 1 2 /
+
+UNIFOUT
+
+UDQDIMS
+ 50 25 0 50 50 0 0 50 0 20 /
+
+GRID
+
+-- The INIT keyword is used to request an .INIT file. The .INIT file
+-- is written before the simulation actually starts, and contains grid
+-- properties and saturation tables as inferred from the input
+-- deck. There are no other keywords which can be used to configure
+-- exactly what is written to the .INIT file.
+INIT
+
+
+-- -------------------------------------------------------------------------
+NOECHO
+
+DX 
+-- There are in total 300 cells with length 1000ft in x-direction 
+      300*1000 /
+DY
+-- There are in total 300 cells with length 1000ft in y-direction 
+   300*1000 /
+DZ
+-- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
+   100*20 100*30 100*50 /
+
+TOPS
+-- The depth of the top of each grid block
+   100*8325 /
+
+PORO
+-- Constant porosity of 0.3 throughout all 300 grid cells
+      300*0.3 /
+
+PERMX
+-- The layers have perm. 500mD, 50mD and 200mD, respectively.
+   100*500 100*50 100*200 /
+
+PERMY
+-- Equal to PERMX
+   100*500 100*50 100*200 /
+
+PERMZ
+-- Cannot find perm. in z-direction in Odeh's paper
+-- For the time being, we will assume PERMZ equal to PERMX and PERMY:
+   100*500 100*50 100*200 /
+ECHO
+
+PROPS
+-- -------------------------------------------------------------------------
+
+PVTW
+-- Item 1: pressure reference (psia)
+-- Item 2: water FVF (rb per bbl or rb per stb)
+-- Item 3: water compressibility (psi^{-1})
+-- Item 4: water viscosity (cp)
+-- Item 5: water 'viscosibility' (psi^{-1})
+
+-- Using values from Norne:
+-- In METRIC units:
+--    277.0 1.038 4.67E-5 0.318 0.0 /
+-- In FIELD units:
+      4017.55 1.038 3.22E-6 0.318 0.0 /
+
+ROCK
+-- Item 1: reference pressure (psia)
+-- Item 2: rock compressibility (psi^{-1})
+
+-- Using values from table 1 in Odeh:
+   14.7 3E-6 /
+
+SWOF
+-- Column 1: water saturation
+--         - this has been set to (almost) equally spaced values from 0.12 to 1
+-- Column 2: water relative permeability
+--         - generated from the Corey-type approx. formula
+--        the coeffisient is set to 10e-5, S_{orw}=0 and S_{wi}=0.12
+-- Column 3: oil relative permeability when only oil and water are present
+--      - we will use the same values as in column 3 in SGOF.
+--           This is not really correct, but since only the first 
+--        two values are of importance, this does not really matter
+-- Column 4: water-oil capillary pressure (psi) 
+
+0.12  0           1  0
+0.18  4.64876033057851E-008   1  0
+0.24  0.000000186    0.997 0
+0.3   4.18388429752066E-007   0.98  0
+0.36  7.43801652892562E-007   0.7   0
+0.42  1.16219008264463E-006   0.35  0
+0.48  1.67355371900826E-006   0.2   0
+0.54  2.27789256198347E-006   0.09  0
+0.6   2.97520661157025E-006   0.021 0
+0.66  3.7654958677686E-006 0.01  0
+0.72  4.64876033057851E-006   0.001 0
+0.78  0.000005625    0.0001   0
+0.84  6.69421487603306E-006   0  0
+0.91  8.05914256198347E-006   0  0
+1  0.00001        0  0 /
+
+
+SGOF
+-- Column 1: gas saturation
+-- Column 2: gas relative permeability
+-- Column 3: oil relative permeability when oil, gas and connate water are present
+-- Column 4: oil-gas capillary pressure (psi)
+--         - stated to be zero in Odeh's paper
+
+-- Values in column 1-3 are taken from table 3 in Odeh's paper:
+0  0  1  0
+0.001 0  1  0
+0.02  0  0.997 0
+0.05  0.005 0.980 0
+0.12  0.025 0.700 0
+0.2   0.075 0.350 0
+0.25  0.125 0.200 0
+0.3   0.190 0.090 0
+0.4   0.410 0.021 0
+0.45  0.60  0.010 0
+0.5   0.72  0.001 0
+0.6   0.87  0.0001   0
+0.7   0.94  0.000 0
+0.85  0.98  0.000 0 
+0.88  0.984 0.000 0 /
+--1.00   1.0   0.000 0 /
+-- Warning from Eclipse: first sat. value in SWOF + last sat. value in SGOF
+--              must not be greater than 1, but Eclipse still runs
+-- Flow needs the sum to be excactly 1 so I added a row with gas sat. =  0.88
+-- The corresponding krg value was estimated by assuming linear rel. between
+-- gas sat. and krw. between gas sat. 0.85 and 1.00 (the last two values given)
+
+DENSITY
+-- Density (lb per ft³) at surface cond. of 
+-- oil, water and gas, respectively (in that order)
+
+-- Using values from Norne:
+-- In METRIC units:
+--      859.5 1033.0 0.854 /
+-- In FIELD units:
+         53.66 64.49 0.0533 /
+
+PVDG
+-- Column 1: gas phase pressure (psia)
+-- Column 2: gas formation volume factor (rb per Mscf)
+--         - in Odeh's paper the units are said to be given in rb per bbl, 
+--           but this is assumed to be a mistake: FVF-values in Odeh's paper 
+--        are given in rb per scf, not rb per bbl. This will be in 
+--        agreement with conventions
+-- Column 3: gas viscosity (cP)
+
+-- Using values from lower right table in Odeh's table 2:
+14.700   166.666  0.008000
+264.70   12.0930  0.009600
+514.70   6.27400  0.011200
+1014.7   3.19700  0.014000
+2014.7   1.61400  0.018900
+2514.7   1.29400  0.020800
+3014.7   1.08000  0.022800
+4014.7   0.81100  0.026800
+5014.7   0.64900  0.030900
+9014.7   0.38600  0.047000 /
+
+PVTO
+-- Column 1: dissolved gas-oil ratio (Mscf per stb)
+-- Column 2: bubble point pressure (psia)
+-- Column 3: oil FVF for saturated oil (rb per stb)
+-- Column 4: oil viscosity for saturated oil (cP)
+
+-- Use values from top left table in Odeh's table 2:
+0.0010   14.7  1.0620   1.0400 /
+0.0905   264.7 1.1500   0.9750 /
+0.1800   514.7 1.2070   0.9100 /
+0.3710   1014.7   1.2950   0.8300 /
+0.6360   2014.7   1.4350   0.6950 /
+0.7750   2514.7   1.5000   0.6410 /
+0.9300   3014.7   1.5650   0.5940 /
+1.2700   4014.7   1.6950   0.5100 
+   9014.7   1.5790   0.7400 /
+1.6180   5014.7   1.8270   0.4490 
+   9014.7   1.7370   0.6310 / 
+-- It is required to enter data for undersaturated oil for the highest GOR
+-- (i.e. the last row) in the PVTO table.
+-- In order to fulfill this requirement, values for oil FVF and viscosity
+-- at 9014.7psia and GOR=1.618 for undersaturated oil have been approximated:
+-- It has been assumed that there is a linear relation between the GOR
+-- and the FVF when keeping the pressure constant at 9014.7psia.
+-- From Odeh we know that (at 9014.7psia) the FVF is 2.357 at GOR=2.984
+-- for saturated oil and that the FVF is 1.579 at GOR=1.27 for undersaturated oil,
+-- so it is possible to use the assumption described above. 
+-- An equivalent approximation for the viscosity has been used.
+/
+
+SOLUTION
+-- -------------------------------------------------------------------------
+
+EQUIL
+-- Item 1: datum depth (ft)
+-- Item 2: pressure at datum depth (psia)
+--       - Odeh's table 1 says that initial reservoir pressure is 
+--         4800 psi at 8400ft, which explains choice of item 1 and 2
+-- Item 3: depth of water-oil contact (ft)
+--       - chosen to be directly under the reservoir
+-- Item 4: oil-water capillary pressure at the water oil contact (psi)
+--       - given to be 0 in Odeh's paper
+-- Item 5: depth of gas-oil contact (ft)
+--       - chosen to be directly above the reservoir
+-- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
+--       - given to be 0 in Odeh's paper
+-- Item 7: RSVD-table
+-- Item 8: RVVD-table
+-- Item 9: Set to 0 as this is the only value supported by OPM
+
+-- Item #: 1 2    3    4 5    6 7 8 9
+   8400 4800 8450 0 8300 0 1 0 0 /
+
+RSVD
+-- Dissolved GOR is initially constant with depth through the reservoir.
+-- The reason is that the initial reservoir pressure given is higher 
+---than the bubble point presssure of 4014.7psia, meaning that there is no 
+-- free gas initially present.
+8300 1.270
+8450 1.270 /
+
+SUMMARY
+-- -------------------------------------------------------------------------   
+
+FOPR
+
+WGOR
+/
+WOPR
+/
+WWPR
+/
+WWCT
+/
+
+
+FGOR
+
+-- 2a) Pressures of the cell where the injector and producer are located
+BPR
+1  1  1 /
+10 10 3 /
+/
+
+-- 2b) Gas saturation at grid points given in Odeh's paper
+BGSAT
+1  1  1 /
+1  1  2 /
+1  1  3 /
+10 1  1 /
+10 1  2 /
+10 1  3 /
+10 10 1 /
+10 10 2 /
+10 10 3 /
+/
+
+-- In order to compare Eclipse with Flow:
+WBHP
+/
+
+WGIR
+  'INJ'
+/
+
+WGIT
+  'INJ'
+/
+
+WGPR
+/
+
+WGPT
+/
+
+WOPR
+/
+
+WOPT
+/
+
+WWIR
+/
+WWIT
+/
+WWPR
+/
+WWPT
+/
+WUBHP
+/
+WUOPRL
+/
+WUWCT
+/
+
+FOPR
+
+FUOPR
+
+
+SCHEDULE
+-- -------------------------------------------------------------------------
+RPTSCHED
+   'PRES' 'SGAS' 'RS' 'WELLS' 'WELSPECS' /
+
+RPTRST
+   'BASIC=1' /
+
+UDQ
+  ASSIGN WUBHP 11 /
+  ASSIGN WUOPRL 20 /
+  ASSIGN WUBHP P2 12 /
+  ASSIGN WUBHP P3 13 /
+  ASSIGN WUBHP P4 14 /
+  UNITS  WUBHP 'BARSA' /
+  UNITS  WUOPRL 'SM3/DAY' /
+  DEFINE WUWCT WWPR / (WWPR + WOPR) /
+  UNITS  WUWCT '1' /
+  DEFINE FUOPR SUM(WOPR) /
+  UNITS  FUOPR 'SM3/DAY' /
+/
+
+
+
+-- If no resolution (i.e. case 1), the two following lines must be added:
+DRSDT
+ 0 /
+-- if DRSDT is set to 0, GOR cannot rise and free gas does not 
+-- dissolve in undersaturated oil -> constant bubble point pressure
+
+WELSPECS
+-- Item #: 1    2 3  4  5   6
+   'P1'  'G1'   3  3 8400  'OIL' /
+   'P2'  'G1'   4  4 8400  'OIL' /
+   'P3'  'G1'   5  5 8400  'OIL' /
+   'P4'  'G1'   6  6 8400  'OIL' /
+   'INJ' 'G1'  1  1  8335  'GAS' /
+/
+-- Coordinates in item 3-4 are retrieved from Odeh's figure 1 and 2
+-- Note that the depth at the midpoint of the well grid blocks
+-- has been used as reference depth for bottom hole pressure in item 5
+
+COMPDAT
+-- Item #: 1   2  3  4  5  6  7  8  9
+   'P1'  3    3   3  3  'OPEN'   1* 1* 0.5 /
+   'P2'  4    4   3  3  'OPEN'   1* 1* 0.5 /
+   'P3'  5    5   3  3  'OPEN'   1* 1* 0.5 /
+   'P4'  6    6   3  3  'OPEN'   1* 1* 0.5 /
+   'INJ' 1  1  1  1  'OPEN'   1* 1* 0.5 /
+/
+-- Coordinates in item 2-5 are retreived from Odeh's figure 1 and 2 
+-- Item 9 is the well bore internal diameter, 
+-- the radius is given to be 0.25ft in Odeh's paper
+
+
+WCONPROD
+-- Item #:1 2      3     4    5  9
+   'P1' 'OPEN' 'ORAT' 5000 4* 1000 /
+   'P2' 'OPEN' 'ORAT' 5000 4* 1000 /
+   'P3' 'OPEN' 'ORAT' 5000 4* 1000 /
+   'P4' 'OPEN' 'ORAT' 5000 4* 1000 /
+/
+
+-- It is stated in Odeh's paper that the maximum oil prod. rate
+-- is 20 000stb per day which explains the choice of value in item 4.
+-- The items > 4 are defaulted with the exception of item  9,
+-- the BHP lower limit, which is given to be 1000psia in Odeh's paper
+
+WCONINJE
+-- Item #:1  2  3  4 5      6  7
+   'INJ' 'GAS' 'OPEN'   'RATE'   100000 1* 9014 /
+/
+-- Stated in Odeh that gas inj. rate (item 5) is 100MMscf per day
+-- BHP upper limit (item 7) should not be exceeding the highest
+-- pressure in the PVT table=9014.7psia (default is 100 000psia)
+
+PYACTION
+   ACTION2 UNLIMITED /
+   'action2_no_run_function.py' /
+
+PYACTION
+   ACTION3 UNLIMITED /
+   'action_count_no_run_function.py' /
+
+DATES
+   1 'JAN'  2015 /
+/
+
+DATES
+   1 'FEB'  2015 /
+/
+
+DATES
+   1 'MAR'  2015 /
+/
+
+DATES
+   1 'APR'  2015 /
+/
+
+DATES
+   1 'MAI'  2015 /
+/
+
+DATES
+   1 'JUN'  2015 /
+/
+
+DATES
+   1 'JUL'  2015 /
+/
+
+DATES
+   1 'AUG'  2015 /
+/
+
+DATES
+   1 'SEP'  2015 /
+/
+
+DATES
+   1 'OCT'  2015 /
+/
+
+DATES
+   1 'NOV'  2015 /
+/
+
+DATES
+   1 'DEC'  2015 /
+/
+
+DATES
+   1 'JAN'  2016 /
+/
+
+DATES
+   1 'FEB'  2016 /
+/
+
+DATES
+   1 'MAR'  2016 /
+/
+
+DATES
+   1 'APR'  2016 /
+/
+
+DATES
+   1 'MAI'  2016 /
+/
+
+DATES
+   1 'JUN'  2016 /
+/
+
+DATES
+   1 'JUL'  2016 /
+/
+
+DATES
+   1 'AUG'  2016 /
+/
+
+DATES
+   1 'SEP'  2016 /
+/
+
+DATES
+   1 'OCT'  2016 /
+/
+
+DATES
+   1 'NOV'  2016 /
+/
+
+DATES
+   1 'DEC'  2016 /
+/
+
+
+END

--- a/tests/msim/action2_no_run_function.py
+++ b/tests/msim/action2_no_run_function.py
@@ -1,0 +1,10 @@
+# This script does the same as action2.py, using the attributes of opm_embedded instead of the run function
+
+import opm_embedded
+
+summary_state = opm_embedded.current_summary_state
+schedule = opm_embedded.current_schedule
+
+for well in summary_state.wells:
+    if summary_state.well_var(well, "WWCT") > 0.50:
+        schedule.shut_well(well, opm_embedded.current_report_step)

--- a/tests/msim/action_count_no_run_function.py
+++ b/tests/msim/action_count_no_run_function.py
@@ -1,0 +1,16 @@
+# This script does the same as action_count.py, using the attributes of opm_embedded instead of the run function
+
+import opm_embedded
+
+summary_state = opm_embedded.current_summary_state
+
+if (not 'stop_on_next_run' in locals()): # Define this variable on the first run
+    stop_on_next_run = False
+
+if (not stop_on_next_run):
+    if not "run_count" in summary_state:
+        summary_state["run_count"] = 0
+    summary_state["run_count"] += 1
+
+if summary_state.elapsed() > (365 + 15)*24*3600:
+    stop_on_next_run = True

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -504,53 +504,57 @@ BOOST_AUTO_TEST_CASE(MSIM_PYACTION_INSERT_KEYWORD) {
     }
 }
 BOOST_AUTO_TEST_CASE(PYTHON_WELL_CLOSE_EXAMPLE) {
-    const auto& deck = Parser().parseFile("msim/MSIM_PYACTION.DATA");
-    test_data td( deck );
-    msim sim(td.state, td.schedule);
-    {
-        WorkArea work_area("test_msim");
-        EclipseIO io(td.state, td.state.getInputGrid(), sim.schedule, td.summary_config);
-
-        sim.well_rate("P1", data::Rates::opt::oil, prod_opr);
-        sim.well_rate("P2", data::Rates::opt::oil, prod_opr);
-        sim.well_rate("P3", data::Rates::opt::oil, prod_opr);
-        sim.well_rate("P4", data::Rates::opt::oil, prod_opr);
-
-        sim.well_rate("P1", data::Rates::opt::wat, prod_wpr_P1);
-        sim.well_rate("P2", data::Rates::opt::wat, prod_wpr_P2);
-        sim.well_rate("P3", data::Rates::opt::wat, prod_wpr_P3);
-        sim.well_rate("P4", data::Rates::opt::wat, prod_wpr_P4);
-
+    const auto& deck1 = Parser().parseFile("msim/MSIM_PYACTION.DATA");
+    const auto& deck2 = Parser().parseFile("msim/MSIM_PYACTION_NO_RUN_FUNCTION.DATA");
+    std::vector<Deck> decks = {deck1, deck2};
+    for (auto&& deck : decks) {
+        test_data td( deck );
+        msim sim(td.state, td.schedule);
         {
-            const auto& w1 = sim.schedule.getWell("P1", 15);
-            const auto& w2 = sim.schedule.getWell("P2", 15);
-            const auto& w3 = sim.schedule.getWell("P3", 15);
-            const auto& w4 = sim.schedule.getWell("P4", 15);
+            WorkArea work_area("test_msim");
+            EclipseIO io(td.state, td.state.getInputGrid(), sim.schedule, td.summary_config);
 
-            BOOST_CHECK(w1.getStatus() == Well::Status::OPEN );
-            BOOST_CHECK(w2.getStatus() == Well::Status::OPEN );
-            BOOST_CHECK(w3.getStatus() == Well::Status::OPEN );
-            BOOST_CHECK(w4.getStatus() == Well::Status::OPEN );
-        }
+            sim.well_rate("P1", data::Rates::opt::oil, prod_opr);
+            sim.well_rate("P2", data::Rates::opt::oil, prod_opr);
+            sim.well_rate("P3", data::Rates::opt::oil, prod_opr);
+            sim.well_rate("P4", data::Rates::opt::oil, prod_opr);
+
+            sim.well_rate("P1", data::Rates::opt::wat, prod_wpr_P1);
+            sim.well_rate("P2", data::Rates::opt::wat, prod_wpr_P2);
+            sim.well_rate("P3", data::Rates::opt::wat, prod_wpr_P3);
+            sim.well_rate("P4", data::Rates::opt::wat, prod_wpr_P4);
+
+            {
+                const auto& w1 = sim.schedule.getWell("P1", 15);
+                const auto& w2 = sim.schedule.getWell("P2", 15);
+                const auto& w3 = sim.schedule.getWell("P3", 15);
+                const auto& w4 = sim.schedule.getWell("P4", 15);
+
+                BOOST_CHECK(w1.getStatus() == Well::Status::OPEN );
+                BOOST_CHECK(w2.getStatus() == Well::Status::OPEN );
+                BOOST_CHECK(w3.getStatus() == Well::Status::OPEN );
+                BOOST_CHECK(w4.getStatus() == Well::Status::OPEN );
+            }
 
 
-        sim.run(io, false);
-        {
-            const auto& w1 = sim.schedule.getWell("P1", 15);
-            const auto& w3 = sim.schedule.getWell("P3", 15);
-            BOOST_CHECK(w1.getStatus() ==  Well::Status::OPEN );
-            BOOST_CHECK(w3.getStatus() ==  Well::Status::OPEN );
+            sim.run(io, false);
+            {
+                const auto& w1 = sim.schedule.getWell("P1", 15);
+                const auto& w3 = sim.schedule.getWell("P3", 15);
+                BOOST_CHECK(w1.getStatus() ==  Well::Status::OPEN );
+                BOOST_CHECK(w3.getStatus() ==  Well::Status::OPEN );
+            }
+            {
+                const auto& w2_6 = sim.schedule.getWell("P2", 6);
+                BOOST_CHECK(w2_6.getStatus() == Well::Status::SHUT );
+            }
+            {
+                const auto& w4_11 = sim.schedule.getWell("P4", 11);
+                BOOST_CHECK(w4_11.getStatus() == Well::Status::SHUT );
+            }
         }
-        {
-            const auto& w2_6 = sim.schedule.getWell("P2", 6);
-            BOOST_CHECK(w2_6.getStatus() == Well::Status::SHUT );
-        }
-        {
-            const auto& w4_11 = sim.schedule.getWell("P4", 11);
-            BOOST_CHECK(w4_11.getStatus() == Well::Status::SHUT );
-        }
+        BOOST_CHECK_EQUAL( sim.st.get("run_count"), 13);
     }
-    BOOST_CHECK_EQUAL( sim.st.get("run_count"), 13);
 }
 
 BOOST_AUTO_TEST_CASE(PYTHON_CHANGING_SCHEUDULE) {


### PR DESCRIPTION
- Make the EclipseState, Schedule, SummaryState available as attributes of the module opm_embedded instead
- This enables tooltips for writing code in a python ide by typing opm_embedded.<tab>
- The code will still be backwards compatible