### PR TITLE
fixed: assignment intended, not comparison

### DIFF
--- a/opm/io/eclipse/EGrid.cpp
+++ b/opm/io/eclipse/EGrid.cpp
@@ -94,7 +94,7 @@ EGrid::EGrid(const std::string &filename, std::string grid_name) :
                 nijk[1] = gridhead[2];
                 nijk[2] = gridhead[3];
 
-                numres == (gridhead.size() > 24)
+                numres = (gridhead.size() > 24)
                     ? gridhead[24] : 1;
 
                 m_radial = (gridhead.size() > 26)


### PR DESCRIPTION
Pointy hat split in two and shared between perpetrator and reviewer.

Caught by debug iterator build.