### PR TITLE
fixed: check indices to avoid compiler warnings

### DIFF
--- a/opm/material/fluidsystems/PTFlashParameterCache.hpp
+++ b/opm/material/fluidsystems/PTFlashParameterCache.hpp
@@ -228,6 +228,9 @@ public:
                          unsigned phaseIdx,
                          int exceptQuantities = ParentType::None)
     {
+        if (phaseIdx >= numPhases) {
+            throw std::logic_error("PTFlashParameterCache: Tried to update eos parameters for invalid phase");
+        }
         if (!(exceptQuantities & ParentType::Temperature))
         {
             updatePure_(fluidState, phaseIdx);

--- a/opm/material/fluidsystems/Spe5ParameterCache.hpp
+++ b/opm/material/fluidsystems/Spe5ParameterCache.hpp
@@ -230,6 +230,9 @@ public:
                          unsigned phaseIdx,
                          int exceptQuantities = ParentType::None)
     {
+        if (phaseIdx >= numPhases) {
+            throw std::logic_error("SPE5ParameterCache: Tried to update eos parameters for invalid phase");
+        }
         if (!(exceptQuantities & ParentType::Temperature))
         {
             updatePure_(fluidState, phaseIdx);


### PR DESCRIPTION
Trying to quell some compiler warnings.

jenkins is still not open for general business so don't follow my example!