### PR TITLE
BUGFIX. Use rsw not rswsat in density calculations

### DIFF
--- a/opm/material/fluidsystems/BlackOilFluidSystem.hpp
+++ b/opm/material/fluidsystems/BlackOilFluidSystem.hpp
@@ -610,7 +610,7 @@ public:
         case waterPhaseIdx:
             if (enableDissolvedGasInWater()) {
                  // gas miscible in water
-                const LhsEval& Rsw = saturatedDissolutionFactor<FluidState, LhsEval>(fluidState, waterPhaseIdx, regionIdx);
+                const LhsEval& Rsw =BlackOil::template getRsw_<ThisType, FluidState, LhsEval>(fluidState, regionIdx);
                 const LhsEval& bw = waterPvt_->inverseFormationVolumeFactor(regionIdx, T, p, Rsw, saltConcentration);
                 return
                     bw*referenceDensity(waterPhaseIdx, regionIdx)


### PR DESCRIPTION
Note that the FluidSystem::density is not used to compute the density of the fluid in the intensive quantities that is used in the equation, but FluidSystem::density is used in the well model and the enthalpy calculations. 