### PR TITLE
Size Defaulted MULT* Arrays From Active Cells in Output

### DIFF
--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -54,8 +54,6 @@
 #include <opm/input/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/T.hpp>
 
-#include <opm/output/data/Solution.hpp>
-
 #include <fmt/format.h>
 
 #include <cstddef>
@@ -149,13 +147,6 @@ namespace Opm {
         , m_micppara(          deck)
         , wag_hyst_config(     deck)
     {
-        if (deck.hasKeyword("GRIDOPTS")) {
-            const auto& gridOpts = deck["GRIDOPTS"].back();
-            const auto& record = gridOpts.getRecord(0);
-            m_write_all_multminus =
-                record.getItem("TRANMULT").getTrimmedString(0)== "YES";
-        }
-
         this->assignRunTitle(deck);
         this->reportNumberOfActivePhases();
 
@@ -302,10 +293,6 @@ namespace Opm {
         return m_transMult;
     }
 
-    data::Solution EclipseState::getMultSimProps() const
-    {
-        return getTransMult().convertToSimProps(m_inputGrid.getNumActive(), m_write_all_multminus);
-    }
     const NNC& EclipseState::getInputNNC() const {
         return m_inputNnc;
     }

--- a/opm/input/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.hpp
@@ -58,9 +58,6 @@ namespace Opm { namespace RestartIO {
 }} // namespace Opm::RestartIO
 
 namespace Opm {
-    namespace data {
-        class Solution;
-    }
 
     class EclipseState {
     public:
@@ -87,11 +84,6 @@ namespace Opm {
         const FaultCollection& getFaults() const;
         const TransMult& getTransMult() const;
         TransMult& getTransMult();
-
-        /// \brief Get the multipliers (MULTX, MULTX-, etc.) for output
-        ///
-        /// These will have the fault multipliers applied.
-        data::Solution getMultSimProps() const;
 
         /// non-neighboring connections
         /// the non-standard adjacencies as specified in input deck
@@ -166,7 +158,6 @@ namespace Opm {
             serializer(m_micppara);
             serializer(wag_hyst_config);
             serializer(this->fipRegionStatistics_);
-            serializer(m_write_all_multminus);
         }
 
         static bool rst_cmp(const EclipseState& full_state, const EclipseState& rst_state);
@@ -210,12 +201,6 @@ namespace Opm {
         std::optional<std::map<std::string, double> > m_restart_network_pressures{std::nullopt};
 
         std::optional<FIPRegionStatistics> fipRegionStatistics_{std::nullopt};
-        /// \brief Whether to write out all MULT?- unconditionally
-        ///
-        /// If false we will only write non-defaulted MULT?- arrays to the
-        /// INIT file. Otherwise all.
-        /// Reflects first entry of GRIDOPTS
-        bool m_write_all_multminus{};
     };
 } // namespace Opm
 

--- a/opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -17,108 +17,55 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <filesystem>
-#include <iomanip>
-#include <iostream>
-#include <iterator>
-#include <sstream>
+#include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
+
 #include <opm/input/eclipse/Deck/Deck.hpp>
 #include <opm/input/eclipse/Deck/DeckItem.hpp>
 #include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/Deck/DeckRecord.hpp>
 #include <opm/input/eclipse/Deck/DeckSection.hpp>
-#include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 
-namespace Opm {
+#include <opm/input/eclipse/Parser/ParserKeywords/F.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/G.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/I.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/M.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/N.hpp>
+#include <opm/input/eclipse/Parser/ParserKeywords/U.hpp>
 
-    namespace {
-        const char* default_dir = ".";
+#include <cctype>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
 
-        bool normalize_case(std::string& s) {
-            int upper_count = 0;
-            int lower_count = 0;
+namespace {
 
-            for (const auto& c : s) {
-                if (std::isupper(c))
-                    upper_count += 1;
+    const char* default_dir = ".";
 
-                if (std::islower(c))
-                    lower_count += 1;
-            }
+    bool write_egrid_file(const Opm::GRIDSection& grid)
+    {
+        if (grid.hasKeyword<Opm::ParserKeywords::NOGGF>()) {
+            return false;
+        }
 
-            if (upper_count * lower_count == 0)
-                return false;
-
-            for (auto& c : s)
-                c = std::toupper(c);
+        if (! grid.hasKeyword<Opm::ParserKeywords::GRIDFILE>()) {
             return true;
         }
 
-
-        inline std::string basename( const std::string& path ) {
-            return std::filesystem::path( path ).stem().string();
-        }
-
-
-        inline std::string outputdir( const std::string& path ) {
-            auto dir = std::filesystem::path( path ).parent_path().string();
-
-            if( dir.empty() ) return default_dir;
-
-            return dir;
-        }
-    }
-
-
-    IOConfig::IOConfig( const Deck& deck ) :
-        IOConfig( GRIDSection( deck ),
-                  RUNSPECSection( deck ),
-                  deck.hasKeyword("NOSIM"),
-                  deck.getDataFile() )
-    {}
-
-    IOConfig::IOConfig( const std::string& input_path ) :
-        m_deck_filename( input_path ),
-        m_output_dir( outputdir( input_path ) )
-    {
-        this->setBaseName(basename(input_path));
-    }
-
-    IOConfig IOConfig::serializationTestObject()
-    {
-        IOConfig result;
-        result.m_write_INIT_file = true;
-        result.m_write_EGRID_file = false;
-        result.m_UNIFIN = true;
-        result.m_UNIFOUT = true;
-        result.m_FMTIN = true;
-        result.m_FMTOUT = true;
-        result.m_deck_filename = "test1";
-        result.m_output_enabled = false;
-        result.m_output_dir = "test2";
-        result.m_nosim = true;
-        result.m_base_name = "test3";
-        result.ecl_compatible_rst = false;
-
-        return result;
-    }
-
-    static inline bool write_egrid_file( const GRIDSection& grid ) {
-        if( grid.hasKeyword( "NOGGF" ) ) return false;
-        if( !grid.hasKeyword( "GRIDFILE" ) ) return true;
-
-        const auto& keyword = grid.getKeyword( "GRIDFILE" );
-        const auto& rec = keyword.getRecord( 0 );
+        const auto& rec = grid.get<Opm::ParserKeywords::GRIDFILE>()
+            .back().getRecord(0);
 
         {
-            const auto& grid_item = rec.getItem( 0 );
+            const auto& grid_item = rec.getItem(0);
+
             if (grid_item.get<int>(0) != 0) {
                 std::cerr << "IOConfig: Reading GRIDFILE keyword from GRID section: "
                           << "Output of GRID file is not supported. "
-                          << "Supported format: EGRID"
-                          << std::endl;
+                          << "Supported format: EGRID\n";
 
                 // It was asked for GRID file - that output is not
                 // supported, but we will output EGRID file;
@@ -129,87 +76,182 @@ namespace Opm {
         }
 
         {
-            const auto& egrid_item = rec.getItem( 1 );
-            return (egrid_item.get<int>(0) == 1);
+            const auto& egrid_item = rec.getItem(1);
+
+            return egrid_item.get<int>(0) == 1;
         }
     }
 
-    IOConfig::IOConfig( const GRIDSection& grid,
-                        const RUNSPECSection& runspec,
-                        bool nosim,
-                        const std::string& input_path ) :
-        m_write_INIT_file( grid.hasKeyword( "INIT" ) ),
-        m_write_EGRID_file( write_egrid_file( grid ) ),
-        m_FMTIN( runspec.hasKeyword( "FMTIN" ) ),
-        m_FMTOUT( runspec.hasKeyword( "FMTOUT" ) ),
-        m_deck_filename( input_path ),
-        m_output_dir( outputdir( input_path ) ),
-        m_nosim( nosim  )
+    bool normalize_case(std::string& s)
+    {
+        int upper_count = 0;
+        int lower_count = 0;
+
+        for (const auto& c : s) {
+            upper_count += std::isupper(c);
+            lower_count += std::islower(c);
+        }
+
+        if (upper_count * lower_count == 0) {
+            return false;
+        }
+
+        for (auto& c : s) {
+            c = std::toupper(c);
+        }
+
+        return true;
+    }
+
+    std::string basename(const std::string& path)
+    {
+        return std::filesystem::path(path).stem().string();
+    }
+
+    std::string outputdir(const std::string& path)
+    {
+        const auto dir = std::filesystem::path(path).parent_path().string();
+
+        if (dir.empty()) {
+            return default_dir;
+        }
+
+        return dir;
+    }
+
+} // Anonymous namespace
+
+namespace Opm {
+
+    IOConfig::IOConfig(const Deck& deck)
+        : IOConfig(GRIDSection(deck),
+                   RUNSPECSection(deck),
+                   deck.hasKeyword<ParserKeywords::NOSIM>(),
+                   deck.getDataFile())
+    {}
+
+    IOConfig::IOConfig(const std::string& input_path)
+        : m_deck_filename(input_path)
+        , m_output_dir(outputdir(input_path))
     {
         this->setBaseName(basename(input_path));
+    }
+
+    IOConfig IOConfig::serializationTestObject()
+    {
+        IOConfig result;
+
+        result.m_deck_filename = "test1";
+        result.m_output_dir = "test2";
+
+        result.m_write_INIT_file = true;
+        result.m_write_EGRID_file = false;
+        result.m_FMTIN = true;
+        result.m_FMTOUT = true;
+
+        result.m_nosim = true;
+
+        result.m_base_name = "test3";
+
+        result.m_UNIFIN = true;
+        result.m_UNIFOUT = true;
+
+        result.m_output_enabled = false;
+        result.ecl_compatible_rst = false;
+
+        return result;
+    }
+
+    IOConfig::IOConfig(const GRIDSection&    grid,
+                       const RUNSPECSection& runspec,
+                       const bool            nosim,
+                       const std::string&    input_path)
+        : m_deck_filename      (input_path)
+        , m_output_dir         (outputdir(input_path))
+        , m_write_INIT_file    (grid.hasKeyword<ParserKeywords::INIT>())
+        , m_write_EGRID_file   (write_egrid_file(grid))
+        , m_FMTIN              (runspec.hasKeyword<ParserKeywords::FMTIN>())
+        , m_FMTOUT             (runspec.hasKeyword<ParserKeywords::FMTOUT>())
+        , m_nosim              (nosim)
+    {
+        this->setBaseName(basename(input_path));
+
+        // Loop keywords in RUNSPEC to determine unified vs. separate
+        // input/output file type flags because the last UNIF*/MULT* keyword
+        // "wins".
         for (const auto& kw : runspec) {
-            if (kw.name() == "UNIFOUT")
+            if (kw.name() == ParserKeywords::UNIFOUT::keywordName) {
                 this->m_UNIFOUT = true;
-            else if (kw.name() == "UNIFIN")
+            }
+            else if (kw.name() == ParserKeywords::UNIFIN::keywordName) {
                 this->m_UNIFIN = true;
-            else if (kw.name() == "MULTOUT")
+            }
+            else if (kw.name() == ParserKeywords::MULTOUT::keywordName) {
                 this->m_UNIFOUT = false;
-            else if (kw.name() == "MULTIN")
+            }
+            else if (kw.name() == ParserKeywords::MULTIN::keywordName) {
                 this->m_UNIFIN = false;
+            }
         }
     }
 
-
-    bool IOConfig::getWriteEGRIDFile() const {
+    bool IOConfig::getWriteEGRIDFile() const
+    {
         return m_write_EGRID_file;
     }
 
-    bool IOConfig::getWriteINITFile() const {
+    bool IOConfig::getWriteINITFile() const
+    {
         return m_write_INIT_file;
     }
 
-
-    bool IOConfig::getEclCompatibleRST() const {
+    bool IOConfig::getEclCompatibleRST() const
+    {
         return this->ecl_compatible_rst;
     }
 
-
-    void IOConfig::setEclCompatibleRST(bool ecl_rst) {
+    void IOConfig::setEclCompatibleRST(bool ecl_rst)
+    {
         this->ecl_compatible_rst = ecl_rst;
     }
 
-
-    void IOConfig::overrideNOSIM(bool nosim) {
+    void IOConfig::overrideNOSIM(bool nosim)
+    {
         m_nosim = nosim;
     }
 
-
-    bool IOConfig::getUNIFIN() const {
+    bool IOConfig::getUNIFIN() const
+    {
         return m_UNIFIN;
     }
 
-    bool IOConfig::getUNIFOUT() const {
+    bool IOConfig::getUNIFOUT() const
+    {
         return m_UNIFOUT;
     }
 
-    void IOConfig::consistentFileFlags(){
-        m_UNIFIN = getUNIFOUT();
-        m_FMTIN = getFMTOUT();
+    void IOConfig::consistentFileFlags()
+    {
+        this->m_UNIFIN = getUNIFOUT();
+        this->m_FMTIN = getFMTOUT();
     }
 
-    bool IOConfig::getFMTIN() const {
+    bool IOConfig::getFMTIN() const
+    {
         return m_FMTIN;
     }
 
-    bool IOConfig::getFMTOUT() const {
+    bool IOConfig::getFMTOUT() const
+    {
         return m_FMTOUT;
     }
 
-
-
-    std::string IOConfig::getRestartFileName(const std::string& restart_base, int report_step, bool output) const {
-        bool unified  = output ? getUNIFOUT() : getUNIFIN();
-        bool fmt_file = output ? getFMTOUT()  : getFMTIN();
+    std::string IOConfig::getRestartFileName(const std::string& restart_base,
+                                             const int          report_step,
+                                             const bool         output) const
+    {
+        const bool unified  = output ? getUNIFOUT() : getUNIFIN();
+        const bool fmt_file = output ? getFMTOUT()  : getFMTIN();
 
         auto ext = std::string{};
         if (unified) {
@@ -234,43 +276,53 @@ namespace Opm {
         return restart_base + '.' + ext;
     }
 
-
-    bool IOConfig::getOutputEnabled() const {
+    bool IOConfig::getOutputEnabled() const
+    {
         return m_output_enabled;
     }
 
-    void IOConfig::setOutputEnabled(bool enabled) {
+    void IOConfig::setOutputEnabled(bool enabled)
+    {
         m_output_enabled = enabled;
     }
 
-    std::string IOConfig::getOutputDir() const {
+    const std::string& IOConfig::getOutputDir() const
+    {
         return m_output_dir;
     }
 
-    std::string IOConfig::getInputDir() const {
-        std::filesystem::path path(m_deck_filename);
-        if (path.has_parent_path()) {
-            return path.parent_path();
-        } else {
-            return std::filesystem::current_path();
-        }
+    std::string IOConfig::getInputDir() const
+    {
+        const auto path = std::filesystem::path {this->m_deck_filename};
+
+        return path.has_parent_path()
+            ? path.parent_path()
+            : std::filesystem::current_path();
     }
 
-    void IOConfig::setOutputDir(const std::string& outputDir) {
+    void IOConfig::setOutputDir(const std::string& outputDir)
+    {
         m_output_dir = outputDir;
     }
 
-    const std::string& IOConfig::getBaseName() const {
+    const std::string& IOConfig::getBaseName() const
+    {
         return m_base_name;
     }
 
-    void IOConfig::setBaseName(const std::string& baseName) {
-        m_base_name = baseName;
-        if (normalize_case(m_base_name))
-            OpmLog::warning("The ALL CAPS case: " + m_base_name + " will be used when writing output files from this simulation.");
+    void IOConfig::setBaseName(const std::string& baseName)
+    {
+        this->m_base_name = baseName;
+
+        if (normalize_case(m_base_name)) {
+            OpmLog::warning("The ALL CAPS case: " + m_base_name +
+                            " will be used when writing output "
+                            "files from this simulation.");
+        }
     }
 
-    std::string IOConfig::fullBasePath( ) const {
+    std::string IOConfig::fullBasePath() const
+    {
         namespace fs = std::filesystem;
 
         fs::path dir( m_output_dir );
@@ -280,49 +332,52 @@ namespace Opm {
         return full_path.string();
     }
 
-
-    bool IOConfig::initOnly( ) const {
+    bool IOConfig::initOnly() const
+    {
         return m_nosim;
     }
 
-
-    bool IOConfig::operator==(const IOConfig& data) const {
-        return this->getWriteINITFile() == data.getWriteINITFile() &&
-               this->getWriteEGRIDFile() == data.getWriteEGRIDFile() &&
-               this->getUNIFIN() == data.getUNIFIN() &&
-               this->getUNIFOUT() == data.getUNIFOUT() &&
-               this->getFMTIN() == data.getFMTIN() &&
-               this->getFMTOUT() == data.getFMTOUT() &&
-               this->m_deck_filename == data.m_deck_filename &&
-               this->getOutputEnabled() == data.getOutputEnabled() &&
-               this->getOutputDir() == data.getOutputDir() &&
-               this->initOnly() == data.initOnly() &&
-               this->getBaseName() == data.getBaseName() &&
-               this->getEclCompatibleRST() == data.getEclCompatibleRST();
+    bool IOConfig::operator==(const IOConfig& data) const
+    {
+        return (this->getWriteINITFile() == data.getWriteINITFile())
+            && (this->getWriteEGRIDFile() == data.getWriteEGRIDFile())
+            && (this->getUNIFIN() == data.getUNIFIN())
+            && (this->getUNIFOUT() == data.getUNIFOUT())
+            && (this->getFMTIN() == data.getFMTIN())
+            && (this->getFMTOUT() == data.getFMTOUT())
+            && (this->writeAllTransMultipliers() == data.writeAllTransMultipliers())
+            && (this->m_deck_filename == data.m_deck_filename)
+            && (this->getOutputEnabled() == data.getOutputEnabled())
+            && (this->getOutputDir() == data.getOutputDir())
+            && (this->initOnly() == data.initOnly())
+            && (this->getBaseName() == data.getBaseName())
+            && (this->getEclCompatibleRST() == data.getEclCompatibleRST())
+            ;
     }
 
-
-    bool IOConfig::rst_cmp(const IOConfig& full_config, const IOConfig& rst_config) {
-        return full_config.getWriteINITFile() == rst_config.getWriteINITFile() &&
-               full_config.getWriteEGRIDFile() == rst_config.getWriteEGRIDFile() &&
-               full_config.getUNIFIN() == rst_config.getUNIFIN() &&
-               full_config.getUNIFOUT() == rst_config.getUNIFOUT() &&
-               full_config.getFMTIN() == rst_config.getFMTIN() &&
-               full_config.getFMTOUT() == rst_config.getFMTOUT();
+    bool IOConfig::rst_cmp(const IOConfig& full_config,
+                           const IOConfig& rst_config)
+    {
+        return (full_config.getWriteINITFile() == rst_config.getWriteINITFile())
+            && (full_config.getWriteEGRIDFile() == rst_config.getWriteEGRIDFile())
+            && (full_config.getUNIFIN() == rst_config.getUNIFIN())
+            && (full_config.getUNIFOUT() == rst_config.getUNIFOUT())
+            && (full_config.getFMTIN() == rst_config.getFMTIN())
+            && (full_config.getFMTOUT() == rst_config.getFMTOUT())
+            ;
     }
 
+    // ------------------------------------------------------------------------
+    //
+    // Here at the bottom are some forwarding proxy methods which just
+    // forward to the appropriate RestartConfig method. They are retained
+    // here as a temporary convenience method to prevent downstream
+    // breakage.
+    //
+    // Currently the EclipseState object can return a mutable IOConfig
+    // object, which application code can alter to override settings from
+    // the deck - this is quite ugly. When the API is reworked to remove the
+    // ability modify IOConfig objects we should also remove these
+    // forwarding methods.
 
-    /*****************************************************************/
-    /* Here at the bottom are some forwarding proxy methods which just
-       forward to the appropriate RestartConfig method. They are
-       retained here as a temporary convenience method to prevent
-       downstream breakage.
-
-       Currently the EclipseState object can return a mutable IOConfig
-       object, which application code can alter to override settings
-       from the deck - this is quite ugly. When the API is reworked to
-       remove the ability modify IOConfig objects we should also
-       remove these forwarding methods.
-    */
-
-} //namespace Opm
+} // namespace Opm

--- a/opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/input/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -46,6 +46,20 @@ namespace {
 
     const char* default_dir = ".";
 
+    bool write_all_trans_multipliers(const Opm::RUNSPECSection& runspec)
+    {
+        using Kw = Opm::ParserKeywords::GRIDOPTS;
+
+        if (! runspec.hasKeyword<Kw>()) {
+            return false;
+        }
+
+        return runspec.get<Kw>().back()
+            .getRecord(0)
+            .getItem<Kw::TRANMULT>()
+            .getTrimmedString(0) == "YES";
+    }
+
     bool write_egrid_file(const Opm::GRIDSection& grid)
     {
         if (grid.hasKeyword<Opm::ParserKeywords::NOGGF>()) {
@@ -150,6 +164,7 @@ namespace Opm {
         result.m_FMTOUT = true;
 
         result.m_nosim = true;
+        result.m_write_all_multminus = true;
 
         result.m_base_name = "test3";
 
@@ -173,6 +188,7 @@ namespace Opm {
         , m_FMTIN              (runspec.hasKeyword<ParserKeywords::FMTIN>())
         , m_FMTOUT             (runspec.hasKeyword<ParserKeywords::FMTOUT>())
         , m_nosim              (nosim)
+        , m_write_all_multminus(write_all_trans_multipliers(runspec))
     {
         this->setBaseName(basename(input_path));
 

--- a/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -162,6 +162,12 @@ namespace Opm {
         bool getUNIFIN() const;
         bool getFMTIN() const;
         bool getFMTOUT() const;
+
+        bool writeAllTransMultipliers() const
+        {
+            return this->m_write_all_multminus;
+        }
+
         const std::string& getEclipseInputPath() const;
 
         void overrideNOSIM(bool nosim);
@@ -200,6 +206,8 @@ namespace Opm {
             serializer(m_FMTIN);
             serializer(m_FMTOUT);
             serializer(m_nosim);
+            serializer(m_write_all_multminus);
+
             serializer(m_base_name);
             serializer(m_UNIFIN);
             serializer(m_UNIFOUT);
@@ -217,6 +225,14 @@ namespace Opm {
         bool m_FMTIN { false };
         bool m_FMTOUT { false };
         bool m_nosim { false };
+
+        /// \brief Whether to write out all MULT?- unconditionally
+        ///
+        /// Reflects first entry of GRIDOPTS
+        ///
+        /// If false we will only write non-defaulted MULT?- arrays to the
+        /// INIT file. Otherwise all.
+        bool m_write_all_multminus {false};
 
         std::string m_base_name{};
 

--- a/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -149,8 +149,8 @@ namespace Opm {
     public:
 
         IOConfig() = default;
-        explicit IOConfig( const Deck& );
-        explicit IOConfig( const std::string& input_path );
+        explicit IOConfig(const Deck&);
+        explicit IOConfig(const std::string& input_path);
 
         static IOConfig serializationTestObject();
 
@@ -172,7 +172,7 @@ namespace Opm {
         bool getOutputEnabled() const;
         void setOutputEnabled(bool enabled);
 
-        std::string getOutputDir() const;
+        const std::string& getOutputDir() const;
         void setOutputDir(const std::string& outputDir);
 
         const std::string& getBaseName() const;
@@ -180,7 +180,7 @@ namespace Opm {
 
         /// Return a string consisting of outputpath and basename;
         /// i.e. /path/to/sim/CASE
-        std::string fullBasePath( ) const;
+        std::string fullBasePath() const;
 
         std::string getInputDir() const;
 
@@ -189,43 +189,47 @@ namespace Opm {
         bool operator==(const IOConfig& data) const;
         static bool rst_cmp(const IOConfig& full_config, const IOConfig& rst_config);
 
-
         template<class Serializer>
         void serializeOp(Serializer& serializer)
         {
+            serializer(m_deck_filename);
+            serializer(m_output_dir);
+
             serializer(m_write_INIT_file);
             serializer(m_write_EGRID_file);
-            serializer(m_UNIFIN);
-            serializer(m_UNIFOUT);
             serializer(m_FMTIN);
             serializer(m_FMTOUT);
-            serializer(m_deck_filename);
-            serializer(m_output_enabled);
-            serializer(m_output_dir);
             serializer(m_nosim);
             serializer(m_base_name);
+            serializer(m_UNIFIN);
+            serializer(m_UNIFOUT);
+
+            serializer(m_output_enabled);
             serializer(ecl_compatible_rst);
         }
 
     private:
-        bool            m_write_INIT_file = false;
-        bool            m_write_EGRID_file = true;
-        bool            m_UNIFIN = false;
-        bool            m_UNIFOUT = false;
-        bool            m_FMTIN = false;
-        bool            m_FMTOUT = false;
-        std::string     m_deck_filename;
-        bool            m_output_enabled = true;
-        std::string     m_output_dir;
-        bool            m_nosim;
-        std::string     m_base_name;
-        bool            ecl_compatible_rst = true;
+        std::string m_deck_filename{};
+        std::string m_output_dir{};
 
-        IOConfig( const GRIDSection&,
-                  const RUNSPECSection&,
-                  bool nosim,
-                  const std::string& input_path );
+        bool m_write_INIT_file { false };
+        bool m_write_EGRID_file { true };
+        bool m_FMTIN { false };
+        bool m_FMTOUT { false };
+        bool m_nosim { false };
 
+        std::string m_base_name{};
+
+        bool m_UNIFIN { false };
+        bool m_UNIFOUT { false };
+
+        bool m_output_enabled { true };
+        bool ecl_compatible_rst { true };
+
+        IOConfig(const GRIDSection&,
+                 const RUNSPECSection&,
+                 bool nosim,
+                 const std::string& input_path);
     };
 
 } //namespace Opm


### PR DESCRIPTION
The `EclipseState`'s input grid's active cells might not coincide with the set of active cells after grid processing&ndash;e.g., due to 
`MINPV`. This commit switches the INIT file's `MULT*` array output to using the `EclipseIO`'s notion of the run's active cells and sizes the defaulted `MULT*` arrays according to that set.

To this end, move the 'write all mult* minus' flag to the `IOConfig` object and form the requisite `MULT*` array `data::Solution` object at the time of output.

While here, also modernise the `IOConfig` implementation files.