### PR TITLE
Write MULTPV to INIT-file and fix a few minor issues with multiple MULTPV occurrences

### DIFF
--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -667,10 +667,15 @@ void Opm::InitIO::write(const ::Opm::EclipseState&              es,
     {
         const auto writeAll = es.cfg().io().writeAllTransMultipliers();
 
-        const auto tranMult = es.getTransMult()
+        auto multipliers = es.getTransMult()
             .convertToSimProps(grid.getNumActive(), writeAll);
+        if (es.fieldProps().has_double("MULTPV")) {
+            multipliers.insert("MULTPV", UnitSystem::measure::identity,
+                        es.fieldProps().get_double("MULTPV"),
+                        data::TargetType::INIT);
+        }
 
-        writeSimulatorProperties(grid, tranMult, initFile);
+        writeSimulatorProperties(grid, multipliers, initFile);
     }
 
     writeTableData(es, units, initFile);

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -838,7 +838,7 @@ SCHEDULE
 
 void checkMULTPV(const std::pair<std::string, std::vector<float>>& deckAndValues)
 {
-    const auto [deckString, exspectedMultPV] = deckAndValues;
+    const auto [deckString, expectedMultPV] = deckAndValues;
     const auto deck = Parser().parseString(deckString);
     auto es = EclipseState( deck );
     const auto& eclGrid = es.getInputGrid();
@@ -853,12 +853,12 @@ void checkMULTPV(const std::pair<std::string, std::vector<float>>& deckAndValues
     BOOST_CHECK_MESSAGE( initFile.hasKey("MULTPV"),
                          R"(INIT file must have MULTPV array)" );
     const auto& multPVValues = initFile.get<float>("MULTPV");
-    auto exspect = exspectedMultPV.begin();
-    BOOST_CHECK(multPVValues.size() == exspectedMultPV.size());
+    auto expect = expectedMultPV.begin();
+    BOOST_CHECK(multPVValues.size() == expectedMultPV.size());
 
     for (auto multVal = multPVValues.begin(); multVal != multPVValues.end();
-         ++multVal, ++exspect) {
-        BOOST_CHECK_CLOSE(*multVal, *exspect, 1e-8);
+         ++multVal, ++expect) {
+        BOOST_CHECK_CLOSE(*multVal, *expect, 1e-8);
     }
 }
 
@@ -867,4 +867,77 @@ BOOST_AUTO_TEST_CASE(MULTPVInit)
     checkMULTPV(createMULTPVDECK(false));
     checkMULTPV(createMULTPVDECK(true));
     
+}
+
+std::pair<std::string,std::vector<float>>
+createMULTPVBOXDECK()
+{
+    auto deckString = std::string { R"(RUNSPEC
+
+TITLE
+   1D OIL WATER
+
+
+
+DIMENS
+   100 1 1 /
+
+EQLDIMS
+/
+TABDIMS
+  2 1 100 /
+
+OIL
+WATER
+
+ENDSCALE
+/
+
+METRIC
+
+START
+   1 'JAN' 2024 /
+
+WELLDIMS
+   3 3 2 2 /
+
+UNIFIN
+UNIFOUT
+
+GRID
+
+INIT
+
+DX 
+  100*1 /
+DY
+        100*10 /
+DZ
+  100*1 /
+
+TOPS
+  100*2000 /
+
+PORO
+  100*0.3 /
+
+BOX
+  11 100 1 1 1 1 /
+MULTPV
+  90*1.5 /
+ENDBOX
+
+EDIT
+PROPS
+SOLUTION
+SCHEDULE
+)"};
+    std::vector<float> expected(10, 1.);
+    expected.insert(expected.end(), 90, 1.5);
+    return { deckString, expected };
+}
+
+BOOST_AUTO_TEST_CASE(MULTPVBOXInit)
+{
+    checkMULTPV(createMULTPVBOXDECK());
 }

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -794,16 +794,30 @@ PORO
   100*0.3 /
 
 MULTPV
-  100*10 /  -- overwritten by the next
+  100*5 /  -- overwritten by the next MULTPV keyword
 
 MULTPV
-  70*1 10*1.5 20*1 /
+  100*10 /  -- partly overwritten by the next BOX statements
+
+BOX
+  69 75 1 1 1 1 /
+MULTPV
+  2*1 5*1.5 /
+ENDBOX
+
+BOX
+  76 85 1 1 1 1 /
+MULTPV
+  5*1.5 5*1 /
+ENDBOX
 
 EDIT
 )"};
-    std::vector<float> multpv(70, 1.);
+    std::vector<float> multpv(68, 10.);
+    multpv.insert(multpv.end(), 2, 1);
     multpv.insert(multpv.end(), 10, 1.5);
-    multpv.insert(multpv.end(), 20, 1.);
+    multpv.insert(multpv.end(), 5, 1.);
+    multpv.insert(multpv.end(), 15, 10.);
 
     if (edit) {
         deckString += std::string { R"(MULTPV


### PR DESCRIPTION
This output was missing from the init file previously. Now MULTPV will be output if it is specified in the GRID or EDIT section.

Support for MULTPV in the SCHEDULE section will be added in an upcoming PR. I need to sort out the parallel handling of that.