### PR TITLE
Update actnum in FieldProps and EclipseGrid right after scanning GRID+EDIT

### DIFF
--- a/opm/input/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/input/eclipse/EclipseState/EclipseState.cpp
@@ -152,8 +152,6 @@ namespace Opm {
         this->reportNumberOfActivePhases();
 
         this->conveyNumericalAquiferEffects();
-        this->m_inputGrid.resetACTNUM(this->field_props.actnum());
-        this->field_props.reset_actnum(this->getInputGrid().getACTNUM());
         if (field_props.has_double("MINPVV")) {
             this->m_inputGrid.setMINPVV(field_props.get_global_double("MINPVV"));
             field_props.deleteMINPVV();

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -1760,6 +1760,10 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
         return this->getCellDepth(globalIndex);
     }
 
+    const std::map<size_t, std::array<int,2>>& EclipseGrid::getAquiferCellTabnums() const {
+        return m_aquifer_cell_tabnums;
+    }
+
     const std::vector<int>& EclipseGrid::getACTNUM( ) const {
 
         return m_actnum;
@@ -1969,6 +1973,11 @@ std::vector<double> EclipseGrid::createDVector(const std::array<int,3>& dims, st
 
                 if (! record.getItem<AQUNUM::DEPTH>().defaultApplied(0))
                     this->m_aquifer_cell_depths.insert_or_assign(global_index, record.getItem<AQUNUM::DEPTH>().getSIDouble(0));
+
+                // Create map global_index -> (PVTNUM, SATNUM) to allow QC during FieldProps creation
+                const int pvtnum = record.getItem<AQUNUM::PVT_TABLE_NUM>().defaultApplied(0) ? 0 : record.getItem<AQUNUM::PVT_TABLE_NUM>().get<int>(0);
+                const int satnum = record.getItem<AQUNUM::SAT_TABLE_NUM>().defaultApplied(0) ? 0 : record.getItem<AQUNUM::SAT_TABLE_NUM>().get<int>(0);
+                this->m_aquifer_cell_tabnums.insert_or_assign(global_index, std::array<int,2>{pvtnum, satnum});
             }
         }
     }

--- a/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -197,6 +197,9 @@ namespace Opm {
         const std::vector<double>& getZCORN() const;
         const std::vector<int>& getACTNUM( ) const;
 
+
+        const std::map<size_t, std::array<int,2>>& getAquiferCellTabnums() const;
+
         /*
           The fixupZCORN method is run as part of constructiong the grid. This will adjust the
           z-coordinates to ensure that cells do not overlap. The return value is the number of
@@ -261,8 +264,9 @@ namespace Opm {
         std::vector<int> m_global_to_active;
         // Numerical aquifer cells, needs to be active
         std::unordered_set<size_t> m_aquifer_cells;
-        // Keep track of aquifer cell depths
+        // Keep track of aquifer cell depths and (pvtnum,satnum)
         std::map<size_t, double> m_aquifer_cell_depths;
+        std::map<size_t, std::array<int,2>> m_aquifer_cell_tabnums;
 
         // Radial grids need this for volume calculations.
         std::optional<std::vector<double>> m_thetav;

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1335,6 +1335,12 @@ const std::string& FieldProps::canonical_fipreg_name(const std::string& fipreg) 
 */
 std::vector<int> FieldProps::actnum() {
     auto actnum = this->m_actnum;
+
+    // Avoid de-activating all cells if PORO has not yet been read (typically in tests)
+    if (!this->has<double>("PORO")) {
+        return actnum;
+    }
+
     const auto& deck_actnum = this->init_get<int>("ACTNUM");
 
     std::vector<int> global_map(this->active_size);

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -535,6 +535,19 @@ FieldProps::FieldProps(const Deck& deck, const Phases& phases, EclipseGrid& grid
     if (DeckSection::hasREGIONS(deck))
         this->scanREGIONSSection(REGIONSSection(deck));
 
+    // Update PVTNUM/SATNUM for numerical aquifer cells
+    const std::map<size_t, std::array<int, 2>>& aqcell_tabnums = grid.getAquiferCellTabnums();
+    const bool has_pvtnum = this->int_data.count("PVTNUM") != 0;
+    const bool has_satnum = this->int_data.count("SATNUM") != 0;
+
+    std::vector<int>* pvtnum = has_pvtnum ? &(this->int_data["PVTNUM"].data) : 0;
+    std::vector<int>* satnum = has_satnum ? &(this->int_data["SATNUM"].data) : 0;
+    for (const auto& it : aqcell_tabnums) {
+        const auto aix = grid.activeIndex(it.first);
+        if (has_pvtnum) (*pvtnum)[aix] = std::max(it.second[0], (*pvtnum)[aix]);
+        if (has_satnum) (*satnum)[aix] = std::max(it.second[1], (*satnum)[aix]);
+    }
+
     if (DeckSection::hasPROPS(deck))
         this->scanPROPSSection(PROPSSection(deck));
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -478,7 +478,7 @@ bool FieldProps::rst_cmp(const FieldProps& full_arg, const FieldProps& rst_arg) 
 }
 
 
-FieldProps::FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid& grid, const TableManager& tables_arg) :
+FieldProps::FieldProps(const Deck& deck, const Phases& phases, EclipseGrid& grid, const TableManager& tables_arg) :
     active_size(grid.getNumActive()),
     global_size(grid.getCartesianSize()),
     unit_system(deck.getActiveUnitSystem()),
@@ -527,6 +527,10 @@ FieldProps::FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid
 
     if (DeckSection::hasEDIT(deck))
         this->scanEDITSection(EDITSection(deck));
+
+    grid.resetACTNUM(this->actnum());
+    this->reset_actnum(grid.getACTNUM());
+
 
     if (DeckSection::hasREGIONS(deck))
         this->scanREGIONSSection(REGIONSSection(deck));

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -389,7 +389,7 @@ public:
     };
 
     /// Normal constructor for FieldProps.
-    FieldProps(const Deck& deck, const Phases& phases, const EclipseGrid& grid, const TableManager& table_arg);
+    FieldProps(const Deck& deck, const Phases& phases, EclipseGrid& grid, const TableManager& table_arg);
 
     /// Special case constructor used to process ACTNUM only.
     FieldProps(const Deck& deck, const EclipseGrid& grid);

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -132,7 +132,7 @@ namespace ALIAS {
 
 namespace GRID {
 static const std::unordered_map<std::string, keyword_info<double>> double_keywords = {{"DISPERC",keyword_info<double>{}.unit_string("Length")},
-                                                                                      {"MINPVV",  keyword_info<double>{}.unit_string("ReservoirVolume").global_kw(true)},
+                                                                                      {"MINPVV",  keyword_info<double>{}.init(0.0).unit_string("ReservoirVolume").global_kw(true)},
                                                                                       {"MULTPV",  keyword_info<double>{}.init(1.0).mult(true)},
                                                                                       {"NTG",     keyword_info<double>{}.init(1.0)},
                                                                                       {"PORO",    keyword_info<double>{}.distribute_top(true)},

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -35,7 +35,7 @@ bool FieldPropsManager::rst_cmp(const FieldPropsManager& full_arg, const FieldPr
     return FieldProps::rst_cmp(*full_arg.fp, *rst_arg.fp);
 }
 
-FieldPropsManager::FieldPropsManager(const Deck& deck, const Phases& phases, const EclipseGrid& grid_arg, const TableManager& tables) :
+FieldPropsManager::FieldPropsManager(const Deck& deck, const Phases& phases, EclipseGrid& grid_arg, const TableManager& tables) :
     fp(std::make_shared<FieldProps>(deck, phases, grid_arg, tables))
 {}
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp
@@ -46,7 +46,7 @@ public:
     // The default constructor should be removed when the FieldPropsManager is mandatory
     // The default constructed fieldProps object is **NOT** usable
     FieldPropsManager() = default;
-    FieldPropsManager(const Deck& deck, const Phases& ph, const EclipseGrid& grid, const TableManager& tables);
+    FieldPropsManager(const Deck& deck, const Phases& ph, EclipseGrid& grid, const TableManager& tables);
     virtual ~FieldPropsManager() = default;
 
     virtual void reset_actnum(const std::vector<int>& actnum);

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -86,7 +86,7 @@ Schedule make_schedule(const std::string& deck_string,
                        const ParseContext& parseContext = {})
 {
     const auto deck = Parser{}.parseString(deck_string);
-    const EclipseGrid grid1(10, 10, 10);
+    EclipseGrid grid1(10, 10, 10);
     const TableManager table(deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid1, table);
     const Runspec runspec(deck);
@@ -1055,7 +1055,7 @@ ENDACTIO
     };
 
     const auto deck = Parser{}.parseString(deck_string);
-    const EclipseGrid grid1(10,10,10);
+    EclipseGrid grid1(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid1, table);
 

--- a/tests/parser/ConnectionTests.cpp
+++ b/tests/parser/ConnectionTests.cpp
@@ -69,7 +69,7 @@ namespace {
         const auto wdfac = Opm::WDFAC{};
         const auto loc = Opm::KeywordLocation{};
 
-        const Opm::EclipseGrid grid { 10, 10, 10 };
+        Opm::EclipseGrid grid { 10, 10, 10 };
         const Opm::FieldPropsManager field_props {
             deck, Opm::Phases{true, true, true}, grid, Opm::TableManager{}
         };

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -1944,7 +1944,7 @@ FIPUNIX
   100*3 100*4 /
 )";
 
-    const EclipseGrid grid { 10, 10, 2 };
+    EclipseGrid grid { 10, 10, 2 };
     const Deck deck = Parser{}.parseString(deck_string);
 
     BOOST_CHECK_MESSAGE(deck.hasKeyword("FIPUNIT"),

--- a/tests/parser/GroupTests.cpp
+++ b/tests/parser/GroupTests.cpp
@@ -50,7 +50,7 @@ Schedule create_schedule(const std::string& deck_string)
 {
     const auto deck = Parser{}.parseString(deck_string);
 
-    const EclipseGrid grid(10, 10, 10);
+    EclipseGrid grid(10, 10, 10);
     const TableManager table(deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);

--- a/tests/parser/MULTREGTScannerTests.cpp
+++ b/tests/parser/MULTREGTScannerTests.cpp
@@ -490,7 +490,7 @@ AQUCON
 BOOST_AUTO_TEST_CASE(AQUNNC_Handling_OneAquCell)
 {
     const auto deck = aquNNCDeck_OneAquCell();
-    const auto grid = Opm::EclipseGrid { deck };
+    auto grid = Opm::EclipseGrid { deck };
     const auto fp   = Opm::FieldPropsManager {
         deck, Opm::Phases { true, true, true },
         grid, Opm::TableManager { deck }
@@ -628,7 +628,7 @@ BOOST_AUTO_TEST_CASE(AQUNNC_Handling_OneAquCell)
 BOOST_AUTO_TEST_CASE(AQUNNC_Handling_ThreeAquCells)
 {
     const auto deck = aquNNCDeck_ThreeAquCells();
-    const auto grid = Opm::EclipseGrid { deck };
+    auto grid = Opm::EclipseGrid { deck };
     const auto fp   = Opm::FieldPropsManager {
         deck, Opm::Phases { true, true, true },
         grid, Opm::TableManager { deck }

--- a/tests/parser/MultisegmentWellTests.cpp
+++ b/tests/parser/MultisegmentWellTests.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(AICDWellTest)
     const auto dir_x = Opm::Connection::Direction::X;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
 
-    const Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25.0, 2500.0 };
+    Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25.0, 2500.0 };
 
     const auto depth = 0.0;
     const auto state = Opm::Connection::State::OPEN;
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(MultisegmentWellTest)
     const auto dir_z = Opm::Connection::Direction::Z;
     const auto dir_x = Opm::Connection::Direction::X;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    const Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25.0, 2500.0 };
+    Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25.0, 2500.0 };
 
     const auto depth = 0.0;
     const auto state = Opm::Connection::State::OPEN;
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(WrongDistanceCOMPSEGS)
     const auto dir_x = Opm::Connection::Direction::X;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
 
-    const Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25., 2500.0 };
+    Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25., 2500.0 };
 
     const auto depth = 0.0;
     const auto state = Opm::Connection::State::OPEN;
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE(NegativeDepthCOMPSEGS)
     const auto dir_x = Opm::Connection::Direction::X;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
 
-    const Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25.0, 2500.0 };
+    Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25.0, 2500.0 };
 
     const auto depth = 0.0;
     const auto state = Opm::Connection::State::OPEN;
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(testwsegvalv)
     const auto dir_z = Opm::Connection::Direction::Z;
     const auto dir_x = Opm::Connection::Direction::X;
     const auto kind = Opm::Connection::CTFKind::DeckValue;
-    const Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25.0, 2500.0 };
+    Opm::EclipseGrid grid { 20,20,20, 1.0, 1.0, 25.0, 2500.0 };
 
     const auto depth = 0.0;
     const auto state = Opm::Connection::State::OPEN;

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -111,7 +111,7 @@ namespace {
     {
         const auto deck = Parser{}.parseString(deck_string);
 
-        const EclipseGrid grid(10, 10, 10);
+        EclipseGrid grid(10, 10, 10);
         const TableManager table (deck);
         const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
         const Runspec runspec (deck);
@@ -2753,7 +2753,7 @@ COMPDAT
 END
 )");
 
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
@@ -2806,7 +2806,7 @@ COMPDAT
 /
 )");
 
-    const EclipseGrid grid(10, 10, 10);
+    EclipseGrid grid(10, 10, 10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
@@ -2876,7 +2876,7 @@ COMPDAT
 /
 )");
 
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
@@ -2972,7 +2972,7 @@ WELOPEN
     constexpr auto open = Connection::State::OPEN;
     constexpr auto shut = Connection::State::SHUT;
 
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
@@ -3091,7 +3091,7 @@ WELOPEN
     constexpr auto open = Connection::State::OPEN;
     constexpr auto shut = Connection::State::SHUT;
 
-    const EclipseGrid grid(10, 10, 10);
+    EclipseGrid grid(10, 10, 10);
     const TableManager table (deck );
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);

--- a/tests/parser/SimulationConfigTest.cpp
+++ b/tests/parser/SimulationConfigTest.cpp
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
     {
         const auto deck = createDeck(inputStr);
         const auto tm = TableManager(deck);
-        const auto eg = EclipseGrid(10, 3, 4);
+        auto eg = EclipseGrid(10, 3, 4);
         const auto fp = FieldPropsManager(deck, Phases{true, true, true}, eg, tm);
         const auto simulationConfig = Opm::SimulationConfig(false, deck, fp);
 
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
     {
         const auto deck = createDeck(simDeckStringTEMP());
         const auto tm = TableManager(deck);
-        const auto eg = EclipseGrid(10, 3, 4);
+        auto eg = EclipseGrid(10, 3, 4);
         const auto fp = FieldPropsManager(deck, Phases{true, true, true}, eg, tm);
         const auto simulationConfig = Opm::SimulationConfig(false, deck, fp);
 
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_TEMP_THERMAL)
     {
         const auto deck = createDeck(simDeckStringTHERMAL());
         const auto tm = TableManager(deck);
-        const auto eg = EclipseGrid(10, 3, 4);
+        auto eg = EclipseGrid(10, 3, 4);
         const auto fp = FieldPropsManager(deck, Phases{true, true, true}, eg, tm);
         const auto simulationConfig = Opm::SimulationConfig(false, deck, fp);
 
@@ -397,7 +397,7 @@ ROCK
 
 )");
 
-    const auto grid = EclipseGrid { 10, 10, 10 };
+    auto grid = EclipseGrid { 10, 10, 10 };
     const auto fp = FieldPropsManager {
         deck, Phases{true, true, true}, grid, TableManager()
     };

--- a/tests/parser/WellSolventTests.cpp
+++ b/tests/parser/WellSolventTests.cpp
@@ -201,7 +201,7 @@ END
 BOOST_AUTO_TEST_CASE(TestNoSolvent)
 {
     const auto deck = createDeckWithOutSolvent();
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(TestNoSolvent)
 
 BOOST_AUTO_TEST_CASE(TestGasInjector) {
     const auto deck = createDeckWithGasInjector();
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(TestGasInjector) {
 BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT)
 {
     const auto deck = createDeckWithDynamicWSOLVENT();
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT)
 BOOST_AUTO_TEST_CASE(TestOilInjector)
 {
     const auto deck = createDeckWithOilInjector();
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(TestOilInjector)
 BOOST_AUTO_TEST_CASE(TestWaterInjector)
 {
     const auto deck = createDeckWithWaterInjector();
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table ( deck );
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);

--- a/tests/parser/WellTracerTests.cpp
+++ b/tests/parser/WellTracerTests.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(TestNoTracer)
 {
     const auto deck = createDeckWithOutTracer();
 
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER)
 {
     const auto deck = createDeckWithDynamicWTRACER();
 
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWTRACER)
 BOOST_AUTO_TEST_CASE(TestTracerInProducerTHROW)
 {
     const auto deck = createDeckWithTracerInProducer();
-    const EclipseGrid grid(10,10,10);
+    EclipseGrid grid(10,10,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);

--- a/tests/parser/integration/ParseKEYWORD.cpp
+++ b/tests/parser/integration/ParseKEYWORD.cpp
@@ -1443,7 +1443,7 @@ BOOST_AUTO_TEST_CASE( WCONINJE )
 {
     const std::string wconprodFile(pathprefix() + "WellWithWildcards/WCONINJE1");
     const auto deck = Parser{}.parseFile(wconprodFile);
-    const EclipseGrid grid(30,30,30);
+    EclipseGrid grid(30,30,30);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec(deck);

--- a/tests/parser/integration/ScheduleCreateFromDeck.cpp
+++ b/tests/parser/integration/ScheduleCreateFromDeck.cpp
@@ -560,7 +560,7 @@ COMPDAT
 END
 )");
 
-    const EclipseGrid grid(30,30,10);
+    EclipseGrid grid(30,30,10);
     const TableManager table (deck);
     const FieldPropsManager fp(deck, Phases{true, true, true}, grid, table);
     const Runspec runspec (deck);

--- a/tests/test_InteHEAD.cpp
+++ b/tests/test_InteHEAD.cpp
@@ -508,7 +508,7 @@ namespace {
     {
         const auto deck = Opm::Parser{}.parseString(deck_string);
 
-        const Opm::EclipseGrid grid(10, 10, 10);
+        Opm::EclipseGrid grid(10, 10, 10);
         const Opm::TableManager table(deck);
         const Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, grid, table);
         const Opm::Runspec runspec(deck);


### PR DESCRIPTION
Reason: Certain workflows de-activate cells by setting PORO=0 while at the same time setting the region numbers (e.g., SATNUM) to invalid values (not supported by current master). 