### PR TITLE
Make SummaryState Objects Aware of Undefined UDQ Value

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -30,12 +30,14 @@
 #include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
 #include <opm/input/eclipse/Schedule/Action/SimulatorUpdate.hpp>
-#include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQState.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
@@ -70,9 +72,10 @@ namespace {
 namespace Opm {
 
 msim::msim(const EclipseState& state_arg, const Schedule& schedule_arg)
-    : state(state_arg)
+    : state   (state_arg)
     , schedule(schedule_arg)
-    , st(TimeService::from_time_t(this->schedule.getStartTime()))
+    , st { TimeService::from_time_t(this->schedule.getStartTime()),
+           state.runspec().udqParams().undefinedValue() }
 {}
 
 

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -32,6 +32,7 @@
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/input/eclipse/EclipseState/Phase.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
 #include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
@@ -44,6 +45,7 @@
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 #include <opm/input/eclipse/Schedule/UDQ/UDQContext.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
 #include <opm/input/eclipse/Schedule/VFPProdTable.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
@@ -4272,7 +4274,8 @@ SummaryImplementation(SummaryConfig&      sumcfg,
     , unif_          { es.cfg().io().getUNIFOUT() }
 {
     const auto st = SummaryState {
-        TimeService::from_time_t(sched.getStartTime())
+        TimeService::from_time_t(sched.getStartTime()),
+        es.runspec().udqParams().undefinedValue()
     };
 
     Evaluator::Factory evaluatorFactory {

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -44,18 +44,21 @@
 
 using namespace Opm;
 
+namespace {
 
-Opm::Schedule create_schedule(const std::string& deck_string) {
-    Opm::Parser parser;
-    auto python = std::make_shared<Python>();
-    auto deck = parser.parseString(deck_string);
-    EclipseGrid grid(10,10,10);
-    TableManager table ( deck );
-    FieldPropsManager fp( deck, Phases{true, true, true}, grid, table);
-    Runspec runspec (deck );
-    return Opm::Schedule(deck,  grid, fp, runspec, python);
+Schedule create_schedule(const std::string& deck_string)
+{
+    const auto deck = Parser{}.parseString(deck_string);
+
+    const EclipseGrid grid(10, 10, 10);
+    const TableManager table(deck);
+    const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
+    const Runspec runspec(deck);
+
+    return { deck, grid, fp, runspec, std::make_shared<Python>() };
 }
 
+} // Anonymous namespace
 
 BOOST_AUTO_TEST_CASE(CreateGroup_CorrectNameAndDefaultValues) {
     Opm::Group group("G1" , 1, 0, UnitSystem::newMETRIC());
@@ -244,7 +247,7 @@ GCONPROD
 )";
 
     auto schedule = create_schedule(input);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), 0.0);
     double metric_to_si = 1.0 / (24.0 * 3600.0);  //cubic meters / day
     double oil_rate_si = 10000 * metric_to_si;
 
@@ -404,7 +407,7 @@ GCONSUMP
 
     auto schedule = create_schedule(input);
     double metric_to_si = 1.0 / (24.0 * 3600.0);  //cubic meters / day
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), 0.0);
 
     {
         const auto& gconsale = schedule[0].gconsale.get();
@@ -502,7 +505,7 @@ GCONINJE
 /)";
 
     auto schedule = create_schedule(input);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), 0.0);
     // Step 0
     {
         const auto& g1 = schedule.getGroup("G1", 0);

--- a/tests/parser/ScheduleRestartTests.cpp
+++ b/tests/parser/ScheduleRestartTests.cpp
@@ -160,10 +160,16 @@ BOOST_AUTO_TEST_CASE(LoadRestartSim) {
 }
 
 
-BOOST_AUTO_TEST_CASE(LoadUDQRestartSim) {
-    const auto& [sched, restart_sched, rst_state] = load_schedule_pair("UDQ_WCONPROD.DATA", "UDQ_WCONPROD_RESTART.DATA", "UDQ_WCONPROD.X0006", 6);
+BOOST_AUTO_TEST_CASE(LoadUDQRestartSim)
+{
+    const auto& [sched, restart_sched, rst_state] =
+        load_schedule_pair("UDQ_WCONPROD.DATA",
+                           "UDQ_WCONPROD_RESTART.DATA",
+                           "UDQ_WCONPROD.X0006", 6);
+
     std::size_t report_step = 10;
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), rst_state.header.udq_undefined);
+
     st.update_well_var("OPL02", "WUOPRL", 1);
     st.update_well_var("OPL02", "WULPRL", 11);
     st.update_well_var("OPU02", "WUOPRU", 111);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -1335,7 +1335,7 @@ I1 THP 4 /
     double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
     double siFactorG = unitSystem.parse("GasSurfaceVolume/Time").getSIScaling();
     double siFactorP = unitSystem.parse("Pressure").getSIScaling();
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), 0.0);
 
     const auto& well_1 = schedule.getWell("OP_1", 1);
     const auto wpp_1 = well_1.getProductionProperties();
@@ -1425,7 +1425,7 @@ WELTARG
 )";
 
     const auto& schedule = make_schedule(input);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), 0.0);
     Opm::UnitSystem unitSystem = UnitSystem( UnitSystem::UnitType::UNIT_TYPE_METRIC );
     double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
 
@@ -1876,7 +1876,7 @@ BOOST_AUTO_TEST_CASE(createDeckModifyMultipleGCONPROD) {
         )";
 
         const auto& schedule = make_schedule(input);
-        Opm::SummaryState st(TimeService::now());
+        Opm::SummaryState st(TimeService::now(), 0.0);
 
         Opm::UnitSystem unitSystem = UnitSystem(UnitSystem::UnitType::UNIT_TYPE_METRIC);
         double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time").getSIScaling();
@@ -2163,7 +2163,7 @@ WCONINJH
 )";
 
     const auto& sched = make_schedule(input);
-    const auto st = ::Opm::SummaryState{ TimeService::now() };
+    const auto st = ::Opm::SummaryState{ TimeService::now(), 0.0 };
     UnitSystem unit_system(UnitSystem::UnitType::UNIT_TYPE_METRIC);
 
     // The BHP limit should not be effected by WCONHIST
@@ -4380,7 +4380,7 @@ END
 )";
 
     const auto sched = make_schedule(input);
-    const auto st = ::Opm::SummaryState{ TimeService::now() };
+    const auto st = ::Opm::SummaryState{ TimeService::now(), 0.0 };
 
     BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W1", 10), st), -1);
     BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W2", 10), st), 3);
@@ -4436,7 +4436,7 @@ END
 )";
 
     const auto sched = make_schedule(input);
-    const auto st = ::Opm::SummaryState{ TimeService::now() };
+    const auto st = ::Opm::SummaryState{ TimeService::now(), 0.0 };
 
     BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W1", 10), st), -1);
     BOOST_CHECK_EQUAL(Well::eclipseControlMode(sched.getWell("W2", 10), st), 1);
@@ -5434,7 +5434,7 @@ WCONPROD
     auto       sched = Schedule{ deck, es };
     const auto& well1 = sched.getWell("P1", 0);
     const auto& well2 = sched.getWell("P2", 0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), 0.0);
 
     st.update("FU_GAS", 123);
     const auto& controls1 = well1.productionControls(st);

--- a/tests/parser/UDQTests.cpp
+++ b/tests/parser/UDQTests.cpp
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(GROUP_VARIABLES)
     UDQParams udqp;
     UDQFunctionTable udqft;
     UDQDefine def_group(udqp, "GUOPRL", 0, location, {"(", "5000",  "-",  "GOPR",  "LOWER",  "*", "0.13",  "-",  "GOPR",  "UPPER",  "*", "0.15", ")" , "*",  "0.89"});
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, {}, {}, UDQContext::MatcherFactories{}, st, udq_state);
     double gopr_lower = 1234;
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(SINGLE_SEGMENT_VARIABLES)
         { "(", "5000", "-", "SOFR", "'OP-*'", "3", "*", "0.13", ")" , "*",  "0.89" }
     };
 
-    auto st = SummaryState { TimeService::now() };
+    auto st = SummaryState { TimeService::now(), udqp.undefinedValue() };
     auto udq_state = UDQState { udqp.undefinedValue() };
 
     auto factories = UDQContext::MatcherFactories{};
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(SUBTRACT)
     UDQDefine def(udqp, "WU", 0, location, {"16", "-", "8", "-", "4", "-", "2", "-", "1"});
     UDQDefine scalar(udqp, "WU", 0, location, {"16"});
 
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"P1"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(TEST)
     UDQDefine def3(udqp, "WUWI3",0, location, {"GOPR" , "FIELD", "-", "2.0", "*", "3"});
     UDQDefine def4(udqp, "WUWI3",0, location, {"FOPR" , "/",  "2"});
 
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"P1", "P2"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(MIX_SCALAR) {
     UDQParams udqp;
     KeywordLocation location;
     UDQDefine def_add(udqp, "WU",0, location, {"WOPR", "+", "1"});
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"P1"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE(UDQFieldSetTest) {
     KeywordLocation location;
     UDQParams udqp;
     UDQFunctionTable udqft(udqp);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"P1", "P2", "P3", "P4"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -442,7 +442,7 @@ BOOST_AUTO_TEST_CASE(UDQ_GROUP_TEST) {
         UDQParams udqp;
         UDQFunctionTable udqft(udqp);
         UDQDefine def_fopr(udqp, "FUOPR",0, location, {"SUM", "(", "GOPR", ")"});
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), udqp.undefinedValue());
         UDQState udq_state(udqp.undefinedValue());
         UDQContext context(udqft, {}, {}, UDQContext::MatcherFactories{}, st, udq_state);
 
@@ -463,7 +463,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     KeywordLocation location;
     {
         UDQDefine def(udqp, "WUBHP",0, location, {"WBHP"});
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), udqp.undefinedValue());
         UDQState udq_state(udqp.undefinedValue());
         WellMatcher wm(NameOrder({"W1", "W2", "W3"}));
         UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -483,7 +483,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     }
     {
         UDQDefine def(udqp, "WUBHP",0, location, {"WBHP" , "'P*'"});
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), udqp.undefinedValue());
         UDQState udq_state(udqp.undefinedValue());
         WellMatcher wm(NameOrder({"I1", "I2", "P1", "P2"}));
         UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DEFINETEST) {
     }
     {
         UDQDefine def(udqp, "WUBHP",0, location, {"NINT" , "(", "WBHP", ")"});
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), udqp.undefinedValue());
         UDQState udq_state(udqp.undefinedValue());
         WellMatcher wm(NameOrder({"P1", "P2", "I1", "I2"}));
         UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -702,9 +702,9 @@ ASSIGN WU2 8.0 /
 }
 
 BOOST_AUTO_TEST_CASE(UDQ_CONTEXT) {
-    SummaryState st(TimeService::now());
-    UDQFunctionTable func_table;
     UDQParams udqp;
+    UDQFunctionTable func_table;
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext ctx(func_table, {}, {}, UDQContext::MatcherFactories{}, st, udq_state);
     BOOST_CHECK_EQUAL(*ctx.get("JAN"), 1.0);
@@ -1159,7 +1159,7 @@ BOOST_AUTO_TEST_CASE(UDQ_POW_TEST) {
     UDQParams udqp;
     UDQDefine def_pow1(udqp, "WU",0, location, {"WOPR", "+", "WWPR", "*", "WGOR", "^", "WWIR"});
     UDQDefine def_pow2(udqp, "WU",0, location, {"(", "WOPR", "+", "WWPR", ")", "^", "(", "WOPR", "+" , "WGOR", "*", "WWIR", "-", "WBHP", ")"});
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     NameOrder wo; wo.add("P1");
     WellMatcher wm(wo);
@@ -1182,7 +1182,7 @@ BOOST_AUTO_TEST_CASE(UDQ_CMP_TEST) {
     UDQFunctionTable udqft;
     UDQParams udqp;
     UDQDefine def_cmp(udqp, "WU",0, location, {"WOPR", ">", "WWPR", "+", "WGOR", "*", "WWIR"});
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"P1", "P2"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -1213,7 +1213,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SCALAR_SET) {
     KeywordLocation location;
     UDQParams udqp;
     UDQFunctionTable udqft;
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"PA1", "PB2", "PC3", "PD4"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -1284,7 +1284,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SORTD_NAN) {
     KeywordLocation location;
     UDQDefine def(udqp, "WUPR1" ,0, location, {"1", "/", "(", "WWIR", "'OP*'" , ")"});
     UDQDefine def_sort(udqp , "WUPR3",0, location, {"SORTD", "(", "WUPR1", ")" });
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"OP1", "OP2", "OP3", "OP4"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -1329,7 +1329,7 @@ BOOST_AUTO_TEST_CASE(UDQ_SORTA) {
     UDQFunctionTable udqft;
     UDQDefine def1(udqp, "WUPR1" ,0, location, {"1", "/", "(", "WWCT", "'OP*'", "+", "0.00001", ")"});
     UDQDefine def_sort(udqp , "WUPR3",0, location, {"SORTA", "(", "WUPR1", ")" });
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"OPL01", "OPL02", "OPU01", "OPU02"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -1358,7 +1358,7 @@ BOOST_AUTO_TEST_CASE(UDQ_BASIC_MATH_TEST) {
     UDQDefine def_div(udqp, "WU2OPR",0, location, {"WOPR", "/", "WOPR"});
     UDQDefine def_muladd(udqp, "WUX",0, location, {"WOPR", "+", "WOPR", "*", "WOPR"});
     UDQDefine def_wuwct(udqp , "WUWCT",0, location, {"WWPR", "/", "(", "WOPR", "+", "WWPR", ")"});
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"P1", "P2", "P3", "P4"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -1421,7 +1421,7 @@ BOOST_AUTO_TEST_CASE(DECK_TEST) {
     UDQParams udqp;
     UDQFunctionTable udqft(udqp);
     UDQDefine def(udqp, "WUOPRL",0, location, {"(", "WOPR", "OP1", "-", "150", ")", "*", "0.90"});
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"OP1", "OP2", "OP3"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -1475,7 +1475,7 @@ BOOST_AUTO_TEST_CASE(UDQ_PARSE_ERROR) {
     parseContext.update(ParseContext::UDQ_PARSE_ERROR, InputErrorAction::IGNORE);
     {
         UDQDefine def1(udqp, "WUBHP",0, location, tokens, parseContext, errors);
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), udqp.undefinedValue());
         UDQFunctionTable udqft(udqp);
         UDQState udq_state(udqp.undefinedValue());
         WellMatcher wm(NameOrder({"P1"}));
@@ -1502,7 +1502,7 @@ BOOST_AUTO_TEST_CASE(UDQ_TYPE_ERROR) {
         UDQDefine def1(udqp, "FUBHP",0, location, tokens1, parseContext, errors);
         UDQDefine def2(udqp, "WUBHP",0, location, tokens2, parseContext, errors);
 
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), udqp.undefinedValue());
         UDQFunctionTable udqft(udqp);
         UDQState udq_state(udqp.undefinedValue());
         WellMatcher wm(NameOrder({"P1", "P2"}));
@@ -1960,7 +1960,7 @@ UDQ
     const auto& udq = schedule.getUDQConfig(0);
     UDQParams udqp;
     auto def0 = udq.definitions()[0];
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQFunctionTable udqft(udqp);
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, {}, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -1985,7 +1985,7 @@ UDQ
     auto def0 = udq.definitions()[0];
     auto def1 = udq.definitions()[1];
     auto def2 = udq.definitions()[2];
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQFunctionTable udqft(udqp);
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, {}, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -2027,7 +2027,7 @@ UDQ
     UDQParams udqp;
     auto def0 = udq.definitions()[0];
     auto def1 = udq.definitions()[1];
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQFunctionTable udqft(udqp);
     UDQState udq_state(udqp.undefinedValue());
     WellMatcher wm(NameOrder({"W1", "W2", "W3"}));
@@ -2066,8 +2066,8 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    SummaryState st(TimeService::now());
-    auto undefined_value =  udq.params().undefinedValue();
+    const auto undefined_value =  udq.params().undefinedValue();
+    SummaryState st(TimeService::now(), undefined_value);
     UDQState udq_state(undefined_value);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
@@ -2093,8 +2093,8 @@ DEFINE FU_PAR2 FU_PAR3 /
 )";
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    SummaryState st(TimeService::now());
-    auto undefined_value =  udq.params().undefinedValue();
+    const auto undefined_value =  udq.params().undefinedValue();
+    SummaryState st(TimeService::now(), undefined_value);
     UDQState udq_state(undefined_value);
     st.update("FMWPR", 100);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
@@ -2114,8 +2114,8 @@ DEFINE FU_PAR3 FU_PAR2 + 1/
 )";
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    SummaryState st(TimeService::now());
-    auto undefined_value =  udq.params().undefinedValue();
+    const auto undefined_value =  udq.params().undefinedValue();
+    SummaryState st(TimeService::now(), undefined_value);
     UDQState udq_state(undefined_value);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
@@ -2213,9 +2213,9 @@ DEFINE WUGASRA  750000 - WGLIR '*' /
 )";
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    auto undefined_value =  udq.params().undefinedValue();
+    const auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), undefined_value);
 
     st.update("TIMESTEP", 100);
     st.update("FMWPR", 100);
@@ -2433,9 +2433,9 @@ DEFINE FU_VAR91 GOPR TEST  /
 )";
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    auto undefined_value =  udq.params().undefinedValue();
+    const auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), undefined_value);
     st.update("FMWPR", 100);
     st.update("FMWIN", 100);
     st.update("FMWPA", 100);
@@ -2464,9 +2464,9 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    auto undefined_value =  udq.params().undefinedValue();
+    const auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), undefined_value);
 
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
@@ -2486,9 +2486,9 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     const auto& udq = schedule.getUDQConfig(0);
-    auto undefined_value =  udq.params().undefinedValue();
+    const auto undefined_value =  udq.params().undefinedValue();
     UDQState udq_state(undefined_value);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), undefined_value);
 
     const auto required_keys = [&udq]()
     {
@@ -2544,7 +2544,7 @@ TSTEP
 
     auto schedule = make_schedule(deck_string);
     UDQState udq_state(0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), schedule.back().udq().params().undefinedValue());
 
     // Counting: 1,2,3,4,5
     for (std::size_t report_step = 0; report_step < 5; report_step++) {
@@ -2593,7 +2593,7 @@ BOOST_AUTO_TEST_CASE(UDQ_DIV_TEST) {
     UDQFunctionTable udqft;
     UDQParams udqp;
     UDQDefine def_div(udqp, "FU",0, location, {"128", "/", "2", "/", "4", "/", "8"});
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), udqp.undefinedValue());
     UDQState udq_state(udqp.undefinedValue());
     UDQContext context(udqft, {}, {}, UDQContext::MatcherFactories{}, st, udq_state);
 
@@ -2619,7 +2619,7 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     UDQState udq_state(0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), schedule.back().udq().params().undefinedValue());
 
     const auto& udq = schedule.getUDQConfig(0);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
@@ -2662,7 +2662,7 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     UDQState udq_state(0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), schedule.back().udq().params().undefinedValue());
     const auto& udq = schedule.getUDQConfig(0);
     st.update_well_var("P1", "WOPR", 1);
     st.update_well_var("P2", "WOPR", 2);
@@ -2695,7 +2695,7 @@ UDQ
 
     auto schedule = make_schedule(deck_string);
     UDQState udq_state(0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), schedule.back().udq().params().undefinedValue());
     const auto& udq = schedule.getUDQConfig(0);
     auto segmentMatcherFactory = []() { return std::make_unique<SegmentMatcher>(ScheduleState {}); };
     auto regionSetMatcherFactory = []() { return std::make_unique<RegionSetMatcher>(FIPRegionStatistics {}); };
@@ -2763,7 +2763,7 @@ TSTEP
     BOOST_CHECK_THROW(make_schedule(invalid1), std::exception);
     auto schedule = make_schedule(valid);
     UDQState udq_state(0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), schedule.back().udq().params().undefinedValue());
     UDQSet result = UDQSet::scalar("RES", 0);
     {
         const auto& udq = schedule.getUDQConfig(0);
@@ -2820,11 +2820,9 @@ UDQ
 
 )";
 
-
-
     auto schedule = make_schedule(valid);
     UDQState udq_state(0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), schedule.back().udq().params().undefinedValue());
     UDQFunctionTable udqft;
     WellMatcher wm(NameOrder({"W1", "W2", "W3"}));
     UDQContext context(udqft, wm, {}, UDQContext::MatcherFactories{}, st, udq_state);
@@ -2892,7 +2890,7 @@ BOOST_AUTO_TEST_CASE(UDQ_ASSIGN_SEGMENT)
 
 BOOST_AUTO_TEST_CASE(UDQ_Update_SummaryState)
 {
-    auto st = SummaryState { TimeService::now() };
+    auto st = SummaryState { TimeService::now(), 0.0 };
 
     // P2 not yet online
     st.update_well_var("P1", "WBHP",  42.0);
@@ -2940,7 +2938,7 @@ DEFINE FU_WBHP TU_FBHP[FU_FOPR] UMIN FU_WBHP0 /
 
     auto schedule = make_schedule(valid);
     UDQState udq_state(0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), schedule.back().udq().params().undefinedValue());
     UDQFunctionTable udqft;
     WellMatcher wm(NameOrder({"W1", "W2", "W3"}));
     const auto& udq = schedule.getUDQConfig(0);
@@ -2986,7 +2984,7 @@ DEFINE WU_WBHP TU_FBHP[WOPR] UMIN WU_WBHP0 /
 
     auto schedule = make_schedule(valid);
     UDQState udq_state(0);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), schedule.back().udq().params().undefinedValue());
     UDQFunctionTable udqft;
     WellMatcher wm(NameOrder({"PROD1", "PROD2"}));
     const auto& udq = schedule.getUDQConfig(0);

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -658,8 +658,8 @@ namespace {
 
 BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
 {
-    Opm::SummaryState st(TimeService::now());
-    const Opm::Well::WellProductionProperties& p =
+    Opm::SummaryState st(TimeService::now(), 0.0);
+    const Opm::Well::WellProductionProperties p =
         WCONHIST::properties(WCONHIST::all_specified());
 
     BOOST_CHECK(p.hasProductionControl(Opm::Well::ProducerCMode::ORAT));
@@ -678,8 +678,8 @@ BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
 
 BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
 {
-    Opm::SummaryState st(TimeService::now());
-    const Opm::Well::WellProductionProperties& p =
+    Opm::SummaryState st(TimeService::now(), 0.0);
+    const Opm::Well::WellProductionProperties p =
         WCONHIST::properties(WCONHIST::orat_defaulted());
 
     BOOST_CHECK( !p.hasProductionControl(Opm::Well::ProducerCMode::ORAT));
@@ -696,8 +696,8 @@ BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
 
 BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
 {
-    Opm::SummaryState st(TimeService::now());
-    const Opm::Well::WellProductionProperties& p =
+    Opm::SummaryState st(TimeService::now(), 0.0);
+    const Opm::Well::WellProductionProperties p =
         WCONHIST::properties(WCONHIST::owrat_defaulted());
 
     BOOST_CHECK( !p.hasProductionControl(Opm::Well::ProducerCMode::ORAT));
@@ -714,8 +714,8 @@ BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
 {
-    Opm::SummaryState st(TimeService::now());
-    const Opm::Well::WellProductionProperties& p =
+    Opm::SummaryState st(TimeService::now(), 0.0);
+    const Opm::Well::WellProductionProperties p =
         WCONHIST::properties(WCONHIST::all_defaulted());
 
     BOOST_CHECK( !p.hasProductionControl(Opm::Well::ProducerCMode::ORAT));
@@ -732,8 +732,8 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
 {
-    Opm::SummaryState st(TimeService::now());
-    const Opm::Well::WellProductionProperties& p =
+    Opm::SummaryState st(TimeService::now(), 0.0);
+    const Opm::Well::WellProductionProperties p =
         WCONHIST::properties(WCONHIST::all_defaulted_with_bhp());
 
     BOOST_CHECK( !p.hasProductionControl(Opm::Well::ProducerCMode::ORAT));
@@ -751,8 +751,8 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_NON_Defaulted_VFP)
 {
-    Opm::SummaryState st(TimeService::now());
-    const Opm::Well::WellProductionProperties& p =
+    Opm::SummaryState st(TimeService::now(), 0.0);
+    const Opm::Well::WellProductionProperties p =
         WCONHIST::properties(WCONHIST::all_defaulted_with_bhp_vfp_table(), VFPProdTable::ALQ_TYPE::ALQ_UNDEF);
 
     BOOST_CHECK( !p.hasProductionControl(Opm::Well::ProducerCMode::ORAT));
@@ -772,8 +772,8 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_NON_Defaulted_VFP)
 
 BOOST_AUTO_TEST_CASE(WCH_BHP_Specified)
 {
-    Opm::SummaryState st(TimeService::now());
-    const Opm::Well::WellProductionProperties& p =
+    Opm::SummaryState st(TimeService::now(), 0.0);
+    const Opm::Well::WellProductionProperties p =
         WCONHIST::properties(WCONHIST::bhp_defaulted());
 
     BOOST_CHECK( !p.hasProductionControl(Opm::Well::ProducerCMode::ORAT));
@@ -880,7 +880,7 @@ BOOST_AUTO_TEST_CASE(WELL_CONTROLS) {
     auto unit_system = UnitSystem::newMETRIC();
     Opm::Well well("WELL", "GROUP", 0, 0, 0, 0, 1000, Opm::WellType(Opm::Phase::OIL), Opm::Well::ProducerCMode::CMODE_UNDEFINED, Opm::Connection::Order::DEPTH, unit_system, 0, 1.0, false, false, 0, Opm::Well::GasInflowEquation::STD);
     Opm::Well::WellProductionProperties prod(unit_system, "OP1");
-    Opm::SummaryState st(Opm::TimeService::now());
+    Opm::SummaryState st(Opm::TimeService::now(), 0.0);
     well.productionControls(st);
 
     // Use a scalar FIELD variable - that should work; although it is a bit weird.

--- a/tests/test_AggregateActionxData.cpp
+++ b/tests/test_AggregateActionxData.cpp
@@ -60,9 +60,9 @@ namespace {
         return Opm::Parser{}.parseFile(fname);
     }
 
-    Opm::SummaryState sum_state_TEST1()
+    Opm::SummaryState sum_state_TEST1(const double udqUndef)
     {
-        auto state = Opm::SummaryState{Opm::TimeService::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now(), udqUndef};
         state.update_well_var("OPU01", "WWPR", 21.);
         state.update_well_var("OPU02", "WWPR", 22.);
         state.update_well_var("OPL01", "WWPR", 23.);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
     const auto simCase = SimulationCase {first_sim("UDQ_ACTIONX_TEST1.DATA")};
 
     const auto& es = simCase.es;
-    const auto st = sum_state_TEST1();
+    const auto st = sum_state_TEST1(es.runspec().udqParams().undefinedValue());
     const auto udq_state = Opm::UDQState{1};
     const auto& sched = simCase.sched;
     const auto& grid = simCase.grid;
@@ -1078,7 +1078,11 @@ BOOST_AUTO_TEST_CASE(Declared_Actionx_data)
                 auto year = 2020;
                 auto day = 1;
                 for (std::size_t month = 1; month <= 12; month++) {
-                    auto state = Opm::SummaryState {Opm::asTimePoint(Opm::TimeStampUTC(year, month, day))};
+                    auto state = Opm::SummaryState {
+                        Opm::asTimePoint(Opm::TimeStampUTC(year, month, day)),
+                        es.runspec().udqParams().undefinedValue()
+                    };
+
                     Opm::Action::Context context(state, wlm);
                     for (const auto& key : rst_keys) {
                         const auto& first_char = key[0];
@@ -1185,7 +1189,7 @@ END
     const auto action_state = Opm::Action::State {};
     const auto simStep = 5;
 
-    auto smstate = Opm::SummaryState { Opm::TimeService::now() };
+    auto smstate = Opm::SummaryState { Opm::TimeService::now(), 0.0 };
     smstate.update("DAY", 3);
     smstate.update("MNTH", 5);
     smstate.update("YEAR", 2024);

--- a/tests/test_AggregateAquiferData.cpp
+++ b/tests/test_AggregateAquiferData.cpp
@@ -613,7 +613,7 @@ AQUANCON
 
     Opm::SummaryState sim_state()
     {
-        auto state = Opm::SummaryState{Opm::TimeService::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now(), 0.0};
 
         state.update("AAQP:1", 123.456);
         state.update("AAQR:1", 234.567);
@@ -648,7 +648,7 @@ AQUANCON
 
     Opm::SummaryState aqunum_sim_state()
     {
-        auto state = Opm::SummaryState{Opm::TimeService::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now(), 0.0};
 
         state.update("ANQP:1", 123.456);
         state.update("ANQR:1", 234.567);

--- a/tests/test_AggregateConnectionData.cpp
+++ b/tests/test_AggregateConnectionData.cpp
@@ -511,7 +511,7 @@ END
         using o = ::Opm::data::Rates::opt;
 
         auto xw = ::Opm::data::Wells {};
-        Opm::SummaryState sum_state(Opm::TimeService::now());
+        Opm::SummaryState sum_state(Opm::TimeService::now(), 0.0);
 
         {
             xw["PROD"].rates.set(o::wat, 1.0).set(o::oil, 2.0).set(o::gas, 3.0);
@@ -998,7 +998,7 @@ END
         auto dyn_state = std::pair<Opm::data::Wells, Opm::SummaryState> {
             std::piecewise_construct,
             std::forward_as_tuple(),
-            std::forward_as_tuple(Opm::TimeService::now())
+            std::forward_as_tuple(Opm::TimeService::now(), 0.0)
         };
 
         using o = ::Opm::data::Rates::opt;

--- a/tests/test_AggregateGroupData.cpp
+++ b/tests/test_AggregateGroupData.cpp
@@ -18,27 +18,32 @@
 */
 
 #define BOOST_TEST_MODULE Aggregate_Group_Data
+
 #include <opm/output/eclipse/AggregateGroupData.hpp>
-#include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <boost/test/unit_test.hpp>
 
 #include <opm/output/eclipse/AggregateWellData.hpp>
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/VectorItems/group.hpp>
 #include <opm/output/eclipse/VectorItems/well.hpp>
-#include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/output/data/Wells.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
+
 #include <opm/common/utility/TimeService.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <cstddef>
 #include <exception>
@@ -447,7 +452,7 @@ Opm::Deck first_sim()
 
 Opm::SummaryState sim_state()
 {
-    auto state = Opm::SummaryState {Opm::TimeService::now()};
+    auto state = Opm::SummaryState {Opm::TimeService::now(), 0.0};
 
     state.update_group_var("GRP1", "GOPR",   235.);
     state.update_group_var("GRP1", "GGPR",   100237.);
@@ -491,7 +496,7 @@ Opm::SummaryState sim_state()
 
 Opm::SummaryState sim_state_2()
 {
-    auto state = Opm::SummaryState {Opm::TimeService::now()};
+    auto state = Opm::SummaryState {Opm::TimeService::now(), 0.0};
     state.update_group_var("UPPER", "GMCTP", -1.);
     state.update_group_var("UPPER", "GMCTW",  0.);
     state.update_group_var("UPPER", "GMCTG",  0.);
@@ -554,7 +559,7 @@ Opm::SummaryState sim_state_2()
 
 Opm::SummaryState sim_state_3()
 {
-    auto state = Opm::SummaryState {Opm::TimeService::now()};
+    auto state = Opm::SummaryState {Opm::TimeService::now(), 0.0};
 
     state.update("FMCTP", 0.0);  // FIELD: Production mode NONE
     state.update("FMCTW", 3.0);  // FIELD: Injection mode VREP for water

--- a/tests/test_AggregateMSWData.cpp
+++ b/tests/test_AggregateMSWData.cpp
@@ -64,9 +64,9 @@ Opm::Deck first_sim(const std::string& fname)
     return Opm::Parser {}.parseFile(fname);
 }
 
-Opm::SummaryState sim_state()
+Opm::SummaryState sim_state(const double udqUndef)
 {
-     auto state = Opm::SummaryState{Opm::TimeService::now()};
+    auto state = Opm::SummaryState{Opm::TimeService::now(), udqUndef};
 
     state.update("SPR:PROD:1",   235.);
     state.update("SPR:PROD:2",   237.);
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE (Constructor)
 
     Opm::EclipseState es = simCase.es;
     Opm::Runspec rspec   = es.runspec();
-    Opm::SummaryState st = sim_state();
+    Opm::SummaryState st = sim_state(rspec.udqParams().undefinedValue());
     Opm::Schedule     sched = simCase.sched;
     Opm::EclipseGrid  grid = simCase.grid;
 
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE (Declared_MSW_Data)
     const auto& grid  = simCase.grid;
     const auto& sched = simCase.sched;
     const auto& units = es.getUnits();
-    const auto  smry  = sim_state();
+    const auto  smry  = sim_state(es.runspec().udqParams().undefinedValue());
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t {1};
@@ -622,7 +622,10 @@ BOOST_AUTO_TEST_CASE(Multilateral_Branches)
     const auto& grid  = cse.grid;
     const auto& sched = cse.sched;
     const auto& units = es.getUnits();
-    const auto  smry  = Opm::SummaryState { Opm::TimeService::now() };
+    const auto  smry  = Opm::SummaryState {
+        Opm::TimeService::now(),
+        es.runspec().udqParams().undefinedValue()
+    };
 
     // Report Step 1: 2023-09-29 --> 2023-10-23
     const auto rptStep = std::size_t {1};
@@ -746,7 +749,10 @@ BOOST_AUTO_TEST_CASE(Multilateral_Segments_ISEG_0)
     const auto& grid  = cse.grid;
     const auto& sched = cse.sched;
     const auto& units = es.getUnits();
-    const auto  smry  = Opm::SummaryState { Opm::TimeService::now() };
+    const auto  smry  = Opm::SummaryState {
+        Opm::TimeService::now(),
+        es.runspec().udqParams().undefinedValue()
+    };
 
     // Report Step 1: 2023-09-29 --> 2023-10-23
     const auto rptStep = std::size_t {1};
@@ -819,7 +825,10 @@ BOOST_AUTO_TEST_CASE(Multilateral_Branches_ICD_Valve)
 
     // No dynamic data needed for this test.  We're checking the structure
     // only.
-    const auto smry = Opm::SummaryState { Opm::TimeService::now() };
+    const auto smry = Opm::SummaryState {
+        Opm::TimeService::now(),
+        es.runspec().udqParams().undefinedValue()
+    };
     const auto xw   = Opm::data::Wells {};
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
@@ -992,7 +1001,10 @@ BOOST_AUTO_TEST_CASE(Multilateral_ICD_Valve_ISEG_0)
 
     // No dynamic data needed for this test.  We're checking the structure
     // only.
-    const auto smry = Opm::SummaryState { Opm::TimeService::now() };
+    const auto smry = Opm::SummaryState {
+        Opm::TimeService::now(),
+        es.runspec().udqParams().undefinedValue()
+    };
     const auto xw   = Opm::data::Wells {};
 
     auto amswd = Opm::RestartIO::Helpers::AggregateMSWData {ih};
@@ -1036,7 +1048,7 @@ BOOST_AUTO_TEST_CASE(MSW_AICD)
     const auto& grid  = simCase.grid;
     const auto& sched = simCase.sched;
     const auto& units = es.getUnits();
-    const auto  smry  = sim_state();
+    const auto  smry  = sim_state(es.runspec().udqParams().undefinedValue());
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t {1};
@@ -1129,7 +1141,7 @@ BOOST_AUTO_TEST_CASE(MSW_RST)
     const auto& grid  = simCase.grid;
     const auto& sched = simCase.sched;
     const auto& units = es.getUnits();
-    const auto  smry  = sim_state();
+    const auto  smry  = sim_state(es.runspec().udqParams().undefinedValue());
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t {1};

--- a/tests/test_AggregateNetworkData.cpp
+++ b/tests/test_AggregateNetworkData.cpp
@@ -18,17 +18,20 @@
 */
 
 #define BOOST_TEST_MODULE Aggregate_Group_Data
-#include <opm/output/eclipse/AggregateGroupData.hpp>
-#include <opm/output/eclipse/AggregateNetworkData.hpp>
-#include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <boost/test/unit_test.hpp>
+
+#include <opm/output/eclipse/AggregateNetworkData.hpp>
+
+#include <opm/output/eclipse/AggregateGroupData.hpp>
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
 
 #include <opm/output/eclipse/AggregateWellData.hpp>
 
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/VectorItems/group.hpp>
 #include <opm/output/eclipse/VectorItems/well.hpp>
+
 #include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/output/data/Wells.hpp>
@@ -43,14 +46,13 @@
 #include <opm/common/utility/TimeService.hpp>
 
 #include <exception>
+#include <memory>
 #include <stdexcept>
 #include <utility>
 #include <vector>
-#include <iostream>
 #include <cstddef>
 
 namespace {
-
 
     Opm::Deck first_sim(std::string fname) {
         return Opm::Parser{}.parseFile(fname);
@@ -58,7 +60,7 @@ namespace {
 
     Opm::SummaryState sum_state()
     {
-        auto state = Opm::SummaryState{Opm::TimeService::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now(), 0.0};
 
         state.update_well_var("P1", "WOPR", 3342.673828);
         state.update_well_var("P1", "WWPR", 0.000005);
@@ -95,21 +97,18 @@ struct SimulationCase
     explicit SimulationCase(const Opm::Deck& deck)
         : es   ( deck )
         , grid { deck }
-        , python( std::make_shared<Opm::Python>() )
-        , sched (deck, es, python )
+        , sched(deck, es, std::make_shared<Opm::Python>())
     {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
     Opm::EclipseState es;
     Opm::EclipseGrid  grid;
-    std::shared_ptr<Opm::Python> python;
     Opm::Schedule     sched;
 };
 
 // =====================================================================
 
 BOOST_AUTO_TEST_SUITE(Aggregate_Network)
-
 
 // test dimensions of multisegment data
 BOOST_AUTO_TEST_CASE (Constructor)

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -144,9 +144,9 @@ namespace {
         return state;
     }
 
-    Opm::SummaryState sum_state()
+    Opm::SummaryState sum_state(const double udqUndef)
     {
-        auto state = Opm::SummaryState{Opm::TimeService::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now(), udqUndef};
         state.update_well_var("PROD1", "WUOPRL", 210.);
         state.update_well_var("PROD2", "WUOPRL", 211.);
         state.update_well_var("WINJ1", "WUOPRL", 212.);
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
     const auto simCase = SimulationCase{first_sim("UDQ_TEST_WCONPROD_IUAD-2.DATA")};
 
     Opm::EclipseState es = simCase.es;
-    Opm::SummaryState st = sum_state();
+    Opm::SummaryState st = sum_state(es.runspec().udqParams().undefinedValue());
     Opm::UDQState     udq_state = make_udq_state();
     Opm::Schedule     sched = simCase.sched;
     Opm::EclipseGrid  grid = simCase.grid;
@@ -930,7 +930,7 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data_2)
     const auto simCase = SimulationCase{first_sim("9_4C_WINJ_GINJ_UDQ_MSW-UDARATE_TEST_PACK.DATA")};
 
     Opm::EclipseState es = simCase.es;
-    Opm::SummaryState st = sum_state();
+    Opm::SummaryState st = sum_state(es.runspec().udqParams().undefinedValue());
     Opm::UDQState     udq_state = make_udq_state();
     Opm::Schedule     sched = simCase.sched;
     Opm::EclipseGrid  grid = simCase.grid;

--- a/tests/test_AggregateWellData.cpp
+++ b/tests/test_AggregateWellData.cpp
@@ -677,7 +677,7 @@ TSTEP            -- 3
 
     Opm::SummaryState sim_state()
     {
-        auto state = Opm::SummaryState{Opm::TimeService::now()};
+        auto state = Opm::SummaryState{Opm::TimeService::now(), 0.0};
 
         state.update_well_var("OP_1", "WOPR" ,    1.0);
         state.update_well_var("OP_1", "WWPR" ,    2.0);
@@ -1750,7 +1750,7 @@ BOOST_AUTO_TEST_CASE(WELL_POD)
     const auto rptStep = std::size_t{2};
     const auto sim_step = rptStep - 1;
 
-    const auto sumState = Opm::SummaryState { Opm::TimeService::now() };
+    const auto sumState = Opm::SummaryState { Opm::TimeService::now(), 0.0 };
 
     const auto xw = well_rates_1();
     const auto ih =
@@ -1907,7 +1907,7 @@ END
         auto dyn_state = std::pair<Opm::data::Wells, Opm::SummaryState> {
             std::piecewise_construct,
             std::forward_as_tuple(),
-            std::forward_as_tuple(Opm::TimeService::now())
+            std::forward_as_tuple(Opm::TimeService::now(), 0.0)
         };
 
         using o = ::Opm::data::Rates::opt;

--- a/tests/test_EclipseIO.cpp
+++ b/tests/test_EclipseIO.cpp
@@ -308,7 +308,7 @@ WELSPECS
         const auto& eclGrid = es.getInputGrid();
         const Schedule schedule(deck, es, std::make_shared<Python>());
         const SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.aquifer());
-        const SummaryState st(TimeService::now());
+        const SummaryState st(TimeService::now(), 0.0);
         es.getIOConfig().setBaseName( "FOO" );
 
         EclipseIO eclWriter( es, eclGrid , schedule, summary_config);
@@ -435,6 +435,8 @@ WELSPECS
     // the file
     BOOST_CHECK_EQUAL(file_size, write_and_check(3, 5));
 }
+
+namespace {
 
 std::pair<std::string,std::array<std::array<std::vector<float>,2>,3>>
 createMULTXYZDECK(std::array<std::bitset<2>,3> doxyz, bool write_all_multminus)
@@ -699,7 +701,7 @@ void testMultxyz(std::array<std::bitset<2>,3> doxyz, bool write_all_multminus = 
     const auto& eclGrid = es.getInputGrid();
     const Schedule schedule(deck, es, std::make_shared<Python>());
     const SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.aquifer());
-    const SummaryState st(TimeService::now());
+    const SummaryState st(TimeService::now(), 0.0);
     es.getIOConfig().setBaseName( "MULTXFOO" );
     EclipseIO eclWriter( es, eclGrid , schedule, summary_config);
     eclWriter.writeInitial( );
@@ -722,6 +724,7 @@ void testMultxyz(std::array<std::bitset<2>,3> doxyz, bool write_all_multminus = 
     }
 }
 
+} // Anonymous namespace
 
 BOOST_AUTO_TEST_CASE(MULTXYZInit)
 {
@@ -740,6 +743,7 @@ BOOST_AUTO_TEST_CASE(MULTXYZInit)
     testMultxyz({ '3', '3' , '3'});
 }
 
+namespace {
 
 std::pair<std::string,std::vector<float>>
 createMULTPVDECK(bool edit)
@@ -844,7 +848,7 @@ void checkMULTPV(const std::pair<std::string, std::vector<float>>& deckAndValues
     const auto& eclGrid = es.getInputGrid();
     const Schedule schedule(deck, es, std::make_shared<Python>());
     const SummaryConfig summary_config( deck, schedule, es.fieldProps(), es.aquifer());
-    const SummaryState st(TimeService::now());
+    const SummaryState st(TimeService::now(), 0.0);
     es.getIOConfig().setBaseName( "MULTPVFOO" );
     EclipseIO eclWriter( es, eclGrid , schedule, summary_config);
     eclWriter.writeInitial( );
@@ -862,12 +866,16 @@ void checkMULTPV(const std::pair<std::string, std::vector<float>>& deckAndValues
     }
 }
 
+} // Anonymous namespace
+
 BOOST_AUTO_TEST_CASE(MULTPVInit)
 {
     checkMULTPV(createMULTPVDECK(false));
     checkMULTPV(createMULTPVDECK(true));
     
 }
+
+namespace {
 
 std::pair<std::string,std::vector<float>>
 createMULTPVBOXDECK()
@@ -936,6 +944,8 @@ SCHEDULE
     expected.insert(expected.end(), 90, 1.5);
     return { deckString, expected };
 }
+
+} // Anonymous namespace
 
 BOOST_AUTO_TEST_CASE(MULTPVBOXInit)
 {

--- a/tests/test_LGOData.cpp
+++ b/tests/test_LGOData.cpp
@@ -2,79 +2,73 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/Schedule/Action/State.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
-#include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
-#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
-
-#include <opm/output/eclipse/AggregateWellData.hpp>
-#include <opm/output/eclipse/WriteRestartHelpers.hpp>
-
 #include <opm/output/eclipse/DoubHEAD.hpp>
 #include <opm/output/eclipse/InteHEAD.hpp>
 #include <opm/output/eclipse/VectorItems/doubhead.hpp>
 #include <opm/output/eclipse/VectorItems/intehead.hpp>
 #include <opm/output/eclipse/VectorItems/well.hpp>
+
+#include <opm/output/eclipse/AggregateWellData.hpp>
+#include <opm/output/eclipse/WriteRestartHelpers.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/TracerConfig.hpp>
+
 #include <opm/input/eclipse/Python/Python.hpp>
+
+#include <opm/input/eclipse/Schedule/Action/State.hpp>
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Schedule/Well/WellTestState.hpp>
 
 #include <opm/input/eclipse/Units/UnitSystem.hpp>
 #include <opm/input/eclipse/Units/Units.hpp>
 #include <opm/common/utility/TimeService.hpp>
 
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <cstddef>
 #include <exception>
-#include <iostream>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
-namespace
-{
+namespace {
 
-Opm::Deck
-first_sim(std::string fname)
+Opm::Deck first_sim(const std::string& fname)
 {
-    return Opm::Parser {}.parseFile(fname);
+    return Opm::Parser{}.parseFile(fname);
 }
-} // namespace
 
-
-
-Opm::SummaryState
-sum_state()
+Opm::SummaryState sum_state()
 {
-    auto state = Opm::SummaryState {Opm::TimeService::now()};
-    state.update("FULPR", 460.);
+    auto state = Opm::SummaryState {Opm::TimeService::now(), 0.0};
+    state.update("FULPR", 460.0);
 
     return state;
 }
 
-
-// int main(int argc, char* argv[])
-struct SimulationCase {
+struct SimulationCase
+{
     explicit SimulationCase(const Opm::Deck& deck)
-        : es {deck}
-        , grid {deck}
-        , python {std::make_shared<Opm::Python>()}
-        , sched {deck, es, python}
-    {
-    }
+        : es    {deck}
+        , grid  {deck}
+        , sched {deck, es, std::make_shared<Opm::Python>()}
+    {}
 
     // Order requirement: 'es' must be declared/initialised before 'sched'.
     Opm::EclipseState es;
     Opm::EclipseGrid grid;
-    std::shared_ptr<Opm::Python> python;
     Opm::Schedule sched;
 };
 
+} // namespace
+
 BOOST_AUTO_TEST_SUITE(LiftGasOptimization)
-
-
 
 // test lift gas optimisation data
 BOOST_AUTO_TEST_CASE(liftGasOptimzation_data)

--- a/tests/test_RFT.cpp
+++ b/tests/test_RFT.cpp
@@ -715,7 +715,7 @@ BOOST_AUTO_TEST_CASE(test_RFT)
         const auto start_time = schedule.posixStartTime();
         const auto step_time  = timeStamp(::Opm::EclIO::ERft::RftDate{ 2008, 10, 10 });
 
-        Opm::SummaryState st(Opm::TimeService::now());
+        Opm::SummaryState st(Opm::TimeService::now(), 0.0);
         Opm::Action::State action_state;
         Opm::UDQState udq_state(1234);
         Opm::WellTestState wtest_state;
@@ -848,7 +848,7 @@ BOOST_AUTO_TEST_CASE(test_RFT2)
 
         Opm::Schedule schedule(deck, eclipseState, python);
         Opm::SummaryConfig summary_config( deck, schedule, eclipseState.fieldProps(), eclipseState.aquifer() );
-        Opm::SummaryState st(Opm::TimeService::now());
+        Opm::SummaryState st(Opm::TimeService::now(), 0.0);
         Opm::Action::State action_state;
         Opm::UDQState udq_state(10);
         Opm::WellTestState wtest_state;

--- a/tests/test_Restart.cpp
+++ b/tests/test_Restart.cpp
@@ -271,7 +271,11 @@ data::Solution mkSolutionFIP(const int numCells)
 
 Opm::SummaryState sim_state(const Opm::Schedule& sched)
 {
-    auto state = Opm::SummaryState{TimeService::now()};
+    auto state = Opm::SummaryState {
+        TimeService::now(),
+        sched.back().udq().params().undefinedValue()
+    };
+
     for (const auto& well : sched.getWellsatEnd()) {
         for (const auto& connection : well.getConnections()) {
             state.update_conn_var(well.name(), "CPR", connection.global_index() + 1, 111);
@@ -697,7 +701,7 @@ BOOST_AUTO_TEST_CASE(WriteWrongSOlutionSize) {
         auto cells = mkSolution( num_cells );
         auto wells = mkWells();
         auto groups = mkGroups();
-        Opm::SummaryState sumState(TimeService::now());
+        Opm::SummaryState sumState(TimeService::now(), 0.0);
         Opm::Action::State action_state;
         Opm::UDQState udq_state(19);
         Opm::WellTestState wtest_state;
@@ -764,7 +768,7 @@ BOOST_AUTO_TEST_CASE(ExtraData_content) {
         const auto& units = setup.es.getUnits();
         {
             RestartValue restart_value(cells, wells, groups, {});
-            SummaryState st(TimeService::now());
+            SummaryState st(TimeService::now(), 0.0);
             const auto sumState = sim_state(setup.schedule);
 
             restart_value.addExtra("EXTRA", UnitSystem::measure::pressure, {10,1,2,3});
@@ -976,10 +980,10 @@ BOOST_AUTO_TEST_CASE(Restore_Cumulatives)
     }
 
     Action::State action_state;
-    SummaryState rstSumState(TimeService::now());
+    SummaryState rstSumState(TimeService::now(), 0.0);
     RestartIO::load(OS::outputFileName(rset, "UNRST"), seqnum, action_state, rstSumState,
                     /* solution_keys = */ {
-                                           RestartKey("SWAT", UnitSystem::measure::identity),
+                        RestartKey("SWAT", UnitSystem::measure::identity),
                     },
                     setup.es, setup.grid, setup.schedule,
                     /* extra_keys = */ {});
@@ -1128,8 +1132,8 @@ BOOST_AUTO_TEST_CASE(UDQ_RESTART) {
     test_area.copyIn("UDQ_RESTART.DATA");
 
     Setup base_setup("UDQ_BASE.DATA");
-    SummaryState st1(TimeService::now());
-    SummaryState st2(TimeService::now());
+    SummaryState st1(TimeService::now(), 0.0);
+    SummaryState st2(TimeService::now(), 0.0);
     Action::State action_state;
     UDQState udq_state(1);
     init_st(st1);

--- a/tests/test_Summary.cpp
+++ b/tests/test_Summary.cpp
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(well_keywords)
         wbp[Quantity::WBP9] = 123.789*unit::barsa;
     }
 
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     writer.eval(st, 0, 0*day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -901,7 +901,7 @@ BOOST_AUTO_TEST_CASE(well_keywords_dynamic_close) {
     cfg.ta.makeSubDir( "PATH" );
     cfg.name = "PATH/CASE";
 
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     writer.eval(st, 0, 0*day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -1119,7 +1119,7 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     setup cfg( "test_summary_group" );
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
 
@@ -1276,7 +1276,7 @@ BOOST_AUTO_TEST_CASE(group_group) {
     setup cfg( "test_summary_group_group" , "group_group.DATA");
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
     writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -1357,7 +1357,7 @@ BOOST_AUTO_TEST_CASE(GLIR_and_ALQ)
 
     const auto wellData = glir_alq_data();
 
-    auto st = SummaryState { TimeService::now() };
+    auto st = SummaryState { TimeService::now(), es.runspec().udqParams().undefinedValue() };
     auto writer = out::Summary{ cfg, es, es.getInputGrid(), sched, name };
     writer.eval(st, 0, 0*day, wellData, {}, {}, {}, {}, {});
     writer.add_timestep(st, 0, false);
@@ -1388,7 +1388,7 @@ BOOST_AUTO_TEST_CASE(connection_kewords) {
     setup cfg( "test_summary_connection" );
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
     writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -1554,7 +1554,7 @@ BOOST_AUTO_TEST_CASE(DATE) {
     setup cfg( "test_summary_DATE" );
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1, false);
     writer.eval( st, 2, 2 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -1593,7 +1593,7 @@ BOOST_AUTO_TEST_CASE(field_keywords) {
     auto single_values = out::Summary::GlobalProcessParameters {};
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
 
     single_values.insert_or_assign("FPR" , 123.45*barsa());
     single_values.insert_or_assign("FPRH", 123.45*barsa());
@@ -1766,7 +1766,7 @@ BOOST_AUTO_TEST_CASE(report_steps_time) {
     setup cfg( "test_summary_report_steps_time" );
 
     out::Summary writer(cfg.config, fg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 1, 2 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1, false);
     writer.eval( st, 1, 5 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -1793,7 +1793,7 @@ BOOST_AUTO_TEST_CASE(skip_unknown_var) {
     setup cfg( "test_summary_skip_unknown_var" );
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 1, 2 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 1, false);
     writer.eval( st, 1, 5 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -1908,7 +1908,7 @@ BOOST_AUTO_TEST_CASE(region_vars) {
 
     {
         out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
         writer.eval( st, 1, 2 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, region_values);
         writer.add_timestep( st, 1, false);
         writer.eval( st, 1, 5 *  day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, region_values);
@@ -1973,7 +1973,7 @@ BOOST_AUTO_TEST_CASE(region_production) {
 
     {
         out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
         writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
         writer.add_timestep( st, 0, false);
         writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -2005,7 +2005,7 @@ BOOST_AUTO_TEST_CASE(region_injection) {
     setup cfg( "region_injection" );
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
     writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -2125,7 +2125,11 @@ BOOST_AUTO_TEST_CASE(inter_region_flows)
     auto cfg = setup{ "inter_region_flows" };
 
     {
-        auto st = SummaryState{ TimeService::now() };
+        auto st = SummaryState {
+            TimeService::now(),
+            cfg.es.runspec().udqParams().undefinedValue()
+        };
+
         auto writer = out::Summary {
             cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name
         };
@@ -2263,7 +2267,7 @@ BOOST_AUTO_TEST_CASE(BLOCK_VARIABLES)
     block_values.emplace(std::piecewise_construct, std::forward_as_tuple("BODEN", 1), std::forward_as_tuple(890.12*kg_pr_m3()));
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {}, block_values);
     writer.add_timestep( st, 0, false);
     writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {}, block_values);
@@ -2333,7 +2337,7 @@ BOOST_AUTO_TEST_CASE(NODE_VARIABLES) {
     setup cfg( "test_summary_node" );
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
 
@@ -2388,7 +2392,7 @@ BOOST_AUTO_TEST_CASE(MISC) {
     setup cfg( "test_misc");
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
     writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep( st, 0, false);
     writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -2407,7 +2411,7 @@ BOOST_AUTO_TEST_CASE(EXTRA) {
 
     {
         out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
         writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, { {"TCPU" , 0 }}, {}, {}, {});
         writer.add_timestep( st, 0, false);
         writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, { {"TCPU" , 1 }}, {}, {}, {});
@@ -2543,7 +2547,7 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
         setup cfg( "test_efficiency_factor", "SUMMARY_EFF_FAC.DATA", false );
 
         out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), cfg.es.runspec().udqParams().undefinedValue());
         writer.eval( st, 0, 0 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
         writer.add_timestep( st, 0, false);
         writer.eval( st, 1, 1 * day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});
@@ -2761,7 +2765,7 @@ BOOST_AUTO_TEST_CASE(efficiency_factor) {
 }
 
 BOOST_AUTO_TEST_CASE(Test_SummaryState) {
-    Opm::SummaryState st(TimeService::now());
+    Opm::SummaryState st(TimeService::now(), 0.0);
     st.update("WWCT:OP_2", 100);
     BOOST_CHECK_CLOSE(st.get("WWCT:OP_2"), 100, 1e-5);
     BOOST_CHECK_THROW(st.get("NO_SUCH_KEY"), std::out_of_range);
@@ -2853,7 +2857,7 @@ namespace {
             config.schedule, "Ignore.This"
         };
 
-        SummaryState st(TimeService::now());
+        SummaryState st(TimeService::now(), config.es.runspec().udqParams().undefinedValue());
         smry.eval(st, 0, 0*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
         smry.add_timestep(st, 0, false);
         smry.eval(st, 1, 1*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
@@ -3923,7 +3927,7 @@ BOOST_AUTO_TEST_CASE(Write_Read)
         config.config, config.es, config.grid, config.schedule
     };
 
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), config.es.runspec().udqParams().undefinedValue());
     writer.eval(st, 0, 0*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
     writer.add_timestep(st, 0, false);
     writer.eval(st, 1, 1*day, config.wells, config.wbp, config.grp_nwrk, {}, {}, {}, {});
@@ -6497,7 +6501,7 @@ BOOST_AUTO_TEST_SUITE_END() // Restart_Segment
 BOOST_AUTO_TEST_SUITE(Summary_State)
 
 BOOST_AUTO_TEST_CASE(SummaryState_TOTAL) {
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), 0.0);
     st.update("FOPR", 100);
     BOOST_CHECK_EQUAL(st.get("FOPR"), 100);
     st.update("FOPR", 100);
@@ -6559,9 +6563,9 @@ BOOST_AUTO_TEST_CASE(SummaryState_TOTAL) {
 
 BOOST_AUTO_TEST_CASE(append_summary_state) {
     auto now = TimeService::now();
-    SummaryState st1(now);
-    SummaryState st2(now);
-    SummaryState st_both(now);
+    SummaryState st1(now, 0.0);
+    SummaryState st2(now, 0.0);
+    SummaryState st_both(now, 0.0);
 
     st1.update_elapsed(1000);
     st1.update("FOPT", 100);

--- a/tests/test_Summary_Group.cpp
+++ b/tests/test_Summary_Group.cpp
@@ -15,12 +15,37 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
 #include "config.h"
 
 #define BOOST_TEST_MODULE Wells
 #include <boost/test/unit_test.hpp>
+
+#include <opm/output/data/Wells.hpp>
+#include <opm/output/data/Groups.hpp>
+#include <opm/output/eclipse/Summary.hpp>
+#include <opm/output/eclipse/Inplace.hpp>
+
+#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
+
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+#include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/Well/Well.hpp>
+#include <opm/input/eclipse/Units/UnitSystem.hpp>
+
+#include <opm/input/eclipse/Units/Units.hpp>
+
+#include <opm/common/utility/TimeService.hpp>
+
+#include <opm/io/eclipse/ESmry.hpp>
+
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Parser/Parser.hpp>
 
 #include <cctype>
 #include <chrono>
@@ -34,27 +59,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include <opm/output/data/Wells.hpp>
-#include <opm/output/data/Groups.hpp>
-#include <opm/output/eclipse/Summary.hpp>
-#include <opm/output/eclipse/Inplace.hpp>
-
-#include <opm/input/eclipse/Python/Python.hpp>
-#include <opm/input/eclipse/Schedule/SummaryState.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Units/UnitSystem.hpp>
-#include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/input/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/input/eclipse/Schedule/Schedule.hpp>
-#include <opm/input/eclipse/Schedule/Well/Well.hpp>
-#include <opm/input/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
-#include <opm/common/utility/TimeService.hpp>
-
-#include <opm/input/eclipse/Units/Units.hpp>
-
-#include <opm/io/eclipse/ESmry.hpp>
-
 #include <tests/WorkArea.hpp>
 
 using namespace Opm;
@@ -63,7 +67,7 @@ using rt = data::Rates::opt;
 namespace {
     double sm3_pr_day()
     {
-       return unit::cubic(unit::meter) / unit::day;
+        return unit::cubic(unit::meter) / unit::day;
     }
 
     std::string toupper(std::string input)
@@ -76,17 +80,17 @@ namespace {
         return input;
     }
 
-    bool ecl_sum_has_group_var( const EclIO::ESmry* smry,
-                           const std::string&  groupname,
-                           const std::string&  variable )
+    bool ecl_sum_has_group_var(const EclIO::ESmry* smry,
+                               const std::string&  groupname,
+                               const std::string&  variable)
     {
         return smry->hasKey(variable + ':' + groupname);
     }
 
-    double ecl_sum_get_group_var( const EclIO::ESmry* smry,
-                              const int           timeIdx,
-                              const std::string&  groupname,
-                              const std::string&  variable )
+    double ecl_sum_get_group_var(const EclIO::ESmry* smry,
+                                 const int           timeIdx,
+                                 const std::string&  groupname,
+                                 const std::string&  variable)
     {
         return smry->get(variable + ':' + groupname)[timeIdx];
     }
@@ -95,7 +99,8 @@ namespace {
 
 namespace {
 
-std::unique_ptr< EclIO::ESmry > readsum( const std::string& base ) {
+std::unique_ptr<EclIO::ESmry> readsum(const std::string& base)
+{
     return std::make_unique<EclIO::ESmry>(base);
 }
 
@@ -108,8 +113,9 @@ using i_cmode = Opm::Group::InjectionCMode;
  */
 static const int day = 24 * 60 * 60;
 
-static data::Wells result_wells() {
-        /* populate with the following pattern:
+data::Wells result_wells()
+{
+    /* populate with the following pattern:
      *
      * Wells are named W_1, W_2 etc, i.e. wells are 1 indexed.
      *
@@ -196,7 +202,8 @@ static data::Wells result_wells() {
 
 }
 
-static data::GroupAndNetworkValues result_group_network() {
+data::GroupAndNetworkValues result_group_network()
+{
     data::GroupAndNetworkValues grp_nwrk;
     data::GroupConstraints cgc_group;
 
@@ -253,7 +260,8 @@ BOOST_AUTO_TEST_SUITE(Summary)
  * Tests works by reading the Deck, write the summary output, then immediately
  * read it again (with ERT), and compare the read values with the input.
  */
-BOOST_AUTO_TEST_CASE(group_keywords) {
+BOOST_AUTO_TEST_CASE(group_keywords)
+{
     setup cfg( "test_summary_group_constraints");
 
     // Force to run in a directory, to make sure the basename with
@@ -261,7 +269,7 @@ BOOST_AUTO_TEST_CASE(group_keywords) {
     cfg.ta.makeSubDir( "PATH" );
     cfg.name = "PATH/CASE";
 
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), 0.0);
 
     out::Summary writer(cfg.config, cfg.es, cfg.grid, cfg.schedule, cfg.name);
     writer.eval(st, 0, 0*day, cfg.wells, cfg.wbp, cfg.grp_nwrk, {}, {}, {}, {});

--- a/tests/test_rst.cpp
+++ b/tests/test_rst.cpp
@@ -392,7 +392,7 @@ END
         const auto& units    = simCase.es.getUnits();
         const auto  sim_step = rptStep - 1;
 
-        const auto sumState     = Opm::SummaryState { Opm::TimeService::now() };
+        const auto sumState     = Opm::SummaryState { Opm::TimeService::now(), 0.0 };
         const auto action_state = Opm::Action::State{};
         const auto wtest_state  = Opm::WellTestState{};
 
@@ -486,7 +486,7 @@ BOOST_AUTO_TEST_CASE(group_test)
     // Report Step 2: 2011-01-20 --> 2013-06-15
     const auto rptStep = std::size_t{2};
     const auto sim_step = rptStep - 1;
-    Opm::SummaryState sumState(Opm::TimeService::now());
+    Opm::SummaryState sumState(Opm::TimeService::now(), 0.0);
 
     const auto ih = Opm::RestartIO::Helpers::createInteHead(simCase.es,
                                                             simCase.grid,
@@ -965,7 +965,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period)
             state.header.udq_undefined
         };
 
-        const auto ctrl = op1.productionControls(Opm::SummaryState { Opm::TimeService::now() });
+        const auto ctrl = op1.productionControls(Opm::SummaryState { Opm::TimeService::now(), 0.0 });
         BOOST_CHECK_MESSAGE(ctrl.cmode == Opm::WellProducerCMode::GRAT,
                             "Well loaded from restart file must be controlled "
                             "by observed surface gas flow rate (GRAT)");
@@ -985,7 +985,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period)
         prop.handleWCONHIST(std::nullopt, 101325.0, Opm::UnitSystem::newMETRIC(),
                             deck.get<Opm::ParserKeywords::WCONHIST>().back().getRecord(0));
 
-        const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now() }, state.header.udq_undefined);
+        const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined }, state.header.udq_undefined);
         BOOST_CHECK_MESSAGE(ctrl.cmode == Opm::WellProducerCMode::RESV,
                             "Well loaded from restart file must be controlled by "
                             "observed reservoir voidage rate (RESV) after WCONHIST");
@@ -1005,7 +1005,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period)
         prop.handleWCONHIST(std::nullopt, 101325.0, Opm::UnitSystem::newMETRIC(),
                             deck.get<Opm::ParserKeywords::WCONHIST>().back().getRecord(0));
 
-        const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now() }, state.header.udq_undefined);
+        const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined }, state.header.udq_undefined);
         BOOST_CHECK_MESSAGE(ctrl.cmode == Opm::WellProducerCMode::ORAT,
                             "Well loaded from restart file must be controlled by "
                             "observed surface oil flow rate (ORAT) after WCONHIST");
@@ -1035,7 +1035,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period_WHistCtl)
             state.header.udq_undefined
         };
 
-        const auto ctrl = op1.productionControls(Opm::SummaryState { Opm::TimeService::now() });
+        const auto ctrl = op1.productionControls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined });
         BOOST_CHECK_MESSAGE(ctrl.cmode == Opm::WellProducerCMode::GRAT,
                             "Well loaded from restart file must be controlled "
                             "by observed surface gas flow rate (GRAT)");
@@ -1055,7 +1055,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period_WHistCtl)
         prop.handleWCONHIST(std::nullopt, 101325.0, Opm::UnitSystem::newMETRIC(),
                             deck.get<Opm::ParserKeywords::WCONHIST>().back().getRecord(0));
 
-        const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now() }, state.header.udq_undefined);
+        const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined }, state.header.udq_undefined);
         BOOST_CHECK_MESSAGE(ctrl.cmode == Opm::WellProducerCMode::ORAT,
                             "Well loaded from restart file must be controlled by "
                             "observed surface oil flow rate (ORAT) after WCONHIST");
@@ -1075,7 +1075,7 @@ BOOST_AUTO_TEST_CASE(Historic_Period_WHistCtl)
         prop.handleWCONHIST(std::nullopt, 101325.0, Opm::UnitSystem::newMETRIC(),
                             deck.get<Opm::ParserKeywords::WCONHIST>().back().getRecord(0));
 
-        const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now() }, state.header.udq_undefined);
+        const auto ctrl = prop.controls(Opm::SummaryState { Opm::TimeService::now(), state.header.udq_undefined }, state.header.udq_undefined);
         BOOST_CHECK_MESSAGE(ctrl.cmode == Opm::WellProducerCMode::RESV,
                             "Well loaded from restart file must be controlled by "
                             "observed reservoir voidage rate (RESV) after WCONHIST");


### PR DESCRIPTION
This PR switches to calling the `SummaryState` constructor which is aware of the value of undefined UDQs (#4052) directly.  In most cases we pick the actual value from `UDQPARAM(3)`, with a fallback provided by the `Runspec` class if `UDQPARAM` is not specified, but certain unit tests which do not care about UDQs just get the value 0.0 as the second parameter.

This is in preparation of making the undefined UDQ value mandatory in follow-up work.