### PR TITLE
Don't Use Moved-From Objects

### DIFF
--- a/opm/input/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/input/eclipse/Parser/ParserKeyword.cpp
@@ -678,12 +678,16 @@ void set_dimensions( ParserItem& item,
         return this->m_validSectionNames;
     }
 
-    void ParserKeyword::addRecord( ParserRecord record ) {
-        m_records.push_back( std::move( record ) );
-        if (record.rawStringRecord())
-            this->raw_string_keyword = true;
-    }
+    void ParserKeyword::addRecord(ParserRecord record)
+    {
+        const auto isRaw = record.rawStringRecord();
 
+        this->m_records.push_back(std::move(record));
+
+        if (isRaw) {
+            this->raw_string_keyword = true;
+        }
+    }
 
     void ParserKeyword::addDataRecord( ParserRecord record) {
         if (this->keyword_size.size_type() != FIXED)

--- a/opm/output/eclipse/AggregateConnectionData.cpp
+++ b/opm/output/eclipse/AggregateConnectionData.cpp
@@ -93,7 +93,7 @@ namespace {
                 ? nullptr : &well_iter->second;
 
             connectionLoop(grid, sched.getWell(wname, sim_step),
-                           wellRes, std::forward<ConnOp>(connOp));
+                           wellRes, connOp);
         }
     }
 


### PR DESCRIPTION
We must never call `forward<>()` in a loop[%].

[%] Poor understanding by [at]bska.