### PR TITLE
make it possible to output every timestep

### DIFF
--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -146,7 +146,8 @@ public:
                        bool                 isSubstep,
                        double               seconds_elapsed,
                        RestartValue         value,
-                       const bool write_double = false);
+                       const bool write_double = false,
+                       std::optional<int>   time_step = std::nullopt);
 
     /// Will load solution data and wellstate from the restart file.  This
     /// method will consult the IOConfig object to get filename and report


### PR DESCRIPTION
With this you can output restart files every time step if --enable-write-all-solutions=true 
The numbering of the restart and summary files will follow the time step index and not the report index. 
This will not be compatible with restart, but it is sometimes useful to investigate the results at every time step. 

Note that we still don't support RPTRST BASIC=6. For that I image more work needs to be done. 
