### PR TITLE
Add macro to throw exceptions indicating only problems.

### DIFF
--- a/opm/common/ErrorMacros.hpp
+++ b/opm/common/ErrorMacros.hpp
@@ -40,7 +40,8 @@
 # define OPM_MESSAGE_IF(cond, m) do {} while (false)
 #endif
 
-// Macro to throw an exception. NOTE: For this macro to work, the
+// Macro to throw an exception that counts as an error in PRT file.
+// NOTE: For this macro to work, the
 // exception class must exhibit a constructor with the signature
 // (const std::string &message). Since this condition is not fulfilled
 // for the std::exception, you should use this macro with some
@@ -54,6 +55,24 @@
                            std::to_string(__LINE__) + "] " +   \
                            message;                            \
         ::Opm::OpmLog::error(oss_);                            \
+        throw Exception(oss_);                                 \
+    } while (false)
+
+// Macro to throw an exception that only counts as a problem in PRT file.
+// NOTE: For this macro to work, the
+// exception class must exhibit a constructor with the signature
+// (const std::string &message). Since this condition is not fulfilled
+// for the std::exception, you should use this macro with some
+// exception class derived from either std::logic_error or
+// std::runtime_error.
+//
+// Usage: OPM_THROW_PROBLEM(ExceptionClass, "Error message");
+#define OPM_THROW_PROBLEM(Exception, message)                          \
+    do {                                                       \
+        std::string oss_ = std::string{"["} + __FILE__ + ":" + \
+                           std::to_string(__LINE__) + "] " +   \
+                           message;                            \
+        ::Opm::OpmLog::problem(oss_);                            \
         throw Exception(oss_);                                 \
     } while (false)
 


### PR DESCRIPTION
OPM_THROW will increase the error count reported in the PRT file. For most of the NumericalProblems thrown this is not what we want as the simulation carries on and errors should halt the simulation. This commit adds another macro OPM_THROW_PROBLEM that will not increase the error count but the problem count.

Note that the counters reported in the PRT are often used to find out whether a simulation succeeded. Hence the error count should only be nonzero if the simulation did abort.