### PR TITLE
Add new tests and corresponing fixes in the hysteresis model

### DIFF
--- a/examples/hysteresis.cpp
+++ b/examples/hysteresis.cpp
@@ -210,29 +210,34 @@ int main(int argc, char **argv)
         outfile << relperm[phaseIdx1] << "," << relperm[phaseIdx2]<< ",";
 
         MaterialLaw::updateHysteresis(param, fs);
-        double krnSwMdc_out = 0.0;
-        double pcSwMdc_out = 0.0;
+        double somax_out = 0.0;
+        double shmax_out = 0.0;
+        double swmax_out = 0.0;
+        double swmin_out = 0.0;
+        double sowmin_out = 0.0;
         double trapped_out = 0.0;
         if (two_phase_system == "WO") {
-            MaterialLaw::oilWaterHysteresisParams(pcSwMdc_out,
-                                                krnSwMdc_out,
+            MaterialLaw::oilWaterHysteresisParams(somax_out,
+                                                swmax_out,
+                                                swmin_out,
                                                 param);
         }
         if (two_phase_system == "GO") {
-            MaterialLaw::gasOilHysteresisParams(pcSwMdc_out,
-                                                krnSwMdc_out,
+            MaterialLaw::gasOilHysteresisParams(somax_out,
+                                                shmax_out,
+                                                sowmin_out,
                                                 param);
         }
         if (two_phase_system == "GW") {
             // The GW hysteresis params is not possible to get directly from the 3p MaterialLaw 
             //MaterialLaw::gasWaterHysteresisParams(pcSwMdc_out,
-            //                                    krnSwMdc_out,
+            //                                    somax_out,
             //                                    param);
         } 
 
         trapped_out = MaterialLaw::trappedGasSaturation(param, /*maximumTrapping*/ false);
 
-        outfile << krnSwMdc_out << "," << trapped_out << std::endl;
+        outfile << somax_out << "," << trapped_out << std::endl;
     }
 
     outfile.close();

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -281,7 +281,7 @@ public:
         if (params.config().krHysteresisModel() == 1 || params.config().krHysteresisModel() == 3)
             return EffectiveLaw::twoPhaseSatKrw(params.imbibitionParams(), Sw);
 
-        if (Sw >= params.krwSwMdc())
+        if (Sw <= params.krwSwMdc())
             return EffectiveLaw::twoPhaseSatKrw(params.drainageParams(), Sw);
 
         // Killough hysteresis for the wetting phase

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLaw.hpp
@@ -340,7 +340,6 @@ public:
                 return KrgDrainNxt;
             }
         }
-
         // if no relperm hysteresis is enabled, use the drainage curve
         if (!params.config().enableHysteresis() || params.config().krHysteresisModel() < 0)
             return EffectiveLaw::twoPhaseSatKrn(params.drainageParams(), Sw);

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -270,7 +270,6 @@ public:
             Swcri_ = info.Swcr;
         }
 
-
         // Killough hysteresis model for pc
         if (config().pcHysteresisModel() == 0) {
             if (twoPhaseSystem == EclTwoPhaseSystemType::GasOil) {

--- a/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
+++ b/opm/material/fluidmatrixinteractions/EclHysteresisTwoPhaseLawParams.hpp
@@ -165,9 +165,9 @@ public:
         if (config().krHysteresisModel() == 2 || config().krHysteresisModel() == 3 || config().krHysteresisModel() == 4 || config().pcHysteresisModel() == 0 || gasOilHysteresisWAG()) {
             Swco_ = info.Swl;
             if (twoPhaseSystem == EclTwoPhaseSystemType::GasOil) {
-                Sncrd_ = info.Sgcr+info.Swl;
-                Swcrd_ = info.Sogcr + info.Swl;
-                Snmaxd_ = info.Sgu+info.Swl;
+                Sncrd_ = info.Sgcr + info.Swl;
+                Swcrd_ = info.Sogcr;
+                Snmaxd_ = info.Sgu + info.Swl;
                 KrndMax_ = EffLawT::twoPhaseSatKrn(drainageParams(), 1.0-Snmaxd_);
             }
             else if (twoPhaseSystem == EclTwoPhaseSystemType::GasWater) {
@@ -257,7 +257,7 @@ public:
 
         // Store critical nonwetting saturation
         if (twoPhaseSystem == EclTwoPhaseSystemType::GasOil) {
-            Sncri_ = info.Sgcr+info.Swl;
+            Sncri_ = info.Sgcr + info.Swl;
             Swcri_ = info.Sogcr;
         }
         else if (twoPhaseSystem == EclTwoPhaseSystemType::GasWater) {

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.cpp
@@ -352,54 +352,58 @@ getKrnumSatIdx(unsigned elemIdx, FaceDir::DirEnum facedir) const
 
 template<class TraitsT>
 void EclMaterialLawManager<TraitsT>::
-oilWaterHysteresisParams(Scalar& pcSwMdc,
-                         Scalar& krnSwMdc,
+oilWaterHysteresisParams(Scalar& soMax,
+                         Scalar& swMax,
+                         Scalar& swMin,
                          unsigned elemIdx) const
 {
     if (!enableHysteresis())
         throw std::runtime_error("Cannot get hysteresis parameters if hysteresis not enabled.");
 
     const auto& params = materialLawParams(elemIdx);
-    MaterialLaw::oilWaterHysteresisParams(pcSwMdc, krnSwMdc, params);
+    MaterialLaw::oilWaterHysteresisParams(soMax, swMax, swMin, params);
 }
 
 template<class TraitsT>
 void EclMaterialLawManager<TraitsT>::
-setOilWaterHysteresisParams(const Scalar& pcSwMdc,
-                            const Scalar& krnSwMdc,
+setOilWaterHysteresisParams(const Scalar& soMax,
+                            const Scalar& swMax,
+                            const Scalar& swMin,
                             unsigned elemIdx)
 {
     if (!enableHysteresis())
         throw std::runtime_error("Cannot set hysteresis parameters if hysteresis not enabled.");
 
     auto& params = materialLawParams(elemIdx);
-    MaterialLaw::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc, params);
+    MaterialLaw::setOilWaterHysteresisParams(soMax, swMax, swMin, params);
 }
 
 template<class TraitsT>
 void EclMaterialLawManager<TraitsT>::
-gasOilHysteresisParams(Scalar& pcSwMdc,
-                       Scalar& krnSwMdc,
+gasOilHysteresisParams(Scalar& sgmax,
+                       Scalar& shmax,
+                       Scalar& somin,
                        unsigned elemIdx) const
 {
     if (!enableHysteresis())
         throw std::runtime_error("Cannot get hysteresis parameters if hysteresis not enabled.");
 
     const auto& params = materialLawParams(elemIdx);
-    MaterialLaw::gasOilHysteresisParams(pcSwMdc, krnSwMdc, params);
+    MaterialLaw::gasOilHysteresisParams(sgmax, shmax, somin, params);
 }
 
 template<class TraitsT>
 void EclMaterialLawManager<TraitsT>::
-setGasOilHysteresisParams(const Scalar& pcSwMdc,
-                          const Scalar& krnSwMdc,
+setGasOilHysteresisParams(const Scalar& sgmax,
+                          const Scalar& shmax,
+                          const Scalar& somin,
                           unsigned elemIdx)
 {
     if (!enableHysteresis())
         throw std::runtime_error("Cannot set hysteresis parameters if hysteresis not enabled.");
 
     auto& params = materialLawParams(elemIdx);
-    MaterialLaw::setGasOilHysteresisParams(pcSwMdc, krnSwMdc, params);
+    MaterialLaw::setGasOilHysteresisParams(sgmax, shmax, somin, params);
 }
 
 template<class TraitsT>

--- a/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMaterialLawManager.hpp
@@ -313,6 +313,15 @@ public:
     bool enableHysteresis() const
     { return hysteresisConfig_->enableHysteresis(); }
 
+    bool enablePCHysteresis() const
+    { return (enableHysteresis() && hysteresisConfig_->pcHysteresisModel() >= 0); }
+
+    bool enableWettingHysteresis() const
+    { return (enableHysteresis() && hysteresisConfig_->krHysteresisModel() >= 4); }
+
+    bool enableNonWettingHysteresis() const
+    { return (enableHysteresis() && hysteresisConfig_->krHysteresisModel() >= 0); }
+
     MaterialLawParams& materialLawParams(unsigned elemIdx)
     {
         assert(elemIdx <  materialLawParams_.size());
@@ -384,20 +393,24 @@ public:
         return changed;
     }
 
-    void oilWaterHysteresisParams(Scalar& pcSwMdc,
-                                  Scalar& krnSwMdc,
+    void oilWaterHysteresisParams(Scalar& soMax,
+                                  Scalar& swMax,
+                                  Scalar& swMin,
                                   unsigned elemIdx) const;
 
-    void setOilWaterHysteresisParams(const Scalar& pcSwMdc,
-                                     const Scalar& krnSwMdc,
+    void setOilWaterHysteresisParams(const Scalar& soMax,
+                                     const Scalar& swMax,
+                                     const Scalar& swMin,
                                      unsigned elemIdx);
 
-    void gasOilHysteresisParams(Scalar& pcSwMdc,
-                                Scalar& krnSwMdc,
+    void gasOilHysteresisParams(Scalar& sgmax,
+                                Scalar& shmax,
+                                Scalar& somin,
                                 unsigned elemIdx) const;
 
-    void setGasOilHysteresisParams(const Scalar& pcSwMdc,
-                                   const Scalar& krnSwMdc,
+    void setGasOilHysteresisParams(const Scalar& sgmax,
+                                   const Scalar& shmax,
+                                   const Scalar& somin,
                                    unsigned elemIdx);
 
     EclEpsScalingPoints<Scalar>& oilWaterScaledEpsPointsDrainage(unsigned elemIdx);

--- a/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
+++ b/opm/material/fluidmatrixinteractions/EclMultiplexerMaterial.hpp
@@ -170,33 +170,35 @@ public:
 
     /*
      * Hysteresis parameters for oil-water
-     * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)
-     * @see EclHysteresisTwoPhaseLawParams::krnSwMdc(...)
+     * @see EclHysteresisTwoPhaseLawParams::soMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::swMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::swMin(...)
      * \param params Parameters
      */
-    static void oilWaterHysteresisParams(Scalar& pcSwMdc,
-                                         Scalar& krnSwMdc,
+    static void oilWaterHysteresisParams(Scalar& soMax,
+                                         Scalar& swMax,
+                                         Scalar& swMin,
                                          const Params& params)
     {
         OPM_TIMEFUNCTION_LOCAL();
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
-            Stone1Material::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
+            Stone1Material::oilWaterHysteresisParams(soMax, swMax, swMin,
                                      params.template getRealParams<EclMultiplexerApproach::Stone1>());
             break;
 
         case EclMultiplexerApproach::Stone2:
-            Stone2Material::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
+            Stone2Material::oilWaterHysteresisParams(soMax, swMax, swMin,
                                      params.template getRealParams<EclMultiplexerApproach::Stone2>());
             break;
 
         case EclMultiplexerApproach::Default:
-            DefaultMaterial::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
+            DefaultMaterial::oilWaterHysteresisParams(soMax, swMax, swMin,
                                      params.template getRealParams<EclMultiplexerApproach::Default>());
             break;
 
         case EclMultiplexerApproach::TwoPhase:
-            TwoPhaseMaterial::oilWaterHysteresisParams(pcSwMdc, krnSwMdc,
+            TwoPhaseMaterial::oilWaterHysteresisParams(soMax, swMax, swMin,
                                      params.template getRealParams<EclMultiplexerApproach::TwoPhase>());
             break;
 
@@ -208,33 +210,35 @@ public:
 
     /*
      * Hysteresis parameters for oil-water
-     * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)
-     * @see EclHysteresisTwoPhaseLawParams::krnSwMdc(...)
+     * @see EclHysteresisTwoPhaseLawParams::soMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::swMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::swMin(...)
      * \param params Parameters
      */
-    static void setOilWaterHysteresisParams(const Scalar& pcSwMdc,
-                                            const Scalar& krnSwMdc,
+    static void setOilWaterHysteresisParams(const Scalar& soMax,
+                                            const Scalar& swMax,
+                                            const Scalar& swMin,
                                             Params& params)
     {
         OPM_TIMEFUNCTION_LOCAL();
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
-            Stone1Material::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
+            Stone1Material::setOilWaterHysteresisParams(soMax, swMax, swMin,
                                      params.template getRealParams<EclMultiplexerApproach::Stone1>());
             break;
 
         case EclMultiplexerApproach::Stone2:
-            Stone2Material::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
+            Stone2Material::setOilWaterHysteresisParams(soMax, swMax, swMin,
                                      params.template getRealParams<EclMultiplexerApproach::Stone2>());
             break;
 
         case EclMultiplexerApproach::Default:
-            DefaultMaterial::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
+            DefaultMaterial::setOilWaterHysteresisParams(soMax, swMax, swMin,
                                      params.template getRealParams<EclMultiplexerApproach::Default>());
             break;
 
         case EclMultiplexerApproach::TwoPhase:
-            TwoPhaseMaterial::setOilWaterHysteresisParams(pcSwMdc, krnSwMdc,
+            TwoPhaseMaterial::setOilWaterHysteresisParams(soMax, swMax, swMin,
                                      params.template getRealParams<EclMultiplexerApproach::TwoPhase>());
             break;
 
@@ -246,33 +250,35 @@ public:
 
     /*
      * Hysteresis parameters for gas-oil
-     * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)
-     * @see EclHysteresisTwoPhaseLawParams::krnSwMdc(...)
+     * @see EclHysteresisTwoPhaseLawParams::sgmax(...)
+     * @see EclHysteresisTwoPhaseLawParams::shmax(...)
+     * @see EclHysteresisTwoPhaseLawParams::somin(...)
      * \param params Parameters
      */
-    static void gasOilHysteresisParams(Scalar& pcSwMdc,
-                                       Scalar& krnSwMdc,
+    static void gasOilHysteresisParams(Scalar& sgmax,
+                                       Scalar& shmax,
+                                       Scalar& somin,
                                        const Params& params)
     {
         OPM_TIMEFUNCTION_LOCAL();
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
-            Stone1Material::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
+            Stone1Material::gasOilHysteresisParams(sgmax, shmax, somin,
                                      params.template getRealParams<EclMultiplexerApproach::Stone1>());
             break;
 
         case EclMultiplexerApproach::Stone2:
-            Stone2Material::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
+            Stone2Material::gasOilHysteresisParams(sgmax, shmax, somin,
                                      params.template getRealParams<EclMultiplexerApproach::Stone2>());
             break;
 
         case EclMultiplexerApproach::Default:
-            DefaultMaterial::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
+            DefaultMaterial::gasOilHysteresisParams(sgmax, shmax, somin,
                                      params.template getRealParams<EclMultiplexerApproach::Default>());
             break;
 
         case EclMultiplexerApproach::TwoPhase:
-            TwoPhaseMaterial::gasOilHysteresisParams(pcSwMdc, krnSwMdc,
+            TwoPhaseMaterial::gasOilHysteresisParams(sgmax, shmax, somin,
                                      params.template getRealParams<EclMultiplexerApproach::TwoPhase>());
             break;
 
@@ -287,17 +293,13 @@ public:
         OPM_TIMEFUNCTION_LOCAL();
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
-            return params.template getRealParams<EclMultiplexerApproach::Stone1>().gasOilParams().SnTrapped(maximumTrapping);
+            return Stone1Material::trappedGasSaturation(params.template getRealParams<EclMultiplexerApproach::Stone1>(), maximumTrapping);
         case EclMultiplexerApproach::Stone2:
-            return params.template getRealParams<EclMultiplexerApproach::Stone2>().gasOilParams().SnTrapped(maximumTrapping);
+            return Stone2Material::trappedGasSaturation(params.template getRealParams<EclMultiplexerApproach::Stone2>(), maximumTrapping);
         case EclMultiplexerApproach::Default:
-            return params.template getRealParams<EclMultiplexerApproach::Default>().gasOilParams().SnTrapped(maximumTrapping);
+            return DefaultMaterial::trappedGasSaturation(params.template getRealParams<EclMultiplexerApproach::Default>(), maximumTrapping);
         case EclMultiplexerApproach::TwoPhase:
-            if(params.template getRealParams<EclMultiplexerApproach::TwoPhase>().approach() == EclTwoPhaseApproach::GasOil)
-                return params.template getRealParams<EclMultiplexerApproach::TwoPhase>().gasOilParams().SnTrapped(maximumTrapping);
-            if(params.template getRealParams<EclMultiplexerApproach::TwoPhase>().approach() == EclTwoPhaseApproach::GasWater)
-                return params.template getRealParams<EclMultiplexerApproach::TwoPhase>().gasWaterParams().SnTrapped(maximumTrapping);
-            return 0.0; // oil-water case
+            return TwoPhaseMaterial::trappedGasSaturation(params.template getRealParams<EclMultiplexerApproach::TwoPhase>(), maximumTrapping); 
         case EclMultiplexerApproach::OnePhase:
             return 0.0;
         }
@@ -309,17 +311,13 @@ public:
         OPM_TIMEFUNCTION_LOCAL();
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
-            return params.template getRealParams<EclMultiplexerApproach::Stone1>().gasOilParams().SnStranded(Sg, Kg);
+            return Stone1Material::strandedGasSaturation(params.template getRealParams<EclMultiplexerApproach::Stone1>(), Sg, Kg);
         case EclMultiplexerApproach::Stone2:
-            return params.template getRealParams<EclMultiplexerApproach::Stone2>().gasOilParams().SnStranded(Sg, Kg);
+            return Stone2Material::strandedGasSaturation(params.template getRealParams<EclMultiplexerApproach::Stone2>(), Sg, Kg);
         case EclMultiplexerApproach::Default:
-            return params.template getRealParams<EclMultiplexerApproach::Default>().gasOilParams().SnStranded(Sg, Kg);
+            return DefaultMaterial::strandedGasSaturation(params.template getRealParams<EclMultiplexerApproach::Default>(), Sg, Kg);
         case EclMultiplexerApproach::TwoPhase:
-            if(params.template getRealParams<EclMultiplexerApproach::TwoPhase>().approach() == EclTwoPhaseApproach::GasOil)
-                return params.template getRealParams<EclMultiplexerApproach::TwoPhase>().gasOilParams().SnStranded(Sg, Kg);
-            if(params.template getRealParams<EclMultiplexerApproach::TwoPhase>().approach() == EclTwoPhaseApproach::GasWater)
-                return params.template getRealParams<EclMultiplexerApproach::TwoPhase>().gasWaterParams().SnStranded(Sg, Kg);
-            return 0.0; // oil-water case
+            return TwoPhaseMaterial::strandedGasSaturation(params.template getRealParams<EclMultiplexerApproach::TwoPhase>(), Sg, Kg); 
         case EclMultiplexerApproach::OnePhase:
             return 0.0;
         }
@@ -331,17 +329,13 @@ public:
         OPM_TIMEFUNCTION_LOCAL();
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
-            return params.template getRealParams<EclMultiplexerApproach::Stone1>().oilWaterParams().SnTrapped(maximumTrapping);
+            return Stone1Material::trappedOilSaturation(params.template getRealParams<EclMultiplexerApproach::Stone1>(), maximumTrapping);
         case EclMultiplexerApproach::Stone2:
-            return params.template getRealParams<EclMultiplexerApproach::Stone2>().oilWaterParams().SnTrapped(maximumTrapping);
+            return Stone2Material::trappedOilSaturation(params.template getRealParams<EclMultiplexerApproach::Stone2>(), maximumTrapping);
         case EclMultiplexerApproach::Default:
-            return params.template getRealParams<EclMultiplexerApproach::Default>().oilWaterParams().SnTrapped(maximumTrapping);
+            return DefaultMaterial::trappedOilSaturation(params.template getRealParams<EclMultiplexerApproach::Default>(), maximumTrapping);
         case EclMultiplexerApproach::TwoPhase:
-            if(params.template getRealParams<EclMultiplexerApproach::TwoPhase>().approach() == EclTwoPhaseApproach::GasOil)
-                return params.template getRealParams<EclMultiplexerApproach::TwoPhase>().gasOilParams().SwTrapped();
-            if(params.template getRealParams<EclMultiplexerApproach::TwoPhase>().approach() == EclTwoPhaseApproach::OilWater)
-                return params.template getRealParams<EclMultiplexerApproach::TwoPhase>().oilWaterParams().SnTrapped(maximumTrapping);
-            return 0.0; // gas-water case
+            return TwoPhaseMaterial::trappedOilSaturation(params.template getRealParams<EclMultiplexerApproach::TwoPhase>(), maximumTrapping); 
         case EclMultiplexerApproach::OnePhase:
             return 0.0;
         }
@@ -353,17 +347,13 @@ public:
         OPM_TIMEFUNCTION_LOCAL();
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
-            return params.template getRealParams<EclMultiplexerApproach::Stone1>().oilWaterParams().SwTrapped();
+            return Stone1Material::trappedWaterSaturation(params.template getRealParams<EclMultiplexerApproach::Stone1>());
         case EclMultiplexerApproach::Stone2:
-            return params.template getRealParams<EclMultiplexerApproach::Stone2>().oilWaterParams().SwTrapped();
+            return Stone2Material::trappedWaterSaturation(params.template getRealParams<EclMultiplexerApproach::Stone2>());
         case EclMultiplexerApproach::Default:
-            return params.template getRealParams<EclMultiplexerApproach::Default>().oilWaterParams().SwTrapped();
+            return DefaultMaterial::trappedWaterSaturation(params.template getRealParams<EclMultiplexerApproach::Default>());
         case EclMultiplexerApproach::TwoPhase:
-            if(params.template getRealParams<EclMultiplexerApproach::TwoPhase>().approach() == EclTwoPhaseApproach::GasWater)
-                return params.template getRealParams<EclMultiplexerApproach::TwoPhase>().gasWaterParams().SwTrapped();
-            if(params.template getRealParams<EclMultiplexerApproach::TwoPhase>().approach() == EclTwoPhaseApproach::OilWater)
-                return params.template getRealParams<EclMultiplexerApproach::TwoPhase>().oilWaterParams().SwTrapped();
-            return 0.0; // gas-oil case
+            return TwoPhaseMaterial::trappedWaterSaturation(params.template getRealParams<EclMultiplexerApproach::TwoPhase>()); 
         case EclMultiplexerApproach::OnePhase:
             return 0.0;
         }
@@ -371,33 +361,35 @@ public:
     }
     /*
      * Hysteresis parameters for gas-oil
-     * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)
-     * @see EclHysteresisTwoPhaseLawParams::krnSwMdc(...)
+     * @see EclHysteresisTwoPhaseLawParams::sgmax(...)
+     * @see EclHysteresisTwoPhaseLawParams::shmax(...)
+     * @see EclHysteresisTwoPhaseLawParams::somin(...)
      * \param params Parameters
      */
-    static void setGasOilHysteresisParams(const Scalar& pcSwMdc,
-                                          const Scalar& krnSwMdc,
+    static void setGasOilHysteresisParams(const Scalar& sgmax,
+                                          const Scalar& shmax,
+                                          const Scalar& somin,
                                           Params& params)
     {
         OPM_TIMEFUNCTION_LOCAL();
         switch (params.approach()) {
         case EclMultiplexerApproach::Stone1:
-            Stone1Material::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
+            Stone1Material::setGasOilHysteresisParams(sgmax, shmax, somin,
                                      params.template getRealParams<EclMultiplexerApproach::Stone1>());
             break;
 
         case EclMultiplexerApproach::Stone2:
-            Stone2Material::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
+            Stone2Material::setGasOilHysteresisParams(sgmax, shmax, somin,
                                      params.template getRealParams<EclMultiplexerApproach::Stone2>());
             break;
 
         case EclMultiplexerApproach::Default:
-            DefaultMaterial::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
+            DefaultMaterial::setGasOilHysteresisParams(sgmax, shmax, somin,
                                      params.template getRealParams<EclMultiplexerApproach::Default>());
             break;
 
         case EclMultiplexerApproach::TwoPhase:
-            TwoPhaseMaterial::setGasOilHysteresisParams(pcSwMdc, krnSwMdc,
+            TwoPhaseMaterial::setGasOilHysteresisParams(sgmax, shmax, somin,
                                      params.template getRealParams<EclMultiplexerApproach::TwoPhase>());
             break;
 

--- a/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
+++ b/opm/material/fluidmatrixinteractions/EclStone2Material.hpp
@@ -148,70 +148,97 @@ public:
 
     /*
      * Hysteresis parameters for oil-water
-     * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)
-     * @see EclHysteresisTwoPhaseLawParams::krnSwMdc(...)
+     * @see EclHysteresisTwoPhaseLawParams::soMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::swMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::swMin(...)
      * \param params Parameters
      */
-    static void oilWaterHysteresisParams(Scalar& pcSwMdc,
-                                         Scalar& krnSwMdc,
+    static void oilWaterHysteresisParams(Scalar& soMax,
+                                         Scalar& swMax,
+                                         Scalar& swMin,
                                          const Params& params)
     {
-        pcSwMdc = params.oilWaterParams().pcSwMdc();
-        krnSwMdc = params.oilWaterParams().krnSwMdc();
-
-        Valgrind::CheckDefined(pcSwMdc);
-        Valgrind::CheckDefined(krnSwMdc);
+        soMax = 1.0 - params.oilWaterParams().krnSwMdc();
+        swMax = params.oilWaterParams().krwSwMdc();
+        swMin = params.oilWaterParams().pcSwMdc();
+        Valgrind::CheckDefined(soMax);
+        Valgrind::CheckDefined(swMax);
+        Valgrind::CheckDefined(swMin);
     }
 
     /*
      * Hysteresis parameters for oil-water
-     * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)
-     * @see EclHysteresisTwoPhaseLawParams::krnSwMdc(...)
+     * @see EclHysteresisTwoPhaseLawParams::soMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::swMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::swMin(...)
      * \param params Parameters
      */
-    static void setOilWaterHysteresisParams(const Scalar& pcSwMdc,
-                                            const Scalar& krnSwMdc,
+    static void setOilWaterHysteresisParams(const Scalar& soMax,
+                                            const Scalar& swMax,
+                                            const Scalar& swMin,
                                             Params& params)
     {
-        constexpr const double krwSw = 2.0; //Should not be used
-        params.oilWaterParams().update(pcSwMdc, krwSw, krnSwMdc);
+        params.oilWaterParams().update(swMin, swMax, 1.0 - soMax);
     }
+
 
     /*
      * Hysteresis parameters for gas-oil
-     * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)
-     * @see EclHysteresisTwoPhaseLawParams::krnSwMdc(...)
+     * @see EclHysteresisTwoPhaseLawParams::sgMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::shMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::soMin(...)
      * \param params Parameters
      */
-    static void gasOilHysteresisParams(Scalar& pcSwMdc,
-                                       Scalar& krnSwMdc,
+    static void gasOilHysteresisParams(Scalar& sgMax,
+                                       Scalar& shMax,
+                                       Scalar& soMin,
                                        const Params& params)
     {
         const auto Swco = params.Swl();
+        sgMax = 1.0 - params.gasOilParams().krnSwMdc() - Swco;
+        shMax = params.gasOilParams().krwSwMdc();
+        soMin = params.gasOilParams().pcSwMdc();
 
-        // Pretend oil saturation is 'Swco' larger than it really is in
-        // order to infer correct maximum Sg values in output layer.
-        pcSwMdc = std::min(params.gasOilParams().pcSwMdc() + Swco, Scalar{2.0});
-        krnSwMdc = std::min(params.gasOilParams().krnSwMdc() + Swco, Scalar{2.0});
-
-        Valgrind::CheckDefined(pcSwMdc);
-        Valgrind::CheckDefined(krnSwMdc);
+        Valgrind::CheckDefined(sgMax);
+        Valgrind::CheckDefined(shMax);
+        Valgrind::CheckDefined(soMin);
     }
 
     /*
      * Hysteresis parameters for gas-oil
-     * @see EclHysteresisTwoPhaseLawParams::pcSwMdc(...)
-     * @see EclHysteresisTwoPhaseLawParams::krnSwMdc(...)
+     * @see EclHysteresisTwoPhaseLawParams::sgMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::shMax(...)
+     * @see EclHysteresisTwoPhaseLawParams::soMin(...)
      * \param params Parameters
      */
-    static void setGasOilHysteresisParams(const Scalar& pcSwMdc,
-                                          const Scalar& krnSwMdc,
+    static void setGasOilHysteresisParams(const Scalar& sgMax,
+                                          const Scalar& shMax,
+                                          const Scalar& soMin,
                                           Params& params)
     {
-        // Maximum attainable oil saturation is 1-SWL
         const auto Swco = params.Swl();
-        constexpr const double krwSw = 2.0; //Should not be used
-        params.gasOilParams().update(pcSwMdc - Swco, krwSw, krnSwMdc - Swco);
+        params.gasOilParams().update(soMin, shMax, 1.0 - sgMax - Swco);
+    }
+
+    static Scalar trappedGasSaturation(const Params& params, bool maximumTrapping)
+    {
+        const auto Swco = params.Swl();
+        return params.gasOilParams().SnTrapped(maximumTrapping) - Swco;
+    }
+
+    static Scalar trappedOilSaturation(const Params& params, bool maximumTrapping)
+    {
+        return params.oilWaterParams().SnTrapped(maximumTrapping) + params.gasOilParams().SwTrapped();
+    }
+
+    static Scalar trappedWaterSaturation(const Params& params)
+    {
+        return params.oilWaterParams().SwTrapped();
+    }
+    static Scalar strandedGasSaturation(const Params& params, Scalar Sg, Scalar Kg)
+    {
+        const auto Swco = params.Swl();
+        return params.gasOilParams().SnStranded(Sg, Kg) - Swco;
     }
 
     /*!
@@ -404,14 +431,22 @@ public:
     static bool updateHysteresis(Params& params, const FluidState& fluidState)
     {
         const Scalar Swco = params.Swl();
-        const Scalar Sw = scalarValue(fluidState.saturation(waterPhaseIdx));
-        const Scalar Sg = scalarValue(fluidState.saturation(gasPhaseIdx));
-        bool changed = false;
-        changed = changed || params.oilWaterParams().update(/*pcSw=*/Sw, /*krwSw=*/Sw, /*krnSw=*/Sw);
-        changed = changed || params.gasOilParams().update(/*pcSw=*/  1.0 - Swco - Sg,
-                                                          /*krwSw=*/ 1.0 - Swco - Sg,
+        const Scalar Sw = clampSaturation(fluidState, waterPhaseIdx);
+        const Scalar So = clampSaturation(fluidState, oilPhaseIdx);
+        const Scalar Sg = clampSaturation(fluidState, gasPhaseIdx);
+        bool owChanged = params.oilWaterParams().update(/*pcSw=*/Sw, /*krwSw=*/Sw, /*krnSw=*/1 - So);
+        bool gochanged = params.gasOilParams().update(/*pcSw=*/  So,
+                                                          /*krwSw=*/ So,
                                                           /*krnSw=*/ 1.0 - Swco - Sg);
-        return changed;
+        return owChanged || gochanged;
+    }
+
+    template <class FluidState>
+    static Scalar clampSaturation(const FluidState& fluidState, const int phaseIndex)
+    {
+        OPM_TIMEFUNCTION_LOCAL();
+        const auto sat = scalarValue(fluidState.saturation(phaseIndex));
+        return std::clamp(sat, Scalar{0.0}, Scalar{1.0});
     }
 };
 

--- a/tests/material/test_eclmateriallawmanager.cpp
+++ b/tests/material/test_eclmateriallawmanager.cpp
@@ -718,29 +718,31 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(Fam1Fam2Hysteresis, Scalar, Types)
 
                 // This should ideally test each of the materials (stone1, stone2, default, two-phase),
                 // but currently only tests default
-                const std::array<Scalar,2> pcSwMdc_in =  {1.0 / 2.0, 1.0 / 3.0};
-                const std::array<Scalar,2> krnSwMdc_in = {1.0 / 5.0, 1.0 / 7.0};
-                hysterMaterialLawManager.setOilWaterHysteresisParams(pcSwMdc_in[0],
-                                                                     krnSwMdc_in[0],
+                const std::array<Scalar,3> sowmax_in =  {1.0 / 2.0, 1.0 / 3.0, 1.0 / 4.0};
+                const std::array<Scalar,3> sgomax_in = {1.0 / 5.0, 1.0 / 7.0,  1.0 / 9.0};
+                hysterMaterialLawManager.setOilWaterHysteresisParams(sowmax_in[0],
+                                                                     sowmax_in[1],
+                                                                     sowmax_in[2],
                                                                      elemIdx);
-                hysterMaterialLawManager.setGasOilHysteresisParams(pcSwMdc_in[1],
-                                                                   krnSwMdc_in[1],
+                hysterMaterialLawManager.setGasOilHysteresisParams(sgomax_in[0],
+                                                                   sgomax_in[1],
+                                                                   sgomax_in[2],
                                                                    elemIdx);
 
-                std::array<Scalar,2> pcSwMdc_out = {0.0, 0.0};
-                std::array<Scalar,2> krnSwMdc_out = {0.0, 0.0};
-                hysterMaterialLawManager.oilWaterHysteresisParams(pcSwMdc_out[0],
-                                                                  krnSwMdc_out[0],
+                std::array<Scalar,3> sowmax_out = {0.0, 0.0, 0.0};
+                std::array<Scalar,3> sgomax_out = {0.0, 0.0, 0.0};
+                hysterMaterialLawManager.oilWaterHysteresisParams(sowmax_out[0],
+                                                                  sowmax_out[1],
+                                                                  sowmax_out[2],
                                                                   elemIdx);
-                hysterMaterialLawManager.gasOilHysteresisParams(pcSwMdc_out[1],
-                                                                krnSwMdc_out[1],
+                hysterMaterialLawManager.gasOilHysteresisParams(sgomax_out[0],
+                                                                sgomax_out[1],
+                                                                sgomax_out[2],
                                                                 elemIdx);
 
-                for (unsigned phasePairIdx = 0; phasePairIdx < 2; ++phasePairIdx) {
-                    BOOST_CHECK_MESSAGE(pcSwMdc_in[phasePairIdx] == pcSwMdc_out[phasePairIdx],
-                                        "Hysteresis parameters did not propagate correctly");
-                    BOOST_CHECK_MESSAGE(krnSwMdc_in[phasePairIdx] == krnSwMdc_out[phasePairIdx],
-                                        "Hysteresis parameters did not propagate correctly");
+                for (unsigned phasePairIdx = 0; phasePairIdx < 3; ++phasePairIdx) {
+                    BOOST_CHECK_CLOSE(sowmax_in[phasePairIdx], sowmax_out[phasePairIdx], 1e-5);
+                    BOOST_CHECK_CLOSE(sgomax_in[phasePairIdx], sgomax_out[phasePairIdx], 1e-5);     
                 }
             }
         }

--- a/tests/material/test_hysteresis.cpp
+++ b/tests/material/test_hysteresis.cpp
@@ -103,6 +103,62 @@ static const char* hysterDeckStringKilloughGasOil = R"(
     IMBNUM
     1*2 / )";
 
+static const char* hysterDeckStringKillough3pBaker = R"(
+    
+    RUNSPEC
+
+    DIMENS
+       1 1 1 /
+    
+    TABDIMS
+     2 /
+    
+    OIL
+    GAS
+    WATER
+    
+    GRID
+    
+    DX
+       1*1000 /
+    DY
+       1*1000 /
+    DZ
+       1*50 /
+    
+    TOPS
+       1*0 /
+
+    PORO
+      1*0.15 /
+    
+    EHYSTR
+      0.1 2 0.1 1* BOTH /
+    
+    SATOPTS
+      HYSTER /
+    
+    PROPS
+    
+    SWOF
+    0.12   0    1.0   0
+    1      1.0  0.0   0 /
+    0.12   0    1.0   0
+    1      1.0  0.0   0 /
+
+    SGOF
+    0      0    1.0   0
+    0.88      1.0  0.0   0 /
+    0.12   0    1.0   0
+    0.88      1.0  0.0   0 /
+    
+    REGIONS
+    
+    SATNUM
+    1*1 /
+    IMBNUM
+    1*2 / )";
+
 static const char* hysterDeckStringKilloughGasOilWetting = R"(
     
     RUNSPEC
@@ -152,6 +208,178 @@ static const char* hysterDeckStringKilloughGasOilWetting = R"(
     IMBNUM
     1*2 / )";
 
+static const char* hysterDeckStringKillough3pBakerWetting = R"(
+    
+    RUNSPEC
+
+    DIMENS
+       1 1 1 /
+    
+    TABDIMS
+     2 /
+    
+    OIL
+    GAS
+    WATER
+    
+    GRID
+    
+    DX
+       1*1000 /
+    DY
+       1*1000 /
+    DZ
+       1*50 /
+    
+    TOPS
+       1*0 /
+
+    PORO
+      1*0.15 /
+    
+    EHYSTR
+      0.1 4 0.1 1* BOTH /
+    
+    SATOPTS
+      HYSTER /
+    
+    PROPS
+    
+
+    SWOF
+    0.12   0    1.0   0
+    1      1.0  0.0   0 /
+    0.12   0    1.0   0
+    1      1.0  0.0   0 /
+
+    SGOF
+    0      0    1.0   0
+    0.88   1.0  0.0   0 /
+    0      0    1.0   0
+    0.76   1.0  0.0   0 /
+    
+    REGIONS
+    
+    SATNUM
+    1*1 /
+    IMBNUM
+    1*2 / )";
+
+static const char* hysterDeckStringKillough3pStone1Wetting = R"(
+    
+    RUNSPEC
+
+    DIMENS
+       1 1 1 /
+    
+    TABDIMS
+     2 /
+    
+    OIL
+    GAS
+    WATER
+    
+    GRID
+    
+    DX
+       1*1000 /
+    DY
+       1*1000 /
+    DZ
+       1*50 /
+    
+    TOPS
+       1*0 /
+
+    PORO
+      1*0.15 /
+    
+    EHYSTR
+      0.1 4 0.1 1* BOTH /
+    
+    SATOPTS
+      HYSTER /
+    
+    PROPS
+    
+    STONE1
+
+    SWOF
+    0.12   0    1.0   0
+    1      1.0  0.0   0 /
+    0.12   0    1.0   0
+    1      1.0  0.0   0 /
+
+    SGOF
+    0      0    1.0   0
+    0.88   1.0  0.0   0 /
+    0      0    1.0   0
+    0.76   1.0  0.0   0 /
+    
+    REGIONS
+    
+    SATNUM
+    1*1 /
+    IMBNUM
+    1*2 / )";
+
+static const char* hysterDeckStringKillough3pStone2Wetting = R"(
+    
+    RUNSPEC
+
+    DIMENS
+       1 1 1 /
+    
+    TABDIMS
+     2 /
+    
+    OIL
+    GAS
+    WATER
+    
+    GRID
+    
+    DX
+       1*1000 /
+    DY
+       1*1000 /
+    DZ
+       1*50 /
+    
+    TOPS
+       1*0 /
+
+    PORO
+      1*0.15 /
+    
+    EHYSTR
+      0.1 4 0.1 1* BOTH /
+    
+    SATOPTS
+      HYSTER /
+    
+    PROPS
+    
+    STONE2
+
+    SWOF
+    0.12   0    1.0   0
+    1      1.0  0.0   0 /
+    0.12   0    1.0   0
+    1      1.0  0.0   0 /
+
+    SGOF
+    0      0    1.0   0
+    0.88   1.0  0.0   0 /
+    0      0    1.0   0
+    0.76   1.0  0.0   0 /
+    
+    REGIONS
+    
+    SATNUM
+    1*1 /
+    IMBNUM
+    1*2 / )";
 
 //Test Carlson hysteresis Gas Oil System
 static constexpr const char* hysterDeckStringCarlsonGasOil = R"(
@@ -354,6 +582,121 @@ static constexpr const char* hysterDeckStringKilloughWettingOilWater = R"(
     IMBNUM
     1*2 / )";
 
+
+static constexpr const char* hysterDeckStringKilloughWetting3phaseBaker = R"(
+    
+    RUNSPEC
+
+    DIMENS
+       1 1 1 /
+    
+    TABDIMS
+     2 /
+    
+    OIL
+    WATER
+    GAS
+    
+    GRID
+    
+    DX
+       1*1000 /
+    DY
+       1*1000 /
+    DZ
+       1*50 /
+    
+    TOPS
+       1*0 /
+
+    PORO
+      1*0.15 /
+    
+    EHYSTR
+      0.1 4 0.1 1* BOTH /
+    
+    SATOPTS
+      HYSTER /
+    
+    PROPS
+    
+    SWOF
+    0      0    1.0   0
+    1      1.0  0.0   0 /
+    0.12     0    1.0   0
+    1.0    1.0  0.0   0 /
+    
+    SGOF
+    0      0    1.0   0
+    1      1.0  0.0   0 /
+    0.12     0    1.0   0
+    0.88    1.0  0.0   0 /
+
+    REGIONS
+    
+    SATNUM
+    1*1 /
+
+    IMBNUM
+    1*2 / )";
+
+static constexpr const char* hysterDeckStringKillough3phaseBaker = R"(
+    
+    RUNSPEC
+
+    DIMENS
+       1 1 1 /
+    
+    TABDIMS
+     2 /
+    
+    OIL
+    WATER
+    GAS
+    
+    GRID
+    
+    DX
+       1*1000 /
+    DY
+       1*1000 /
+    DZ
+       1*50 /
+    
+    TOPS
+       1*0 /
+
+    PORO
+      1*0.15 /
+    
+    EHYSTR
+      0.1 2 0.1 1* BOTH /
+    
+    SATOPTS
+      HYSTER /
+    
+    PROPS
+    
+   SWOF
+    0      0    1.0   0
+    1      1.0  0.0   0 /
+    0      0    1.0   0
+    0.88   1.0  0.0   0 /
+    
+    SGOF
+    0      0    1.0   0
+    1      1.0  0.0   0 /
+    0.12     0    1.0   0
+    1.0    1.0  0.0   0 /
+
+    REGIONS
+    
+    SATNUM
+    1*1 /
+
+    IMBNUM
+    1*2 / )";
+
 template<class Scalar>
 struct Fixture {
     enum { numPhases = 3 };
@@ -503,14 +846,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughGasOilScanning, Scalar, Types)
         BOOST_CHECK_CLOSE(Sg, kr[Fixture<Scalar>::gasPhaseIdx], tol);
     }
     Scalar trappedSg = MaterialLaw::trappedGasSaturation(param, /*maximumTrapping*/true);
-    Scalar krnSwMdc_out = 0.0;
-    Scalar pcSwMdc_out = 0.0;
-    MaterialLaw::gasOilHysteresisParams(pcSwMdc_out,
-                                        krnSwMdc_out,
+    Scalar sgmax_out = 0.0;
+    Scalar shmax_out = 0.0;
+    Scalar somin_out = 0.0;
+    MaterialLaw::gasOilHysteresisParams(sgmax_out,
+                                        shmax_out,
+                                        somin_out,
                                         param);
 
-    Scalar maxKrg = 1.0 - krnSwMdc_out; 
-    Scalar maxSg = 1.0 - krnSwMdc_out;
+    Scalar maxKrg = sgmax_out; 
+    Scalar maxSg = sgmax_out;
     BOOST_CHECK_CLOSE(0.5, maxKrg, tol);
     BOOST_CHECK_CLOSE(0.5, maxSg, tol);
     Scalar Sncri = 0.12;
@@ -534,6 +879,80 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughGasOilScanning, Scalar, Types)
 
         BOOST_CHECK_CLOSE(Sw, kr[Fixture<Scalar>::waterPhaseIdx], tol);
         BOOST_CHECK_CLOSE(So, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKillough3pBakerConnateWaterScanning, Scalar, Types)
+{
+    using MaterialLaw = typename Fixture<Scalar>::MaterialLaw;
+    using MaterialLawManager = typename Fixture<Scalar>::MaterialLawManager;
+    constexpr int numPhases = Fixture<Scalar>::numPhases;
+
+    Opm::Parser parser;
+
+    const auto deck = parser.parseString(hysterDeckStringKillough3pBaker);
+    const Opm::EclipseState eclState(deck);
+
+    const auto& eclGrid = eclState.getInputGrid();
+    std::size_t n = eclGrid.getCartesianSize();
+
+    MaterialLawManager hysteresis;
+    hysteresis.initFromState(eclState);
+    hysteresis.initParamsForElements(eclState, n, doOldLookup, doNothing);
+    auto& param = hysteresis.materialLawParams(0);
+    Scalar Sw = 0.12;
+    Scalar tol = 1e-3;
+    std::array<Scalar,numPhases> kr = {0.0, 0.0, 0.0};
+    for (int i = 0; i <= 50; ++ i) {
+        Scalar Sg = Scalar(i) / 100;
+        Scalar So = 1 - Sg - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        MaterialLaw::updateHysteresis(param, fs);
+        BOOST_CHECK_CLOSE(0, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(So/0.88, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Sg/0.88, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+    Scalar trappedSg = MaterialLaw::trappedGasSaturation(param, /*maximumTrapping*/true);
+    Scalar sgmax_out = 0.0;
+    Scalar shmax_out = 0.0;
+    Scalar somin_out = 0.0;
+    MaterialLaw::gasOilHysteresisParams(sgmax_out,
+                                        shmax_out,
+                                        somin_out,
+                                        param);
+
+    Scalar maxKrg = sgmax_out/0.88; 
+    Scalar maxSg = sgmax_out;
+    BOOST_CHECK_CLOSE(0.5, maxSg, tol);
+    Scalar Sncri = 0.12;
+    Scalar killoughScalingParam = 0.1;
+    Scalar C = 1 / Sncri - 1.0/0.88;
+    Scalar Snr = maxSg / (1 + killoughScalingParam * (0.88 - maxSg) + C*maxSg );
+    BOOST_CHECK_CLOSE(Snr, trappedSg, tol);
+
+    for (int i = 50; i >= 0; -- i) {
+        Scalar Sg = Scalar(i) / 100;
+        Scalar So = 1 - Sg - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        MaterialLaw::updateHysteresis(param, fs);
+        Scalar Khyst = (Sg < trappedSg)? 0.0 : (Sg - trappedSg) * ( maxKrg/ (maxSg - trappedSg)); 
+
+        BOOST_CHECK_CLOSE(0, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(So/0.88, kr[Fixture<Scalar>::oilPhaseIdx], tol);
         BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
     }
 }
@@ -577,14 +996,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughGasOilScanningWetting, Scalar, T
         BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
     }
     Scalar trappedSg = MaterialLaw::trappedGasSaturation(param, /*maximumTrapping*/true);
-    Scalar krnSwMdc_out = 0.0;
-    Scalar pcSwMdc_out = 0.0;
-    MaterialLaw::gasOilHysteresisParams(pcSwMdc_out,
-                                        krnSwMdc_out,
+    Scalar sgmax_out = 0.0;
+    Scalar shmax_out = 0.0;
+    Scalar somin_out = 0.0;
+    MaterialLaw::gasOilHysteresisParams(sgmax_out,
+                                        shmax_out,
+                                        somin_out,
                                         param);
 
-    Scalar maxKrg = 1.0 - krnSwMdc_out; 
-    Scalar maxSg = 1.0 - krnSwMdc_out;
+    Scalar maxKrg = sgmax_out; 
+    Scalar maxSg = sgmax_out;
     BOOST_CHECK_CLOSE(1.0, maxKrg, tol);
     BOOST_CHECK_CLOSE(1.0, maxSg, tol);
     Scalar Sncri = 0.12;
@@ -614,8 +1035,425 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughGasOilScanningWetting, Scalar, T
         BOOST_CHECK_CLOSE(KhystO, kr[Fixture<Scalar>::oilPhaseIdx], tol);
         BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
     }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar sgmax_out2= 0.0;
+        Scalar shmax_out2= 0.0;
+        Scalar somin_out2= 0.0;
+        hysteresis.gasOilHysteresisParams(sgmax_out2,
+                                          shmax_out2,
+                                          somin_out2,
+                                          0);
+
+                                            
+        // the maximum number shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(sgmax_out, sgmax_out2, tol);
+        BOOST_CHECK_CLOSE(shmax_out, shmax_out2, tol);
+        hysteresis_restart.setGasOilHysteresisParams(sgmax_out2, shmax_out2, somin_out2, 0);
+        
+        Scalar Sg = 0.5;
+        Scalar So = 1.0 - Sg;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
+    }
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKillough3pBakerConnateWaterScanningWetting, Scalar, Types)
+{
+    using MaterialLaw = typename Fixture<Scalar>::MaterialLaw;
+    using MaterialLawManager = typename Fixture<Scalar>::MaterialLawManager;
+    constexpr int numPhases = Fixture<Scalar>::numPhases;
+
+    Opm::Parser parser;
+
+    const auto deck = parser.parseString(hysterDeckStringKillough3pBakerWetting);
+    const Opm::EclipseState eclState(deck);
+
+    const auto& eclGrid = eclState.getInputGrid();
+    std::size_t n = eclGrid.getCartesianSize();
+
+    MaterialLawManager hysteresis;
+    hysteresis.initFromState(eclState);
+    hysteresis.initParamsForElements(eclState, n, doOldLookup, doNothing);
+    auto& param = hysteresis.materialLawParams(0);
+    Scalar Sw = 0.12;
+    Scalar tol = 1e-3;
+    std::array<Scalar,numPhases> kr = {0.0, 0.0, 0.0};
+    for (int i = 0; i <= 50; ++ i) {
+        Scalar So = Scalar(i) / 100;
+        Scalar Sg = 1 - So - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        MaterialLaw::updateHysteresis(param, fs);
+        Scalar Khyst = (Sg > (0.76))? 1.0 :1 - (1 - Sg - 0.12 - 0.12) * ( 1.0/ (1.0 - 0.12 - 0.12)); 
+        
+        BOOST_CHECK_CLOSE(0, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(So/0.88, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+    Scalar trappedSg = MaterialLaw::trappedGasSaturation(param, /*maximumTrapping*/true);
+    Scalar sgmax_out = 0.0;
+    Scalar shmax_out = 0.0;
+    Scalar somin_out = 0.0;
+    MaterialLaw::gasOilHysteresisParams(sgmax_out,
+                                        shmax_out,
+                                        somin_out,
+                                        param);
+
+    Scalar maxKrg = sgmax_out; 
+    Scalar maxSg = sgmax_out;
+    BOOST_CHECK_CLOSE(1.0 - Sw, maxKrg, tol);
+    BOOST_CHECK_CLOSE(1.0 - Sw, maxSg, tol);
+    Scalar Sncri = 0.12;
+    Scalar killoughScalingParam = 0.1;
+    Scalar maxSo = 0.5;
+    Scalar maxKro = 0.5/0.88;
+    Scalar C = 1 / Sncri - 1.0/0.88;
+    Scalar Snr = maxSg / (1 + killoughScalingParam * (0.88 - maxSg) + C*maxSg );
+
+    BOOST_CHECK_SMALL(trappedSg, tol);
+    Scalar trappedSo = MaterialLaw::trappedOilSaturation(param, /*maximumTrapping*/true);
+    BOOST_CHECK_CLOSE(trappedSo, Snr, tol);
+
+    for (int i = 50; i >= 0; -- i) {
+        Scalar So = Scalar(i) / 100;
+        Scalar Sg = 1 - So - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        Scalar KhystO = (So < trappedSo)? 0.0 : (So - trappedSo) * ( maxKro/ (maxSo - trappedSo)); 
+        Scalar Khyst = (Sg > 0.76)? 1.0 :1 - (1 - Sg - 0.12 - 0.12) * ( 1.0/ (1.0 - 0.12 - 0.12));
+        MaterialLaw::updateHysteresis(param, fs);
+        BOOST_CHECK_CLOSE(0, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        if (KhystO < tol) {
+            BOOST_CHECK_SMALL(kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        } else {    
+            BOOST_CHECK_CLOSE(KhystO, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        }
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar sgmax_out2= 0.0;
+        Scalar shmax_out2= 0.0;
+        Scalar somin_out2= 0.0;
+        hysteresis.gasOilHysteresisParams(sgmax_out2,
+                                          shmax_out2,
+                                          somin_out2,
+                                          0);
+
+                                            
+        // the maximum number shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(sgmax_out, sgmax_out2, tol);
+        BOOST_CHECK_CLOSE(shmax_out, shmax_out2, tol);
+        hysteresis_restart.setGasOilHysteresisParams(sgmax_out2, shmax_out2, somin_out2, 0);
+        
+        Scalar Sg = 0.5;
+        Scalar So = 1.0 - Sg;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKillough3pStone1ConnateWaterScanningWetting, Scalar, Types)
+{
+    using MaterialLaw = typename Fixture<Scalar>::MaterialLaw;
+    using MaterialLawManager = typename Fixture<Scalar>::MaterialLawManager;
+    constexpr int numPhases = Fixture<Scalar>::numPhases;
+
+    Opm::Parser parser;
+
+    const auto deck = parser.parseString(hysterDeckStringKillough3pStone1Wetting);
+    const Opm::EclipseState eclState(deck);
+
+    const auto& eclGrid = eclState.getInputGrid();
+    std::size_t n = eclGrid.getCartesianSize();
+
+    MaterialLawManager hysteresis;
+    hysteresis.initFromState(eclState);
+    hysteresis.initParamsForElements(eclState, n, doOldLookup, doNothing);
+    auto& param = hysteresis.materialLawParams(0);
+    Scalar Sw = 0.12;
+    Scalar tol = 1e-3;
+    std::array<Scalar,numPhases> kr = {0.0, 0.0, 0.0};
+    for (int i = 0; i <= 50; ++ i) {
+        Scalar So = Scalar(i) / 100;
+        Scalar Sg = 1 - So - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        MaterialLaw::updateHysteresis(param, fs);
+        Scalar Khyst = (Sg > (0.76))? 1.0 :1 - (1 - Sg - 0.12 - 0.12) * ( 1.0/ (1.0 - 0.12 - 0.12)); 
+        
+        BOOST_CHECK_CLOSE(0, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        if (So < tol) {
+            BOOST_CHECK_SMALL(kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        } else {    
+            BOOST_CHECK_CLOSE(So/0.88, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        }
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+    Scalar trappedSg = MaterialLaw::trappedGasSaturation(param, /*maximumTrapping*/true);
+    Scalar sgmax_out = 0.0;
+    Scalar shmax_out = 0.0;
+    Scalar somin_out = 0.0;
+    MaterialLaw::gasOilHysteresisParams(sgmax_out,
+                                        shmax_out,
+                                        somin_out,
+                                        param);
+
+    Scalar maxKrg = sgmax_out; 
+    Scalar maxSg = sgmax_out;
+    BOOST_CHECK_CLOSE(1.0 - Sw, maxKrg, tol);
+    BOOST_CHECK_CLOSE(1.0 - Sw, maxSg, tol);
+    Scalar Sncri = 0.12;
+    Scalar killoughScalingParam = 0.1;
+    Scalar maxSo = 0.5;
+    Scalar maxKro = 0.5/0.88;
+    Scalar C = 1 / Sncri - 1.0/0.88;
+    Scalar Snr = maxSg / (1 + killoughScalingParam * (0.88 - maxSg) + C*maxSg );
+
+    BOOST_CHECK_SMALL(trappedSg, tol);
+    Scalar trappedSo = MaterialLaw::trappedOilSaturation(param, /*maximumTrapping*/true);
+    BOOST_CHECK_CLOSE(trappedSo, Snr, tol);
+
+    for (int i = 50; i >= 0; -- i) {
+        Scalar So = Scalar(i) / 100;
+        Scalar Sg = 1 - So - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        Scalar KhystO = (So < trappedSo)? 0.0 : (So - trappedSo) * ( maxKro/ (maxSo - trappedSo)); 
+        Scalar Khyst = (Sg > 0.76)? 1.0 :1 - (1 - Sg - 0.12 - 0.12) * ( 1.0/ (1.0 - 0.12 - 0.12));
+        MaterialLaw::updateHysteresis(param, fs);
+        BOOST_CHECK_CLOSE(0, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        if (KhystO < tol) {
+            BOOST_CHECK_SMALL(kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        } else {    
+            BOOST_CHECK_CLOSE(KhystO, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        }
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar sgmax_out2= 0.0;
+        Scalar shmax_out2= 0.0;
+        Scalar somin_out2= 0.0;
+        hysteresis.gasOilHysteresisParams(sgmax_out2,
+                                          shmax_out2,
+                                          somin_out2,
+                                          0);
+
+                                            
+        // the maximum number shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(sgmax_out, sgmax_out2, tol);
+        BOOST_CHECK_CLOSE(shmax_out, shmax_out2, tol);
+        hysteresis_restart.setGasOilHysteresisParams(sgmax_out2, shmax_out2, somin_out2, 0);
+        
+        Scalar Sg = 0.5;
+        Scalar So = 1.0 - Sg;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKillough3pStone2ConnateWaterScanningWetting, Scalar, Types)
+{
+    using MaterialLaw = typename Fixture<Scalar>::MaterialLaw;
+    using MaterialLawManager = typename Fixture<Scalar>::MaterialLawManager;
+    constexpr int numPhases = Fixture<Scalar>::numPhases;
+
+    Opm::Parser parser;
+
+    const auto deck = parser.parseString(hysterDeckStringKillough3pStone2Wetting);
+    const Opm::EclipseState eclState(deck);
+
+    const auto& eclGrid = eclState.getInputGrid();
+    std::size_t n = eclGrid.getCartesianSize();
+
+    MaterialLawManager hysteresis;
+    hysteresis.initFromState(eclState);
+    hysteresis.initParamsForElements(eclState, n, doOldLookup, doNothing);
+    auto& param = hysteresis.materialLawParams(0);
+    Scalar Sw = 0.12;
+    Scalar tol = 1e-3;
+    std::array<Scalar,numPhases> kr = {0.0, 0.0, 0.0};
+    for (int i = 0; i <= 50; ++ i) {
+        Scalar So = Scalar(i) / 100;
+        Scalar Sg = 1 - So - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        MaterialLaw::updateHysteresis(param, fs);
+        Scalar Khyst = (Sg > (0.76))? 1.0 :1 - (1 - Sg - 0.12 - 0.12) * ( 1.0/ (1.0 - 0.12 - 0.12)); 
+        
+        BOOST_CHECK_CLOSE(0, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(So/0.88, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+    Scalar trappedSg = MaterialLaw::trappedGasSaturation(param, /*maximumTrapping*/true);
+    Scalar sgmax_out = 0.0;
+    Scalar shmax_out = 0.0;
+    Scalar somin_out = 0.0;
+    MaterialLaw::gasOilHysteresisParams(sgmax_out,
+                                        shmax_out,
+                                        somin_out,
+                                        param);
+
+    Scalar maxKrg = sgmax_out; 
+    Scalar maxSg = sgmax_out;
+    BOOST_CHECK_CLOSE(1.0 - Sw, maxKrg, tol);
+    BOOST_CHECK_CLOSE(1.0 - Sw, maxSg, tol);
+    Scalar Sncri = 0.12;
+    Scalar killoughScalingParam = 0.1;
+    Scalar maxSo = 0.5;
+    Scalar maxKro = 0.5/0.88;
+    Scalar C = 1 / Sncri - 1.0/0.88;
+    Scalar Snr = maxSg / (1 + killoughScalingParam * (0.88 - maxSg) + C*maxSg );
+
+    BOOST_CHECK_SMALL(trappedSg, tol);
+    Scalar trappedSo = MaterialLaw::trappedOilSaturation(param, /*maximumTrapping*/true);
+    BOOST_CHECK_CLOSE(trappedSo, Snr, tol);
+
+    for (int i = 50; i >= 0; -- i) {
+        Scalar So = Scalar(i) / 100;
+        Scalar Sg = 1 - So - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        Scalar KhystO = (So < trappedSo)? 0.0 : (So - trappedSo) * ( maxKro/ (maxSo - trappedSo)); 
+        Scalar Khyst = (Sg > 0.76)? 1.0 :1 - (1 - Sg - 0.12 - 0.12) * ( 1.0/ (1.0 - 0.12 - 0.12));
+        MaterialLaw::updateHysteresis(param, fs);
+        BOOST_CHECK_CLOSE(0, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        if (KhystO < tol) {
+            BOOST_CHECK_SMALL(kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        } else {    
+            BOOST_CHECK_CLOSE(KhystO, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        }
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar sgmax_out2= 0.0;
+        Scalar shmax_out2= 0.0;
+        Scalar somin_out2= 0.0;
+        hysteresis.gasOilHysteresisParams(sgmax_out2,
+                                          shmax_out2,
+                                          somin_out2,
+                                          0);
+
+                                            
+        // the maximum number shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(sgmax_out, sgmax_out2, tol);
+        BOOST_CHECK_CLOSE(shmax_out, shmax_out2, tol);
+        hysteresis_restart.setGasOilHysteresisParams(sgmax_out2, shmax_out2, somin_out2, 0);
+        
+        Scalar Sg = 0.5;
+        Scalar So = 1.0 - Sg;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
+    }
+}
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisCarlsonGasOilScanning, Scalar, Types)
 {
@@ -658,14 +1496,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisCarlsonGasOilScanning, Scalar, Types)
     // if false the trapped saturation will be 0 during primary drainage
     Scalar trappedSg_active = MaterialLaw::trappedGasSaturation(param, /*maximumTrapping*/false);
     BOOST_CHECK_CLOSE(0.0, trappedSg_active, tol);
-    Scalar krnSwMdc_out = 0.0;
-    Scalar pcSwMdc_out = 0.0;
-    MaterialLaw::gasOilHysteresisParams(pcSwMdc_out,
-                                        krnSwMdc_out,
+    Scalar sgmax_out = 0.0;
+    Scalar shmax_out = 0.0;
+    Scalar somin_out = 0.0;
+    MaterialLaw::gasOilHysteresisParams(sgmax_out,
+                                        shmax_out,
+                                        somin_out,
                                         param);
 
-    Scalar maxKrg = 1.0 - krnSwMdc_out; 
-    Scalar maxSg = 1.0 - krnSwMdc_out;
+    Scalar maxKrg = sgmax_out; 
+    Scalar maxSg = sgmax_out;
     BOOST_CHECK_CLOSE(0.5, maxKrg, tol);
     BOOST_CHECK_CLOSE(0.5, maxSg, tol);
     Scalar Si = 0.5 / ( 1.0/ (1.0 - 0.12)) + 0.12; //inverting the imb curve to find sg at krg(sg)=0.5 
@@ -708,6 +1548,45 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisCarlsonGasOilScanning, Scalar, Types)
         BOOST_CHECK_CLOSE(So, kr[Fixture<Scalar>::oilPhaseIdx], tol);
         // need to use SMALL to avoid failure between zero and epsilon
         BOOST_CHECK_SMALL(Khyst - kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar sgmax_out2= 0.0;
+        Scalar shmax_out2= 0.0;
+        Scalar somin_out2= 0.0;
+        hysteresis.gasOilHysteresisParams(sgmax_out2,
+                                          shmax_out2,
+                                          somin_out2,
+                                          0);
+
+                                            
+        // the maximum number shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(sgmax_out, sgmax_out2, tol);
+        BOOST_CHECK_CLOSE(shmax_out, shmax_out2, tol);
+        hysteresis_restart.setGasOilHysteresisParams(sgmax_out2, shmax_out2, somin_out2, 0);
+        
+        Scalar Sg = 0.5;
+        Scalar So = 1.0 - Sg;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
     }
 }
 
@@ -812,17 +1691,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughOilWaterScanning, Scalar, Types)
     }
 
     Scalar trappedSo = MaterialLaw::trappedOilSaturation(param, /*maximumTrapping*/false);
-    Scalar krnSwMdc_out = 0.0;
-    Scalar pcSwMdc_out = 0.0;
-    MaterialLaw::oilWaterHysteresisParams(pcSwMdc_out,
-                                        krnSwMdc_out,
-                                        param);
+    Scalar somax_out = 0.0;
+    Scalar swmax_out = 0.0;
+    Scalar swmin_out = 0.0;
+    MaterialLaw::oilWaterHysteresisParams(somax_out,
+                                          swmax_out,
+                                          swmin_out,
+                                          param);
 
-    Scalar maxKro = 1.0 - krnSwMdc_out; 
-    Scalar maxSo = 1.0 - krnSwMdc_out;
+    Scalar maxKro = somax_out; 
+    Scalar maxSo = somax_out;
     BOOST_CHECK_CLOSE(1.0, maxKro, tol);
     BOOST_CHECK_CLOSE(1.0, maxSo, tol);
     BOOST_CHECK_CLOSE(0.12, trappedSo, tol);
+    BOOST_CHECK_CLOSE(swmin_out, 1 - somax_out, tol);
 
     for (int i = 50; i >= 0; -- i) {
         Scalar Sw = Scalar(i) / 100;
@@ -842,6 +1724,42 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughOilWaterScanning, Scalar, Types)
         BOOST_CHECK_CLOSE(Sw, kr[Fixture<Scalar>::waterPhaseIdx], tol);
         BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::oilPhaseIdx], tol);
         BOOST_CHECK_CLOSE(Sg, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar somax_out2 = 0.0;
+        Scalar swmax_out2 = 0.0;
+        Scalar swmin_out2 = 0.0;
+        hysteresis.oilWaterHysteresisParams(somax_out2,
+                                            swmax_out2,
+                                            swmin_out2,
+                                            0);
+        // the maximum oil saturation shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(somax_out, somax_out2, tol);
+        hysteresis_restart.setOilWaterHysteresisParams(somax_out2, swmax_out2, swmin_out2, 0);
+        
+        Scalar So = 0.5;
+        Scalar Sw = 1.0 - So;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
     }
 }
 
@@ -890,14 +1808,259 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughWettingOilWater, Scalar, Types)
     }
 
     Scalar trappedSo = MaterialLaw::trappedOilSaturation(param, /*maximumTrapping*/false);
-    Scalar krnSwMdc_out = 0.0;
-    Scalar pcSwMdc_out = 0.0;
-    MaterialLaw::oilWaterHysteresisParams(pcSwMdc_out,
-                                        krnSwMdc_out,
+    Scalar somax_out = 0.0;
+    Scalar swmax_out = 0.0;
+    Scalar swmin_out = 0.0;
+    MaterialLaw::oilWaterHysteresisParams(somax_out,
+                                        swmax_out,
+                                        swmin_out,
                                         param);
 
-    Scalar maxKro = 1.0 - krnSwMdc_out; 
-    Scalar maxSo = 1.0 - krnSwMdc_out;
+    Scalar maxKro = somax_out; 
+    Scalar maxSo = somax_out;
+    BOOST_CHECK_CLOSE(1.0, maxKro, tol);
+    BOOST_CHECK_CLOSE(1.0, maxSo, tol);
+    BOOST_CHECK_SMALL(trappedSo, tol);
+    BOOST_CHECK_CLOSE(swmin_out, 1 - somax_out, tol);
+
+    Scalar maxSw = 0.5;
+    Scalar maxKrw = 0.5;
+    Scalar trappedSw = MaterialLaw::trappedWaterSaturation(param);
+    Scalar Swcri = 0.12;
+    Scalar killoughScalingParam = 0.1;
+    Scalar Cw = 1 / Swcri - 1.0;
+    Scalar Swr = 1 / ( (Cw + killoughScalingParam) + 1.0/maxSw);
+    BOOST_CHECK_CLOSE(Swr, trappedSw, tol);
+
+    for (int i = 50; i >= 0; -- i) {
+        Scalar Sw = Scalar(i) / 100;
+        Scalar So = 1 - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        MaterialLaw::updateHysteresis(param, fs);
+
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        
+        Scalar Khyst = (Sw < trappedSw)? 0.0 : (Sw - trappedSw) * ( maxKrw/ (maxSw - trappedSw)); 
+        
+        Scalar KhystOil = (Sw < 0.12)? 1.0 : 1 - (Sw-0.12) * ( 1.0/ (1.0 - 0.12)); 
+
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(KhystOil, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Sg, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar somax_out2 = 0.0;
+        Scalar swmax_out2 = 0.0;
+        Scalar swmin_out2 = 0.0;
+        hysteresis.oilWaterHysteresisParams(somax_out2,
+                                            swmax_out2,
+                                            swmin_out2,
+                                            0);
+        // the maximum oil saturation shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(somax_out, somax_out2, tol);
+        hysteresis_restart.setOilWaterHysteresisParams(somax_out2, swmax_out2, swmin_out2, 0);
+
+        Scalar So = 0.5;
+        Scalar Sw = 1.0 - So;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKillough3pBakerScanning, Scalar, Types)
+{
+    using MaterialLaw = typename Fixture<Scalar>::MaterialLaw;
+    using MaterialLawManager = typename Fixture<Scalar>::MaterialLawManager;
+    constexpr int numPhases = Fixture<Scalar>::numPhases;
+
+    Opm::Parser parser;
+
+    const auto deck = parser.parseString(hysterDeckStringKillough3phaseBaker);
+    const Opm::EclipseState eclState(deck);
+
+    const auto& eclGrid = eclState.getInputGrid();
+    std::size_t n = eclGrid.getCartesianSize();
+
+    MaterialLawManager hysteresis;
+    hysteresis.initFromState(eclState);
+    hysteresis.initParamsForElements(eclState, n, doOldLookup, doNothing);
+    auto& param = hysteresis.materialLawParams(0);
+    Scalar Sg = 0.0;
+    Scalar tol = 1e-3;
+    
+    std::array<Scalar,numPhases> kr = {0.0, 0.0, 0.0};
+    for (int i = 0; i <= 50; ++ i) {
+        Scalar Sw = Scalar(i) / 100;
+        Scalar So = 1 - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        MaterialLaw::updateHysteresis(param, fs);
+
+        Scalar Khyst = (So < 0.12)? 0.0 : (So - 0.12) * ( 1.0/ (1.0 - 0.12)); 
+
+        BOOST_CHECK_CLOSE(Sw, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Sg, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    Scalar trappedSo = MaterialLaw::trappedOilSaturation(param, /*maximumTrapping*/false);
+    Scalar somax_out = 0.0;
+    Scalar swmax_out = 0.0;
+    Scalar swmin_out = 0.0;
+    MaterialLaw::oilWaterHysteresisParams(somax_out,
+                                          swmax_out,
+                                          swmin_out,
+                                          param);
+
+    Scalar maxKro = somax_out; 
+    Scalar maxSo = somax_out;
+    BOOST_CHECK_CLOSE(1.0, maxKro, tol);
+    BOOST_CHECK_CLOSE(1.0, maxSo, tol);
+    BOOST_CHECK_CLOSE(0.12, trappedSo, tol);
+    BOOST_CHECK_CLOSE(swmin_out, 1 - somax_out, tol);
+
+    for (int i = 50; i >= 0; -- i) {
+        Scalar Sw = Scalar(i) / 100;
+        Scalar So = 1 - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        MaterialLaw::updateHysteresis(param, fs);
+        
+        Scalar Khyst = (So < trappedSo)? 0.0 : (So - trappedSo) * ( maxKro/ (maxSo - trappedSo)); 
+
+        BOOST_CHECK_CLOSE(Sw, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Sg, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar somax_out2 = 0.0;
+        Scalar swmax_out2 = 0.0;
+        Scalar swmin_out2 = 0.0;
+        hysteresis.oilWaterHysteresisParams(somax_out2,
+                                            swmax_out2,
+                                            swmin_out2,
+                                            0);
+        // the maximum oil saturation shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(somax_out, somax_out2, tol);
+        hysteresis_restart.setOilWaterHysteresisParams(somax_out2, swmax_out2, swmin_out2, 0);
+        
+        Scalar So = 0.5;
+        Scalar Sw = 1.0 - So;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
+    }
+}
+
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughWetting3phaseBaker, Scalar, Types)
+{
+    using MaterialLaw = typename Fixture<Scalar>::MaterialLaw;
+    using MaterialLawManager = typename Fixture<Scalar>::MaterialLawManager;
+    constexpr int numPhases = Fixture<Scalar>::numPhases;
+
+    Opm::Parser parser;
+
+    const auto deck = parser.parseString(hysterDeckStringKilloughWetting3phaseBaker);
+    const Opm::EclipseState eclState(deck);
+
+    const auto& eclGrid = eclState.getInputGrid();
+    std::size_t n = eclGrid.getCartesianSize();
+
+    MaterialLawManager hysteresis;
+    hysteresis.initFromState(eclState);
+    hysteresis.initParamsForElements(eclState, n, doOldLookup, doNothing);
+    auto& param = hysteresis.materialLawParams(0);
+    Scalar Sg = 0.0;
+    Scalar tol = 1e-3;
+    
+    std::array<Scalar,numPhases> kr = {0.0, 0.0, 0.0};
+    for (int i = 0; i <= 50; ++ i) {
+        Scalar Sw = Scalar(i) / 100;
+        Scalar So = 1 - Sw;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        MaterialLaw::updateHysteresis(param, fs);
+
+
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+
+        Scalar Khyst = (Sw < 0.12)? 1.0 : 1 - (Sw-0.12) * ( 1.0/ (1.0 - 0.12)); 
+
+        BOOST_CHECK_CLOSE(Sw, kr[Fixture<Scalar>::waterPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::oilPhaseIdx], tol);
+        BOOST_CHECK_CLOSE(Sg, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    Scalar trappedSo = MaterialLaw::trappedOilSaturation(param, /*maximumTrapping*/false);
+    Scalar somax_out = 0.0;
+    Scalar swmax_out = 0.0;
+    Scalar swmin_out = 0.0;
+    MaterialLaw::oilWaterHysteresisParams(somax_out,
+                                        swmax_out,
+                                        swmin_out,
+                                        param);
+
+    Scalar maxKro = somax_out; 
+    Scalar maxSo = somax_out;
     BOOST_CHECK_CLOSE(1.0, maxKro, tol);
     BOOST_CHECK_CLOSE(1.0, maxSo, tol);
     BOOST_CHECK_SMALL(trappedSo, tol);
@@ -931,5 +2094,41 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(HysteresisKilloughWettingOilWater, Scalar, Types)
         BOOST_CHECK_CLOSE(Khyst, kr[Fixture<Scalar>::waterPhaseIdx], tol);
         BOOST_CHECK_CLOSE(KhystOil, kr[Fixture<Scalar>::oilPhaseIdx], tol);
         BOOST_CHECK_CLOSE(Sg, kr[Fixture<Scalar>::gasPhaseIdx], tol);
+    }
+
+    // test restart
+    {
+        MaterialLawManager hysteresis_restart;
+        hysteresis_restart.initFromState(eclState);
+        hysteresis_restart.initParamsForElements(eclState, n, doOldLookup, doNothing);
+        Scalar somax_out2 = 0.0;
+        Scalar swmax_out2 = 0.0;
+        Scalar swmin_out2 = 0.0;
+        hysteresis.oilWaterHysteresisParams(somax_out2,
+                                            swmax_out2,
+                                            swmin_out2,
+                                            0);
+        // the maximum oil saturation shouldn't change during imbibition
+        BOOST_CHECK_CLOSE(somax_out, somax_out2, tol);
+        hysteresis_restart.setOilWaterHysteresisParams(somax_out2, swmax_out2, swmin_out2, 0);
+
+        Scalar So = 0.5;
+        Scalar Sw = 1.0 - So;
+        typename Fixture<Scalar>::FluidState fs;
+        fs.setSaturation(Fixture<Scalar>::waterPhaseIdx, Sw);
+        fs.setSaturation(Fixture<Scalar>::oilPhaseIdx, So);
+        fs.setSaturation(Fixture<Scalar>::gasPhaseIdx, Sg);
+        const auto& param_restart = hysteresis_restart.materialLawParams(0);
+        std::array<Scalar,numPhases> kr_restart = {0.0, 0.0, 0.0};
+        MaterialLaw::relativePermeabilities(kr_restart,
+                                            param_restart,
+                                            fs);
+                                      
+        MaterialLaw::relativePermeabilities(kr,
+                                            param,
+                                            fs);
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            BOOST_CHECK_CLOSE(kr_restart[phaseIdx], kr[phaseIdx], tol);
+        }
     }
 }


### PR DESCRIPTION
- New tests for restart is added for gasoil, oilwater nonwetting hysteresis
- 3-Phase tests are added for Baker (default), Stone 1 and Stone 2
- hysteresis parameter set and get methods directly work on min/max saturations to avoid conversion in output layer
UPDATE
- fix for wetting phase hysteresis