### PR TITLE
[bugfix] Fix multiplier handling in the EDIT section.

### DIFF
--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -380,16 +380,19 @@ namespace Opm {
     }
 
     void EclipseState::applyMULTXYZ() {
-        const auto& fp = this->field_props;
         static const std::vector<std::pair<std::string, FaceDir::DirEnum>> multipliers = {{"MULTX" , FaceDir::XPlus},
                                                                                           {"MULTX-", FaceDir::XMinus},
                                                                                           {"MULTY" , FaceDir::YPlus},
                                                                                           {"MULTY-", FaceDir::YMinus},
                                                                                           {"MULTZ" , FaceDir::ZPlus},
                                                                                           {"MULTZ-", FaceDir::ZMinus}};
+
+        const auto& fp = this->field_props;
         for (const auto& [field, face] : multipliers) {
             if (fp.has_double(field))
+            {
                 this->m_transMult.applyMULT(fp.get_global_double(field), face);
+            }
         }
     }
 

--- a/opm/input/eclipse/EclipseState/Grid/Box.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/Box.cpp
@@ -40,15 +40,23 @@ namespace {
             };
         }
 
-        if ((l1 < 0) || (l2 < 0) || (l1 > l2)) {
+        if ((l1 < 0) || (l2 < 0)){
             throw std::invalid_argument {
-                "Invalid index values for sub box"
-            };
+                "Invalid index values for sub box (" + std::to_string(l1)
+                + " or " + std::to_string(l2) + " below 0)"};
+        }
+
+        if (l1 > l2) {
+            throw std::invalid_argument {
+                "Invalid index values for sub box (" + std::to_string(l1)
+                + " > " + std::to_string(l2) + ")"};
         }
 
         if (l2 >= len) {
             throw std::invalid_argument {
-                "Invalid index values for sub box"
+                "Invalid index values for sub box. Index "
+                + std::to_string(l2) + " is not below "
+                + std::to_string(len)
             };
         }
     }

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -16,8 +16,7 @@
   OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <opm/input/eclipse/EclipseState/Grid/FieldProps.hpp>
-
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/OpmLog/LogUtil.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 
@@ -26,6 +25,7 @@
 #include <opm/input/eclipse/EclipseState/Aquifer/NumericalAquifer/NumericalAquifers.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/FieldProps.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp> // Layering violation.  Needed for apply_tran() function.
 #include <opm/input/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
@@ -672,16 +672,64 @@ bool FieldProps::supported<int>(const std::string& keyword) {
     return Fieldprops::keywords::isFipxxx(keyword);
 }
 
+void FieldProps::apply_multipliers()
+{
+    static const auto prefix = FieldPropsManager::getMultiplierPrefix();
+
+    for(auto pos =multiplier_kw_infos_.begin(); pos != multiplier_kw_infos_.end(); ++pos)
+    {
+        const auto& [mult_keyword, kw_info] = *pos;
+        const std::string keyword = mult_keyword.substr(prefix.size());
+        auto mult_iter = this->double_data.find(mult_keyword);
+        assert(mult_iter != this->double_data.end());
+        auto iter = this->double_data.find(keyword);
+        if (iter == this->double_data.end()) {
+            iter = this->double_data
+                .emplace(std::piecewise_construct,
+                         std::forward_as_tuple(keyword),
+                         std::forward_as_tuple(kw_info, this->active_size, kw_info.global ? this->global_size : 0))
+                .first;
+        }
+        auto multiplier = mult_iter->second.data.begin();
+        for(auto data = iter->second.data.begin(); data != iter->second.data.end(); ++data, ++multiplier)
+        {
+            *data *= *multiplier;
+        }
+        // If data is global, then we also need to set the global_data. I think they should be the same at this stage, though!
+        if (kw_info.global)
+        {
+            assert(mult_iter->second.global_data.has_value() && iter->second.global_data.has_value());
+            multiplier = mult_iter->second.global_data.value().begin();
+            auto& global_array = iter->second.global_data.value();
+            for(auto data = global_array.begin(); data != global_array.end(); ++data, ++multiplier)
+            {
+                *data *= *multiplier;
+            }
+        }
+        this->double_data.erase(mult_iter);
+    }
+    multiplier_kw_infos_.clear();
+}
 
 template <>
-Fieldprops::FieldData<double>& FieldProps::init_get(const std::string& keyword_name, const Fieldprops::keywords::keyword_info<double>& kw_info) {
+Fieldprops::FieldData<double>& FieldProps::init_get(const std::string& keyword_name, const Fieldprops::keywords::keyword_info<double>& kw_info,
+                                                    bool multiply_variant) {
+    
+    if(multiply_variant && !kw_info.scalar_init.has_value())
+        OPM_THROW(std::logic_error, std::string("Keyword " +  keyword_name + " is a multiplier and should have a default initial value."));
     const std::string& keyword = Fieldprops::keywords::get_keyword_from_alias(keyword_name);
+    const std::string& mult_keyword = std::string(multiply_variant? FieldPropsManager::getMultiplierPrefix() : "") + keyword;
 
-    auto iter = this->double_data.find(keyword);
-    if (iter != this->double_data.end())
+    auto iter = this->double_data.find(mult_keyword);
+    if (iter != this->double_data.end()) {
         return iter->second;
+    } else if(multiply_variant){
+        assert(keyword != ParserKeywords::PORV::keywordName || keyword != ParserKeywords::TEMPI::keywordName ||
+               (Fieldprops::keywords::PROPS::satfunc.count(keyword) == 1) || is_capillary_pressure(keyword));
+        multiplier_kw_infos_[mult_keyword] = kw_info;
+    }
 
-    this->double_data[keyword] = Fieldprops::FieldData<double>(kw_info, this->active_size, kw_info.global ? this->global_size : 0);
+    this->double_data[mult_keyword] = Fieldprops::FieldData<double>(kw_info, this->active_size, kw_info.global ? this->global_size : 0);
 
     if (keyword == ParserKeywords::PORV::keywordName)
         this->init_porv(this->double_data[keyword]);
@@ -695,7 +743,7 @@ Fieldprops::FieldData<double>& FieldProps::init_get(const std::string& keyword_n
         this->init_satfunc(keyword, this->double_data[keyword]);
     }
 
-    return this->double_data[keyword];
+    return this->double_data[mult_keyword];
 }
 
 template <>
@@ -707,7 +755,7 @@ Fieldprops::FieldData<double>& FieldProps::init_get(const std::string& keyword,
 
 
 template <>
-Fieldprops::FieldData<int>& FieldProps::init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<int>& kw_info) {
+Fieldprops::FieldData<int>& FieldProps::init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<int>& kw_info, bool) {
     auto iter = this->int_data.find(keyword);
     if (iter != this->int_data.end())
         return iter->second;
@@ -870,15 +918,20 @@ void FieldProps::handle_int_keyword(const Fieldprops::keywords::keyword_info<int
 
 
 void FieldProps::handle_double_keyword(Section section, const Fieldprops::keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const std::string& keyword_name, const Box& box) {
-    auto& field_data = this->init_get<double>(keyword_name, kw_info);
+    // if second paramter is true then this will not be the actual keyword but one prefixed with __MULT__ that will be used to construct the
+    // multiplier for later application to the actual keyword.
+    auto& field_data = this->init_get<double>(keyword_name, kw_info, section == Section::EDIT && kw_info.multiplier);
     const auto& deck_data = keyword.getSIDoubleData();
     const auto& deck_status = keyword.getValueStatus();
 
-    if ((section == Section::EDIT || section == Section::SCHEDULE) && kw_info.multiplier)
+    if (section == Section::SCHEDULE && kw_info.multiplier)
+    {
+        // Apply all multipliers cummulatively
         multiply_deck(kw_info, keyword, field_data, deck_data, deck_status, box);
-    else
+    } else{
+        // Apply only latest multiplier (overwrite these previous one)
         assign_deck(kw_info, keyword, field_data, deck_data, deck_status, box);
-
+    }
 
     if (section == Section::GRID) {
         if (field_data.valid())
@@ -1035,7 +1088,7 @@ void FieldProps::handle_OPERATE(const DeckKeyword& keyword, Box box) {
 }
 
 
-void FieldProps::handle_operation(const DeckKeyword& keyword, Box box) {
+void FieldProps::handle_operation(Section section, const DeckKeyword& keyword, Box box) {
     std::unordered_map<std::string, std::string> tran_fields;
     for (const auto& record : keyword) {
         const std::string& target_kw = Fieldprops::keywords::get_keyword_from_alias(record.getItem(0).get<std::string>(0));
@@ -1069,7 +1122,7 @@ void FieldProps::handle_operation(const DeckKeyword& keyword, Box box) {
             } else
                 kw_info = Fieldprops::keywords::global_kw_info<double>(target_kw);
 
-            auto& field_data = this->init_get<double>(unique_name, kw_info);
+            auto& field_data = this->init_get<double>(unique_name, kw_info, section == Section::EDIT && kw_info.multiplier);
 
             FieldProps::apply(operation, field_data.data, field_data.value_status, scalar_value, box.index_list());
             if (field_data.global_data)
@@ -1128,11 +1181,11 @@ void FieldProps::handle_COPY(const DeckKeyword& keyword, Box box, bool region) {
     }
 }
 
-void FieldProps::handle_keyword(const DeckKeyword& keyword, Box& box) {
+void FieldProps::handle_keyword(Section section, const DeckKeyword& keyword, Box& box) {
     const std::string& name = keyword.name();
 
     if (Fieldprops::keywords::oper_keywords.count(name) == 1)
-        this->handle_operation(keyword, box);
+        this->handle_operation(section, keyword, box);
 
     else if (name == ParserKeywords::OPERATE::keywordName)
         this->handle_OPERATE(keyword, box);
@@ -1306,7 +1359,7 @@ void FieldProps::scanGRIDSection(const GRIDSection& grid_section) {
             continue;
         }
 
-        this->handle_keyword(keyword, box);
+        this->handle_keyword(Section::GRID, keyword, box);
     }
 }
 
@@ -1318,7 +1371,7 @@ void FieldProps::scanGRIDSectionOnlyACTNUM(const GRIDSection& grid_section) {
         if (name == "ACTNUM") {
             this->handle_int_keyword(Fieldprops::keywords::GRID::int_keywords.at(name), keyword, box);
         } else if (name == "EQUALS" || (Fieldprops::keywords::box_keywords.count(name) == 1)) {
-            this->handle_keyword(keyword, box);
+            this->handle_keyword(Section::GRID, keyword, box);
         }
     }
     const auto iter = this->int_data.find("ACTNUM");
@@ -1353,8 +1406,12 @@ void FieldProps::scanEDITSection(const EDITSection& edit_section) {
             continue;
         }
 
-        this->handle_keyword(keyword, box);
+        this->handle_keyword(Section::EDIT, keyword, box);
     }
+    // Multiplier will not have been applied yet to prevent EQUALS MULT* from overwriting values
+    // and to only honor the last MULT* occurrence
+    // apply recorded multipliers of section to existing ones
+    apply_multipliers();
 }
 
 
@@ -1393,7 +1450,7 @@ void FieldProps::scanPROPSSection(const PROPSSection& props_section) {
             continue;
         }
 
-        this->handle_keyword(keyword, box);
+        this->handle_keyword(Section::PROPS, keyword, box);
     }
 }
 
@@ -1415,7 +1472,7 @@ void FieldProps::scanREGIONSSection(const REGIONSSection& regions_section) {
             continue;
         }
 
-        this->handle_keyword(keyword, box);
+        this->handle_keyword(Section::REGIONS, keyword, box);
     }
 }
 
@@ -1429,7 +1486,7 @@ void FieldProps::scanSOLUTIONSection(const SOLUTIONSection& solution_section) {
             continue;
         }
 
-        this->handle_keyword(keyword, box);
+        this->handle_keyword(Section::SOLUTION, keyword, box);
     }
 }
 
@@ -1437,7 +1494,7 @@ void FieldProps::handle_schedule_keywords(const std::vector<DeckKeyword>& keywor
     auto box = makeGlobalGridBox(this->grid_ptr);
 
     // When called in the SCHEDULE section the context is that the scaling factors
-    // have already been applied.
+    // have already been applied. We set them to zero for reuse here.
     for (const auto& [kw, _] : Fieldprops::keywords::SCHEDULE::double_keywords) {
         (void)_;
         if (this->has<double>(kw)) {

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -41,6 +41,7 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -585,19 +586,19 @@ private:
     Fieldprops::FieldData<T>& init_get(const std::string& keyword, bool allow_unsupported = false);
 
     template <typename T>
-    Fieldprops::FieldData<T>& init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<T>& kw_info);
+    Fieldprops::FieldData<T>& init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<T>& kw_info, bool multiply_variant = false);
 
     std::string region_name(const DeckItem& region_item);
     std::vector<Box::cell_index> region_index( const std::string& region_name, int region_value );
     void handle_OPERATE(const DeckKeyword& keyword, Box box);
-    void handle_operation(const DeckKeyword& keyword, Box box);
+    void handle_operation(Section section, const DeckKeyword& keyword, Box box);
     void handle_region_operation(const DeckKeyword& keyword);
     void handle_COPY(const DeckKeyword& keyword, Box box, bool region);
     void distribute_toplayer(Fieldprops::FieldData<double>& field_data, const std::vector<double>& deck_data, const Box& box);
     double get_beta(const std::string& func_name, const std::string& target_array, double raw_beta);
     double get_alpha(const std::string& func_name, const std::string& target_array, double raw_alpha);
 
-    void handle_keyword(const DeckKeyword& keyword, Box& box);
+    void handle_keyword(Section section, const DeckKeyword& keyword, Box& box);
     void handle_double_keyword(Section section, const Fieldprops::keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const std::string& keyword_name, const Box& box);
     void handle_double_keyword(Section section, const Fieldprops::keywords::keyword_info<double>& kw_info, const DeckKeyword& keyword, const Box& box);
     void handle_int_keyword(const Fieldprops::keywords::keyword_info<int>& kw_info, const DeckKeyword& keyword, const Box& box);
@@ -606,6 +607,13 @@ private:
     void init_tempi(Fieldprops::FieldData<double>& tempi);
     std::string canonical_fipreg_name(const std::string& fipreg);
     const std::string& canonical_fipreg_name(const std::string& fipreg) const;
+
+    /// \brief Apply multipliers of the EDIT section
+    ///
+    /// Multipliers are stored intermediately in FieldPropsManager::getMultiplierPrefix()+keyword_name FieldData arrays
+    /// to prevent EQUALS MULT* in the EDIT section from overwriting values from the GRID
+    /// section. This method will now apply them to keyword_name FieldData arrays and throw away the intermediate storage
+    void apply_multipliers();
 
     const UnitSystem unit_system;
     std::size_t nx,ny,nz;
@@ -624,6 +632,13 @@ private:
     std::unordered_map<std::string, std::string> fipreg_shortname_translation{};
 
     std::unordered_map<std::string,Fieldprops::TranCalculator> tran;
+
+    /// \brief A map of multiplier keywords found in the EDIT/SCHEDULE section
+    ///
+    /// key ist the original keyword name. and value is the keyword information.
+    /// This list is used in apply_multipliers, where the multipliers will actually
+    /// be applied.
+    std::unordered_map<std::string,Fieldprops::keywords::keyword_info<double>> multiplier_kw_infos_;
 };
 
 }

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -586,7 +586,7 @@ private:
     Fieldprops::FieldData<T>& init_get(const std::string& keyword, bool allow_unsupported = false);
 
     template <typename T>
-    Fieldprops::FieldData<T>& init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<T>& kw_info, bool multiply_variant = false);
+    Fieldprops::FieldData<T>& init_get(const std::string& keyword, const Fieldprops::keywords::keyword_info<T>& kw_info, bool multiplier_in_edit = false);
 
     std::string region_name(const DeckItem& region_item);
     std::vector<Box::cell_index> region_index( const std::string& region_name, int region_value );
@@ -614,6 +614,12 @@ private:
     /// to prevent EQUALS MULT* in the EDIT section from overwriting values from the GRID
     /// section. This method will now apply them to keyword_name FieldData arrays and throw away the intermediate storage
     void apply_multipliers();
+
+    static constexpr std::string_view getMultiplierPrefix()
+    {
+        using namespace std::literals;
+        return "__MULT__"sv;
+    }
 
     const UnitSystem unit_system;
     std::size_t nx,ny,nz;

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -240,11 +240,6 @@ public:
 
     const std::unordered_map<std::string,Fieldprops::TranCalculator>& getTran() const;
 
-    static constexpr std::string_view getMultiplierPrefix()
-    {
-        using namespace std::literals;
-        return "__MULT__"sv;
-    }
 private:
     /*
       Return the keyword values as a std::vector<>. All elements in the return

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -239,6 +240,11 @@ public:
 
     const std::unordered_map<std::string,Fieldprops::TranCalculator>& getTran() const;
 
+    static constexpr std::string_view getMultiplierPrefix()
+    {
+        using namespace std::literals;
+        return "__MULT__"sv;
+    }
 private:
     /*
       Return the keyword values as a std::vector<>. All elements in the return

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/M/MULT_XYZ
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/M/MULT_XYZ
@@ -19,6 +19,7 @@
   ],
   "data": {
     "value_type": "DOUBLE",
+    "default": 1.0,
     "dimension": "1"
   }
 }


### PR DESCRIPTION
This is for MULTX, MULTX-, MULTY, MULTY-, MULTZ, MULTZ-.

Previously, EQUALS MULT* would have reset the multiplier of the GRID section and multiple occurrences of MULT* in the EDIT section would have been applied cummulatively.

Now the EDIT section has its own multiplier (stored in FieldProperties with a prefix) which is applied to the one of the GRID section (without prefix) when we leave the EDIT section.

Hence for multiple occurrences the last one wins and EQUALS MULT* can be used to only reset some values of the multiplier that will be applied to the one of the GRID section.

This bugfix form #3997 where also test for this are added. Tests without writing MULT* to INIT are unfortunately not possible. Here we will be able to see whether any regression tests are failing.