### PR TITLE
Update piecewiseLinearTwoPhaseMaterialParams header

### DIFF
--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterial.hpp
@@ -144,12 +144,12 @@ public:
     static Evaluation twoPhaseSatPcnw(const Params& params, const Evaluation& Sw)
     {
         OPM_TIMEFUNCTION_LOCAL();
-        return eval_(params.SwPcwnSamples(), params.pcnwSamples(), Sw);
+        return eval_(params.SwPcwnSamples(), params.pcwnSamples(), Sw);
     }
 
     template <class Evaluation>
     static Evaluation twoPhaseSatPcnwInv(const Params& params, const Evaluation& pcnw)
-    { return eval_(params.pcnwSamples(), params.SwPcwnSamples(), pcnw); }
+    { return eval_(params.pcwnSamples(), params.SwPcwnSamples(), pcnw); }
 
     /*!
      * \brief The saturation-capillary pressure curve

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -29,17 +29,18 @@
 
 #include <algorithm>
 #include <cassert>
-#include <vector>
 #include <opm/material/common/EnsureFinalized.hpp>
+#include <vector>
 
-namespace Opm {
+namespace Opm
+{
 /*!
  * \ingroup FluidMatrixInteractions
  *
  * \brief Specification of the material parameters for a two-phase material law which
  *        uses a table and piecewise constant interpolation.
  */
-template<class TraitsT, class VectorT=std::vector<typename TraitsT::Scalar>>
+template <class TraitsT, class VectorT = std::vector<typename TraitsT::Scalar>>
 class PiecewiseLinearTwoPhaseMaterialParams : public EnsureFinalized
 {
     using Scalar = typename TraitsT::Scalar;
@@ -54,17 +55,17 @@ public:
     }
 
     PiecewiseLinearTwoPhaseMaterialParams(ValueVector SwPcwnSamples,
-                                            ValueVector pcwnSamples,
-                                            ValueVector SwKrwSamples,
-                                            ValueVector krwSamples,
-                                            ValueVector SwKrnSamples,
-                                            ValueVector krnSamples)
-                                        : SwPcwnSamples_(SwPcwnSamples),
-                                            SwKrwSamples_(SwKrwSamples),
-                                            SwKrnSamples_(SwKrnSamples),
-                                            pcwnSamples_(pcwnSamples),
-                                            krwSamples_(krwSamples),
-                                            krnSamples_(krnSamples)
+                                          ValueVector pcwnSamples,
+                                          ValueVector SwKrwSamples,
+                                          ValueVector krwSamples,
+                                          ValueVector SwKrnSamples,
+                                          ValueVector krnSamples)
+        : SwPcwnSamples_(SwPcwnSamples)
+        , SwKrwSamples_(SwKrwSamples)
+        , SwKrnSamples_(SwKrnSamples)
+        , pcwnSamples_(pcwnSamples)
+        , krwSamples_(krwSamples)
+        , krnSamples_(krnSamples)
     {
         finalize();
     }
@@ -75,7 +76,7 @@ public:
      */
     void finalize()
     {
-        EnsureFinalized :: finalize ();
+        EnsureFinalized ::finalize();
 
         // revert the order of the sampling points if they were given
         // in reverse direction.
@@ -83,7 +84,7 @@ public:
         // The const expr ensures we can create constant parameter views.
         using vecElementType = typename ValueVector::value_type;
         using vecElementTypeNoConst = std::remove_const_t<vecElementType>;
-        if constexpr(std::is_same_v<vecElementType, vecElementTypeNoConst>){
+        if constexpr (std::is_same_v<vecElementType, vecElementTypeNoConst>) {
             if (SwPcwnSamples_.front() > SwPcwnSamples_.back())
                 swapOrder_(SwPcwnSamples_, pcwnSamples_);
 
@@ -99,19 +100,28 @@ public:
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
     const ValueVector& SwKrwSamples() const
-    { EnsureFinalized::check(); return SwKrwSamples_; }
+    {
+        EnsureFinalized::check();
+        return SwKrwSamples_;
+    }
 
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
     const ValueVector& SwKrnSamples() const
-    { EnsureFinalized::check(); return SwKrnSamples_; }
+    {
+        EnsureFinalized::check();
+        return SwKrnSamples_;
+    }
 
     /*!
      * \brief Return the wetting-phase saturation values of all sampling points.
      */
     const ValueVector& SwPcwnSamples() const
-    { EnsureFinalized::check(); return SwPcwnSamples_; }
+    {
+        EnsureFinalized::check();
+        return SwPcwnSamples_;
+    }
 
     /*!
      * \brief Return the sampling points for the capillary pressure curve.
@@ -119,7 +129,10 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const ValueVector& pcwnSamples() const
-    { EnsureFinalized::check(); return pcwnSamples_; }
+    {
+        EnsureFinalized::check();
+        return pcwnSamples_;
+    }
 
     /*!
      * \brief Set the sampling points for the capillary pressure curve.
@@ -146,7 +159,10 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const ValueVector& krwSamples() const
-    { EnsureFinalized::check(); return krwSamples_; }
+    {
+        EnsureFinalized::check();
+        return krwSamples_;
+    }
 
     /*!
      * \brief Set the sampling points for the relative permeability
@@ -174,7 +190,10 @@ public:
      * This curve is assumed to depend on the wetting phase saturation
      */
     const ValueVector& krnSamples() const
-    { EnsureFinalized::check(); return krnSamples_; }
+    {
+        EnsureFinalized::check();
+        return krnSamples_;
+    }
 
     /*!
      * \brief Set the sampling points for the relative permeability
@@ -199,10 +218,7 @@ private:
     void swapOrder_(ValueVector& swValues, ValueVector& values) const
     {
         if (swValues.front() > values.back()) {
-            for (unsigned origSampleIdx = 0;
-                 origSampleIdx < swValues.size() / 2;
-                 ++ origSampleIdx)
-            {
+            for (unsigned origSampleIdx = 0; origSampleIdx < swValues.size() / 2; ++origSampleIdx) {
                 size_t newSampleIdx = swValues.size() - origSampleIdx - 1;
 
                 std::swap(swValues[origSampleIdx], swValues[newSampleIdx]);

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -82,9 +82,7 @@ public:
         // in reverse direction.
         // Reverting the order involves swapping which only works for non-consts.
         // The const expr ensures we can create constant parameter views.
-        using vecElementType = typename ValueVector::value_type;
-        using vecElementTypeNoConst = std::remove_const_t<vecElementType>;
-        if constexpr (std::is_same_v<vecElementType, vecElementTypeNoConst>) {
+        if constexpr (std::is_const_v<typename ValueVector::value_type>) {
             if (SwPcwnSamples_.front() > SwPcwnSamples_.back())
                 swapOrder_(SwPcwnSamples_, pcwnSamples_);
 

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -29,8 +29,9 @@
 
 #include <algorithm>
 #include <cassert>
-#include <opm/material/common/EnsureFinalized.hpp>
 #include <vector>
+
+#include <opm/material/common/EnsureFinalized.hpp>
 
 namespace Opm
 {
@@ -82,7 +83,7 @@ public:
         // in reverse direction.
         // Reverting the order involves swapping which only works for non-consts.
         // The const expr ensures we can create constant parameter views.
-        if constexpr (std::is_const_v<typename ValueVector::value_type>) {
+        if constexpr (!std::is_const_v<typename ValueVector::value_type>) {
             if (SwPcwnSamples_.front() > SwPcwnSamples_.back())
                 swapOrder_(SwPcwnSamples_, pcwnSamples_);
 

--- a/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
+++ b/opm/material/fluidmatrixinteractions/PiecewiseLinearTwoPhaseMaterialParams.hpp
@@ -83,7 +83,7 @@ public:
         // in reverse direction.
         // Reverting the order involves swapping which only works for non-consts.
         // The const expr ensures we can create constant parameter views.
-        if constexpr (!std::is_const_v<typename ValueVector::value_type>) {
+        if constexpr (!std::is_const_v<typename ValueVector::value_type> && !std::is_const_v<ValueVector>) {
             if (SwPcwnSamples_.front() > SwPcwnSamples_.back())
                 swapOrder_(SwPcwnSamples_, pcwnSamples_);
 


### PR DESCRIPTION
A few minor revisions:

- Generalize the type storing the interpolation tables, default to the std::vector<Scalar> used earlier to avoid code changes other places
- Add a constructor to simplify instantiation process.
- Throw exception if the finalization step requires reordering the buffers while the underlying data container is const, this is useful when instantiating the class with a read-only view that will be done later to avoid allocations inside GPU kernel code. 
- Run clang format to make the file more consistent
- Fix typo in pcnwSamples(), the "w" should come before the "n", there was a mismatch between the variable and the function retrieving it