### PR TITLE
Feature/py action insert kw

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -701,11 +701,13 @@ if(ENABLE_ECL_OUTPUT)
           tests/msim/MSIM_PYACTION.DATA
           tests/msim/MSIM_PYACTION_CHANGING_SCHEDULE.DATA
           tests/msim/MSIM_PYACTION_CHANGING_SCHEDULE_ACTIONX_CALLBACK.DATA
+          tests/msim/MSIM_PYACTION_INSERT_KEYWORD.DATA
           tests/msim/action1.py
           tests/msim/action2.py
           tests/msim/action3.py
           tests/msim/action3_actionx_callback.py
           tests/msim/action_count.py
+          tests/msim/insert_keyword.py
           tests/VFP_CASE.DATA)
 endif()
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -271,7 +271,8 @@ namespace Opm
           for the schedule instances created by loading a restart file.
         */
         static bool cmp(const Schedule& sched1, const Schedule& sched2, std::size_t report_step);
-        void applyKeywords(std::vector<DeckKeyword*>& keywords, std::size_t report_step);
+        void applyKeywords(std::vector<std::unique_ptr<DeckKeyword>>& keywords, std::size_t report_step);
+        void applyKeywords(std::vector<std::unique_ptr<DeckKeyword>>& keywords);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)
@@ -463,6 +464,11 @@ namespace Opm
         std::vector<ScheduleState> snapshots;
         WriteRestartFileEvents restart_output;
         CompletedCells completed_cells;
+
+        // The current_report_step is set to the current report step when a PYACTION call is executed.
+        // This is needed since the Schedule object does not know the current report step of the simulator and
+        // we only allow PYACTIONS for the current and future report steps. 
+        std::size_t current_report_step = 0;
         // The simUpdateFromPython points to a SimulatorUpdate collecting all updates from one PYACTION call.
         // The SimulatorUpdate is reset before a new PYACTION call is executed.
         // It is a shared_ptr, so a Schedule can be constructed using the copy constructor sharing the simUpdateFromPython.

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -271,7 +271,7 @@ namespace Opm
           for the schedule instances created by loading a restart file.
         */
         static bool cmp(const Schedule& sched1, const Schedule& sched2, std::size_t report_step);
-        void applyKeywords(std::vector<DeckKeyword*>& keywords, std::size_t timeStep);
+        void applyKeywords(std::vector<DeckKeyword*>& keywords, std::size_t report_step);
 
         template<class Serializer>
         void serializeOp(Serializer& serializer)

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -144,14 +144,14 @@ namespace {
     }
 
 
-    const ScheduleState& getitem(const Schedule& sch, std::size_t index) {
-        return sch[index];
+    const ScheduleState& getitem(const Schedule& sch, std::size_t report_step) {
+        return sch[report_step];
     }
 
     void insert_keywords(
         Schedule& sch,
         const std::string& deck_string,
-        std::size_t index,
+        std::size_t report_step,
         const UnitSystem& unit_system
     )
     {
@@ -162,7 +162,7 @@ namespace {
         for (auto &keyword : deck) {
             keywords.push_back(&keyword);
         }
-        sch.applyKeywords(keywords, index);
+        sch.applyKeywords(keywords, report_step);
     }
 
     // NOTE: this overload does currently not work, see PR #2833. The plan
@@ -170,7 +170,7 @@ namespace {
     //  above taking a deck_string (std::string) instead of a list of DeckKeywords
     //  has to be used instead.
     void insert_keywords(
-        Schedule& sch, py::list& deck_keywords, std::size_t index)
+        Schedule& sch, py::list& deck_keywords, std::size_t report_step)
     {
         Parser parser;
         std::vector<DeckKeyword*> keywords;
@@ -178,7 +178,7 @@ namespace {
             DeckKeyword &keyword = item.cast<DeckKeyword&>();
             keywords.push_back(&keyword);
         }
-        sch.applyKeywords(keywords, index);
+        sch.applyKeywords(keywords, report_step);
     }
 }
 

--- a/python/cxx/schedule.cpp
+++ b/python/cxx/schedule.cpp
@@ -148,21 +148,33 @@ namespace {
         return sch[report_step];
     }
 
-    void insert_keywords(
-        Schedule& sch,
-        const std::string& deck_string,
-        std::size_t report_step,
-        const UnitSystem& unit_system
-    )
+    std::vector<std::unique_ptr<DeckKeyword>> parseKeywords(const std::string& deck_string, const UnitSystem& unit_system)
     {
         Parser parser;
         std::string str {unit_system.deck_name() + "\n\n" + deck_string};
         auto deck = parser.parseString(str);
-        std::vector<DeckKeyword*> keywords;
+        std::vector<std::unique_ptr<DeckKeyword>> keywords;
         for (auto &keyword : deck) {
-            keywords.push_back(&keyword);
+            keywords.push_back(std::make_unique<DeckKeyword>(keyword));
         }
-        sch.applyKeywords(keywords, report_step);
+        return keywords;
+    }
+    void insert_keywords(Schedule& sch, const std::string& deck_string, std::size_t report_step, const UnitSystem& unit_system)
+    {
+        auto kws = parseKeywords(deck_string, unit_system);
+        sch.applyKeywords(kws, report_step);
+    }
+
+    void insert_keywords(Schedule& sch, const std::string& deck_string, std::size_t report_step)
+    {
+        auto kws = parseKeywords(deck_string,sch.getUnits());
+        sch.applyKeywords(kws, report_step);
+    }
+
+    void insert_keywords(Schedule& sch, const std::string& deck_string)
+    {
+        auto kws = parseKeywords(deck_string,sch.getUnits());
+        sch.applyKeywords(kws);
     }
 
     // NOTE: this overload does currently not work, see PR #2833. The plan
@@ -172,11 +184,10 @@ namespace {
     void insert_keywords(
         Schedule& sch, py::list& deck_keywords, std::size_t report_step)
     {
-        Parser parser;
-        std::vector<DeckKeyword*> keywords;
+        std::vector<std::unique_ptr<DeckKeyword>> keywords;
         for (py::handle item : deck_keywords) {
             DeckKeyword &keyword = item.cast<DeckKeyword&>();
-            keywords.push_back(&keyword);
+            keywords.push_back(std::make_unique<DeckKeyword>(keyword));
         }
         sch.applyKeywords(keywords, report_step);
     }
@@ -215,14 +226,10 @@ void python::common::export_Schedule(py::module& module) {
     .def( "get_production_properties", &get_production_properties, py::arg("well_name"), py::arg("report_step"))
     .def("well_names", py::overload_cast<const std::string&>(&Schedule::wellNames, py::const_))
     .def( "get_well", &get_well)
-    .def( "insert_keywords",
-        py::overload_cast<Schedule&, py::list&, std::size_t>(&insert_keywords),
-        py::arg("keywords"), py::arg("step"))
-    .def( "insert_keywords",
-        py::overload_cast<
-               Schedule&, const std::string&, std::size_t, const UnitSystem&
-           >(&insert_keywords),
-        py::arg("data"), py::arg("step"), py::arg("unit_system"))
+    .def( "insert_keywords", py::overload_cast<Schedule&, py::list&, std::size_t>(&insert_keywords), py::arg("keywords"), py::arg("step"))
+    .def( "insert_keywords", py::overload_cast<Schedule&, const std::string&, std::size_t, const UnitSystem&>(&insert_keywords), py::arg("data"), py::arg("step"), py::arg("unit_system"))
+    .def( "insert_keywords", py::overload_cast<Schedule&, const std::string&, std::size_t>(&insert_keywords), py::arg("data"), py::arg("step"))
+    .def( "insert_keywords", py::overload_cast<Schedule&, const std::string&>(&insert_keywords),py::arg("data"))
     .def( "__contains__", &has_well );
 
 }

--- a/tests/msim/MSIM_PYACTION_INSERT_KEYWORD.DATA
+++ b/tests/msim/MSIM_PYACTION_INSERT_KEYWORD.DATA
@@ -1,0 +1,542 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2015-2024 Equinor ASA
+
+-- This simulation is based on the data given in 
+-- 'Comparison of Solutions to a Three-Dimensional
+-- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+-- Journal of Petroleum Technology, January 1981
+
+-- This file is the same as MSIM_PYACTION.DATA, except for calling another python script in PYACTION
+
+---------------------------------------------------------------------------
+------------------------ SPE1 - CASE 1 ------------------------------------
+---------------------------------------------------------------------------
+
+RUNSPEC
+-- -------------------------------------------------------------------------
+
+TITLE
+   SPE1 - CASE 1
+
+DIMENS
+   10 10 3 /
+
+-- The number of equilibration regions is inferred from the EQLDIMS
+-- keyword.
+EQLDIMS
+/
+
+-- The number of PVTW tables is inferred from the TABDIMS keyword;
+-- when no data is included in the keyword the default values are used.
+TABDIMS
+/
+
+OIL
+GAS
+WATER
+DISGAS
+-- As seen from figure 4 in Odeh, GOR is increasing with time,
+-- which means that dissolved gas is present
+
+FIELD
+
+START
+   1 'DEC' 2014 /
+
+WELLDIMS
+-- Item 1: maximum number of wells in the model
+-- 	   - there are two wells in the problem; injector and producer
+-- Item 2: maximum number of grid blocks connected to any one well
+-- 	   - must be one as the wells are located at specific grid blocks
+-- Item 3: maximum number of groups in the model
+-- 	   - we are dealing with only one 'group'
+-- Item 4: maximum number of wells in any one group
+-- 	   - there must be two wells in a group as there are two wells in total
+   5 1 1 5 /
+
+UNIFOUT
+
+UDQDIMS
+ 50 25 0 50 50 0 0 50 0 20 /
+
+GRID
+
+-- The INIT keyword is used to request an .INIT file. The .INIT file
+-- is written before the simulation actually starts, and contains grid
+-- properties and saturation tables as inferred from the input
+-- deck. There are no other keywords which can be used to configure
+-- exactly what is written to the .INIT file.
+INIT
+
+
+-- -------------------------------------------------------------------------
+NOECHO
+
+DX 
+-- There are in total 300 cells with length 1000ft in x-direction	
+   	300*1000 /
+DY
+-- There are in total 300 cells with length 1000ft in y-direction	
+	300*1000 /
+DZ
+-- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
+	100*20 100*30 100*50 /
+
+TOPS
+-- The depth of the top of each grid block
+	100*8325 /
+
+PORO
+-- Constant porosity of 0.3 throughout all 300 grid cells
+   	300*0.3 /
+
+PERMX
+-- The layers have perm. 500mD, 50mD and 200mD, respectively.
+	100*500 100*50 100*200 /
+
+PERMY
+-- Equal to PERMX
+	100*500 100*50 100*200 /
+
+PERMZ
+-- Cannot find perm. in z-direction in Odeh's paper
+-- For the time being, we will assume PERMZ equal to PERMX and PERMY:
+	100*500 100*50 100*200 /
+ECHO
+
+PROPS
+-- -------------------------------------------------------------------------
+
+PVTW
+-- Item 1: pressure reference (psia)
+-- Item 2: water FVF (rb per bbl or rb per stb)
+-- Item 3: water compressibility (psi^{-1})
+-- Item 4: water viscosity (cp)
+-- Item 5: water 'viscosibility' (psi^{-1})
+
+-- Using values from Norne:
+-- In METRIC units:
+-- 	277.0 1.038 4.67E-5 0.318 0.0 /
+-- In FIELD units:
+    	4017.55 1.038 3.22E-6 0.318 0.0 /
+
+ROCK
+-- Item 1: reference pressure (psia)
+-- Item 2: rock compressibility (psi^{-1})
+
+-- Using values from table 1 in Odeh:
+	14.7 3E-6 /
+
+SWOF
+-- Column 1: water saturation
+--   	     - this has been set to (almost) equally spaced values from 0.12 to 1
+-- Column 2: water relative permeability
+--   	     - generated from the Corey-type approx. formula
+--	       the coeffisient is set to 10e-5, S_{orw}=0 and S_{wi}=0.12
+-- Column 3: oil relative permeability when only oil and water are present
+--	     - we will use the same values as in column 3 in SGOF.
+-- 	       This is not really correct, but since only the first 
+--	       two values are of importance, this does not really matter
+-- Column 4: water-oil capillary pressure (psi) 
+
+0.12	0    		 	1	0
+0.18	4.64876033057851E-008	1	0
+0.24	0.000000186		0.997	0
+0.3	4.18388429752066E-007	0.98	0
+0.36	7.43801652892562E-007	0.7	0
+0.42	1.16219008264463E-006	0.35	0
+0.48	1.67355371900826E-006	0.2	0
+0.54	2.27789256198347E-006	0.09	0
+0.6	2.97520661157025E-006	0.021	0
+0.66	3.7654958677686E-006	0.01	0
+0.72	4.64876033057851E-006	0.001	0
+0.78	0.000005625		0.0001	0
+0.84	6.69421487603306E-006	0	0
+0.91	8.05914256198347E-006	0	0
+1	0.00001			0	0 /
+
+
+SGOF
+-- Column 1: gas saturation
+-- Column 2: gas relative permeability
+-- Column 3: oil relative permeability when oil, gas and connate water are present
+-- Column 4: oil-gas capillary pressure (psi)
+-- 	     - stated to be zero in Odeh's paper
+
+-- Values in column 1-3 are taken from table 3 in Odeh's paper:
+0	0	1	0
+0.001	0	1	0
+0.02	0	0.997	0
+0.05	0.005	0.980	0
+0.12	0.025	0.700	0
+0.2	0.075	0.350	0
+0.25	0.125	0.200	0
+0.3	0.190	0.090	0
+0.4	0.410	0.021	0
+0.45	0.60	0.010	0
+0.5	0.72	0.001	0
+0.6	0.87	0.0001	0
+0.7	0.94	0.000	0
+0.85	0.98	0.000	0 
+0.88	0.984	0.000	0 /
+--1.00	1.0	0.000	0 /
+-- Warning from Eclipse: first sat. value in SWOF + last sat. value in SGOF
+-- 	   		 must not be greater than 1, but Eclipse still runs
+-- Flow needs the sum to be excactly 1 so I added a row with gas sat. =  0.88
+-- The corresponding krg value was estimated by assuming linear rel. between
+-- gas sat. and krw. between gas sat. 0.85 and 1.00 (the last two values given)
+
+DENSITY
+-- Density (lb per ft³) at surface cond. of 
+-- oil, water and gas, respectively (in that order)
+
+-- Using values from Norne:
+-- In METRIC units:
+--      859.5 1033.0 0.854 /
+-- In FIELD units:
+      	53.66 64.49 0.0533 /
+
+PVDG
+-- Column 1: gas phase pressure (psia)
+-- Column 2: gas formation volume factor (rb per Mscf)
+-- 	     - in Odeh's paper the units are said to be given in rb per bbl, 
+-- 	       but this is assumed to be a mistake: FVF-values in Odeh's paper 
+--	       are given in rb per scf, not rb per bbl. This will be in 
+--	       agreement with conventions
+-- Column 3: gas viscosity (cP)
+
+-- Using values from lower right table in Odeh's table 2:
+14.700	166.666	0.008000
+264.70	12.0930	0.009600
+514.70	6.27400	0.011200
+1014.7	3.19700	0.014000
+2014.7	1.61400	0.018900
+2514.7	1.29400	0.020800
+3014.7	1.08000	0.022800
+4014.7	0.81100	0.026800
+5014.7	0.64900	0.030900
+9014.7	0.38600	0.047000 /
+
+PVTO
+-- Column 1: dissolved gas-oil ratio (Mscf per stb)
+-- Column 2: bubble point pressure (psia)
+-- Column 3: oil FVF for saturated oil (rb per stb)
+-- Column 4: oil viscosity for saturated oil (cP)
+
+-- Use values from top left table in Odeh's table 2:
+0.0010	14.7	1.0620	1.0400 /
+0.0905	264.7	1.1500	0.9750 /
+0.1800	514.7	1.2070	0.9100 /
+0.3710	1014.7	1.2950	0.8300 /
+0.6360	2014.7	1.4350	0.6950 /
+0.7750	2514.7	1.5000	0.6410 /
+0.9300	3014.7	1.5650	0.5940 /
+1.2700	4014.7	1.6950	0.5100 
+	9014.7	1.5790	0.7400 /
+1.6180	5014.7	1.8270	0.4490 
+	9014.7	1.7370	0.6310 /	
+-- It is required to enter data for undersaturated oil for the highest GOR
+-- (i.e. the last row) in the PVTO table.
+-- In order to fulfill this requirement, values for oil FVF and viscosity
+-- at 9014.7psia and GOR=1.618 for undersaturated oil have been approximated:
+-- It has been assumed that there is a linear relation between the GOR
+-- and the FVF when keeping the pressure constant at 9014.7psia.
+-- From Odeh we know that (at 9014.7psia) the FVF is 2.357 at GOR=2.984
+-- for saturated oil and that the FVF is 1.579 at GOR=1.27 for undersaturated oil,
+-- so it is possible to use the assumption described above. 
+-- An equivalent approximation for the viscosity has been used.
+/
+
+SOLUTION
+-- -------------------------------------------------------------------------
+
+EQUIL
+-- Item 1: datum depth (ft)
+-- Item 2: pressure at datum depth (psia)
+-- 	   - Odeh's table 1 says that initial reservoir pressure is 
+-- 	     4800 psi at 8400ft, which explains choice of item 1 and 2
+-- Item 3: depth of water-oil contact (ft)
+-- 	   - chosen to be directly under the reservoir
+-- Item 4: oil-water capillary pressure at the water oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 5: depth of gas-oil contact (ft)
+-- 	   - chosen to be directly above the reservoir
+-- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 7: RSVD-table
+-- Item 8: RVVD-table
+-- Item 9: Set to 0 as this is the only value supported by OPM
+
+-- Item #: 1 2    3    4 5    6 7 8 9
+	8400 4800 8450 0 8300 0 1 0 0 /
+
+RSVD
+-- Dissolved GOR is initially constant with depth through the reservoir.
+-- The reason is that the initial reservoir pressure given is higher 
+---than the bubble point presssure of 4014.7psia, meaning that there is no 
+-- free gas initially present.
+8300 1.270
+8450 1.270 /
+
+SUMMARY
+-- -------------------------------------------------------------------------	 
+
+FOPR
+
+WGOR
+/
+WOPR
+/
+WWPR
+/
+WWCT
+/
+
+
+FGOR
+
+-- 2a) Pressures of the cell where the injector and producer are located
+BPR
+1  1  1 /
+10 10 3 /
+/
+
+-- 2b) Gas saturation at grid points given in Odeh's paper
+BGSAT
+1  1  1 /
+1  1  2 /
+1  1  3 /
+10 1  1 /
+10 1  2 /
+10 1  3 /
+10 10 1 /
+10 10 2 /
+10 10 3 /
+/
+
+-- In order to compare Eclipse with Flow:
+WBHP
+/
+
+WGIR
+  'INJ'
+/
+
+WGIT
+  'INJ'
+/
+
+WGPR
+/
+
+WGPT
+/
+
+WOPR
+/
+
+WOPT
+/
+
+WWIR
+/
+WWIT
+/
+WWPR
+/
+WWPT
+/
+WUBHP
+/
+WUOPRL
+/
+WUWCT
+/
+
+FOPR
+
+FUOPR
+
+
+SCHEDULE
+-- -------------------------------------------------------------------------
+RPTSCHED
+	'PRES' 'SGAS' 'RS' 'WELLS' 'WELSPECS' /
+
+RPTRST
+	'BASIC=1' /
+
+UDQ
+  ASSIGN WUBHP 11 /
+  ASSIGN WUOPRL 20 /
+  ASSIGN WUBHP P2 12 /
+  ASSIGN WUBHP P3 13 /
+  ASSIGN WUBHP P4 14 /
+  UNITS  WUBHP 'BARSA' /
+  UNITS  WUOPRL 'SM3/DAY' /
+  DEFINE WUWCT WWPR / (WWPR + WOPR) /
+  UNITS  WUWCT '1' /
+  DEFINE FUOPR SUM(WOPR) /
+  UNITS  FUOPR 'SM3/DAY' /
+/
+
+
+
+-- If no resolution (i.e. case 1), the two following lines must be added:
+DRSDT
+ 0 /
+-- if DRSDT is set to 0, GOR cannot rise and free gas does not 
+-- dissolve in undersaturated oil -> constant bubble point pressure
+
+WELSPECS
+-- Item #: 1	 2	3	4	5	 6
+	'P1'	'G1'	 3	 3	8400	'OIL' /
+	'P2'	'G1'	 4	 4	8400	'OIL' /
+	'P3'	'G1'	 5	 5	8400	'OIL' /
+	'P4'	'G1'	 6	 6	8400	'OIL' /
+	'INJ'	'G1'	1	1	8335	'GAS' /
+/
+-- Coordinates in item 3-4 are retrieved from Odeh's figure 1 and 2
+-- Note that the depth at the midpoint of the well grid blocks
+-- has been used as reference depth for bottom hole pressure in item 5
+
+COMPDAT
+-- Item #: 1	2	3	4	5	6	7	8	9
+	'P1'	3    3	3	3	'OPEN'	1*	1*	0.5 /
+	'P2'	4    4	3	3	'OPEN'	1*	1*	0.5 /
+	'P3'	5    5	3	3	'OPEN'	1*	1*	0.5 /
+	'P4'	6    6	3	3	'OPEN'	1*	1*	0.5 /
+	'INJ'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+-- Coordinates in item 2-5 are retreived from Odeh's figure 1 and 2 
+-- Item 9 is the well bore internal diameter, 
+-- the radius is given to be 0.25ft in Odeh's paper
+
+
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+	'P1' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P2' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P3' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P4' 'OPEN' 'ORAT' 5000 4* 1000 /
+/
+
+-- It is stated in Odeh's paper that the maximum oil prod. rate
+-- is 20 000stb per day which explains the choice of value in item 4.
+-- The items > 4 are defaulted with the exception of item  9,
+-- the BHP lower limit, which is given to be 1000psia in Odeh's paper
+
+WCONINJE
+-- Item #:1	 2	 3	 4	5      6  7
+	'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
+-- Stated in Odeh that gas inj. rate (item 5) is 100MMscf per day
+-- BHP upper limit (item 7) should not be exceeding the highest
+-- pressure in the PVT table=9014.7psia (default is 100 000psia)
+
+PYACTION
+   INSERT_KEYWORD UNLIMITED /
+   'insert_keyword.py' /
+
+DATES
+   1 'JAN'  2015 /
+/
+
+DATES
+   1 'FEB'  2015 /
+/
+
+DATES
+   1 'MAR'  2015 /
+/
+
+DATES
+   1 'APR'  2015 /
+/
+
+DATES
+   1 'MAI'  2015 /
+/
+
+DATES
+   1 'JUN'  2015 /
+/
+
+DATES
+   1 'JUL'  2015 /
+/
+
+DATES
+   1 'AUG'  2015 /
+/
+
+DATES
+   1 'SEP'  2015 /
+/
+
+DATES
+   1 'OCT'  2015 /
+/
+
+DATES
+   1 'NOV'  2015 /
+/
+
+DATES
+   1 'DEC'  2015 /
+/
+
+DATES
+   1 'JAN'  2016 /
+/
+
+DATES
+   1 'FEB'  2016 /
+/
+
+DATES
+   1 'MAR'  2016 /
+/
+
+DATES
+   1 'APR'  2016 /
+/
+
+DATES
+   1 'MAI'  2016 /
+/
+
+DATES
+   1 'JUN'  2016 /
+/
+
+DATES
+   1 'JUL'  2016 /
+/
+
+DATES
+   1 'AUG'  2016 /
+/
+
+DATES
+   1 'SEP'  2016 /
+/
+
+DATES
+   1 'OCT'  2016 /
+/
+
+DATES
+   1 'NOV'  2016 /
+/
+
+DATES
+   1 'DEC'  2016 /
+/
+
+
+END

--- a/tests/msim/insert_keyword.py
+++ b/tests/msim/insert_keyword.py
@@ -1,0 +1,14 @@
+def run(ecl_state, schedule, report_step, summary_state, actionx_callback):
+	if (report_step == 2):
+		wconprod_shut = """
+		WCONPROD
+			'{}' '{}' '{}' {} 4* {} /
+		/
+			""".format('P1', 'SHUT', 'ORAT', 4000, 1000)
+		schedule.insert_keywords(wconprod_shut)
+		wconprod_open = """
+		WCONPROD
+			'{}' '{}' '{}' {} 4* {} /
+		/
+			""".format('P1', 'OPEN', 'ORAT', 4000, 1000)
+		schedule.insert_keywords(wconprod_open, report_step + 1)

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -481,6 +481,28 @@ BOOST_AUTO_TEST_CASE(COMPDAT) {
 
 #ifdef EMBEDDED_PYTHON
 
+BOOST_AUTO_TEST_CASE(MSIM_PYACTION_INSERT_KEYWORD) {
+    const auto& deck = Parser().parseFile("msim/MSIM_PYACTION_INSERT_KEYWORD.DATA");
+    test_data td( deck );
+    msim sim(td.state, td.schedule);
+    {
+        WorkArea work_area("test_msim");
+        EclipseIO io(td.state, td.state.getInputGrid(), sim.schedule, td.summary_config);
+        {
+            const auto& w1 = sim.schedule.getWell("P1", 1);
+            BOOST_CHECK(w1.getStatus() == Well::Status::OPEN );
+        }
+
+        sim.run(io, false);
+
+        {
+            const auto& w1_2 = sim.schedule.getWell("P1", 2); // Closed well P1 at report step 2
+            const auto& w1_3 = sim.schedule.getWell("P1", 3); // And scheduled for reopening at the report step after that
+            BOOST_CHECK(w1_2.getStatus() ==  Well::Status::SHUT);
+            BOOST_CHECK(w1_3.getStatus() ==  Well::Status::OPEN);
+        }
+    }
+}
 BOOST_AUTO_TEST_CASE(PYTHON_WELL_CLOSE_EXAMPLE) {
     const auto& deck = Parser().parseFile("msim/MSIM_PYACTION.DATA");
     test_data td( deck );


### PR DESCRIPTION
This PR adds the functions insert_keyword(const std::string& deck_string) and insert_keyword(const std::string& deck_string, std::size_t report_step) functions.
You can insert a keyword at a later report step or at the current report step; inserting a keyword at a past report step or at a report step exceeding the total number of report steps throws an error.