### PR TITLE
Initialise All Data Members in AST Node Constructors

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ASTNode.cpp
+++ b/opm/input/eclipse/Schedule/Action/ASTNode.cpp
@@ -17,65 +17,78 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <cmath>
+#include <opm/input/eclipse/Schedule/Action/ASTNode.hpp>
 
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
-#include <opm/input/eclipse/Schedule/Action/ASTNode.hpp>
 #include <opm/input/eclipse/Schedule/Well/WList.hpp>
 #include <opm/input/eclipse/Schedule/Well/WListManager.hpp>
+
 #include <opm/common/utility/shmatch.hpp>
 
+#include <cmath>
+#include <cstddef>
 #include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <fmt/format.h>
 
 namespace {
-    std::string strip_quotes(const std::string& s) {
-        if (s[0] == '\'')
+    std::string strip_quotes(const std::string& s)
+    {
+        if (s.front() == '\'') {
             return s.substr(1, s.size() - 2);
-        else
+        }
+        else {
             return s;
+        }
     }
 
-    std::vector<std::string> strip_quotes(const std::vector<std::string>& quoted_strings) {
+    std::vector<std::string>
+    strip_quotes(const std::vector<std::string>& quoted_strings)
+    {
         std::vector<std::string> strings;
-        for (const auto& qs : quoted_strings)
+
+        for (const auto& qs : quoted_strings) {
             strings.push_back(strip_quotes(qs));
+        }
 
         return strings;
     }
+} // Anonymous namespace
 
+Opm::Action::ASTNode::ASTNode()
+    : ASTNode { TokenType::error }
+{}
+
+Opm::Action::ASTNode::ASTNode(const TokenType type_arg)
+    : ASTNode { type_arg, FuncType::none, "", {} }
+{}
+
+Opm::Action::ASTNode::ASTNode(const double value)
+    : ASTNode { TokenType::number }
+{
+    this->number = value;
 }
 
-namespace Opm {
-namespace Action {
-
-ASTNode::ASTNode() :
-    type(TokenType::error)
+Opm::Action::ASTNode::ASTNode(const TokenType                 type_arg,
+                              const FuncType                  func_type_arg,
+                              const std::string&              func_arg,
+                              const std::vector<std::string>& arg_list_arg)
+    : type     (type_arg)
+    , func_type(func_type_arg)
+    , func     (func_arg)
+    , arg_list (strip_quotes(arg_list_arg))
 {}
 
-
-ASTNode::ASTNode(TokenType type_arg):
-    type(type_arg)
-{}
-
-
-ASTNode::ASTNode(double value) :
-    type(TokenType::number),
-    number(value)
-{}
-
-
-ASTNode::ASTNode(TokenType type_arg, FuncType func_type_arg, const std::string& func_arg, const std::vector<std::string>& arg_list_arg):
-    type(type_arg),
-    func_type(func_type_arg),
-    func(func_arg),
-    arg_list(strip_quotes(arg_list_arg))
-{}
-
-ASTNode ASTNode::serializationTestObject()
+Opm::Action::ASTNode
+Opm::Action::ASTNode::serializationTestObject()
 {
     ASTNode result;
-    result.type = ::number;
+
+    result.type = TokenType::number;
     result.func_type = FuncType::field;
     result.func = "test1";
     result.arg_list = {"test2"};
@@ -86,125 +99,151 @@ ASTNode ASTNode::serializationTestObject()
     return result;
 }
 
-size_t ASTNode::size() const {
+std::size_t Opm::Action::ASTNode::size() const
+{
     return this->children.size();
 }
 
-bool ASTNode::empty() const {
+bool Opm::Action::ASTNode::empty() const
+{
     return this->size() == 0;
 }
 
-void ASTNode::add_child(const ASTNode& child) {
+void Opm::Action::ASTNode::add_child(const ASTNode& child)
+{
     this->children.push_back(child);
 }
 
-Action::Value ASTNode::value(const Action::Context& context) const {
-    if (this->children.size() != 0)
-        throw std::invalid_argument("value() method should only reach leafnodes");
+Opm::Action::Value
+Opm::Action::ASTNode::value(const Action::Context& context) const
+{
+    if (! this->children.empty()) {
+        throw std::invalid_argument {
+            "value() method should only reach leafnodes"
+        };
+    }
 
-    if (this->type == TokenType::number)
-        return Action::Value(this->number);
+    if (this->type == TokenType::number) {
+        return Value { this->number };
+    }
 
-    if (this->arg_list.size() == 0)
-        return Action::Value(context.get(this->func));
-    else {
-        /*
-          The matching code is special case to handle one-argument cases with
-          well patterns like 'P*'.
-        */
-        if ((this->arg_list.size() == 1) && (this->arg_list[0].find("*") != std::string::npos)) {
-            if (this->func_type != FuncType::well)
-                throw std::logic_error(": attempted to action-evaluate list not of type well.");
+    if (this->arg_list.empty()) {
+        return Value { context.get(this->func) };
+    }
 
-            const auto& well_arg = this->arg_list[0];
-            Action::Value well_values;
-            std::vector<std::string> wnames;
+    // The matching code is special case to handle one-argument cases with
+    // well patterns like 'P*'.
+    if ((this->arg_list.size() == 1) &&
+        (this->arg_list.front().find("*") != std::string::npos))
+    {
+        if (this->func_type != FuncType::well) {
+            throw std::logic_error {
+                ": attempted to action-evaluate list not of type well."
+            };
+        }
 
-            if (well_arg[0] == '*' && well_arg.size() > 1) {
-                const auto& wlm = context.wlist_manager();
-                wnames = wlm.wells(well_arg);
-            } else {
-                for (const auto& well : context.wells(this->func)) {
-                    if (shmatch(well_arg, well))
-                        wnames.push_back(well);
+        const auto& well_arg = this->arg_list[0];
+
+        auto well_values = Value{};
+        auto wnames = std::vector<std::string>{};
+
+        if ((well_arg.front() == '*') && (well_arg.size() > 1)) {
+            const auto& wlm = context.wlist_manager();
+            wnames = wlm.wells(well_arg);
+        }
+        else {
+            for (const auto& well : context.wells(this->func)) {
+                if (shmatch(well_arg, well)) {
+                    wnames.push_back(well);
                 }
             }
-            for (const auto& wname : wnames)
-                well_values.add_well(wname, context.get(this->func, wname));
-
-            return well_values;
-        } else {
-            std::string arg_key = this->arg_list[0];
-            for (size_t index = 1; index < this->arg_list.size(); index++)
-                arg_key += ":" + this->arg_list[index];
-
-            auto scalar_value = context.get(this->func, arg_key);
-
-            if (this->func_type == FuncType::well)
-                return Action::Value(this->arg_list[0], scalar_value);
-            else
-                return Action::Value(scalar_value);
         }
+
+        for (const auto& wname : wnames) {
+            well_values.add_well(wname, context.get(this->func, wname));
+        }
+
+        return well_values;
+    }
+    else {
+        const auto arg_key = fmt::format("{}", fmt::join(this->arg_list, ":"));
+        const auto scalar_value = context.get(this->func, arg_key);
+
+        if (this->func_type == FuncType::well) {
+            return Value { this->arg_list.front(), scalar_value };
+        }
+
+        return Value { scalar_value };
     }
 }
 
+Opm::Action::Result
+Opm::Action::ASTNode::eval(const Action::Context& context) const
+{
+    if (this->empty()) {
+        throw std::invalid_argument {
+            "ASTNode::eval() should not reach leafnodes"
+        };
+    }
 
-Action::Result ASTNode::eval(const Action::Context& context) const {
-    if (this->children.size() == 0)
-        throw std::invalid_argument("ASTNode::eval() should not reach leafnodes");
+    if ((this->type == TokenType::op_or) ||
+        (this->type == TokenType::op_and))
+    {
+        auto result = Result { this->type == TokenType::op_and };
 
-    if (this->type == TokenType::op_or || this->type == TokenType::op_and) {
-        Action::Result result(this->type == TokenType::op_and);
         for (const auto& child : this->children) {
-            if (this->type == TokenType::op_or)
+            if (this->type == TokenType::op_or) {
                 result |= child.eval(context);
-            else
+            }
+            else {
                 result &= child.eval(context);
+            }
         }
+
         return result;
     }
 
-    auto v1 = this->children[0].value(context);
-    Action::Value v2;
+    auto v2 = Value {};
 
-    /*
-      Special casing of MONTH comparisons where in addition symbolic month names
-      we can compare with numeric months, in the case of numeric months the
-      numerical value should be rounded before comparison - i.e.
-
-        MNTH = 4.3
-
-      Should evaluate to true for the month April.
-     */
-    if (this->children[0].func_type == FuncType::time_month) {
+    // Special casing of MONTH comparisons where in addition symbolic month
+    // names we can compare with numeric months, in the case of numeric
+    // months the numerical value should be rounded before comparison - i.e.
+    //
+    //   MNTH = 4.3
+    //
+    // should evaluate to true for the month of April (4).
+    if (this->children.front().func_type == FuncType::time_month) {
         const auto& rhs = this->children[1];
-        if (rhs.type == TokenType::number) {
-            v2 = Action::Value(std::round(rhs.number));
-        } else
-            v2 = rhs.value(context);
-    } else
+
+        v2 = (rhs.type == TokenType::number)
+            ? Value { std::round(rhs.number) }
+            : rhs.value(context);
+    }
+    else {
         v2 = this->children[1].value(context);
+    }
 
-    return v1.eval_cmp(this->type, v2);
+    return this->children.front().value(context).eval_cmp(this->type, v2);
 }
 
-
-bool ASTNode::operator==(const ASTNode& data) const {
-    return type == data.type &&
-           func_type == data.func_type &&
-           func == data.func &&
-           arg_list == data.arg_list &&
-           number == data.number &&
-           children == data.children;
+bool Opm::Action::ASTNode::operator==(const ASTNode& data) const
+{
+    return (type == data.type)
+        && (func_type == data.func_type)
+        && (func == data.func)
+        && (arg_list == data.arg_list)
+        && (number == data.number)
+        && (children == data.children)
+        ;
 }
 
-void ASTNode::required_summary(std::unordered_set<std::string>& required_summary) const {
-    if (this->type == TokenType::ecl_expr)
-        required_summary.insert( this->func );
+void Opm::Action::ASTNode::required_summary(std::unordered_set<std::string>& required_summary) const
+{
+    if (this->type == TokenType::ecl_expr) {
+        required_summary.insert(this->func);
+    }
 
-    for (const auto& node : this->children)
+    for (const auto& node : this->children) {
         node.required_summary(required_summary);
-}
-
-}
+    }
 }

--- a/opm/input/eclipse/Schedule/Action/ASTNode.hpp
+++ b/opm/input/eclipse/Schedule/Action/ASTNode.hpp
@@ -1,39 +1,66 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #ifndef ASTNODE_HPP
 #define ASTNODE_HPP
-
-#include <unordered_set>
 
 #include <opm/input/eclipse/Schedule/Action/ActionContext.hpp>
 
 #include "ActionValue.hpp"
 
-namespace Opm {
-namespace Action {
+#include <cstddef>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace Opm { namespace Action {
 
 class ActionContext;
 class WellSet;
-class ASTNode {
-public:
 
+class ASTNode
+{
+public:
     ASTNode();
-    ASTNode(TokenType type_arg);
-    ASTNode(double value);
-    ASTNode(TokenType type_arg, FuncType func_type_arg, const std::string& func_arg, const std::vector<std::string>& arg_list_arg);
+    explicit ASTNode(TokenType type_arg);
+    explicit ASTNode(double value);
+    explicit ASTNode(TokenType type_arg,
+                     FuncType func_type_arg,
+                     const std::string& func_arg,
+                     const std::vector<std::string>& arg_list_arg);
 
     static ASTNode serializationTestObject();
 
     Action::Result eval(const Action::Context& context) const;
     Action::Value value(const Action::Context& context) const;
-    TokenType type;
-    FuncType func_type;
-    void add_child(const ASTNode& child);
-    size_t size() const;
-    bool empty() const;
 
-    std::string func;
     void required_summary(std::unordered_set<std::string>& required_summary) const;
 
     bool operator==(const ASTNode& data) const;
+
+    TokenType type;
+    FuncType func_type;
+    std::string func;
+
+    void add_child(const ASTNode& child);
+    std::size_t size() const;
+    bool empty() const;
 
     template<class Serializer>
     void serializeOp(Serializer& serializer)
@@ -47,16 +74,15 @@ public:
     }
 
 private:
-    std::vector<std::string> arg_list;
-    double number = 0.0;
+    std::vector<std::string> arg_list{};
+    double number {0.0};
 
-    /*
-      To have a member std::vector<ASTNode> inside the ASTNode class is
-      supposedly borderline undefined behaviour; it compiles without warnings
-      and works. Good for enough for me.
-    */
-    std::vector<ASTNode> children;
+    // To have a member std::vector<ASTNode> inside the ASTNode class is
+    // supposedly borderline undefined behaviour; it compiles without
+    // warnings and works.  Good for enough for me.
+    std::vector<ASTNode> children{};
 };
-}
-}
-#endif
+
+}} // namespace Opm::Action
+
+#endif // ASTNODE_HPP

--- a/opm/input/eclipse/Schedule/Action/ActionParser.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionParser.hpp
@@ -20,26 +20,25 @@
 #ifndef ACTION_PARSER_HPP
 #define ACTION_PARSER_HPP
 
-#include <vector>
-#include <string>
-
 #include <opm/input/eclipse/Schedule/Action/ASTNode.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 
-namespace Opm {
+#include <string>
+#include <vector>
 
-namespace Action {
+namespace Opm { namespace Action {
 
-struct ParseNode {
-    ParseNode(TokenType type_arg, const std::string& value_arg) :
-        type(type_arg),
-        value(value_arg)
+struct ParseNode
+{
+    ParseNode(TokenType type_arg, const std::string& value_arg)
+        : type (type_arg)
+        , value(value_arg)
     {}
 
     // Implicit converting constructor.
-    ParseNode(TokenType type_arg) : ParseNode(type_arg, "")
+    ParseNode(TokenType type_arg)
+        : ParseNode(type_arg, "")
     {}
-
 
     TokenType type;
     std::string value;
@@ -47,7 +46,8 @@ struct ParseNode {
 
 
 
-class Parser {
+class Parser
+{
 public:
     static Action::ASTNode parse(const std::vector<std::string>& tokens);
     static TokenType get_type(const std::string& arg);
@@ -70,7 +70,6 @@ private:
     ssize_t current_pos = -1;
 };
 
+}} // namespace Opm::Action
 
-}
-}
-#endif
+#endif // ACTION_PARSER_HPP

--- a/opm/input/eclipse/Schedule/Action/ActionValue.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionValue.cpp
@@ -1,9 +1,29 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 
-#include <stdexcept>
+#include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 
-namespace Opm {
-namespace Action {
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace {
 
@@ -47,96 +67,109 @@ inline std::string tokenString(TokenType op) {
 }
 #endif
 
-bool eval_cmp_scalar(double lhs, TokenType op, double rhs) {
+bool eval_cmp_scalar(const double lhs, const Opm::Action::TokenType op, const double rhs)
+{
     switch (op) {
-
-    case TokenType::op_eq:
+    case Opm::Action::TokenType::op_eq:
         return lhs == rhs;
 
-    case TokenType::op_ge:
+    case Opm::Action::TokenType::op_ge:
         return lhs >= rhs;
 
-    case TokenType::op_le:
+    case Opm::Action::TokenType::op_le:
         return lhs <= rhs;
 
-    case TokenType::op_ne:
+    case Opm::Action::TokenType::op_ne:
         return lhs != rhs;
 
-    case TokenType::op_gt:
+    case Opm::Action::TokenType::op_gt:
         return lhs > rhs;
 
-    case TokenType::op_lt:
+    case Opm::Action::TokenType::op_lt:
         return lhs < rhs;
 
     default:
-        throw std::invalid_argument("Incorrect operator type - expected comparison");
+        throw std::invalid_argument {
+            "Incorrect operator type - expected comparison"
+        };
     }
 }
 
-}
+} // Anonymous namespace
 
+Opm::Action::Value::Value(double value)
+    : scalar_value(value)
+    , is_scalar(true)
+{}
 
-Value::Value(double value) :
-    scalar_value(value),
-    is_scalar(true)
-{ }
-
-Value::Value(const std::string& wname, double value) : scalar_value(0.0) {
+Opm::Action::Value::Value(const std::string& wname, double value)
+    : scalar_value(0.0)
+{
     this->add_well(wname, value);
 }
 
-double Value::scalar() const {
-    if (!this->is_scalar)
-        throw std::invalid_argument("This value node represents a well list and can not be evaluated in scalar context");
+double Opm::Action::Value::scalar() const
+{
+    if (!this->is_scalar) {
+        throw std::invalid_argument {
+            "This value node represents a well list and "
+            "cannot be evaluated in scalar context"
+        };
+    }
 
     return this->scalar_value;
 }
 
-
-void Value::add_well(const std::string& well, double value) {
-    if (this->is_scalar)
-        throw std::invalid_argument("This value node has been created as a scalar node - can not add well variables");
+void Opm::Action::Value::add_well(const std::string& well, const double value)
+{
+    if (this->is_scalar) {
+        throw std::invalid_argument {
+            "This value node has been created as a "
+            "scalar node - cannot add well variables"
+        };
+    }
 
     this->well_values.emplace_back(well, value);
 }
 
-
-Result Value::eval_cmp_wells(TokenType op, double rhs) const {
+Opm::Action::Result
+Opm::Action::Value::eval_cmp_wells(const TokenType op, const double rhs) const
+{
     std::vector<std::string> wells;
     bool result = false;
 
-    for (const auto& pair : this->well_values) {
-        const std::string& well = pair.first;
-        const double value = pair.second;
-
+    for (const auto& [well, value] : this->well_values) {
         if (eval_cmp_scalar(value, op, rhs)) {
             wells.push_back(well);
             result = true;
         }
     }
+
     return Result(result, wells);
 }
 
-
-Result Value::eval_cmp(TokenType op, const Value& rhs) const {
-    if (op == TokenType::number ||
-        op == TokenType::ecl_expr ||
-        op == TokenType::open_paren ||
-        op == TokenType::close_paren ||
-        op == TokenType::op_and ||
-        op == TokenType::op_or ||
-        op == TokenType::end ||
-        op == TokenType::error)
+Opm::Action::Result
+Opm::Action::Value::eval_cmp(const TokenType op, const Value& rhs) const
+{
+    if ((op == TokenType::number) ||
+        (op == TokenType::ecl_expr) ||
+        (op == TokenType::open_paren) ||
+        (op == TokenType::close_paren) ||
+        (op == TokenType::op_and) ||
+        (op == TokenType::op_or) ||
+        (op == TokenType::end) ||
+        (op == TokenType::error))
+    {
         throw std::invalid_argument("Invalid operator");
+    }
 
-    if (!rhs.is_scalar)
+    if (!rhs.is_scalar) {
         throw std::invalid_argument("The right hand side must be a scalar value");
+    }
 
-    if (this->is_scalar)
-        return Action::Result(eval_cmp_scalar(this->scalar(), op, rhs.scalar()));
+    if (this->is_scalar) {
+        return Result(eval_cmp_scalar(this->scalar(), op, rhs.scalar()));
+    }
 
     return this->eval_cmp_wells(op, rhs.scalar());
-}
-
-}
 }

--- a/opm/input/eclipse/Schedule/Action/ActionValue.hpp
+++ b/opm/input/eclipse/Schedule/Action/ActionValue.hpp
@@ -1,46 +1,69 @@
+/*
+  Copyright 2019 Equinor ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #ifndef ACTION_VALUE_HPP
 #define ACTION_VALUE_HPP
 
 #include <opm/input/eclipse/Schedule/Action/ActionResult.hpp>
 
-enum TokenType {
-  number,        //  0
-  ecl_expr,      //  1
-  open_paren,    //  2
-  close_paren,   //  3
-  op_gt,         //  4
-  op_ge,         //  5
-  op_lt,         //  6
-  op_le,         //  7
-  op_eq,         //  8
-  op_ne,         //  9
-  op_and,        // 10
-  op_or,         // 11
-  end,           // 12
-  error          // 13
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace Opm { namespace Action {
+
+enum class TokenType
+{
+    number,        //  0
+    ecl_expr,      //  1
+    open_paren,    //  2
+    close_paren,   //  3
+    op_gt,         //  4
+    op_ge,         //  5
+    op_lt,         //  6
+    op_le,         //  7
+    op_eq,         //  8
+    op_ne,         //  9
+    op_and,        // 10
+    op_or,         // 11
+    end,           // 12
+    error,         // 13
 };
 
-enum class FuncType {
-  none,
-  time,
-  time_month,
-  region,
-  field,
-  group,
-  well,
-  well_segment,
-  well_connection,
-  Well_lgr,
-  aquifer,
-  block
+enum class FuncType
+{
+    none,
+    time,
+    time_month,
+    region,
+    field,
+    group,
+    well,
+    well_segment,
+    well_connection,
+    Well_lgr,
+    aquifer,
+    block,
 };
 
-
-
-namespace Opm {
-namespace Action {
-
-class Value {
+class Value
+{
 public:
     explicit Value(double value);
     Value(const std::string& wname, double value);
@@ -51,14 +74,13 @@ public:
     double scalar() const;
 
 private:
-    Action::Result eval_cmp_wells(TokenType op, double rhs) const;
+    double scalar_value{};
+    double is_scalar{false};
+    std::vector<std::pair<std::string, double>> well_values{};
 
-    double scalar_value;
-    double is_scalar = false;
-    std::vector<std::pair<std::string, double>> well_values;
+    Result eval_cmp_wells(TokenType op, double rhs) const;
 };
 
+}} // namespace Opm::Action
 
-}
-}
-#endif
+#endif // ACTION_VALUE_HPP


### PR DESCRIPTION
Otherwise, we risk making decisions based on left-over data.

While here, mark a couple of constructors as `explicit`, split some long lines, and prefer `fmt::format()` for generating diagnostic messages.