### PR TITLE
Fix: Add mechansim to check if a keyword is a valid PYACTION keyword for being inserted

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -706,6 +706,7 @@ if(ENABLE_ECL_OUTPUT)
           tests/msim/MSIM_PYACTION_CHANGING_SCHEDULE.DATA
           tests/msim/MSIM_PYACTION_CHANGING_SCHEDULE_ACTIONX_CALLBACK.DATA
           tests/msim/MSIM_PYACTION_INSERT_KEYWORD.DATA
+          tests/msim/MSIM_PYACTION_INSERT_INVALID_KEYWORD.DATA
           tests/msim/MSIM_PYACTION_NO_RUN_FUNCTION.DATA
           tests/msim/action1.py
           tests/msim/action2.py
@@ -714,6 +715,7 @@ if(ENABLE_ECL_OUTPUT)
           tests/msim/action3_actionx_callback.py
           tests/msim/action_count.py
           tests/msim/insert_keyword.py
+          tests/msim/insert_invalid_keyword.py
           tests/msim/action_count_no_run_function.py
           tests/VFP_CASE.DATA)
 endif()

--- a/opm/input/eclipse/Parser/ParseContext.cpp
+++ b/opm/input/eclipse/Parser/ParseContext.cpp
@@ -114,6 +114,7 @@ namespace Opm {
         this->addKey(SUMMARY_REGION_TOO_LARGE, InputErrorAction::WARN);
 
         addKey(ACTIONX_ILLEGAL_KEYWORD, InputErrorAction::THROW_EXCEPTION);
+        addKey(PYACTION_ILLEGAL_KEYWORD, InputErrorAction::THROW_EXCEPTION);
         addKey(ACTIONX_CONDITION_ERROR, InputErrorAction::THROW_EXCEPTION);
         addKey(ACTIONX_NO_CONDITION, InputErrorAction::WARN);
 
@@ -371,6 +372,7 @@ namespace Opm {
 
     const std::string ParseContext::SCHEDULE_INVALID_NAME = "SCHEDULE_INVALID_NAME";
     const std::string ParseContext::ACTIONX_ILLEGAL_KEYWORD = "ACTIONX_ILLEGAL_KEYWORD";
+    const std::string ParseContext::PYACTION_ILLEGAL_KEYWORD = "PYACTION_ILLEGAL_KEYWORD";
     const std::string ParseContext::ACTIONX_CONDITION_ERROR = "ACTIONX_CONDITION_ERROR";
     const std::string ParseContext::ACTIONX_NO_CONDITION = "ACTIONX_NO_CONDITION";
 

--- a/opm/input/eclipse/Parser/ParseContext.hpp
+++ b/opm/input/eclipse/Parser/ParseContext.hpp
@@ -309,10 +309,11 @@ class KeywordLocation;
 
         /*
           Only keywords explicitly white-listed can be included in the ACTIONX
-          block. This error flag controls what should happen when an illegal
-          keyword is encountered in an ACTIONX block.
+          or PYACTION block. These error flags controls what should happen when
+          an illegal keyword is encountered in an ACTIONX and a PYACTION block.
          */
         const static std::string ACTIONX_ILLEGAL_KEYWORD;
+        const static std::string PYACTION_ILLEGAL_KEYWORD;
 
         /*
           Error flag marking parser errors ic ACTIONX conditions

--- a/opm/input/eclipse/Python/PyRunModule.cpp
+++ b/opm/input/eclipse/Python/PyRunModule.cpp
@@ -21,6 +21,7 @@ error BUG: The PyRunModule.hpp header should *not* be included in a configuratio
 #endif
 
 
+#include <opm/common/ErrorMacros.hpp>
 #include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
@@ -39,12 +40,12 @@ PyRunModule::PyRunModule(std::shared_ptr<const Python> python, const std::string
     if (python->enabled())
         this->python_handle = python;
     else
-        throw std::logic_error("Tried to make a PYACTION object with an invalid Python handle");
+        OPM_THROW(std::logic_error, "Tried to make a PYACTION object with an invalid Python handle");
 
 
     fs::path file(fname);
     if (!fs::is_regular_file(file))
-        throw std::invalid_argument("No such module: " + fname);
+        OPM_THROW(std::invalid_argument, "No such module: " + fname);
 
     this->module_path = fs::current_path().string() / file.parent_path();
     this->module_name = file.filename().stem();
@@ -56,9 +57,7 @@ PyRunModule::PyRunModule(std::shared_ptr<const Python> python, const std::string
         OpmLog::error(fmt::format("Exception thrown when loading Python module opm_embedded: {}"), e.what());
         throw e;
     } catch (...) {
-        std::string errorMessage = "General exception thrown when loading Python module opm_embedded!";
-        OpmLog::error(errorMessage);
-        throw std::runtime_error(errorMessage);
+        OPM_THROW(std::runtime_error, "General exception thrown when loading Python module opm_embedded!");
     }
 }
 
@@ -79,9 +78,7 @@ bool PyRunModule::executeInnerRunFunction(const std::function<void(const std::st
         OpmLog::error(fmt::format("Exception thrown when calling run(ecl_state, schedule, report_step, summary_state, actionx_callback) function of {}: {}", this->module_name, e.what()));
         throw e;
     } catch(...) {
-        auto errorMessage = fmt::format("General exception thrown when calling run(ecl_state, schedule, report_step, summary_state, actionx_callback) function of {}", this->module_name);
-        OpmLog::error(errorMessage);
-        throw std::runtime_error(errorMessage);
+        OPM_THROW(std::runtime_error, fmt::format("General exception thrown when calling run(ecl_state, schedule, report_step, summary_state, actionx_callback) function of {}", this->module_name));
     }
 }
 
@@ -114,15 +111,11 @@ bool PyRunModule::run(EclipseState& ecl_state, Schedule& sched, std::size_t repo
             OpmLog::error(fmt::format("Exception thrown when loading Python module {}: {}", this->module_name, e.what()));
             throw e;
         } catch (...) {
-            auto errorMessage = fmt::format("General exception thrown when loading Python module {}", this->module_name);
-            OpmLog::error(errorMessage);
-            throw std::runtime_error(errorMessage);
+            OPM_THROW(std::runtime_error, fmt::format("General exception thrown when loading Python module {}", this->module_name));
         }
 
         if (this->module.is_none()) {
-            auto errorMessage = fmt::format("Syntax error when loading Python module: {}", this->module_name);
-            OpmLog::error(errorMessage);
-            throw std::runtime_error(errorMessage);
+            OPM_THROW(std::runtime_error, fmt::format("Syntax error when loading Python module: {}", this->module_name));
         }
 
         this->module.attr("storage") = this->storage;

--- a/opm/input/eclipse/Python/PyRunModule.cpp
+++ b/opm/input/eclipse/Python/PyRunModule.cpp
@@ -137,7 +137,14 @@ help(opm_embedded.current_summary_state)
         if (!this->run_function.is_none()) {
             return this->executeInnerRunFunction(actionx_callback);            
         } else {
-            this->module.reload();
+            try {
+                this->module.reload();
+            } catch (const std::exception& e) {
+                OpmLog::error(fmt::format("Exception thrown in python module {}: {}", this->module_name, e.what()));
+                throw e;
+            } catch(...) {
+                OPM_THROW(std::runtime_error, fmt::format("General exception thrown in python module {}", this->module_name));
+            }
         }
     }
 

--- a/opm/input/eclipse/Schedule/Action/PyAction.cpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.cpp
@@ -37,6 +37,19 @@ namespace py = pybind11;
 namespace Opm {
 namespace Action {
 
+bool PyAction::valid_keyword(const std::string& keyword) {
+    static std::unordered_set<std::string> pyaction_allowed_list = {
+        "BOX",
+        "FIELD",
+        "ENDBOX",
+        "GCONINJE", "GCONPROD",
+        "METRIC", "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
+        "NEXT", "NEXTSTEP",
+        "WCONINJE", "WCONPROD", "WEFAC", "WELOPEN", "WELTARG"
+    };
+    return pyaction_allowed_list.find(keyword) != pyaction_allowed_list.end();
+}
+
 PyAction::RunCount PyAction::from_string(std::string run_count) {
     run_count = uppercase(run_count);
 

--- a/opm/input/eclipse/Schedule/Action/PyAction.hpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.hpp
@@ -65,6 +65,7 @@ public:
         serializer(module_file);
         serializer(m_active);
     }
+    static bool valid_keyword(const std::string& keyword);
 
 private:
     void update(bool result) const;

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1420,18 +1420,23 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         auto& input_block = this->m_sched_deck[reportStep];
         std::unordered_map<std::string, double> wpimult_global_factor;
         for (auto& keyword : keywords) {
-            input_block.push_back(*keyword);
-            this->handleKeyword(reportStep,
-                                input_block,
-                                *keyword,
-                                parseContext,
-                                errors,
-                                grid,
-                                matching_wells,
-                                /*actionx_mode=*/false,
-                                &sim_update,
-                                &target_wellpi,
-                                wpimult_global_factor);
+            if (Action::PyAction::valid_keyword(keyword->name())) {
+                input_block.push_back(*keyword);
+                this->handleKeyword(reportStep,
+                                    input_block,
+                                    *keyword,
+                                    parseContext,
+                                    errors,
+                                    grid,
+                                    matching_wells,
+                                    /*actionx_mode=*/false,
+                                    &sim_update,
+                                    &target_wellpi,
+                                    wpimult_global_factor);    
+            } else {
+                const std::string msg_fmt = fmt::format("The keyword {} is not supported for inserting it from Python into a simulation", keyword->name());
+                parseContext.handleError(ParseContext::PYACTION_ILLEGAL_KEYWORD, msg_fmt, keyword->location(), errors);
+            }
         }
         this->applyGlobalWPIMULT(wpimult_global_factor);
         this->end_report(reportStep);

--- a/tests/msim/MSIM_PYACTION_INSERT_INVALID_KEYWORD.DATA
+++ b/tests/msim/MSIM_PYACTION_INSERT_INVALID_KEYWORD.DATA
@@ -1,0 +1,542 @@
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2015-2024 Equinor ASA
+
+-- This simulation is based on the data given in 
+-- 'Comparison of Solutions to a Three-Dimensional
+-- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+-- Journal of Petroleum Technology, January 1981
+
+-- This file is the same as MSIM_PYACTION.DATA, except for calling another python script in PYACTION
+
+---------------------------------------------------------------------------
+------------------------ SPE1 - CASE 1 ------------------------------------
+---------------------------------------------------------------------------
+
+RUNSPEC
+-- -------------------------------------------------------------------------
+
+TITLE
+   SPE1 - CASE 1
+
+DIMENS
+   10 10 3 /
+
+-- The number of equilibration regions is inferred from the EQLDIMS
+-- keyword.
+EQLDIMS
+/
+
+-- The number of PVTW tables is inferred from the TABDIMS keyword;
+-- when no data is included in the keyword the default values are used.
+TABDIMS
+/
+
+OIL
+GAS
+WATER
+DISGAS
+-- As seen from figure 4 in Odeh, GOR is increasing with time,
+-- which means that dissolved gas is present
+
+FIELD
+
+START
+   1 'DEC' 2014 /
+
+WELLDIMS
+-- Item 1: maximum number of wells in the model
+-- 	   - there are two wells in the problem; injector and producer
+-- Item 2: maximum number of grid blocks connected to any one well
+-- 	   - must be one as the wells are located at specific grid blocks
+-- Item 3: maximum number of groups in the model
+-- 	   - we are dealing with only one 'group'
+-- Item 4: maximum number of wells in any one group
+-- 	   - there must be two wells in a group as there are two wells in total
+   5 1 1 5 /
+
+UNIFOUT
+
+UDQDIMS
+ 50 25 0 50 50 0 0 50 0 20 /
+
+GRID
+
+-- The INIT keyword is used to request an .INIT file. The .INIT file
+-- is written before the simulation actually starts, and contains grid
+-- properties and saturation tables as inferred from the input
+-- deck. There are no other keywords which can be used to configure
+-- exactly what is written to the .INIT file.
+INIT
+
+
+-- -------------------------------------------------------------------------
+NOECHO
+
+DX 
+-- There are in total 300 cells with length 1000ft in x-direction	
+   	300*1000 /
+DY
+-- There are in total 300 cells with length 1000ft in y-direction	
+	300*1000 /
+DZ
+-- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
+	100*20 100*30 100*50 /
+
+TOPS
+-- The depth of the top of each grid block
+	100*8325 /
+
+PORO
+-- Constant porosity of 0.3 throughout all 300 grid cells
+   	300*0.3 /
+
+PERMX
+-- The layers have perm. 500mD, 50mD and 200mD, respectively.
+	100*500 100*50 100*200 /
+
+PERMY
+-- Equal to PERMX
+	100*500 100*50 100*200 /
+
+PERMZ
+-- Cannot find perm. in z-direction in Odeh's paper
+-- For the time being, we will assume PERMZ equal to PERMX and PERMY:
+	100*500 100*50 100*200 /
+ECHO
+
+PROPS
+-- -------------------------------------------------------------------------
+
+PVTW
+-- Item 1: pressure reference (psia)
+-- Item 2: water FVF (rb per bbl or rb per stb)
+-- Item 3: water compressibility (psi^{-1})
+-- Item 4: water viscosity (cp)
+-- Item 5: water 'viscosibility' (psi^{-1})
+
+-- Using values from Norne:
+-- In METRIC units:
+-- 	277.0 1.038 4.67E-5 0.318 0.0 /
+-- In FIELD units:
+    	4017.55 1.038 3.22E-6 0.318 0.0 /
+
+ROCK
+-- Item 1: reference pressure (psia)
+-- Item 2: rock compressibility (psi^{-1})
+
+-- Using values from table 1 in Odeh:
+	14.7 3E-6 /
+
+SWOF
+-- Column 1: water saturation
+--   	     - this has been set to (almost) equally spaced values from 0.12 to 1
+-- Column 2: water relative permeability
+--   	     - generated from the Corey-type approx. formula
+--	       the coeffisient is set to 10e-5, S_{orw}=0 and S_{wi}=0.12
+-- Column 3: oil relative permeability when only oil and water are present
+--	     - we will use the same values as in column 3 in SGOF.
+-- 	       This is not really correct, but since only the first 
+--	       two values are of importance, this does not really matter
+-- Column 4: water-oil capillary pressure (psi) 
+
+0.12	0    		 	1	0
+0.18	4.64876033057851E-008	1	0
+0.24	0.000000186		0.997	0
+0.3	4.18388429752066E-007	0.98	0
+0.36	7.43801652892562E-007	0.7	0
+0.42	1.16219008264463E-006	0.35	0
+0.48	1.67355371900826E-006	0.2	0
+0.54	2.27789256198347E-006	0.09	0
+0.6	2.97520661157025E-006	0.021	0
+0.66	3.7654958677686E-006	0.01	0
+0.72	4.64876033057851E-006	0.001	0
+0.78	0.000005625		0.0001	0
+0.84	6.69421487603306E-006	0	0
+0.91	8.05914256198347E-006	0	0
+1	0.00001			0	0 /
+
+
+SGOF
+-- Column 1: gas saturation
+-- Column 2: gas relative permeability
+-- Column 3: oil relative permeability when oil, gas and connate water are present
+-- Column 4: oil-gas capillary pressure (psi)
+-- 	     - stated to be zero in Odeh's paper
+
+-- Values in column 1-3 are taken from table 3 in Odeh's paper:
+0	0	1	0
+0.001	0	1	0
+0.02	0	0.997	0
+0.05	0.005	0.980	0
+0.12	0.025	0.700	0
+0.2	0.075	0.350	0
+0.25	0.125	0.200	0
+0.3	0.190	0.090	0
+0.4	0.410	0.021	0
+0.45	0.60	0.010	0
+0.5	0.72	0.001	0
+0.6	0.87	0.0001	0
+0.7	0.94	0.000	0
+0.85	0.98	0.000	0 
+0.88	0.984	0.000	0 /
+--1.00	1.0	0.000	0 /
+-- Warning from Eclipse: first sat. value in SWOF + last sat. value in SGOF
+-- 	   		 must not be greater than 1, but Eclipse still runs
+-- Flow needs the sum to be excactly 1 so I added a row with gas sat. =  0.88
+-- The corresponding krg value was estimated by assuming linear rel. between
+-- gas sat. and krw. between gas sat. 0.85 and 1.00 (the last two values given)
+
+DENSITY
+-- Density (lb per ft³) at surface cond. of 
+-- oil, water and gas, respectively (in that order)
+
+-- Using values from Norne:
+-- In METRIC units:
+--      859.5 1033.0 0.854 /
+-- In FIELD units:
+      	53.66 64.49 0.0533 /
+
+PVDG
+-- Column 1: gas phase pressure (psia)
+-- Column 2: gas formation volume factor (rb per Mscf)
+-- 	     - in Odeh's paper the units are said to be given in rb per bbl, 
+-- 	       but this is assumed to be a mistake: FVF-values in Odeh's paper 
+--	       are given in rb per scf, not rb per bbl. This will be in 
+--	       agreement with conventions
+-- Column 3: gas viscosity (cP)
+
+-- Using values from lower right table in Odeh's table 2:
+14.700	166.666	0.008000
+264.70	12.0930	0.009600
+514.70	6.27400	0.011200
+1014.7	3.19700	0.014000
+2014.7	1.61400	0.018900
+2514.7	1.29400	0.020800
+3014.7	1.08000	0.022800
+4014.7	0.81100	0.026800
+5014.7	0.64900	0.030900
+9014.7	0.38600	0.047000 /
+
+PVTO
+-- Column 1: dissolved gas-oil ratio (Mscf per stb)
+-- Column 2: bubble point pressure (psia)
+-- Column 3: oil FVF for saturated oil (rb per stb)
+-- Column 4: oil viscosity for saturated oil (cP)
+
+-- Use values from top left table in Odeh's table 2:
+0.0010	14.7	1.0620	1.0400 /
+0.0905	264.7	1.1500	0.9750 /
+0.1800	514.7	1.2070	0.9100 /
+0.3710	1014.7	1.2950	0.8300 /
+0.6360	2014.7	1.4350	0.6950 /
+0.7750	2514.7	1.5000	0.6410 /
+0.9300	3014.7	1.5650	0.5940 /
+1.2700	4014.7	1.6950	0.5100 
+	9014.7	1.5790	0.7400 /
+1.6180	5014.7	1.8270	0.4490 
+	9014.7	1.7370	0.6310 /	
+-- It is required to enter data for undersaturated oil for the highest GOR
+-- (i.e. the last row) in the PVTO table.
+-- In order to fulfill this requirement, values for oil FVF and viscosity
+-- at 9014.7psia and GOR=1.618 for undersaturated oil have been approximated:
+-- It has been assumed that there is a linear relation between the GOR
+-- and the FVF when keeping the pressure constant at 9014.7psia.
+-- From Odeh we know that (at 9014.7psia) the FVF is 2.357 at GOR=2.984
+-- for saturated oil and that the FVF is 1.579 at GOR=1.27 for undersaturated oil,
+-- so it is possible to use the assumption described above. 
+-- An equivalent approximation for the viscosity has been used.
+/
+
+SOLUTION
+-- -------------------------------------------------------------------------
+
+EQUIL
+-- Item 1: datum depth (ft)
+-- Item 2: pressure at datum depth (psia)
+-- 	   - Odeh's table 1 says that initial reservoir pressure is 
+-- 	     4800 psi at 8400ft, which explains choice of item 1 and 2
+-- Item 3: depth of water-oil contact (ft)
+-- 	   - chosen to be directly under the reservoir
+-- Item 4: oil-water capillary pressure at the water oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 5: depth of gas-oil contact (ft)
+-- 	   - chosen to be directly above the reservoir
+-- Item 6: gas-oil capillary pressure at gas-oil contact (psi)
+-- 	   - given to be 0 in Odeh's paper
+-- Item 7: RSVD-table
+-- Item 8: RVVD-table
+-- Item 9: Set to 0 as this is the only value supported by OPM
+
+-- Item #: 1 2    3    4 5    6 7 8 9
+	8400 4800 8450 0 8300 0 1 0 0 /
+
+RSVD
+-- Dissolved GOR is initially constant with depth through the reservoir.
+-- The reason is that the initial reservoir pressure given is higher 
+---than the bubble point presssure of 4014.7psia, meaning that there is no 
+-- free gas initially present.
+8300 1.270
+8450 1.270 /
+
+SUMMARY
+-- -------------------------------------------------------------------------	 
+
+FOPR
+
+WGOR
+/
+WOPR
+/
+WWPR
+/
+WWCT
+/
+
+
+FGOR
+
+-- 2a) Pressures of the cell where the injector and producer are located
+BPR
+1  1  1 /
+10 10 3 /
+/
+
+-- 2b) Gas saturation at grid points given in Odeh's paper
+BGSAT
+1  1  1 /
+1  1  2 /
+1  1  3 /
+10 1  1 /
+10 1  2 /
+10 1  3 /
+10 10 1 /
+10 10 2 /
+10 10 3 /
+/
+
+-- In order to compare Eclipse with Flow:
+WBHP
+/
+
+WGIR
+  'INJ'
+/
+
+WGIT
+  'INJ'
+/
+
+WGPR
+/
+
+WGPT
+/
+
+WOPR
+/
+
+WOPT
+/
+
+WWIR
+/
+WWIT
+/
+WWPR
+/
+WWPT
+/
+WUBHP
+/
+WUOPRL
+/
+WUWCT
+/
+
+FOPR
+
+FUOPR
+
+
+SCHEDULE
+-- -------------------------------------------------------------------------
+RPTSCHED
+	'PRES' 'SGAS' 'RS' 'WELLS' 'WELSPECS' /
+
+RPTRST
+	'BASIC=1' /
+
+UDQ
+  ASSIGN WUBHP 11 /
+  ASSIGN WUOPRL 20 /
+  ASSIGN WUBHP P2 12 /
+  ASSIGN WUBHP P3 13 /
+  ASSIGN WUBHP P4 14 /
+  UNITS  WUBHP 'BARSA' /
+  UNITS  WUOPRL 'SM3/DAY' /
+  DEFINE WUWCT WWPR / (WWPR + WOPR) /
+  UNITS  WUWCT '1' /
+  DEFINE FUOPR SUM(WOPR) /
+  UNITS  FUOPR 'SM3/DAY' /
+/
+
+
+
+-- If no resolution (i.e. case 1), the two following lines must be added:
+DRSDT
+ 0 /
+-- if DRSDT is set to 0, GOR cannot rise and free gas does not 
+-- dissolve in undersaturated oil -> constant bubble point pressure
+
+WELSPECS
+-- Item #: 1	 2	3	4	5	 6
+	'P1'	'G1'	 3	 3	8400	'OIL' /
+	'P2'	'G1'	 4	 4	8400	'OIL' /
+	'P3'	'G1'	 5	 5	8400	'OIL' /
+	'P4'	'G1'	 6	 6	8400	'OIL' /
+	'INJ'	'G1'	1	1	8335	'GAS' /
+/
+-- Coordinates in item 3-4 are retrieved from Odeh's figure 1 and 2
+-- Note that the depth at the midpoint of the well grid blocks
+-- has been used as reference depth for bottom hole pressure in item 5
+
+COMPDAT
+-- Item #: 1	2	3	4	5	6	7	8	9
+	'P1'	3    3	3	3	'OPEN'	1*	1*	0.5 /
+	'P2'	4    4	3	3	'OPEN'	1*	1*	0.5 /
+	'P3'	5    5	3	3	'OPEN'	1*	1*	0.5 /
+	'P4'	6    6	3	3	'OPEN'	1*	1*	0.5 /
+	'INJ'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+-- Coordinates in item 2-5 are retreived from Odeh's figure 1 and 2 
+-- Item 9 is the well bore internal diameter, 
+-- the radius is given to be 0.25ft in Odeh's paper
+
+
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+	'P1' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P2' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P3' 'OPEN' 'ORAT' 5000 4* 1000 /
+	'P4' 'OPEN' 'ORAT' 5000 4* 1000 /
+/
+
+-- It is stated in Odeh's paper that the maximum oil prod. rate
+-- is 20 000stb per day which explains the choice of value in item 4.
+-- The items > 4 are defaulted with the exception of item  9,
+-- the BHP lower limit, which is given to be 1000psia in Odeh's paper
+
+WCONINJE
+-- Item #:1	 2	 3	 4	5      6  7
+	'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
+-- Stated in Odeh that gas inj. rate (item 5) is 100MMscf per day
+-- BHP upper limit (item 7) should not be exceeding the highest
+-- pressure in the PVT table=9014.7psia (default is 100 000psia)
+
+PYACTION
+   INSERT_KEYWORD UNLIMITED /
+   'insert_invalid_keyword.py' /
+
+DATES
+   1 'JAN'  2015 /
+/
+
+DATES
+   1 'FEB'  2015 /
+/
+
+DATES
+   1 'MAR'  2015 /
+/
+
+DATES
+   1 'APR'  2015 /
+/
+
+DATES
+   1 'MAI'  2015 /
+/
+
+DATES
+   1 'JUN'  2015 /
+/
+
+DATES
+   1 'JUL'  2015 /
+/
+
+DATES
+   1 'AUG'  2015 /
+/
+
+DATES
+   1 'SEP'  2015 /
+/
+
+DATES
+   1 'OCT'  2015 /
+/
+
+DATES
+   1 'NOV'  2015 /
+/
+
+DATES
+   1 'DEC'  2015 /
+/
+
+DATES
+   1 'JAN'  2016 /
+/
+
+DATES
+   1 'FEB'  2016 /
+/
+
+DATES
+   1 'MAR'  2016 /
+/
+
+DATES
+   1 'APR'  2016 /
+/
+
+DATES
+   1 'MAI'  2016 /
+/
+
+DATES
+   1 'JUN'  2016 /
+/
+
+DATES
+   1 'JUL'  2016 /
+/
+
+DATES
+   1 'AUG'  2016 /
+/
+
+DATES
+   1 'SEP'  2016 /
+/
+
+DATES
+   1 'OCT'  2016 /
+/
+
+DATES
+   1 'NOV'  2016 /
+/
+
+DATES
+   1 'DEC'  2016 /
+/
+
+
+END

--- a/tests/msim/insert_invalid_keyword.py
+++ b/tests/msim/insert_invalid_keyword.py
@@ -1,0 +1,20 @@
+import opm_embedded
+
+schedule = opm_embedded.current_schedule
+report_step = opm_embedded.current_report_step
+
+if (report_step == 2):
+	invalid_kw = """
+	GRID
+
+	PORO
+	    1000*0.1 /
+	PERMX
+	    1000*1 /
+	PERMY
+	    1000*0.1 /
+	PERMZ
+	    1000*0.01 /
+	"""
+	schedule.insert_keywords(invalid_kw)
+	

--- a/tests/msim/test_msim_ACTIONX.cpp
+++ b/tests/msim/test_msim_ACTIONX.cpp
@@ -622,5 +622,17 @@ BOOST_AUTO_TEST_CASE(PYTHON_CHANGING_SCHEUDULE) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(MSIM_PYACTION_INSERT_INVALID_KEYWORD) {
+    const auto& deck = Parser().parseFile("msim/MSIM_PYACTION_INSERT_INVALID_KEYWORD.DATA");
+    test_data td( deck );
+    msim sim(td.state, td.schedule);
+    {
+        WorkArea work_area("test_msim");
+        EclipseIO io(td.state, td.state.getInputGrid(), sim.schedule, td.summary_config);
+
+        BOOST_CHECK_THROW(sim.run(io, false), std::exception);
+    }
+}
+
 #endif
 


### PR DESCRIPTION
Before, there was no such check, I've added all keywords I've tested so far to the valid list, and I'll keep adding more keywords after having tested them.

Also, I've added the keyword "WELTARG" from https://github.com/OPM/opm-simulators/blob/master/python/test/test_schedule.py
@hakonhagland: Did you do more tests with the "insert_keywords" function for other keywords that are not in this [list](https://github.com/OPM/opm-common/pull/4008/files#diff-c473c725418b8f6963c6e2b19371ebaab58f49f41334deef2b666082e7637740R40) yet?
If so, I will add the respective keywords!