### PR TITLE
Don't Generate Independent UDQ Objects for Output Purposes

### DIFF
--- a/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQConfig.cpp
@@ -413,10 +413,10 @@ namespace Opm {
                 ? this->unit(key) : std::string{};
 
             if (index.action == UDQAction::DEFINE) {
-                res.push_back(UDQInput(index, this->m_definitions.at(key), u));
+                res.emplace_back(index, &this->m_definitions.at(key), u);
             }
             else if (index.action == UDQAction::ASSIGN) {
-                res.push_back(UDQInput(index, this->m_assignments.at(key), u));
+                res.emplace_back(index, &this->m_assignments.at(key), u);
             }
         }
 
@@ -487,7 +487,7 @@ namespace Opm {
 
     UDQInput UDQConfig::operator[](const std::string& keyword) const
     {
-        const auto index_iter = this->input_index.find(keyword);
+        auto index_iter = this->input_index.find(keyword);
         if (index_iter == this->input_index.end()) {
             throw std::invalid_argument("Keyword: '" + keyword +
                                         "' not recognized as ASSIGN/DEFINE UDQ");
@@ -497,11 +497,11 @@ namespace Opm {
             ? this->unit(keyword) : std::string{};
 
         if (index_iter->second.action == UDQAction::ASSIGN) {
-            return UDQInput(this->input_index.at(keyword), this->m_assignments.at(keyword), u);
+            return { index_iter->second, &this->m_assignments.at(keyword), u };
         }
 
         if (index_iter->second.action == UDQAction::DEFINE) {
-            return UDQInput(this->input_index.at(keyword), this->m_definitions.at(keyword), u);
+            return { index_iter->second, &this->m_definitions.at(keyword), u };
         }
 
         throw std::logic_error("Internal error - should not be here");
@@ -524,11 +524,11 @@ namespace Opm {
             ? this->unit(keyword) : std::string{};
 
         if (index.action == UDQAction::ASSIGN) {
-            return UDQInput(index, this->m_assignments.at(keyword), u);
+            return { index, &this->m_assignments.at(keyword), u };
         }
 
         if (index.action == UDQAction::DEFINE) {
-            return UDQInput(index, this->m_definitions.at(keyword), u);
+            return { index, &this->m_definitions.at(keyword), u };
         }
 
         throw std::logic_error("Internal error - should not be here");

--- a/opm/input/eclipse/Schedule/UDQ/UDQInput.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQInput.cpp
@@ -29,78 +29,75 @@
 namespace Opm {
 
 UDQInput::UDQInput(const UDQIndex&    index_arg,
-                   const UDQDefine&   udq_define,
+                   const UDQDefine*   udq_define,
                    const std::string& unit_arg)
     : index     (index_arg)
     , value     (udq_define)
-    , m_keyword (udq_define.keyword())
-    , m_var_type(udq_define.var_type())
+    , m_keyword (udq_define->keyword())
+    , m_var_type(udq_define->var_type())
     , m_unit    (unit_arg)
 {}
 
 UDQInput::UDQInput(const UDQIndex&    index_arg,
-                   const UDQAssign&   udq_assign,
+                   const UDQAssign*   udq_assign,
                    const std::string& unit_arg)
     : index     (index_arg)
     , value     (udq_assign)
-    , m_keyword (udq_assign.keyword())
-    , m_var_type(udq_assign.var_type())
+    , m_keyword (udq_assign->keyword())
+    , m_var_type(udq_assign->var_type())
     , m_unit    (unit_arg)
 {}
-
-const std::string& UDQInput::unit() const
-{
-    return this->m_unit;
-}
-
-const std::string& UDQInput::keyword() const
-{
-    return this->m_keyword;
-}
-
-const UDQVarType& UDQInput::var_type() const
-{
-    return this->m_var_type;
-}
 
 template<>
 bool UDQInput::is<UDQAssign>() const
 {
-    return std::holds_alternative<UDQAssign>(this->value);
+    return std::holds_alternative<const UDQAssign*>(this->value);
 }
 
 template<>
 bool UDQInput::is<UDQDefine>() const
 {
-    return std::holds_alternative<UDQDefine>(this->value);
+    return std::holds_alternative<const UDQDefine*>(this->value);
 }
 
 template<>
 const UDQAssign& UDQInput::get<UDQAssign>() const
 {
     if (this->is<UDQAssign>()) {
-        return std::get<UDQAssign>(this->value);
+        return *std::get<const UDQAssign*>(this->value);
     }
 
-    throw std::runtime_error("Invalid get");
+    throw std::runtime_error {
+        "Requested UDQ assignment object from non-assignment container"
+    };
 }
 
 template<>
 const UDQDefine& UDQInput::get<UDQDefine>() const
 {
     if (this->is<UDQDefine>()) {
-        return std::get<UDQDefine>(this->value);
+        return *std::get<const UDQDefine*>(this->value);
     }
 
-    throw std::runtime_error("Invalid get");
+    throw std::runtime_error {
+        "Requested UDQ definition object from non-definition container"
+    };
 }
 
 bool UDQInput::operator==(const UDQInput& other) const
 {
-    return (this->value == other.value)
-        && (this->m_keyword == other.m_keyword)
-        && (this->m_var_type == other.m_var_type)
-        && (this->m_unit == other.m_unit)
+    const auto structure_okay =
+        (this->value.index() == other.value.index()) &&
+        (this->m_keyword == other.m_keyword)         &&
+        (this->m_var_type == other.m_var_type)       &&
+        (this->m_unit == other.m_unit)
+        ;
+
+    if (! structure_okay) { return false; }
+
+    return (this->is<UDQDefine>())
+        ? (this->get<UDQDefine>() == other.get<UDQDefine>())
+        : (this->get<UDQAssign>() == other.get<UDQAssign>())
         ;
 }
 

--- a/opm/input/eclipse/Schedule/UDQ/UDQInput.hpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQInput.hpp
@@ -83,8 +83,8 @@ public:
 class UDQInput
 {
 public:
-    UDQInput(const UDQIndex& index, const UDQDefine& udq_define, const std::string& unit);
-    UDQInput(const UDQIndex& index, const UDQAssign& udq_assign, const std::string& unit);
+    UDQInput(const UDQIndex& index, const UDQDefine* udq_define, const std::string& unit);
+    UDQInput(const UDQIndex& index, const UDQAssign* udq_assign, const std::string& unit);
 
     template <typename T>
     const T& get() const;
@@ -92,15 +92,15 @@ public:
     template <typename T>
     bool is() const;
 
-    const std::string& keyword() const;
-    const UDQVarType& var_type() const;
-    const std::string& unit() const;
+    const std::string& keyword()  const { return this->m_keyword; }
+    const std::string& unit()     const { return this->m_unit; }
+    UDQVarType         var_type() const { return this->m_var_type; }
     const UDQIndex index;
 
     bool operator==(const UDQInput& other) const;
 
 private:
-    std::variant<UDQDefine, UDQAssign> value;
+    std::variant<const UDQDefine*, const UDQAssign*> value;
     std::string m_keyword;
     UDQVarType m_var_type;
     std::string m_unit;


### PR DESCRIPTION
We don't actually need full copies of the moderately large `UDQDefine` or `UDQAssign` objects, so switch to storing pointers to the objects managed by `UDQConfig` instead.  This makes `UDQConfig::input()` slightly less expensive.

While here, also make the trivial `UDQInput` member functions inline.