### PR TITLE
Fix build with gcc-14

### DIFF
--- a/cmake/Modules/FindQuadMath.cmake
+++ b/cmake/Modules/FindQuadMath.cmake
@@ -46,4 +46,24 @@ if(QuadMath_FOUND AND NOT TARGET QuadMath::QuadMath)
   target_compile_options(QuadMath::QuadMath INTERFACE
     $<$<CXX_COMPILER_ID:GNU>:-fext-numeric-literals>
   )
+
+  # Check for numeric_limits specialization
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_LIBRARIES quadmath)
+  set(CMAKE_REQUIRED_FLAGS)
+  if(${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+    set(CMAKE_REQUIRED_FLAGS "-fext-numeric-literals")
+  endif()
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -D_GLIBCXX_USE_FLOAT128")
+  check_cxx_source_compiles("
+  #include <limits>
+  int main()
+  {
+     static_assert(std::numeric_limits<__float128>::is_specialized);
+     return 0;
+  }" QuadMath_HAS_LIMITS)
+  cmake_pop_check_state()  # Reset CMAKE_REQUIRED_XXX variables
+  if(QuadMath_HAS_LIMITS)
+    target_compile_definitions(QuadMath::QuadMath INTERFACE LIMITS_HAS_QUAD=1)
+  endif()
 endif()

--- a/examples/make_ext_smry.cpp
+++ b/examples/make_ext_smry.cpp
@@ -17,7 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
+#include <algorithm>
 #include <filesystem>
 #include <iostream>
 #include <getopt.h>

--- a/opm/material/common/quad.hpp
+++ b/opm/material/common/quad.hpp
@@ -45,6 +45,7 @@ typedef __float128 quad;
 
 namespace std {
 
+#if !LIMITS_HAS_QUAD
 // provide the numeric limits for the quad precision type
 template <>
 class numeric_limits<quad>
@@ -97,6 +98,7 @@ public:
     static constexpr bool tinyness_before = std::numeric_limits<double>::tinyness_before;
     static constexpr float_round_style round_style = round_to_nearest;
 };
+#endif // LIMITS_HAS_QUAD
 
 // provide some type traits for the quadruple precision type
 template <>


### PR DESCRIPTION
In gcc-14 std::numeric_limits already has a specialization for __float128. Use a probe to detect this fact.
And add a missing include.

Closes #4062 