### PR TITLE
Switch to Named Accessors for UDQ Dimensions

### DIFF
--- a/opm/output/eclipse/AggregateUDQData.cpp
+++ b/opm/output/eclipse/AggregateUDQData.cpp
@@ -554,13 +554,13 @@ namespace {
     namespace iUdq {
 
         Opm::RestartIO::Helpers::WindowedArray<int>
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
-            int nwin = std::max(udqDims[0], 1);
+
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(nwin) },
-                WV::WindowSize{ static_cast<std::size_t>(udqDims[1]) }
+                WV::NumWindows{ std::max(udqDims.totalNumUDQs(), std::size_t{1}) },
+                WV::WindowSize{ Opm::UDQDims::entriesPerIUDQ() }
             };
         }
 
@@ -589,22 +589,24 @@ namespace {
     namespace iUad {
 
         std::optional<Opm::RestartIO::Helpers::WindowedArray<int>>
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
 
             auto iuad = std::optional<WV>{};
 
-            if (const auto numIUAD = udqDims[2]; numIUAD > 0) {
-                iuad.emplace(WV::NumWindows{ static_cast<std::size_t>(numIUAD) },
-                             WV::WindowSize{ static_cast<std::size_t>(udqDims[3]) });
+            if (udqDims.numIUAD() > 0) {
+                iuad.emplace(WV::NumWindows{ udqDims.numIUAD() },
+                             WV::WindowSize{ Opm::UDQDims::entriesPerIUAD() });
             }
 
             return iuad;
         }
 
         template <class IUADArray>
-        void staticContrib(const Opm::UDQActive::OutputRecord& udq_record, IUADArray& iUad, int use_cnt_diff)
+        void staticContrib(const Opm::UDQActive::OutputRecord& udq_record,
+                           const int                           use_cnt_diff,
+                           IUADArray&                          iUad)
         {
             iUad[0] = udq_record.uda_code;
             iUad[1] = udq_record.input_index + 1;
@@ -623,14 +625,17 @@ namespace {
         Opm::RestartIO::Helpers::WindowedArray<
             Opm::EclIO::PaddedOutputString<8>
         >
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<
-                Opm::EclIO::PaddedOutputString<8>>;
-            int nwin = std::max(udqDims[0], 1);
+                Opm::EclIO::PaddedOutputString<8>
+                >;
+
+            const auto nwin = std::max(udqDims.totalNumUDQs(), std::size_t{1});
+
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(nwin) },
-                WV::WindowSize{ static_cast<std::size_t>(udqDims[4]) }
+                WV::NumWindows{ nwin },
+                WV::WindowSize{ Opm::UDQDims::entriesPerZUDN() }
             };
         }
 
@@ -649,15 +654,17 @@ namespace {
         Opm::RestartIO::Helpers::WindowedArray<
             Opm::EclIO::PaddedOutputString<8>
         >
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<
-                Opm::EclIO::PaddedOutputString<8>>;
+                Opm::EclIO::PaddedOutputString<8>
+                >;
 
-            const int nwin = std::max(udqDims[0], 1);
+            const auto nwin = std::max(udqDims.totalNumUDQs(), std::size_t{1});
+
             return WV {
-                WV::NumWindows{ static_cast<std::size_t>(nwin) },
-                WV::WindowSize{ static_cast<std::size_t>(udqDims[5]) }
+                WV::NumWindows{ nwin },
+                WV::WindowSize{ Opm::UDQDims::entriesPerZUDL() }
             };
         }
 
@@ -715,15 +722,15 @@ namespace {
     namespace iGph {
 
         std::optional<Opm::RestartIO::Helpers::WindowedArray<int>>
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
 
             auto igph = std::optional<WV>{};
 
-            if (const auto numIGPH = udqDims[6]; numIGPH > 0) {
-                igph.emplace(WV::NumWindows{ static_cast<std::size_t>(numIGPH) },
-                             WV::WindowSize{ static_cast<std::size_t>(1) });
+            if (udqDims.numIGPH() > 0) {
+                igph.emplace(WV::NumWindows{ udqDims.numIGPH() },
+                             WV::WindowSize{ std::size_t{1} });
             }
 
             return igph;
@@ -741,15 +748,15 @@ namespace {
     namespace iUap {
 
         std::optional<Opm::RestartIO::Helpers::WindowedArray<int>>
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<int>;
 
             auto iuap = std::optional<WV>{};
 
-            if (const auto numIUAP = udqDims[7]; numIUAP > 0) {
-                iuap.emplace(WV::NumWindows{ static_cast<std::size_t>(numIUAP) },
-                             WV::WindowSize{ static_cast<std::size_t>(1) });
+            if (udqDims.numIUAP() > 0) {
+                iuap.emplace(WV::NumWindows{ udqDims.numIUAP() },
+                             WV::WindowSize{ std::size_t{1} });
             }
 
             return iuap;
@@ -767,15 +774,15 @@ namespace {
     namespace dUdf {
 
         std::optional<Opm::RestartIO::Helpers::WindowedArray<double>>
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<double>;
 
             auto dudf = std::optional<WV>{};
 
-            if (const auto numFieldUDQs = udqDims[12]; numFieldUDQs > 0) {
-                dudf.emplace(WV::NumWindows { static_cast<std::size_t>(numFieldUDQs) },
-                             WV::WindowSize { static_cast<std::size_t>(1) });
+            if (udqDims.numFieldUDQs() > 0) {
+                dudf.emplace(WV::NumWindows { udqDims.numFieldUDQs() },
+                             WV::WindowSize { std::size_t{1} });
             }
 
             return dudf;
@@ -797,15 +804,15 @@ namespace {
     namespace dUdg {
 
         std::optional<Opm::RestartIO::Helpers::WindowedArray<double>>
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<double>;
 
             auto dudg = std::optional<WV>{};
 
-            if (const auto numGroupUDQs = udqDims[11]; numGroupUDQs > 0) {
-                dudg.emplace(WV::NumWindows{ static_cast<std::size_t>(numGroupUDQs) },
-                             WV::WindowSize{ static_cast<std::size_t>(udqDims[10]) });
+            if (udqDims.numGroupUDQs() > 0) {
+                dudg.emplace(WV::NumWindows{ udqDims.numGroupUDQs() },
+                             WV::WindowSize{ udqDims.maxNumGroups() });
             }
 
             return dudg;
@@ -835,17 +842,18 @@ namespace {
     namespace dUdw {
 
         std::optional<Opm::RestartIO::Helpers::WindowedArray<double>>
-        allocate(const std::vector<int>& udqDims)
+        allocate(const Opm::UDQDims& udqDims)
         {
             using WV = Opm::RestartIO::Helpers::WindowedArray<double>;
 
             auto dudw = std::optional<WV>{};
 
-            if (const auto numWellUDQs = udqDims[9]; numWellUDQs > 0) {
-                const auto numWells = std::max(udqDims[8], 1);
+            if (udqDims.numWellUDQs() > 0) {
+                const auto numWells =
+                    std::max(udqDims.maxNumWells(), std::size_t{1});
 
-                dudw.emplace(WV::NumWindows{ static_cast<std::size_t>(numWellUDQs) },
-                             WV::WindowSize{ static_cast<std::size_t>(numWells) });
+                dudw.emplace(WV::NumWindows{ udqDims.numWellUDQs() },
+                             WV::WindowSize{ numWells });
             }
 
             return dudw;
@@ -876,16 +884,16 @@ namespace {
 
 Opm::RestartIO::Helpers::AggregateUDQData::
 AggregateUDQData(const UDQDims& udqDims)
-    : iUDQ_ { iUdq::allocate(udqDims.data()) }
-    , iUAD_ { iUad::allocate(udqDims.data()) }
-    , zUDN_ { zUdn::allocate(udqDims.data()) }
-    , zUDL_ { zUdl::allocate(udqDims.data()) }
-    , iGPH_ { iGph::allocate(udqDims.data()) }
-    , iUAP_ { iUap::allocate(udqDims.data()) }
+    : iUDQ_ { iUdq::allocate(udqDims) }
+    , iUAD_ { iUad::allocate(udqDims) }
+    , zUDN_ { zUdn::allocate(udqDims) }
+    , zUDL_ { zUdl::allocate(udqDims) }
+    , iGPH_ { iGph::allocate(udqDims) }
+    , iUAP_ { iUap::allocate(udqDims) }
       // ------------------------------------------------------------
-    , dUDF_ { dUdf::allocate(udqDims.data()) }
-    , dUDG_ { dUdg::allocate(udqDims.data()) }
-    , dUDW_ { dUdw::allocate(udqDims.data()) }
+    , dUDF_ { dUdf::allocate(udqDims) }
+    , dUDG_ { dUdg::allocate(udqDims) }
+    , dUDW_ { dUdw::allocate(udqDims) }
 {}
 
 // ---------------------------------------------------------------------------
@@ -986,7 +994,7 @@ collectUserDefinedArguments(const Schedule&         sched,
             auto iuad = (*this->iUAD_)[cnt];
 
             const auto use_count_diff = static_cast<int>(index) - cnt;
-            iUad::staticContrib(record, iuad, use_count_diff);
+            iUad::staticContrib(record, use_count_diff, iuad);
 
             ++cnt;
         }

--- a/opm/output/eclipse/UDQDims.cpp
+++ b/opm/output/eclipse/UDQDims.cpp
@@ -23,12 +23,10 @@
 
 #include <opm/input/eclipse/Schedule/UDQ/UDQConfig.hpp>
 
-namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
+#include <cstddef>
+#include <vector>
 
-const std::vector<int>& Opm::UDQDims::data() const
-{
-    return this->m_data;
-}
+namespace VI = ::Opm::RestartIO::Helpers::VectorItems;
 
 Opm::UDQDims::UDQDims(const UDQConfig&        config,
                       const std::vector<int>& inteHead)
@@ -54,4 +52,49 @@ Opm::UDQDims::UDQDims(const UDQConfig&        config,
     this->m_data[11] = inteHead[VI::intehead::NO_GROUP_UDQS];
 
     this->m_data[12] = inteHead[VI::intehead::NO_FIELD_UDQS];
+}
+
+std::size_t Opm::UDQDims::totalNumUDQs() const
+{
+    return this->m_data[0];
+}
+
+std::size_t Opm::UDQDims::numIUAD() const
+{
+    return this->m_data[2];
+}
+
+std::size_t Opm::UDQDims::numIGPH() const
+{
+    return this->m_data[6];
+}
+
+std::size_t Opm::UDQDims::numIUAP() const
+{
+    return this->m_data[7];
+}
+
+std::size_t Opm::UDQDims::numFieldUDQs() const
+{
+    return this->m_data[12];
+}
+
+std::size_t Opm::UDQDims::maxNumGroups() const
+{
+    return this->m_data[10];
+}
+
+std::size_t Opm::UDQDims::numGroupUDQs() const
+{
+    return this->m_data[11];
+}
+
+std::size_t Opm::UDQDims::maxNumWells() const
+{
+    return this->m_data[8];
+}
+
+std::size_t Opm::UDQDims::numWellUDQs() const
+{
+    return this->m_data[9];
 }

--- a/opm/output/eclipse/UDQDims.hpp
+++ b/opm/output/eclipse/UDQDims.hpp
@@ -21,6 +21,8 @@
 #define OPM_UDQDIMS_HPP
 
 #include <cstddef>
+#include <functional>
+#include <optional>
 #include <vector>
 
 namespace Opm {
@@ -56,13 +58,24 @@ public:
 
     const std::vector<int>& data() const
     {
-        return this->m_data;
+        if (! this->dimensionData_.has_value()) {
+            this->collectDimensions();
+        }
+
+        return *this->dimensionData_;
     }
 
 private:
-    std::vector<int> m_data;
+    std::size_t totalNumUDQs_{};
+    std::reference_wrapper<const std::vector<int>> intehead_;
+
+    mutable std::optional<std::vector<int>> dimensionData_;
+
+    void collectDimensions() const;
+
+    std::size_t intehead(const std::vector<int>::size_type i) const;
 };
 
 } // namespace Opm
 
-#endif  // OPM_UDQDIMS_HPP
+#endif // OPM_UDQDIMS_HPP

--- a/opm/output/eclipse/UDQDims.hpp
+++ b/opm/output/eclipse/UDQDims.hpp
@@ -36,12 +36,28 @@ class UDQDims
 public:
     explicit UDQDims(const UDQConfig& config, const std::vector<int>& intehead);
 
-    const std::vector<int>& data() const;
-
     static std::size_t entriesPerIUDQ() { return  3; }
     static std::size_t entriesPerIUAD() { return  5; }
     static std::size_t entriesPerZUDN() { return  2; }
     static std::size_t entriesPerZUDL() { return 16; }
+
+    std::size_t totalNumUDQs() const;
+    std::size_t numIUAD() const;
+    std::size_t numIGPH() const;
+    std::size_t numIUAP() const;
+
+    std::size_t numFieldUDQs() const;
+
+    std::size_t maxNumGroups() const;
+    std::size_t numGroupUDQs() const;
+
+    std::size_t maxNumWells() const;
+    std::size_t numWellUDQs() const;
+
+    const std::vector<int>& data() const
+    {
+        return this->m_data;
+    }
 
 private:
     std::vector<int> m_data;

--- a/tests/test_AggregateUDQData.cpp
+++ b/tests/test_AggregateUDQData.cpp
@@ -227,32 +227,37 @@ BOOST_AUTO_TEST_SUITE(Aggregate_UDQ)
 // test constructed UDQ restart data
 BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 {
-    const auto simCase = SimulationCase{first_sim("UDQ_TEST_WCONPROD_IUAD-2.DATA")};
+    const auto simCase = SimulationCase {
+        first_sim("UDQ_TEST_WCONPROD_IUAD-2.DATA")
+    };
 
-    Opm::EclipseState es = simCase.es;
-    Opm::SummaryState st = sum_state(es.runspec().udqParams().undefinedValue());
-    Opm::UDQState     udq_state = make_udq_state();
-    Opm::Schedule     sched = simCase.sched;
-    Opm::EclipseGrid  grid = simCase.grid;
+    const auto& es = simCase.es;
+    const auto& sched = simCase.sched;
+    const auto& grid = simCase.grid;
+
+    auto st = sum_state(es.runspec().udqParams().undefinedValue());
+    auto udq_state = make_udq_state();
 
     const auto& ioConfig = es.getIOConfig();
-    //const auto& restart = es.cfg().restart();
 
     // Report Step 1: 2008-10-10 --> 2011-01-20
     const auto rptStep = std::size_t{1};
 
-    double secs_elapsed = 3.1536E07;
+    const auto secs_elapsed = 3.1536E07;
+
     const auto ih = Opm::RestartIO::Helpers::
         createInteHead(es, grid, sched, secs_elapsed,
                        rptStep, rptStep, rptStep - 1);
 
-    //set dummy value for next_step_size
-    const double next_step_size= 0.1;
+    // Dummy value for next_step_size
+    const auto next_step_size = 0.1;
+
     const auto dh = Opm::RestartIO::Helpers::
         createDoubHead(es, sched, rptStep - 1, rptStep,
                        secs_elapsed, next_step_size);
 
-    const auto udqDims = Opm::UDQDims {sched.getUDQConfig(rptStep - 1), ih};
+    const auto udqDims = Opm::UDQDims { sched[rptStep - 1].udq(), ih };
+
     auto udqData = Opm::RestartIO::Helpers::AggregateUDQData(udqDims);
     udqData.captureDeclaredUDQData(sched, rptStep - 1, udq_state, ih);
 
@@ -367,308 +372,308 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             const auto& iUdq = udqData.getIUDQ();
 
-            auto start = 0 * udqDims.data()[1];
+            auto start = 0 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 1 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 1
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 1); // udq NO. 1 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 1 * udqDims.data()[1];
+            start = 1 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 0); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], 0); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 2); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 2 * udqDims.data()[1];
+            start = 2 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 3); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 3 * udqDims.data()[1];
+            start = 3 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 1); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 4 * udqDims.data()[1];
+            start = 4 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 4); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 5 * udqDims.data()[1];
+            start = 5 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 1); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 6 * udqDims.data()[1];
+            start = 6 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 2); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 7 * udqDims.data()[1];
+            start = 7 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 3); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 8 * udqDims.data()[1];
+            start = 8 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -5); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 4); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 9 * udqDims.data()[1];
+            start = 9 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -8); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 5); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 10 * udqDims.data()[1];
+            start = 10 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 6); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 11 * udqDims.data()[1];
+            start = 11 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -5); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 7); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 12 * udqDims.data()[1];
+            start = 12 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -3); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 8); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 13 * udqDims.data()[1];
+            start = 13 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 9); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 14 * udqDims.data()[1];
+            start = 14 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -2); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 10); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 15 * udqDims.data()[1];
+            start = 15 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -3); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 11); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 16 * udqDims.data()[1];
+            start = 16 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 12); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 17 * udqDims.data()[1];
+            start = 17 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 13); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 18 * udqDims.data()[1];
+            start = 18 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -3); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 14); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 19 * udqDims.data()[1];
+            start = 19 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -5); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 15); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 20 * udqDims.data()[1];
+            start = 20 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -5); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 16); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 21 * udqDims.data()[1];
+            start = 21 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], 1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 17); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 22 * udqDims.data()[1];
+            start = 22 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], 1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 18); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 23 * udqDims.data()[1];
+            start = 23 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 19); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 24 * udqDims.data()[1];
+            start = 24 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 20); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 25 * udqDims.data()[1];
+            start = 25 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -2); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 21); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 26 * udqDims.data()[1];
+            start = 26 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 22); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 27 * udqDims.data()[1];
+            start = 27 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -2); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 23); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 28 * udqDims.data()[1];
+            start = 28 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -2); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 24); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 29 * udqDims.data()[1];
+            start = 29 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -8); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 25); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 30 * udqDims.data()[1];
+            start = 30 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -6); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 26); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 31 * udqDims.data()[1];
+            start = 31 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 27); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 32 * udqDims.data()[1];
+            start = 32 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -5); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 28); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 33 * udqDims.data()[1];
+            start = 33 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 29); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 34 * udqDims.data()[1];
+            start = 34 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -8); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 30); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 35 * udqDims.data()[1];
+            start = 35 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 31); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 36 * udqDims.data()[1];
+            start = 36 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -5); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 32); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 37 * udqDims.data()[1];
+            start = 37 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -6); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 33); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 38 * udqDims.data()[1];
+            start = 38 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 34); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 39 * udqDims.data()[1];
+            start = 39 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 35); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 40 * udqDims.data()[1];
+            start = 40 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -6); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 36); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 41 * udqDims.data()[1];
+            start = 41 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -2); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 37); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 42 * udqDims.data()[1];
+            start = 42 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -4); // udq NO. 2
             BOOST_CHECK_EQUAL(
                 iUdq[start + 2],
                 38); // udq NO. 2 - (sequence number of UDQ pr type (CU, FU, GU, RU, , SU, WU, AU or BU etc.)
 
-            start = 43 * udqDims.data()[1];
+            start = 43 * Opm::UDQDims::entriesPerIUDQ();
             BOOST_CHECK_EQUAL(iUdq[start + 0], 2); // udq NO. 2 - ( 0 - ASSIGN, 2 - DEFINE)
             BOOST_CHECK_EQUAL(iUdq[start + 1], -1); // udq NO. 2
             BOOST_CHECK_EQUAL(
@@ -708,15 +713,15 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             const auto& iUad = udqData.getIUAD()->data();
 
-            auto start = 0 * udqDims.data()[3];
-            BOOST_CHECK_EQUAL(iUad[start + 0], 300004); // iuad NO. 1
+            auto start = 0 * Opm::UDQDims::entriesPerIUAD();
+            BOOST_CHECK_EQUAL(iUad[start + 0], 300'004); // iuad NO. 1
             BOOST_CHECK_EQUAL(iUad[start + 1], 3); // iuad NO. 1
             BOOST_CHECK_EQUAL(iUad[start + 2], 1); // iuad NO. 1
             BOOST_CHECK_EQUAL(iUad[start + 3], 2); // iuad NO. 1
             BOOST_CHECK_EQUAL(iUad[start + 4], 1); // iuad NO. 1
 
-            start = 1 * udqDims.data()[3];
-            BOOST_CHECK_EQUAL(iUad[start + 0], 600004); // iuad NO. 2
+            start = 1 * Opm::UDQDims::entriesPerIUAD();
+            BOOST_CHECK_EQUAL(iUad[start + 0], 600'004); // iuad NO. 2
             BOOST_CHECK_EQUAL(iUad[start + 1], 5); // iuad NO. 2
             BOOST_CHECK_EQUAL(iUad[start + 2], 1); // iuad NO. 2
             BOOST_CHECK_EQUAL(iUad[start + 3], 2); // iuad NO. 2
@@ -734,27 +739,27 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             const auto& zUdn = udqData.getZUDN();
 
-            auto start = 0 * udqDims.data()[4];
+            auto start = 0 * Opm::UDQDims::entriesPerZUDN();
             BOOST_CHECK_EQUAL(zUdn[start + 0].c_str(), "WUOPRL  "); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdn[start + 1].c_str(), "SM3/DAY "); // udq NO. 1
 
-            start = 1 * udqDims.data()[4];
+            start = 1 * Opm::UDQDims::entriesPerZUDN();
             BOOST_CHECK_EQUAL(zUdn[start + 0].c_str(), "WULPRL  "); // udq NO. 2
             BOOST_CHECK_EQUAL(zUdn[start + 1].c_str(), "SM3/DAY "); // udq NO. 2
 
-            start = 2 * udqDims.data()[4];
+            start = 2 * Opm::UDQDims::entriesPerZUDN();
             BOOST_CHECK_EQUAL(zUdn[start + 0].c_str(), "WUOPRU  "); // udq NO. 3
             BOOST_CHECK_EQUAL(zUdn[start + 1].c_str(), "SM3/DAY "); // udq NO. 3
 
-            start = 3 * udqDims.data()[4];
+            start = 3 * Opm::UDQDims::entriesPerZUDN();
             BOOST_CHECK_EQUAL(zUdn[start + 0].c_str(), "GUOPRU  "); // udq NO. 4
             BOOST_CHECK_EQUAL(zUdn[start + 1].c_str(), "SM3/DAY "); // udq NO. 4
 
-            start = 4 * udqDims.data()[4];
+            start = 4 * Opm::UDQDims::entriesPerZUDN();
             BOOST_CHECK_EQUAL(zUdn[start + 0].c_str(), "WULPRU  "); // udq NO. 5
             BOOST_CHECK_EQUAL(zUdn[start + 1].c_str(), "SM3/DAY "); // udq NO. 5
 
-            start = 5 * udqDims.data()[4];
+            start = 5 * Opm::UDQDims::entriesPerZUDN();
             BOOST_CHECK_EQUAL(zUdn[start + 0].c_str(), "FULPR   "); // udq NO. 6
             BOOST_CHECK_EQUAL(zUdn[start + 1].c_str(), "SM3/DAY "); // udq NO. 6
         }
@@ -772,25 +777,25 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             const auto& zUdl = udqData.getZUDL();
 
-            auto start = 0 * udqDims.data()[5];
+            auto start = 0 * Opm::UDQDims::entriesPerZUDL();
             BOOST_CHECK_EQUAL(zUdl[start + 0].c_str(), "(WOPR 'P"); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 1].c_str(), "ROD1' - "); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 2].c_str(), "170) * 0"); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 3].c_str(), ".6      "); // udq NO. 1
 
-            start = 3 * udqDims.data()[5];
+            start = 3 * Opm::UDQDims::entriesPerZUDL();
             BOOST_CHECK_EQUAL(zUdl[start + 0].c_str(), "(GOPR 'G"); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 1].c_str(), "RP1' - 4"); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 2].c_str(), "49) * 0."); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 3].c_str(), "77      "); // udq NO. 1
 
-            start = 4 * udqDims.data()[5];
+            start = 4 * Opm::UDQDims::entriesPerZUDL();
             BOOST_CHECK_EQUAL(zUdl[start + 0].c_str(), "(WLPR 'P"); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 1].c_str(), "ROD2' - "); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 2].c_str(), "300) * 0"); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 3].c_str(), ".8      "); // udq NO. 1
 
-            start = 5 * udqDims.data()[5];
+            start = 5 * Opm::UDQDims::entriesPerZUDL();
             BOOST_CHECK_EQUAL(zUdl[start + 0].c_str(), "(FLPR - "); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 1].c_str(), "543) * 0"); // udq NO. 1
             BOOST_CHECK_EQUAL(zUdl[start + 2].c_str(), ".65     "); // udq NO. 1
@@ -807,14 +812,14 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             BOOST_CHECK_MESSAGE(dUdw.has_value(), "There must be well level UDQ results");
 
-            auto start = 0 * udqDims.data()[8];
+            auto start = 0 * udqDims.maxNumWells();
             BOOST_CHECK_EQUAL(dUdw->data()[start + 0], 210); // duDw NO. 1
             BOOST_CHECK_EQUAL(dUdw->data()[start + 1], 211); // duDw NO. 1
             BOOST_CHECK_EQUAL(dUdw->data()[start + 2], 212); // duDw NO. 1
             BOOST_CHECK_EQUAL(dUdw->data()[start + 3], 213); // duDw NO. 1
             BOOST_CHECK_EQUAL(dUdw->data()[start + 4], -0.3E+21); // duDw NO. 1
 
-            start = 1 * udqDims.data()[8];
+            start = 1 * udqDims.maxNumWells();
             BOOST_CHECK_EQUAL(dUdw->data()[start + 0], 400); // duDw NO. 1
             BOOST_CHECK_EQUAL(dUdw->data()[start + 1], 400); // duDw NO. 1
             BOOST_CHECK_EQUAL(dUdw->data()[start + 2], 400); // duDw NO. 1
@@ -832,7 +837,7 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             BOOST_CHECK_MESSAGE(dUdg.has_value(), "There must be group level UDQ results");
 
-            auto start = 0 * udqDims.data()[11];
+            auto start = 0 * udqDims.maxNumGroups();
             BOOST_CHECK_EQUAL(dUdg->data()[start + 0], 362); // duDg NO. 1
             BOOST_CHECK_EQUAL(dUdg->data()[start + 1], 360); // duDg NO. 1
             BOOST_CHECK_EQUAL(dUdg->data()[start + 2], 361); // duDg NO. 1
@@ -850,7 +855,7 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 
             BOOST_CHECK_MESSAGE(dUdf.has_value(), "There must be field level UDQ results");
 
-            auto start = 0 * udqDims.data()[12];
+            auto start = 0 * udqDims.numFieldUDQs();
             BOOST_CHECK_EQUAL(dUdf->data()[start + 0], 460); // duDf NO. 1
         }
 
@@ -937,65 +942,67 @@ BOOST_AUTO_TEST_CASE (Declared_UDQ_data)
 // test constructed UDQ restart data
 BOOST_AUTO_TEST_CASE (Declared_UDQ_data_2)
 {
-    const auto simCase = SimulationCase{first_sim("9_4C_WINJ_GINJ_UDQ_MSW-UDARATE_TEST_PACK.DATA")};
+    const auto simCase = SimulationCase{
+        first_sim("9_4C_WINJ_GINJ_UDQ_MSW-UDARATE_TEST_PACK.DATA")
+    };
 
-    Opm::EclipseState es = simCase.es;
-    Opm::SummaryState st = sum_state(es.runspec().udqParams().undefinedValue());
-    Opm::UDQState     udq_state = make_udq_state();
-    Opm::Schedule     sched = simCase.sched;
-    Opm::EclipseGrid  grid = simCase.grid;
+    const auto& es    = simCase.es;
+    const auto& st    = sum_state(es.runspec().udqParams().undefinedValue());
+    const auto& sched = simCase.sched;
+    const auto& grid  = simCase.grid;
+
+    const auto udq_state = make_udq_state();
+
+    // Dummy values
+    const double next_step_size = 0.1;
+    const auto secs_elapsed = 3.1536E07;
 
     // Report Step 1: 2018-12-05
-    auto rptStep = std::size_t{1};
-    auto simStep = rptStep - 1;
-
-    double secs_elapsed = 3.1536E07;
-    auto ih = Opm::RestartIO::Helpers::
-        createInteHead(es, grid, sched, secs_elapsed,
-                       rptStep, rptStep, simStep);
-
-    //set dummy value for next_step_size
-    double next_step_size= 0.1;
-    auto dh = Opm::RestartIO::Helpers::createDoubHead(es, sched, simStep, simStep+1,
-                                                      secs_elapsed, next_step_size);
-
-    auto lh = Opm::RestartIO::Helpers::createLogiHead(es);
-
-    auto udqDims = Opm::UDQDims { sched[simStep].udq(), ih };
-    auto udqData = Opm::RestartIO::Helpers::AggregateUDQData(udqDims);
-    udqData.captureDeclaredUDQData(sched, simStep, udq_state, ih);
-
     {
+        const auto rptStep = std::size_t{1};
+        const auto simStep = rptStep - 1;
+
+        auto ih = Opm::RestartIO::Helpers::
+            createInteHead(es, grid, sched, secs_elapsed,
+                           rptStep, rptStep, simStep);
+
+        const auto dh = Opm::RestartIO::Helpers::
+            createDoubHead(es, sched, simStep, simStep + 1,
+                           secs_elapsed, next_step_size);
+
+        const auto udqDims = Opm::UDQDims { sched[simStep].udq(), ih };
+
+        auto udqData = Opm::RestartIO::Helpers::AggregateUDQData(udqDims);
+        udqData.captureDeclaredUDQData(sched, simStep, udq_state, ih);
+
         const auto& iGph = udqData.getIGPH()->data();
 
-        auto start = 0*udqDims.data()[1];
-        BOOST_CHECK_EQUAL(iGph[start + 0] ,  3); // (3 - gas injection)
+        BOOST_CHECK_GT(udqDims.numIGPH(), 0);
+        BOOST_CHECK_EQUAL(iGph[0], 3); // (3 - gas injection)
     }
 
     // Report Step 4: 2018-12-20
-    rptStep = std::size_t{4};
-    simStep = rptStep - 1;
-
-    ih = Opm::RestartIO::Helpers::
-        createInteHead(es, grid, sched, secs_elapsed,
-                       rptStep, rptStep, simStep);
-
-    //set dummy value for next_step_size
-    next_step_size= 0.1;
-    dh = Opm::RestartIO::Helpers::createDoubHead(es, sched, simStep, simStep+1,
-                                                 secs_elapsed, next_step_size);
-
-    lh = Opm::RestartIO::Helpers::createLogiHead(es);
-
-    udqDims = Opm::UDQDims { sched[simStep].udq(), ih };
-    udqData = Opm::RestartIO::Helpers::AggregateUDQData(udqDims);
-    udqData.captureDeclaredUDQData(sched, simStep, udq_state, ih);
-
     {
+        const auto rptStep = std::size_t{4};
+        const auto simStep = rptStep - 1;
+
+        const auto ih = Opm::RestartIO::Helpers::
+            createInteHead(es, grid, sched, secs_elapsed,
+                           rptStep, rptStep, simStep);
+
+        const auto dh = Opm::RestartIO::Helpers::
+            createDoubHead(es, sched, simStep, simStep + 1,
+                           secs_elapsed, next_step_size);
+
+        const auto udqDims = Opm::UDQDims { sched[simStep].udq(), ih };
+
+        auto udqData = Opm::RestartIO::Helpers::AggregateUDQData(udqDims);
+        udqData.captureDeclaredUDQData(sched, simStep, udq_state, ih);
+
         const auto& iGph = udqData.getIGPH()->data();
 
-        auto start = 0*udqDims.data()[1];
-        BOOST_CHECK_EQUAL(iGph[start + 0] ,  2); // (2 - water injection)
+        BOOST_CHECK_GT(udqDims.numIGPH(), 0);
+        BOOST_CHECK_EQUAL(iGph[0], 2); // (2 - water injection)
     }
 }
 


### PR DESCRIPTION
This is in preparation of adding support for outputting segment level UDQs to the restart file.

We add a named accessors for the individual UDQ dimension elements and provide the `UDQDims::data()` vector only as a fallback alternative.  We intend to remove that alternative at some point in the future, because having multiple sources of truth will likely lead to inconsistencies.  Instead, we now hold a reference to the report step's `INTEHEAD` vector and forward all dimension requests to that array.