### PR TITLE
Go back to using fnmatch() instead of lots of regexes.

### DIFF
--- a/opm/common/utility/shmatch.cpp
+++ b/opm/common/utility/shmatch.cpp
@@ -17,12 +17,18 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <regex>
+#include <fnmatch.h>
+//#include <regex>
 
 #include <opm/common/utility/shmatch.hpp>
 
 
 bool Opm::shmatch(const std::string& pattern, const std::string& symbol) {
+
+    return fnmatch(pattern.c_str(), symbol.c_str(), 0) == 0;
+
+// Keeping regex based version for now in case we need to resurrect it.
+#if 0
     // Shell patterns should implicitly be interpreted as anchored at beginning
     // and end.
     std::string re_pattern = "^" + pattern + "$";
@@ -43,5 +49,6 @@ bool Opm::shmatch(const std::string& pattern, const std::string& symbol) {
 
     std::regex regexp(re_pattern);
     return std::regex_search(symbol, regexp);
+#endif
 }
 


### PR DESCRIPTION
This cuts a lot of time off Norne for me, and is noticable even on SPE9.

Norne summaries:
```
Number of MPI processes:         6
Threads per MPI process:         1
Setup time:                      9.91 s
  Deck input:                    3.42 s
Number of timesteps:           344
Simulation time:               213.35 s
  Assembly time:                34.56 s (Wasted: 0.0 s; 0.0%)
    Well assembly:               2.37 s (Wasted: 0.0 s; 0.0%)
  Linear solve time:            80.08 s (Wasted: 0.0 s; 0.0%)
    Linear setup:               38.98 s (Wasted: 0.0 s; 0.0%)
  Props/update time:            31.29 s (Wasted: 0.0 s; 0.0%)
  Pre/post step:                45.60 s (Wasted: 0.0 s; 0.0%)
  Output write time:            15.62 s
Overall Linearizations:       1525      (Wasted:     0; 0.0%)
Overall Newton Iterations:    1181      (Wasted:     0; 0.0%)
Overall Linear Iterations:    2325      (Wasted:     0; 0.0%)

Number of MPI processes:         6
Threads per MPI process:         1
Setup time:                      6.96 s
  Deck input:                    3.27 s
Number of timesteps:           344
Simulation time:               190.98 s
  Assembly time:                33.83 s (Wasted: 0.0 s; 0.0%)
    Well assembly:               2.31 s (Wasted: 0.0 s; 0.0%)
  Linear solve time:            77.33 s (Wasted: 0.0 s; 0.0%)
    Linear setup:               37.92 s (Wasted: 0.0 s; 0.0%)
  Props/update time:            30.60 s (Wasted: 0.0 s; 0.0%)
  Pre/post step:                28.06 s (Wasted: 0.0 s; 0.0%)
  Output write time:            15.14 s
Overall Linearizations:       1525      (Wasted:     0; 0.0%)
Overall Newton Iterations:    1181      (Wasted:     0; 0.0%)
Overall Linear Iterations:    2325      (Wasted:     0; 0.0%)
```
Ignoring random variations in runtimes there is still a significant difference to pre/post.