### PR TITLE
Relax Assumption That All Connections are Active

### DIFF
--- a/opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp
+++ b/opm/input/eclipse/Schedule/Well/PAvgCalculator.hpp
@@ -427,12 +427,28 @@ private:
         std::vector<ContrIndexType> diagNeighbours{};
     };
 
+    /// Number of input connections.
+    ///
+    /// Saved copy of \code .size() \endcode from \c connections constructor
+    /// parameter.
+    std::vector<PAvgConnection>::size_type numInputConns_{};
+
     /// Set of well/reservoir connections from which the block-average
     /// pressures derive.
     std::vector<PAvgConnection> connections_{};
 
     /// List of indices into \c connections_ that represent open connections.
     std::vector<std::vector<PAvgConnection>::size_type> openConns_{};
+
+    /// Map \c connections_ indices to input indices (0..numInputConns_-1).
+    ///
+    /// In particular, \code connections_[i] \endcode corresponds to input
+    /// connection \code inputConn_[i] \endcode.
+    ///
+    /// Needed to handle connections to inactive cells.  See
+    /// pruneInactiveConnections() and connectionPressureOffsetWell() for
+    /// details.
+    std::vector<std::vector<PAvgConnection>::size_type> inputConn_{};
 
     /// Collection of all (global) cell indices that potentially contribute
     /// to this block-average well pressure calculation.
@@ -459,6 +475,18 @@ private:
     void addConnection(const GridDims&   cellIndexMap,
                        const Connection& conn,
                        SetupMap&         setupHelperMap);
+
+    /// Finish construction by pruning inactive PAvgConnections.
+    ///
+    /// \param[in] isActive Linearised predicate for whether or not given
+    ///   cell amongst \code allWBPCells() \endcode is actually active in
+    ///   the model.
+    ///
+    ///   Assumed to have the same size--number of elements--as the return
+    ///   value from member function \code allWBPCells() \endcode, and
+    ///   organise its elements such that \code isActive[i] \endcode holds
+    ///   the active status of \code allWBPCells()[i] \endcode.
+    void pruneInactiveConnections(const std::vector<bool>& isActive);
 
     /// Top-level entry point for accumulating local WBP contributions.
     ///


### PR DESCRIPTION
This PR allows for the possibility that not all well connections might be in active cells for the purpose of calculcating the WBPn summary vectors.  This situation might arise when "re-parsing" portions of the SCHEDULE section following the successful triggering of an `ACTIONX` block.  In this case, the well's connections might not be filtered down to the active set only through a call to member function `Schedule::filterConnections()` so it is better to add some logic here that will filter out the inactive connections.

To this end, add three new members to the `PAvgCalculator` class:

  - Data member `numInputConns_` records the number of original well connections&ndash;i.e., `Well::getConnections().size()`.  The vector of connection-based source locations must be sized according to this number of connections.

  - Data member `inputConn_` which records a mapping of active ➡️ input connection IDs.  This is needed to properly identify the correct input source location of an active connection

  - Member function `pruneInactiveConnections()` which filters the recorded list of well connections (`connections_`) down to the set of active connections only

We call the latter from the existing member function
```
PAvgCalculator::pruneInactiveWBPCells()
```
since that function knows which cells are active and which are not.

Together with downstream PR OPM/opm-simulators#5258 this PR enables running a field case to completion which would previously stop at the end of the history period/start of the prediction period.