### PR TITLE
Move initialization of prediction_mode members.

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -1694,7 +1694,6 @@ bool Well::wellNameInWellNamePattern(const std::string& wellName, const std::str
 Well::ProductionControls Well::productionControls(const SummaryState& st) const {
     if (this->isProducer()) {
         auto controls = this->production->controls(st, this->udq_undefined);
-        controls.prediction_mode = this->predictionMode();
         return controls;
     } else
         throw std::logic_error("Trying to get production data from an injector");
@@ -1703,7 +1702,6 @@ Well::ProductionControls Well::productionControls(const SummaryState& st) const 
 Well::InjectionControls Well::injectionControls(const SummaryState& st) const {
     if (!this->isProducer()) {
         auto controls = this->injection->controls(this->unit_system, st, this->udq_undefined);
-        controls.prediction_mode = this->predictionMode();
         return controls;
     } else
         throw std::logic_error("Trying to get injection data from a producer");

--- a/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellInjectionProperties.cpp
@@ -340,6 +340,7 @@ namespace Opm {
         controls.injector_type = this->injectorType;
         controls.cmode = this->controlMode;
         controls.vfp_table_number = this->VFPTableNumber;
+        controls.prediction_mode = this->predictionMode;
         controls.injector_type = this->injectorType;
         controls.rs_rv_inj = this->rsRvInj;
 

--- a/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellProductionProperties.cpp
@@ -415,6 +415,7 @@ void Well::WellProductionProperties::handleWCONHIST(const std::optional<VFPProdT
         controls.bhp_history = this->BHPH;
         controls.thp_history = this->THPH;
         controls.vfp_table_number = this->VFPTableNumber;
+        controls.prediction_mode = this->predictionMode;
         controls.cmode = this->controlMode;
 
         return controls;


### PR DESCRIPTION
The controls() functions are returning incompletely initialized objects. While there is no risk, since the remaining prediction_mode members are set in the calling function, it is better to set them inside controls().