### PR TITLE
Explicitly Initialise GTNode Parent as Nullopt

### DIFF
--- a/opm/input/eclipse/Schedule/Group/GTNode.cpp
+++ b/opm/input/eclipse/Schedule/Group/GTNode.cpp
@@ -15,52 +15,67 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
 #include <opm/input/eclipse/Schedule/Group/GTNode.hpp>
 
+#include <fmt/format.h>
+
 namespace Opm {
 
-GTNode::GTNode(const Group& group_arg, std::size_t level, const std::optional<std::string>& parent_name) :
-    m_group(group_arg),
-    m_level(level),
-    m_parent_name(parent_name)
-{
-}
+GTNode::GTNode(const Group&                      group_arg,
+               const std::size_t                 level,
+               const std::optional<std::string>& parent_name)
+    : m_group      (group_arg)
+    , m_level      (level)
+    , m_parent_name(parent_name)
+{}
 
-const std::string& GTNode::name() const {
+const std::string& GTNode::name() const
+{
     return this->m_group.name();
 }
 
-const Group& GTNode::group() const {
+const Group& GTNode::group() const
+{
     return this->m_group;
 }
 
-const std::string& GTNode::parent_name() const {
-    if (this->m_parent_name.has_value())
+const std::string& GTNode::parent_name() const
+{
+    if (this->m_parent_name.has_value()) {
         return *this->m_parent_name;
+    }
 
-    throw std::invalid_argument("Tried to access parent of root in GroupTree. Root: " + this->name());
+    throw std::invalid_argument {
+        fmt::format("Tried to access parent of root "
+                    "in GroupTree. Root: {}", this->name())
+    };
 }
 
 
-void GTNode::add_well(const Well& well) {
+void GTNode::add_well(const Well& well)
+{
     this->m_wells.push_back(well);
 }
 
-void GTNode::add_group(const GTNode& child_group) {
+void GTNode::add_group(const GTNode& child_group)
+{
     this->m_child_groups.push_back(child_group);
 }
 
-const std::vector<Well>& GTNode::wells() const {
+const std::vector<Well>& GTNode::wells() const
+{
     return this->m_wells;
 }
 
-const std::vector<GTNode>& GTNode::groups() const {
+const std::vector<GTNode>& GTNode::groups() const
+{
     return this->m_child_groups;
 }
 
-std::vector<const GTNode*> GTNode::all_nodes() const {
+std::vector<const GTNode*> GTNode::all_nodes() const
+{
     std::vector<const GTNode*> nodes { this };
 
     for (const auto& child_group : m_child_groups) {
@@ -71,8 +86,9 @@ std::vector<const GTNode*> GTNode::all_nodes() const {
     return nodes;
 }
 
-std::size_t GTNode::level() const {
+std::size_t GTNode::level() const
+{
     return this->m_level;
 }
 
-}
+} // namespace Opm

--- a/opm/input/eclipse/Schedule/Group/GTNode.hpp
+++ b/opm/input/eclipse/Schedule/Group/GTNode.hpp
@@ -20,15 +20,18 @@
 #ifndef GROUPTREE2
 #define GROUPTREE2
 
-#include <optional>
-#include <vector>
-
 #include <opm/input/eclipse/Schedule/Group/Group.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
 namespace Opm {
 
-class GTNode {
+class GTNode
+{
 public:
     GTNode(const Group& group, std::size_t level, const std::optional<std::string>& parent_name);
 
@@ -43,17 +46,18 @@ public:
     const Group& group() const;
     std::size_t level() const;
     std::vector<const GTNode*> all_nodes() const;
+
 private:
-    const Group m_group;
-    std::size_t m_level;
-    std::optional<std::string> m_parent_name;
-    /*
-      Class T with a stl container <T> - supposedly undefined behavior before
-      C++17 - but it compiles without warnings.
-    */
-    std::vector<GTNode> m_child_groups;
-    std::vector<Well> m_wells;
+    Group m_group;
+    std::size_t m_level{};
+    std::optional<std::string> m_parent_name {std::nullopt};
+
+    // Class T with a stl container <T> - supposedly undefined behavior
+    // before C++17 - but it compiles without warnings.
+    std::vector<GTNode> m_child_groups{};
+    std::vector<Well> m_wells{};
 };
 
-}
-#endif
+} // namespace Opm
+
+#endif // GROUPTREE2


### PR DESCRIPTION
Mostly to placate static analyzers.

While here, switch to `fmt::format()` for generating diagnostic messages and adjust whitespace.