### PR TITLE
changed: remove HAVE_QUAD compile definition from QuadMath::QuadMath target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ macro (sources_hook)
 
   if(QuadMath_FOUND)
     get_target_property(qm_defs QuadMath::QuadMath INTERFACE_COMPILE_DEFINITIONS)
+    list(APPEND qm_defs HAVE_QUAD=1)
     get_target_property(qm_options QuadMath::QuadMath INTERFACE_COMPILE_OPTIONS)
     set_source_files_properties(opm/material/components/CO2.cpp
                                 opm/material/densead/Evaluation.cpp

--- a/cmake/Modules/FindQuadMath.cmake
+++ b/cmake/Modules/FindQuadMath.cmake
@@ -41,7 +41,7 @@ if(QuadMath_FOUND AND NOT TARGET QuadMath::QuadMath)
   target_link_libraries(QuadMath::QuadMath INTERFACE quadmath)
 
   target_compile_definitions(QuadMath::QuadMath INTERFACE
-    _GLIBCXX_USE_FLOAT128 HAVE_QUAD=1
+    _GLIBCXX_USE_FLOAT128
   )
   target_compile_options(QuadMath::QuadMath INTERFACE
     $<$<CXX_COMPILER_ID:GNU>:-fext-numeric-literals>


### PR DESCRIPTION
this target is always linked if dune-fem is enabled, while we only want the define for targets where we want to actually use quads