### PR TITLE
Require Explicit End-Point Scaling for SCALECRS and SWATINIT

### DIFF
--- a/opm/input/eclipse/share/keywords/000_Eclipse100/S/SCALECRS
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/S/SCALECRS
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["ENDSCALE"],
   "size": 1,
   "items": [
     {

--- a/opm/input/eclipse/share/keywords/000_Eclipse100/S/SWATINIT
+++ b/opm/input/eclipse/share/keywords/000_Eclipse100/S/SWATINIT
@@ -3,6 +3,7 @@
   "sections": [
     "PROPS"
   ],
+  "requires": ["ENDSCALE"],
   "data": {
     "value_type": "DOUBLE",
     "dimension": "1"


### PR DESCRIPTION
It is typically an error to have either of `SCALECRS` or `SWATINIT` in a run without also enabling the end-point scaling facility.