### PR TITLE
Add missing '#include <optional>' that can break compilation.

### DIFF
--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <optional>
 
 namespace Opm {
 

--- a/opm/output/eclipse/EclipseIO.hpp
+++ b/opm/output/eclipse/EclipseIO.hpp
@@ -26,9 +26,9 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
-#include <optional>
 
 namespace Opm {
 


### PR DESCRIPTION
Does so for me locally at least, with gcc 11.3.0.