### PR TITLE
returning bool for phaseIsActive() function

### DIFF
--- a/opm/material/fluidsystems/BaseFluidSystem.hpp
+++ b/opm/material/fluidsystems/BaseFluidSystem.hpp
@@ -291,7 +291,7 @@ public:
 
 
     //! \brief Returns whether a fluid phase is active
-    static unsigned phaseIsActive(unsigned /*phaseIdx*/)
+    static bool phaseIsActive(unsigned /*phaseIdx*/)
     {
         return true;
     }

--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -394,7 +394,7 @@ public:
     { return numActivePhases_; }
 
     //! \brief Returns whether a fluid phase is active
-    static unsigned phaseIsActive(unsigned phaseIdx)
+    static bool phaseIsActive(unsigned phaseIdx)
     {
         assert(phaseIdx < numPhases);
         return phaseIsActive_[phaseIdx];


### PR DESCRIPTION
there might be something I am not aware of this, but it looks like returning `bool` should be the better practice?