### PR TITLE
WELSEGS needs to be specified before COMPSEGS

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -918,6 +918,14 @@ bool Well::handleCOMPSEGS(const DeckKeyword& keyword,
                           const ScheduleGrid& grid,
                           const ParseContext& parseContext,
                           ErrorGuard& errors) {
+    if (!this->segments) {
+        throw OpmInputError{
+                fmt::format("WELSEGS must be specified for well {} "
+                            "before COMPSEGS being input.",
+                            this->name()),
+                keyword.location()
+        };
+    }
     auto [new_connections, new_segments] = Compsegs::processCOMPSEGS(
         keyword,
         *this->connections,


### PR DESCRIPTION
It does not address the situation that some segments are not specified within the WELSEGS keyword. 

It gives the following error message when WELSGES is missing totally, 
```
Error: Problem with keyword COMPSEGS
In /home/kaib/OPM-master-test/opm/opm-tests/model1/include/history_msw.sch line 52
WELSEGS needs to be specified for well PROD-2 before COMPSEGS being parsed.
```