### PR TITLE
Saving the restart path relative the deck (or absolute) for use in SMSPEC

### DIFF
--- a/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -78,6 +78,8 @@ namespace Opm {
         const std::string& root = record.getItem( 0 ).get< std::string >( 0 );
         const std::string& input_path = deck.getInputPath();
 
+        // Need the restart path as input (absolute or relative .DATA file) for writing to SMSPEC
+        this->m_restartRootNameInput = root;
         if (root[0] == '/' || input_path.empty())
             this->setRestart(root, step);
         else
@@ -95,6 +97,7 @@ namespace Opm {
         result.m_restartRequested = true;
         result.m_restartStep = 20;
         result.m_restartRootName = "test1";
+        result.m_restartRootNameInput = "test2";
 
         return result;
     }
@@ -115,6 +118,10 @@ namespace Opm {
 
     const std::string& InitConfig::getRestartRootName() const {
         return m_restartRootName;
+    }
+
+    const std::string& InitConfig::getRestartRootNameInput() const {
+        return m_restartRootNameInput;
     }
 
     bool InitConfig::hasEquil() const {
@@ -163,7 +170,8 @@ namespace Opm {
                m_gravity == data.m_gravity &&
                m_restartRequested == data.m_restartRequested &&
                m_restartStep == data.m_restartStep &&
-               m_restartRootName == data.m_restartRootName;
+               m_restartRootName == data.m_restartRootName &&
+               m_restartRootNameInput == data.m_restartRootNameInput;
     }
 
     bool InitConfig::rst_cmp(const InitConfig& full_config, const InitConfig& rst_config) {

--- a/opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/input/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -41,6 +41,7 @@ namespace Opm {
         bool restartRequested() const;
         int getRestartStep() const;
         const std::string& getRestartRootName() const;
+        const std::string& getRestartRootNameInput() const;
 
         bool hasEquil() const;
         const Equil& getEquil() const;
@@ -74,6 +75,7 @@ namespace Opm {
             serializer(m_restartRequested);
             serializer(m_restartStep);
             serializer(m_restartRootName);
+            serializer(m_restartRootNameInput);
         }
 
     private:
@@ -86,6 +88,7 @@ namespace Opm {
         bool m_restartRequested = false;
         int m_restartStep = 0;
         std::string m_restartRootName;
+        std::string m_restartRootNameInput;
     };
 
 } //namespace Opm

--- a/opm/output/eclipse/Summary.cpp
+++ b/opm/output/eclipse/Summary.cpp
@@ -4075,7 +4075,7 @@ SMSpecStreamDeferredCreation(const Opm::InitConfig&          initcfg,
     , start_   (Opm::TimeService::from_time_t(start))
 {
     if (initcfg.restartRequested()) {
-        this->restart_.root = initcfg.getRestartRootName();
+        this->restart_.root = initcfg.getRestartRootNameInput();
         this->restart_.step = initcfg.getRestartStep();
     }
 }


### PR DESCRIPTION
Currently the path relative the path where the simulator is actually run is saved, which breaks certain post-processors. 