### PR TITLE
Trigger Target Update From WTMULT in ACTIONX

### DIFF
--- a/opm/input/eclipse/Schedule/Action/ActionX.cpp
+++ b/opm/input/eclipse/Schedule/Action/ActionX.cpp
@@ -15,25 +15,38 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
+*/
 
-#include <optional>
-#include <sstream>
-#include <unordered_set>
-#include <fmt/format.h>
-
-#include <opm/input/eclipse/Utility/Typetools.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
-#include <opm/input/eclipse/Deck/DeckOutput.hpp>
-#include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 #include <opm/input/eclipse/Schedule/Action/ActionX.hpp>
+
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/io/eclipse/rst/action.hpp>
+
+#include <opm/input/eclipse/Schedule/Action/ActionValue.hpp>
 #include <opm/input/eclipse/Schedule/Action/Actdims.hpp>
 #include <opm/input/eclipse/Schedule/Action/State.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellMatcher.hpp>
+
+#include <opm/input/eclipse/Utility/Typetools.hpp>
+
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/input/eclipse/Deck/DeckOutput.hpp>
+
 #include <opm/input/eclipse/Parser/ParseContext.hpp>
 #include <opm/input/eclipse/Parser/ParserKeywords/W.hpp>
-#include <opm/io/eclipse/rst/action.hpp>
-#include <opm/common/utility/OpmInputError.hpp>
+
+#include <ctime>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
 
 #include "ActionParser.hpp"
 
@@ -59,19 +72,38 @@ std::string dequote(const std::string& token, const std::optional<KeywordLocatio
 }
 
 
-bool ActionX::valid_keyword(const std::string& keyword) {
-    static std::unordered_set<std::string> actionx_allowed_list = {
+bool ActionX::valid_keyword(const std::string& keyword)
+{
+    static const auto actionx_allowed_list = std::unordered_set<std::string> {
         "BOX",
+
         "COMPLUMP", "COMPDAT", "COMPSEGS",
+
         "ENDBOX", "EXIT",
-        "GCONINJE", "GCONPROD", "GCONSUMP", "GLIFTOPT", "GRUPNET", "GRUPTARG", "GRUPTREE", "GSATINJE", "GSATPROD",
+
+        "GCONINJE", "GCONPROD", "GCONSUMP",
+        "GLIFTOPT",
+        "GRUPNET", "GRUPTARG", "GRUPTREE",
+        "GSATINJE", "GSATPROD",
+
         "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",
+
         "UDQ",
-        "WCONINJE", "WCONPROD", "WECON", "WEFAC", "WELOPEN", "WELPI", "WELTARG", "WGRUPCON", "WPIMULT", "WELSEGS", "WELSPECS", "WSEGVALV", "WTEST", "WTMULT", "WLIST",
-        "TEST"
+
+        "WCONINJE", "WCONPROD",
+        "WECON", "WEFAC",
+        "WELOPEN", "WELPI", "WELSEGS", "WELSPECS", "WELTARG",
+        "WGRUPCON",
+        "WLIST",
+        "WPIMULT",
+        "WSEGVALV",
+        "WTEST", "WTMULT",
+
+        "TEST",
     };
-    return (actionx_allowed_list.find(keyword) != actionx_allowed_list.end());
+
+    return actionx_allowed_list.find(keyword) != actionx_allowed_list.end();
 }
 
 std::tuple<ActionX, std::vector<std::pair<std::string, std::string>>>

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1091,22 +1091,23 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
             this->snapshots[report_step].guide_rate.update( std::move(new_config) );
     }
 
-    /*
-      There are many SCHEDULE keyword which take a wellname as argument. In
-      addition to giving a fully qualified name like 'W1' you can also specify
-      shell wildcard patterns like like 'W*', you can get all the wells in the
-      well-list '*WL'[1] and the wellname '?' is used to get all the wells which
-      already have matched a condition in a ACTIONX keyword. This function
-      should be one-stop function to get all well names according to a input
-      pattern. The timestep argument is used to check that the wells have
-      indeed been defined at the point in time we are considering.
-
-      [1]: The leading '*' in a WLIST name should not be interpreted as a shell
-           wildcard!
-    */
-
-
-    std::vector<std::string> Schedule::wellNames(const std::string& pattern, std::size_t timeStep, const std::vector<std::string>& matching_wells) const {
+    // There are many SCHEDULE keyword which take a wellname as argument.
+    // In addition to giving a fully qualified name like 'W1' you can also
+    // specify shell wildcard patterns like like 'W*', you can get all the
+    // wells in the well-list '*WL'[1] and the wellname '?' is used to get
+    // all the wells which already have matched a condition in a ACTIONX
+    // keyword.  This function should be one-stop function to get all well
+    // names according to a input pattern.  The timestep argument is used to
+    // check that the wells have indeed been defined at the point in time we
+    // are considering.
+    //
+    // [1]: The leading '*' in a WLIST name should not be interpreted as a
+    //      shell wildcard!
+    std::vector<std::string>
+    Schedule::wellNames(const std::string&              pattern,
+                        const std::size_t               timeStep,
+                        const std::vector<std::string>& matching_wells) const
+    {
         const auto wm = this->wellMatcher(timeStep);
 
         return (pattern == "?")
@@ -1116,24 +1117,28 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
 
 
 
-    std::vector<std::string> Schedule::wellNames(const std::string& pattern,
-                                                 const HandlerContext& context,
-                                                 bool allowEmpty)
+    std::vector<std::string>
+    Schedule::wellNames(const std::string&    pattern,
+                        const HandlerContext& context,
+                        const bool            allowEmpty)
     {
-        std::vector<std::string> valid_names;
-        const auto& report_step = context.currentStep;
-        auto names = this->wellNames(pattern, report_step, context.matching_wells);
+        auto names = this->wellNames(pattern, context.currentStep, context.matching_wells);
+
         if (names.empty() && !allowEmpty) {
-            const auto& location = context.keyword.location();
             if (this->action_wgnames.has_well(pattern)) {
-                std::string msg = fmt::format(R"(Well: {} not yet defined for keyword {}.
+                const auto& location = context.keyword.location();
+
+                const auto msg = fmt::format(R"(Well: {} not yet defined for keyword {}.
 Expecting well to be defined with WELSPECS in ACTIONX before actual use.
 File {} line {}.)", pattern, location.keyword, location.filename, location.lineno);
+
                 OpmLog::warning(msg);
-            } else {
+            }
+            else {
                 context.invalidNamePattern(pattern);
             }
         }
+
         return names;
     }
 

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1091,18 +1091,18 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
             this->snapshots[report_step].guide_rate.update( std::move(new_config) );
     }
 
-    // There are many SCHEDULE keyword which take a wellname as argument.
-    // In addition to giving a fully qualified name like 'W1' you can also
-    // specify shell wildcard patterns like like 'W*', you can get all the
-    // wells in the well-list '*WL'[1] and the wellname '?' is used to get
-    // all the wells which already have matched a condition in a ACTIONX
-    // keyword.  This function should be one-stop function to get all well
-    // names according to a input pattern.  The timestep argument is used to
-    // check that the wells have indeed been defined at the point in time we
-    // are considering.
+    // There are many SCHEDULE keywords which operate on well names.  In
+    // addition to fully qualified names like 'W1', there are shell-style
+    // wildcard patterns like 'W*'.  Similarly, you can request all wells in
+    // a well list '*WL'[1] and the well name '?', when used in an ACTIONX
+    // keyword block, matches all wells which trigger the condition in the
+    // same ACTIONX keyword.  This function is intended to be the final
+    // arbiter for well names matching these kinds of patterns.  The time
+    // step argument filters out wells which do not exist at that time level
+    // (i.e., zero-based report step index).
     //
-    // [1]: The leading '*' in a WLIST name should not be interpreted as a
-    //      shell wildcard!
+    // [1]: The leading '*' in a WLIST name should not be treated as a
+    //      pattern matching wildcard.
     std::vector<std::string>
     Schedule::wellNames(const std::string&              pattern,
                         const std::size_t               timeStep,

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -603,6 +603,8 @@ void handleWTMULT(HandlerContext& handlerContext)
                     handlerContext.state().wells.update(std::move(well));
                 }
             }
+
+            handlerContext.affected_well(well_name);
         }
     }
 }

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -526,54 +526,80 @@ void handleWTEMP(HandlerContext& handlerContext)
 void handleWTMULT(HandlerContext& handlerContext)
 {
     for (const auto& record : handlerContext.keyword) {
-        const auto& wellNamePattern = record.getItem<ParserKeywords::WTMULT::WELL>().getTrimmedString(0);
-        const auto& control = record.getItem<ParserKeywords::WTMULT::CONTROL>().get<std::string>(0);
         const auto& factor = record.getItem<ParserKeywords::WTMULT::FACTOR>().get<UDAValue>(0);
-        const auto& num = record.getItem<ParserKeywords::WTMULT::NUM>().get<int>(0);
-
         if (factor.is<std::string>()) {
-            std::string reason = fmt::format("Use of UDA value: {} is not supported as multiplier", factor.get<std::string>());
-            throw OpmInputError(reason, handlerContext.keyword.location());
+            const auto reason =
+                fmt::format("UDA value {} is not supported "
+                            "as multiplier", factor.get<std::string>());
+
+            throw OpmInputError {
+                reason, handlerContext.keyword.location()
+            };
         }
 
+        const auto& control = record.getItem<ParserKeywords::WTMULT::CONTROL>().get<std::string>(0);
         if (handlerContext.state().udq().has_keyword(control)) {
-            std::string reason = fmt::format("Use of UDA value: {} is not supported for control target", control);
-            throw OpmInputError(reason, handlerContext.keyword.location());
+            const auto reason =
+                fmt::format("UDA value {} is not supported "
+                            "for control target", control);
+
+            throw OpmInputError {
+                reason, handlerContext.keyword.location()
+            };
         }
 
+        const auto num = record.getItem<ParserKeywords::WTMULT::NUM>().get<int>(0);
         if (num != 1) {
-            std::string reason = fmt::format("Only NUM=1 is supported in WTMULT keyword");
-            throw OpmInputError(reason, handlerContext.keyword.location());
+            throw OpmInputError {
+                "Only NUM=1 is supported in WTMULT keyword",
+                handlerContext.keyword.location()
+            };
         }
 
         const auto cmode = WellWELTARGCModeFromString(control);
-        if (cmode == Well::WELTARGCMode::GUID)
-            throw std::logic_error("Multiplying guide rate is not implemented");
+        if (cmode == Well::WELTARGCMode::GUID) {
+            throw OpmInputError {
+                "Multiplying the guide rate is not supported",
+                handlerContext.keyword.location()
+            };
+        }
 
+        const auto& wellNamePattern = record.getItem<ParserKeywords::WTMULT::WELL>().getTrimmedString(0);
         const auto well_names = handlerContext.wellNames(wellNamePattern);
         for (const auto& well_name : well_names) {
             auto well = handlerContext.state().wells.get(well_name);
+
             if (well.isInjector()) {
-                bool update_well = true;
+                const bool update_well = true;
+
                 auto properties = std::make_shared<Well::WellInjectionProperties>(well.getInjectionProperties());
-                properties->handleWTMULT( cmode, factor.get<double>());
+                properties->handleWTMULT(cmode, factor.get<double>());
 
                 well.updateInjection(properties);
                 if (update_well) {
-                    handlerContext.state().events().addEvent(ScheduleEvents::INJECTION_UPDATE);
-                    handlerContext.state().wellgroup_events().addEvent(well_name, ScheduleEvents::INJECTION_UPDATE);
+                    handlerContext.state().events()
+                        .addEvent(ScheduleEvents::INJECTION_UPDATE);
+
+                    handlerContext.state().wellgroup_events()
+                        .addEvent(well_name, ScheduleEvents::INJECTION_UPDATE);
+
                     handlerContext.state().wells.update(std::move(well));
                 }
-            } else {
-                bool update_well = true;
+            }
+            else {
+                const bool update_well = true;
+
                 auto properties = std::make_shared<Well::WellProductionProperties>(well.getProductionProperties());
-                properties->handleWTMULT( cmode, factor.get<double>());
+                properties->handleWTMULT(cmode, factor.get<double>());
 
                 well.updateProduction(properties);
                 if (update_well) {
-                    handlerContext.state().events().addEvent(ScheduleEvents::PRODUCTION_UPDATE);
-                    handlerContext.state().wellgroup_events().addEvent(well_name,
-                                                                     ScheduleEvents::PRODUCTION_UPDATE);
+                    handlerContext.state().events()
+                        .addEvent(ScheduleEvents::PRODUCTION_UPDATE);
+
+                    handlerContext.state().wellgroup_events()
+                        .addEvent(well_name, ScheduleEvents::PRODUCTION_UPDATE);
+
                     handlerContext.state().wells.update(std::move(well));
                 }
             }


### PR DESCRIPTION
We need to inform the simulator about possible changes to wells when running `WTMULT` in an `ACTIONX` block.  Recording the keyword's affected wells in the handler context enables the simulator to run any requisite post-action operations such as updating the active wells' operating targets.  Without the call to
```
HandlerContext::affected_well
```
those post-action operations might not run.