### PR TITLE
Don't Needlessly Copy EPS Property Arrays

### DIFF
--- a/opm/material/fluidmatrixinteractions/EclEpsGridProperties.cpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsGridProperties.cpp
@@ -27,58 +27,60 @@
 
 #include <string>
 
-namespace Opm {
-
-EclEpsGridProperties::EclEpsGridProperties(const EclipseState& eclState,
-                                           bool useImbibition)
+Opm::EclEpsGridProperties::
+EclEpsGridProperties(const EclipseState& eclState,
+                     const bool          useImbibition)
 {
-    const std::string kwPrefix = useImbibition ? "I" : "";
-
     const auto& fp = eclState.fieldProps();
-    std::vector<double> empty;
-    auto try_get = [&fp,&empty](const std::string& keyword) -> const std::vector<double>&
-    {
-        if (fp.has_double(keyword))
-            return fp.get_double(keyword);
 
-        return empty;
+    auto try_get = [&fp, kwPrefix = useImbibition ? "I" : ""]
+        (const std::string& keyword)
+    {
+        return fp.has_double(kwPrefix + keyword)
+            ? &fp.get_double(kwPrefix + keyword)
+            : nullptr;
     };
 
-    compressed_satnum = useImbibition
-        ? fp.get_int("IMBNUM") : fp.get_int("SATNUM");
+    this->satnum_ = useImbibition
+        ? &fp.get_int("IMBNUM")
+        : &fp.get_int("SATNUM");
 
-    this->compressed_swl = try_get(kwPrefix + "SWL");
-    this->compressed_sgl = try_get(kwPrefix + "SGL");
-    this->compressed_swcr = try_get(kwPrefix + "SWCR");
-    this->compressed_sgcr = try_get(kwPrefix + "SGCR");
-    this->compressed_sowcr = try_get(kwPrefix + "SOWCR");
-    this->compressed_sogcr = try_get(kwPrefix + "SOGCR");
-    this->compressed_swu = try_get(kwPrefix + "SWU");
-    this->compressed_sgu = try_get(kwPrefix + "SGU");
-    this->compressed_pcw = try_get(kwPrefix + "PCW");
-    this->compressed_pcg = try_get(kwPrefix + "PCG");
-    this->compressed_krw = try_get(kwPrefix + "KRW");
-    this->compressed_krwr = try_get(kwPrefix + "KRWR");
-    this->compressed_kro = try_get(kwPrefix + "KRO");
-    this->compressed_krorg = try_get(kwPrefix + "KRORG");
-    this->compressed_krorw = try_get(kwPrefix + "KRORW");
-    this->compressed_krg = try_get(kwPrefix + "KRG");
-    this->compressed_krgr = try_get(kwPrefix + "KRGR");
+    this->swl_   = try_get("SWL");
+    this->sgl_   = try_get("SGL");
+
+    this->swcr_  = try_get("SWCR");
+    this->sgcr_  = try_get("SGCR");
+    this->sowcr_ = try_get("SOWCR");
+    this->sogcr_ = try_get("SOGCR");
+
+    this->swu_   = try_get("SWU");
+    this->sgu_   = try_get("SGU");
+
+    this->pcw_   = try_get("PCW");
+    this->pcg_   = try_get("PCG");
+
+    this->krw_   = try_get("KRW");
+    this->krwr_  = try_get("KRWR");
+    this->kro_   = try_get("KRO");
+    this->krorg_ = try_get("KRORG");
+    this->krorw_ = try_get("KRORW");
+    this->krg_   = try_get("KRG");
+    this->krgr_  = try_get("KRGR");
 
     // _may_ be needed to calculate the Leverett capillary pressure scaling factor
-    if (fp.has_double("PORO"))
-        this->compressed_poro = fp.get_double("PORO");
+    if (fp.has_double("PORO")) {
+        this->poro_ = &fp.get_double("PORO");
+    }
 
-    this->compressed_permx = fp.has_double("PERMX")
-        ? fp.get_double("PERMX")
-        : std::vector<double>(this->compressed_satnum.size());
+    this->permx_ = fp.has_double("PERMX")
+        ? &fp.get_double("PERMX")
+        : nullptr;
 
-    this->compressed_permy = fp.has_double("PERMY")
-        ? fp.get_double("PERMY") : this->compressed_permx;
+    this->permy_ = fp.has_double("PERMY")
+        ? &fp.get_double("PERMY")
+        : this->permx_;
 
-    this->compressed_permz = fp.has_double("PERMZ")
-        ? fp.get_double("PERMZ") : this->compressed_permx;
+    this->permz_ = fp.has_double("PERMZ")
+        ? &fp.get_double("PERMZ")
+        : this->permx_;
 }
-
-}
-

--- a/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsGridProperties.hpp
@@ -52,127 +52,162 @@ public:
                          bool useImbibition);
 #endif
 
-    unsigned satRegion(std::size_t active_index) const {
-        return this->compressed_satnum[active_index] - 1;
+    int satRegion(const std::size_t active_index) const
+    {
+        return (*this->satnum_)[active_index] - 1;
     }
 
-    double permx(std::size_t active_index) const {
-        return this->compressed_permx[active_index];
+    double permx(const std::size_t active_index) const
+    {
+        return this->perm(this->permx_, active_index);
     }
 
-    double permy(std::size_t active_index) const {
-        return this->compressed_permy[active_index];
+    double permy(const std::size_t active_index) const
+    {
+        return this->perm(this->permy_, active_index);
     }
 
-    double permz(std::size_t active_index) const {
-        return this->compressed_permz[active_index];
+    double permz(const std::size_t active_index) const
+    {
+        return this->perm(this->permy_, active_index);
     }
 
-    double poro(std::size_t active_index) const {
-        return this->compressed_poro[active_index];
+    double poro(const std::size_t active_index) const
+    {
+        return (*this->poro_)[active_index];
     }
 
-    const double * swl(std::size_t active_index) const {
-        return this->satfunc(this->compressed_swl, active_index);
+    const double* swl(const std::size_t active_index) const
+    {
+        return this->satfunc(this->swl_, active_index);
     }
 
-    const double * sgl(std::size_t active_index) const {
-        return this->satfunc(this->compressed_sgl, active_index);
+    const double* sgl(const std::size_t active_index) const
+    {
+        return this->satfunc(this->sgl_, active_index);
     }
 
-    const double * swcr(std::size_t active_index) const {
-        return this->satfunc(this->compressed_swcr, active_index);
+    const double* swcr(const std::size_t active_index) const
+    {
+        return this->satfunc(this->swcr_, active_index);
     }
 
-    const double * sgcr(std::size_t active_index) const {
-        return this->satfunc(this->compressed_sgcr, active_index);
+    const double* sgcr(const std::size_t active_index) const
+    {
+        return this->satfunc(this->sgcr_, active_index);
     }
 
-    const double * sowcr(std::size_t active_index) const {
-        return this->satfunc(this->compressed_sowcr, active_index);
+    const double* sowcr(const std::size_t active_index) const
+    {
+        return this->satfunc(this->sowcr_, active_index);
     }
 
-    const double * sogcr(std::size_t active_index) const {
-        return this->satfunc(this->compressed_sogcr, active_index);
+    const double* sogcr(const std::size_t active_index) const
+    {
+        return this->satfunc(this->sogcr_, active_index);
     }
 
-    const double * swu(std::size_t active_index) const {
-        return this->satfunc(this->compressed_swu, active_index);
+    const double* swu(const std::size_t active_index) const
+    {
+        return this->satfunc(this->swu_, active_index);
     }
 
-    const double * sgu(std::size_t active_index) const {
-        return this->satfunc(this->compressed_sgu, active_index);
+    const double* sgu(const std::size_t active_index) const
+    {
+        return this->satfunc(this->sgu_, active_index);
     }
 
-    const double * pcw(std::size_t active_index) const {
-        return this->satfunc(this->compressed_pcw, active_index);
+    const double* pcw(const std::size_t active_index) const
+    {
+        return this->satfunc(this->pcw_, active_index);
     }
 
-    const double * pcg(std::size_t active_index) const {
-        return this->satfunc(this->compressed_pcg, active_index);
+    const double* pcg(const std::size_t active_index) const
+    {
+        return this->satfunc(this->pcg_, active_index);
     }
 
-    const double * krw(std::size_t active_index) const {
-        return this->satfunc(this->compressed_krw, active_index);
+    const double* krw(const std::size_t active_index) const
+    {
+        return this->satfunc(this->krw_, active_index);
     }
 
-    const double * krwr(std::size_t active_index) const {
-        return this->satfunc(this->compressed_krwr, active_index);
+    const double* krwr(const std::size_t active_index) const
+    {
+        return this->satfunc(this->krwr_, active_index);
     }
 
-    const double * krg(std::size_t active_index) const {
-        return this->satfunc(this->compressed_krg, active_index);
+    const double* krg(const std::size_t active_index) const
+    {
+        return this->satfunc(this->krg_, active_index);
     }
 
-    const double * krgr(std::size_t active_index) const {
-        return this->satfunc(this->compressed_krgr, active_index);
+    const double* krgr(const std::size_t active_index) const
+    {
+        return this->satfunc(this->krgr_, active_index);
     }
 
-    const double * kro(std::size_t active_index) const {
-        return this->satfunc(this->compressed_kro, active_index);
+    const double* kro(const std::size_t active_index) const
+    {
+        return this->satfunc(this->kro_, active_index);
     }
 
-    const double * krorg(std::size_t active_index) const {
-        return this->satfunc(this->compressed_krorg, active_index);
+    const double* krorg(const std::size_t active_index) const
+    {
+        return this->satfunc(this->krorg_, active_index);
     }
 
-    const double * krorw(std::size_t active_index) const {
-        return this->satfunc(this->compressed_krorw, active_index);
+    const double* krorw(const std::size_t active_index) const
+    {
+        return this->satfunc(this->krorw_, active_index);
     }
 
 private:
-    const double *
-    satfunc(const std::vector<double>& data,
+    const std::vector<int>* satnum_ { nullptr };
+
+    const std::vector<double>* swl_ { nullptr };
+    const std::vector<double>* sgl_ { nullptr };
+    const std::vector<double>* swcr_ { nullptr };
+    const std::vector<double>* sgcr_ { nullptr };
+    const std::vector<double>* sowcr_ { nullptr };
+    const std::vector<double>* sogcr_ { nullptr };
+    const std::vector<double>* swu_ { nullptr };
+    const std::vector<double>* sgu_ { nullptr };
+
+    const std::vector<double>* pcw_ { nullptr };
+    const std::vector<double>* pcg_ { nullptr };
+
+    const std::vector<double>* krw_ { nullptr };
+    const std::vector<double>* krwr_ { nullptr };
+    const std::vector<double>* kro_ { nullptr };
+    const std::vector<double>* krorg_ { nullptr };
+    const std::vector<double>* krorw_ { nullptr };
+    const std::vector<double>* krg_ { nullptr };
+    const std::vector<double>* krgr_ { nullptr };
+
+    const std::vector<double>* permx_ { nullptr };
+    const std::vector<double>* permy_ { nullptr };
+    const std::vector<double>* permz_ { nullptr };
+    const std::vector<double>* poro_ { nullptr };
+
+    const double*
+    satfunc(const std::vector<double>* data,
             const std::size_t          active_index) const
     {
-        return data.empty() ? nullptr : &data[active_index];
+        return ((data == nullptr) || data->empty())
+            ? nullptr
+            : &(*data)[active_index];
     }
 
-
-    std::vector<int> compressed_satnum;
-    std::vector<double> compressed_swl;
-    std::vector<double> compressed_sgl;
-    std::vector<double> compressed_swcr;
-    std::vector<double> compressed_sgcr;
-    std::vector<double> compressed_sowcr;
-    std::vector<double> compressed_sogcr;
-    std::vector<double> compressed_swu;
-    std::vector<double> compressed_sgu;
-    std::vector<double> compressed_pcw;
-    std::vector<double> compressed_pcg;
-    std::vector<double> compressed_krw;
-    std::vector<double> compressed_krwr;
-    std::vector<double> compressed_kro;
-    std::vector<double> compressed_krorg;
-    std::vector<double> compressed_krorw;
-    std::vector<double> compressed_krg;
-    std::vector<double> compressed_krgr;
-
-    std::vector<double> compressed_permx;
-    std::vector<double> compressed_permy;
-    std::vector<double> compressed_permz;
-    std::vector<double> compressed_poro;
+    double perm(const std::vector<double>* data,
+                const std::size_t          active_index) const
+    {
+        return ((data == nullptr) || data->empty())
+            ? 0.0
+            : (*data)[active_index];
+    }
 };
-}
-#endif
 
+} // namespace Opm
+
+#endif

--- a/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
+++ b/opm/material/fluidmatrixinteractions/EclEpsScalingPoints.hpp
@@ -92,26 +92,27 @@ struct EclEpsScalingPointsInfo
 
     bool operator==(const EclEpsScalingPointsInfo<Scalar>& data) const
     {
-        return Swl == data.Swl &&
-               Sgl == data.Sgl &&
-               Swcr == data.Swcr &&
-               Sgcr == data.Sgcr &&
-               Sowcr == data.Sowcr &&
-               Sogcr == data.Sogcr &&
-               Swu == data.Swu &&
-               Sgu == data.Sgu &&
-               maxPcow == data.maxPcow &&
-               maxPcgo == data.maxPcgo &&
-               pcowLeverettFactor == data.pcowLeverettFactor &&
-               pcgoLeverettFactor == data.pcgoLeverettFactor &&
-               Krwr == data.Krwr &&
-               Krgr == data.Krgr &&
-               Krorw == data.Krorw &&
-               Krorg == data.Krorg &&
-               maxKrw == data.maxKrw &&
-               maxKrow == data.maxKrow &&
-               maxKrog == data.maxKrog &&
-               maxKrg == data.maxKrg;
+        return (Swl == data.Swl)
+            && (Sgl == data.Sgl)
+            && (Swcr == data.Swcr)
+            && (Sgcr == data.Sgcr)
+            && (Sowcr == data.Sowcr)
+            && (Sogcr == data.Sogcr)
+            && (Swu == data.Swu)
+            && (Sgu == data.Sgu)
+            && (maxPcow == data.maxPcow)
+            && (maxPcgo == data.maxPcgo)
+            && (pcowLeverettFactor == data.pcowLeverettFactor)
+            && (pcgoLeverettFactor == data.pcgoLeverettFactor)
+            && (Krwr == data.Krwr)
+            && (Krgr == data.Krgr)
+            && (Krorw == data.Krorw)
+            && (Krorg == data.Krorg)
+            && (maxKrw == data.maxKrw)
+            && (maxKrow == data.maxKrow)
+            && (maxKrog == data.maxKrog)
+            && (maxKrg == data.maxKrg)
+            ;
     }
 
     void print() const;
@@ -123,15 +124,9 @@ struct EclEpsScalingPointsInfo
      * I.e., the values which are used for the nested Fluid-Matrix interactions and which
      * are produced by them.
      */
-    void extractUnscaled(const satfunc::RawTableEndPoints& rtep,
-                         const satfunc::RawFunctionValues& rfunc,
+    void extractUnscaled(const satfunc::RawTableEndPoints&    rtep,
+                         const satfunc::RawFunctionValues&    rfunc,
                          const std::vector<double>::size_type satRegionIdx);
-
-    void update(Scalar& targetValue, const double * value_ptr)
-    {
-        if (value_ptr)
-            targetValue = *value_ptr;
-    }
 
     /*!
      * \brief Extract the values of the scaled scaling parameters.
@@ -141,18 +136,12 @@ struct EclEpsScalingPointsInfo
     void extractScaled(const EclipseState& eclState,
                        const EclEpsGridProperties& epsProperties,
                        unsigned activeIndex);
-#endif
 
 private:
-    void extractGridPropertyValue_(Scalar& targetValue,
-                                   const std::vector<double>* propData,
-                                   unsigned cartesianCellIdx)
-    {
-        if (!propData)
-            return;
-
-        targetValue = (*propData)[cartesianCellIdx];
-    }
+    void calculateLeverettFactors(const EclipseState& eclState,
+                                  const EclEpsGridProperties& epsProperties,
+                                  unsigned activeIndex);
+#endif  // HAVE_ECL_INPUT
 };
 
 /*!


### PR DESCRIPTION
These copies may have been needed in the past, but that is no longer the case.  EPS property arrays such as `SWL`, `SOGCR`, and `SGU` are backed by long-term storage in the `FieldPropsManager` so we can use pointers to those instead of storing separate copies of these within the `EclEpsGridProperties` structure.

While here, move the `EclEpsScalingPointsInfo::update()` function into the `.cpp` file as it does not need direct access to any data members of `EclEpsScalingPointsInfo`.  Finally, move the Leverett J-function initialisation to a separate member function to reduce the cognitive load on reading `EclEpsScalingPointsInfo<>::extractScaled()`.