### PR TITLE
Include Scotch when scotchmetis is used

### DIFF
--- a/cmake/Modules/FindMETIS.cmake
+++ b/cmake/Modules/FindMETIS.cmake
@@ -71,6 +71,8 @@ if (METIS_INCLUDE_DIRS OR METIS_LIBRARY)
     # Silently assume version 5, it is >=2024 after all...
     set(METIS_API_VERSION "5")
     find_package(PTScotch)
+    # If we use scotchmetis, we need Scotch, which is automatically installed then
+    find_package(Scotch REQUIRED)
   endif()
   if (NOT TARGET METIS::METIS)
     add_library(METIS::METIS UNKNOWN IMPORTED)
@@ -85,6 +87,14 @@ if (METIS_INCLUDE_DIRS OR METIS_LIBRARY)
       set_property(TARGET METIS::METIS APPEND PROPERTY
         INTERFACE_COMPILE_DEFINITIONS
          SCOTCH_METIS_VERSION=${METIS_API_VERSION})
+    endif()
+    if(Scotch_FOUND)
+        set_property(TARGET METIS::METIS APPEND PROPERTY
+          INTERFACE_INCLUDE_DIRECTORIES ${SCOTCH_INCLUDE_DIRS})
+        set_property(TARGET METIS::METIS APPEND PROPERTY
+          INTERFACE_LINK_LIBRARIES ${SCOTCH_LIBRARIES})
+    else()
+        message(FATAL_ERROR "Scotch library not found")
     endif()
     # Force our build system to use the target
     set(METIS_LIBRARIES METIS::METIS)

--- a/cmake/Modules/FindScotch.cmake
+++ b/cmake/Modules/FindScotch.cmake
@@ -1,0 +1,43 @@
+# Module that checks whether Scotch is available.
+#
+# Accepts the following variables:
+#
+# Sets the following variables:
+# SCOTCH_INCLUDE_DIRS: All include directories needed to compile Scotch programs.
+# SCOTCH_LIBRARIES:    Alle libraries needed to link Scotch programs.
+# SCOTCH_FOUND:        True if Scotch was found.
+#
+# Provides the following macros:
+#
+# find_package(Scotch)
+
+# Search for Scotch includes
+find_path(SCOTCH_INCLUDE_DIR scotch.h
+    PATHS /usr/include /usr/local/include
+    PATH_SUFFIXES scotch
+)
+
+if (SCOTCH_INCLUDE_DIR)
+    set(SCOTCH_INCLUDE_DIRS ${SCOTCH_INCLUDE_DIR})
+endif()
+
+# Search for Scotch libraries
+find_library(SCOTCH_LIBRARY NAMES scotch scotch-int32 scotch-int64 scotch-long
+    PATHS
+        /usr/lib
+        /usr/local/lib
+)
+
+if (SCOTCH_LIBRARY)
+    set(SCOTCH_LIBRARIES ${SCOTCH_LIBRARY})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  "Scotch"
+  DEFAULT_MSG
+  SCOTCH_INCLUDE_DIRS
+  SCOTCH_LIBRARIES
+)
+
+mark_as_advanced(SCOTCH_INCLUDE_DIRS SCOTCH_LIBRARIES)


### PR DESCRIPTION
Without this change, building opm-grid resulted in an import error on my system when libscotchmetis-dev was installed and only libptscotch-7.0 and libscotch-dev but not libptscotch-dev.
This PR is not relevant for the user manual.