### PR TITLE
Fix EclRegressionTest.cpp-functionality to accept extra keywords 

### DIFF
--- a/test_util/EclRegressionTest.cpp
+++ b/test_util/EclRegressionTest.cpp
@@ -263,7 +263,7 @@ void ECLRegressionTest::printDeviationReport()
 
 void ECLRegressionTest::compareKeywords(const std::vector<std::string> &keywords1, const std::vector<std::string> &keywords2, const std::string &reference) {
 
-    if (!acceptExtraKeywords) {
+    if (!(acceptExtraKeywords or acceptExtraKeywordsBoth)) {
         if (keywords1 != keywords2) {
             std::cout << "not same keywords in " << reference << std::endl;
 

--- a/test_util/EclRegressionTest.hpp
+++ b/test_util/EclRegressionTest.hpp
@@ -74,7 +74,6 @@ public:
     //Accept extra keywords in both simulations and compare only the keywords available in both runs
     void setAcceptExtraKeywordsBoth(bool acceptExtraKeywordsArg) {
         this->acceptExtraKeywordsBoth = acceptExtraKeywordsArg;
-        this->acceptExtraKeywords = acceptExtraKeywordsArg;
     }
 
     void setIntegrationTest(bool inregrationTestArg) {


### PR DESCRIPTION
only from the second deck.