### PR TITLE
Improve ACTIONX Diagnostic Message

### DIFF
--- a/opm/input/eclipse/Schedule/HandlerContext.cpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.cpp
@@ -126,13 +126,11 @@ void HandlerContext::invalidNamePattern(const std::string& namePattern) const
 {
     std::string msg_fmt = fmt::format("No wells/groups match the pattern: \'{}\'", namePattern);
     if (namePattern == "?") {
-        /*
-          In particular when an ACTIONX keyword is called via PYACTION
-          coming in here with an empty list of matching wells is not
-          entirely unheard of. It is probably not what the user wanted and
-          we give a warning, but the simulation continues.
-        */
-        auto msg = OpmInputError::format("No matching wells for ACTIONX {keyword}"
+        // In particular when an ACTIONX keyword is called via PYACTION
+        // coming in here with an empty list of matching wells is not
+        // entirely unheard of. It is probably not what the user wanted and
+        // we give a warning, but the simulation continues.
+        auto msg = OpmInputError::format("No matching wells for ACTIONX keyword '{keyword}' "
                                          "in {file} line {line}.", keyword.location());
         OpmLog::warning(msg);
     } else {


### PR DESCRIPTION
At present we issue diagnostic messages of the form
```
Warning: No matching wells for ACTIONX WTMULTin CASE.DATA line 123.
```
This commit amends the diagnostic message to read
```
Warning: No matching wells for ACTIONX keyword 'WTMULT' in CASE.DATA line 123.
```
instead.

While here, also switch to `//` comments.