### PR TITLE
only set well temperature if WTEMP or WINJTEMP is set

### DIFF
--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -314,7 +314,7 @@ Well::Well(const RestartIO::RstWell& rst_well,
     wvfpexp(explicitTHPOptions(rst_well)),
     wdfac(std::make_shared<WDFAC>(rst_well)),
     status(status_from_int(rst_well.well_status)),
-    well_temperature(std::nullopt),
+    well_inj_temperature(std::nullopt),
     well_inj_mult(std::nullopt)
 {
     if (this->wtype.producer()) {
@@ -501,7 +501,7 @@ Well::Well(const std::string& wname_arg,
     wvfpexp(std::make_shared<WVFPEXP>()),
     wdfac(std::make_shared<WDFAC>()),
     status(Status::SHUT),
-    well_temperature(std::nullopt),
+    well_inj_temperature(std::nullopt),
     well_inj_mult(std::nullopt)
 {
     auto p = std::make_shared<WellProductionProperties>(this->unit_system, this->wname);
@@ -546,7 +546,7 @@ Well Well::serializationTestObject()
     result.wvfpexp = std::make_shared<WVFPEXP>(WVFPEXP::serializationTestObject());
     result.wdfac = std::make_shared<WDFAC>(WDFAC::serializationTestObject());
     result.m_pavg = PAvg();
-    result.well_temperature = 10.0;
+    result.well_inj_temperature = 10.0;
     result.well_inj_mult = InjMult::serializationTestObject();
     result.m_filter_concentration = UDAValue::serializationTestObject();
 
@@ -1732,18 +1732,18 @@ int Well::vfp_table_number() const {
         return this->injection->VFPTableNumber;
 }
 
-double Well::temperature() const {
-    if (!this->wtype.producer() && this->well_temperature)
-        return *this->well_temperature;
+double Well::inj_temperature() const {
+    if (this->wtype.injector() && this->well_inj_temperature)
+        return *this->well_inj_temperature;
 
     throw std::runtime_error("Can only ask for well temperature for" 
                     "injectors with non-default temperature.");
 }
-bool Well::hasTemperature() const {
-    return this->well_temperature.has_value(); 
+bool Well::hasInjTemperature() const {
+    return this->well_inj_temperature.has_value(); 
 }
-void Well::setWellTemperature(const double temp) {
-    this->well_temperature = temp;
+void Well::setWellInjTemperature(const double temp) {
+    this->well_inj_temperature = temp;
 }
 
 bool Well::cmp_structure(const Well& other) const {
@@ -1796,7 +1796,7 @@ bool Well::operator==(const Well& data) const {
         && (this->getProductionProperties() == data.getProductionProperties())
         && (this->m_pavg == data.m_pavg)
         && (this->getInjectionProperties() == data.getInjectionProperties())
-        && (this->well_temperature == data.well_temperature)
+        && (this->well_inj_temperature == data.well_inj_temperature)
         && (this->inj_mult_mode == data.inj_mult_mode)
         && (this->well_inj_mult == data.well_inj_mult)
         && (this->m_filter_concentration == data.m_filter_concentration)

--- a/opm/input/eclipse/Schedule/Well/Well.cpp
+++ b/opm/input/eclipse/Schedule/Well/Well.cpp
@@ -314,7 +314,7 @@ Well::Well(const RestartIO::RstWell& rst_well,
     wvfpexp(explicitTHPOptions(rst_well)),
     wdfac(std::make_shared<WDFAC>(rst_well)),
     status(status_from_int(rst_well.well_status)),
-    well_temperature(Metric::TemperatureOffset + ParserKeywords::STCOND::TEMPERATURE::defaultValue),
+    well_temperature(std::nullopt),
     well_inj_mult(std::nullopt)
 {
     if (this->wtype.producer()) {
@@ -501,7 +501,7 @@ Well::Well(const std::string& wname_arg,
     wvfpexp(std::make_shared<WVFPEXP>()),
     wdfac(std::make_shared<WDFAC>()),
     status(Status::SHUT),
-    well_temperature(Metric::TemperatureOffset + ParserKeywords::STCOND::TEMPERATURE::defaultValue),
+    well_temperature(std::nullopt),
     well_inj_mult(std::nullopt)
 {
     auto p = std::make_shared<WellProductionProperties>(this->unit_system, this->wname);
@@ -1733,10 +1733,14 @@ int Well::vfp_table_number() const {
 }
 
 double Well::temperature() const {
-    if (!this->wtype.producer())
-        return this->well_temperature;
+    if (!this->wtype.producer() && this->well_temperature)
+        return *this->well_temperature;
 
-    throw std::runtime_error("Can only ask for temperature in an injector");
+    throw std::runtime_error("Can only ask for well temperature for" 
+                    "injectors with non-default temperature.");
+}
+bool Well::hasTemperature() const {
+    return this->well_temperature.has_value(); 
 }
 void Well::setWellTemperature(const double temp) {
     this->well_temperature = temp;

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -553,9 +553,9 @@ public:
     GasInflowEquation gas_inflow_equation() const;
     bool segmented_density_calculation() const { return true; }
     double alq_value(const SummaryState& st) const;
-    double temperature() const;
-    bool hasTemperature() const;
-    void setWellTemperature(const double temp);
+    double inj_temperature() const;
+    bool hasInjTemperature() const;
+    void setWellInjTemperature(const double temp);
     bool hasInjected( ) const;
     bool hasProduced( ) const;
     bool updateHasInjected( );
@@ -610,7 +610,7 @@ public:
         serializer(wdfac);
         serializer(wvfpexp);
         serializer(m_pavg);
-        serializer(well_temperature);
+        serializer(well_inj_temperature);
         serializer(inj_mult_mode);
         serializer(well_inj_mult);
         serializer(m_filter_concentration);
@@ -662,7 +662,7 @@ private:
 
     Status status;
     PAvg m_pavg;
-    std::optional<double> well_temperature;
+    std::optional<double> well_inj_temperature;
     InjMultMode inj_mult_mode = InjMultMode::NONE;
     std::optional<InjMult> well_inj_mult;
     UDAValue m_filter_concentration;

--- a/opm/input/eclipse/Schedule/Well/Well.hpp
+++ b/opm/input/eclipse/Schedule/Well/Well.hpp
@@ -554,6 +554,7 @@ public:
     bool segmented_density_calculation() const { return true; }
     double alq_value(const SummaryState& st) const;
     double temperature() const;
+    bool hasTemperature() const;
     void setWellTemperature(const double temp);
     bool hasInjected( ) const;
     bool hasProduced( ) const;
@@ -661,7 +662,7 @@ private:
 
     Status status;
     PAvg m_pavg;
-    double well_temperature;
+    std::optional<double> well_temperature;
     InjMultMode inj_mult_mode = InjMultMode::NONE;
     std::optional<InjMult> well_inj_mult;
     UDAValue m_filter_concentration;

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -332,10 +332,10 @@ void handleWINJTEMP(HandlerContext& handlerContext)
 
         for (const auto& well_name : well_names) {
             const auto& well = handlerContext.state().wells.get(well_name);
-            const double current_temp = well.hasTemperature()? well.temperature(): 0.0;
+            const double current_temp = well.hasInjTemperature()? well.inj_temperature(): 0.0;
             if (current_temp != temp) {
                 auto well2 = handlerContext.state().wells( well_name );
-                well2.setWellTemperature(temp);
+                well2.setWellInjTemperature(temp);
                 handlerContext.state().wells.update( std::move(well2) );
             }
         }
@@ -500,10 +500,10 @@ void handleWTEMP(HandlerContext& handlerContext)
 
         for (const auto& well_name : well_names) {
             const auto& well = handlerContext.state().wells.get(well_name);
-            const double current_temp = well.hasTemperature()? well.temperature(): 0.0;
+            const double current_temp = well.hasInjTemperature()? well.inj_temperature(): 0.0;
             if (current_temp != temp) {
                 auto well2 = handlerContext.state().wells( well_name );
-                well2.setWellTemperature(temp);
+                well2.setWellInjTemperature(temp);
                 handlerContext.state().wells.update( std::move(well2) );
             }
         }

--- a/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
+++ b/opm/input/eclipse/Schedule/Well/WellPropertiesKeywordHandlers.cpp
@@ -332,7 +332,7 @@ void handleWINJTEMP(HandlerContext& handlerContext)
 
         for (const auto& well_name : well_names) {
             const auto& well = handlerContext.state().wells.get(well_name);
-            const double current_temp = !well.isProducer()? well.temperature(): 0.0;
+            const double current_temp = well.hasTemperature()? well.temperature(): 0.0;
             if (current_temp != temp) {
                 auto well2 = handlerContext.state().wells( well_name );
                 well2.setWellTemperature(temp);
@@ -500,7 +500,7 @@ void handleWTEMP(HandlerContext& handlerContext)
 
         for (const auto& well_name : well_names) {
             const auto& well = handlerContext.state().wells.get(well_name);
-            const double current_temp = !well.isProducer()? well.temperature(): 0.0;
+            const double current_temp = well.hasTemperature()? well.temperature(): 0.0;
             if (current_temp != temp) {
                 auto well2 = handlerContext.state().wells( well_name );
                 well2.setWellTemperature(temp);

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2721,12 +2721,14 @@ BOOST_AUTO_TEST_CASE(WTEMPINJ_well_template) {
         Schedule schedule( deck, grid, fp, runspec, python);
 
         BOOST_CHECK_THROW(schedule.getWell("W1", 1).temperature(), std::runtime_error);
+        BOOST_CHECK_THROW(schedule.getWell("W2", 1).temperature(), std::runtime_error);
+        BOOST_CHECK_THROW(schedule.getWell("W3", 1).temperature(), std::runtime_error);
+
+        BOOST_CHECK(schedule.getWell("W1", 2).hasTemperature());
         BOOST_CHECK_THROW(schedule.getWell("W1", 2).temperature(), std::runtime_error);
-
-        BOOST_CHECK_CLOSE(288.71, schedule.getWell("W2", 1).temperature(), 1e-5);
+        BOOST_CHECK(schedule.getWell("W2", 2).hasTemperature());
         BOOST_CHECK_CLOSE(313.15, schedule.getWell("W2", 2).temperature(), 1e-5);
-
-        BOOST_CHECK_CLOSE(288.71, schedule.getWell("W2", 1).temperature(), 1e-5);
+        BOOST_CHECK(schedule.getWell("W3", 2).hasTemperature());
         BOOST_CHECK_CLOSE(313.15, schedule.getWell("W3", 2).temperature(), 1e-5);
 }
 

--- a/tests/parser/ScheduleTests.cpp
+++ b/tests/parser/ScheduleTests.cpp
@@ -2673,14 +2673,14 @@ BOOST_AUTO_TEST_CASE(WTEMP_well_template) {
     Runspec runspec (deck);
     Schedule schedule( deck, grid, fp, runspec, python);
 
-    BOOST_CHECK_THROW(schedule.getWell("W1", 1).temperature(), std::runtime_error);
-    BOOST_CHECK_THROW(schedule.getWell("W1", 2).temperature(), std::runtime_error);
+    BOOST_CHECK_THROW(schedule.getWell("W1", 1).inj_temperature(), std::runtime_error);
+    BOOST_CHECK_THROW(schedule.getWell("W1", 2).inj_temperature(), std::runtime_error);
 
-    BOOST_CHECK_THROW(schedule.getWell("W2", 1).temperature(), std::runtime_error);
-    BOOST_CHECK_CLOSE(313.15, schedule.getWell("W2", 2).temperature(), 1e-5);
+    BOOST_CHECK_THROW(schedule.getWell("W2", 1).inj_temperature(), std::runtime_error);
+    BOOST_CHECK_CLOSE(313.15, schedule.getWell("W2", 2).inj_temperature(), 1e-5);
 
-    BOOST_CHECK_THROW(schedule.getWell("W3", 1).temperature(), std::runtime_error);
-    BOOST_CHECK_CLOSE(313.15, schedule.getWell("W3", 2).temperature(), 1e-5);
+    BOOST_CHECK_THROW(schedule.getWell("W3", 1).inj_temperature(), std::runtime_error);
+    BOOST_CHECK_CLOSE(313.15, schedule.getWell("W3", 2).inj_temperature(), 1e-5);
 }
 
 
@@ -2720,16 +2720,16 @@ BOOST_AUTO_TEST_CASE(WTEMPINJ_well_template) {
         Runspec runspec (deck);
         Schedule schedule( deck, grid, fp, runspec, python);
 
-        BOOST_CHECK_THROW(schedule.getWell("W1", 1).temperature(), std::runtime_error);
-        BOOST_CHECK_THROW(schedule.getWell("W2", 1).temperature(), std::runtime_error);
-        BOOST_CHECK_THROW(schedule.getWell("W3", 1).temperature(), std::runtime_error);
+        BOOST_CHECK_THROW(schedule.getWell("W1", 1).inj_temperature(), std::runtime_error);
+        BOOST_CHECK_THROW(schedule.getWell("W2", 1).inj_temperature(), std::runtime_error);
+        BOOST_CHECK_THROW(schedule.getWell("W3", 1).inj_temperature(), std::runtime_error);
 
-        BOOST_CHECK(schedule.getWell("W1", 2).hasTemperature());
-        BOOST_CHECK_THROW(schedule.getWell("W1", 2).temperature(), std::runtime_error);
-        BOOST_CHECK(schedule.getWell("W2", 2).hasTemperature());
-        BOOST_CHECK_CLOSE(313.15, schedule.getWell("W2", 2).temperature(), 1e-5);
-        BOOST_CHECK(schedule.getWell("W3", 2).hasTemperature());
-        BOOST_CHECK_CLOSE(313.15, schedule.getWell("W3", 2).temperature(), 1e-5);
+        BOOST_CHECK(schedule.getWell("W1", 2).hasInjTemperature());
+        BOOST_CHECK_THROW(schedule.getWell("W1", 2).inj_temperature(), std::runtime_error);
+        BOOST_CHECK(schedule.getWell("W2", 2).hasInjTemperature());
+        BOOST_CHECK_CLOSE(313.15, schedule.getWell("W2", 2).inj_temperature(), 1e-5);
+        BOOST_CHECK(schedule.getWell("W3", 2).hasInjTemperature());
+        BOOST_CHECK_CLOSE(313.15, schedule.getWell("W3", 2).inj_temperature(), 1e-5);
 }
 
 BOOST_AUTO_TEST_CASE( COMPDAT_sets_automatic_complnum ) {

--- a/tests/parser/WellTests.cpp
+++ b/tests/parser/WellTests.cpp
@@ -910,7 +910,7 @@ BOOST_AUTO_TEST_CASE(ExtraAccessors) {
     prod_props->VFPTableNumber = 200;
     prod.updateProduction(prod_props);
 
-    BOOST_CHECK_THROW(prod.temperature(), std::runtime_error);
+    BOOST_CHECK_THROW(prod.inj_temperature(), std::runtime_error);
     BOOST_CHECK_EQUAL(inj.vfp_table_number(), 100);
     BOOST_CHECK_EQUAL(prod.vfp_table_number(), 200);
 }


### PR DESCRIPTION
Make it possible to check if temperature is defaulted or not. For CO2STORE runs we would like to use the perforation temperature as default if WTEMP or WINJTEMP is not set. In particular this apply to isothermal runs