### PR TITLE
makre sure defining VFP table for THP processing

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -50,6 +50,7 @@ class DeckKeyword;
 class DeckRecord;
 class ErrorGuard;
 class EclipseGrid;
+class KeywordLocation;
 class ParseContext;
 class ScheduleGrid;
 class SICD;
@@ -177,7 +178,8 @@ public:
         void handleWCONINJE(const DeckRecord& record,
                             const double bhp_def,
                             bool availableForGroupControl,
-                            const std::string& well_name);
+                            const std::string& well_name,
+                            const KeywordLocation& location);
 
         //! \brief Handle a WCONINJH keyword.
         //! \param record The deck record to use
@@ -306,7 +308,8 @@ public:
                             const double bhp_def,
                             const UnitSystem& unit_system,
                             const std::string& well,
-                            const DeckRecord& record);
+                            const DeckRecord& record,
+                            const KeywordLocation& location);
 
         //! \brief Handle WCONHIST keyword.
         //! \param alq_type ALQ type

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -175,6 +175,7 @@ public:
         //! \param bhp_def The default BHP target in input units
         //! \param availableForGroupControl True if available for group control
         //! \param well_name Name of well
+        //! \param location Location of keyword for logging purpose
         void handleWCONINJE(const DeckRecord& record,
                             const double bhp_def,
                             bool availableForGroupControl,
@@ -186,7 +187,7 @@ public:
         //! \param bhp_def The default BHP limit in SI units
         //! \param is_producer True if well is a producer
         //! \param well_name Name of well
-        //! \param loc Location of keyword for logging purpuses
+        //! \param loc Location of keyword for logging purpose
         void handleWCONINJH(const DeckRecord& record,
                             const double bhp_def,
                             const bool is_producer,
@@ -304,6 +305,7 @@ public:
         //! \param unit_system Unit system to use
         //! \param well Well name
         //! \param record Deck record to use
+        //! \param location Location of keyword for logging purpose
         void handleWCONPROD(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type,
                             const double bhp_def,
                             const UnitSystem& unit_system,

--- a/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -200,14 +200,12 @@ namespace Opm {
                     // a zero value THP limit will not be handled as a THP limit
                     if (this->THPTarget.is<double>() && this->THPTarget.zero()) {
                         continue;
-                    } else {
+                    } else if (this->VFPTableNumber == 0) {
                         // make sure we specify a VFP table for it
                         // const int vfp_table = record.getItem("VFP_TABLE").get<int>(0);
-                        if (this->VFPTableNumber == 0) {
                             const auto msg = fmt::format("Well {} must have a VFP table to handle"
                                                          " non-zero THP constraint", well_name);
                             throw OpmInputError(msg, location);
-                        }
                     }
                 }
 

--- a/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -21,7 +21,9 @@
 #include <ostream>
 #include <string>
 
+#include <opm/common/OpmLog/KeywordLocation.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/UDAValue.hpp>
@@ -166,8 +168,9 @@ namespace Opm {
     void Well::WellProductionProperties::handleWCONPROD(const std::optional<VFPProdTable::ALQ_TYPE>& alq_type,
                                                         const double bhp_def,
                                                         const UnitSystem& unit_system_arg,
-                                                        const std::string& /* well */,
-                                                        const DeckRecord& record)
+                                                        const std::string& well_name,
+                                                        const DeckRecord& record,
+                                                        const KeywordLocation& location)
     {
         this->predictionMode = true;
         this->init_vfp(alq_type, unit_system_arg, record);
@@ -193,9 +196,20 @@ namespace Opm {
         for( const auto& cmode : modes ) {
             if( !record.getItem( cmode.first ).defaultApplied( 0 ) ) {
 
-                // a zero value THP limit will not be handled as a THP limit
-                if (cmode.first == "THP" && this->THPTarget.is<double>() && this->THPTarget.zero())
-                    continue;
+                if (cmode.first == "THP") {
+                    // a zero value THP limit will not be handled as a THP limit
+                    if (this->THPTarget.is<double>() && this->THPTarget.zero()) {
+                        continue;
+                    } else {
+                        // make sure we specify a VFP table for it
+                        // const int vfp_table = record.getItem("VFP_TABLE").get<int>(0);
+                        if (this->VFPTableNumber == 0) {
+                            const auto msg = fmt::format("Well {} must have a VFP table to handle"
+                                                         " non-zero THP constraint", well_name);
+                            throw OpmInputError(msg, location);
+                        }
+                    }
+                }
 
                 this->addProductionControl( cmode.second );
             }

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -3608,7 +3608,7 @@ WCONHIST
  P SHUT ORAT 6  500 0 0 0 1.2 1.1 /
 /
 WCONPROD
- P1 SHUT ORAT 6  500 0 0 0 3.2 3.1 /
+ P1 SHUT ORAT 6  500 0 0 0 3.2 /
 /
 WCONINJH
  I WATER STOP 100 2.1 2.2 /
@@ -4351,6 +4351,17 @@ WELSPECS
      'W6'    'G3'   2 4  3.92       'OIL'  3*  NO /
      'W7'    'G3'   3 2  3.92       'OIL'  3*  NO /
 /
+VFPINJ
+-- Table Depth  Rate   TAB  UNITS  BODY
+-- ----- ----- ----- ----- ------ -----
+       5  32.9   WAT   THP METRIC   BHP /
+-- Rate axis
+1 3 5 /
+-- THP axis
+7 11 /
+-- Table data with THP# <values 1-num_rates>
+1 1.5 2.5 3.5 /
+2 4.5 5.5 6.5 /
 
 WCONINJE
   'W1' 'WATER'  'OPEN'  'GRUP' /
@@ -4359,7 +4370,7 @@ WCONINJE
   'W4' 'WATER'  'OPEN'  'RATE'  200  1*  450.0 /
   'W5' 'WATER'  'OPEN'  'RESV'  200  175  450.0 /
   'W6' 'GAS'  'OPEN'  'BHP'  200  1*  450.0 /
-  'W7' 'GAS'  'OPEN'  'THP'  200  1*  450.0 150 /
+  'W7' 'GAS'  'OPEN'  'THP'  200  1*  450.0 150 5 /
 /
 
 TSTEP
@@ -4384,6 +4395,18 @@ BOOST_AUTO_TEST_CASE(Production_Control_Mode_From_Well) {
     const auto input = R"(RUNSPEC
 
 SCHEDULE
+VFPPROD
+-- table_num, datum_depth, flo, wfr, gfr, pressure, alq, unit, table_vals
+42 7.0E+03 LIQ WCT GOR THP ' ' METRIC BHP /
+1.0 / flo axis
+0.0 1.0 / THP axis
+0.0 / WFR axis
+0.0 / GFR axis
+0.0 / ALQ axis
+-- Table itself: thp_idx wfr_idx gfr_idx alq_idx <vals>
+1 1 1 1 0.0 /
+2 1 1 1 1.0 /
+
 WELSPECS
      'W1'    'G1'   1 2  3.33       'OIL'  7*/
      'W2'    'G2'   1 3  3.33       'OIL'  3*  YES /
@@ -4403,7 +4426,7 @@ WCONPROD
   'W5' 'OPEN'  'LRAT' 1000.0 250.0 30.0e3 1500.0 /
   'W6' 'OPEN'  'RESV' 1000.0 250.0 30.0e3 1500.0 314.15 /
   'W7' 'OPEN'  'BHP' 1000.0 250.0 30.0e3 1500.0 314.15 27.1828 /
-  'W8' 'OPEN'  'THP' 1000.0 250.0 30.0e3 1500.0 314.15 27.1828 31.415 /
+  'W8' 'OPEN'  'THP' 1000.0 250.0 30.0e3 1500.0 314.15 27.1828 31.415 42 /
 /
 
 TSTEP

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -1241,7 +1241,7 @@ DATES             -- 2
 /
 
 WCONPROD
- 'P' 'OPEN' 'BHP' 1 2 3 2* 20. 10. 0 13 /
+ 'P' 'OPEN' 'BHP' 1 2 3 2* 20. 2* 13 /
 /
 
 WCONINJE

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -648,7 +648,7 @@ namespace {
             Opm::Well::WellProductionProperties pred(unit_system, "W");
             pred.handleWCONPROD(alq_type,
                                 Opm::ParserKeywords::FBHPDEF::TARGET_BHP::defaultValue * unit::barsa,
-                                unit_system, "WELL", record);
+                                unit_system, "WELL", record, {});
 
             return pred;
         }

--- a/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_WELLS2
+++ b/tests/parser/data/integration_tests/SCHEDULE/SCHEDULE_WELLS2
@@ -136,9 +136,21 @@ DATES
    10  AUG 2008 /
 /
 
+VFPINJ
+-- Table Depth  Rate   TAB  UNITS  BODY
+-- ----- ----- ----- ----- ------ -----
+       5  32.9   WAT   THP METRIC   BHP /
+-- Rate axis
+1 3 5 /
+-- THP axis
+7 11 /
+-- Table data with THP# <values 1-num_rates>
+1 1.5 2.5 3.5 /
+2 4.5 5.5 6.5 /
+
 -- 10
 WCONINJE
-     'W_1'     'WATER'  1*      'RATE'  20000.000  200000.000 123 678 4* /
+     'W_1'     'WATER'  1*      'RATE'  20000.000  200000.000 123 678 5 4* /
 /
 
 DATES
@@ -156,9 +168,10 @@ DATES
    10  SEP 2008 /
 /
 
+
 -- 12
 WCONINJE
-     'W_1'     'WATER'  'OPEN'      'RATE'  20000.000  * 123 678 4* /
+     'W_1'     'WATER'  'OPEN'      'RATE'  20000.000  * 123 678 5 4* /
 /
 
 DATES
@@ -167,7 +180,7 @@ DATES
 
 -- 13
 WCONINJE
-     'W_1'     'WATER'  'OPEN'      'RATE'  0.000  * 123 678 4* /
+     'W_1'     'WATER'  'OPEN'      'RATE'  0.000  * 123 678 5 4* /
 /
 
 DATES

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -1012,12 +1012,12 @@ COMPDAT
 /
 
 WCONPROD
---  Well_name  Status  Ctrl  Orate   Wrate  Grate Lrate   RFV  FBHP   WHP  VFP Glift
-   'B-1H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   0   1*  /
-   'B-2H'      SHUT    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   0   1*  /
-   'B-3H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   0   1*  /
-   'C-1H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   0   1*  /
-   'C-2H'      SHUT    ORAT  4000.0  1*     1*    6000.0  1*   100.0  30   0   1*  /
+--  Well_name  Status  Ctrl  Orate   Wrate  Grate Lrate   RFV  FBHP   THP  VFP Glift
+   'B-1H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  1*   0   1*  /
+   'B-2H'      SHUT    ORAT  4000.0  1*     1*    6000.0  1*   100.0  1*   0   1*  /
+   'B-3H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  1*   0   1*  /
+   'C-1H'      OPEN    ORAT  4000.0  1*     1*    6000.0  1*   100.0  1*   0   1*  /
+   'C-2H'      SHUT    ORAT  4000.0  1*     1*    6000.0  1*   100.0  1*   0   1*  /
 /
 
 GCONINJE

--- a/tests/test_GuideRate.cpp
+++ b/tests/test_GuideRate.cpp
@@ -160,11 +160,11 @@ GUIDERAT
 
         const auto epilog = std::string { R"(
 WCONPROD
-  P* OPEN GRUP 150 100 15E+3 250 1* 50 25 /
+  P* OPEN GRUP 150 100 15E+3 250 1* 50 /
 /
 
 WCONINJE
-  I1 GAS OPEN RATE 20.0E+3 1* 500 350 /
+  I1 GAS OPEN RATE 20.0E+3 1* 500 /
 /
 
 GCONPROD


### PR DESCRIPTION
When we have non-defaulted THP constraint, we have to make sure to provide a VFP table for it. 

When we refer to a VFP table, we make sure the table is valid/defined. 

Originally, the plan was to checking whether VFP table is properly defined from the simulator, but it turns out to be extremely difficult to do it well/properly. The main point was to trigger the throw before all the possible circumstances that can utilize it. 

At the end, it can be the decent solution to do it from the parser side, avoiding to consider all kinds of complicated SCHEDULE setup. 