### PR TITLE
Stop Processing if COPYing From Undefined Source Array

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -126,6 +126,7 @@ if(ENABLE_ECL_INPUT)
     opm/input/eclipse/EclipseState/Grid/CarfinManager.cpp
     opm/input/eclipse/EclipseState/Grid/LgrCollection.cpp
     opm/input/eclipse/EclipseState/Grid/EclipseGrid.cpp
+    opm/input/eclipse/EclipseState/Grid/FieldData.cpp
     opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
     opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
     opm/input/eclipse/EclipseState/Grid/FaceDir.cpp

--- a/opm/input/eclipse/EclipseState/Grid/FieldData.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldData.cpp
@@ -1,0 +1,86 @@
+/*
+  Copyright 2024 Equinor AS.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <opm/input/eclipse/EclipseState/Grid/FieldData.hpp>
+
+#include <opm/common/OpmLog/KeywordLocation.hpp>
+#include <opm/common/OpmLog/OpmLog.hpp>
+#include <opm/common/utility/OpmInputError.hpp>
+
+#include <opm/input/eclipse/EclipseState/Grid/Box.hpp>
+
+#include <opm/input/eclipse/Deck/value_status.hpp>
+
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+
+template <typename T>
+void
+Opm::Fieldprops::FieldData<T>::
+checkInitialisedCopy(const FieldData&                    src,
+                     const std::vector<Box::cell_index>& index_list,
+                     const std::string&                  from,
+                     const std::string&                  to,
+                     const KeywordLocation&              loc)
+{
+    auto unInit = 0;
+
+    for (const auto& ci : index_list) {
+        const auto ix = ci.active_index;
+        const auto st = src.value_status[ix];
+
+        if (st != value::status::deck_value) {
+            ++unInit;
+            continue;
+        }
+
+        this->data[ix] = src.data[ix];
+        this->value_status[ix] = st;
+    }
+
+    if (unInit > 0) {
+        const auto* plural = (unInit > 1) ? "s" : "";
+
+        throw OpmInputError {
+            fmt::format
+            (R"(Copying from source array {0}
+would generate an undefined result in {2} block{3} of target array {1}.)",
+             from, to, unInit, plural),
+            loc
+        };
+    }
+}
+
+template
+void Opm::Fieldprops::FieldData<double>::
+checkInitialisedCopy(const FieldData&,
+                     const std::vector<Box::cell_index>&,
+                     const std::string&,
+                     const std::string&,
+                     const KeywordLocation&);
+
+template
+void Opm::Fieldprops::FieldData<int>::
+checkInitialisedCopy(const FieldData&,
+                     const std::vector<Box::cell_index>&,
+                     const std::string&,
+                     const std::string&,
+                     const KeywordLocation&);

--- a/opm/input/eclipse/EclipseState/Grid/FieldData.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldData.hpp
@@ -33,6 +33,10 @@
 #include <string>
 #include <vector>
 
+namespace Opm {
+    class KeywordLocation;
+} // namespace Opm
+
 namespace Opm::Fieldprops {
 
     template <typename T>
@@ -148,12 +152,11 @@ namespace Opm::Fieldprops {
             Fieldprops::compress(this->value_status, active_map, this->numValuePerCell());
         }
 
-        void copy(const FieldData<T>& src, const std::vector<Box::cell_index>& index_list) {
-            for (const auto& ci : index_list) {
-                this->data[ci.active_index] = src.data[ci.active_index];
-                this->value_status[ci.active_index] = src.value_status[ci.active_index];
-            }
-        }
+        void checkInitialisedCopy(const FieldData&                    src,
+                                  const std::vector<Box::cell_index>& index_list,
+                                  const std::string&                  from,
+                                  const std::string&                  to,
+                                  const KeywordLocation&              loc);
 
         void default_assign(T value)
         {

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -517,25 +517,31 @@ void apply(const Fieldprops::ScalarOperation   op,
            const T                             scalar_value,
            const std::vector<Box::cell_index>& index_list)
 {
-    if (op == Fieldprops::ScalarOperation::EQUAL) {
+    switch (op) {
+    case Fieldprops::ScalarOperation::EQUAL:
         assign_scalar(data, value_status, scalar_value, index_list);
-    }
+        return;
 
-    else if (op == Fieldprops::ScalarOperation::MUL) {
+    case Fieldprops::ScalarOperation::MUL:
         multiply_scalar(loc, arrayName, data, value_status, scalar_value, index_list);
-    }
+        return;
 
-    else if (op == Fieldprops::ScalarOperation::ADD) {
+    case Fieldprops::ScalarOperation::ADD:
         add_scalar(loc, arrayName, data, value_status, scalar_value, index_list);
-    }
+        return;
 
-    else if (op == Fieldprops::ScalarOperation::MIN) {
+    case Fieldprops::ScalarOperation::MIN:
         min_value(loc, arrayName, data, value_status, scalar_value, index_list);
+        return;
+
+    case Fieldprops::ScalarOperation::MAX:
+        max_value(loc, arrayName, data, value_status, scalar_value, index_list);
+        return;
     }
 
-    else if (op == Fieldprops::ScalarOperation::MAX) {
-        max_value(loc, arrayName, data, value_status, scalar_value, index_list);
-    }
+    throw std::invalid_argument {
+        fmt::format("'{}' is not a known operation.", static_cast<int>(op))
+    };
 }
 
 std::string make_region_name(const std::string& deck_value)

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.cpp
@@ -1623,6 +1623,7 @@ void FieldProps::handle_COPY(const DeckKeyword& keyword,
         const auto target_kw = arrayName(record.getItem(1));
 
         std::vector<Box::cell_index> index_list;
+        auto srcDescr = std::string {};
 
         if (isRegionOperation) {
             using Kw = ParserKeywords::COPYREG;
@@ -1630,11 +1631,18 @@ void FieldProps::handle_COPY(const DeckKeyword& keyword,
             const auto& regionName = this->region_name(record.getItem<Kw::REGION_NAME>());
 
             index_list = this->region_index(regionName, regionId);
+            srcDescr = fmt::format("{} in region {} of region set {}",
+                                   src_kw, regionId, regionName);
         }
         else {
             box.update(record);
             index_list = box.index_list();
 
+            srcDescr = fmt::format("{} in BOX ({}-{}, {}-{}, {}-{})",
+                                   src_kw,
+                                   box.I1() + 1, box.I2() + 1,
+                                   box.J1() + 1, box.J2() + 1,
+                                   box.K1() + 1, box.K2() + 1);
         }
 
         if (FieldProps::supported<double>(src_kw)) {
@@ -1642,7 +1650,9 @@ void FieldProps::handle_COPY(const DeckKeyword& keyword,
             src_data.verify_status();
 
             auto& target_data = this->init_get<double>(target_kw);
-            target_data.copy(src_data.field_data(), index_list);
+            target_data.checkInitialisedCopy(src_data.field_data(), index_list,
+                                             srcDescr, target_kw,
+                                             keyword.location());
             continue;
         }
 
@@ -1651,7 +1661,9 @@ void FieldProps::handle_COPY(const DeckKeyword& keyword,
             src_data.verify_status();
 
             auto& target_data = this->init_get<int>(target_kw);
-            target_data.copy(src_data.field_data(), index_list);
+            target_data.checkInitialisedCopy(src_data.field_data(), index_list,
+                                             srcDescr, target_kw,
+                                             keyword.location());
             continue;
         }
     }

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -339,7 +339,7 @@ public:
 
     /// Property array existence status
     enum class GetStatus {
-        /// Property exists and its property data is well formed.
+        /// Property exists and its property data is fully defined.
         OK = 1,
 
         /// Property array has not been fully initialised.
@@ -401,7 +401,7 @@ public:
         /// \code this->status \endcode is not \code GetStatus::OK \endcode.
         /// Does nothing otherwise.
         ///
-        /// \param[in] Input keyword which prompted request
+        /// \param[in] Input keyword which prompted request.
         ///
         /// \param[in] descr Textual description of context in which request
         ///   occurred.
@@ -462,7 +462,7 @@ public:
 
         /// Access underlying property data elements
         ///
-        /// Returns \c nullptr if property data is not well formed.
+        /// Returns \c nullptr if property data is not fully defined.
         const std::vector<T>* ptr() const
         {
             return (this->data_ptr != nullptr)
@@ -473,7 +473,7 @@ public:
         /// Access underlying property data elements
         ///
         /// Throws an exception as outlined in \c GetStatus if property data
-        /// is not well formed.
+        /// is not fully defined.
         const std::vector<T>& data() const
         {
             this->verify_status();
@@ -483,7 +483,7 @@ public:
         /// Read-only access to contained FieldData object
         ///
         /// Throws an exception as outlined in \c GetStatus if property data
-        /// is not well formed.
+        /// is not fully defined.
         const Fieldprops::FieldData<T>& field_data() const
         {
             this->verify_status();
@@ -492,7 +492,7 @@ public:
 
         /// Property validity predicate.
         ///
-        /// Returns true if propery exists and has well defined data
+        /// Returns true if property exists and has fully defined data
         /// elements.  False otherwise.
         bool valid() const
         {

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -19,6 +19,8 @@
 #ifndef FIELDPROPS_HPP
 #define FIELDPROPS_HPP
 
+#include <opm/common/utility/OpmInputError.hpp>
+
 #include <opm/input/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/FieldData.hpp>
 #include <opm/input/eclipse/EclipseState/Grid/Keywords.hpp>
@@ -355,7 +357,36 @@ public:
             , data_ptr(d)
         {}
 
+        void verify_status(const KeywordLocation& loc,
+                           const std::string&     descr,
+                           const std::string&     operation) const
+        {
+            switch (this->status) {
+            case FieldProps::GetStatus::OK:
+                return;
 
+            case FieldProps::GetStatus::INVALID_DATA:
+                throw OpmInputError {
+                    descr + " " + this->keyword +
+                    " is not fully initialised for " + operation,
+                    loc
+                };
+
+            case FieldProps::GetStatus::MISSING_KEYWORD:
+                throw OpmInputError {
+                    descr + " " + this->keyword +
+                    " does not exist in input deck for " + operation,
+                    loc
+                };
+
+            case FieldProps::GetStatus::NOT_SUPPPORTED_KEYWORD:
+                throw OpmInputError {
+                    descr + " " + this->keyword +
+                    " is not supported for " + operation,
+                    loc
+                };
+            }
+        }
 
         void verify_status() const
         {

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -310,7 +310,7 @@ keyword_info<T> global_kw_info(const std::string& name, bool allow_unsupported =
 bool is_oper_keyword(const std::string& name);
 } // end namespace keywords
 
-} // end namespace FieldProps
+} // end namespace Fieldprops
 
 class FieldProps {
 public:
@@ -337,26 +337,76 @@ public:
         }
     };
 
+    /// Property array existence status
     enum class GetStatus {
-         OK = 1,
-         INVALID_DATA = 2,               // std::runtime_error
-         MISSING_KEYWORD = 3,            // std::out_of_range
-         NOT_SUPPPORTED_KEYWORD = 4      // std::logic_error
+        /// Property exists and its property data is well formed.
+        OK = 1,
+
+        /// Property array has not been fully initialised.
+        ///
+        /// At least one data element is uninitialised or has an empty
+        /// default.
+        ///
+        /// Will throw an exception of type \code std::runtime_error
+        /// \endcode in FieldDataManager::verify_status().
+        INVALID_DATA = 2,
+
+        /// Property has not yet been defined in the input file.
+        ///
+        /// Will throw an exception of type \code std::out_of_range \endcode
+        /// in FieldDataManager::verify_status().
+        MISSING_KEYWORD = 3,
+
+        /// Named property is not known to the internal handling mechanism.
+        ///
+        /// Might for instance be because the client code requested a
+        /// property of type \c int, but the name is only known as property
+        /// of type \c double, or because there was a misprint in the
+        /// property name.
+        ///
+        /// Will throw an exception of type \code std::logic_error \endcode
+        /// in FieldDataManager::verify_status().
+        NOT_SUPPPORTED_KEYWORD = 4,
     };
 
+    /// Wrapper type for field properties
+    ///
+    /// \tparam T Property element type.  Typically \c double or \c int.
     template<typename T>
     struct FieldDataManager
     {
+        /// Property name.
         const std::string& keyword;
+
+        /// Request status.
         GetStatus status;
+
+        /// Property data.
         const Fieldprops::FieldData<T>* data_ptr;
 
+        /// Constructor
+        ///
+        /// \param[in] k Property name
+        /// \param[in] s Request status
+        /// \param[in] d Property data.  Pass \c nullptr for missing property data.
         FieldDataManager(const std::string& k, GetStatus s, const Fieldprops::FieldData<T>* d)
             : keyword(k)
             , status(s)
             , data_ptr(d)
         {}
 
+        /// Validate result of \code try_get<>() \endcode request
+        ///
+        /// Throws an exception of type \code OpmInputError \endcode if
+        /// \code this->status \endcode is not \code GetStatus::OK \endcode.
+        /// Does nothing otherwise.
+        ///
+        /// \param[in] Input keyword which prompted request
+        ///
+        /// \param[in] descr Textual description of context in which request
+        ///   occurred.
+        ///
+        /// \param[in] operation Name of operation which prompted request.
         void verify_status(const KeywordLocation& loc,
                            const std::string&     descr,
                            const std::string&     operation) const
@@ -388,6 +438,11 @@ public:
             }
         }
 
+        /// Validate result of \code try_get<>() \endcode request
+        ///
+        /// Throws an exception as outlined in \c GetStatus if \code
+        /// this->status \endcode is not \code GetStatus::OK \endcode.  Does
+        /// nothing otherwise.
         void verify_status() const
         {
             switch (status) {
@@ -405,6 +460,9 @@ public:
             }
         }
 
+        /// Access underlying property data elements
+        ///
+        /// Returns \c nullptr if property data is not well formed.
         const std::vector<T>* ptr() const
         {
             return (this->data_ptr != nullptr)
@@ -412,22 +470,54 @@ public:
                 : nullptr;
         }
 
+        /// Access underlying property data elements
+        ///
+        /// Throws an exception as outlined in \c GetStatus if property data
+        /// is not well formed.
         const std::vector<T>& data() const
         {
             this->verify_status();
             return this->data_ptr->data;
         }
 
+        /// Read-only access to contained FieldData object
+        ///
+        /// Throws an exception as outlined in \c GetStatus if property data
+        /// is not well formed.
         const Fieldprops::FieldData<T>& field_data() const
         {
             this->verify_status();
             return *this->data_ptr;
         }
 
+        /// Property validity predicate.
+        ///
+        /// Returns true if propery exists and has well defined data
+        /// elements.  False otherwise.
         bool valid() const
         {
             return this->status == GetStatus::OK;
         }
+    };
+
+    /// Options to restrict or relax a try_get() request.
+    ///
+    /// For instance, the source array of a COPY operation must exist and be
+    /// fully defined, whereas the target array need not be either.  On the
+    /// other hand, certain use cases might want to look up property names
+    /// of an unsupported keyword type--e.g., transmissibility keywords
+    /// among the integer properties--and those requests should specify the
+    /// AllowUnsupported flag.
+    ///
+    /// Note: We would ideally use strong enums (i.e., "enum class") for
+    /// this, but those don't mesh very well with bitwise operations.
+    enum TryGetFlags : unsigned int {
+        /// Whether or not to permit looking up property names of unmatching
+        /// types.
+        AllowUnsupported = (1u << 0),
+
+        /// Whether or not the property must already exist.
+        MustExist = (1u << 1),
     };
 
     /// Normal constructor for FieldProps.
@@ -455,15 +545,36 @@ public:
     template <typename T>
     std::vector<std::string> keys() const;
 
+    /// Request read-only property array from internal cache
+    ///
+    /// Will create property array if permitted and possible.
+    ///
+    /// \tparam T Property element type.  Typically \c double or \c int.
+    ///
+    /// \param[in] keyword Property name
+    ///
+    /// \param[in] flags Options to limit or relax request processing.
+    ///   Treated as a bitwise mask of \c TryGetFlags.
+    ///
+    /// \return Access structure for requested property array.
     template <typename T>
     FieldDataManager<T>
-    try_get(const std::string& keyword, const bool allow_unsupported = false)
+    try_get(const std::string& keyword, const unsigned int flags = 0u)
     {
+        const auto allow_unsupported =
+            (flags & TryGetFlags::AllowUnsupported) != 0u;
+
         if (!allow_unsupported && !FieldProps::template supported<T>(keyword)) {
             return { keyword, GetStatus::NOT_SUPPPORTED_KEYWORD, nullptr };
         }
 
         const auto has0 = this->template has<T>(keyword);
+        if (!has0 && ((flags & TryGetFlags::MustExist) != 0)) {
+            // Client requested a property which must exist, e.g., as a
+            // source array for a COPY operation, but the property has not
+            // (yet) been defined in the run's input.
+            return { keyword, GetStatus::MISSING_KEYWORD, nullptr };
+        }
 
         const auto& field_data = this->template
             init_get<T>(keyword, std::is_same_v<T, double> && allow_unsupported);
@@ -475,11 +586,15 @@ public:
         }
 
         if (! has0) {
+            // Client requested a property which did not exist and which
+            // could not be created from a default description.
             this->template erase<T>(keyword);
 
             return { keyword, GetStatus::MISSING_KEYWORD, nullptr };
         }
 
+        // If we get here then the property exists but has not been fully
+        // defined yet.
         return { keyword, GetStatus::INVALID_DATA, nullptr };
     }
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldProps.hpp
@@ -628,13 +628,6 @@ private:
                  const std::vector<Box::cell_index>& index_list);
 
     template <typename T>
-    static void apply(ScalarOperation op,
-                      std::vector<T>& data,
-                      std::vector<value::status>& value_status,
-                      T scalar_value,
-                      const std::vector<Box::cell_index>& index_list);
-
-    template <typename T>
     Fieldprops::FieldData<T>&
     init_get(const std::string& keyword, bool allow_unsupported = false);
 

--- a/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
+++ b/opm/input/eclipse/EclipseState/Grid/FieldPropsManager.cpp
@@ -86,7 +86,11 @@ const Fieldprops::FieldData<double>&
 FieldPropsManager::get_double_field_data(const std::string& keyword,
                                          bool allow_unsupported) const
 {
-    const auto& data = this->fp->try_get<double>(keyword, allow_unsupported);
+    const auto flags = allow_unsupported
+        ? FieldProps::TryGetFlags::AllowUnsupported
+        : 0u;
+
+    const auto& data = this->fp->try_get<double>(keyword, flags);
     if (allow_unsupported || data.valid())
         return data.field_data();
 

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -212,6 +212,82 @@ COPY
     BOOST_CHECK_THROW( FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager()), std::out_of_range);
 }
 
+BOOST_AUTO_TEST_CASE(INVALID_COPY_UNDEFINED_BOX)
+{
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+TABDIMS
+/
+DIMENS
+ 10 10 10 /
+PROPS
+SGFN
+ 0.0 0.0 0.0
+ 0.8 1.0 0.0
+/
+SWFN
+ 0.2 0.0 0.0
+ 1.0 1.0 0.0
+/
+SOF3
+ 0.0 0.0 0.0
+ 0.8 1.0 1.0
+/
+EQUALS
+ 'SGL' 0.0 2* 2* 1 5 /
+/
+COPY
+  SGL SWL 2* 2* 6 10 /
+/
+)");
+
+    // Note: 'grid' must be mutable.
+    auto grid = EclipseGrid { 10, 10, 10 };
+
+    BOOST_CHECK_THROW(FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager{deck}),
+                      OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(INVALID_COPY_PARTIALLY_DEFINED)
+{
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+TABDIMS
+/
+DIMENS
+ 10 10 10 /
+PROPS
+SGFN
+ 0.0 0.0 0.0
+ 0.8 1.0 0.0
+/
+SWFN
+ 0.2 0.0 0.0
+ 1.0 1.0 0.0
+/
+SOF3
+ 0.0 0.0 0.0
+ 0.8 1.0 1.0
+/
+EQUALS
+ 'SGL' 0.0 2* 2* 1 5 /
+/
+COPY
+  SGL SWL 2* 2* 4 7 /
+/
+)");
+
+    // Note: 'grid' must be mutable.
+    auto grid = EclipseGrid { 10, 10, 10 };
+
+    BOOST_CHECK_THROW(FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager{deck}),
+                      OpmInputError);
+}
+
 BOOST_AUTO_TEST_CASE(GRID_RESET) {
     std::string deck_string = R"(
 REGIONS

--- a/tests/parser/FieldPropsTests.cpp
+++ b/tests/parser/FieldPropsTests.cpp
@@ -207,9 +207,13 @@ COPY
 /
 )";
 
-    EclipseGrid grid(EclipseGrid(10,10,10));
-    Deck deck = Parser{}.parseString(deck_string);
-    BOOST_CHECK_THROW( FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager()), std::out_of_range);
+    const auto deck = Parser{}.parseString(deck_string);
+
+    // Note: 'grid' must be mutable.
+    auto grid = EclipseGrid { 10, 10, 10 };
+
+    BOOST_CHECK_THROW(FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager{}),
+                      OpmInputError);
 }
 
 BOOST_AUTO_TEST_CASE(INVALID_COPY_UNDEFINED_BOX)
@@ -278,6 +282,41 @@ EQUALS
 /
 COPY
   SGL SWL 2* 2* 4 7 /
+/
+)");
+
+    // Note: 'grid' must be mutable.
+    auto grid = EclipseGrid { 10, 10, 10 };
+
+    BOOST_CHECK_THROW(FieldPropsManager(deck, Phases{true, true, true}, grid, TableManager{deck}),
+                      OpmInputError);
+}
+
+BOOST_AUTO_TEST_CASE(INVALID_ADD)
+{
+    const auto deck = Parser{}.parseString(R"(RUNSPEC
+OIL
+GAS
+WATER
+TABDIMS
+/
+DIMENS
+ 10 10 10 /
+PROPS
+SGFN
+ 0.0 0.0 0.0
+ 0.8 1.0 0.0
+/
+SWFN
+ 0.2 0.0 0.0
+ 1.0 1.0 0.0
+/
+SOF3
+ 0.0 0.0 0.0
+ 0.8 1.0 1.0
+/
+ADD
+  SGU 0.123 /
 /
 )");
 


### PR DESCRIPTION
This PR adds defined value checking to the source array from which we're copying in a `COPY` operation&ndash;either with the `COPY` or with the `COPYREG` keywords.  We count the number of source array values which do not have the status of `deck_value` and if this count is positive, then we throw an `OpmInputError` exception which halts further input processing.

As an example of this behaviour, the (deliberately faulty) setup
```
EQUALS
-- SGL not defined prior to this point
  'SGL' 0.0 2* 2* 1 5 /
/

COPY
  SGL SWL 2* 2* 4 7 /
/
```
will generate an "Error" of the form
```
Error: Problem with keyword COPY
In USER_ERR_COPY_BOX_PARTIALLY_UNDEF.DATA line 195
Copying from source array SGL in BOX (1-13, 1-22, 4-7)
would generate an undefined result in 572 blocks of target array SWL.
```
and stop input processing.

Similarly, For operations other than assignment (`EQUALS` keyword), this PR ensures that the array being mutated already exists in the input. In particular, this means that a request of the form
```
ADD
  SGU 0.123 /
/
```
will halt input processing and generate an "Error" of the form
```
Error: Problem with keyword ADD
In USER_ERR_ADD.DATA line 202
Target array SGU must already exist when operated upon in ADD.
```
unless the `SGU` array has already been assigned earlier.

To this end, repurpose the second parameter to member function
```
FieldProps::try_get<>()
```
and make this a bitmask of flags instead of a single `bool`.  The currently supported flags are `AllowUnsupported` and `MustExist`
with the former representing the original 'bool' parameter and the second requesting that the property array must already exist for the request to succeed.