### PR TITLE
Output Well Level Control Limits to Summary File

### DIFF
--- a/opm/input/eclipse/share/keywords/000_Eclipse100/W/WELL_PROBE
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/W/WELL_PROBE
@@ -102,6 +102,7 @@
     "WBGLR",
     "WBHP",
     "WBHPH",
+    "WBHPT",
     "WTHP",
     "WTHPH",
     "WPI",

--- a/tests/summary_deck.DATA
+++ b/tests/summary_deck.DATA
@@ -652,7 +652,7 @@ WNIT
 WTIRSEA
 /
 
--- Production Cummulatives
+-- Production Cumulatives
 WWPT
 /
 WWPTH
@@ -678,7 +678,7 @@ WOPTS
 -- Tracers
 WTPTSEA
 /
--- Injection Cummulatives
+-- Injection Cumulatives
 WWIT
   W_3
 /
@@ -705,6 +705,27 @@ WTITSEA
 WTICSEA
 /
 
+-- Targets/limits
+WBHPT
+W_1 W_2 W_3 W_6 /
+WOPRT
+W_1 W_2 W_3 W_6 /
+WGPRT
+W_1 W_2 W_3 W_6 /
+WLPRT
+W_1 W_2 W_3 W_6 /
+WVPRT
+W_1 W_2 W_3 W_6 /
+WWPRT
+W_1 W_2 W_3 W_6 /
+WOIRT
+W_1 W_2 W_3 W_6 /
+WGIRT
+W_1 W_2 W_3 W_6 /
+WVIRT
+W_1 W_2 W_3 W_6 /
+WWIRT
+W_1 W_2 W_3 W_6 /
 
 -- Performance
 WBHP
@@ -765,8 +786,6 @@ WGLIR
 WVPR
 /
 WVPT
-/
-WVPRT
 /
 WOPP
 /


### PR DESCRIPTION
This PR implements the well level target/limit summary vectors

  * `WBHPT` (well level BHP target/limit)
  * `W[OGLVW]PRT` (well level phase flow production rate target/limit)
  * `W[OGVW]IRT` (well level phase flow injection rate target/limit)

with `O` representing oil, `G` representing gas, `L` representing liquid, `V` representing reservoir voidage (`RESV`), and `W` representing water.