### PR TITLE
Fall Back to Undefined Value for Missing UDQs

### DIFF
--- a/opm/input/eclipse/Schedule/SummaryState.hpp
+++ b/opm/input/eclipse/Schedule/SummaryState.hpp
@@ -75,8 +75,6 @@ public:
 
     explicit SummaryState(time_point sim_start_arg, double udqUndefined);
 
-    explicit SummaryState(time_point sim_start_arg);
-
     // The std::time_t constructor is only for export to Python
     explicit SummaryState(std::time_t sim_start_arg);
 

--- a/tests/parser/EmbeddedPython.cpp
+++ b/tests/parser/EmbeddedPython.cpp
@@ -21,14 +21,16 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <opm/input/eclipse/Python/Python.hpp>
-
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/input/eclipse/EclipseState/Runspec.hpp>
+
+#include <opm/input/eclipse/Python/Python.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/Actions.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Schedule.hpp>
 #include <opm/input/eclipse/Schedule/SummaryState.hpp>
+#include <opm/input/eclipse/Schedule/UDQ/UDQParams.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
 #include <opm/common/utility/TimeService.hpp>
@@ -138,7 +140,7 @@ BOOST_AUTO_TEST_CASE(PYACTION)
     auto ecl_state = EclipseState(deck);
     auto schedule = Schedule(deck, ecl_state, python);
 
-    SummaryState st(TimeService::now());
+    SummaryState st(TimeService::now(), ecl_state.runspec().udqParams().undefinedValue());
     const auto& pyaction_kw = deck.get<ParserKeywords::PYACTION>().front();
     const std::string& fname = pyaction_kw.getRecord(1).getItem(0).get<std::string>(0);
     Action::PyAction py_action(python, "WCLOSE", Action::PyAction::RunCount::unlimited, deck.makeDeckPath(fname));

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -39,6 +39,10 @@ WATER
 UNIFIN
 UNIFOUT
 
+UDQPARAM
+-- Undefined => 0.1729 (default = 0.0)
+ 2* 0.1729 /
+
 GRID
 
 DX


### PR DESCRIPTION
This PR switches to using the "undefined" value (`SummaryState::udq_undefined`) as a fallback default for undefined or missing user-defined quantities in the `SummaryState::has*()` and `SummaryState::get*var()` member functions.  In particular, we use this fallback value if the request is a well UDQ in member functions `(has|get)_well_var()`, a group UDQ in `(has|get)_group_var()`, or a segment UDQ in `(has|get)_segment_var()`.

Other UDQ categories, e.g., region, will be provided as needed.