### PR TITLE
Comment unused EclHysteriseTwoPhaseLawParam::krwSwMdc_

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -716,7 +716,7 @@ private:
     // largest wettinging phase saturation which is on the main-drainage curve. These are
     // three different values because the sourounding code can choose to use different
     // definitions for the saturations for different quantities
-    Scalar krwSwMdc_;
+    //Scalar krwSwMdc_;
     Scalar krnSwMdc_;
     Scalar pcSwMdc_;
 


### PR DESCRIPTION
It is not used, but creates warnings about uninitialized variables.