### PR TITLE
fixed: fix close_at_tolerance in test_binarycoefficients.cpp with old boost

### DIFF
--- a/tests/material/test_binarycoefficients.cpp
+++ b/tests/material/test_binarycoefficients.cpp
@@ -46,7 +46,11 @@
 template<class Scalar>
 bool close_at_tolerance(Scalar n1, Scalar n2, Scalar tolerance)
 {
+#if BOOST_VERSION / 100000 == 1 && BOOST_VERSION / 100 % 1000 < 64
+    auto comp = boost::test_tools::close_at_tolerance<Scalar>(boost::test_tools::percent_tolerance_t<Scalar>(tolerance*100.0));
+#else
     auto comp = boost::math::fpc::close_at_tolerance<Scalar>(tolerance);
+#endif
     return comp(n1, n2);
 }
 


### PR DESCRIPTION
this is copied from test_components.cpp and is necessary to fix build on RHEL7.