### PR TITLE
[feature] Write Multipliers (MULTX, MULTX+, etc) to the INIT file.

### DIFF
--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -54,6 +54,8 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 
+#include <opm/output/data/Solution.hpp>
+
 #include <fmt/format.h>
 
 #include <cstddef>
@@ -293,6 +295,10 @@ namespace Opm {
         return m_transMult;
     }
 
+    data::Solution EclipseState::getMultSimProps() const
+    {
+        return getTransMult().convertToSimProps(m_inputGrid.getNumActive());
+    }
     const NNC& EclipseState::getInputNNC() const {
         return m_inputNnc;
     }

--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -149,6 +149,13 @@ namespace Opm {
         , m_micppara(          deck)
         , wag_hyst_config(     deck)
     {
+        if (deck.hasKeyword("GRIDOPTS")) {
+            const auto& gridOpts = deck["GRIDOPTS"].back();
+            const auto& record = gridOpts.getRecord(0);
+            m_write_all_multminus =
+                record.getItem("TRANMULT").getTrimmedString(0)== "YES";
+        }
+
         this->assignRunTitle(deck);
         this->reportNumberOfActivePhases();
 
@@ -297,7 +304,7 @@ namespace Opm {
 
     data::Solution EclipseState::getMultSimProps() const
     {
-        return getTransMult().convertToSimProps(m_inputGrid.getNumActive());
+        return getTransMult().convertToSimProps(m_inputGrid.getNumActive(), m_write_all_multminus);
     }
     const NNC& EclipseState::getInputNNC() const {
         return m_inputNnc;

--- a/opm/input/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.hpp
@@ -166,6 +166,7 @@ namespace Opm {
             serializer(m_micppara);
             serializer(wag_hyst_config);
             serializer(this->fipRegionStatistics_);
+            serializer(m_write_all_multminus);
         }
 
         static bool rst_cmp(const EclipseState& full_state, const EclipseState& rst_state);
@@ -209,6 +210,12 @@ namespace Opm {
         std::optional<std::map<std::string, double> > m_restart_network_pressures{std::nullopt};
 
         std::optional<FIPRegionStatistics> fipRegionStatistics_{std::nullopt};
+        /// \brief Whether to write out all MULT?- unconditionally
+        ///
+        /// If false we will only write non-defaulted MULT?- arrays to the
+        /// INIT file. Otherwise all.
+        /// Reflects first entry of GRIDOPTS
+        bool m_write_all_multminus{};
     };
 } // namespace Opm
 

--- a/opm/input/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.hpp
@@ -58,6 +58,9 @@ namespace Opm { namespace RestartIO {
 }} // namespace Opm::RestartIO
 
 namespace Opm {
+    namespace data {
+        class Solution;
+    }
 
     class EclipseState {
     public:
@@ -84,6 +87,11 @@ namespace Opm {
         const FaultCollection& getFaults() const;
         const TransMult& getTransMult() const;
         TransMult& getTransMult();
+
+        /// \brief Get the multipliers (MULTX, MULTX-, etc.) for output
+        ///
+        /// These will have the fault multipliers applied.
+        data::Solution getMultSimProps() const;
 
         /// non-neighboring connections
         /// the non-standard adjacencies as specified in input deck

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
@@ -167,7 +167,8 @@ namespace Opm {
         m_multregtScanner.applyNumericalAquifer(aquifer_cells);
     }
 
-    data::Solution TransMult::convertToSimProps(std::size_t grid_size) const {
+    data::Solution TransMult::convertToSimProps(std::size_t grid_size,
+                                                bool include_all_multminus) const {
         data::Solution solution{false}; // not in si to prevent conversions
         const auto size = m_trans.empty()? grid_size : m_trans.begin()->second.size();
         for(const auto& [face_dir, name]: m_names) {
@@ -177,7 +178,9 @@ namespace Opm {
             {
                 solution.insert(name, UnitSystem::measure::identity, pair->second, data::TargetType::INIT);
             } else {
-                solution.insert(name, UnitSystem::measure::identity, std::vector<double>(size, 1.), data::TargetType::INIT);
+                // defaulted MULT?- are only written if requested
+                if(include_all_multminus or name.size() < 6)
+                    solution.insert(name, UnitSystem::measure::identity, std::vector<double>(size, 1.), data::TargetType::INIT);
             }
         }
         return solution;

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.cpp
@@ -36,6 +36,9 @@
 #include <opm/input/eclipse/EclipseState/Grid/GridDims.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+#include <opm/output/data/Cells.hpp>
+#include <opm/output/data/Solution.hpp>
 
 
 namespace Opm {
@@ -162,6 +165,22 @@ namespace Opm {
 
     void TransMult::applyNumericalAquifer(const std::vector<std::size_t>& aquifer_cells) {
         m_multregtScanner.applyNumericalAquifer(aquifer_cells);
+    }
+
+    data::Solution TransMult::convertToSimProps(std::size_t grid_size) const {
+        data::Solution solution{false}; // not in si to prevent conversions
+        const auto size = m_trans.empty()? grid_size : m_trans.begin()->second.size();
+        for(const auto& [face_dir, name]: m_names) {
+            const auto pair = m_trans.find(face_dir);
+
+            if (pair != m_trans.end())
+            {
+                solution.insert(name, UnitSystem::measure::identity, pair->second, data::TargetType::INIT);
+            } else {
+                solution.insert(name, UnitSystem::measure::identity, std::vector<double>(size, 1.), data::TargetType::INIT);
+            }
+        }
+        return solution;
     }
 
     bool TransMult::operator==(const TransMult& data) const {

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
@@ -38,6 +38,10 @@
 #include <opm/input/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 
 namespace Opm {
+    namespace data {
+        class Solution;
+    }
+
     template< typename > class GridProperty;
     class Fault;
     class FaultCollection;
@@ -61,6 +65,11 @@ namespace Opm {
         void applyMULTFLT(const FaultCollection& faults);
         void applyMULTFLT(const Fault& fault);
         void applyNumericalAquifer(const std::vector<std::size_t>& aquifer_cells);
+
+        /// \brief Creates a solution object with all multipliers for output
+        /// \param active_cells If the model has no multipliers then this number is used as the size of
+        ///                     the array (containing 1) that are constructed in this case.
+        data::Solution convertToSimProps(std::size_t active_cells) const;
 
         bool operator==(const TransMult& data) const;
 

--- a/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/TransMult.hpp
@@ -69,7 +69,10 @@ namespace Opm {
         /// \brief Creates a solution object with all multipliers for output
         /// \param active_cells If the model has no multipliers then this number is used as the size of
         ///                     the array (containing 1) that are constructed in this case.
-        data::Solution convertToSimProps(std::size_t active_cells) const;
+        /// \param include_all_multminus If false only non-defaulted MULT?- arrays will
+        ///                              included. Otherwise even defaulted ones.
+        data::Solution convertToSimProps(std::size_t active_cells,
+                                         bool include_all_multminus) const;
 
         bool operator==(const TransMult& data) const;
 

--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -659,6 +659,7 @@ void Opm::InitIO::write(const ::Opm::EclipseState&              es,
     writeGridGeometry(grid, units, initFile);
     writeDoubleCellProperties(es, units, initFile);
     writeSimulatorProperties(grid, simProps, initFile);
+    writeSimulatorProperties(grid, es.getMultSimProps(), initFile);
     writeTableData(es, units, initFile);
     writeIntegerCellProperties(es, initFile);
     writeIntegerMaps(std::move(int_data), initFile);

--- a/test_util/summary.cpp
+++ b/test_util/summary.cpp
@@ -146,7 +146,7 @@ int main(int argc, char **argv) {
     std::vector<std::string> smryList;
     for (int i=0; i<argc - argOffset-1; i++) {
 
-        bool hasKey;
+        bool hasKey = false;
 
         switch(filetype) {
         case SMSPEC:

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -192,6 +192,10 @@ void checkInitFile(const Deck& deck, const data::Solution& simProps)
     BOOST_CHECK_MESSAGE( initFile.hasKey("NTG"), R"(INIT file must have "NTG" array)" );
     BOOST_CHECK_MESSAGE( initFile.hasKey("FIPNUM"), R"(INIT file must have "FIPNUM" array)");
     BOOST_CHECK_MESSAGE( initFile.hasKey("SATNUM"), R"(INIT file must have "SATNUM" array)");
+    std::array<std::string, 6> multipliers{"MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-"};
+    for (const auto& mult: multipliers) {
+       BOOST_CHECK_MESSAGE( initFile.hasKey(mult), R"(INIT file must have ")" + mult + R"(" array)" );
+    }
 
     for (const auto& prop : simProps) {
         BOOST_CHECK_MESSAGE( initFile.hasKey(prop.first), R"(INIT file must have ")" + prop.first + R"(" array)" );

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -470,22 +470,22 @@ GRIDFILE
 INIT
 
 SPECGRID
- 3 2 3 1 F / 
+ 3 2 3 1 F /
 
 COORD
-  2000.0000  2000.0000  2000.0000   2000.0000  2000.0000  2009.0000 
-  2100.0000  2000.0000  2000.0000   2100.0000  2000.0000  2009.0000 
-  2200.0000  2000.0000  2000.0000   2200.0000  2000.0000  2009.0000 
-  2300.0000  2000.0000  2000.0000   2300.0000  2000.0000  2009.0000 
-  2000.0000  2100.0000  2000.0000   2000.0000  2100.0000  2009.0000 
-  2100.0000  2100.0000  2000.0000   2100.0000  2100.0000  2009.0000 
-  2200.0000  2100.0000  2000.0000   2200.0000  2100.0000  2009.0000 
-  2300.0000  2100.0000  2000.0000   2300.0000  2100.0000  2009.0000 
-  2000.0000  2200.0000  2000.0000   2000.0000  2200.0000  2009.0000 
-  2100.0000  2200.0000  2000.0000   2100.0000  2200.0000  2009.0000 
-  2200.0000  2200.0000  2000.0000   2200.0000  2200.0000  2009.0000 
-  2300.0000  2200.0000  2000.0000   2300.0000  2200.0000  2009.0000 
-/ 
+  2000.0000  2000.0000  2000.0000   2000.0000  2000.0000  2009.0000
+  2100.0000  2000.0000  2000.0000   2100.0000  2000.0000  2009.0000
+  2200.0000  2000.0000  2000.0000   2200.0000  2000.0000  2009.0000
+  2300.0000  2000.0000  2000.0000   2300.0000  2000.0000  2009.0000
+  2000.0000  2100.0000  2000.0000   2000.0000  2100.0000  2009.0000
+  2100.0000  2100.0000  2000.0000   2100.0000  2100.0000  2009.0000
+  2200.0000  2100.0000  2000.0000   2200.0000  2100.0000  2009.0000
+  2300.0000  2100.0000  2000.0000   2300.0000  2100.0000  2009.0000
+  2000.0000  2200.0000  2000.0000   2000.0000  2200.0000  2009.0000
+  2100.0000  2200.0000  2000.0000   2100.0000  2200.0000  2009.0000
+  2200.0000  2200.0000  2000.0000   2200.0000  2200.0000  2009.0000
+  2300.0000  2200.0000  2000.0000   2300.0000  2200.0000  2009.0000
+/
 
 ZCORN
   2000.0000  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000
@@ -519,10 +519,10 @@ NTG
 
 PORO
  18*0.25 /
- 
+
 PERMX
  18*100.0 /
-  
+
 PERMZ
  18*10.0 /
 
@@ -563,14 +563,14 @@ COPY
      }
      if (doxyz[2].test(0)) {
          deckString += std::string{ R"(MULTZ
- 18*0.34325 / 
+ 18*0.34325 /
 )"};
          exspected_multipliers[2][0].assign(18, 0.34325);
      }
 
      if (doxyz[2].test(1)) {
          deckString += std::string{ R"(MULTZ-
- 18*0.554325 / 
+ 18*0.554325 /
 )"};
          exspected_multipliers[2][1].assign(18, 0.554325);
      }
@@ -589,7 +589,7 @@ COPY
              exspected_multipliers[0][1][1] = 0.7447794567;
          }
          if (doxyz[1].test(0)) {
-             deckString += std::string{ R"('MULTY' 0.94567  3 3 1 1 1 1 / 
+             deckString += std::string{ R"('MULTY' 0.94567  3 3 1 1 1 1 /
 )"};
              exspected_multipliers[1][0][2] = 0.94567;
          }
@@ -612,13 +612,77 @@ COPY
          deckString += std::string{ R"(/
 )"};
      }
+     std::vector<double> edit_mult_x(18, 1);
+     std::vector<double> edit_mult_z(18, 1);
+     if (doxyz[0].test(0) || doxyz[2].test(1))
+     {
+         // add an EDIT section
+         deckString += std::string{ R"(
+EDIT
+)"};
+
+         if (doxyz[0].test(0))
+         {
+             deckString += std::string{ R"(
+MULTX
+ 18*100 /
+MULTX
+ 18*0.1 /
+)"};
+             edit_mult_x.assign(18, .1);
+         }
+
+         if (doxyz[2].test(1))
+         {
+             deckString += std::string{ R"(
+MULTZ-
+ 18*30 /
+MULTZ-
+ 18*0.3 /
+)"};
+             edit_mult_z.assign(18, .3);
+         }
+         deckString += std::string{ R"(
+EQUALS
+)"};
+         if (doxyz[0].test(0))
+         {
+             deckString += std::string{ R"(
+ 'MULTX' 1.5 3 3 2 2 1 1 / -- Should not overwrite the value of GRID section but of EDIT section
+)"};
+             edit_mult_x[5] = 1.5;
+         }
+
+         if (doxyz[2].test(1))
+         {
+             deckString += std::string{ R"(
+ 'MULTZ-' 3.0 1 1  2 2 1 1 /
+)"};
+             edit_mult_z[3] = 3.0;
+         }
+
+             deckString += std::string{ R"(/
+)"};
+         auto mult = edit_mult_x.begin();
+         if (doxyz[0].test(0)) {
+             for (auto&& val: exspected_multipliers[0][0]) {
+                 val *= *(mult++);
+             }
+         }
+         mult = edit_mult_z.begin();
+         if (doxyz[2].test(1)) {
+             for (auto&& val: exspected_multipliers[2][1]) {
+                 val *= *(mult++);
+             }
+         }
+     }
+
      return {deckString, exspected_multipliers};
 }
 
 void testMultxyz(std::array<std::bitset<2>,3> doxyz)
 {
     const auto [deckString, exspectedMult] = createMULTXYZDECK(doxyz);
-    std::cout << "deck:" <<std::endl<<deckString <<std::endl;
     const auto deck = Parser().parseString(deckString);
     auto es = EclipseState( deck );
     const auto& eclGrid = es.getInputGrid();
@@ -633,6 +697,7 @@ void testMultxyz(std::array<std::bitset<2>,3> doxyz)
 
     std::array<std::string, 6> multipliers{"MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-"};
     int i=0;
+    auto mult = multipliers[i];
     for (const auto& mult: multipliers) {
        BOOST_CHECK_MESSAGE( initFile.hasKey(mult), R"(INIT file must have ")" + mult + R"(" array)" );
        const auto& multValues   = initFile.get<float>(mult);

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -435,3 +435,232 @@ WELSPECS
     // the file
     BOOST_CHECK_EQUAL(file_size, write_and_check(3, 5));
 }
+
+std::pair<std::string,std::array<std::array<std::vector<float>,2>,3>>
+createMULTXYZDECK(std::array<std::bitset<2>,3> doxyz)
+{
+     auto deckString = std::string { R"(RUNSPEC
+DIMENS
+ 3 2 3  /
+
+OIL
+WATER
+GAS
+DISGAS
+VAPOIL
+
+METRIC
+
+START
+ 01  'NOV' 2018 /
+
+FAULTDIM
+ 10 /         -- max. number os fault segments
+
+
+UNIFIN
+UNIFOUT
+
+GRID
+NEWTRAN
+
+GRIDFILE
+0  1 /
+
+INIT
+
+SPECGRID
+ 3 2 3 1 F / 
+
+COORD
+  2000.0000  2000.0000  2000.0000   2000.0000  2000.0000  2009.0000 
+  2100.0000  2000.0000  2000.0000   2100.0000  2000.0000  2009.0000 
+  2200.0000  2000.0000  2000.0000   2200.0000  2000.0000  2009.0000 
+  2300.0000  2000.0000  2000.0000   2300.0000  2000.0000  2009.0000 
+  2000.0000  2100.0000  2000.0000   2000.0000  2100.0000  2009.0000 
+  2100.0000  2100.0000  2000.0000   2100.0000  2100.0000  2009.0000 
+  2200.0000  2100.0000  2000.0000   2200.0000  2100.0000  2009.0000 
+  2300.0000  2100.0000  2000.0000   2300.0000  2100.0000  2009.0000 
+  2000.0000  2200.0000  2000.0000   2000.0000  2200.0000  2009.0000 
+  2100.0000  2200.0000  2000.0000   2100.0000  2200.0000  2009.0000 
+  2200.0000  2200.0000  2000.0000   2200.0000  2200.0000  2009.0000 
+  2300.0000  2200.0000  2000.0000   2300.0000  2200.0000  2009.0000 
+/ 
+
+ZCORN
+  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000
+  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000
+  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000
+  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000  2000.0000
+  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000
+  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000
+  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000
+  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000
+  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000
+  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000
+  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000
+  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000  2002.5000
+  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000
+  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000
+  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000
+  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000
+  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000
+  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000
+  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000
+  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000  2005.5000
+  2009.0000  2009.0000  2009.0000  2009.0000  2009.0000  2009.0000
+  2009.0000  2009.0000  2009.0000  2009.0000  2009.0000  2009.0000
+  2009.0000  2009.0000  2009.0000  2009.0000  2009.0000  2009.0000
+  2009.0000  2009.0000  2009.0000  2009.0000  2009.0000  2009.0000
+/
+
+NTG
+ 18*0.9 /
+
+PORO
+ 18*0.25 /
+ 
+PERMX
+ 18*100.0 /
+  
+PERMZ
+ 18*10.0 /
+
+COPY
+ PERMX PERMY /
+/
+)"};
+
+     std::array<std::array<std::vector<float>, 2>, 3> exspected_multipliers;
+
+     for(auto&& pair: exspected_multipliers)
+         for(auto&& entry: pair)
+             entry.resize(18, 1.);
+
+     if (doxyz[0].test(0)) {
+         deckString += std::string{ R"(MULTX
+ 18*0.5 /
+)"};
+         exspected_multipliers[0][0].assign(18, .5);
+     }
+     if (doxyz[0].test(1)) {
+         deckString += std::string{ R"(MULTX-
+ 18*2.0 /
+)"};
+         exspected_multipliers[0][1].assign(18, 2.);
+     }
+     if (doxyz[1].test(0)) {
+         deckString += std::string{ R"(MULTY
+ 18*0.1435 /
+)"};
+         exspected_multipliers[1][0].assign(18, .1435);
+     }
+     if (doxyz[1].test(0)) {
+         deckString += std::string{ R"(MULTY-
+ 18*2.1435 /
+)"};
+         exspected_multipliers[1][1].assign(18, 2.1435);
+     }
+     if (doxyz[2].test(0)) {
+         deckString += std::string{ R"(MULTZ
+ 18*0.34325 / 
+)"};
+         exspected_multipliers[2][0].assign(18, 0.34325);
+     }
+
+     if (doxyz[2].test(1)) {
+         deckString += std::string{ R"(MULTZ-
+ 18*0.554325 / 
+)"};
+         exspected_multipliers[2][1].assign(18, 0.554325);
+     }
+     if(doxyz[0].any() || doxyz[1].any() || doxyz[2].any())
+     {
+         deckString += std::string{ R"(EQUALS
+)"};
+         if (doxyz[0].test(0)) {
+             deckString += std::string{ R"('MULTX' 0.87794567  1 1 1 1 1 1 /
+)"};
+             exspected_multipliers[0][0][0] = 0.87794567;
+         }
+         if (doxyz[0].test(1)) {
+             deckString += std::string{ R"('MULTX-' 0.7447794567  2 2 1 1 1 1 /
+)"};
+             exspected_multipliers[0][1][1] = 0.7447794567;
+         }
+         if (doxyz[1].test(0)) {
+             deckString += std::string{ R"('MULTY' 0.94567  3 3 1 1 1 1 / 
+)"};
+             exspected_multipliers[1][0][2] = 0.94567;
+         }
+         if (doxyz[1].test(0)) {
+             deckString += std::string{ R"('MULTY-' 0.6647794567  1 1  2 2 1 1 /
+)"};
+             exspected_multipliers[1][1][3] = 0.6647794567;
+         }
+         if (doxyz[2].test(0)) {
+             deckString += std::string{ R"('MULTZ' 0.094567  2 2 2 2 1 1 /
+)"};
+             exspected_multipliers[2][0][4] = 0.094567;
+         }
+         if (doxyz[2].test(1)) {
+             deckString += std::string{ R"('MULTZ-' 0.089567  3 3 2 2 1 1 /
+)"};
+             exspected_multipliers[2][1][5] = 0.089567;
+         }
+
+         deckString += std::string{ R"(/
+)"};
+     }
+     return {deckString, exspected_multipliers};
+}
+
+void testMultxyz(std::array<std::bitset<2>,3> doxyz)
+{
+    const auto [deckString, exspectedMult] = createMULTXYZDECK(doxyz);
+    std::cout << "deck:" <<std::endl<<deckString <<std::endl;
+    const auto deck = Parser().parseString(deckString);
+    auto es = EclipseState( deck );
+    const auto& eclGrid = es.getInputGrid();
+    const Schedule schedule(deck, es, std::make_shared<Python>());
+    const SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.aquifer());
+    const SummaryState st(TimeService::now());
+    es.getIOConfig().setBaseName( "MULTXFOO" );
+    EclipseIO eclWriter( es, eclGrid , schedule, summary_config);
+    eclWriter.writeInitial( );
+
+    EclIO::EclFile initFile { "MULTXFOO.INIT" };
+
+    std::array<std::string, 6> multipliers{"MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-"};
+    int i=0;
+    for (const auto& mult: multipliers) {
+       BOOST_CHECK_MESSAGE( initFile.hasKey(mult), R"(INIT file must have ")" + mult + R"(" array)" );
+       const auto& multValues   = initFile.get<float>(mult);
+       auto exspect = exspectedMult[i/2][i%2].begin();
+       BOOST_CHECK(multValues.size() == exspectedMult[i/2][i%2].size());
+
+       for (auto mult = multValues.begin(); mult != multValues.end(); ++mult, ++exspect)
+       {
+           BOOST_CHECK_CLOSE(*mult, *exspect, 1e-8);
+       }
+       ++i;
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE(MULTXYZInit)
+{
+    testMultxyz({ '0', '0' , '0'});
+    testMultxyz({ '0', '0' , '1'});
+    testMultxyz({ '0', '0' , '2'});
+    testMultxyz({ '0', '0' , '3'});
+    testMultxyz({ '1', '0' , '0'});
+    testMultxyz({ '1', '0' , '1'});
+    testMultxyz({ '1', '0' , '3'});
+    testMultxyz({ '2', '0' , '0'});
+    testMultxyz({ '1', '1' , '0'});
+    testMultxyz({ '3', '3' , '0'});
+    testMultxyz({ '3', '3' , '1'});
+    testMultxyz({ '3', '3' , '2'});
+    testMultxyz({ '3', '3' , '3'});
+}


### PR DESCRIPTION
When we write these they will also have the fault multipliers applied.

All MULT? (without trailing "-") arrays are always written. If the first item of GRIDOPTS is NO we will write just those MULT?- arrays that have be specified in the model. If first item of GRIDOPTS is YES then all MULT?- arrays are written.

Note that flow will not abort if the first item of GRIDOPTS is NO, but MULT?- arrays are present. Instead it will still apply those multipliers and continue with the simulation. Other simulators might abort in this case.

I am using `data::Solution` to hold the values for writing. I hope that this approach works and I prevented any unit conversion. Would be good if @bska would double check whether this is sound.