### PR TITLE
BUGFIX: Fix salinity input co2 module

### DIFF
--- a/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/BrineCo2Pvt.cpp
@@ -96,7 +96,7 @@ initFromState(const EclipseState& eclState, const Schedule&)
     
     std::size_t numRegions = eclState.runspec().tabdims().getNumPVTTables();
     setNumRegions(numRegions);
-    for (size_t regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+    for (std::size_t regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
         // Currently we only support constant salinity converted to mass fraction
         salinity_[regionIdx] = eclState.getCo2StoreConfig().salinity();
         if (enableEzrokhiDensity_) {

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.cpp
@@ -54,14 +54,23 @@ initFromState(const EclipseState& eclState, const Schedule&)
     if (T_ref != Scalar(288.71) || P_ref != Scalar(1.01325e5)) {
         OPM_THROW(std::runtime_error, "CO2STORE/CO2SOL can only be used with default values for STCOND!");
     }
+    setEzrokhiDenCoeff(eclState.getCo2StoreConfig().getDenaqaTables());
 
     std::size_t numRegions = eclState.runspec().tabdims().getNumPVTTables();
     setNumRegions(numRegions);
-    for (size_t regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
+    for (std::size_t regionIdx = 0; regionIdx < numRegions; ++regionIdx) {
         // Currently we only support constant salinity converted to mass fraction
         salinity_[regionIdx] = eclState.getCo2StoreConfig().salinity();
+        // For consistency we compute the reference density the same way as in BrineCo2Pvt.cpp
+        if (enableEzrokhiDensity_) { 
+            const Scalar& rho_pure = H2O::liquidDensity(T_ref, P_ref, extrapolate);
+            const Scalar& nacl_exponent = ezrokhiExponent_(T_ref, ezrokhiDenNaClCoeff_);
+            brineReferenceDensity_[regionIdx] = rho_pure * pow(10.0, nacl_exponent * salinity_[regionIdx]);
+        }
+        else {
+            brineReferenceDensity_[regionIdx] = Brine::liquidDensity(T_ref, P_ref, salinity_[regionIdx], extrapolate);
+        }
         gasReferenceDensity_[regionIdx] = CO2::gasDensity(T_ref, P_ref, extrapolate);
-        brineReferenceDensity_[regionIdx] = Brine::liquidDensity(T_ref, P_ref, salinity_[regionIdx], extrapolate);
     }
 
     initEnd();

--- a/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
+++ b/opm/material/fluidsystems/blackoilpvt/Co2GasPvt.hpp
@@ -330,7 +330,26 @@ public:
     Scalar salinity(unsigned regionIdx) const
     { return salinity_[regionIdx]; }
 
+    void setEzrokhiDenCoeff(const std::vector<EzrokhiTable>& denaqa)
+    {
+        if (denaqa.empty())
+            return;
+
+        enableEzrokhiDensity_ = true;
+        ezrokhiDenNaClCoeff_ = {static_cast<Scalar>(denaqa[0].getC0("NACL")), 
+                                static_cast<Scalar>(denaqa[0].getC1("NACL")), 
+                                static_cast<Scalar>(denaqa[0].getC2("NACL"))};
+    }
+
 private:
+
+    template <class LhsEval>
+    LhsEval ezrokhiExponent_(const LhsEval& temperature,
+                             const std::vector<Scalar>& ezrokhiCoeff) const
+    {
+        const LhsEval& tempC = temperature - 273.15;
+        return ezrokhiCoeff[0] + tempC * (ezrokhiCoeff[1] + ezrokhiCoeff[2] * tempC);
+    }
 
     template <class LhsEval>
     LhsEval rvwSat_(unsigned regionIdx,
@@ -409,6 +428,8 @@ private:
     std::vector<Scalar> brineReferenceDensity_;
     std::vector<Scalar> gasReferenceDensity_;
     std::vector<Scalar> salinity_;
+    std::vector<Scalar> ezrokhiDenNaClCoeff_;
+    bool enableEzrokhiDensity_ = false;
     bool enableVaporization_ = true;
     int activityModel_;
     Co2StoreConfig::GasMixingType gastype_; 


### PR DESCRIPTION
This sets the salinity in the CO2Store module
It also make it possible to run CO2STORE with multiple pvt regions without crashing