### PR TITLE
[bugfix] Fix deadlock when outputting MULTPV to INIT file in parallel.

### DIFF
--- a/opm/output/eclipse/WriteInit.cpp
+++ b/opm/output/eclipse/WriteInit.cpp
@@ -669,9 +669,9 @@ void Opm::InitIO::write(const ::Opm::EclipseState&              es,
 
         auto multipliers = es.getTransMult()
             .convertToSimProps(grid.getNumActive(), writeAll);
-        if (es.fieldProps().has_double("MULTPV")) {
+        if (es.globalFieldProps().has_double("MULTPV")) {
             multipliers.insert("MULTPV", UnitSystem::measure::identity,
-                        es.fieldProps().get_double("MULTPV"),
+                        es.globalFieldProps().get_double("MULTPV"),
                         data::TargetType::INIT);
         }
 


### PR DESCRIPTION
The writing takes place after the loadbalancing during which the field properties are adjusted to the local grid. Hence we need to explicitly query the field properties for the global grid. Otherwise the writer will throw because the arrays are smaller than expected,

Closes OPM/opm-simulators#5359