### PR TITLE
Activate WELPI and WPIMULT for use in Pyaction

### DIFF
--- a/msim/src/msim.cpp
+++ b/msim/src/msim.cpp
@@ -141,8 +141,7 @@ void msim::post_step(data::Solution& /* sol */,
     for (const auto& action : actions.pending(this->action_state, std::chrono::system_clock::to_time_t(sim_time))) {
         const auto result = action->eval(context);
         if (result.conditionSatisfied()) {
-            this->schedule.applyAction(report_step, *action, result.matches(),
-                                       std::unordered_map<std::string,double>{});
+            this->schedule.applyAction(report_step, *action, result.matches());
         }
     }
 

--- a/opm/input/eclipse/Schedule/Action/PyAction.cpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.cpp
@@ -47,7 +47,7 @@ bool PyAction::valid_keyword(const std::string& keyword) {
         "METRIC", "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",
         "WCONINJE", "WCONPROD", "WECON", "WEFAC", "WELOPEN", "WELPI", "WELTARG", "WGRUPCON",
-        "WELSEGS", "WELSPECS", "WSEGVALV", "WLIST", "WTEST", "WTMULT"
+        "WELSEGS", "WELSPECS", "WSEGVALV", "WLIST", "WPIMULT", "WTEST", "WTMULT"
     };
     return pyaction_allowed_list.find(keyword) != pyaction_allowed_list.end();
 }

--- a/opm/input/eclipse/Schedule/Action/PyAction.cpp
+++ b/opm/input/eclipse/Schedule/Action/PyAction.cpp
@@ -46,7 +46,7 @@ bool PyAction::valid_keyword(const std::string& keyword) {
         "GCONINJE", "GCONPROD", "GCONSUMP","GRUPTREE",
         "METRIC", "MULTX", "MULTX-", "MULTY", "MULTY-", "MULTZ", "MULTZ-",
         "NEXT", "NEXTSTEP",
-        "WCONINJE", "WCONPROD", "WECON", "WEFAC", "WELOPEN", "WELTARG", "WGRUPCON",
+        "WCONINJE", "WCONPROD", "WECON", "WEFAC", "WELOPEN", "WELPI", "WELTARG", "WGRUPCON",
         "WELSEGS", "WELSPECS", "WSEGVALV", "WLIST", "WTEST", "WTMULT"
     };
     return pyaction_allowed_list.find(keyword) != pyaction_allowed_list.end();

--- a/opm/input/eclipse/Schedule/HandlerContext.hpp
+++ b/opm/input/eclipse/Schedule/HandlerContext.hpp
@@ -61,7 +61,7 @@ public:
                    const ScheduleGrid& grid_,
                    const std::size_t currentStep_,
                    const Action::Result::MatchingEntities& matches_,
-                   bool actionx_mode_,
+                   bool welpi_action_mode_,
                    const ParseContext& parseContext_,
                    ErrorGuard& errors_,
                    SimulatorUpdate* sim_update_,
@@ -73,7 +73,7 @@ public:
         , keyword(keyword_)
         , currentStep(currentStep_)
         , matches(matches_)
-        , actionx_mode(actionx_mode_)
+        , welpi_action_mode(welpi_action_mode_)
         , parseContext(parseContext_)
         , errors(errors_)
         , wpimult_global_factor(wpimult_global_factor_)
@@ -166,7 +166,7 @@ public:
     const DeckKeyword& keyword;
     const std::size_t currentStep;
     const Action::Result::MatchingEntities& matches;
-    const bool actionx_mode;
+    const bool welpi_action_mode;
     const ParseContext& parseContext;
     ErrorGuard& errors;
     std::unordered_map<std::string, double>& wpimult_global_factor;

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -393,7 +393,7 @@ namespace Opm {
                                  ErrorGuard& errors,
                                  const ScheduleGrid& grid,
                                  const Action::Result::MatchingEntities& matches,
-                                 const bool actionx_mode,
+                                 const bool welpi_action_mode,
                                  SimulatorUpdate* sim_update,
                                  const std::unordered_map<std::string, double>* target_wellpi,
                                  std::unordered_map<std::string, double>& wpimult_global_factor,
@@ -401,7 +401,7 @@ namespace Opm {
                                  std::set<std::string>* compsegs_wells)
     {
         HandlerContext handlerContext { *this, block, keyword, grid, currentStep,
-                                        matches, actionx_mode,
+                                        matches, welpi_action_mode,
                                         parseContext, errors, sim_update, target_wellpi,
                                         wpimult_global_factor, welsegs_wells, compsegs_wells};
 
@@ -1664,7 +1664,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         auto& input_block = this->m_sched_deck[reportStep];
         ScheduleLogger logger(ScheduleLogger::select_stream(false, false), // will log to OpmLog::info
                               prefix, this->m_sched_deck.location());
-        
+
         for (const auto& keyword : keywords) {
             const auto valid = Action::PyAction::valid_keyword(keyword->name());
 
@@ -1685,7 +1685,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
                                     errors,
                                     grid,
                                     matches,
-                                    /* actionx_mode= */ false,
+                                    /*welpi_action_mode=*/false,
                                     &sim_update,
                                     &target_wellpi,
                                     wpimult_global_factor);    

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -363,6 +363,7 @@ namespace Opm {
         result.completed_cells = CompletedCells::serializationTestObject();
         result.current_report_step = 0;
         result.m_lowActionParsingStrictness = false;
+        result.welpi_action_mode = false;
         result.simUpdateFromPython = std::make_shared<SimulatorUpdate>(SimulatorUpdate::serializationTestObject());
 
         return result;
@@ -2101,6 +2102,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
             && this->completed_cells == data.completed_cells
             && this->current_report_step == data.current_report_step
             && this->m_lowActionParsingStrictness == data.m_lowActionParsingStrictness
+            && this->welpi_action_mode == data.welpi_action_mode
             && simUpdateFromPythonIsEqual
             ;
      }

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -1686,7 +1686,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
                                     errors,
                                     grid,
                                     matches,
-                                    /*welpi_action_mode=*/false,
+                                    this->welpi_action_mode,
                                     &sim_update,
                                     &target_wellpi,
                                     wpimult_global_factor);    
@@ -1982,6 +1982,9 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
     */
 
     SimulatorUpdate Schedule::runPyAction(std::size_t reportStep, const Action::PyAction& pyaction, Action::State& action_state, EclipseState& ecl_state, SummaryState& summary_state) {
+        // Set welpi_action_mode to true, this is necessary for the keyword WELPI.
+        // This keyword is handled differently when it's called during a running simulation (see functions handleWELPI and handleWELPIRuntime).
+        this->welpi_action_mode = true;
         // Reset simUpdateFromPython, pyaction.run(...) will run through the PyAction script, the calls that trigger a simulator update will append this to simUpdateFromPython.
         this->simUpdateFromPython->reset();
         // Set the current_report_step to the report step in which this PyAction was triggered.
@@ -1996,7 +1999,8 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
         auto result = pyaction.run(ecl_state, *this, reportStep, summary_state, apply_action_callback);
         action_state.add_run(pyaction, result);
 
-        // The whole pyaction script was executed, now the simUpdateFromPython is returned.
+        // The whole PyAction was executed, welpi_action_mode is set to false and the simUpdateFromPython is returned.
+        this->welpi_action_mode = false;
         return *(this->simUpdateFromPython);
     }
 

--- a/opm/input/eclipse/Schedule/Schedule.cpp
+++ b/opm/input/eclipse/Schedule/Schedule.cpp
@@ -168,12 +168,12 @@ namespace Opm {
 
             auto restart_step = this->m_static.rst_info.report_step;
             this->iterateScheduleSection(0, restart_step, parseContext, errors,
-                                         grid, nullptr, "", keepKeywords);
+                                         grid, "", keepKeywords);
             this->load_rst(*rst, *tracer_config, grid, fp);
             if (! this->restart_output.writeRestartFile(restart_step))
                 this->restart_output.addRestartOutput(restart_step);
             this->iterateScheduleSection(restart_step, this->m_sched_deck.size(),
-                                         parseContext, errors, grid, nullptr, "", keepKeywords);
+                                         parseContext, errors, grid, "", keepKeywords);
             // Events added during restart reading well be added to previous step, but need to be active at the
             // restart step to ensure well potentials and guide rates are available at the first step.
             const auto prev_step = std::max(static_cast<int>(restart_step-1), 0);
@@ -181,7 +181,7 @@ namespace Opm {
             this->snapshots[restart_step].update_events(this->snapshots[prev_step].events());
         } else {
             this->iterateScheduleSection(0, this->m_sched_deck.size(),
-                                         parseContext, errors, grid, nullptr, "", keepKeywords);
+                                         parseContext, errors, grid, "", keepKeywords);
         }
     }
     catch (const OpmInputError& opm_error) {
@@ -575,7 +575,6 @@ void Schedule::iterateScheduleSection(std::size_t load_start, std::size_t load_e
                                       const ParseContext& parseContext,
                                       ErrorGuard& errors,
                                       const ScheduleGrid& grid,
-                                      const std::unordered_map<std::string, double> * target_wellpi,
                                       const std::string& prefix,
                                       const bool keepKeywords,
                                       const bool log_to_debug)
@@ -1703,7 +1702,6 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
                                          parseContext,
                                          errors,
                                          grid,
-                                         &(this->m_wellPIMap),
                                          prefix,
                                          /* keepKeywords = */ true);
         }
@@ -1779,7 +1777,7 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
             const auto keepKeywords = true;
             const auto log_to_debug = true;
             this->iterateScheduleSection(reportStep + 1, this->m_sched_deck.size(),
-                                         parseContext, errors, grid, &(this->m_wellPIMap),
+                                         parseContext, errors, grid,
                                          prefix, keepKeywords, log_to_debug);
         }
 
@@ -1863,7 +1861,6 @@ File {} line {}.)", pattern, location.keyword, location.filename, location.linen
             const auto log_to_debug = true;
             this->iterateScheduleSection(reportStep + 1, this->m_sched_deck.size(),
                                          parseContext, errors, grid,
-                                         /* target_wellpi = */ nullptr,
                                          prefix, keepKeywords, log_to_debug);
         }
 

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -478,7 +478,6 @@ namespace Opm {
                            ErrorGuard& errors,
                            const ScheduleGrid& grid,
                            const Action::Result::MatchingEntities& matches,
-                           bool welpi_action_mode,
                            SimulatorUpdate* sim_update,
                            const std::unordered_map<std::string, double>* target_wellpi,
                            std::unordered_map<std::string, double>& wpimult_global_factor,

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -474,7 +474,7 @@ namespace Opm {
                            ErrorGuard& errors,
                            const ScheduleGrid& grid,
                            const Action::Result::MatchingEntities& matches,
-                           bool actionx_mode,
+                           bool welpi_action_mode,
                            SimulatorUpdate* sim_update,
                            const std::unordered_map<std::string, double>* target_wellpi,
                            std::unordered_map<std::string, double>& wpimult_global_factor,

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -458,7 +458,6 @@ namespace Opm {
                                     const ParseContext& parseContext,
                                     ErrorGuard& errors,
                                     const ScheduleGrid& grid,
-                                    const std::unordered_map<std::string, double> * target_wellpi,
                                     const std::string& prefix,
                                     const bool keepKeywords,
                                     const bool log_to_debug = false);

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -310,6 +310,9 @@ namespace Opm {
         SimulatorUpdate modifyCompletions(const std::size_t reportStep,
                                           const std::map<std::string, std::vector<Connection>>& extraConns);
 
+        template<typename Scalar>
+        void setWellPIMap(std::unordered_map<std::string, Scalar>);
+
         const GasLiftOpt& glo(std::size_t report_step) const;
 
         bool operator==(const Schedule& data) const;
@@ -352,6 +355,7 @@ namespace Opm {
             serializer(this->m_lowActionParsingStrictness);
             serializer(this->welpi_action_mode);
             serializer(this->simUpdateFromPython);
+            serializer(this->m_wellPIMap);
 
             // If we are deserializing we need to setup the pointer to the
             // unit system since this is process specific. This is safe
@@ -425,6 +429,10 @@ namespace Opm {
         // It is a shared_ptr, so a Schedule can be constructed using the copy constructor sharing the simUpdateFromPython.
         // The copy constructor is needed for creating a mocked simulator (msim).
         std::shared_ptr<SimulatorUpdate> simUpdateFromPython{};
+        // The wellPIMap is used when a PYACTION is executed for handling the keyword WELPI.
+        // It is a map containing wells and their production index.
+        // This map is set in the ActionHandler with the setWellPIMap function of the Schedule.
+        std::unordered_map<std::string, double> m_wellPIMap;
 
         void load_rst(const RestartIO::RstState& rst,
                       const TracerConfig& tracer_config,

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -291,13 +291,7 @@ namespace Opm {
         // keywords have been applied.
         SimulatorUpdate applyAction(std::size_t reportStep,
                                     const Action::ActionX& action,
-                                    const Action::Result::MatchingEntities& matches,
-                                    const std::unordered_map<std::string, double>& wellpi);
-
-        SimulatorUpdate applyAction(std::size_t reportStep,
-                                    const Action::ActionX& action,
-                                    const Action::Result::MatchingEntities& matches,
-                                    const std::unordered_map<std::string, float>& wellpi);
+                                    const Action::Result::MatchingEntities& matches);
         /*
           The runPyAction() will run the Python script in a PYACTION keyword. In
           the case of Schedule updates the recommended way of doing that from
@@ -487,7 +481,6 @@ namespace Opm {
                            const ScheduleGrid& grid,
                            const Action::Result::MatchingEntities& matches,
                            SimulatorUpdate* sim_update,
-                           const std::unordered_map<std::string, double>* target_wellpi,
                            std::unordered_map<std::string, double>& wpimult_global_factor,
                            WelSegsSet* welsegs_wells = nullptr,
                            std::set<std::string>* compsegs_wells = nullptr);

--- a/opm/input/eclipse/Schedule/Schedule.hpp
+++ b/opm/input/eclipse/Schedule/Schedule.hpp
@@ -350,6 +350,7 @@ namespace Opm {
             serializer(this->m_treat_critical_as_non_critical);
             serializer(this->current_report_step);
             serializer(this->m_lowActionParsingStrictness);
+            serializer(this->welpi_action_mode);
             serializer(this->simUpdateFromPython);
 
             // If we are deserializing we need to setup the pointer to the
@@ -412,6 +413,9 @@ namespace Opm {
         // end up on the same partition.
         std::unordered_map<std::string, std::set<int>> possibleFutureConnections;
 
+        // The action mode is set to true when a PYACTION call is executed, when the PYACTION execution is
+        // over, it is set to false again. This is needed for handling the keyword WELPI from a PYACTION.
+        bool welpi_action_mode = false;
         // The current_report_step is set to the current report step when a PYACTION call is executed.
         // This is needed since the Schedule object does not know the current report step of the simulator and
         // we only allow PYACTIONS for the current and future report steps. 

--- a/opm/input/eclipse/Schedule/UDQ/UDQKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/UDQ/UDQKeywordHandlers.cpp
@@ -42,7 +42,7 @@ namespace {
     {
         auto dynSelector = std::optional<Opm::UDQConfig::DynamicSelector>{};
 
-        if (handlerContext.actionx_mode) {
+        if (handlerContext.welpi_action_mode) {
             dynSelector = Opm::UDQConfig::DynamicSelector{};
 
             if (const auto dynWells = handlerContext.matches.wells();

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -192,7 +192,7 @@ void handleWELPIRuntime(HandlerContext& handlerContext)
 
 void handleWELPI(HandlerContext& handlerContext)
 {
-    if (handlerContext.actionx_mode) {
+    if (handlerContext.welpi_action_mode) {
         handleWELPIRuntime(handlerContext);
         return;
     }

--- a/tests/parser/ACTIONX.cpp
+++ b/tests/parser/ACTIONX.cpp
@@ -224,8 +224,7 @@ TSTEP
         const auto action_result = Action::Result { true };
 
         const auto& action1 = sched[0].actions.get()["ACTION"];
-        auto sim_update = sched.applyAction(0, action1, action_result.matches(),
-                                            std::unordered_map<std::string,double>{});
+        auto sim_update = sched.applyAction(0, action1, action_result.matches());
 
         const auto& affected_wells = sim_update.affected_wells;
         const std::vector<std::string> expected_wells{"W0", "W1", "W3"};
@@ -295,8 +294,7 @@ COMPDAT
     Schedule sched = make_schedule(TRAILING_COMPDAT);
     const auto& action1 = sched[0].actions.get()["ACTION"];
 
-    BOOST_CHECK_NO_THROW(sched.applyAction(0, action1, Action::Result{false}.matches(),
-                                           std::unordered_map<std::string,double>{}));
+    BOOST_CHECK_NO_THROW(sched.applyAction(0, action1, Action::Result{false}.matches()));
 }
 
 BOOST_AUTO_TEST_CASE(EMPTY)
@@ -1222,8 +1220,7 @@ END
     }
 
     const Action::Result action_result{true};
-    sched.applyAction(0, action1, action_result.matches(),
-                      std::unordered_map<std::string,double>{});
+    sched.applyAction(0, action1, action_result.matches());
 
     {
         const auto& group = sched.getGroup("G1", 1);
@@ -1349,8 +1346,7 @@ END
 
     {
         const Action::Result action_result(true);
-        const auto& sim_update = sched.applyAction(0, action1, action_result.matches(),
-                                                   std::unordered_map<std::string,double>{});
+        const auto& sim_update = sched.applyAction(0, action1, action_result.matches());
 
         BOOST_CHECK(sim_update.affected_wells.empty());
     }
@@ -1432,8 +1428,7 @@ END
     BOOST_CHECK(!sched.hasWell("PROD1"));
 
     Action::Result action_result(true);
-    sched.applyAction(0, action1, action_result.matches(),
-                      std::unordered_map<std::string,double>{});
+    sched.applyAction(0, action1, action_result.matches());
 
     const auto& well = sched.getWell("PROD1", 1);
     const auto& connections = well.getConnections();
@@ -1493,15 +1488,12 @@ END
     const auto CF0 = sched.getWell("PROD1", 0).getConnections()[0].CF();
 
     const Action::Result action_result(true);
-    BOOST_CHECK_THROW(sched.applyAction(0, action1, action_result.matches(),
-                                        std::unordered_map<std::string,double>{}), std::exception);
+    BOOST_CHECK_THROW(sched.applyAction(0, action1, action_result.matches()), std::exception);
 
     {
         const auto& well = sched.getWell("PROD1", 0);
-        const auto& sim_update = sched.applyAction(0, action1, action_result.matches(),
-                                                   std::unordered_map<std::string,double> {
-                                                       { "PROD1", well.convertDeckPI(500) },
-                                                   });
+        sched.setWellPIMap(std::unordered_map<std::string, double>{{"PROD1",  static_cast<double>(well.convertDeckPI(500))}});
+        const auto& sim_update = sched.applyAction(0, action1, action_result.matches());
 
         BOOST_CHECK_EQUAL(sim_update.welpi_wells.count("PROD1"), 1);
         BOOST_CHECK_EQUAL(sim_update.welpi_wells.size(), 1);
@@ -1574,8 +1566,7 @@ END
 
     const auto& action1 = sched[0].actions.get()["A"];
     const Action::Result action_result(true);
-    auto sim_update = sched.applyAction(0, action1, action_result.matches(),
-                                        std::unordered_map<std::string,double>{});
+    auto sim_update = sched.applyAction(0, action1, action_result.matches());
 
     BOOST_CHECK(sim_update.tran_update);
     BOOST_CHECK_EQUAL(sched[0].geo_keywords().size(), 3);


### PR DESCRIPTION
To activate the WELPI keyword for the use in a PyAction, I had to add a way of communicating the old well production indices from the ActionHandler (i.e. the Well Model) back to the Schedule. For this, I have added the function setWellPIMap to the Schedule object, setting the attribute m_wellPIMap, a std::unordered_map<std::string, double>, of the Schedule . This map is set from the Action Handler before pending PyActions are executed.

Then, to further simplify the code, I have removed this map from the arguments of the handleKeyword, applyAction and iterateScheduleSection (there it was called target_wellpi), since these functions can now use the m_wellPIMap.
Then, I have removed a call that was done before for each ActionX: This call fetched such a map for the matching wells of each ActionX, but now, since we have the m_wellPIMap, these calls are not needed anymore.

It would be interesting to have a benchmark for this, possibly time and memory wise.

For the reference manual: With this PR and https://github.com/OPM/opm-simulators/pull/5467, the keywords WELPI and WPIMULT can be used in the "insert keywords"-function in Pyaction.