### PR TITLE
Use options 1-3 in TRACERS

### DIFF
--- a/opm/input/eclipse/EclipseState/Runspec.cpp
+++ b/opm/input/eclipse/EclipseState/Runspec.cpp
@@ -591,8 +591,8 @@ Tracers Tracers::serializationTestObject() {
     return tracers;
 }
 
-int Tracers::water_tracers() const {
-    return this->m_water_tracers;
+int Tracers::all_tracers() const {
+    return this->m_water_tracers + this->m_oil_tracers + this->m_gas_tracers;
 }
 
 

--- a/opm/input/eclipse/EclipseState/Runspec.hpp
+++ b/opm/input/eclipse/EclipseState/Runspec.hpp
@@ -449,7 +449,7 @@ public:
     Tracers() = default;
 
     explicit Tracers(const Deck& );
-    int water_tracers() const;
+    int all_tracers() const;
 
     template<class Serializer>
     void serializeOp(Serializer& serializer) {

--- a/opm/io/eclipse/rst/well.cpp
+++ b/opm/io/eclipse/rst/well.cpp
@@ -184,7 +184,7 @@ Opm::RestartIO::RstWell::RstWell(const UnitSystem&  unit_system,
 {
 
     for (std::size_t tracer_index = 0;
-         tracer_index < static_cast<std::size_t>(header.runspec.tracers().water_tracers());
+         tracer_index < static_cast<std::size_t>(header.runspec.tracers().all_tracers());
          ++tracer_index)
     {
         this->tracer_concentration_injection.push_back(swel[VI::SWell::TracerOffset + tracer_index]);

--- a/opm/output/eclipse/AggregateMSWData.cpp
+++ b/opm/output/eclipse/AggregateMSWData.cpp
@@ -737,7 +737,7 @@ namespace {
                               RSegArray& rSeg)
         {
             auto tracer_offset = segment_offset + Opm::RestartIO::InteHEAD::numRsegElem(runspec.phases());
-            auto tracer_end    = tracer_offset + runspec.tracers().water_tracers() * 8;
+            auto tracer_end    = tracer_offset + runspec.tracers().all_tracers() * 8;
 
             std::fill(rSeg.begin() + tracer_offset, rSeg.begin() + tracer_end, 0.0);
         }

--- a/opm/output/eclipse/AggregateWellData.cpp
+++ b/opm/output/eclipse/AggregateWellData.cpp
@@ -1354,7 +1354,7 @@ namespace {
 
             for (std::size_t tracer_index=0; tracer_index < tracers.size(); tracer_index++) {
                 const auto& tracer = tracers[tracer_index];
-                std::size_t output_index = Ix::TracerOffset + tracer_dims.water_tracers() + tracer_index;
+                std::size_t output_index = Ix::TracerOffset + tracer_dims.all_tracers() + tracer_index;
                 if (well.isProducer()) {
                     const auto& wtpr = smry.get_well_var(well.name(), fmt::format("WTPT{}", tracer.name), 0);
                     xWell[output_index] = wtpr;
@@ -1363,7 +1363,7 @@ namespace {
 
             for (std::size_t tracer_index=0; tracer_index < tracers.size(); tracer_index++) {
                 const auto& tracer = tracers[tracer_index];
-                std::size_t output_index = Ix::TracerOffset + 2*tracer_dims.water_tracers() + tracer_index;
+                std::size_t output_index = Ix::TracerOffset + 2*tracer_dims.all_tracers() + tracer_index;
                 if (well.isInjector()) {
                     const auto& wtir = smry.get_well_var(well.name(), fmt::format("WTIT{}", tracer.name), 0);
                     xWell[output_index] = wtir;
@@ -1373,7 +1373,7 @@ namespace {
             for (std::size_t n=0; n < 2; n++) {
                 for (std::size_t tracer_index=0; tracer_index < tracers.size(); tracer_index++) {
                     const auto& tracer = tracers[tracer_index];
-                    std::size_t output_index = Ix::TracerOffset + (3 + n)*tracer_dims.water_tracers() + tracer_index;
+                    std::size_t output_index = Ix::TracerOffset + (3 + n)*tracer_dims.all_tracers() + tracer_index;
                     const auto& wtic = smry.get_well_var(well.name(), fmt::format("WTIC{}", tracer.name), 0);
                     const auto& wtpc = smry.get_well_var(well.name(), fmt::format("WTPC{}", tracer.name), 0);
 
@@ -1384,7 +1384,7 @@ namespace {
                 }
             }
 
-            std::size_t output_index = Ix::TracerOffset + 5*tracer_dims.water_tracers();
+            std::size_t output_index = Ix::TracerOffset + 5*tracer_dims.all_tracers();
             xWell[output_index] = 0;
             xWell[output_index + 1] = 0;
         }

--- a/opm/output/eclipse/LoadRestart.cpp
+++ b/opm/output/eclipse/LoadRestart.cpp
@@ -1488,8 +1488,8 @@ namespace {
 
         for (std::size_t tracer_index = 0; tracer_index < tracer_config.size(); tracer_index++) {
             const auto& tracer_name = tracer_config[tracer_index].name;
-            auto wtpt_offset = VI::XWell::index::TracerOffset +   tracer_dims.water_tracers();
-            auto wtit_offset = VI::XWell::index::TracerOffset + 2*tracer_dims.water_tracers();
+            auto wtpt_offset = VI::XWell::index::TracerOffset +   tracer_dims.all_tracers();
+            auto wtit_offset = VI::XWell::index::TracerOffset + 2*tracer_dims.all_tracers();
 
             smry.update_well_var(well, fmt::format("WTPT{}", tracer_name), xwel[wtpt_offset + tracer_index]);
             smry.update_well_var(well, fmt::format("WTIT{}", tracer_name), xwel[wtit_offset + tracer_index]);


### PR DESCRIPTION
Return the sum of all passive tracers from TRACERS (options 1-3) instead of just max water tracers (option 2) when requested. This PR is in draft mode to test/discuss implications of the changes in restart-related code.