### PR TITLE
Varnish FieldProps Implementation

### DIFF
--- a/opm/input/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldData.hpp
@@ -22,37 +22,41 @@
 
 #include <opm/input/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/Keywords.hpp>
+
 #include <opm/input/eclipse/Deck/value_status.hpp>
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <optional>
-#include <array>
-#include <algorithm>
-#include <stdexcept>
 
-namespace Opm
-{
-namespace Fieldprops
-{
-   template<typename T>
-    static void compress(std::vector<T>& data, const std::vector<bool>& active_map) {
+namespace Opm { namespace Fieldprops {
+
+    template <typename T>
+    static void compress(std::vector<T>&          data,
+                         const std::vector<bool>& active_map)
+    {
         std::size_t shift = 0;
-        for (std::size_t g = 0; g < active_map.size(); g++) {
+        for (std::size_t g = 0; g < active_map.size(); ++g) {
             if (active_map[g] && shift > 0) {
                 data[g - shift] = data[g];
                 continue;
             }
 
-            if (!active_map[g])
+            if (!active_map[g]) {
                 shift += 1;
+            }
         }
 
         data.resize(data.size() - shift);
     }
 
-    template<typename T>
-    struct FieldData {
+    template <typename T>
+    struct FieldData
+    {
         std::vector<T> data;
         std::vector<value::status> value_status;
         keywords::keyword_info<T> kw_info;
@@ -60,7 +64,8 @@ namespace Fieldprops
         std::optional<std::vector<value::status>> global_value_status;
         mutable bool all_set;
 
-        bool operator==(const FieldData& other) const {
+        bool operator==(const FieldData& other) const
+        {
             return this->data == other.data &&
                    this->value_status == other.value_status &&
                    this->kw_info == other.kw_info &&
@@ -68,46 +73,59 @@ namespace Fieldprops
                    this->global_value_status == other.global_value_status;
         }
 
-
         FieldData() = default;
 
-        FieldData(const keywords::keyword_info<T>& info, std::size_t active_size, std::size_t global_size) :
-            data(std::vector<T>(active_size)),
-            value_status(active_size, value::status::uninitialized),
-            kw_info(info),
-            all_set(false)
+        FieldData(const keywords::keyword_info<T>& info,
+                  const std::size_t                active_size,
+                  const std::size_t                global_size)
+            : data        (active_size)
+            , value_status(active_size, value::status::uninitialized)
+            , kw_info     (info)
+            , all_set     (false)
         {
             if (global_size != 0) {
-                this->global_data = std::vector<T>(global_size);
-                this->global_value_status = std::vector<value::status>(global_size, value::status::uninitialized);
+                this->global_data.emplace(global_size);
+                this->global_value_status.emplace(global_size, value::status::uninitialized);
             }
 
-            if (info.scalar_init)
-                this->default_assign( *info.scalar_init );
+            if (info.scalar_init) {
+                this->default_assign(*info.scalar_init);
+            }
         }
 
-
-        std::size_t size() const {
+        std::size_t size() const
+        {
             return this->data.size();
         }
 
-        bool valid() const {
-            if (this->all_set)
+        bool valid() const
+        {
+            if (this->all_set) {
                 return true;
+            }
 
-            static const std::array<value::status,2> invalid_value = {value::status::uninitialized, value::status::empty_default};
-            const auto& it = std::find_first_of(this->value_status.begin(), this->value_status.end(), invalid_value.begin(), invalid_value.end());
-            this->all_set = (it == this->value_status.end());
-
-            return this->all_set;
+            // Object is "valid" if the 'value_status' of every element is
+            // neither uninitialised nor empty.
+            return this->all_set =
+                std::none_of(this->value_status.begin(), this->value_status.end(),
+                             [](const value::status& status)
+                             {
+                                 return (status == value::status::uninitialized)
+                                     || (status == value::status::empty_default);
+                             });
         }
 
-        bool valid_default() const {
-            return std::all_of( this->value_status.begin(), this->value_status.end(), [] (const value::status& status) {return status == value::status::valid_default; });
+        bool valid_default() const
+        {
+            return std::all_of(this->value_status.begin(), this->value_status.end(),
+                               [](const value::status& status)
+                               {
+                                   return status == value::status::valid_default;
+                               });
         }
 
-
-        void compress(const std::vector<bool>& active_map) {
+        void compress(const std::vector<bool>& active_map)
+        {
             Fieldprops::compress(this->data, active_map);
             Fieldprops::compress(this->value_status, active_map);
         }
@@ -119,29 +137,47 @@ namespace Fieldprops
             }
         }
 
-        void default_assign(T value) {
+        void default_assign(T value)
+        {
             std::fill(this->data.begin(), this->data.end(), value);
-            std::fill(this->value_status.begin(), this->value_status.end(), value::status::valid_default);
+            std::fill(this->value_status.begin(),
+                      this->value_status.end(),
+                      value::status::valid_default);
 
             if (this->global_data) {
-                std::fill(this->global_data->begin(), this->global_data->end(), value);
-                std::fill(this->global_value_status->begin(), this->global_value_status->end(), value::status::valid_default);
+                std::fill(this->global_data->begin(),
+                          this->global_data->end(), value);
+
+                std::fill(this->global_value_status->begin(),
+                          this->global_value_status->end(),
+                          value::status::valid_default);
             }
         }
 
-        void default_assign(const std::vector<T>& src) {
-            if (src.size() != this->size())
-                throw std::invalid_argument("Size mismatch got: " + std::to_string(src.size()) + " expected: " + std::to_string(this->size()));
+        void default_assign(const std::vector<T>& src)
+        {
+            if (src.size() != this->size()) {
+                throw std::invalid_argument {
+                    "Size mismatch got: " + std::to_string(src.size()) +
+                    ", expected: " + std::to_string(this->size())
+                };
+            }
 
             std::copy(src.begin(), src.end(), this->data.begin());
-            std::fill(this->value_status.begin(), this->value_status.end(), value::status::valid_default);
+            std::fill(this->value_status.begin(), this->value_status.end(),
+                      value::status::valid_default);
         }
 
-        void default_update(const std::vector<T>& src) {
-            if (src.size() != this->size())
-                throw std::invalid_argument("Size mismatch got: " + std::to_string(src.size()) + " expected: " + std::to_string(this->size()));
+        void default_update(const std::vector<T>& src)
+        {
+            if (src.size() != this->size()) {
+                throw std::invalid_argument {
+                    "Size mismatch got: " + std::to_string(src.size()) +
+                    ", expected: " + std::to_string(this->size())
+                };
+            }
 
-            for (std::size_t i = 0; i < src.size(); i++) {
+            for (std::size_t i = 0; i < src.size(); ++i) {
                 if (!value::has_value(this->value_status[i])) {
                     this->value_status[i] = value::status::valid_default;
                     this->data[i] = src[i];
@@ -149,12 +185,15 @@ namespace Fieldprops
             }
         }
 
-        void update(std::size_t index, T value, value::status status) {
+        void update(const std::size_t index,
+                    T value,
+                    const value::status status)
+        {
             this->data[index] = value;
             this->value_status[index] = status;
         }
-
     };
-} // end namespace Fieldprops
-} // end namespace Opm
+
+}} // namespace Opm::Fieldprops
+
 #endif // FIELD_DATA_HPP

--- a/opm/input/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldData.hpp
@@ -33,7 +33,7 @@
 #include <string>
 #include <vector>
 
-namespace Opm { namespace Fieldprops {
+namespace Opm::Fieldprops {
 
     template <typename T>
     static void compress(std::vector<T>&          data,
@@ -194,6 +194,6 @@ namespace Opm { namespace Fieldprops {
         }
     };
 
-}} // namespace Opm::Fieldprops
+} // namespace Opm::Fieldprops
 
 #endif // FIELD_DATA_HPP

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -233,7 +233,7 @@ namespace {
 //
 // This quite weird behaviour comes from reading the GRIDOPTS and MULTNUM
 // documentation, and practical experience with ECLIPSE simulations.
-// Ufortunately the documentation of the xxxREG keywords does not confirm
+// Unfortunately the documentation of the xxxREG keywords does not confirm
 // this.
 std::string default_region_keyword(const Deck& deck)
 {
@@ -838,10 +838,10 @@ FieldProps::init_get(const std::string& keyword_name,
         return iter->second;
     }
     else if (multiplier_in_edit) {
-        assert((keyword != ParserKeywords::PORV::keywordName) &&
-               (keyword != ParserKeywords::TEMPI::keywordName) &&
-               (Fieldprops::keywords::PROPS::satfunc.count(keyword) != 1) &&
-               !is_capillary_pressure(keyword));
+        assert(keyword != ParserKeywords::PORV::keywordName);
+        assert(keyword != ParserKeywords::TEMPI::keywordName);
+        assert(Fieldprops::keywords::PROPS::satfunc.count(keyword) != 1);
+        assert(!is_capillary_pressure(keyword));
 
         this->multiplier_kw_infos_.insert_or_assign(mult_keyword, kw_info);
     }
@@ -992,7 +992,8 @@ void FieldProps::apply_multipliers()
         // If data is global, then we also need to set the global_data. I think they should be the same at this stage, though!
         if (kw_info.global)
         {
-            assert(mult_iter->second.global_data.has_value() && iter->second.global_data.has_value());
+            assert(mult_iter->second.global_data.has_value());
+            assert(iter->second.global_data.has_value());
             std::transform(iter->second.global_data->begin(),
                            iter->second.global_data->end(),
                            mult_iter->second.global_data->begin(),
@@ -1013,14 +1014,14 @@ void FieldProps::apply_multipliers()
 }
 
 // The ACTNUM and PORV keywords are special cased with quite extensive
-// postprocessing, and should be access through the special ::porv() and
+// postprocessing, and should be accessed through the special ::porv() and
 // ::actnum() methods instead of the general ::get<T>( ) method. These two
 // keywords are also hidden from the keys<T>() vectors.
 //
-// If there are TRAN? fields in the container they are transferred even if they
-// are not completely defined. This is because that TRAN? fields will ultimately
-// be combined with the TRAN? values calculated from the simulator, it does
-// therefore not make sense to require that these fields are fully defined.
+// If there are TRAN? fields in the container, these will be transferred
+// even if they are not fully defined. These TRAN? fields will ultimately be
+// combined with the TRAN? values calculated from the simulator, and it does
+// therefore not make sense to require fully defined fields.
 
 template <>
 std::vector<std::string> FieldProps::keys<double>() const
@@ -1685,12 +1686,12 @@ FieldProps::canonical_fipreg_name(const std::string& fipreg) const
         : fipreg;
 }
 
-// This function generates a new ACTNUM vector.The ACTNUM vector which is
-// returned is joined result of three different data sources:
+// Generate a combined ACTNUM property array from three distinct data
+// sources.
 //
-//    1. The ACTNUM of if the grid which is part of this FieldProps structure.
+//    1. The property array stored internally in this FieldProps object.
 //
-//    2. If there have been ACTNUM operations in the DECK of the type:
+//    2. Direct ACTNUM array operations of the form
 //
 //       EQUALS
 //           ACTNUM 0 1 10 1 10 1 3 /
@@ -1698,9 +1699,8 @@ FieldProps::canonical_fipreg_name(const std::string& fipreg) const
 //
 //    3. Cells with PORV == 0 will get ACTNUM = 0.
 //
-// Observe that due to steps 2 and 3 the ACTNUM vector returned from this
-// function will in general differ from the internal ACTNUM used in the
-// FieldProps instance.
+// Note that steps 2 and 3 generally forms an ACTNUM property which differs
+// from the ACTNUM property stored internally in the FieldProps instance.
 std::vector<int> FieldProps::actnum()
 {
     auto actnum = this->m_actnum;

--- a/tests/parser/MultiRegTests.cpp
+++ b/tests/parser/MultiRegTests.cpp
@@ -15,229 +15,208 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-#include <stdexcept>
-#include <cstdio>
+*/
 
 #define BOOST_TEST_MODULE MultiRegTests
 #include <boost/test/unit_test.hpp>
-#include <opm/input/eclipse/Parser/Parser.hpp>
 
-#include <opm/input/eclipse/Deck/DeckSection.hpp>
-#include <opm/input/eclipse/Deck/Deck.hpp>
-#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/input/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldPropsManager.hpp>
 #include <opm/input/eclipse/EclipseState/Runspec.hpp>
 
-static Opm::Deck createDeckInvalidArray() {
-    const char* deckData =
-        "RUNSPEC\n"
-        "\n"
-        "DIMENS\n"
-        " 10 10 10 /\n"
-        "GRID\n"
-        "MULTIREG\n"
-        "  MISSING 10 10 M / \n"
-        "/\n"
-        "EDIT\n"
-        "\n";
+#include <opm/input/eclipse/Deck/DeckSection.hpp>
+#include <opm/input/eclipse/Deck/Deck.hpp>
+#include <opm/input/eclipse/Deck/DeckKeyword.hpp>
 
-    Opm::Parser parser;
-    return parser.parseString(deckData) ;
+#include <opm/input/eclipse/Parser/Parser.hpp>
+
+#include <stdexcept>
+#include <cstdio>
+
+namespace {
+
+Opm::Deck createDeckInvalidArray()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+ 10 10 10 /
+GRID
+MULTIREG
+  MISSING 10 10 M /
+/
+
+EDIT
+)");
 }
 
-
-static Opm::Deck createDeckInvalidRegion() {
-    const char* deckData =
-        "RUNSPEC\n"
-        "\n"
-        "DIMENS\n"
-        " 10 10 10 /\n"
-        "GRID\n"
-        "REGIONS\n"
-        "SATNUM\n"
-        "  1000*1 /\n"
-        "MULTIREG\n"
-        "  SATNUM 10 10 MX / \n"
-        "/\n"
-        "EDIT\n"
-        "\n";
-
-    Opm::Parser parser;
-    return parser.parseString(deckData) ;
+Opm::Deck createDeckInvalidRegion()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+ 10 10 10 /
+GRID
+REGIONS
+SATNUM
+  1000*1 /
+MULTIREG
+  SATNUM 10 10 MX /
+/
+EDIT
+)");
 }
 
-
-static Opm::Deck createDeckInvalidValue() {
-    const char* deckData =
-        "RUNSPEC\n"
-        "\n"
-        "DIMENS\n"
-        " 10 10 10 /\n"
-        "GRID\n"
-        "REGIONS\n"
-        "SATNUM\n"
-        "  1000*1 /\n"
-        "MULTIREG\n"
-        "  SATNUM 0.2 10 M / \n"
-        "/\n"
-        "EDIT\n"
-        "\n";
-
-    Opm::Parser parser;
-    return parser.parseString(deckData) ;
+Opm::Deck createDeckInvalidValue()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+ 10 10 10 /
+GRID
+REGIONS
+SATNUM
+  1000*1 /
+MULTIREG
+  SATNUM 0.2 10 M /
+/
+EDIT
+)");
 }
 
-
-static Opm::Deck createDeckMissingVector() {
-    const char* deckData =
-        "RUNSPEC\n"
-        "\n"
-        "DIMENS\n"
-        " 10 10 10 /\n"
-        "GRID\n"
-        "REGIONS\n"
-        "SATNUM\n"
-        "  1000*1 /\n"
-        "MULTIREG\n"
-        "  SATNUM 2 10 M / \n"
-        "/\n"
-        "EDIT\n"
-        "\n";
-
-    Opm::Parser parser;
-    return parser.parseString(deckData) ;
+Opm::Deck createDeckMissingVector()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+ 10 10 10 /
+GRID
+REGIONS
+SATNUM
+  1000*1 /
+MULTIREG
+  SATNUM 2 10 M /
+/
+EDIT
+)");
 }
 
-
-static Opm::Deck createDeckUnInitialized() {
-    const char* deckData =
-        "RUNSPEC\n"
-        "\n"
-        "DIMENS\n"
-        " 10 10 10 /\n"
-        "GRID\n"
-        "REGIONS\n"
-        "MULTIREG\n"
-        "  SATNUM 2 10 M / \n"
-        "/\n"
-        "EDIT\n"
-        "\n";
-
-    Opm::Parser parser;
-    return parser.parseString(deckData) ;
+Opm::Deck createDeckUnInitialized()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+DIMENS
+ 10 10 10 /
+GRID
+REGIONS
+MULTIREG
+  SATNUM 2 10 M /
+/
+EDIT
+)");
 }
 
+Opm::Deck createValidIntDeck()
+{
+    return Opm::Parser{}.parseString(R"(RUNSPEC
+GRIDOPTS
+  'YES'  2 /
 
-static Opm::Deck createValidIntDeck() {
-    const char* deckData =
-        "RUNSPEC\n"
-        "GRIDOPTS\n"
-        "  'YES'  2 /\n"
-        "\n"
-        "DIMENS\n"
-        " 5 5 1 /\n"
-        "GRID\n"
-        "DX\n"
-        "25*1.0 /\n"
-        "DY\n"
-        "25*1.0 /\n"
-        "DZ\n"
-        "25*1.0 /\n"
-        "TOPS\n"
-        "25*0.25 /\n"
-        "PERMY\n"
-        "   25*1.0 /\n"
-        "PERMX\n"
-        "   25*1.0 /\n"
-        "PORO\n"
-        "   25*1.0 /\n"
-        "MULTNUM \n"
-        "1  1  2  2 2\n"
-        "1  1  2  2 2\n"
-        "1  1  2  2 2\n"
-        "1  1  2  2 2\n"
-        "1  1  2  2 2\n"
-        "/\n"
-        "REGIONS\n"
-        "SATNUM \n"
-        "1  1  2  2 2\n"
-        "1  1  2  2 2\n"
-        "1  1  2  2 2\n"
-        "1  1  2  2 2\n"
-        "1  1  2  2 2\n"
-        "/\n"
-        "OPERNUM \n"
-        "1  2  3   4  5\n"
-        "6  7  8   9 10\n"
-        "11 12 13 14 15\n"
-        "16 17 18 19 20\n"
-        "21 22 23 24 25\n"
-        "/\n"
-        "OPERATER\n"
-        " PERMX 1 MULTX  PERMY 0.50 /\n"
-        " PERMX 2 COPY   PERMY /\n"
-        " PORV 1 'MULTX' PORV 0.50 /\n"
-        "/\n"
-        "MULTIREG\n"
-        "  SATNUM 11 1    M / \n"
-        "  SATNUM 20 2      / \n"
-        "/\n"
-        "EDIT\n"
-        "\n";
-
-    Opm::Parser parser;
-    return parser.parseString(deckData) ;
+DIMENS
+ 5 5 1 /
+GRID
+DX
+25*1.0 /
+DY
+25*1.0 /
+DZ
+25*1.0 /
+TOPS
+25*0.25 /
+PERMY
+   25*1.0 /
+PERMX
+   25*1.0 /
+PORO
+   25*1.0 /
+MULTNUM
+1  1  2  2 2
+1  1  2  2 2
+1  1  2  2 2
+1  1  2  2 2
+1  1  2  2 2
+/
+REGIONS
+SATNUM
+1  1  2  2 2
+1  1  2  2 2
+1  1  2  2 2
+1  1  2  2 2
+1  1  2  2 2
+/
+OPERNUM
+1  2  3   4  5
+6  7  8   9 10
+11 12 13 14 15
+16 17 18 19 20
+21 22 23 24 25
+/
+OPERATER
+ PERMX 1 MULTX  PERMY 0.50 /
+ PERMX 2 COPY   PERMY /
+ PORV 1 'MULTX' PORV 0.50 /
+/
+MULTIREG
+  SATNUM 11 1    M /
+  SATNUM 20 2      /
+/
+EDIT
+)");
 }
 
+} // Anonymous namespace
 
+// ---------------------------------------------------------------------------
 
-
-
-
-BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
-    Opm::Deck deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
+BOOST_AUTO_TEST_CASE(InvalidArrayThrows)
+{
+    BOOST_CHECK_THROW(Opm::EclipseState{createDeckInvalidArray()}, std::invalid_argument);
 }
 
-
-BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
-    Opm::Deck deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
+BOOST_AUTO_TEST_CASE(InvalidRegionThrows)
+{
+    BOOST_CHECK_THROW(Opm::EclipseState{createDeckInvalidRegion()}, std::invalid_argument);
 }
 
-
-BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
-    Opm::Deck deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
+BOOST_AUTO_TEST_CASE(ExpectedIntThrows)
+{
+    BOOST_CHECK_THROW(Opm::EclipseState{createDeckInvalidValue()}, std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE(MissingRegionVectorThrows) {
-    Opm::Deck deck = createDeckMissingVector();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
+BOOST_AUTO_TEST_CASE(MissingRegionVectorThrows)
+{
+    BOOST_CHECK_THROW(Opm::EclipseState{createDeckMissingVector()}, std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
-    Opm::Deck deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck) , std::invalid_argument );
+BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows)
+{
+    BOOST_CHECK_THROW(Opm::EclipseState{createDeckUnInitialized()}, std::invalid_argument);
 }
 
-BOOST_AUTO_TEST_CASE(Test_OPERATER) {
-    Opm::Deck deck = createValidIntDeck();
-    Opm::TableManager tm(deck);
-    Opm::EclipseGrid eg(deck);
-    Opm::FieldPropsManager fp(deck, Opm::Phases{true, true, true}, eg, tm);
+BOOST_AUTO_TEST_CASE(Test_OPERATER)
+{
+    const auto deck = createValidIntDeck();
+
+    // Note: the EclipseGrid object must be mutable.
+    auto eg = Opm::EclipseGrid { deck };
+
+    const auto tm = Opm::TableManager { deck };
+    const auto fp = Opm::FieldPropsManager {
+        deck, Opm::Phases{true, true, true}, eg, tm
+    };
 
     const auto& porv  = fp.porv(true);
     const auto& permx = fp.get_global_double("PERMX");
     const auto& permy = fp.get_global_double("PERMY");
 
-    BOOST_CHECK_EQUAL( porv[0], 0.50 );
-    BOOST_CHECK_EQUAL( porv[1], 1.00 );
-    BOOST_CHECK_EQUAL( permx[0] / permy[0], 0.50 );
-    BOOST_CHECK_EQUAL( permx[1], permy[1]);
+    BOOST_CHECK_CLOSE(porv[0], 0.50, 1.0e-8);
+    BOOST_CHECK_CLOSE(porv[1], 1.00, 1.0e-8);
+    BOOST_CHECK_CLOSE(permx[0] / permy[0], 0.50, 1.0e-8);
+    BOOST_CHECK_CLOSE(permx[1], permy[1], 1.0e-8);
 }
-


### PR DESCRIPTION
In particular,

  * Prefer in-place map element construction where possible, and `insert_or_assign()` where not
  * Apply `const` where meaningful
  * Hoist constant conditions/objects out of loops
  * Split long lines and make a few other whitespace adjustments
  * Prefer prefix increment and `//` comments
  * Remove an unneeded static object
  * Add `{}` to single statement control structures
  * Separate `OPERATER` handling out from the other `*REG` operations (`ADDREG`, `EQUALREG`, `MULTIREG`).  The distinctions are greater than the commonalities and that justifies separate handling.

This is in preparation of making our implementation of array operations like `COPY` more strict.