### PR TITLE
Replace hardcoded name in github action with github.repository_owner …

### DIFF
--- a/.github/workflows/dispatch_opm_simulators.yml
+++ b/.github/workflows/dispatch_opm_simulators.yml
@@ -25,5 +25,5 @@ jobs:
         curl -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}" \
-          https://api.github.com/repos/lisajulia/opm-simulators/dispatches \
+          https://api.github.com/repos/${{ github.repository_owner }}/opm-simulators/dispatches \
           -d '{"event_type":"docstrings_common_updated"}'


### PR DESCRIPTION
…(in .yml file)

Like this the notification will reach OPM/opm-simulators and not lisajulia/opm-simulators