### PR TITLE
Increase restart compatibility 

### DIFF
--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1870,7 +1870,10 @@ namespace {
 
         {
             const auto& header = rst_state.header;
-            if (GuideRateModel::rst_valid(header.guide_rate_delay,
+            // A NONE target written to .UNRST may indicate no GUIDERAT (i.e., during history)
+            const auto target = GuideRateModel::TargetFromRestart(header.guide_rate_nominated_phase);
+            if ((target != GuideRateModel::Target::NONE) &&
+                GuideRateModel::rst_valid(header.guide_rate_delay,
                                           header.guide_rate_a,
                                           header.guide_rate_b,
                                           header.guide_rate_c,
@@ -1884,7 +1887,7 @@ namespace {
 
                 const auto guide_rate_model = GuideRateModel {
                     header.guide_rate_delay,
-                    GuideRateModel::TargetFromRestart(header.guide_rate_nominated_phase),
+                    target,
                     header.guide_rate_a,
                     header.guide_rate_b,
                     header.guide_rate_c,
@@ -1896,9 +1899,7 @@ namespace {
                     use_free_gas
                 };
 
-                // A NONE target written to .UNRST may indicate no GUIDERAT (i.e., during history)
-                if (! (guide_rate_model.target()==GuideRateModel::Target::NONE))
-                    this->updateGuideRateModel(guide_rate_model, report_step);
+                this->updateGuideRateModel(guide_rate_model, report_step);
             }
         }
 

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1896,7 +1896,9 @@ namespace {
                     use_free_gas
                 };
 
-                this->updateGuideRateModel(guide_rate_model, report_step);
+                // A NONE target written to .UNRST may indicate no GUIDERAT (i.e., during history)
+                if (! (guide_rate_model.target()==GuideRateModel::Target::NONE))
+                    this->updateGuideRateModel(guide_rate_model, report_step);
             }
         }
 

--- a/opm/input/eclipse/Schedule/Well/WellTestConfig.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestConfig.cpp
@@ -50,7 +50,7 @@ bool WellTestConfig::WTESTWell::test_well(int num_attempt, double elapsed) const
 
 int WellTestConfig::WTESTWell::ecl_reasons() const
 {
-    int ecl_value = 1;
+    int ecl_value = WTest::EclConfigReason::NONE;
 
     if (this->reasons & static_cast<int>(Reason::PHYSICAL))
         ecl_value *= WTest::EclConfigReason::PHYSICAL;

--- a/opm/input/eclipse/Schedule/Well/WellTestConfig.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestConfig.hpp
@@ -37,6 +37,7 @@ namespace WTest {
 */
 
 namespace EclConfigReason {
+constexpr int NOTUSED   =  1;
 constexpr int PHYSICAL   = 2;
 constexpr int ECONOMIC   = 3;
 constexpr int GCON       = 5;
@@ -45,6 +46,7 @@ constexpr int CONNECTION = 11;
 }
 
 namespace EclCloseReason {
+constexpr int NOTUSED  = 1; // May be written to UNRST during history
 constexpr int PHYSICAL = 3;
 constexpr int ECONOMIC = 5;
 constexpr int GCON     = 6;
@@ -52,6 +54,7 @@ constexpr int THPLimit = 9;
 }
 
 enum class Reason {
+    NOTUSED  = 0,
     PHYSICAL = 1,
     ECONOMIC = 2,
     GROUP = 4,

--- a/opm/input/eclipse/Schedule/Well/WellTestConfig.hpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestConfig.hpp
@@ -37,7 +37,7 @@ namespace WTest {
 */
 
 namespace EclConfigReason {
-constexpr int NOTUSED   =  1;
+constexpr int NONE      =  1;
 constexpr int PHYSICAL   = 2;
 constexpr int ECONOMIC   = 3;
 constexpr int GCON       = 5;
@@ -46,7 +46,7 @@ constexpr int CONNECTION = 11;
 }
 
 namespace EclCloseReason {
-constexpr int NOTUSED  = 1; // May be written to UNRST during history
+constexpr int NONE     = 1; // May be written to UNRST during history
 constexpr int PHYSICAL = 3;
 constexpr int ECONOMIC = 5;
 constexpr int GCON     = 6;
@@ -54,7 +54,7 @@ constexpr int THPLimit = 9;
 }
 
 enum class Reason {
-    NOTUSED  = 0,
+    NONE     = 0,
     PHYSICAL = 1,
     ECONOMIC = 2,
     GROUP = 4,

--- a/opm/input/eclipse/Schedule/Well/WellTestState.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.cpp
@@ -39,7 +39,7 @@ namespace Opm {
             return 0;
 
         switch (this->reason) {
-        case WellTestConfig::Reason::NOTUSED:    return WTest::EclCloseReason::NOTUSED;
+        case WellTestConfig::Reason::NONE:       return WTest::EclCloseReason::NONE;
         case WellTestConfig::Reason::PHYSICAL:   return WTest::EclCloseReason::PHYSICAL;
         case WellTestConfig::Reason::ECONOMIC:   return WTest::EclCloseReason::ECONOMIC;
         case WellTestConfig::Reason::GROUP:      return WTest::EclCloseReason::GCON;
@@ -51,7 +51,7 @@ namespace Opm {
 
     WellTestConfig::Reason WellTestState::WTestWell::inverse_ecl_reason(int ecl_reason) {
         switch (ecl_reason) {
-        case  WTest::EclCloseReason::NOTUSED:  return WellTestConfig::Reason::NOTUSED;
+        case  WTest::EclCloseReason::NONE:     return WellTestConfig::Reason::NONE;
         case  WTest::EclCloseReason::PHYSICAL: return WellTestConfig::Reason::PHYSICAL;
         case  WTest::EclCloseReason::ECONOMIC: return WellTestConfig::Reason::ECONOMIC;
         case  WTest::EclCloseReason::GCON:     return WellTestConfig::Reason::GROUP;

--- a/opm/input/eclipse/Schedule/Well/WellTestState.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellTestState.cpp
@@ -39,6 +39,7 @@ namespace Opm {
             return 0;
 
         switch (this->reason) {
+        case WellTestConfig::Reason::NOTUSED:    return WTest::EclCloseReason::NOTUSED;
         case WellTestConfig::Reason::PHYSICAL:   return WTest::EclCloseReason::PHYSICAL;
         case WellTestConfig::Reason::ECONOMIC:   return WTest::EclCloseReason::ECONOMIC;
         case WellTestConfig::Reason::GROUP:      return WTest::EclCloseReason::GCON;
@@ -50,6 +51,7 @@ namespace Opm {
 
     WellTestConfig::Reason WellTestState::WTestWell::inverse_ecl_reason(int ecl_reason) {
         switch (ecl_reason) {
+        case  WTest::EclCloseReason::NOTUSED:  return WellTestConfig::Reason::NOTUSED;
         case  WTest::EclCloseReason::PHYSICAL: return WellTestConfig::Reason::PHYSICAL;
         case  WTest::EclCloseReason::ECONOMIC: return WellTestConfig::Reason::ECONOMIC;
         case  WTest::EclCloseReason::GCON:     return WellTestConfig::Reason::GROUP;


### PR DESCRIPTION
Specifically
  * Allow a well test closure reason that appear to be written for some wells that are shut during history
  * Do not use guide rate models with NONE target (apparently also be written during history)
 